### PR TITLE
[Synthetics] Fix monitor status refresh

### DIFF
--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/hooks/use_monitor_latest_ping.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/hooks/use_monitor_latest_ping.tsx
@@ -8,6 +8,7 @@
 import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { ConfigKey } from '../../../../../../common/runtime_types';
+import { useSyntheticsRefreshContext } from '../../../contexts';
 import { getMonitorLastRunAction, selectLastRunMetadata } from '../../../state';
 import { useSelectedLocation } from './use_selected_location';
 import { useSelectedMonitor } from './use_selected_monitor';
@@ -19,6 +20,7 @@ interface UseMonitorLatestPingParams {
 
 export const useMonitorLatestPing = (params?: UseMonitorLatestPingParams) => {
   const dispatch = useDispatch();
+  const { lastRefresh } = useSyntheticsRefreshContext();
 
   const { monitor } = useSelectedMonitor();
   const location = useSelectedLocation();
@@ -41,7 +43,7 @@ export const useMonitorLatestPing = (params?: UseMonitorLatestPingParams) => {
     if (monitorId && locationLabel && !isUpToDate) {
       dispatch(getMonitorLastRunAction.get({ monitorId, locationId: locationLabel }));
     }
-  }, [dispatch, monitorId, locationLabel, isUpToDate]);
+  }, [dispatch, monitorId, locationLabel, isUpToDate, lastRefresh]);
 
   if (!monitorId || !locationLabel) {
     return { loading, latestPing: undefined };


### PR DESCRIPTION
Fixes #147892

## Summary

Uses `lastRefresh` from `syntheticsRefreshContext` to update Monitor Status on Monitor Details -> Overview/History pages.
