### PR TITLE
[Synthetics] Fix fetching monitor latest ping on refresh

### DIFF
--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/hooks/use_monitor_latest_ping.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/hooks/use_monitor_latest_ping.tsx
@@ -40,7 +40,7 @@ export const useMonitorLatestPing = (params?: UseMonitorLatestPingParams) => {
   const isUpToDate = isIdSame && isLocationSame;
 
   useEffect(() => {
-    if (monitorId && locationLabel && !isUpToDate) {
+    if (monitorId && locationLabel) {
       dispatch(getMonitorLastRunAction.get({ monitorId, locationId: locationLabel }));
     }
   }, [dispatch, monitorId, locationLabel, isUpToDate, lastRefresh]);


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/147901

## Summary

The PR removes the hard check to cache fetched data against a monitor and location id, when refreshing monitor's latest ping. 