### PR TITLE
[ci] Add build scripts for latest docker image

### DIFF
--- a/.buildkite/pipelines/artifacts_container_image.yml
+++ b/.buildkite/pipelines/artifacts_container_image.yml
@@ -1,0 +1,10 @@
+steps:
+  - command: .buildkite/scripts/steps/artifacts/docker_image.sh
+    label: Build default container images
+    agents:
+      queue: n2-16-spot
+    timeout_in_minutes: 60
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 3

--- a/.buildkite/scripts/steps/artifacts/docker_image.sh
+++ b/.buildkite/scripts/steps/artifacts/docker_image.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+set -euo pipefail
+
+.buildkite/scripts/bootstrap.sh
+
+source .buildkite/scripts/steps/artifacts/env.sh
+
+GIT_ABBREV_COMMIT=${BUILDKITE_COMMIT:0:7}
+KIBANA_IMAGE="docker.elastic.co/kibana-ci/kibana:$GIT_ABBREV_COMMIT"
+
+echo "--- Verify image does not already exist"
+echo "$KIBANA_DOCKER_PASSWORD" | docker login -u "$KIBANA_DOCKER_USERNAME" --password-stdin docker.elastic.co
+trap 'docker logout docker.elastic.co' EXIT
+
+if docker manifest inspect $KIBANA_IMAGE &> /dev/null; then
+  echo "Image already exists, exiting"
+  exit 1
+fi
+
+echo "--- Build image"
+node scripts/build \
+  --debug \
+  --release \
+  --docker-cross-compile \
+  --docker-images \
+  --docker-namespace="kibana-ci" \
+  --docker-tag="$GIT_ABBREV_COMMIT" \
+  --skip-docker-ubi \
+  --skip-docker-cloud \
+  --skip-docker-contexts
+docker logout docker.elastic.co
+
+echo "--- Build dependencies report"
+node scripts/licenses_csv_report "--csv=target/dependencies-$GIT_ABBREV_COMMIT.csv"
+
+echo "--- Upload artifacts"
+cd target
+buildkite-agent artifact upload "kibana-$BASE_VERSION-linux-x86_64.tar.gz"
+buildkite-agent artifact upload "kibana-$BASE_VERSION-linux-aarch64.tar.gz"
+buildkite-agent artifact upload "kibana-$BASE_VERSION-docker-image.tar.gz"
+buildkite-agent artifact upload "kibana-$BASE_VERSION-docker-image-aarch64.tar.gz"
+buildkite-agent artifact upload "dependencies-$GIT_ABBREV_COMMIT.csv"
+cd -


### PR DESCRIPTION
This adds a new pipeline to build our default container image, using the `kibana-ci` docker namespace and the docker version based on the first 7 digits of the commit hash.

https://buildkite.com/elastic/kibana-artifacts-container-image/builds/3

Will have followups for: 
1) on-merge trigger
2) docker push / controller pipeline trigger

need to make sure branches other than main, and manual triggers (untested) skip publishing.