### PR TITLE
[Fleet] Fix updating task interval for agent log usage

### DIFF
--- a/x-pack/plugins/fleet/server/services/fleet_usage_logger.ts
+++ b/x-pack/plugins/fleet/server/services/fleet_usage_logger.ts
@@ -56,12 +56,25 @@ export async function startFleetUsageLogger(taskManager: TaskManagerStartContrac
   if (!isInfoLogLevelEnabled) {
     return;
   }
-  appContextService.getLogger().info(`Task ${TASK_ID} scheduled with interval 5m`);
+  const interval = isDebugLogLevelEnabled ? '5m' : '15m';
+
+  // Re-schedule the task if interval changed
+  const task = await taskManager?.get(TASK_ID).catch((err) => {
+    if (err.output.statusCode === 404) {
+      return null;
+    }
+
+    throw err;
+  });
+  if (task?.schedule?.interval !== interval) {
+    await taskManager?.removeIfExists(TASK_ID);
+  }
+  appContextService.getLogger().info(`Task ${TASK_ID} scheduled with interval ${interval}`);
   await taskManager?.ensureScheduled({
     id: TASK_ID,
     taskType: TASK_TYPE,
     schedule: {
-      interval: isDebugLogLevelEnabled ? '5m' : '15m',
+      interval,
     },
     scope: ['fleet'],
     state: {},


### PR DESCRIPTION
## Summary

Resolve https://github.com/elastic/kibana/issues/140014#issuecomment-1370581009

We use a task to log agent usage with a different interval depending on the log level, it seems that updating the interval on a existing task do not work, so that PR fix that by removing the task before scheduling it again if the interval change.




<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->