### PR TITLE
[Security Solution] Add support for Fleet packages with historical rule versions

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/get_prebuilt_rules_and_timelines_status/route.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/get_prebuilt_rules_and_timelines_status/route.test.ts
@@ -12,7 +12,7 @@ import {
   getFindResultWithSingleHit,
   getPrepackagedRulesStatusRequest,
 } from '../../../routes/__mocks__/request_responses';
-import { requestContextMock, serverMock, createMockConfig } from '../../../routes/__mocks__';
+import { requestContextMock, serverMock } from '../../../routes/__mocks__';
 import type { SecurityPluginSetup } from '@kbn/security-plugin/server';
 import { checkTimelinesStatus } from '../../../../timeline/utils/check_timelines_status';
 import {
@@ -82,7 +82,7 @@ describe('get_prepackaged_rule_status_route', () => {
       prepackagedTimelines: [],
     });
 
-    getPrebuiltRulesAndTimelinesStatusRoute(server.router, createMockConfig(), securitySetup);
+    getPrebuiltRulesAndTimelinesStatusRoute(server.router, securitySetup);
   });
 
   describe('status codes', () => {

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/get_prebuilt_rules_and_timelines_status/route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/get_prebuilt_rules_and_timelines_status/route.ts
@@ -8,7 +8,6 @@
 import { transformError } from '@kbn/securitysolution-es-utils';
 import { validate } from '@kbn/securitysolution-io-ts-utils';
 import { buildSiemResponse } from '../../../routes/utils';
-import type { ConfigType } from '../../../../../config';
 import type { SetupPlugins } from '../../../../../plugin';
 import type { SecuritySolutionPluginRouter } from '../../../../../types';
 
@@ -22,7 +21,7 @@ import { findRules } from '../../../rule_management/logic/search/find_rules';
 import { getLatestPrebuiltRules } from '../../logic/get_latest_prebuilt_rules';
 import { getRulesToInstall } from '../../logic/get_rules_to_install';
 import { getRulesToUpdate } from '../../logic/get_rules_to_update';
-import { ruleAssetSavedObjectsClientFactory } from '../../logic/rule_asset/rule_asset_saved_objects_client';
+import { ruleAssetsClientFactory } from '../../logic/rule_asset/rule_asset_saved_objects_client';
 import { rulesToMap } from '../../logic/utils';
 
 import { buildFrameworkRequest } from '../../../../timeline/utils/common';
@@ -33,7 +32,6 @@ import {
 
 export const getPrebuiltRulesAndTimelinesStatusRoute = (
   router: SecuritySolutionPluginRouter,
-  config: ConfigType,
   security: SetupPlugins['security']
 ) => {
   router.get(
@@ -49,7 +47,7 @@ export const getPrebuiltRulesAndTimelinesStatusRoute = (
       const ctx = await context.resolve(['core', 'alerting']);
       const savedObjectsClient = ctx.core.savedObjects.client;
       const rulesClient = ctx.alerting.getRulesClient();
-      const ruleAssetsClient = ruleAssetSavedObjectsClientFactory(savedObjectsClient);
+      const ruleAssetsClient = ruleAssetsClientFactory(savedObjectsClient);
 
       try {
         const latestPrebuiltRules = await getLatestPrebuiltRules(ruleAssetsClient);

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/install_prebuilt_rules_and_timelines/route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/install_prebuilt_rules_and_timelines/route.ts
@@ -27,7 +27,7 @@ import { createPrebuiltRules } from '../../logic/create_prebuilt_rules';
 import { updatePrebuiltRules } from '../../logic/update_prebuilt_rules';
 import { getRulesToInstall } from '../../logic/get_rules_to_install';
 import { getRulesToUpdate } from '../../logic/get_rules_to_update';
-import { ruleAssetSavedObjectsClientFactory } from '../../logic/rule_asset/rule_asset_saved_objects_client';
+import { ruleAssetsClientFactory } from '../../logic/rule_asset/rule_asset_saved_objects_client';
 import { rulesToMap } from '../../logic/utils';
 
 import { installPrepackagedTimelines } from '../../../../timeline/routes/prepackaged_timelines/install_prepackaged_timelines';
@@ -90,7 +90,7 @@ export const createPrepackagedRules = async (
   const savedObjectsClient = context.core.savedObjects.client;
   const siemClient = context.getAppClient();
   const exceptionsListClient = context.getExceptionListClient() ?? exceptionsClient;
-  const ruleAssetsClient = ruleAssetSavedObjectsClientFactory(savedObjectsClient);
+  const ruleAssetsClient = ruleAssetsClientFactory(savedObjectsClient);
 
   const { maxTimelineImportExportSize } = config;
 

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/register_routes.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/register_routes.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import type { ConfigType } from '../../../../config';
 import type { SetupPlugins } from '../../../../plugin_contract';
 import type { SecuritySolutionPluginRouter } from '../../../../types';
 
@@ -14,9 +13,8 @@ import { installPrebuiltRulesAndTimelinesRoute } from './install_prebuilt_rules_
 
 export const registerPrebuiltRulesRoutes = (
   router: SecuritySolutionPluginRouter,
-  config: ConfigType,
   security: SetupPlugins['security']
 ) => {
-  getPrebuiltRulesAndTimelinesStatusRoute(router, config, security);
+  getPrebuiltRulesAndTimelinesStatusRoute(router, security);
   installPrebuiltRulesAndTimelinesRoute(router);
 };

--- a/x-pack/plugins/security_solution/server/routes/index.ts
+++ b/x-pack/plugins/security_solution/server/routes/index.ts
@@ -91,7 +91,7 @@ export const initRoutes = (
 ) => {
   registerFleetIntegrationsRoutes(router, logger);
   registerLegacyRuleActionsRoutes(router, logger);
-  registerPrebuiltRulesRoutes(router, config, security);
+  registerPrebuiltRulesRoutes(router, security);
   registerRuleExceptionsRoutes(router);
   registerManageExceptionsRoutes(router);
   registerRuleManagementRoutes(router, config, ml, logger);


### PR DESCRIPTION
**Resolves: https://github.com/elastic/kibana/issues/148179**

## Summary

As a result of [this PoC](https://github.com/elastic/kibana/issues/137420) flat package structure was chosen for storing historical detection rules, and this PR adds support for Fleet packages containing multiple historical versions per rule. 

Updated API endpoints:
- Install prepackaged rules (`PUT /api/detection_engine/rules/prepackaged`)
- Get prepackaged rules status (`GET /api/detection_engine/rules/prepackaged/_status`)

The API endpoints can work interchangeably with the current historical rules package structure and the new "flat" structure. Therefore, the API interface has not been changed, and the existing `security-rule` saved objects are still used.

### How to test this PR

To test this PR, you should create a new `security_detection_engine` package version. See [the documentation](https://docs.elastic.dev/security-solution/analyst-experience/detections/rules/prebuilt-rules#how-to-build-a-custom-prebuilt-rules-package) on how to spin up a local package registry with custom packages. 

The package should contain rule saved objects with rule id and version in the name (`security_rule/[ruleId]:[ruleVersion].json`) with the following content:

```json
{
  "id": "[ruleId]:[ruleVersion]",
  "type": "security-rule",
  "attributes": {
    // Rule attributes
  }
}
```

You should be able to upgrade the current rules package to the new "flat" and vice-versa.

