### PR TITLE
[Enterprise Search] Fix configured sources cards

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source.scss
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source.scss
@@ -98,9 +98,3 @@
     background: transparent;
   }
 }
-
-@media (min-width: 768px) {
-  .organizational-content-source-item {
-    max-width: calc(33.3% - #{$euiSize});
-  }
-}


### PR DESCRIPTION
## Summary

This fixes the look of the configured sources cards, which was broken by an unrelated EUI change.

Before fix:
![image](https://user-images.githubusercontent.com/94373878/211583041-a4dcf94d-c67a-4556-a038-ca223e4111c8.png)

After fix:
<img width="1005" alt="Screenshot 2023-01-10 at 15 47 33" src="https://user-images.githubusercontent.com/94373878/211583089-ab8cf11e-932d-475f-a928-17b44ca0b0aa.png">

Originally in 8.6:
<img width="1277" alt="Screenshot 2023-01-10 at 15 47 19" src="https://user-images.githubusercontent.com/94373878/211583158-2236f72d-1ab4-4415-a7ea-e21bc1e274e7.png">
