### PR TITLE
[8.6] [RAM] Unskip test in `connector_form.test.tsx`  (#148083)

### DIFF
--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/connector_form.test.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/connector_form.test.tsx
@@ -87,7 +87,7 @@ describe('ConnectorForm', () => {
     });
   });
 
-  it.skip('calls onChange when the form is invalid', async () => {
+  it('calls onChange when the form is invalid', async () => {
     const actionTypeModel = actionTypeRegistryMock.createMockActionTypeModel({
       actionConnectorFields: lazy(() => import('./connector_mock')),
     });
@@ -103,19 +103,20 @@ describe('ConnectorForm', () => {
     );
 
     expect(result.getByTestId('nameInput')).toBeInTheDocument();
+
     await act(async () => {
       const submit = onChange.mock.calls[0][0].submit;
       await submit();
     });
 
-    await waitFor(() => {
-      expect(onChange).toHaveBeenCalledWith({
-        isSubmitted: true,
-        isSubmitting: true,
-        isValid: false,
-        preSubmitValidator: null,
-        submit: expect.anything(),
-      });
+    await waitFor(() => expect(onChange).toHaveBeenCalled());
+
+    expect(onChange).toHaveBeenCalledWith({
+      isSubmitted: false,
+      isSubmitting: false,
+      isValid: false,
+      preSubmitValidator: expect.anything(),
+      submit: expect.anything(),
     });
   });
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.6`:
 - [[RAM] Unskip test in `connector_form.test.tsx`  (#148083)](https://github.com/elastic/kibana/pull/148083)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Christos Nasikas","email":"christos.nasikas@elastic.co"},"sourceCommit":{"committedDate":"2023-01-10T09:24:10Z","message":"[RAM] Unskip test in `connector_form.test.tsx`  (#148083)\n\n## Summary\r\n\r\nAs a continuation of https://github.com/elastic/kibana/pull/147535 this\r\nPR unskips and fixes a test in\r\n`x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/connector_form.test.tsx`.\r\n\r\nSince the flaky test runner doesn't work with jest tests, I put a for\r\nloop to confirm it doesn't cause issues anymore:\r\n- Commit looping 1000 times to ensure no more flakiness:\r\nhttps://github.com/elastic/kibana/pull/148083/commits/0b673c5c293105133d12c508e700939608593724\r\n([CI\r\nRun](https://buildkite.com/elastic/kibana-pull-request/builds/96949))\r\n\r\ncc @jcger \r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n\r\n### For maintainers\r\n\r\n- [x] This was checked for breaking API changes and was [labeled\r\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"09ec33ba9c39198906dd950007cbde878d2bb265","branchLabelMapping":{"^v8.7.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:ResponseOps","Feature:Actions/ConnectorsManagement","v8.6.0","v8.7.0"],"number":148083,"url":"https://github.com/elastic/kibana/pull/148083","mergeCommit":{"message":"[RAM] Unskip test in `connector_form.test.tsx`  (#148083)\n\n## Summary\r\n\r\nAs a continuation of https://github.com/elastic/kibana/pull/147535 this\r\nPR unskips and fixes a test in\r\n`x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/connector_form.test.tsx`.\r\n\r\nSince the flaky test runner doesn't work with jest tests, I put a for\r\nloop to confirm it doesn't cause issues anymore:\r\n- Commit looping 1000 times to ensure no more flakiness:\r\nhttps://github.com/elastic/kibana/pull/148083/commits/0b673c5c293105133d12c508e700939608593724\r\n([CI\r\nRun](https://buildkite.com/elastic/kibana-pull-request/builds/96949))\r\n\r\ncc @jcger \r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n\r\n### For maintainers\r\n\r\n- [x] This was checked for breaking API changes and was [labeled\r\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"09ec33ba9c39198906dd950007cbde878d2bb265"}},"sourceBranch":"main","suggestedTargetBranches":["8.6"],"targetPullRequestStates":[{"branch":"8.6","label":"v8.6.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.7.0","labelRegex":"^v8.7.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/148083","number":148083,"mergeCommit":{"message":"[RAM] Unskip test in `connector_form.test.tsx`  (#148083)\n\n## Summary\r\n\r\nAs a continuation of https://github.com/elastic/kibana/pull/147535 this\r\nPR unskips and fixes a test in\r\n`x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/connector_form.test.tsx`.\r\n\r\nSince the flaky test runner doesn't work with jest tests, I put a for\r\nloop to confirm it doesn't cause issues anymore:\r\n- Commit looping 1000 times to ensure no more flakiness:\r\nhttps://github.com/elastic/kibana/pull/148083/commits/0b673c5c293105133d12c508e700939608593724\r\n([CI\r\nRun](https://buildkite.com/elastic/kibana-pull-request/builds/96949))\r\n\r\ncc @jcger \r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n\r\n### For maintainers\r\n\r\n- [x] This was checked for breaking API changes and was [labeled\r\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"09ec33ba9c39198906dd950007cbde878d2bb265"}}]}] BACKPORT-->