### PR TITLE
[Security Solution] Fix Timeline and Notes user display name

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/timeline/saved_object/notes/saved_object.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/timeline/saved_object/notes/saved_object.test.ts
@@ -1,0 +1,127 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { AuthenticatedUser } from '@kbn/security-plugin/common/model';
+import type { NoteSavedObject } from '../../../../../common/types/timeline/note';
+
+import { pickSavedNote } from './saved_object';
+
+describe('saved_object', () => {
+  const mockDateNow = new Date('2020-04-03T23:00:00.000Z').valueOf();
+  const getMockSavedNote = (): NoteSavedObject => ({
+    noteId: '7ba7a520-03f4-11eb-9d9d-ffba20fabba8',
+    version: 'WzQ0ODEsMV0=',
+    note: '789',
+    timelineId: '7af80430-03f4-11eb-9d9d-ffba20fabba8',
+    created: 1601563414477,
+    createdBy: 'Elastic',
+    updated: 1601563414477,
+    updatedBy: 'Elastic',
+  });
+
+  beforeAll(() => {
+    Date = jest.fn(() => ({
+      valueOf: jest.fn().mockReturnValue(mockDateNow),
+    })) as unknown as DateConstructor;
+  });
+
+  afterAll(() => {
+    (Date as unknown as jest.Mock).mockRestore();
+  });
+
+  describe('Set create / update time correctly ', () => {
+    test('Creating a timeline', () => {
+      const savedNote = getMockSavedNote();
+      const noteId = null;
+      const userInfo = { username: 'elastic' } as AuthenticatedUser;
+      const result = pickSavedNote(noteId, savedNote, userInfo);
+
+      expect(result.created).toEqual(mockDateNow);
+      expect(result.updated).toEqual(mockDateNow);
+    });
+
+    test('Updating a timeline', () => {
+      const savedNote = getMockSavedNote();
+      const noteId = savedNote.noteId ?? null;
+      const userInfo = { username: 'elastic' } as AuthenticatedUser;
+      const result = pickSavedNote(noteId, savedNote, userInfo);
+
+      expect(result.created).toEqual(savedNote.created);
+      expect(result.updated).toEqual(mockDateNow);
+    });
+  });
+
+  describe('Set userInfo correctly ', () => {
+    test('Creating a timeline', () => {
+      const savedNote = getMockSavedNote();
+      const noteId = null;
+      const userInfo = { username: 'elastic' } as AuthenticatedUser;
+      const result = pickSavedNote(noteId, savedNote, userInfo);
+
+      expect(result.createdBy).toEqual(userInfo.username);
+      expect(result.updatedBy).toEqual(userInfo.username);
+    });
+
+    test('Creating a timeline with user email', () => {
+      const savedNote = getMockSavedNote();
+      const noteId = null;
+      const userInfo = { username: 'elastic', email: 'some@email.com' } as AuthenticatedUser;
+      const result = pickSavedNote(noteId, savedNote, userInfo);
+
+      expect(result.createdBy).toEqual(userInfo.email);
+      expect(result.updatedBy).toEqual(userInfo.email);
+    });
+
+    test('Creating a timeline with user full name', () => {
+      const savedNote = getMockSavedNote();
+      const noteId = null;
+      const userInfo = {
+        username: 'elastic',
+        email: 'some@email.com',
+        full_name: 'Some Full Name',
+      } as AuthenticatedUser;
+      const result = pickSavedNote(noteId, savedNote, userInfo);
+
+      expect(result.createdBy).toEqual(userInfo.full_name);
+      expect(result.updatedBy).toEqual(userInfo.full_name);
+    });
+
+    test('Updating a timeline', () => {
+      const savedNote = getMockSavedNote();
+      const noteId = savedNote.noteId ?? null;
+      const userInfo = { username: 'elastic' } as AuthenticatedUser;
+      const result = pickSavedNote(noteId, savedNote, userInfo);
+
+      expect(result.createdBy).toEqual(savedNote.createdBy);
+      expect(result.updatedBy).toEqual(userInfo.username);
+    });
+
+    test('Updating a timeline with user email', () => {
+      const savedNote = getMockSavedNote();
+      const noteId = savedNote.noteId ?? null;
+      const userInfo = { username: 'elastic', email: 'some@email.com' } as AuthenticatedUser;
+      const result = pickSavedNote(noteId, savedNote, userInfo);
+
+      expect(result.createdBy).toEqual(savedNote.createdBy);
+      expect(result.updatedBy).toEqual(userInfo.email);
+    });
+
+    test('Updating a timeline with user full name', () => {
+      const savedNote = getMockSavedNote();
+      const noteId = savedNote.noteId ?? null;
+      const userInfo = {
+        username: 'elastic',
+        email: 'some@email.com',
+        full_name: 'Some Full Name',
+      } as AuthenticatedUser;
+      const result = pickSavedNote(noteId, savedNote, userInfo);
+
+      expect(result.createdBy).toEqual(savedNote.createdBy);
+      expect(result.updatedBy).toEqual(userInfo.full_name);
+    });
+  });
+});

--- a/x-pack/plugins/security_solution/server/lib/timeline/saved_object/notes/saved_object.ts
+++ b/x-pack/plugins/security_solution/server/lib/timeline/saved_object/notes/saved_object.ts
@@ -14,7 +14,8 @@ import { map, fold } from 'fp-ts/lib/Either';
 import { identity } from 'fp-ts/lib/function';
 
 import type { SavedObjectsFindOptions } from '@kbn/core/server';
-import { getUserDisplayName, type AuthenticatedUser } from '@kbn/security-plugin/common/model';
+import type { AuthenticatedUser } from '@kbn/security-plugin/common/model';
+import { getUserDisplayName } from '@kbn/user-profile-components';
 import { UNAUTHENTICATED_USER } from '../../../../../common/constants';
 import type {
   SavedNote,

--- a/x-pack/plugins/security_solution/server/lib/timeline/saved_object/notes/saved_object.ts
+++ b/x-pack/plugins/security_solution/server/lib/timeline/saved_object/notes/saved_object.ts
@@ -14,7 +14,7 @@ import { map, fold } from 'fp-ts/lib/Either';
 import { identity } from 'fp-ts/lib/function';
 
 import type { SavedObjectsFindOptions } from '@kbn/core/server';
-import type { AuthenticatedUser } from '@kbn/security-plugin/common/model';
+import { getUserDisplayName, type AuthenticatedUser } from '@kbn/security-plugin/common/model';
 import { UNAUTHENTICATED_USER } from '../../../../../common/constants';
 import type {
   SavedNote,
@@ -258,17 +258,17 @@ export const convertSavedObjectToSavedNote = (
     }, identity)
   );
 
-const pickSavedNote = (
+export const pickSavedNote = (
   noteId: string | null,
   savedNote: SavedNote,
   userInfo: AuthenticatedUser | null
 ) => {
   if (noteId == null) {
     savedNote.created = new Date().valueOf();
-    savedNote.createdBy = userInfo?.username ?? UNAUTHENTICATED_USER;
+    savedNote.createdBy = userInfo ? getUserDisplayName(userInfo) : UNAUTHENTICATED_USER;
   }
 
   savedNote.updated = new Date().valueOf();
-  savedNote.updatedBy = userInfo?.username ?? UNAUTHENTICATED_USER;
+  savedNote.updatedBy = userInfo ? getUserDisplayName(userInfo) : UNAUTHENTICATED_USER;
   return savedNote;
 };

--- a/x-pack/plugins/security_solution/server/lib/timeline/saved_object/timelines/pick_saved_timeline.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/timeline/saved_object/timelines/pick_saved_timeline.test.ts
@@ -120,6 +120,26 @@ describe('pickSavedTimeline', () => {
       expect(result.updatedBy).toEqual(userInfo.username);
     });
 
+    test('Creating a timeline with user email', () => {
+      const savedTimeline = getMockSavedTimeline();
+      const timelineId = null;
+      const userInfo = { username: 'elastic', email: 'some@email.com' } as AuthenticatedUser;
+      const result = pickSavedTimeline(timelineId, savedTimeline, userInfo);
+
+      expect(result.createdBy).toEqual(userInfo.email);
+      expect(result.updatedBy).toEqual(userInfo.email);
+    });
+    
+    test('Creating a timeline with user full name', () => {
+      const savedTimeline = getMockSavedTimeline();
+      const timelineId = null;
+      const userInfo = { username: 'elastic', email: 'some@email.com', full_name: 'Some Full Name' } as AuthenticatedUser;
+      const result = pickSavedTimeline(timelineId, savedTimeline, userInfo);
+
+      expect(result.createdBy).toEqual(userInfo.full_name);
+      expect(result.updatedBy).toEqual(userInfo.full_name);
+    });
+
     test('Updating a timeline', () => {
       const savedTimeline = getMockSavedTimeline();
       const timelineId = savedTimeline.savedObjectId ?? null;
@@ -128,6 +148,26 @@ describe('pickSavedTimeline', () => {
 
       expect(result.createdBy).toEqual(savedTimeline.createdBy);
       expect(result.updatedBy).toEqual(userInfo.username);
+    });
+
+    test('Updating a timeline with user email', () => {
+      const savedTimeline = getMockSavedTimeline();
+      const timelineId = savedTimeline.savedObjectId ?? null;
+      const userInfo = { username: 'elastic', email: 'some@email.com' } as AuthenticatedUser;
+      const result = pickSavedTimeline(timelineId, savedTimeline, userInfo);
+
+      expect(result.createdBy).toEqual(savedTimeline.createdBy);
+      expect(result.updatedBy).toEqual(userInfo.email);
+    });
+
+    test('Updating a timeline with user full name', () => {
+      const savedTimeline = getMockSavedTimeline();
+      const timelineId = savedTimeline.savedObjectId ?? null;
+      const userInfo = { username: 'elastic', email: 'some@email.com', full_name: 'Some Full Name' } as AuthenticatedUser;
+      const result = pickSavedTimeline(timelineId, savedTimeline, userInfo);
+
+      expect(result.createdBy).toEqual(savedTimeline.createdBy);
+      expect(result.updatedBy).toEqual(userInfo.full_name);
     });
   });
 

--- a/x-pack/plugins/security_solution/server/lib/timeline/saved_object/timelines/pick_saved_timeline.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/timeline/saved_object/timelines/pick_saved_timeline.test.ts
@@ -129,11 +129,15 @@ describe('pickSavedTimeline', () => {
       expect(result.createdBy).toEqual(userInfo.email);
       expect(result.updatedBy).toEqual(userInfo.email);
     });
-    
+
     test('Creating a timeline with user full name', () => {
       const savedTimeline = getMockSavedTimeline();
       const timelineId = null;
-      const userInfo = { username: 'elastic', email: 'some@email.com', full_name: 'Some Full Name' } as AuthenticatedUser;
+      const userInfo = {
+        username: 'elastic',
+        email: 'some@email.com',
+        full_name: 'Some Full Name',
+      } as AuthenticatedUser;
       const result = pickSavedTimeline(timelineId, savedTimeline, userInfo);
 
       expect(result.createdBy).toEqual(userInfo.full_name);
@@ -163,7 +167,11 @@ describe('pickSavedTimeline', () => {
     test('Updating a timeline with user full name', () => {
       const savedTimeline = getMockSavedTimeline();
       const timelineId = savedTimeline.savedObjectId ?? null;
-      const userInfo = { username: 'elastic', email: 'some@email.com', full_name: 'Some Full Name' } as AuthenticatedUser;
+      const userInfo = {
+        username: 'elastic',
+        email: 'some@email.com',
+        full_name: 'Some Full Name',
+      } as AuthenticatedUser;
       const result = pickSavedTimeline(timelineId, savedTimeline, userInfo);
 
       expect(result.createdBy).toEqual(savedTimeline.createdBy);

--- a/x-pack/plugins/security_solution/server/lib/timeline/saved_object/timelines/pick_saved_timeline.ts
+++ b/x-pack/plugins/security_solution/server/lib/timeline/saved_object/timelines/pick_saved_timeline.ts
@@ -6,7 +6,7 @@
  */
 
 import { isEmpty } from 'lodash/fp';
-import type { AuthenticatedUser } from '@kbn/security-plugin/common/model';
+import { getUserDisplayName, type AuthenticatedUser } from '@kbn/security-plugin/common/model';
 import { UNAUTHENTICATED_USER } from '../../../../../common/constants';
 import type { SavedTimelineWithSavedObjectId } from '../../../../../common/types/timeline';
 import { TimelineType, TimelineStatus } from '../../../../../common/types/timeline';
@@ -20,12 +20,12 @@ export const pickSavedTimeline = (
 
   if (timelineId == null) {
     savedTimeline.created = dateNow;
-    savedTimeline.createdBy = userInfo?.username ?? UNAUTHENTICATED_USER;
+    savedTimeline.createdBy = userInfo ? getUserDisplayName(userInfo) : UNAUTHENTICATED_USER;
     savedTimeline.updated = dateNow;
-    savedTimeline.updatedBy = userInfo?.username ?? UNAUTHENTICATED_USER;
+    savedTimeline.updatedBy = userInfo ? getUserDisplayName(userInfo) : UNAUTHENTICATED_USER;
   } else if (timelineId != null) {
     savedTimeline.updated = dateNow;
-    savedTimeline.updatedBy = userInfo?.username ?? UNAUTHENTICATED_USER;
+    savedTimeline.updatedBy = userInfo ? getUserDisplayName(userInfo) : UNAUTHENTICATED_USER;
   }
 
   if (savedTimeline.status === TimelineStatus.draft || savedTimeline.status == null) {

--- a/x-pack/plugins/security_solution/server/lib/timeline/saved_object/timelines/pick_saved_timeline.ts
+++ b/x-pack/plugins/security_solution/server/lib/timeline/saved_object/timelines/pick_saved_timeline.ts
@@ -6,7 +6,8 @@
  */
 
 import { isEmpty } from 'lodash/fp';
-import { getUserDisplayName, type AuthenticatedUser } from '@kbn/security-plugin/common/model';
+import type { AuthenticatedUser } from '@kbn/security-plugin/common/model';
+import { getUserDisplayName } from '@kbn/user-profile-components';
 import { UNAUTHENTICATED_USER } from '../../../../../common/constants';
 import type { SavedTimelineWithSavedObjectId } from '../../../../../common/types/timeline';
 import { TimelineType, TimelineStatus } from '../../../../../common/types/timeline';

--- a/x-pack/plugins/security_solution/tsconfig.json
+++ b/x-pack/plugins/security_solution/tsconfig.json
@@ -133,5 +133,6 @@
     "@kbn/cypress-config",
     "@kbn/controls-plugin",
     "@kbn/shared-ux-utility",
+    "@kbn/user-profile-components",
   ]
 }


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/148626

Improve the way we show the `updatedBy` and `createdBy` user display names in Timelines and Timeline's Notes.

This fixes a bug on the Timeline table and Notes showing a numeric user name when the user performing the action was authenticated using SSO.

![modified_by](https://user-images.githubusercontent.com/17747913/211526840-133da0a5-b217-45bd-85fa-71215b8bcf3c.png)

### Changes

The way to store the user name now has the same logic as in the Cases pages, using the `getUserDisplayName` function that takes the following field precedence: 
`full_name || email || username`

### Old Timelines / Notes Saved Objects

This fix does not affect the already existing Timeline and Notes SOs. They will continue to show the numeric value in the UI unless they are modified after this fix, in this case, the `updatedBy` value will be changed using a correct display name.

* It is not currently possible to migrate old SOs that have numeric values in the `updatedBy` fields, the only information we have there is the `username`. There's no way to know the `uid` of those users, which is required to retrieve the information from the userProfiles API.

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
