### PR TITLE
[Dashboard] [Controls] Backport flaky test fix

### DIFF
--- a/test/functional/apps/dashboard_elements/controls/options_list.ts
+++ b/test/functional/apps/dashboard_elements/controls/options_list.ts
@@ -444,6 +444,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
           await dashboardControls.optionsListOpenPopover(controlId);
           await dashboardControls.optionsListPopoverSelectOption('B');
           await dashboardControls.optionsListEnsurePopoverIsClosed(controlId);
+          await dashboard.waitForRenderComplete();
+
           expect(await pieChart.getPieChartLabels()).to.eql(['bark', 'bow ow ow']);
         });
 


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/146086

## Summary

Backports the flaky test fix from https://github.com/elastic/kibana/pull/144867 to `8.6`

<a href="https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/1720"><img src="https://user-images.githubusercontent.com/8698078/211655383-3fa1ef92-d402-4efe-9b51-23a4ea6727d9.png"/></a>

