### PR TITLE
[chart-expressions] convert common code dir into a package

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1066,6 +1066,7 @@ packages/shared-ux/router/mocks @elastic/kibana-global-experience
 packages/shared-ux/router/types @elastic/kibana-global-experience
 packages/shared-ux/storybook/config @elastic/kibana-global-experience
 packages/shared-ux/storybook/mock @elastic/kibana-global-experience
+src/plugins/chart_expressions/common @elastic/kibana-visualizations
 x-pack/packages/ml/agg_utils @elastic/ml-ui
 x-pack/packages/ml/aiops_components @elastic/ml-ui
 x-pack/packages/ml/aiops_utils @elastic/ml-ui

--- a/package.json
+++ b/package.json
@@ -143,6 +143,7 @@
     "@kbn/apm-config-loader": "link:packages/kbn-apm-config-loader",
     "@kbn/apm-utils": "link:packages/kbn-apm-utils",
     "@kbn/cases-components": "link:packages/kbn-cases-components",
+    "@kbn/chart-expressions-common": "link:src/plugins/chart_expressions/common",
     "@kbn/chart-icons": "link:packages/kbn-chart-icons",
     "@kbn/coloring": "link:packages/kbn-coloring",
     "@kbn/config": "link:packages/kbn-config",

--- a/src/dev/build/tasks/copy_source_task.ts
+++ b/src/dev/build/tasks/copy_source_task.ts
@@ -8,6 +8,7 @@
 
 import { resolve } from 'path';
 
+import { getPackages } from '@kbn/repo-packages';
 import globby from 'globby';
 import Piscina from 'piscina';
 
@@ -48,6 +49,13 @@ export const CopySource: Task = {
       '!x-pack/plugins/lens/layout.png', // README.md
       '!x-pack/plugins/cases/images', // README.md
       '!x-pack/plugins/canvas/images', // unused
+
+      // explicitly exclude every package directory outside of the root packages dir
+      `!{${getPackages(config.resolveFromRepo('.'))
+        .flatMap((p) =>
+          p.normalizedRepoRelativeDir.startsWith('packages/') ? [] : p.normalizedRepoRelativeDir
+        )
+        .join(',')}}/**`,
     ];
 
     const piscina = new Piscina({

--- a/src/plugins/chart_expressions/common/README.md
+++ b/src/plugins/chart_expressions/common/README.md
@@ -1,0 +1,3 @@
+# @kbn/chart-expressions-common
+
+Basic utility functions used by several different chart-expressions

--- a/src/plugins/chart_expressions/common/jest.config.js
+++ b/src/plugins/chart_expressions/common/jest.config.js
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+module.exports = {
+  preset: '@kbn/test/jest_node',
+  rootDir: '../../../..',
+  roots: ['<rootDir>/src/plugins/chart_expressions/common'],
+};

--- a/src/plugins/chart_expressions/common/kibana.jsonc
+++ b/src/plugins/chart_expressions/common/kibana.jsonc
@@ -1,0 +1,5 @@
+{
+  "type": "shared-common",
+  "id": "@kbn/chart-expressions-common",
+  "owner": "@elastic/kibana-visualizations"
+}

--- a/src/plugins/chart_expressions/common/package.json
+++ b/src/plugins/chart_expressions/common/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@kbn/chart-expressions-common",
+  "private": true,
+  "version": "1.0.0",
+  "license": "SSPL-1.0 OR Elastic License 2.0"
+}

--- a/src/plugins/chart_expressions/common/tsconfig.json
+++ b/src/plugins/chart_expressions/common/tsconfig.json
@@ -1,16 +1,19 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "../../../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "target/types",
-    "isolatedModules": true
+    "types": [
+      "jest",
+      "node"
+    ]
   },
   "include": [
-    "common/**/*"
+    "**/*.ts",
+  ],
+  "exclude": [
+    "target/**/*"
   ],
   "kbn_references": [
     "@kbn/core-execution-context-common",
-  ],
-  "exclude": [
-    "target/**/*",
   ]
 }

--- a/src/plugins/chart_expressions/expression_gauge/public/expression_renderers/gauge_renderer.tsx
+++ b/src/plugins/chart_expressions/expression_gauge/public/expression_renderers/gauge_renderer.tsx
@@ -13,11 +13,10 @@ import { KibanaThemeProvider } from '@kbn/kibana-react-plugin/public';
 import { ExpressionRenderDefinition } from '@kbn/expressions-plugin/common/expression_renderers';
 import { StartServicesGetter } from '@kbn/kibana-utils-plugin/public';
 import { METRIC_TYPE } from '@kbn/analytics';
+import { extractContainerType, extractVisualizationType } from '@kbn/chart-expressions-common';
 import { ExpressionGaugePluginStart } from '../plugin';
 import { EXPRESSION_GAUGE_NAME, GaugeExpressionProps, GaugeShapes } from '../../common';
 import { getFormatService, getPaletteService } from '../services';
-// eslint-disable-next-line @kbn/imports/no_boundary_crossing
-import { extractContainerType, extractVisualizationType } from '../../../common';
 
 interface ExpressionGaugeRendererDependencies {
   getStartDeps: StartServicesGetter<ExpressionGaugePluginStart>;

--- a/src/plugins/chart_expressions/expression_gauge/tsconfig.json
+++ b/src/plugins/chart_expressions/expression_gauge/tsconfig.json
@@ -26,6 +26,7 @@
     "@kbn/kibana-react-plugin",
     "@kbn/analytics",
     "@kbn/chart-icons",
+    "@kbn/chart-expressions-common",
   ],
   "exclude": [
     "target/**/*",

--- a/src/plugins/chart_expressions/expression_heatmap/public/expression_renderers/heatmap_renderer.tsx
+++ b/src/plugins/chart_expressions/expression_heatmap/public/expression_renderers/heatmap_renderer.tsx
@@ -13,6 +13,7 @@ import { KibanaThemeProvider } from '@kbn/kibana-react-plugin/public';
 import { ExpressionRenderDefinition } from '@kbn/expressions-plugin/common/expression_renderers';
 import { StartServicesGetter } from '@kbn/kibana-utils-plugin/public';
 import { METRIC_TYPE } from '@kbn/analytics';
+import { extractContainerType, extractVisualizationType } from '@kbn/chart-expressions-common';
 import { ExpressionHeatmapPluginStart } from '../plugin';
 import {
   EXPRESSION_HEATMAP_NAME,
@@ -27,8 +28,6 @@ import {
   getUISettings,
 } from '../services';
 import { getTimeZone } from '../utils/get_timezone';
-// eslint-disable-next-line @kbn/imports/no_boundary_crossing
-import { extractContainerType, extractVisualizationType } from '../../../common';
 
 interface ExpressioHeatmapRendererDependencies {
   getStartDeps: StartServicesGetter<ExpressionHeatmapPluginStart>;

--- a/src/plugins/chart_expressions/expression_heatmap/tsconfig.json
+++ b/src/plugins/chart_expressions/expression_heatmap/tsconfig.json
@@ -26,6 +26,7 @@
     "@kbn/chart-icons",
     "@kbn/kibana-react-plugin",
     "@kbn/analytics",
+    "@kbn/chart-expressions-common",
   ],
   "exclude": [
     "target/**/*",

--- a/src/plugins/chart_expressions/expression_legacy_metric/public/expression_renderers/metric_vis_renderer.tsx
+++ b/src/plugins/chart_expressions/expression_legacy_metric/public/expression_renderers/metric_vis_renderer.tsx
@@ -21,10 +21,9 @@ import {
 import { getColumnByAccessor } from '@kbn/visualizations-plugin/common/utils';
 import { Datatable } from '@kbn/expressions-plugin/common';
 import { StartServicesGetter } from '@kbn/kibana-utils-plugin/public';
+import { extractContainerType, extractVisualizationType } from '@kbn/chart-expressions-common';
 import { ExpressionLegacyMetricPluginStart } from '../plugin';
 import { EXPRESSION_METRIC_NAME, MetricVisRenderConfig, VisParams } from '../../common';
-// eslint-disable-next-line @kbn/imports/no_boundary_crossing
-import { extractContainerType, extractVisualizationType } from '../../../common';
 
 // @ts-ignore
 const MetricVisComponent = lazy(() => import('../components/metric_component'));

--- a/src/plugins/chart_expressions/expression_legacy_metric/tsconfig.json
+++ b/src/plugins/chart_expressions/expression_legacy_metric/tsconfig.json
@@ -25,6 +25,7 @@
     "@kbn/analytics",
     "@kbn/kibana-react-plugin",
     "@kbn/ui-theme",
+    "@kbn/chart-expressions-common",
   ],
   "exclude": [
     "target/**/*",

--- a/src/plugins/chart_expressions/expression_metric/public/expression_renderers/metric_vis_renderer.tsx
+++ b/src/plugins/chart_expressions/expression_metric/public/expression_renderers/metric_vis_renderer.tsx
@@ -16,10 +16,9 @@ import { StartServicesGetter } from '@kbn/kibana-utils-plugin/public';
 import { METRIC_TYPE } from '@kbn/analytics';
 import type { IInterpreterRenderHandlers, Datatable } from '@kbn/expressions-plugin/common';
 import { getColumnByAccessor } from '@kbn/visualizations-plugin/common/utils';
+import { extractContainerType, extractVisualizationType } from '@kbn/chart-expressions-common';
 import { ExpressionMetricPluginStart } from '../plugin';
 import { EXPRESSION_METRIC_NAME, MetricVisRenderConfig, VisParams } from '../../common';
-// eslint-disable-next-line @kbn/imports/no_boundary_crossing
-import { extractContainerType, extractVisualizationType } from '../../../common';
 
 async function metricFilterable(
   dimensions: VisParams['dimensions'],

--- a/src/plugins/chart_expressions/expression_metric/tsconfig.json
+++ b/src/plugins/chart_expressions/expression_metric/tsconfig.json
@@ -25,6 +25,7 @@
     "@kbn/ui-theme",
     "@kbn/kibana-react-plugin",
     "@kbn/analytics",
+    "@kbn/chart-expressions-common",
   ],
   "exclude": [
     "target/**/*",

--- a/src/plugins/chart_expressions/expression_partition_vis/public/expression_renderers/partition_vis_renderer.tsx
+++ b/src/plugins/chart_expressions/expression_partition_vis/public/expression_renderers/partition_vis_renderer.tsx
@@ -21,12 +21,11 @@ import { withSuspense } from '@kbn/presentation-util-plugin/public';
 import { KibanaThemeProvider } from '@kbn/kibana-react-plugin/public';
 import { METRIC_TYPE } from '@kbn/analytics';
 import { getColumnByAccessor } from '@kbn/visualizations-plugin/common/utils';
+import { extractContainerType, extractVisualizationType } from '@kbn/chart-expressions-common';
 import { VisTypePieDependencies } from '../plugin';
 import { PARTITION_VIS_RENDERER_NAME } from '../../common/constants';
 import { CellValueAction, GetCompatibleCellValueActions } from '../types';
 import { ChartTypes, PartitionVisParams, RenderValue } from '../../common/types';
-// eslint-disable-next-line @kbn/imports/no_boundary_crossing
-import { extractContainerType, extractVisualizationType } from '../../../common';
 
 export const strings = {
   getDisplayName: () =>

--- a/src/plugins/chart_expressions/expression_partition_vis/tsconfig.json
+++ b/src/plugins/chart_expressions/expression_partition_vis/tsconfig.json
@@ -28,6 +28,7 @@
     "@kbn/kibana-react-plugin",
     "@kbn/analytics",
     "@kbn/chart-icons",
+    "@kbn/chart-expressions-common",
   ],
   "exclude": [
     "target/**/*",

--- a/src/plugins/chart_expressions/expression_tagcloud/public/expression_renderers/tagcloud_renderer.tsx
+++ b/src/plugins/chart_expressions/expression_tagcloud/public/expression_renderers/tagcloud_renderer.tsx
@@ -15,11 +15,11 @@ import { KibanaThemeProvider } from '@kbn/kibana-react-plugin/public';
 import { VisualizationContainer } from '@kbn/visualizations-plugin/public';
 import { ExpressionRenderDefinition } from '@kbn/expressions-plugin/common/expression_renderers';
 import { METRIC_TYPE } from '@kbn/analytics';
+import { extractContainerType, extractVisualizationType } from '@kbn/chart-expressions-common';
+
 import { ExpressionTagcloudRendererDependencies } from '../plugin';
 import { TagcloudRendererConfig } from '../../common/types';
 import { EXPRESSION_NAME } from '../../common';
-// eslint-disable-next-line @kbn/imports/no_boundary_crossing
-import { extractContainerType, extractVisualizationType } from '../../../common';
 
 export const strings = {
   getDisplayName: () =>

--- a/src/plugins/chart_expressions/expression_tagcloud/tsconfig.json
+++ b/src/plugins/chart_expressions/expression_tagcloud/tsconfig.json
@@ -25,6 +25,7 @@
     "@kbn/i18n-react",
     "@kbn/kibana-react-plugin",
     "@kbn/analytics",
+    "@kbn/chart-expressions-common",
   ],
   "exclude": [
     "target/**/*",

--- a/src/plugins/chart_expressions/expression_xy/public/expression_renderers/xy_chart_renderer.tsx
+++ b/src/plugins/chart_expressions/expression_xy/public/expression_renderers/xy_chart_renderer.tsx
@@ -26,13 +26,12 @@ import { FormatFactory } from '@kbn/field-formats-plugin/common';
 import { KibanaThemeProvider } from '@kbn/kibana-react-plugin/public';
 import { UsageCollectionStart } from '@kbn/usage-collection-plugin/public';
 import { getColumnByAccessor } from '@kbn/visualizations-plugin/common/utils';
+import { extractContainerType, extractVisualizationType } from '@kbn/chart-expressions-common';
 
 import type { getDataLayers } from '../helpers';
 import { LayerTypes, SeriesTypes } from '../../common/constants';
 import type { CommonXYDataLayerConfig, XYChartProps } from '../../common';
 import type { BrushEvent, FilterEvent, GetCompatibleCellValueActions } from '../types';
-// eslint-disable-next-line @kbn/imports/no_boundary_crossing
-import { extractContainerType, extractVisualizationType } from '../../../common';
 
 export type GetStartDepsFn = () => Promise<{
   data: DataPublicPluginStart;

--- a/src/plugins/chart_expressions/expression_xy/tsconfig.json
+++ b/src/plugins/chart_expressions/expression_xy/tsconfig.json
@@ -30,6 +30,7 @@
     "@kbn/ui-theme",
     "@kbn/analytics",
     "@kbn/kibana-react-plugin",
+    "@kbn/chart-expressions-common",
   ],
   "exclude": [
     "target/**/*",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -90,6 +90,8 @@
       "@kbn/cases-fixture-plugin/*": ["x-pack/test/functional_with_es_ssl/fixtures/plugins/cases/*"],
       "@kbn/cases-plugin": ["x-pack/plugins/cases"],
       "@kbn/cases-plugin/*": ["x-pack/plugins/cases/*"],
+      "@kbn/chart-expressions-common": ["src/plugins/chart_expressions/common"],
+      "@kbn/chart-expressions-common/*": ["src/plugins/chart_expressions/common/*"],
       "@kbn/chart-icons": ["packages/kbn-chart-icons"],
       "@kbn/chart-icons/*": ["packages/kbn-chart-icons/*"],
       "@kbn/charts-plugin": ["src/plugins/charts"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -2821,6 +2821,10 @@
   version "0.0.0"
   uid ""
 
+"@kbn/chart-expressions-common@link:src/plugins/chart_expressions/common":
+  version "0.0.0"
+  uid ""
+
 "@kbn/chart-icons@link:packages/kbn-chart-icons":
   version "0.0.0"
   uid ""


### PR DESCRIPTION
Moves the `src/plugins/chart_expressions/common` directory to a package. This was done by:

```sh
# move the existing code out of the way
mv src/plugins/chart_expressions/common src/plugins/chart_expressions/_common

# generate the new package in the previous location
node scripts/generate package @kbn/chart-expressions-common --dir src/plugins/chart_expressions/common

# move the old files into the new package
mv src/plugins/chart_expressions/_common/* src/plugins/chart_expressions/common/
rmdir src/plugins/chart_expressions/_common
```

After that I just needed to fix the eslint violations 👍 