### PR TITLE
[Fleet] Generate time_series_metric when metric_type is set

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/mappings.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/mappings.ts
@@ -34,9 +34,6 @@ export function scaledFloat(field: Field): Properties {
   const fieldProps = getDefaultProperties(field);
   fieldProps.type = 'scaled_float';
   fieldProps.scaling_factor = field.scaling_factor || DEFAULT_SCALING_FACTOR;
-  if (field.metric_type) {
-    fieldProps.time_series_metric = field.metric_type;
-  }
 
   return fieldProps;
 }

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.test.ts
@@ -772,7 +772,7 @@ describe('EPM template', () => {
     expect(mappings).toEqual(expectedMapping);
   });
 
-  it('tests processing metric_type field with long fiekd ', () => {
+  it('tests processing metric_type field with long field ', () => {
     const literalYml = `
     - name: total
       type: long

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.test.ts
@@ -756,7 +756,6 @@ describe('EPM template', () => {
                   scaling_factor: 1000,
                   type: 'scaled_float',
                   meta: {
-                    metric_type: 'gauge',
                     unit: 'percent',
                   },
                   time_series_metric: 'gauge',
@@ -764,6 +763,33 @@ describe('EPM template', () => {
               },
             },
           },
+        },
+      },
+    };
+    const fields: Field[] = safeLoad(literalYml);
+    const processedFields = processFields(fields);
+    const mappings = generateMappings(processedFields);
+    expect(mappings).toEqual(expectedMapping);
+  });
+
+  it('tests processing metric_type field with long fiekd ', () => {
+    const literalYml = `
+    - name: total
+      type: long
+      format: bytes
+      unit: byte
+      metric_type: gauge
+      description: |
+        Total swap memory.
+`;
+    const expectedMapping = {
+      properties: {
+        total: {
+          type: 'long',
+          meta: {
+            unit: 'byte',
+          },
+          time_series_metric: 'gauge',
         },
       },
     };

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.ts
@@ -311,11 +311,14 @@ function _generateMappings(
               break;
             default: {
               const meta = {};
-              if ('metric_type' in field) Reflect.set(meta, 'metric_type', field.metric_type);
               if ('unit' in field) Reflect.set(meta, 'unit', field.unit);
               fieldProps.meta = meta;
             }
           }
+        }
+
+        if ('metric_type' in field) {
+          fieldProps.time_series_metric = field.metric_type;
         }
 
         props[field.name] = fieldProps;


### PR DESCRIPTION
## Summary

Resolve #148057

Generate `time_series_metric` for every field when `metric_type` is set. 
The previous implementation was only doing it for scaled float.

That PR also remove `metric_type` from meta as the original issue mentioned to keep only `meta.unit` https://github.com/elastic/kibana/issues/115621

