### PR TITLE
[ci] Increase FTR timeout

### DIFF
--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order.ts
@@ -446,7 +446,7 @@ export async function pickTestGroupRunOrder() {
                 ({ title, key, queue = defaultQueue }): BuildkiteStep => ({
                   label: title,
                   command: getRequiredEnv('FTR_CONFIGS_SCRIPT'),
-                  timeout_in_minutes: 60,
+                  timeout_in_minutes: 90,
                   agents: {
                     queue,
                   },


### PR DESCRIPTION
FTR groups on CI target a 40 minute runtime.  In situations where tests are updated or moved, and there's no prior data, we're seeing occasional timeouts with a 60 minute timeout.  This increases the timeout to 90 minutes.

<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->