### PR TITLE
[Fleet] Fix add Fleet Server from fleet server policy

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/details_page/components/header/right_content.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/details_page/components/header/right_content.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { useMemo } from 'react';
 import { i18n } from '@kbn/i18n';
 import { FormattedDate, FormattedMessage } from '@kbn/i18n-react';
 import styled from 'styled-components';
@@ -24,6 +24,7 @@ import { useLink } from '../../../../../hooks';
 import type { AgentPolicy, GetAgentStatusResponse } from '../../../../../types';
 import { AgentPolicyActionMenu, LinkedAgentCount } from '../../../components';
 import { AddAgentHelpPopover } from '../../../../../components';
+import { FLEET_SERVER_PACKAGE } from '../../../../../../../../common/constants';
 
 export interface HeaderRightContentProps {
   isLoading: boolean;
@@ -55,12 +56,31 @@ export const HeaderRightContent: React.FunctionComponent<HeaderRightContentProps
   const { getPath } = useLink();
   const history = useHistory();
 
+  const isFleetServerPolicy = useMemo(
+    () =>
+      agentPolicy?.package_policies?.some(
+        (packagePolicy) => packagePolicy.package?.name === FLEET_SERVER_PACKAGE
+      ),
+    [agentPolicy]
+  );
+
   if (!agentPolicy) {
     return null;
   }
+
   const addAgentLink = (
     <EuiLink onClick={addAgent}>
-      <FormattedMessage id="xpack.fleet.policyDetails.addAgentButton" defaultMessage="Add agent" />
+      {isFleetServerPolicy ? (
+        <FormattedMessage
+          id="xpack.fleet.policyDetails.addFleetServerButton"
+          defaultMessage="Add Fleet Server"
+        />
+      ) : (
+        <FormattedMessage
+          id="xpack.fleet.policyDetails.addAgentButton"
+          defaultMessage="Add agent"
+        />
+      )}
     </EuiLink>
   );
 

--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/instructions.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/instructions.tsx
@@ -72,14 +72,14 @@ export const Instructions = (props: InstructionProps) => {
 
   const showAgentEnrollment =
     fleetStatus.isReady &&
-    !isFleetServerUnhealthy &&
-    fleetServers.length > 0 &&
-    (fleetServerHosts?.length ?? 0) > 0;
+    (isFleetServerPolicySelected ||
+      (!isFleetServerUnhealthy && fleetServers.length > 0 && (fleetServerHosts?.length ?? 0) > 0));
 
   const showFleetServerEnrollment =
-    fleetServers.length === 0 ||
-    isFleetServerUnhealthy ||
-    (fleetStatus.missingRequirements ?? []).some((r) => r === FLEET_SERVER_PACKAGE);
+    !isFleetServerPolicySelected &&
+    (fleetServers.length === 0 ||
+      isFleetServerUnhealthy ||
+      (fleetStatus.missingRequirements ?? []).some((r) => r === FLEET_SERVER_PACKAGE));
 
   if (!isIntegrationFlow && showAgentEnrollment) {
     setSelectionType('radio');


### PR DESCRIPTION
## Summary

Resolve #143519
Fix add Fleet Server from fleet server policy when no fleet server are setup, we now show the instructions to setup Fleet Server with the selected fleet server policy instead of redirecting to the Add Fleet Server flyout

## UI Changes

<img width="1318" alt="Screen Shot 2023-01-11 at 8 05 49 AM" src="https://user-images.githubusercontent.com/1336873/211803699-591246d9-e2d3-4bed-8238-c52cd47c9775.png">
<img width="860" alt="Screen Shot 2023-01-11 at 8 07 51 AM" src="https://user-images.githubusercontent.com/1336873/211803739-0e843900-3323-4a77-b03b-bbe761028954.png">


<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->