### PR TITLE
[APM] Add `ratePerMinute` helper

### DIFF
--- a/packages/kbn-apm-synthtrace-client/src/lib/timerange.ts
+++ b/packages/kbn-apm-synthtrace-client/src/lib/timerange.ts
@@ -15,8 +15,20 @@ export class Timerange {
     return new Interval({ from: this.from, to: this.to, interval });
   }
 
-  ratePerMinute(rate: number) {
-    return this.interval(`1m`).rate(rate);
+  ratePerMinute(ratePerMin: number) {
+    const intervalPerSecond = Math.max(1, 60 / ratePerMin);
+
+    // rate per second
+    let interval = `${intervalPerSecond}s`;
+    let rate = (ratePerMin / 60) * intervalPerSecond;
+
+    // rate per minute
+    if (!Number.isInteger(rate) || !Number.isInteger(intervalPerSecond)) {
+      interval = '1m';
+      rate = rate * 60;
+    }
+
+    return this.interval(interval).rate(rate);
   }
 }
 


### PR DESCRIPTION
`range.ratePerMinute(x)` is a shorthand for `range.interval(...).rate(...)`. 

We show throughput as tpm (transaction per minute) in the UI so it is easier to reason about if synthtrace also declares throughput in tpm. 
`range.ratePerMinute(60)` will produce an event once every second, whereas `range.interval('1m').rate(60)` will produce 60 events every minute. This means that the former will smooth the events out evenly. The latter will create them in spikes.

