### PR TITLE
[TIP] Extract translations to separate file

### DIFF
--- a/x-pack/plugins/threat_intelligence/public/components/update_status/translations.ts
+++ b/x-pack/plugins/threat_intelligence/public/components/update_status/translations.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export const UPDATING = i18n.translate('xpack.threatIntelligence.updateStatus.updating', {
+  defaultMessage: 'Updating...',
+});
+
+export const UPDATED = i18n.translate('xpack.threatIntelligence.updateStatus.updated', {
+  defaultMessage: 'Updated',
+});

--- a/x-pack/plugins/threat_intelligence/public/components/update_status/update_status.tsx
+++ b/x-pack/plugins/threat_intelligence/public/components/update_status/update_status.tsx
@@ -8,21 +8,13 @@
 import React from 'react';
 
 import { EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
-import { i18n } from '@kbn/i18n';
 import { FormattedRelative } from '@kbn/i18n-react';
+import { UPDATED, UPDATING } from './translations';
 
 interface UpdateStatusProps {
   updatedAt: number;
   isUpdating: boolean;
 }
-
-const UPDATING = i18n.translate('xpack.threatIntelligence.updateStatus.updating', {
-  defaultMessage: 'Updating...',
-});
-
-const UPDATED = i18n.translate('xpack.threatIntelligence.updateStatus.updated', {
-  defaultMessage: 'Updated',
-});
 
 export const UpdateStatus: React.FC<UpdateStatusProps> = ({ isUpdating, updatedAt }) => (
   <EuiFlexGroup>

--- a/x-pack/plugins/threat_intelligence/public/hooks/translations.ts
+++ b/x-pack/plugins/threat_intelligence/public/hooks/translations.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export const INSPECTOR_FLYOUT_TITLE = i18n.translate(
+  'xpack.threatIntelligence.inspectorFlyoutTitle',
+  {
+    defaultMessage: 'Indicators search requests',
+  }
+);

--- a/x-pack/plugins/threat_intelligence/public/hooks/use_inspector.ts
+++ b/x-pack/plugins/threat_intelligence/public/hooks/use_inspector.ts
@@ -7,13 +7,9 @@
 
 import { useCallback, useContext, useEffect, useState } from 'react';
 import { InspectorSession } from '@kbn/inspector-plugin/public';
-import { i18n } from '@kbn/i18n';
 import { useKibana } from '.';
 import { InspectorContext } from '../containers/inspector';
-
-const INSPECTOR_FLYOUT_TITLE = i18n.translate('xpack.threatIntelligence.inspectorFlyoutTitle', {
-  defaultMessage: 'Indicators search requests',
-});
+import { INSPECTOR_FLYOUT_TITLE } from './translations';
 
 /**
  *

--- a/x-pack/plugins/threat_intelligence/public/modules/empty_page/empty_page.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/empty_page/empty_page.tsx
@@ -8,8 +8,8 @@
 import React, { VFC } from 'react';
 
 import { EuiButton, EuiEmptyPrompt, EuiImage, EuiLink } from '@elastic/eui';
-import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { IMAGE } from './translations';
 import { useIntegrationsPageLink, useTIDocumentationLink } from '../../hooks';
 import illustration from './integrations_light.svg';
 import { SecuritySolutionPluginTemplateWrapper } from '../../containers/security_solution_plugin_template_wrapper';
@@ -25,15 +25,7 @@ export const EmptyPage: VFC = () => {
   return (
     <SecuritySolutionPluginTemplateWrapper isEmptyState>
       <EuiEmptyPrompt
-        icon={
-          <EuiImage
-            size="fullWidth"
-            alt={i18n.translate('xpack.threatIntelligence.common.emptyPage.imgAlt', {
-              defaultMessage: 'Enable Threat Intelligence Integrations',
-            })}
-            src={illustration}
-          />
-        }
+        icon={<EuiImage size="fullWidth" alt={IMAGE} src={illustration} />}
         title={
           <h3>
             <FormattedMessage

--- a/x-pack/plugins/threat_intelligence/public/modules/empty_page/translations.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/empty_page/translations.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export const IMAGE = i18n.translate('xpack.threatIntelligence.common.emptyPage.imgAlt', {
+  defaultMessage: 'Enable Threat Intelligence Integrations',
+});

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/barchart/field_selector/field_selector.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/barchart/field_selector/field_selector.tsx
@@ -7,13 +7,13 @@
 
 import React, { memo, useCallback, useMemo, useState } from 'react';
 import { EuiComboBox } from '@elastic/eui';
-import { i18n } from '@kbn/i18n';
 import { DataViewField } from '@kbn/data-views-plugin/common';
 import { EuiComboBoxOptionOption } from '@elastic/eui/src/components/combo_box/types';
 import { SecuritySolutionDataViewBase } from '../../../../../types';
 import { RawIndicatorFieldId } from '../../../../../../common/types/indicator';
 import { useStyles } from './styles';
 import { DROPDOWN_TEST_ID } from './test_ids';
+import { COMBOBOX_PREPEND_LABEL } from './translations';
 
 export interface IndicatorsFieldSelectorProps {
   indexPattern: SecuritySolutionDataViewBase;
@@ -22,12 +22,6 @@ export interface IndicatorsFieldSelectorProps {
 }
 
 const DEFAULT_STACK_BY_VALUE = RawIndicatorFieldId.Feed;
-const COMBOBOX_PREPEND_LABEL = i18n.translate(
-  'xpack.threatIntelligence.indicator.fieldSelector.label',
-  {
-    defaultMessage: 'Stack by',
-  }
-);
 const COMBOBOX_SINGLE_SELECTION = { asPlainText: true };
 
 export const IndicatorsFieldSelector = memo<IndicatorsFieldSelectorProps>(

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/barchart/field_selector/translations.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/barchart/field_selector/translations.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export const COMBOBOX_PREPEND_LABEL = i18n.translate(
+  'xpack.threatIntelligence.indicator.fieldSelector.label',
+  {
+    defaultMessage: 'Stack by',
+  }
+);

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/barchart/legend_action/legend_action.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/barchart/legend_action/legend_action.tsx
@@ -7,7 +7,6 @@
 
 import React, { useState, VFC } from 'react';
 import { EuiButtonIcon, EuiContextMenuPanel, EuiPopover, EuiToolTip } from '@elastic/eui';
-import { i18n } from '@kbn/i18n';
 import { CopyToClipboardContextMenu } from '../../copy_to_clipboard';
 import { FilterInContextMenu, FilterOutContextMenu } from '../../../../query_bar';
 import { AddToTimelineContextMenu } from '../../../../timeline';
@@ -18,10 +17,7 @@ import {
   POPOVER_BUTTON_TEST_ID,
   TIMELINE_BUTTON_TEST_ID,
 } from './test_ids';
-
-const BUTTON_LABEL = i18n.translate('xpack.threatIntelligence.indicator.barChart.popover', {
-  defaultMessage: 'More actions',
-});
+import { BUTTON_LABEL } from './translations';
 
 export interface IndicatorBarchartLegendActionProps {
   /**

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/barchart/legend_action/translations.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/barchart/legend_action/translations.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export const BUTTON_LABEL = i18n.translate('xpack.threatIntelligence.indicator.barChart.popover', {
+  defaultMessage: 'More actions',
+});

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/copy_to_clipboard/copy_to_clipboard.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/copy_to_clipboard/copy_to_clipboard.tsx
@@ -7,15 +7,9 @@
 
 import React, { VFC } from 'react';
 import { EuiButtonEmpty, EuiButtonIcon, EuiContextMenuItem, EuiCopy } from '@elastic/eui';
-import { i18n } from '@kbn/i18n';
+import { COPY_TITLE } from './translations';
 
 const COPY_ICON = 'copyClipboard';
-const COPY_TITLE = i18n.translate(
-  'xpack.threatIntelligence.indicators.table.copyToClipboardLabel',
-  {
-    defaultMessage: 'Copy to clipboard',
-  }
-);
 
 export interface CopyToClipboardProps {
   /**

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/copy_to_clipboard/translations.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/copy_to_clipboard/translations.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export const COPY_TITLE = i18n.translate(
+  'xpack.threatIntelligence.indicators.table.copyToClipboardLabel',
+  {
+    defaultMessage: 'Copy to clipboard',
+  }
+);

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/field_label/field_label.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/field_label/field_label.tsx
@@ -6,8 +6,17 @@
  */
 
 import React, { VFC } from 'react';
-import { i18n } from '@kbn/i18n';
 import { RawIndicatorFieldId } from '../../../../../common/types/indicator';
+import {
+  CONFIDENCE,
+  FEED,
+  FIRST_SEEN,
+  INDICATORS,
+  LAST_SEEN,
+  TIMESTAMP,
+  TLP_MARKETING,
+  TYPE,
+} from './translations';
 
 interface IndicatorFieldLabelProps {
   field: string;
@@ -26,44 +35,28 @@ export const translateFieldLabel = (field: string) => {
   // https://github.com/elastic/kibana/blob/main/src/dev/i18n/README.md
   switch (field) {
     case RawIndicatorFieldId.TimeStamp: {
-      return i18n.translate('xpack.threatIntelligence.field.@timestamp', {
-        defaultMessage: '@timestamp',
-      });
+      return TIMESTAMP;
     }
     case RawIndicatorFieldId.Name: {
-      return i18n.translate('xpack.threatIntelligence.field.threat.indicator.name', {
-        defaultMessage: 'Indicator',
-      });
+      return INDICATORS;
     }
     case RawIndicatorFieldId.Type: {
-      return i18n.translate('xpack.threatIntelligence.field.threat.indicator.type', {
-        defaultMessage: 'Indicator type',
-      });
+      return TYPE;
     }
     case RawIndicatorFieldId.Feed: {
-      return i18n.translate('xpack.threatIntelligence.field.threat.feed.name', {
-        defaultMessage: 'Feed',
-      });
+      return FEED;
     }
     case RawIndicatorFieldId.FirstSeen: {
-      return i18n.translate('xpack.threatIntelligence.field.threat.indicator.first_seen', {
-        defaultMessage: 'First seen',
-      });
+      return FIRST_SEEN;
     }
     case RawIndicatorFieldId.LastSeen: {
-      return i18n.translate('xpack.threatIntelligence.field.threat.indicator.last_seen', {
-        defaultMessage: 'Last seen',
-      });
+      return LAST_SEEN;
     }
     case RawIndicatorFieldId.Confidence: {
-      return i18n.translate('xpack.threatIntelligence.field.threat.indicator.confidence', {
-        defaultMessage: 'Confidence',
-      });
+      return CONFIDENCE;
     }
     case RawIndicatorFieldId.MarkingTLP: {
-      return i18n.translate('xpack.threatIntelligence.field.threat.indicator.marking.tlp', {
-        defaultMessage: 'TLP Marking',
-      });
+      return TLP_MARKETING;
     }
     default:
       return field;

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/field_label/translations.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/field_label/translations.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export const TIMESTAMP = i18n.translate('xpack.threatIntelligence.field.@timestamp', {
+  defaultMessage: '@timestamp',
+});
+
+export const INDICATORS = i18n.translate('xpack.threatIntelligence.field.threat.indicator.name', {
+  defaultMessage: 'Indicator',
+});
+
+export const TYPE = i18n.translate('xpack.threatIntelligence.field.threat.indicator.type', {
+  defaultMessage: 'Indicator type',
+});
+
+export const FEED = i18n.translate('xpack.threatIntelligence.field.threat.feed.name', {
+  defaultMessage: 'Feed',
+});
+
+export const FIRST_SEEN = i18n.translate(
+  'xpack.threatIntelligence.field.threat.indicator.first_seen',
+  {
+    defaultMessage: 'First seen',
+  }
+);
+
+export const LAST_SEEN = i18n.translate(
+  'xpack.threatIntelligence.field.threat.indicator.last_seen',
+  {
+    defaultMessage: 'Last seen',
+  }
+);
+
+export const CONFIDENCE = i18n.translate(
+  'xpack.threatIntelligence.field.threat.indicator.confidence',
+  {
+    defaultMessage: 'Confidence',
+  }
+);
+
+export const TLP_MARKETING = i18n.translate(
+  'xpack.threatIntelligence.field.threat.indicator.marking.tlp',
+  {
+    defaultMessage: 'TLP Marking',
+  }
+);

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/flyout/indicator_value_actions/indicator_value_actions.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/flyout/indicator_value_actions/indicator_value_actions.tsx
@@ -13,7 +13,6 @@ import {
   EuiPopover,
   EuiToolTip,
 } from '@elastic/eui';
-import { i18n } from '@kbn/i18n';
 import { useIndicatorsFlyoutContext } from '../use_context';
 import { Indicator } from '../../../../../../common/types/indicator';
 import { FilterInButtonIcon, FilterOutButtonIcon } from '../../../../query_bar';
@@ -27,10 +26,7 @@ import {
   POPOVER_BUTTON_TEST_ID,
   TIMELINE_BUTTON_TEST_ID,
 } from './test_ids';
-
-const MORE_ACTIONS_BUTTON_LABEL = i18n.translate('xpack.threatIntelligence.more-actions.popover', {
-  defaultMessage: 'More actions',
-});
+import { MORE_ACTIONS_BUTTON_LABEL } from './translations';
 
 interface IndicatorValueActions {
   /**

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/flyout/indicator_value_actions/translations.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/flyout/indicator_value_actions/translations.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export const MORE_ACTIONS_BUTTON_LABEL = i18n.translate(
+  'xpack.threatIntelligence.more-actions.popover',
+  {
+    defaultMessage: 'More actions',
+  }
+);

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/table/components/more_actions/more_actions.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/table/components/more_actions/more_actions.tsx
@@ -13,7 +13,6 @@ import {
   EuiToolTip,
   useGeneratedHtmlId,
 } from '@elastic/eui';
-import { i18n } from '@kbn/i18n';
 import { AddToBlockListContextMenu } from '../../../../../block_list/components/add_to_block_list';
 import { AddToNewCase } from '../../../../../cases/components/add_to_new_case/add_to_new_case';
 import { AddToExistingCase } from '../../../../../cases/components/add_to_existing_case/add_to_existing_case';
@@ -25,10 +24,7 @@ import {
   ADD_TO_NEW_CASE_TEST_ID,
   MORE_ACTIONS_TEST_ID,
 } from './test_ids';
-
-const BUTTON_LABEL = i18n.translate('xpack.threatIntelligence.indicator.table.moreActions', {
-  defaultMessage: 'More actions',
-});
+import { BUTTON_LABEL } from './translations';
 
 export interface TakeActionProps {
   /**

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/table/components/more_actions/translations.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/table/components/more_actions/translations.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export const BUTTON_LABEL = i18n.translate('xpack.threatIntelligence.indicator.table.moreActions', {
+  defaultMessage: 'More actions',
+});

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/table/components/open_flyout_button/open_flyout_button.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/table/components/open_flyout_button/open_flyout_button.tsx
@@ -7,16 +7,9 @@
 
 import React, { VFC } from 'react';
 import { EuiButtonIcon, EuiToolTip } from '@elastic/eui';
-import { i18n } from '@kbn/i18n';
 import { Indicator } from '../../../../../../../common/types/indicator';
 import { BUTTON_TEST_ID } from './test_ids';
-
-const BUTTON_LABEL: string = i18n.translate(
-  'xpack.threatIntelligence.indicator.table.viewDetailsButton',
-  {
-    defaultMessage: 'View details',
-  }
-);
+import { BUTTON_LABEL } from './translations';
 
 export interface OpenIndicatorFlyoutButtonProps {
   /**

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/table/components/open_flyout_button/translations.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/table/components/open_flyout_button/translations.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export const BUTTON_LABEL: string = i18n.translate(
+  'xpack.threatIntelligence.indicator.table.viewDetailsButton',
+  {
+    defaultMessage: 'View details',
+  }
+);

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/table/hooks/translations.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/table/hooks/translations.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export const INSPECT_BUTTON_TITLE = i18n.translate('xpack.threatIntelligence.inspectTitle', {
+  defaultMessage: 'Inspect',
+});

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/table/hooks/use_toolbar_options.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/table/hooks/use_toolbar_options.tsx
@@ -7,15 +7,11 @@
 
 import React, { useMemo } from 'react';
 import { EuiButtonIcon, EuiDataGridColumn, EuiText } from '@elastic/eui';
-import { i18n } from '@kbn/i18n';
 import { BrowserField } from '@kbn/rule-registry-plugin/common';
 import { useInspector } from '../../../../../hooks';
 import { IndicatorsFieldBrowser } from '../components';
 import { INSPECT_BUTTON_TEST_ID } from './test_ids';
-
-const INSPECT_BUTTON_TITLE = i18n.translate('xpack.threatIntelligence.inspectTitle', {
-  defaultMessage: 'Inspect',
-});
+import { INSPECT_BUTTON_TITLE } from './translations';
 
 export const useToolbarOptions = ({
   browserFields,

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/hooks/translations.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/hooks/translations.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export const DESCRIPTION = i18n.translate(
+  'xpack.threatIntelligence.indicatorNameFieldDescription',
+  {
+    defaultMessage: 'Indicator display name generated in the runtime ',
+  }
+);

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/hooks/use_sourcerer_data_view.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/hooks/use_sourcerer_data_view.ts
@@ -6,10 +6,10 @@
  */
 
 import { useMemo } from 'react';
-import { i18n } from '@kbn/i18n';
 import { RawIndicatorFieldId } from '../../../../common/types/indicator';
 import { SecuritySolutionDataViewBase } from '../../../types';
 import { useSecurityContext } from '../../../hooks/use_security_context';
+import { DESCRIPTION } from './translations';
 
 /**
  * Inline definition for a runtime field "threat.indicator.name" we are adding for indicators grid
@@ -20,9 +20,7 @@ const indicatorNameField = {
   searchable: true,
   type: 'string',
   category: 'threat',
-  description: i18n.translate('xpack.threatIntelligence.indicatorNameFieldDescription', {
-    defaultMessage: 'Indicator display name generated in the runtime ',
-  }),
+  description: DESCRIPTION,
   esTypes: ['keyword'],
 } as const;
 

--- a/x-pack/plugins/threat_intelligence/public/modules/query_bar/components/filter_in/filter_in.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/query_bar/components/filter_in/filter_in.tsx
@@ -6,7 +6,6 @@
  */
 
 import React, { VFC } from 'react';
-import { i18n } from '@kbn/i18n';
 import {
   EuiButtonEmpty,
   EuiButtonIcon,
@@ -17,11 +16,9 @@ import {
 import { useFilterInOut } from '../../hooks';
 import { FilterIn } from '../../utils';
 import { Indicator } from '../../../../../common/types/indicator';
+import { TITLE } from './translations';
 
 const ICON_TYPE = 'plusInCircle';
-const TITLE = i18n.translate('xpack.threatIntelligence.queryBar.filterIn', {
-  defaultMessage: 'Filter In',
-});
 
 export interface FilterInProps {
   /**

--- a/x-pack/plugins/threat_intelligence/public/modules/query_bar/components/filter_in/translations.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/query_bar/components/filter_in/translations.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export const TITLE = i18n.translate('xpack.threatIntelligence.queryBar.filterIn', {
+  defaultMessage: 'Filter In',
+});

--- a/x-pack/plugins/threat_intelligence/public/modules/query_bar/components/filter_out/filter_out.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/query_bar/components/filter_out/filter_out.tsx
@@ -6,7 +6,6 @@
  */
 
 import React, { VFC } from 'react';
-import { i18n } from '@kbn/i18n';
 import {
   EuiButtonEmpty,
   EuiButtonIcon,
@@ -17,11 +16,9 @@ import {
 import { useFilterInOut } from '../../hooks';
 import { FilterOut } from '../../utils';
 import { Indicator } from '../../../../../common/types/indicator';
+import { TITLE } from './translations';
 
 const ICON_TYPE = 'minusInCircle';
-const TITLE = i18n.translate('xpack.threatIntelligence.queryBar.filterOut', {
-  defaultMessage: 'Filter Out',
-});
 
 export interface FilterOutProps {
   /**

--- a/x-pack/plugins/threat_intelligence/public/modules/query_bar/components/filter_out/translations.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/query_bar/components/filter_out/translations.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export const TITLE = i18n.translate('xpack.threatIntelligence.queryBar.filterOut', {
+  defaultMessage: 'Filter Out',
+});

--- a/x-pack/plugins/threat_intelligence/public/modules/timeline/components/add_to_timeline/add_to_timeline.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/timeline/components/add_to_timeline/add_to_timeline.tsx
@@ -15,18 +15,15 @@ import {
   EuiFlexItem,
   EuiToolTip,
 } from '@elastic/eui';
-import { i18n } from '@kbn/i18n';
 import { generateDataProvider } from '../../utils';
 import { fieldAndValueValid, getIndicatorFieldAndValue } from '../../../indicators';
 import { Indicator } from '../../../../../common/types/indicator';
 import { useKibana } from '../../../../hooks';
 import { useStyles } from './styles';
 import { useAddToTimeline } from '../../hooks';
+import { TITLE } from './translations';
 
 const ICON_TYPE = 'timeline';
-const TITLE = i18n.translate('xpack.threatIntelligence.timeline.addToTimeline', {
-  defaultMessage: 'Add to Timeline',
-});
 
 export interface AddToTimelineProps {
   /**

--- a/x-pack/plugins/threat_intelligence/public/modules/timeline/components/add_to_timeline/translations.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/timeline/components/add_to_timeline/translations.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export const TITLE = i18n.translate('xpack.threatIntelligence.timeline.addToTimeline', {
+  defaultMessage: 'Add to Timeline',
+});

--- a/x-pack/plugins/threat_intelligence/public/modules/timeline/components/investigate_in_timeline/investigate_in_timeline.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/timeline/components/investigate_in_timeline/investigate_in_timeline.tsx
@@ -8,16 +8,9 @@
 import React, { VFC } from 'react';
 import { EuiButtonIcon, EuiContextMenuItem, EuiToolTip } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { i18n } from '@kbn/i18n';
 import { useInvestigateInTimeline } from '../../hooks';
 import { Indicator } from '../../../../../common/types/indicator';
-
-const BUTTON_ICON_LABEL: string = i18n.translate(
-  'xpack.threatIntelligence.timeline.investigateInTimelineButtonIcon',
-  {
-    defaultMessage: 'Investigate in Timeline',
-  }
-);
+import { BUTTON_ICON_LABEL } from './translations';
 
 export interface InvestigateInTimelineProps {
   /**

--- a/x-pack/plugins/threat_intelligence/public/modules/timeline/components/investigate_in_timeline/translations.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/timeline/components/investigate_in_timeline/translations.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export const BUTTON_ICON_LABEL: string = i18n.translate(
+  'xpack.threatIntelligence.timeline.investigateInTimelineButtonIcon',
+  {
+    defaultMessage: 'Investigate in Timeline',
+  }
+);


### PR DESCRIPTION
## Summary

Extract translations constants to translations.ts file, colocated where they're used.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->