### PR TITLE
[Enterprise Search] Flag incomplete fields

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_logic.test.ts
@@ -57,6 +57,7 @@ describe('EngineLogic', () => {
     apiTokens: [],
     apiKey: 'some-key',
     adaptive_relevance_suggestions_active: true,
+    incompleteFields: [],
   };
 
   const DEFAULT_VALUES = {
@@ -74,6 +75,7 @@ describe('EngineLogic', () => {
     engineNotFound: false,
     searchKey: '',
     intervalId: null,
+    hasIncompleteFields: false,
   };
 
   const DEFAULT_VALUES_WITH_ENGINE = {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_logic.ts
@@ -30,6 +30,7 @@ interface EngineValues {
   engineNotFound: boolean;
   searchKey: string;
   intervalId: number | null;
+  hasIncompleteFields: boolean;
 }
 
 interface EngineActions {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_logic.ts
@@ -128,6 +128,10 @@ export const EngineLogic = kea<MakeLogicType<EngineValues, EngineActions>>({
         return searchKey?.key || '';
       },
     ],
+    hasIncompleteFields: [
+      () => [selectors.engine],
+      ({ incompleteFields }) => incompleteFields?.length > 0,
+    ],
   }),
   listeners: ({ actions, values }) => ({
     initializeEngine: async (_, breakpoint) => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_nav.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_nav.tsx
@@ -73,6 +73,7 @@ export const useEngineNav = () => {
     hasSchemaConflicts,
     hasUnconfirmedSchemaFields,
     engine,
+    hasIncompleteFields,
   } = useValues(EngineLogic);
 
   if (!isEngineRoute) return undefined;
@@ -186,6 +187,20 @@ export const useEngineNav = () => {
                 defaultMessage: 'Schema conflicts',
               })}
               data-test-subj="EngineNavSchemaConflicts"
+            />
+          )}
+          {hasIncompleteFields && (
+            <EuiIcon
+              type="alert"
+              color="warning"
+              className="appSearchNavIcon"
+              title={i18n.translate(
+                'xpack.enterpriseSearch.appSearch.engine.schema.hasIncompleteFields',
+                {
+                  defaultMessage: 'Precision tuning is not enabled on all fields',
+                }
+              )}
+              data-test-subj="EngineNavPrecisionTuningWarning"
             />
           )}
         </>

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/components/schema_callouts.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/components/schema_callouts.test.tsx
@@ -160,7 +160,7 @@ describe('SchemaCallouts', () => {
     it('renders a warning callout about incomplete fields with a link to the subfields support documentation', () => {
       const wrapper = shallow(<MissingSubfieldsCallout />);
 
-      expect(wrapper.prop('title')).toMatch(/^\d+ field\(s\) are missing subfields$/);
+      expect(wrapper.prop('title')).toMatch(/^\d+ fields are missing subfields$/);
       expect(wrapper.find('[data-test-subj="missingSubfieldsLearnMoreLink"]').prop('href')).toEqual(
         'https://www.elastic.co/guide/en/app-search/current/elasticsearch-engines-text-subfields-support-conventions.html'
       );

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/components/schema_callouts.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/components/schema_callouts.test.tsx
@@ -18,6 +18,7 @@ import {
   UnsearchedFieldsCallout,
   UnconfirmedFieldsCallout,
   ConfirmSchemaButton,
+  MissingSubfieldsCallout,
 } from './schema_callouts';
 
 import { SchemaCallouts } from '.';
@@ -26,6 +27,8 @@ describe('SchemaCallouts', () => {
   const values = {
     hasUnconfirmedFields: false,
     hasNewUnsearchedFields: false,
+    hasIncompleteFields: false,
+    incompleteFields: [],
     mostRecentIndexJob: {
       hasErrors: false,
       activeReindexJobId: 'some-id',
@@ -79,6 +82,16 @@ describe('SchemaCallouts', () => {
     const wrapper = shallow(<SchemaCallouts />);
 
     expect(wrapper.find(UnconfirmedFieldsCallout)).toHaveLength(1);
+  });
+
+  it('renders a missing subfields callout if the schema has incomplete fields', () => {
+    setMockValues({
+      ...values,
+      hasIncompleteFields: true,
+    });
+    const wrapper = shallow(<SchemaCallouts />);
+
+    expect(wrapper.find(MissingSubfieldsCallout)).toHaveLength(1);
   });
 
   describe('non-owner/admins', () => {
@@ -140,6 +153,17 @@ describe('SchemaCallouts', () => {
 
       wrapper.simulate('click');
       expect(actions.updateSchema).toHaveBeenCalled();
+    });
+  });
+
+  describe('MissingSubfieldsCallout', () => {
+    it('renders a warning callout about incomplete fields with a link to the subfields support documentation', () => {
+      const wrapper = shallow(<MissingSubfieldsCallout />);
+
+      expect(wrapper.prop('title')).toMatch(/^\d+ field\(s\) are missing subfields$/);
+      expect(wrapper.find('[data-test-subj="missingSubfieldsLearnMoreLink"]').prop('href')).toEqual(
+        'https://www.elastic.co/guide/en/app-search/current/elasticsearch-engines-text-subfields-support-conventions.html'
+      );
     });
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/components/schema_callouts.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/components/schema_callouts.test.tsx
@@ -160,7 +160,7 @@ describe('SchemaCallouts', () => {
     it('renders a warning callout about incomplete fields with a link to the subfields support documentation', () => {
       const wrapper = shallow(<MissingSubfieldsCallout />);
 
-      expect(wrapper.prop('title')).toMatch(/^\d+ fields are missing subfields$/);
+      expect(wrapper.prop('title')).toMatch(/^(?:A field is|\d+ fields are) missing subfields$/);
       expect(wrapper.find('[data-test-subj="missingSubfieldsLearnMoreLink"]').prop('href')).toEqual(
         'https://www.elastic.co/guide/en/app-search/current/elasticsearch-engines-text-subfields-support-conventions.html'
       );

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/components/schema_callouts.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/components/schema_callouts.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 
 import { useValues, useActions } from 'kea';
 
-import { EuiCallOut, EuiButton, EuiSpacer, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { EuiCallOut, EuiButton, EuiSpacer, EuiFlexGroup, EuiFlexItem, EuiLink } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
 import { EuiButtonTo } from '../../../../shared/react_router_helpers';
@@ -161,16 +161,16 @@ export const MissingSubfieldsCallout: React.FC = () => {
               'Some fields are missing one or more subfields used by App Search. Some search features may not work until those subfields are added.',
           }
         )}{' '}
-        <a
-          href="https://www.elastic.co/guide/en/app-search/current/elasticsearch-engines-text-subfields-support-conventions.html"
-          data-test-subj="missingSubfieldsLearnMoreLink"
-          target="_blank"
-        >
-          {i18n.translate('xpack.enterpriseSearch.appSearch.engine.schema.incompleteFields.link', {
-            defaultMessage: 'Learn more.',
-          })}
-        </a>
       </p>
+      <EuiLink
+        href="https://www.elastic.co/guide/en/app-search/current/elasticsearch-engines-text-subfields-support-conventions.html"
+        data-test-subj="missingSubfieldsLearnMoreLink"
+        target="_blank"
+      >
+        {i18n.translate('xpack.enterpriseSearch.appSearch.engine.schema.incompleteFields.link', {
+          defaultMessage: 'Learn more.',
+        })}
+      </EuiLink>
     </EuiCallOut>
   );
 };

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/components/schema_callouts.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/components/schema_callouts.tsx
@@ -145,7 +145,7 @@ export const MissingSubfieldsCallout: React.FC = () => {
       iconType="alert"
       color="warning"
       title={`${incompleteFields.length} ${i18n.translate(
-        'xpack.enterpriseSearch.appSearch.engine.schema.unconfirmedFields.title',
+        'xpack.enterpriseSearch.appSearch.engine.schema.incompleteFields.title',
         { defaultMessage: 'field(s) are missing subfields' }
       )}`}
     >
@@ -159,6 +159,7 @@ export const MissingSubfieldsCallout: React.FC = () => {
         )}{' '}
         <a
           href="https://www.elastic.co/guide/en/app-search/current/elasticsearch-engines-text-subfields-support-conventions.html"
+          data-test-subj="missingSubfieldsLearnMoreLink"
           target="_blank"
         >
           {i18n.translate('xpack.enterpriseSearch.appSearch.engine.schema.incompleteFields.link', {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/components/schema_callouts.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/components/schema_callouts.tsx
@@ -28,6 +28,7 @@ export const SchemaCallouts: React.FC = () => {
     hasUnconfirmedFields,
     hasNewUnsearchedFields,
     mostRecentIndexJob: { hasErrors, activeReindexJobId },
+    hasIncompleteFields,
   } = useValues(SchemaLogic);
 
   return (
@@ -45,6 +46,12 @@ export const SchemaCallouts: React.FC = () => {
       {hasUnconfirmedFields && canManageEngines && (
         <>
           {hasNewUnsearchedFields ? <UnsearchedFieldsCallout /> : <UnconfirmedFieldsCallout />}
+          <EuiSpacer />
+        </>
+      )}
+      {hasIncompleteFields && (
+        <>
+          <MissingSubfieldsCallout />
           <EuiSpacer />
         </>
       )}
@@ -127,5 +134,38 @@ export const ConfirmSchemaButton: React.FC = () => {
         defaultMessage: 'Confirm types',
       })}
     </EuiButton>
+  );
+};
+
+export const MissingSubfieldsCallout: React.FC = () => {
+  const { incompleteFields } = useValues(SchemaLogic);
+
+  return (
+    <EuiCallOut
+      iconType="alert"
+      color="warning"
+      title={`${incompleteFields.length} ${i18n.translate(
+        'xpack.enterpriseSearch.appSearch.engine.schema.unconfirmedFields.title',
+        { defaultMessage: 'field(s) are missing subfields' }
+      )}`}
+    >
+      <p>
+        {i18n.translate(
+          'xpack.enterpriseSearch.appSearch.engine.schema.incompleteFields.description',
+          {
+            defaultMessage:
+              'The field(s) are missing one or more subfields used by App Search. Some relevance features may not work until those subfields are added.',
+          }
+        )}{' '}
+        <a
+          href="https://www.elastic.co/guide/en/app-search/current/elasticsearch-engines-text-subfields-support-conventions.html"
+          target="_blank"
+        >
+          {i18n.translate('xpack.enterpriseSearch.appSearch.engine.schema.incompleteFields.link', {
+            defaultMessage: 'Learn more.',
+          })}
+        </a>
+      </p>
+    </EuiCallOut>
   );
 };

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/components/schema_callouts.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/components/schema_callouts.tsx
@@ -146,7 +146,7 @@ export const MissingSubfieldsCallout: React.FC = () => {
       color="warning"
       title={`${incompleteFields.length} ${i18n.translate(
         'xpack.enterpriseSearch.appSearch.engine.schema.incompleteFields.title',
-        { defaultMessage: 'field(s) are missing subfields' }
+        { defaultMessage: 'fields are missing subfields' }
       )}`}
     >
       <p>
@@ -154,7 +154,7 @@ export const MissingSubfieldsCallout: React.FC = () => {
           'xpack.enterpriseSearch.appSearch.engine.schema.incompleteFields.description',
           {
             defaultMessage:
-              'The field(s) are missing one or more subfields used by App Search. Some search features may not work until those subfields are added.',
+              'The fields are missing one or more subfields used by App Search. Some search features may not work until those subfields are added.',
           }
         )}{' '}
         <a

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/components/schema_callouts.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/components/schema_callouts.tsx
@@ -158,7 +158,7 @@ export const MissingSubfieldsCallout: React.FC = () => {
           'xpack.enterpriseSearch.appSearch.engine.schema.incompleteFields.description',
           {
             defaultMessage:
-              'The fields are missing one or more subfields used by App Search. Some search features may not work until those subfields are added.',
+              'Some fields are missing one or more subfields used by App Search. Some search features may not work until those subfields are added.',
           }
         )}{' '}
         <a

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/components/schema_callouts.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/components/schema_callouts.tsx
@@ -154,7 +154,7 @@ export const MissingSubfieldsCallout: React.FC = () => {
           'xpack.enterpriseSearch.appSearch.engine.schema.incompleteFields.description',
           {
             defaultMessage:
-              'The field(s) are missing one or more subfields used by App Search. Some relevance features may not work until those subfields are added.',
+              'The field(s) are missing one or more subfields used by App Search. Some search features may not work until those subfields are added.',
           }
         )}{' '}
         <a

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/components/schema_callouts.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/components/schema_callouts.tsx
@@ -144,10 +144,14 @@ export const MissingSubfieldsCallout: React.FC = () => {
     <EuiCallOut
       iconType="alert"
       color="warning"
-      title={`${incompleteFields.length} ${i18n.translate(
+      title={i18n.translate(
         'xpack.enterpriseSearch.appSearch.engine.schema.incompleteFields.title',
-        { defaultMessage: 'fields are missing subfields' }
-      )}`}
+        {
+          defaultMessage:
+            '{count, plural, one {A field is} other {# fields are}} missing subfields',
+          values: { count: incompleteFields.length },
+        }
+      )}
     >
       <p>
         {i18n.translate(

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/components/schema_table.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/components/schema_table.test.tsx
@@ -21,6 +21,7 @@ describe('SchemaTable', () => {
   const values = {
     schema: {},
     unconfirmedFields: [],
+    incompleteFields: [],
     myRole: { canManageEngines: true },
   };
   const actions = {
@@ -95,5 +96,17 @@ describe('SchemaTable', () => {
     const wrapper = shallow(<SchemaTable />);
 
     expect(wrapper.find(SchemaFieldTypeSelect).at(0).prop('disabled')).toEqual(true);
+  });
+
+  it('renders a missing subfields status if a field is incomplete', () => {
+    setMockValues({
+      ...values,
+      schema: { some_incomplete_field: 'text' },
+      incompleteFields: ['some_incomplete_field'],
+    });
+    const wrapper = shallow(<SchemaTable />);
+
+    expect(wrapper.find(EuiHealth)).toHaveLength(1);
+    expect(wrapper.find(EuiHealth).childAt(0).prop('children')).toEqual('Missing subfields');
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/components/schema_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/components/schema_table.tsx
@@ -34,7 +34,7 @@ export const SchemaTable: React.FC = () => {
   const {
     myRole: { canManageEngines },
   } = useValues(AppLogic);
-  const { schema, unconfirmedFields } = useValues(SchemaLogic);
+  const { schema, unconfirmedFields, incompleteFields } = useValues(SchemaLogic);
   const { updateSchemaFieldType } = useActions(SchemaLogic);
   const { isElasticsearchEngine } = useValues(EngineLogic);
 
@@ -58,14 +58,15 @@ export const SchemaTable: React.FC = () => {
           <EuiTableRowCell align="right" />
         </EuiTableRow>
         {Object.entries(schema).map(([fieldName, fieldType]) => {
-          const isRecentlyAdded = unconfirmedFields.length && unconfirmedFields.includes(fieldName);
+          const isRecentlyAdded = unconfirmedFields.includes(fieldName);
+          const isMissingSubfields = fieldType === 'text' && incompleteFields.includes(fieldName);
 
           return (
             <EuiTableRow key={fieldName}>
               <EuiTableRowCell>
                 <code>{fieldName}</code>
               </EuiTableRowCell>
-              {isRecentlyAdded ? (
+              {isRecentlyAdded && (
                 <EuiTableRowCell align="right">
                   <EuiHealth color="success">
                     <EuiText color="subdued" size="s">
@@ -76,9 +77,20 @@ export const SchemaTable: React.FC = () => {
                     </EuiText>
                   </EuiHealth>
                 </EuiTableRowCell>
-              ) : (
-                <EuiTableRowCell aria-hidden />
               )}
+              {isMissingSubfields && (
+                <EuiTableRowCell align="right">
+                  <EuiHealth color="warning">
+                    <EuiText color="subdued" size="s">
+                      {i18n.translate(
+                        'xpack.enterpriseSearch.appSearch.engine.schema.missingSubfieldsLabel',
+                        { defaultMessage: 'Missing subfields' }
+                      )}
+                    </EuiText>
+                  </EuiHealth>
+                </EuiTableRowCell>
+              )}
+              {!(isRecentlyAdded || isMissingSubfields) && <EuiTableRowCell aria-hidden />}
               <EuiTableRowCell align="right" width={150}>
                 <SchemaFieldTypeSelect
                   fieldName={fieldName}

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/schema_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/schema_logic.test.ts
@@ -37,6 +37,7 @@ describe('SchemaLogic', () => {
     },
     unconfirmedFields: ['some_field'],
     unsearchedUnconfirmedFields: true,
+    incompleteFields: ['some_other_field'],
   };
 
   const DEFAULT_VALUES = {
@@ -51,6 +52,8 @@ describe('SchemaLogic', () => {
     hasUnconfirmedFields: false,
     hasNewUnsearchedFields: false,
     isModalOpen: false,
+    incompleteFields: [],
+    hasIncompleteFields: false,
   };
 
   /*
@@ -93,6 +96,8 @@ describe('SchemaLogic', () => {
           unconfirmedFields: MOCK_RESPONSE.unconfirmedFields,
           hasUnconfirmedFields: true,
           hasNewUnsearchedFields: MOCK_RESPONSE.unsearchedUnconfirmedFields,
+          incompleteFields: MOCK_RESPONSE.incompleteFields,
+          hasIncompleteFields: true,
         });
       });
     });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/schema_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/schema_logic.ts
@@ -32,6 +32,8 @@ interface SchemaValues extends SchemaBaseValues {
   hasUnconfirmedFields: boolean;
   hasNewUnsearchedFields: boolean;
   isModalOpen: boolean;
+  incompleteFields: string[];
+  hasIncompleteFields: boolean;
 }
 
 interface SchemaActions extends SchemaBaseActions {
@@ -128,7 +130,7 @@ export const SchemaLogic = kea<MakeLogicType<SchemaValues, SchemaActions>>({
     ],
     hasIncompleteFields: [
       (selectors) => [selectors.incompleteFields],
-      (incompleteFields) => incompleteFields.length > 0,
+      (incompleteFields: string[]) => incompleteFields.length > 0,
     ],
   },
   listeners: ({ actions, values }) => ({

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/schema_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/schema_logic.ts
@@ -91,6 +91,12 @@ export const SchemaLogic = kea<MakeLogicType<SchemaValues, SchemaActions>>({
         onSchemaLoad: (_, { unconfirmedFields }) => unconfirmedFields,
       },
     ],
+    incompleteFields: [
+      [],
+      {
+        onSchemaLoad: (_, { incompleteFields }) => incompleteFields,
+      },
+    ],
     hasNewUnsearchedFields: [
       false,
       {
@@ -119,6 +125,10 @@ export const SchemaLogic = kea<MakeLogicType<SchemaValues, SchemaActions>>({
     hasUnconfirmedFields: [
       (selectors) => [selectors.unconfirmedFields],
       (unconfirmedFields) => unconfirmedFields.length > 0,
+    ],
+    hasIncompleteFields: [
+      (selectors) => [selectors.incompleteFields],
+      (incompleteFields) => incompleteFields.length > 0,
     ],
   },
   listeners: ({ actions, values }) => ({

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/types.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/types.ts
@@ -17,6 +17,7 @@ export interface SchemaApiResponse {
   mostRecentIndexJob: IndexJob;
   unconfirmedFields: string[];
   unsearchedUnconfirmedFields: boolean;
+  incompleteFields: string[];
 }
 
 export interface MetaEngineSchemaApiResponse {


### PR DESCRIPTION
## Summary

Consumes new API data to surface fields that are missing subfields used in precision tuning, relevance, highlighting and more for BYOI engines.

### TODO

- [x] Updated copy for warning message
- [x] Approval on visuals of per-field flagging approach

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)



### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
