### PR TITLE
[8.6] [Expressions] Replace React.lazy and withSuspense with async imports in expressions plugins (#147693)

### DIFF
--- a/src/plugins/expression_metric/public/components/index.ts
+++ b/src/plugins/expression_metric/public/components/index.ts
@@ -6,4 +6,4 @@
  * Side Public License, v 1.
  */
 
-export * from './metric_component';
+export { MetricComponent } from './metric_component';

--- a/src/plugins/expression_metric/public/components/metric_component.tsx
+++ b/src/plugins/expression_metric/public/components/metric_component.tsx
@@ -8,7 +8,6 @@
 
 import React, { FunctionComponent, CSSProperties } from 'react';
 import numeral from '@elastic/numeral';
-
 interface Props {
   /** The text to display under the metric */
   label?: string;
@@ -22,24 +21,23 @@ interface Props {
   metricFormat?: string;
 }
 
-const Metric: FunctionComponent<Props> = ({
+export const MetricComponent: FunctionComponent<Props> = ({
   label,
   metric,
   labelFont,
   metricFont,
   metricFormat,
-}) => (
-  <div className="canvasMetric">
-    <div className="canvasMetric__metric" style={metricFont}>
-      {metricFormat ? numeral(metric).format(metricFormat) : metric}
-    </div>
-    {label && (
-      <div className="canvasMetric__label" style={labelFont}>
-        {label}
+}) => {
+  return (
+    <div className="canvasMetric">
+      <div className="canvasMetric__metric" style={metricFont}>
+        {metricFormat ? numeral(metric).format(metricFormat) : metric}
       </div>
-    )}
-  </div>
-);
-
-// eslint-disable-next-line import/no-default-export
-export { Metric as default };
+      {label && (
+        <div className="canvasMetric__label" style={labelFont}>
+          {label}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/plugins/expression_metric/public/expression_renderers/metric_renderer.tsx
+++ b/src/plugins/expression_metric/public/expression_renderers/metric_renderer.tsx
@@ -5,10 +5,11 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
-import React, { CSSProperties, lazy } from 'react';
+import React, { CSSProperties } from 'react';
 import { Observable } from 'rxjs';
 import { CoreTheme } from '@kbn/core/public';
 import { render, unmountComponentAtNode } from 'react-dom';
+import { EuiErrorBoundary } from '@elastic/eui';
 import {
   ExpressionRenderDefinition,
   IInterpreterRenderHandlers,
@@ -16,7 +17,7 @@ import {
 import { i18n } from '@kbn/i18n';
 import { CoreSetup } from '@kbn/core/public';
 import { KibanaThemeProvider } from '@kbn/kibana-react-plugin/public';
-import { withSuspense, defaultTheme$ } from '@kbn/presentation-util-plugin/public';
+import { defaultTheme$ } from '@kbn/presentation-util-plugin/public';
 import { MetricRendererConfig } from '../../common/types';
 
 const strings = {
@@ -30,9 +31,6 @@ const strings = {
     }),
 };
 
-const LazyMetricComponent = lazy(() => import('../components/metric_component'));
-const MetricComponent = withSuspense(LazyMetricComponent);
-
 export const getMetricRenderer =
   (theme$: Observable<CoreTheme> = defaultTheme$) =>
   (): ExpressionRenderDefinition<MetricRendererConfig> => ({
@@ -45,20 +43,23 @@ export const getMetricRenderer =
       config: MetricRendererConfig,
       handlers: IInterpreterRenderHandlers
     ) => {
+      const { MetricComponent } = await import('../components/metric_component');
       handlers.onDestroy(() => {
         unmountComponentAtNode(domNode);
       });
 
       render(
-        <KibanaThemeProvider theme$={theme$}>
-          <MetricComponent
-            label={config.label}
-            labelFont={config.labelFont ? (config.labelFont.spec as CSSProperties) : {}}
-            metric={config.metric}
-            metricFont={config.metricFont ? (config.metricFont.spec as CSSProperties) : {}}
-            metricFormat={config.metricFormat}
-          />
-        </KibanaThemeProvider>,
+        <EuiErrorBoundary>
+          <KibanaThemeProvider theme$={theme$}>
+            <MetricComponent
+              label={config.label}
+              labelFont={config.labelFont ? (config.labelFont.spec as CSSProperties) : {}}
+              metric={config.metric}
+              metricFont={config.metricFont ? (config.metricFont.spec as CSSProperties) : {}}
+              metricFormat={config.metricFormat}
+            />
+          </KibanaThemeProvider>
+        </EuiErrorBoundary>,
         domNode,
         () => handlers.done()
       );

--- a/src/plugins/expression_repeat_image/public/components/repeat_image_component.tsx
+++ b/src/plugins/expression_repeat_image/public/components/repeat_image_component.tsx
@@ -53,7 +53,7 @@ function createImageJSX(img: HTMLImageElement | null) {
   return <img src={img.src} {...params} alt="" />;
 }
 
-function RepeatImageComponent({
+export function RepeatImageComponent({
   max,
   count,
   emptyImage: emptyImageSrc,
@@ -98,6 +98,3 @@ function RepeatImageComponent({
     </div>
   );
 }
-// default export required for React.Lazy
-// eslint-disable-next-line import/no-default-export
-export { RepeatImageComponent as default };

--- a/src/plugins/expression_repeat_image/public/expression_renderers/repeat_image_renderer.tsx
+++ b/src/plugins/expression_repeat_image/public/expression_renderers/repeat_image_renderer.tsx
@@ -18,11 +18,7 @@ import { i18n } from '@kbn/i18n';
 import { I18nProvider } from '@kbn/i18n-react';
 import { KibanaThemeProvider } from '@kbn/kibana-react-plugin/public';
 import { CoreSetup } from '@kbn/core/public';
-import {
-  defaultTheme$,
-  getElasticOutline,
-  isValidUrl,
-} from '@kbn/presentation-util-plugin/public';
+import { defaultTheme$, getElasticOutline, isValidUrl } from '@kbn/presentation-util-plugin/public';
 import { RepeatImageRendererConfig } from '../../common/types';
 
 const strings = {

--- a/src/plugins/expression_repeat_image/public/expression_renderers/repeat_image_renderer.tsx
+++ b/src/plugins/expression_repeat_image/public/expression_renderers/repeat_image_renderer.tsx
@@ -5,9 +5,10 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
-import React, { lazy } from 'react';
+import React from 'react';
 import { render, unmountComponentAtNode } from 'react-dom';
 import { Observable } from 'rxjs';
+import { EuiErrorBoundary } from '@elastic/eui';
 import { CoreTheme } from '@kbn/core/public';
 import {
   ExpressionRenderDefinition,
@@ -21,7 +22,6 @@ import {
   defaultTheme$,
   getElasticOutline,
   isValidUrl,
-  withSuspense,
 } from '@kbn/presentation-util-plugin/public';
 import { RepeatImageRendererConfig } from '../../common/types';
 
@@ -36,9 +36,6 @@ const strings = {
     }),
 };
 
-const LazyRepeatImageComponent = lazy(() => import('../components/repeat_image_component'));
-const RepeatImageComponent = withSuspense(LazyRepeatImageComponent, null);
-
 export const getRepeatImageRenderer =
   (theme$: Observable<CoreTheme> = defaultTheme$) =>
   (): ExpressionRenderDefinition<RepeatImageRendererConfig> => ({
@@ -51,6 +48,7 @@ export const getRepeatImageRenderer =
       config: RepeatImageRendererConfig,
       handlers: IInterpreterRenderHandlers
     ) => {
+      const { RepeatImageComponent } = await import('../components/repeat_image_component');
       const { elasticOutline } = await getElasticOutline();
       const settings = {
         ...config,
@@ -63,11 +61,13 @@ export const getRepeatImageRenderer =
       });
 
       render(
-        <KibanaThemeProvider theme$={theme$}>
-          <I18nProvider>
-            <RepeatImageComponent onLoaded={handlers.done} {...settings} parentNode={domNode} />
-          </I18nProvider>
-        </KibanaThemeProvider>,
+        <EuiErrorBoundary>
+          <KibanaThemeProvider theme$={theme$}>
+            <I18nProvider>
+              <RepeatImageComponent onLoaded={handlers.done} {...settings} parentNode={domNode} />
+            </I18nProvider>
+          </KibanaThemeProvider>
+        </EuiErrorBoundary>,
         domNode
       );
     },

--- a/src/plugins/expression_reveal_image/public/components/reveal_image_component.tsx
+++ b/src/plugins/expression_reveal_image/public/components/reveal_image_component.tsx
@@ -46,7 +46,7 @@ interface AlignerStyles {
   backgroundImage?: string;
 }
 
-function RevealImageComponent({
+export function RevealImageComponent({
   onLoaded,
   parentNode,
   percent,
@@ -152,7 +152,3 @@ function RevealImageComponent({
     </div>
   );
 }
-
-// default export required for React.Lazy
-// eslint-disable-next-line import/no-default-export
-export { RevealImageComponent as default };

--- a/src/plugins/expression_reveal_image/public/expression_renderers/reveal_image_renderer.tsx
+++ b/src/plugins/expression_reveal_image/public/expression_renderers/reveal_image_renderer.tsx
@@ -5,9 +5,10 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
-import React, { lazy } from 'react';
+import React from 'react';
 import { render, unmountComponentAtNode } from 'react-dom';
 import { Observable } from 'rxjs';
+import { EuiErrorBoundary } from '@elastic/eui';
 import { CoreTheme } from '@kbn/core/public';
 import { I18nProvider } from '@kbn/i18n-react';
 import {
@@ -17,7 +18,7 @@ import {
 import { i18n } from '@kbn/i18n';
 import { CoreSetup } from '@kbn/core/public';
 import { KibanaThemeProvider } from '@kbn/kibana-react-plugin/public';
-import { withSuspense, defaultTheme$ } from '@kbn/presentation-util-plugin/public';
+import { defaultTheme$ } from '@kbn/presentation-util-plugin/public';
 import { RevealImageRendererConfig } from '../../common/types';
 
 export const strings = {
@@ -31,9 +32,6 @@ export const strings = {
     }),
 };
 
-const LazyRevealImageComponent = lazy(() => import('../components/reveal_image_component'));
-const RevealImageComponent = withSuspense(LazyRevealImageComponent, null);
-
 export const getRevealImageRenderer =
   (theme$: Observable<CoreTheme> = defaultTheme$) =>
   (): ExpressionRenderDefinition<RevealImageRendererConfig> => ({
@@ -41,21 +39,24 @@ export const getRevealImageRenderer =
     displayName: strings.getDisplayName(),
     help: strings.getHelpDescription(),
     reuseDomNode: true,
-    render: (
+    render: async (
       domNode: HTMLElement,
       config: RevealImageRendererConfig,
       handlers: IInterpreterRenderHandlers
     ) => {
+      const { RevealImageComponent } = await import('../components/reveal_image_component');
       handlers.onDestroy(() => {
         unmountComponentAtNode(domNode);
       });
 
       render(
-        <KibanaThemeProvider theme$={theme$}>
-          <I18nProvider>
-            <RevealImageComponent onLoaded={handlers.done} {...config} parentNode={domNode} />
-          </I18nProvider>
-        </KibanaThemeProvider>,
+        <EuiErrorBoundary>
+          <KibanaThemeProvider theme$={theme$}>
+            <I18nProvider>
+              <RevealImageComponent onLoaded={handlers.done} {...config} parentNode={domNode} />
+            </I18nProvider>
+          </KibanaThemeProvider>
+        </EuiErrorBoundary>,
         domNode
       );
     },

--- a/src/plugins/expression_shape/public/components/progress/index.ts
+++ b/src/plugins/expression_shape/public/components/progress/index.ts
@@ -6,7 +6,5 @@
  * Side Public License, v 1.
  */
 
-import { lazy } from 'react';
-
-export const LazyProgressComponent = lazy(() => import('./progress_component'));
-export const LazyProgressDrawer = lazy(() => import('./progress_drawer'));
+export { ProgressComponent } from './progress_component';
+export { ProgressDrawerComponent } from './progress_drawer';

--- a/src/plugins/expression_shape/public/components/progress/progress_component.tsx
+++ b/src/plugins/expression_shape/public/components/progress/progress_component.tsx
@@ -9,23 +9,20 @@
 import React, { CSSProperties, RefCallback, useCallback, useEffect, useRef, useState } from 'react';
 import { useResizeObserver } from '@elastic/eui';
 import { IInterpreterRenderHandlers } from '@kbn/expressions-plugin/common';
-import { withSuspense } from '@kbn/presentation-util-plugin/public';
 import { NodeDimensions, ProgressRendererConfig } from '../../../common/types';
 import { ShapeRef, SvgConfig, SvgTextAttributes } from '../reusable/types';
 import { getShapeContentElement } from '../reusable/shape_factory';
 import { getTextAttributes, getViewBox } from './utils';
 import { getId } from '../../../common/lib';
 import { getDefaultShapeData } from '../reusable';
-import { LazyProgressDrawer } from '../..';
-
-const ProgressDrawer = withSuspense(LazyProgressDrawer);
+import { ProgressDrawerComponent } from './progress_drawer';
 
 interface ProgressComponentProps extends ProgressRendererConfig {
   onLoaded: IInterpreterRenderHandlers['done'];
   parentNode: HTMLElement;
 }
 
-function ProgressComponent({
+export function ProgressComponent({
   onLoaded,
   parentNode,
   shape: shapeType,
@@ -113,7 +110,7 @@ function ProgressComponent({
 
   return (
     <div className="shapeAligner">
-      <ProgressDrawer
+      <ProgressDrawerComponent
         shapeType={shapeType}
         shapeContentAttributes={{ ...shapeContentAttributes, ref: progressRef }}
         shapeAttributes={shapeAttributes}
@@ -121,11 +118,7 @@ function ProgressComponent({
         ref={shapeRef}
       >
         {BarProgress && <BarProgress {...barProgressAttributes} />}
-      </ProgressDrawer>
+      </ProgressDrawerComponent>
     </div>
   );
 }
-
-// default export required for React.Lazy
-// eslint-disable-next-line import/no-default-export
-export { ProgressComponent as default };

--- a/src/plugins/expression_shape/public/components/progress/progress_drawer.tsx
+++ b/src/plugins/expression_shape/public/components/progress/progress_drawer.tsx
@@ -9,11 +9,8 @@ import React, { Ref } from 'react';
 import { ShapeDrawer, ShapeRef, ShapeDrawerComponentProps } from '../reusable';
 import { getShape } from './shapes';
 
-const ProgressDrawerComponent = React.forwardRef(
+export const ProgressDrawerComponent = React.forwardRef(
   (props: ShapeDrawerComponentProps, ref: Ref<ShapeRef>) => (
     <ShapeDrawer {...props} ref={ref} getShape={getShape} />
   )
 );
-
-// eslint-disable-next-line import/no-default-export
-export { ProgressDrawerComponent as default };

--- a/src/plugins/expression_shape/public/components/shape/index.ts
+++ b/src/plugins/expression_shape/public/components/shape/index.ts
@@ -6,7 +6,5 @@
  * Side Public License, v 1.
  */
 
-import { lazy } from 'react';
-
-export const LazyShapeComponent = lazy(() => import('./shape_component'));
-export const LazyShapeDrawer = lazy(() => import('./shape_drawer'));
+export { ShapeComponent } from './shape_component';
+export { ShapeDrawerComponent } from './shape_drawer';

--- a/src/plugins/expression_shape/public/components/shape/shape_component.tsx
+++ b/src/plugins/expression_shape/public/components/shape/shape_component.tsx
@@ -8,7 +8,6 @@
 
 import React, { useState, useEffect, useCallback, RefCallback } from 'react';
 import { useResizeObserver } from '@elastic/eui';
-import { withSuspense } from '@kbn/presentation-util-plugin/public';
 import {
   ShapeRef,
   ShapeAttributes,
@@ -18,11 +17,9 @@ import {
 } from '../reusable';
 import { Dimensions, ShapeComponentProps } from './types';
 import { getViewBox } from '../../../common/lib';
-import { LazyShapeDrawer } from '../..';
+import { ShapeDrawerComponent } from '../..';
 
-const ShapeDrawer = withSuspense(LazyShapeDrawer);
-
-function ShapeComponent({
+export function ShapeComponent({
   onLoaded,
   parentNode,
   shape: shapeType,
@@ -78,7 +75,7 @@ function ShapeComponent({
 
   return (
     <div className="shapeAligner">
-      <ShapeDrawer
+      <ShapeDrawerComponent
         shapeType={shapeType}
         shapeContentAttributes={shapeContentAttributes}
         shapeAttributes={shapeAttributes}
@@ -87,7 +84,3 @@ function ShapeComponent({
     </div>
   );
 }
-
-// default export required for React.Lazy
-// eslint-disable-next-line import/no-default-export
-export { ShapeComponent as default };

--- a/src/plugins/expression_shape/public/components/shape/shape_drawer.tsx
+++ b/src/plugins/expression_shape/public/components/shape/shape_drawer.tsx
@@ -9,11 +9,8 @@ import React, { Ref } from 'react';
 import { ShapeDrawer, ShapeRef, ShapeDrawerComponentProps } from '../reusable';
 import { getShape } from './shapes';
 
-const ShapeDrawerComponent = React.forwardRef(
+export const ShapeDrawerComponent = React.forwardRef(
   (props: ShapeDrawerComponentProps, ref: Ref<ShapeRef>) => (
     <ShapeDrawer {...props} ref={ref} getShape={getShape} />
   )
 );
-
-// eslint-disable-next-line import/no-default-export
-export { ShapeDrawerComponent as default };

--- a/src/plugins/expression_shape/public/expression_renderers/progress_renderer.tsx
+++ b/src/plugins/expression_shape/public/expression_renderers/progress_renderer.tsx
@@ -8,6 +8,7 @@
 import React from 'react';
 import { render, unmountComponentAtNode } from 'react-dom';
 import { Observable } from 'rxjs';
+import { EuiErrorBoundary } from '@elastic/eui';
 import { CoreTheme } from '@kbn/core/public';
 import {
   ExpressionRenderDefinition,
@@ -17,11 +18,8 @@ import { i18n } from '@kbn/i18n';
 import { I18nProvider } from '@kbn/i18n-react';
 import { KibanaThemeProvider } from '@kbn/kibana-react-plugin/public';
 import { CoreSetup } from '@kbn/core/public';
-import { withSuspense, defaultTheme$ } from '@kbn/presentation-util-plugin/public';
+import { defaultTheme$ } from '@kbn/presentation-util-plugin/public';
 import { ProgressRendererConfig } from '../../common/types';
-import { LazyProgressComponent } from '../components/progress';
-
-const ProgressComponent = withSuspense(LazyProgressComponent);
 
 const strings = {
   getDisplayName: () =>
@@ -46,16 +44,19 @@ export const getProgressRenderer =
       config: ProgressRendererConfig,
       handlers: IInterpreterRenderHandlers
     ) => {
+      const { ProgressComponent } = await import('../components/progress');
       handlers.onDestroy(() => {
         unmountComponentAtNode(domNode);
       });
 
       render(
-        <KibanaThemeProvider theme$={theme$}>
-          <I18nProvider>
-            <ProgressComponent {...config} parentNode={domNode} onLoaded={handlers.done} />
-          </I18nProvider>
-        </KibanaThemeProvider>,
+        <EuiErrorBoundary>
+          <KibanaThemeProvider theme$={theme$}>
+            <I18nProvider>
+              <ProgressComponent {...config} parentNode={domNode} onLoaded={handlers.done} />
+            </I18nProvider>
+          </KibanaThemeProvider>
+        </EuiErrorBoundary>,
         domNode
       );
     },

--- a/src/plugins/expression_shape/public/expression_renderers/shape_renderer.tsx
+++ b/src/plugins/expression_shape/public/expression_renderers/shape_renderer.tsx
@@ -8,6 +8,7 @@
 import React from 'react';
 import { render, unmountComponentAtNode } from 'react-dom';
 import { Observable } from 'rxjs';
+import { EuiErrorBoundary } from '@elastic/eui';
 import { CoreTheme } from '@kbn/core/public';
 import { I18nProvider } from '@kbn/i18n-react';
 import {
@@ -17,9 +18,8 @@ import {
 import { i18n } from '@kbn/i18n';
 import { CoreSetup } from '@kbn/core/public';
 import { KibanaThemeProvider } from '@kbn/kibana-react-plugin/public';
-import { withSuspense, defaultTheme$ } from '@kbn/presentation-util-plugin/public';
+import { defaultTheme$ } from '@kbn/presentation-util-plugin/public';
 import { ShapeRendererConfig } from '../../common/types';
-import { LazyShapeComponent } from '../components/shape';
 
 const strings = {
   getDisplayName: () =>
@@ -31,8 +31,6 @@ const strings = {
       defaultMessage: 'Render a basic shape',
     }),
 };
-
-const ShapeComponent = withSuspense(LazyShapeComponent);
 
 export const getShapeRenderer =
   (theme$: Observable<CoreTheme> = defaultTheme$) =>
@@ -46,16 +44,19 @@ export const getShapeRenderer =
       config: ShapeRendererConfig,
       handlers: IInterpreterRenderHandlers
     ) => {
+      const { ShapeComponent } = await import('../components/shape');
       handlers.onDestroy(() => {
         unmountComponentAtNode(domNode);
       });
 
       render(
-        <KibanaThemeProvider theme$={theme$}>
-          <I18nProvider>
-            <ShapeComponent onLoaded={handlers.done} {...config} parentNode={domNode} />
-          </I18nProvider>
-        </KibanaThemeProvider>,
+        <EuiErrorBoundary>
+          <KibanaThemeProvider theme$={theme$}>
+            <I18nProvider>
+              <ShapeComponent onLoaded={handlers.done} {...config} parentNode={domNode} />
+            </I18nProvider>
+          </KibanaThemeProvider>
+        </EuiErrorBoundary>,
         domNode
       );
     },

--- a/src/plugins/expression_shape/public/index.ts
+++ b/src/plugins/expression_shape/public/index.ts
@@ -21,8 +21,8 @@ export {
   progressRendererFactory,
 } from './expression_renderers';
 
-export { LazyShapeDrawer } from './components/shape';
-export { LazyProgressDrawer } from './components/progress';
+export { ShapeDrawerComponent } from './components/shape';
+export { ProgressDrawerComponent } from './components/progress';
 export { getDefaultShapeData } from './components/reusable';
 
 export type {

--- a/x-pack/plugins/canvas/public/components/shape_preview/shape_preview.tsx
+++ b/x-pack/plugins/canvas/public/components/shape_preview/shape_preview.tsx
@@ -8,20 +8,16 @@
 import React, { FC, RefCallback, useCallback, useState } from 'react';
 import PropTypes from 'prop-types';
 import {
-  LazyShapeDrawer,
-  ShapeDrawerComponentProps,
+  ShapeDrawerComponent,
   getDefaultShapeData,
   SvgConfig,
   ShapeRef,
   ViewBoxParams,
 } from '@kbn/expression-shape-plugin/public';
-import { withSuspense } from '@kbn/presentation-util-plugin/public';
 
 interface Props {
   shape?: string;
 }
-
-const ShapeDrawer = withSuspense<ShapeDrawerComponentProps, ShapeRef>(LazyShapeDrawer);
 
 function getViewBox(defaultWidth: number, defaultViewBox: ViewBoxParams): ViewBoxParams {
   const { minX, minY, width, height } = defaultViewBox;
@@ -45,7 +41,7 @@ export const ShapePreview: FC<Props> = ({ shape }) => {
   if (!shape) return <div className="canvasShapePreview" />;
   return (
     <div className="canvasShapePreview">
-      <ShapeDrawer
+      <ShapeDrawerComponent
         ref={shapeRef}
         shapeType={shape}
         shapeAttributes={{


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.6`:
 - [[Expressions] Replace React.lazy and withSuspense with async imports in expressions plugins (#147693)](https://github.com/elastic/kibana/pull/147693)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Nick Peihl","email":"nick.peihl@elastic.co"},"sourceCommit":{"committedDate":"2022-12-21T16:00:28Z","message":"[Expressions] Replace React.lazy and withSuspense with async imports in expressions plugins (#147693)\n\nFixes #147648 \r\n\r\n## Summary\r\n\r\nReplace React.lazy and withSuspense with async imports in expressions\r\nplugins\r\n\r\nThe `withSuspense` method shows a loading state (`EuiLoadingSpinner`)\r\nwhile React.lazy imports the component module. However, expression\r\nrenderers have a second loading state after the module is imported. This\r\ncauses a flash of two separate loading states . Unfortunately, this\r\ncaused a much larger problem with reporting where the report was\r\ntriggered before the second loading state was complete.\r\n\r\nUsing async imports rather than `React.lazy` ensures that components are\r\nfully available before the expression renderers call their `done`\r\nmethod.\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"af77f5a261e9183b35de5b7ad617171e1b12ffc0","branchLabelMapping":{"^v8.7.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Presentation","backport:skip","v8.7.0","v8.6.1"],"number":147693,"url":"https://github.com/elastic/kibana/pull/147693","mergeCommit":{"message":"[Expressions] Replace React.lazy and withSuspense with async imports in expressions plugins (#147693)\n\nFixes #147648 \r\n\r\n## Summary\r\n\r\nReplace React.lazy and withSuspense with async imports in expressions\r\nplugins\r\n\r\nThe `withSuspense` method shows a loading state (`EuiLoadingSpinner`)\r\nwhile React.lazy imports the component module. However, expression\r\nrenderers have a second loading state after the module is imported. This\r\ncauses a flash of two separate loading states . Unfortunately, this\r\ncaused a much larger problem with reporting where the report was\r\ntriggered before the second loading state was complete.\r\n\r\nUsing async imports rather than `React.lazy` ensures that components are\r\nfully available before the expression renderers call their `done`\r\nmethod.\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"af77f5a261e9183b35de5b7ad617171e1b12ffc0"}},"sourceBranch":"main","suggestedTargetBranches":["8.6"],"targetPullRequestStates":[{"branch":"main","label":"v8.7.0","labelRegex":"^v8.7.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/147693","number":147693,"mergeCommit":{"message":"[Expressions] Replace React.lazy and withSuspense with async imports in expressions plugins (#147693)\n\nFixes #147648 \r\n\r\n## Summary\r\n\r\nReplace React.lazy and withSuspense with async imports in expressions\r\nplugins\r\n\r\nThe `withSuspense` method shows a loading state (`EuiLoadingSpinner`)\r\nwhile React.lazy imports the component module. However, expression\r\nrenderers have a second loading state after the module is imported. This\r\ncauses a flash of two separate loading states . Unfortunately, this\r\ncaused a much larger problem with reporting where the report was\r\ntriggered before the second loading state was complete.\r\n\r\nUsing async imports rather than `React.lazy` ensures that components are\r\nfully available before the expression renderers call their `done`\r\nmethod.\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"af77f5a261e9183b35de5b7ad617171e1b12ffc0"}},{"branch":"8.6","label":"v8.6.1","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->