### PR TITLE
[ML] AIOps: Enhance the UX for grouped results which only contain field / value pairs that appear in other groups

### DIFF
--- a/x-pack/plugins/aiops/public/components/spike_analysis_table/spike_analysis_table_groups.tsx
+++ b/x-pack/plugins/aiops/public/components/spike_analysis_table/spike_analysis_table_groups.tsx
@@ -281,10 +281,17 @@ export const SpikeAnalysisGroupsTable: FC<SpikeAnalysisTableProps> = ({
                     <br />
                   </>
                 ) : null}
-                {repeatedValues.length > 0 ? (
+                {repeatedValues.length > 0 && valuesBadges.length ? (
                   <FormattedMessage
                     id="xpack.aiops.explainLogRateSpikes.spikeAnalysisTableGroups.moreRepeatedLabel"
                     defaultMessage="+{count, plural, one {# more field/value pair} other {# more field/value pairs}} also appearing in other groups"
+                    values={{ count: repeatedValues.length }}
+                  />
+                ) : null}
+                {repeatedValues.length > 0 && !valuesBadges.length ? (
+                  <FormattedMessage
+                    id="xpack.aiops.explainLogRateSpikes.spikeAnalysisTableGroups.onlyMoreRepeatedLabel"
+                    defaultMessage="{count, plural, one {# field/value pair} other {# more field/value pairs}} also appearing in other groups"
                     values={{ count: repeatedValues.length }}
                   />
                 ) : null}

--- a/x-pack/plugins/aiops/public/components/spike_analysis_table/spike_analysis_table_groups.tsx
+++ b/x-pack/plugins/aiops/public/components/spike_analysis_table/spike_analysis_table_groups.tsx
@@ -291,7 +291,7 @@ export const SpikeAnalysisGroupsTable: FC<SpikeAnalysisTableProps> = ({
                 {repeatedValues.length > 0 && !valuesBadges.length ? (
                   <FormattedMessage
                     id="xpack.aiops.explainLogRateSpikes.spikeAnalysisTableGroups.onlyMoreRepeatedLabel"
-                    defaultMessage="{count, plural, one {# field/value pair} other {# more field/value pairs}} also appearing in other groups"
+                    defaultMessage="{count, plural, one {# field/value pair} other {# field/value pairs}} also appearing in other groups"
                     values={{ count: repeatedValues.length }}
                   />
                 ) : null}


### PR DESCRIPTION
## Summary

Related meta issue: https://github.com/elastic/kibana/issues/146162

This PR updates the UX for grouped results which only contain field / value pairs that appear in other groups. In the updated text the '+' and 'more' are dropped from the label.

<img width="1098" alt="image" src="https://user-images.githubusercontent.com/7405507/212317301-7cd40c62-d96f-4a0e-934e-2dc6e39e25a4.png">


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)


