### PR TITLE
[Fleet] Generate time_serie_metrics only for time_series index

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/install.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/install.ts
@@ -491,7 +491,12 @@ export function prepareTemplate({
   const { name: packageName, version: packageVersion } = pkg;
   const fields = loadFieldsFromYaml(pkg, dataStream.path);
   const validFields = processFields(fields);
-  const mappings = generateMappings(validFields);
+
+  const isIndexModeTimeSeries =
+    dataStream.elasticsearch?.index_mode === 'time_series' ||
+    experimentalDataStreamFeature?.features.tsdb;
+
+  const mappings = generateMappings(validFields, { isIndexModeTimeSeries });
   const templateName = generateTemplateName(dataStream);
   const templateIndexPattern = generateTemplateIndexPattern(dataStream);
   const templatePriority = getTemplatePriority(dataStream);
@@ -524,6 +529,7 @@ export function prepareTemplate({
     hidden: dataStream.hidden,
     registryElasticsearch: dataStream.elasticsearch,
     mappings,
+    isIndexModeTimeSeries,
   });
 
   return {

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.test.ts
@@ -738,7 +738,7 @@ describe('EPM template', () => {
     expect(mappings).toEqual(expectedMapping);
   });
 
-  it('tests processing metric_type field', () => {
+  it('tests processing metric_type field with index mode time series', () => {
     const literalYml = `
 - name: total.norm.pct
   type: scaled_float
@@ -768,11 +768,44 @@ describe('EPM template', () => {
     };
     const fields: Field[] = safeLoad(literalYml);
     const processedFields = processFields(fields);
-    const mappings = generateMappings(processedFields);
+    const mappings = generateMappings(processedFields, { isIndexModeTimeSeries: true });
     expect(mappings).toEqual(expectedMapping);
   });
 
-  it('tests processing metric_type field with long field ', () => {
+  it('tests processing metric_type field with index mode time series disabled', () => {
+    const literalYml = `
+- name: total.norm.pct
+  type: scaled_float
+  metric_type: gauge
+  unit: percent
+  format: percent
+`;
+    const expectedMapping = {
+      properties: {
+        total: {
+          properties: {
+            norm: {
+              properties: {
+                pct: {
+                  scaling_factor: 1000,
+                  type: 'scaled_float',
+                  meta: {
+                    unit: 'percent',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    const fields: Field[] = safeLoad(literalYml);
+    const processedFields = processFields(fields);
+    const mappings = generateMappings(processedFields, { isIndexModeTimeSeries: false });
+    expect(mappings).toEqual(expectedMapping);
+  });
+
+  it('tests processing metric_type field with long field and index mode timeseries', () => {
     const literalYml = `
     - name: total
       type: long
@@ -795,7 +828,7 @@ describe('EPM template', () => {
     };
     const fields: Field[] = safeLoad(literalYml);
     const processedFields = processFields(fields);
-    const mappings = generateMappings(processedFields);
+    const mappings = generateMappings(processedFields, { isIndexModeTimeSeries: true });
     expect(mappings).toEqual(expectedMapping);
   });
 

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.ts
@@ -65,6 +65,7 @@ export function getTemplate({
   hidden,
   registryElasticsearch,
   mappings,
+  isIndexModeTimeSeries,
 }: {
   templateIndexPattern: string;
   packageName: string;
@@ -73,6 +74,7 @@ export function getTemplate({
   mappings: IndexTemplateMappings;
   hidden?: boolean;
   registryElasticsearch?: RegistryElasticsearch | undefined;
+  isIndexModeTimeSeries?: boolean;
 }): IndexTemplate {
   const template = getBaseTemplate({
     templateIndexPattern,
@@ -82,6 +84,7 @@ export function getTemplate({
     registryElasticsearch,
     hidden,
     mappings,
+    isIndexModeTimeSeries,
   });
   if (template.template.settings.index.final_pipeline) {
     throw new Error(`Error template for ${templateIndexPattern} contains a final_pipeline`);
@@ -98,6 +101,10 @@ export function getTemplate({
   return template;
 }
 
+interface GenerateMappingsOptions {
+  isIndexModeTimeSeries?: boolean;
+}
+
 /**
  * Generate mapping takes the given nested fields array and creates the Elasticsearch
  * mapping properties out of it.
@@ -106,37 +113,44 @@ export function getTemplate({
  *
  * @param fields
  */
-export function generateMappings(fields: Field[]): IndexTemplateMappings {
+export function generateMappings(
+  fields: Field[],
+  options?: GenerateMappingsOptions
+): IndexTemplateMappings {
   const dynamicTemplates: Array<Record<string, Properties>> = [];
   const dynamicTemplateNames = new Set<string>();
 
-  const { properties } = _generateMappings(fields, {
-    addDynamicMapping: (dynamicMapping: {
-      path: string;
-      matchingType: string;
-      pathMatch: string;
-      properties: string;
-    }) => {
-      const name = dynamicMapping.path;
-      if (dynamicTemplateNames.has(name)) {
-        return;
-      }
+  const { properties } = _generateMappings(
+    fields,
+    {
+      addDynamicMapping: (dynamicMapping: {
+        path: string;
+        matchingType: string;
+        pathMatch: string;
+        properties: string;
+      }) => {
+        const name = dynamicMapping.path;
+        if (dynamicTemplateNames.has(name)) {
+          return;
+        }
 
-      const dynamicTemplate: Properties = {
-        mapping: dynamicMapping.properties,
-      };
+        const dynamicTemplate: Properties = {
+          mapping: dynamicMapping.properties,
+        };
 
-      if (dynamicMapping.matchingType) {
-        dynamicTemplate.match_mapping_type = dynamicMapping.matchingType;
-      }
+        if (dynamicMapping.matchingType) {
+          dynamicTemplate.match_mapping_type = dynamicMapping.matchingType;
+        }
 
-      if (dynamicMapping.pathMatch) {
-        dynamicTemplate.path_match = dynamicMapping.pathMatch;
-      }
-      dynamicTemplateNames.add(name);
-      dynamicTemplates.push({ [dynamicMapping.path]: dynamicTemplate });
+        if (dynamicMapping.pathMatch) {
+          dynamicTemplate.path_match = dynamicMapping.pathMatch;
+        }
+        dynamicTemplateNames.add(name);
+        dynamicTemplates.push({ [dynamicMapping.path]: dynamicTemplate });
+      },
     },
-  });
+    options
+  );
 
   return dynamicTemplates.length
     ? {
@@ -159,7 +173,8 @@ function _generateMappings(
   ctx: {
     addDynamicMapping: any;
     groupFieldName?: string;
-  }
+  },
+  options?: GenerateMappingsOptions
 ): {
   properties: IndexTemplateMappings['properties'];
   hasNonDynamicTemplateMappings: boolean;
@@ -219,12 +234,16 @@ function _generateMappings(
 
         switch (type) {
           case 'group':
-            const mappings = _generateMappings(field.fields!, {
-              ...ctx,
-              groupFieldName: ctx.groupFieldName
-                ? `${ctx.groupFieldName}.${field.name}`
-                : field.name,
-            });
+            const mappings = _generateMappings(
+              field.fields!,
+              {
+                ...ctx,
+                groupFieldName: ctx.groupFieldName
+                  ? `${ctx.groupFieldName}.${field.name}`
+                  : field.name,
+              },
+              options
+            );
             if (!mappings.hasNonDynamicTemplateMappings) {
               return;
             }
@@ -236,12 +255,16 @@ function _generateMappings(
             break;
           case 'group-nested':
             fieldProps = {
-              properties: _generateMappings(field.fields!, {
-                ...ctx,
-                groupFieldName: ctx.groupFieldName
-                  ? `${ctx.groupFieldName}.${field.name}`
-                  : field.name,
-              }).properties,
+              properties: _generateMappings(
+                field.fields!,
+                {
+                  ...ctx,
+                  groupFieldName: ctx.groupFieldName
+                    ? `${ctx.groupFieldName}.${field.name}`
+                    : field.name,
+                },
+                options
+              ).properties,
               ...generateNestedProps(field),
               type: 'nested',
             };
@@ -317,7 +340,7 @@ function _generateMappings(
           }
         }
 
-        if ('metric_type' in field) {
+        if (options?.isIndexModeTimeSeries && 'metric_type' in field) {
           fieldProps.time_series_metric = field.metric_type;
         }
 
@@ -488,6 +511,7 @@ function getBaseTemplate({
   hidden,
   registryElasticsearch,
   mappings,
+  isIndexModeTimeSeries,
 }: {
   templateIndexPattern: string;
   packageName: string;
@@ -496,10 +520,9 @@ function getBaseTemplate({
   hidden?: boolean;
   registryElasticsearch: RegistryElasticsearch | undefined;
   mappings: IndexTemplateMappings;
+  isIndexModeTimeSeries?: boolean;
 }): IndexTemplate {
   const _meta = getESAssetMetadata({ packageName });
-
-  const isIndexModeTimeSeries = registryElasticsearch?.index_mode === 'time_series';
 
   let settingsIndex = {};
   if (isIndexModeTimeSeries) {


### PR DESCRIPTION
## Summary

Related to https://github.com/elastic/kibana/pull/148666#issuecomment-1379299963

https://github.com/elastic/kibana/pull/148666 introduced a breaking change by adding `time_serie_metrics` to every field that define `metric_type` this seems to break existing dashboard.

For example for the elastic agent dashboard we got the following error
<img width="705" alt="Screen Shot 2023-01-11 at 2 16 12 PM" src="https://user-images.githubusercontent.com/1336873/211896227-e5bd53e5-2ccd-46f2-8b6c-d9ebf402c56a.png">


That PR mitigate that by adding `time_serie_metrics` only when `index_mode:time_series` is enabled for a datastream.

## Test 

- [x] The change is covered by unit tests
