### PR TITLE
[Tines] Add story library link to the documentation

### DIFF
--- a/docs/management/connectors/action-types/tines.asciidoc
+++ b/docs/management/connectors/action-types/tines.asciidoc
@@ -87,7 +87,7 @@ image::management/connectors/images/tines-webhook-url-fallback.png[Tines Webhook
 === Tines story library
 
 In order to simplify the integration with Elastic, Tines offers a set of pre-defined Elastic stories in the Story library.
-They can be found by searching for "Elastic" in the Tines Story library:
+They can be found by searching for "Elastic" in the https://www.tines.com/story-library?s=elastic[Tines Story library]:
 
 [role="screenshot"]
 image::management/connectors/images/tines_elastic_stories.png[Tines Elastic stories]


### PR DESCRIPTION
## Summary

This change comes from a suggestion by the Tines team. 
The link to the Elastic stories in the Tines story library has been added

![tines docs](https://user-images.githubusercontent.com/17747913/212025082-045f1754-4bb6-47c6-9a81-4857963660fe.png)

