### PR TITLE
[Cases] update style to handle truncate text in safari browser

### DIFF
--- a/x-pack/plugins/cases/public/components/recent_cases/recent_cases.tsx
+++ b/x-pack/plugins/cases/public/components/recent_cases/recent_cases.tsx
@@ -33,12 +33,14 @@ const MarkdownContainer = styled.div`
 `;
 
 const TruncateComp = styled.div`
-  text-overflow: ellipsis;
-  display: -webkit-box;
-  -webkit-line-clamp: 3;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
-  word-break: break-word;
+  & .euiMarkdownFormat {
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    word-break: break-word;
+  }
 `;
 
 export interface RecentCasesProps {


### PR DESCRIPTION
## Summary

This PR fixes an issue of text not truncated in **Safari** browser.

**Before:**
![Screenshot 2023-01-12 at 14 34 12](https://user-images.githubusercontent.com/117571355/212080707-77b4af28-82ee-4d7b-9aef-227b3c6b9ea1.png)


**After:**
![image](https://user-images.githubusercontent.com/117571355/212079641-afde73aa-8ed6-4e51-97d0-8ad50f7848dd.png)


### Checklist
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)
