### PR TITLE
[8.1] Removes perlGuide from doc link service (#148803)

### DIFF
--- a/packages/kbn-doc-links/src/get_doc_links.ts
+++ b/packages/kbn-doc-links/src/get_doc_links.ts
@@ -592,7 +592,6 @@ export const getDocLinks = ({ kibanaBranch }: GetDocLinkOptions): DocLinks => {
       javaIndex: `${ELASTIC_WEBSITE_URL}guide/en/elasticsearch/client/java-api-client/${DOC_LINK_VERSION}/index.html`,
       jsIntro: `${ELASTIC_WEBSITE_URL}guide/en/elasticsearch/client/javascript-api/${DOC_LINK_VERSION}/introduction.html`,
       netGuide: `${ELASTIC_WEBSITE_URL}guide/en/elasticsearch/client/net-api/${DOC_LINK_VERSION}/index.html`,
-      perlGuide: `${ELASTIC_WEBSITE_URL}guide/en/elasticsearch/client/perl-api/${DOC_LINK_VERSION}/index.html`,
       phpGuide: `${ELASTIC_WEBSITE_URL}guide/en/elasticsearch/client/php-api/${DOC_LINK_VERSION}/index.html`,
       pythonGuide: `${ELASTIC_WEBSITE_URL}guide/en/elasticsearch/client/python-api/${DOC_LINK_VERSION}/index.html`,
       rubyOverview: `${ELASTIC_WEBSITE_URL}guide/en/elasticsearch/client/ruby-api/${DOC_LINK_VERSION}/ruby_client.html`,

--- a/packages/kbn-doc-links/src/types.ts
+++ b/packages/kbn-doc-links/src/types.ts
@@ -354,7 +354,6 @@ export interface DocLinks {
     readonly javaIndex: string;
     readonly jsIntro: string;
     readonly netGuide: string;
-    readonly perlGuide: string;
     readonly phpGuide: string;
     readonly pythonGuide: string;
     readonly rubyOverview: string;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.1`:
 - [Removes perlGuide from doc link service (#148803)](https://github.com/elastic/kibana/pull/148803)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"István Zoltán Szabó","email":"szabosteve@gmail.com"},"sourceCommit":{"committedDate":"2023-01-12T15:13:14Z","message":"Removes perlGuide from doc link service (#148803)","sha":"a82e62f0cd29497a8dbbb5f2f7eff07ed14fbf2e","branchLabelMapping":{"^v8.7.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Docs","release_note:skip","docs","v8.0.2","v8.1.4","v8.2.4","v8.3.4","v8.4.4","v8.7.0","v8.6.1","v8.5.4"],"number":148803,"url":"https://github.com/elastic/kibana/pull/148803","mergeCommit":{"message":"Removes perlGuide from doc link service (#148803)","sha":"a82e62f0cd29497a8dbbb5f2f7eff07ed14fbf2e"}},"sourceBranch":"main","suggestedTargetBranches":["8.0","8.1"],"targetPullRequestStates":[{"branch":"8.0","label":"v8.0.2","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.1","label":"v8.1.4","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.2","label":"v8.2.4","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/148812","number":148812,"state":"OPEN"},{"branch":"8.3","label":"v8.3.4","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/148813","number":148813,"state":"OPEN"},{"branch":"8.4","label":"v8.4.4","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/148814","number":148814,"state":"OPEN"},{"branch":"main","label":"v8.7.0","labelRegex":"^v8.7.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/148803","number":148803,"mergeCommit":{"message":"Removes perlGuide from doc link service (#148803)","sha":"a82e62f0cd29497a8dbbb5f2f7eff07ed14fbf2e"}},{"branch":"8.6","label":"v8.6.1","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/148816","number":148816,"state":"OPEN"},{"branch":"8.5","label":"v8.5.4","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/148815","number":148815,"state":"OPEN"}]}] BACKPORT-->