### PR TITLE
[packages] prevent and remove basename collisions for js/ts code

### DIFF
--- a/packages/kbn-lint-packages-cli/rules/index.ts
+++ b/packages/kbn-lint-packages-cli/rules/index.ts
@@ -9,5 +9,6 @@
 import type { PackageRule } from '@kbn/repo-linter';
 
 import { matchingPackageNameRule } from './matching_package_name';
+import { noBasenameCollisionsRule } from './no_basename_collisions';
 
-export const RULES: PackageRule[] = [matchingPackageNameRule];
+export const RULES: PackageRule[] = [matchingPackageNameRule, noBasenameCollisionsRule];

--- a/packages/kbn-lint-packages-cli/rules/no_basename_collisions.ts
+++ b/packages/kbn-lint-packages-cli/rules/no_basename_collisions.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import Path from 'path';
+
+import { PackageRule } from '@kbn/repo-linter';
+import { SetMap } from '@kbn/set-map';
+
+export const noBasenameCollisionsRule = PackageRule.create('noBasenameCollisions', {
+  async check() {
+    const groupedByBasename = new SetMap<string, string>();
+
+    for (const file of this.getAllFiles()) {
+      if (!file.isJsTsCode()) {
+        continue;
+      }
+
+      const repoRelWithoutExt = Path.resolve(
+        file.repoRelDir,
+        Path.basename(file.repoRel, file.ext)
+      );
+
+      groupedByBasename.add(repoRelWithoutExt, file.repoRel);
+    }
+
+    for (const [, paths] of groupedByBasename) {
+      if (paths.size > 1) {
+        const list = Array.from(paths, (p) => `\n  - ${p}`).join('');
+        this.err(
+          `Having two JS/TS files with the same name but different extensions is not allowed:${list}`
+        );
+      }
+    }
+  },
+});

--- a/packages/kbn-lint-packages-cli/tsconfig.json
+++ b/packages/kbn-lint-packages-cli/tsconfig.json
@@ -23,5 +23,6 @@
     "@kbn/ts-projects",
     "@kbn/repo-file-maps",
     "@kbn/json-ast",
+    "@kbn/set-map",
   ]
 }

--- a/packages/kbn-repo-path/repo_path.ts
+++ b/packages/kbn-repo-path/repo_path.ts
@@ -36,7 +36,7 @@ export class RepoPath {
 
   private _basename: string | undefined;
   /**
-   * basename of the path
+   * basename of the path (including extension)
    * (lazy and cached getter)
    */
   public get basename() {
@@ -62,6 +62,10 @@ export class RepoPath {
 
   isJavaScript() {
     return this.ext === '.js' || this.ext === '.jsx' || this.ext === '.mjs';
+  }
+
+  isJsTsCode() {
+    return this.isTypeScript() || this.isJavaScript();
   }
 
   isFixture() {

--- a/x-pack/plugins/ml/server/models/filter/index.js
+++ b/x-pack/plugins/ml/server/models/filter/index.js
@@ -1,8 +1,0 @@
-/*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0; you may not use this file except in compliance with the Elastic License
- * 2.0.
- */
-
-export { FilterManager } from './filter_manager';

--- a/x-pack/plugins/watcher/common/lib/get_moment/index.js
+++ b/x-pack/plugins/watcher/common/lib/get_moment/index.js
@@ -1,8 +1,0 @@
-/*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0; you may not use this file except in compliance with the Elastic License
- * 2.0.
- */
-
-export { getMoment } from './get_moment';


### PR DESCRIPTION
It seems like these files were unintentionally committed, or left behind, so I have added a package linter rule which will verify that we don't have any JS/TS files with exactly the same path, but different extensions.