### PR TITLE
[Fleet] Add help text to Fleet policy output fields

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_advanced_fields/hooks.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_advanced_fields/hooks.tsx
@@ -140,6 +140,12 @@ export function useOutputOptions(agentPolicy: Partial<NewAgentPolicy | AgentPoli
           value: item.id,
           inputDisplay: item.name,
           disabled: !isPolicyPerOutputAllowed || isInternalOutput,
+          helpText: isPolicyPerOutputAllowed ? undefined : (
+            <FormattedMessage
+              id="xpack.fleet.agentPolicyForm.outputOptionDisabledPolicyPerOutput"
+              defaultMessage="The current license does not allow defining output per policy."
+            />
+          )
         };
       }),
     ];

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_advanced_fields/hooks.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_advanced_fields/hooks.tsx
@@ -135,17 +135,19 @@ export function useOutputOptions(agentPolicy: Partial<NewAgentPolicy | AgentPoli
       getDefaultOutput(defaultOutputName),
       ...outputsRequest.data.items.map((item) => {
         const isInternalOutput = !!item.is_internal;
+        const hasMinimumLicense = licenseService.hasAtLeast(LICENCE_FOR_PER_POLICY_OUTPUT);
 
         return {
           value: item.id,
-          inputDisplay: item.name,
-          disabled: !isPolicyPerOutputAllowed || isInternalOutput,
-          helpText: isPolicyPerOutputAllowed ? undefined : (
-            <FormattedMessage
-              id="xpack.fleet.agentPolicyForm.outputOptionDisabledPolicyPerOutput"
-              defaultMessage="The current license does not allow defining output per policy."
-            />
-          )
+          inputDisplay: getOutputLabel(
+            item.name,
+            !hasMinimumLicense ? <FormattedMessage
+                                   id="xpack.fleet.agentPolicyForm.outputOptionDisabledPolicyPerOutput"
+                                   defaultMessage="The current license does not allow defining output per policy."
+                                 />
+            : undefined
+          ),
+          disabled: !hasMinimumLicense || isInternalOutput,
         };
       }),
     ];


### PR DESCRIPTION
If the current license does not allow setting output the field is disabled. Before this patch no explanation as to why the field was disabled was shown, which was the cause of a bit of frustration.

This PR is completely untested and serves mostly as a suggestion for how it could be implemented.

See https://github.com/elastic/kibana/issues/148839.

## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
