### PR TITLE
[Fleet] Fix skipped test with concurrent install error

### DIFF
--- a/x-pack/test/fleet_api_integration/apis/package_policy/update.ts
+++ b/x-pack/test/fleet_api_integration/apis/package_policy/update.ts
@@ -28,8 +28,7 @@ export default function (providerContext: FtrProviderContext) {
   // because `this` has to point to the Mocha context
   // see https://mochajs.org/#arrow-functions
 
-  // Failing: See https://github.com/elastic/kibana/issues/148806
-  describe.skip('Package Policy - update', async function () {
+  describe('Package Policy - update', async function () {
     skipIfNoDockerRegistry(providerContext);
     let agentPolicyId: string;
     let managedAgentPolicyId: string;

--- a/x-pack/test/fleet_api_integration/apis/package_policy/update.ts
+++ b/x-pack/test/fleet_api_integration/apis/package_policy/update.ts
@@ -105,99 +105,96 @@ export default function (providerContext: FtrProviderContext) {
         package: { name: 'input_package', title: 'Input only package', version: '1.0.0' },
       };
 
-      const [
-        { body: packagePolicyResponse },
-        { body: packagePolicyResponse2 },
-        { body: packagePolicyResponse3 },
-        { body: endpointPackagePolicyResponse },
-        { body: inputOnlyPolicyResponse },
-      ] = await Promise.all([
-        supertest
-          .post(`/api/fleet/package_policies`)
-          .set('kbn-xsrf', 'xxxx')
-          .send({
-            name: 'filetest-1',
-            description: '',
-            namespace: 'default',
-            policy_id: agentPolicyId,
-            enabled: true,
-            inputs: [],
-            package: {
-              name: 'filetest',
-              title: 'For File Tests',
-              version: '0.1.0',
-            },
-          }),
-        supertest
-          .post(`/api/fleet/package_policies`)
-          .set('kbn-xsrf', 'xxxx')
-          .send({
-            name: 'filetest-2',
-            description: '',
-            namespace: 'default',
-            policy_id: agentPolicyId,
-            enabled: true,
-            inputs: [],
-            package: {
-              name: 'filetest',
-              title: 'For File Tests',
-              version: '0.1.0',
-            },
-          }),
-        supertest
-          .post(`/api/fleet/package_policies`)
-          .set('kbn-xsrf', 'xxxx')
-          .send({
-            name: 'update-package-policy-with_required_variables-1',
-            description: '',
-            namespace: 'default',
-            policy_id: agentPolicyId,
-            inputs: {
-              'with_required_variables-test_input': {
-                streams: {
-                  'with_required_variables.log': {
-                    vars: { test_var_required: 'I am required' },
-                  },
+      const { body: packagePolicyResponse } = await supertest
+        .post(`/api/fleet/package_policies`)
+        .set('kbn-xsrf', 'xxxx')
+        .send({
+          name: 'filetest-1',
+          description: '',
+          namespace: 'default',
+          policy_id: agentPolicyId,
+          enabled: true,
+          inputs: [],
+          package: {
+            name: 'filetest',
+            title: 'For File Tests',
+            version: '0.1.0',
+          },
+        });
+      packagePolicyId = packagePolicyResponse.item.id;
+
+      const { body: packagePolicyResponse2 } = await supertest
+        .post(`/api/fleet/package_policies`)
+        .set('kbn-xsrf', 'xxxx')
+        .send({
+          name: 'filetest-2',
+          description: '',
+          namespace: 'default',
+          policy_id: agentPolicyId,
+          enabled: true,
+          inputs: [],
+          package: {
+            name: 'filetest',
+            title: 'For File Tests',
+            version: '0.1.0',
+          },
+        });
+      packagePolicyId2 = packagePolicyResponse2.item.id;
+
+      const { body: packagePolicyResponse3 } = await supertest
+        .post(`/api/fleet/package_policies`)
+        .set('kbn-xsrf', 'xxxx')
+        .send({
+          name: 'update-package-policy-with_required_variables-1',
+          description: '',
+          namespace: 'default',
+          policy_id: agentPolicyId,
+          inputs: {
+            'with_required_variables-test_input': {
+              streams: {
+                'with_required_variables.log': {
+                  vars: { test_var_required: 'I am required' },
                 },
               },
             },
-            package: {
-              name: 'with_required_variables',
-              version: '0.1.0',
-            },
-          }),
-        supertest
-          .post(`/api/fleet/package_policies`)
-          .set('kbn-xsrf', 'xxxx')
-          .send({
-            name: 'endpoint-1',
-            description: '',
-            namespace: 'default',
-            policy_id: agentPolicyId,
-            enabled: true,
-            inputs: [
-              {
-                enabled: true,
-                streams: [],
-                type: 'endpoint',
-              },
-            ],
-            force: true,
-            package: {
-              name: 'endpoint',
-              title: 'Elastic Defend',
-              version: '8.6.1',
-            },
-          }),
-        supertest
-          .post(`/api/fleet/package_policies`)
-          .set('kbn-xsrf', 'xxxx')
-          .send(inputOnlyBasePackagePolicy),
-      ]);
-      packagePolicyId = packagePolicyResponse.item.id;
-      packagePolicyId2 = packagePolicyResponse2.item.id;
+          },
+          package: {
+            name: 'with_required_variables',
+            version: '0.1.0',
+          },
+        });
       packagePolicyId3 = packagePolicyResponse3.item.id;
+
+      const { body: endpointPackagePolicyResponse } = await supertest
+        .post(`/api/fleet/package_policies`)
+        .set('kbn-xsrf', 'xxxx')
+        .send({
+          name: 'endpoint-1',
+          description: '',
+          namespace: 'default',
+          policy_id: agentPolicyId,
+          enabled: true,
+          inputs: [
+            {
+              enabled: true,
+              streams: [],
+              type: 'endpoint',
+            },
+          ],
+          force: true,
+          package: {
+            name: 'endpoint',
+            title: 'Elastic Defend',
+            version: '8.6.1',
+          },
+        });
       endpointPackagePolicyId = endpointPackagePolicyResponse.item.id;
+
+      const { body: inputOnlyPolicyResponse } = await supertest
+        .post(`/api/fleet/package_policies`)
+        .set('kbn-xsrf', 'xxxx')
+        .send(inputOnlyBasePackagePolicy);
+
       inputOnlyPackagePolicyId = inputOnlyPolicyResponse.item.id;
     });
 


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/148806

In a previous attempt to speed up the tests I added the setup to a Promise.all, however this caused concurrent install errors to happen: 

```
[00:18:54]         proc [kibana] [2023-01-12T13:39:27.821+00:00][WARN ][plugins.fleet] Failure to install package [filetest]: [ConcurrentInstallOperationError: Concurrent installation or upgrade of filetest-0.1.0 detected, aborting.]
[00:18:54]         proc [kibana] [2023-01-12T13:39:27.822+00:00][ERROR][plugins.fleet] Error installing filetest 0.1.0: Concurrent installation or upgrade of filetest-0.1.0 detected, aborting.
```

I have moved back to sequential setup.
