### PR TITLE
[Cloud Posture] refactor default input type selection

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/components/fleet_extensions/csp_boxed_radio_group.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/fleet_extensions/csp_boxed_radio_group.tsx
@@ -65,7 +65,10 @@ export const RadioGroup = ({ idSelected, size, options, disabled, onChange }: Pr
               // Use empty string to fallback to no color
               // @ts-ignore
               color={isChecked ? 'primary' : ''}
-              onClick={() => onChange(option.id)}
+              onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+                e.preventDefault();
+                onChange(option.id);
+              }}
               iconType={option.icon}
               iconSide="right"
               contentProps={{

--- a/x-pack/plugins/cloud_security_posture/public/components/fleet_extensions/utils.ts
+++ b/x-pack/plugins/cloud_security_posture/public/components/fleet_extensions/utils.ts
@@ -41,6 +41,9 @@ export const isPostureInput = (
   SUPPORTED_POLICY_TEMPLATES.includes(input.policy_template as PosturePolicyTemplate) &&
   SUPPORTED_CLOUDBEAT_INPUTS.includes(input.type as PostureInput);
 
+export const isPosturePolicyTemplate = (name: string): name is PosturePolicyTemplate =>
+  SUPPORTED_POLICY_TEMPLATES.includes(name as PosturePolicyTemplate);
+
 const getInputPolicyTemplate = (inputs: NewPackagePolicyInput[], inputType: PostureInput) =>
   inputs.filter(isPostureInput).find((i) => i.type === inputType)!.policy_template;
 
@@ -93,11 +96,15 @@ export const getPolicyTemplateInputOptions = (policyTemplate: PosturePolicyTempl
     disabled: o.disabled,
   }));
 
-export const getEnabledPostureInput = (policy: NewPackagePolicy) => {
-  // Take first enabled input
-  const input = policy.inputs.find((i) => i.enabled);
+export const getEnabledPostureInput = (
+  policy: NewPackagePolicy,
+  defaultInputType: PostureInput
+) => {
+  // Prefer enabled input, fallback to default input type
+  let input = policy.inputs.find((i) => i.enabled);
+  if (!input) input = policy.inputs.find((i) => i.type === defaultInputType);
 
-  assert(input, 'Missing enabled input'); // We can't provide a default input without knowing the policy template
+  assert(input, 'Missing enabled input');
   assert(isPostureInput(input), 'Invalid enabled input');
 
   return input;


### PR DESCRIPTION
## Summary

the `cloud_security_posture` package requires a single enabled policy input. 
currently, all policy template inputs are enabled by default by fleet, and in https://github.com/elastic/kibana/pull/147751 we included a `useEffect` to select a default input type. 

this PR suggests a new solution:
1. change all inputs to be disabled by default in integration 
2. select a default integration in kibana based on the policy template (mapping kept in kibana)

another option would be to enable a single input type directly for each policy template in our integration.




