### PR TITLE
[8.0] Removes perlGuide from doc link service

### DIFF
--- a/src/core/public/doc_links/doc_links_service.ts
+++ b/src/core/public/doc_links/doc_links_service.ts
@@ -581,7 +581,6 @@ export class DocLinksService {
           javaIndex: `${ELASTIC_WEBSITE_URL}guide/en/elasticsearch/client/java-api-client/${DOC_LINK_VERSION}/index.html`,
           jsIntro: `${ELASTIC_WEBSITE_URL}guide/en/elasticsearch/client/javascript-api/${DOC_LINK_VERSION}/introduction.html`,
           netGuide: `${ELASTIC_WEBSITE_URL}guide/en/elasticsearch/client/net-api/${DOC_LINK_VERSION}/index.html`,
-          perlGuide: `${ELASTIC_WEBSITE_URL}guide/en/elasticsearch/client/perl-api/${DOC_LINK_VERSION}/index.html`,
           phpGuide: `${ELASTIC_WEBSITE_URL}guide/en/elasticsearch/client/php-api/${DOC_LINK_VERSION}/index.html`,
           pythonGuide: `${ELASTIC_WEBSITE_URL}guide/en/elasticsearch/client/python-api/${DOC_LINK_VERSION}/index.html`,
           rubyOverview: `${ELASTIC_WEBSITE_URL}guide/en/elasticsearch/client/ruby-api/${DOC_LINK_VERSION}/ruby_client.html`,
@@ -925,7 +924,6 @@ export interface DocLinksStart {
       readonly javaIndex: string;
       readonly jsIntro: string;
       readonly netGuide: string;
-      readonly perlGuide: string;
       readonly phpGuide: string;
       readonly pythonGuide: string;
       readonly rubyOverview: string;

--- a/src/plugins/custom_integrations/server/language_clients/index.ts
+++ b/src/plugins/custom_integrations/server/language_clients/index.ts
@@ -79,17 +79,6 @@ export const integrations: LanguageIntegration[] = [
     docUrlTemplate: `${ELASTICSEARCH_CLIENT_URL}/php-api/{branch}/index.html`,
   },
   {
-    id: 'perl',
-    title: i18n.translate('customIntegrations.languageclients.PerlTitle', {
-      defaultMessage: 'Elasticsearch Perl Client',
-    }),
-    icon: 'perl.svg',
-    description: i18n.translate('customIntegrations.languageclients.PerlDescription', {
-      defaultMessage: 'Index data to Elasticsearch with the Perl client.',
-    }),
-    docUrlTemplate: `${ELASTICSEARCH_CLIENT_URL}/perl-api/{branch}/index.html`,
-  },
-  {
     id: 'python',
     title: i18n.translate('customIntegrations.languageclients.PythonTitle', {
       defaultMessage: 'Elasticsearch Python Client',


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.0`:
 - [Removes perlGuide from doc link service (#148803)](https://github.com/elastic/kibana/pull/148803)