### PR TITLE
[performance] Disable telemetry for journey by default 

### DIFF
--- a/.buildkite/pipelines/performance/daily.yml
+++ b/.buildkite/pipelines/performance/daily.yml
@@ -15,6 +15,8 @@ steps:
 
   - label: '💪 Performance Tests with Playwright config'
     command: .buildkite/scripts/steps/functional/performance_playwright.sh
+    env:
+      PERFORMANCE_ENABLE_TELEMETRY: true
     agents:
       queue: kb-static-ubuntu
     depends_on: build

--- a/.buildkite/pipelines/performance/data_set_extraction_daily.yml
+++ b/.buildkite/pipelines/performance/data_set_extraction_daily.yml
@@ -16,8 +16,6 @@ steps:
 
   - label: ':kibana: Performance Tests with Playwright config'
     command: .buildkite/scripts/steps/functional/performance_playwright.sh
-    env:
-      PERFORMANCE_DISABLE_TELEMETRY: true
     agents:
       queue: n2-2-spot
     depends_on: build

--- a/.buildkite/pipelines/performance/data_set_extraction_daily.yml
+++ b/.buildkite/pipelines/performance/data_set_extraction_daily.yml
@@ -16,6 +16,8 @@ steps:
 
   - label: ':kibana: Performance Tests with Playwright config'
     command: .buildkite/scripts/steps/functional/performance_playwright.sh
+    env:
+      PERFORMANCE_DISABLE_TELEMETRY: true
     agents:
       queue: n2-2-spot
     depends_on: build

--- a/packages/kbn-journeys/journey/journey_ftr_config.ts
+++ b/packages/kbn-journeys/journey/journey_ftr_config.ts
@@ -46,8 +46,8 @@ export function makeFtrConfigProvider(
       throw new Error('invalid GITHUB_PR_NUMBER environment variable');
     }
 
-    // There is no need to collect performance events for perf data set extraction pipeline
-    const disableTelemetry = !!process.env.PERFORMANCE_DISABLE_TELEMETRY;
+    // Set variable to collect performance events using EBT
+    const enableTelemetry = !!process.env.PERFORMANCE_ENABLE_TELEMETRY;
 
     const telemetryLabels: Record<string, string | boolean | undefined | number> = {
       branch: process.env.BUILDKITE_BRANCH,
@@ -89,7 +89,7 @@ export function makeFtrConfigProvider(
 
         serverArgs: [
           ...baseConfig.kbnTestServer.serverArgs,
-          `--telemetry.optIn=${!disableTelemetry && process.env.TEST_PERFORMANCE_PHASE === 'TEST'}`,
+          `--telemetry.optIn=${enableTelemetry && process.env.TEST_PERFORMANCE_PHASE === 'TEST'}`,
           `--telemetry.labels=${JSON.stringify(telemetryLabels)}`,
           '--csp.strict=false',
           '--csp.warnLegacyBrowsers=false',

--- a/packages/kbn-journeys/journey/journey_ftr_config.ts
+++ b/packages/kbn-journeys/journey/journey_ftr_config.ts
@@ -46,6 +46,9 @@ export function makeFtrConfigProvider(
       throw new Error('invalid GITHUB_PR_NUMBER environment variable');
     }
 
+    // There is no need to collect performance events for perf data set extraction pipeline
+    const disableTelemetry = !!process.env.PERFORMANCE_DISABLE_TELEMETRY;
+
     const telemetryLabels: Record<string, string | boolean | undefined | number> = {
       branch: process.env.BUILDKITE_BRANCH,
       ciBuildId: process.env.BUILDKITE_BUILD_ID,
@@ -86,7 +89,7 @@ export function makeFtrConfigProvider(
 
         serverArgs: [
           ...baseConfig.kbnTestServer.serverArgs,
-          `--telemetry.optIn=${process.env.TEST_PERFORMANCE_PHASE === 'TEST'}`,
+          `--telemetry.optIn=${!disableTelemetry && process.env.TEST_PERFORMANCE_PHASE === 'TEST'}`,
           `--telemetry.labels=${JSON.stringify(telemetryLabels)}`,
           '--csp.strict=false',
           '--csp.warnLegacyBrowsers=false',


### PR DESCRIPTION
## Summary

I noticed some noise in [Performance dashboard](https://telemetry-v2-staging.elastic.dev/s/kibana-performance/app/dashboards#/view/dd0473ac-826f-5621-9a10-25319700326e?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-24h%2Fh,to:now))) and think it is better to disable Telemetry for journeys by default.

We use it to report performance events and this PR enables it in the performance pipeline via env variable `PERFORMANCE_ENABLE_TELEMETRY`.
For other pipelines (PRs, [performance-data-set-extraction](https://buildkite.com/elastic/kibana-performance-data-set-extraction)) running on regular workers or local troubleshooting there is no much value to collect inconsistent values.