### PR TITLE
[Synthetics] Fix screenshot loading

### DIFF
--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/common/screenshot/journey_step_screenshot_container.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/common/screenshot/journey_step_screenshot_container.tsx
@@ -39,7 +39,9 @@ export const JourneyStepScreenshotContainer = ({
 
   const { basePath } = useContext(SyntheticsSettingsContext);
 
-  const imgPath = `${basePath}/internal/uptime/journey/screenshot/${checkGroup}/${initialStepNumber}`;
+  const imgPath = checkGroup
+    ? `${basePath}/internal/uptime/journey/screenshot/${checkGroup}/${initialStepNumber}`
+    : '';
 
   const intersection = useIntersection(intersectionRef, {
     root: null,

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/hooks/use_journey_steps.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/hooks/use_journey_steps.tsx
@@ -29,7 +29,9 @@ export const useJourneySteps = (checkGroup?: string, lastRefresh?: number) => {
   const dispatch = useDispatch();
 
   useEffect(() => {
-    dispatch(fetchJourneyAction.get({ checkGroup: checkGroupId }));
+    if (checkGroupId) {
+      dispatch(fetchJourneyAction.get({ checkGroup: checkGroupId }));
+    }
   }, [checkGroupId, dispatch, lastRefresh]);
 
   const isFailed =
@@ -43,7 +45,7 @@ export const useJourneySteps = (checkGroup?: string, lastRefresh?: number) => {
   const stepLabels = stepEnds.map((stepEnd) => stepEnd?.synthetics?.step?.name ?? '');
 
   const currentStep = stepIndex
-    ? journeyData?.steps.find((step) => step.synthetics?.step?.index === Number(stepIndex))
+    ? stepEnds.find((step) => step.synthetics?.step?.index === Number(stepIndex))
     : undefined;
 
   return {

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/browser_journey/effects.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/browser_journey/effects.ts
@@ -113,7 +113,7 @@ export function* fetchJourneyStepsEffect() {
           yield put(fetchJourneyAction.success(response));
         }
       } catch (e) {
-				inProgressRequests.delete(action.payload.checkGroup);
+        inProgressRequests.delete(action.payload.checkGroup);
         yield put(fetchJourneyAction.fail(serializeHttpFetchError(e, action.payload)));
       }
     }

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/browser_journey/effects.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/browser_journey/effects.ts
@@ -6,8 +6,14 @@
  */
 
 import { Action } from 'redux-actions';
-import { all, call, fork, put, select, takeEvery, takeLeading, throttle } from 'redux-saga/effects';
-import { ScreenshotBlockDoc, ScreenshotBlockCache } from '../../../../../common/runtime_types';
+import { all, call, fork, put, select, takeEvery, throttle } from 'redux-saga/effects';
+import { serializeHttpFetchError } from '../utils/http_error';
+import { FetchNetworkEventsParams } from '../network_events/actions';
+import {
+  ScreenshotBlockDoc,
+  ScreenshotBlockCache,
+  SyntheticsJourneyApiResponse,
+} from '../../../../../common/runtime_types';
 import { fetchBrowserJourney, fetchScreenshotBlockSet } from './api';
 
 import {
@@ -23,7 +29,6 @@ import {
 import { isPendingBlock } from './models';
 
 import { selectBrowserJourneyState } from './selectors';
-import { fetchEffectFactory } from '../utils/fetch_effect';
 
 export function* browserJourneyEffects() {
   yield all([fork(fetchScreenshotBlocks), fork(generateBlockStatsOnPut), fork(pruneBlockCache)]);
@@ -89,8 +94,27 @@ function* pruneBlockCache() {
 }
 
 export function* fetchJourneyStepsEffect() {
-  yield takeLeading(
-    fetchJourneyAction.get,
-    fetchEffectFactory(fetchBrowserJourney, fetchJourneyAction.success, fetchJourneyAction.fail)
+  const inProgressRequests = new Set<string>();
+
+  yield takeEvery(
+    String(fetchJourneyAction.get),
+    function* (action: Action<FetchNetworkEventsParams>): Generator {
+      try {
+        if (!inProgressRequests.has(action.payload.checkGroup)) {
+          inProgressRequests.add(action.payload.checkGroup);
+
+          const response = (yield call(
+            fetchBrowserJourney,
+            action.payload
+          )) as SyntheticsJourneyApiResponse;
+
+          inProgressRequests.delete(action.payload.checkGroup);
+
+          yield put(fetchJourneyAction.success(response));
+        }
+      } catch (e) {
+        yield put(fetchJourneyAction.fail(serializeHttpFetchError(e, action.payload)));
+      }
+    }
   );
 }

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/browser_journey/effects.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/browser_journey/effects.ts
@@ -113,6 +113,7 @@ export function* fetchJourneyStepsEffect() {
           yield put(fetchJourneyAction.success(response));
         }
       } catch (e) {
+				inProgressRequests.delete(action.payload.checkGroup);
         yield put(fetchJourneyAction.fail(serializeHttpFetchError(e, action.payload)));
       }
     }


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/148847

When on the page, it needed to load multiple browser jouney redux-saga takeLeading was only loading the first. 

Tweaked the implementation a bit to make sure multiple check group journeys can be loaded on the page . 