### PR TITLE
[Unified search] do not show discard changes modal on cancel

### DIFF
--- a/src/plugins/unified_search/public/filter_bar/filter_item/filter_item.tsx
+++ b/src/plugins/unified_search/public/filter_bar/filter_item/filter_item.tsx
@@ -389,7 +389,7 @@ function FilterItemComponent(props: FilterItemProps) {
                 onSubmit={onSubmit}
                 onLocalFilterUpdate={onLocalFilterUpdate}
                 onLocalFilterCreate={onLocalFilterCreate}
-                onCancel={closePopover}
+                onCancel={() => setIsPopoverOpen(false)}
                 timeRangeForSuggestionsOverride={props.timeRangeForSuggestionsOverride}
               />
             </div>,

--- a/src/plugins/unified_search/public/query_string_input/add_filter_popover.tsx
+++ b/src/plugins/unified_search/public/query_string_input/add_filter_popover.tsx
@@ -102,7 +102,9 @@ const AddFilterPopoverComponent = React.memo(function AddFilterPopover({
           closePopoverOnAdd={() => {
             setShowAddFilterPopover(false);
           }}
-          closePopoverOnCancel={closePopover}
+          closePopoverOnCancel={() => {
+            setShowAddFilterPopover(false);
+          }}
         />
       </EuiPopover>
     </EuiFlexItem>

--- a/src/plugins/unified_search/public/query_string_input/query_bar_menu.tsx
+++ b/src/plugins/unified_search/public/query_string_input/query_bar_menu.tsx
@@ -190,7 +190,7 @@ function QueryBarMenuComponent({
                 onLocalFilterUpdate={onLocalFilterUpdate}
                 onLocalFilterCreate={onLocalFilterCreate}
                 closePopoverOnAdd={plainClosePopover}
-                closePopoverOnCancel={closePopover}
+                closePopoverOnCancel={plainClosePopover}
               />,
             ]}
           />


### PR DESCRIPTION
## Summary

After playing a bit with https://github.com/elastic/kibana/pull/147777 we decided to show the Discard changes modal only when the user clicks outside the modal and not when the user clicks the cancel button.

<img width="505" alt="image" src="https://user-images.githubusercontent.com/17003240/212666954-362052ac-3aae-45e6-80b5-7f89890ce939.png">
