### PR TITLE
fix(NA): @kbn/cli-dev-mode nonPackageMatcher patterns

### DIFF
--- a/packages/kbn-cli-dev-mode/src/watcher.ts
+++ b/packages/kbn-cli-dev-mode/src/watcher.ts
@@ -24,8 +24,8 @@ const nonPackageMatcher = makeMatcher([
   'src/**',
   '!src/{dev,fixtures}/**',
   'x-pack/plugins/**',
-  '!x-pack/plugins/screenshotting/chromium',
-  '!x-pack/plugins/canvas/canvas_plugin_src',
+  '!x-pack/plugins/screenshotting/chromium/**',
+  '!x-pack/plugins/canvas/canvas_plugin_src/**',
 ]);
 
 export interface Options {

--- a/packages/kbn-cli-dev-mode/src/watcher.ts
+++ b/packages/kbn-cli-dev-mode/src/watcher.ts
@@ -24,8 +24,8 @@ const nonPackageMatcher = makeMatcher([
   'src/**',
   '!src/{dev,fixtures}/**',
   'x-pack/plugins/**',
-  '!x-pack/plugins/screenshotting/chromium/**',
-  '!x-pack/plugins/canvas/canvas_plugin_src/**',
+  '!x-pack/plugins/screenshotting/chromium/**/*',
+  '!x-pack/plugins/canvas/shareable_runtime/**/*',
 ]);
 
 export interface Options {

--- a/packages/kbn-cli-dev-mode/src/watcher.ts
+++ b/packages/kbn-cli-dev-mode/src/watcher.ts
@@ -24,8 +24,8 @@ const nonPackageMatcher = makeMatcher([
   'src/**',
   '!src/{dev,fixtures}/**',
   'x-pack/plugins/**',
-  '!x-pack/plugins/screenshotting/chromium/**/*',
-  '!x-pack/plugins/canvas/shareable_runtime/**/*',
+  '!x-pack/plugins/screenshotting/chromium/**',
+  '!x-pack/plugins/canvas/shareable_runtime/**',
 ]);
 
 export interface Options {

--- a/packages/kbn-repo-source-classifier/src/repo_source_classifier.ts
+++ b/packages/kbn-repo-source-classifier/src/repo_source_classifier.ts
@@ -125,6 +125,17 @@ export class RepoSourceClassifier {
   }
 
   /**
+   * Apply screenshotting specific rules
+   * @param root the root dir within the screenshotting plugin
+   * @returns a type, or undefined if the file should be classified as a standard file
+   */
+  private classifyScreenshotting(root: string): ModuleType | undefined {
+    if (root === 'chromium') {
+      return 'non-package';
+    }
+  }
+
+  /**
    * Determine the "type" of a file
    */
   private getType(path: RepoPath): ModuleType {
@@ -190,6 +201,13 @@ export class RepoSourceClassifier {
 
     if (pkgId === '@kbn/canvas-plugin') {
       const type = this.classifyCanvas(root, dirs);
+      if (type) {
+        return type;
+      }
+    }
+
+    if (pkgId === '@kbn/screenshotting-plugin') {
+      const type = this.classifyScreenshotting(root);
       if (type) {
         return type;
       }


### PR DESCRIPTION
This PR fixes the pattern matchers for `nonPackageMatcher` into our new watcher logic as well as correctly classifies all the files found inside the `screenshotting plugin`