### PR TITLE
[Security Solution] Display job friendly name on detection pages

### DIFF
--- a/x-pack/plugins/security_solution/cypress/objects/rule.ts
+++ b/x-pack/plugins/security_solution/cypress/objects/rule.ts
@@ -387,8 +387,8 @@ export const getNewTermsRule = (): NewTermsRule => ({
 
 export const getMachineLearningRule = (): MachineLearningRule => ({
   machineLearningJobs: [
-    'v3_linux_anomalous_network_activity',
-    'v3_linux_anomalous_process_all_hosts',
+    'Unusual Linux Network Activity',
+    'Anomalous Process for a Linux Population',
   ],
   anomalyScoreThreshold: 20,
   name: 'New ML Rule Test',

--- a/x-pack/plugins/security_solution/cypress/screens/create_new_rule.ts
+++ b/x-pack/plugins/security_solution/cypress/screens/create_new_rule.ts
@@ -111,6 +111,8 @@ export const LOOK_BACK_TIME_TYPE =
 export const MACHINE_LEARNING_DROPDOWN_INPUT =
   '[data-test-subj="mlJobSelect"] [data-test-subj="comboBoxInput"]';
 
+export const MACHINE_LEARNING_DROPDOWN_OPTION = '[data-test-subj="comboBoxOptionsList "] button';
+
 export const MACHINE_LEARNING_TYPE = '[data-test-subj="machineLearningRuleType"]';
 
 export const MITRE_TACTIC = '.euiContextMenuItem__text';

--- a/x-pack/plugins/security_solution/cypress/screens/rule_details.ts
+++ b/x-pack/plugins/security_solution/cypress/screens/rule_details.ts
@@ -59,7 +59,7 @@ export const INVESTIGATION_NOTES_MARKDOWN = 'test markdown';
 
 export const INVESTIGATION_NOTES_TOGGLE = '[data-test-subj="stepAboutDetailsToggle-notes"]';
 
-export const MACHINE_LEARNING_JOB_ID = '[data-test-subj="machineLearningJobId"]';
+export const MACHINE_LEARNING_JOB_ID = '[data-test-subj="machineLearningJob"]';
 
 export const MACHINE_LEARNING_JOB_STATUS = '[data-test-subj="machineLearningJobStatus"]';
 

--- a/x-pack/plugins/security_solution/cypress/tasks/create_new_rule.ts
+++ b/x-pack/plugins/security_solution/cypress/tasks/create_new_rule.ts
@@ -617,11 +617,14 @@ export const fillDefineIndicatorMatchRuleAndContinue = (rule: ThreatIndicatorRul
 };
 
 export const fillDefineMachineLearningRuleAndContinue = (rule: MachineLearningRule) => {
-  rule.machineLearningJobs.forEach((machineLearningJob) => {
-    cy.get(MACHINE_LEARNING_DROPDOWN_INPUT).click({ force: true });
-    cy.get(MACHINE_LEARNING_DROPDOWN_INPUT).type(`${machineLearningJob}{enter}`);
-    cy.get(MACHINE_LEARNING_DROPDOWN_INPUT).type('{esc}');
-  });
+  const text = rule.machineLearningJobs
+    .map((machineLearningJob) => `${machineLearningJob}{downArrow}{enter}`)
+    .join('');
+  cy.get(MACHINE_LEARNING_DROPDOWN_INPUT).click({ force: true });
+  cy.get(MACHINE_LEARNING_DROPDOWN_INPUT).type(text);
+
+  cy.get(MACHINE_LEARNING_DROPDOWN_INPUT).type('{esc}');
+
   cy.get(ANOMALY_THRESHOLD_INPUT).type(
     `{selectall}${getMachineLearningRule().anomalyScoreThreshold}`,
     {

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/ml_rule_warning_popover.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/ml_rule_warning_popover.tsx
@@ -76,7 +76,7 @@ const MlRuleWarningPopoverComponent: React.FC<MlRuleWarningPopoverComponentProps
       </div>
       <EuiSpacer size="s" />
       {notRunningJobs.map((job) => (
-        <EuiText>{job.id}</EuiText>
+        <EuiText>{job.customSettings?.security_app_display_name ?? job.id}</EuiText>
       ))}
       <EuiPopoverFooter>
         <SecuritySolutionLinkButton

--- a/x-pack/plugins/security_solution/public/detections/components/rules/ml_job_link/ml_job_link.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/ml_job_link/ml_job_link.test.tsx
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import { MlJobLink } from './ml_job_link';
+import { TestProviders } from '../../../../common/mock';
+
+jest.mock('../../../../common/lib/kibana', () => {
+  const originalModule = jest.requireActual('../../../../common/lib/kibana');
+  return {
+    ...originalModule,
+    useKibana: jest.fn().mockReturnValue({
+      services: { theme: { theme$: {} }, http: { basePath: { get: jest.fn(() => {}) } } },
+    }),
+  };
+});
+
+describe('MlJobLink', () => {
+  it('renders job name when available', () => {
+    const jobName = 'test_job_name';
+    const { getByTestId } = render(<MlJobLink jobId={'test_job_id'} jobName={jobName} />, {
+      wrapper: TestProviders,
+    });
+
+    expect(getByTestId('machineLearningJobLink')).toHaveTextContent(jobName);
+  });
+
+  it('renders job id when job name is unavailable', () => {
+    const jobId = 'test_job_id';
+    const { getByTestId } = render(<MlJobLink jobId={jobId} jobName={undefined} />, {
+      wrapper: TestProviders,
+    });
+
+    expect(getByTestId('machineLearningJobLink')).toHaveTextContent(jobId);
+  });
+});

--- a/x-pack/plugins/security_solution/public/detections/components/rules/ml_job_link/ml_job_link.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/ml_job_link/ml_job_link.tsx
@@ -18,9 +18,10 @@ const StyledJobEuiLInk = styled(EuiLink)`
 
 interface MlJobLinkProps {
   jobId: string;
+  jobName: string | undefined;
 }
 
-const MlJobLinkComponent: React.FC<MlJobLinkProps> = ({ jobId }) => {
+const MlJobLinkComponent: React.FC<MlJobLinkProps> = ({ jobId, jobName }) => {
   const {
     services: { http, ml },
   } = useKibana();
@@ -33,7 +34,7 @@ const MlJobLinkComponent: React.FC<MlJobLinkProps> = ({ jobId }) => {
 
   return (
     <StyledJobEuiLInk data-test-subj="machineLearningJobLink" href={jobUrl} target="_blank">
-      <span data-test-subj="machineLearningJobId">{jobId}</span>
+      <span data-test-subj="machineLearningJobId">{jobName ?? jobId}</span>
     </StyledJobEuiLInk>
   );
 };

--- a/x-pack/plugins/security_solution/public/detections/components/rules/ml_job_link/ml_job_link.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/ml_job_link/ml_job_link.tsx
@@ -34,7 +34,7 @@ const MlJobLinkComponent: React.FC<MlJobLinkProps> = ({ jobId, jobName }) => {
 
   return (
     <StyledJobEuiLInk data-test-subj="machineLearningJobLink" href={jobUrl} target="_blank">
-      <span data-test-subj="machineLearningJobId">{jobName ?? jobId}</span>
+      <span data-test-subj="machineLearningJob">{jobName ?? jobId}</span>
     </StyledJobEuiLInk>
   );
 };

--- a/x-pack/plugins/security_solution/public/detections/components/rules/ml_job_select/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/ml_job_select/index.tsx
@@ -31,6 +31,7 @@ import * as i18n from './translations';
 interface MlJobValue {
   id: string;
   description: string;
+  name?: string;
 }
 
 const JobDisplayContainer = styled.div`
@@ -50,9 +51,9 @@ const MlJobEuiButton = styled(EuiButton)`
   margin-top: 20px;
 `;
 
-const JobDisplay: React.FC<{ description: string; label: string }> = ({ description, label }) => (
+const JobDisplay: React.FC<MlJobValue> = ({ description, name, id }) => (
   <JobDisplayContainer>
-    <strong>{label}</strong>
+    <strong>{name ?? id}</strong>
     <EuiToolTip content={description}>
       <EuiText size="xs" color="subdued">
         <p>{description}</p>
@@ -67,8 +68,13 @@ interface MlJobSelectProps {
 }
 
 const renderJobOption = (option: MlJobOption) => (
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  <JobDisplay description={option.value!.description} label={option.label} />
+  <JobDisplay
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    id={option.value!.id}
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    description={option.value!.description}
+    name={option.value?.name}
+  />
 );
 
 export const MlJobSelect: React.FC<MlJobSelectProps> = ({ describedByIds = [], field }) => {
@@ -90,11 +96,17 @@ export const MlJobSelect: React.FC<MlJobSelectProps> = ({ describedByIds = [], f
     value: {
       id: job.id,
       description: job.description,
+      name: job.customSettings?.security_app_display_name,
     },
-    label: job.customSettings?.security_app_display_name ?? job.id,
+    // Make sure users can search for id or name.
+    // The label contains the name and id because EuiComboBox uses it for the textual search.
+    label: `${job.customSettings?.security_app_display_name} ${job.id}`,
   }));
 
-  const selectedJobOptions = jobOptions.filter((option) => jobIds.includes(option.value.id));
+  const selectedJobOptions = jobOptions
+    .filter((option) => jobIds.includes(option.value.id))
+    // 'label' defines what is rendered inside the selected ComboBoxPill
+    .map((options) => ({ ...options, label: options.value.name ?? options.value.id }));
 
   const notRunningJobIds = useMemo<string[]>(() => {
     const selectedJobs = jobs.filter(({ id }) => jobIds.includes(id));

--- a/x-pack/plugins/security_solution/public/detections/components/rules/ml_job_select/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/ml_job_select/index.tsx
@@ -50,9 +50,9 @@ const MlJobEuiButton = styled(EuiButton)`
   margin-top: 20px;
 `;
 
-const JobDisplay: React.FC<MlJobValue> = ({ id, description }) => (
+const JobDisplay: React.FC<{ description: string; label: string }> = ({ description, label }) => (
   <JobDisplayContainer>
-    <strong>{id}</strong>
+    <strong>{label}</strong>
     <EuiToolTip content={description}>
       <EuiText size="xs" color="subdued">
         <p>{description}</p>
@@ -68,7 +68,7 @@ interface MlJobSelectProps {
 
 const renderJobOption = (option: MlJobOption) => (
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  <JobDisplay id={option.value!.id} description={option.value!.description} />
+  <JobDisplay description={option.value!.description} label={option.label} />
 );
 
 export const MlJobSelect: React.FC<MlJobSelectProps> = ({ describedByIds = [], field }) => {
@@ -91,7 +91,7 @@ export const MlJobSelect: React.FC<MlJobSelectProps> = ({ describedByIds = [], f
       id: job.id,
       description: job.description,
     },
-    label: job.id,
+    label: job.customSettings?.security_app_display_name ?? job.id,
   }));
 
   const selectedJobOptions = jobOptions.filter((option) => jobIds.includes(option.value.id));

--- a/x-pack/plugins/security_solution/public/detections/components/rules/ml_jobs_description/ml_job_item.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/ml_jobs_description/ml_job_item.tsx
@@ -32,7 +32,7 @@ const MlJobItemComponent: FC<{
   return (
     <Wrapper {...props}>
       <div>
-        <MlJobLink jobId={job.id} />
+        <MlJobLink jobId={job.id} jobName={job.customSettings?.security_app_display_name} />
         <MlAuditIcon message={job.auditMessage} />
       </div>
       <EuiFlexGroup justifyContent="flexStart">

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/executors/ml.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/executors/ml.ts
@@ -80,6 +80,7 @@ export const mlExecutor = async ({
         ...jobSummaries.map((job) =>
           [
             `job id: "${job.id}"`,
+            `job name: "${job?.customSettings?.security_app_display_name ?? job.id}"`,
             `job status: "${job.jobState}"`,
             `datafeed status: "${job.datafeedState}"`,
           ].join(', ')


### PR DESCRIPTION
issue: https://github.com/elastic/kibana/issues/148973
Similar to: https://github.com/elastic/kibana/issues/146772

## Summary

When friendly names are available as job meta information, we should display it on:
*  Manage Rules table - Job warning message
* New rule page - Machine Learning job selector
* Rule details page - Machine Learning job description and warning message

<img width="600" alt="Screenshot 2023-01-16 at 14 34 50" src="https://user-images.githubusercontent.com/1490444/212692378-9fcb59b5-179c-4054-b2b8-9972b9f35bab.png">
<img width="600" alt="Screenshot 2023-01-16 at 14 33 14" src="https://user-images.githubusercontent.com/1490444/212692408-bc978eea-a4c6-4a43-bb67-3098969da7e2.png">
<img width="600" alt="Screenshot 2023-01-16 at 13 39 51" src="https://user-images.githubusercontent.com/1490444/212692445-8bacb22d-5160-45f7-aa56-ec5f296d3fb4.png">


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
