### PR TITLE
[Synthetics] Monitor Management - Monitor Stats section

### DIFF
--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/configurations/synthetics/kpi_over_time_config.ts
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/configurations/synthetics/kpi_over_time_config.ts
@@ -120,6 +120,18 @@ export function getSyntheticsKPIConfig({ dataView }: ConfigProps): SeriesConfig 
         ],
       },
       {
+        label: 'Total runs',
+        id: 'monitor.check_group',
+        field: 'monitor.check_group',
+        columnType: OPERATION_COLUMN,
+        columnFilters: [
+          {
+            language: 'kuery',
+            query: `summary: *`,
+          },
+        ],
+      },
+      {
         field: SUMMARY_UP,
         id: SUMMARY_UP,
         label: UP_LABEL,

--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/configurations/synthetics/single_metric_config.ts
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/configurations/synthetics/single_metric_config.ts
@@ -103,7 +103,7 @@ export function getSyntheticsSingleMetricConfig({ dataView }: ConfigProps): Seri
           titlePosition: 'bottom',
         },
         columnType: FORMULA_COLUMN,
-        formula: 'unique_count(monitor.check_group)',
+        formula: "unique_count(monitor.check_group, kql='summary: *')",
         format: 'number',
       },
       {

--- a/x-pack/plugins/synthetics/common/runtime_types/monitor_management/synthetics_overview_status.ts
+++ b/x-pack/plugins/synthetics/common/runtime_types/monitor_management/synthetics_overview_status.ts
@@ -18,6 +18,8 @@ export const OverviewStatusMetaDataCodec = t.interface({
 });
 
 export const OverviewStatusCodec = t.interface({
+  allMonitorsCount: t.number,
+  disabledMonitorsCount: t.number,
   up: t.number,
   down: t.number,
   disabledCount: t.number,

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/hooks/use_overview_status.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/hooks/use_overview_status.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useSyntheticsRefreshContext } from '../../../contexts/synthetics_refresh_context';
 import {
@@ -22,18 +22,22 @@ export function useOverviewStatus({ pageState }: { pageState: MonitorOverviewPag
   const lastRefreshRef = useRef(lastRefresh);
 
   const dispatch = useDispatch();
+  const reload = useCallback(() => {
+    dispatch(fetchOverviewStatusAction.get(pageState));
+  }, [dispatch, pageState]);
 
   useEffect(() => {
     if (lastRefresh !== lastRefreshRef.current) {
       dispatch(quietFetchOverviewStatusAction.get(pageState));
       lastRefreshRef.current = lastRefresh;
     } else {
-      dispatch(fetchOverviewStatusAction.get(pageState));
+      reload();
     }
-  }, [dispatch, lastRefresh, pageState]);
+  }, [dispatch, reload, lastRefresh, pageState]);
 
   return {
     status,
     statusError,
+    reload,
   };
 }

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/management/labels.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/management/labels.ts
@@ -87,6 +87,10 @@ export const DISABLED_LABEL = i18n.translate('xpack.synthetics.monitorManagement
   defaultMessage: 'Disabled',
 });
 
+export const TEST_RUNS_LABEL = i18n.translate('xpack.synthetics.monitorManagement.testRuns.label', {
+  defaultMessage: 'Test runs',
+});
+
 export function getLastXDaysLabel(count: number) {
   return i18n.translate('xpack.synthetics.monitorManagement.lastXDays', {
     defaultMessage: 'Last {count, number} {count, plural, one {day} other {days}}',

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/management/labels.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/management/labels.ts
@@ -71,3 +71,27 @@ export const BETA_TOOLTIP_MESSAGE = i18n.translate(
       'This functionality is in beta and is subject to change. The design and code is less mature than official generally available features and is being provided as-is with no warranties. Beta features are not subject to the support service level agreement of official generally available features.',
   }
 );
+
+export const SUMMARY_LABEL = i18n.translate('xpack.synthetics.monitorManagement.summary.heading', {
+  defaultMessage: 'Summary',
+});
+
+export const CONFIGURATIONS_LABEL = i18n.translate(
+  'xpack.synthetics.monitorManagement.configurations.label',
+  {
+    defaultMessage: 'Configurations',
+  }
+);
+
+export const DISABLED_LABEL = i18n.translate('xpack.synthetics.monitorManagement.disabled.label', {
+  defaultMessage: 'Disabled',
+});
+
+export function getLastXDaysLabel(count: number) {
+  return i18n.translate('xpack.synthetics.monitorManagement.lastXDays', {
+    defaultMessage: 'Last {count, number} {count, plural, one {day} other {days}}',
+    values: {
+      count,
+    },
+  });
+}

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/management/monitor_list_container.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/management/monitor_list_container.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useMemo } from 'react';
+import React, { useMemo, useEffect } from 'react';
 import { EuiSpacer } from '@elastic/eui';
 
 import type { useMonitorList } from '../hooks/use_monitor_list';
@@ -13,6 +13,7 @@ import { MonitorAsyncError } from './monitor_errors/monitor_async_error';
 import { useOverviewStatus } from '../hooks/use_overview_status';
 import { ListFilters } from './list_filters/list_filters';
 import { MonitorList } from './monitor_list_table/monitor_list';
+import { MonitorStats } from './monitor_stats/monitor_stats';
 
 export const MonitorListContainer = ({
   isEnabled,
@@ -46,7 +47,11 @@ export const MonitorListContainer = ({
     };
   }, [pageState]);
 
-  const { status } = useOverviewStatus(overviewStatusArgs);
+  const { status, reload: reloadStatus } = useOverviewStatus(overviewStatusArgs);
+
+  useEffect(() => {
+    reloadStatus();
+  }, [reloadStatus, syntheticsMonitors]);
 
   if (!isEnabled && absoluteTotal === 0) {
     return null;
@@ -56,6 +61,8 @@ export const MonitorListContainer = ({
     <>
       <MonitorAsyncError />
       <ListFilters />
+      <EuiSpacer />
+      <MonitorStats status={status} />
       <EuiSpacer />
       <MonitorList
         syntheticsMonitors={syntheticsMonitors}

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/management/monitor_stats/monitor_stats.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/management/monitor_stats/monitor_stats.tsx
@@ -19,6 +19,7 @@ import {
 import { euiStyled } from '@kbn/kibana-react-plugin/common';
 
 import { OverviewStatusState } from '../../../../../../../common/runtime_types';
+import { useSyntheticsRefreshContext } from '../../../../contexts/synthetics_refresh_context';
 
 import * as labels from '../labels';
 import { MonitorTestRunsCount } from './monitor_test_runs';
@@ -26,6 +27,8 @@ import { MonitorTestRunsSparkline } from './monitor_test_runs_sparkline';
 
 export const MonitorStats = ({ status }: { status: OverviewStatusState | null }) => {
   const { euiTheme } = useEuiTheme();
+  const { lastRefresh } = useSyntheticsRefreshContext();
+  const to = new Date(lastRefresh).toISOString();
 
   return (
     <>
@@ -63,9 +66,9 @@ export const MonitorStats = ({ status }: { status: OverviewStatusState | null })
           <EuiFlexItem
             css={{ display: 'flex', flexDirection: 'row', gap: euiTheme.size.l, height: '200px' }}
           >
-            <MonitorTestRunsCount />
+            <MonitorTestRunsCount to={to} />
             <EuiFlexItem grow={true}>
-              <MonitorTestRunsSparkline />
+              <MonitorTestRunsSparkline to={to} />
             </EuiFlexItem>
           </EuiFlexItem>
         </EuiPanel>

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/management/monitor_stats/monitor_stats.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/management/monitor_stats/monitor_stats.tsx
@@ -1,0 +1,110 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import {
+  EuiFlexGroup,
+  EuiPanel,
+  EuiStat,
+  EuiI18nNumber,
+  useEuiTheme,
+  EuiText,
+  EuiFlexItem,
+  EuiLoadingContent,
+} from '@elastic/eui';
+import { euiStyled } from '@kbn/kibana-react-plugin/common';
+
+import { OverviewStatusState } from '../../../../../../../common/runtime_types';
+
+import * as labels from '../labels';
+import { MonitorTestRunsCount } from './monitor_test_runs';
+import { MonitorTestRunsSparkline } from './monitor_test_runs_sparkline';
+
+export const MonitorStats = ({ status }: { status: OverviewStatusState | null }) => {
+  const { euiTheme } = useEuiTheme();
+
+  return (
+    <>
+      <EuiFlexGroup gutterSize="l">
+        <EuiPanel
+          css={{ display: 'flex', flexDirection: 'column', gap: euiTheme.size.l, flexGrow: 0 }}
+          hasBorder={true}
+          hasShadow={false}
+        >
+          <EuiText>
+            <h5>{labels.SUMMARY_LABEL}</h5>
+          </EuiText>
+
+          <EuiFlexItem css={{ display: 'flex', flexDirection: 'row', gap: euiTheme.size.l }}>
+            <MonitorStat
+              description={labels.CONFIGURATIONS_LABEL}
+              value={status?.allMonitorsCount}
+            />
+            <MonitorStat
+              description={labels.DISABLED_LABEL}
+              value={status?.disabledMonitorsCount}
+            />
+          </EuiFlexItem>
+        </EuiPanel>
+
+        <EuiPanel
+          css={{ display: 'flex', flexDirection: 'column', gap: euiTheme.size.l }}
+          hasBorder={true}
+          hasShadow={false}
+        >
+          <EuiText>
+            <h5>{labels.getLastXDaysLabel(30)}</h5>
+          </EuiText>
+
+          <EuiFlexItem
+            css={{ display: 'flex', flexDirection: 'row', gap: euiTheme.size.l, height: '200px' }}
+          >
+            <MonitorTestRunsCount />
+            <EuiFlexItem grow={true}>
+              <MonitorTestRunsSparkline />
+            </EuiFlexItem>
+          </EuiFlexItem>
+        </EuiPanel>
+      </EuiFlexGroup>
+    </>
+  );
+};
+
+const EuiStatStyled = euiStyled(EuiStat)`
+  &&& {
+  color: ${({ theme }) => theme.eui.euiTitleColor};
+    .euiStat__title {
+        color: ${({ theme }) => theme.eui.euiTitleColor};
+        font-size: ${({ theme }) => theme.eui.euiFontSizeXL};
+    }
+  }
+`;
+
+const MonitorStat = ({
+  description,
+  value,
+}: {
+  description: string | undefined;
+  value: number | undefined;
+}) => {
+  const { euiTheme } = useEuiTheme();
+  const statValue = (value as number) ?? undefined;
+
+  return (
+    <EuiStatStyled
+      description={description}
+      title={
+        !isNaN(statValue) ? (
+          <EuiI18nNumber css={{ fontSize: euiTheme.size.m }} value={statValue} />
+        ) : (
+          <EuiLoadingContent lines={2} />
+        )
+      }
+      reverse={true}
+    />
+  );
+};

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/management/monitor_stats/monitor_test_runs.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/management/monitor_stats/monitor_test_runs.tsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { useKibana } from '@kbn/kibana-react-plugin/public';
+import { useTheme } from '@kbn/observability-plugin/public';
+import { ReportTypes } from '@kbn/observability-plugin/public';
+import { euiStyled } from '@kbn/kibana-react-plugin/common';
+
+import { ClientPluginsStart } from '../../../../../../plugin';
+
+interface MonitorCompleteCountProps {
+  from?: string;
+  to?: string;
+}
+
+export const MonitorTestRunsCount = ({
+  from = 'now-30d',
+  to = 'now',
+}: MonitorCompleteCountProps) => {
+  const { observability } = useKibana<ClientPluginsStart>().services;
+  const theme = useTheme();
+
+  const { ExploratoryViewEmbeddable } = observability;
+
+  return (
+    <StyledWrapper metricColor={theme.eui.euiColorVis1}>
+      <ExploratoryViewEmbeddable
+        align="left"
+        reportType={ReportTypes.SINGLE_METRIC}
+        attributes={[
+          {
+            time: { from, to },
+            reportDefinitions: {
+              'monitor.id': [],
+              'observer.geo.name': [],
+            },
+            dataType: 'synthetics',
+            selectedMetricField: 'monitor_total_runs',
+            name: 'synthetics-series-1',
+          },
+        ]}
+      />
+    </StyledWrapper>
+  );
+};
+
+const StyledWrapper = euiStyled.div<{ metricColor: string }>`
+&&& {
+  .legacyMtrVis__container {
+    .legacyMtrVis__value {
+     color: ${({ metricColor }) => metricColor};
+    }
+  }
+}
+`;

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/management/monitor_stats/monitor_test_runs.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/management/monitor_stats/monitor_test_runs.tsx
@@ -10,9 +10,9 @@ import React from 'react';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { useTheme } from '@kbn/observability-plugin/public';
 import { ReportTypes } from '@kbn/observability-plugin/public';
-import { euiStyled } from '@kbn/kibana-react-plugin/common';
 
 import { ClientPluginsStart } from '../../../../../../plugin';
+import * as labels from '../labels';
 
 interface MonitorCompleteCountProps {
   from?: string;
@@ -29,33 +29,22 @@ export const MonitorTestRunsCount = ({
   const { ExploratoryViewEmbeddable } = observability;
 
   return (
-    <StyledWrapper metricColor={theme.eui.euiColorVis1}>
-      <ExploratoryViewEmbeddable
-        align="left"
-        reportType={ReportTypes.SINGLE_METRIC}
-        attributes={[
-          {
-            time: { from, to },
-            reportDefinitions: {
-              'monitor.id': [],
-              'observer.geo.name': [],
-            },
-            dataType: 'synthetics',
-            selectedMetricField: 'monitor_total_runs',
-            name: 'synthetics-series-1',
+    <ExploratoryViewEmbeddable
+      align="left"
+      reportType={ReportTypes.SINGLE_METRIC}
+      attributes={[
+        {
+          time: { from, to },
+          reportDefinitions: {
+            'monitor.id': [],
+            'observer.geo.name': [],
           },
-        ]}
-      />
-    </StyledWrapper>
+          dataType: 'synthetics',
+          selectedMetricField: 'monitor_total_runs',
+          name: labels.TEST_RUNS_LABEL,
+          color: theme.eui.euiColorVis1,
+        },
+      ]}
+    />
   );
 };
-
-const StyledWrapper = euiStyled.div<{ metricColor: string }>`
-&&& {
-  .legacyMtrVis__container {
-    .legacyMtrVis__value {
-     color: ${({ metricColor }) => metricColor};
-    }
-  }
-}
-`;

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/management/monitor_stats/monitor_test_runs_sparkline.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/management/monitor_stats/monitor_test_runs_sparkline.tsx
@@ -39,7 +39,7 @@ export const MonitorTestRunsSparkline = ({ from = 'now-30d', to = 'now' }: Props
             'observer.geo.name': [],
           },
           dataType: 'synthetics',
-          selectedMetricField: 'state.id',
+          selectedMetricField: 'monitor.check_group',
           name: labels.TEST_RUNS_LABEL,
           color: theme.eui.euiColorVis1,
           operationType: 'unique_count',

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/management/monitor_stats/monitor_test_runs_sparkline.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/management/monitor_stats/monitor_test_runs_sparkline.tsx
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { useKibana } from '@kbn/kibana-react-plugin/public';
+import { useTheme } from '@kbn/observability-plugin/public';
+
+import { ClientPluginsStart } from '../../../../../../plugin';
+
+interface Props {
+  from?: string;
+  to?: string;
+}
+export const MonitorTestRunsSparkline = ({ from = 'now-30d', to = 'now' }: Props) => {
+  const { observability } = useKibana<ClientPluginsStart>().services;
+
+  const { ExploratoryViewEmbeddable } = observability;
+
+  const theme = useTheme();
+
+  return (
+    <ExploratoryViewEmbeddable
+      reportType="kpi-over-time"
+      axisTitlesVisibility={{ x: false, yRight: false, yLeft: false }}
+      legendIsVisible={false}
+      hideTicks={true}
+      attributes={[
+        {
+          seriesType: 'area',
+          time: { from, to },
+          reportDefinitions: {
+            'monitor.id': [],
+            'observer.geo.name': [],
+          },
+          dataType: 'synthetics',
+          selectedMetricField: 'state.id',
+          name: 'Monitor complete',
+          color: theme.eui.euiColorVis1,
+          operationType: 'unique_count',
+        },
+      ]}
+      customHeight={'68px'}
+    />
+  );
+};

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/management/monitor_stats/monitor_test_runs_sparkline.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/management/monitor_stats/monitor_test_runs_sparkline.tsx
@@ -11,6 +11,7 @@ import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { useTheme } from '@kbn/observability-plugin/public';
 
 import { ClientPluginsStart } from '../../../../../../plugin';
+import * as labels from '../labels';
 
 interface Props {
   from?: string;
@@ -39,7 +40,7 @@ export const MonitorTestRunsSparkline = ({ from = 'now-30d', to = 'now' }: Props
           },
           dataType: 'synthetics',
           selectedMetricField: 'state.id',
-          name: 'Monitor complete',
+          name: labels.TEST_RUNS_LABEL,
           color: theme.eui.euiColorVis1,
           operationType: 'unique_count',
         },

--- a/x-pack/plugins/synthetics/server/alert_rules/status_rule/status_rule_executor.ts
+++ b/x-pack/plugins/synthetics/server/alert_rules/status_rule/status_rule_executor.ts
@@ -129,7 +129,7 @@ export class StatusRuleExecutor {
   async getDownChecks(
     prevDownConfigs: OverviewStatus['downConfigs'] = {}
   ): Promise<AlertOverviewStatus> {
-    const { listOfLocations, enabledIds } = await this.getMonitors();
+    const { listOfLocations, allIds, enabledIds } = await this.getMonitors();
 
     if (enabledIds.length > 0) {
       const currentStatus = await queryMonitorStatus(
@@ -153,7 +153,12 @@ export class StatusRuleExecutor {
 
       const staleDownConfigs = this.markDeletedConfigs(downConfigs);
 
-      return { ...currentStatus, staleDownConfigs };
+      return {
+        ...currentStatus,
+        staleDownConfigs,
+        allMonitorsCount: allIds.length,
+        disabledMonitorsCount: allIds.length - enabledIds.length,
+      };
     }
     const staleDownConfigs = this.markDeletedConfigs(prevDownConfigs);
     return {
@@ -163,6 +168,8 @@ export class StatusRuleExecutor {
       down: 0,
       up: 0,
       enabledIds,
+      allMonitorsCount: allIds.length,
+      disabledMonitorsCount: allIds.length,
     };
   }
 

--- a/x-pack/plugins/synthetics/server/queries/query_monitor_status.ts
+++ b/x-pack/plugins/synthetics/server/queries/query_monitor_status.ts
@@ -18,7 +18,7 @@ export async function queryMonitorStatus(
   range: { from: string | number; to: string },
   ids: string[],
   monitorLocationsMap?: Record<string, string[]>
-): Promise<Omit<OverviewStatus, 'disabledCount'>> {
+): Promise<Omit<OverviewStatus, 'disabledCount' | 'allMonitorsCount' | 'disabledMonitorsCount'>> {
   const idSize = Math.trunc(DEFAULT_MAX_ES_BUCKET_SIZE / listOfLocations.length || 1);
   const pageCount = Math.ceil(ids.length / idSize);
   const promises: Array<Promise<any>> = [];

--- a/x-pack/plugins/synthetics/server/routes/status/current_status.ts
+++ b/x-pack/plugins/synthetics/server/routes/status/current_status.ts
@@ -48,6 +48,7 @@ export async function getStatus(
   const { query } = params;
   const enabledIds: string[] = [];
   let disabledCount = 0;
+  let disabledMonitorsCount = 0;
   let maxPeriod = 0;
   let listOfLocationsSet = new Set<string>();
   const monitorLocationMap: Record<string, string[]> = {};
@@ -89,6 +90,7 @@ export async function getStatus(
     const attrs = monitor.attributes;
     if (attrs[ConfigKey.ENABLED] === false) {
       disabledCount += attrs[ConfigKey.LOCATIONS].length;
+      disabledMonitorsCount += 1;
     } else {
       const missingLabels = new Set<string>();
 
@@ -127,6 +129,8 @@ export async function getStatus(
   );
 
   return {
+    allMonitorsCount: allMonitors.length,
+    disabledMonitorsCount,
     enabledIds,
     disabledCount,
     up,


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/148986

## Summary

Adds the monitor stats section on Synthetics -> Monitors -> Management page.

<img width="1263" alt="Screenshot 2023-01-16 at 15 07 39" src="https://user-images.githubusercontent.com/2748376/212745033-693d45f5-3825-4a4c-a757-1c61e0e85e14.png">

<img width="1262" alt="Screenshot 2023-01-16 at 18 36 33" src="https://user-images.githubusercontent.com/2748376/212745044-5a5951e1-cb25-479b-b6f4-c4584e3e2bbd.png">

