### PR TITLE
[APM] Tech preview feature on General settings

### DIFF
--- a/x-pack/plugins/apm/public/components/app/settings/general_settings/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/settings/general_settings/index.tsx
@@ -11,7 +11,6 @@ import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import {
   apmLabsButton,
-  apmProgressiveLoading,
   apmServiceGroupMaxNumberOfServices,
   defaultApmServiceEnvironment,
   enableComparisonByDefault,
@@ -28,7 +27,6 @@ import { BottomBarActions } from '../bottom_bar_actions';
 const apmSettingsKeys = [
   enableComparisonByDefault,
   defaultApmServiceEnvironment,
-  apmProgressiveLoading,
   apmServiceGroupMaxNumberOfServices,
   enableInspectEsQueries,
   apmLabsButton,


### PR DESCRIPTION
Removes tech preview item `Use progressive loading of selected APM views` from the APM settings page since it should be available under Labs.

<img width="1521" alt="Screen Shot 2023-01-16 at 4 22 43 PM" src="https://user-images.githubusercontent.com/55978943/212767738-527a5ab7-e16c-4909-880a-764a7d5d0113.png">
<img width="909" alt="Screen Shot 2023-01-16 at 4 22 49 PM" src="https://user-images.githubusercontent.com/55978943/212767740-de419204-3e9a-42a9-9163-5233f0583836.png">
