### PR TITLE
[GaugeToLens] Always display the major label

### DIFF
--- a/src/plugins/vis_types/gauge/public/convert_to_lens/configurations/gauge.test.ts
+++ b/src/plugins/vis_types/gauge/public/convert_to_lens/configurations/gauge.test.ts
@@ -68,7 +68,7 @@ describe('getConfiguration', () => {
       })
     ).toEqual({
       colorMode: 'palette',
-      labelMajorMode: 'none',
+      labelMajorMode: 'auto',
       labelMinor: undefined,
       layerId: 'layer-id',
       layerType: 'data',

--- a/src/plugins/vis_types/gauge/public/convert_to_lens/configurations/gauge.ts
+++ b/src/plugins/vis_types/gauge/public/convert_to_lens/configurations/gauge.ts
@@ -34,7 +34,7 @@ export const getConfiguration = (
     maxAccessor,
     shape: 'horizontalBullet',
     ticksPosition: 'bands',
-    labelMajorMode: showLabels ? 'auto' : 'none',
+    labelMajorMode: 'auto',
     colorMode: palette ? 'palette' : 'none',
     labelMinor: showLabels ? params.gauge.style.subText : undefined,
   };


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/148992
The logic before was to check the status of the showLabels switch and display or not the major label. But in Visualize the label always appear (bottom of the page) so I changed the logic to auto for the major Label and only the subtitle to follow the show labels switch status

![bug](https://user-images.githubusercontent.com/17003240/212848900-1a19252d-76ea-4325-b1bd-32e3685d085f.gif)


### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios