### PR TITLE
[Lens] Displays mosaic and waffle on suggestions

### DIFF
--- a/x-pack/plugins/lens/public/visualizations/partition/suggestions.test.ts
+++ b/x-pack/plugins/lens/public/visualizations/partition/suggestions.test.ts
@@ -992,7 +992,7 @@ describe('suggestions', () => {
       expect(suggs[0].state.layers[0].allowMultipleMetrics).toBeFalsy();
     });
 
-    it('mosaic type should be hidden from the suggestion list', () => {
+    it('mosaic type not should be hidden from the suggestion list', () => {
       expect(
         suggestions({
           table: {
@@ -1106,7 +1106,7 @@ describe('suggestions', () => {
       ).toHaveLength(0);
     });
 
-    it('waffle type should be hidden from the suggestion list', () => {
+    it('waffle type should not be hidden from the suggestion list', () => {
       expect(
         suggestions({
           table: {
@@ -1150,7 +1150,7 @@ describe('suggestions', () => {
           Object {
             "hide": false,
             "previewIcon": "bullseye",
-            "score": 0.56,
+            "score": 0.46,
             "state": Object {
               "layers": Array [
                 Object {

--- a/x-pack/plugins/lens/public/visualizations/partition/suggestions.test.ts
+++ b/x-pack/plugins/lens/public/visualizations/partition/suggestions.test.ts
@@ -992,7 +992,7 @@ describe('suggestions', () => {
       expect(suggs[0].state.layers[0].allowMultipleMetrics).toBeFalsy();
     });
 
-    it('mosaic type should not be hidden from the suggestion list', () => {
+    it('mosaic type should be shown in the suggestion list', () => {
       expect(
         suggestions({
           table: {

--- a/x-pack/plugins/lens/public/visualizations/partition/suggestions.test.ts
+++ b/x-pack/plugins/lens/public/visualizations/partition/suggestions.test.ts
@@ -992,7 +992,7 @@ describe('suggestions', () => {
       expect(suggs[0].state.layers[0].allowMultipleMetrics).toBeFalsy();
     });
 
-    it('mosaic type not should be hidden from the suggestion list', () => {
+    it('mosaic type should not be hidden from the suggestion list', () => {
       expect(
         suggestions({
           table: {

--- a/x-pack/plugins/lens/public/visualizations/partition/suggestions.test.ts
+++ b/x-pack/plugins/lens/public/visualizations/partition/suggestions.test.ts
@@ -1106,7 +1106,7 @@ describe('suggestions', () => {
       ).toHaveLength(0);
     });
 
-    it('waffle type should not be hidden from the suggestion list', () => {
+    it('waffle type should be shown in the suggestion list', () => {
       expect(
         suggestions({
           table: {

--- a/x-pack/plugins/lens/public/visualizations/partition/suggestions.test.ts
+++ b/x-pack/plugins/lens/public/visualizations/partition/suggestions.test.ts
@@ -1012,6 +1012,7 @@ describe('suggestions', () => {
                 operation: { label: 'Count', dataType: 'number' as DataType, isBucketed: false },
               },
             ],
+
             changeType: 'unchanged',
           },
           state: {
@@ -1035,7 +1036,43 @@ describe('suggestions', () => {
           },
           keptLayerIds: ['first'],
         }).filter(({ hide, state }) => !hide && state.shape === 'mosaic')
-      ).toMatchInlineSnapshot(`Array []`);
+      ).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "hide": false,
+            "previewIcon": "bullseye",
+            "score": 0.61,
+            "state": Object {
+              "layers": Array [
+                Object {
+                  "allowMultipleMetrics": false,
+                  "categoryDisplay": "default",
+                  "layerId": "first",
+                  "layerType": "data",
+                  "legendDisplay": "show",
+                  "legendMaxLines": 1,
+                  "metrics": Array [
+                    "c",
+                  ],
+                  "nestedLegend": true,
+                  "numberDisplay": "hidden",
+                  "percentDecimals": 0,
+                  "primaryGroups": Array [
+                    "a",
+                  ],
+                  "secondaryGroups": Array [
+                    "b",
+                  ],
+                  "truncateLegend": true,
+                },
+              ],
+              "palette": undefined,
+              "shape": "mosaic",
+            },
+            "title": "As Mosaic",
+          },
+        ]
+      `);
     });
   });
 
@@ -1085,6 +1122,7 @@ describe('suggestions', () => {
                 operation: { label: 'Count', dataType: 'number' as DataType, isBucketed: false },
               },
             ],
+
             changeType: 'unchanged',
           },
           state: {
@@ -1107,7 +1145,40 @@ describe('suggestions', () => {
           },
           keptLayerIds: ['first'],
         }).filter(({ hide, state }) => !hide && state.shape === 'waffle')
-      ).toMatchInlineSnapshot(`Array []`);
+      ).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "hide": false,
+            "previewIcon": "bullseye",
+            "score": 0.56,
+            "state": Object {
+              "layers": Array [
+                Object {
+                  "categoryDisplay": "default",
+                  "layerId": "first",
+                  "layerType": "data",
+                  "legendDisplay": "show",
+                  "legendMaxLines": 1,
+                  "metrics": Array [
+                    "b",
+                  ],
+                  "nestedLegend": true,
+                  "numberDisplay": "hidden",
+                  "percentDecimals": 0,
+                  "primaryGroups": Array [
+                    "a",
+                  ],
+                  "secondaryGroups": Array [],
+                  "truncateLegend": true,
+                },
+              ],
+              "palette": undefined,
+              "shape": "waffle",
+            },
+            "title": "As Waffle",
+          },
+        ]
+      `);
     });
   });
 });

--- a/x-pack/plugins/lens/public/visualizations/partition/suggestions.ts
+++ b/x-pack/plugins/lens/public/visualizations/partition/suggestions.ts
@@ -267,7 +267,11 @@ export function suggestions({
         ],
       },
       previewIcon: 'bullseye',
-      hide: true,
+      hide:
+        groups.length !== 2 ||
+        table.changeType === 'reduced' ||
+        hasIntervalScale(groups) ||
+        (state && state.shape === 'mosaic'),
     });
   }
 
@@ -307,7 +311,11 @@ export function suggestions({
         ],
       },
       previewIcon: 'bullseye',
-      hide: true,
+      hide:
+        groups.length !== 1 ||
+        table.changeType === 'reduced' ||
+        hasIntervalScale(groups) ||
+        (state && state.shape === 'waffle'),
     });
   }
 

--- a/x-pack/plugins/lens/public/visualizations/partition/suggestions.ts
+++ b/x-pack/plugins/lens/public/visualizations/partition/suggestions.ts
@@ -283,7 +283,7 @@ export function suggestions({
       title: i18n.translate('xpack.lens.pie.waffleSuggestionLabel', {
         defaultMessage: 'As Waffle',
       }),
-      score: state?.shape === PieChartTypes.WAFFLE ? 0.7 : 0.5,
+      score: state?.shape === PieChartTypes.WAFFLE ? 0.7 : 0.4,
       state: {
         shape: PieChartTypes.WAFFLE,
         palette: mainPalette || state?.palette,


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/120505
Now that both mosaic and waffle are on GA, we should show them to the the suggestions. Reverted the changes of the PR mentioned on the issue.

<img width="2063" alt="image" src="https://user-images.githubusercontent.com/17003240/213116496-5a0804ac-510a-4706-9a93-93fd557e2974.png">


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios