### PR TITLE
[Cases] Change delete actions color to `danger`

### DIFF
--- a/x-pack/plugins/cases/public/components/case_action_bar/actions.tsx
+++ b/x-pack/plugins/cases/public/components/case_action_bar/actions.tsx
@@ -53,6 +53,7 @@ const ActionsComponent: React.FC<CaseViewActions> = ({ caseData, currentExternal
             {
               iconType: 'trash',
               label: i18n.DELETE_CASE(),
+              color: 'danger' as const,
               onClick: openModal,
             },
           ]

--- a/x-pack/plugins/cases/public/components/property_actions/index.tsx
+++ b/x-pack/plugins/cases/public/components/property_actions/index.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, { useCallback, useState } from 'react';
+import type { EuiButtonProps } from '@elastic/eui';
 import { EuiFlexGroup, EuiFlexItem, EuiPopover, EuiButtonIcon, EuiButtonEmpty } from '@elastic/eui';
 
 import * as i18n from './translations';
@@ -15,15 +16,16 @@ export interface PropertyActionButtonProps {
   onClick: () => void;
   iconType: string;
   label: string;
+  color?: EuiButtonProps['color'];
 }
 
 const ComponentId = 'property-actions';
 
 const PropertyActionButton = React.memo<PropertyActionButtonProps>(
-  ({ disabled = false, onClick, iconType, label }) => (
+  ({ disabled = false, onClick, iconType, label, color }) => (
     <EuiButtonEmpty
       aria-label={label}
-      color="text"
+      color={color ? color : 'text'}
       data-test-subj={`${ComponentId}-${iconType}`}
       iconSide="left"
       iconType={iconType}
@@ -86,6 +88,7 @@ export const PropertyActions = React.memo<PropertyActionsProps>(({ propertyActio
                 disabled={action.disabled}
                 iconType={action.iconType}
                 label={action.label}
+                color={action.color}
                 onClick={() => onClosePopover(action.onClick)}
               />
             </span>

--- a/x-pack/plugins/cases/public/components/user_actions/property_actions/alert_property_actions.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/property_actions/alert_property_actions.tsx
@@ -32,6 +32,7 @@ const AlertPropertyActionsComponent: React.FC<Props> = ({ isLoading, totalAlerts
         ? [
             {
               iconType: 'minusInCircle',
+              color: 'danger' as const,
               label: i18n.REMOVE_ALERTS(totalAlerts),
               onClick: onModalOpen,
             },

--- a/x-pack/plugins/cases/public/components/user_actions/property_actions/registered_attachments_property_actions.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/property_actions/registered_attachments_property_actions.tsx
@@ -34,6 +34,7 @@ const RegisteredAttachmentsPropertyActionsComponent: React.FC<Props> = ({
         ? [
             {
               iconType: 'trash',
+              color: 'danger' as const,
               label: i18n.DELETE_ATTACHMENT,
               onClick: onModalOpen,
             },

--- a/x-pack/plugins/cases/public/components/user_actions/property_actions/user_comment_property_actions.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/property_actions/user_comment_property_actions.tsx
@@ -54,21 +54,22 @@ const UserCommentPropertyActionsComponent: React.FC<Props> = ({
             },
           ]
         : []),
-      ...(showTrashIcon
-        ? [
-            {
-              iconType: 'trash',
-              label: i18n.DELETE_COMMENT,
-              onClick: onModalOpen,
-            },
-          ]
-        : []),
       ...(showQuoteIcon
         ? [
             {
               iconType: 'quote',
               label: i18n.QUOTE,
               onClick: onQuote,
+            },
+          ]
+        : []),
+      ...(showTrashIcon
+        ? [
+            {
+              iconType: 'trash',
+              color: 'danger' as const,
+              label: i18n.DELETE_COMMENT,
+              onClick: onModalOpen,
             },
           ]
         : []),


### PR DESCRIPTION
## Summary

This PR changes the color of all delete actions inside the case view page to `danger` (red).

<img width="193" alt="Screenshot 2023-01-17 at 11 33 22 AM" src="https://user-images.githubusercontent.com/7871006/212862297-a9ee7d1e-1282-45d2-947a-43684174b6d1.png">
<img width="247" alt="Screenshot 2023-01-17 at 11 31 38 AM" src="https://user-images.githubusercontent.com/7871006/212862299-e88388a7-fa84-46e8-a16d-7b00521369e3.png">
<img width="254" alt="Screenshot 2023-01-17 at 11 30 43 AM" src="https://user-images.githubusercontent.com/7871006/212862309-727ad382-8306-478f-a005-a4144fce048e.png">
<img width="210" alt="Screenshot 2023-01-17 at 11 27 56 AM" src="https://user-images.githubusercontent.com/7871006/212862311-41b826c6-702f-4524-a6e4-143ce60b7ac0.png">


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
