### PR TITLE
[APM] Unskipping agent configuration api test

### DIFF
--- a/x-pack/test/apm_api_integration/tests/settings/agent_configuration/agent_configuration.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/settings/agent_configuration/agent_configuration.spec.ts
@@ -383,8 +383,7 @@ export default function agentConfigurationTests({ getService }: FtrProviderConte
           expect(await waitFor(hasBeenAppliedByAgent)).to.be(true);
         });
       });
-    },
-    true
+    }
   );
 
   registry.when('Agent configurations through fleet', { config: 'basic', archives: [] }, () => {
@@ -530,12 +529,12 @@ async function expectStatusCode(
   try {
     response = await fn();
   } catch (e) {
-    if (e && e.response && e.response.status) {
-      if (e.response.status === statusCode) {
+    if (e && e.res && e.res.status) {
+      if (e.res.status === statusCode) {
         return;
       }
       throw new Error(
-        `Expected a [${statusCode}] response, got [${e.response.status}]: ${inspect(e.response)}`
+        `Expected a [${statusCode}] response, got [${e.res.status}]: ${inspect(e.res)}`
       );
     } else {
       throw new Error(


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/148204.

### Changes
- Extracting status from `error.res` instead of `error.response`. `error.response` was undefined.
