### PR TITLE
[Enterprise Search] Rename stuck jobs to idle jobs

### DIFF
--- a/x-pack/plugins/enterprise_search/common/stats.ts
+++ b/x-pack/plugins/enterprise_search/common/stats.ts
@@ -8,10 +8,10 @@
 export interface SyncJobsStats {
   connected: number;
   errors: number;
+  idle: number;
   in_progress: number;
   incomplete: number;
   orphaned_jobs: number;
-  stuck: number;
 }
 export interface CloudHealth {
   has_min_connector_memory: boolean;

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_indices/indices_stats.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_indices/indices_stats.tsx
@@ -26,6 +26,11 @@ export const IndicesStats: React.FC = () => {
     makeRequest({});
   }, []);
 
+  const UNKNOWN_STRING = i18n.translate(
+    'xpack.enterpriseSearch.content.searchIndices.jobStats.unknown',
+    { defaultMessage: 'Unknown' }
+  );
+
   return (
     <EuiFlexGroup direction="column">
       <EuiFlexItem>
@@ -44,7 +49,7 @@ export const IndicesStats: React.FC = () => {
                   }
                 )}
                 isLoading={isLoading}
-                title={data?.connected}
+                title={data?.connected ?? UNKNOWN_STRING}
               />
             </EuiPanel>
           </EuiFlexItem>
@@ -62,7 +67,7 @@ export const IndicesStats: React.FC = () => {
                   }
                 )}
                 isLoading={isLoading}
-                title={data?.incomplete}
+                title={data?.incomplete ?? UNKNOWN_STRING}
               />
             </EuiPanel>
           </EuiFlexItem>
@@ -80,21 +85,21 @@ export const IndicesStats: React.FC = () => {
                   }
                 )}
                 isLoading={isLoading}
-                title={data?.in_progress}
+                title={data?.in_progress ?? UNKNOWN_STRING}
               />
             </EuiPanel>
           </EuiFlexItem>
           <EuiFlexItem>
-            <EuiPanel color={data?.stuck ? 'warning' : 'subdued'} hasShadow={false} paddingSize="l">
+            <EuiPanel color={data?.idle ? 'warning' : 'subdued'} hasShadow={false} paddingSize="l">
               <EuiStat
                 description={i18n.translate(
                   'xpack.enterpriseSearch.content.searchIndices.jobStats.longRunningSyncs',
                   {
-                    defaultMessage: 'Stuck syncs',
+                    defaultMessage: 'Idle syncs',
                   }
                 )}
                 isLoading={isLoading}
-                title={data?.stuck}
+                title={data?.idle ?? UNKNOWN_STRING}
               />
             </EuiPanel>
           </EuiFlexItem>
@@ -112,7 +117,7 @@ export const IndicesStats: React.FC = () => {
                   }
                 )}
                 isLoading={isLoading}
-                title={data?.orphaned_jobs}
+                title={data?.orphaned_jobs ?? UNKNOWN_STRING}
               />
             </EuiPanel>
           </EuiFlexItem>
@@ -126,7 +131,7 @@ export const IndicesStats: React.FC = () => {
                   }
                 )}
                 isLoading={isLoading}
-                title={data?.errors}
+                title={data?.errors ?? UNKNOWN_STRING}
               />
             </EuiPanel>
           </EuiFlexItem>

--- a/x-pack/plugins/enterprise_search/server/lib/stats/get_sync_jobs.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/stats/get_sync_jobs.ts
@@ -45,7 +45,7 @@ export const fetchSyncJobsStats = async (client: IScopedClusterClient): Promise<
     },
   });
 
-  const stuckJobsCountResponse = await client.asCurrentUser.count({
+  const idleJobsCountResponse = await client.asCurrentUser.count({
     index: CONNECTORS_JOBS_INDEX,
     query: {
       bool: {
@@ -127,10 +127,10 @@ export const fetchSyncJobsStats = async (client: IScopedClusterClient): Promise<
   const response = {
     connected: connectedResponse.count,
     errors: errorResponse.count,
+    idle: idleJobsCountResponse.count,
     in_progress: inProgressJobsCountResponse.count,
     incomplete: incompleteResponse.count,
     orphaned_jobs: orphanedJobsCountResponse.count,
-    stuck: stuckJobsCountResponse.count,
   };
 
   return response;


### PR DESCRIPTION
## Summary

This replaces the 'Stuck syncs' nomenclature with 'Idle syncs'