### PR TITLE
[Lens] Improve request error in case of last value of a runtime field returning array values

### DIFF
--- a/x-pack/plugins/lens/public/datasources/form_based/mocks.ts
+++ b/x-pack/plugins/lens/public/datasources/form_based/mocks.ts
@@ -81,6 +81,16 @@ export const createMockedIndexPattern = (someProps?: Partial<IndexPattern>): Ind
       lang: 'painless' as const,
       script: '1234',
     },
+    {
+      name: 'runtime',
+      displayName: 'RuntimeField',
+      type: 'string',
+      searchable: true,
+      aggregatable: true,
+      runtime: true,
+      lang: 'painless' as const,
+      script: '1234',
+    },
   ];
   return {
     id: '1',

--- a/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/formula/editor/formula_editor.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/formula/editor/formula_editor.tsx
@@ -53,9 +53,10 @@ import { LANGUAGE_ID } from './math_tokenization';
 import './formula.scss';
 import { FormulaIndexPatternColumn } from '../formula';
 import { insertOrReplaceFormulaColumn } from '../parse';
-import { filterByVisibleOperation, nonNullable } from '../util';
+import { filterByVisibleOperation } from '../util';
 import { getColumnTimeShiftWarnings, getDateHistogramInterval } from '../../../../time_shift_utils';
 import { getDocumentationSections } from './formula_help';
+import { nonNullable } from '../../../../utils';
 
 function tableHasData(
   activeData: ParamEditorProps<FormulaIndexPatternColumn>['activeData'],

--- a/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/formula/editor/math_completion.ts
+++ b/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/formula/editor/math_completion.ts
@@ -26,7 +26,7 @@ import moment from 'moment';
 import { DateRange } from '../../../../../../../common/types';
 import type { IndexPattern } from '../../../../../../types';
 import { memoizedGetAvailableOperationsByMetadata } from '../../../operations';
-import { tinymathFunctions, groupArgsByType, unquotedStringRegex, nonNullable } from '../util';
+import { tinymathFunctions, groupArgsByType, unquotedStringRegex } from '../util';
 import type { GenericOperationDefinition } from '../..';
 import { getFunctionSignatureLabel, getHelpTextContent } from './formula_help';
 import { hasFunctionFieldArgument } from '../validation';
@@ -35,6 +35,7 @@ import {
   reducedTimeRangeOptionOrder,
   reducedTimeRangeOptions,
 } from '../../../../reduced_time_range_utils';
+import { nonNullable } from '../../../../utils';
 
 export enum SUGGESTION_TYPE {
   FIELD = 'field',

--- a/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/formula/formula.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/formula/formula.tsx
@@ -13,9 +13,10 @@ import { runASTValidation, tryToParse } from './validation';
 import { WrappedFormulaEditor } from './editor';
 import { insertOrReplaceFormulaColumn } from './parse';
 import { generateFormula } from './generate';
-import { filterByVisibleOperation, nonNullable } from './util';
+import { filterByVisibleOperation } from './util';
 import { getManagedColumnsFrom } from '../../layer_helpers';
 import { getFilter, isColumnFormatted } from '../helpers';
+import { nonNullable } from '../../../utils';
 
 const defaultLabel = i18n.translate('xpack.lens.indexPattern.formulaLabel', {
   defaultMessage: 'Formula',

--- a/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/formula/parse.ts
+++ b/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/formula/parse.ts
@@ -26,10 +26,10 @@ import {
   getOperationParams,
   groupArgsByType,
   mergeWithGlobalFilters,
-  nonNullable,
 } from './util';
 import { FormulaIndexPatternColumn, isFormulaIndexPatternColumn } from './formula';
 import { getColumnOrder } from '../../layer_helpers';
+import { nonNullable } from '../../../utils';
 
 /** @internal **/
 export function getManagedId(mainId: string, index: number) {

--- a/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/formula/util.ts
+++ b/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/formula/util.ts
@@ -20,6 +20,7 @@ import type {
   GenericOperationDefinition,
 } from '..';
 import type { GroupedNodes } from './types';
+import { nonNullable } from '../../../utils';
 
 export const unquotedStringRegex = /[^0-9A-Za-z._@\[\]/]/;
 
@@ -735,10 +736,6 @@ Example: Average revenue per customer but in some cases customer id is not provi
     }),
   },
 };
-
-export function nonNullable<T>(v: T): v is NonNullable<T> {
-  return v != null;
-}
 
 export function isMathNode(node: TinymathAST | string) {
   return isObject(node) && node.type === 'function' && tinymathFunctions[node.name];

--- a/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/formula/validation.ts
+++ b/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/formula/validation.ts
@@ -26,7 +26,6 @@ import {
   getValueOrName,
   groupArgsByType,
   isMathNode,
-  nonNullable,
   tinymathFunctions,
 } from './util';
 
@@ -38,6 +37,7 @@ import type {
 import type { FormBasedLayer } from '../../../types';
 import type { IndexPattern } from '../../../../../types';
 import type { TinymathNodeTypes } from './types';
+import { nonNullable } from '../../../utils';
 
 interface ValidationErrors {
   missingField: { message: string; type: { variablesLength: number; variablesList: string } };

--- a/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/index.ts
+++ b/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/index.ts
@@ -330,6 +330,13 @@ interface BaseOperationDefinitionProps<
       >
     | undefined;
 
+  getRuntimeErrorHandler?: (
+    layer: FormBasedLayer,
+    columnId: string,
+    indexPattern: IndexPattern,
+    operationDefinitionMap?: Record<string, GenericOperationDefinition>
+  ) => (runtimeError: string) => string;
+
   /*
    * Flag whether this operation can be scaled by time unit if a date histogram is available.
    * If set to mandatory or optional, a UI element is shown in the config flyout to configure the time unit

--- a/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/last_value.test.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/last_value.test.tsx
@@ -833,23 +833,6 @@ describe('last_value', () => {
         expect(new Harness(instance).showArrayValuesSwitchDisabled).toBeTruthy();
       });
 
-      it('should set showArrayValues and disable switch when runtime field', () => {
-        (layer.columns.col2 as LastValueIndexPatternColumn).sourceField = 'runtime';
-
-        const updateLayerSpy = jest.fn();
-        const instance = shallow(
-          <InlineOptions
-            {...defaultProps}
-            layer={layer}
-            paramEditorUpdater={updateLayerSpy}
-            columnId="col2"
-            currentColumn={layer.columns.col2 as LastValueIndexPatternColumn}
-          />
-        );
-
-        expect(new Harness(instance).showArrayValuesSwitchDisabled).toBeTruthy();
-      });
-
       it('should not display an array for the last value if the column is referenced', () => {
         const updateLayerSpy = jest.fn();
         const instance = shallow(

--- a/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/last_value.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/last_value.tsx
@@ -367,10 +367,7 @@ export const lastValueOperation: OperationDefinition<
                 }
                 compressed={true}
                 checked={Boolean(currentColumn.params.showArrayValues)}
-                disabled={
-                  isScriptedField(currentColumn.sourceField, indexPattern) ||
-                  isRuntimeField(currentColumn.sourceField, indexPattern)
-                }
+                disabled={isScriptedField(currentColumn.sourceField, indexPattern)}
                 onChange={() => setShowArrayValues(!currentColumn.params.showArrayValues)}
               />
             </EuiToolTip>

--- a/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/terms/helpers.ts
+++ b/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/terms/helpers.ts
@@ -252,6 +252,16 @@ export function isSortableByColumn(layer: FormBasedLayer, columnId: string) {
   );
 }
 
+export function isRuntimeField(field: IndexPatternField): boolean;
+export function isRuntimeField(fieldName: string, indexPattern: IndexPattern): boolean;
+export function isRuntimeField(fieldName: string | IndexPatternField, indexPattern?: IndexPattern) {
+  if (typeof fieldName === 'string') {
+    const field = indexPattern?.getFieldByName(fieldName);
+    return field && field.runtime;
+  }
+  return fieldName.runtime;
+}
+
 export function isScriptedField(field: IndexPatternField): boolean;
 export function isScriptedField(fieldName: string, indexPattern: IndexPattern): boolean;
 export function isScriptedField(

--- a/x-pack/plugins/lens/public/datasources/form_based/utils.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/utils.tsx
@@ -672,3 +672,7 @@ export const cloneLayer = (
   }
   return layers;
 };
+
+export function nonNullable<T>(v: T): v is NonNullable<T> {
+  return v != null;
+}

--- a/x-pack/plugins/lens/public/types.ts
+++ b/x-pack/plugins/lens/public/types.ts
@@ -444,6 +444,11 @@ export interface Datasource<T = unknown, P = unknown> {
       }>
     | undefined;
 
+  getRuntimeErrorHandlers: (
+    state: T,
+    indexPatterns: Record<string, IndexPattern>
+  ) => (runtimeErrors: string[]) => string[];
+
   /**
    * The frame calls this function to display warnings about visualization
    */


### PR DESCRIPTION
## Summary

Fix #148613 

This PR introduces a basic infrastructure to improve with more context runtime errors (errors that we know only after an ES request) in Lens by applying specific operations knowledge to the raw error message.
In this case a runtime field of type `keyword` that returns an array of strings would not be supported if the used operation is `last value` (top_metrics underneath) and the new error message would try to explain to the user the problem and how to solve it.

<img width="823" alt="Screenshot 2023-01-17 at 11 04 17" src="https://user-images.githubusercontent.com/924948/212870984-f29e521c-c50b-45e9-a7ba-d6c3ac3c7802.png">

In the screenshot above a single runtime error is reported, and translated. Once the `runtime_array` configuration is resolved a new runtime error would appear about the `runtime_ip_array` dimension. Unfortunately ES will report a single error at the time, based on the order in the request, but the logic in this PR is flexible enough to handle also multiple errors in the future.

Note: due to tech challenges in the current Lens flow there's no easy way to highlight the specific dimension component for the error yet. This is a known limitation of this fix.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
