### PR TITLE
[Lens] Automatically enable show array values for non-numeric runtime fields

### DIFF
--- a/x-pack/plugins/lens/public/datasources/form_based/mocks.ts
+++ b/x-pack/plugins/lens/public/datasources/form_based/mocks.ts
@@ -81,6 +81,26 @@ export const createMockedIndexPattern = (someProps?: Partial<IndexPattern>): Ind
       lang: 'painless' as const,
       script: '1234',
     },
+    {
+      name: 'runtime-keyword',
+      displayName: 'Runtime keyword field',
+      type: 'string',
+      searchable: true,
+      aggregatable: true,
+      runtime: true,
+      lang: 'painless' as const,
+      script: 'emit("123")',
+    },
+    {
+      name: 'runtime-number',
+      displayName: 'Runtime number field',
+      type: 'number',
+      searchable: true,
+      aggregatable: true,
+      runtime: true,
+      lang: 'painless' as const,
+      script: 'emit(123)',
+    },
   ];
   return {
     id: '1',

--- a/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/formula/editor/math_completion.test.ts
+++ b/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/formula/editor/math_completion.test.ts
@@ -335,7 +335,7 @@ describe('math completion', () => {
           triggerCharacter: '(',
         })
       );
-      expect(results.list).toEqual(['bytes', 'memory']);
+      expect(results.list).toEqual(['bytes', 'memory', 'runtime-number']);
     });
 
     it('should autocomplete only operations that provide numeric or date output', async () => {
@@ -346,7 +346,13 @@ describe('math completion', () => {
           triggerCharacter: '(',
         })
       );
-      expect(results.list).toEqual(['bytes', 'memory', 'timestamp', 'start_date']);
+      expect(results.list).toEqual([
+        'bytes',
+        'memory',
+        'runtime-number',
+        'timestamp',
+        'start_date',
+      ]);
     });
 
     it('should autocomplete shift parameter with relative suggestions and a couple of abs ones', async () => {

--- a/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/last_value.test.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/last_value.test.tsx
@@ -290,6 +290,44 @@ describe('last_value', () => {
         ).params.showArrayValues
       ).toBeTruthy();
     });
+
+    it('should set show array values if field is runtime and not of type number', () => {
+      const oldColumn: LastValueIndexPatternColumn = {
+        operationType: 'last_value',
+        sourceField: 'bytes',
+        label: 'Last value of bytes',
+        isBucketed: false,
+        dataType: 'number',
+        params: {
+          sortField: 'datefield',
+          showArrayValues: false,
+        },
+      };
+      const indexPattern = createMockedIndexPattern();
+      const field = indexPattern.fields.find((i) => i.name === 'runtime-keyword')!;
+
+      expect(
+        lastValueOperation.onFieldChange(oldColumn, field).params.showArrayValues
+      ).toBeTruthy();
+    });
+
+    it('should not set show array values if field is runtime and of type number', () => {
+      const oldColumn: LastValueIndexPatternColumn = {
+        operationType: 'last_value',
+        sourceField: 'bytes',
+        label: 'Last value of bytes',
+        isBucketed: false,
+        dataType: 'number',
+        params: {
+          sortField: 'datefield',
+          showArrayValues: false,
+        },
+      };
+      const indexPattern = createMockedIndexPattern();
+      const field = indexPattern.fields.find((i) => i.name === 'runtime-number')!;
+
+      expect(lastValueOperation.onFieldChange(oldColumn, field).params.showArrayValues).toBeFalsy();
+    });
   });
 
   describe('getPossibleOperationForField', () => {
@@ -480,11 +518,19 @@ describe('last_value', () => {
       );
     });
 
-    it('should set showArrayValues if field is scripted or comes from existing params', () => {
+    it('should set showArrayValues if field is scripted, non-numeric runtime or comes from existing params', () => {
       const indexPattern = createMockedIndexPattern();
 
       const scriptedField = indexPattern.fields.find((field) => field.scripted);
-      const nonScriptedField = indexPattern.fields.find((field) => !field.scripted);
+      const runtimeKeywordField = indexPattern.fields.find(
+        (field) => field.runtime && field.type !== 'number'
+      );
+      const runtimeNumericField = indexPattern.fields.find(
+        (field) => field.runtime && field.type === 'number'
+      );
+      const nonScriptedField = indexPattern.fields.find(
+        (field) => !field.scripted && !field.runtime
+      );
 
       const localLayer = {
         columns: {
@@ -507,6 +553,22 @@ describe('last_value', () => {
           field: scriptedField!,
         }).params.showArrayValues
       ).toBeTruthy();
+
+      expect(
+        lastValueOperation.buildColumn({
+          indexPattern,
+          layer: localLayer,
+          field: runtimeKeywordField!,
+        }).params.showArrayValues
+      ).toBeTruthy();
+
+      expect(
+        lastValueOperation.buildColumn({
+          indexPattern,
+          layer: localLayer,
+          field: runtimeNumericField!,
+        }).params.showArrayValues
+      ).toBeFalsy();
 
       expect(
         lastValueOperation.buildColumn(

--- a/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/last_value.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/last_value.tsx
@@ -30,7 +30,7 @@ import {
 } from './helpers';
 import { adjustTimeScaleLabelSuffix } from '../time_scale_utils';
 import { getDisallowedPreviousShiftMessage } from '../../time_shift_utils';
-import { isScriptedField } from './terms/helpers';
+import { isRuntimeField, isScriptedField } from './terms/helpers';
 import { FormRow } from './shared_components/form_row';
 import { getColumnReducedTimeRangeError } from '../../reduced_time_range_utils';
 import { getGroupByKey } from './get_group_by_key';
@@ -107,6 +107,17 @@ function getDateFields(indexPattern: IndexPattern): IndexPatternField[] {
   return dateFields;
 }
 
+function setDefaultShowArrayValues(
+  field: IndexPatternField,
+  oldParams: LastValueIndexPatternColumn['params']
+) {
+  return (
+    isScriptedField(field) ||
+    (isRuntimeField(field) && field.type !== 'number') ||
+    oldParams?.showArrayValues
+  );
+}
+
 export interface LastValueIndexPatternColumn extends FieldBasedIndexPatternColumn {
   operationType: 'last_value';
   params: {
@@ -154,7 +165,7 @@ export const lastValueOperation: OperationDefinition<
   onFieldChange: (oldColumn, field) => {
     const newParams = { ...oldColumn.params };
 
-    newParams.showArrayValues = isScriptedField(field) || oldColumn.params.showArrayValues;
+    newParams.showArrayValues = setDefaultShowArrayValues(field, oldColumn.params);
 
     if ('format' in newParams && field.type !== 'number') {
       delete newParams.format;
@@ -221,7 +232,7 @@ export const lastValueOperation: OperationDefinition<
       );
     }
 
-    const showArrayValues = isScriptedField(field) || lastValueParams?.showArrayValues;
+    const showArrayValues = setDefaultShowArrayValues(field, lastValueParams);
 
     return {
       label: ofName(field.displayName, previousColumn?.timeShift, previousColumn?.reducedTimeRange),

--- a/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/terms/helpers.ts
+++ b/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/terms/helpers.ts
@@ -265,6 +265,10 @@ export function isScriptedField(
   return fieldName.scripted;
 }
 
+export function isRuntimeField(field: IndexPatternField): boolean {
+  return Boolean(field.runtime);
+}
+
 export function getFieldsByValidationState(
   newIndexPattern: IndexPattern,
   column?: GenericIndexPatternColumn,


### PR DESCRIPTION
## Summary

Fixes #148613 

After investigating the issue via a different approach #149011 I've decided to handle it in this minimal way.
This PR will automatically switch the `show_array` toggle for non numeric fields avoiding as much as possible direct appearance of the error to the user.
If the user decides to explicitly disable the toggle, then the runtime error will be shown (the message there can still be improved).

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
