### PR TITLE
[APM] Extracting serviceGroupApiMethods to avoid duplication of code

### DIFF
--- a/x-pack/test/apm_api_integration/common/config.ts
+++ b/x-pack/test/apm_api_integration/common/config.ts
@@ -58,6 +58,8 @@ type ApmApiClientKey =
   | 'createAndAllAgentKeysUser'
   | 'monitorClusterAndIndicesUser';
 
+export type ApmApiClient = Record<ApmApiClientKey, Awaited<ReturnType<typeof getApmApiClient>>>;
+
 export interface CreateTest {
   testFiles: string[];
   servers: any;
@@ -66,9 +68,7 @@ export interface CreateTest {
     apmFtrConfig: () => ApmFtrConfig;
     registry: ({ getService }: FtrProviderContext) => ReturnType<typeof RegistryProvider>;
     synthtraceEsClient: (context: InheritedFtrProviderContext) => Promise<ApmSynthtraceEsClient>;
-    apmApiClient: (
-      context: InheritedFtrProviderContext
-    ) => Record<ApmApiClientKey, Awaited<ReturnType<typeof getApmApiClient>>>;
+    apmApiClient: (context: InheritedFtrProviderContext) => ApmApiClient;
     ml: ({ getService }: FtrProviderContext) => ReturnType<typeof MachineLearningAPIProvider>;
   };
   junit: { reportName: string };

--- a/x-pack/test/apm_api_integration/tests/service_groups/save_service_group.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/service_groups/save_service_group.spec.ts
@@ -8,85 +8,44 @@ import expect from '@kbn/expect';
 import { ApmApiError } from '../../common/apm_api_supertest';
 import { FtrProviderContext } from '../../common/ftr_provider_context';
 import { expectToReject } from '../../common/utils/expect_to_reject';
+import {
+  createServiceGroupApi,
+  deleteAllServiceGroups,
+  getServiceGroupsApi,
+} from './service_groups_api_methods';
 
 export default function ApiTest({ getService }: FtrProviderContext) {
   const registry = getService('registry');
   const apmApiClient = getService('apmApiClient');
 
-  async function createServiceGroupApi({
-    serviceGroupId,
-    groupName,
-    kuery,
-    description,
-    color,
-  }: {
-    serviceGroupId?: string;
-    groupName: string;
-    kuery: string;
-    description?: string;
-    color?: string;
-  }) {
-    const response = await apmApiClient.writeUser({
-      endpoint: 'POST /internal/apm/service-group',
-      params: {
-        query: {
-          serviceGroupId,
-        },
-        body: {
-          groupName,
-          kuery,
-          description,
-          color,
-        },
-      },
-    });
-    return response;
-  }
-
-  async function getServiceGroupsApi() {
-    return apmApiClient.writeUser({
-      endpoint: 'GET /internal/apm/service-groups',
-    });
-  }
-
-  async function deleteAllServiceGroups() {
-    return await getServiceGroupsApi().then((response) => {
-      const promises = response.body.serviceGroups.map((item) => {
-        if (item.id) {
-          return apmApiClient.writeUser({
-            endpoint: 'DELETE /internal/apm/service-group',
-            params: { query: { serviceGroupId: item.id } },
-          });
-        }
-      });
-      return Promise.all(promises);
-    });
-  }
-
   registry.when('Service group create', { config: 'basic', archives: [] }, () => {
-    afterEach(deleteAllServiceGroups);
+    afterEach(async () => {
+      await deleteAllServiceGroups(apmApiClient);
+    });
 
     it('creates a new service group', async () => {
       const serviceGroup = {
         groupName: 'synthbeans',
         kuery: 'service.name: synth*',
       };
-      const createResponse = await createServiceGroupApi(serviceGroup);
+      const createResponse = await createServiceGroupApi({ apmApiClient, ...serviceGroup });
       expect(createResponse.status).to.be(200);
       expect(createResponse.body).to.have.property('id');
       expect(createResponse.body).to.have.property('groupName', serviceGroup.groupName);
       expect(createResponse.body).to.have.property('kuery', serviceGroup.kuery);
       expect(createResponse.body).to.have.property('updatedAt');
-      const serviceGroupsResponse = await getServiceGroupsApi();
+      const serviceGroupsResponse = await getServiceGroupsApi(apmApiClient);
       expect(serviceGroupsResponse.body.serviceGroups.length).to.be(1);
     });
 
     it('handles invalid fields with error response', async () => {
-      const err = await expectToReject<ApmApiError>(() =>
-        createServiceGroupApi({
-          groupName: 'synthbeans',
-          kuery: 'service.name: synth* or transaction.type: request',
-        })
+      const err = await expectToReject<ApmApiError>(
+        async () =>
+          await createServiceGroupApi({
+            apmApiClient,
+            groupName: 'synthbeans',
+            kuery: 'service.name: synth* or transaction.type: request',
+          })
       );
 
       expect(err.res.status).to.be(400);

--- a/x-pack/test/apm_api_integration/tests/service_groups/service_groups_api_methods.ts
+++ b/x-pack/test/apm_api_integration/tests/service_groups/service_groups_api_methods.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ApmApiClient } from '../../common/config';
+
+export async function getServiceGroupsApi(apmApiClient: ApmApiClient) {
+  return apmApiClient.writeUser({
+    endpoint: 'GET /internal/apm/service-groups',
+  });
+}
+
+export async function createServiceGroupApi({
+  apmApiClient,
+  serviceGroupId,
+  groupName,
+  kuery,
+  description,
+  color,
+}: {
+  apmApiClient: ApmApiClient;
+  serviceGroupId?: string;
+  groupName: string;
+  kuery: string;
+  description?: string;
+  color?: string;
+}) {
+  const response = await apmApiClient.writeUser({
+    endpoint: 'POST /internal/apm/service-group',
+    params: {
+      query: {
+        serviceGroupId,
+      },
+      body: {
+        groupName,
+        kuery,
+        description,
+        color,
+      },
+    },
+  });
+  return response;
+}
+
+export async function getServiceGroupCounts(apmApiClient: ApmApiClient) {
+  return apmApiClient.readUser({
+    endpoint: 'GET /internal/apm/service-group/counts',
+  });
+}
+
+export async function deleteAllServiceGroups(apmApiClient: ApmApiClient) {
+  return await getServiceGroupsApi(apmApiClient).then((response) => {
+    const promises = response.body.serviceGroups.map((item) => {
+      if (item.id) {
+        return apmApiClient.writeUser({
+          endpoint: 'DELETE /internal/apm/service-group',
+          params: { query: { serviceGroupId: item.id } },
+        });
+      }
+    });
+    return Promise.all(promises);
+  });
+}


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/148280.

### Changes
- Created `ApmApiClient` type.
- Extracted service groups api methods to reuse in `save_service_groups` and `service_group_count` tests.