### PR TITLE
[Unified search] Fix the bug with the default value on numeric field filters

### DIFF
--- a/packages/kbn-es-query/src/filters/helpers/update_filter.test.ts
+++ b/packages/kbn-es-query/src/filters/helpers/update_filter.test.ts
@@ -127,7 +127,7 @@ describe('updateFilter', () => {
       meta: {
         alias: '',
         index: 'index1',
-        params: { query: 0 },
+        params: { query: undefined },
         key: 'test-field',
         negate: true,
         type: 'phrase',

--- a/packages/kbn-es-query/src/filters/helpers/update_filter.ts
+++ b/packages/kbn-es-query/src/filters/helpers/update_filter.ts
@@ -79,7 +79,7 @@ function updateWithIsOperator(
       ...filter.meta,
       negate: operator?.negate,
       type: operator?.type,
-      params: { ...filter.meta.params, query: safeParams },
+      params: { ...filter.meta.params, query: params },
       value: undefined,
     },
     query: { match_phrase: { [filter.meta.key!]: safeParams ?? '' } },

--- a/src/plugins/data/public/query/filter_manager/lib/get_display_value.test.ts
+++ b/src/plugins/data/public/query/filter_manager/lib/get_display_value.test.ts
@@ -36,6 +36,33 @@ describe('getDisplayValueFromFilter', () => {
     expect(displayValue).toBe('');
   });
 
+  it('returns 0 if value undefined and numeric field', () => {
+    const filter = {
+      meta: {
+        negate: false,
+        index: 'logstash-*',
+        type: 'phrase',
+        key: 'bytes',
+        value: undefined,
+        disabled: false,
+        alias: null,
+        params: {
+          query: undefined,
+        },
+      },
+      $state: {
+        store: FilterStateStore.APP_STATE,
+      },
+      query: {
+        match_phrase: {
+          bytes: '0',
+        },
+      },
+    };
+    const displayValue = getDisplayValueFromFilter(filter, [stubIndexPattern]);
+    expect(displayValue).toBe('0');
+  });
+
   it('phrase filters without formatter', () => {
     jest.spyOn(stubIndexPattern, 'getFormatterForField').mockImplementation(() => undefined!);
     const displayValue = getDisplayValueFromFilter(phraseFilter, [stubIndexPattern]);

--- a/src/plugins/data/public/query/filter_manager/lib/get_display_value.ts
+++ b/src/plugins/data/public/query/filter_manager/lib/get_display_value.ts
@@ -61,10 +61,12 @@ export function getFieldDisplayValueFromFilter(
 export function getDisplayValueFromFilter(filter: Filter, indexPatterns: DataViewBase[]): string {
   const indexPattern = getIndexPatternFromFilter(filter, indexPatterns);
   const fieldName = getFilterField(filter);
+  const field = indexPattern?.fields.find((f) => f.name === fieldName);
+  const fieldType = field?.type;
   const valueFormatter = getValueFormatter(indexPattern, fieldName);
 
   if (isPhraseFilter(filter) || isScriptedPhraseFilter(filter)) {
-    return getPhraseDisplayValue(filter, valueFormatter);
+    return getPhraseDisplayValue(filter, valueFormatter, fieldType);
   } else if (isPhrasesFilter(filter)) {
     return getPhrasesDisplayValue(filter, valueFormatter);
   } else if (isRangeFilter(filter) || isScriptedRangeFilter(filter)) {

--- a/src/plugins/data/public/query/filter_manager/lib/mappers/map_phrase.ts
+++ b/src/plugins/data/public/query/filter_manager/lib/mappers/map_phrase.ts
@@ -22,13 +22,15 @@ const getScriptedPhraseValue = (filter: PhraseFilter) =>
 
 export function getPhraseDisplayValue(
   filter: PhraseFilter | ScriptedPhraseFilter,
-  formatter?: FieldFormat
+  formatter?: FieldFormat,
+  fieldType?: string
 ): string {
   const value = filter.meta.value ?? filter.meta.params.query;
+  const updatedValue = fieldType === 'number' && !value ? 0 : value;
   if (formatter?.convert) {
-    return formatter.convert(value);
+    return formatter.convert(updatedValue);
   }
-  return value === undefined ? '' : `${value}`;
+  return updatedValue === undefined ? '' : `${updatedValue}`;
 }
 
 const getParams = (filter: PhraseFilter) => {


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/149020

I created this bad ux with https://github.com/elastic/kibana/pull/148802

When you try to add a negative value to a numeric field filter, is not easily applied.

I changed the behavior, so now the 0 is not automatically added on the operator selection, the user can still add a filter without a required value and I fixed the preview.
<img width="970" alt="image" src="https://user-images.githubusercontent.com/17003240/212900946-d397eba8-debb-45a5-8d11-d9b515a989c6.png">
