### PR TITLE
[Unified Search][i18n] fix datepicker i18n

### DIFF
--- a/src/plugins/unified_search/public/search_bar/create_search_bar.tsx
+++ b/src/plugins/unified_search/public/search_bar/create_search_bar.tsx
@@ -193,45 +193,47 @@ export function createSearchBar({
           ...core,
         }}
       >
-        <SearchBar
-          showAutoRefreshOnly={props.showAutoRefreshOnly}
-          showDatePicker={props.showDatePicker}
-          showFilterBar={props.showFilterBar}
-          showQueryMenu={props.showQueryMenu}
-          showQueryInput={props.showQueryInput}
-          showSaveQuery={props.showSaveQuery}
-          showSubmitButton={props.showSubmitButton}
-          submitButtonStyle={props.submitButtonStyle}
-          isDisabled={props.isDisabled}
-          screenTitle={props.screenTitle}
-          indexPatterns={props.indexPatterns}
-          indicateNoData={props.indicateNoData}
-          timeHistory={data.query.timefilter.history}
-          dateRangeFrom={timeRange.from}
-          dateRangeTo={timeRange.to}
-          refreshInterval={refreshInterval.value}
-          isRefreshPaused={refreshInterval.pause}
-          filters={filters}
-          query={query}
-          onFiltersUpdated={defaultFiltersUpdated(data.query, props.onFiltersUpdated)}
-          onRefreshChange={defaultOnRefreshChange(data.query)}
-          savedQuery={savedQuery}
-          onQuerySubmit={defaultOnQuerySubmit(props, data.query, query)}
-          onClearSavedQuery={defaultOnClearSavedQuery(props, clearSavedQuery)}
-          onSavedQueryUpdated={defaultOnSavedQueryUpdated(props, setSavedQuery)}
-          onSaved={defaultOnSavedQueryUpdated(props, setSavedQuery)}
-          iconType={props.iconType}
-          nonKqlMode={props.nonKqlMode}
-          customSubmitButton={props.customSubmitButton}
-          isClearable={props.isClearable}
-          placeholder={props.placeholder}
-          {...overrideDefaultBehaviors(props)}
-          dataViewPickerComponentProps={props.dataViewPickerComponentProps}
-          textBasedLanguageModeErrors={props.textBasedLanguageModeErrors}
-          onTextBasedSavedAndExit={props.onTextBasedSavedAndExit}
-          displayStyle={props.displayStyle}
-          isScreenshotMode={isScreenshotMode}
-        />
+        <core.i18n.Context>
+          <SearchBar
+            showAutoRefreshOnly={props.showAutoRefreshOnly}
+            showDatePicker={props.showDatePicker}
+            showFilterBar={props.showFilterBar}
+            showQueryMenu={props.showQueryMenu}
+            showQueryInput={props.showQueryInput}
+            showSaveQuery={props.showSaveQuery}
+            showSubmitButton={props.showSubmitButton}
+            submitButtonStyle={props.submitButtonStyle}
+            isDisabled={props.isDisabled}
+            screenTitle={props.screenTitle}
+            indexPatterns={props.indexPatterns}
+            indicateNoData={props.indicateNoData}
+            timeHistory={data.query.timefilter.history}
+            dateRangeFrom={timeRange.from}
+            dateRangeTo={timeRange.to}
+            refreshInterval={refreshInterval.value}
+            isRefreshPaused={refreshInterval.pause}
+            filters={filters}
+            query={query}
+            onFiltersUpdated={defaultFiltersUpdated(data.query, props.onFiltersUpdated)}
+            onRefreshChange={defaultOnRefreshChange(data.query)}
+            savedQuery={savedQuery}
+            onQuerySubmit={defaultOnQuerySubmit(props, data.query, query)}
+            onClearSavedQuery={defaultOnClearSavedQuery(props, clearSavedQuery)}
+            onSavedQueryUpdated={defaultOnSavedQueryUpdated(props, setSavedQuery)}
+            onSaved={defaultOnSavedQueryUpdated(props, setSavedQuery)}
+            iconType={props.iconType}
+            nonKqlMode={props.nonKqlMode}
+            customSubmitButton={props.customSubmitButton}
+            isClearable={props.isClearable}
+            placeholder={props.placeholder}
+            {...overrideDefaultBehaviors(props)}
+            dataViewPickerComponentProps={props.dataViewPickerComponentProps}
+            textBasedLanguageModeErrors={props.textBasedLanguageModeErrors}
+            onTextBasedSavedAndExit={props.onTextBasedSavedAndExit}
+            displayStyle={props.displayStyle}
+            isScreenshotMode={isScreenshotMode}
+          />
+        </core.i18n.Context>
       </KibanaContextProvider>
     );
   };


### PR DESCRIPTION
## Summary

Wrap `SearchBar` component with `core.i18n.Context` to provide EUI i18n tokens to the Date picker. this affects everywhere where the unified search is used (discover and dashboard).

**Before:**
<img width="463" alt="image" src="https://user-images.githubusercontent.com/6191849/212900676-dead9c41-b169-4f94-806f-53d17e4e6e60.png">

**After:**
<img width="538" alt="image" src="https://user-images.githubusercontent.com/6191849/212900501-54ac69e1-7074-4157-87b6-c118f9d93b4f.png">

Closes https://github.com/elastic/kibana/issues/148885
Closes https://github.com/elastic/kibana/issues/148525

Notes: I tried looking for a unified place to inject the context but we don't have an ideal place for this for now so plugins need to wrap their components with the core i18n context wrapper manually. Issue tracker for this enhancement discussion: https://github.com/elastic/kibana/issues/149032

<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->