### PR TITLE
[Cases] Fix name error messages in the creation form

### DIFF
--- a/x-pack/plugins/cases/public/common/translations.ts
+++ b/x-pack/plugins/cases/public/common/translations.ts
@@ -166,7 +166,7 @@ export const NO_TAGS = i18n.translate('xpack.cases.caseView.noTags', {
 });
 
 export const TITLE_REQUIRED = i18n.translate('xpack.cases.createCase.titleFieldRequiredError', {
-  defaultMessage: 'A title is required.',
+  defaultMessage: 'A name is required.',
 });
 
 export const CONFIGURE_CASES_PAGE_TITLE = i18n.translate('xpack.cases.configureCases.headerTitle', {

--- a/x-pack/plugins/cases/public/components/create/form_context.test.tsx
+++ b/x-pack/plugins/cases/public/components/create/form_context.test.tsx
@@ -282,7 +282,7 @@ describe('Create case', () => {
 
       await waitFor(() => {
         expect(
-          screen.getByText('The length of the title is too long. The maximum length is 160.')
+          screen.getByText('The length of the name is too long. The maximum length is 160.')
         ).toBeInTheDocument();
       });
 

--- a/x-pack/plugins/cases/public/components/create/schema.tsx
+++ b/x-pack/plugins/cases/public/components/create/schema.tsx
@@ -58,7 +58,7 @@ export const schema: FormSchema<FormProps> = {
       {
         validator: maxLengthField({
           length: MAX_TITLE_LENGTH,
-          message: i18n.MAX_LENGTH_ERROR('title', MAX_TITLE_LENGTH),
+          message: i18n.MAX_LENGTH_ERROR('name', MAX_TITLE_LENGTH),
         }),
       },
     ],


### PR DESCRIPTION
## Summary

Fixes: https://github.com/elastic/kibana/issues/148041

<img width="1161" alt="Screenshot 2023-01-17 at 2 44 27 PM" src="https://user-images.githubusercontent.com/7871006/212903358-18b5107d-5d9b-4815-904d-e0dd3939a513.png">

<img width="1158" alt="Screenshot 2023-01-17 at 2 45 07 PM" src="https://user-images.githubusercontent.com/7871006/212903353-7476d88d-a938-4f1c-b74a-f31a5cb68281.png">

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
