### PR TITLE
[Fleet] Add default `inactivity_timeout` value of 2 weeks to all new agent policies

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_create_inline.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_create_inline.tsx
@@ -22,8 +22,7 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import styled from 'styled-components';
 import { i18n } from '@kbn/i18n';
 
-import { dataTypes } from '../../../../../../common/constants';
-
+import { generateNewAgentPolicyWithDefaults } from '../../../services';
 import type { AgentPolicy, NewAgentPolicy } from '../../../types';
 
 import { sendCreateAgentPolicy, useStartServices } from '../../../hooks';
@@ -57,13 +56,12 @@ export const AgentPolicyCreateInlineForm: React.FunctionComponent<Props> = ({
 
   const [isLoading, setIsLoading] = useState(false);
 
-  const [newAgentPolicy, setNewAgentPolicy] = useState<NewAgentPolicy>({
-    name: agentPolicyName,
-    description: '',
-    namespace: 'default',
-    monitoring_enabled: Object.values(dataTypes),
-    has_fleet_server: isFleetServerPolicy,
-  });
+  const [newAgentPolicy, setNewAgentPolicy] = useState<NewAgentPolicy>(
+    generateNewAgentPolicyWithDefaults({
+      name: agentPolicyName,
+      has_fleet_server: isFleetServerPolicy,
+    })
+  );
 
   const updateNewAgentPolicy = useCallback(
     (updatedFields: Partial<NewAgentPolicy>) => {

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/multi_page_layout/hooks/use_get_agent_policy_or_default.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/multi_page_layout/hooks/use_get_agent_policy_or_default.tsx
@@ -14,6 +14,8 @@ import {
   sendGetEnrollmentAPIKeys,
 } from '../../../../../../../hooks';
 
+import { generateNewAgentPolicyWithDefaults } from '../../../../../../../services';
+
 import type { AgentPolicy, NewAgentPolicy, EnrollmentAPIKey } from '../../../../../../../types';
 
 interface UseGetAgentPolicyOrDefaultResponse {
@@ -24,14 +26,14 @@ interface UseGetAgentPolicyOrDefaultResponse {
   created?: boolean;
 }
 export const DEFAULT_AGENT_POLICY_ID: string = 'fleet-first-agent-policy';
-export const DEFAULT_AGENT_POLICY: NewAgentPolicy = Object.freeze({
-  id: DEFAULT_AGENT_POLICY_ID,
-  name: i18n.translate('xpack.fleet.createPackagePolicy.firstAgentPolicyNameText', {
-    defaultMessage: 'My first agent policy',
-  }),
-  namespace: 'default',
-  monitoring_enabled: ['logs', 'metrics'] as NewAgentPolicy['monitoring_enabled'],
-});
+export const DEFAULT_AGENT_POLICY: NewAgentPolicy = Object.freeze(
+  generateNewAgentPolicyWithDefaults({
+    id: DEFAULT_AGENT_POLICY_ID,
+    name: i18n.translate('xpack.fleet.createPackagePolicy.firstAgentPolicyNameText', {
+      defaultMessage: 'My first agent policy',
+    }),
+  })
+);
 
 const sendGetAgentPolicy = async (agentPolicyId: string) => {
   let result;

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.test.tsx
@@ -383,6 +383,7 @@ describe('when on the package policy create page', () => {
           monitoring_enabled: ['logs', 'metrics'],
           name: 'Agent policy 2',
           namespace: 'default',
+          inactivity_timeout: 1209600,
         },
         { withSysMonitoring: false }
       );
@@ -413,6 +414,7 @@ describe('when on the package policy create page', () => {
             monitoring_enabled: ['logs', 'metrics'],
             name: 'Agent policy 2',
             namespace: 'default',
+            inactivity_timeout: 1209600,
           },
           { withSysMonitoring: true }
         );

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.tsx
@@ -25,7 +25,7 @@ import type { EuiStepProps } from '@elastic/eui/src/components/steps/step';
 import { useCancelAddPackagePolicy } from '../hooks';
 
 import { splitPkgKey } from '../../../../../../../common/services';
-import { dataTypes } from '../../../../../../../common/constants';
+import { generateNewAgentPolicyWithDefaults } from '../../../../services';
 import type { NewAgentPolicy } from '../../../../types';
 import { useConfig, sendGetAgentStatus, useGetPackageInfoByKey } from '../../../../hooks';
 import {
@@ -80,12 +80,9 @@ export const CreatePackagePolicySinglePage: CreatePackagePolicyParams = ({
   } = useConfig();
   const { params } = useRouteMatch<AddToPolicyParams>();
 
-  const [newAgentPolicy, setNewAgentPolicy] = useState<NewAgentPolicy>({
-    name: 'Agent policy 1',
-    description: '',
-    namespace: 'default',
-    monitoring_enabled: Object.values(dataTypes),
-  });
+  const [newAgentPolicy, setNewAgentPolicy] = useState<NewAgentPolicy>(
+    generateNewAgentPolicyWithDefaults()
+  );
 
   const [withSysMonitoring, setWithSysMonitoring] = useState<boolean>(true);
   const validation = agentPolicyFormValidation(newAgentPolicy);

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.tsx
@@ -81,7 +81,7 @@ export const CreatePackagePolicySinglePage: CreatePackagePolicyParams = ({
   const { params } = useRouteMatch<AddToPolicyParams>();
 
   const [newAgentPolicy, setNewAgentPolicy] = useState<NewAgentPolicy>(
-    generateNewAgentPolicyWithDefaults()
+    generateNewAgentPolicyWithDefaults({ name: 'Agent policy 1' })
   );
 
   const [withSysMonitoring, setWithSysMonitoring] = useState<boolean>(true);

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/list_page/components/create_agent_policy.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/list_page/components/create_agent_policy.tsx
@@ -24,13 +24,15 @@ import {
   EuiSpacer,
 } from '@elastic/eui';
 
-import { dataTypes } from '../../../../../../../common/constants';
 import type { NewAgentPolicy, AgentPolicy } from '../../../../types';
 import { useAuthz, useStartServices, sendCreateAgentPolicy } from '../../../../hooks';
 import { AgentPolicyForm, agentPolicyFormValidation } from '../../components';
 import { DevtoolsRequestFlyoutButton } from '../../../../components';
 import { generateCreateAgentPolicyDevToolsRequest } from '../../services';
-import { ExperimentalFeaturesService } from '../../../../services';
+import {
+  ExperimentalFeaturesService,
+  generateNewAgentPolicyWithDefaults,
+} from '../../../../services';
 
 const FlyoutWithHigherZIndex = styled(EuiFlyout)`
   z-index: ${(props) => props.theme.eui.euiZLevel5};
@@ -47,12 +49,9 @@ export const CreateAgentPolicyFlyout: React.FunctionComponent<Props> = ({
 }) => {
   const { notifications } = useStartServices();
   const hasFleetAllPrivileges = useAuthz().fleet.all;
-  const [agentPolicy, setAgentPolicy] = useState<NewAgentPolicy>({
-    name: '',
-    description: '',
-    namespace: 'default',
-    monitoring_enabled: Object.values(dataTypes),
-  });
+  const [agentPolicy, setAgentPolicy] = useState<NewAgentPolicy>(
+    generateNewAgentPolicyWithDefaults()
+  );
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [withSysMonitoring, setWithSysMonitoring] = useState<boolean>(true);
   const validation = agentPolicyFormValidation(agentPolicy);

--- a/x-pack/plugins/fleet/public/services/generate_new_agent_policy.test.ts
+++ b/x-pack/plugins/fleet/public/services/generate_new_agent_policy.test.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { generateNewAgentPolicyWithDefaults } from './generate_new_agent_policy';
+
+describe('generateNewAgentPolicyWithDefaults', () => {
+  it('should generate a new agent policy with defaults', () => {
+    const newAgentPolicy = generateNewAgentPolicyWithDefaults({
+      name: 'test',
+    });
+
+    expect(newAgentPolicy).toEqual({
+      name: 'test',
+      description: '',
+      namespace: 'default',
+      monitoring_enabled: ['logs', 'metrics', 'endpoint'],
+    });
+  });
+
+  it('should override defaults', () => {
+    const newAgentPolicy = generateNewAgentPolicyWithDefaults({
+      name: 'test',
+      description: 'test description',
+      namespace: 'test-namespace',
+      monitoring_enabled: ['logs'],
+    });
+
+    expect(newAgentPolicy).toEqual({
+      name: 'test',
+      description: 'test description',
+      namespace: 'test-namespace',
+      monitoring_enabled: ['logs'],
+    });
+  });
+});

--- a/x-pack/plugins/fleet/public/services/generate_new_agent_policy.test.ts
+++ b/x-pack/plugins/fleet/public/services/generate_new_agent_policy.test.ts
@@ -9,15 +9,14 @@ import { generateNewAgentPolicyWithDefaults } from './generate_new_agent_policy'
 
 describe('generateNewAgentPolicyWithDefaults', () => {
   it('should generate a new agent policy with defaults', () => {
-    const newAgentPolicy = generateNewAgentPolicyWithDefaults({
-      name: 'test',
-    });
+    const newAgentPolicy = generateNewAgentPolicyWithDefaults();
 
     expect(newAgentPolicy).toEqual({
-      name: 'test',
+      name: '',
       description: '',
       namespace: 'default',
-      monitoring_enabled: ['logs', 'metrics', 'endpoint'],
+      monitoring_enabled: ['logs', 'metrics'],
+      inactivity_timeout: 1209600,
     });
   });
 
@@ -34,6 +33,7 @@ describe('generateNewAgentPolicyWithDefaults', () => {
       description: 'test description',
       namespace: 'test-namespace',
       monitoring_enabled: ['logs'],
+      inactivity_timeout: 1209600,
     });
   });
 });

--- a/x-pack/plugins/fleet/public/services/generate_new_agent_policy.ts
+++ b/x-pack/plugins/fleet/public/services/generate_new_agent_policy.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { dataTypes } from '../../common/constants';
+
+import type { NewAgentPolicy } from '../types';
+
+// create a new agent policy with the defaults set
+// used by forms which create new agent policies for initial state value
+export function generateNewAgentPolicyWithDefaults(
+  overrideProps: Partial<NewAgentPolicy> & Pick<NewAgentPolicy, 'name'>
+): NewAgentPolicy {
+  return {
+    description: '',
+    namespace: 'default',
+    monitoring_enabled: Object.values(dataTypes),
+    ...overrideProps,
+  };
+}

--- a/x-pack/plugins/fleet/public/services/generate_new_agent_policy.ts
+++ b/x-pack/plugins/fleet/public/services/generate_new_agent_policy.ts
@@ -9,15 +9,18 @@ import { dataTypes } from '../../common/constants';
 
 import type { NewAgentPolicy } from '../types';
 
+const TWO_WEEKS_SECONDS = 1209600;
 // create a new agent policy with the defaults set
 // used by forms which create new agent policies for initial state value
 export function generateNewAgentPolicyWithDefaults(
-  overrideProps: Partial<NewAgentPolicy> & Pick<NewAgentPolicy, 'name'>
+  overrideProps: Partial<NewAgentPolicy> = {}
 ): NewAgentPolicy {
   return {
+    name: '',
     description: '',
     namespace: 'default',
     monitoring_enabled: Object.values(dataTypes),
+    inactivity_timeout: TWO_WEEKS_SECONDS,
     ...overrideProps,
   };
 }

--- a/x-pack/plugins/fleet/public/services/index.ts
+++ b/x-pack/plugins/fleet/public/services/index.ts
@@ -49,3 +49,4 @@ export { createExtensionRegistrationCallback } from './ui_extensions';
 export { incrementPolicyName } from './increment_policy_name';
 export { policyHasFleetServer } from './has_fleet_server';
 export { isPackagePrerelease } from './package_prerelease';
+export { generateNewAgentPolicyWithDefaults } from './generate_new_agent_policy';

--- a/x-pack/plugins/fleet/server/types/models/agent_policy.ts
+++ b/x-pack/plugins/fleet/server/types/models/agent_policy.ts
@@ -17,6 +17,8 @@ function validateNonEmptyString(val: string) {
   }
 }
 
+const TWO_WEEKS_SECONDS = 1209600;
+
 export const AgentPolicyBaseSchema = {
   id: schema.maybe(schema.string()),
   name: schema.string({ minLength: 1, validate: validateNonEmptyString }),
@@ -27,7 +29,7 @@ export const AgentPolicyBaseSchema = {
   is_default: schema.maybe(schema.boolean()),
   is_default_fleet_server: schema.maybe(schema.boolean()),
   unenroll_timeout: schema.maybe(schema.number({ min: 0 })),
-  inactivity_timeout: schema.maybe(schema.number({ min: 0 })),
+  inactivity_timeout: schema.maybe(schema.number({ min: 0, defaultValue: TWO_WEEKS_SECONDS })),
   monitoring_enabled: schema.maybe(
     schema.arrayOf(
       schema.oneOf([schema.literal(dataTypes.Logs), schema.literal(dataTypes.Metrics)])

--- a/x-pack/plugins/fleet/server/types/models/agent_policy.ts
+++ b/x-pack/plugins/fleet/server/types/models/agent_policy.ts
@@ -29,7 +29,7 @@ export const AgentPolicyBaseSchema = {
   is_default: schema.maybe(schema.boolean()),
   is_default_fleet_server: schema.maybe(schema.boolean()),
   unenroll_timeout: schema.maybe(schema.number({ min: 0 })),
-  inactivity_timeout: schema.maybe(schema.number({ min: 0, defaultValue: TWO_WEEKS_SECONDS })),
+  inactivity_timeout: schema.number({ min: 0, defaultValue: TWO_WEEKS_SECONDS }),
   monitoring_enabled: schema.maybe(
     schema.arrayOf(
       schema.oneOf([schema.literal(dataTypes.Logs), schema.literal(dataTypes.Metrics)])

--- a/x-pack/test/fleet_api_integration/apis/agent_policy/agent_policy.ts
+++ b/x-pack/test/fleet_api_integration/apis/agent_policy/agent_policy.ts
@@ -58,6 +58,7 @@ export default function (providerContext: FtrProviderContext) {
 
         const { body } = await supertest.get(`/api/fleet/agent_policies/${createdPolicy.id}`);
         expect(body.item.is_managed).to.equal(false);
+        expect(body.item.inactivity_timeout).to.equal(1209600);
         expect(body.item.status).to.be('active');
       });
 

--- a/x-pack/test/fleet_api_integration/apis/agent_policy/agent_policy.ts
+++ b/x-pack/test/fleet_api_integration/apis/agent_policy/agent_policy.ts
@@ -625,6 +625,7 @@ export default function (providerContext: FtrProviderContext) {
           revision: 2,
           schema_version: FLEET_AGENT_POLICIES_SCHEMA_VERSION,
           updated_by: 'elastic',
+          inactivity_timeout: 1209600,
           package_policies: [],
         });
       });
@@ -788,6 +789,7 @@ export default function (providerContext: FtrProviderContext) {
           updated_by: 'elastic',
           package_policies: [],
           monitoring_enabled: ['logs', 'metrics'],
+          inactivity_timeout: 1209600,
         });
 
         const listResponseAfterUpdate = await fetchPackageList();

--- a/x-pack/test/fleet_api_integration/apis/fleet_telemetry.ts
+++ b/x-pack/test/fleet_api_integration/apis/fleet_telemetry.ts
@@ -110,6 +110,7 @@ export default function (providerContext: FtrProviderContext) {
       await generateAgent(providerContext, 'healthy', `agent-${++agentCount}`, agentPolicy.id);
       await generateAgent(providerContext, 'offline', `agent-${++agentCount}`, agentPolicy.id);
       await generateAgent(providerContext, 'error', `agent-${++agentCount}`, agentPolicy.id);
+      await generateAgent(providerContext, 'inactive', `agent-${++agentCount}`, agentPolicy.id);
       await generateAgent(providerContext, 'degraded', `agent-${++agentCount}`, agentPolicy.i);
       await generateAgent(
         providerContext,
@@ -137,7 +138,7 @@ export default function (providerContext: FtrProviderContext) {
         unhealthy: 3,
         offline: 1,
         unenrolled: 0,
-        inactive: 0,
+        inactive: 1,
         updating: 1,
         total_all_statuses: 8,
       });

--- a/x-pack/test/fleet_api_integration/helpers.ts
+++ b/x-pack/test/fleet_api_integration/helpers.ts
@@ -80,7 +80,7 @@ export async function generateAgent(
     index: '.fleet-agents',
     id,
     body: {
-      id: id + '-' + status,
+      id,
       active: true,
       last_checkin: new Date().toISOString(),
       policy_id: policyId,

--- a/x-pack/test/fleet_api_integration/helpers.ts
+++ b/x-pack/test/fleet_api_integration/helpers.ts
@@ -52,7 +52,17 @@ export async function generateAgent(
       data = { policy_revision_idx: 1, last_checkin_status: 'degraded' };
       break;
     case 'offline':
-      data = { policy_revision_idx: 1, last_checkin: '2017-06-07T18:59:04.498Z' };
+      // default inactivity timeout is 2 weeks
+      // anything less + above offline timeout will be offline
+      const oneWeekAgoTimestamp = new Date().getTime() - 7 * 24 * 60 * 60 * 1000;
+      data = { policy_revision_idx: 1, last_checkin: new Date(oneWeekAgoTimestamp).toISOString() };
+      break;
+    case 'inactive':
+      const threeWeeksAgoTimestamp = new Date().getTime() - 21 * 24 * 60 * 60 * 1000;
+      data = {
+        policy_revision_idx: 1,
+        last_checkin: new Date(threeWeeksAgoTimestamp).toISOString(),
+      };
       break;
     // Agent with last checkin status as error and currently unenrolling => should displayd updating status
     case 'error-unenrolling':
@@ -70,7 +80,7 @@ export async function generateAgent(
     index: '.fleet-agents',
     id,
     body: {
-      id,
+      id: id + '-' + status,
       active: true,
       last_checkin: new Date().toISOString(),
       policy_id: policyId,


### PR DESCRIPTION
## Summary

Closes #148527

All new agent policies should default inactivity timeout to 2 weeks (1209600 seconds).

### Test cases

- When installing a package for the first time in cloud, the 'My first agent policy' agent policy should have inactivity timeout set to `1209600`. This can be tested locally by adding `?useMultiPageLayout` to the add integration URL e.g: `/app/fleet/integrations/system-1.20.4/add-integration?useMultiPageLayout`

- When adding an integration (non multi page layout e.g `/app/fleet/integrations/system-1.20.4/add-integration`)  and electing to create a new agent policy, under 'advanced' inactivity timeout should be pre-populated with 1209600:

<img width="883" alt="Screenshot 2023-01-17 at 12 22 59" src="https://user-images.githubusercontent.com/3315046/212898300-e1a97d2e-b660-45f9-a5d3-8b0d7b6abe4d.png">


- When creating a new agent policy from the agent policy screen, under "advanced options", inactivity timeout should be pre-populated with 1209600:
<img width="1540" alt="Screenshot 2023-01-17 at 12 25 20" src="https://user-images.githubusercontent.com/3315046/212899294-027a3cfe-cc43-48b0-96fe-515956bb2da7.png">

- (covered by integration test also) When creating a new agent policy via the API, if no inactivity timeout is specified it should default to 1209600:

```
POST kbn:/api/fleet/agent_policies
{
  "name": "Default inactivity timeout",
  "description": "",
  "namespace": "default",
  "monitoring_enabled": [
    "logs",
    "metrics"
  ]
}
```

