### PR TITLE
[Response Ops][Alerting] Restoring `ActionGroupId` generics

### DIFF
--- a/x-pack/plugins/alerting/server/alert/create_alert_factory.ts
+++ b/x-pack/plugins/alerting/server/alert/create_alert_factory.ts
@@ -129,7 +129,12 @@ export function createAlertFactory<
             return [];
           }
 
-          const { currentRecoveredAlerts } = processAlerts<State, Context>({
+          const { currentRecoveredAlerts } = processAlerts<
+            State,
+            Context,
+            ActionGroupIds,
+            ActionGroupIds
+          >({
             alerts,
             existingAlerts: originalAlerts,
             previouslyRecoveredAlerts: {},

--- a/x-pack/plugins/alerting/server/alerts_client/legacy_alerts_client.ts
+++ b/x-pack/plugins/alerting/server/alerts_client/legacy_alerts_client.ts
@@ -17,7 +17,12 @@ import { AlertingEventLogger } from '../lib/alerting_event_logger/alerting_event
 import { RuleRunMetricsStore } from '../lib/rule_run_metrics_store';
 import { UntypedNormalizedRuleType } from '../rule_type_registry';
 import { logAlerts } from '../task_runner/log_alerts';
-import { AlertInstanceContext, AlertInstanceState, RawAlertInstance } from '../types';
+import {
+  AlertInstanceContext,
+  AlertInstanceState,
+  RawAlertInstance,
+  WithoutReservedActionGroups,
+} from '../types';
 
 interface ConstructorOpts {
   logger: Logger;
@@ -28,19 +33,24 @@ interface ConstructorOpts {
 export class LegacyAlertsClient<
   State extends AlertInstanceState,
   Context extends AlertInstanceContext,
-  ActionGroupIds extends string
+  ActionGroupIds extends string,
+  RecoveryActionGroupId extends string
 > {
   private activeAlertsFromPreviousExecution: Record<string, Alert<State, Context>>;
   private recoveredAlertsFromPreviousExecution: Record<string, Alert<State, Context>>;
   private alerts: Record<string, Alert<State, Context>>;
   private processedAlerts: {
-    new: Record<string, Alert<State, Context>>;
-    active: Record<string, Alert<State, Context>>;
-    recovered: Record<string, Alert<State, Context>>;
-    recoveredCurrent: Record<string, Alert<State, Context>>;
+    new: Record<string, Alert<State, Context, ActionGroupIds>>;
+    active: Record<string, Alert<State, Context, ActionGroupIds>>;
+    recovered: Record<string, Alert<State, Context, RecoveryActionGroupId>>;
+    recoveredCurrent: Record<string, Alert<State, Context, RecoveryActionGroupId>>;
   };
 
-  private alertFactory?: AlertFactory<State, Context, ActionGroupIds>;
+  private alertFactory?: AlertFactory<
+    State,
+    Context,
+    WithoutReservedActionGroups<ActionGroupIds, RecoveryActionGroupId>
+  >;
   constructor(private readonly options: ConstructorOpts) {
     this.alerts = {};
     this.activeAlertsFromPreviousExecution = {};
@@ -77,7 +87,11 @@ export class LegacyAlertsClient<
 
     this.alerts = cloneDeep(this.activeAlertsFromPreviousExecution);
 
-    this.alertFactory = createAlertFactory<State, Context, ActionGroupIds>({
+    this.alertFactory = createAlertFactory<
+      State,
+      Context,
+      WithoutReservedActionGroups<ActionGroupIds, RecoveryActionGroupId>
+    >({
       alerts: this.alerts,
       logger: this.options.logger,
       maxAlerts: this.options.maxAlerts,
@@ -101,7 +115,7 @@ export class LegacyAlertsClient<
       activeAlerts: processedAlertsActive,
       currentRecoveredAlerts: processedAlertsRecoveredCurrent,
       recoveredAlerts: processedAlertsRecovered,
-    } = processAlerts<State, Context>({
+    } = processAlerts<State, Context, ActionGroupIds, RecoveryActionGroupId>({
       alerts: this.alerts,
       existingAlerts: this.activeAlertsFromPreviousExecution,
       previouslyRecoveredAlerts: this.recoveredAlertsFromPreviousExecution,
@@ -110,7 +124,10 @@ export class LegacyAlertsClient<
       setFlapping: true,
     });
 
-    setFlapping<State, Context>(processedAlertsActive, processedAlertsRecovered);
+    setFlapping<State, Context, ActionGroupIds, RecoveryActionGroupId>(
+      processedAlertsActive,
+      processedAlertsRecovered
+    );
 
     this.processedAlerts.new = processedAlertsNew;
     this.processedAlerts.active = processedAlertsActive;
@@ -139,7 +156,7 @@ export class LegacyAlertsClient<
   }
 
   public getAlertsToSerialize() {
-    return determineAlertsToReturn<State, Context>(
+    return determineAlertsToReturn<State, Context, ActionGroupIds, RecoveryActionGroupId>(
       this.processedAlerts.active,
       this.processedAlerts.recovered
     );

--- a/x-pack/plugins/alerting/server/lib/determine_alerts_to_return.ts
+++ b/x-pack/plugins/alerting/server/lib/determine_alerts_to_return.ts
@@ -12,10 +12,12 @@ import { AlertInstanceState, AlertInstanceContext, RawAlertInstance } from '../t
 // determines which alerts to return in the state
 export function determineAlertsToReturn<
   State extends AlertInstanceState,
-  Context extends AlertInstanceContext
+  Context extends AlertInstanceContext,
+  ActionGroupIds extends string,
+  RecoveryActionGroupId extends string
 >(
-  activeAlerts: Record<string, Alert<State, Context>> = {},
-  recoveredAlerts: Record<string, Alert<State, Context>> = {}
+  activeAlerts: Record<string, Alert<State, Context, ActionGroupIds>> = {},
+  recoveredAlerts: Record<string, Alert<State, Context, RecoveryActionGroupId>> = {}
 ): {
   alertsToReturn: Record<string, RawAlertInstance>;
   recoveredAlertsToReturn: Record<string, RawAlertInstance>;

--- a/x-pack/plugins/alerting/server/lib/process_alerts.ts
+++ b/x-pack/plugins/alerting/server/lib/process_alerts.ts
@@ -25,18 +25,22 @@ interface ProcessAlertsOpts<
 }
 interface ProcessAlertsResult<
   State extends AlertInstanceState,
-  Context extends AlertInstanceContext
+  Context extends AlertInstanceContext,
+  ActionGroupIds extends string,
+  RecoveryActionGroupId extends string
 > {
-  newAlerts: Record<string, Alert<State, Context>>;
-  activeAlerts: Record<string, Alert<State, Context>>;
+  newAlerts: Record<string, Alert<State, Context, ActionGroupIds>>;
+  activeAlerts: Record<string, Alert<State, Context, ActionGroupIds>>;
   // recovered alerts in the current rule run that were previously active
-  currentRecoveredAlerts: Record<string, Alert<State, Context>>;
-  recoveredAlerts: Record<string, Alert<State, Context>>;
+  currentRecoveredAlerts: Record<string, Alert<State, Context, RecoveryActionGroupId>>;
+  recoveredAlerts: Record<string, Alert<State, Context, RecoveryActionGroupId>>;
 }
 
 export function processAlerts<
   State extends AlertInstanceState,
-  Context extends AlertInstanceContext
+  Context extends AlertInstanceContext,
+  ActionGroupIds extends string,
+  RecoveryActionGroupId extends string
 >({
   alerts,
   existingAlerts,
@@ -44,7 +48,12 @@ export function processAlerts<
   hasReachedAlertLimit,
   alertLimit,
   setFlapping,
-}: ProcessAlertsOpts<State, Context>): ProcessAlertsResult<State, Context> {
+}: ProcessAlertsOpts<State, Context>): ProcessAlertsResult<
+  State,
+  Context,
+  ActionGroupIds,
+  RecoveryActionGroupId
+> {
   return hasReachedAlertLimit
     ? processAlertsLimitReached(
         alerts,
@@ -58,21 +67,23 @@ export function processAlerts<
 
 function processAlertsHelper<
   State extends AlertInstanceState,
-  Context extends AlertInstanceContext
+  Context extends AlertInstanceContext,
+  ActionGroupIds extends string,
+  RecoveryActionGroupId extends string
 >(
   alerts: Record<string, Alert<State, Context>>,
   existingAlerts: Record<string, Alert<State, Context>>,
   previouslyRecoveredAlerts: Record<string, Alert<State, Context>>,
   setFlapping: boolean
-): ProcessAlertsResult<State, Context> {
+): ProcessAlertsResult<State, Context, ActionGroupIds, RecoveryActionGroupId> {
   const existingAlertIds = new Set(Object.keys(existingAlerts));
   const previouslyRecoveredAlertsIds = new Set(Object.keys(previouslyRecoveredAlerts));
 
   const currentTime = new Date().toISOString();
-  const newAlerts: Record<string, Alert<State, Context>> = {};
-  const activeAlerts: Record<string, Alert<State, Context>> = {};
-  const currentRecoveredAlerts: Record<string, Alert<State, Context>> = {};
-  const recoveredAlerts: Record<string, Alert<State, Context>> = {};
+  const newAlerts: Record<string, Alert<State, Context, ActionGroupIds>> = {};
+  const activeAlerts: Record<string, Alert<State, Context, ActionGroupIds>> = {};
+  const currentRecoveredAlerts: Record<string, Alert<State, Context, RecoveryActionGroupId>> = {};
+  const recoveredAlerts: Record<string, Alert<State, Context, RecoveryActionGroupId>> = {};
 
   for (const id in alerts) {
     if (alerts.hasOwnProperty(id)) {
@@ -147,14 +158,16 @@ function processAlertsHelper<
 
 function processAlertsLimitReached<
   State extends AlertInstanceState,
-  Context extends AlertInstanceContext
+  Context extends AlertInstanceContext,
+  ActionGroupIds extends string,
+  RecoveryActionGroupId extends string
 >(
   alerts: Record<string, Alert<State, Context>>,
   existingAlerts: Record<string, Alert<State, Context>>,
   previouslyRecoveredAlerts: Record<string, Alert<State, Context>>,
   alertLimit: number,
   setFlapping: boolean
-): ProcessAlertsResult<State, Context> {
+): ProcessAlertsResult<State, Context, ActionGroupIds, RecoveryActionGroupId> {
   const existingAlertIds = new Set(Object.keys(existingAlerts));
   const previouslyRecoveredAlertsIds = new Set(Object.keys(previouslyRecoveredAlerts));
 
@@ -164,10 +177,12 @@ function processAlertsLimitReached<
   // - add any new alerts, up to the max allowed
 
   const currentTime = new Date().toISOString();
-  const newAlerts: Record<string, Alert<State, Context>> = {};
+  const newAlerts: Record<string, Alert<State, Context, ActionGroupIds>> = {};
 
   // all existing alerts stay active
-  const activeAlerts: Record<string, Alert<State, Context>> = cloneDeep(existingAlerts);
+  const activeAlerts: Record<string, Alert<State, Context, ActionGroupIds>> = cloneDeep(
+    existingAlerts
+  );
 
   // update duration for existing alerts
   for (const id in activeAlerts) {
@@ -231,8 +246,10 @@ function processAlertsLimitReached<
 
 export function updateAlertFlappingHistory<
   State extends AlertInstanceState,
-  Context extends AlertInstanceContext
->(alert: Alert<State, Context>, state: boolean) {
+  Context extends AlertInstanceContext,
+  ActionGroupIds extends string,
+  RecoveryActionGroupId extends string
+>(alert: Alert<State, Context, ActionGroupIds | RecoveryActionGroupId>, state: boolean) {
   const updatedFlappingHistory = updateFlappingHistory(alert.getFlappingHistory() || [], state);
   alert.setFlappingHistory(updatedFlappingHistory);
 }

--- a/x-pack/plugins/alerting/server/lib/set_flapping.test.ts
+++ b/x-pack/plugins/alerting/server/lib/set_flapping.test.ts
@@ -7,7 +7,7 @@
 
 import { pick } from 'lodash';
 import { Alert } from '../alert';
-import { AlertInstanceState, AlertInstanceContext } from '../../common';
+import { AlertInstanceState, AlertInstanceContext, DefaultActionGroupId } from '../../common';
 import { setFlapping, isAlertFlapping } from './set_flapping';
 
 describe('setFlapping', () => {
@@ -85,25 +85,34 @@ describe('setFlapping', () => {
     describe('not currently flapping', () => {
       test('returns true if the flap count exceeds the threshold', () => {
         const flappingHistory = [true, true, true, true].concat(new Array(16).fill(false));
-        const alert = new Alert<AlertInstanceState, AlertInstanceContext>('1', {
-          meta: { flappingHistory },
-        });
+        const alert = new Alert<AlertInstanceState, AlertInstanceContext, DefaultActionGroupId>(
+          '1',
+          {
+            meta: { flappingHistory },
+          }
+        );
         expect(isAlertFlapping(alert)).toEqual(true);
       });
 
       test("returns false the flap count doesn't exceed the threshold", () => {
         const flappingHistory = [true, true].concat(new Array(20).fill(false));
-        const alert = new Alert<AlertInstanceState, AlertInstanceContext>('1', {
-          meta: { flappingHistory },
-        });
+        const alert = new Alert<AlertInstanceState, AlertInstanceContext, DefaultActionGroupId>(
+          '1',
+          {
+            meta: { flappingHistory },
+          }
+        );
         expect(isAlertFlapping(alert)).toEqual(false);
       });
 
       test('returns true if not at capacity and the flap count exceeds the threshold', () => {
         const flappingHistory = new Array(5).fill(true);
-        const alert = new Alert<AlertInstanceState, AlertInstanceContext>('1', {
-          meta: { flappingHistory },
-        });
+        const alert = new Alert<AlertInstanceState, AlertInstanceContext, DefaultActionGroupId>(
+          '1',
+          {
+            meta: { flappingHistory },
+          }
+        );
         expect(isAlertFlapping(alert)).toEqual(true);
       });
     });
@@ -111,33 +120,45 @@ describe('setFlapping', () => {
     describe('currently flapping', () => {
       test('returns true if at capacity and the flap count exceeds the threshold', () => {
         const flappingHistory = new Array(16).fill(false).concat([true, true, true, true]);
-        const alert = new Alert<AlertInstanceState, AlertInstanceContext>('1', {
-          meta: { flappingHistory, flapping: true },
-        });
+        const alert = new Alert<AlertInstanceState, AlertInstanceContext, DefaultActionGroupId>(
+          '1',
+          {
+            meta: { flappingHistory, flapping: true },
+          }
+        );
         expect(isAlertFlapping(alert)).toEqual(true);
       });
 
       test("returns true if not at capacity and the flap count doesn't exceed the threshold", () => {
         const flappingHistory = new Array(16).fill(false);
-        const alert = new Alert<AlertInstanceState, AlertInstanceContext>('1', {
-          meta: { flappingHistory, flapping: true },
-        });
+        const alert = new Alert<AlertInstanceState, AlertInstanceContext, DefaultActionGroupId>(
+          '1',
+          {
+            meta: { flappingHistory, flapping: true },
+          }
+        );
         expect(isAlertFlapping(alert)).toEqual(true);
       });
 
       test('returns true if not at capacity and the flap count exceeds the threshold', () => {
         const flappingHistory = new Array(10).fill(false).concat([true, true, true, true]);
-        const alert = new Alert<AlertInstanceState, AlertInstanceContext>('1', {
-          meta: { flappingHistory, flapping: true },
-        });
+        const alert = new Alert<AlertInstanceState, AlertInstanceContext, DefaultActionGroupId>(
+          '1',
+          {
+            meta: { flappingHistory, flapping: true },
+          }
+        );
         expect(isAlertFlapping(alert)).toEqual(true);
       });
 
       test("returns false if at capacity and the flap count doesn't exceed the threshold", () => {
         const flappingHistory = new Array(20).fill(false);
-        const alert = new Alert<AlertInstanceState, AlertInstanceContext>('1', {
-          meta: { flappingHistory, flapping: true },
-        });
+        const alert = new Alert<AlertInstanceState, AlertInstanceContext, DefaultActionGroupId>(
+          '1',
+          {
+            meta: { flappingHistory, flapping: true },
+          }
+        );
         expect(isAlertFlapping(alert)).toEqual(false);
       });
     });

--- a/x-pack/plugins/alerting/server/lib/set_flapping.ts
+++ b/x-pack/plugins/alerting/server/lib/set_flapping.ts
@@ -10,9 +10,14 @@ import { Alert } from '../alert';
 import { AlertInstanceState, AlertInstanceContext } from '../types';
 import { isFlapping } from './flapping_utils';
 
-export function setFlapping<State extends AlertInstanceState, Context extends AlertInstanceContext>(
-  activeAlerts: Record<string, Alert<State, Context>> = {},
-  recoveredAlerts: Record<string, Alert<State, Context>> = {}
+export function setFlapping<
+  State extends AlertInstanceState,
+  Context extends AlertInstanceContext,
+  ActionGroupIds extends string,
+  RecoveryActionGroupIds extends string
+>(
+  activeAlerts: Record<string, Alert<State, Context, ActionGroupIds>> = {},
+  recoveredAlerts: Record<string, Alert<State, Context, RecoveryActionGroupIds>> = {}
 ) {
   for (const id of keys(activeAlerts)) {
     const alert = activeAlerts[id];
@@ -29,8 +34,10 @@ export function setFlapping<State extends AlertInstanceState, Context extends Al
 
 export function isAlertFlapping<
   State extends AlertInstanceState,
-  Context extends AlertInstanceContext
->(alert: Alert<State, Context>): boolean {
+  Context extends AlertInstanceContext,
+  ActionGroupIds extends string,
+  RecoveryActionGroupId extends string
+>(alert: Alert<State, Context, ActionGroupIds | RecoveryActionGroupId>): boolean {
   const flappingHistory: boolean[] = alert.getFlappingHistory() || [];
   const isCurrentlyFlapping = alert.getFlapping();
   return isFlapping(flappingHistory, isCurrentlyFlapping);

--- a/x-pack/plugins/alerting/server/task_runner/log_alerts.test.ts
+++ b/x-pack/plugins/alerting/server/task_runner/log_alerts.test.ts
@@ -9,6 +9,7 @@ import { loggingSystemMock } from '@kbn/core-logging-server-mocks';
 import { Alert } from '../alert';
 import { alertingEventLoggerMock } from '../lib/alerting_event_logger/alerting_event_logger.mock';
 import { RuleRunMetricsStore } from '../lib/rule_run_metrics_store';
+import { DefaultActionGroupId } from '../types';
 import { logAlerts } from './log_alerts';
 
 const logger: ReturnType<typeof loggingSystemMock.createLogger> = loggingSystemMock.createLogger();
@@ -28,8 +29,8 @@ describe('logAlerts', () => {
       alertingEventLogger,
       newAlerts: {},
       activeAlerts: {
-        '1': new Alert<{}, {}>('1'),
-        '2': new Alert<{}, {}>('2'),
+        '1': new Alert<{}, {}, DefaultActionGroupId>('1'),
+        '2': new Alert<{}, {}, DefaultActionGroupId>('2'),
       },
       recoveredAlerts: {},
       ruleLogPrefix: `test-rule-type-id:123: 'test rule'`,
@@ -51,11 +52,11 @@ describe('logAlerts', () => {
       alertingEventLogger,
       newAlerts: {},
       activeAlerts: {
-        '1': new Alert<{}, {}>('1'),
-        '2': new Alert<{}, {}>('2'),
+        '1': new Alert<{}, {}, DefaultActionGroupId>('1'),
+        '2': new Alert<{}, {}, DefaultActionGroupId>('2'),
       },
       recoveredAlerts: {
-        '8': new Alert<{}, {}>('8'),
+        '8': new Alert<{}, {}, DefaultActionGroupId>('8'),
       },
       ruleLogPrefix: `test-rule-type-id:123: 'test rule'`,
       ruleRunMetricsStore,
@@ -75,8 +76,8 @@ describe('logAlerts', () => {
   });
 
   test('should correctly debug log recovered alerts if canSetRecoveryContext is true', () => {
-    const recoveredAlert1 = new Alert<{ value: string }, {}>('8');
-    const recoveredAlert2 = new Alert<{ value: string }, {}>('9');
+    const recoveredAlert1 = new Alert<{ value: string }, {}, DefaultActionGroupId>('8');
+    const recoveredAlert2 = new Alert<{ value: string }, {}, DefaultActionGroupId>('9');
     const recoveredAlerts = {
       '8': recoveredAlert1,
       '9': recoveredAlert2,
@@ -127,18 +128,18 @@ describe('logAlerts', () => {
       logger,
       alertingEventLogger,
       newAlerts: {
-        '4': new Alert<{}, {}>('4'),
+        '4': new Alert<{}, {}, DefaultActionGroupId>('4'),
       },
       activeAlerts: {
-        '1': new Alert<{}, {}>('1'),
-        '2': new Alert<{}, {}>('2'),
-        '4': new Alert<{}, {}>('4'),
+        '1': new Alert<{}, {}, DefaultActionGroupId>('1'),
+        '2': new Alert<{}, {}, DefaultActionGroupId>('2'),
+        '4': new Alert<{}, {}, DefaultActionGroupId>('4'),
       },
       recoveredAlerts: {
-        '7': new Alert<{}, {}>('7'),
-        '8': new Alert<{}, {}>('8'),
-        '9': new Alert<{}, {}>('9'),
-        '10': new Alert<{}, {}>('10'),
+        '7': new Alert<{}, {}, DefaultActionGroupId>('7'),
+        '8': new Alert<{}, {}, DefaultActionGroupId>('8'),
+        '9': new Alert<{}, {}, DefaultActionGroupId>('9'),
+        '10': new Alert<{}, {}, DefaultActionGroupId>('10'),
       },
       ruleLogPrefix: `test-rule-type-id:123: 'test rule'`,
       ruleRunMetricsStore,
@@ -215,18 +216,18 @@ describe('logAlerts', () => {
       logger,
       alertingEventLogger,
       newAlerts: {
-        '4': new Alert<{}, {}>('4'),
+        '4': new Alert<{}, {}, DefaultActionGroupId>('4'),
       },
       activeAlerts: {
-        '1': new Alert<{}, {}>('1'),
-        '2': new Alert<{}, {}>('2'),
-        '4': new Alert<{}, {}>('4'),
+        '1': new Alert<{}, {}, DefaultActionGroupId>('1'),
+        '2': new Alert<{}, {}, DefaultActionGroupId>('2'),
+        '4': new Alert<{}, {}, DefaultActionGroupId>('4'),
       },
       recoveredAlerts: {
-        '7': new Alert<{}, {}>('7'),
-        '8': new Alert<{}, {}>('8'),
-        '9': new Alert<{}, {}>('9'),
-        '10': new Alert<{}, {}>('10'),
+        '7': new Alert<{}, {}, DefaultActionGroupId>('7'),
+        '8': new Alert<{}, {}, DefaultActionGroupId>('8'),
+        '9': new Alert<{}, {}, DefaultActionGroupId>('9'),
+        '10': new Alert<{}, {}, DefaultActionGroupId>('10'),
       },
       ruleLogPrefix: `test-rule-type-id:123: 'test rule'`,
       ruleRunMetricsStore,
@@ -246,18 +247,18 @@ describe('logAlerts', () => {
       logger,
       alertingEventLogger,
       newAlerts: {
-        '4': new Alert<{}, {}>('4'),
+        '4': new Alert<{}, {}, DefaultActionGroupId>('4'),
       },
       activeAlerts: {
-        '1': new Alert<{}, {}>('1', { meta: { flapping: true } }),
-        '2': new Alert<{}, {}>('2'),
-        '4': new Alert<{}, {}>('4'),
+        '1': new Alert<{}, {}, DefaultActionGroupId>('1', { meta: { flapping: true } }),
+        '2': new Alert<{}, {}, DefaultActionGroupId>('2'),
+        '4': new Alert<{}, {}, DefaultActionGroupId>('4'),
       },
       recoveredAlerts: {
-        '7': new Alert<{}, {}>('7'),
-        '8': new Alert<{}, {}>('8', { meta: { flapping: true } }),
-        '9': new Alert<{}, {}>('9'),
-        '10': new Alert<{}, {}>('10'),
+        '7': new Alert<{}, {}, DefaultActionGroupId>('7'),
+        '8': new Alert<{}, {}, DefaultActionGroupId>('8', { meta: { flapping: true } }),
+        '9': new Alert<{}, {}, DefaultActionGroupId>('9'),
+        '10': new Alert<{}, {}, DefaultActionGroupId>('10'),
       },
       ruleLogPrefix: `test-rule-type-id:123: 'test rule'`,
       ruleRunMetricsStore,

--- a/x-pack/plugins/alerting/server/task_runner/log_alerts.ts
+++ b/x-pack/plugins/alerting/server/task_runner/log_alerts.ts
@@ -15,20 +15,27 @@ import { RuleRunMetricsStore } from '../lib/rule_run_metrics_store';
 
 export interface LogAlertsParams<
   State extends AlertInstanceState,
-  Context extends AlertInstanceContext
+  Context extends AlertInstanceContext,
+  ActionGroupIds extends string,
+  RecoveryActionGroupId extends string
 > {
   logger: Logger;
   alertingEventLogger: AlertingEventLogger;
-  newAlerts: Record<string, Alert<State, Context>>;
-  activeAlerts: Record<string, Alert<State, Context>>;
-  recoveredAlerts: Record<string, Alert<State, Context>>;
+  newAlerts: Record<string, Alert<State, Context, ActionGroupIds>>;
+  activeAlerts: Record<string, Alert<State, Context, ActionGroupIds>>;
+  recoveredAlerts: Record<string, Alert<State, Context, RecoveryActionGroupId>>;
   ruleLogPrefix: string;
   ruleRunMetricsStore: RuleRunMetricsStore;
   canSetRecoveryContext: boolean;
   shouldPersistAlerts: boolean;
 }
 
-export function logAlerts<State extends AlertInstanceState, Context extends AlertInstanceContext>({
+export function logAlerts<
+  State extends AlertInstanceState,
+  Context extends AlertInstanceContext,
+  ActionGroupIds extends string,
+  RecoveryActionGroupId extends string
+>({
   logger,
   alertingEventLogger,
   newAlerts,
@@ -38,7 +45,7 @@ export function logAlerts<State extends AlertInstanceState, Context extends Aler
   ruleRunMetricsStore,
   canSetRecoveryContext,
   shouldPersistAlerts,
-}: LogAlertsParams<State, Context>) {
+}: LogAlertsParams<State, Context, ActionGroupIds, RecoveryActionGroupId>) {
   const newAlertIds = Object.keys(newAlerts);
   const activeAlertIds = Object.keys(activeAlerts);
   const recoveredAlertIds = Object.keys(recoveredAlerts);

--- a/x-pack/plugins/alerting/server/task_runner/task_runner.ts
+++ b/x-pack/plugins/alerting/server/task_runner/task_runner.ts
@@ -44,7 +44,6 @@ import {
   RuleTypeParams,
   RuleTypeState,
   parseDuration,
-  WithoutReservedActionGroups,
 } from '../../common';
 import { NormalizedRuleType, UntypedNormalizedRuleType } from '../rule_type_registry';
 import { getEsErrorMessage } from '../lib/errors';
@@ -114,7 +113,8 @@ export class TaskRunner<
   private legacyAlertsClient: LegacyAlertsClient<
     State,
     Context,
-    WithoutReservedActionGroups<ActionGroupIds, RecoveryActionGroupId>
+    ActionGroupIds,
+    RecoveryActionGroupId
   >;
 
   constructor(


### PR DESCRIPTION
## Summary

As part of [this PR](https://github.com/elastic/kibana/pull/148751) to encapsulate alert related functionality into a `LegacyAlertsClient`, we removed some generics for `ActionGroupId` because they did not seem necessary. However, they are needed to support scheduling actions, which we add in [this PR](https://github.com/elastic/kibana/pull/147810). This PR is just for restoring the generics for alert related functions.

