### PR TITLE
[APM] increasing maxTraceItems

### DIFF
--- a/x-pack/plugins/apm/common/critical_path/get_critical_path.test.ts
+++ b/x-pack/plugins/apm/common/critical_path/get_critical_path.test.ts
@@ -24,7 +24,7 @@ describe('getCriticalPath', () => {
         exceedsMax: false,
         spanLinksCountById: {},
         traceItemCount: events.length,
-        maxTraceItems: 1000,
+        maxTraceItems: 5000,
       },
       entryTransaction,
     });

--- a/x-pack/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/index.tsx
@@ -159,7 +159,11 @@ export function Waterfall({
                 flyoutDetailTab: string
               ) => toggleFlyout({ history, item, flyoutDetailTab })}
               showCriticalPath={showCriticalPath}
-              maxLevelOpen={maxLevelOpen}
+              maxLevelOpen={
+                waterfall.traceItemCount > 500
+                  ? maxLevelOpen
+                  : waterfall.traceItemCount
+              }
             />
           )}
         </WaterfallItemsContainer>

--- a/x-pack/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/waterfall_helpers/waterfall_helpers.test.ts
+++ b/x-pack/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/waterfall_helpers/waterfall_helpers.test.ts
@@ -139,7 +139,7 @@ describe('waterfall_helpers', () => {
           exceedsMax: false,
           spanLinksCountById: {},
           traceItemCount: hits.length,
-          maxTraceItems: 1000,
+          maxTraceItems: 5000,
         },
         entryTransaction: {
           processor: { event: 'transaction' },
@@ -169,7 +169,7 @@ describe('waterfall_helpers', () => {
           exceedsMax: false,
           spanLinksCountById: {},
           traceItemCount: hits.length,
-          maxTraceItems: 1000,
+          maxTraceItems: 5000,
         },
         entryTransaction: {
           parent: { id: 'mySpanIdD' },
@@ -272,7 +272,7 @@ describe('waterfall_helpers', () => {
           exceedsMax: false,
           spanLinksCountById: {},
           traceItemCount: traceItems.length,
-          maxTraceItems: 1000,
+          maxTraceItems: 5000,
         },
         entryTransaction: {
           processor: { event: 'transaction' },
@@ -391,7 +391,7 @@ describe('waterfall_helpers', () => {
           exceedsMax: false,
           spanLinksCountById: {},
           traceItemCount: traceItems.length,
-          maxTraceItems: 1000,
+          maxTraceItems: 5000,
         },
         entryTransaction: {
           processor: { event: 'transaction' },

--- a/x-pack/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall_container.stories.tsx
+++ b/x-pack/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall_container.stories.tsx
@@ -82,7 +82,7 @@ export const Example: Story<any> = () => {
     errorDocs: errorDocs.map((error) => dedot(error, {}) as WaterfallError),
     spanLinksCountById: {},
     traceItemCount: traceDocs.length,
-    maxTraceItems: 1000,
+    maxTraceItems: 5000,
   };
 
   const entryTransaction = dedot(traceDocs[0]!, {}) as Transaction;

--- a/x-pack/plugins/apm/server/index.ts
+++ b/x-pack/plugins/apm/server/index.ts
@@ -29,7 +29,7 @@ const configSchema = schema.object({
   ui: schema.object({
     enabled: schema.boolean({ defaultValue: true }),
     transactionGroupBucketSize: schema.number({ defaultValue: 1000 }),
-    maxTraceItems: schema.number({ defaultValue: 1000 }),
+    maxTraceItems: schema.number({ defaultValue: 5000 }),
   }),
   searchAggregatedTransactions: schema.oneOf(
     [

--- a/x-pack/plugins/apm/server/routes/traces/__snapshots__/queries.test.ts.snap
+++ b/x-pack/plugins/apm/server/routes/traces/__snapshots__/queries.test.ts.snap
@@ -48,7 +48,7 @@ Object {
         },
       },
     },
-    "size": 1000,
+    "size": 5000,
     "track_total_hits": false,
   },
 }

--- a/x-pack/plugins/apm/server/utils/test_helpers.tsx
+++ b/x-pack/plugins/apm/server/utils/test_helpers.tsx
@@ -79,7 +79,7 @@ export async function inspectSearchParams(
             return {
               enabled: true,
               transactionGroupBucketSize: 1000,
-              maxTraceItems: 1000,
+              maxTraceItems: 5000,
             };
           case 'metricsInterval':
             return 30;

--- a/x-pack/test/apm_api_integration/tests/traces/trace_by_id.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/traces/trace_by_id.spec.ts
@@ -52,7 +52,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
           errorDocs: [],
           spanLinksCountById: {},
           traceItemCount: 0,
-          maxTraceItems: 1000,
+          maxTraceItems: 5000,
         },
       });
     });


### PR DESCRIPTION
In this PR I automatically collapse items after the third level https://github.com/elastic/kibana/pull/147569. This change has boosted the performance of the trace waterfall giving us confidence to increase the `maxTraceItems` to 5k initially.

More details about the performance can be found here: https://docs.google.com/document/d/1sHAISHcdfJYM7Cky2qmXHYr9unDMyvjvsjAwcwoRb9g/edit?usp=sharing