### PR TITLE
[DOCS] Fix deduplication spelling

### DIFF
--- a/docs/api/actions-and-connectors/execute.asciidoc
+++ b/docs/api/actions-and-connectors/execute.asciidoc
@@ -178,7 +178,7 @@ the `subAction` value.
 (Optional, array of strings) The custom actions available to the alert.
 
 `alias`::::
-(Optional, string) The unique identifier used for alert de-duplication in {opsgenie}.
+(Optional, string) The unique identifier used for alert deduplication in {opsgenie}.
 
 `description`::::
 (Optional, string) A description that provides detailed information about the alert.
@@ -258,7 +258,7 @@ required.
 [%collapsible%open]
 ======
 `alias`::::
-(Required, string) The unique identifier used for alert de-duplication in {opsgenie}.
+(Required, string) The unique identifier used for alert deduplication in {opsgenie}.
 The alias must match the value used when creating the alert.
 
 `note`::::

--- a/docs/management/connectors/action-types/opsgenie.asciidoc
+++ b/docs/management/connectors/action-types/opsgenie.asciidoc
@@ -88,7 +88,7 @@ Message::   The message for the alert (required).
 Opsgenie tags::   The tags for the alert (optional).
 Priority::  The priority level for the alert.
 Description::   A description that provides detailed information about the alert (optional).
-Alias::   The alert identifier, which is used for alert de-duplication in Opsgenie. For more information, refer to the https://support.atlassian.com/opsgenie/docs/what-is-alert-de-duplication/[Opsgenie documentation] (optional).
+Alias::   The alert identifier, which is used for alert deduplication in Opsgenie. For more information, refer to the https://support.atlassian.com/opsgenie/docs/what-is-alert-de-duplication/[Opsgenie documentation] (optional).
 Entity::  The domain of the alert (optional).
 Source::  The source of the alert (optional).
 User::    The display name of the owner (optional).
@@ -145,7 +145,7 @@ Example JSON editor contents
 
 The close alert action has the following configuration properties.
 
-Alias::   The alert identifier, which is used for alert de-duplication in Opsgenie (required). The alias must match the value used when creating the alert. For more information, refer to the https://support.atlassian.com/opsgenie/docs/what-is-alert-de-duplication/[Opsgenie documentation].
+Alias::   The alert identifier, which is used for alert deduplication in Opsgenie (required). The alias must match the value used when creating the alert. For more information, refer to the https://support.atlassian.com/opsgenie/docs/what-is-alert-de-duplication/[Opsgenie documentation].
 Note::    Additional information for the alert (optional).
 Source::  The display name of the source (optional).
 User::    The display name of the owner (optional).

--- a/x-pack/plugins/stack_connectors/public/connector_types/opsgenie/translations.ts
+++ b/x-pack/plugins/stack_connectors/public/connector_types/opsgenie/translations.ts
@@ -127,7 +127,7 @@ export const OPSGENIE_DOCUMENTATION = i18n.translate(
 export const OPSGENIE_ALIAS_HELP = i18n.translate(
   'xpack.stackConnectors.components.opsgenie.fieldAliasHelpText',
   {
-    defaultMessage: 'The unique alert identifier used for de-deduplication in Opsgenie.',
+    defaultMessage: 'The unique alert identifier used for deduplication in Opsgenie.',
   }
 );
 


### PR DESCRIPTION
## Summary

This PR fixes occurrences of "de-deduplication" and "de-duplication" in the Opsgenie documentation and UI text.

<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->