### PR TITLE
[Saved Objects] Fixes namespace argument to encryption calls in repository update method

### DIFF
--- a/packages/core/saved-objects/core-saved-objects-api-server-internal/src/lib/repository.ts
+++ b/packages/core/saved-objects/core-saved-objects-api-server-internal/src/lib/repository.ts
@@ -1957,7 +1957,7 @@ export class SavedObjectsRepository implements ISavedObjectsRepository {
         ...(savedObjectNamespace && { namespace: savedObjectNamespace }),
         ...(savedObjectNamespaces && { namespaces: savedObjectNamespaces }),
         attributes: {
-          ...(await this.optionallyEncryptAttributes(type, id, options.namespace, upsert)),
+          ...(await this.optionallyEncryptAttributes(type, id, namespace, upsert)),
         },
         updated_at: time,
       });
@@ -1965,7 +1965,7 @@ export class SavedObjectsRepository implements ISavedObjectsRepository {
     }
 
     const doc = {
-      [type]: await this.optionallyEncryptAttributes(type, id, options.namespace, attributes),
+      [type]: await this.optionallyEncryptAttributes(type, id, namespace, attributes),
       updated_at: time,
       ...(Array.isArray(references) && { references }),
     };


### PR DESCRIPTION
Closes #149037.

## Summary

The namespace argument in Saved Object Repository Update method's call to optionallyEncryptAttributes was being supplied by an unqualified optional parameter. This means that when the namespace option was not defined, the current namespace was not being passed to the encrypt method. This PR updates the argument to the qualified namespace determined by the optional parameter and the Spaces Extension's getCurrentNamespace method.

Unit tests have also been updated to catch this case should it occur in the future. The same consideration will be made for security extension unit tests in [PR 148165](https://github.com/elastic/kibana/pull/148165).

## Testing
To test, follow the instructions given in [the issue](https://github.com/elastic/kibana/issues/149037).