### PR TITLE
[ci] Fix storybooks

### DIFF
--- a/.buildkite/scripts/steps/storybooks/build_and_upload.sh
+++ b/.buildkite/scripts/steps/storybooks/build_and_upload.sh
@@ -4,4 +4,6 @@ set -euo pipefail
 
 .buildkite/scripts/bootstrap.sh
 
+# Broken during Node 18 upgrade
+export NODE_OPTIONS="--openssl-legacy-provider"
 ts-node .buildkite/scripts/steps/storybooks/build_and_upload.ts

--- a/.buildkite/scripts/steps/storybooks/build_and_upload.sh
+++ b/.buildkite/scripts/steps/storybooks/build_and_upload.sh
@@ -4,7 +4,4 @@ set -euo pipefail
 
 .buildkite/scripts/bootstrap.sh
 
-# Broken during Node 18 upgrade
-# https://github.com/storybookjs/storybook/issues/20482
-export NODE_OPTIONS="--openssl-legacy-provider"
 ts-node .buildkite/scripts/steps/storybooks/build_and_upload.ts

--- a/.buildkite/scripts/steps/storybooks/build_and_upload.sh
+++ b/.buildkite/scripts/steps/storybooks/build_and_upload.sh
@@ -5,5 +5,6 @@ set -euo pipefail
 .buildkite/scripts/bootstrap.sh
 
 # Broken during Node 18 upgrade
+# https://github.com/storybookjs/storybook/issues/20482
 export NODE_OPTIONS="--openssl-legacy-provider"
 ts-node .buildkite/scripts/steps/storybooks/build_and_upload.ts

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "makelogs": "node scripts/makelogs",
     "spec_to_console": "node scripts/spec_to_console",
     "start": "node scripts/kibana --dev",
-    "storybook": "node scripts/storybook",
+    "storybook": "node --openssl-legacy-provider scripts/storybook",
     "test:ftr": "node scripts/functional_tests",
     "test:ftr:runner": "node scripts/functional_test_runner",
     "test:ftr:server": "node scripts/functional_tests_server",


### PR DESCRIPTION
There's a [known issue](https://github.com/storybookjs/storybook/issues/20482) with storybooks 6 and node 17+ requiring use of the legacy openssl provider.  This adds the `--openssl-legacy-provider` flag to our storybooks entrypoint.

This is similar to a few of the webpack related changes in https://github.com/elastic/kibana/pull/144012, merging early to fix CI.  FYI @watson 