### PR TITLE
[Security Solution][Detections] Testing cypress suite against detection rules package 8.3.4-beta.1

### DIFF
--- a/x-pack/test/security_solution_cypress/config.ts
+++ b/x-pack/test/security_solution_cypress/config.ts
@@ -53,7 +53,7 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
         '--xpack.cloud.id=test',
         `--home.disableWelcomeScreen=true`,
         // Specify which version of the detection-rules package to install
-        // `--xpack.securitySolution.prebuiltRulesPackageVersion=8.3.1`,
+        `--xpack.securitySolution.prebuiltRulesPackageVersion=8.3.4-beta.1`,
       ],
     },
   };


### PR DESCRIPTION
# Test PR - Do Not Merge!

## Summary

Test PR follow-up from https://github.com/elastic/kibana/pull/148426 that will run our cypress test suites against the `8.3.4-beta.1` `detection-rules` package.


cc @terrancedejesus @elastic/threat-research-and-detection-engineering 

