### PR TITLE
[Synthetics] monitor details - use configId for locations in monitor details card

### DIFF
--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/common/components/monitor_details_panel.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/common/components/monitor_details_panel.tsx
@@ -123,7 +123,7 @@ export const MonitorDetailsPanel = ({
           <DescriptionLabel>{frequencyStr(monitor[ConfigKey.SCHEDULE])}</DescriptionLabel>
           <TitleLabel>{LOCATIONS_LABEL}</TitleLabel>
           <DescriptionLabel>
-            <LocationsStatus configId={monitor.id} monitorLocations={monitor.locations} />
+            <LocationsStatus configId={configId} monitorLocations={monitor.locations} />
           </DescriptionLabel>
 
           <TitleLabel>{TAGS_LABEL}</TitleLabel>


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/149084

Uses `configId` for the locations card in the monitor details card. This ensures this field is populated appropriately for both project and UI monitors.

<img width="1450" alt="Screen Shot 2023-01-17 at 7 18 10 PM" src="https://user-images.githubusercontent.com/11356435/213043507-e7bd2e09-d871-40f0-9b3e-8dbfada614e3.png">

### Testing

1. Create 1 project monitor and 1 UI monitor
2. Navigate to the monitor details page for both. Ensure the location is populated appropriately in the Monitor Details card for each monitor, including the status of the location.
