### PR TITLE
[Fleet] changed telemetry log to debug

### DIFF
--- a/x-pack/plugins/fleet/server/services/agents/status.ts
+++ b/x-pack/plugins/fleet/server/services/agents/status.ts
@@ -108,7 +108,7 @@ export async function getAgentStatusForAgentPolicy(
       },
     });
   } catch (error) {
-    logger.warn(`Error getting agent statuses: ${error}`);
+    logger.debug(`Error getting agent statuses: ${error}`);
     throw error;
   }
 

--- a/x-pack/plugins/fleet/server/services/fleet_usage_logger.ts
+++ b/x-pack/plugins/fleet/server/services/fleet_usage_logger.ts
@@ -39,7 +39,7 @@ export async function registerFleetUsageLogger(
             } catch (error) {
               appContextService
                 .getLogger()
-                .warn('Error occurred while fetching fleet usage: ' + error);
+                .debug('Error occurred while fetching fleet usage: ' + error);
             }
           },
 


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/148060

Changed telemetry log to debug if `.fleet-agents` index does not exist, so it is not flagging error/warning.



<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->