### PR TITLE
feat(slo): Create historical summary API

### DIFF
--- a/packages/kbn-slo-schema/src/rest_specs/slo.ts
+++ b/packages/kbn-slo-schema/src/rest_specs/slo.ts
@@ -11,6 +11,7 @@ import * as t from 'io-ts';
 import {
   budgetingMethodSchema,
   dateType,
+  historicalSummarySchema,
   indicatorSchema,
   indicatorTypesArraySchema,
   objectiveSchema,
@@ -109,6 +110,9 @@ const findSLOResponseSchema = t.type({
   results: t.array(sloWithSummaryResponseSchema),
 });
 
+const fetchHistoricalSummaryParamsSchema = t.type({ body: t.type({ sloIds: t.array(t.string) }) });
+const fetchHistoricalSummaryResponseSchema = t.record(t.string, t.array(historicalSummarySchema));
+
 type SLOResponse = t.OutputOf<typeof sloResponseSchema>;
 type SLOWithSummaryResponse = t.OutputOf<typeof sloWithSummaryResponseSchema>;
 
@@ -125,6 +129,9 @@ type UpdateSLOResponse = t.OutputOf<typeof updateSLOResponseSchema>;
 type FindSLOParams = t.TypeOf<typeof findSLOParamsSchema.props.query>;
 type FindSLOResponse = t.OutputOf<typeof findSLOResponseSchema>;
 
+type FetchHistoricalSummaryParams = t.TypeOf<typeof fetchHistoricalSummaryParamsSchema.props.body>;
+type FetchHistoricalSummaryResponse = t.OutputOf<typeof fetchHistoricalSummaryResponseSchema>;
+
 type BudgetingMethod = t.TypeOf<typeof budgetingMethodSchema>;
 
 export {
@@ -134,6 +141,8 @@ export {
   findSLOResponseSchema,
   getSLOParamsSchema,
   getSLOResponseSchema,
+  fetchHistoricalSummaryParamsSchema,
+  fetchHistoricalSummaryResponseSchema,
   sloResponseSchema,
   sloWithSummaryResponseSchema,
   updateSLOParamsSchema,
@@ -147,6 +156,8 @@ export type {
   FindSLOParams,
   FindSLOResponse,
   GetSLOResponse,
+  FetchHistoricalSummaryParams,
+  FetchHistoricalSummaryResponse,
   SLOResponse,
   SLOWithSummaryResponse,
   UpdateSLOInput,

--- a/packages/kbn-slo-schema/src/schema/indicators.ts
+++ b/packages/kbn-slo-schema/src/schema/indicators.ts
@@ -7,7 +7,13 @@
  */
 
 import * as t from 'io-ts';
-import { allOrAnyString, dateRangeSchema } from './common';
+import {
+  allOrAnyString,
+  dateRangeSchema,
+  dateType,
+  errorBudgetSchema,
+  statusSchema,
+} from './common';
 
 const apmTransactionDurationIndicatorTypeSchema = t.literal('sli.apm.transactionDuration');
 const apmTransactionDurationIndicatorSchema = t.type({
@@ -62,6 +68,13 @@ const indicatorDataSchema = t.type({
   total: t.number,
 });
 
+const historicalSummarySchema = t.type({
+  date: dateType,
+  errorBudget: errorBudgetSchema,
+  sliValue: t.number,
+  status: statusSchema,
+});
+
 const indicatorTypesSchema = t.union([
   apmTransactionDurationIndicatorTypeSchema,
   apmTransactionErrorRateIndicatorTypeSchema,
@@ -104,4 +117,5 @@ export {
   indicatorTypesArraySchema,
   indicatorTypesSchema,
   indicatorDataSchema,
+  historicalSummarySchema,
 };

--- a/x-pack/plugins/observability/server/domain/models/indicators.ts
+++ b/x-pack/plugins/observability/server/domain/models/indicators.ts
@@ -9,6 +9,7 @@ import * as t from 'io-ts';
 import {
   apmTransactionDurationIndicatorSchema,
   apmTransactionErrorRateIndicatorSchema,
+  historicalSummarySchema,
   indicatorDataSchema,
   indicatorSchema,
   indicatorTypesSchema,
@@ -21,6 +22,7 @@ type KQLCustomIndicator = t.TypeOf<typeof kqlCustomIndicatorSchema>;
 type Indicator = t.TypeOf<typeof indicatorSchema>;
 type IndicatorTypes = t.TypeOf<typeof indicatorTypesSchema>;
 type IndicatorData = t.TypeOf<typeof indicatorDataSchema>;
+type HistoricalSummary = t.TypeOf<typeof historicalSummarySchema>;
 
 export type {
   Indicator,
@@ -29,4 +31,5 @@ export type {
   APMTransactionDurationIndicator,
   KQLCustomIndicator,
   IndicatorData,
+  HistoricalSummary,
 };

--- a/x-pack/plugins/observability/server/domain/services/compute_sli.test.ts
+++ b/x-pack/plugins/observability/server/domain/services/compute_sli.test.ts
@@ -5,24 +5,22 @@
  * 2.0.
  */
 
-import { DateRange } from '../models';
 import { computeSLI } from './compute_sli';
 
-const DATE_RANGE: DateRange = { from: new Date(), to: new Date() };
 describe('computeSLI', () => {
   it('returns -1 when no total events', () => {
-    expect(computeSLI({ good: 100, total: 0, dateRange: DATE_RANGE })).toEqual(-1);
+    expect(computeSLI({ good: 100, total: 0 })).toEqual(-1);
   });
 
   it('returns the sli value', () => {
-    expect(computeSLI({ good: 100, total: 1000, dateRange: DATE_RANGE })).toEqual(0.1);
+    expect(computeSLI({ good: 100, total: 1000 })).toEqual(0.1);
   });
 
   it('returns 1 when good is greater than total events', () => {
-    expect(computeSLI({ good: 9999, total: 9, dateRange: DATE_RANGE })).toEqual(1);
+    expect(computeSLI({ good: 9999, total: 9 })).toEqual(1);
   });
 
   it('returns rounds the value to 6 digits', () => {
-    expect(computeSLI({ good: 33, total: 90, dateRange: DATE_RANGE })).toEqual(0.366667);
+    expect(computeSLI({ good: 33, total: 90 })).toEqual(0.366667);
   });
 });

--- a/x-pack/plugins/observability/server/domain/services/compute_sli.ts
+++ b/x-pack/plugins/observability/server/domain/services/compute_sli.ts
@@ -10,7 +10,7 @@ import { toHighPrecision } from '../../utils/number';
 
 const NO_DATA = -1;
 
-export function computeSLI(sliData: IndicatorData): number {
+export function computeSLI(sliData: Pick<IndicatorData, 'good' | 'total'>): number {
   const { good, total } = sliData;
   if (total === 0) {
     return NO_DATA;

--- a/x-pack/plugins/observability/server/saved_objects/slo.ts
+++ b/x-pack/plugins/observability/server/saved_objects/slo.ts
@@ -19,6 +19,7 @@ export const slo: SavedObjectsType = {
   mappings: {
     dynamic: false,
     properties: {
+      id: { type: 'keyword' },
       name: { type: 'keyword' },
       description: { type: 'text' },
       indicator: {

--- a/x-pack/plugins/observability/server/services/slo/__snapshots__/historical_summary_client.test.ts.snap
+++ b/x-pack/plugins/observability/server/services/slo/__snapshots__/historical_summary_client.test.ts.snap
@@ -1,0 +1,1345 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 1`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.004019,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.995981,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 2`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.023374,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.976626,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 3`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.042725,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.957275,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 4`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.06208,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.93792,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 5`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.081433,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.918567,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 6`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.100784,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.899216,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 7`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.120137,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.879863,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 8`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.139494,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.860506,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 9`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.15887,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.84113,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 10`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.1782,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.8218,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 11`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.197546,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.802454,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 12`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.216933,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.783067,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 13`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.236292,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.763708,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 14`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.25563,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.74437,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 15`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.274977,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.725023,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 16`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.294298,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.705702,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 17`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.313653,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.686347,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 18`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.333025,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.666975,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 1`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.001344,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.998656,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 2`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.002688,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.997312,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 3`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.004032,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.995968,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 4`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.005376,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.994624,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 5`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.00672,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.99328,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 6`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.008065,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.991935,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 7`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.009409,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.990591,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 8`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.010753,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.989247,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 9`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.012097,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.987903,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 10`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.013441,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.986559,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 11`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.014785,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.985215,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 12`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.016129,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.983871,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 13`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.017473,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.982527,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 14`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.018817,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.981183,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 15`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.020161,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.979839,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 16`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.021505,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.978495,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 17`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.022849,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.977151,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 18`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.024194,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.975806,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 1`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 2`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 3`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 4`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 5`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 6`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 7`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 8`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 9`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 10`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 11`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 12`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 13`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 14`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 15`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 16`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 17`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 18`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 19`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 20`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 21`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 22`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 23`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 24`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 25`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 26`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 27`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 28`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 29`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 30`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 1`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 2`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 3`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 4`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 5`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 6`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 7`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 8`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 9`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 10`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 11`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 12`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 13`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 14`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 15`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 16`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 17`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 18`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 19`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 20`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 21`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 22`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 23`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 24`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 25`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 26`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 27`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 28`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 29`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 30`] = `
+Object {
+  "date": Any<Date>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;

--- a/x-pack/plugins/observability/server/services/slo/fetch_historical_summary.ts
+++ b/x-pack/plugins/observability/server/services/slo/fetch_historical_summary.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  FetchHistoricalSummaryParams,
+  FetchHistoricalSummaryResponse,
+  fetchHistoricalSummaryResponseSchema,
+} from '@kbn/slo-schema';
+import { HistoricalSummaryClient } from './historical_summary_client';
+import { SLORepository } from './slo_repository';
+
+export class FetchHistoricalSummary {
+  constructor(
+    private repository: SLORepository,
+    private historicalSummaryClient: HistoricalSummaryClient
+  ) {}
+
+  public async execute({
+    sloIds,
+  }: FetchHistoricalSummaryParams): Promise<FetchHistoricalSummaryResponse> {
+    const sloList = await this.repository.findAllByIds(sloIds);
+    const historicalSummaryBySlo = await this.historicalSummaryClient.fetch(sloList);
+    return fetchHistoricalSummaryResponseSchema.encode(historicalSummaryBySlo);
+  }
+}

--- a/x-pack/plugins/observability/server/services/slo/fixtures/duration.ts
+++ b/x-pack/plugins/observability/server/services/slo/fixtures/duration.ts
@@ -7,6 +7,14 @@
 
 import { Duration, DurationUnit } from '../../../domain/models';
 
+export function thirtyDays(): Duration {
+  return new Duration(30, DurationUnit.Day);
+}
+
+export function oneMonth(): Duration {
+  return new Duration(1, DurationUnit.Month);
+}
+
 export function sevenDays(): Duration {
   return new Duration(7, DurationUnit.Day);
 }

--- a/x-pack/plugins/observability/server/services/slo/historical_summary_client.test.ts
+++ b/x-pack/plugins/observability/server/services/slo/historical_summary_client.test.ts
@@ -1,0 +1,192 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ElasticsearchClientMock, elasticsearchServiceMock } from '@kbn/core/server/mocks';
+import moment from 'moment';
+import { oneMinute, oneMonth, thirtyDays } from './fixtures/duration';
+import { createSLO } from './fixtures/slo';
+import { DefaultHistoricalSummaryClient } from './historical_summary_client';
+
+const commonEsResponse = {
+  took: 100,
+  timed_out: false,
+  _shards: {
+    total: 0,
+    successful: 0,
+    skipped: 0,
+    failed: 0,
+  },
+  hits: {
+    hits: [],
+  },
+};
+
+const generateEsResponseForRollingSLO = (
+  rollingDays: number = 30,
+  good: number = 97,
+  total: number = 100
+) => {
+  const numberOfBuckets = rollingDays * 2;
+  const day = moment.utc().subtract(numberOfBuckets, 'day').startOf('day');
+  return {
+    ...commonEsResponse,
+    responses: [
+      {
+        ...commonEsResponse,
+        aggregations: {
+          daily: {
+            buckets: Array(numberOfBuckets)
+              .fill(0)
+              .map((_, index) => ({
+                key_as_string: day.clone().add(index, 'day').toISOString(),
+                key: day.clone().add(index, 'day').format('x'),
+                doc_count: 1440,
+                total: {
+                  value: total,
+                },
+                good: {
+                  value: good,
+                },
+                cumulative_good: {
+                  value: good * (index + 1),
+                },
+                cumulative_total: {
+                  value: total * (index + 1),
+                },
+              })),
+          },
+        },
+      },
+    ],
+  };
+};
+
+const generateEsResponseForCalendarAlignedSLO = (good: number = 97, total: number = 100) => {
+  const day = moment.utc().startOf('month');
+  return {
+    ...commonEsResponse,
+    responses: [
+      {
+        ...commonEsResponse,
+        aggregations: {
+          daily: {
+            buckets: Array(18)
+              .fill(0)
+              .map((_, index) => ({
+                key_as_string: day.clone().add(index, 'day').toISOString(),
+                key: day.clone().add(index, 'day').format('x'),
+                doc_count: 1440,
+                total: {
+                  value: total,
+                },
+                good: {
+                  value: good,
+                },
+                cumulative_good: {
+                  value: good * (index + 1),
+                },
+                cumulative_total: {
+                  value: total * (index + 1),
+                },
+              })),
+          },
+        },
+      },
+    ],
+  };
+};
+
+describe('FetchHistoricalSummary', () => {
+  let esClientMock: ElasticsearchClientMock;
+
+  beforeEach(() => {
+    esClientMock = elasticsearchServiceMock.createElasticsearchClient();
+  });
+
+  describe('Rolling and Occurrences SLOs', () => {
+    it('returns the summary', async () => {
+      const slo = createSLO({
+        timeWindow: { isRolling: true, duration: thirtyDays() },
+        objective: { target: 0.95 },
+      });
+      esClientMock.msearch.mockResolvedValueOnce(generateEsResponseForRollingSLO(30));
+      const client = new DefaultHistoricalSummaryClient(esClientMock);
+
+      const results = await client.fetch([slo]);
+      results[slo.id].forEach((dailyResult) =>
+        expect(dailyResult).toMatchSnapshot({ date: expect.any(Date) })
+      );
+
+      expect(results[slo.id]).toHaveLength(30);
+    });
+  });
+
+  describe('Rolling and Timeslices SLOs', () => {
+    it('returns the summary', async () => {
+      const slo = createSLO({
+        timeWindow: { isRolling: true, duration: thirtyDays() },
+        budgetingMethod: 'timeslices',
+        objective: { target: 0.95, timesliceTarget: 0.9, timesliceWindow: oneMinute() },
+      });
+      esClientMock.msearch.mockResolvedValueOnce(generateEsResponseForRollingSLO(30));
+      const client = new DefaultHistoricalSummaryClient(esClientMock);
+
+      const results = await client.fetch([slo]);
+
+      results[slo.id].forEach((dailyResult) =>
+        expect(dailyResult).toMatchSnapshot({ date: expect.any(Date) })
+      );
+      expect(results[slo.id]).toHaveLength(30);
+    });
+  });
+
+  describe('Calendar Aligned and Timeslices SLOs', () => {
+    it('returns the summary', async () => {
+      const slo = createSLO({
+        timeWindow: {
+          duration: oneMonth(),
+          calendar: { startTime: new Date('2023-01-01T00:00:00.000Z') },
+        },
+        budgetingMethod: 'timeslices',
+        objective: { target: 0.95, timesliceTarget: 0.9, timesliceWindow: oneMinute() },
+      });
+      esClientMock.msearch.mockResolvedValueOnce(generateEsResponseForCalendarAlignedSLO());
+      const client = new DefaultHistoricalSummaryClient(esClientMock);
+
+      const results = await client.fetch([slo]);
+
+      results[slo.id].forEach((dailyResult) =>
+        expect(dailyResult).toMatchSnapshot({ date: expect.any(Date) })
+      );
+
+      expect(results[slo.id]).toHaveLength(18);
+    });
+  });
+
+  describe('Calendar Aligned and Occurrences SLOs', () => {
+    it('returns the summary', async () => {
+      const slo = createSLO({
+        timeWindow: {
+          duration: oneMonth(),
+          calendar: { startTime: new Date('2023-01-01T00:00:00.000Z') },
+        },
+        budgetingMethod: 'occurrences',
+        objective: { target: 0.95 },
+      });
+      esClientMock.msearch.mockResolvedValueOnce(generateEsResponseForCalendarAlignedSLO());
+      const client = new DefaultHistoricalSummaryClient(esClientMock);
+
+      const results = await client.fetch([slo]);
+
+      results[slo.id].forEach((dailyResult) =>
+        expect(dailyResult).toMatchSnapshot({ date: expect.any(Date) })
+      );
+
+      expect(results[slo.id]).toHaveLength(18);
+    });
+  });
+});

--- a/x-pack/plugins/observability/server/services/slo/historical_summary_client.ts
+++ b/x-pack/plugins/observability/server/services/slo/historical_summary_client.ts
@@ -1,0 +1,302 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { MsearchMultisearchBody } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import { ElasticsearchClient } from '@kbn/core/server';
+import {
+  calendarAlignedTimeWindowSchema,
+  occurrencesBudgetingMethodSchema,
+  rollingTimeWindowSchema,
+  timeslicesBudgetingMethodSchema,
+  toMomentUnitOfTime,
+} from '@kbn/slo-schema';
+import { assertNever } from '@kbn/std';
+import moment from 'moment';
+
+import { SLO_DESTINATION_INDEX_NAME } from '../../assets/constants';
+import { DateRange, HistoricalSummary, SLO, SLOId } from '../../domain/models';
+import {
+  computeSLI,
+  computeSummaryStatus,
+  computeTotalSlicesFromDateRange,
+  toDateRange,
+  toErrorBudget,
+} from '../../domain/services';
+
+interface DailyAggBucket {
+  key_as_string: string;
+  key: number;
+  doc_count: number;
+  total: {
+    value: number;
+  };
+  good: {
+    value: number;
+  };
+  cumulative_good?: {
+    value: number;
+  };
+  cumulative_total?: {
+    value: number;
+  };
+}
+
+export interface HistoricalSummaryClient {
+  fetch(sloList: SLO[]): Promise<Record<SLOId, HistoricalSummary[]>>;
+}
+
+export class DefaultHistoricalSummaryClient implements HistoricalSummaryClient {
+  constructor(private esClient: ElasticsearchClient) {}
+
+  async fetch(sloList: SLO[]): Promise<Record<SLOId, HistoricalSummary[]>> {
+    const dateRangeBySlo: Record<SLOId, DateRange> = sloList.reduce(
+      (acc, slo) => ({ [slo.id]: getDateRange(slo), ...acc }),
+      {}
+    );
+
+    const searches = sloList.flatMap((slo) => [
+      { index: `${SLO_DESTINATION_INDEX_NAME}*` },
+      generateSearchQuery(slo, dateRangeBySlo[slo.id]),
+    ]);
+
+    const historicalSummaryBySlo: Record<SLOId, HistoricalSummary[]> = {};
+    if (searches.length === 0) {
+      return historicalSummaryBySlo;
+    }
+
+    const result = await this.esClient.msearch({ searches });
+
+    for (let i = 0; i < result.responses.length; i++) {
+      const slo = sloList[i];
+      if ('error' in result.responses[i]) {
+        // handle errorneous responses with an empty historical summary
+        historicalSummaryBySlo[slo.id] = [];
+        continue;
+      }
+
+      // @ts-ignore typing msearch is hard, we cast the response to what it is supposed to be.
+      const buckets = (result.responses[i].aggregations?.daily?.buckets as DailyAggBucket[]) || [];
+
+      if (rollingTimeWindowSchema.is(slo.timeWindow)) {
+        historicalSummaryBySlo[slo.id] = handleResultForRolling(slo, buckets);
+        continue;
+      }
+
+      if (calendarAlignedTimeWindowSchema.is(slo.timeWindow)) {
+        if (timeslicesBudgetingMethodSchema.is(slo.budgetingMethod)) {
+          const dateRange = dateRangeBySlo[slo.id];
+          historicalSummaryBySlo[slo.id] = handleResultForCalendarAlignedAndTimeslices(
+            slo,
+            buckets,
+            dateRange
+          );
+          continue;
+        }
+
+        if (occurrencesBudgetingMethodSchema.is(slo.budgetingMethod)) {
+          const dateRange = dateRangeBySlo[slo.id];
+          historicalSummaryBySlo[slo.id] = handleResultForCalendarAlignedAndOccurrences(
+            slo,
+            buckets,
+            dateRange
+          );
+          continue;
+        }
+
+        assertNever(slo.budgetingMethod);
+      }
+
+      assertNever(slo.timeWindow);
+    }
+
+    return historicalSummaryBySlo;
+  }
+}
+
+function handleResultForCalendarAlignedAndOccurrences(
+  slo: SLO,
+  buckets: DailyAggBucket[],
+  dateRange: DateRange
+): HistoricalSummary[] {
+  const initialErrorBudget = 1 - slo.objective.target;
+
+  return buckets.map((bucket: DailyAggBucket): HistoricalSummary => {
+    const good = bucket.cumulative_good?.value ?? 0;
+    const total = bucket.cumulative_total?.value ?? 0;
+    const sliValue = computeSLI({ good, total });
+
+    const durationCalendarPeriod = moment(dateRange.to).diff(dateRange.from, 'minutes');
+    const bucketDate = moment(bucket.key_as_string).endOf('day');
+    const durationSinceBeginning = bucketDate.isAfter(dateRange.to)
+      ? durationCalendarPeriod
+      : moment(bucketDate).diff(dateRange.from, 'minutes');
+
+    const totalEventsEstimatedAtPeriodEnd = Math.round(
+      (total / durationSinceBeginning) * durationCalendarPeriod
+    );
+
+    const consumedErrorBudget =
+      (total - good) / (totalEventsEstimatedAtPeriodEnd * initialErrorBudget);
+
+    const errorBudget = toErrorBudget(initialErrorBudget, consumedErrorBudget, true);
+
+    return {
+      date: new Date(bucket.key_as_string),
+      errorBudget,
+      sliValue,
+      status: computeSummaryStatus(slo, sliValue, errorBudget),
+    };
+  });
+}
+
+function handleResultForCalendarAlignedAndTimeslices(
+  slo: SLO,
+  buckets: DailyAggBucket[],
+  dateRange: DateRange
+): HistoricalSummary[] {
+  const initialErrorBudget = 1 - slo.objective.target;
+
+  return buckets.map((bucket: DailyAggBucket): HistoricalSummary => {
+    const good = bucket.cumulative_good?.value ?? 0;
+    const total = bucket.cumulative_total?.value ?? 0;
+    const sliValue = computeSLI({ good, total });
+    const totalSlices = computeTotalSlicesFromDateRange(dateRange, slo.objective.timesliceWindow!);
+    const consumedErrorBudget = (total - good) / (totalSlices * initialErrorBudget);
+    const errorBudget = toErrorBudget(initialErrorBudget, consumedErrorBudget);
+
+    return {
+      date: new Date(bucket.key_as_string),
+      errorBudget,
+      sliValue,
+      status: computeSummaryStatus(slo, sliValue, errorBudget),
+    };
+  });
+}
+
+function handleResultForRolling(slo: SLO, buckets: DailyAggBucket[]): HistoricalSummary[] {
+  const initialErrorBudget = 1 - slo.objective.target;
+  const rollingWindowDurationInDays = moment
+    .duration(slo.timeWindow.duration.value, toMomentUnitOfTime(slo.timeWindow.duration.unit))
+    .asDays();
+
+  return buckets
+    .slice(-rollingWindowDurationInDays)
+    .map((bucket: DailyAggBucket): HistoricalSummary => {
+      const good = bucket.cumulative_good?.value ?? 0;
+      const total = bucket.cumulative_total?.value ?? 0;
+      const sliValue = computeSLI({ good, total });
+      const consumedErrorBudget = total === 0 ? 0 : (total - good) / (total * initialErrorBudget);
+      const errorBudget = toErrorBudget(initialErrorBudget, consumedErrorBudget);
+
+      return {
+        date: new Date(bucket.key_as_string),
+        errorBudget,
+        sliValue,
+        status: computeSummaryStatus(slo, sliValue, errorBudget),
+      };
+    });
+}
+
+function generateSearchQuery(slo: SLO, dateRange: DateRange): MsearchMultisearchBody {
+  const unit = toMomentUnitOfTime(slo.timeWindow.duration.unit);
+  const timeWindowDurationInDays = moment.duration(slo.timeWindow.duration.value, unit).asDays();
+
+  return {
+    size: 0,
+    query: {
+      bool: {
+        filter: [
+          { term: { 'slo.id': slo.id } },
+          { term: { 'slo.revision': slo.revision } },
+          {
+            range: {
+              '@timestamp': {
+                gte: dateRange.from.toISOString(),
+                lte: dateRange.to.toISOString(),
+              },
+            },
+          },
+        ],
+      },
+    },
+    aggs: {
+      daily: {
+        date_histogram: {
+          field: '@timestamp',
+          fixed_interval: '1d',
+          extended_bounds: {
+            min: dateRange.from.toISOString(),
+            max: 'now/d',
+          },
+        },
+        aggs: {
+          ...(occurrencesBudgetingMethodSchema.is(slo.budgetingMethod) && {
+            good: {
+              sum: {
+                field: 'slo.numerator',
+              },
+            },
+            total: {
+              sum: {
+                field: 'slo.denominator',
+              },
+            },
+          }),
+          ...(timeslicesBudgetingMethodSchema.is(slo.budgetingMethod) && {
+            good: {
+              sum: {
+                field: 'slo.isGoodSlice',
+              },
+            },
+            total: {
+              value_count: {
+                field: 'slo.isGoodSlice',
+              },
+            },
+          }),
+          cumulative_good: {
+            moving_fn: {
+              buckets_path: 'good',
+              window: timeWindowDurationInDays,
+              shift: 1,
+              script: 'MovingFunctions.sum(values)',
+            },
+          },
+          cumulative_total: {
+            moving_fn: {
+              buckets_path: 'total',
+              window: timeWindowDurationInDays,
+              shift: 1,
+              script: 'MovingFunctions.sum(values)',
+            },
+          },
+        },
+      },
+    },
+  };
+}
+
+function getDateRange(slo: SLO) {
+  const unit = toMomentUnitOfTime(slo.timeWindow.duration.unit);
+
+  if (rollingTimeWindowSchema.is(slo.timeWindow)) {
+    const now = moment();
+    return {
+      from: now
+        .clone()
+        .subtract(slo.timeWindow.duration.value * 2, unit)
+        .startOf('day')
+        .toDate(),
+      to: now.startOf('minute').toDate(),
+    };
+  }
+  if (calendarAlignedTimeWindowSchema.is(slo.timeWindow)) {
+    return toDateRange(slo.timeWindow);
+  }
+
+  assertNever(slo.timeWindow);
+}

--- a/x-pack/plugins/observability/server/services/slo/index.ts
+++ b/x-pack/plugins/observability/server/services/slo/index.ts
@@ -7,8 +7,10 @@
 
 export * from './create_slo';
 export * from './delete_slo';
+export * from './fetch_historical_summary';
 export * from './find_slo';
 export * from './get_slo';
+export * from './historical_summary_client';
 export * from './resource_installer';
 export * from './sli_client';
 export * from './slo_repository';

--- a/x-pack/plugins/observability/server/services/slo/mocks/index.ts
+++ b/x-pack/plugins/observability/server/services/slo/mocks/index.ts
@@ -29,6 +29,7 @@ const createSLORepositoryMock = (): jest.Mocked<SLORepository> => {
   return {
     save: jest.fn(),
     findById: jest.fn(),
+    findAllByIds: jest.fn(),
     deleteById: jest.fn(),
     find: jest.fn(),
   };

--- a/x-pack/plugins/observability/server/services/slo/sli_client.test.ts
+++ b/x-pack/plugins/observability/server/services/slo/sli_client.test.ts
@@ -10,7 +10,6 @@ import moment from 'moment';
 
 import { SLO_DESTINATION_INDEX_NAME } from '../../assets/constants';
 import { toDateRange } from '../../domain/services';
-import { InternalQueryError } from '../../errors';
 import { Duration, DurationUnit } from '../../domain/models';
 import { createSLO } from './fixtures/slo';
 import { DefaultSLIClient } from './sli_client';
@@ -52,24 +51,6 @@ describe('SLIClient', () => {
 
   describe('fetchCurrentSLIData', () => {
     describe('with occurrences budgeting method', () => {
-      it('throws when aggregations failed', async () => {
-        const slo = createSLO({ timeWindow: sevenDaysRolling() });
-        esClientMock.msearch.mockResolvedValueOnce({
-          ...commonEsResponse,
-          responses: [
-            {
-              ...commonEsResponse,
-              aggregations: {},
-            },
-          ],
-        });
-        const sliClient = new DefaultSLIClient(esClientMock);
-
-        await expect(sliClient.fetchCurrentSLIData([slo])).rejects.toThrowError(
-          new InternalQueryError('SLI aggregation query')
-        );
-      });
-
       describe('with a rolling time window', () => {
         it('returns the aggregated good and total values', async () => {
           const slo = createSLO({ timeWindow: sevenDaysRolling() });
@@ -158,32 +139,6 @@ describe('SLIClient', () => {
     });
 
     describe('with timeslices budgeting method', () => {
-      it('throws when aggregations failed', async () => {
-        const slo = createSLO({
-          budgetingMethod: 'timeslices',
-          objective: {
-            target: 0.95,
-            timesliceTarget: 0.95,
-            timesliceWindow: new Duration(10, DurationUnit.Minute),
-          },
-        });
-
-        esClientMock.msearch.mockResolvedValueOnce({
-          ...commonEsResponse,
-          responses: [
-            {
-              ...commonEsResponse,
-              aggregations: {},
-            },
-          ],
-        });
-        const sliClient = new DefaultSLIClient(esClientMock);
-
-        await expect(sliClient.fetchCurrentSLIData([slo])).rejects.toThrowError(
-          new InternalQueryError('SLI aggregation query')
-        );
-      });
-
       describe('with a calendar aligned time window', () => {
         it('returns the aggregated good and total values', async () => {
           const slo = createSLO({

--- a/x-pack/plugins/observability/server/services/slo/slo_repository.test.ts
+++ b/x-pack/plugins/observability/server/services/slo/slo_repository.test.ts
@@ -26,21 +26,20 @@ import { createAPMTransactionDurationIndicator, createSLO, aStoredSLO } from './
 import { SLONotFound } from '../../errors';
 
 const SOME_SLO = createSLO({ indicator: createAPMTransactionDurationIndicator() });
+const ANOTHER_SLO = createSLO();
 
-function aFindResponse(slo: SLO): SavedObjectsFindResponse<StoredSLO> {
+function createFindResponse(sloList: SLO[]): SavedObjectsFindResponse<StoredSLO> {
   return {
     page: 1,
     per_page: 25,
-    total: 1,
-    saved_objects: [
-      {
-        id: slo.id,
-        attributes: sloSchema.encode(slo),
-        type: SO_SLO_TYPE,
-        references: [],
-        score: 1,
-      },
-    ],
+    total: sloList.length,
+    saved_objects: sloList.map((slo) => ({
+      id: slo.id,
+      attributes: sloSchema.encode(slo),
+      type: SO_SLO_TYPE,
+      references: [],
+      score: 1,
+    })),
   };
 }
 
@@ -96,6 +95,21 @@ describe('KibanaSavedObjectsSLORepository', () => {
     expect(soClientMock.get).toHaveBeenCalledWith(SO_SLO_TYPE, SOME_SLO.id);
   });
 
+  it('finds all SLOs by ids', async () => {
+    const repository = new KibanaSavedObjectsSLORepository(soClientMock);
+    soClientMock.find.mockResolvedValueOnce(createFindResponse([SOME_SLO, ANOTHER_SLO]));
+
+    const results = await repository.findAllByIds([SOME_SLO.id, ANOTHER_SLO.id]);
+
+    expect(results).toEqual([SOME_SLO, ANOTHER_SLO]);
+    expect(soClientMock.find).toHaveBeenCalledWith({
+      type: SO_SLO_TYPE,
+      page: 1,
+      perPage: 2,
+      filter: `slo.attributes.id:(${SOME_SLO.id} or ${ANOTHER_SLO.id})`,
+    });
+  });
+
   it('deletes an SLO', async () => {
     const repository = new KibanaSavedObjectsSLORepository(soClientMock);
 
@@ -114,7 +128,7 @@ describe('KibanaSavedObjectsSLORepository', () => {
     describe('Name filter', () => {
       it('includes the filter on name with wildcard when provided', async () => {
         const repository = new KibanaSavedObjectsSLORepository(soClientMock);
-        soClientMock.find.mockResolvedValueOnce(aFindResponse(SOME_SLO));
+        soClientMock.find.mockResolvedValueOnce(createFindResponse([SOME_SLO]));
 
         const result = await repository.find(
           { name: 'availability*' },
@@ -140,7 +154,7 @@ describe('KibanaSavedObjectsSLORepository', () => {
 
       it('includes the filter on name with added wildcard when not provided', async () => {
         const repository = new KibanaSavedObjectsSLORepository(soClientMock);
-        soClientMock.find.mockResolvedValueOnce(aFindResponse(SOME_SLO));
+        soClientMock.find.mockResolvedValueOnce(createFindResponse([SOME_SLO]));
 
         const result = await repository.find(
           { name: 'availa' },
@@ -168,7 +182,7 @@ describe('KibanaSavedObjectsSLORepository', () => {
     describe('indicatorTypes filter', () => {
       it('includes the filter on indicator types when provided', async () => {
         const repository = new KibanaSavedObjectsSLORepository(soClientMock);
-        soClientMock.find.mockResolvedValueOnce(aFindResponse(SOME_SLO));
+        soClientMock.find.mockResolvedValueOnce(createFindResponse([SOME_SLO]));
 
         const result = await repository.find(
           { indicatorTypes: ['sli.kql.custom'] },
@@ -194,7 +208,7 @@ describe('KibanaSavedObjectsSLORepository', () => {
 
       it('includes the filter on indicator types as logical OR when provided', async () => {
         const repository = new KibanaSavedObjectsSLORepository(soClientMock);
-        soClientMock.find.mockResolvedValueOnce(aFindResponse(SOME_SLO));
+        soClientMock.find.mockResolvedValueOnce(createFindResponse([SOME_SLO]));
 
         const result = await repository.find(
           { indicatorTypes: ['sli.kql.custom', 'sli.apm.transactionDuration'] },
@@ -221,7 +235,7 @@ describe('KibanaSavedObjectsSLORepository', () => {
 
     it('includes filter on name and indicator types', async () => {
       const repository = new KibanaSavedObjectsSLORepository(soClientMock);
-      soClientMock.find.mockResolvedValueOnce(aFindResponse(SOME_SLO));
+      soClientMock.find.mockResolvedValueOnce(createFindResponse([SOME_SLO]));
 
       const result = await repository.find(
         { name: 'latency', indicatorTypes: ['sli.kql.custom', 'sli.apm.transactionDuration'] },
@@ -247,7 +261,7 @@ describe('KibanaSavedObjectsSLORepository', () => {
 
     it('does not include the filter when no criteria provided', async () => {
       const repository = new KibanaSavedObjectsSLORepository(soClientMock);
-      soClientMock.find.mockResolvedValueOnce(aFindResponse(SOME_SLO));
+      soClientMock.find.mockResolvedValueOnce(createFindResponse([SOME_SLO]));
 
       const result = await repository.find({}, DEFAULT_SORTING, DEFAULT_PAGINATION);
 
@@ -268,7 +282,7 @@ describe('KibanaSavedObjectsSLORepository', () => {
 
     it('sorts by name ascending', async () => {
       const repository = new KibanaSavedObjectsSLORepository(soClientMock);
-      soClientMock.find.mockResolvedValueOnce(aFindResponse(SOME_SLO));
+      soClientMock.find.mockResolvedValueOnce(createFindResponse([SOME_SLO]));
 
       await repository.find({}, DEFAULT_SORTING, DEFAULT_PAGINATION);
 
@@ -283,7 +297,7 @@ describe('KibanaSavedObjectsSLORepository', () => {
 
     it('sorts by name descending', async () => {
       const repository = new KibanaSavedObjectsSLORepository(soClientMock);
-      soClientMock.find.mockResolvedValueOnce(aFindResponse(SOME_SLO));
+      soClientMock.find.mockResolvedValueOnce(createFindResponse([SOME_SLO]));
 
       await repository.find(
         {},
@@ -302,7 +316,7 @@ describe('KibanaSavedObjectsSLORepository', () => {
 
     it('sorts by indicator type', async () => {
       const repository = new KibanaSavedObjectsSLORepository(soClientMock);
-      soClientMock.find.mockResolvedValueOnce(aFindResponse(SOME_SLO));
+      soClientMock.find.mockResolvedValueOnce(createFindResponse([SOME_SLO]));
 
       await repository.find(
         {},


### PR DESCRIPTION
## 📝 Summary

Resolves https://github.com/elastic/kibana/issues/148463

This PR introduces an internal API for fetching the historical summary of a given list of SLOs.
Initially, the story was about rolling SLO only, but it was not too hard to include the calendar aligned ones as well.

## ✅ Manual testing

Create some SLOs and then query the API with their SLO ids:
```
curl --request POST \
  --url http://localhost:5601/kibana/internal/observability/slos/_historical_summary \
  --header 'Authorization: Basic ZWxhc3RpYzpjaGFuZ2VtZQ==' \
  --header 'Content-Type: application/json' \
  --header 'kbn-xsrf: oui' \
  --data '{
	"sloIds": ["192afad0-9684-11ed-968d-09d2827f09d2"]
}'
```

