### PR TITLE
[Synthetics] Update codeblock parent wrapping

### DIFF
--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/common/links/step_details_link.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/common/links/step_details_link.tsx
@@ -30,6 +30,7 @@ export const StepDetailsLinkIcon = ({
   if (asButton) {
     return (
       <EuiButtonEmpty
+        flush="left"
         iconType="apmTrace"
         href={`${basePath}/app/synthetics/monitor/${configId}/test-run/${checkGroup}/step/${stepIndex}?locationId=${selectedLocation?.id}`}
       >

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/error_details/error_details_page.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/error_details/error_details_page.tsx
@@ -43,7 +43,7 @@ export function ErrorDetailsPage() {
       </PanelWithTitle>
       <EuiSpacer size="m" />
       <EuiFlexGroup gutterSize="m">
-        <EuiFlexItem grow={2}>
+        <EuiFlexItem grow={2} style={{ minWidth: 0 }}>
           <PanelWithTitle title="Failed tests">
             <FailedTestsList failedTests={failedTests} loading={loading} />
           </PanelWithTitle>

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/test_run_details/components/step_info.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/test_run_details/components/step_info.tsx
@@ -60,7 +60,7 @@ export const StepMetaInfo = ({
         </EuiFlexItem>
       </EuiFlexGroup>
       <EuiSpacer size="s" />
-      <EuiFlexGroup gutterSize="m">
+      <EuiFlexGroup gutterSize="m" wrap>
         {isFailed && stateId && (
           <EuiFlexItem grow={false}>
             <ErrorDetailsButton configId={monitorId} stateId={stateId} />

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/test_run_details/test_run_details.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/test_run_details/test_run_details.tsx
@@ -43,7 +43,7 @@ export const TestRunDetails = () => {
   return (
     <>
       <EuiFlexGroup gutterSize="m">
-        <EuiFlexItem grow={2}>
+        <EuiFlexItem grow={2} style={{ minWidth: 0 }}>
           <EuiPanel hasShadow={false} hasBorder>
             <EuiFlexGroup alignItems="center">
               <EuiFlexItem grow={true}>


### PR DESCRIPTION
## Summary

Properly wrap code block to adjust on small screen !!

Before:
<img width="1247" alt="image" src="https://user-images.githubusercontent.com/3505601/213261317-e8bf02fc-50f4-43c9-ba44-5f96821a3003.png">



After:
<img width="1082" alt="image" src="https://user-images.githubusercontent.com/3505601/213261171-0af282b2-542a-4ff0-b583-7a9f5641d3e4.png">
