### PR TITLE
[Enterprise Search] Search for Engines List

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/engines/fetch_engines_api_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/engines/fetch_engines_api_logic.ts
@@ -25,7 +25,7 @@ export const fetchEngines = async ({
   const query = {
     from: meta.from,
     size: meta.size,
-    ...(searchQuery && searchQuery !== '' ? { q: searchQuery } : {}),
+    ...(searchQuery && searchQuery.trim() !== '' ? { q: searchQuery } : {}),
   };
   return await HttpLogic.values.http.get<EnterpriseSearchEnginesResponse>(route, {
     query,

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/engines/fetch_engines_api_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/engines/fetch_engines_api_logic.ts
@@ -14,16 +14,18 @@ import { Meta } from '../../components/engines/types';
 
 export interface EnginesListAPIArguments {
   meta: Meta;
-  // searchQuery?: string;
+  searchQuery?: string;
 }
 
 export const fetchEngines = async ({
   meta,
+  searchQuery,
 }: EnginesListAPIArguments): Promise<EnterpriseSearchEnginesResponse> => {
   const route = '/internal/enterprise_search/engines';
   const query = {
     from: meta.from,
     size: meta.size,
+    ...(searchQuery && searchQuery !== '' ? { q: searchQuery } : {}),
   };
   return await HttpLogic.values.http.get<EnterpriseSearchEnginesResponse>(route, {
     query,

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engines/engines_list.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engines/engines_list.tsx
@@ -15,6 +15,7 @@ import { EuiButton, EuiFieldSearch, EuiLink, EuiSpacer, EuiText } from '@elastic
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage, FormattedNumber } from '@kbn/i18n-react';
 
+import { INPUT_THROTTLE_DELAY_MS } from '../../../shared/constants/timers';
 import { DataPanel } from '../../../shared/data_panel/data_panel';
 
 import { EnterpriseSearchContentPageTemplate } from '../layout/page_template';
@@ -23,13 +24,11 @@ import { EnginesListTable } from './components/tables/engines_table';
 import { DeleteEngineModal } from './delete_engine_modal';
 import { EnginesListLogic } from './engines_list_logic';
 
-const ENGINES_SEARCH_THROTTLE_MS = 500;
-
 export const EnginesList: React.FC = () => {
   const { fetchEngines, onPaginate, openDeleteEngineModal } = useActions(EnginesListLogic);
   const { meta, results } = useValues(EnginesListLogic);
   const [searchQuery, setSearchValue] = useState('');
-  const throttledSearchQuery = useThrottle(searchQuery, ENGINES_SEARCH_THROTTLE_MS);
+  const throttledSearchQuery = useThrottle(searchQuery, INPUT_THROTTLE_DELAY_MS);
 
   useEffect(() => {
     fetchEngines({

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engines/engines_list.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engines/engines_list.tsx
@@ -8,6 +8,7 @@
 import React, { useEffect, useState } from 'react';
 
 import { useActions, useValues } from 'kea';
+import useThrottle from 'react-use/lib/useThrottle';
 
 import { EuiButton, EuiFieldSearch, EuiLink, EuiSpacer, EuiText } from '@elastic/eui';
 
@@ -22,17 +23,20 @@ import { EnginesListTable } from './components/tables/engines_table';
 import { DeleteEngineModal } from './delete_engine_modal';
 import { EnginesListLogic } from './engines_list_logic';
 
+const ENGINES_SEARCH_THROTTLE_MS = 500;
+
 export const EnginesList: React.FC = () => {
   const { fetchEngines, onPaginate, openDeleteEngineModal } = useActions(EnginesListLogic);
   const { meta, results } = useValues(EnginesListLogic);
   const [searchQuery, setSearchValue] = useState('');
+  const throttledSearchQuery = useThrottle(searchQuery, ENGINES_SEARCH_THROTTLE_MS);
 
   useEffect(() => {
     fetchEngines({
       meta,
-      searchQuery,
+      searchQuery: throttledSearchQuery,
     });
-  }, [meta.from, meta.size, searchQuery]);
+  }, [meta.from, meta.size, throttledSearchQuery]);
 
   return (
     <>

--- a/x-pack/plugins/enterprise_search/public/applications/shared/constants/timers.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/constants/timers.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const INPUT_THROTTLE_DELAY_MS = 1000;

--- a/x-pack/plugins/enterprise_search/server/routes/enterprise_search/engines.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/enterprise_search/engines.ts
@@ -18,6 +18,7 @@ export function registerEnginesRoutes({
       validate: {
         query: schema.object({
           from: schema.number({ defaultValue: 0, min: 0 }),
+          q: schema.maybe(schema.string()),
           size: schema.number({ defaultValue: 10, min: 1 }),
         }),
       },
@@ -41,12 +42,12 @@ export function registerEnginesRoutes({
     {
       path: '/internal/enterprise_search/engines/{engine_name}',
       validate: {
+        body: schema.object({
+          indices: schema.arrayOf(schema.string()),
+          name: schema.maybe(schema.string()),
+        }),
         params: schema.object({
           engine_name: schema.string(),
-        }),
-        body: schema.object({
-          name: schema.maybe(schema.string()),
-          indices: schema.arrayOf(schema.string()),
         }),
       },
     },
@@ -63,8 +64,8 @@ export function registerEnginesRoutes({
       },
     },
     enterpriseSearchRequestHandler.createRequest({
-      path: '/api/engines/:engine_name',
       hasJsonResponse: false,
+      path: '/api/engines/:engine_name',
     })
   );
 }


### PR DESCRIPTION
## Summary

Connects the search field on the engines list page to the API.

https://user-images.githubusercontent.com/1699281/213272985-3e9bda82-f1f3-40dd-abf9-6fea874b94b3.mov

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
