### PR TITLE
[journeys] use uuid to create dashboard with unique name

### DIFF
--- a/x-pack/performance/journeys/dashboard_listing_page.ts
+++ b/x-pack/performance/journeys/dashboard_listing_page.ts
@@ -6,6 +6,7 @@
  */
 
 import { Journey } from '@kbn/journeys';
+import uuid from 'uuid';
 
 export const journey = new Journey({
   esArchives: ['x-pack/performance/es_archives/sample_data_flights'],
@@ -24,7 +25,7 @@ export const journey = new Journey({
     });
     await page.waitForSelector(`[data-test-subj="table-is-ready"]`);
   })
-  .step('Delete dashboard', async ({ page, log }) => {
+  .step('Delete dashboard', async ({ page }) => {
     await page.click('[data-test-subj="checkboxSelectRow-edf84fe0-e1a0-11e7-b6d5-4dc382ef7f5b"]');
     await page.click('[data-test-subj="deleteSelectedItems"]');
     await page.click('[data-test-subj="confirmModalConfirmButton"]');
@@ -33,13 +34,13 @@ export const journey = new Journey({
   .step('Add  dashboard', async ({ page, inputDelays }) => {
     await page.click('[data-test-subj="newItemButton"]');
     await page.click('[data-test-subj="dashboardSaveMenuItem"]');
-    await page.type('[data-test-subj="savedObjectTitle"]', 'foobar dashboard', {
+    await page.type('[data-test-subj="savedObjectTitle"]', `foobar dashboard ${uuid.v4()}`, {
       delay: inputDelays.TYPING,
     });
     await page.click('[data-test-subj="confirmSaveSavedObjectButton"]');
     await page.locator('[data-test-subj="saveDashboardSuccess"]');
   })
-  .step('Return to dashboard list', async ({ page, inputDelays }) => {
+  .step('Return to dashboard list', async ({ page }) => {
     await page.click('[data-test-subj="breadcrumb dashboardListingBreadcrumb first"]');
     await page.waitForSelector(`[data-test-subj="table-is-ready"]`);
   });


### PR DESCRIPTION
## Summary

After [148818](https://github.com/elastic/kibana/pull/148818) was merged performance pipeline started to fail.
Since we run each journey twice (warmup & test) with Kibana started each time, but ES is started only once, dashboard `foobar dashboard` already exists after warmup run. Adding `uuid` in the title to always have a unique title.

<img width="1454" alt="Screenshot 2023-01-18 at 21 01 15" src="https://user-images.githubusercontent.com/10977896/213284884-edf67030-95be-48af-a50a-c2eb967d1eb2.png">
