### PR TITLE
[DOCS] Fix capitalization of responseOps feature privileges

### DIFF
--- a/docs/api/alerting/create_rule.asciidoc
+++ b/docs/api/alerting/create_rule.asciidoc
@@ -18,7 +18,7 @@ Create {kib} rules.
 
 You must have `all` privileges for the appropriate {kib} features, depending on
 the `consumer` and `rule_type_id` of the rules you're creating. For example, the
-*Management* > *Stack Rules* feature, *Analytics* > *Discover* and *{ml-app}*
+*Management* > *{stack-rules-feature}* feature, *Analytics* > *Discover* and *{ml-app}*
 features, *{observability}*, and *Security* features. If the rule has `actions`,
 you must also have `read` privileges for the *Management* >
 *{connectors-feature}* feature. For more details, refer to

--- a/docs/api/alerting/delete_rule.asciidoc
+++ b/docs/api/alerting/delete_rule.asciidoc
@@ -25,7 +25,7 @@ For the most up-to-date API details, refer to the
 
 You must have `all` privileges for the appropriate {kib} features, depending on
 the `consumer` and `rule_type_id` of the rule you're deleting. For example, the
-*Management* > *Stack Rules* feature,  *Analytics* > *Discover* or *{ml-app}*
+*Management* > *{stack-rules-feature}* feature,  *Analytics* > *Discover* or *{ml-app}*
 features, *{observability}*, or *Security* features. For more details, refer to
 <<kibana-feature-privileges>>.
 

--- a/docs/api/alerting/disable_rule.asciidoc
+++ b/docs/api/alerting/disable_rule.asciidoc
@@ -24,7 +24,7 @@ For the most up-to-date API details, refer to the
 
 You must have `all` privileges for the appropriate {kib} features, depending on
 the `consumer` and `rule_type_id` of the rule. For example,
-the *Management* > *Stack Rules* feature, *Analytics* > *Discover* and *{ml-app}*
+the *Management* > *{stack-rules-feature}* feature, *Analytics* > *Discover* and *{ml-app}*
 features, *{observability}*, and *Security* features. For more details, refer to
 <<kibana-feature-privileges>>.
 

--- a/docs/api/alerting/enable_rule.asciidoc
+++ b/docs/api/alerting/enable_rule.asciidoc
@@ -25,7 +25,7 @@ For the most up-to-date API details, refer to the
 
 You must have `all` privileges for the appropriate {kib} features, depending on
 the `consumer` and `rule_type_id` of the rule. For example, the
-*Management* > *Stack Rules* feature, *Analytics* > *Discover* and *{ml-app}*
+*Management* > *{stack-rules-feature}* feature, *Analytics* > *Discover* and *{ml-app}*
 features, *{observability}*, and *Security* features. For more details, refer to
 <<kibana-feature-privileges>>.
 

--- a/docs/api/alerting/find_rules.asciidoc
+++ b/docs/api/alerting/find_rules.asciidoc
@@ -23,7 +23,7 @@ For the most up-to-date API details, refer to the
 
 You must have `read` privileges for the appropriate {kib} features, depending on
 the `consumer` and `rule_type_id` of the rules you're seeking. For example, the
-*Management* > *Stack Rules* feature, *Analytics* > *Discover* and *{ml-app}*
+*Management* > *{stack-rules-feature}* feature, *Analytics* > *Discover* and *{ml-app}*
 features, *{observability}*, and *Security* features. To find rules associated
 with the *{stack-monitor-app}* feature, use the `monitoring_user` built-in role.
 

--- a/docs/api/alerting/get_rules.asciidoc
+++ b/docs/api/alerting/get_rules.asciidoc
@@ -23,7 +23,7 @@ For the most up-to-date API details, refer to the
 
 You must have `read` privileges for the appropriate {kib} features, depending on
 the `consumer` and `rule_type_id` of the rules you're seeking. For example, the
-*Management* > *Stack Rules* feature, *Analytics* > *Discover* and *{ml-app}*
+*Management* > *{stack-rules-feature}* feature, *Analytics* > *Discover* and *{ml-app}*
 features, *{observability}*, and *Security* features. To get rules associated
 with the *{stack-monitor-app}* feature, use the `monitoring_user` built-in role.
 

--- a/docs/api/alerting/health.asciidoc
+++ b/docs/api/alerting/health.asciidoc
@@ -21,8 +21,8 @@ For the most up-to-date API details, refer to the
 
 === {api-prereq-title}
 
-You must have `read` privileges for the *Management* > *Stack Rules* feature or
-for at least one of the *Analytics* > *Discover*, *Analytics* > *{ml-app}*,
+You must have `read` privileges for the *Management* > *{stack-rules-feature}*
+feature or for at least one of the *Analytics* > *Discover*, *Analytics* > *{ml-app}*,
 *{observability}*, or *Security* features.
 
 [[get-alerting-framework-health-api-params]]

--- a/docs/api/alerting/list_rule_types.asciidoc
+++ b/docs/api/alerting/list_rule_types.asciidoc
@@ -24,7 +24,7 @@ For the most up-to-date API details, refer to the
 
 If you have `read` privileges for one or more {kib} features, the API response
 contains information about the appropriate rule types. For example, there are
-rule types associated with the *Management* > *Stack Rules* feature,
+rule types associated with the *Management* > *{stack-rules-feature}* feature,
 *Analytics* > *Discover* and *{ml-app}* features, *{observability}*, and
 *Security* features. To get rule types associated with the
 *{stack-monitor-app}* feature, use the `monitoring_user` built-in role.

--- a/docs/api/alerting/mute_alert.asciidoc
+++ b/docs/api/alerting/mute_alert.asciidoc
@@ -23,7 +23,7 @@ For the most up-to-date API details, refer to the
 
 You must have `all` privileges for the appropriate {kib} features, depending on
 the `consumer` and `rule_type_id` of the rule. For example, the
-*Management* > *Stack Rules* feature, *Analytics* > *Discover* and *{ml-app}*
+*Management* > *{stack-rules-feature}* feature, *Analytics* > *Discover* and *{ml-app}*
 features, *{observability}*, and *Security* features. If the rule has `actions`,
 you must also have `read` privileges for the *Management* >
 *{connectors-feature}* feature. For more details, refer to

--- a/docs/api/alerting/mute_all_alerts.asciidoc
+++ b/docs/api/alerting/mute_all_alerts.asciidoc
@@ -23,7 +23,7 @@ For the most up-to-date API details, refer to the
 
 You must have `all` privileges for the appropriate {kib} features, depending on
 the `consumer` and `rule_type_id` of the rule. For example, the
-*Management* > *Stack Rules* feature, *Analytics* > *Discover* and *{ml-app}*
+*Management* > *{stack-rules-feature}* feature, *Analytics* > *Discover* and *{ml-app}*
 features, *{observability}*, and *Security* features. If the rule has `actions`,
 you must also have `read` privileges for the *Management* >
 *{connectors-feature}* feature. For more details, refer to

--- a/docs/api/alerting/unmute_alert.asciidoc
+++ b/docs/api/alerting/unmute_alert.asciidoc
@@ -23,7 +23,7 @@ For the most up-to-date API details, refer to the
 
 You must have `all` privileges for the appropriate {kib} features, depending on
 the `consumer` and `rule_type_id` of the rule. For example, the
-*Management* > *Stack Rules* feature, *Analytics* > *Discover* and *{ml-app}*
+*Management* > *{stack-rules-feature}* feature, *Analytics* > *Discover* and *{ml-app}*
 features, *{observability}*, and *Security* features. If the rule has `actions`,
 you must also have `read` privileges for the *Management* >
 *{connectors-feature}* feature. For more details, refer to

--- a/docs/api/alerting/unmute_all_alerts.asciidoc
+++ b/docs/api/alerting/unmute_all_alerts.asciidoc
@@ -23,7 +23,7 @@ For the most up-to-date API details, refer to the
 
 You must have `all` privileges for the appropriate {kib} features, depending on
 the `consumer` and `rule_type_id` of the rule. For example, the
-*Management* > *Stack Rules* feature, *Analytics* > *Discover* and *{ml-app}*
+*Management* > *{stack-rules-feature}* feature, *Analytics* > *Discover* and *{ml-app}*
 features, *{observability}*, and *Security* features. If the rule has `actions`,
 you must also have `read` privileges for the *Management* >
 *{connectors-feature}* feature. For more details, refer to

--- a/docs/api/alerting/update_rule.asciidoc
+++ b/docs/api/alerting/update_rule.asciidoc
@@ -23,7 +23,7 @@ For the most up-to-date API details, refer to the
 
 You must have `all` privileges for the appropriate {kib} features, depending on
 the `consumer` and `rule_type_id` of the rule you're updating. For example, the 
-*Management* > *Stack Rules* feature, *Analytics* > *Discover* and *{ml-app}*
+*Management* > *{stack-rules-feature}* feature, *Analytics* > *Discover* and *{ml-app}*
 features, *{observability}*, or *Security* features. If the rule has
 `actions`, you must also have `read` privileges for the *Management* >
 *{connectors-feature}* feature. For more details, refer to

--- a/docs/user/alerting/alerting-setup.asciidoc
+++ b/docs/user/alerting/alerting-setup.asciidoc
@@ -47,7 +47,7 @@ For more information on the scalability of {alert-features}, go to
 If you want to use the {alert-features} in a {kib} app, you must have the
 appropriate feature privileges. For example, to create rules in
 *{stack-manage-app} > {rules-ui}*, you must have `all` privileges for the
-*Management > Stack Rules* feature. To attach actions to the rule, you must also
+*Management > {stack-rules-feature}* feature. To attach actions to the rule, you must also
 have `read` privileges for the *{connectors-feature}* feature. For more
 information on configuring roles that provide access to features, go to
 <<kibana-feature-privileges>>.

--- a/docs/user/alerting/rule-types.asciidoc
+++ b/docs/user/alerting/rule-types.asciidoc
@@ -16,7 +16,8 @@ see {subscriptions}[the subscription page].
 [[stack-rules]]
 === Stack rules
 
-<<create-and-manage-rules, Stack rules>> are built into {kib}. To access the *Stack Rules* feature and create and edit rules, users require the `all` privilege. See <<kibana-feature-privileges, feature privileges>> for more information.
+Stack rules are built into {kib}. To create and edit rules, you must have the
+appropriate {kib} feature privileges. Refer to <<alerting-security>>.
 
 [cols="2*<"]
 |===

--- a/x-pack/plugins/actions/server/feature.ts
+++ b/x-pack/plugins/actions/server/feature.ts
@@ -22,7 +22,7 @@ const FEATURE_ORDER = 3000;
 export const ACTIONS_FEATURE = {
   id: 'actions',
   name: i18n.translate('xpack.actions.featureRegistry.actionsFeatureName', {
-    defaultMessage: 'Actions and Connectors',
+    defaultMessage: 'Actions and connectors',
   }),
   category: DEFAULT_APP_CATEGORIES.management,
   app: [],

--- a/x-pack/plugins/alerting/server/rules_settings_feature.ts
+++ b/x-pack/plugins/alerting/server/rules_settings_feature.ts
@@ -19,7 +19,7 @@ import {
 export const rulesSettingsFeature: KibanaFeatureConfig = {
   id: RULES_SETTINGS_FEATURE_ID,
   name: i18n.translate('xpack.alerting.feature.rulesSettingsFeatureName', {
-    defaultMessage: 'Rules Settings',
+    defaultMessage: 'Rules settings',
   }),
   category: DEFAULT_APP_CATEGORIES.management,
   app: [],
@@ -55,7 +55,7 @@ export const rulesSettingsFeature: KibanaFeatureConfig = {
   subFeatures: [
     {
       name: i18n.translate('xpack.alerting.feature.flappingSettingsSubFeatureName', {
-        defaultMessage: 'Flapping Detection',
+        defaultMessage: 'Flapping detection',
       }),
       privilegeGroups: [
         {

--- a/x-pack/plugins/stack_alerts/server/feature.ts
+++ b/x-pack/plugins/stack_alerts/server/feature.ts
@@ -19,7 +19,7 @@ const TransformHealth = TRANSFORM_RULE_TYPE.TRANSFORM_HEALTH;
 export const BUILT_IN_ALERTS_FEATURE: KibanaFeatureConfig = {
   id: STACK_ALERTS_FEATURE_ID,
   name: i18n.translate('xpack.stackAlerts.featureRegistry.actionsFeatureName', {
-    defaultMessage: 'Stack Rules',
+    defaultMessage: 'Stack rules',
   }),
   app: [],
   category: DEFAULT_APP_CATEGORIES.management,


### PR DESCRIPTION
## Summary

Per https://elastic.github.io/eui/#/guidelines/writing/guidelines#capitalization, we ought to use sentence case for almost all UI text. Therefore this PR fixes the capitalization for the "Actions and Connectors", "Rule Settings", and "Stack Rules" Kibana feature privileges. 

It must be merged after https://github.com/elastic/docs/pull/2599, which introduces shared attributes for the "Stack Rules" feature privilege.

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/26471269/213287211-1d73315b-575a-4a13-81f3-c7b11c8c5fd9.png)

![image](https://user-images.githubusercontent.com/26471269/213298468-836aec74-50a5-475d-89b3-719af738c557.png)

### After

![image](https://user-images.githubusercontent.com/26471269/213298952-05bc424a-fe84-4c28-9034-be51ffb356ab.png)

![image](https://user-images.githubusercontent.com/26471269/213298728-64b1804e-e7e8-496a-8574-1dcb49c1a50c.png)

