### PR TITLE
[build] Fix canvas shareable runtime

### DIFF
--- a/x-pack/plugins/canvas/scripts/shareable_runtime.js
+++ b/x-pack/plugins/canvas/scripts/shareable_runtime.js
@@ -55,6 +55,7 @@ run(
       execa.sync(
         process.execPath,
         [
+          '--openssl-legacy-provider',
           require.resolve('webpack-dev-server/bin/webpack-dev-server'),
           '--config',
           webpackConfig,
@@ -88,6 +89,7 @@ run(
     execa.sync(
       process.execPath,
       [
+        '--openssl-legacy-provider',
         require.resolve('webpack/bin/webpack'),
         '--config',
         webpackConfig,


### PR DESCRIPTION
The canvas shareable runtime build uses webpack 4, which needs the `--legacy-openssl-provider` flag after the recent Node 16 -> 18 upgrade.

Context: the runtime build is disabled by default in pull requests because it's currently untested and adds ~3 minutes to build time.  It is enabled in our nightly snapshots pipeline, which we've been using as a slower feedback loop for build issues.

## Testing
```
node x-pack/plugins/canvas/scripts/shareable_runtime.js
```
should exit 0