### PR TITLE
[Fleet] fixed package install without version

### DIFF
--- a/x-pack/plugins/fleet/common/openapi/bundled.json
+++ b/x-pack/plugins/fleet/common/openapi/bundled.json
@@ -474,6 +474,15 @@
             "name": "pkgkey",
             "in": "path",
             "required": true
+          },
+          {
+            "in": "query",
+            "name": "prerelease",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            },
+            "description": "Whether to return prerelease versions of packages (e.g. beta, rc, preview) "
           }
         ],
         "deprecated": true
@@ -726,6 +735,15 @@
           "name": "full",
           "description": "Return all fields from the package manifest, not just those supported by the Elastic Package Registry",
           "in": "query"
+        },
+        {
+          "in": "query",
+          "name": "prerelease",
+          "schema": {
+            "type": "boolean",
+            "default": false
+          },
+          "description": "Whether to return prerelease versions of packages (e.g. beta, rc, preview) "
         }
       ],
       "post": {

--- a/x-pack/plugins/fleet/common/openapi/bundled.json
+++ b/x-pack/plugins/fleet/common/openapi/bundled.json
@@ -380,9 +380,40 @@
             }
           }
         },
-        "operationId": "bulk-install-packages"
-      },
-      "parameters": []
+        "operationId": "bulk-install-packages",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "prerelease",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            },
+            "description": "Whether to return prerelease versions of packages (e.g. beta, rc, preview) "
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "packages": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "list of package names to install"
+                  }
+                },
+                "required": [
+                  "packages"
+                ]
+              }
+            }
+          }
+        }
+      }
     },
     "/epm/packages/{pkgkey}": {
       "get": {

--- a/x-pack/plugins/fleet/common/openapi/bundled.json
+++ b/x-pack/plugins/fleet/common/openapi/bundled.json
@@ -404,6 +404,10 @@
                       "type": "string"
                     },
                     "description": "list of package names to install"
+                  },
+                  "force": {
+                    "type": "boolean",
+                    "description": "force install to ignore package verification errors"
                   }
                 },
                 "required": [

--- a/x-pack/plugins/fleet/common/openapi/bundled.yaml
+++ b/x-pack/plugins/fleet/common/openapi/bundled.yaml
@@ -247,7 +247,28 @@ paths:
               schema:
                 $ref: '#/components/schemas/bulk_install_packages_response'
       operationId: bulk-install-packages
-    parameters: []
+      parameters:
+        - in: query
+          name: prerelease
+          schema:
+            type: boolean
+            default: false
+          description: >-
+            Whether to return prerelease versions of packages (e.g. beta, rc,
+            preview) 
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                packages:
+                  type: array
+                  items:
+                    type: string
+                  description: list of package names to install
+              required:
+                - packages
   /epm/packages/{pkgkey}:
     get:
       summary: Packages - Info

--- a/x-pack/plugins/fleet/common/openapi/bundled.yaml
+++ b/x-pack/plugins/fleet/common/openapi/bundled.yaml
@@ -267,6 +267,9 @@ paths:
                   items:
                     type: string
                   description: list of package names to install
+                force:
+                  type: boolean
+                  description: force install to ignore package verification errors
               required:
                 - packages
   /epm/packages/{pkgkey}:

--- a/x-pack/plugins/fleet/common/openapi/bundled.yaml
+++ b/x-pack/plugins/fleet/common/openapi/bundled.yaml
@@ -306,6 +306,14 @@ paths:
           name: pkgkey
           in: path
           required: true
+        - in: query
+          name: prerelease
+          schema:
+            type: boolean
+            default: false
+          description: >-
+            Whether to return prerelease versions of packages (e.g. beta, rc,
+            preview) 
       deprecated: true
     post:
       summary: Packages - Install
@@ -458,6 +466,14 @@ paths:
           Return all fields from the package manifest, not just those supported
           by the Elastic Package Registry
         in: query
+      - in: query
+        name: prerelease
+        schema:
+          type: boolean
+          default: false
+        description: >-
+          Whether to return prerelease versions of packages (e.g. beta, rc,
+          preview) 
     post:
       summary: Packages - Install
       tags: []

--- a/x-pack/plugins/fleet/common/openapi/paths/epm@packages@{pkg_name}@{pkg_version}.yaml
+++ b/x-pack/plugins/fleet/common/openapi/paths/epm@packages@{pkg_name}@{pkg_version}.yaml
@@ -57,6 +57,13 @@ parameters:
     name: full
     description: 'Return all fields from the package manifest, not just those supported by the Elastic Package Registry'
     in: query
+  - in: query 
+    name: prerelease
+    schema:
+      type: boolean
+      default: false
+    description: >-
+      Whether to return prerelease versions of packages (e.g. beta, rc, preview) 
 post:
   summary: Packages - Install
   tags: []

--- a/x-pack/plugins/fleet/common/openapi/paths/epm@packages@{pkgkey}_deprecated.yaml
+++ b/x-pack/plugins/fleet/common/openapi/paths/epm@packages@{pkgkey}_deprecated.yaml
@@ -34,6 +34,13 @@ get:
       name: pkgkey
       in: path
       required: true
+    - in: query 
+      name: prerelease
+      schema:
+        type: boolean
+        default: false
+      description: >-
+        Whether to return prerelease versions of packages (e.g. beta, rc, preview) 
   deprecated: true
 post:
   summary: Packages - Install

--- a/x-pack/plugins/fleet/common/openapi/paths/epm@packages_bulk.yaml
+++ b/x-pack/plugins/fleet/common/openapi/paths/epm@packages_bulk.yaml
@@ -28,6 +28,9 @@ post:
               items:
                 type: string
               description: list of package names to install
+            force:
+              type: boolean
+              description: force install to ignore package verification errors 
           required:
             - packages
 

--- a/x-pack/plugins/fleet/common/openapi/paths/epm@packages_bulk.yaml
+++ b/x-pack/plugins/fleet/common/openapi/paths/epm@packages_bulk.yaml
@@ -9,4 +9,25 @@ post:
           schema:
             $ref: ../components/schemas/bulk_install_packages_response.yaml
   operationId: bulk-install-packages
-parameters: []
+  parameters:
+    - in: query 
+      name: prerelease
+      schema:
+        type: boolean
+        default: false
+      description: >-
+        Whether to return prerelease versions of packages (e.g. beta, rc, preview) 
+  requestBody:
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            packages:
+              type: array
+              items:
+                type: string
+              description: list of package names to install
+          required:
+            - packages
+

--- a/x-pack/plugins/fleet/server/routes/epm/handlers.ts
+++ b/x-pack/plugins/fleet/server/routes/epm/handlers.ts
@@ -338,6 +338,7 @@ export const bulkInstallPackagesFromRegistryHandler: FleetRequestHandler<
     packagesToInstall: request.body.packages,
     spaceId,
     prerelease: request.query.prerelease,
+    force: request.body.force,
   });
   const payload = bulkInstalledResponses.map(bulkInstallServiceResponseToHttpEntry);
   const body: BulkInstallPackagesResponse = {

--- a/x-pack/plugins/fleet/server/routes/epm/handlers.ts
+++ b/x-pack/plugins/fleet/server/routes/epm/handlers.ts
@@ -273,7 +273,7 @@ export const getStatsHandler: FleetRequestHandler<
 
 export const installPackageFromRegistryHandler: FleetRequestHandler<
   TypeOf<typeof InstallPackageFromRegistryRequestSchema.params>,
-  undefined,
+  TypeOf<typeof InstallPackageFromRegistryRequestSchema.query>,
   TypeOf<typeof InstallPackageFromRegistryRequestSchema.body>
 > = async (context, request, response) => {
   const coreContext = await context.core;
@@ -291,6 +291,7 @@ export const installPackageFromRegistryHandler: FleetRequestHandler<
     spaceId,
     force: request.body?.force,
     ignoreConstraints: request.body?.ignore_constraints,
+    prerelease: request.query?.prerelease,
   });
 
   if (!res.error) {

--- a/x-pack/plugins/fleet/server/routes/epm/handlers.ts
+++ b/x-pack/plugins/fleet/server/routes/epm/handlers.ts
@@ -33,7 +33,7 @@ import type {
   InstallPackageFromRegistryRequestSchema,
   InstallPackageByUploadRequestSchema,
   DeletePackageRequestSchema,
-  BulkUpgradePackagesFromRegistryRequestSchema,
+  BulkInstallPackagesFromRegistryRequestSchema,
   GetStatsRequestSchema,
   FleetRequestHandler,
   UpdatePackageRequestSchema,
@@ -323,8 +323,8 @@ const bulkInstallServiceResponseToHttpEntry = (
 
 export const bulkInstallPackagesFromRegistryHandler: FleetRequestHandler<
   undefined,
-  TypeOf<typeof BulkUpgradePackagesFromRegistryRequestSchema.query>,
-  TypeOf<typeof BulkUpgradePackagesFromRegistryRequestSchema.body>
+  TypeOf<typeof BulkInstallPackagesFromRegistryRequestSchema.query>,
+  TypeOf<typeof BulkInstallPackagesFromRegistryRequestSchema.body>
 > = async (context, request, response) => {
   const coreContext = await context.core;
   const fleetContext = await context.fleet;

--- a/x-pack/plugins/fleet/server/routes/epm/index.ts
+++ b/x-pack/plugins/fleet/server/routes/epm/index.ts
@@ -244,7 +244,11 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       },
     },
     async (context, request, response) => {
-      const newRequest = { ...request, params: splitPkgKey(request.params.pkgkey) } as any;
+      const newRequest = {
+        ...request,
+        params: splitPkgKey(request.params.pkgkey),
+        query: request.query,
+      } as any;
       const resp: IKibanaResponse<InstallPackageResponse> = await installPackageFromRegistryHandler(
         context,
         newRequest,

--- a/x-pack/plugins/fleet/server/routes/epm/index.ts
+++ b/x-pack/plugins/fleet/server/routes/epm/index.ts
@@ -35,7 +35,7 @@ import {
   InstallPackageByUploadRequestSchema,
   DeletePackageRequestSchema,
   DeletePackageRequestSchemaDeprecated,
-  BulkUpgradePackagesFromRegistryRequestSchema,
+  BulkInstallPackagesFromRegistryRequestSchema,
   GetStatsRequestSchema,
   UpdatePackageRequestSchema,
   UpdatePackageRequestSchemaDeprecated,
@@ -149,7 +149,7 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
   router.post(
     {
       path: EPM_API_ROUTES.BULK_INSTALL_PATTERN,
-      validate: BulkUpgradePackagesFromRegistryRequestSchema,
+      validate: BulkInstallPackagesFromRegistryRequestSchema,
       fleetAuthz: {
         integrations: { installPackages: true, upgradePackages: true },
       },

--- a/x-pack/plugins/fleet/server/services/epm/packages/bulk_install_packages.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/bulk_install_packages.ts
@@ -93,6 +93,7 @@ export async function bulkInstallPackages({
         installSource: 'registry',
         spaceId,
         force,
+        prerelease,
       });
 
       if (installResult.error) {

--- a/x-pack/plugins/fleet/server/types/rest_spec/epm.ts
+++ b/x-pack/plugins/fleet/server/types/rest_spec/epm.ts
@@ -122,6 +122,7 @@ export const BulkInstallPackagesFromRegistryRequestSchema = {
   }),
   body: schema.object({
     packages: schema.arrayOf(schema.string(), { minSize: 1 }),
+    force: schema.boolean({ defaultValue: false }),
   }),
 };
 

--- a/x-pack/plugins/fleet/server/types/rest_spec/epm.ts
+++ b/x-pack/plugins/fleet/server/types/rest_spec/epm.ts
@@ -91,6 +91,9 @@ export const InstallPackageFromRegistryRequestSchema = {
     pkgName: schema.string(),
     pkgVersion: schema.maybe(schema.string()),
   }),
+  query: schema.object({
+    prerelease: schema.maybe(schema.boolean()),
+  }),
   body: schema.nullable(
     schema.object({
       force: schema.boolean({ defaultValue: false }),
@@ -102,6 +105,9 @@ export const InstallPackageFromRegistryRequestSchema = {
 export const InstallPackageFromRegistryRequestSchemaDeprecated = {
   params: schema.object({
     pkgkey: schema.string(),
+  }),
+  query: schema.object({
+    prerelease: schema.maybe(schema.boolean()),
   }),
   body: schema.nullable(
     schema.object({

--- a/x-pack/plugins/fleet/server/types/rest_spec/epm.ts
+++ b/x-pack/plugins/fleet/server/types/rest_spec/epm.ts
@@ -110,7 +110,7 @@ export const InstallPackageFromRegistryRequestSchemaDeprecated = {
   ),
 };
 
-export const BulkUpgradePackagesFromRegistryRequestSchema = {
+export const BulkInstallPackagesFromRegistryRequestSchema = {
   query: schema.object({
     prerelease: schema.maybe(schema.boolean()),
   }),

--- a/x-pack/test/fleet_api_integration/apis/epm/install_prerelease.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/install_prerelease.ts
@@ -40,20 +40,63 @@ export default function (providerContext: FtrProviderContext) {
         .expect(200);
     });
 
-    describe('installs GA package that has a prerelease version', async () => {
-      const pkg = 'endpoint';
-      const version = '8.6.1';
+    const pkg = 'endpoint';
+    const gaVersion = '8.6.1';
+    const betaVersion = '8.7.0-next';
 
-      it('should install the GA package correctly', async function () {
-        const response = await supertest
-          .post(`/api/fleet/epm/packages/${pkg}/${version}`)
-          .set('kbn-xsrf', 'xxxx')
-          .expect(200);
+    afterEach(async () => {
+      await deletePackage(pkg, gaVersion);
+      await deletePackage(pkg, betaVersion);
+    });
 
-        expect(response.body.items.find((item: any) => item.id.includes(version)));
+    it('should install the GA package correctly', async function () {
+      const response = await supertest
+        .post(`/api/fleet/epm/packages/${pkg}/${gaVersion}`)
+        .set('kbn-xsrf', 'xxxx')
+        .send({ force: true })
+        .expect(200);
 
-        await deletePackage(pkg, version);
-      });
+      expect(response.body.items.find((item: any) => item.id.includes(gaVersion)));
+    });
+
+    it('should install the GA package when no version is provided', async function () {
+      const response = await supertest
+        .post(`/api/fleet/epm/packages/${pkg}`)
+        .set('kbn-xsrf', 'xxxx')
+        .send({ force: true })
+        .expect(200);
+
+      expect(response.body.items.find((item: any) => item.id.includes(gaVersion)));
+    });
+
+    it('should install the beta package when no version is provided and prerelease is true', async function () {
+      const response = await supertest
+        .post(`/api/fleet/epm/packages/${pkg}?prerelease=true`)
+        .set('kbn-xsrf', 'xxxx')
+        .send({ force: true }) // using force to ignore package verification error
+        .expect(200);
+
+      expect(response.body.items.find((item: any) => item.id.includes(betaVersion)));
+    });
+
+    it('should bulk install the beta packages when prerelease is true', async function () {
+      const response = await supertest
+        .post(`/api/fleet/epm/packages/_bulk?prerelease=true`)
+        .set('kbn-xsrf', 'xxxx')
+        .send({ packages: ['endpoint'], force: true })
+        .expect(200);
+
+      expect(response.body.items[0].version).equal(betaVersion);
+    });
+
+    it('should bulk install the GA packages when prerelease is not set', async function () {
+      const response = await supertest
+        .post(`/api/fleet/epm/packages/_bulk`)
+        .set('kbn-xsrf', 'xxxx')
+        .send({ packages: ['endpoint'], force: true })
+        .expect(200);
+
+      expect(response.body.items[0].version).equal(gaVersion);
     });
   });
 }


### PR DESCRIPTION
## Summary

Fixes install and bulk install package API to install packages without version.
Fixes https://github.com/elastic/kibana/issues/149056#issuecomment-1387203363

While I was at it, fixed https://github.com/elastic/kibana/issues/148499 to update openapi spec and renamed a schema type.

How I tested:

Call bulk API with prerelease flag:

```
POST kbn:/api/fleet/epm/packages/_bulk?prerelease=true
{
  "packages": ["endpoint", "security_detection_engine"]
}
```

This installs latest prerelease versions:
```
[2023-01-19T11:00:30.859+01:00][DEBUG][plugins.fleet] kicking off bulk install of endpoint, security_detection_engine
[2023-01-19T11:00:30.862+01:00][DEBUG][plugins.fleet] kicking off install of endpoint-8.7.0-next from registry
[2023-01-19T11:00:30.863+01:00][DEBUG][plugins.fleet] kicking off install of security_detection_engine-8.4.2-beta.1 from registry
```

Without the prerelease flag, the latest GA version is installed:

```
POST kbn:/api/fleet/epm/packages/_bulk?prerelease=false
{
  "packages": ["endpoint", "security_detection_engine"]
}

[2023-01-19T11:18:48.634+01:00][DEBUG][plugins.fleet] kicking off bulk install of endpoint, security_detection_engine
[2023-01-19T11:18:48.637+01:00][DEBUG][plugins.fleet] kicking off install of security_detection_engine-8.4.1 from registry
[2023-01-19T11:18:48.637+01:00][DEBUG][plugins.fleet] kicking off install of endpoint-8.6.1 from registry
```

Similarly the single package install API without a version installs latest GA. 
```
POST kbn:/api/fleet/epm/packages/endpoint

[2023-01-19T11:17:13.390+01:00][DEBUG][plugins.fleet] kicking off install of endpoint from registry
...
[2023-01-19T11:17:13.865+01:00][DEBUG][plugins.fleet] setting package info to the cache for endpoint-8.6.1
```

Added prerelease flag to single API too for completeness.
```
POST kbn:/api/fleet/epm/packages/endpoint?prerelease=true

[2023-01-19T11:38:07.925+01:00][DEBUG][plugins.fleet] kicking off install of endpoint from registry
...
[2023-01-19T11:38:08.356+01:00][DEBUG][plugins.fleet] setting file list to the cache for endpoint-8.7.0-next
```

OpenAPI spec:
https://petstore.swagger.io/?url=https://raw.githubusercontent.com/elastic/kibana/f83b7d32abdb4aa3fb55630057a74bba3abe6d73/x-pack/plugins/fleet/common/openapi/bundled.json#/default/bulk-install-packages

<img width="1459" alt="image" src="https://user-images.githubusercontent.com/90178898/213417371-ce50c0c2-bf41-4619-a6c6-d0f73aae516a.png">


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->