### PR TITLE
[Saved Objects] Fix deprecated Browser SO types

### DIFF
--- a/packages/core/lifecycle/core-lifecycle-browser/src/core_start.ts
+++ b/packages/core/lifecycle/core-lifecycle-browser/src/core_start.ts
@@ -46,7 +46,10 @@ export interface CoreStart {
   executionContext: ExecutionContextStart;
   /** {@link HttpStart} */
   http: HttpStart;
-  /** {@link SavedObjectsStart} */
+  /**
+   * {@link SavedObjectsStart}
+   * @deprecated See https://github.com/elastic/kibana/issues/149098
+   */
   savedObjects: SavedObjectsStart;
   /** {@link I18nStart} */
   i18n: I18nStart;

--- a/packages/core/saved-objects/core-saved-objects-api-browser/src/apis/bulk_create.ts
+++ b/packages/core/saved-objects/core-saved-objects-api-browser/src/apis/bulk_create.ts
@@ -26,7 +26,7 @@ export interface SavedObjectsBulkCreateObject<T = unknown> extends SavedObjectsC
  *
  * @public
  * @deprecated See https://github.com/elastic/kibana/issues/149098
- * */
+ */
 export interface SavedObjectsBulkCreateOptions {
   /** If a document with the given `id` already exists, overwrite its contents (default=false). */
   overwrite?: boolean;

--- a/packages/core/saved-objects/core-saved-objects-api-browser/src/saved_objects_client.ts
+++ b/packages/core/saved-objects/core-saved-objects-api-browser/src/saved_objects_client.ts
@@ -40,6 +40,7 @@ export interface SavedObjectsClientContract {
    * @param {string} attributes - the attributes of the object
    * @param {string} options {@link  SavedObjectsCreateOptions}
    * @returns The result of the create operation - the created saved object
+   * @deprecated See https://github.com/elastic/kibana/issues/149098
    */
   create<T = unknown>(
     type: string,
@@ -53,6 +54,7 @@ export interface SavedObjectsClientContract {
    * @param {string} objects - an array of objects containing type, attributes
    * @param {string} options {@link  SavedObjectsBulkCreateOptions}
    * @returns The result of the create operation containing created saved objects.
+   * @deprecated See https://github.com/elastic/kibana/issues/149098
    */
   bulkCreate(
     objects: SavedObjectsBulkCreateObject[],
@@ -66,6 +68,7 @@ export interface SavedObjectsClientContract {
    * @param {string} id - the id of the object to delete
    * @param {string} options {@link  SavedObjectsDeleteOptions}
    * @param {string} options.force - required to delete objects shared to multiple spaces
+   * @deprecated See https://github.com/elastic/kibana/issues/149098
    */
   delete(type: string, id: string, options?: SavedObjectsDeleteOptions): Promise<{}>;
 
@@ -74,6 +77,7 @@ export interface SavedObjectsClientContract {
    * @param objects - an array of objects containing id, type
    * @param options - optional force argument to force deletion of objects in a namespace other than the scoped client
    * @returns The bulk delete result for the saved objects for the given types and ids.
+   * @deprecated See https://github.com/elastic/kibana/issues/149098
    */
   bulkDelete(
     objects: SavedObjectTypeIdTuple[],
@@ -93,6 +97,7 @@ export interface SavedObjectsClientContract {
    * @property {array} options.fields
    * @property {object} [options.hasReference] - { type, id }
    * @returns A find result with objects matching the specified search.
+   * @deprecated See https://github.com/elastic/kibana/issues/149098
    */
   find<T = unknown, A = unknown>(
     options: SavedObjectsFindOptions
@@ -104,6 +109,7 @@ export interface SavedObjectsClientContract {
    * @param {string} type - the type of the object to get
    * @param {string} id - the ID of the object to get
    * @returns The saved object for the given type and id.
+   * @deprecated See https://github.com/elastic/kibana/issues/149098
    */
   get<T = unknown>(type: string, id: string): Promise<SimpleSavedObject<T>>;
 
@@ -118,6 +124,7 @@ export interface SavedObjectsClientContract {
    *   { id: 'one', type: 'config' },
    *   { id: 'foo', type: 'index-pattern' }
    * ])
+   * @deprecated See https://github.com/elastic/kibana/issues/149098
    */
   bulkGet(objects: SavedObjectTypeIdTuple[]): Promise<SavedObjectsBatchResponse<unknown>>;
 
@@ -132,6 +139,7 @@ export interface SavedObjectsClientContract {
    * outcome is that "exactMatch" is the default outcome, and the outcome only changes if an alias is found. This behavior for the `resolve`
    * API is unique to the public client, which batches individual calls with `bulkResolve` under the hood. We don't throw an error in that
    * case for legacy compatibility reasons.
+   * @deprecated See https://github.com/elastic/kibana/issues/149098
    */
   resolve<T = unknown>(type: string, id: string): Promise<ResolvedSimpleSavedObject<T>>;
 
@@ -150,6 +158,7 @@ export interface SavedObjectsClientContract {
    * @note Saved objects that Kibana fails to find are replaced with an error object and an "exactMatch" outcome. The rationale behind the
    * outcome is that "exactMatch" is the default outcome, and the outcome only changes if an alias is found. The `resolve` method in the
    * public client uses `bulkResolve` under the hood, so it behaves the same way.
+   * @deprecated See https://github.com/elastic/kibana/issues/149098
    */
   bulkResolve<T = unknown>(
     objects: SavedObjectTypeIdTuple[]
@@ -165,6 +174,7 @@ export interface SavedObjectsClientContract {
    * @prop {integer} options.version - ensures version matches that of persisted object
    * @prop {object} options.migrationVersion - The optional migrationVersion of this document
    * @returns the udpated simple saved object
+   * @deprecated See https://github.com/elastic/kibana/issues/149098
    */
   update<T = unknown>(
     type: string,
@@ -178,6 +188,7 @@ export interface SavedObjectsClientContract {
    *
    * @param {array} objects - an array of objects containing type, id, attributes, and references
    * @returns the result of the bulk update operation containing both failed and updated saved objects.
+   * @deprecated See https://github.com/elastic/kibana/issues/149098
    */
   bulkUpdate<T = unknown>(
     objects: SavedObjectsBulkUpdateObject[]

--- a/packages/core/saved-objects/core-saved-objects-api-browser/src/simple_saved_object.ts
+++ b/packages/core/saved-objects/core-saved-objects-api-browser/src/simple_saved_object.ts
@@ -72,11 +72,13 @@ export interface SimpleSavedObject<T = unknown> {
 
   /**
    * Saves this object
+   * @deprecated See https://github.com/elastic/kibana/issues/149098
    */
   save(): Promise<SimpleSavedObject<T>>;
 
   /**
    * Deletes this object
+   * @deprecated See https://github.com/elastic/kibana/issues/149098
    */
   delete(): Promise<{}>;
 }

--- a/packages/core/saved-objects/core-saved-objects-server/index.ts
+++ b/packages/core/saved-objects/core-saved-objects-server/index.ts
@@ -93,6 +93,7 @@ export {
 export type {
   SavedObject,
   SavedObjectAttribute,
+  SavedObjectAttributes,
   SavedObjectAttributeSingle,
   SavedObjectReference,
 } from '@kbn/core-saved-objects-common/src/server_types';

--- a/src/core/server/index.ts
+++ b/src/core/server/index.ts
@@ -239,7 +239,6 @@ export type { PluginName, DiscoveredPlugin } from '@kbn/core-base-common';
 
 export type { SavedObjectsStart } from '@kbn/core-saved-objects-browser';
 export type {
-  SavedObjectAttributes,
   SavedObjectsMigrationVersion,
   SavedObjectsImportConflictError,
   SavedObjectsImportAmbiguousConflictError,
@@ -310,6 +309,7 @@ export type {
 export type {
   SavedObject,
   SavedObjectAttribute,
+  SavedObjectAttributes,
   SavedObjectAttributeSingle,
   SavedObjectReference,
   SavedObjectsServiceSetup,

--- a/src/core/server/index.ts
+++ b/src/core/server/index.ts
@@ -239,11 +239,7 @@ export type { PluginName, DiscoveredPlugin } from '@kbn/core-base-common';
 
 export type { SavedObjectsStart } from '@kbn/core-saved-objects-browser';
 export type {
-  SavedObject,
-  SavedObjectAttribute,
   SavedObjectAttributes,
-  SavedObjectAttributeSingle,
-  SavedObjectReference,
   SavedObjectsMigrationVersion,
   SavedObjectsImportConflictError,
   SavedObjectsImportAmbiguousConflictError,
@@ -312,6 +308,10 @@ export type {
   SavedObjectsBulkDeleteStatus,
 } from '@kbn/core-saved-objects-api-server';
 export type {
+  SavedObject,
+  SavedObjectAttribute,
+  SavedObjectAttributeSingle,
+  SavedObjectReference,
   SavedObjectsServiceSetup,
   SavedObjectsServiceStart,
   SavedObjectsClientProviderOptions,


### PR DESCRIPTION
## Summary

* Re-exporting SO types from `common` inside server code
* Deprecated individual APIs on interfaces, not just interfaces, to make deprecation visible to consumers
* Deprecates the `savedObjects` prop on the `CoreStart` interface too

Related: https://github.com/elastic/kibana/pull/148979