### PR TITLE
[Fleet] Remove _source.mode stored as it no more supported

### DIFF
--- a/x-pack/plugins/fleet/server/services/package_policies/experimental_datastream_features.test.ts
+++ b/x-pack/plugins/fleet/server/services/package_policies/experimental_datastream_features.test.ts
@@ -98,9 +98,7 @@ describe('experimental_datastream_features', () => {
             template: {
               settings: {},
               mappings: {
-                _source: {
-                  mode: 'stored',
-                },
+                _source: {},
                 properties: {
                   test_dimension: {
                     type: 'keyword',

--- a/x-pack/plugins/fleet/server/services/package_policies/experimental_datastream_features.ts
+++ b/x-pack/plugins/fleet/server/services/package_policies/experimental_datastream_features.ts
@@ -63,7 +63,7 @@ export async function handleExperimentalDatastreamFeatureOptIn({
           mappings: {
             ...componentTemplate.template.mappings,
             _source: {
-              mode: featureMapEntry.features.synthetic_source ? 'synthetic' : 'stored',
+              ...(featureMapEntry.features.synthetic_source ? { mode: 'synthetic' } : {}),
             },
           },
         },


### PR DESCRIPTION
## Summary

While upgrading elasticsearch-js https://github.com/elastic/kibana/pull/148521 @rudolf found that _source.mode:stored is no more supported that PR fix that.

If the source mode is no synthetic we do not set _source.mode

## Tests

I updated unit test for that and I try to activate/desactivate source mode on a datastream