### PR TITLE
[Fleet] removed unused telemetry usage schema

### DIFF
--- a/x-pack/plugins/fleet/server/services/telemetry/fleet_usages_schema.ts
+++ b/x-pack/plugins/fleet/server/services/telemetry/fleet_usages_schema.ts
@@ -125,18 +125,6 @@ export const fleetUsagesSchema: RootSchema<any> = {
           description: 'The number of Fleet Server hosts configured in Fleet settings.',
         },
       },
-      inactive: {
-        type: 'long',
-        _meta: {
-          description: 'The total number of enrolled agents currently inactive',
-        },
-      },
-      unenrolled: {
-        type: 'long',
-        _meta: {
-          description: 'The total number of unenrolled agents',
-        },
-      },
     },
   },
   packages: {
@@ -201,18 +189,18 @@ export const fleetUsagesSchema: RootSchema<any> = {
       },
     },
   },
-  agent_logs_top_errors: {
-    type: 'array',
-    items: {
-      type: 'text',
-      _meta: { description: 'Top messages from agent error logs' },
-    },
-  },
-  fleet_server_logs_top_errors: {
-    type: 'array',
-    items: {
-      type: 'text',
-      _meta: { description: 'Top messages from fleet server error logs' },
-    },
-  },
+  // agent_logs_top_errors: {
+  //   type: 'array',
+  //   items: {
+  //     type: 'text',
+  //     _meta: { description: 'Top messages from agent error logs' },
+  //   },
+  // },
+  // fleet_server_logs_top_errors: {
+  //   type: 'array',
+  //   items: {
+  //     type: 'text',
+  //     _meta: { description: 'Top messages from fleet server error logs' },
+  //   },
+  // },
 };

--- a/x-pack/plugins/fleet/server/services/telemetry/fleet_usages_schema.ts
+++ b/x-pack/plugins/fleet/server/services/telemetry/fleet_usages_schema.ts
@@ -189,18 +189,4 @@ export const fleetUsagesSchema: RootSchema<any> = {
       },
     },
   },
-  // agent_logs_top_errors: {
-  //   type: 'array',
-  //   items: {
-  //     type: 'text',
-  //     _meta: { description: 'Top messages from agent error logs' },
-  //   },
-  // },
-  // fleet_server_logs_top_errors: {
-  //   type: 'array',
-  //   items: {
-  //     type: 'text',
-  //     _meta: { description: 'Top messages from fleet server error logs' },
-  //   },
-  // },
 };


### PR DESCRIPTION
## Summary

Follow up for https://github.com/elastic/kibana/pull/148981

Removed unused agent error logs from telemetry schema to fix this error

```
[2023-01-19T10:04:18.443+01:00][ERROR][plugins.fleet] Error occurred while sending Fleet Usage telemetry: Error: Failed to validate payload coming from "Event Type 'fleet_usage'":
        - [fleet_server.inactive]: {"expected":"number","actual":"undefined","value":"undefined"}
        - [fleet_server.unenrolled]: {"expected":"number","actual":"undefined","value":"undefined"}
        - [agent_logs_top_errors]: {"expected":"Array<string>","actual":"undefined","value":"undefined"}
        - [fleet_server_logs_top_errors]: {"expected":"Array<string>","actual":"undefined","value":"undefined"}
```

The fleet server new statuses are not yet published to telemetry, so removed for now. This will be fixed in https://github.com/elastic/kibana/issues/148720



<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->