### PR TITLE
Adding index_template.data_stream.hidden to RegistryElasticSearch

### DIFF
--- a/x-pack/plugins/fleet/common/types/models/epm.ts
+++ b/x-pack/plugins/fleet/common/types/models/epm.ts
@@ -357,9 +357,14 @@ export interface RegistryElasticsearch {
   privileges?: RegistryDataStreamPrivileges;
   'index_template.settings'?: estypes.IndicesIndexSettings;
   'index_template.mappings'?: estypes.MappingTypeMapping;
+  'index_template.data_stream'?: RegistryDataStreamProperties;
   'ingest_pipeline.name'?: string;
   source_mode?: 'default' | 'synthetic';
   index_mode?: 'time_series';
+}
+
+export interface RegistryDataStreamProperties {
+  hidden?: boolean;
 }
 
 export interface RegistryDataStreamPrivileges {

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.test.ts
@@ -109,6 +109,73 @@ describe('EPM template', () => {
     expect(templateWithoutHidden.data_stream.hidden).toEqual(undefined);
   });
 
+  it('adds index_template.data_stream.hidden field correctly', () => {
+    const templateIndexPattern = 'logs-nginx.access-abcd-*';
+
+    const templateWithGlobalAndDataStreamHidden = getTemplate({
+      templateIndexPattern,
+      packageName: 'nginx',
+      composedOfTemplates: [],
+      templatePriority: 200,
+      hidden: false,
+      mappings: { properties: [] },
+      registryElasticsearch: {
+        'index_template.data_stream': {
+          hidden: true,
+        },
+      },
+    });
+    expect(templateWithGlobalAndDataStreamHidden.data_stream.hidden).toEqual(true);
+
+    const templateWithDataStreamHidden = getTemplate({
+      templateIndexPattern,
+      packageName: 'nginx',
+      composedOfTemplates: [],
+      templatePriority: 200,
+      mappings: { properties: [] },
+      registryElasticsearch: {
+        'index_template.data_stream': {
+          hidden: true,
+        },
+      },
+    });
+    expect(templateWithDataStreamHidden.data_stream.hidden).toEqual(true);
+
+    const templateWithoutDataStreamHidden = getTemplate({
+      templateIndexPattern,
+      packageName: 'nginx',
+      composedOfTemplates: [],
+      templatePriority: 200,
+      hidden: true,
+      mappings: { properties: [] },
+    });
+    expect(templateWithoutDataStreamHidden.data_stream.hidden).toEqual(true);
+
+    const templateWithGlobalHiddenTrueAndDataStreamHiddenFalse = getTemplate({
+      templateIndexPattern,
+      packageName: 'nginx',
+      composedOfTemplates: [],
+      templatePriority: 200,
+      hidden: true,
+      mappings: { properties: [] },
+      registryElasticsearch: {
+        'index_template.data_stream': {
+          hidden: false,
+        },
+      },
+    });
+    expect(templateWithGlobalHiddenTrueAndDataStreamHiddenFalse.data_stream.hidden).toEqual(true);
+
+    const templateWithoutHidden = getTemplate({
+      templateIndexPattern,
+      packageName: 'nginx',
+      composedOfTemplates: [],
+      templatePriority: 200,
+      mappings: { properties: [] },
+    });
+    expect(templateWithoutHidden.data_stream.hidden).toEqual(undefined);
+  });
+
   it('tests loading base.yml', () => {
     const ymlPath = path.join(__dirname, '../../fields/tests/base.yml');
     const fieldsYML = readFileSync(ymlPath, 'utf-8');

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.ts
@@ -542,7 +542,9 @@ function getBaseTemplate({
         _meta,
       },
     },
-    data_stream: { hidden },
+    data_stream: {
+      hidden: registryElasticsearch?.['index_template.data_stream']?.hidden ?? hidden,
+    },
     composed_of: composedOfTemplates,
     _meta,
   };

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.ts
@@ -543,7 +543,7 @@ function getBaseTemplate({
       },
     },
     data_stream: {
-      hidden: registryElasticsearch?.['index_template.data_stream']?.hidden ?? hidden,
+      hidden: registryElasticsearch?.['index_template.data_stream']?.hidden || hidden,
     },
     composed_of: composedOfTemplates,
     _meta,


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/149151.

### Changes
- Extended `RegistryElasticSearch` to include `index_template.data_stream`.
- Use `index_template.data_stream.hidden` in `getBaseTemplate`.
