### PR TITLE
Fix broken page id

### DIFF
--- a/nav-kibana-dev.docnav.json
+++ b/nav-kibana-dev.docnav.json
@@ -117,7 +117,7 @@
       "label": "Tutorials",
       "items": [
         {
-          "id": "kibDevTutorialAddingPerformanceMetrics"
+          "id": "kibDevTutorialAddingCustomPerformanceMetrics"
         },
         {
           "id": "kibDevTutorialSetupWindowsDevWSL"


### PR DESCRIPTION
## Summary

[This change](https://github.com/elastic/kibana/pull/147533/files#diff-7855e9b3a9d0239ce2c0344047c2f83ee459436b2a2da839d3b5db43e8757451R2) has [broken](https://vercel.com/elastic-dev/docs-elastic-dev/ABfUE8aEtaSUUqQ4LRLgcKJ4MuEW) the internal docs builds because the changed page ID was not updated in the navigation.  This PR fixes that change

