### PR TITLE
[Fleet] Move callbacks from http methods to package policy service

### DIFF
--- a/x-pack/plugins/apm/server/plugin.ts
+++ b/x-pack/plugins/apm/server/plugin.ts
@@ -225,6 +225,9 @@ export class APMPlugin
       coreStartPromise: getCoreStart(),
       plugins: resourcePlugins,
       config: currentConfig,
+    }).catch((e) => {
+      this.logger?.error('Failed to register APM Fleet policy callbacks');
+      this.logger?.error(e);
     });
 
     // This will add an API key to all existing APM package policies
@@ -232,6 +235,9 @@ export class APMPlugin
       coreStartPromise: getCoreStart(),
       pluginStartPromise: getPluginStart(),
       logger: this.logger,
+    }).catch((e) => {
+      this.logger?.error('Failed to add API keys to APM package policies');
+      this.logger?.error(e);
     });
 
     const taskManager = plugins.taskManager;

--- a/x-pack/plugins/apm/server/routes/fleet/register_fleet_policy_callbacks.ts
+++ b/x-pack/plugins/apm/server/routes/fleet/register_fleet_policy_callbacks.ts
@@ -75,7 +75,6 @@ function onPackagePolicyDelete({
   logger: Logger;
 }): PostPackagePolicyDeleteCallback {
   return async (packagePolicies) => {
-    // console.log(`packagePolicyDelete:`, packagePolicies);
     const promises = packagePolicies.map(async (packagePolicy) => {
       if (packagePolicy.package?.name !== 'apm') {
         return packagePolicy;

--- a/x-pack/plugins/fleet/server/services/agent_policy.test.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policy.test.ts
@@ -171,9 +171,11 @@ describe('agent policy', () => {
 
     it('should run package policy delete external callbacks', async () => {
       await agentPolicyService.delete(soClient, esClient, 'mocked');
-      expect(packagePolicyService.runPostDeleteExternalCallbacks).toHaveBeenCalledWith([
-        { id: 'package-1' },
-      ]);
+      expect(packagePolicyService.runPostDeleteExternalCallbacks).toHaveBeenCalledWith(
+        [{ id: 'package-1' }],
+        expect.any(Object),
+        expect.any(Object)
+      );
     });
 
     it('should throw error for agent policy which has managed package poolicy', async () => {
@@ -195,9 +197,11 @@ describe('agent policy', () => {
 
       await agentPolicyService.delete(soClient, esClient, 'mocked', { force: true });
 
-      expect(packagePolicyService.runPostDeleteExternalCallbacks).toHaveBeenCalledWith([
-        { id: 'package-1' },
-      ]);
+      expect(packagePolicyService.runPostDeleteExternalCallbacks).toHaveBeenCalledWith(
+        [{ id: 'package-1' }],
+        soClient,
+        esClient
+      );
     });
   });
 

--- a/x-pack/plugins/fleet/server/services/agent_policy.test.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policy.test.ts
@@ -169,15 +169,6 @@ describe('agent policy', () => {
       ]);
     });
 
-    it('should run package policy delete external callbacks', async () => {
-      await agentPolicyService.delete(soClient, esClient, 'mocked');
-      expect(packagePolicyService.runPostDeleteExternalCallbacks).toHaveBeenCalledWith(
-        [{ id: 'package-1' }],
-        expect.any(Object),
-        expect.any(Object)
-      );
-    });
-
     it('should throw error for agent policy which has managed package poolicy', async () => {
       mockedPackagePolicyService.findAllForAgentPolicy.mockReturnValue([
         {
@@ -194,14 +185,6 @@ describe('agent policy', () => {
           ).message
         );
       }
-
-      await agentPolicyService.delete(soClient, esClient, 'mocked', { force: true });
-
-      expect(packagePolicyService.runPostDeleteExternalCallbacks).toHaveBeenCalledWith(
-        [{ id: 'package-1' }],
-        soClient,
-        esClient
-      );
     });
   });
 

--- a/x-pack/plugins/fleet/server/services/agent_policy.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policy.ts
@@ -681,7 +681,7 @@ class AgentPolicyService {
         );
       }
 
-      await packagePolicyService.runDeleteExternalCallbacks(packagePolicies);
+      await packagePolicyService.runDeleteExternalCallbacks(packagePolicies, soClient, esClient);
 
       const deletedPackagePolicies: PostDeletePackagePoliciesResponse =
         await packagePolicyService.delete(
@@ -694,10 +694,14 @@ class AgentPolicyService {
           }
         );
       try {
-        await packagePolicyService.runPostDeleteExternalCallbacks(deletedPackagePolicies);
+        await packagePolicyService.runPostDeleteExternalCallbacks(
+          deletedPackagePolicies,
+          soClient,
+          esClient
+        );
       } catch (error) {
         const logger = appContextService.getLogger();
-        logger.error(`An error occurred executing external callback: ${error}`);
+        logger.error(`An error occurred executing "packagePolicyPostDelete" callback: ${error}`);
         logger.error(error);
       }
     }

--- a/x-pack/plugins/fleet/server/services/agent_policy.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policy.ts
@@ -51,7 +51,6 @@ import type {
   FleetServerPolicy,
   Installation,
   Output,
-  PostDeletePackagePoliciesResponse,
   PackageInfo,
 } from '../../common/types';
 import {
@@ -681,29 +680,15 @@ class AgentPolicyService {
         );
       }
 
-      await packagePolicyService.runDeleteExternalCallbacks(packagePolicies, soClient, esClient);
-
-      const deletedPackagePolicies: PostDeletePackagePoliciesResponse =
-        await packagePolicyService.delete(
-          soClient,
-          esClient,
-          packagePolicies.map((p) => p.id),
-          {
-            force: options?.force,
-            skipUnassignFromAgentPolicies: true,
-          }
-        );
-      try {
-        await packagePolicyService.runPostDeleteExternalCallbacks(
-          deletedPackagePolicies,
-          soClient,
-          esClient
-        );
-      } catch (error) {
-        const logger = appContextService.getLogger();
-        logger.error(`An error occurred executing "packagePolicyPostDelete" callback: ${error}`);
-        logger.error(error);
-      }
+      await packagePolicyService.delete(
+        soClient,
+        esClient,
+        packagePolicies.map((p) => p.id),
+        {
+          force: options?.force,
+          skipUnassignFromAgentPolicies: true,
+        }
+      );
     }
 
     if (agentPolicy.is_preconfigured && !options?.force) {

--- a/x-pack/plugins/fleet/server/services/package_policy.ts
+++ b/x-pack/plugins/fleet/server/services/package_policy.ts
@@ -1336,7 +1336,7 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
   ): Promise<PackagePolicy | NewPackagePolicy | void> {
     const logger = appContextService.getLogger();
     const numberOfCallbacks = appContextService.getExternalCallbacks(externalCallbackType)?.size;
-    logger.info(`Running ${numberOfCallbacks} external callbacks for ${externalCallbackType}`);
+    logger.debug(`Running ${numberOfCallbacks} external callbacks for ${externalCallbackType}`);
     try {
       if (externalCallbackType === 'packagePolicyPostDelete') {
         return await this.runPostDeleteExternalCallbacks(

--- a/x-pack/plugins/fleet/server/services/package_policy.ts
+++ b/x-pack/plugins/fleet/server/services/package_policy.ts
@@ -765,8 +765,7 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
     }
 
     try {
-      await packagePolicyService.runExternalCallbacks(
-        'packagePolicyDelete',
+      await packagePolicyService.runDeleteExternalCallbacks(
         packagePolicies,
         soClient,
         esClient,
@@ -879,8 +878,7 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
     }
 
     try {
-      await packagePolicyService.runExternalCallbacks(
-        'packagePolicyPostDelete',
+      await packagePolicyService.runPostDeleteExternalCallbacks(
         result,
         soClient,
         esClient,

--- a/x-pack/plugins/fleet/server/services/package_policy.ts
+++ b/x-pack/plugins/fleet/server/services/package_policy.ts
@@ -1521,7 +1521,9 @@ class PackagePolicyClientWithAuthz extends PackagePolicyClientImpl {
       skipUniqueNameVerification?: boolean;
       overwrite?: boolean;
       packageInfo?: PackageInfo;
-    }
+    },
+    context?: RequestHandlerContext,
+    request?: KibanaRequest
   ): Promise<PackagePolicy> {
     await this.#runPreflight({
       fleetAuthz: {
@@ -1529,7 +1531,7 @@ class PackagePolicyClientWithAuthz extends PackagePolicyClientImpl {
       },
     });
 
-    return super.create(soClient, esClient, packagePolicy, options);
+    return super.create(soClient, esClient, packagePolicy, options, context, request);
   }
 }
 

--- a/x-pack/plugins/fleet/server/services/package_policy.ts
+++ b/x-pack/plugins/fleet/server/services/package_policy.ts
@@ -1335,6 +1335,8 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
     request?: KibanaRequest
   ): Promise<PackagePolicy | NewPackagePolicy | void> {
     const logger = appContextService.getLogger();
+    const numberOfCallbacks = appContextService.getExternalCallbacks(externalCallbackType)?.size;
+    logger.info(`Running ${numberOfCallbacks} external callbacks for ${externalCallbackType}`);
     try {
       if (externalCallbackType === 'packagePolicyPostDelete') {
         return await this.runPostDeleteExternalCallbacks(

--- a/x-pack/plugins/fleet/server/services/package_policy_service.ts
+++ b/x-pack/plugins/fleet/server/services/package_policy_service.ts
@@ -5,12 +5,8 @@
  * 2.0.
  */
 
-import type { KibanaRequest, Logger } from '@kbn/core/server';
-import type {
-  ElasticsearchClient,
-  RequestHandlerContext,
-  SavedObjectsClientContract,
-} from '@kbn/core/server';
+import type { KibanaRequest, Logger, RequestHandlerContext } from '@kbn/core/server';
+import type { ElasticsearchClient, SavedObjectsClientContract } from '@kbn/core/server';
 import type { AuthenticatedUser } from '@kbn/security-plugin/server';
 
 import type {
@@ -50,7 +46,9 @@ export interface PackagePolicyClient {
       skipUniqueNameVerification?: boolean;
       overwrite?: boolean;
       packageInfo?: PackageInfo;
-    }
+    },
+    context?: RequestHandlerContext,
+    request?: KibanaRequest
   ): Promise<PackagePolicy>;
 
   bulkCreate(
@@ -108,7 +106,13 @@ export interface PackagePolicyClient {
     soClient: SavedObjectsClientContract,
     esClient: ElasticsearchClient,
     ids: string[],
-    options?: { user?: AuthenticatedUser; skipUnassignFromAgentPolicies?: boolean; force?: boolean }
+    options?: {
+      user?: AuthenticatedUser;
+      skipUnassignFromAgentPolicies?: boolean;
+      force?: boolean;
+    },
+    context?: RequestHandlerContext,
+    request?: KibanaRequest
   ): Promise<PostDeletePackagePoliciesResponse>;
 
   upgrade(
@@ -146,9 +150,13 @@ export interface PackagePolicyClient {
       ? PostDeletePackagePoliciesResponse
       : A extends 'packagePolicyPostCreate'
       ? PackagePolicy
+      : A extends 'packagePolicyUpdate'
+      ? UpdatePackagePolicy
       : NewPackagePolicy,
-    context: RequestHandlerContext,
-    request: KibanaRequest
+    soClient: SavedObjectsClientContract,
+    esClient: ElasticsearchClient,
+    context?: RequestHandlerContext,
+    request?: KibanaRequest
   ): Promise<
     A extends 'packagePolicyDelete'
       ? void
@@ -156,13 +164,25 @@ export interface PackagePolicyClient {
       ? void
       : A extends 'packagePolicyPostCreate'
       ? PackagePolicy
+      : A extends 'packagePolicyUpdate'
+      ? UpdatePackagePolicy
       : NewPackagePolicy
   >;
 
-  runDeleteExternalCallbacks(deletedPackagePolicies: DeletePackagePoliciesResponse): Promise<void>;
+  runDeleteExternalCallbacks(
+    deletedPackagePolicies: DeletePackagePoliciesResponse,
+    soClient: SavedObjectsClientContract,
+    esClient: ElasticsearchClient,
+    context?: RequestHandlerContext,
+    request?: KibanaRequest
+  ): Promise<void>;
 
   runPostDeleteExternalCallbacks(
-    deletedPackagePolicies: PostDeletePackagePoliciesResponse
+    deletedPackagePolicies: PostDeletePackagePoliciesResponse,
+    soClient: SavedObjectsClientContract,
+    esClient: ElasticsearchClient,
+    context?: RequestHandlerContext,
+    request?: KibanaRequest
   ): Promise<void>;
 
   getUpgradePackagePolicyInfo(

--- a/x-pack/plugins/fleet/server/types/extensions.ts
+++ b/x-pack/plugins/fleet/server/types/extensions.ts
@@ -6,6 +6,7 @@
  */
 
 import type { KibanaRequest, RequestHandlerContext } from '@kbn/core/server';
+import type { ElasticsearchClient, SavedObjectsClientContract } from '@kbn/core/server';
 
 import type { DeepReadonly } from 'utility-types';
 
@@ -18,29 +19,43 @@ import type {
 } from '../../common/types';
 
 export type PostPackagePolicyDeleteCallback = (
-  packagePolicies: DeletePackagePoliciesResponse
+  packagePolicies: DeletePackagePoliciesResponse,
+  soClient: SavedObjectsClientContract,
+  esClient: ElasticsearchClient,
+  context?: RequestHandlerContext,
+  request?: KibanaRequest
 ) => Promise<void>;
 
 export type PostPackagePolicyPostDeleteCallback = (
-  deletedPackagePolicies: DeepReadonly<PostDeletePackagePoliciesResponse>
+  deletedPackagePolicies: DeepReadonly<PostDeletePackagePoliciesResponse>,
+  soClient: SavedObjectsClientContract,
+  esClient: ElasticsearchClient,
+  context?: RequestHandlerContext,
+  request?: KibanaRequest
 ) => Promise<void>;
 
 export type PostPackagePolicyCreateCallback = (
   newPackagePolicy: NewPackagePolicy,
-  context: RequestHandlerContext,
-  request: KibanaRequest
+  soClient: SavedObjectsClientContract,
+  esClient: ElasticsearchClient,
+  context?: RequestHandlerContext,
+  request?: KibanaRequest
 ) => Promise<NewPackagePolicy>;
 
 export type PostPackagePolicyPostCreateCallback = (
   packagePolicy: PackagePolicy,
-  context: RequestHandlerContext,
-  request: KibanaRequest
+  soClient: SavedObjectsClientContract,
+  esClient: ElasticsearchClient,
+  context?: RequestHandlerContext,
+  request?: KibanaRequest
 ) => Promise<PackagePolicy>;
 
 export type PutPackagePolicyUpdateCallback = (
   updatePackagePolicy: UpdatePackagePolicy,
-  context: RequestHandlerContext,
-  request: KibanaRequest
+  soClient: SavedObjectsClientContract,
+  esClient: ElasticsearchClient,
+  context?: RequestHandlerContext,
+  request?: KibanaRequest
 ) => Promise<UpdatePackagePolicy>;
 
 export type ExternalCallbackCreate = ['packagePolicyCreate', PostPackagePolicyCreateCallback];

--- a/x-pack/plugins/security_solution/server/fleet_integration/fleet_integration.ts
+++ b/x-pack/plugins/security_solution/server/fleet_integration/fleet_integration.ts
@@ -63,6 +63,7 @@ export const getPackagePolicyCreateCallback = (
   ): Promise<NewPackagePolicy> => {
     // callback is called outside request context
     if (!context || !request) {
+      logger.info('PackagePolicyCreateCallback called outside request context. Skipping...');
       return newPackagePolicy;
     }
 
@@ -70,6 +71,7 @@ export const getPackagePolicyCreateCallback = (
     if (!isEndpointPackagePolicy(newPackagePolicy)) {
       return newPackagePolicy;
     }
+    logger.info('PackagePolicyCreateCallback called with request. Processing...');
 
     // Optional endpoint integration configuration
     let endpointIntegrationConfig;

--- a/x-pack/plugins/security_solution/server/fleet_integration/fleet_integration.ts
+++ b/x-pack/plugins/security_solution/server/fleet_integration/fleet_integration.ts
@@ -63,7 +63,7 @@ export const getPackagePolicyCreateCallback = (
   ): Promise<NewPackagePolicy> => {
     // callback is called outside request context
     if (!context || !request) {
-      logger.info('PackagePolicyCreateCallback called outside request context. Skipping...');
+      logger.debug('PackagePolicyCreateCallback called outside request context. Skipping...');
       return newPackagePolicy;
     }
 
@@ -71,7 +71,6 @@ export const getPackagePolicyCreateCallback = (
     if (!isEndpointPackagePolicy(newPackagePolicy)) {
       return newPackagePolicy;
     }
-    logger.info('PackagePolicyCreateCallback called with request. Processing...');
 
     // Optional endpoint integration configuration
     let endpointIntegrationConfig;

--- a/x-pack/plugins/security_solution/server/fleet_integration/fleet_integration.ts
+++ b/x-pack/plugins/security_solution/server/fleet_integration/fleet_integration.ts
@@ -177,7 +177,7 @@ export const getPackagePolicyPostCreateCallback = (
       return packagePolicy;
     }
 
-    const integrationConfig = packagePolicy?.inputs[0].config?.integration_config;
+    const integrationConfig = packagePolicy?.inputs[0]?.config?.integration_config;
 
     if (integrationConfig && integrationConfig?.value?.eventFilters !== undefined) {
       createEventFilters(


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/129383

This PR ensures that fleet callbacks are called regardless if operations on a package policy are performed via the api or directly using the package policy service. 