### PR TITLE
renderCustomActionsRow with named params instead of args

### DIFF
--- a/x-pack/plugins/observability/public/pages/alerts/containers/alerts_table/get_row_actions.tsx
+++ b/x-pack/plugins/observability/public/pages/alerts/containers/alerts_table/get_row_actions.tsx
@@ -6,6 +6,7 @@
  */
 import React from 'react';
 import { EcsFieldsResponse } from '@kbn/rule-registry-plugin/common/search_strategy';
+import { RenderCustomActionsRowArgs } from '@kbn/triggers-actions-ui-plugin/public/types';
 import { ObservabilityRuleTypeRegistry } from '../../../../rules/create_observability_rule_type_registry';
 import { ObservabilityActions } from '../../components/observability_actions';
 import type { ObservabilityActionsProps } from '../../components/observability_actions';
@@ -22,11 +23,7 @@ export const getRowActions = (
   config: ConfigSchema
 ) => {
   return () => ({
-    renderCustomActionsRow: (
-      alert: EcsFieldsResponse,
-      setFlyoutAlert: (data: unknown, id?: string) => void,
-      id?: string
-    ) => {
+    renderCustomActionsRow: ({ alert, setFlyoutAlert, id }: RenderCustomActionsRowArgs) => {
       return (
         <ObservabilityActions
           data={buildData(alert)}

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/alerts_table.test.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/alerts_table.test.tsx
@@ -322,7 +322,7 @@ describe('AlertsTable', () => {
           fireEvent.click((await screen.findAllByTestId('testActionColumn'))[0]);
 
           // the callback given to our clients to run when they want to update the loading state
-          mockedFn.mock.calls[0][3](true);
+          mockedFn.mock.calls[0][0].setIsActionLoading(true);
 
           expect(await screen.findAllByTestId('row-loader')).toHaveLength(1);
           const selectedOptions = await screen.findAllByTestId('dataGridRowCell');
@@ -351,7 +351,7 @@ describe('AlertsTable', () => {
           fireEvent.click((await screen.findAllByTestId('testActionColumn'))[0]);
 
           // the callback given to our clients to run when they want to update the loading state
-          mockedFn.mock.calls[0][3](false);
+          mockedFn.mock.calls[0][0].setIsActionLoading(false);
 
           expect(screen.queryByTestId('row-loader')).not.toBeInTheDocument();
         });

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/alerts_table.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/alerts_table.tsx
@@ -173,12 +173,12 @@ const AlertsTable: React.FunctionComponent<AlertsTableProps> = (props: AlertsTab
                 )}
                 {renderCustomActionsRow &&
                   alerts[visibleRowIndex] &&
-                  renderCustomActionsRow(
-                    alerts[visibleRowIndex],
-                    handleFlyoutAlert,
-                    props.id,
-                    getSetIsActionLoadingCallback(visibleRowIndex)
-                  )}
+                  renderCustomActionsRow({
+                    alert: alerts[visibleRowIndex],
+                    setFlyoutAlert: handleFlyoutAlert,
+                    id: props.id,
+                    setIsActionLoading: getSetIsActionLoadingCallback(visibleRowIndex),
+                  })}
               </EuiFlexGroup>
             );
           },

--- a/x-pack/plugins/triggers_actions_ui/public/types.ts
+++ b/x-pack/plugins/triggers_actions_ui/public/types.ts
@@ -518,13 +518,15 @@ export interface BulkActionsConfig {
   ) => void;
 }
 
+export interface RenderCustomActionsRowArgs {
+  alert: EcsFieldsResponse;
+  setFlyoutAlert: (data: unknown) => void;
+  id?: string;
+  setIsActionLoading?: (isLoading: boolean) => void;
+}
+
 export type UseActionsColumnRegistry = () => {
-  renderCustomActionsRow: (
-    alert: EcsFieldsResponse,
-    setFlyoutAlert: (data: unknown) => void,
-    id?: string,
-    setIsActionLoading?: (isLoading: boolean) => void
-  ) => JSX.Element;
+  renderCustomActionsRow: (args: RenderCustomActionsRowArgs) => JSX.Element;
   width?: number;
 };
 


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/149303

## QA

Run the alerts table and check that the actions cell is working. 

https://user-images.githubusercontent.com/17549662/214009339-afc1fe7f-fb2a-4461-aec9-70a2335a875b.mov


