### PR TITLE
[7.17] Update dependency require-in-the-middle to v6 (main) (#149292)

### DIFF
--- a/package.json
+++ b/package.json
@@ -371,7 +371,7 @@
     "regenerator-runtime": "^0.13.3",
     "remark-parse": "^8.0.3",
     "remark-stringify": "^8.0.3",
-    "require-in-the-middle": "^5.2.0",
+    "require-in-the-middle": "^6.0.0",
     "reselect": "^4.0.0",
     "resize-observer-polyfill": "^1.5.1",
     "rison-node": "1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -24246,10 +24246,19 @@ require-from-string@^2.0.1, require-from-string@^2.0.2:
   resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
   integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
 
-require-in-the-middle@^5.0.3, require-in-the-middle@^5.2.0:
+require-in-the-middle@^5.0.3:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/require-in-the-middle/-/require-in-the-middle-5.2.0.tgz#4b71e3cc7f59977100af9beb76bf2d056a5a6de2"
   integrity sha512-efCx3b+0Z69/LGJmm9Yvi4cqEdxnoGnxYxGxBghkkTTFeXRtTCmmhO0AnAfHz59k957uTSuy8WaHqOs8wbYUWg==
+  dependencies:
+    debug "^4.1.1"
+    module-details-from-path "^1.0.3"
+    resolve "^1.22.1"
+
+require-in-the-middle@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/require-in-the-middle/-/require-in-the-middle-6.0.0.tgz#01cc6416286fb5e672d0fe031d996f8bc202509d"
+  integrity sha512-+dtWQ7l2lqQDxheaG3jjyN1QI37gEwvzACSgjYi4/C2y+ZTUMeRW8BIOm+9NBKvwaMBUSZfPXVOt1skB0vBkRw==
   dependencies:
     debug "^4.1.1"
     module-details-from-path "^1.0.3"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [Update dependency require-in-the-middle to v6 (main) (#149292)](https://github.com/elastic/kibana/pull/149292)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"renovate[bot]","email":"29139614+renovate[bot]@users.noreply.github.com"},"sourceCommit":{"committedDate":"2023-01-23T11:42:43Z","message":"Update dependency require-in-the-middle to v6 (main) (#149292)","sha":"57fd55bf85691a439c6be78fe9bc6062150d9338","branchLabelMapping":{"^v8.7.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Security","release_note:skip","backport:all-open","v8.7.0"],"number":149292,"url":"https://github.com/elastic/kibana/pull/149292","mergeCommit":{"message":"Update dependency require-in-the-middle to v6 (main) (#149292)","sha":"57fd55bf85691a439c6be78fe9bc6062150d9338"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.7.0","labelRegex":"^v8.7.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/149292","number":149292,"mergeCommit":{"message":"Update dependency require-in-the-middle to v6 (main) (#149292)","sha":"57fd55bf85691a439c6be78fe9bc6062150d9338"}},{"url":"https://github.com/elastic/kibana/pull/149312","number":149312,"branch":"8.6","state":"OPEN"}]}] BACKPORT-->