### PR TITLE
[Fleet] Move view agent dashboard button

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_dashboard_link.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_dashboard_link.test.tsx
@@ -87,7 +87,7 @@ describe('AgentDashboardLink', () => {
     expect(result.getByRole('button').hasAttribute('disabled')).toBeTruthy();
   });
 
-  it('should not enable the button if elastic_agent package is installed and policy do not have monitoring enabled', async () => {
+  it('should link to the agent policy settings tab if logs and metrics are not enabled for that policy', async () => {
     mockedUseGetPackageInfoByKey.mockReturnValue({
       isLoading: false,
       data: {
@@ -107,14 +107,15 @@ describe('AgentDashboardLink', () => {
         }
         agentPolicy={
           {
+            id: 'policy123',
             monitoring_enabled: [],
           } as unknown as AgentPolicy
         }
       />
     );
 
-    expect(result.queryByRole('link')).toBeNull();
-    expect(result.queryByRole('button')).not.toBeNull();
-    expect(result.getByRole('button').hasAttribute('disabled')).toBeTruthy();
+    const link = result.queryByRole('link');
+    expect(link).not.toBeNull();
+    expect(link?.getAttribute('href')).toBe('/mock/app/fleet/policies/policy123/settings');
   });
 });

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_dashboard_link.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_dashboard_link.tsx
@@ -8,8 +8,9 @@
 import React from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { EuiButton, EuiToolTip } from '@elastic/eui';
+import styled from 'styled-components';
 
-import { useGetPackageInfoByKey, useKibanaLink } from '../../../../hooks';
+import { useGetPackageInfoByKey, useKibanaLink, useLink } from '../../../../hooks';
 import type { Agent, AgentPolicy } from '../../../../types';
 import {
   FLEET_ELASTIC_AGENT_PACKAGE,
@@ -32,11 +33,16 @@ function useAgentDashboardLink(agent: Agent) {
   };
 }
 
+const EuiButtonCompressed = styled(EuiButton)`
+  height: 32px;
+`;
+
 export const AgentDashboardLink: React.FunctionComponent<{
   agent: Agent;
   agentPolicy?: AgentPolicy;
 }> = ({ agent, agentPolicy }) => {
   const { isInstalled, link, isLoading } = useAgentDashboardLink(agent);
+  const { getHref } = useLink();
 
   const isLogAndMetricsEnabled = agentPolicy?.monitoring_enabled?.length ?? 0 > 0;
 
@@ -44,15 +50,15 @@ export const AgentDashboardLink: React.FunctionComponent<{
     !isInstalled || isLoading || !isLogAndMetricsEnabled ? { disabled: true } : { href: link };
 
   const button = (
-    <EuiButton fill {...buttonArgs} isLoading={isLoading}>
+    <EuiButtonCompressed {...buttonArgs} isLoading={isLoading} color="primary">
       <FormattedMessage
         id="xpack.fleet.agentDetails.viewDashboardButtonLabel"
-        defaultMessage="View agent dashboard"
+        defaultMessage="View more agent metrics"
       />
-    </EuiButton>
+    </EuiButtonCompressed>
   );
 
-  if (!isLogAndMetricsEnabled) {
+  if (!isLoading && !isLogAndMetricsEnabled && agentPolicy) {
     return (
       <EuiToolTip
         content={
@@ -62,7 +68,16 @@ export const AgentDashboardLink: React.FunctionComponent<{
           />
         }
       >
-        {button}
+        <EuiButtonCompressed
+          isLoading={isLoading}
+          color="primary"
+          href={getHref('policy_details', { policyId: agentPolicy.id, tabId: 'settings' })}
+        >
+          <FormattedMessage
+            id="xpack.fleet.agentDetails.enableLogsAndMetricsLabel"
+            defaultMessage="Enable logs and metrics"
+          />
+        </EuiButtonCompressed>
       </EuiToolTip>
     );
   }

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_details/agent_details_overview.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_details/agent_details_overview.tsx
@@ -27,6 +27,7 @@ import { AgentPolicySummaryLine } from '../../../../../components';
 import { AgentHealth } from '../../../components';
 import { Tags } from '../../../components/tags';
 import { formatAgentCPU, formatAgentMemory } from '../../../services/agent_metrics';
+import { AgentDashboardLink } from '../agent_dashboard_link';
 
 // Allows child text to be truncated
 const FlexItemWithMinWidth = styled(EuiFlexItem)`
@@ -44,23 +45,53 @@ export const AgentDetailsOverviewSection: React.FunctionComponent<{
     <EuiPanel>
       <EuiDescriptionList compressed>
         <EuiFlexGroup direction="column" gutterSize="m">
+          {displayAgentMetrics && (
+            <EuiFlexGroup>
+              <FlexItemWithMinWidth grow={5}>
+                <EuiFlexGroup direction="column" gutterSize="m">
+                  {[
+                    {
+                      title: i18n.translate('xpack.fleet.agentDetails.cpuLabel', {
+                        defaultMessage: 'CPU',
+                      }),
+                      description: formatAgentCPU(agent.metrics, agentPolicy),
+                    },
+                    {
+                      title: i18n.translate('xpack.fleet.agentDetails.memoryLabel', {
+                        defaultMessage: 'Memory',
+                      }),
+                      description: formatAgentMemory(agent.metrics, agentPolicy),
+                    },
+                  ].map(({ title, description }) => {
+                    const tooltip =
+                      typeof description === 'string' && description.length > 20 ? description : '';
+                    return (
+                      <EuiFlexGroup>
+                        <FlexItemWithMinWidth grow={8}>
+                          <EuiDescriptionListTitle>{title}</EuiDescriptionListTitle>
+                        </FlexItemWithMinWidth>
+                        <FlexItemWithMinWidth grow={4}>
+                          <EuiToolTip position="top" content={tooltip}>
+                            <EuiDescriptionListDescription className="eui-textTruncate">
+                              {description}
+                            </EuiDescriptionListDescription>
+                          </EuiToolTip>
+                        </FlexItemWithMinWidth>
+                      </EuiFlexGroup>
+                    );
+                  })}
+                </EuiFlexGroup>
+              </FlexItemWithMinWidth>
+              <FlexItemWithMinWidth grow={5}>
+                <EuiFlexGroup justifyContent="flexEnd">
+                  <EuiFlexItem grow={false}>
+                    <AgentDashboardLink agent={agent} agentPolicy={agentPolicy} />
+                  </EuiFlexItem>
+                </EuiFlexGroup>
+              </FlexItemWithMinWidth>
+            </EuiFlexGroup>
+          )}
           {[
-            ...(displayAgentMetrics
-              ? [
-                  {
-                    title: i18n.translate('xpack.fleet.agentDetails.cpuLabel', {
-                      defaultMessage: 'CPU',
-                    }),
-                    description: formatAgentCPU(agent.metrics, agentPolicy),
-                  },
-                  {
-                    title: i18n.translate('xpack.fleet.agentDetails.memoryLabel', {
-                      defaultMessage: 'Memory',
-                    }),
-                    description: formatAgentMemory(agent.metrics, agentPolicy),
-                  },
-                ]
-              : []),
             {
               title: i18n.translate('xpack.fleet.agentDetails.statusLabel', {
                 defaultMessage: 'Status',

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/index.tsx
@@ -32,7 +32,6 @@ import {
   AgentLogs,
   AgentDetailsActionMenu,
   AgentDetailsContent,
-  AgentDashboardLink,
   AgentDiagnosticsTab,
 } from './components';
 
@@ -131,9 +130,6 @@ export const AgentDetailsPage: React.FunctionComponent = () => {
                 />
               </EuiFlexItem>
             )}
-            <EuiFlexItem grow={false}>
-              <AgentDashboardLink agent={agentData?.item} agentPolicy={agentPolicyData?.item} />
-            </EuiFlexItem>
           </EuiFlexGroup>
         </>
       ) : undefined,


### PR DESCRIPTION
## Summary

Resolve https://github.com/elastic/ingest-dev/issues/1396

Move the view agent dashoard button in the agent details view and show a button to enable logs and metrics that redirect to the policy settings tab if logs and metrics are not enabled.

## UI Changes

#### With logs and metrics enabled

<img width="1157" alt="Screen Shot 2023-01-23 at 8 14 15 AM" src="https://user-images.githubusercontent.com/1336873/214041012-05d232c4-3c75-4cf9-916f-f9e9d77563dd.png">




#### With logs and metrics disabled

<img width="1252" alt="Screen Shot 2023-01-23 at 8 34 38 AM" src="https://user-images.githubusercontent.com/1336873/214040944-b52135d7-f851-42b3-bd18-3a1df70bd946.png">
