### PR TITLE
[Enterprise Search]Add empty prompt for Engines List page

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engines/components/empty_engines_prompt.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engines/components/empty_engines_prompt.test.tsx
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React from 'react';
+
+import { shallow } from 'enzyme';
+
+import { EuiEmptyPrompt } from '@elastic/eui';
+
+import { EmptyEnginesPrompt } from './empty_engines_prompt';
+
+describe('EmptyEnginesPrompt', () => {
+  it('should pass children to prompt actions', () => {
+    const dummyEl = <div>dummy</div>;
+    const wrapper = shallow(<EmptyEnginesPrompt>{dummyEl}</EmptyEnginesPrompt>);
+    const euiPrompt = wrapper.find(EuiEmptyPrompt);
+
+    expect(euiPrompt.prop('actions')).toEqual(dummyEl);
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engines/components/empty_engines_prompt.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engines/components/empty_engines_prompt.tsx
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { EuiEmptyPrompt } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n-react';
+
+export const EmptyEnginesPrompt: React.FC = ({ children }) => {
+  return (
+    <EuiEmptyPrompt
+      iconType="aggregate"
+      title={
+        <h2>
+          <FormattedMessage
+            id="xpack.enterpriseSearch.content.engines.enginesList.empty.title"
+            defaultMessage="Create your first engine"
+          />
+        </h2>
+      }
+      body={
+        <p>
+          <FormattedMessage
+            id="xpack.enterpriseSearch.content.engines.enginesList.empty.description"
+            defaultMessage="Let's walk you through creating your first engine."
+          />
+        </p>
+      }
+      actions={children}
+    />
+  );
+};

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engines/engine_list_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engines/engine_list_logic.test.ts
@@ -24,7 +24,7 @@ const DEFAULT_VALUES = {
   deleteStatus: Status.IDLE,
   isDeleteLoading: false,
   isDeleteModalVisible: false,
-  isLoading: false,
+  isLoading: true,
   meta: DEFAULT_META,
   parameters: { meta: DEFAULT_META },
   results: [],
@@ -146,6 +146,7 @@ describe('EnginesListLogic', () => {
             meta: newPageMeta,
             // searchQuery: 'k',
           },
+          isLoading: false,
           meta: newPageMeta,
           parameters: {
             meta: newPageMeta,
@@ -224,6 +225,7 @@ describe('EnginesListLogic', () => {
             results,
             meta: DEFAULT_META,
           },
+          isLoading: false,
           meta: DEFAULT_META,
           parameters: {
             meta: DEFAULT_META,

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engines/engines_list.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engines/engines_list.test.tsx
@@ -13,18 +13,34 @@ import { shallow } from 'enzyme';
 
 import { Status } from '../../../../../common/types/api';
 
+import { EnterpriseSearchContentPageTemplate } from '../layout/page_template';
+
+import { EmptyEnginesPrompt } from './components/empty_engines_prompt';
 import { EnginesListTable } from './components/tables/engines_table';
 import { EnginesList } from './engines_list';
 import { DEFAULT_META } from './types';
 
 const DEFAULT_VALUES = {
   data: undefined,
-  results: [],
+  isLoading: true,
   meta: DEFAULT_META,
   parameters: { meta: DEFAULT_META },
+  results: [],
   status: Status.IDLE,
 };
-const mockValues = { ...DEFAULT_VALUES };
+const mockValues = {
+  ...DEFAULT_VALUES,
+  isLoading: false,
+  results: [
+    {
+      created: '1999-12-31T23:59:59Z',
+      indices: ['index-18', 'index-23'],
+      name: 'engine-name-1',
+      updated: '1999-12-31T23:59:59Z',
+    },
+  ],
+  status: Status.SUCCESS,
+};
 
 const mockActions = {
   fetchEngines: jest.fn(),
@@ -36,7 +52,23 @@ describe('EnginesList', () => {
     jest.clearAllMocks();
     global.localStorage.clear();
   });
-  describe('Empty state', () => {});
+  it('renders loading when isLoading', () => {
+    setMockValues(DEFAULT_VALUES);
+    setMockActions(mockActions);
+
+    const wrapper = shallow(<EnginesList />);
+    const pageTemplate = wrapper.find(EnterpriseSearchContentPageTemplate);
+
+    expect(pageTemplate.prop('isLoading')).toEqual(true);
+  });
+  it('renders empty prompt when no data is available', () => {
+    setMockValues(DEFAULT_VALUES);
+    setMockActions(mockActions);
+    const wrapper = shallow(<EnginesList />);
+
+    expect(wrapper.find(EmptyEnginesPrompt)).toHaveLength(1);
+    expect(wrapper.find(EnginesListTable)).toHaveLength(0);
+  });
 
   it('renders with Engines data ', async () => {
     setMockValues(mockValues);
@@ -45,5 +77,6 @@ describe('EnginesList', () => {
     const wrapper = shallow(<EnginesList />);
 
     expect(wrapper.find(EnginesListTable)).toHaveLength(1);
+    expect(wrapper.find(EmptyEnginesPrompt)).toHaveLength(0);
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engines/engines_list.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engines/engines_list.tsx
@@ -20,13 +20,30 @@ import { DataPanel } from '../../../shared/data_panel/data_panel';
 
 import { EnterpriseSearchContentPageTemplate } from '../layout/page_template';
 
+import { EmptyEnginesPrompt } from './components/empty_engines_prompt';
 import { EnginesListTable } from './components/tables/engines_table';
 import { DeleteEngineModal } from './delete_engine_modal';
 import { EnginesListLogic } from './engines_list_logic';
 
+const CreateButton: React.FC = () => {
+  return (
+    <EuiButton
+      fill
+      iconType="plusInCircle"
+      data-test-subj="enterprise-search-content-engines-creation-button"
+      data-telemetry-id="entSearchContent-engines-list-createEngine"
+      href={'TODO'}
+    >
+      {i18n.translate('xpack.enterpriseSearch.content.engines.createEngineButtonLabel', {
+        defaultMessage: 'Create engine',
+      })}
+    </EuiButton>
+  );
+};
+
 export const EnginesList: React.FC = () => {
   const { fetchEngines, onPaginate, openDeleteEngineModal } = useActions(EnginesListLogic);
-  const { meta, results } = useValues(EnginesListLogic);
+  const { meta, results, isLoading } = useValues(EnginesListLogic);
   const [searchQuery, setSearchValue] = useState('');
   const throttledSearchQuery = useThrottle(searchQuery, INPUT_THROTTLE_DELAY_MS);
 
@@ -47,114 +64,113 @@ export const EnginesList: React.FC = () => {
           }),
         ]}
         pageHeader={{
+          description: (
+            <FormattedMessage
+              id="xpack.enterpriseSearch.content.engines.description"
+              defaultMessage="Engines allow you to query indexed data with a complete set of relevance, analytics and personalization tools. To learn more about how engines work in Enterprise search {documentationUrl}"
+              values={{
+                documentationUrl: (
+                  <EuiLink
+                    data-test-subj="engines-documentation-link"
+                    href="TODO"
+                    target="_blank"
+                    data-telemetry-id="entSearchContent-engines-documentation-viewDocumentaion"
+                  >
+                    {' '}
+                    {/* TODO: navigate to documentation url */}{' '}
+                    {i18n.translate('xpack.enterpriseSearch.content.engines.documentation', {
+                      defaultMessage: 'explore our Engines documentation',
+                    })}
+                  </EuiLink>
+                ),
+              }}
+            />
+          ),
           pageTitle: i18n.translate('xpack.enterpriseSearch.content.engines.title', {
             defaultMessage: 'Engines',
           }),
-          rightSideItems: [
-            <EuiButton
-              fill
-              iconType="plusInCircle"
-              data-test-subj="enterprise-search-content-engines-creation-button"
-              data-telemetry-id="entSearchContent-engines-list-createEngine"
-              href={'TODO'}
-            >
-              {i18n.translate('xpack.enterpriseSearch.content.engines.createEngineButtonLabel', {
-                defaultMessage: 'Create engine',
-              })}
-            </EuiButton>,
-          ],
+          rightSideItems: [<CreateButton />],
         }}
         pageViewTelemetry="Engines"
-        isLoading={false}
+        isLoading={isLoading}
       >
-        <EuiText>
-          <FormattedMessage
-            id="xpack.enterpriseSearch.content.engines.description"
-            defaultMessage="Engines allow you to query indexed data with a complete set of relevance, analytics and personalization tools. To learn more about how engines work in Enterprise search {documentationUrl}"
-            values={{
-              documentationUrl: (
-                <EuiLink
-                  data-test-subj="engines-documentation-link"
-                  href="TODO"
-                  target="_blank"
-                  data-telemetry-id="entSearchContent-engines-documentation-viewDocumentaion"
-                >
-                  {' '}
-                  {/* TODO: navigate to documentation url */}{' '}
-                  {i18n.translate('xpack.enterpriseSearch.content.engines.documentation', {
-                    defaultMessage: 'explore our Engines documentation',
-                  })}
-                </EuiLink>
-              ),
-            }}
-          />
-        </EuiText>
         <EuiSpacer />
-        <div>
-          <EuiFieldSearch
-            value={searchQuery}
-            placeholder={i18n.translate(
-              'xpack.enterpriseSearch.content.engines.searchPlaceholder',
-              {
-                defaultMessage: 'Search engines',
-              }
-            )}
-            aria-label={i18n.translate(
-              'xpack.enterpriseSearch.content.engines.searchBar.ariaLabel',
-              {
-                defaultMessage: 'Search engines',
-              }
-            )}
-            fullWidth
-            onChange={(event) => {
-              setSearchValue(event.currentTarget.value);
-            }}
-          />
-        </div>
-        <EuiSpacer size="s" />
-        <EuiText color="subdued" size="s">
-          {i18n.translate('xpack.enterpriseSearch.content.engines.searchPlaceholder.description', {
-            defaultMessage: 'Locate an engine via name or indices',
-          })}
-        </EuiText>
+        {results.length ? (
+          <>
+            <div>
+              <EuiFieldSearch
+                value={searchQuery}
+                placeholder={i18n.translate(
+                  'xpack.enterpriseSearch.content.engines.searchPlaceholder',
+                  {
+                    defaultMessage: 'Search engines',
+                  }
+                )}
+                aria-label={i18n.translate(
+                  'xpack.enterpriseSearch.content.engines.searchBar.ariaLabel',
+                  {
+                    defaultMessage: 'Search engines',
+                  }
+                )}
+                fullWidth
+                onChange={(event) => {
+                  setSearchValue(event.currentTarget.value);
+                }}
+              />
+            </div>
+            <EuiSpacer size="s" />
+            <EuiText color="subdued" size="s">
+              {i18n.translate(
+                'xpack.enterpriseSearch.content.engines.searchPlaceholder.description',
+                {
+                  defaultMessage: 'Locate an engine via name or indices',
+                }
+              )}
+            </EuiText>
 
-        <EuiSpacer size="m" />
-        <EuiText size="s">
-          <FormattedMessage
-            id="xpack.enterpriseSearch.content.engines.enginesList.description"
-            defaultMessage="Showing {from}-{to} of {total}"
-            values={{
-              from: (
-                <strong>
-                  <FormattedNumber value={meta.from + 1} />
-                </strong>
-              ),
-              to: (
-                <strong>
-                  <FormattedNumber value={meta.from + (results?.length ?? 0)} />
-                </strong>
-              ),
-              total: <FormattedNumber value={meta.total} />,
-            }}
-          />
-        </EuiText>
-        <DataPanel
-          title={
-            <h2>
-              {i18n.translate('xpack.enterpriseSearch.content.engines.title', {
-                defaultMessage: 'Engines',
-              })}
-            </h2>
-          }
-        >
-          <EnginesListTable
-            enginesList={results}
-            meta={meta}
-            onChange={onPaginate}
-            onDelete={openDeleteEngineModal}
-            loading={false}
-          />
-        </DataPanel>
+            <EuiSpacer size="m" />
+            <EuiText size="s">
+              <FormattedMessage
+                id="xpack.enterpriseSearch.content.engines.enginesList.description"
+                defaultMessage="Showing {from}-{to} of {total}"
+                values={{
+                  from: (
+                    <strong>
+                      <FormattedNumber value={meta.from + 1} />
+                    </strong>
+                  ),
+                  to: (
+                    <strong>
+                      <FormattedNumber value={meta.from + (results?.length ?? 0)} />
+                    </strong>
+                  ),
+                  total: <FormattedNumber value={meta.total} />,
+                }}
+              />
+            </EuiText>
+            <DataPanel
+              title={
+                <h2>
+                  {i18n.translate('xpack.enterpriseSearch.content.engines.title', {
+                    defaultMessage: 'Engines',
+                  })}
+                </h2>
+              }
+            >
+              <EnginesListTable
+                enginesList={results}
+                meta={meta}
+                onChange={onPaginate}
+                onDelete={openDeleteEngineModal}
+                loading={false}
+              />
+            </DataPanel>
+          </>
+        ) : (
+          <EmptyEnginesPrompt>
+            <CreateButton />
+          </EmptyEnginesPrompt>
+        )}
 
         <EuiSpacer size="xxl" />
         <div />

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engines/engines_list_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engines/engines_list_logic.ts
@@ -124,7 +124,7 @@ export const EnginesListLogic = kea<MakeLogicType<EngineListValues, EnginesListA
     ],
     isLoading: [
       () => [selectors.status],
-      (status: EngineListValues['status']) => [Status.LOADING].includes(status),
+      (status: EngineListValues['status']) => [Status.LOADING, Status.IDLE].includes(status),
     ],
     results: [() => [selectors.data], (data) => data?.results ?? []],
     meta: [() => [selectors.parameters], (parameters) => parameters.meta],


### PR DESCRIPTION
## Summary


- Add empty prompt for Engines page.
![Screenshot 2023-01-23 at 13 52 09](https://user-images.githubusercontent.com/1410658/214045131-4926210e-e42e-4e5b-b5d1-5837c39fd4a8.png)


- Moves page descriptions to page header to match designs.
![Screenshot 2023-01-23 at 13 53 44](https://user-images.githubusercontent.com/1410658/214045218-e2c44680-5823-4c46-8e4f-6114f30d6c20.png)

Note on designs: Description page won't extend under right side items per EUI don't allow it.
See the screenshot from EUI cc/ @julianrosado 
![Screenshot 2023-01-23 at 13 16 30](https://user-images.githubusercontent.com/1410658/214045427-4e41edc8-17c1-44a2-8463-32df5fc77044.png)
https://eui.elastic.co/#/layout/page-header


- Update isLoading logic for engine list logic.
- Update and add tests.


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


