### PR TITLE
[APM] Allow calling `createInternalESClient` without `context`

### DIFF
--- a/x-pack/plugins/apm/server/lib/helpers/create_es_client/call_async_with_debug.ts
+++ b/x-pack/plugins/apm/server/lib/helpers/create_es_client/call_async_with_debug.ts
@@ -23,7 +23,6 @@ export async function callAsyncWithDebug<T>({
   getDebugMessage,
   debug,
   request,
-  requestType,
   requestParams,
   operationName,
   isCalledWithInternalUser,
@@ -31,8 +30,7 @@ export async function callAsyncWithDebug<T>({
   cb: () => Promise<T>;
   getDebugMessage: () => { body: string; title: string };
   debug: boolean;
-  request: KibanaRequest;
-  requestType: string;
+  request?: KibanaRequest;
   requestParams: Record<string, any>;
   operationName: string;
   isCalledWithInternalUser: boolean; // only allow inspection of queries that were retrieved with credentials of the end user
@@ -70,19 +68,21 @@ export async function callAsyncWithDebug<T>({
     console.log(body);
     console.log(`\n`);
 
-    const inspectableEsQueries = inspectableEsQueriesMap.get(request);
-    if (!isCalledWithInternalUser && inspectableEsQueries) {
-      inspectableEsQueries.push(
-        getInspectResponse({
-          esError,
-          esRequestParams: requestParams,
-          esRequestStatus,
-          esResponse: res,
-          kibanaRequest: request,
-          operationName,
-          startTime,
-        })
-      );
+    if (request) {
+      const inspectableEsQueries = inspectableEsQueriesMap.get(request);
+      if (!isCalledWithInternalUser && inspectableEsQueries) {
+        inspectableEsQueries.push(
+          getInspectResponse({
+            esError,
+            esRequestParams: requestParams,
+            esRequestStatus,
+            esResponse: res,
+            kibanaRequest: request,
+            operationName,
+            startTime,
+          })
+        );
+      }
     }
   }
 

--- a/x-pack/plugins/apm/server/lib/helpers/create_es_client/create_apm_event_client/index.ts
+++ b/x-pack/plugins/apm/server/lib/helpers/create_es_client/create_apm_event_client/index.ts
@@ -124,7 +124,6 @@ export class APMEventClient {
       isCalledWithInternalUser: false,
       debug: this.debug,
       request: this.request,
-      requestType,
       operationName,
       requestParams: params,
       cb: () => {

--- a/x-pack/plugins/apm/server/routes/fleet/route.ts
+++ b/x-pack/plugins/apm/server/routes/fleet/route.ts
@@ -26,7 +26,7 @@ import { getInternalSavedObjectsClient } from '../../lib/helpers/get_internal_sa
 import { createApmServerRoute } from '../apm_routes/create_apm_server_route';
 import { getLatestApmPackage } from './get_latest_apm_package';
 import { getJavaAgentVersionsFromRegistry } from './get_java_agent_versions';
-import { createInternalESClient } from '../../lib/helpers/create_es_client/create_internal_es_client';
+import { createInternalESClientWithContext } from '../../lib/helpers/create_es_client/create_internal_es_client';
 
 const hasFleetDataRoute = createApmServerRoute({
   endpoint: 'GET /internal/apm/fleet/has_apm_policies',
@@ -249,7 +249,7 @@ const createCloudApmPackagePolicyRoute = createApmServerRoute({
       throw Boom.forbidden(CLOUD_SUPERUSER_REQUIRED_MESSAGE);
     }
 
-    const internalESClient = await createInternalESClient({
+    const internalESClient = await createInternalESClientWithContext({
       context,
       request,
       debug: resources.params.query._inspect,

--- a/x-pack/plugins/apm/server/routes/settings/agent_configuration/route.ts
+++ b/x-pack/plugins/apm/server/routes/settings/agent_configuration/route.ts
@@ -25,7 +25,7 @@ import {
 import { getSearchTransactionsEvents } from '../../../lib/helpers/transactions';
 import { syncAgentConfigsToApmPackagePolicies } from '../../fleet/sync_agent_configs_to_apm_package_policies';
 import { getApmEventClient } from '../../../lib/helpers/get_apm_event_client';
-import { createInternalESClient } from '../../../lib/helpers/create_es_client/create_internal_es_client';
+import { createInternalESClientWithContext } from '../../../lib/helpers/create_es_client/create_internal_es_client';
 
 // get list of configurations
 const agentConfigurationRoute = createApmServerRoute({
@@ -39,7 +39,7 @@ const agentConfigurationRoute = createApmServerRoute({
     >;
   }> => {
     const { context, request, params, config } = resources;
-    const internalESClient = await createInternalESClient({
+    const internalESClient = await createInternalESClientWithContext({
       context,
       request,
       debug: params.query._inspect,
@@ -68,7 +68,7 @@ const getSingleAgentConfigurationRoute = createApmServerRoute({
     const { name, environment, _inspect } = params.query;
     const service = { name, environment };
 
-    const internalESClient = await createInternalESClient({
+    const internalESClient = await createInternalESClientWithContext({
       context,
       request,
       debug: _inspect,
@@ -114,7 +114,7 @@ const deleteAgentConfigurationRoute = createApmServerRoute({
     } = resources;
     const { service } = params.body;
 
-    const internalESClient = await createInternalESClient({
+    const internalESClient = await createInternalESClientWithContext({
       context,
       request,
       debug: params.query._inspect,
@@ -179,7 +179,7 @@ const createOrUpdateAgentConfigurationRoute = createApmServerRoute({
     } = resources;
     const { body, query } = params;
 
-    const internalESClient = await createInternalESClient({
+    const internalESClient = await createInternalESClientWithContext({
       context,
       request,
       debug: params.query._inspect,
@@ -258,7 +258,7 @@ const agentConfigurationSearchRoute = createApmServerRoute({
       mark_as_applied_by_agent: markAsAppliedByAgent,
     } = params.body;
 
-    const internalESClient = await createInternalESClient({
+    const internalESClient = await createInternalESClientWithContext({
       context,
       request,
       debug: params.query._inspect,
@@ -323,7 +323,7 @@ const listAgentConfigurationEnvironmentsRoute = createApmServerRoute({
   }> => {
     const { context, request, params, config } = resources;
     const [internalESClient, apmEventClient] = await Promise.all([
-      createInternalESClient({
+      createInternalESClientWithContext({
         context,
         request,
         debug: params.query._inspect,

--- a/x-pack/plugins/apm/server/routes/settings/custom_link/route.ts
+++ b/x-pack/plugins/apm/server/routes/settings/custom_link/route.ts
@@ -19,7 +19,7 @@ import { getTransaction } from './get_transaction';
 import { listCustomLinks } from './list_custom_links';
 import { createApmServerRoute } from '../../apm_routes/create_apm_server_route';
 import { getApmEventClient } from '../../../lib/helpers/get_apm_event_client';
-import { createInternalESClient } from '../../../lib/helpers/create_es_client/create_internal_es_client';
+import { createInternalESClientWithContext } from '../../../lib/helpers/create_es_client/create_internal_es_client';
 
 const customLinkTransactionRoute = createApmServerRoute({
   endpoint: 'GET /internal/apm/settings/custom_links/transaction',
@@ -63,7 +63,7 @@ const listCustomLinksRoute = createApmServerRoute({
 
     const { query } = params;
 
-    const internalESClient = await createInternalESClient({
+    const internalESClient = await createInternalESClientWithContext({
       context,
       request,
       debug: resources.params.query._inspect,
@@ -94,7 +94,7 @@ const createCustomLinkRoute = createApmServerRoute({
       throw Boom.forbidden(INVALID_LICENSE);
     }
 
-    const internalESClient = await createInternalESClient({
+    const internalESClient = await createInternalESClientWithContext({
       context,
       request,
       debug: resources.params.query._inspect,
@@ -130,7 +130,7 @@ const updateCustomLinkRoute = createApmServerRoute({
       throw Boom.forbidden(INVALID_LICENSE);
     }
 
-    const internalESClient = await createInternalESClient({
+    const internalESClient = await createInternalESClientWithContext({
       context,
       request,
       debug: resources.params.query._inspect,
@@ -166,7 +166,7 @@ const deleteCustomLinkRoute = createApmServerRoute({
       throw Boom.forbidden(INVALID_LICENSE);
     }
 
-    const internalESClient = await createInternalESClient({
+    const internalESClient = await createInternalESClientWithContext({
       context,
       request,
       debug: resources.params.query._inspect,

--- a/x-pack/plugins/apm/tsconfig.json
+++ b/x-pack/plugins/apm/tsconfig.json
@@ -76,6 +76,7 @@
     "@kbn/babel-register",
     "@kbn/core-saved-objects-migration-server-internal",
     "@kbn/core-elasticsearch-server",
+    "@kbn/core-saved-objects-api-server",
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
Required by: https://github.com/elastic/kibana/pull/149272

In some cases we need to call `createInternalESClient` outside of the normal `request` lifecycle (eg during startup). This PR breaks `createInternalESClient` up so it can be called without `request` and `context`.

**Outside the scope of this PR**
 - deprecate `createInternalESClient` and instead rely on dedicated clients (eg we don't have an `agentConfigurationClient`)
 - change `getApmEventClient` so it can be called outside the request lifecycle (making `request` optional).