### PR TITLE
[Security Solution] Reduce scope of osquery update fix to only update the package

### DIFF
--- a/x-pack/plugins/osquery/server/utils/upgrade_integration.ts
+++ b/x-pack/plugins/osquery/server/utils/upgrade_integration.ts
@@ -28,7 +28,6 @@ export const upgradeIntegration = async ({
   esClient,
   logger,
 }: UpgradeIntegrationOptions) => {
-
   if (packageInfo && satisfies(packageInfo?.version ?? '', '<1.6.0')) {
     try {
       logger.info('Updating osquery_manager integration');

--- a/x-pack/plugins/osquery/server/utils/upgrade_integration.ts
+++ b/x-pack/plugins/osquery/server/utils/upgrade_integration.ts
@@ -9,13 +9,10 @@ import { satisfies } from 'semver';
 import { installPackage } from '@kbn/fleet-plugin/server/services/epm/packages';
 import { pkgToPkgKey } from '@kbn/fleet-plugin/server/services/epm/registry';
 import { DEFAULT_SPACE_ID } from '@kbn/spaces-plugin/common/constants';
-import { asyncForEach } from '@kbn/std';
-import { orderBy } from 'lodash';
 import type { Installation } from '@kbn/fleet-plugin/common';
 import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
 import type { SavedObjectsClientContract } from '@kbn/core-saved-objects-api-server';
 import type { Logger } from '@kbn/logging';
-import { OSQUERY_INTEGRATION_NAME } from '../../common';
 
 interface UpgradeIntegrationOptions {
   packageInfo?: Installation;
@@ -31,12 +28,11 @@ export const upgradeIntegration = async ({
   esClient,
   logger,
 }: UpgradeIntegrationOptions) => {
-  let updatedPackageResult;
 
   if (packageInfo && satisfies(packageInfo?.version ?? '', '<1.6.0')) {
     try {
       logger.info('Updating osquery_manager integration');
-      updatedPackageResult = await installPackage({
+      await installPackage({
         installSource: 'registry',
         savedObjectsClient: client,
         pkgkey: pkgToPkgKey({
@@ -49,48 +45,6 @@ export const upgradeIntegration = async ({
         force: true,
       });
       logger.info('osquery_manager integration updated');
-    } catch (e) {
-      logger.error(e);
-    }
-  }
-
-  // Check to see if the package has already been updated to at least 1.6.0
-  if (
-    satisfies(packageInfo?.version ?? '', '>=1.6.0') ||
-    updatedPackageResult?.status === 'installed'
-  ) {
-    try {
-      // First get all datastreams matching the pattern.
-      const dataStreams = await esClient.indices.getDataStream({
-        name: `logs-${OSQUERY_INTEGRATION_NAME}.result-*`,
-      });
-
-      // Then for each of those datastreams, we need to see if they need to rollover.
-      await asyncForEach(dataStreams.data_streams, async (dataStream) => {
-        const mapping = await esClient.indices.getMapping({
-          index: dataStream.name,
-        });
-
-        const valuesToSort = Object.entries(mapping).map(([key, value]) => ({
-          index: key,
-          mapping: value,
-        }));
-
-        // Sort by index name to get the latest index for detecting if we need to rollover
-        const dataStreamMapping = orderBy(valuesToSort, ['index'], 'desc');
-
-        if (
-          dataStreamMapping &&
-          // @ts-expect-error 'properties' does not exist on type 'MappingMatchOnlyTextProperty'
-          dataStreamMapping[0]?.mapping?.mappings?.properties?.data_stream?.properties?.dataset
-            ?.value === 'generic'
-        ) {
-          logger.info('Rolling over index: ' + dataStream.name);
-          await esClient.indices.rollover({
-            alias: dataStream.name,
-          });
-        }
-      });
     } catch (e) {
       logger.error(e);
     }


### PR DESCRIPTION
## Summary

Reduce the scope of the OSQuery start task to only update the OSQuery integration package to 1.6.0.  Originally, we had a check to also rollover indices to fix a bug on a potentially small subset of users who tried OSQuery for the first time in the first few days of release in 8.6.0.  However, this check is potentially expensive and risky since it is in the start of Kibana/OSQuery plugin.

Here, we reduce the risk by only upgrade the OSQuery integration package automatically which should fix the issue for most users.  It is also less risky/expensive as searching over all existing data.


<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->