### PR TITLE
[dev-cli] restart Kibana when config is changed

### DIFF
--- a/packages/kbn-cli-dev-mode/src/watcher.ts
+++ b/packages/kbn-cli-dev-mode/src/watcher.ts
@@ -18,9 +18,10 @@ import { Log } from './log';
 const packageMatcher = makeMatcher(['**/*', '!**/.*']);
 
 /**
- * Any non-package code must match this in order to trigger a restart
+ * Any code that is outside of a package must match this in order to trigger a restart
  */
 const nonPackageMatcher = makeMatcher([
+  'config/**/*.yml',
   'src/**',
   '!src/{dev,fixtures}/**',
   'x-pack/plugins/**',


### PR DESCRIPTION
Restores the behavior of the dev cli prior to https://github.com/elastic/kibana/pull/148924, allowing changes in `config/**/*.yml` files to trigger server restarts.