### PR TITLE
[8.6] [Security Solution] Reduce scope of osquery update fix to only update the package (#149325)

### DIFF
--- a/x-pack/plugins/osquery/server/plugin.ts
+++ b/x-pack/plugins/osquery/server/plugin.ts
@@ -17,6 +17,7 @@ import type { PackagePolicy } from '@kbn/fleet-plugin/common';
 import type { DataRequestHandlerContext } from '@kbn/data-plugin/server';
 import type { DataViewsService } from '@kbn/data-views-plugin/common';
 
+import { upgradeIntegration } from './utils/upgrade_integration';
 import type { PackSavedObjectAttributes } from './common/types';
 import { updateGlobalPacksCreateCallback } from './lib/update_global_packs';
 import { packSavedObjectType } from '../common/types';
@@ -134,6 +135,9 @@ export class OsqueryPlugin implements Plugin<OsqueryPluginSetup, OsqueryPluginSt
         await this.initialize(core, dataViewsService);
       }
 
+      // Upgrade integration into 1.6.0 and rollover if found 'generic' dataset - we do not want to wait for it
+      upgradeIntegration({ packageInfo, client, esClient, logger: this.logger });
+      
       if (registerIngestCallback) {
         registerIngestCallback(
           'packagePolicyPostCreate',

--- a/x-pack/plugins/osquery/server/plugin.ts
+++ b/x-pack/plugins/osquery/server/plugin.ts
@@ -137,7 +137,7 @@ export class OsqueryPlugin implements Plugin<OsqueryPluginSetup, OsqueryPluginSt
 
       // Upgrade integration into 1.6.0 and rollover if found 'generic' dataset - we do not want to wait for it
       upgradeIntegration({ packageInfo, client, esClient, logger: this.logger });
-      
+
       if (registerIngestCallback) {
         registerIngestCallback(
           'packagePolicyPostCreate',

--- a/x-pack/plugins/osquery/server/utils/upgrade_integration.ts
+++ b/x-pack/plugins/osquery/server/utils/upgrade_integration.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { satisfies } from 'semver';
+import { installPackage } from '@kbn/fleet-plugin/server/services/epm/packages';
+import { pkgToPkgKey } from '@kbn/fleet-plugin/server/services/epm/registry';
+import { DEFAULT_SPACE_ID } from '@kbn/spaces-plugin/common/constants';
+import type { Installation } from '@kbn/fleet-plugin/common';
+import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
+import type { SavedObjectsClientContract } from '@kbn/core-saved-objects-api-server';
+import type { Logger } from '@kbn/logging';
+
+interface UpgradeIntegrationOptions {
+  packageInfo?: Installation;
+  client: SavedObjectsClientContract;
+  esClient: ElasticsearchClient;
+  logger: Logger;
+}
+
+// Conditionally upgrade osquery integration in order to fix 8.6.0 agent issue
+export const upgradeIntegration = async ({
+  packageInfo,
+  client,
+  esClient,
+  logger,
+}: UpgradeIntegrationOptions) => {
+  if (packageInfo && satisfies(packageInfo?.version ?? '', '<1.6.0')) {
+    try {
+      logger.info('Updating osquery_manager integration');
+      await installPackage({
+        installSource: 'registry',
+        savedObjectsClient: client,
+        pkgkey: pkgToPkgKey({
+          name: packageInfo.name,
+          version: '1.6.0', // This package upgrade is specific to a bug fix, so keeping the upgrade focused on 1.6.0
+        }),
+        esClient,
+        spaceId: packageInfo.installed_kibana_space_id || DEFAULT_SPACE_ID,
+        // Force install the package will update the index template and the datastream write indices
+        force: true,
+      });
+      logger.info('osquery_manager integration updated');
+    } catch (e) {
+      logger.error(e);
+    }
+  }
+};


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.6`:
 - [[Security Solution] Reduce scope of osquery update fix to only update the package (#149325)](https://github.com/elastic/kibana/pull/149325)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Kevin Logan","email":"56395104+kevinlog@users.noreply.github.com"},"sourceCommit":{"committedDate":"2023-01-23T15:23:11Z","message":"[Security Solution] Reduce scope of osquery update fix to only update the package (#149325)\n\n## Summary\r\n\r\nReduce the scope of the OSQuery start task to only update the OSQuery\r\nintegration package to 1.6.0. Originally, we had a check to also\r\nrollover indices to fix a bug on a potentially small subset of users who\r\ntried OSQuery for the first time in the first few days of release in\r\n8.6.0. However, this check is potentially expensive and risky since it\r\nis in the start of Kibana/OSQuery plugin.\r\n\r\nHere, we reduce the risk by only upgrade the OSQuery integration package\r\nautomatically which should fix the issue for most users. It is also less\r\nrisky/expensive as searching over all existing data.\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"e5df1b8bc068094cabf74062212ca07559aff748","branchLabelMapping":{"^v8.7.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Defend Workflows","auto-backport","v8.6.0","v8.7.0","v8.6.1"],"number":149325,"url":"https://github.com/elastic/kibana/pull/149325","mergeCommit":{"message":"[Security Solution] Reduce scope of osquery update fix to only update the package (#149325)\n\n## Summary\r\n\r\nReduce the scope of the OSQuery start task to only update the OSQuery\r\nintegration package to 1.6.0. Originally, we had a check to also\r\nrollover indices to fix a bug on a potentially small subset of users who\r\ntried OSQuery for the first time in the first few days of release in\r\n8.6.0. However, this check is potentially expensive and risky since it\r\nis in the start of Kibana/OSQuery plugin.\r\n\r\nHere, we reduce the risk by only upgrade the OSQuery integration package\r\nautomatically which should fix the issue for most users. It is also less\r\nrisky/expensive as searching over all existing data.\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"e5df1b8bc068094cabf74062212ca07559aff748"}},"sourceBranch":"main","suggestedTargetBranches":["8.6"],"targetPullRequestStates":[{"branch":"8.6","label":"v8.6.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.7.0","labelRegex":"^v8.7.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/149325","number":149325,"mergeCommit":{"message":"[Security Solution] Reduce scope of osquery update fix to only update the package (#149325)\n\n## Summary\r\n\r\nReduce the scope of the OSQuery start task to only update the OSQuery\r\nintegration package to 1.6.0. Originally, we had a check to also\r\nrollover indices to fix a bug on a potentially small subset of users who\r\ntried OSQuery for the first time in the first few days of release in\r\n8.6.0. However, this check is potentially expensive and risky since it\r\nis in the start of Kibana/OSQuery plugin.\r\n\r\nHere, we reduce the risk by only upgrade the OSQuery integration package\r\nautomatically which should fix the issue for most users. It is also less\r\nrisky/expensive as searching over all existing data.\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"e5df1b8bc068094cabf74062212ca07559aff748"}}]}] BACKPORT-->