### PR TITLE
Fix a11y issue with dev tool tabs

### DIFF
--- a/src/plugins/dev_tools/public/application.tsx
+++ b/src/plugins/dev_tools/public/application.tsx
@@ -108,9 +108,6 @@ function DevToolsWrapper({
                     label={i18n.translate('devTools.badge.betaLabel', {
                       defaultMessage: 'Beta',
                     })}
-                    tooltipContent={i18n.translate('devTools.badge.betaTooltipText', {
-                      defaultMessage: 'This feature might change drastically in future releases',
-                    })}
                   />
                 )}
               </span>

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -36229,7 +36229,6 @@
     "cases.components.status.inProgress": "进行中",
     "cases.components.status.open": "打开",
     "devTools.badge.betaLabel": "公测版",
-    "devTools.badge.betaTooltipText": "此功能在未来的版本中可能会变化很大",
     "devTools.badge.readOnly.text": "只读",
     "devTools.badge.readOnly.tooltip": "无法保存",
     "devTools.breadcrumb.homeLabel": "开发工具",


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/148538

## Summary

This PR fixes the a11y issue with the Beta badge used in the Dev Tools tabs.

The proposed solution in the GH issue (moving `EuiBetaBadge` outside of the `EuiTab` component) didn't work well as it introduced another a11y issue - `EuiTabs` would contain an `EuiBetaBadge` component which is not its direct child (it needs to wrap `EuiTab` components only). Also, this solution caused some styling issues.

Removing the `tooltipContent` prop from `EuiBetaBadge` resolves the a11y issue without introducing other a11y issues. Also, the `Beta` text is still announced by screen readers as part of the `Painless Lab` tab (tested on Mac's VoiceOver and the Screen Reader Chrome extension) and the design is not changed.

<img width="1828" alt="Screenshot 2023-01-23 at 16 17 55" src="https://user-images.githubusercontent.com/59341489/214102739-bf0783e3-755a-474d-8978-17fb4b7d0fbd.png">



### Checklist

- [X] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [X] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [X] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
