### PR TITLE
[Fleet] Fix parsing logic for data_stream.hidden manifest field

### DIFF
--- a/x-pack/plugins/fleet/common/types/models/package_spec.ts
+++ b/x-pack/plugins/fleet/common/types/models/package_spec.ts
@@ -29,7 +29,7 @@ export interface PackageSpecManifest {
   owner: { github: string };
   elasticsearch?: Pick<
     RegistryElasticsearch,
-    'index_template.settings' | 'index_template.mappings'
+    'index_template.settings' | 'index_template.mappings' | 'index_template.data_stream'
   >;
 }
 

--- a/x-pack/plugins/fleet/server/services/epm/archive/parse.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/archive/parse.test.ts
@@ -106,6 +106,42 @@ describe('parseDataStreamElasticsearchEntry', () => {
       },
     });
   });
+  it('Should handle dotted values for data_stream', () => {
+    expect(
+      parseDataStreamElasticsearchEntry({
+        'index_template.data_stream': { hidden: true },
+      })
+    ).toEqual({
+      'index_template.data_stream': { hidden: true },
+    });
+    expect(
+      parseDataStreamElasticsearchEntry({
+        'index_template.data_stream': { hidden: false },
+      })
+    ).toEqual({
+      'index_template.data_stream': { hidden: false },
+    });
+  });
+  it('Should handle non-dotted values for data_stream', () => {
+    expect(
+      parseDataStreamElasticsearchEntry({
+        index_template: {
+          data_stream: { hidden: true },
+        },
+      })
+    ).toEqual({
+      'index_template.data_stream': { hidden: true },
+    });
+    expect(
+      parseDataStreamElasticsearchEntry({
+        index_template: {
+          data_stream: { hidden: false },
+        },
+      })
+    ).toEqual({
+      'index_template.data_stream': { hidden: false },
+    });
+  });
   it('Should handle dotted values for mappings and settings', () => {
     expect(
       parseDataStreamElasticsearchEntry({

--- a/x-pack/plugins/fleet/server/services/epm/archive/parse.ts
+++ b/x-pack/plugins/fleet/server/services/epm/archive/parse.ts
@@ -558,6 +558,12 @@ export function parseDataStreamElasticsearchEntry(
     );
   }
 
+  if (expandedElasticsearch?.index_template?.data_stream) {
+    parsedElasticsearchEntry['index_template.data_stream'] = {
+      ...expandedElasticsearch.index_template.data_stream,
+    };
+  }
+
   if (expandedElasticsearch?.index_mode) {
     parsedElasticsearchEntry.index_mode = expandedElasticsearch.index_mode;
   }

--- a/x-pack/plugins/fleet/server/services/epm/archive/parse.ts
+++ b/x-pack/plugins/fleet/server/services/epm/archive/parse.ts
@@ -559,9 +559,9 @@ export function parseDataStreamElasticsearchEntry(
   }
 
   if (expandedElasticsearch?.index_template?.data_stream) {
-    parsedElasticsearchEntry['index_template.data_stream'] = {
-      ...expandedElasticsearch.index_template.data_stream,
-    };
+    parsedElasticsearchEntry['index_template.data_stream'] = expandDottedEntries(
+      expandedElasticsearch.index_template.data_stream
+    );
   }
 
   if (expandedElasticsearch?.index_mode) {


### PR DESCRIPTION
## Summary

Fixes package archive parsing logic for the `index_template_data_stream.hidden` property, implemented in line with other `index_template.*` "dotted property name" values from package manifests. 

## To test

Create a test package that includes `elasticsearch.index_template.data_stream.hidden: true` in a `data_stream/**/manifest.yml` file, install the package, then verify (via dev tools - NOT stack management!!!) that the generated index template contains `data_stream.hidden: true`

![image](https://user-images.githubusercontent.com/6766512/214155715-1a78a7f6-cde0-4cb1-a6e3-fd1ac3749f1e.png)

It'd be great to have automated tests around this, but testing our archive parsing logic is very challenging due to the nature of reading directories/files and how much mocking is required. See https://github.com/elastic/kibana/issues/147050. I'll see about adding an integration test for this.


