### PR TITLE
[Fleet] Get agents API separate inactive and unenrolled count

### DIFF
--- a/x-pack/plugins/fleet/common/types/rest_spec/agent.ts
+++ b/x-pack/plugins/fleet/common/types/rest_spec/agent.ts
@@ -28,6 +28,7 @@ export interface GetAgentsRequest {
 
 export interface GetAgentsResponse extends ListResult<Agent> {
   totalInactive: number;
+  totalUnenrolled: number;
   // deprecated in 8.x
   list?: Agent[];
 }

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/bulk_actions.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/bulk_actions.tsx
@@ -36,7 +36,7 @@ import { TagsAddRemove } from './tags_add_remove';
 
 export interface Props {
   totalAgents: number;
-  totalInactiveAgents: number;
+  totalInactiveAndUnenrolledAgents: number;
   selectionMode: SelectionMode;
   currentQuery: string;
   selectedAgents: Agent[];
@@ -48,7 +48,7 @@ export interface Props {
 
 export const AgentBulkActions: React.FunctionComponent<Props> = ({
   totalAgents,
-  totalInactiveAgents,
+  totalInactiveAndUnenrolledAgents,
   selectionMode,
   currentQuery,
   selectedAgents,
@@ -77,8 +77,8 @@ export const AgentBulkActions: React.FunctionComponent<Props> = ({
   const atLeastOneActiveAgentSelected =
     selectionMode === 'manual'
       ? !!selectedAgents.find((agent) => agent.active)
-      : totalAgents > totalInactiveAgents;
-  const totalActiveAgents = totalAgents - totalInactiveAgents;
+      : totalAgents > totalInactiveAndUnenrolledAgents;
+  const totalActiveAgents = totalAgents - totalInactiveAndUnenrolledAgents;
   const agentCount = selectionMode === 'manual' ? selectedAgents.length : totalActiveAgents;
   const agents = selectionMode === 'manual' ? selectedAgents : currentQuery;
   const [tagsPopoverButton, setTagsPopoverButton] = useState<HTMLElement>();

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/search_and_filter_bar.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/search_and_filter_bar.tsx
@@ -56,6 +56,7 @@ export const SearchAndFilterBar: React.FunctionComponent<{
   onSelectedTagsChange: (selectedTags: string[]) => void;
   totalAgents: number;
   totalInactiveAgents: number;
+  totalUnenrolledAgents: number;
   selectionMode: SelectionMode;
   currentQuery: string;
   selectedAgents: Agent[];
@@ -81,6 +82,7 @@ export const SearchAndFilterBar: React.FunctionComponent<{
   onSelectedTagsChange,
   totalAgents,
   totalInactiveAgents,
+  totalUnenrolledAgents,
   selectionMode,
   currentQuery,
   selectedAgents,
@@ -312,7 +314,7 @@ export const SearchAndFilterBar: React.FunctionComponent<{
               <EuiFlexItem grow={false}>
                 <AgentBulkActions
                   totalAgents={totalAgents}
-                  totalInactiveAgents={totalInactiveAgents}
+                  totalInactiveAndUnenrolledAgents={totalInactiveAgents + totalUnenrolledAgents}
                   selectionMode={selectionMode}
                   currentQuery={currentQuery}
                   selectedAgents={selectedAgents}

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/index.tsx
@@ -225,6 +225,7 @@ export const AgentListPage: React.FunctionComponent<{}> = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [totalAgents, setTotalAgents] = useState(0);
   const [totalInactiveAgents, setTotalInactiveAgents] = useState(0);
+  const [totalUnenrolledAgents, setTotalUnenrolledAgents] = useState(0);
   const [showAgentActivityTour, setShowAgentActivityTour] = useState({ isOpen: false });
 
   const getSortFieldForAPI = (field: keyof Agent): string => {
@@ -340,6 +341,7 @@ export const AgentListPage: React.FunctionComponent<{}> = () => {
           setAgents(agentsResponse.data.items);
           setTotalAgents(agentsResponse.data.total);
           setTotalInactiveAgents(agentsResponse.data.totalInactive);
+          setTotalUnenrolledAgents(agentsResponse.data.totalUnenrolled);
         } catch (error) {
           notifications.toasts.addError(error, {
             title: i18n.translate('xpack.fleet.agentList.errorFetchingDataTitle', {
@@ -587,6 +589,7 @@ export const AgentListPage: React.FunctionComponent<{}> = () => {
         onSelectedTagsChange={setSelectedTags}
         totalAgents={totalAgents}
         totalInactiveAgents={totalInactiveAgents}
+        totalUnenrolledAgents={totalUnenrolledAgents}
         selectionMode={selectionMode}
         currentQuery={kuery}
         selectedAgents={selectedAgents}

--- a/x-pack/plugins/fleet/server/routes/agent/handlers.ts
+++ b/x-pack/plugins/fleet/server/routes/agent/handlers.ts
@@ -189,7 +189,7 @@ export const getAgentsHandler: RequestHandler<
       getTotalInactive: request.query.showInactive,
     });
 
-    const { total, page, perPage, totalInactive = 0 } = agentRes;
+    const { total, page, perPage, totalInactive = 0, totalUnenrolled = 0 } = agentRes;
     let { agents } = agentRes;
 
     // Assign metrics
@@ -202,6 +202,7 @@ export const getAgentsHandler: RequestHandler<
       items: agents,
       total,
       totalInactive,
+      totalUnenrolled,
       page,
       perPage,
     };

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/store/mock_endpoint_result_list.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/store/mock_endpoint_result_list.ts
@@ -157,6 +157,7 @@ const endpointListApiPathHandlerMocks = ({
         total: totalAgentsUsingEndpoint,
         items: [],
         totalInactive: 0,
+        totalUnenrolled: 0,
         page: 1,
         perPage: 10,
       };


### PR DESCRIPTION
## Summary

closes #149380 

I missed that the totalInactive returned from the get agents API also returned unenrolled agents, this was a mistake in the first implementation, I have split those into two separate fields now, and used the inactive count for the new callout introduced in https://github.com/elastic/kibana/pull/149226.