### PR TITLE
[FTRs] Execution Context: fix no data flakiness

### DIFF
--- a/x-pack/test/functional_execution_context/tests/browser.ts
+++ b/x-pack/test/functional_execution_context/tests/browser.ts
@@ -10,7 +10,7 @@ import type { FtrProviderContext } from '../ftr_provider_context';
 import { assertLogContains, forceSyncLogFile, isExecutionContextLog } from '../test_utils';
 
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
-  const PageObjects = getPageObjects(['common', 'dashboard', 'header', 'home']);
+  const PageObjects = getPageObjects(['common', 'dashboard', 'header', 'home', 'timePicker']);
   const retry = getService('retry');
 
   describe('Browser apps', () => {
@@ -33,6 +33,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     describe('discover app', () => {
       before(async () => {
         await PageObjects.common.navigateToApp('discover');
+        await PageObjects.timePicker.setCommonlyUsedTime('Last_7 days');
         await PageObjects.header.waitUntilLoadingHasFinished();
         await forceSyncLogFile();
       });
@@ -48,56 +49,62 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
           });
       }
 
-      it('propagates context for Discover', async () => {
-        await assertLogContains({
-          description: 'execution context propagates to Elasticsearch via "x-opaque-id" header',
-          predicate: (record) =>
-            Boolean(record.http?.request?.id?.includes('kibana:application:discover')),
-          retry,
+      describe('propagates context for Discover', () => {
+        it('propagates to Elasticsearch via "x-opaque-id" header', async () => {
+          await assertLogContains({
+            description: 'execution context propagates to Elasticsearch via "x-opaque-id" header',
+            predicate: (record) =>
+              Boolean(record.http?.request?.id?.includes('kibana:application:discover')),
+            retry,
+          });
         });
 
-        await assertLogContains({
-          description: 'execution context propagates to Kibana logs (fetch documents)',
-          predicate: checkExecutionContextEntry({
-            type: 'application',
-            name: 'discover',
-            url: '/app/discover',
-            child: {
+        it('propagates to Kibana logs (fetch documents)', async () => {
+          await assertLogContains({
+            description: 'execution context propagates to Kibana logs (fetch documents)',
+            predicate: checkExecutionContextEntry({
+              type: 'application',
               name: 'discover',
               url: '/app/discover',
-              type: 'application',
-              page: 'app',
-              id: 'new',
-              description: 'fetch documents',
-            },
-          }),
-          retry,
-        });
-
-        await assertLogContains({
-          description:
-            'execution context propagates to Kibana logs (fetch chart data and total hits)',
-          predicate: checkExecutionContextEntry({
-            type: 'application',
-            name: 'discover',
-            url: '/app/discover',
-            child: {
-              name: 'discover',
-              url: '/app/discover',
-              type: 'application',
-              page: 'app',
-              id: 'new',
-              description: 'fetch chart data and total hits',
               child: {
-                type: 'lens',
-                name: 'lnsXY',
-                id: 'unifiedHistogramLensComponent',
-                description: 'Edit visualization',
-                url: '/app/lens#/edit_by_value',
+                name: 'discover',
+                url: '/app/discover',
+                type: 'application',
+                page: 'app',
+                id: 'new',
+                description: 'fetch documents',
               },
-            },
-          }),
-          retry,
+            }),
+            retry,
+          });
+        });
+
+        it('propagates to Kibana logs (fetch chart data and total hits)', async () => {
+          await assertLogContains({
+            description:
+              'execution context propagates to Kibana logs (fetch chart data and total hits)',
+            predicate: checkExecutionContextEntry({
+              type: 'application',
+              name: 'discover',
+              url: '/app/discover',
+              child: {
+                name: 'discover',
+                url: '/app/discover',
+                type: 'application',
+                page: 'app',
+                id: 'new',
+                description: 'fetch chart data and total hits',
+                child: {
+                  type: 'lens',
+                  name: 'lnsXY',
+                  id: 'unifiedHistogramLensComponent',
+                  description: 'Edit visualization',
+                  url: '/app/lens#/edit_by_value',
+                },
+              },
+            }),
+            retry,
+          });
         });
       });
     });
@@ -106,6 +113,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       before(async () => {
         await PageObjects.common.navigateToApp('dashboard');
         await PageObjects.dashboard.loadSavedDashboard('[Flights] Global Flight Dashboard');
+        await PageObjects.timePicker.setCommonlyUsedTime('Last_7 days');
         await PageObjects.dashboard.waitForRenderComplete();
         await PageObjects.header.waitUntilLoadingHasFinished();
         await forceSyncLogFile();
@@ -156,138 +164,194 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       }
 
       describe('propagates context for Lens visualizations', () => {
-        it('lnsXY', async () => {
+        describe('lnsXY', () => {
+          it('propagates to Elasticsearch via "x-opaque-id" header', async () => {
+            await assertLogContains({
+              description: 'execution context propagates to Elasticsearch via "x-opaque-id" header',
+              predicate: checkHttpRequestId(
+                'dashboard:dashboards:7adfa750-4c81-11e8-b3d7-01146121b73d;lens:lnsXY:086ac2e9-dd16-4b45-92b8-1e43ff7e3f65'
+              ),
+              retry,
+            });
+          });
+
+          it('propagates to Kibana logs', async () => {
+            await assertLogContains({
+              description: 'execution context propagates to Kibana logs',
+              predicate: checkExecutionContextEntry({
+                type: 'application',
+                name: 'dashboards',
+                url: '/app/dashboards',
+                child: {
+                  name: 'dashboards',
+                  url: '/app/dashboards',
+                  type: 'dashboard',
+                  page: 'app',
+                  id: '7adfa750-4c81-11e8-b3d7-01146121b73d',
+                  description: '[Flights] Global Flight Dashboard',
+                  child: {
+                    type: 'lens',
+                    name: 'lnsXY',
+                    id: '086ac2e9-dd16-4b45-92b8-1e43ff7e3f65',
+                    description: '[Flights] Flight count',
+                    url: '/app/lens#/edit_by_value',
+                  },
+                },
+              }),
+              retry,
+            });
+          });
+        });
+
+        describe('lnsMetric', () => {
+          it('propagates to Elasticsearch via "x-opaque-id" header', async () => {
+            await assertLogContains({
+              description: 'execution context propagates to Elasticsearch via "x-opaque-id" header',
+              predicate: checkHttpRequestId(
+                'dashboard:dashboards:7adfa750-4c81-11e8-b3d7-01146121b73d;lens:lnsLegacyMetric:b766e3b8-4544-46ed-99e6-9ecc4847e2a2'
+              ),
+              retry,
+            });
+          });
+
+          it('propagates to Kibana logs', async () => {
+            await assertLogContains({
+              description: 'execution context propagates to Kibana logs',
+              predicate: checkExecutionContextEntry({
+                name: 'dashboards',
+                url: '/app/dashboards',
+                type: 'application',
+                child: {
+                  name: 'dashboards',
+                  url: '/app/dashboards',
+                  type: 'dashboard',
+                  page: 'app',
+                  id: '7adfa750-4c81-11e8-b3d7-01146121b73d',
+                  description: '[Flights] Global Flight Dashboard',
+                  child: {
+                    type: 'lens',
+                    name: 'lnsLegacyMetric',
+                    id: 'b766e3b8-4544-46ed-99e6-9ecc4847e2a2',
+                    description: '',
+                    url: '/app/lens#/edit_by_value',
+                  },
+                },
+              }),
+              retry,
+            });
+          });
+        });
+
+        describe('lnsDatatable', () => {
+          it('propagates to Elasticsearch via "x-opaque-id" header', async () => {
+            await assertLogContains({
+              description: 'execution context propagates to Elasticsearch via "x-opaque-id" header',
+              predicate: checkHttpRequestId(
+                'dashboard:dashboards:7adfa750-4c81-11e8-b3d7-01146121b73d;lens:lnsDatatable:fb86b32f-fb7a-45cf-9511-f366fef51bbd'
+              ),
+              retry,
+            });
+          });
+
+          it('propagates to Kibana logs', async () => {
+            await assertLogContains({
+              description: 'execution context propagates to Kibana logs',
+              predicate: checkExecutionContextEntry({
+                name: 'dashboards',
+                url: '/app/dashboards',
+                type: 'application',
+                child: {
+                  name: 'dashboards',
+                  url: '/app/dashboards',
+                  type: 'dashboard',
+                  page: 'app',
+                  id: '7adfa750-4c81-11e8-b3d7-01146121b73d',
+                  description: '[Flights] Global Flight Dashboard',
+                  child: {
+                    type: 'lens',
+                    name: 'lnsDatatable',
+                    id: 'fb86b32f-fb7a-45cf-9511-f366fef51bbd',
+                    description: 'Cities by delay, cancellation',
+                    url: '/app/lens#/edit_by_value',
+                  },
+                },
+              }),
+              retry,
+            });
+          });
+        });
+
+        describe('lnsPie', () => {
+          it('propagates to Elasticsearch via "x-opaque-id" header', async () => {
+            await assertLogContains({
+              description: 'execution context propagates to Elasticsearch via "x-opaque-id" header',
+              predicate: checkHttpRequestId(
+                'dashboard:dashboards:7adfa750-4c81-11e8-b3d7-01146121b73d;lens:lnsPie:5d53db36-2d5a-4adc-af7b-cec4c1a294e0'
+              ),
+              retry,
+            });
+          });
+
+          it('propagates to Kibana logs', async () => {
+            await assertLogContains({
+              description: 'execution context propagates to Kibana logs',
+              predicate: checkExecutionContextEntry({
+                name: 'dashboards',
+                url: '/app/dashboards',
+                type: 'application',
+                child: {
+                  name: 'dashboards',
+                  url: '/app/dashboards',
+                  type: 'dashboard',
+                  page: 'app',
+                  id: '7adfa750-4c81-11e8-b3d7-01146121b73d',
+                  description: '[Flights] Global Flight Dashboard',
+                  child: {
+                    type: 'lens',
+                    name: 'lnsPie',
+                    id: '5d53db36-2d5a-4adc-af7b-cec4c1a294e0',
+                    description: '[Flights] Delay Type',
+                    url: '/app/lens#/edit_by_value',
+                  },
+                },
+              }),
+              retry,
+            });
+          });
+        });
+      });
+
+      describe('propagates context for built-in Discover', () => {
+        it('propagates to Elasticsearch via "x-opaque-id" header', async () => {
           await assertLogContains({
             description: 'execution context propagates to Elasticsearch via "x-opaque-id" header',
             predicate: checkHttpRequestId(
-              'dashboard:dashboards:7adfa750-4c81-11e8-b3d7-01146121b73d;lens:lnsXY:086ac2e9-dd16-4b45-92b8-1e43ff7e3f65'
+              'dashboard:dashboards:7adfa750-4c81-11e8-b3d7-01146121b73d;search:discover:571aaf70-4c88-11e8-b3d7-01146121b73d'
             ),
-            retry,
-          });
-
-          await assertLogContains({
-            description: 'execution context propagates to Kibana logs',
-            predicate: checkExecutionContextEntry({
-              type: 'application',
-              name: 'dashboards',
-              url: '/app/dashboards',
-              child: {
-                name: 'dashboards',
-                url: '/app/dashboards',
-                type: 'dashboard',
-                page: 'app',
-                id: '7adfa750-4c81-11e8-b3d7-01146121b73d',
-                description: '[Flights] Global Flight Dashboard',
-                child: {
-                  type: 'lens',
-                  name: 'lnsXY',
-                  id: '086ac2e9-dd16-4b45-92b8-1e43ff7e3f65',
-                  description: '[Flights] Flight count',
-                  url: '/app/lens#/edit_by_value',
-                },
-              },
-            }),
             retry,
           });
         });
 
-        it('lnsMetric', async () => {
-          await assertLogContains({
-            description: 'execution context propagates to Elasticsearch via "x-opaque-id" header',
-            predicate: checkHttpRequestId(
-              'dashboard:dashboards:7adfa750-4c81-11e8-b3d7-01146121b73d;lens:lnsLegacyMetric:b766e3b8-4544-46ed-99e6-9ecc4847e2a2'
-            ),
-            retry,
-          });
-
+        it('propagates to Kibana logs', async () => {
           await assertLogContains({
             description: 'execution context propagates to Kibana logs',
             predicate: checkExecutionContextEntry({
+              type: 'application',
               name: 'dashboards',
               url: '/app/dashboards',
-              type: 'application',
               child: {
+                type: 'dashboard',
                 name: 'dashboards',
                 url: '/app/dashboards',
-                type: 'dashboard',
                 page: 'app',
                 id: '7adfa750-4c81-11e8-b3d7-01146121b73d',
                 description: '[Flights] Global Flight Dashboard',
                 child: {
-                  type: 'lens',
-                  name: 'lnsLegacyMetric',
-                  id: 'b766e3b8-4544-46ed-99e6-9ecc4847e2a2',
-                  description: '',
-                  url: '/app/lens#/edit_by_value',
-                },
-              },
-            }),
-            retry,
-          });
-        });
-
-        it('lnsDatatable', async () => {
-          await assertLogContains({
-            description: 'execution context propagates to Elasticsearch via "x-opaque-id" header',
-            predicate: checkHttpRequestId(
-              'dashboard:dashboards:7adfa750-4c81-11e8-b3d7-01146121b73d;lens:lnsDatatable:fb86b32f-fb7a-45cf-9511-f366fef51bbd'
-            ),
-            retry,
-          });
-
-          await assertLogContains({
-            description: 'execution context propagates to Kibana logs',
-            predicate: checkExecutionContextEntry({
-              name: 'dashboards',
-              url: '/app/dashboards',
-              type: 'application',
-              child: {
-                name: 'dashboards',
-                url: '/app/dashboards',
-                type: 'dashboard',
-                page: 'app',
-                id: '7adfa750-4c81-11e8-b3d7-01146121b73d',
-                description: '[Flights] Global Flight Dashboard',
-                child: {
-                  type: 'lens',
-                  name: 'lnsDatatable',
-                  id: 'fb86b32f-fb7a-45cf-9511-f366fef51bbd',
-                  description: 'Cities by delay, cancellation',
-                  url: '/app/lens#/edit_by_value',
-                },
-              },
-            }),
-            retry,
-          });
-        });
-
-        it('lnsPie', async () => {
-          await assertLogContains({
-            description: 'execution context propagates to Elasticsearch via "x-opaque-id" header',
-            predicate: checkHttpRequestId(
-              'dashboard:dashboards:7adfa750-4c81-11e8-b3d7-01146121b73d;lens:lnsPie:5d53db36-2d5a-4adc-af7b-cec4c1a294e0'
-            ),
-            retry,
-          });
-          await assertLogContains({
-            description: 'execution context propagates to Kibana logs',
-            predicate: checkExecutionContextEntry({
-              name: 'dashboards',
-              url: '/app/dashboards',
-              type: 'application',
-              child: {
-                name: 'dashboards',
-                url: '/app/dashboards',
-                type: 'dashboard',
-                page: 'app',
-                id: '7adfa750-4c81-11e8-b3d7-01146121b73d',
-                description: '[Flights] Global Flight Dashboard',
-                child: {
-                  type: 'lens',
-                  name: 'lnsPie',
-                  id: '5d53db36-2d5a-4adc-af7b-cec4c1a294e0',
-                  description: '[Flights] Delay Type',
-                  url: '/app/lens#/edit_by_value',
+                  type: 'search',
+                  name: 'discover',
+                  id: '571aaf70-4c88-11e8-b3d7-01146121b73d',
+                  description: '[Flights] Flight Log',
+                  url: '/app/discover#/view/571aaf70-4c88-11e8-b3d7-01146121b73d',
                 },
               },
             }),
@@ -296,169 +360,151 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         });
       });
 
-      it('propagates context for built-in Discover', async () => {
-        await assertLogContains({
-          description: 'execution context propagates to Elasticsearch via "x-opaque-id" header',
-          predicate: checkHttpRequestId(
-            'dashboard:dashboards:7adfa750-4c81-11e8-b3d7-01146121b73d;search:discover:571aaf70-4c88-11e8-b3d7-01146121b73d'
-          ),
-          retry,
+      describe('propagates context for TSVB visualizations', () => {
+        it('propagates to Elasticsearch via "x-opaque-id" header', async () => {
+          await assertLogContains({
+            description: 'execution context propagates to Elasticsearch via "x-opaque-id" header',
+            predicate: checkHttpRequestId('agg_based:metrics:bcb63b50-4c89-11e8-b3d7-01146121b73d'),
+            retry,
+          });
         });
-        await assertLogContains({
-          description: 'execution context propagates to Kibana logs',
-          predicate: checkExecutionContextEntry({
-            type: 'application',
-            name: 'dashboards',
-            url: '/app/dashboards',
-            child: {
-              type: 'dashboard',
+
+        it('propagates to Kibana logs', async () => {
+          await assertLogContains({
+            description: 'execution context propagates to Kibana logs',
+            predicate: checkExecutionContextEntry({
               name: 'dashboards',
               url: '/app/dashboards',
+              type: 'application',
               page: 'app',
-              id: '7adfa750-4c81-11e8-b3d7-01146121b73d',
-              description: '[Flights] Global Flight Dashboard',
-              child: {
-                type: 'search',
-                name: 'discover',
-                id: '571aaf70-4c88-11e8-b3d7-01146121b73d',
-                description: '[Flights] Flight Log',
-                url: '/app/discover#/view/571aaf70-4c88-11e8-b3d7-01146121b73d',
-              },
-            },
-          }),
-          retry,
-        });
-      });
-
-      it('propagates context for TSVB visualizations', async () => {
-        await assertLogContains({
-          description: 'execution context propagates to Elasticsearch via "x-opaque-id" header',
-          predicate: checkHttpRequestId('agg_based:metrics:bcb63b50-4c89-11e8-b3d7-01146121b73d'),
-          retry,
-        });
-
-        await assertLogContains({
-          description: 'execution context propagates to Kibana logs',
-          predicate: checkExecutionContextEntry({
-            name: 'dashboards',
-            url: '/app/dashboards',
-            type: 'application',
-            page: 'app',
-            description: '[Flights] Global Flight Dashboard',
-            child: {
-              type: 'agg_based',
-              name: 'metrics',
-              id: 'bcb63b50-4c89-11e8-b3d7-01146121b73d',
-              description: '[Flights] Delays & Cancellations',
-              url: '/app/visualize#/edit/bcb63b50-4c89-11e8-b3d7-01146121b73d',
-            },
-          }),
-          retry,
-        });
-      });
-
-      it('propagates context for Vega visualizations', async () => {
-        await assertLogContains({
-          description: 'execution context propagates to Elasticsearch via "x-opaque-id" header',
-          predicate: checkHttpRequestId(
-            'dashboard:dashboards:7adfa750-4c81-11e8-b3d7-01146121b73d;agg_based:vega:ed78a660-53a0-11e8-acbd-0be0ad9d822b'
-          ),
-          retry,
-        });
-
-        await assertLogContains({
-          description: 'execution context propagates to Kibana logs',
-          predicate: checkExecutionContextEntry({
-            name: 'dashboards',
-            url: '/app/dashboards',
-            type: 'application',
-            child: {
-              name: 'dashboards',
-              url: '/app/dashboards',
-              type: 'dashboard',
-              page: 'app',
-              id: '7adfa750-4c81-11e8-b3d7-01146121b73d',
               description: '[Flights] Global Flight Dashboard',
               child: {
                 type: 'agg_based',
-                name: 'vega',
-                id: 'ed78a660-53a0-11e8-acbd-0be0ad9d822b',
-                description: '[Flights] Airport Connections (Hover Over Airport)',
-                url: '/app/visualize#/edit/ed78a660-53a0-11e8-acbd-0be0ad9d822b',
+                name: 'metrics',
+                id: 'bcb63b50-4c89-11e8-b3d7-01146121b73d',
+                description: '[Flights] Delays & Cancellations',
+                url: '/app/visualize#/edit/bcb63b50-4c89-11e8-b3d7-01146121b73d',
               },
-            },
-          }),
-          retry,
+            }),
+            retry,
+          });
         });
       });
 
-      it('propagates context for Tag Cloud visualization', async () => {
-        await assertLogContains({
-          description: 'execution context propagates to Elasticsearch via "x-opaque-id" header',
-          predicate: checkHttpRequestId(
-            'dashboard:dashboards:7adfa750-4c81-11e8-b3d7-01146121b73d;agg_based:tagcloud:293b5a30-4c8f-11e8-b3d7-01146121b73d'
-          ),
-          retry,
+      describe('propagates context for Vega visualizations', () => {
+        it('propagates to Elasticsearch via "x-opaque-id" header', async () => {
+          await assertLogContains({
+            description: 'execution context propagates to Elasticsearch via "x-opaque-id" header',
+            predicate: checkHttpRequestId(
+              'dashboard:dashboards:7adfa750-4c81-11e8-b3d7-01146121b73d;agg_based:vega:ed78a660-53a0-11e8-acbd-0be0ad9d822b'
+            ),
+            retry,
+          });
         });
 
-        await assertLogContains({
-          description: 'execution context propagates to Kibana logs',
-          predicate: checkExecutionContextEntry({
-            name: 'dashboards',
-            url: '/app/dashboards',
-            type: 'application',
-            child: {
+        it('propagates to Kibana logs', async () => {
+          await assertLogContains({
+            description: 'execution context propagates to Kibana logs',
+            predicate: checkExecutionContextEntry({
               name: 'dashboards',
               url: '/app/dashboards',
-              type: 'dashboard',
-              page: 'app',
-              id: '7adfa750-4c81-11e8-b3d7-01146121b73d',
-              description: '[Flights] Global Flight Dashboard',
+              type: 'application',
               child: {
-                type: 'agg_based',
-                name: 'tagcloud',
-                id: '293b5a30-4c8f-11e8-b3d7-01146121b73d',
-                description: '[Flights] Destination Weather',
-                url: '/app/visualize#/edit/293b5a30-4c8f-11e8-b3d7-01146121b73d',
+                name: 'dashboards',
+                url: '/app/dashboards',
+                type: 'dashboard',
+                page: 'app',
+                id: '7adfa750-4c81-11e8-b3d7-01146121b73d',
+                description: '[Flights] Global Flight Dashboard',
+                child: {
+                  type: 'agg_based',
+                  name: 'vega',
+                  id: 'ed78a660-53a0-11e8-acbd-0be0ad9d822b',
+                  description: '[Flights] Airport Connections (Hover Over Airport)',
+                  url: '/app/visualize#/edit/ed78a660-53a0-11e8-acbd-0be0ad9d822b',
+                },
               },
-            },
-          }),
-          retry,
+            }),
+            retry,
+          });
         });
       });
 
-      it('propagates context for Vertical bar visualization', async () => {
-        await assertLogContains({
-          description: 'execution context propagates to Elasticsearch via "x-opaque-id" header',
-          predicate: checkHttpRequestId(
-            'dashboard:dashboards:7adfa750-4c81-11e8-b3d7-01146121b73d;agg_based:histogram:9886b410-4c8b-11e8-b3d7-01146121b73d'
-          ),
-          retry,
+      describe('propagates context for Tag Cloud visualization', () => {
+        it('propagates to Elasticsearch via "x-opaque-id" header', async () => {
+          await assertLogContains({
+            description: 'execution context propagates to Elasticsearch via "x-opaque-id" header',
+            predicate: checkHttpRequestId(
+              'dashboard:dashboards:7adfa750-4c81-11e8-b3d7-01146121b73d;agg_based:tagcloud:293b5a30-4c8f-11e8-b3d7-01146121b73d'
+            ),
+            retry,
+          });
         });
 
-        await assertLogContains({
-          description: 'execution context propagates to Kibana logs',
-          predicate: checkExecutionContextEntry({
-            type: 'application',
-            name: 'dashboards',
-            url: '/app/dashboards',
-            child: {
-              type: 'dashboard',
+        it('propagates to Kibana logs', async () => {
+          await assertLogContains({
+            description: 'execution context propagates to Kibana logs',
+            predicate: checkExecutionContextEntry({
               name: 'dashboards',
               url: '/app/dashboards',
-              page: 'app',
-              id: '7adfa750-4c81-11e8-b3d7-01146121b73d',
-              description: '[Flights] Global Flight Dashboard',
+              type: 'application',
               child: {
-                type: 'agg_based',
-                name: 'histogram',
-                id: '9886b410-4c8b-11e8-b3d7-01146121b73d',
-                description: '[Flights] Delay Buckets',
-                url: '/app/visualize#/edit/9886b410-4c8b-11e8-b3d7-01146121b73d',
+                name: 'dashboards',
+                url: '/app/dashboards',
+                type: 'dashboard',
+                page: 'app',
+                id: '7adfa750-4c81-11e8-b3d7-01146121b73d',
+                description: '[Flights] Global Flight Dashboard',
+                child: {
+                  type: 'agg_based',
+                  name: 'tagcloud',
+                  id: '293b5a30-4c8f-11e8-b3d7-01146121b73d',
+                  description: '[Flights] Destination Weather',
+                  url: '/app/visualize#/edit/293b5a30-4c8f-11e8-b3d7-01146121b73d',
+                },
               },
-            },
-          }),
-          retry,
+            }),
+            retry,
+          });
+        });
+      });
+
+      describe('propagates context for Vertical bar visualization', () => {
+        it('propagates to Elasticsearch via "x-opaque-id" header', async () => {
+          await assertLogContains({
+            description: 'execution context propagates to Elasticsearch via "x-opaque-id" header',
+            predicate: checkHttpRequestId(
+              'dashboard:dashboards:7adfa750-4c81-11e8-b3d7-01146121b73d;agg_based:histogram:9886b410-4c8b-11e8-b3d7-01146121b73d'
+            ),
+            retry,
+          });
+        });
+
+        it('propagates to Kibana logs', async () => {
+          await assertLogContains({
+            description: 'execution context propagates to Kibana logs',
+            predicate: checkExecutionContextEntry({
+              type: 'application',
+              name: 'dashboards',
+              url: '/app/dashboards',
+              child: {
+                type: 'dashboard',
+                name: 'dashboards',
+                url: '/app/dashboards',
+                page: 'app',
+                id: '7adfa750-4c81-11e8-b3d7-01146121b73d',
+                description: '[Flights] Global Flight Dashboard',
+                child: {
+                  type: 'agg_based',
+                  name: 'histogram',
+                  id: '9886b410-4c8b-11e8-b3d7-01146121b73d',
+                  description: '[Flights] Delay Buckets',
+                  url: '/app/visualize#/edit/9886b410-4c8b-11e8-b3d7-01146121b73d',
+                },
+              },
+            }),
+            retry,
+          });
         });
       });
     });


### PR DESCRIPTION
## Summary

Resolves #112102 (hopefully)

Another race condition in the tests was that no data was found when loading discover, so the charts were not requested. This PR extends the datepicker to the last 7 days (instead of the last 15 days).

On top of that, it makes sure that each assertion is an individual test, so we have better insight into which assertion failed.

Flaky Test runner (x100): https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/1781


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["7.17","8.6"]} ONMERGE-->