### PR TITLE
[Lens] only reload embeddable when a new message was actually added

### DIFF
--- a/x-pack/plugins/lens/public/embeddable/embeddable.tsx
+++ b/x-pack/plugins/lens/public/embeddable/embeddable.tsx
@@ -552,7 +552,7 @@ export class Embeddable
 
     if (addedMessageIds.length) {
       this.additionalUserMessages = newMessageMap;
-      this.reload();
+      this.renderBadgeMessages();
     }
 
     return () => {
@@ -875,6 +875,10 @@ export class Embeddable
       domNode
     );
 
+    this.renderBadgeMessages();
+  }
+
+  private renderBadgeMessages() {
     const warningsToDisplay = this.getUserMessages('embeddableBadge', {
       severity: 'warning',
     });

--- a/x-pack/plugins/lens/public/embeddable/embeddable.tsx
+++ b/x-pack/plugins/lens/public/embeddable/embeddable.tsx
@@ -552,9 +552,8 @@ export class Embeddable
 
     if (addedMessageIds.length) {
       this.additionalUserMessages = newMessageMap;
+      this.reload();
     }
-
-    this.reload();
 
     return () => {
       const withMessagesRemoved = {
@@ -712,15 +711,11 @@ export class Embeddable
 
     const newActiveData = adapters?.tables?.tables;
 
-    if (!fastIsEqual(this.activeData, newActiveData)) {
-      // we check equality because this.addUserMessage triggers a render, so we get an infinite loop
-      // if we just execute without checking if the data has changed
-      this.removeActiveDataWarningMessages();
-      const searchWarningMessages = this.getSearchWarningMessages(adapters);
-      this.removeActiveDataWarningMessages = this.addUserMessages(
-        searchWarningMessages.filter(isMessageRemovable)
-      );
-    }
+    this.removeActiveDataWarningMessages();
+    const searchWarningMessages = this.getSearchWarningMessages(adapters);
+    this.removeActiveDataWarningMessages = this.addUserMessages(
+      searchWarningMessages.filter(isMessageRemovable)
+    );
 
     this.activeData = newActiveData;
   };


### PR DESCRIPTION
## Summary

Fix https://github.com/elastic/kibana/issues/149397

This is not a perfect fix to https://github.com/elastic/kibana/issues/149397, but it does unblock the O11y team, so I'm moving forward.

The problem with it is that it won't support user messages that are rendered on the embeddable visualization which depend on active data, since the messages won't get rendered when active data is set.