### PR TITLE
[ML] Fix ML page crash due to css string 

### DIFF
--- a/x-pack/plugins/ml/public/application/jobs/new_job/utils/use_field_stats_trigger.tsx
+++ b/x-pack/plugins/ml/public/application/jobs/new_job/utils/use_field_stats_trigger.tsx
@@ -7,6 +7,7 @@
 
 import React, { ReactNode, useCallback } from 'react';
 import { EuiComboBoxOptionOption } from '@elastic/eui';
+import { css } from '@emotion/react';
 import { useFieldStatsFlyoutContext } from '../../../components/field_stats_flyout';
 import { FieldStatsInfoButton } from '../common/components/field_stats_info_button';
 import { Field } from '../../../../../common/types/fields';
@@ -14,17 +15,17 @@ import { Field } from '../../../../../common/types/fields';
 interface Option extends EuiComboBoxOptionOption<string> {
   field: Field;
 }
-const optionCss = `
-          .euiComboBoxOption__enterBadge {
-            display: none;
-          }
-          .euiFlexGroup {
-            gap: 0px;
-          }
-          .euiComboBoxOption__content{
-            margin-left: 2px;
-          }
-        `;
+const optionCss = css`
+  .euiComboBoxOption__enterBadge {
+    display: none;
+  }
+  .euiFlexGroup {
+    gap: 0px;
+  }
+  .euiComboBoxOption__content {
+    margin-left: 2px;
+  }
+`;
 
 export const useFieldStatsTrigger = () => {
   const { setIsFlyoutVisible, setFieldName } = useFieldStatsFlyoutContext();


### PR DESCRIPTION
## Summary

Fix a regression introduced by merge of https://github.com/elastic/kibana/pull/147322 due to css string not being wrapped in emotion `css` tag.

![image](https://user-images.githubusercontent.com/43350163/214348591-9f931d0d-8e15-42e4-9a30-65c159e4d149.png)

