### PR TITLE
[ML] Transforms: Use concise fragment syntax.

### DIFF
--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/aggregation_list/list_form.tsx
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/aggregation_list/list_form.tsx
@@ -29,7 +29,7 @@ export interface AggListProps {
 export const AggListForm: React.FC<AggListProps> = ({ deleteHandler, list, onChange, options }) => {
   const listKeys = Object.keys(list);
   return (
-    <Fragment>
+    <>
       {listKeys.map((aggName: AggName, i) => {
         const otherAggNames = listKeys.filter((k) => k !== aggName);
         return (
@@ -47,6 +47,6 @@ export const AggListForm: React.FC<AggListProps> = ({ deleteHandler, list, onCha
           </Fragment>
         );
       })}
-    </Fragment>
+    </>
   );
 };

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/group_by_list/list_form.tsx
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/group_by_list/list_form.tsx
@@ -34,7 +34,7 @@ export const GroupByListForm: React.FC<ListProps> = ({
 }) => {
   const listKeys = Object.keys(list);
   return (
-    <Fragment>
+    <>
       {listKeys.map((aggName: AggName, i) => {
         const otherAggNames = listKeys.filter((k) => k !== aggName);
         return (
@@ -52,6 +52,6 @@ export const GroupByListForm: React.FC<ListProps> = ({
           </Fragment>
         );
       })}
-    </Fragment>
+    </>
   );
 };

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/group_by_list/list_summary.tsx
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/group_by_list/list_summary.tsx
@@ -20,7 +20,7 @@ interface ListProps {
 export const GroupByListSummary: React.FC<ListProps> = ({ list }) => {
   const listKeys = Object.keys(list);
   return (
-    <Fragment>
+    <>
       {listKeys.map((optionsDataId: string) => {
         return (
           <Fragment key={optionsDataId}>
@@ -31,6 +31,6 @@ export const GroupByListSummary: React.FC<ListProps> = ({ list }) => {
           </Fragment>
         );
       })}
-    </Fragment>
+    </>
   );
 };

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/step_create/step_create_form.tsx
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/step_create/step_create_form.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { Fragment, FC, useEffect, useState } from 'react';
+import React, { type FC, useEffect, useState } from 'react';
 import { i18n } from '@kbn/i18n';
 
 import {
@@ -485,7 +485,7 @@ export const StepCreateForm: FC<StepCreateFormProps> = React.memo(
             </EuiFlexItem>
           </EuiFlexGroup>
           {progressPercentComplete !== undefined && isBatchTransform && (
-            <Fragment>
+            <>
               <EuiSpacer size="m" />
               <EuiText size="xs">
                 <strong>
@@ -508,10 +508,10 @@ export const StepCreateForm: FC<StepCreateFormProps> = React.memo(
                   <EuiText size="xs">{progressPercentComplete}%</EuiText>
                 </EuiFlexItem>
               </EuiFlexGroup>
-            </Fragment>
+            </>
           )}
           {created && (
-            <Fragment>
+            <>
               <EuiHorizontalRule />
               <EuiFlexGroup gutterSize="l">
                 <EuiFlexItem style={PANEL_ITEM_STYLE} grow={false}>
@@ -566,7 +566,7 @@ export const StepCreateForm: FC<StepCreateFormProps> = React.memo(
                   </EuiFlexItem>
                 )}
               </EuiFlexGroup>
-            </Fragment>
+            </>
           )}
         </EuiForm>
         {alertFlyoutVisible ? (

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/step_define_summary.tsx
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/step_define_summary.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { Fragment, FC } from 'react';
+import React, { type FC } from 'react';
 
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
@@ -86,7 +86,7 @@ export const StepDefineSummary: FC<Props> = ({
     <div data-test-subj="transformStepDefineSummary">
       <EuiForm>
         {searchItems.savedSearch === undefined && (
-          <Fragment>
+          <>
             <EuiFormRow
               label={i18n.translate('xpack.transform.stepDefineSummary.dataViewLabel', {
                 defaultMessage: 'Data view',
@@ -121,7 +121,7 @@ export const StepDefineSummary: FC<Props> = ({
                 </EuiCodeBlock>
               </EuiFormRow>
             )}
-          </Fragment>
+          </>
         )}
 
         {searchItems.savedSearch !== undefined && searchItems.savedSearch.id !== undefined && (

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/wizard/wizard.tsx
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/wizard/wizard.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { Fragment, FC, useRef, useState, createContext, useMemo } from 'react';
+import React, { type FC, useRef, useState, createContext, useMemo } from 'react';
 
 import { i18n } from '@kbn/i18n';
 
@@ -58,10 +58,10 @@ const StepDefine: FC<DefinePivotStepProps> = ({
   const definePivotRef = useRef(null);
 
   return (
-    <Fragment>
+    <>
       <div ref={definePivotRef} />
       {isCurrentStep && (
-        <Fragment>
+        <>
           <StepDefineForm
             onChange={setStepDefineState}
             overrides={{ ...stepDefineState }}
@@ -71,12 +71,12 @@ const StepDefine: FC<DefinePivotStepProps> = ({
             next={() => setCurrentStep(WIZARD_STEPS.DETAILS)}
             nextActive={stepDefineState.valid}
           />
-        </Fragment>
+        </>
       )}
       {!isCurrentStep && (
         <StepDefineSummary formState={{ ...stepDefineState }} searchItems={searchItems} />
       )}
-    </Fragment>
+    </>
   );
 };
 
@@ -141,7 +141,7 @@ export const Wizard: FC<WizardProps> = React.memo(({ cloneConfig, searchItems })
         defaultMessage: 'Transform details',
       }),
       children: (
-        <Fragment>
+        <>
           {currentStep === WIZARD_STEPS.DETAILS ? (
             <StepDetailsForm
               onChange={setStepDetailsState}
@@ -161,7 +161,7 @@ export const Wizard: FC<WizardProps> = React.memo(({ cloneConfig, searchItems })
               nextActive={stepDetailsState.valid}
             />
           )}
-        </Fragment>
+        </>
       ),
       status: currentStep >= WIZARD_STEPS.DETAILS ? undefined : ('incomplete' as EuiStepStatus),
     };
@@ -173,7 +173,7 @@ export const Wizard: FC<WizardProps> = React.memo(({ cloneConfig, searchItems })
         defaultMessage: 'Create',
       }),
       children: (
-        <Fragment>
+        <>
           {currentStep === WIZARD_STEPS.CREATE ? (
             <StepCreateForm
               createDataView={stepDetailsState.createDataView}
@@ -189,7 +189,7 @@ export const Wizard: FC<WizardProps> = React.memo(({ cloneConfig, searchItems })
           {currentStep === WIZARD_STEPS.CREATE && !stepCreateState.created && (
             <WizardNav previous={() => setCurrentStep(WIZARD_STEPS.DETAILS)} />
           )}
-        </Fragment>
+        </>
       ),
       status: currentStep >= WIZARD_STEPS.CREATE ? undefined : ('incomplete' as EuiStepStatus),
     };

--- a/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/use_columns.tsx
+++ b/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/use_columns.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { Fragment } from 'react';
+import React from 'react';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import {
@@ -266,7 +266,7 @@ export const useColumns = (
         return (
           <EuiFlexGroup alignItems="center" gutterSize="xs">
             {isBatchTransform && (
-              <Fragment>
+              <>
                 <EuiFlexItem style={{ width: '40px' }} grow={false}>
                   <EuiProgress
                     value={progress}
@@ -281,10 +281,10 @@ export const useColumns = (
                 <EuiFlexItem style={{ width: '35px' }} grow={false}>
                   <EuiText size="xs">{`${progress}%`}</EuiText>
                 </EuiFlexItem>
-              </Fragment>
+              </>
             )}
             {!isBatchTransform && (
-              <Fragment>
+              <>
                 <EuiFlexItem style={{ width: '40px' }} grow={false}>
                   {/* If not stopped, failed or waiting show the animated progress bar */}
                   {item.stats.state !== TRANSFORM_STATE.STOPPED &&
@@ -302,7 +302,7 @@ export const useColumns = (
                 <EuiFlexItem style={{ width: '35px' }} grow={false}>
                   &nbsp;
                 </EuiFlexItem>
-              </Fragment>
+              </>
             )}
           </EuiFlexGroup>
         );


### PR DESCRIPTION
## Summary

Refactor to use concise fragment syntax (`<>...</>` instead of `<Fragment>...</Fragment>`) where applicable.

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
