### PR TITLE
[artifacts/container-image] Trigger image tag update

### DIFF
--- a/.buildkite/scripts/steps/artifacts/docker_image.sh
+++ b/.buildkite/scripts/steps/artifacts/docker_image.sh
@@ -65,3 +65,23 @@ buildkite-agent artifact upload "kibana-$BASE_VERSION-docker-image.tar.gz"
 buildkite-agent artifact upload "kibana-$BASE_VERSION-docker-image-aarch64.tar.gz"
 buildkite-agent artifact upload "dependencies-$GIT_ABBREV_COMMIT.csv"
 cd -
+
+echo "--- Trigger image tag update"
+if [[ "$BUILDKITE_BRANCH" == "$KIBANA_BASE_BRANCH" ]]; then
+
+  cat << EOF | buildkite-agent pipeline upload
+steps:
+  - trigger: k8s-gitops-update-image-tag
+    label: ":argo: Update image tag for deployment-api"
+    branches: main
+    build:
+      env:
+        MODE: sed
+        TARGET_FILE: kibana-controller.yaml
+        IMAGE_TAG: "$KIBANA_IMAGE"
+        SERVICE: kibana-controller
+EOF
+
+else
+  echo "Skipping update for untracked branch $BUILDKITE_BRANCH"
+fi


### PR DESCRIPTION
Reopens #149143 with updates to the target file and service

After a commit is merged, tested, and images are built and pushed to the container registry we need to send a notification that a new tag is available.

This triggers a promotion pipeline with the latest container tag when: 1) the branch is tracked (i.e. main, and not a personal branch) 1) ~triggered from our on-merge test pipeline.~
https://github.com/elastic/kibana/pull/149350 had to remove support for this - we're triggering via REST now which removes the from trigger environment variable.