### PR TITLE
[8.6] [Synthetics] Omit or include `ssl` keys when appropriate for project monitors and private locations (#149298)

### DIFF
--- a/x-pack/plugins/synthetics/common/formatters/format_synthetics_policy.test.ts
+++ b/x-pack/plugins/synthetics/common/formatters/format_synthetics_policy.test.ts
@@ -1,0 +1,1319 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { ConfigKey, DataStream } from '../runtime_types';
+import { formatSyntheticsPolicy } from './format_synthetics_policy';
+
+describe('formatSyntheticsPolicy', () => {
+  it('formats browser policy', () => {
+    const { formattedPolicy } = formatSyntheticsPolicy(
+      testNewPolicy,
+      DataStream.BROWSER,
+      browserConfig
+    );
+
+    expect(formattedPolicy).toEqual({
+      enabled: true,
+      inputs: [
+        {
+          enabled: false,
+          policy_template: 'synthetics',
+          streams: [
+            {
+              data_stream: {
+                dataset: 'http',
+                type: 'synthetics',
+              },
+              enabled: false,
+              vars: {
+                __ui: {
+                  type: 'yaml',
+                },
+                'check.request.body': {
+                  type: 'yaml',
+                },
+                'check.request.headers': {
+                  type: 'yaml',
+                },
+                'check.request.method': {
+                  type: 'text',
+                },
+                'check.response.body.negative': {
+                  type: 'yaml',
+                },
+                'check.response.body.positive': {
+                  type: 'yaml',
+                },
+                'check.response.headers': {
+                  type: 'yaml',
+                },
+                'check.response.status': {
+                  type: 'yaml',
+                },
+                config_id: {
+                  type: 'text',
+                },
+                enabled: {
+                  type: 'bool',
+                  value: true,
+                },
+                id: {
+                  type: 'text',
+                },
+                location_name: {
+                  type: 'text',
+                  value: 'Fleet managed',
+                },
+                max_redirects: {
+                  type: 'integer',
+                },
+                'monitor.project.id': {
+                  type: 'text',
+                },
+                'monitor.project.name': {
+                  type: 'text',
+                },
+                name: {
+                  type: 'text',
+                },
+                origin: {
+                  type: 'text',
+                },
+                password: {
+                  type: 'password',
+                },
+                proxy_url: {
+                  type: 'text',
+                },
+                'response.include_body': {
+                  type: 'text',
+                },
+                'response.include_headers': {
+                  type: 'bool',
+                },
+                run_once: {
+                  type: 'bool',
+                  value: false,
+                },
+                schedule: {
+                  type: 'text',
+                  value: '"@every 3m"',
+                },
+                'service.name': {
+                  type: 'text',
+                },
+                'ssl.certificate': {
+                  type: 'yaml',
+                },
+                'ssl.certificate_authorities': {
+                  type: 'yaml',
+                },
+                'ssl.key': {
+                  type: 'yaml',
+                },
+                'ssl.key_passphrase': {
+                  type: 'text',
+                },
+                'ssl.supported_protocols': {
+                  type: 'yaml',
+                },
+                'ssl.verification_mode': {
+                  type: 'text',
+                },
+                tags: {
+                  type: 'yaml',
+                },
+                timeout: {
+                  type: 'text',
+                },
+                type: {
+                  type: 'text',
+                  value: 'http',
+                },
+                urls: {
+                  type: 'text',
+                },
+                username: {
+                  type: 'text',
+                },
+              },
+            },
+          ],
+          type: 'synthetics/http',
+        },
+        {
+          enabled: false,
+          policy_template: 'synthetics',
+          streams: [
+            {
+              data_stream: {
+                dataset: 'tcp',
+                type: 'synthetics',
+              },
+              enabled: false,
+              vars: {
+                __ui: {
+                  type: 'yaml',
+                },
+                'check.receive': {
+                  type: 'text',
+                },
+                'check.send': {
+                  type: 'text',
+                },
+                config_id: {
+                  type: 'text',
+                },
+                enabled: {
+                  type: 'bool',
+                  value: true,
+                },
+                hosts: {
+                  type: 'text',
+                },
+                id: {
+                  type: 'text',
+                },
+                location_name: {
+                  type: 'text',
+                  value: 'Fleet managed',
+                },
+                'monitor.project.id': {
+                  type: 'text',
+                },
+                'monitor.project.name': {
+                  type: 'text',
+                },
+                name: {
+                  type: 'text',
+                },
+                origin: {
+                  type: 'text',
+                },
+                proxy_url: {
+                  type: 'text',
+                },
+                proxy_use_local_resolver: {
+                  type: 'bool',
+                  value: false,
+                },
+                run_once: {
+                  type: 'bool',
+                  value: false,
+                },
+                schedule: {
+                  type: 'text',
+                  value: '"@every 3m"',
+                },
+                'service.name': {
+                  type: 'text',
+                },
+                'ssl.certificate': {
+                  type: 'yaml',
+                },
+                'ssl.certificate_authorities': {
+                  type: 'yaml',
+                },
+                'ssl.key': {
+                  type: 'yaml',
+                },
+                'ssl.key_passphrase': {
+                  type: 'text',
+                },
+                'ssl.supported_protocols': {
+                  type: 'yaml',
+                },
+                'ssl.verification_mode': {
+                  type: 'text',
+                },
+                tags: {
+                  type: 'yaml',
+                },
+                timeout: {
+                  type: 'text',
+                },
+                type: {
+                  type: 'text',
+                  value: 'tcp',
+                },
+              },
+            },
+          ],
+          type: 'synthetics/tcp',
+        },
+        {
+          enabled: false,
+          policy_template: 'synthetics',
+          streams: [
+            {
+              data_stream: {
+                dataset: 'icmp',
+                type: 'synthetics',
+              },
+              enabled: false,
+              vars: {
+                __ui: {
+                  type: 'yaml',
+                },
+                config_id: {
+                  type: 'text',
+                },
+                enabled: {
+                  type: 'bool',
+                  value: true,
+                },
+                hosts: {
+                  type: 'text',
+                },
+                id: {
+                  type: 'text',
+                },
+                location_name: {
+                  type: 'text',
+                  value: 'Fleet managed',
+                },
+                'monitor.project.id': {
+                  type: 'text',
+                },
+                'monitor.project.name': {
+                  type: 'text',
+                },
+                name: {
+                  type: 'text',
+                },
+                origin: {
+                  type: 'text',
+                },
+                run_once: {
+                  type: 'bool',
+                  value: false,
+                },
+                schedule: {
+                  type: 'text',
+                  value: '"@every 3m"',
+                },
+                'service.name': {
+                  type: 'text',
+                },
+                tags: {
+                  type: 'yaml',
+                },
+                timeout: {
+                  type: 'text',
+                },
+                type: {
+                  type: 'text',
+                  value: 'icmp',
+                },
+                wait: {
+                  type: 'text',
+                  value: '1s',
+                },
+              },
+            },
+          ],
+          type: 'synthetics/icmp',
+        },
+        {
+          enabled: true,
+          policy_template: 'synthetics',
+          streams: [
+            {
+              data_stream: {
+                dataset: 'browser',
+                type: 'synthetics',
+              },
+              enabled: true,
+              vars: {
+                __ui: {
+                  type: 'yaml',
+                  value:
+                    '{"script_source":{"is_generated_script":false,"file_name":""},"is_zip_url_tls_enabled":false,"is_tls_enabled":false}',
+                },
+                config_id: {
+                  type: 'text',
+                  value: '00bb3ceb-a242-4c7a-8405-8da963661374',
+                },
+                enabled: {
+                  type: 'bool',
+                  value: true,
+                },
+                'filter_journeys.match': {
+                  type: 'text',
+                  value: null,
+                },
+                'filter_journeys.tags': {
+                  type: 'yaml',
+                  value: null,
+                },
+                id: {
+                  type: 'text',
+                  value: '00bb3ceb-a242-4c7a-8405-8da963661374',
+                },
+                ignore_https_errors: {
+                  type: 'bool',
+                  value: false,
+                },
+                location_name: {
+                  type: 'text',
+                  value: 'Test private location 0',
+                },
+                'monitor.project.id': {
+                  type: 'text',
+                },
+                'monitor.project.name': {
+                  type: 'text',
+                },
+                name: {
+                  type: 'text',
+                  value: 'Test HTTP Monitor 03',
+                },
+                origin: {
+                  type: 'text',
+                  value: 'ui',
+                },
+                params: {
+                  type: 'yaml',
+                  value: '',
+                },
+                playwright_options: {
+                  type: 'yaml',
+                  value: '',
+                },
+                run_once: {
+                  type: 'bool',
+                  value: false,
+                },
+                schedule: {
+                  type: 'text',
+                  value: '"@every 3m"',
+                },
+                screenshots: {
+                  type: 'text',
+                  value: 'on',
+                },
+                'service.name': {
+                  type: 'text',
+                  value: '',
+                },
+                'source.inline.script': {
+                  type: 'yaml',
+                  value:
+                    '"step(\\"Visit /users api route\\", async () => {\\\\n  const response = await page.goto(\'https://nextjs-test-synthetics.vercel.app/api/users\');\\\\n  expect(response.status()).toEqual(200);\\\\n});"',
+                },
+                'source.project.content': {
+                  type: 'text',
+                  value: '',
+                },
+                'source.zip_url.folder': {
+                  type: 'text',
+                  value: '',
+                },
+                'source.zip_url.password': {
+                  type: 'password',
+                  value: '',
+                },
+                'source.zip_url.proxy_url': {
+                  type: 'text',
+                  value: '',
+                },
+                'source.zip_url.ssl.certificate': {
+                  type: 'yaml',
+                },
+                'source.zip_url.ssl.certificate_authorities': {
+                  type: 'yaml',
+                },
+                'source.zip_url.ssl.key': {
+                  type: 'yaml',
+                },
+                'source.zip_url.ssl.key_passphrase': {
+                  type: 'text',
+                },
+                'source.zip_url.ssl.supported_protocols': {
+                  type: 'yaml',
+                },
+                'source.zip_url.ssl.verification_mode': {
+                  type: 'text',
+                },
+                'source.zip_url.url': {
+                  type: 'text',
+                  value: '',
+                },
+                'source.zip_url.username': {
+                  type: 'text',
+                  value: '',
+                },
+                synthetics_args: {
+                  type: 'text',
+                  value: null,
+                },
+                tags: {
+                  type: 'yaml',
+                  value: '["cookie-test","browser"]',
+                },
+                'throttling.config': {
+                  type: 'text',
+                  value: '5d/3u/20l',
+                },
+                timeout: {
+                  type: 'text',
+                  value: '16s',
+                },
+                type: {
+                  type: 'text',
+                  value: 'browser',
+                },
+              },
+            },
+            {
+              data_stream: {
+                dataset: 'browser.network',
+                type: 'synthetics',
+              },
+              enabled: true,
+            },
+            {
+              data_stream: {
+                dataset: 'browser.screenshot',
+                type: 'synthetics',
+              },
+              enabled: true,
+            },
+          ],
+          type: 'synthetics/browser',
+        },
+      ],
+      is_managed: true,
+      name: 'Test HTTP Monitor 03-Test private location 0-default',
+      namespace: 'testnamespace',
+      package: {
+        experimental_data_stream_features: [],
+        name: 'synthetics',
+        title: 'Elastic Synthetics',
+        version: '0.11.4',
+      },
+      policy_id: '404812e0-90e1-11ed-8111-f7f9cad30b61',
+    });
+  });
+
+  it.each([true, false])('formats http policy', (isTLSEnabled) => {
+    const { formattedPolicy } = formatSyntheticsPolicy(testNewPolicy, DataStream.HTTP, {
+      ...httpPolicy,
+      [ConfigKey.METADATA]: { is_tls_enabled: isTLSEnabled },
+    });
+
+    expect(formattedPolicy).toEqual({
+      enabled: true,
+      inputs: [
+        {
+          enabled: true,
+          policy_template: 'synthetics',
+          streams: [
+            {
+              data_stream: {
+                dataset: 'http',
+                type: 'synthetics',
+              },
+              enabled: true,
+              vars: {
+                __ui: {
+                  type: 'yaml',
+                  value: `{"is_tls_enabled":${isTLSEnabled}}`,
+                },
+                'check.request.body': {
+                  type: 'yaml',
+                  value: null,
+                },
+                'check.request.headers': {
+                  type: 'yaml',
+                  value: null,
+                },
+                'check.request.method': {
+                  type: 'text',
+                  value: 'GET',
+                },
+                'check.response.body.negative': {
+                  type: 'yaml',
+                  value: null,
+                },
+                'check.response.body.positive': {
+                  type: 'yaml',
+                  value: null,
+                },
+                'check.response.headers': {
+                  type: 'yaml',
+                  value: null,
+                },
+                'check.response.status': {
+                  type: 'yaml',
+                  value: null,
+                },
+                config_id: {
+                  type: 'text',
+                  value: '51ccd9d9-fc3f-4718-ba9d-b6ef80e73fc5',
+                },
+                enabled: {
+                  type: 'bool',
+                  value: true,
+                },
+                id: {
+                  type: 'text',
+                  value: '51ccd9d9-fc3f-4718-ba9d-b6ef80e73fc5',
+                },
+                location_name: {
+                  type: 'text',
+                  value: 'Test private location 0',
+                },
+                max_redirects: {
+                  type: 'integer',
+                  value: '0',
+                },
+                'monitor.project.id': {
+                  type: 'text',
+                },
+                'monitor.project.name': {
+                  type: 'text',
+                },
+                name: {
+                  type: 'text',
+                  value: 'Test Monitor',
+                },
+                origin: {
+                  type: 'text',
+                  value: 'ui',
+                },
+                password: {
+                  type: 'password',
+                  value: 'changeme',
+                },
+                proxy_url: {
+                  type: 'text',
+                  value: '',
+                },
+                'response.include_body': {
+                  type: 'text',
+                  value: 'on_error',
+                },
+                'response.include_headers': {
+                  type: 'bool',
+                  value: true,
+                },
+                run_once: {
+                  type: 'bool',
+                  value: false,
+                },
+                schedule: {
+                  type: 'text',
+                  value: '"@every 3m"',
+                },
+                'service.name': {
+                  type: 'text',
+                  value: 'LocalService',
+                },
+                'ssl.certificate': {
+                  type: 'yaml',
+                  value: null,
+                },
+                'ssl.certificate_authorities': {
+                  type: 'yaml',
+                  value: null,
+                },
+                'ssl.key': {
+                  type: 'yaml',
+                  value: null,
+                },
+                'ssl.key_passphrase': {
+                  type: 'text',
+                  value: null,
+                },
+                'ssl.supported_protocols': {
+                  type: 'yaml',
+                  value: isTLSEnabled ? '["TLSv1.1","TLSv1.2","TLSv1.3"]' : null,
+                },
+                'ssl.verification_mode': {
+                  type: 'text',
+                  value: isTLSEnabled ? 'full' : null,
+                },
+                tags: {
+                  type: 'yaml',
+                  value: null,
+                },
+                timeout: {
+                  type: 'text',
+                  value: '16s',
+                },
+                type: {
+                  type: 'text',
+                  value: 'http',
+                },
+                urls: {
+                  type: 'text',
+                  value: 'https://www.google.com',
+                },
+                username: {
+                  type: 'text',
+                  value: '',
+                },
+              },
+            },
+          ],
+          type: 'synthetics/http',
+        },
+        {
+          enabled: false,
+          policy_template: 'synthetics',
+          streams: [
+            {
+              data_stream: {
+                dataset: 'tcp',
+                type: 'synthetics',
+              },
+              enabled: false,
+              vars: {
+                __ui: {
+                  type: 'yaml',
+                },
+                'check.receive': {
+                  type: 'text',
+                },
+                'check.send': {
+                  type: 'text',
+                },
+                config_id: {
+                  type: 'text',
+                },
+                enabled: {
+                  type: 'bool',
+                  value: true,
+                },
+                hosts: {
+                  type: 'text',
+                },
+                id: {
+                  type: 'text',
+                },
+                location_name: {
+                  type: 'text',
+                  value: 'Fleet managed',
+                },
+                'monitor.project.id': {
+                  type: 'text',
+                },
+                'monitor.project.name': {
+                  type: 'text',
+                },
+                name: {
+                  type: 'text',
+                },
+                origin: {
+                  type: 'text',
+                },
+                proxy_url: {
+                  type: 'text',
+                },
+                proxy_use_local_resolver: {
+                  type: 'bool',
+                  value: false,
+                },
+                run_once: {
+                  type: 'bool',
+                  value: false,
+                },
+                schedule: {
+                  type: 'text',
+                  value: '"@every 3m"',
+                },
+                'service.name': {
+                  type: 'text',
+                },
+                'ssl.certificate': {
+                  type: 'yaml',
+                },
+                'ssl.certificate_authorities': {
+                  type: 'yaml',
+                },
+                'ssl.key': {
+                  type: 'yaml',
+                },
+                'ssl.key_passphrase': {
+                  type: 'text',
+                },
+                'ssl.supported_protocols': {
+                  type: 'yaml',
+                },
+                'ssl.verification_mode': {
+                  type: 'text',
+                },
+                tags: {
+                  type: 'yaml',
+                },
+                timeout: {
+                  type: 'text',
+                },
+                type: {
+                  type: 'text',
+                  value: 'tcp',
+                },
+              },
+            },
+          ],
+          type: 'synthetics/tcp',
+        },
+        {
+          enabled: false,
+          policy_template: 'synthetics',
+          streams: [
+            {
+              data_stream: {
+                dataset: 'icmp',
+                type: 'synthetics',
+              },
+              enabled: false,
+              vars: {
+                __ui: {
+                  type: 'yaml',
+                },
+                config_id: {
+                  type: 'text',
+                },
+                enabled: {
+                  type: 'bool',
+                  value: true,
+                },
+                hosts: {
+                  type: 'text',
+                },
+                id: {
+                  type: 'text',
+                },
+                location_name: {
+                  type: 'text',
+                  value: 'Fleet managed',
+                },
+                'monitor.project.id': {
+                  type: 'text',
+                },
+                'monitor.project.name': {
+                  type: 'text',
+                },
+                name: {
+                  type: 'text',
+                },
+                origin: {
+                  type: 'text',
+                },
+                run_once: {
+                  type: 'bool',
+                  value: false,
+                },
+                schedule: {
+                  type: 'text',
+                  value: '"@every 3m"',
+                },
+                'service.name': {
+                  type: 'text',
+                },
+                tags: {
+                  type: 'yaml',
+                },
+                timeout: {
+                  type: 'text',
+                },
+                type: {
+                  type: 'text',
+                  value: 'icmp',
+                },
+                wait: {
+                  type: 'text',
+                  value: '1s',
+                },
+              },
+            },
+          ],
+          type: 'synthetics/icmp',
+        },
+        {
+          enabled: false,
+          policy_template: 'synthetics',
+          streams: [
+            {
+              data_stream: {
+                dataset: 'browser',
+                type: 'synthetics',
+              },
+              enabled: true,
+              vars: {
+                __ui: {
+                  type: 'yaml',
+                  value:
+                    '{"script_source":{"is_generated_script":false,"file_name":""},"is_zip_url_tls_enabled":false,"is_tls_enabled":false}',
+                },
+                config_id: {
+                  type: 'text',
+                  value: '00bb3ceb-a242-4c7a-8405-8da963661374',
+                },
+                enabled: {
+                  type: 'bool',
+                  value: true,
+                },
+                'filter_journeys.match': {
+                  type: 'text',
+                  value: null,
+                },
+                'filter_journeys.tags': {
+                  type: 'yaml',
+                  value: null,
+                },
+                id: {
+                  type: 'text',
+                  value: '00bb3ceb-a242-4c7a-8405-8da963661374',
+                },
+                ignore_https_errors: {
+                  type: 'bool',
+                  value: false,
+                },
+                location_name: {
+                  type: 'text',
+                  value: 'Test private location 0',
+                },
+                'monitor.project.id': {
+                  type: 'text',
+                },
+                'monitor.project.name': {
+                  type: 'text',
+                },
+                name: {
+                  type: 'text',
+                  value: 'Test HTTP Monitor 03',
+                },
+                origin: {
+                  type: 'text',
+                  value: 'ui',
+                },
+                params: {
+                  type: 'yaml',
+                  value: '',
+                },
+                playwright_options: {
+                  type: 'yaml',
+                  value: '',
+                },
+                run_once: {
+                  type: 'bool',
+                  value: false,
+                },
+                schedule: {
+                  type: 'text',
+                  value: '"@every 3m"',
+                },
+                screenshots: {
+                  type: 'text',
+                  value: 'on',
+                },
+                'service.name': {
+                  type: 'text',
+                  value: '',
+                },
+                'source.inline.script': {
+                  type: 'yaml',
+                  value:
+                    '"step(\\"Visit /users api route\\", async () => {\\\\n  const response = await page.goto(\'https://nextjs-test-synthetics.vercel.app/api/users\');\\\\n  expect(response.status()).toEqual(200);\\\\n});"',
+                },
+                'source.project.content': {
+                  type: 'text',
+                  value: '',
+                },
+                'source.zip_url.folder': {
+                  type: 'text',
+                  value: '',
+                },
+                'source.zip_url.password': {
+                  type: 'password',
+                  value: '',
+                },
+                'source.zip_url.proxy_url': {
+                  type: 'text',
+                  value: '',
+                },
+                'source.zip_url.ssl.certificate': {
+                  type: 'yaml',
+                },
+                'source.zip_url.ssl.certificate_authorities': {
+                  type: 'yaml',
+                },
+                'source.zip_url.ssl.key': {
+                  type: 'yaml',
+                },
+                'source.zip_url.ssl.key_passphrase': {
+                  type: 'text',
+                },
+                'source.zip_url.ssl.supported_protocols': {
+                  type: 'yaml',
+                },
+                'source.zip_url.ssl.verification_mode': {
+                  type: 'text',
+                },
+                'source.zip_url.url': {
+                  type: 'text',
+                  value: '',
+                },
+                'source.zip_url.username': {
+                  type: 'text',
+                  value: '',
+                },
+                synthetics_args: {
+                  type: 'text',
+                  value: null,
+                },
+                tags: {
+                  type: 'yaml',
+                  value: '["cookie-test","browser"]',
+                },
+                'throttling.config': {
+                  type: 'text',
+                  value: '5d/3u/20l',
+                },
+                timeout: {
+                  type: 'text',
+                  value: '16s',
+                },
+                type: {
+                  type: 'text',
+                  value: 'browser',
+                },
+              },
+            },
+            {
+              data_stream: {
+                dataset: 'browser.network',
+                type: 'synthetics',
+              },
+              enabled: true,
+            },
+            {
+              data_stream: {
+                dataset: 'browser.screenshot',
+                type: 'synthetics',
+              },
+              enabled: true,
+            },
+          ],
+          type: 'synthetics/browser',
+        },
+      ],
+      is_managed: true,
+      name: 'Test HTTP Monitor 03-Test private location 0-default',
+      namespace: 'testnamespace',
+      package: {
+        experimental_data_stream_features: [],
+        name: 'synthetics',
+        title: 'Elastic Synthetics',
+        version: '0.11.4',
+      },
+      policy_id: '404812e0-90e1-11ed-8111-f7f9cad30b61',
+    });
+  });
+});
+
+const testNewPolicy = {
+  name: 'Test HTTP Monitor 03-Test private location 0-default',
+  namespace: 'testnamespace',
+  package: {
+    name: 'synthetics',
+    title: 'Elastic Synthetics',
+    version: '0.11.4',
+    experimental_data_stream_features: [],
+  },
+  enabled: true,
+  policy_id: '404812e0-90e1-11ed-8111-f7f9cad30b61',
+  inputs: [
+    {
+      type: 'synthetics/http',
+      policy_template: 'synthetics',
+      enabled: false,
+      streams: [
+        {
+          enabled: false,
+          data_stream: { type: 'synthetics', dataset: 'http' },
+          vars: {
+            __ui: { type: 'yaml' },
+            enabled: { value: true, type: 'bool' },
+            type: { value: 'http', type: 'text' },
+            name: { type: 'text' },
+            schedule: { value: '"@every 3m"', type: 'text' },
+            urls: { type: 'text' },
+            'service.name': { type: 'text' },
+            timeout: { type: 'text' },
+            max_redirects: { type: 'integer' },
+            proxy_url: { type: 'text' },
+            tags: { type: 'yaml' },
+            username: { type: 'text' },
+            password: { type: 'password' },
+            'response.include_headers': { type: 'bool' },
+            'response.include_body': { type: 'text' },
+            'check.request.method': { type: 'text' },
+            'check.request.headers': { type: 'yaml' },
+            'check.request.body': { type: 'yaml' },
+            'check.response.status': { type: 'yaml' },
+            'check.response.headers': { type: 'yaml' },
+            'check.response.body.positive': { type: 'yaml' },
+            'check.response.body.negative': { type: 'yaml' },
+            'ssl.certificate_authorities': { type: 'yaml' },
+            'ssl.certificate': { type: 'yaml' },
+            'ssl.key': { type: 'yaml' },
+            'ssl.key_passphrase': { type: 'text' },
+            'ssl.verification_mode': { type: 'text' },
+            'ssl.supported_protocols': { type: 'yaml' },
+            location_name: { value: 'Fleet managed', type: 'text' },
+            id: { type: 'text' },
+            config_id: { type: 'text' },
+            run_once: { value: false, type: 'bool' },
+            origin: { type: 'text' },
+            'monitor.project.id': { type: 'text' },
+            'monitor.project.name': { type: 'text' },
+          },
+        },
+      ],
+    },
+    {
+      type: 'synthetics/tcp',
+      policy_template: 'synthetics',
+      enabled: false,
+      streams: [
+        {
+          enabled: false,
+          data_stream: { type: 'synthetics', dataset: 'tcp' },
+          vars: {
+            __ui: { type: 'yaml' },
+            enabled: { value: true, type: 'bool' },
+            type: { value: 'tcp', type: 'text' },
+            name: { type: 'text' },
+            schedule: { value: '"@every 3m"', type: 'text' },
+            hosts: { type: 'text' },
+            'service.name': { type: 'text' },
+            timeout: { type: 'text' },
+            proxy_url: { type: 'text' },
+            proxy_use_local_resolver: { value: false, type: 'bool' },
+            tags: { type: 'yaml' },
+            'check.send': { type: 'text' },
+            'check.receive': { type: 'text' },
+            'ssl.certificate_authorities': { type: 'yaml' },
+            'ssl.certificate': { type: 'yaml' },
+            'ssl.key': { type: 'yaml' },
+            'ssl.key_passphrase': { type: 'text' },
+            'ssl.verification_mode': { type: 'text' },
+            'ssl.supported_protocols': { type: 'yaml' },
+            location_name: { value: 'Fleet managed', type: 'text' },
+            id: { type: 'text' },
+            config_id: { type: 'text' },
+            run_once: { value: false, type: 'bool' },
+            origin: { type: 'text' },
+            'monitor.project.id': { type: 'text' },
+            'monitor.project.name': { type: 'text' },
+          },
+        },
+      ],
+    },
+    {
+      type: 'synthetics/icmp',
+      policy_template: 'synthetics',
+      enabled: false,
+      streams: [
+        {
+          enabled: false,
+          data_stream: { type: 'synthetics', dataset: 'icmp' },
+          vars: {
+            __ui: { type: 'yaml' },
+            enabled: { value: true, type: 'bool' },
+            type: { value: 'icmp', type: 'text' },
+            name: { type: 'text' },
+            schedule: { value: '"@every 3m"', type: 'text' },
+            wait: { value: '1s', type: 'text' },
+            hosts: { type: 'text' },
+            'service.name': { type: 'text' },
+            timeout: { type: 'text' },
+            tags: { type: 'yaml' },
+            location_name: { value: 'Fleet managed', type: 'text' },
+            id: { type: 'text' },
+            config_id: { type: 'text' },
+            run_once: { value: false, type: 'bool' },
+            origin: { type: 'text' },
+            'monitor.project.id': { type: 'text' },
+            'monitor.project.name': { type: 'text' },
+          },
+        },
+      ],
+    },
+    {
+      type: 'synthetics/browser',
+      policy_template: 'synthetics',
+      enabled: true,
+      streams: [
+        {
+          enabled: true,
+          data_stream: { type: 'synthetics', dataset: 'browser' },
+          vars: {
+            __ui: { type: 'yaml' },
+            enabled: { value: true, type: 'bool' },
+            type: { value: 'browser', type: 'text' },
+            name: { type: 'text' },
+            schedule: { value: '"@every 3m"', type: 'text' },
+            'service.name': { type: 'text' },
+            timeout: { type: 'text' },
+            tags: { type: 'yaml' },
+            'source.zip_url.url': { type: 'text' },
+            'source.zip_url.username': { type: 'text' },
+            'source.zip_url.folder': { type: 'text' },
+            'source.zip_url.password': { type: 'password' },
+            'source.inline.script': { type: 'yaml' },
+            'source.project.content': { type: 'text' },
+            params: { type: 'yaml' },
+            playwright_options: { type: 'yaml' },
+            screenshots: { type: 'text' },
+            synthetics_args: { type: 'text' },
+            ignore_https_errors: { type: 'bool' },
+            'throttling.config': { type: 'text' },
+            'filter_journeys.tags': { type: 'yaml' },
+            'filter_journeys.match': { type: 'text' },
+            'source.zip_url.ssl.certificate_authorities': { type: 'yaml' },
+            'source.zip_url.ssl.certificate': { type: 'yaml' },
+            'source.zip_url.ssl.key': { type: 'yaml' },
+            'source.zip_url.ssl.key_passphrase': { type: 'text' },
+            'source.zip_url.ssl.verification_mode': { type: 'text' },
+            'source.zip_url.ssl.supported_protocols': { type: 'yaml' },
+            'source.zip_url.proxy_url': { type: 'text' },
+            location_name: { value: 'Fleet managed', type: 'text' },
+            id: { type: 'text' },
+            config_id: { type: 'text' },
+            run_once: { value: false, type: 'bool' },
+            origin: { type: 'text' },
+            'monitor.project.id': { type: 'text' },
+            'monitor.project.name': { type: 'text' },
+          },
+        },
+        { enabled: true, data_stream: { type: 'synthetics', dataset: 'browser.network' } },
+        { enabled: true, data_stream: { type: 'synthetics', dataset: 'browser.screenshot' } },
+      ],
+    },
+  ],
+  is_managed: true,
+};
+
+const browserConfig: any = {
+  type: 'browser',
+  form_monitor_type: 'multistep',
+  enabled: true,
+  alert: { status: { enabled: true } },
+  schedule: { number: '3', unit: 'm' },
+  'service.name': '',
+  config_id: '00bb3ceb-a242-4c7a-8405-8da963661374',
+  tags: ['cookie-test', 'browser'],
+  timeout: '16',
+  name: 'Test HTTP Monitor 03',
+  locations: [
+    {
+      id: '404812e0-90e1-11ed-8111-f7f9cad30b61',
+      label: 'Test private location 0',
+      isServiceManaged: false,
+    },
+  ],
+  namespace: 'testnamespace',
+  origin: 'ui',
+  journey_id: '',
+  hash: '',
+  id: '00bb3ceb-a242-4c7a-8405-8da963661374',
+  project_id: '',
+  playwright_options: '',
+  __ui: {
+    script_source: { is_generated_script: false, file_name: '' },
+    is_zip_url_tls_enabled: false,
+    is_tls_enabled: false,
+  },
+  params: '',
+  'url.port': null,
+  'source.inline.script':
+    'step("Visit /users api route", async () => {\\n  const response = await page.goto(\'https://nextjs-test-synthetics.vercel.app/api/users\');\\n  expect(response.status()).toEqual(200);\\n});',
+  'source.project.content': '',
+  'source.zip_url.url': '',
+  'source.zip_url.username': '',
+  'source.zip_url.password': '',
+  'source.zip_url.folder': '',
+  'source.zip_url.proxy_url': '',
+  playwright_text_assertion: '',
+  urls: '',
+  screenshots: 'on',
+  synthetics_args: [],
+  'filter_journeys.match': '',
+  'filter_journeys.tags': [],
+  ignore_https_errors: false,
+  'throttling.is_enabled': true,
+  'throttling.download_speed': '5',
+  'throttling.upload_speed': '3',
+  'throttling.latency': '20',
+  'throttling.config': '5d/3u/20l',
+  'ssl.certificate_authorities': '',
+  'ssl.certificate': '',
+  'ssl.key': '',
+  'ssl.key_passphrase': '',
+  'ssl.verification_mode': 'full',
+  'ssl.supported_protocols': ['TLSv1.1', 'TLSv1.2', 'TLSv1.3'],
+  revision: 1,
+  fields: { config_id: '00bb3ceb-a242-4c7a-8405-8da963661374' },
+  fields_under_root: true,
+  location_name: 'Test private location 0',
+};
+
+const httpPolicy: any = {
+  type: 'http',
+  form_monitor_type: 'http',
+  enabled: true,
+  alert: { status: { enabled: true } },
+  schedule: { number: '3', unit: 'm' },
+  'service.name': 'LocalService',
+  config_id: '51ccd9d9-fc3f-4718-ba9d-b6ef80e73fc5',
+  tags: [],
+  timeout: '16',
+  name: 'Test Monitor',
+  locations: [
+    {
+      id: '404812e0-90e1-11ed-8111-f7f9cad30b61',
+      label: 'Test private location 0',
+      geo: { lat: '', lon: '' },
+      isServiceManaged: false,
+    },
+  ],
+  namespace: 'default',
+  origin: 'ui',
+  journey_id: '',
+  hash: '',
+  id: '51ccd9d9-fc3f-4718-ba9d-b6ef80e73fc5',
+  __ui: { is_tls_enabled: false },
+  urls: 'https://www.google.com',
+  max_redirects: '0',
+  'url.port': null,
+  password: 'changeme',
+  proxy_url: '',
+  'check.response.body.negative': [],
+  'check.response.body.positive': [],
+  'response.include_body': 'on_error',
+  'check.response.headers': {},
+  'response.include_headers': true,
+  'check.response.status': [],
+  'check.request.body': { type: 'text', value: '' },
+  'check.request.headers': {},
+  'check.request.method': 'GET',
+  username: '',
+  'ssl.certificate_authorities': '',
+  'ssl.certificate': '',
+  'ssl.key': '',
+  'ssl.key_passphrase': '',
+  'ssl.verification_mode': 'full',
+  'ssl.supported_protocols': ['TLSv1.1', 'TLSv1.2', 'TLSv1.3'],
+  fields: { config_id: '51ccd9d9-fc3f-4718-ba9d-b6ef80e73fc5' },
+  fields_under_root: true,
+  params: '',
+  location_name: 'Test private location 0',
+};

--- a/x-pack/plugins/synthetics/common/formatters/tls/formatters.ts
+++ b/x-pack/plugins/synthetics/common/formatters/tls/formatters.ts
@@ -4,29 +4,43 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { TLSFields, ConfigKey } from '../../runtime_types/monitor_management';
+import { TLSFields, TLSVersion, ConfigKey } from '../../runtime_types/monitor_management';
 import { Formatter } from '../common/formatters';
 
 type TLSFormatMap = Record<keyof TLSFields, Formatter>;
 
 export const tlsFormatters: TLSFormatMap = {
   [ConfigKey.TLS_CERTIFICATE_AUTHORITIES]: (fields) =>
-    tlsValueToYamlFormatter(fields[ConfigKey.TLS_CERTIFICATE_AUTHORITIES]),
+    fields[ConfigKey.METADATA]?.is_tls_enabled
+      ? tlsValueToYamlFormatter(fields[ConfigKey.TLS_CERTIFICATE_AUTHORITIES])
+      : null,
   [ConfigKey.TLS_CERTIFICATE]: (fields) =>
-    tlsValueToYamlFormatter(fields[ConfigKey.TLS_CERTIFICATE]),
-  [ConfigKey.TLS_KEY]: (fields) => tlsValueToYamlFormatter(fields[ConfigKey.TLS_KEY]),
+    fields[ConfigKey.METADATA]?.is_tls_enabled
+      ? tlsValueToYamlFormatter(fields[ConfigKey.TLS_CERTIFICATE])
+      : null,
+  [ConfigKey.TLS_KEY]: (fields) =>
+    fields[ConfigKey.METADATA]?.is_tls_enabled
+      ? tlsValueToYamlFormatter(fields[ConfigKey.TLS_KEY])
+      : null,
   [ConfigKey.TLS_KEY_PASSPHRASE]: (fields) =>
-    tlsValueToStringFormatter(fields[ConfigKey.TLS_KEY_PASSPHRASE]),
+    fields[ConfigKey.METADATA]?.is_tls_enabled
+      ? tlsValueToStringFormatter(fields[ConfigKey.TLS_KEY_PASSPHRASE])
+      : null,
   [ConfigKey.TLS_VERIFICATION_MODE]: (fields) =>
-    tlsValueToStringFormatter(fields[ConfigKey.TLS_VERIFICATION_MODE]),
-  [ConfigKey.TLS_VERSION]: (fields) => tlsArrayToYamlFormatter(fields[ConfigKey.TLS_VERSION]),
+    fields[ConfigKey.METADATA]?.is_tls_enabled
+      ? tlsValueToStringFormatter(fields[ConfigKey.TLS_VERIFICATION_MODE])
+      : null,
+  [ConfigKey.TLS_VERSION]: (fields) =>
+    fields[ConfigKey.METADATA]?.is_tls_enabled
+      ? tlsArrayToYamlFormatter(fields[ConfigKey.TLS_VERSION])
+      : null,
 };
 
 // only add tls settings if they are enabled by the user and isEnabled is true
-export const tlsValueToYamlFormatter = (tlsValue: string = '') =>
+export const tlsValueToYamlFormatter = (tlsValue: string | null = '') =>
   tlsValue ? JSON.stringify(tlsValue) : null;
 
-export const tlsValueToStringFormatter = (tlsValue: string = '') => tlsValue || null;
+export const tlsValueToStringFormatter = (tlsValue: string | null = '') => tlsValue || null;
 
-export const tlsArrayToYamlFormatter = (tlsValue: string[] = []) =>
-  tlsValue.length ? JSON.stringify(tlsValue) : null;
+export const tlsArrayToYamlFormatter = (tlsValue: TLSVersion[] | null = []) =>
+  tlsValue?.length ? JSON.stringify(tlsValue) : null;

--- a/x-pack/plugins/synthetics/public/legacy_uptime/components/fleet_package/hooks/use_update_policy.test.tsx
+++ b/x-pack/plugins/synthetics/public/legacy_uptime/components/fleet_package/hooks/use_update_policy.test.tsx
@@ -23,7 +23,7 @@ import {
 } from '../types';
 import { defaultConfig } from '../synthetics_policy_create_extension';
 
-describe('useBarChartsHooks', () => {
+describe('useUpdatePolicy', () => {
   const newPolicy: NewPackagePolicy = {
     name: '',
     description: '',
@@ -433,6 +433,9 @@ describe('useBarChartsHooks', () => {
       ...initialProps,
       config: {
         ...defaultConfig[DataStream.HTTP],
+        [ConfigKey.METADATA]: {
+          is_tls_enabled: true,
+        },
         [ConfigKey.RESPONSE_BODY_CHECK_POSITIVE]: ['test'],
         [ConfigKey.RESPONSE_BODY_CHECK_NEGATIVE]: ['test'],
         [ConfigKey.RESPONSE_STATUS_CHECK]: ['test'],

--- a/x-pack/plugins/synthetics/server/synthetics_service/project_monitor/normalizers/common_fields.ts
+++ b/x-pack/plugins/synthetics/server/synthetics_service/project_monitor/normalizers/common_fields.ts
@@ -51,7 +51,6 @@ export const getNormalizeCommonFields = ({
   namespace,
 }: NormalizedProjectProps): Partial<CommonFields> => {
   const defaultFields = DEFAULT_COMMON_FIELDS;
-
   const normalizedFields = {
     [ConfigKey.JOURNEY_ID]: monitor.id || defaultFields[ConfigKey.JOURNEY_ID],
     [ConfigKey.MONITOR_SOURCE_TYPE]: SourceType.PROJECT,
@@ -231,3 +230,7 @@ export const normalizeYamlConfig = (monitor: NormalizedProjectProps['monitor']) 
     unsupportedKeys,
   };
 };
+
+// returns true when any ssl fields are defined
+export const getHasTLSFields = (monitor: ProjectMonitor) =>
+  Object.keys(monitor).some((key) => key.includes('ssl'));

--- a/x-pack/plugins/synthetics/server/synthetics_service/project_monitor/normalizers/http_monitor.test.ts
+++ b/x-pack/plugins/synthetics/server/synthetics_service/project_monitor/normalizers/http_monitor.test.ts
@@ -270,9 +270,9 @@ describe('http normalizers', () => {
           errors: [
             {
               details:
-                '`http` project monitors must have exactly one value for field `urls` in version `8.5.0`. Your monitor was not created or updated.',
+                'Multiple urls are not supported for http project monitors in 8.5.0. Please set only 1 url per monitor. You monitor was not created or updated.',
               id: 'my-monitor-2',
-              reason: 'Invalid Heartbeat configuration',
+              reason: 'Unsupported Heartbeat option',
             },
             {
               details:

--- a/x-pack/plugins/synthetics/server/synthetics_service/project_monitor/normalizers/http_monitor.test.ts
+++ b/x-pack/plugins/synthetics/server/synthetics_service/project_monitor/normalizers/http_monitor.test.ts
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-
+import { omit } from 'lodash';
 import {
   DataStream,
   Locations,
@@ -144,7 +144,147 @@ describe('http normalizers', () => {
           normalizedFields: {
             ...DEFAULT_FIELDS[DataStream.HTTP],
             __ui: {
-              is_tls_enabled: false,
+              is_tls_enabled: true,
+            },
+            'check.request.body': {
+              type: 'json',
+              value: '{"json":"body"}',
+            },
+            'check.request.headers': {
+              'a-header': 'a-header-value',
+            },
+            'check.request.method': 'POST',
+            'check.response.body.negative': [],
+            'check.response.body.positive': [],
+            'check.response.headers': {},
+            'check.response.status': ['200'],
+            config_id: '',
+            custom_heartbeat_id: 'my-monitor-2-test-project-id-test-space',
+            enabled: false,
+            form_monitor_type: 'http',
+            journey_id: 'my-monitor-2',
+            locations: [],
+            max_redirects: '0',
+            name: 'My Monitor 2',
+            namespace: 'test_space',
+            origin: 'project',
+            original_space: 'test-space',
+            password: '',
+            project_id: 'test-project-id',
+            proxy_url: '',
+            'response.include_body': 'always',
+            'response.include_headers': false,
+            schedule: {
+              number: '60',
+              unit: 'm',
+            },
+            'service.name': 'test service',
+            'ssl.certificate': '',
+            'ssl.certificate_authorities': '',
+            'ssl.key': '',
+            'ssl.key_passphrase': '',
+            'ssl.supported_protocols': ['TLSv1.2', 'TLSv1.3'],
+            'ssl.verification_mode': 'full',
+            tags: [],
+            timeout: '80',
+            type: 'http',
+            urls: 'http://localhost:9200',
+            'url.port': null,
+            username: '',
+            id: '',
+            hash: testHash,
+          },
+          unsupportedKeys: ['check.response.body', 'unsupportedKey.nestedUnsupportedKey'],
+        },
+        {
+          errors: [],
+          normalizedFields: {
+            ...DEFAULT_FIELDS[DataStream.HTTP],
+            __ui: {
+              is_tls_enabled: true,
+            },
+            'check.request.body': {
+              type: 'text',
+              value: 'sometextbody',
+            },
+            'check.request.headers': {
+              'a-header': 'a-header-value',
+            },
+            'check.request.method': 'POST',
+            'check.response.body.negative': [],
+            'check.response.body.positive': ['Saved', 'saved'],
+            'check.response.headers': {},
+            'check.response.status': ['200'],
+            config_id: '',
+            custom_heartbeat_id: 'my-monitor-3-test-project-id-test-space',
+            enabled: false,
+            form_monitor_type: 'http',
+            journey_id: 'my-monitor-3',
+            locations: [],
+            max_redirects: '0',
+            name: 'My Monitor 3',
+            namespace: 'test_space',
+            origin: 'project',
+            original_space: 'test-space',
+            password: '',
+            project_id: 'test-project-id',
+            proxy_url: '',
+            'response.include_body': 'always',
+            'response.include_headers': false,
+            schedule: {
+              number: '60',
+              unit: 'm',
+            },
+            'service.name': 'test service',
+            'ssl.certificate': '',
+            'ssl.certificate_authorities': '',
+            'ssl.key': '',
+            'ssl.key_passphrase': '',
+            'ssl.supported_protocols': ['TLSv1.2', 'TLSv1.3'],
+            'ssl.verification_mode': 'full',
+            tags: ['tag2', 'tag2'],
+            timeout: '80',
+            type: 'http',
+            urls: 'http://localhost:9200',
+            'url.port': null,
+            username: '',
+            id: '',
+            hash: testHash,
+          },
+          unsupportedKeys: [],
+        },
+      ]);
+    });
+
+    it('sets is_tls_enabled appropriately', () => {
+      const actual = normalizeProjectMonitors({
+        locations,
+        privateLocations,
+        monitors: [monitors[0], { ...omit(monitors[1], ['ssl.supported_protocols']) }],
+        projectId,
+        namespace: 'test-space',
+        version: '8.5.0',
+      });
+      expect(actual).toEqual([
+        {
+          errors: [
+            {
+              details:
+                '`http` project monitors must have exactly one value for field `urls` in version `8.5.0`. Your monitor was not created or updated.',
+              id: 'my-monitor-2',
+              reason: 'Invalid Heartbeat configuration',
+            },
+            {
+              details:
+                'The following Heartbeat options are not supported for http project monitors in 8.5.0: check.response.body|unsupportedKey.nestedUnsupportedKey. You monitor was not created or updated.',
+              id: 'my-monitor-2',
+              reason: 'Unsupported Heartbeat option',
+            },
+          ],
+          normalizedFields: {
+            ...DEFAULT_FIELDS[DataStream.HTTP],
+            __ui: {
+              is_tls_enabled: true,
             },
             'check.request.body': {
               type: 'json',
@@ -240,7 +380,7 @@ describe('http normalizers', () => {
             'ssl.certificate_authorities': '',
             'ssl.key': '',
             'ssl.key_passphrase': '',
-            'ssl.supported_protocols': ['TLSv1.2', 'TLSv1.3'],
+            'ssl.supported_protocols': ['TLSv1.1', 'TLSv1.2', 'TLSv1.3'],
             'ssl.verification_mode': 'full',
             tags: ['tag2', 'tag2'],
             timeout: '80',

--- a/x-pack/plugins/synthetics/server/synthetics_service/project_monitor/normalizers/http_monitor.ts
+++ b/x-pack/plugins/synthetics/server/synthetics_service/project_monitor/normalizers/http_monitor.ts
@@ -23,6 +23,7 @@ import {
   getOptionalArrayField,
   getUnsupportedKeysError,
   getMultipleUrlsOrHostsError,
+  getHasTLSFields,
 } from './common_fields';
 
 export const getNormalizeHTTPFields = ({
@@ -70,7 +71,12 @@ export const getNormalizeHTTPFields = ({
     [ConfigKey.TLS_VERSION]: get(monitor, ConfigKey.TLS_VERSION)
       ? (getOptionalListField(get(monitor, ConfigKey.TLS_VERSION)) as TLSVersion[])
       : defaultFields[ConfigKey.TLS_VERSION],
+    [ConfigKey.METADATA]: {
+      ...DEFAULT_FIELDS[DataStream.HTTP][ConfigKey.METADATA],
+      is_tls_enabled: getHasTLSFields(monitor),
+    },
   };
+
   return {
     normalizedFields: {
       ...defaultFields,

--- a/x-pack/plugins/synthetics/server/synthetics_service/project_monitor/normalizers/tcp_monitor.test.ts
+++ b/x-pack/plugins/synthetics/server/synthetics_service/project_monitor/normalizers/tcp_monitor.test.ts
@@ -215,9 +215,9 @@ describe('tcp normalizers', () => {
           errors: [
             {
               details:
-                '`tcp` project monitors must have exactly one value for field `hosts` in version `8.5.0`. Your monitor was not created or updated.',
+                'Multiple hosts are not supported for tcp project monitors in 8.5.0. Please set only 1 host per monitor. You monitor was not created or updated.',
               id: 'always-down',
-              reason: 'Invalid Heartbeat configuration',
+              reason: 'Unsupported Heartbeat option',
             },
             {
               details:

--- a/x-pack/plugins/synthetics/server/synthetics_service/project_monitor/normalizers/tcp_monitor.test.ts
+++ b/x-pack/plugins/synthetics/server/synthetics_service/project_monitor/normalizers/tcp_monitor.test.ts
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-
+import { omit } from 'lodash';
 import {
   DataStream,
   Locations,
@@ -108,7 +108,7 @@ describe('tcp normalizers', () => {
           normalizedFields: {
             ...DEFAULT_FIELDS[DataStream.TCP],
             __ui: {
-              is_tls_enabled: false,
+              is_tls_enabled: true,
             },
             'check.receive': '',
             'check.send': '',
@@ -162,7 +162,195 @@ describe('tcp normalizers', () => {
           normalizedFields: {
             ...DEFAULT_FIELDS[DataStream.TCP],
             __ui: {
+              is_tls_enabled: true,
+            },
+            'check.receive': '',
+            'check.send': '',
+            config_id: '',
+            custom_heartbeat_id: 'always-down-test-project-id-test-space',
+            enabled: true,
+            form_monitor_type: 'tcp',
+            hosts: 'localhost:18278',
+            'url.port': null,
+            journey_id: 'always-down',
+            locations: [
+              {
+                geo: {
+                  lat: 33.333,
+                  lon: 73.333,
+                },
+                id: 'us_central',
+                isServiceManaged: true,
+                label: 'Test Location',
+              },
+            ],
+            name: 'Always Down',
+            namespace: 'test_space',
+            origin: 'project',
+            original_space: 'test-space',
+            project_id: 'test-project-id',
+            proxy_url: '',
+            proxy_use_local_resolver: false,
+            schedule: {
+              number: '1',
+              unit: 'm',
+            },
+            'service.name': 'test service',
+            'ssl.certificate': '',
+            'ssl.certificate_authorities': '',
+            'ssl.key': '',
+            'ssl.key_passphrase': '',
+            'ssl.supported_protocols': ['TLSv1.2', 'TLSv1.3'],
+            'ssl.verification_mode': 'full',
+            tags: ['tag1', 'tag2'],
+            timeout: '16',
+            type: 'tcp',
+            id: '',
+            urls: '',
+            hash: testHash,
+          },
+          unsupportedKeys: [],
+        },
+        {
+          errors: [
+            {
+              details:
+                '`tcp` project monitors must have exactly one value for field `hosts` in version `8.5.0`. Your monitor was not created or updated.',
+              id: 'always-down',
+              reason: 'Invalid Heartbeat configuration',
+            },
+            {
+              details:
+                'The following Heartbeat options are not supported for tcp project monitors in 8.5.0: ports|unsupportedKey.nestedUnsupportedKey. You monitor was not created or updated.',
+              id: 'always-down',
+              reason: 'Unsupported Heartbeat option',
+            },
+          ],
+          normalizedFields: {
+            ...DEFAULT_FIELDS[DataStream.TCP],
+            __ui: {
               is_tls_enabled: false,
+            },
+            'check.receive': '',
+            'check.send': '',
+            config_id: '',
+            custom_heartbeat_id: 'always-down-test-project-id-test-space',
+            enabled: true,
+            form_monitor_type: 'tcp',
+            hosts: 'localhost',
+            'url.port': null,
+            journey_id: 'always-down',
+            locations: [
+              {
+                geo: {
+                  lat: 33.333,
+                  lon: 73.333,
+                },
+                id: 'us_central',
+                isServiceManaged: true,
+                label: 'Test Location',
+              },
+            ],
+            name: 'Always Down',
+            namespace: 'test_space',
+            origin: 'project',
+            original_space: 'test-space',
+            project_id: 'test-project-id',
+            proxy_url: '',
+            proxy_use_local_resolver: false,
+            schedule: {
+              number: '1',
+              unit: 'm',
+            },
+            'service.name': '',
+            'ssl.certificate': '',
+            'ssl.certificate_authorities': '',
+            'ssl.key': '',
+            'ssl.key_passphrase': '',
+            'ssl.supported_protocols': ['TLSv1.1', 'TLSv1.2', 'TLSv1.3'],
+            'ssl.verification_mode': 'full',
+            tags: ['tag1', 'tag2'],
+            timeout: '16',
+            type: 'tcp',
+            id: '',
+            urls: '',
+            hash: testHash,
+          },
+          unsupportedKeys: ['ports', 'unsupportedKey.nestedUnsupportedKey'],
+        },
+      ]);
+    });
+
+    it('sets is_tls_enabled appropriately', () => {
+      const actual = normalizeProjectMonitors({
+        locations,
+        privateLocations,
+        monitors: [monitors[0], monitors[1], { ...omit(monitors[2], ['ssl.supported_protocols']) }],
+        projectId,
+        namespace: 'test-space',
+        version: '8.5.0',
+      });
+      expect(actual).toEqual([
+        {
+          errors: [],
+          normalizedFields: {
+            ...DEFAULT_FIELDS[DataStream.TCP],
+            __ui: {
+              is_tls_enabled: true,
+            },
+            'check.receive': '',
+            'check.send': '',
+            config_id: '',
+            custom_heartbeat_id: 'gmail-smtp-test-project-id-test-space',
+            enabled: true,
+            form_monitor_type: 'tcp',
+            hosts: 'smtp.gmail.com:587',
+            'url.port': null,
+            journey_id: 'gmail-smtp',
+            locations: [
+              {
+                geo: {
+                  lat: 33.333,
+                  lon: 73.333,
+                },
+                id: 'us_central',
+                isServiceManaged: true,
+                label: 'Test Location',
+              },
+            ],
+            name: 'GMail SMTP',
+            namespace: 'test_space',
+            origin: 'project',
+            original_space: 'test-space',
+            project_id: 'test-project-id',
+            proxy_url: '',
+            proxy_use_local_resolver: false,
+            schedule: {
+              number: '1',
+              unit: 'm',
+            },
+            'service.name': 'test service',
+            'ssl.certificate': '',
+            'ssl.certificate_authorities': '',
+            'ssl.key': '',
+            'ssl.key_passphrase': '',
+            'ssl.supported_protocols': ['TLSv1.2', 'TLSv1.3'],
+            'ssl.verification_mode': 'full',
+            tags: ['service:smtp', 'org:google'],
+            timeout: '16',
+            type: 'tcp',
+            id: '',
+            urls: '',
+            hash: testHash,
+          },
+          unsupportedKeys: [],
+        },
+        {
+          errors: [],
+          normalizedFields: {
+            ...DEFAULT_FIELDS[DataStream.TCP],
+            __ui: {
+              is_tls_enabled: true,
             },
             'check.receive': '',
             'check.send': '',

--- a/x-pack/plugins/synthetics/server/synthetics_service/project_monitor/normalizers/tcp_monitor.ts
+++ b/x-pack/plugins/synthetics/server/synthetics_service/project_monitor/normalizers/tcp_monitor.ts
@@ -22,6 +22,7 @@ import {
   getOptionalListField,
   getMultipleUrlsOrHostsError,
   getUnsupportedKeysError,
+  getHasTLSFields,
 } from './common_fields';
 
 export const getNormalizeTCPFields = ({
@@ -65,6 +66,10 @@ export const getNormalizeTCPFields = ({
     [ConfigKey.TLS_VERSION]: get(monitor, ConfigKey.TLS_VERSION)
       ? (getOptionalListField(get(monitor, ConfigKey.TLS_VERSION)) as TLSVersion[])
       : defaultFields[ConfigKey.TLS_VERSION],
+    [ConfigKey.METADATA]: {
+      ...DEFAULT_FIELDS[DataStream.TCP][ConfigKey.METADATA],
+      is_tls_enabled: getHasTLSFields(monitor),
+    },
   };
   return {
     normalizedFields: {

--- a/x-pack/test/api_integration/apis/synthetics/add_monitor_private_location.ts
+++ b/x-pack/test/api_integration/apis/synthetics/add_monitor_private_location.ts
@@ -34,6 +34,7 @@ export default function ({ getService }: FtrProviderContext) {
     const security = getService('security');
 
     before(async () => {
+      await supertestAPI.post(API_URLS.SYNTHETICS_ENABLEMENT).set('kbn-xsrf', 'true').expect(200);
       await supertestAPI.post('/api/fleet/setup').set('kbn-xsrf', 'true').send().expect(200);
       await supertestAPI
         .post('/api/fleet/epm/packages/synthetics/0.10.3')

--- a/x-pack/test/api_integration/apis/synthetics/add_monitor_private_location.ts
+++ b/x-pack/test/api_integration/apis/synthetics/add_monitor_private_location.ts
@@ -99,7 +99,8 @@ export default function ({ getService }: FtrProviderContext) {
       const apiResponse = await supertestAPI
         .post(API_URLS.SYNTHETICS_MONITORS)
         .set('kbn-xsrf', 'true')
-        .send(newMonitor);
+        .send(newMonitor)
+        .expect(200);
 
       expect(apiResponse.body.attributes).eql(
         omit(
@@ -329,6 +330,97 @@ export default function ({ getService }: FtrProviderContext) {
       }
     });
 
+    it('handles is_tls_enabled true', async () => {
+      let monitorId = '';
+
+      const monitor = {
+        ...httpMonitorJson,
+        locations: [
+          {
+            id: testFleetPolicyID,
+            label: 'Test private location 0',
+            isServiceManaged: false,
+          },
+        ],
+        [ConfigKey.METADATA]: {
+          is_tls_enabled: true,
+        },
+      };
+
+      try {
+        const apiResponse = await supertestAPI
+          .post(API_URLS.SYNTHETICS_MONITORS)
+          .set('kbn-xsrf', 'true')
+          .send(monitor)
+          .expect(200);
+
+        monitorId = apiResponse.body.id;
+
+        const policyResponse = await supertestAPI.get(
+          '/api/fleet/package_policies?page=1&perPage=2000&kuery=ingest-package-policies.package.name%3A%20synthetics'
+        );
+
+        const packagePolicy = policyResponse.body.items.find(
+          (pkgPolicy: PackagePolicy) =>
+            pkgPolicy.id === monitorId + '-' + testFleetPolicyID + `-default`
+        );
+        comparePolicies(
+          packagePolicy,
+          getTestSyntheticsPolicy(monitor.name, monitorId, undefined, undefined, true)
+        );
+      } finally {
+        await supertestAPI
+          .delete(API_URLS.SYNTHETICS_MONITORS + '/' + monitorId)
+          .set('kbn-xsrf', 'true')
+          .send()
+          .expect(200);
+      }
+    });
+
+    it('handles is_tls_enabled false', async () => {
+      let monitorId = '';
+
+      const monitor = {
+        ...httpMonitorJson,
+        locations: [
+          {
+            id: testFleetPolicyID,
+            label: 'Test private location 0',
+            isServiceManaged: false,
+          },
+        ],
+        [ConfigKey.METADATA]: {
+          is_tls_enabled: false,
+        },
+      };
+
+      try {
+        const apiResponse = await supertestAPI
+          .post(API_URLS.SYNTHETICS_MONITORS)
+          .set('kbn-xsrf', 'true')
+          .send(monitor)
+          .expect(200);
+
+        monitorId = apiResponse.body.id;
+
+        const policyResponse = await supertestAPI.get(
+          '/api/fleet/package_policies?page=1&perPage=2000&kuery=ingest-package-policies.package.name%3A%20synthetics'
+        );
+
+        const packagePolicy = policyResponse.body.items.find(
+          (pkgPolicy: PackagePolicy) =>
+            pkgPolicy.id === monitorId + '-' + testFleetPolicyID + `-default`
+        );
+        comparePolicies(packagePolicy, getTestSyntheticsPolicy(monitor.name, monitorId));
+      } finally {
+        await supertestAPI
+          .delete(API_URLS.SYNTHETICS_MONITORS + '/' + monitorId)
+          .set('kbn-xsrf', 'true')
+          .send()
+          .expect(200);
+      }
+    });
+
     it('handles auto upgrading policies', async () => {
       let monitorId = '';
 
@@ -349,8 +441,8 @@ export default function ({ getService }: FtrProviderContext) {
         const apiResponse = await supertestAPI
           .post(API_URLS.SYNTHETICS_MONITORS)
           .set('kbn-xsrf', 'true')
-          .send(monitor);
-
+          .send(monitor)
+          .expect(200);
         monitorId = apiResponse.body.id;
 
         const policyResponse = await supertestAPI.get(

--- a/x-pack/test/api_integration/apis/synthetics/add_monitor_project.ts
+++ b/x-pack/test/api_integration/apis/synthetics/add_monitor_project.ts
@@ -72,6 +72,7 @@ export default function ({ getService }: FtrProviderContext) {
     };
 
     before(async () => {
+      await supertest.post(API_URLS.SYNTHETICS_ENABLEMENT).set('kbn-xsrf', 'true').expect(200);
       await supertest.post('/api/fleet/setup').set('kbn-xsrf', 'true').send().expect(200);
       await supertest
         .post('/api/fleet/epm/packages/synthetics/0.10.3')
@@ -283,6 +284,7 @@ export default function ({ getService }: FtrProviderContext) {
 
         for (const monitor of successfulMonitors) {
           const journeyId = monitor.id;
+          const isTLSEnabled = Object.keys(monitor).some((key) => key.includes('ssl'));
           const createdMonitorsResponse = await supertest
             .get(API_URLS.SYNTHETICS_MONITORS)
             .query({ filter: `${syntheticsMonitorType}.attributes.journey_id: ${journeyId}` })
@@ -296,7 +298,7 @@ export default function ({ getService }: FtrProviderContext) {
 
           expect(decryptedCreatedMonitor.body.attributes).to.eql({
             __ui: {
-              is_tls_enabled: false,
+              is_tls_enabled: isTLSEnabled,
             },
             'check.request.method': 'POST',
             'check.response.status': ['200'],
@@ -346,7 +348,7 @@ export default function ({ getService }: FtrProviderContext) {
             'ssl.certificate': '',
             'ssl.certificate_authorities': '',
             'ssl.supported_protocols': ['TLSv1.1', 'TLSv1.2', 'TLSv1.3'],
-            'ssl.verification_mode': 'full',
+            'ssl.verification_mode': isTLSEnabled ? 'strict' : 'full',
             'ssl.key': '',
             'ssl.key_passphrase': '',
             tags: Array.isArray(monitor.tags) ? monitor.tags : monitor.tags?.split(','),
@@ -398,6 +400,7 @@ export default function ({ getService }: FtrProviderContext) {
 
         for (const monitor of successfulMonitors) {
           const journeyId = monitor.id;
+          const isTLSEnabled = Object.keys(monitor).some((key) => key.includes('ssl'));
           const createdMonitorsResponse = await supertest
             .get(API_URLS.SYNTHETICS_MONITORS)
             .query({ filter: `${syntheticsMonitorType}.attributes.journey_id: ${journeyId}` })
@@ -411,7 +414,7 @@ export default function ({ getService }: FtrProviderContext) {
 
           expect(decryptedCreatedMonitor.body.attributes).to.eql({
             __ui: {
-              is_tls_enabled: false,
+              is_tls_enabled: isTLSEnabled,
             },
             config_id: decryptedCreatedMonitor.body.id,
             custom_heartbeat_id: `${journeyId}-${project}-default`,
@@ -447,7 +450,7 @@ export default function ({ getService }: FtrProviderContext) {
             'ssl.certificate': '',
             'ssl.certificate_authorities': '',
             'ssl.supported_protocols': ['TLSv1.1', 'TLSv1.2', 'TLSv1.3'],
-            'ssl.verification_mode': 'full',
+            'ssl.verification_mode': isTLSEnabled ? 'strict' : 'full',
             'ssl.key': '',
             'ssl.key_passphrase': '',
             tags: Array.isArray(monitor.tags) ? monitor.tags : monitor.tags?.split(','),
@@ -1543,6 +1546,7 @@ export default function ({ getService }: FtrProviderContext) {
                 type: 'http',
                 tags: 'tag2,tag2',
                 urls: ['http://localhost:9200'],
+                'ssl.verification_mode': 'strict',
               },
               reason: 'Cannot update monitor to different type.',
             },

--- a/x-pack/test/api_integration/apis/synthetics/add_monitor_project_legacy.ts
+++ b/x-pack/test/api_integration/apis/synthetics/add_monitor_project_legacy.ts
@@ -237,6 +237,7 @@ export default function ({ getService }: FtrProviderContext) {
 
         for (const monitor of successfulMonitors) {
           const journeyId = monitor.id;
+          const isTLSEnabled = Object.keys(monitor).some((key) => key.includes('ssl'));
           const createdMonitorsResponse = await supertest
             .get(API_URLS.SYNTHETICS_MONITORS)
             .query({ filter: `${syntheticsMonitorType}.attributes.journey_id: ${journeyId}` })
@@ -250,7 +251,7 @@ export default function ({ getService }: FtrProviderContext) {
 
           expect(decryptedCreatedMonitor.body.attributes).to.eql({
             __ui: {
-              is_tls_enabled: false,
+              is_tls_enabled: isTLSEnabled,
             },
             'check.request.method': 'POST',
             'check.response.status': ['200'],
@@ -300,7 +301,7 @@ export default function ({ getService }: FtrProviderContext) {
             'ssl.certificate': '',
             'ssl.certificate_authorities': '',
             'ssl.supported_protocols': ['TLSv1.1', 'TLSv1.2', 'TLSv1.3'],
-            'ssl.verification_mode': 'full',
+            'ssl.verification_mode': isTLSEnabled ? 'strict' : 'full',
             'ssl.key': '',
             'ssl.key_passphrase': '',
             tags: Array.isArray(monitor.tags) ? monitor.tags : monitor.tags?.split(','),
@@ -349,6 +350,7 @@ export default function ({ getService }: FtrProviderContext) {
 
         for (const monitor of successfulMonitors) {
           const journeyId = monitor.id;
+          const isTLSEnabled = Object.keys(monitor).some((key) => key.includes('ssl'));
           const createdMonitorsResponse = await supertest
             .get(API_URLS.SYNTHETICS_MONITORS)
             .query({ filter: `${syntheticsMonitorType}.attributes.journey_id: ${journeyId}` })
@@ -362,7 +364,7 @@ export default function ({ getService }: FtrProviderContext) {
 
           expect(decryptedCreatedMonitor.body.attributes).to.eql({
             __ui: {
-              is_tls_enabled: false,
+              is_tls_enabled: isTLSEnabled,
             },
             config_id: decryptedCreatedMonitor.body.id,
             custom_heartbeat_id: `${journeyId}-test-suite-default`,
@@ -398,7 +400,7 @@ export default function ({ getService }: FtrProviderContext) {
             'ssl.certificate': '',
             'ssl.certificate_authorities': '',
             'ssl.supported_protocols': ['TLSv1.1', 'TLSv1.2', 'TLSv1.3'],
-            'ssl.verification_mode': 'full',
+            'ssl.verification_mode': isTLSEnabled ? 'strict' : 'full',
             'ssl.key': '',
             'ssl.key_passphrase': '',
             tags: Array.isArray(monitor.tags) ? monitor.tags : monitor.tags?.split(','),
@@ -1755,7 +1757,7 @@ export default function ({ getService }: FtrProviderContext) {
               data_stream: { type: 'synthetics', dataset: 'http' },
               release: 'experimental',
               vars: {
-                __ui: { value: '{"is_tls_enabled":false}', type: 'yaml' },
+                __ui: { value: '{"is_tls_enabled":true}', type: 'yaml' },
                 enabled: { value: false, type: 'bool' },
                 type: { value: 'http', type: 'text' },
                 name: { value: 'My Monitor 3', type: 'text' },
@@ -1784,7 +1786,7 @@ export default function ({ getService }: FtrProviderContext) {
                 'ssl.certificate': { value: null, type: 'yaml' },
                 'ssl.key': { value: null, type: 'yaml' },
                 'ssl.key_passphrase': { value: null, type: 'text' },
-                'ssl.verification_mode': { value: 'full', type: 'text' },
+                'ssl.verification_mode': { value: 'strict', type: 'text' },
                 'ssl.supported_protocols': {
                   value: '["TLSv1.1","TLSv1.2","TLSv1.3"]',
                   type: 'yaml',
@@ -1808,7 +1810,7 @@ export default function ({ getService }: FtrProviderContext) {
               },
               id: `synthetics/http-http-${id}-${testPolicyId}`,
               compiled_stream: {
-                __ui: { is_tls_enabled: false },
+                __ui: { is_tls_enabled: true },
                 type: 'http',
                 name: 'My Monitor 3',
                 id,
@@ -1825,7 +1827,7 @@ export default function ({ getService }: FtrProviderContext) {
                 'check.request.headers': { 'Content-Type': 'application/x-www-form-urlencoded' },
                 'check.response.status': ['200'],
                 'check.response.body.positive': ['Saved', 'saved'],
-                'ssl.verification_mode': 'full',
+                'ssl.verification_mode': 'strict',
                 'ssl.supported_protocols': ['TLSv1.1', 'TLSv1.2', 'TLSv1.3'],
                 processors: [
                   { add_observer_metadata: { geo: { name: 'Test private location 0' } } },

--- a/x-pack/test/api_integration/apis/uptime/rest/fixtures/http_monitor.json
+++ b/x-pack/test/api_integration/apis/uptime/rest/fixtures/http_monitor.json
@@ -13,12 +13,7 @@
   "config_id": "",
   "timeout": "3m",
   "__ui": {
-    "is_tls_enabled": false,
-    "is_zip_url_tls_enabled": false,
-    "script_source": {
-      "is_generated_script": false,
-      "file_name": "test-file.name"
-    }
+    "is_tls_enabled": false
   },
   "max_redirects": "3",
   "password": "test",

--- a/x-pack/test/api_integration/apis/uptime/rest/fixtures/project_http_monitor.json
+++ b/x-pack/test/api_integration/apis/uptime/rest/fixtures/project_http_monitor.json
@@ -71,7 +71,8 @@
           ]
         }
       },
-      "hash": "ekrjelkjrelkjre"
+      "hash": "ekrjelkjrelkjre",
+      "ssl.verification_mode": "strict"
     }
   ]
 }

--- a/x-pack/test/api_integration/apis/uptime/rest/fixtures/project_tcp_monitor.json
+++ b/x-pack/test/api_integration/apis/uptime/rest/fixtures/project_tcp_monitor.json
@@ -11,7 +11,8 @@
       "schedule": 1,
       "tags": [ "service:smtp", "org:google" ],
       "privateLocations": [ "BEEP" ],
-      "hash": "ekrjelkjrelkjre"
+      "hash": "ekrjelkjrelkjre",
+      "ssl.verification_mode": "strict"
     },
     {
       "locations": [ "localhost" ],

--- a/x-pack/test/api_integration/apis/uptime/rest/sample_data/test_policy.ts
+++ b/x-pack/test/api_integration/apis/uptime/rest/sample_data/test_policy.ts
@@ -117,13 +117,13 @@ export const getTestSyntheticsPolicy = (
             'check.response.status': ['200', '201'],
             ...(isTLSEnabled
               ? {
-                'ssl.certificate': 't.string',
-                'ssl.certificate_authorities': 't.string',
-                'ssl.key': 't.string',
-                'ssl.key_passphrase': 't.string',
-                'ssl.verification_mode': 'certificate',
-                'ssl.supported_protocols': ['TLSv1.1', 'TLSv1.2'],
-              }
+                  'ssl.certificate': 't.string',
+                  'ssl.certificate_authorities': 't.string',
+                  'ssl.key': 't.string',
+                  'ssl.key_passphrase': 't.string',
+                  'ssl.verification_mode': 'certificate',
+                  'ssl.supported_protocols': ['TLSv1.1', 'TLSv1.2'],
+                }
               : {}),
             processors: [
               {

--- a/x-pack/test/api_integration/apis/uptime/rest/sample_data/test_policy.ts
+++ b/x-pack/test/api_integration/apis/uptime/rest/sample_data/test_policy.ts
@@ -20,7 +20,7 @@ export const getTestSyntheticsPolicy = (
   version: 'WzE2MjYsMV0=',
   name: 'test-monitor-name-Test private location 0-default',
   namespace: namespace || 'testnamespace',
-  package: { name: 'synthetics', title: 'Elastic Synthetics', version: '0.11.4' },
+  package: { name: 'synthetics', title: 'Elastic Synthetics', version: '0.10.3' },
   enabled: true,
   policy_id: '5347cd10-0368-11ed-8df7-a7424c6f5167',
   inputs: [
@@ -31,15 +31,8 @@ export const getTestSyntheticsPolicy = (
       streams: [
         {
           enabled: true,
-          data_stream: {
-            type: 'synthetics',
-            dataset: 'http',
-            elasticsearch: {
-              privileges: {
-                indices: ['auto_configure', 'create_doc', 'read'],
-              },
-            },
-          },
+          data_stream: { type: 'synthetics', dataset: 'http' },
+          release: 'experimental',
           vars: {
             __ui: {
               value: `{"is_tls_enabled":${isTLSEnabled || false}}`,
@@ -81,7 +74,7 @@ export const getTestSyntheticsPolicy = (
               value: isTLSEnabled ? '["TLSv1.1","TLSv1.2"]' : null,
               type: 'yaml',
             },
-            location_name: { value: locationName ?? 'Test private location 0', type: 'text' },
+            location_name: { value: locationName || 'Test private location 0', type: 'text' },
             id: { value: id, type: 'text' },
             config_id: { value: id, type: 'text' },
             run_once: { value: false, type: 'bool' },
@@ -107,8 +100,6 @@ export const getTestSyntheticsPolicy = (
             tags: ['tag1', 'tag2'],
             username: 'test-username',
             password: 'test',
-            'run_from.geo.name': locationName ?? 'Test private location 0',
-            'run_from.id': locationName ?? 'Test private location 0',
             'response.include_headers': true,
             'response.include_body': 'never',
             'check.request.method': null,
@@ -126,6 +117,9 @@ export const getTestSyntheticsPolicy = (
                 }
               : {}),
             processors: [
+              {
+                add_observer_metadata: { geo: { name: locationName || 'Test private location 0' } },
+              },
               {
                 add_fields: {
                   target: '',
@@ -147,10 +141,8 @@ export const getTestSyntheticsPolicy = (
       streams: [
         {
           enabled: false,
-          data_stream: {
-            type: 'synthetics',
-            dataset: 'tcp',
-          },
+          release: 'experimental',
+          data_stream: { type: 'synthetics', dataset: 'tcp' },
           vars: {
             __ui: { type: 'yaml' },
             enabled: { value: true, type: 'bool' },
@@ -190,10 +182,8 @@ export const getTestSyntheticsPolicy = (
       streams: [
         {
           enabled: false,
-          data_stream: {
-            type: 'synthetics',
-            dataset: 'icmp',
-          },
+          release: 'experimental',
+          data_stream: { type: 'synthetics', dataset: 'icmp' },
           vars: {
             __ui: { type: 'yaml' },
             enabled: { value: true, type: 'bool' },
@@ -224,15 +214,8 @@ export const getTestSyntheticsPolicy = (
       streams: [
         {
           enabled: true,
-          data_stream: {
-            type: 'synthetics',
-            dataset: 'browser',
-            elasticsearch: {
-              privileges: {
-                indices: ['auto_configure', 'create_doc', 'read'],
-              },
-            },
-          },
+          release: 'beta',
+          data_stream: { type: 'synthetics', dataset: 'browser' },
           vars: {
             __ui: { type: 'yaml' },
             enabled: { value: true, type: 'bool' },
@@ -278,24 +261,18 @@ export const getTestSyntheticsPolicy = (
             name: null,
             enabled: true,
             schedule: '@every 3m',
-            'run_from.id': 'Fleet managed',
-            'run_from.geo.name': 'Fleet managed',
             timeout: null,
             throttling: null,
-            processors: [{ add_fields: { target: '', fields: { 'monitor.fleet_managed': true } } }],
+            processors: [
+              { add_observer_metadata: { geo: { name: 'Fleet managed' } } },
+              { add_fields: { target: '', fields: { 'monitor.fleet_managed': true } } },
+            ],
           },
         },
         {
           enabled: true,
-          data_stream: {
-            type: 'synthetics',
-            dataset: 'browser.network',
-            elasticsearch: {
-              privileges: {
-                indices: ['auto_configure', 'create_doc', 'read'],
-              },
-            },
-          },
+          data_stream: { type: 'synthetics', dataset: 'browser.network' },
+          release: 'beta',
           id: 'synthetics/browser-browser.network-2bfd7da0-22ed-11ed-8c6b-09a2d21dfbc3-27337270-22ed-11ed-8c6b-09a2d21dfbc3-default',
           compiled_stream: {
             processors: [
@@ -306,15 +283,8 @@ export const getTestSyntheticsPolicy = (
         },
         {
           enabled: true,
-          data_stream: {
-            type: 'synthetics',
-            dataset: 'browser.screenshot',
-            elasticsearch: {
-              privileges: {
-                indices: ['auto_configure', 'create_doc', 'read'],
-              },
-            },
-          },
+          data_stream: { type: 'synthetics', dataset: 'browser.screenshot' },
+          release: 'beta',
           id: 'synthetics/browser-browser.screenshot-2bfd7da0-22ed-11ed-8c6b-09a2d21dfbc3-27337270-22ed-11ed-8c6b-09a2d21dfbc3-default',
           compiled_stream: {
             processors: [
@@ -331,6 +301,290 @@ export const getTestSyntheticsPolicy = (
   created_at: '2022-08-23T14:09:17.176Z',
   created_by: 'system',
   updated_at: '2022-08-23T14:09:17.176Z',
+  updated_by: 'system',
+});
+
+export const getTestProjectSyntheticsPolicy = (
+  {
+    name,
+    inputs = {},
+    configId,
+    id,
+    projectId = 'test-suite',
+  }: {
+    name?: string;
+    inputs: Record<string, { value: string | boolean; type: string }>;
+    configId: string;
+    id: string;
+    projectId?: string;
+  } = {
+    name: 'check if title is present-Test private location 0',
+    inputs: {},
+    configId: '',
+    id: '',
+  }
+): PackagePolicy => ({
+  id: `4b6abc6c-118b-4d93-a489-1135500d09f1-${projectId}-default-d70a46e0-22ea-11ed-8c6b-09a2d21dfbc3`,
+  version: 'WzEzMDksMV0=',
+  name: `4b6abc6c-118b-4d93-a489-1135500d09f1-${projectId}-default-Test private location 0`,
+  namespace: 'default',
+  package: { name: 'synthetics', title: 'Elastic Synthetics', version: '0.10.3' },
+  enabled: true,
+  policy_id: '46034710-0ba6-11ed-ba04-5f123b9faa8b',
+  inputs: [
+    {
+      type: 'synthetics/http',
+      policy_template: 'synthetics',
+      enabled: false,
+      streams: [
+        {
+          enabled: false,
+          data_stream: { type: 'synthetics', dataset: 'http' },
+          release: 'experimental',
+          vars: {
+            __ui: { type: 'yaml' },
+            enabled: { value: true, type: 'bool' },
+            type: { value: 'http', type: 'text' },
+            name: { type: 'text' },
+            schedule: { value: '"@every 3m"', type: 'text' },
+            urls: { type: 'text' },
+            'service.name': { type: 'text' },
+            timeout: { type: 'text' },
+            max_redirects: { type: 'integer' },
+            proxy_url: { type: 'text' },
+            tags: { type: 'yaml' },
+            username: { type: 'text' },
+            password: { type: 'password' },
+            'response.include_headers': { type: 'bool' },
+            'response.include_body': { type: 'text' },
+            'check.request.method': { type: 'text' },
+            'check.request.headers': { type: 'yaml' },
+            'check.request.body': { type: 'yaml' },
+            'check.response.status': { type: 'yaml' },
+            'check.response.headers': { type: 'yaml' },
+            'check.response.body.positive': { type: 'yaml' },
+            'check.response.body.negative': { type: 'yaml' },
+            'ssl.certificate_authorities': { type: 'yaml' },
+            'ssl.certificate': { type: 'yaml' },
+            'ssl.key': { type: 'yaml' },
+            'ssl.key_passphrase': { type: 'text' },
+            'ssl.verification_mode': { type: 'text' },
+            'ssl.supported_protocols': { type: 'yaml' },
+            location_name: { value: 'Fleet managed', type: 'text' },
+            id: { type: 'text' },
+            config_id: { type: 'text' },
+            run_once: { value: false, type: 'bool' },
+            origin: { type: 'text' },
+            'monitor.project.id': { type: 'text' },
+            'monitor.project.name': { type: 'text' },
+          },
+          id: `synthetics/http-http-4b6abc6c-118b-4d93-a489-1135500d09f1-${projectId}-default-d70a46e0-22ea-11ed-8c6b-09a2d21dfbc3`,
+        },
+      ],
+    },
+    {
+      type: 'synthetics/tcp',
+      policy_template: 'synthetics',
+      enabled: false,
+      streams: [
+        {
+          enabled: false,
+          data_stream: { type: 'synthetics', dataset: 'tcp' },
+          release: 'experimental',
+          vars: {
+            __ui: { type: 'yaml' },
+            enabled: { value: true, type: 'bool' },
+            type: { value: 'tcp', type: 'text' },
+            name: { type: 'text' },
+            schedule: { value: '"@every 3m"', type: 'text' },
+            hosts: { type: 'text' },
+            'service.name': { type: 'text' },
+            timeout: { type: 'text' },
+            proxy_url: { type: 'text' },
+            proxy_use_local_resolver: { value: false, type: 'bool' },
+            tags: { type: 'yaml' },
+            'check.send': { type: 'text' },
+            'check.receive': { type: 'text' },
+            'ssl.certificate_authorities': { type: 'yaml' },
+            'ssl.certificate': { type: 'yaml' },
+            'ssl.key': { type: 'yaml' },
+            'ssl.key_passphrase': { type: 'text' },
+            'ssl.verification_mode': { type: 'text' },
+            'ssl.supported_protocols': { type: 'yaml' },
+            location_name: { value: 'Fleet managed', type: 'text' },
+            id: { type: 'text' },
+            config_id: { type: 'text' },
+            run_once: { value: false, type: 'bool' },
+            origin: { type: 'text' },
+            'monitor.project.id': { type: 'text' },
+            'monitor.project.name': { type: 'text' },
+          },
+          id: `synthetics/tcp-tcp-4b6abc6c-118b-4d93-a489-1135500d09f1-${projectId}-default-d70a46e0-22ea-11ed-8c6b-09a2d21dfbc3`,
+        },
+      ],
+    },
+    {
+      type: 'synthetics/icmp',
+      policy_template: 'synthetics',
+      enabled: false,
+      streams: [
+        {
+          enabled: false,
+          release: 'experimental',
+          data_stream: { type: 'synthetics', dataset: 'icmp' },
+          vars: {
+            __ui: { type: 'yaml' },
+            enabled: { value: true, type: 'bool' },
+            type: { value: 'icmp', type: 'text' },
+            name: { type: 'text' },
+            schedule: { value: '"@every 3m"', type: 'text' },
+            wait: { value: '1s', type: 'text' },
+            hosts: { type: 'text' },
+            'service.name': { type: 'text' },
+            timeout: { type: 'text' },
+            tags: { type: 'yaml' },
+            location_name: { value: 'Fleet managed', type: 'text' },
+            id: { type: 'text' },
+            config_id: { type: 'text' },
+            run_once: { value: false, type: 'bool' },
+            origin: { type: 'text' },
+            'monitor.project.id': { type: 'text' },
+            'monitor.project.name': { type: 'text' },
+          },
+          id: `synthetics/icmp-icmp-4b6abc6c-118b-4d93-a489-1135500d09f1-${projectId}-default-d70a46e0-22ea-11ed-8c6b-09a2d21dfbc3`,
+        },
+      ],
+    },
+    {
+      type: 'synthetics/browser',
+      policy_template: 'synthetics',
+      enabled: true,
+      streams: [
+        {
+          enabled: true,
+          data_stream: { type: 'synthetics', dataset: 'browser' },
+          release: 'beta',
+          vars: {
+            __ui: {
+              value:
+                '{"script_source":{"is_generated_script":false,"file_name":""},"is_zip_url_tls_enabled":false}',
+              type: 'yaml',
+            },
+            enabled: { value: true, type: 'bool' },
+            type: { value: 'browser', type: 'text' },
+            name: { value: 'check if title is present', type: 'text' },
+            schedule: { value: '"@every 10m"', type: 'text' },
+            'service.name': { value: '', type: 'text' },
+            timeout: { value: null, type: 'text' },
+            tags: { value: null, type: 'yaml' },
+            'source.zip_url.url': { value: '', type: 'text' },
+            'source.zip_url.username': { value: '', type: 'text' },
+            'source.zip_url.folder': { value: '', type: 'text' },
+            'source.zip_url.password': { value: '', type: 'password' },
+            'source.inline.script': { value: null, type: 'yaml' },
+            'source.project.content': {
+              value:
+                'UEsDBBQACAAIAON5qVQAAAAAAAAAAAAAAAAfAAAAZXhhbXBsZXMvdG9kb3MvYmFzaWMuam91cm5leS50c22Q0WrDMAxF3/sVF7MHB0LMXlc6RvcN+wDPVWNviW0sdUsp/fe5SSiD7UFCWFfHujIGlpnkybwxFTZfoY/E3hsaLEtwhs9RPNWKDU12zAOxkXRIbN4tB9d9pFOJdO6EN2HMqQguWN9asFBuQVMmJ7jiWNII9fIXrbabdUYr58l9IhwhQQZCYORCTFFUC31Btj21NRc7Mq4Nds+4bDD/pNVgT9F52Jyr2Fa+g75LAPttg8yErk+S9ELpTmVotlVwnfNCuh2lepl3+JflUmSBJ3uggt1v9INW/lHNLKze9dJe1J3QJK8pSvWkm6aTtCet5puq+x63+AFQSwcIAPQ3VfcAAACcAQAAUEsBAi0DFAAIAAgA43mpVAD0N1X3AAAAnAEAAB8AAAAAAAAAAAAgAKSBAAAAAGV4YW1wbGVzL3RvZG9zL2Jhc2ljLmpvdXJuZXkudHNQSwUGAAAAAAEAAQBNAAAARAEAAAAA',
+              type: 'text',
+            },
+            params: { value: '', type: 'yaml' },
+            playwright_options: {
+              value: '{"headless":true,"chromiumSandbox":false}',
+              type: 'yaml',
+            },
+            screenshots: { value: 'on', type: 'text' },
+            synthetics_args: { value: null, type: 'text' },
+            ignore_https_errors: { value: false, type: 'bool' },
+            'throttling.config': { value: '5d/3u/20l', type: 'text' },
+            'filter_journeys.tags': { value: null, type: 'yaml' },
+            'filter_journeys.match': { value: '"check if title is present"', type: 'text' },
+            'source.zip_url.ssl.certificate_authorities': { value: null, type: 'yaml' },
+            'source.zip_url.ssl.certificate': { value: null, type: 'yaml' },
+            'source.zip_url.ssl.key': { value: null, type: 'yaml' },
+            'source.zip_url.ssl.key_passphrase': { value: null, type: 'text' },
+            'source.zip_url.ssl.verification_mode': { value: null, type: 'text' },
+            'source.zip_url.ssl.supported_protocols': { value: null, type: 'yaml' },
+            'source.zip_url.proxy_url': { value: '', type: 'text' },
+            location_name: { value: 'Test private location 0', type: 'text' },
+            id: { value: id, type: 'text' },
+            config_id: { value: configId, type: 'text' },
+            run_once: { value: false, type: 'bool' },
+            origin: { value: 'project', type: 'text' },
+            'monitor.project.id': { value: projectId, type: 'text' },
+            'monitor.project.name': { value: projectId, type: 'text' },
+            ...inputs,
+          },
+          id: `synthetics/browser-browser-4b6abc6c-118b-4d93-a489-1135500d09f1-${projectId}-default-d70a46e0-22ea-11ed-8c6b-09a2d21dfbc3`,
+          compiled_stream: {
+            __ui: {
+              script_source: { is_generated_script: false, file_name: '' },
+              is_zip_url_tls_enabled: false,
+            },
+            type: 'browser',
+            name: 'check if title is present',
+            id,
+            origin: 'project',
+            enabled: true,
+            schedule: '@every 10m',
+            timeout: null,
+            throttling: '5d/3u/20l',
+            'source.project.content':
+              'UEsDBBQACAAIAON5qVQAAAAAAAAAAAAAAAAfAAAAZXhhbXBsZXMvdG9kb3MvYmFzaWMuam91cm5leS50c22Q0WrDMAxF3/sVF7MHB0LMXlc6RvcN+wDPVWNviW0sdUsp/fe5SSiD7UFCWFfHujIGlpnkybwxFTZfoY/E3hsaLEtwhs9RPNWKDU12zAOxkXRIbN4tB9d9pFOJdO6EN2HMqQguWN9asFBuQVMmJ7jiWNII9fIXrbabdUYr58l9IhwhQQZCYORCTFFUC31Btj21NRc7Mq4Nds+4bDD/pNVgT9F52Jyr2Fa+g75LAPttg8yErk+S9ELpTmVotlVwnfNCuh2lepl3+JflUmSBJ3uggt1v9INW/lHNLKze9dJe1J3QJK8pSvWkm6aTtCet5puq+x63+AFQSwcIAPQ3VfcAAACcAQAAUEsBAi0DFAAIAAgA43mpVAD0N1X3AAAAnAEAAB8AAAAAAAAAAAAgAKSBAAAAAGV4YW1wbGVzL3RvZG9zL2Jhc2ljLmpvdXJuZXkudHNQSwUGAAAAAAEAAQBNAAAARAEAAAAA',
+            playwright_options: { headless: true, chromiumSandbox: false },
+            screenshots: 'on',
+            'filter_journeys.match': 'check if title is present',
+            processors: [
+              { add_observer_metadata: { geo: { name: 'Test private location 0' } } },
+              {
+                add_fields: {
+                  target: '',
+                  fields: {
+                    'monitor.fleet_managed': true,
+                    config_id: configId,
+                    'monitor.project.name': projectId,
+                    'monitor.project.id': projectId,
+                  },
+                },
+              },
+            ],
+            ...Object.keys(inputs).reduce((acc: Record<string, unknown>, key) => {
+              acc[key] = inputs[key].value;
+              return acc;
+            }, {}),
+          },
+        },
+        {
+          enabled: true,
+          release: 'beta',
+          data_stream: { type: 'synthetics', dataset: 'browser.network' },
+          id: `synthetics/browser-browser.network-4b6abc6c-118b-4d93-a489-1135500d09f1-${projectId}-default-d70a46e0-22ea-11ed-8c6b-09a2d21dfbc3`,
+          compiled_stream: {
+            processors: [
+              { add_observer_metadata: { geo: { name: 'Fleet managed' } } },
+              { add_fields: { target: '', fields: { 'monitor.fleet_managed': true } } },
+            ],
+          },
+        },
+        {
+          enabled: true,
+          release: 'beta',
+          data_stream: { type: 'synthetics', dataset: 'browser.screenshot' },
+          id: `synthetics/browser-browser.screenshot-4b6abc6c-118b-4d93-a489-1135500d09f1-${projectId}-default-d70a46e0-22ea-11ed-8c6b-09a2d21dfbc3`,
+          compiled_stream: {
+            processors: [
+              { add_observer_metadata: { geo: { name: 'Fleet managed' } } },
+              { add_fields: { target: '', fields: { 'monitor.fleet_managed': true } } },
+            ],
+          },
+        },
+      ],
+    },
+  ],
+  is_managed: true,
+  revision: 1,
+  created_at: '2022-08-23T13:52:42.531Z',
+  created_by: 'system',
+  updated_at: '2022-08-23T13:52:42.531Z',
   updated_by: 'system',
 });
 

--- a/x-pack/test/api_integration/apis/uptime/rest/sample_data/test_policy.ts
+++ b/x-pack/test/api_integration/apis/uptime/rest/sample_data/test_policy.ts
@@ -13,13 +13,14 @@ export const getTestSyntheticsPolicy = (
   name: string,
   id: string,
   locationName?: string,
-  namespace?: string
+  namespace?: string,
+  isTLSEnabled?: boolean
 ): PackagePolicy => ({
   id: '2bfd7da0-22ed-11ed-8c6b-09a2d21dfbc3-27337270-22ed-11ed-8c6b-09a2d21dfbc3-default',
   version: 'WzE2MjYsMV0=',
   name: 'test-monitor-name-Test private location 0-default',
   namespace: namespace || 'testnamespace',
-  package: { name: 'synthetics', title: 'Elastic Synthetics', version: '0.10.3' },
+  package: { name: 'synthetics', title: 'Elastic Synthetics', version: '0.11.4' },
   enabled: true,
   policy_id: '5347cd10-0368-11ed-8df7-a7424c6f5167',
   inputs: [
@@ -30,12 +31,18 @@ export const getTestSyntheticsPolicy = (
       streams: [
         {
           enabled: true,
-          data_stream: { type: 'synthetics', dataset: 'http' },
-          release: 'experimental',
+          data_stream: {
+            type: 'synthetics',
+            dataset: 'http',
+            elasticsearch: {
+              privileges: {
+                indices: ['auto_configure', 'create_doc', 'read'],
+              },
+            },
+          },
           vars: {
             __ui: {
-              value:
-                '{"is_tls_enabled":false,"is_zip_url_tls_enabled":false,"script_source":{"is_generated_script":false,"file_name":"test-file.name"}}',
+              value: `{"is_tls_enabled":${isTLSEnabled || false}}`,
               type: 'yaml',
             },
             enabled: { value: true, type: 'bool' },
@@ -62,13 +69,19 @@ export const getTestSyntheticsPolicy = (
             'check.response.headers': { value: null, type: 'yaml' },
             'check.response.body.positive': { value: null, type: 'yaml' },
             'check.response.body.negative': { value: null, type: 'yaml' },
-            'ssl.certificate_authorities': { value: '"t.string"', type: 'yaml' },
-            'ssl.certificate': { value: '"t.string"', type: 'yaml' },
-            'ssl.key': { value: '"t.string"', type: 'yaml' },
-            'ssl.key_passphrase': { value: 't.string', type: 'text' },
-            'ssl.verification_mode': { value: 'certificate', type: 'text' },
-            'ssl.supported_protocols': { value: '["TLSv1.1","TLSv1.2"]', type: 'yaml' },
-            location_name: { value: locationName || 'Test private location 0', type: 'text' },
+            'ssl.certificate_authorities': {
+              value: isTLSEnabled ? '"t.string"' : null,
+              type: 'yaml',
+            },
+            'ssl.certificate': { value: isTLSEnabled ? '"t.string"' : null, type: 'yaml' },
+            'ssl.key': { value: isTLSEnabled ? '"t.string"' : null, type: 'yaml' },
+            'ssl.key_passphrase': { value: isTLSEnabled ? 't.string' : null, type: 'text' },
+            'ssl.verification_mode': { value: isTLSEnabled ? 'certificate' : null, type: 'text' },
+            'ssl.supported_protocols': {
+              value: isTLSEnabled ? '["TLSv1.1","TLSv1.2"]' : null,
+              type: 'yaml',
+            },
+            location_name: { value: locationName ?? 'Test private location 0', type: 'text' },
             id: { value: id, type: 'text' },
             config_id: { value: id, type: 'text' },
             run_once: { value: false, type: 'bool' },
@@ -79,9 +92,7 @@ export const getTestSyntheticsPolicy = (
           id: 'synthetics/http-http-2bfd7da0-22ed-11ed-8c6b-09a2d21dfbc3-27337270-22ed-11ed-8c6b-09a2d21dfbc3-default',
           compiled_stream: {
             __ui: {
-              is_tls_enabled: false,
-              is_zip_url_tls_enabled: false,
-              script_source: { is_generated_script: false, file_name: 'test-file.name' },
+              is_tls_enabled: isTLSEnabled || false,
             },
             type: 'http',
             name,
@@ -96,22 +107,25 @@ export const getTestSyntheticsPolicy = (
             tags: ['tag1', 'tag2'],
             username: 'test-username',
             password: 'test',
+            'run_from.geo.name': locationName ?? 'Test private location 0',
+            'run_from.id': locationName ?? 'Test private location 0',
             'response.include_headers': true,
             'response.include_body': 'never',
             'check.request.method': null,
             'check.request.headers': { sampleHeader: 'sampleHeaderValue' },
             'check.request.body': 'testValue',
             'check.response.status': ['200', '201'],
-            'ssl.certificate': 't.string',
-            'ssl.certificate_authorities': 't.string',
-            'ssl.key': 't.string',
-            'ssl.key_passphrase': 't.string',
-            'ssl.verification_mode': 'certificate',
-            'ssl.supported_protocols': ['TLSv1.1', 'TLSv1.2'],
+            ...(isTLSEnabled
+              ? {
+                'ssl.certificate': 't.string',
+                'ssl.certificate_authorities': 't.string',
+                'ssl.key': 't.string',
+                'ssl.key_passphrase': 't.string',
+                'ssl.verification_mode': 'certificate',
+                'ssl.supported_protocols': ['TLSv1.1', 'TLSv1.2'],
+              }
+              : {}),
             processors: [
-              {
-                add_observer_metadata: { geo: { name: locationName || 'Test private location 0' } },
-              },
               {
                 add_fields: {
                   target: '',
@@ -133,8 +147,10 @@ export const getTestSyntheticsPolicy = (
       streams: [
         {
           enabled: false,
-          release: 'experimental',
-          data_stream: { type: 'synthetics', dataset: 'tcp' },
+          data_stream: {
+            type: 'synthetics',
+            dataset: 'tcp',
+          },
           vars: {
             __ui: { type: 'yaml' },
             enabled: { value: true, type: 'bool' },
@@ -174,8 +190,10 @@ export const getTestSyntheticsPolicy = (
       streams: [
         {
           enabled: false,
-          release: 'experimental',
-          data_stream: { type: 'synthetics', dataset: 'icmp' },
+          data_stream: {
+            type: 'synthetics',
+            dataset: 'icmp',
+          },
           vars: {
             __ui: { type: 'yaml' },
             enabled: { value: true, type: 'bool' },
@@ -206,8 +224,15 @@ export const getTestSyntheticsPolicy = (
       streams: [
         {
           enabled: true,
-          release: 'beta',
-          data_stream: { type: 'synthetics', dataset: 'browser' },
+          data_stream: {
+            type: 'synthetics',
+            dataset: 'browser',
+            elasticsearch: {
+              privileges: {
+                indices: ['auto_configure', 'create_doc', 'read'],
+              },
+            },
+          },
           vars: {
             __ui: { type: 'yaml' },
             enabled: { value: true, type: 'bool' },
@@ -253,18 +278,24 @@ export const getTestSyntheticsPolicy = (
             name: null,
             enabled: true,
             schedule: '@every 3m',
+            'run_from.id': 'Fleet managed',
+            'run_from.geo.name': 'Fleet managed',
             timeout: null,
             throttling: null,
-            processors: [
-              { add_observer_metadata: { geo: { name: 'Fleet managed' } } },
-              { add_fields: { target: '', fields: { 'monitor.fleet_managed': true } } },
-            ],
+            processors: [{ add_fields: { target: '', fields: { 'monitor.fleet_managed': true } } }],
           },
         },
         {
           enabled: true,
-          data_stream: { type: 'synthetics', dataset: 'browser.network' },
-          release: 'beta',
+          data_stream: {
+            type: 'synthetics',
+            dataset: 'browser.network',
+            elasticsearch: {
+              privileges: {
+                indices: ['auto_configure', 'create_doc', 'read'],
+              },
+            },
+          },
           id: 'synthetics/browser-browser.network-2bfd7da0-22ed-11ed-8c6b-09a2d21dfbc3-27337270-22ed-11ed-8c6b-09a2d21dfbc3-default',
           compiled_stream: {
             processors: [
@@ -275,8 +306,15 @@ export const getTestSyntheticsPolicy = (
         },
         {
           enabled: true,
-          data_stream: { type: 'synthetics', dataset: 'browser.screenshot' },
-          release: 'beta',
+          data_stream: {
+            type: 'synthetics',
+            dataset: 'browser.screenshot',
+            elasticsearch: {
+              privileges: {
+                indices: ['auto_configure', 'create_doc', 'read'],
+              },
+            },
+          },
           id: 'synthetics/browser-browser.screenshot-2bfd7da0-22ed-11ed-8c6b-09a2d21dfbc3-27337270-22ed-11ed-8c6b-09a2d21dfbc3-default',
           compiled_stream: {
             processors: [
@@ -293,290 +331,6 @@ export const getTestSyntheticsPolicy = (
   created_at: '2022-08-23T14:09:17.176Z',
   created_by: 'system',
   updated_at: '2022-08-23T14:09:17.176Z',
-  updated_by: 'system',
-});
-
-export const getTestProjectSyntheticsPolicy = (
-  {
-    name,
-    inputs = {},
-    configId,
-    id,
-    projectId = 'test-suite',
-  }: {
-    name?: string;
-    inputs: Record<string, { value: string | boolean; type: string }>;
-    configId: string;
-    id: string;
-    projectId?: string;
-  } = {
-    name: 'check if title is present-Test private location 0',
-    inputs: {},
-    configId: '',
-    id: '',
-  }
-): PackagePolicy => ({
-  id: `4b6abc6c-118b-4d93-a489-1135500d09f1-${projectId}-default-d70a46e0-22ea-11ed-8c6b-09a2d21dfbc3`,
-  version: 'WzEzMDksMV0=',
-  name: `4b6abc6c-118b-4d93-a489-1135500d09f1-${projectId}-default-Test private location 0`,
-  namespace: 'default',
-  package: { name: 'synthetics', title: 'Elastic Synthetics', version: '0.10.3' },
-  enabled: true,
-  policy_id: '46034710-0ba6-11ed-ba04-5f123b9faa8b',
-  inputs: [
-    {
-      type: 'synthetics/http',
-      policy_template: 'synthetics',
-      enabled: false,
-      streams: [
-        {
-          enabled: false,
-          data_stream: { type: 'synthetics', dataset: 'http' },
-          release: 'experimental',
-          vars: {
-            __ui: { type: 'yaml' },
-            enabled: { value: true, type: 'bool' },
-            type: { value: 'http', type: 'text' },
-            name: { type: 'text' },
-            schedule: { value: '"@every 3m"', type: 'text' },
-            urls: { type: 'text' },
-            'service.name': { type: 'text' },
-            timeout: { type: 'text' },
-            max_redirects: { type: 'integer' },
-            proxy_url: { type: 'text' },
-            tags: { type: 'yaml' },
-            username: { type: 'text' },
-            password: { type: 'password' },
-            'response.include_headers': { type: 'bool' },
-            'response.include_body': { type: 'text' },
-            'check.request.method': { type: 'text' },
-            'check.request.headers': { type: 'yaml' },
-            'check.request.body': { type: 'yaml' },
-            'check.response.status': { type: 'yaml' },
-            'check.response.headers': { type: 'yaml' },
-            'check.response.body.positive': { type: 'yaml' },
-            'check.response.body.negative': { type: 'yaml' },
-            'ssl.certificate_authorities': { type: 'yaml' },
-            'ssl.certificate': { type: 'yaml' },
-            'ssl.key': { type: 'yaml' },
-            'ssl.key_passphrase': { type: 'text' },
-            'ssl.verification_mode': { type: 'text' },
-            'ssl.supported_protocols': { type: 'yaml' },
-            location_name: { value: 'Fleet managed', type: 'text' },
-            id: { type: 'text' },
-            config_id: { type: 'text' },
-            run_once: { value: false, type: 'bool' },
-            origin: { type: 'text' },
-            'monitor.project.id': { type: 'text' },
-            'monitor.project.name': { type: 'text' },
-          },
-          id: `synthetics/http-http-4b6abc6c-118b-4d93-a489-1135500d09f1-${projectId}-default-d70a46e0-22ea-11ed-8c6b-09a2d21dfbc3`,
-        },
-      ],
-    },
-    {
-      type: 'synthetics/tcp',
-      policy_template: 'synthetics',
-      enabled: false,
-      streams: [
-        {
-          enabled: false,
-          data_stream: { type: 'synthetics', dataset: 'tcp' },
-          release: 'experimental',
-          vars: {
-            __ui: { type: 'yaml' },
-            enabled: { value: true, type: 'bool' },
-            type: { value: 'tcp', type: 'text' },
-            name: { type: 'text' },
-            schedule: { value: '"@every 3m"', type: 'text' },
-            hosts: { type: 'text' },
-            'service.name': { type: 'text' },
-            timeout: { type: 'text' },
-            proxy_url: { type: 'text' },
-            proxy_use_local_resolver: { value: false, type: 'bool' },
-            tags: { type: 'yaml' },
-            'check.send': { type: 'text' },
-            'check.receive': { type: 'text' },
-            'ssl.certificate_authorities': { type: 'yaml' },
-            'ssl.certificate': { type: 'yaml' },
-            'ssl.key': { type: 'yaml' },
-            'ssl.key_passphrase': { type: 'text' },
-            'ssl.verification_mode': { type: 'text' },
-            'ssl.supported_protocols': { type: 'yaml' },
-            location_name: { value: 'Fleet managed', type: 'text' },
-            id: { type: 'text' },
-            config_id: { type: 'text' },
-            run_once: { value: false, type: 'bool' },
-            origin: { type: 'text' },
-            'monitor.project.id': { type: 'text' },
-            'monitor.project.name': { type: 'text' },
-          },
-          id: `synthetics/tcp-tcp-4b6abc6c-118b-4d93-a489-1135500d09f1-${projectId}-default-d70a46e0-22ea-11ed-8c6b-09a2d21dfbc3`,
-        },
-      ],
-    },
-    {
-      type: 'synthetics/icmp',
-      policy_template: 'synthetics',
-      enabled: false,
-      streams: [
-        {
-          enabled: false,
-          release: 'experimental',
-          data_stream: { type: 'synthetics', dataset: 'icmp' },
-          vars: {
-            __ui: { type: 'yaml' },
-            enabled: { value: true, type: 'bool' },
-            type: { value: 'icmp', type: 'text' },
-            name: { type: 'text' },
-            schedule: { value: '"@every 3m"', type: 'text' },
-            wait: { value: '1s', type: 'text' },
-            hosts: { type: 'text' },
-            'service.name': { type: 'text' },
-            timeout: { type: 'text' },
-            tags: { type: 'yaml' },
-            location_name: { value: 'Fleet managed', type: 'text' },
-            id: { type: 'text' },
-            config_id: { type: 'text' },
-            run_once: { value: false, type: 'bool' },
-            origin: { type: 'text' },
-            'monitor.project.id': { type: 'text' },
-            'monitor.project.name': { type: 'text' },
-          },
-          id: `synthetics/icmp-icmp-4b6abc6c-118b-4d93-a489-1135500d09f1-${projectId}-default-d70a46e0-22ea-11ed-8c6b-09a2d21dfbc3`,
-        },
-      ],
-    },
-    {
-      type: 'synthetics/browser',
-      policy_template: 'synthetics',
-      enabled: true,
-      streams: [
-        {
-          enabled: true,
-          data_stream: { type: 'synthetics', dataset: 'browser' },
-          release: 'beta',
-          vars: {
-            __ui: {
-              value:
-                '{"script_source":{"is_generated_script":false,"file_name":""},"is_zip_url_tls_enabled":false}',
-              type: 'yaml',
-            },
-            enabled: { value: true, type: 'bool' },
-            type: { value: 'browser', type: 'text' },
-            name: { value: 'check if title is present', type: 'text' },
-            schedule: { value: '"@every 10m"', type: 'text' },
-            'service.name': { value: '', type: 'text' },
-            timeout: { value: null, type: 'text' },
-            tags: { value: null, type: 'yaml' },
-            'source.zip_url.url': { value: '', type: 'text' },
-            'source.zip_url.username': { value: '', type: 'text' },
-            'source.zip_url.folder': { value: '', type: 'text' },
-            'source.zip_url.password': { value: '', type: 'password' },
-            'source.inline.script': { value: null, type: 'yaml' },
-            'source.project.content': {
-              value:
-                'UEsDBBQACAAIAON5qVQAAAAAAAAAAAAAAAAfAAAAZXhhbXBsZXMvdG9kb3MvYmFzaWMuam91cm5leS50c22Q0WrDMAxF3/sVF7MHB0LMXlc6RvcN+wDPVWNviW0sdUsp/fe5SSiD7UFCWFfHujIGlpnkybwxFTZfoY/E3hsaLEtwhs9RPNWKDU12zAOxkXRIbN4tB9d9pFOJdO6EN2HMqQguWN9asFBuQVMmJ7jiWNII9fIXrbabdUYr58l9IhwhQQZCYORCTFFUC31Btj21NRc7Mq4Nds+4bDD/pNVgT9F52Jyr2Fa+g75LAPttg8yErk+S9ELpTmVotlVwnfNCuh2lepl3+JflUmSBJ3uggt1v9INW/lHNLKze9dJe1J3QJK8pSvWkm6aTtCet5puq+x63+AFQSwcIAPQ3VfcAAACcAQAAUEsBAi0DFAAIAAgA43mpVAD0N1X3AAAAnAEAAB8AAAAAAAAAAAAgAKSBAAAAAGV4YW1wbGVzL3RvZG9zL2Jhc2ljLmpvdXJuZXkudHNQSwUGAAAAAAEAAQBNAAAARAEAAAAA',
-              type: 'text',
-            },
-            params: { value: '', type: 'yaml' },
-            playwright_options: {
-              value: '{"headless":true,"chromiumSandbox":false}',
-              type: 'yaml',
-            },
-            screenshots: { value: 'on', type: 'text' },
-            synthetics_args: { value: null, type: 'text' },
-            ignore_https_errors: { value: false, type: 'bool' },
-            'throttling.config': { value: '5d/3u/20l', type: 'text' },
-            'filter_journeys.tags': { value: null, type: 'yaml' },
-            'filter_journeys.match': { value: '"check if title is present"', type: 'text' },
-            'source.zip_url.ssl.certificate_authorities': { value: null, type: 'yaml' },
-            'source.zip_url.ssl.certificate': { value: null, type: 'yaml' },
-            'source.zip_url.ssl.key': { value: null, type: 'yaml' },
-            'source.zip_url.ssl.key_passphrase': { value: null, type: 'text' },
-            'source.zip_url.ssl.verification_mode': { value: null, type: 'text' },
-            'source.zip_url.ssl.supported_protocols': { value: null, type: 'yaml' },
-            'source.zip_url.proxy_url': { value: '', type: 'text' },
-            location_name: { value: 'Test private location 0', type: 'text' },
-            id: { value: id, type: 'text' },
-            config_id: { value: configId, type: 'text' },
-            run_once: { value: false, type: 'bool' },
-            origin: { value: 'project', type: 'text' },
-            'monitor.project.id': { value: projectId, type: 'text' },
-            'monitor.project.name': { value: projectId, type: 'text' },
-            ...inputs,
-          },
-          id: `synthetics/browser-browser-4b6abc6c-118b-4d93-a489-1135500d09f1-${projectId}-default-d70a46e0-22ea-11ed-8c6b-09a2d21dfbc3`,
-          compiled_stream: {
-            __ui: {
-              script_source: { is_generated_script: false, file_name: '' },
-              is_zip_url_tls_enabled: false,
-            },
-            type: 'browser',
-            name: 'check if title is present',
-            id,
-            origin: 'project',
-            enabled: true,
-            schedule: '@every 10m',
-            timeout: null,
-            throttling: '5d/3u/20l',
-            'source.project.content':
-              'UEsDBBQACAAIAON5qVQAAAAAAAAAAAAAAAAfAAAAZXhhbXBsZXMvdG9kb3MvYmFzaWMuam91cm5leS50c22Q0WrDMAxF3/sVF7MHB0LMXlc6RvcN+wDPVWNviW0sdUsp/fe5SSiD7UFCWFfHujIGlpnkybwxFTZfoY/E3hsaLEtwhs9RPNWKDU12zAOxkXRIbN4tB9d9pFOJdO6EN2HMqQguWN9asFBuQVMmJ7jiWNII9fIXrbabdUYr58l9IhwhQQZCYORCTFFUC31Btj21NRc7Mq4Nds+4bDD/pNVgT9F52Jyr2Fa+g75LAPttg8yErk+S9ELpTmVotlVwnfNCuh2lepl3+JflUmSBJ3uggt1v9INW/lHNLKze9dJe1J3QJK8pSvWkm6aTtCet5puq+x63+AFQSwcIAPQ3VfcAAACcAQAAUEsBAi0DFAAIAAgA43mpVAD0N1X3AAAAnAEAAB8AAAAAAAAAAAAgAKSBAAAAAGV4YW1wbGVzL3RvZG9zL2Jhc2ljLmpvdXJuZXkudHNQSwUGAAAAAAEAAQBNAAAARAEAAAAA',
-            playwright_options: { headless: true, chromiumSandbox: false },
-            screenshots: 'on',
-            'filter_journeys.match': 'check if title is present',
-            processors: [
-              { add_observer_metadata: { geo: { name: 'Test private location 0' } } },
-              {
-                add_fields: {
-                  target: '',
-                  fields: {
-                    'monitor.fleet_managed': true,
-                    config_id: configId,
-                    'monitor.project.name': projectId,
-                    'monitor.project.id': projectId,
-                  },
-                },
-              },
-            ],
-            ...Object.keys(inputs).reduce((acc: Record<string, unknown>, key) => {
-              acc[key] = inputs[key].value;
-              return acc;
-            }, {}),
-          },
-        },
-        {
-          enabled: true,
-          release: 'beta',
-          data_stream: { type: 'synthetics', dataset: 'browser.network' },
-          id: `synthetics/browser-browser.network-4b6abc6c-118b-4d93-a489-1135500d09f1-${projectId}-default-d70a46e0-22ea-11ed-8c6b-09a2d21dfbc3`,
-          compiled_stream: {
-            processors: [
-              { add_observer_metadata: { geo: { name: 'Fleet managed' } } },
-              { add_fields: { target: '', fields: { 'monitor.fleet_managed': true } } },
-            ],
-          },
-        },
-        {
-          enabled: true,
-          release: 'beta',
-          data_stream: { type: 'synthetics', dataset: 'browser.screenshot' },
-          id: `synthetics/browser-browser.screenshot-4b6abc6c-118b-4d93-a489-1135500d09f1-${projectId}-default-d70a46e0-22ea-11ed-8c6b-09a2d21dfbc3`,
-          compiled_stream: {
-            processors: [
-              { add_observer_metadata: { geo: { name: 'Fleet managed' } } },
-              { add_fields: { target: '', fields: { 'monitor.fleet_managed': true } } },
-            ],
-          },
-        },
-      ],
-    },
-  ],
-  is_managed: true,
-  revision: 1,
-  created_at: '2022-08-23T13:52:42.531Z',
-  created_by: 'system',
-  updated_at: '2022-08-23T13:52:42.531Z',
   updated_by: 'system',
 });
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.6`:
 - [[Synthetics] Omit or include `ssl` keys when appropriate for project monitors and private locations (#149298)](https://github.com/elastic/kibana/pull/149298)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Dominique Clarke","email":"dominique.clarke@elastic.co"},"sourceCommit":{"committedDate":"2023-01-24T19:56:38Z","message":"[Synthetics] Omit or include `ssl` keys when appropriate for project monitors and private locations (#149298)\n\n## Summary\r\n\r\nResolves https://github.com/elastic/kibana/issues/149083\r\n\r\n1. [Prevents tls fields from being\r\nsaved](https://github.com/elastic/kibana/pull/149298/files#diff-56296f634bf379eb71629f426c670cd030d2a15263a59964847c0d10af09a767R14)\r\non the Synthetics Integration policy when `is_tls_enabled` is false\r\n2. Ensures `is_tls_enabled` is set properly for project monitors\r\n([http](https://github.com/elastic/kibana/pull/149298/files#diff-0f42bb3b11a6ab864dee3488d5e9f7282adc009a261b3caee743a880b825c766R73)\r\nand\r\n[tcp](https://github.com/elastic/kibana/pull/149298/files#diff-3ad87e629abc6f17c395e8435c94f0f1a6274c9efea7d24ab81b7635ef0e43dfR69)).\r\nThis ensures that when a monitor is sent to a public location or a\r\nprivate location, the `ssl` fields are sent or stripped appropriately.\r\n\r\n### Testing\r\n\r\n1. Create a private location\r\n2. Create 2 lightweight project monitors using the following\r\nconfiguration\r\n```\r\n- type: tcp\r\n  id: 'tls-enabled'\r\n  name: 'TLS-Enabled'\r\n  hosts: [\"8.8.8.8:80\"]\r\n  ssl:\r\n     verification_mode: 'strict'\r\n```\r\n```\r\n- type: tcp\r\n  id: 'tls-disabled'\r\n  name: 'TLS-Disabled'\r\n  hosts: [\"8.8.8.8:80\"]\r\n```\r\n3. Set these monitors to execute from both a private and public location\r\nvia the `monitor` key in your `synthetics.config.ts` file.\r\n```\r\n    monitor: {\r\n      schedule: 3,\r\n      privateLocations: [\"YOUR PRIVATE LOCATION\"],\r\n      locations: [\"us_central\"], // to test against dev environment\r\n    },\r\n```\r\n4. Navigate to the agent policy for the private location and inspect the\r\nfull policy. Ensure the Synthetics policy on the agent package policy\r\ndoes not have `ssl` fields set for ssl disabled monitor. Ensure the\r\n`ssl` fields are set for the ssl enabled monitor.","sha":"0592abdab5c2d074468465380066b3dbeea89f4a","branchLabelMapping":{"^v8.7.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:fix","Team:uptime","v8.7.0","v8.6.1"],"number":149298,"url":"https://github.com/elastic/kibana/pull/149298","mergeCommit":{"message":"[Synthetics] Omit or include `ssl` keys when appropriate for project monitors and private locations (#149298)\n\n## Summary\r\n\r\nResolves https://github.com/elastic/kibana/issues/149083\r\n\r\n1. [Prevents tls fields from being\r\nsaved](https://github.com/elastic/kibana/pull/149298/files#diff-56296f634bf379eb71629f426c670cd030d2a15263a59964847c0d10af09a767R14)\r\non the Synthetics Integration policy when `is_tls_enabled` is false\r\n2. Ensures `is_tls_enabled` is set properly for project monitors\r\n([http](https://github.com/elastic/kibana/pull/149298/files#diff-0f42bb3b11a6ab864dee3488d5e9f7282adc009a261b3caee743a880b825c766R73)\r\nand\r\n[tcp](https://github.com/elastic/kibana/pull/149298/files#diff-3ad87e629abc6f17c395e8435c94f0f1a6274c9efea7d24ab81b7635ef0e43dfR69)).\r\nThis ensures that when a monitor is sent to a public location or a\r\nprivate location, the `ssl` fields are sent or stripped appropriately.\r\n\r\n### Testing\r\n\r\n1. Create a private location\r\n2. Create 2 lightweight project monitors using the following\r\nconfiguration\r\n```\r\n- type: tcp\r\n  id: 'tls-enabled'\r\n  name: 'TLS-Enabled'\r\n  hosts: [\"8.8.8.8:80\"]\r\n  ssl:\r\n     verification_mode: 'strict'\r\n```\r\n```\r\n- type: tcp\r\n  id: 'tls-disabled'\r\n  name: 'TLS-Disabled'\r\n  hosts: [\"8.8.8.8:80\"]\r\n```\r\n3. Set these monitors to execute from both a private and public location\r\nvia the `monitor` key in your `synthetics.config.ts` file.\r\n```\r\n    monitor: {\r\n      schedule: 3,\r\n      privateLocations: [\"YOUR PRIVATE LOCATION\"],\r\n      locations: [\"us_central\"], // to test against dev environment\r\n    },\r\n```\r\n4. Navigate to the agent policy for the private location and inspect the\r\nfull policy. Ensure the Synthetics policy on the agent package policy\r\ndoes not have `ssl` fields set for ssl disabled monitor. Ensure the\r\n`ssl` fields are set for the ssl enabled monitor.","sha":"0592abdab5c2d074468465380066b3dbeea89f4a"}},"sourceBranch":"main","suggestedTargetBranches":["8.6"],"targetPullRequestStates":[{"branch":"main","label":"v8.7.0","labelRegex":"^v8.7.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/149298","number":149298,"mergeCommit":{"message":"[Synthetics] Omit or include `ssl` keys when appropriate for project monitors and private locations (#149298)\n\n## Summary\r\n\r\nResolves https://github.com/elastic/kibana/issues/149083\r\n\r\n1. [Prevents tls fields from being\r\nsaved](https://github.com/elastic/kibana/pull/149298/files#diff-56296f634bf379eb71629f426c670cd030d2a15263a59964847c0d10af09a767R14)\r\non the Synthetics Integration policy when `is_tls_enabled` is false\r\n2. Ensures `is_tls_enabled` is set properly for project monitors\r\n([http](https://github.com/elastic/kibana/pull/149298/files#diff-0f42bb3b11a6ab864dee3488d5e9f7282adc009a261b3caee743a880b825c766R73)\r\nand\r\n[tcp](https://github.com/elastic/kibana/pull/149298/files#diff-3ad87e629abc6f17c395e8435c94f0f1a6274c9efea7d24ab81b7635ef0e43dfR69)).\r\nThis ensures that when a monitor is sent to a public location or a\r\nprivate location, the `ssl` fields are sent or stripped appropriately.\r\n\r\n### Testing\r\n\r\n1. Create a private location\r\n2. Create 2 lightweight project monitors using the following\r\nconfiguration\r\n```\r\n- type: tcp\r\n  id: 'tls-enabled'\r\n  name: 'TLS-Enabled'\r\n  hosts: [\"8.8.8.8:80\"]\r\n  ssl:\r\n     verification_mode: 'strict'\r\n```\r\n```\r\n- type: tcp\r\n  id: 'tls-disabled'\r\n  name: 'TLS-Disabled'\r\n  hosts: [\"8.8.8.8:80\"]\r\n```\r\n3. Set these monitors to execute from both a private and public location\r\nvia the `monitor` key in your `synthetics.config.ts` file.\r\n```\r\n    monitor: {\r\n      schedule: 3,\r\n      privateLocations: [\"YOUR PRIVATE LOCATION\"],\r\n      locations: [\"us_central\"], // to test against dev environment\r\n    },\r\n```\r\n4. Navigate to the agent policy for the private location and inspect the\r\nfull policy. Ensure the Synthetics policy on the agent package policy\r\ndoes not have `ssl` fields set for ssl disabled monitor. Ensure the\r\n`ssl` fields are set for the ssl enabled monitor.","sha":"0592abdab5c2d074468465380066b3dbeea89f4a"}},{"branch":"8.6","label":"v8.6.1","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->