### PR TITLE
[artifacts/container-image] Fix image tag when triggering update

### DIFF
--- a/.buildkite/scripts/steps/artifacts/docker_image.sh
+++ b/.buildkite/scripts/steps/artifacts/docker_image.sh
@@ -78,7 +78,7 @@ steps:
       env:
         MODE: sed
         TARGET_FILE: kibana-controller.yaml
-        IMAGE_TAG: "$KIBANA_IMAGE"
+        IMAGE_TAG: "$GIT_ABBREV_COMMIT"
         SERVICE: kibana-controller
 EOF
 


### PR DESCRIPTION
Instead of passing the entire qualified tag when triggering an update, this sets the image tag to the abbreviated commit.