### PR TITLE
[Cases] Adding oldestPushDate field to get connectors API

### DIFF
--- a/x-pack/plugins/cases/common/api/connectors/index.ts
+++ b/x-pack/plugins/cases/common/api/connectors/index.ts
@@ -120,7 +120,7 @@ export const GetCaseConnectorsResponseRt = rt.record(
   rt.string,
   rt.intersection([
     rt.type({ needsToBePushed: rt.boolean, hasBeenPushed: rt.boolean }),
-    rt.partial(rt.type({ latestPushDate: rt.string }).props),
+    rt.partial(rt.type({ latestPushDate: rt.string, oldestPushDate: rt.string }).props),
     CaseConnectorRt,
   ])
 );

--- a/x-pack/plugins/cases/server/client/user_actions/connectors.ts
+++ b/x-pack/plugins/cases/server/client/user_actions/connectors.ts
@@ -22,7 +22,7 @@ import type { CasesClientArgs } from '..';
 import type { Authorization, OwnerEntity } from '../../authorization';
 import { Operations } from '../../authorization';
 import type { GetConnectorsRequest } from './types';
-import type { CaseConnectorActivity, PushInfo } from '../../services/user_actions/types';
+import type { CaseConnectorActivity } from '../../services/user_actions/types';
 import type { CaseUserActionService } from '../../services';
 
 export const getConnectors = async (
@@ -82,10 +82,18 @@ const checkConnectorsAuthorization = async ({
     });
 
     if (connector.push) {
-      entities.push({
-        owner: connector.push.attributes.owner,
-        id: connector.connectorId,
-      });
+      entities.push(
+        ...[
+          {
+            owner: connector.push.mostRecent.attributes.owner,
+            id: connector.connectorId,
+          },
+          {
+            owner: connector.push.oldest.attributes.owner,
+            id: connector.connectorId,
+          },
+        ]
+      );
     }
   }
 
@@ -96,7 +104,8 @@ const checkConnectorsAuthorization = async ({
 };
 
 interface EnrichedPushInfo {
-  pushDate: Date;
+  latestPushDate: Date;
+  oldestPushDate: Date;
   connectorFieldsUsedInPush: CaseConnector;
 }
 
@@ -123,6 +132,12 @@ const getConnectorsInfo = async ({
   return createConnectorInfoResult({ actionConnectors, connectors, pushInfo, latestUserAction });
 };
 
+interface PushTimeFrameDetails {
+  connectorId: string;
+  mostRecentPush: Date;
+  oldestPush: Date;
+}
+
 const getPushInfo = async ({
   caseId,
   activity,
@@ -132,29 +147,39 @@ const getPushInfo = async ({
   activity: CaseConnectorActivity[];
   userActionService: CaseUserActionService;
 }): Promise<Map<string, EnrichedPushInfo>> => {
-  const pushRequest: PushInfo[] = [];
+  const pushDetails: PushTimeFrameDetails[] = [];
 
   for (const connectorInfo of activity) {
-    const pushCreatedAt = getDate(connectorInfo.push?.attributes.created_at);
+    const mostRecentPushCreatedAt = getDate(connectorInfo.push?.mostRecent.attributes.created_at);
+    const oldestPushCreatedAt = getDate(connectorInfo.push?.oldest.attributes.created_at);
 
-    if (connectorInfo.push != null && pushCreatedAt != null) {
-      pushRequest.push({ connectorId: connectorInfo.connectorId, date: pushCreatedAt });
+    if (
+      connectorInfo.push != null &&
+      mostRecentPushCreatedAt != null &&
+      oldestPushCreatedAt != null
+    ) {
+      pushDetails.push({
+        connectorId: connectorInfo.connectorId,
+        mostRecentPush: mostRecentPushCreatedAt,
+        oldestPush: oldestPushCreatedAt,
+      });
     }
   }
 
   const connectorFieldsForPushes = await userActionService.getConnectorFieldsBeforeLatestPush(
     caseId,
-    pushRequest
+    pushDetails.map((push) => ({ connectorId: push.connectorId, date: push.mostRecentPush }))
   );
 
   const enrichedPushInfo = new Map<string, EnrichedPushInfo>();
-  for (const request of pushRequest) {
-    const connectorFieldsSO = connectorFieldsForPushes.get(request.connectorId);
+  for (const pushInfo of pushDetails) {
+    const connectorFieldsSO = connectorFieldsForPushes.get(pushInfo.connectorId);
     const connectorFields = getConnectorInfoFromSavedObject(connectorFieldsSO);
 
     if (connectorFields != null) {
-      enrichedPushInfo.set(request.connectorId, {
-        pushDate: request.date,
+      enrichedPushInfo.set(pushInfo.connectorId, {
+        latestPushDate: pushInfo.mostRecentPush,
+        oldestPushDate: pushInfo.oldestPush,
         connectorFieldsUsedInPush: connectorFields,
       });
     }
@@ -223,7 +248,8 @@ const createConnectorInfoResult = ({
         ...connector,
         name: connectorDetails.name,
         needsToBePushed,
-        latestPushDate: enrichedPushInfo?.pushDate.toISOString(),
+        latestPushDate: enrichedPushInfo?.latestPushDate.toISOString(),
+        oldestPushDate: enrichedPushInfo?.oldestPushDate.toISOString(),
         hasBeenPushed: hasBeenPushed(enrichedPushInfo),
       };
     }
@@ -256,7 +282,9 @@ const hasDataToPush = ({
      * push fields will be undefined which will not equal the latest connector fields anyway.
      */
     !isEqual(connector, pushInfo?.connectorFieldsUsedInPush) ||
-    (pushInfo != null && latestUserActionDate != null && latestUserActionDate > pushInfo.pushDate)
+    (pushInfo != null &&
+      latestUserActionDate != null &&
+      latestUserActionDate > pushInfo.latestPushDate)
   );
 };
 

--- a/x-pack/plugins/cases/server/services/user_actions/types.ts
+++ b/x-pack/plugins/cases/server/services/user_actions/types.ts
@@ -143,10 +143,15 @@ export interface ServiceContext {
   auditLogger: AuditLogger;
 }
 
+export interface PushTimeFrameInfo {
+  mostRecent: SavedObject<CaseUserActionInjectedAttributesWithoutActionId>;
+  oldest: SavedObject<CaseUserActionInjectedAttributesWithoutActionId>;
+}
+
 export interface CaseConnectorActivity {
   connectorId: string;
   fields: SavedObject<CaseUserActionInjectedAttributesWithoutActionId>;
-  push?: SavedObject<CaseUserActionInjectedAttributesWithoutActionId>;
+  push?: PushTimeFrameInfo;
 }
 
 export type CaseConnectorFields = Map<

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/trial/internal/get_connectors.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/trial/internal/get_connectors.ts
@@ -233,7 +233,7 @@ export default ({ getService }: FtrProviderContext): void => {
 
     describe('push', () => {
       describe('latestPushDate', () => {
-        it('does not set latestPushDate when the connector has not been used to push', async () => {
+        it('does not set latestPushDate or oldestPushDate when the connector has not been used to push', async () => {
           const { postedCase, connector } = await createCaseWithConnector({
             supertest,
             serviceNowSimulatorURL,
@@ -245,9 +245,10 @@ export default ({ getService }: FtrProviderContext): void => {
           expect(Object.keys(connectors).length).to.be(1);
           expect(connectors).to.have.property(connector.id);
           expect(connectors[connector.id].latestPushDate).to.be(undefined);
+          expect(connectors[connector.id].oldestPushDate).to.be(undefined);
         });
 
-        it('sets latestPushDate to the most recent push date', async () => {
+        it('sets latestPushDate to the most recent push date and oldestPushDate to the first push date', async () => {
           const { postedCase, connector } = await createCaseWithConnector({
             supertest,
             serviceNowSimulatorURL,
@@ -278,10 +279,12 @@ export default ({ getService }: FtrProviderContext): void => {
           ]);
 
           const pushes = userActions.filter((ua) => ua.type === ActionTypes.pushed);
+          const oldestPush = pushes[0];
           const latestPush = pushes[pushes.length - 1];
 
           expect(Object.keys(connectors).length).to.be(1);
           expect(connectors[connector.id].latestPushDate).to.eql(latestPush.created_at);
+          expect(connectors[connector.id].oldestPushDate).to.eql(oldestPush.created_at);
         });
       });
 


### PR DESCRIPTION
This PR adds the `oldestPushDate` field to the `_connectors` API. This is needed to determine whether to show the text `pushed as new incident <name>`  or `updated incident <name>`.

Update response
```
{
    "8548e270-9c26-11ed-8376-87998de9968e": {
        "name": "Jira",
        "type": ".jira",
        "fields": {
            "issueType": "10001",
            "parent": null,
            "priority": null
        },
        "id": "8548e270-9c26-11ed-8376-87998de9968e",
        "needsToBePushed": false,
        "latestPushDate": "2023-01-24T20:35:54.325Z",
        "oldestPushDate": "2023-01-24T20:35:43.730Z", <--- New field
        "hasBeenPushed": true
    }
}
```