### PR TITLE
[Fleet] Update openAPI to include agent metrics

### DIFF
--- a/x-pack/plugins/fleet/common/openapi/bundled.json
+++ b/x-pack/plugins/fleet/common/openapi/bundled.json
@@ -1369,6 +1369,9 @@
           },
           {
             "$ref": "#/components/parameters/sort_order"
+          },
+          {
+            "$ref": "#/components/parameters/with_metrics"
           }
         ],
         "security": [
@@ -1569,7 +1572,12 @@
             }
           }
         },
-        "operationId": "get-agent"
+        "operationId": "get-agent",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/with_metrics"
+          }
+        ]
       },
       "put": {
         "summary": "Agent - Update",
@@ -4708,6 +4716,15 @@
             "desc"
           ]
         }
+      },
+      "with_metrics": {
+        "name": "withMetrics",
+        "in": "query",
+        "description": "Return agent metrics, false by default",
+        "required": false,
+        "schema": {
+          "type": "boolean"
+        }
       }
     },
     "schemas": {
@@ -5375,6 +5392,19 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/agent_component"
+            }
+          },
+          "metrics": {
+            "type": "object",
+            "properties": {
+              "cpu_avg": {
+                "type": "number",
+                "description": "Average agent CPU usage during the last 5 minute, number between 0-1"
+              },
+              "memory_size_byte_avg": {
+                "type": "number",
+                "description": "Average agent memory consumption during the last 5 minute"
+              }
             }
           }
         },

--- a/x-pack/plugins/fleet/common/openapi/bundled.yaml
+++ b/x-pack/plugins/fleet/common/openapi/bundled.yaml
@@ -856,6 +856,7 @@ paths:
         - $ref: '#/components/parameters/show_upgradeable'
         - $ref: '#/components/parameters/sort_field'
         - $ref: '#/components/parameters/sort_order'
+        - $ref: '#/components/parameters/with_metrics'
       security:
         - basicAuth: []
   /agents/bulk_upgrade:
@@ -983,6 +984,8 @@ paths:
                 required:
                   - item
       operationId: get-agent
+      parameters:
+        - $ref: '#/components/parameters/with_metrics'
     put:
       summary: Agent - Update
       tags: []
@@ -2934,6 +2937,13 @@ components:
         enum:
           - asc
           - desc
+    with_metrics:
+      name: withMetrics
+      in: query
+      description: Return agent metrics, false by default
+      required: false
+      schema:
+        type: boolean
   schemas:
     fleet_setup_response:
       title: Fleet Setup response
@@ -3405,6 +3415,17 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/agent_component'
+        metrics:
+          type: object
+          properties:
+            cpu_avg:
+              type: number
+              description: >-
+                Average agent CPU usage during the last 5 minute, number between
+                0-1
+            memory_size_byte_avg:
+              type: number
+              description: Average agent memory consumption during the last 5 minute
       required:
         - type
         - active

--- a/x-pack/plugins/fleet/common/openapi/components/parameters/with_metrics.yaml
+++ b/x-pack/plugins/fleet/common/openapi/components/parameters/with_metrics.yaml
@@ -1,0 +1,6 @@
+name: withMetrics
+in: query
+description: Return agent metrics, false by default
+required: false
+schema:
+  type: boolean

--- a/x-pack/plugins/fleet/common/openapi/components/schemas/agent.yaml
+++ b/x-pack/plugins/fleet/common/openapi/components/schemas/agent.yaml
@@ -42,10 +42,10 @@ properties:
     properties:
       cpu_avg:
         type: number
-        description: Average agent CPU usage during the last 5 minute, number between 0-1
+        description: Average agent CPU usage during the last 5 minutes, number between 0-1
       memory_size_byte_avg:
         type: number
-        description: Average agent memory consumption during the last 5 minute
+        description: Average agent memory consumption during the last 5 minutes
 
 required:
   - type

--- a/x-pack/plugins/fleet/common/openapi/components/schemas/agent.yaml
+++ b/x-pack/plugins/fleet/common/openapi/components/schemas/agent.yaml
@@ -37,6 +37,16 @@ properties:
     type: array
     items:
       $ref: ./agent_component.yaml
+  metrics:
+    type: object
+    properties:
+      cpu_avg:
+        type: number
+        description: Average agent CPU usage during the last 5 minute, number between 0-1
+      memory_size_byte_avg:
+        type: number
+        description: Average agent memory consumption during the last 5 minute
+
 required:
   - type
   - active

--- a/x-pack/plugins/fleet/common/openapi/paths/agents.yaml
+++ b/x-pack/plugins/fleet/common/openapi/paths/agents.yaml
@@ -17,5 +17,6 @@ get:
     - $ref: ../components/parameters/show_upgradeable.yaml
     - $ref: ../components/parameters/sort_field.yaml
     - $ref: ../components/parameters/sort_order.yaml
+    - $ref: ../components/parameters/with_metrics.yaml
   security:
     - basicAuth: []

--- a/x-pack/plugins/fleet/common/openapi/paths/agents@{agent_id}.yaml
+++ b/x-pack/plugins/fleet/common/openapi/paths/agents@{agent_id}.yaml
@@ -20,6 +20,8 @@ get:
             required:
               - item
   operationId: get-agent
+  parameters:
+    - $ref: ../components/parameters/with_metrics.yaml
 put:
   summary: Agent - Update
   tags: []
@@ -45,12 +47,12 @@ put:
         schema:
           type: object
           properties:
-              user_provided_metadata:
-                type: object  
-              tags:
-                type: array
-                items:
-                  type: string  
+            user_provided_metadata:
+              type: object
+            tags:
+              type: array
+              items:
+                type: string
 delete:
   summary: Agent - Delete
   tags: []


### PR DESCRIPTION
## Summary

Related to https://github.com/elastic/kibana/pull/149119

Update the fleet openAPI to reflect the change made to return metrics in the GET agent endpoints.

<img width="871" alt="Screen Shot 2023-01-24 at 4 55 49 PM" src="https://user-images.githubusercontent.com/1336873/214411910-bd369ab9-80db-4581-a01e-32cb2669e596.png">
<img width="756" alt="Screen Shot 2023-01-24 at 4 55 04 PM" src="https://user-images.githubusercontent.com/1336873/214411915-156a1574-2899-403d-960a-2b3ca1199623.png">
