### PR TITLE
[Security solution] Re-add country flag to Top Countries Table

### DIFF
--- a/x-pack/plugins/security_solution/public/explore/network/components/network_top_countries_table/columns.tsx
+++ b/x-pack/plugins/security_solution/public/explore/network/components/network_top_countries_table/columns.tsx
@@ -10,6 +10,7 @@ import numeral from '@elastic/numeral';
 import React from 'react';
 import type { DataViewBase } from '@kbn/es-query';
 import { CellActions, CellActionsMode } from '@kbn/cell-actions';
+import { CountryFlagAndName } from '../source_destination/country_flag';
 import type {
   NetworkTopCountriesEdges,
   TopNetworkTablesEcsField,
@@ -17,7 +18,7 @@ import type {
 import { FlowTargetSourceDest } from '../../../../../common/search_strategy/security_solution/network';
 import { networkModel } from '../../store';
 import { escapeDataProviderId } from '../../../../common/components/drag_and_drop/helpers';
-import { defaultToEmptyTag, getEmptyTagValue } from '../../../../common/components/empty_value';
+import { getEmptyTagValue } from '../../../../common/components/empty_value';
 import type { Columns } from '../../../components/paginated_table';
 import * as i18n from './translations';
 import { PreferenceFormattedBytes } from '../../../../common/components/formatted_bytes';
@@ -66,7 +67,7 @@ export const getNetworkTopCountriesColumns = (
               type: 'keyword',
             }}
           >
-            {defaultToEmptyTag(geo)}
+            <CountryFlagAndName countryCode={geo} />
           </CellActions>
         );
       } else {


### PR DESCRIPTION
## Summary

[The CellActions PR](https://github.com/elastic/kibana/pull/148056/files#r1085874035) changed the design of the Top Countries Table (unintentionally I believe). The country name column should have the flag and full country name. Fixed by re-adding the original component.

### Before
<img width="1088" alt="Screen Shot 2023-01-24 at 2 42 27 PM" src="https://user-images.githubusercontent.com/6935300/214427453-8a9cd4da-0a53-40fb-a811-ad1c8dadca01.png">

### After
<img width="1094" alt="Screen Shot 2023-01-24 at 2 41 55 PM" src="https://user-images.githubusercontent.com/6935300/214427456-eb2457bb-c78b-466c-9a4d-463e28468a8a.png">

