### PR TITLE
[DOCS] Removes tag from 8.6.1 release notes

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -44,8 +44,6 @@ Review important information about the {kib} 8.6.x releases.
 [[release-notes-8.6.1]]
 == {kib} 8.6.1
 
-coming::[8.6.1]
-
 Review the following information about the {kib} 8.6.1 release.
 
 [float]


### PR DESCRIPTION
## Summary

Removes the `coming` tag from the 8.6.1 release notes.

