### PR TITLE
[RAM] Reduce triggers actions UI bundle size

### DIFF
--- a/x-pack/plugins/triggers_actions_ui/public/application/lib/action_connector_api/index.ts
+++ b/x-pack/plugins/triggers_actions_ui/public/application/lib/action_connector_api/index.ts
@@ -11,7 +11,3 @@ export { createActionConnector } from './create';
 export { deleteActions } from './delete';
 export { executeAction } from './execute';
 export { updateActionConnector } from './update';
-export type { LoadGlobalConnectorExecutionLogAggregationsProps } from './load_execution_log_aggregations';
-export { loadGlobalConnectorExecutionLogAggregations } from './load_execution_log_aggregations';
-export type { LoadGlobalConnectorExecutionKPIAggregationsProps } from './load_execution_kpi_aggregations';
-export { loadGlobalConnectorExecutionKPIAggregations } from './load_execution_kpi_aggregations';

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/actions_connectors_list/components/actions_connectors_event_log_list_table.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/actions_connectors_list/components/actions_connectors_event_log_list_table.tsx
@@ -29,7 +29,7 @@ import {
   CONNECTOR_LOCKED_COLUMNS,
 } from '../../../constants';
 import { CenterJustifiedSpinner } from '../../../components/center_justified_spinner';
-import { LoadGlobalConnectorExecutionLogAggregationsProps } from '../../../lib/action_connector_api';
+import { LoadGlobalConnectorExecutionLogAggregationsProps } from '../../../lib/action_connector_api/load_execution_log_aggregations';
 import {
   ComponentOpts as ConnectorApis,
   withActionOperations,

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/common/components/with_actions_api_operations.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/common/components/with_actions_api_operations.tsx
@@ -9,13 +9,15 @@ import React from 'react';
 
 import { IExecutionLogResult, IExecutionKPIResult } from '@kbn/actions-plugin/common';
 import { ActionType } from '../../../../types';
+import { loadActionTypes } from '../../../lib/action_connector_api';
 import {
-  loadActionTypes,
-  LoadGlobalConnectorExecutionLogAggregationsProps,
-  loadGlobalConnectorExecutionLogAggregations,
-  LoadGlobalConnectorExecutionKPIAggregationsProps,
   loadGlobalConnectorExecutionKPIAggregations,
-} from '../../../lib/action_connector_api';
+  LoadGlobalConnectorExecutionKPIAggregationsProps,
+} from '../../../lib/action_connector_api/load_execution_kpi_aggregations';
+import {
+  loadGlobalConnectorExecutionLogAggregations,
+  LoadGlobalConnectorExecutionLogAggregationsProps,
+} from '../../../lib/action_connector_api/load_execution_log_aggregations';
 import { useKibana } from '../../../../common/lib/kibana';
 
 export interface ComponentOpts {


### PR DESCRIPTION
## Summary
Reduces the bundle size of `triggersActionsUI`. Fix a change in a recent PR that added util functions to an index file that was in turn being imported when it wasn't needed. Gets it down to `118085`.

![image](https://user-images.githubusercontent.com/74562234/214467217-7e778b38-51e9-482a-8ce2-5774f9d96425.png)
