### PR TITLE
Upgrade `simple-git` dependency (`3.15.1` → `3.16.0`).

### DIFF
--- a/package.json
+++ b/package.json
@@ -1156,7 +1156,7 @@
     "rxjs-marbles": "^7.0.1",
     "sass-loader": "^10.4.1",
     "selenium-webdriver": "^4.7.1",
-    "simple-git": "^3.15.1",
+    "simple-git": "^3.16.0",
     "sinon": "^7.4.2",
     "sort-package-json": "^1.53.1",
     "source-map": "^0.7.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3817,7 +3817,6 @@
   version "0.0.0"
   uid ""
 
-
 "@kbn/ml-date-picker@link:x-pack/packages/ml/date_picker":
   version "0.0.0"
   uid ""
@@ -24811,10 +24810,10 @@ simple-get@^4.0.0, simple-get@^4.0.1:
     once "^1.3.1"
     simple-concat "^1.0.0"
 
-simple-git@^3.15.1:
-  version "3.15.1"
-  resolved "https://registry.yarnpkg.com/simple-git/-/simple-git-3.15.1.tgz#57f595682cb0c2475d5056da078a05c8715a25ef"
-  integrity sha512-73MVa5984t/JP4JcQt0oZlKGr42ROYWC3BcUZfuHtT3IHKPspIvL0cZBnvPXF7LL3S/qVeVHVdYYmJ3LOTw4Rg==
+simple-git@^3.16.0:
+  version "3.16.0"
+  resolved "https://registry.yarnpkg.com/simple-git/-/simple-git-3.16.0.tgz#421773e24680f5716999cc4a1d60127b4b6a9dec"
+  integrity sha512-zuWYsOLEhbJRWVxpjdiXl6eyAyGo/KzVW+KFhhw9MqEEJttcq+32jTWSGyxTdf9e/YCohxRE+9xpWFj9FdiJNw==
   dependencies:
     "@kwsites/file-exists" "^1.1.1"
     "@kwsites/promise-deferred" "^1.1.1"


### PR DESCRIPTION
## Summary

Upgrade `simple-git` dependency (`3.15.1` → `3.16.0`).

Change log: https://github.com/steveukx/git-js/releases/tag/simple-git%403.16.0
Change set: https://github.com/steveukx/git-js/compare/simple-git%403.15.1...simple-git%403.16.0

There are no breaking or notable changes in the release.


<!--ONMERGE {"backportTargets":["7.17","8.6"]} ONMERGE-->