### PR TITLE
[Console] Update autocomplete proxy configuration to inlcude proxy headers

### DIFF
--- a/src/plugins/console/server/routes/api/console/autocomplete_entities/get_entity.ts
+++ b/src/plugins/console/server/routes/api/console/autocomplete_entities/get_entity.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import http from 'http';
+import https from 'https';
+import { Buffer } from 'buffer';
+import Boom from '@hapi/boom';
+import { sanitizeHostname } from '../../../../lib/utils';
+import { getRequestConfig, getProxyHeaders } from '../proxy/create_handler';
+import type { Config } from '.';
+
+const MAX_RESPONSE_SIZE = 10 * 1024 * 1024; // 10MB
+// Limit the response size to 10MB, because the response can be very large and sending it to the client
+// can cause the browser to hang.
+
+/**
+ * Get the autocomplete suggestions for the given entity.
+ * We are using the raw http request in this function to retrieve the entities instead of esClient because
+ * the esClient does not handle large responses well. For example, the response size for
+ * the mappings can be very large(> 1GB) and the esClient will throw an 'Invalid string length'
+ * error when trying to parse the response. By using the raw http request, we can limit the
+ * response size and avoid the error.
+ * @param path  The path to the entity to retrieve. For example, '/_mapping' or '/_alias'.
+ * @param config The configuration for the request.
+ * @returns The entity retrieved from Elasticsearch.
+ */
+export const getEntity = (path: string, config: Config) => {
+  return new Promise((resolve, reject) => {
+    const { hosts, kibanaVersion } = config;
+    for (let idx = 0; idx < hosts.length; idx++) {
+      const host = hosts[idx];
+      const uri = new URL(host + path);
+      const { protocol, hostname, port } = uri;
+      const { headers, agent } = getRequestConfig(
+        config.request.headers,
+        config,
+        uri.toString(),
+        kibanaVersion,
+        config.proxyConfigCollection
+      );
+      const proxyHeaders = getProxyHeaders(config.request);
+      const client = protocol === 'https:' ? https : http;
+      const requestHeaders = {
+        ...headers,
+        ...proxyHeaders,
+        'x-elastic-product-origin': 'kibana', // This header is used to identify the origin of the request. It is used to filter out deprecation logs.
+        'content-type': 'application/json',
+        'transfer-encoding': 'chunked',
+      };
+      const hasHostHeader = Object.keys(requestHeaders).some((key) => key.toLowerCase() === 'host');
+      if (!hasHostHeader) {
+        // If the user didn't specify a host header, we need to set one so that the request
+        // doesn't get rejected by Elasticsearch.
+        requestHeaders.host = hostname;
+      }
+      const options = {
+        method: 'GET',
+        headers: requestHeaders,
+        host: sanitizeHostname(hostname),
+        port: port === '' ? undefined : parseInt(port, 10),
+        protocol,
+        path: `${path}?pretty=false`, // add pretty=false to compress the response by removing whitespace
+        agent,
+      };
+
+      try {
+        const req = client.request(options, (res) => {
+          const chunks: Buffer[] = [];
+
+          let currentLength = 0;
+
+          res.on('data', (chunk) => {
+            currentLength += Buffer.byteLength(chunk);
+
+            chunks.push(chunk);
+
+            // Destroy the request if the response is too large
+            if (currentLength > MAX_RESPONSE_SIZE) {
+              req.destroy();
+              reject(Boom.badRequest(`Response size is too large for ${path}`));
+            }
+          });
+          res.on('end', () => {
+            const body = Buffer.concat(chunks).toString('utf8');
+            resolve(JSON.parse(body));
+          });
+        });
+        req.on('error', reject);
+        req.end();
+        break;
+      } catch (err) {
+        if (idx === hosts.length - 1) {
+          reject(err);
+        }
+        // Try the next host
+      }
+    }
+  });
+};

--- a/src/plugins/console/server/routes/api/console/proxy/create_handler.ts
+++ b/src/plugins/console/server/routes/api/console/proxy/create_handler.ts
@@ -15,6 +15,7 @@ import { KibanaRequest, RequestHandler } from '@kbn/core/server';
 // TODO: find a better way to get information from the request like remoteAddress and remotePort
 // for forwarding.
 import { ensureRawRequest } from '@kbn/core-http-router-server-internal';
+import type { OutgoingHttpHeaders } from 'http';
 import { ESConfigForProxy } from '../../../../types';
 import {
   getElasticsearchProxyConfig,
@@ -49,7 +50,12 @@ export function getRequestConfig(
   uri: string,
   kibanaVersion: SemVer,
   proxyConfigCollection?: ProxyConfigCollection
-): { agent: Agent; timeout: number; headers: object; rejectUnauthorized?: boolean } {
+): {
+  agent: Agent;
+  timeout: number;
+  headers: OutgoingHttpHeaders;
+  rejectUnauthorized?: boolean;
+} {
   const filteredHeaders = filterHeaders(headers, esConfig.requestHeadersWhitelist);
   const newHeaders = setHeaders(filteredHeaders, esConfig.customHeaders);
 
@@ -70,7 +76,7 @@ export function getRequestConfig(
   };
 }
 
-function getProxyHeaders(req: KibanaRequest) {
+export function getProxyHeaders(req: KibanaRequest) {
   const headers = Object.create(null);
 
   // Scope this proto-unsafe functionality to where it is being used.

--- a/src/plugins/console/tsconfig.json
+++ b/src/plugins/console/tsconfig.json
@@ -29,7 +29,7 @@
     "@kbn/config-schema",
     "@kbn/core-http-router-server-internal",
     "@kbn/web-worker-stub",
-    "@kbn/core-elasticsearch-server",
+    "@kbn/core-http-server",
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION

## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
