### PR TITLE
[Console] Update autocomplete route configuration to include proxy headers

### DIFF
--- a/src/plugins/console/server/routes/api/console/autocomplete_entities/index.ts
+++ b/src/plugins/console/server/routes/api/console/autocomplete_entities/index.ts
@@ -118,6 +118,9 @@ const getEntity = (path: string, config: Config) => {
       };
 
       const hasHostHeader = Object.keys(requestHeaders).some((key) => key.toLowerCase() === 'host');
+      // if the host header is not set, then set it to the hostname. This is needed because the
+      // request will fail if the host header is not set and it is used to determine the node to
+      // send the request to in a multi-node cluster.
       if (!hasHostHeader) {
         requestHeaders.host = hostname;
       }
@@ -193,7 +196,7 @@ export const registerAutocompleteEntitiesRoute = (deps: RouteDependencies) => {
       }
 
       const legacyConfig = await deps.proxy.readLegacyESConfig();
-      const configWithHeaders = {
+      const config = {
         ...legacyConfig,
         request,
         kibanaVersion: deps.kibanaVersion,
@@ -201,12 +204,12 @@ export const registerAutocompleteEntitiesRoute = (deps: RouteDependencies) => {
 
       // Wait for all requests to complete, in case one of them fails return the successfull ones
       const results = await Promise.allSettled([
-        getMappings(settings, configWithHeaders),
-        getAliases(settings, configWithHeaders),
-        getDataStreams(settings, configWithHeaders),
-        getLegacyTemplates(settings, configWithHeaders),
-        getIndexTemplates(settings, configWithHeaders),
-        getComponentTemplates(settings, configWithHeaders),
+        getMappings(settings, config),
+        getAliases(settings, config),
+        getDataStreams(settings, config),
+        getLegacyTemplates(settings, config),
+        getIndexTemplates(settings, config),
+        getComponentTemplates(settings, config),
       ]);
 
       const [mappings, aliases, dataStreams, legacyTemplates, indexTemplates, componentTemplates] =

--- a/src/plugins/console/server/routes/api/console/autocomplete_entities/index.ts
+++ b/src/plugins/console/server/routes/api/console/autocomplete_entities/index.ts
@@ -103,18 +103,23 @@ const getEntity = (path: string, config: Config) => {
       const host = hosts[idx];
       const uri = new URL(host + path);
       const { protocol, hostname, port } = uri;
-      const { headers, agent } = getRequestConfig(config.request.headers, config, uri.toString(), kibanaVersion);
+      const { headers, agent } = getRequestConfig(
+        config.request.headers,
+        config,
+        uri.toString(),
+        kibanaVersion
+      );
       const proxyHeaders = getProxyHeaders(config.request);
       const client = protocol === 'https:' ? https : http;
 
       const requestHeaders = {
         ...headers,
         ...proxyHeaders,
-      }
+      };
 
       const hasHostHeader = Object.keys(requestHeaders).some((key) => key.toLowerCase() === 'host');
       if (!hasHostHeader) {
-        requestHeaders['host'] = hostname;
+        requestHeaders.host = hostname;
       }
 
       const options = {

--- a/src/plugins/console/server/routes/api/console/proxy/create_handler.ts
+++ b/src/plugins/console/server/routes/api/console/proxy/create_handler.ts
@@ -70,7 +70,7 @@ export function getRequestConfig(
   };
 }
 
-function getProxyHeaders(req: KibanaRequest) {
+export function getProxyHeaders(req: KibanaRequest) {
   const headers = Object.create(null);
 
   // Scope this proto-unsafe functionality to where it is being used.


### PR DESCRIPTION
### Summary

This PR updates the autocomplete route configuration to include missing proxy headers such as `x-forwarded-for`,
`x-forwarded-host`, `x-forwarded-port`, and `x-forwarded-proto` to ensure that remote headers are forwarded to the Elasticsearch server. And also adds a check to ensure that the `host` header is set to the hostname if it is not already set. Users reported that the autocomplete indices were not showing up in the autocomplete dropdown in some cases due to the misconfiguration in autocomplete route. This PR should fix that issue.

This PR is only aimed to 8.6.x since in main we recently [merged a PR](https://github.com/elastic/kibana/pull/148146) which refactors this raw queries in favour of using the native es client which already takes into consideration proxy header and es ssl configurations.

### Testing

To test this PR, verify that the correct headers are being sent to the Elasticsearch server when using the autocomplete route. You can use the `console.log` statement in the [`getEntity`](https://github.com/elastic/kibana/pull/149498/files#diff-dc97f758bd78991f73f2f928fc59d00923790286e12766dd7c91d148ec40cfeeR118) function to verify that the headers are being sent correctly. 

#### Release note

This PR fixes an issue where the autocomplete indices were not showing up in the autocomplete dropdown in some cases due to the misconfiguration in autocomplete route.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
