### PR TITLE
[Fleet] Add check for legacy managed_by field in datastream mappings

### DIFF
--- a/x-pack/plugins/fleet/server/routes/data_streams/handlers.ts
+++ b/x-pack/plugins/fleet/server/routes/data_streams/handlers.ts
@@ -54,8 +54,11 @@ export const getListHandler: RequestHandler = async (context, request, response)
       getPackageSavedObjects(savedObjects.client),
     ]);
 
+    // managed_by property 'ingest-manager' added to allow for legacy data streams to be displayed
+    // See https://github.com/elastic/elastic-agent/issues/654
+
     const filteredDataStreamsInfo = dataStreamsInfo.filter(
-      (ds) => ds?._meta?.managed_by === 'fleet'
+      (ds) => ds?._meta?.managed_by === 'fleet' || ds?._meta?.managed_by === 'ingest-manager'
     );
 
     const dataStreamsInfoByName = keyBy<ESDataStreamInfo>(filteredDataStreamsInfo, 'name');
@@ -116,6 +119,7 @@ export const getListHandler: RequestHandler = async (context, request, response)
     // Query additional information for each data stream
     const dataStreamPromises = dataStreamNames.map(async (dataStreamName) => {
       const dataStream = dataStreams[dataStreamName];
+
       const dataStreamResponse: DataStream = {
         index: dataStreamName,
         dataset: '',

--- a/x-pack/plugins/fleet/server/routes/data_streams/handlers.ts
+++ b/x-pack/plugins/fleet/server/routes/data_streams/handlers.ts
@@ -16,6 +16,9 @@ import { dataStreamService } from '../../services/data_streams';
 
 import { getDataStreamsQueryMetadata } from './get_data_streams_query_metadata';
 
+const MANAGED_BY = 'fleet';
+const LEGACY_MANAGED_BY = 'ingest-manager';
+
 interface ESDataStreamInfo {
   name: string;
   timestamp_field: {
@@ -58,7 +61,7 @@ export const getListHandler: RequestHandler = async (context, request, response)
     // See https://github.com/elastic/elastic-agent/issues/654
 
     const filteredDataStreamsInfo = dataStreamsInfo.filter(
-      (ds) => ds?._meta?.managed_by === 'fleet' || ds?._meta?.managed_by === 'ingest-manager'
+      (ds) => ds?._meta?.managed_by === MANAGED_BY || ds?._meta?.managed_by === LEGACY_MANAGED_BY
     );
 
     const dataStreamsInfoByName = keyBy<ESDataStreamInfo>(filteredDataStreamsInfo, 'name');


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/147605

### Description
Clusters that exist since pre-8.0 might have data streams that have `managed_by: ingest_manager` in their` _meta` properties, instead of the current value `managed_by: fleet`.
However, with the merge of https://github.com/elastic/kibana/pull/143300, the data streams view filters out any data streams that don't have `managed_by: fleet` metadata, so when updating from 7.x to 8.6.x no data streams are returned.

### Solution
It was decided to simply add an additional check in the data stream handler to allow for "legacy" metadata, and to avoid doing migrations that can be dangerous for the users data.


### Testing
I'm looking for a way to reliably test this locally - I've only managed to reproduce it on cloud



<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->