### PR TITLE
[Security Solution] Migrate rules table tags filter to EuiSelectable

### DIFF
--- a/x-pack/plugins/security_solution/cypress/e2e/detection_rules/bulk_edit_rules.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_rules/bulk_edit_rules.cy.ts
@@ -290,12 +290,6 @@ describe('Detection rules, bulk edit', () => {
       // check if only pre-populated tags exist in the tags filter
       checkTagsInTagsFilter(prePopulatedTags);
 
-      cy.get(EUI_FILTER_SELECT_ITEM)
-        .should('have.length', prePopulatedTags.length)
-        .each(($el, index) => {
-          cy.wrap($el).should('have.text', prePopulatedTags[index]);
-        });
-
       selectNumberOfRules(expectedNumberOfCustomRulesToBeEdited);
 
       // open add tags form and add 2 new tags

--- a/x-pack/plugins/security_solution/cypress/e2e/detection_rules/bulk_edit_rules.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_rules/bulk_edit_rules.cy.ts
@@ -267,12 +267,6 @@ describe('Detection rules, bulk edit', () => {
       // check if only pre-populated tags exist in the tags filter
       checkTagsInTagsFilter(prePopulatedTags);
 
-      cy.get(EUI_FILTER_SELECT_ITEM)
-        .should('have.length', prePopulatedTags.length)
-        .each(($el, index) => {
-          cy.wrap($el).should('have.text', prePopulatedTags[index]);
-        });
-
       selectNumberOfRules(expectedNumberOfCustomRulesToBeEdited);
 
       // open add tags form and add 2 new tags

--- a/x-pack/plugins/security_solution/cypress/screens/common/controls.ts
+++ b/x-pack/plugins/security_solution/cypress/screens/common/controls.ts
@@ -9,6 +9,8 @@ export const TIMELINE_SEARCHBOX = '[data-test-subj="timeline-super-select-search
 
 export const EUI_FILTER_SELECT_ITEM = '.euiFilterSelectItem';
 
+export const EUI_SELECTABLE_LIST_ITEM = '[data-test-subj="euiSelectableList"] li';
+
 export const EUI_CHECKBOX = '.euiCheckbox__input';
 
 export const COMBO_BOX_INPUT = '[data-test-subj="comboBoxInput"]';

--- a/x-pack/plugins/security_solution/cypress/tasks/rules_bulk_edit.ts
+++ b/x-pack/plugins/security_solution/cypress/tasks/rules_bulk_edit.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { TIMELINE_SEARCHBOX, EUI_FILTER_SELECT_ITEM } from '../screens/common/controls';
+import { TIMELINE_SEARCHBOX, EUI_SELECTABLE_LIST_ITEM } from '../screens/common/controls';
 
 import {
   BULK_ACTIONS_BTN,
@@ -226,7 +226,7 @@ export const selectTimelineTemplate = (timelineTitle: string) => {
 export const checkTagsInTagsFilter = (tags: string[]) => {
   cy.get(RULES_TAGS_FILTER_BTN).contains(`Tags${tags.length}`).click();
 
-  cy.get(EUI_FILTER_SELECT_ITEM)
+  cy.get(EUI_SELECTABLE_LIST_ITEM)
     .should('have.length', tags.length)
     .each(($el, index) => {
       cy.wrap($el).should('have.text', tags[index]);

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table_filters/tags_filter_popover.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table_filters/tags_filter_popover.tsx
@@ -93,9 +93,9 @@ const TagsFilterPopoverComponent = ({
       <EuiSelectable
         searchable
         searchProps={{
-          placeholder: 'Search tags',
+          placeholder: i18n.SEARCH_TAGS,
         }}
-        aria-label="Rules tag search"
+        aria-label={i18n.RULES_TAG_SEARCH}
         options={selectableOptions}
         onChange={handleSelectableOptionsChange}
         emptyMessage={i18n.NO_TAGS_AVAILABLE}

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table_filters/tags_filter_popover.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table_filters/tags_filter_popover.tsx
@@ -101,7 +101,7 @@ const TagsFilterPopoverComponent = ({
       >
         {(list, search) => (
           <div style={{ width: 275 }}>
-            <EuiPopoverTitle paddingSize="s">{search}</EuiPopoverTitle>
+            <EuiPopoverTitle>{search}</EuiPopoverTitle>
             {list}
           </div>
         )}

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table_filters/tags_filter_popover.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table_filters/tags_filter_popover.tsx
@@ -12,6 +12,8 @@ import * as i18n from '../../../../../detections/pages/detection_engine/rules/tr
 import { toggleSelectedGroup } from '../../../../../common/components/ml_popover/jobs_table/filters/toggle_selected_group';
 import { caseInsensitiveSort } from '../helpers';
 
+const TAGS_POPOVER_WIDTH = 274;
+
 interface TagsFilterPopoverProps {
   selectedTags: string[];
   tags: string[];
@@ -100,7 +102,7 @@ const TagsFilterPopoverComponent = ({
         noMatchesMessage={i18n.NO_TAGS_AVAILABLE}
       >
         {(list, search) => (
-          <div style={{ width: 275 }}>
+          <div style={{ width: TAGS_POPOVER_WIDTH }}>
             <EuiPopoverTitle>{search}</EuiPopoverTitle>
             {list}
           </div>

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table_filters/tags_filter_popover.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table_filters/tags_filter_popover.tsx
@@ -92,7 +92,6 @@ const TagsFilterPopoverComponent = ({
         searchable
         searchProps={{
           placeholder: 'Search tags',
-          compressed: true,
         }}
         aria-label="Rules tag search"
         options={selectableOptions}

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table_filters/tags_filter_popover.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table_filters/tags_filter_popover.tsx
@@ -73,6 +73,9 @@ const TagsFilterPopoverComponent = ({
       closePopover={() => setIsTagPopoverOpen(!isTagPopoverOpen)}
       panelPaddingSize="none"
       repositionOnScroll
+      panelProps={{
+        'data-test-subj': 'tags-filter-popover',
+      }}
     >
       <EuiSelectable
         searchable

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table_filters/tags_filter_popover.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table_filters/tags_filter_popover.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import type { EuiSelectableOption } from '@elastic/eui';
 import { EuiFilterButton, EuiPopover, EuiPopoverTitle, EuiSelectable } from '@elastic/eui';
 import * as i18n from '../../../../../detections/pages/detection_engine/rules/translations';
@@ -50,6 +50,17 @@ const TagsFilterPopoverComponent = ({
     setSelectableOptions(newOptions);
     toggleSelectedGroup(changedOption.label, selectedTags, onSelectedTagsChanged);
   };
+
+  useEffect(() => {
+    const selectedTagsSet = new Set(selectedTags);
+    const newSelectableOptions: EuiSelectableOption[] = sortedTags.map((label) => ({
+      label,
+      checked: selectedTagsSet.has(label) ? 'on' : undefined,
+    }));
+
+    setSelectableOptions(newSelectableOptions);
+  }, [sortedTags, selectedTags]);
+
   const triggerButton = (
     <EuiFilterButton
       grow

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/translations.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/translations.ts
@@ -659,6 +659,20 @@ export const TAGS = i18n.translate(
   }
 );
 
+export const SEARCH_TAGS = i18n.translate(
+  'xpack.securitySolution.detectionEngine.rules.allRules.filters.searchTagsPlaceholder',
+  {
+    defaultMessage: 'Search tags',
+  }
+);
+
+export const RULES_TAG_SEARCH = i18n.translate(
+  'xpack.securitySolution.detectionEngine.rules.allRules.filters.rulesTagSearchText',
+  {
+    defaultMessage: 'Rules tag search',
+  }
+);
+
 export const NO_TAGS_AVAILABLE = i18n.translate(
   'xpack.securitySolution.detectionEngine.rules.allRules.filters.noTagsAvailableDescription',
   {


### PR DESCRIPTION
**Relates to**: https://github.com/elastic/kibana/issues/140263

## Summary

This PR migrates custom tags selector implementation on the rules page which mimics EuiSelectable to **EuiSelectable**. Besides simplification it brings keyboard and accessibility support as well as simplifies accessing the component in e2e tests.

*Before:*

https://user-images.githubusercontent.com/3775283/214831542-737aa9cf-8f76-4777-a23f-cbbfe0a01825.mov

*After:*

https://user-images.githubusercontent.com/3775283/214831568-e0809fd7-3c17-4789-8d3a-9ecbe379fb56.mov

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)
