### PR TITLE
[SecuritySolution] Fix data view not found when rendering with adHocDataView

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/risk_scores/__snapshots__/risk_score_donut.test.ts.snap
+++ b/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/risk_scores/__snapshots__/risk_score_donut.test.ts.snap
@@ -6,11 +6,11 @@ Object {
   "references": Array [],
   "state": Object {
     "adHocDataViews": Object {
-      "1dd5663b-f062-43f8-8688-fc8166c2ca8e": Object {
+      "d594baeb-5eca-480c-8885-ba79eaf41372": Object {
         "allowNoIndex": false,
         "fieldAttrs": Object {},
         "fieldFormats": Object {},
-        "id": "1dd5663b-f062-43f8-8688-fc8166c2ca8e",
+        "id": "d594baeb-5eca-480c-8885-ba79eaf41372",
         "name": "ml_host_risk_score_latest_mockSpaceId",
         "runtimeFieldMap": Object {},
         "sourceFilters": Array [],
@@ -21,7 +21,7 @@ Object {
     "datasourceStates": Object {
       "formBased": Object {
         "layers": Object {
-          "d594baeb-5eca-480c-8885-ba79eaf41372": Object {
+          "2cc5663b-f062-43f8-8688-fc8166c2ca8e": Object {
             "columnOrder": Array [
               "a2e8541a-c22f-4e43-8a12-caa33edc5de0",
               "75179122-96fc-40e1-93b4-8e9310af5f06",
@@ -115,8 +115,8 @@ Object {
     ],
     "internalReferences": Array [
       Object {
-        "id": "1dd5663b-f062-43f8-8688-fc8166c2ca8e",
-        "name": "indexpattern-datasource-layer-d594baeb-5eca-480c-8885-ba79eaf41372",
+        "id": "d594baeb-5eca-480c-8885-ba79eaf41372",
+        "name": "indexpattern-datasource-layer-2cc5663b-f062-43f8-8688-fc8166c2ca8e",
         "type": "index-pattern",
       },
     ],
@@ -129,7 +129,7 @@ Object {
         Object {
           "categoryDisplay": "hide",
           "emptySizeRatio": 0.82,
-          "layerId": "d594baeb-5eca-480c-8885-ba79eaf41372",
+          "layerId": "2cc5663b-f062-43f8-8688-fc8166c2ca8e",
           "layerType": "data",
           "legendDisplay": "show",
           "legendPosition": "left",

--- a/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/risk_scores/__snapshots__/risk_score_over_time_area.test.ts.snap
+++ b/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/risk_scores/__snapshots__/risk_score_over_time_area.test.ts.snap
@@ -6,11 +6,11 @@ Object {
   "references": Array [],
   "state": Object {
     "adHocDataViews": Object {
-      "e614baeb-5eca-480c-8885-ba79eaf41372": Object {
+      "d594baeb-5eca-480c-8885-ba79eaf41372": Object {
         "allowNoIndex": false,
         "fieldAttrs": Object {},
         "fieldFormats": Object {},
-        "id": "e614baeb-5eca-480c-8885-ba79eaf41372",
+        "id": "d594baeb-5eca-480c-8885-ba79eaf41372",
         "name": "ml_host_risk_score_mockSpaceId",
         "runtimeFieldMap": Object {},
         "sourceFilters": Array [],
@@ -21,30 +21,7 @@ Object {
     "datasourceStates": Object {
       "formBased": Object {
         "layers": Object {
-          "c604baeb-5eca-480c-8885-ba79eaf41372": Object {
-            "columnOrder": Array [
-              "1dd5663b-f062-43f8-8688-fc8166c2ca8e",
-            ],
-            "columns": Object {
-              "1dd5663b-f062-43f8-8688-fc8166c2ca8e": Object {
-                "customLabel": true,
-                "dataType": "number",
-                "isBucketed": false,
-                "isStaticValue": true,
-                "label": "Risky threshold",
-                "operationType": "static_value",
-                "params": Object {
-                  "value": "70",
-                },
-                "references": Array [],
-                "scale": "ratio",
-              },
-            },
-            "incompleteColumns": Object {},
-            "linkToLayers": Array [],
-            "sampling": 1,
-          },
-          "d594baeb-5eca-480c-8885-ba79eaf41372": Object {
+          "e614baeb-5eca-480c-8885-ba79eaf41372": Object {
             "columnOrder": Array [
               "02a55c97-d7a4-440d-ac77-33b941c16189",
               "8886a925-4419-4d9a-8498-3bda4ecf1b0a",
@@ -83,6 +60,29 @@ Object {
               },
             },
             "incompleteColumns": Object {},
+            "sampling": 1,
+          },
+          "f614baeb-5eca-480c-8885-ba79eaf52483": Object {
+            "columnOrder": Array [
+              "1dd5663b-f062-43f8-8688-fc8166c2ca8e",
+            ],
+            "columns": Object {
+              "1dd5663b-f062-43f8-8688-fc8166c2ca8e": Object {
+                "customLabel": true,
+                "dataType": "number",
+                "isBucketed": false,
+                "isStaticValue": true,
+                "label": "Risky threshold",
+                "operationType": "static_value",
+                "params": Object {
+                  "value": "70",
+                },
+                "references": Array [],
+                "scale": "ratio",
+              },
+            },
+            "incompleteColumns": Object {},
+            "linkToLayers": Array [],
             "sampling": 1,
           },
         },
@@ -129,13 +129,13 @@ Object {
     ],
     "internalReferences": Array [
       Object {
-        "id": "e614baeb-5eca-480c-8885-ba79eaf41372",
-        "name": "indexpattern-datasource-layer-d594baeb-5eca-480c-8885-ba79eaf41372",
+        "id": "d594baeb-5eca-480c-8885-ba79eaf41372",
+        "name": "indexpattern-datasource-layer-e614baeb-5eca-480c-8885-ba79eaf41372",
         "type": "index-pattern",
       },
       Object {
-        "id": "e614baeb-5eca-480c-8885-ba79eaf41372",
-        "name": "indexpattern-datasource-layer-c604baeb-5eca-480c-8885-ba79eaf41372",
+        "id": "d594baeb-5eca-480c-8885-ba79eaf41372",
+        "name": "indexpattern-datasource-layer-f614baeb-5eca-480c-8885-ba79eaf52483",
         "type": "index-pattern",
       },
     ],
@@ -159,7 +159,7 @@ Object {
           "accessors": Array [
             "8886a925-4419-4d9a-8498-3bda4ecf1b0a",
           ],
-          "layerId": "d594baeb-5eca-480c-8885-ba79eaf41372",
+          "layerId": "e614baeb-5eca-480c-8885-ba79eaf41372",
           "layerType": "data",
           "position": "top",
           "seriesType": "line",
@@ -176,7 +176,7 @@ Object {
           "accessors": Array [
             "1dd5663b-f062-43f8-8688-fc8166c2ca8e",
           ],
-          "layerId": "c604baeb-5eca-480c-8885-ba79eaf41372",
+          "layerId": "f614baeb-5eca-480c-8885-ba79eaf52483",
           "layerType": "referenceLine",
           "yConfig": Array [
             Object {

--- a/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/risk_scores/risk_score_donut.test.ts
+++ b/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/risk_scores/risk_score_donut.test.ts
@@ -34,7 +34,8 @@ jest.mock('uuid', () => ({
   v4: jest
     .fn()
     .mockReturnValueOnce('d594baeb-5eca-480c-8885-ba79eaf41372')
-    .mockReturnValue('1dd5663b-f062-43f8-8688-fc8166c2ca8e'),
+    .mockReturnValueOnce('1dd5663b-f062-43f8-8688-fc8166c2ca8e')
+    .mockReturnValue('2cc5663b-f062-43f8-8688-fc8166c2ca8e'),
 }));
 
 describe('getRiskScoreDonutAttributes', () => {

--- a/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/risk_scores/risk_score_donut.ts
+++ b/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/risk_scores/risk_score_donut.ts
@@ -8,12 +8,14 @@
 import { v4 as uuidv4 } from 'uuid';
 import type { GetLensAttributes } from '../../../types';
 
+const internalReferenceIdMapping: Record<string, string> = { host: uuidv4(), user: uuidv4() };
+
 export const getRiskScoreDonutAttributes: GetLensAttributes = (
-  stackByField,
+  stackByField = 'host',
   extraOptions = { spaceId: 'default' }
 ) => {
   const layerId = uuidv4();
-  const internalReferenceId = uuidv4();
+  const internalReferenceId = internalReferenceIdMapping[stackByField];
   return {
     title: `${stackByField} risk donut`,
     description: '',

--- a/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/risk_scores/risk_score_over_time_area.test.ts
+++ b/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/risk_scores/risk_score_over_time_area.test.ts
@@ -36,6 +36,7 @@ jest.mock('uuid', () => ({
     .mockReturnValueOnce('d594baeb-5eca-480c-8885-ba79eaf41372')
     .mockReturnValueOnce('c604baeb-5eca-480c-8885-ba79eaf41372')
     .mockReturnValueOnce('e614baeb-5eca-480c-8885-ba79eaf41372')
+    .mockReturnValueOnce('f614baeb-5eca-480c-8885-ba79eaf52483')
     .mockReturnValue('1dd5663b-f062-43f8-8688-fc8166c2ca8e'),
 }));
 

--- a/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/risk_scores/risk_score_over_time_area.ts
+++ b/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/risk_scores/risk_score_over_time_area.ts
@@ -7,13 +7,16 @@
 
 import { v4 as uuidv4 } from 'uuid';
 import type { GetLensAttributes } from '../../../types';
+
+const internalReferenceIdMapping: Record<string, string> = { host: uuidv4(), user: uuidv4() };
+
 export const getRiskScoreOverTimeAreaAttributes: GetLensAttributes = (
   stackByField = 'host',
   extraOptions = { spaceId: 'default' }
 ) => {
   const layerIds = [uuidv4(), uuidv4()];
-  const internalReferenceId = uuidv4();
   const layer2ColumnId = uuidv4();
+  const internalReferenceId = internalReferenceIdMapping[stackByField];
   return {
     title: `${stackByField} risk score over time`,
     description: '',


### PR DESCRIPTION
## Summary

Please Enable feature flags. Please add this to kibana.dev.yml xpack.securitySolution.enableExperimental: ['chartEmbeddablesEnabled']

<img width="1513" alt="Screenshot 2023-01-25 at 12 54 54" src="https://user-images.githubusercontent.com/6295984/214573163-1e606e07-c7c6-4980-99c5-0ce4347fb6c0.png">

AdHocDataview requires a static reference to point internal reference Id to the given data view.
The reference of data view will be lost If we re-generate internal reference Id every time the function is called.
To fix this, I assigned the id out side of the function so it wouldn't change when the function is called.

Expected: Risk score over time should be rendered properly:

<img width="1501" alt="Screenshot 2023-01-25 at 13 42 56" src="https://user-images.githubusercontent.com/6295984/214578964-06dc8d11-cf65-4ede-a2ba-a42a1268d6e5.png">

<img width="1513" alt="Screenshot 2023-01-25 at 13 43 57" src="https://user-images.githubusercontent.com/6295984/214579194-d64ef60f-28fe-407e-8d71-abb56ef845e4.png">


### Checklist

Delete any items that are not applicable to this PR.


- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
