### PR TITLE
[8.6] [Fleet] fix updates available when beta integrations are off (#149486)

### DIFF
--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/home/available_packages.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/home/available_packages.tsx
@@ -181,7 +181,9 @@ const packageListToIntegrationsList = (packages: PackageList): PackageList => {
 
 // TODO: clintandrewhall - this component is hard to test due to the hooks, particularly those that use `http`
 // or `location` to load data.  Ideally, we'll split this into "connected" and "pure" components.
-export const AvailablePackages: React.FC<{}> = ({}) => {
+export const AvailablePackages: React.FC<{
+  setPrereleaseEnabled: (isEnabled: boolean) => void;
+}> = ({ setPrereleaseEnabled }) => {
   const [preference, setPreference] = useState<IntegrationPreferenceType>('recommended');
   const [prereleaseIntegrationsEnabled, setPrereleaseIntegrationsEnabled] = React.useState<
     boolean | undefined
@@ -304,6 +306,7 @@ export const AvailablePackages: React.FC<{}> = ({}) => {
         onChange={setPreference}
         onPrereleaseEnabledChange={(isEnabled) => {
           setPrereleaseIntegrationsEnabled(isEnabled);
+          setPrereleaseEnabled(isEnabled);
         }}
       />
     </EuiFlexItem>,

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/home/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/home/index.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import { Switch, Route } from 'react-router-dom';
 
 import type { CustomIntegration } from '@kbn/custom-integrations-plugin/common';
@@ -113,9 +113,11 @@ export const mapToCard = ({
 };
 
 export const EPMHomePage: React.FC = () => {
+  const [prereleaseEnabled, setPrereleaseEnabled] = useState<boolean>(false);
+
   // loading packages to find installed ones
   const { data: allPackages, isLoading } = useGetPackages({
-    prerelease: true,
+    prerelease: prereleaseEnabled,
   });
 
   const installedPackages = useMemo(
@@ -138,7 +140,7 @@ export const EPMHomePage: React.FC = () => {
       </Route>
       <Route path={INTEGRATIONS_ROUTING_PATHS.integrations_all}>
         <DefaultLayout section="browse" sectionsWithWarning={sectionsWithWarning}>
-          <AvailablePackages />
+          <AvailablePackages setPrereleaseEnabled={setPrereleaseEnabled} />
         </DefaultLayout>
       </Route>
     </Switch>


### PR DESCRIPTION
## Summary

Backport https://github.com/elastic/kibana/pull/149486 to 8.6
