### PR TITLE
[APM] Use constants for system indices

### DIFF
--- a/x-pack/plugins/apm/server/routes/fleet/api_keys/create_apm_api_keys.ts
+++ b/x-pack/plugins/apm/server/routes/fleet/api_keys/create_apm_api_keys.ts
@@ -6,6 +6,10 @@
  */
 
 import { CoreStart, Logger } from '@kbn/core/server';
+import {
+  APM_AGENT_CONFIGURATION_INDEX,
+  APM_SOURCE_MAP_INDEX,
+} from '../../settings/apm_indices/get_apm_indices';
 
 const apiKeyMetadata = {
   application: 'apm',
@@ -41,7 +45,7 @@ export async function createApmSourceMapApiKey({
           apmSystemIndices: {
             index: [
               {
-                names: ['.apm-source-map'],
+                names: [APM_SOURCE_MAP_INDEX],
                 privileges: indexLevelPrivileges,
                 allow_restricted_indices: true,
               },
@@ -82,7 +86,7 @@ export async function createApmAgentConfigApiKey({
           apmSystemIndices: {
             index: [
               {
-                names: ['.apm-agent-configuration'],
+                names: [APM_AGENT_CONFIGURATION_INDEX],
                 privileges: indexLevelPrivileges,
                 allow_restricted_indices: true,
               },

--- a/x-pack/plugins/apm/server/routes/settings/apm_indices/get_apm_indices.ts
+++ b/x-pack/plugins/apm/server/routes/settings/apm_indices/get_apm_indices.ts
@@ -25,7 +25,7 @@ export type ApmIndicesConfig = Readonly<{
 
 export const APM_AGENT_CONFIGURATION_INDEX = '.apm-agent-configuration';
 export const APM_CUSTOM_LINK_INDEX = '.apm-custom-link';
-export const APM_SOURCE_MAP_INDEX = '.apm-source-map';
+export const APM_SOURCE_MAP_INDEX = 'apm-agent-sourcemap';
 
 type ISavedObjectsClient = Pick<SavedObjectsClient, 'get'>;
 

--- a/x-pack/plugins/apm/server/routes/settings/apm_indices/get_apm_indices.ts
+++ b/x-pack/plugins/apm/server/routes/settings/apm_indices/get_apm_indices.ts
@@ -25,7 +25,7 @@ export type ApmIndicesConfig = Readonly<{
 
 export const APM_AGENT_CONFIGURATION_INDEX = '.apm-agent-configuration';
 export const APM_CUSTOM_LINK_INDEX = '.apm-custom-link';
-export const APM_SOURCE_MAP_INDEX = 'apm-agent-sourcemap';
+export const APM_SOURCE_MAP_INDEX = '.apm-source-map';
 
 type ISavedObjectsClient = Pick<SavedObjectsClient, 'get'>;
 

--- a/x-pack/plugins/apm/server/routes/source_maps/schedule_source_map_migration.ts
+++ b/x-pack/plugins/apm/server/routes/source_maps/schedule_source_map_migration.ts
@@ -41,8 +41,7 @@ export async function scheduleSourceMapMigration({
   taskManager.registerTaskDefinitions({
     [TASK_TYPE]: {
       title: 'Migrate fleet source map artifacts',
-      description:
-        'Migrates fleet source map artifacts to `.apm-source-map` index',
+      description: `Migrates fleet source map artifacts to "${APM_SOURCE_MAP_INDEX}" index`,
       timeout: '1h',
       maxAttempts: 5,
       maxConcurrency: 1,


### PR DESCRIPTION
We should use constants when referring to the system indices.