### PR TITLE
[Security Solution][Endpoint] Replace `localhost` with `127.0.0.1` in all endpoint CLI scripts

### DIFF
--- a/x-pack/plugins/security_solution/scripts/endpoint/agent_emulator/index.ts
+++ b/x-pack/plugins/security_solution/scripts/endpoint/agent_emulator/index.ts
@@ -22,8 +22,8 @@ export const cli = () => {
         string: ['kibana', 'elastic', 'username', 'password'],
         boolean: ['asSuperuser'],
         default: {
-          kibana: 'http://localhost:5601',
-          elasticsearch: 'http://localhost:9200',
+          kibana: 'http://127.0.0.1:5601',
+          elasticsearch: 'http://127.0.0.1:9200',
           username: 'elastic',
           password: 'changeme',
           asSuperuser: false,
@@ -39,8 +39,8 @@ export const cli = () => {
         --asSuperuser       If defined, then a Security super user will be created using the
                             the credentials defined via 'username' and 'password' options. This
                             new user will then be used to run this utility.
-        --kibana            The url to Kibana (Default: http://localhost:5601)
-        --elasticsearch     The url to Elasticsearch (Default: http://localhost:9200)
+        --kibana            The url to Kibana (Default: http://127.0.0.1:5601)
+        --elasticsearch     The url to Elasticsearch (Default: http://127.0.0.1:9200)
         --checkinInterval   The interval between how often the Agent is checked into fleet and a
                             metadata document update is sent for the endpoint. Default is 1 minute
         --actionDelay       The delay (in milliseconds) that should be applied before responding

--- a/x-pack/plugins/security_solution/scripts/endpoint/blocklists/index.ts
+++ b/x-pack/plugins/security_solution/scripts/endpoint/blocklists/index.ts
@@ -40,11 +40,11 @@ export const cli = () => {
         string: ['kibana'],
         default: {
           count: 10,
-          kibana: 'http://elastic:changeme@localhost:5601',
+          kibana: 'http://elastic:changeme@127.0.0.1:5601',
         },
         help: `
         --count            Number of blocklists to create. Default: 10
-        --kibana           The URL to kibana including credentials. Default: http://elastic:changeme@localhost:5601
+        --kibana           The URL to kibana including credentials. Default: http://elastic:changeme@127.0.0.1:5601
       `,
       },
     }

--- a/x-pack/plugins/security_solution/scripts/endpoint/endpoint_policies/index.ts
+++ b/x-pack/plugins/security_solution/scripts/endpoint/endpoint_policies/index.ts
@@ -53,11 +53,11 @@ export const cli = () => {
         string: ['kibana'],
         default: {
           count: 15,
-          kibana: 'http://elastic:changeme@localhost:5601',
+          kibana: 'http://elastic:changeme@127.0.0.1:5601',
         },
         help: `
         --count            Number of Endpoint Policies to create. Default: 15
-        --kibana           The URL to kibana including credentials. Default: http://elastic:changeme@localhost:5601
+        --kibana           The URL to kibana including credentials. Default: http://elastic:changeme@127.0.0.1:5601
       `,
       },
     }

--- a/x-pack/plugins/security_solution/scripts/endpoint/event_filters/index.ts
+++ b/x-pack/plugins/security_solution/scripts/endpoint/event_filters/index.ts
@@ -44,11 +44,11 @@ export const cli = () => {
         string: ['kibana'],
         default: {
           count: 10,
-          kibana: 'http://elastic:changeme@localhost:5601',
+          kibana: 'http://elastic:changeme@127.0.0.1:5601',
         },
         help: `
         --count               Number of event filters to create. Default: 10
-        --kibana              The URL to kibana including credentials. Default: http://elastic:changeme@localhost:5601
+        --kibana              The URL to kibana including credentials. Default: http://elastic:changeme@127.0.0.1:5601
       `,
       },
     }

--- a/x-pack/plugins/security_solution/scripts/endpoint/host_isolation_exceptions/index.ts
+++ b/x-pack/plugins/security_solution/scripts/endpoint/host_isolation_exceptions/index.ts
@@ -38,11 +38,11 @@ export const cli = () => {
         string: ['kibana'],
         default: {
           count: 10,
-          kibana: 'http://elastic:changeme@localhost:5601',
+          kibana: 'http://elastic:changeme@127.0.0.1:5601',
         },
         help: `
         --count            Number of host isolation exceptions to create. Default: 10
-        --kibana           The URL to kibana including credentials. Default: http://elastic:changeme@localhost:5601
+        --kibana           The URL to kibana including credentials. Default: http://elastic:changeme@127.0.0.1:5601
       `,
       },
     }

--- a/x-pack/plugins/security_solution/scripts/endpoint/resolver_generator_script.ts
+++ b/x-pack/plugins/security_solution/scripts/endpoint/resolver_generator_script.ts
@@ -170,13 +170,13 @@ async function main() {
     node: {
       alias: 'n',
       describe: 'elasticsearch node url',
-      default: 'http://elastic:changeme@localhost:9200',
+      default: 'http://elastic:changeme@127.0.0.1:9200',
       type: 'string',
     },
     kibana: {
       alias: 'k',
       describe: 'kibana url',
-      default: 'http://elastic:changeme@localhost:5601',
+      default: 'http://elastic:changeme@127.0.0.1:5601',
       type: 'string',
     },
     eventIndex: {

--- a/x-pack/plugins/security_solution/scripts/endpoint/trusted_apps/index.ts
+++ b/x-pack/plugins/security_solution/scripts/endpoint/trusted_apps/index.ts
@@ -33,7 +33,7 @@ export const cli = async () => {
     string: ['kibana'],
     default: {
       count: 10,
-      kibana: 'http://elastic:changeme@localhost:5601',
+      kibana: 'http://elastic:changeme@127.0.0.1:5601',
     },
   };
   const options: RunOptions = minimist<RunOptions>(process.argv.slice(2), cliDefaults);
@@ -70,7 +70,7 @@ interface RunOptions {
 }
 export const run: (options?: RunOptions) => Promise<TrustedApp[]> = async ({
   count = 10,
-  kibana = 'http://elastic:changeme@localhost:5601',
+  kibana = 'http://elastic:changeme@127.0.0.1:5601',
   logger = defaultLogger,
 }: RunOptions = {}) => {
   const kbnClient = new KbnClient({


### PR DESCRIPTION
## Summary

- Replaces `localhost` with `127.0.0.1` in all endpoint CLI scripts. This is needed as a result of the stack's upgrade to NodeJS, as it now seems to default `localhost` to the IPv6 loopback IP if that interface is available on the local machine. Problem is that Kibana does not listen on IPv6.

