### PR TITLE
[Docs] Replace outdated ingest-guide attribute

### DIFF
--- a/docs/ingest_manager/ingest-manager.asciidoc
+++ b/docs/ingest_manager/ingest-manager.asciidoc
@@ -24,4 +24,4 @@ image::ingest_manager/images/ingest-manager-start.png[{ingest-manager} app in {k
 == Get started
 
 To get started with {ingest-management}, refer to the
-{ingest-guide}/index.html[Ingest Management Guide].
+{fleet-guide}/index.html[Ingest Management Guide].

--- a/docs/settings/ingest-manager-settings.asciidoc
+++ b/docs/settings/ingest-manager-settings.asciidoc
@@ -10,7 +10,7 @@ experimental[]
 You can configure `xpack.ingestManager` settings in your `kibana.yml`. 
 By default, {ingest-manager} is enabled. To use {fleet}, you also need to configure {kib} and {es} hosts.
 
-See the {ingest-guide}/index.html[Ingest Management] docs for more information.
+See the {fleet-guide}/index.html[Ingest Management] docs for more information.
 
 [[general-ingest-manager-settings-kb]]
 ==== General {ingest-manager} settings


### PR DESCRIPTION
This pre-emptively fixes broken links that will occur when the docs shared `ingest-guide` attribute is repurposed.

```
15:24:17 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/kibana/7.8/ingest-manager-settings-kb.html contains broken links to:
15:24:17 INFO:build_docs:   - en/ingest/7.8/index.html
15:24:17 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/kibana/7.8/ingest-manager.html contains broken links to:
15:24:17 INFO:build_docs:   - en/ingest/7.8/index.html
15:24:17 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/kibana/7.9/ingest-manager-settings-kb.html contains broken links to:
15:24:17 INFO:build_docs:   - en/ingest/7.9/index.html
15:24:17 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/kibana/7.9/ingest-manager.html contains broken links to:
15:24:17 INFO:build_docs:   - en/ingest/7.9/index.html
```