### PR TITLE
[Lens] Fix download csv flaky test

### DIFF
--- a/x-pack/test/functional/apps/lens/group2/dashboard.ts
+++ b/x-pack/test/functional/apps/lens/group2/dashboard.ts
@@ -173,11 +173,14 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await dashboardAddPanel.clickOpenAddPanel();
       await dashboardAddPanel.filterEmbeddableNames('lnsPieVis');
       await find.clickByButtonText('lnsPieVis');
+      await PageObjects.header.waitUntilLoadingHasFinished();
       await dashboardAddPanel.closeAddPanel();
 
-      await panelActions.openContextMenu();
-      await panelActions.clickContextMenuMoreItem();
-      await testSubjects.existOrFail(ACTION_TEST_SUBJ);
+      await retry.try(async () => {
+        await panelActions.openContextMenu();
+        await panelActions.clickContextMenuMoreItem();
+        await testSubjects.existOrFail(ACTION_TEST_SUBJ);
+      });
     });
 
     it('should show all data from all layers in the inspector', async () => {


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/149353

I think the Download CSV doesn't appear on the menu due to a race condition. I am waiting for the dashboard to be stabilized and I add a retry to be sure that it will run the test again if it fails.

Flaky runner https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/1796
One test fails but not this one.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios