### PR TITLE
[Unified search] Allows case sensitive option on multiselection filters input

### DIFF
--- a/src/plugins/unified_search/public/filter_bar/filter_editor/phrases_values_input.tsx
+++ b/src/plugins/unified_search/public/filter_bar/filter_editor/phrases_values_input.tsx
@@ -55,6 +55,7 @@ class PhrasesValuesInputUI extends PhraseSuggestorUI<PhrasesValuesInputProps> {
             defaultMessage: 'Select values',
           })}
           delimiter=","
+          isCaseSensitive={true}
           options={options}
           getLabel={(option) => option}
           selectedOptions={values || []}


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/142064

Allows the selection/search of values that are same but have a different case notation.
 
![uni](https://user-images.githubusercontent.com/17003240/214783777-3149430c-22fc-47d0-ae52-cc29a667134e.gif)