### PR TITLE
Update documentation of PHP APM agent support for service maps

### DIFF
--- a/docs/apm/service-maps.asciidoc
+++ b/docs/apm/service-maps.asciidoc
@@ -112,7 +112,7 @@ iOS agent:: _Not yet supported_
 Java agent:: ≥ v1.13.0
 .NET agent:: ≥ v1.3.0
 Node.js agent:: ≥ v3.6.0
-PHP agent:: _Not yet supported_
+PHP agent:: ≥ v1.2.0
 Python agent:: ≥ v5.5.0
 Ruby agent:: ≥ v3.6.0
 Real User Monitoring (RUM) agent:: ≥ v4.7.0


### PR DESCRIPTION
## Summary

The PHP APM agent has supported service maps since version 1.2 so this PR updates the services maps table.


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
