### PR TITLE
Revert "[build] Fix canvas shareable runtime"

### DIFF
--- a/x-pack/plugins/canvas/scripts/shareable_runtime.js
+++ b/x-pack/plugins/canvas/scripts/shareable_runtime.js
@@ -55,7 +55,6 @@ run(
       execa.sync(
         process.execPath,
         [
-          '--openssl-legacy-provider',
           require.resolve('webpack-dev-server/bin/webpack-dev-server'),
           '--config',
           webpackConfig,
@@ -89,7 +88,6 @@ run(
     execa.sync(
       process.execPath,
       [
-        '--openssl-legacy-provider',
         require.resolve('webpack/bin/webpack'),
         '--config',
         webpackConfig,


### PR DESCRIPTION
Reverts elastic/kibana#149165

Node 18 was downgraded to Node 16, this flag is not supported - https://github.com/elastic/kibana/pull/149531