### PR TITLE
[@kbn/legacy-logging] Stream is capable of handling more load

### DIFF
--- a/packages/kbn-legacy-logging/src/log_interceptor.ts
+++ b/packages/kbn-legacy-logging/src/log_interceptor.ts
@@ -83,6 +83,15 @@ export class LogInterceptor extends Stream.Transform {
     super({
       readableObjectMode: true,
       writableObjectMode: true,
+      // Ideally, the writer to this stream should handle the backpressure
+      // and hold any writes until the 'drain' event is emitted.
+      // More info: https://nodejs.org/docs/latest-v16.x/api/stream.html#writablewritechunk-encoding-callback
+      //
+      // However, the writer (@elastic/good) doesn't apply such control,
+      // so we need to add extra room in this buffer to handle peaks.
+      //
+      // Note that, in objectMode, this number refers to the number of objects instead of the bytes.
+      readableHighWaterMark: 1000,
     });
   }
 

--- a/packages/kbn-legacy-logging/src/log_reporter.test.ts
+++ b/packages/kbn-legacy-logging/src/log_reporter.test.ts
@@ -9,10 +9,12 @@
 import os from 'os';
 import path from 'path';
 import fs from 'fs';
+import Fs from 'fs/promises';
 
 import stripAnsi from 'strip-ansi';
 
 import { getLogReporter } from './log_reporter';
+import { LogInterceptor } from './log_interceptor';
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -126,6 +128,67 @@ describe('getLogReporter', () => {
       type: 'log',
       tags: ['foo'],
       message: 'hello world',
+    });
+  });
+
+  describe('Stream processing capacity', () => {
+    const NUM_OF_LINES = 1_000;
+    const logEntry = { event: 'log', tags: ['foo'], data: 'hello world' };
+    let loggerStream: LogInterceptor;
+    let dest: string;
+
+    beforeEach(() => {
+      const dir = os.tmpdir();
+      const logfile = `dest-${Date.now()}.log`;
+      dest = path.join(dir, logfile);
+
+      loggerStream = getLogReporter({
+        config: {
+          json: true, // Using JSON layout and file dest because it's the slowest combination.
+          dest,
+          filter: {},
+        },
+        events: { log: '*' },
+      });
+    });
+
+    it(`handles a sudden burst of ${NUM_OF_LINES} log entries`, async () => {
+      const closedStream = new Promise((resolve) => loggerStream.once('close', resolve));
+
+      const acceptsMore = new Array(NUM_OF_LINES).fill(0).map(() => loggerStream.write(logEntry));
+
+      loggerStream.end(logEntry);
+
+      // Wait for the stream to be closed
+      await closedStream;
+      // Then wait some more for the OS i/o operations to complete
+      await sleep(500);
+
+      const lines = (await Fs.readFile(dest, { encoding: 'utf8' })).trim().split(os.EOL);
+      expect(lines.length).toBe(NUM_OF_LINES + 1);
+      expect(acceptsMore.filter(Boolean)).toHaveLength(NUM_OF_LINES);
+    });
+
+    it(`using the 'drain' event helps makes everything to go through`, async () => {
+      const HIGH_LOAD = 10 * NUM_OF_LINES;
+
+      const closedStream = new Promise((resolve) => loggerStream.once('close', resolve));
+
+      for (let i = 0; i < HIGH_LOAD; i++) {
+        if (!loggerStream.write(logEntry)) {
+          await new Promise((resolve) => loggerStream.once('drain', resolve));
+        }
+      }
+
+      loggerStream.end(logEntry);
+
+      // Wait for the stream to be closed
+      await closedStream;
+      // Then wait some more for the OS i/o operations to complete
+      await sleep(500);
+
+      const lines = (await Fs.readFile(dest, { encoding: 'utf8' })).trim().split(os.EOL);
+      expect(lines.length).toBe(HIGH_LOAD + 1);
     });
   });
 });


### PR DESCRIPTION
## Summary

Related to #134724 (not sure if it entirely solves it).

We identified some scenarios where a sudden spike in logs, accompanied by a higher-than-usual event-loop delay, might stop writing logs to the log file (only in the legacy logger).

An example is: starting Kibana without an Elasticsearch to reach out to. The extra event-loop delays when attempting to resolve the host and open the socket to a non-listening port puts the minimum extra load to make the startup logs to collapse the stream buffers of the legacy logger (when running in verbose mode).

This PR increases the size of the stream buffer `LogInterceptor` to handle those bursts and minimize the chances of the log writer collapsing it.

### Test notes

The newly added tests confirm that, when using the default `highWatermark`, the logger fails to write some entries in the file:
![image](https://user-images.githubusercontent.com/5469006/214871250-a8795d8e-25aa-42e6-bc2f-da0b7eb665c2.png)


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Leading to potential OOMs | Low | High | The risk is very low: even if the log entries took 10kB (many orders of magnitude over the expected average size), this means the buffer would use 10MB of memory. |
| Increasing logs might force us to increase the `highWatermark` option | Low | Low | The default is `16`, and we bumped it to 1k. We should have plenty of room for now. Also, when the legacy logger doesn't work, using the configuration of the new logger is a valid workaround for most cases. |
| It's not solving the underlying problem: the writer doesn't apply backpressure. | Low | Low | We could refactor [the underlying package](https://github.com/elastic/good/blob/master/lib/monitor.js#L198-L207) to add the necessary backpressure. But this logger is deprecated and removed in 8.0, so it's probably not worth the effort. |


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
