### PR TITLE
Add rule spaceId to APM transaction when a rule is running

### DIFF
--- a/x-pack/plugins/alerting/server/task_runner/task_runner.ts
+++ b/x-pack/plugins/alerting/server/task_runner/task_runner.ts
@@ -487,6 +487,7 @@ export class TaskRunner<
     if (apm.currentTransaction) {
       apm.currentTransaction.name = `Execute Alerting Rule`;
       apm.currentTransaction.addLabels({
+        alerting_rule_space_id: spaceId,
         alerting_rule_id: ruleId,
       });
     }


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/149318

In this PR, I'm adding `alerting_rule_space_id` label to the apm transaction whenever a rule is running.