### PR TITLE
[Security Soltuion] Add messaging when files are not found about quarantined files

### DIFF
--- a/x-pack/plugins/security_solution/public/management/components/endpoint_action_failure_message/endpoint_action_failure_message.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/endpoint_action_failure_message/endpoint_action_failure_message.tsx
@@ -23,7 +23,7 @@ export const EndpointActionFailureMessage = memo<EndpointActionFailureMessagePro
         return null;
       }
 
-      const errors: string[] = [];
+      const errors: React.ReactNode[] = [];
 
       // Determine if each endpoint returned a response code and if so,
       // see if we have a localized message for it
@@ -62,7 +62,11 @@ export const EndpointActionFailureMessage = memo<EndpointActionFailureMessagePro
             values={{ errorCount: errors.length }}
           />
           <EuiSpacer size="s" />
-          <div>{errors.join(' | ')}</div>
+          <>
+            {errors.map((error) => (
+              <div>{error}</div>
+            ))}
+          </>
         </>
       );
     }, [action]);

--- a/x-pack/plugins/security_solution/public/management/components/endpoint_responder/lib/endpoint_action_response_codes.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/endpoint_responder/lib/endpoint_action_response_codes.tsx
@@ -5,16 +5,38 @@
  * 2.0.
  */
 
+import React from 'react';
 import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { EuiLink, EuiSpacer } from '@elastic/eui';
 
 const CODES = Object.freeze({
   // -----------------------------------------------------------------
   // GET-FILE CODES
   // -----------------------------------------------------------------
   /** file not found */
-  'ra_get-file_error_not-found': i18n.translate(
-    'xpack.securitySolution.endpointActionResponseCodes.getFile.notFound',
-    { defaultMessage: 'The file specified was not found' }
+  'ra_get-file_error_not-found': (
+    <>
+      <FormattedMessage
+        id="xpack.securitySolution.endpointActionResponseCodes.getFile.notFound"
+        defaultMessage="The file specified was not found."
+      />
+      <EuiSpacer size="s" />
+      <FormattedMessage
+        id="xpack.securitySolution.endpointActionResponseCodes.getFile.quarantineHint"
+        defaultMessage="Note: the requested file may be quarantined. To retrieve a quarantined file, { quarantinedDocsLink }."
+        values={{
+          quarantinedDocsLink: (
+            <EuiLink>
+              <FormattedMessage
+                id="xpack.securitySolution.endpointActionResponseCodes.getFile.quarantineDocsLink"
+                defaultMessage="read here"
+              />
+            </EuiLink>
+          ),
+        }}
+      />
+    </>
   ),
 
   /** path is reachable but does not point to a file */
@@ -128,5 +150,6 @@ const CODES = Object.freeze({
 /**
  * A map of possible code's that can be returned from the endpoint for response actions
  */
-export const endpointActionResponseCodes: Readonly<Record<string | keyof typeof CODES, string>> =
-  CODES;
+export const endpointActionResponseCodes: Readonly<
+  Record<string | keyof typeof CODES, React.ReactNode>
+> = CODES;


### PR DESCRIPTION
## Summary

![image](https://user-images.githubusercontent.com/56395104/214882374-3d519ecc-4f7d-49fd-b49a-541429531671.png)

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
