### PR TITLE
[RAM] Fix rewriting frequency param in _find API

### DIFF
--- a/x-pack/plugins/alerting/server/routes/lib/rewrite_rule.ts
+++ b/x-pack/plugins/alerting/server/routes/lib/rewrite_rule.ts
@@ -63,9 +63,11 @@ export const rewriteRule = ({
     connector_type_id: actionTypeId,
     ...(frequency
       ? {
-          summary: frequency.summary,
-          notify_when: frequency.notifyWhen,
-          throttle: frequency.throttle,
+          frequency: {
+            summary: frequency.summary,
+            notify_when: frequency.notifyWhen,
+            throttle: frequency.throttle,
+          },
         }
       : {}),
   })),


### PR DESCRIPTION
## Summary

Fixes an issue that was cropping up in the `_find` API where the `rewriteRule` function was spreading all `frequency` props into the action instead of applying them to a `frequency` prop