### PR TITLE
[Fleet] Fix Lock icon aligment for managed agent policies

### DIFF
--- a/x-pack/plugins/fleet/public/components/link_and_revision.tsx
+++ b/x-pack/plugins/fleet/public/components/link_and_revision.tsx
@@ -33,31 +33,40 @@ export const AgentPolicySummaryLine = memo<{
       alignItems="baseline"
       style={MIN_WIDTH}
       responsive={false}
+      justifyContent={'flexStart'}
     >
-      <EuiFlexItem grow={false} className="eui-textTruncate">
-        <EuiLink
-          className={`eui-textTruncate`}
-          href={getHref('policy_details', { policyId: id })}
-          title={name || id}
-          data-test-subj="agentPolicyNameLink"
-        >
-          {name || id}
-        </EuiLink>
+      <EuiFlexItem grow={false}>
+        <EuiFlexGroup style={MIN_WIDTH} gutterSize="s" alignItems="baseline" responsive={false}>
+          <EuiFlexItem grow={false} className="eui-textTruncate">
+            <EuiLink
+              className={`eui-textTruncate`}
+              href={getHref('policy_details', { policyId: id })}
+              title={name || id}
+              data-test-subj="agentPolicyNameLink"
+            >
+              {name || id}
+            </EuiLink>
+          </EuiFlexItem>
+
+          {isManaged && (
+            <EuiFlexItem grow={false}>
+              <EuiIconTip
+                title="Hosted agent policy"
+                content={i18n.translate('xpack.fleet.agentPolicySummaryLine.hostedPolicyTooltip', {
+                  defaultMessage:
+                    'This policy is managed outside of Fleet. Most actions related to this policy are unavailable.',
+                })}
+                type="lock"
+                size="m"
+                color="subdued"
+              />
+            </EuiFlexItem>
+          )}
+        </EuiFlexGroup>
       </EuiFlexItem>
-      {isManaged && (
-        <EuiIconTip
-          title="Hosted agent policy"
-          content={i18n.translate('xpack.fleet.agentPolicySummaryLine.hostedPolicyTooltip', {
-            defaultMessage:
-              'This policy is managed outside of Fleet. Most actions related to this policy are unavailable.',
-          })}
-          type="lock"
-          size="m"
-          color="subdued"
-        />
-      )}
+
       {revision && (
-        <EuiFlexItem grow={direction === 'column' ? false : true}>
+        <EuiFlexItem grow={false}>
           <EuiText color="subdued" size="xs" style={NO_WRAP_WHITE_SPACE}>
             <FormattedMessage
               id="xpack.fleet.agentPolicySummaryLine.revisionNumber"


### PR DESCRIPTION
## Summary

Resolve https://github.com/elastic/kibana/issues/149480

Fix an alignment bug introduced when adding agent metrics, to align the lock icon for managed agent policies

## Before 

![214507259-a993c39b-38a0-47ff-8bcf-3354797028b6](https://user-images.githubusercontent.com/1336873/214945068-688e6095-5b3d-4b67-b4ed-c9e781269f51.png)

## After 
<img width="1265" alt="Screen Shot 2023-01-26 at 4 35 18 PM" src="https://user-images.githubusercontent.com/1336873/214945109-2782c5c5-a0ce-43fa-904c-4c6bb52c01b5.png">


