### PR TITLE
[uiSettings] improves browser-side public types

### DIFF
--- a/packages/core/rendering/core-rendering-server-internal/src/render_utils.ts
+++ b/packages/core/rendering/core-rendering-server-internal/src/render_utils.ts
@@ -8,13 +8,13 @@
 
 import UiSharedDepsNpm from '@kbn/ui-shared-deps-npm';
 import * as UiSharedDepsSrc from '@kbn/ui-shared-deps-src';
-import type { PublicUiSettingsParams, UserProvidedValues } from '@kbn/core-ui-settings-common';
+import type { UiSettingsParams, UserProvidedValues } from '@kbn/core-ui-settings-common';
 
 export const getSettingValue = <T>(
   settingName: string,
   settings: {
     user?: Record<string, UserProvidedValues<unknown>>;
-    defaults: Readonly<Record<string, PublicUiSettingsParams>>;
+    defaults: Readonly<Record<string, Omit<UiSettingsParams, 'schema'>>>;
   },
   convert: (raw: unknown) => T
 ): T => {

--- a/packages/core/ui-settings/core-ui-settings-browser-internal/src/ui_settings_client_common.ts
+++ b/packages/core/ui-settings/core-ui-settings-browser-internal/src/ui_settings_client_common.ts
@@ -10,8 +10,12 @@ import { cloneDeep, defaultsDeep } from 'lodash';
 import { Observable, Subject, concat, defer, of } from 'rxjs';
 import { filter, map } from 'rxjs/operators';
 
-import { UserProvidedValues, PublicUiSettingsParams } from '@kbn/core-ui-settings-common';
-import { IUiSettingsClient, UiSettingsState } from '@kbn/core-ui-settings-browser';
+import { UserProvidedValues } from '@kbn/core-ui-settings-common';
+import {
+  IUiSettingsClient,
+  UiSettingsState,
+  PublicUiSettingsParams,
+} from '@kbn/core-ui-settings-browser';
 
 import { UiSettingsApi } from './ui_settings_api';
 

--- a/packages/core/ui-settings/core-ui-settings-browser/index.ts
+++ b/packages/core/ui-settings/core-ui-settings-browser/index.ts
@@ -6,4 +6,10 @@
  * Side Public License, v 1.
  */
 
-export type { UiSettingsState, IUiSettingsClient, SettingsStart, SettingsSetup } from './src/types';
+export type {
+  PublicUiSettingsParams,
+  UiSettingsState,
+  IUiSettingsClient,
+  SettingsStart,
+  SettingsSetup,
+} from './src/types';

--- a/packages/core/ui-settings/core-ui-settings-browser/src/types.ts
+++ b/packages/core/ui-settings/core-ui-settings-browser/src/types.ts
@@ -7,7 +7,9 @@
  */
 
 import type { Observable } from 'rxjs';
-import type { PublicUiSettingsParams, UserProvidedValues } from '@kbn/core-ui-settings-common';
+import type { UiSettingsParams, UserProvidedValues } from '@kbn/core-ui-settings-common';
+
+export type PublicUiSettingsParams = Omit<UiSettingsParams, 'schema'>;
 
 /** @public */
 export interface UiSettingsState {

--- a/packages/core/ui-settings/core-ui-settings-common/index.ts
+++ b/packages/core/ui-settings/core-ui-settings-common/index.ts
@@ -10,7 +10,6 @@ export type {
   UiSettingsType,
   DeprecationSettings,
   UiSettingsParams,
-  PublicUiSettingsParams,
   UserProvidedValues,
   UiSettingsScope,
 } from './src/ui_settings';

--- a/packages/core/ui-settings/core-ui-settings-common/src/ui_settings.ts
+++ b/packages/core/ui-settings/core-ui-settings-common/src/ui_settings.ts
@@ -95,12 +95,6 @@ export interface UiSettingsParams<T = unknown> {
 }
 
 /**
- * A sub-set of {@link UiSettingsParams} exposed to the client-side.
- * @public
- * */
-export type PublicUiSettingsParams = Omit<UiSettingsParams, 'schema'>;
-
-/**
  * Describes the values explicitly set by user.
  * @public
  * */

--- a/packages/core/ui-settings/core-ui-settings-server-internal/src/clients/base_ui_settings_client.ts
+++ b/packages/core/ui-settings/core-ui-settings-server-internal/src/clients/base_ui_settings_client.ts
@@ -8,11 +8,7 @@
 
 import { omit } from 'lodash';
 import type { Logger } from '@kbn/logging';
-import type {
-  UiSettingsParams,
-  PublicUiSettingsParams,
-  UserProvidedValues,
-} from '@kbn/core-ui-settings-common';
+import type { UiSettingsParams, UserProvidedValues } from '@kbn/core-ui-settings-common';
 import type { IUiSettingsClient } from '@kbn/core-ui-settings-server';
 
 export interface BaseUiSettingsDefaultsClientOptions {
@@ -42,7 +38,7 @@ export abstract class BaseUiSettingsClient implements IUiSettingsClient {
   }
 
   getRegistered() {
-    const copiedDefaults: Record<string, PublicUiSettingsParams> = {};
+    const copiedDefaults: Record<string, Omit<UiSettingsParams, 'schema'>> = {};
     for (const [key, value] of Object.entries(this.defaults)) {
       copiedDefaults[key] = omit(value, 'schema');
     }

--- a/packages/core/ui-settings/core-ui-settings-server/src/ui_settings_client.ts
+++ b/packages/core/ui-settings/core-ui-settings-server/src/ui_settings_client.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import type { UserProvidedValues, PublicUiSettingsParams } from '@kbn/core-ui-settings-common';
+import type { UserProvidedValues, UiSettingsParams } from '@kbn/core-ui-settings-common';
 
 /**
  * Server-side client that provides access to the advanced settings stored in elasticsearch.
@@ -20,7 +20,7 @@ export interface IUiSettingsClient {
   /**
    * Returns registered uiSettings values {@link UiSettingsParams}
    */
-  getRegistered: () => Readonly<Record<string, PublicUiSettingsParams>>;
+  getRegistered: () => Readonly<Record<string, Omit<UiSettingsParams, 'schema'>>>;
   /**
    * Retrieves uiSettings values set by the user with fallbacks to default values if not specified.
    */

--- a/src/core/public/index.ts
+++ b/src/core/public/index.ts
@@ -34,7 +34,11 @@ export type {
   FatalErrorsStart,
   FatalErrorInfo,
 } from '@kbn/core-fatal-errors-browser';
-export type { UiSettingsState, IUiSettingsClient } from '@kbn/core-ui-settings-browser';
+export type {
+  UiSettingsState,
+  IUiSettingsClient,
+  PublicUiSettingsParams,
+} from '@kbn/core-ui-settings-browser';
 export type { Capabilities } from '@kbn/core-capabilities-common';
 export type { SavedObjectsStart } from '@kbn/core-saved-objects-browser';
 export type { NotificationsSetup, NotificationsStart } from '@kbn/core-notifications-browser';
@@ -76,7 +80,6 @@ export {
 } from '@kbn/core-application-common';
 export type {
   UiSettingsParams,
-  PublicUiSettingsParams,
   UserProvidedValues,
   UiSettingsType,
 } from '@kbn/core-ui-settings-common';

--- a/src/core/server/index.ts
+++ b/src/core/server/index.ts
@@ -47,6 +47,7 @@ import type { CapabilitiesSetup, CapabilitiesStart } from '@kbn/core-capabilitie
 import type { RequestHandlerContext } from '@kbn/core-http-request-handler-context-server';
 import type { HttpResources } from '@kbn/core-http-resources-server';
 import type { PluginsServiceSetup, PluginsServiceStart } from '@kbn/core-plugins-server-internal';
+import { UiSettingsParams } from '@kbn/core-ui-settings-common';
 
 export { bootstrap } from '@kbn/core-root-server-internal';
 
@@ -389,7 +390,6 @@ export type {
 
 export type {
   UiSettingsParams,
-  PublicUiSettingsParams,
   UiSettingsType,
   UserProvidedValues,
   DeprecationSettings,

--- a/src/core/server/index.ts
+++ b/src/core/server/index.ts
@@ -47,7 +47,6 @@ import type { CapabilitiesSetup, CapabilitiesStart } from '@kbn/core-capabilitie
 import type { RequestHandlerContext } from '@kbn/core-http-request-handler-context-server';
 import type { HttpResources } from '@kbn/core-http-resources-server';
 import type { PluginsServiceSetup, PluginsServiceStart } from '@kbn/core-plugins-server-internal';
-import { UiSettingsParams } from '@kbn/core-ui-settings-common';
 
 export { bootstrap } from '@kbn/core-root-server-internal';
 

--- a/src/core/types/index.ts
+++ b/src/core/types/index.ts
@@ -23,6 +23,5 @@ export type {
   UiSettingsType,
   DeprecationSettings,
   UiSettingsParams,
-  PublicUiSettingsParams,
   UserProvidedValues,
 } from '@kbn/core-ui-settings-common';


### PR DESCRIPTION
fix https://github.com/elastic/kibana/issues/137609

When we migrated core's `uiSettings` service to packages, we ended up exporting two variations of `UiSettingsParams`, one as the full type and the other as the params excluding the `schema`.
This PR cleans that up and moves the export of `PublicUiSettingsParams` to the public browser-side package.
