### PR TITLE
Store error in RuleDataClient when initialization fails

### DIFF
--- a/x-pack/plugins/rule_registry/server/rule_data_client/rule_data_client.test.ts
+++ b/x-pack/plugins/rule_registry/server/rule_data_client/rule_data_client.test.ts
@@ -235,7 +235,7 @@ describe('RuleDataClient', () => {
 
       // getting the writer again at this point should throw another error
       await expect(() => ruleDataClient.getWriter()).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"Rule registry writing is disabled due to an error during Rule Data Client initialization."`
+        `"There has been a catastrophic error trying to install index level resources for the following registration context: observability.apm. This may have been due to a non-additive change to the mappings, removal and type changes are not permitted. Full error: Error: could not get cluster client"`
       );
       expect(logger.debug).toHaveBeenCalledWith(
         `Writing is disabled, bulk() will not write any data.`
@@ -267,7 +267,7 @@ describe('RuleDataClient', () => {
 
       // getting the writer again at this point should throw another error
       await expect(() => ruleDataClient.getWriter()).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"Rule registry writing is disabled due to an error during Rule Data Client initialization."`
+        `"There has been a catastrophic error trying to install namespace level resources for the following registration context: observability.apm. This may have been due to a non-additive change to the mappings, removal and type changes are not permitted. Full error: Error: bad resource installation"`
       );
       expect(logger.debug).toHaveBeenCalledWith(
         `Writing is disabled, bulk() will not write any data.`

--- a/x-pack/plugins/rule_registry/server/rule_data_client/rule_data_client.ts
+++ b/x-pack/plugins/rule_registry/server/rule_data_client/rule_data_client.ts
@@ -38,7 +38,7 @@ export type WaitResult = Either<Error, ElasticsearchClient>;
 
 export class RuleDataClient implements IRuleDataClient {
   private _isWriteEnabled: boolean = false;
-  private _isWriteInitializationFailed: boolean = false;
+  private _writeInitializationError: RuleDataWriterInitializationError | undefined = undefined;
   private _isWriterCacheEnabled: boolean = true;
 
   // Writers cached by namespace
@@ -72,12 +72,12 @@ export class RuleDataClient implements IRuleDataClient {
     this._isWriteEnabled = isEnabled;
   }
 
-  private get writeInitializationFailed(): boolean {
-    return this._isWriteInitializationFailed;
+  private get writeInitializationError(): RuleDataWriterInitializationError | undefined {
+    return this._writeInitializationError;
   }
 
-  private set writeInitializationFailed(isFailed: boolean) {
-    this._isWriteInitializationFailed = isFailed;
+  private set writeInitializationError(error: RuleDataWriterInitializationError | undefined) {
+    this._writeInitializationError = error;
   }
 
   public isWriteEnabled(): boolean {
@@ -174,10 +174,9 @@ export class RuleDataClient implements IRuleDataClient {
 
   private async initializeWriter(namespace: string): Promise<IRuleDataWriter> {
     const isWriteEnabled = () => this.writeEnabled;
-    const isWriteInitializationError = () => this.writeInitializationFailed;
-    const turnOffWriteDueToInitializationError = () => {
+    const turnOffWriteDueToInitializationError = (error: RuleDataWriterInitializationError) => {
       this.writeEnabled = false;
-      this.writeInitializationFailed = true;
+      this.writeInitializationError = error;
     };
 
     const { indexInfo, resourceInstaller } = this.options;
@@ -186,10 +185,18 @@ export class RuleDataClient implements IRuleDataClient {
     // Wait until both index and namespace level resources have been installed / updated.
     if (!isWriteEnabled()) {
       this.options.logger.debug(`Writing is disabled, bulk() will not write any data.`);
-      throw new RuleDataWriteDisabledError({
-        reason: isWriteInitializationError() ? 'error' : 'config',
-        registrationContext: indexInfo.indexOptions.registrationContext,
-      });
+      if (this.writeInitializationError != null) {
+        throw new RuleDataWriteDisabledError({
+          reason: 'error',
+          registrationContext: indexInfo.indexOptions.registrationContext,
+          message: this.writeInitializationError.message,
+        });
+      } else {
+        throw new RuleDataWriteDisabledError({
+          reason: 'config',
+          registrationContext: indexInfo.indexOptions.registrationContext,
+        });
+      }
     }
 
     try {
@@ -219,7 +226,7 @@ export class RuleDataClient implements IRuleDataClient {
         this.options.logger.error(
           `The writer for the Rule Data Client for the ${indexInfo.indexOptions.registrationContext} registration context was not initialized properly, bulk() cannot continue, and writing will be disabled.`
         );
-        turnOffWriteDueToInitializationError();
+        turnOffWriteDueToInitializationError(error);
       }
 
       throw error;


### PR DESCRIPTION
## Summary

We receive a number of SDHs each month around Rule Data Client initialization failures causing rule failures later on. Often these are due to `.partial` indices preventing the mapping update process during initialization, but we've also seen transient failures due to ES being overloaded during startup, as well as mapping issues from customers adding additional component templates.

This PR stores any error encountered during initialization and throws the same error message again each time `getWriter` is called instead of throwing a generic error message. This should help triage the issues faster, as we won't have to spend as much time asking for support to track down the error message from the first attempt at initializing the RDC.

### Before
![image](https://user-images.githubusercontent.com/55718608/214979913-4b570a0b-a047-45b2-ada7-637b70c405ef.png)

### After
![image](https://user-images.githubusercontent.com/55718608/214979736-715dce87-f7e1-46b1-a120-08b2c56f3185.png)
