### PR TITLE
[Lens] Display the metric title on the dashboard panel

### DIFF
--- a/x-pack/plugins/lens/public/visualizations/metric/visualization.test.ts
+++ b/x-pack/plugins/lens/public/visualizations/metric/visualization.test.ts
@@ -1099,7 +1099,7 @@ describe('metric visualization', () => {
 
   it('implements custom display options', () => {
     expect(visualization.getDisplayOptions!()).toEqual({
-      noPanelTitle: true,
+      noPanelTitle: false,
       noPadding: true,
     });
   });

--- a/x-pack/plugins/lens/public/visualizations/metric/visualization.tsx
+++ b/x-pack/plugins/lens/public/visualizations/metric/visualization.tsx
@@ -636,7 +636,7 @@ export const getMetricVisualization = ({
 
   getDisplayOptions() {
     return {
-      noPanelTitle: true,
+      noPanelTitle: false,
       noPadding: true,
     };
   },


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/148563

After this [PR](
https://github.com/elastic/kibana/pull/148301) being merged, it will be easier to add the description info icon and the custom data range to the new metric. For this reason we decided to also allow the panel title for now.

On the next minors we are going to hide it from the panel and display all the aforementioned info on the viz title.
<img width="988" alt="image" src="https://user-images.githubusercontent.com/17003240/215037834-0f556673-8628-484e-aa32-c34188fc7064.png">

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios