### PR TITLE
[ML] Adding anomaly explanation help link

### DIFF
--- a/packages/kbn-doc-links/src/get_doc_links.ts
+++ b/packages/kbn-doc-links/src/get_doc_links.ts
@@ -415,6 +415,7 @@ export const getDocLinks = ({ kibanaBranch }: GetDocLinkOptions): DocLinks => {
       anomalyDetection: `${MACHINE_LEARNING_DOCS}ml-ad-overview.html`,
       anomalyDetectionJobs: `${MACHINE_LEARNING_DOCS}ml-ad-finding-anomalies.html`,
       anomalyDetectionConfiguringCategories: `${MACHINE_LEARNING_DOCS}ml-configuring-categories.html`,
+      anomalyDetectionScoreExplanation: `${MACHINE_LEARNING_DOCS}ml-ad-explain.html`,
       anomalyDetectionBucketSpan: `${MACHINE_LEARNING_DOCS}ml-ad-run-jobs.html#ml-ad-bucket-span`,
       anomalyDetectionCardinality: `${MACHINE_LEARNING_DOCS}ml-ad-run-jobs.html#ml-ad-cardinality`,
       anomalyDetectionCreateJobs: `${MACHINE_LEARNING_DOCS}ml-ad-run-jobs.html#ml-ad-create-job`,

--- a/x-pack/plugins/ml/public/application/components/anomalies_table/anomaly_details_utils.tsx
+++ b/x-pack/plugins/ml/public/application/components/anomalies_table/anomaly_details_utils.tsx
@@ -16,6 +16,7 @@ import {
   useEuiTheme,
   EuiText,
   EuiSpacer,
+  EuiLink,
 } from '@elastic/eui';
 import { EntityCell, EntityCellFilter } from '../entity_cell';
 import { formatHumanReadableDateTimeSeconds } from '../../../../common/util/date_utils';
@@ -30,6 +31,7 @@ import {
   getAnomalyScoreExplanationImpactValue,
   getSeverityColor,
 } from '../../../../common/util/anomaly_utils';
+import { useMlKibana } from '../../contexts/kibana';
 
 const TIME_FIELD_NAME = 'timestamp';
 
@@ -327,6 +329,11 @@ export const DetailsItems: FC<{
 };
 
 export const AnomalyExplanationDetails: FC<{ anomaly: AnomaliesTableRecord }> = ({ anomaly }) => {
+  const {
+    services: { docLinks },
+  } = useMlKibana();
+  const docsUrl = docLinks.links.ml.anomalyDetectionScoreExplanation;
+
   const explanation = anomaly.source.anomaly_score_explanation;
   if (explanation === undefined) {
     return null;
@@ -509,14 +516,26 @@ export const AnomalyExplanationDetails: FC<{ anomaly: AnomaliesTableRecord }> = 
 
   return (
     <div>
-      <EuiText size="xs">
-        <h4>
-          <FormattedMessage
-            id="xpack.ml.anomaliesTable.anomalyDetails.anomalyExplanationTitle"
-            defaultMessage="Anomaly explanation"
-          />
-        </h4>
-      </EuiText>
+      <EuiFlexGroup gutterSize="none">
+        <EuiFlexItem>
+          <EuiText size="xs">
+            <h4>
+              <FormattedMessage
+                id="xpack.ml.anomaliesTable.anomalyDetails.anomalyExplanationTitle"
+                defaultMessage="Anomaly explanation"
+              />
+            </h4>
+          </EuiText>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiLink href={docsUrl} target="_blank">
+            <FormattedMessage
+              id="xpack.ml.anomaliesTable.anomalyDetails.anomalyExplanation.learnMoreLinkText"
+              defaultMessage="Learn more"
+            />
+          </EuiLink>
+        </EuiFlexItem>
+      </EuiFlexGroup>
       <EuiSpacer size="s" />
 
       {explanationDetails.map(({ title, description }) => (

--- a/x-pack/plugins/ml/public/application/components/anomalies_table/anomaly_details_utils.tsx
+++ b/x-pack/plugins/ml/public/application/components/anomalies_table/anomaly_details_utils.tsx
@@ -516,26 +516,25 @@ export const AnomalyExplanationDetails: FC<{ anomaly: AnomaliesTableRecord }> = 
 
   return (
     <div>
-      <EuiFlexGroup gutterSize="none">
-        <EuiFlexItem>
-          <EuiText size="xs">
-            <h4>
-              <FormattedMessage
-                id="xpack.ml.anomaliesTable.anomalyDetails.anomalyExplanationTitle"
-                defaultMessage="Anomaly explanation"
-              />
-            </h4>
-          </EuiText>
-        </EuiFlexItem>
-        <EuiFlexItem grow={false}>
-          <EuiLink href={docsUrl} target="_blank">
-            <FormattedMessage
-              id="xpack.ml.anomaliesTable.anomalyDetails.anomalyExplanation.learnMoreLinkText"
-              defaultMessage="Learn more"
-            />
-          </EuiLink>
-        </EuiFlexItem>
-      </EuiFlexGroup>
+      <EuiText size="xs">
+        <h4>
+          <FormattedMessage
+            id="xpack.ml.anomaliesTable.anomalyDetails.anomalyExplanationTitle"
+            defaultMessage="Anomaly explanation {learnMoreLink}"
+            values={{
+              learnMoreLink: (
+                <EuiLink href={docsUrl} target="_blank" css={{ marginLeft: '8px' }}>
+                  <FormattedMessage
+                    id="xpack.ml.anomaliesTable.anomalyDetails.anomalyExplanation.learnMoreLinkText"
+                    defaultMessage="Learn more"
+                  />
+                </EuiLink>
+              ),
+            }}
+          />
+        </h4>
+      </EuiText>
+
       <EuiSpacer size="s" />
 
       {explanationDetails.map(({ title, description }) => (

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -20652,7 +20652,6 @@
     "xpack.ml.anomaliesTable.anomalyDetails.anomalyExplanationDetails.singleBucketTooltip.high": "此存储桶中的实际值与典型值之间的差异会产生较大影响。",
     "xpack.ml.anomaliesTable.anomalyDetails.anomalyExplanationDetails.singleBucketTooltip.low": "此存储桶中的实际值与典型值之间的差异会产生适度影响。",
     "xpack.ml.anomaliesTable.anomalyDetails.anomalyExplanationDetails.singleBucketTooltip.medium": "此存储桶中的实际值与典型值之间的差异会产生重大影响。",
-    "xpack.ml.anomaliesTable.anomalyDetails.anomalyExplanationTitle": "异常解释",
     "xpack.ml.anomaliesTable.anomalyDetails.categoryExamplesTitle": "类别示例",
     "xpack.ml.anomaliesTable.anomalyDetails.descriptionTitle": "描述",
     "xpack.ml.anomaliesTable.anomalyDetails.detailsOnHighestSeverityAnomalyTitle": "有关最高严重性异常的详情",


### PR DESCRIPTION
Adds link to docs.

![image](https://user-images.githubusercontent.com/22172091/215071538-9e474468-6e7b-4c9a-9be9-60c12d0dca7d.png)


Even though the help page in question has specific anchor tags for items such as `Single bucket impact`, I decided it would look too noisy with links next to each item in the UI.
The help page isn't too large so it will be easy to find any specific items.
