### PR TITLE
[Lens] Fixes problem with query based annotations on the embeddable

### DIFF
--- a/x-pack/plugins/lens/public/embeddable/embeddable.tsx
+++ b/x-pack/plugins/lens/public/embeddable/embeddable.tsx
@@ -451,7 +451,7 @@ export class Embeddable
       this.activeVisualization.fromPersistableState?.(
         this.savedVis?.state.visualization,
         this.savedVis?.references
-      ) ?? this.activeVisualization.initialize(() => '', this.savedVis?.state.visualization)
+      ) || this.activeVisualization.initialize(() => '', this.savedVis?.state.visualization)
     );
   }
 

--- a/x-pack/plugins/lens/public/embeddable/embeddable.tsx
+++ b/x-pack/plugins/lens/public/embeddable/embeddable.tsx
@@ -447,7 +447,10 @@ export class Embeddable
 
   private get activeVisualizationState() {
     if (!this.activeVisualization) return;
-    return this.activeVisualization.initialize(() => '', this.savedVis?.state.visualization);
+    return this.activeVisualization.fromPersistableState?.(
+      this.savedVis?.state.visualization,
+      this.savedVis?.references
+    );
   }
 
   private indexPatterns: IndexPatternMap = {};

--- a/x-pack/plugins/lens/public/embeddable/embeddable.tsx
+++ b/x-pack/plugins/lens/public/embeddable/embeddable.tsx
@@ -447,9 +447,11 @@ export class Embeddable
 
   private get activeVisualizationState() {
     if (!this.activeVisualization) return;
-    return this.activeVisualization.fromPersistableState?.(
-      this.savedVis?.state.visualization,
-      this.savedVis?.references
+    return (
+      this.activeVisualization.fromPersistableState?.(
+        this.savedVis?.state.visualization,
+        this.savedVis?.references
+      ) ?? this.activeVisualization.initialize(() => '', this.savedVis?.state.visualization)
     );
   }
 


### PR DESCRIPTION
## Summary
Fixes #149667 

This is a quick fix for #149667 where the `initialize` method was used on SO visualization state before hydrating it with the `fromPersistableState`.

It would be even better to refactor the `initialize` method to detect if the state has been hydrated and call it internally rather than have two distinct methods, where the most appropriate one does not do what's expected.

Before the fix
![image](https://user-images.githubusercontent.com/17003240/215092349-fda7d98c-07c7-48b8-b816-4c4ab1f15007.png)


After
<img width="817" alt="image" src="https://user-images.githubusercontent.com/17003240/215092411-369548fb-35b3-4fd2-9bdf-fcddca1c7b5f.png">

