### PR TITLE
[8.5] [DOCS] Updates telemetry settings (#149651)

### DIFF
--- a/docs/settings/telemetry-settings.asciidoc
+++ b/docs/settings/telemetry-settings.asciidoc
@@ -25,8 +25,7 @@ See our https://www.elastic.co/legal/privacy-statement[Privacy Statement] to lea
 
 [[telemetry-optIn]] `telemetry.optIn`::
   Set to `true` to send cluster statistics to Elastic. Reporting your
-  cluster statistics helps us improve your user experience. Your data is never
-  shared with anyone. Set to `false` to stop sending any telemetry data to Elastic. +
+  cluster statistics helps us improve your user experience. Set to `false` to stop sending any telemetry data to Elastic. +
 +
 This setting can be changed at any time in <<advanced-options, Advanced Settings>>.
 To prevent users from changing it,

--- a/docs/setup/settings.asciidoc
+++ b/docs/setup/settings.asciidoc
@@ -377,6 +377,11 @@ Specifies an array of trusted hostnames, such as the {kib} host, or a reverse
 proxy sitting in front of it. This determines whether HTTP compression may be used for responses, based on the request `Referer` header.
 This setting may not be used when <<server-compression, `server.compression.enabled`>> is set to `false`. *Default: `none`*
 
+`server.compression.brotli.enabled`::
+Set to `true` to enable brotli (br) compression format.
+Note: browsers not supporting brotli compression will fallback to using gzip instead.
+This setting may not be used when <<server-compression, `server.compression.enabled`>> is set to `false`. *Default: `false`*
+
 [[server-securityResponseHeaders-strictTransportSecurity]] `server.securityResponseHeaders.strictTransportSecurity`::
 Controls whether the https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security[`Strict-Transport-Security`]
 header is used in all responses to the client from the {kib} server, and specifies what value is used. Allowed values are any text value or
@@ -398,7 +403,7 @@ experimental[] Controls whether the https://developer.mozilla.org/en-US/docs/Web
 is used in all responses to the client from the {kib} server, and specifies what value is used. Allowed values are any text value or `null`.
 To disable, set to `null`. *Default:* `null`
 
-[[server-securityResponseHeaders-disableEmbedding]]`server.securityResponseHeaders.disableEmbedding`:: 
+[[server-securityResponseHeaders-disableEmbedding]]`server.securityResponseHeaders.disableEmbedding`::
 Controls whether the https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy[`Content-Security-Policy`] and
 https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options[`X-Frame-Options`] headers are configured to disable embedding
 {kib} in other webpages using iframes. When set to `true`, secure headers are used to disable embedding, which adds the `frame-ancestors:
@@ -543,7 +548,7 @@ When `true`, users are able to change the telemetry setting at a later time in
 
 [[settings-telemetry-optIn]] `telemetry.optIn`::
 Reporting your cluster statistics helps
-us improve your user experience. Your data is never shared with anyone.
+us improve your user experience.
 Set to `true` to allow telemetry data to be sent to Elastic.
 When `false`, the telemetry data is never sent to Elastic. +
 +
@@ -563,7 +568,7 @@ Set this value to false to disable the Cross-Cluster Replication UI.
 [[settings-explore-data-in-context]] `xpack.discoverEnhanced.actions.exploreDataInContextMenu.enabled`::
 Enables the *Explore underlying data* option that allows you to open *Discover* from a dashboard panel and view the panel data. *Default: `false`*
 +
-When you create visualizations using the *Lens* drag-and-drop editor, you can use the toolbar to open and explore your data in *Discover*. For more information, check out <<explore-lens-data-in-discover, Explore the data in Discover>>. 
+When you create visualizations using the *Lens* drag-and-drop editor, you can use the toolbar to open and explore your data in *Discover*. For more information, check out <<explore-lens-data-in-discover, Explore the data in Discover>>.
 
 [[settings-explore-data-in-chart]] `xpack.discoverEnhanced.actions.exploreDataInChart.enabled`::
 Enables you to view the underlying documents in a data series from a dashboard panel. *Default: `false`*


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.5`:
 - [[DOCS] Updates telemetry settings (#149651)](https://github.com/elastic/kibana/pull/149651)

<!--- Backport version: 8.9.7 -->

