### PR TITLE
[TIP] disable add to blocklist feature if user doesn't have write privilege

### DIFF
--- a/x-pack/plugins/security_solution/public/threat_intelligence/routes.tsx
+++ b/x-pack/plugins/security_solution/public/threat_intelligence/routes.tsx
@@ -12,6 +12,7 @@ import { THREAT_INTELLIGENCE_BASE_PATH } from '@kbn/threat-intelligence-plugin/p
 import type { SourcererDataView } from '@kbn/threat-intelligence-plugin/public/types';
 import type { Store } from 'redux';
 import { useSelector } from 'react-redux';
+import { useUserPrivileges } from '../common/components/user_privileges';
 import { useSetUrlParams } from '../management/components/artifact_list_page/hooks/use_set_url_params';
 import { BlockListForm } from '../management/pages/blocklist/view/components/blocklist_form';
 import { BlocklistsApiClient } from '../management/pages/blocklist/services';
@@ -49,6 +50,7 @@ const ThreatIntelligence = memo(() => {
     getUseInvestigateInTimeline: useInvestigateInTimeline,
 
     blockList: {
+      canWriteBlocklist: useUserPrivileges().endpointPrivileges.canWriteBlocklist,
       exceptionListApiClient: BlocklistsApiClient.getInstance(http),
       useSetUrlParams,
       // @ts-ignore

--- a/x-pack/plugins/threat_intelligence/public/common/mocks/mock_security_context.tsx
+++ b/x-pack/plugins/threat_intelligence/public/common/mocks/mock_security_context.tsx
@@ -54,6 +54,7 @@ export const getSecuritySolutionContextMock = (): SecuritySolutionPluginContext 
   deregisterQuery: () => {},
 
   blockList: {
+    canWriteBlocklist: true,
     exceptionListApiClient: {},
     useSetUrlParams: () => (params, replace) => {},
     getFlyoutComponent: () => (<div />) as unknown as NamedExoticComponent<BlockListFlyoutProps>,

--- a/x-pack/plugins/threat_intelligence/public/modules/block_list/components/add_to_block_list/__snapshots__/add_to_block_list.test.tsx.snap
+++ b/x-pack/plugins/threat_intelligence/public/modules/block_list/components/add_to_block_list/__snapshots__/add_to_block_list.test.tsx.snap
@@ -1,6 +1,103 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<AddToBlockListContextMenu /> should render a disabled EuiContextMenuItem 1`] = `
+exports[`<AddToBlockListContextMenu /> should render a disabled EuiContextMenuItem if data is null 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <button
+        class="euiContextMenuItem euiContextMenuItem-isDisabled"
+        disabled=""
+        type="button"
+      >
+        <span
+          class="euiContextMenu__itemLayout"
+        >
+          <span
+            class="euiContextMenuItem__text"
+          >
+            <span>
+              Add blocklist entry
+            </span>
+          </span>
+        </span>
+      </button>
+    </div>
+  </body>,
+  "container": <div>
+    <button
+      class="euiContextMenuItem euiContextMenuItem-isDisabled"
+      disabled=""
+      type="button"
+    >
+      <span
+        class="euiContextMenu__itemLayout"
+      >
+        <span
+          class="euiContextMenuItem__text"
+        >
+          <span>
+            Add blocklist entry
+          </span>
+        </span>
+      </span>
+    </button>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
+exports[`<AddToBlockListContextMenu /> should render a disabled EuiContextMenuItem if no write blocklist privilege 1`] = `
 Object {
   "asFragment": [Function],
   "baseElement": <body>

--- a/x-pack/plugins/threat_intelligence/public/modules/block_list/components/add_to_block_list/add_to_block_list.stories.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/block_list/components/add_to_block_list/add_to_block_list.stories.tsx
@@ -35,3 +35,22 @@ export const ContextMenu: Story<void> = () => {
     </SecuritySolutionContext.Provider>
   );
 };
+
+export const Disabled: Story<void> = () => {
+  const mockSecurityContext: SecuritySolutionPluginContext = getSecuritySolutionContextMock();
+  mockSecurityContext.blockList.canWriteBlocklist = false;
+
+  const mockIndicatorFileHashValue: string = 'abc';
+  const mockOnClick: () => void = () => window.alert('clicked!');
+  const items = [
+    <AddToBlockListContextMenu data={mockIndicatorFileHashValue} onClick={mockOnClick} />,
+  ];
+
+  return (
+    <SecuritySolutionContext.Provider value={mockSecurityContext}>
+      <BlockListProvider>
+        <EuiContextMenuPanel items={items} />
+      </BlockListProvider>
+    </SecuritySolutionContext.Provider>
+  );
+};

--- a/x-pack/plugins/threat_intelligence/public/modules/block_list/components/add_to_block_list/add_to_block_list.test.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/block_list/components/add_to_block_list/add_to_block_list.test.tsx
@@ -31,10 +31,28 @@ describe('<AddToBlockListContextMenu />', () => {
     expect(component).toMatchSnapshot();
   });
 
-  it('should render a disabled EuiContextMenuItem', () => {
+  it('should render a disabled EuiContextMenuItem if data is null', () => {
     const mockSecurityContext: SecuritySolutionPluginContext = getSecuritySolutionContextMock();
 
     const mockIndicatorFileHashValue = null;
+    const mockOnClick: () => void = () => window.alert('clicked!');
+
+    const component = render(
+      <SecuritySolutionContext.Provider value={mockSecurityContext}>
+        <BlockListProvider>
+          <AddToBlockListContextMenu data={mockIndicatorFileHashValue} onClick={mockOnClick} />
+        </BlockListProvider>
+      </SecuritySolutionContext.Provider>
+    );
+
+    expect(component).toMatchSnapshot();
+  });
+
+  it('should render a disabled EuiContextMenuItem if no write blocklist privilege', () => {
+    const mockSecurityContext: SecuritySolutionPluginContext = getSecuritySolutionContextMock();
+    mockSecurityContext.blockList.canWriteBlocklist = false;
+
+    const mockIndicatorFileHashValue: string = 'abc';
     const mockOnClick: () => void = () => window.alert('clicked!');
 
     const component = render(

--- a/x-pack/plugins/threat_intelligence/public/modules/block_list/components/add_to_block_list/add_to_block_list.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/block_list/components/add_to_block_list/add_to_block_list.tsx
@@ -8,6 +8,7 @@
 import React, { VFC } from 'react';
 import { EuiContextMenuItem } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { useSecurityContext } from '../../../../hooks';
 import { useBlockListContext } from '../../../indicators/hooks/use_block_list_context';
 import { useSetUrlParams } from '../../hooks/use_set_url_params';
 
@@ -37,6 +38,9 @@ export const AddToBlockListContextMenu: VFC<AddToBlockListProps> = ({
   'data-test-subj': dataTestSub,
   onClick,
 }) => {
+  const { blockList } = useSecurityContext();
+  const canWriteBlocklist = blockList.canWriteBlocklist;
+
   const { setBlockListIndicatorValue } = useBlockListContext();
   const { setUrlParams } = useSetUrlParams();
 
@@ -46,12 +50,14 @@ export const AddToBlockListContextMenu: VFC<AddToBlockListProps> = ({
     setUrlParams({ show: 'create' });
   };
 
+  const disabled: boolean = !canWriteBlocklist;
+
   return (
     <EuiContextMenuItem
       key="addToBlocklist"
       onClick={() => menuItemClicked()}
       data-test-subj={dataTestSub}
-      disabled={data == null}
+      disabled={disabled || data == null}
     >
       <FormattedMessage
         defaultMessage="Add blocklist entry"

--- a/x-pack/plugins/threat_intelligence/public/modules/block_list/components/add_to_block_list/add_to_block_list.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/block_list/components/add_to_block_list/add_to_block_list.tsx
@@ -38,9 +38,9 @@ export const AddToBlockListContextMenu: VFC<AddToBlockListProps> = ({
   'data-test-subj': dataTestSub,
   onClick,
 }) => {
-  const { blockList } = useSecurityContext();
-  const canWriteBlocklist = blockList.canWriteBlocklist;
-
+  const {
+    blockList: { canWriteBlocklist },
+  } = useSecurityContext();
   const { setBlockListIndicatorValue } = useBlockListContext();
   const { setUrlParams } = useSetUrlParams();
 
@@ -50,14 +50,14 @@ export const AddToBlockListContextMenu: VFC<AddToBlockListProps> = ({
     setUrlParams({ show: 'create' });
   };
 
-  const disabled: boolean = !canWriteBlocklist;
+  const disabled = !canWriteBlocklist || data === null;
 
   return (
     <EuiContextMenuItem
       key="addToBlocklist"
       onClick={() => menuItemClicked()}
       data-test-subj={dataTestSub}
-      disabled={disabled || data == null}
+      disabled={disabled}
     >
       <FormattedMessage
         defaultMessage="Add blocklist entry"

--- a/x-pack/plugins/threat_intelligence/public/types.ts
+++ b/x-pack/plugins/threat_intelligence/public/types.ts
@@ -106,14 +106,17 @@ export interface SecuritySolutionPluginContext {
    * Get the user's license to drive the Threat Intelligence plugin's visibility.
    */
   licenseService: LicenseAware;
+
   /**
    * Gets Security Solution shared information like browerFields, indexPattern and selectedPatterns in DataView.
    */
   sourcererDataView: SourcererDataView;
+
   /**
    * Security Solution store
    */
   securitySolutionStore: Store;
+
   /**
    * Pass UseInvestigateInTimeline functionality to TI plugin
    */
@@ -124,7 +127,9 @@ export interface SecuritySolutionPluginContext {
   }: UseInvestigateInTimelineProps) => () => Promise<void>;
 
   useQuery: () => Query;
+
   useFilters: () => Filter[];
+
   useGlobalTime: () => TimeRange;
 
   SiemSearchBar: VFC<any>;
@@ -139,7 +144,11 @@ export interface SecuritySolutionPluginContext {
    */
   deregisterQuery: (query: { id: string }) => void;
 
+  /**
+   * Add to blocklist feature
+   */
   blockList: {
+    canWriteBlocklist: boolean;
     exceptionListApiClient: unknown;
     useSetUrlParams: () => (
       params: Record<string, string | number | null | undefined>,


### PR DESCRIPTION
## Summary

This [previous PR](https://github.com/elastic/kibana/pull/148516) added the add to blocklist functionality to the Threat Intelligence plugin. 

This PR checks the RBAC privilege from the Security Solution plugin. If the user doesn't have write permission on the blocklist feature, the button is disabled (both in the context menu button in the Indicators table action column and Indicator flyout take action button).

![Screenshot 2023-01-27 at 9 49 47 AM](https://user-images.githubusercontent.com/17276605/215135407-c3160153-9471-4cb0-9ff3-730636c412f7.png)

Fixes https://github.com/elastic/security-team/issues/5819