### PR TITLE
[DOCS] [8.5] Removes data share statement in Advanced Settings

### DIFF
--- a/docs/management/advanced-options.asciidoc
+++ b/docs/management/advanced-options.asciidoc
@@ -562,4 +562,4 @@ If enabled, document sampling is used to determine field existence (available or
 [horizontal]
 [[telemetry-enabled-advanced-setting]]`telemetry:enabled`::
 When enabled, helps improve the Elastic Stack by providing usage statistics for
-basic features. This data will not be shared outside of Elastic.
+basic features.


### PR DESCRIPTION
## Summary

Removes `This data will not be shared outside of Elastic.` from Advanced Settings.