### PR TITLE
[DOCS] [8.2] Removes data share statement in Advanced Settings

### DIFF
--- a/docs/management/advanced-options.asciidoc
+++ b/docs/management/advanced-options.asciidoc
@@ -548,4 +548,4 @@ only production-ready visualizations are available to users.
 [horizontal]
 [[telemetry-enabled-advanced-setting]]`telemetry:enabled`::
 When enabled, helps improve the Elastic Stack by providing usage statistics for
-basic features. This data will not be shared outside of Elastic.
+basic features.


### PR DESCRIPTION
## Summary

Removes `This data will not be shared outside of Elastic.` from Advanced Settings.