### PR TITLE
[Anduril] (D4C) added cloud_defend as a logs destination for fleet/elastic-agent

### DIFF
--- a/x-pack/plugins/fleet/common/constants/agent_policy.ts
+++ b/x-pack/plugins/fleet/common/constants/agent_policy.ts
@@ -25,6 +25,7 @@ export const AGENT_POLICY_DEFAULT_MONITORING_DATASETS = [
   'elastic_agent.auditbeat',
   'elastic_agent.heartbeat',
   'elastic_agent.cloudbeat',
+  'elastic_agent.cloud_defend',
 ];
 
 export const LICENSE_FOR_SCHEDULE_UPGRADE = 'platinum';

--- a/x-pack/plugins/fleet/server/services/agent_policies/__snapshots__/monitoring_permissions.test.ts.snap
+++ b/x-pack/plugins/fleet/server/services/agent_policies/__snapshots__/monitoring_permissions.test.ts.snap
@@ -117,6 +117,7 @@ Object {
           "logs-elastic_agent.auditbeat-testnamespace123",
           "logs-elastic_agent.heartbeat-testnamespace123",
           "logs-elastic_agent.cloudbeat-testnamespace123",
+          "logs-elastic_agent.cloud_defend-testnamespace123",
           "metrics-elastic_agent-testnamespace123",
           "metrics-elastic_agent.elastic_agent-testnamespace123",
           "metrics-elastic_agent.apm_server-testnamespace123",
@@ -129,6 +130,7 @@ Object {
           "metrics-elastic_agent.auditbeat-testnamespace123",
           "metrics-elastic_agent.heartbeat-testnamespace123",
           "metrics-elastic_agent.cloudbeat-testnamespace123",
+          "metrics-elastic_agent.cloud_defend-testnamespace123",
         ],
         "privileges": Array [
           "auto_configure",
@@ -158,6 +160,7 @@ Object {
           "logs-elastic_agent.auditbeat-testnamespace123",
           "logs-elastic_agent.heartbeat-testnamespace123",
           "logs-elastic_agent.cloudbeat-testnamespace123",
+          "logs-elastic_agent.cloud_defend-testnamespace123",
         ],
         "privileges": Array [
           "auto_configure",
@@ -187,6 +190,7 @@ Object {
           "metrics-elastic_agent.auditbeat-testnamespace123",
           "metrics-elastic_agent.heartbeat-testnamespace123",
           "metrics-elastic_agent.cloudbeat-testnamespace123",
+          "metrics-elastic_agent.cloud_defend-testnamespace123",
         ],
         "privileges": Array [
           "auto_configure",


### PR DESCRIPTION
## Summary

Adds to the appropriate mappings to ensure elastic-agent can write logs for the new "Defend for containers" service coming in 8.8

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios