### PR TITLE
[uiSettings] Fix and uiSettings api-integration tests for global settings

### DIFF
--- a/src/core/server/integration_tests/ui_settings/doc_exists.ts
+++ b/src/core/server/integration_tests/ui_settings/doc_exists.ts
@@ -9,8 +9,13 @@
 import { getServices, chance } from './lib';
 
 export const docExistsSuite = (savedObjectsIndex: string) => () => {
-  async function setup(options: { initialSettings?: Record<string, any> } = {}) {
-    const { initialSettings } = options;
+  async function setup(
+    options: {
+      initialSettings?: Record<string, any>;
+      initialGlobalSettings?: Record<string, any>;
+    } = {}
+  ) {
+    const { initialSettings, initialGlobalSettings } = options;
 
     const { uiSettings, uiSettingsGlobal, esClient, supertest } = getServices();
 
@@ -27,7 +32,9 @@ export const docExistsSuite = (savedObjectsIndex: string) => () => {
 
     if (initialSettings) {
       await uiSettings.setMany(initialSettings);
-      await uiSettingsGlobal.setMany(uiSettingsGlobal);
+    }
+    if (initialGlobalSettings) {
+      await uiSettingsGlobal.setMany(initialGlobalSettings);
     }
 
     return { uiSettings, uiSettingsGlobal, supertest };
@@ -198,7 +205,7 @@ export const docExistsSuite = (savedObjectsIndex: string) => () => {
         const defaultIndex = chance.word({ length: 10 });
 
         const { supertest } = await setup({
-          initialSettings: {
+          initialGlobalSettings: {
             defaultIndex,
           },
         });
@@ -212,10 +219,6 @@ export const docExistsSuite = (savedObjectsIndex: string) => () => {
             },
             defaultIndex: {
               userValue: defaultIndex,
-            },
-            foo: {
-              userValue: 'bar',
-              isOverridden: true,
             },
           },
         });
@@ -242,15 +245,12 @@ export const docExistsSuite = (savedObjectsIndex: string) => () => {
             defaultIndex: {
               userValue: defaultIndex,
             },
-            foo: {
-              userValue: 'bar',
-              isOverridden: true,
-            },
           },
         });
       });
 
-      it('returns a 400 if trying to set overridden value', async () => {
+      // kbn server only created with uiSettings overrides. Global settings don't seem to support overrides from kibana.yml
+      it.skip('returns a 400 if trying to set overridden value', async () => {
         const { supertest } = await setup();
 
         const { body } = await supertest('delete', '/api/kibana/global_settings/foo')
@@ -288,15 +288,12 @@ export const docExistsSuite = (savedObjectsIndex: string) => () => {
             defaultIndex: {
               userValue: defaultIndex,
             },
-            foo: {
-              userValue: 'bar',
-              isOverridden: true,
-            },
           },
         });
       });
 
-      it('returns a 400 if trying to set overridden value', async () => {
+      // kbn server only created with uiSettings overrides. Global settings don't seem to support overrides from kibana.yml
+      it.skip('returns a 400 if trying to set overridden value', async () => {
         const { supertest } = await setup();
 
         const { body } = await supertest('post', '/api/kibana/global_settings')
@@ -320,7 +317,7 @@ export const docExistsSuite = (savedObjectsIndex: string) => () => {
         const defaultIndex = chance.word({ length: 10 });
 
         const { uiSettingsGlobal, supertest } = await setup({
-          initialSettings: { defaultIndex },
+          initialGlobalSettings: { defaultIndex },
         });
 
         expect(await uiSettingsGlobal.get('defaultIndex')).toBe(defaultIndex);
@@ -335,14 +332,11 @@ export const docExistsSuite = (savedObjectsIndex: string) => () => {
             buildNum: {
               userValue: expect.any(Number),
             },
-            foo: {
-              userValue: 'bar',
-              isOverridden: true,
-            },
           },
         });
       });
-      it('returns a 400 if deleting overridden value', async () => {
+      // kbn server only created with uiSettings overrides. Global settings don't seem to support overrides from kibana.yml
+      it.skip('returns a 400 if deleting overridden value', async () => {
         const { supertest } = await setup();
 
         const { body } = await supertest('delete', '/api/kibana/global_settings/foo').expect(400);

--- a/src/core/server/integration_tests/ui_settings/doc_missing.ts
+++ b/src/core/server/integration_tests/ui_settings/doc_missing.ts
@@ -45,7 +45,6 @@ export const docMissingSuite = (savedObjectsIndex: string) => () => {
   describe('set route', () => {
     it('creates doc, returns a 200 with value set', async () => {
       const { supertest } = getServices();
-
       const defaultIndex = chance.word();
 
       const { body } = await supertest('post', '/api/kibana/settings/defaultIndex')

--- a/src/core/server/integration_tests/ui_settings/index.test.ts
+++ b/src/core/server/integration_tests/ui_settings/index.test.ts
@@ -21,7 +21,7 @@ describe('uiSettings/routes', function () {
 
   beforeAll(startServers);
   // eslint-disable-next-line jest/valid-describe
-  describe('doc missing', docMissingSuite(savedObjectIndex));
+  describe.skip('doc missing', docMissingSuite(savedObjectIndex));
   // eslint-disable-next-line jest/valid-describe
   describe('doc exists', docExistsSuite(savedObjectIndex));
   afterAll(stopServers);

--- a/src/core/server/integration_tests/ui_settings/index.test.ts
+++ b/src/core/server/integration_tests/ui_settings/index.test.ts
@@ -21,7 +21,7 @@ describe('uiSettings/routes', function () {
 
   beforeAll(startServers);
   // eslint-disable-next-line jest/valid-describe
-  describe.skip('doc missing', docMissingSuite(savedObjectIndex));
+  describe('doc missing', docMissingSuite(savedObjectIndex));
   // eslint-disable-next-line jest/valid-describe
   describe('doc exists', docExistsSuite(savedObjectIndex));
   afterAll(stopServers);

--- a/src/core/server/integration_tests/ui_settings/lib/servers.ts
+++ b/src/core/server/integration_tests/ui_settings/lib/servers.ts
@@ -50,7 +50,7 @@ export async function startServers() {
   });
   esServer = await servers.startES();
   kbn = await servers.startKibana();
-  // register global setting
+  // register global settings
   kbn.coreSetup.uiSettings.registerGlobal({
     foo: {
       value: 'bar',
@@ -78,7 +78,6 @@ export function getServices() {
 
   const uiSettings = kbn.coreStart.uiSettings.asScopedToClient(savedObjectsClient);
   const uiSettingsGlobal = kbn.coreStart.uiSettings.globalAsScopedToClient(savedObjectsClient);
-
   services = {
     supertest: (method: HttpMethod, path: string) => getSupertest(kbn.root, method, path),
     esClient,

--- a/src/core/server/integration_tests/ui_settings/lib/servers.ts
+++ b/src/core/server/integration_tests/ui_settings/lib/servers.ts
@@ -18,6 +18,7 @@ import {
   type TestUtils,
   type HttpMethod,
 } from '@kbn/core-test-helpers-kbn-server';
+import { schema } from '@kbn/config-schema';
 import type { SavedObjectsClientContract, IUiSettingsClient } from '../../..';
 
 let servers: TestUtils;
@@ -49,6 +50,19 @@ export async function startServers() {
   });
   esServer = await servers.startES();
   kbn = await servers.startKibana();
+  // register global setting
+  kbn.coreSetup.uiSettings.registerGlobal({
+    foo: {
+      value: 'bar',
+      schema: schema.string(),
+    },
+  });
+  kbn.coreSetup.uiSettings.registerGlobal({
+    defaultIndex: {
+      value: 'something',
+      schema: schema.string(),
+    },
+  });
 }
 
 export function getServices() {

--- a/src/core/server/integration_tests/ui_settings/routes.test.ts
+++ b/src/core/server/integration_tests/ui_settings/routes.test.ts
@@ -26,6 +26,19 @@ describe('ui settings service', () => {
           schema: schema.string(),
         },
       });
+      // global uiSettings have to be registerd to be set
+      uiSettings.registerGlobal({
+        custom: {
+          value: '42',
+          schema: schema.string(),
+        },
+      });
+      uiSettings.registerGlobal({
+        foo: {
+          value: 'foo',
+          schema: schema.string(),
+        },
+      });
 
       await root.start();
     });


### PR DESCRIPTION
While trying to [migrate the API integration tests](https://github.com/elastic/kibana/issues/145063) for core's `uiSettings` service, we realized the tests for global `uiSettings` (added in https://github.com/elastic/kibana/pull/147069 and https://github.com/elastic/kibana/pull/146270) were failing.
It turns out that these failures are expected because global `uiSettings` have to be registered before they can be set.

This PR fixes most of the failed tests and skips the ones that test against a user-overridden value.

cc @majagrubic 

**TBD**: ~~Migrate the tests to a package as part of this PR or follow it up with another PR.~~ The tests will be moved automatically when `src/core` gets bundled as a package.

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
