### PR TITLE
[Synthetics] Enable view test run details when test is competed

### DIFF
--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/test_now_mode/test_result_header.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/test_now_mode/test_result_header.tsx
@@ -16,6 +16,8 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import * as React from 'react';
+import { getTestRunDetailLink } from '../common/links/test_details_link';
+import { useLocations } from '../../hooks';
 import { useSyntheticsSettingsContext } from '../../contexts';
 import { JourneyStep, Ping } from '../../../../../common/runtime_types';
 import { formatDuration } from '../../utils/formatting';
@@ -44,6 +46,8 @@ export function TestResultHeader({
       duration += sDoc.monitor.duration?.us ?? 0;
     });
   }
+
+  const { getLocationByLabel } = useLocations();
 
   const summaryDoc = summaryDocs?.[0] as Ping;
 
@@ -84,11 +88,15 @@ export function TestResultHeader({
           </EuiFlexGroup>
         )}
       </EuiFlexItem>
-      {checkGroupId && (
+      {checkGroupId && configId && isCompleted && (
         <EuiFlexItem grow={false}>
           <EuiLink
-            href={`${basePath}/app/synthetics/monitor/${configId}/test-run/${checkGroupId}`}
-            target="_blank"
+            href={getTestRunDetailLink({
+              basePath,
+              monitorId: configId,
+              checkGroup: checkGroupId,
+              locationId: getLocationByLabel(summaryDoc?.observer?.geo?.name!)?.id,
+            })}
           >
             {VIEW_DETAILS}
           </EuiLink>

--- a/x-pack/plugins/synthetics/public/apps/synthetics/hooks/use_locations.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/hooks/use_locations.ts
@@ -21,10 +21,15 @@ export function useLocations() {
     }
   }, [dispatch, locations, locationsLoaded]);
 
+  const getLocationByLabel = (label: string) => {
+    return locations.find((location) => location.label === label);
+  };
+
   return {
     error,
     loading,
     locations,
     throttling,
+    getLocationByLabel,
   };
 }


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/149666

Enable view test run details when test is competed

Will show test results details only when the check is completed

<img width="1784" alt="image" src="https://user-images.githubusercontent.com/3505601/215454762-11757086-55e1-4751-9016-b63088ece892.png">

