### PR TITLE
[Discover] Unskip flaky a11y tests

### DIFF
--- a/test/accessibility/apps/discover.ts
+++ b/test/accessibility/apps/discover.ts
@@ -20,8 +20,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const browser = getService('browser');
   const retry = getService('retry');
 
-  // Failing: See https://github.com/elastic/kibana/issues/147186
-  describe.skip('Discover a11y tests', () => {
+  describe('Discover a11y tests', () => {
     before(async () => {
       await PageObjects.common.navigateToApp('discover');
       await PageObjects.timePicker.setCommonlyUsedTime('Last_7 days');
@@ -139,6 +138,9 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       await retry.try(async () => {
         await testSubjects.click('euiFlyoutCloseButton');
+      });
+
+      await retry.try(async () => {
         await toasts.dismissAllToasts();
       });
 


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/147186

100x https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/1811

<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->