### PR TITLE
[8.6] [Osquery] Fix styling of Ecs Field and url slash issue (#148719)

### DIFF
--- a/x-pack/plugins/osquery/public/packs/utils.tsx
+++ b/x-pack/plugins/osquery/public/packs/utils.tsx
@@ -5,4 +5,4 @@
  * 2.0.
  */
 
-export const overflowCss = { overflow: 'auto' };
+export const overflowCss = { overflow: 'hidden' };

--- a/x-pack/plugins/osquery/public/shared_components/osquery_action/use_is_osquery_available_simple.tsx
+++ b/x-pack/plugins/osquery/public/shared_components/osquery_action/use_is_osquery_available_simple.tsx
@@ -26,7 +26,7 @@ export const useIsOsqueryAvailableSimple = ({ agentId }: IProps) => {
           `/internal/osquery/fleet_wrapper/agents/${agentId}`
         );
         const { item: packageInfo }: { item: AgentPolicy } = await http.get(
-          `/internal/osquery/fleet_wrapper/agent_policies/${agentInfo.policy_id}/`
+          `/internal/osquery/fleet_wrapper/agent_policies/${agentInfo.policy_id}`
         );
         const osqueryPackageInstalled = find(packageInfo?.package_policies, [
           'package.name',


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.6`:
 - [[Osquery] Fix styling of Ecs Field and url slash issue (#148719)](https://github.com/elastic/kibana/pull/148719)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Tomasz Ciecierski","email":"tomasz.ciecierski@elastic.co"},"sourceCommit":{"committedDate":"2023-01-30T12:02:24Z","message":"[Osquery] Fix styling of Ecs Field and url slash issue (#148719)","sha":"1e90bcdb2204b169512127e0afa6068c9cb790d0","branchLabelMapping":{"^v8.7.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","Team:Defend Workflows","Team:Asset Management","Feature:Osquery","ci:cloud-deploy","v8.7.0","v8.6.2"],"number":148719,"url":"https://github.com/elastic/kibana/pull/148719","mergeCommit":{"message":"[Osquery] Fix styling of Ecs Field and url slash issue (#148719)","sha":"1e90bcdb2204b169512127e0afa6068c9cb790d0"}},"sourceBranch":"main","suggestedTargetBranches":["8.6"],"targetPullRequestStates":[{"branch":"main","label":"v8.7.0","labelRegex":"^v8.7.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/148719","number":148719,"mergeCommit":{"message":"[Osquery] Fix styling of Ecs Field and url slash issue (#148719)","sha":"1e90bcdb2204b169512127e0afa6068c9cb790d0"}},{"branch":"8.6","label":"v8.6.2","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->