### PR TITLE
[Enterprise Search] Fix pagination issue on indices page

### DIFF
--- a/x-pack/plugins/enterprise_search/server/routes/enterprise_search/indices.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/enterprise_search/indices.ts
@@ -120,7 +120,7 @@ export function registerIndexRoutes({
           meta: {
             page: {
               current: page,
-              size: indices.length,
+              size,
               total_pages: totalPages,
               total_results: totalResults,
             },


### PR DESCRIPTION
## Summary

Fixes a bug where the fetch indices request was incorrectly reporting the page size

<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->