### PR TITLE
[Fleet] Bugfix: count agent policies not agent policy revisions in telemetry

### DIFF
--- a/x-pack/plugins/fleet/server/collectors/register.ts
+++ b/x-pack/plugins/fleet/server/collectors/register.ts
@@ -62,7 +62,7 @@ export const fetchFleetUsage = async (
     packages: await getPackageUsage(soClient),
     ...(await getAgentData(esClient, abortController)),
     fleet_server_config: await getFleetServerConfig(soClient),
-    agent_policies: await getAgentPoliciesUsage(esClient, abortController),
+    agent_policies: await getAgentPoliciesUsage(soClient),
     ...(await getPanicLogsLastHour(esClient)),
     // TODO removed top errors telemetry as it causes this issue: https://github.com/elastic/kibana/issues/148976
     // ...(await getAgentLogsTopErrors(esClient)),

--- a/x-pack/plugins/fleet/server/integration_tests/fleet_usage_telemetry.test.ts
+++ b/x-pack/plugins/fleet/server/integration_tests/fleet_usage_telemetry.test.ts
@@ -270,6 +270,50 @@ describe('fleet usage telemetry', () => {
         },
       ],
     });
+
+    await soClient.create(
+      'ingest-outputs',
+      {
+        name: 'output2',
+        type: 'third_type',
+        hosts: ['http://localhost:9300'],
+        is_default: false,
+        is_default_monitoring: false,
+        config_yaml: '',
+        ca_trusted_fingerprint: '',
+        proxy_id: null,
+      },
+      { id: 'output2' }
+    );
+    await soClient.create(
+      'ingest-outputs',
+      {
+        name: 'output3',
+        type: 'logstash',
+        hosts: ['http://localhost:9400'],
+        is_default: false,
+        is_default_monitoring: false,
+        config_yaml: '',
+        ca_trusted_fingerprint: '',
+        proxy_id: null,
+      },
+      { id: 'output3' }
+    );
+
+    await soClient.create('ingest-agent-policies', {
+      namespace: 'default',
+      monitoring_enabled: ['logs', 'metrics'],
+      name: 'Another policy',
+      description: 'Policy 2',
+      inactivity_timeout: 1209600,
+      status: 'active',
+      is_managed: false,
+      revision: 2,
+      updated_by: 'system',
+      schema_version: '1.0.0',
+      data_output_id: 'output2',
+      monitoring_output_id: 'output3',
+    });
   });
 
   afterAll(async () => {
@@ -324,7 +368,10 @@ describe('fleet usage telemetry', () => {
             },
           ],
         },
-        agent_policies: { count: 3, output_types: ['elasticsearch'] },
+        agent_policies: {
+          count: 2,
+          output_types: expect.arrayContaining(['elasticsearch', 'logstash', 'third_type']),
+        },
         agent_logs_panics_last_hour: [
           {
             timestamp: expect.any(String),


### PR DESCRIPTION
## Summary

Previously we were counting all agent policy revisions + even if the agent policy had been deleted. I have moved to using the saved object client to get the agent policies.



<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->