### PR TITLE
[Enterprise Search] Standardize on Elasticsearch pagination

### DIFF
--- a/x-pack/plugins/enterprise_search/common/types/pagination.ts
+++ b/x-pack/plugins/enterprise_search/common/types/pagination.ts
@@ -5,11 +5,17 @@
  * 2.0.
  */
 
+export interface Page {
+  from: number; // current page index, 0-based
+  has_more_hits_than_total?: boolean;
+  size: number; // size per page
+  total: number; // total number of hits
+}
+export interface Meta {
+  page: Page;
+}
+
 export interface Paginate<T> {
+  _meta: Meta;
   data: T[];
-  has_more_hits_than_total: boolean;
-  pageIndex: number;
-  pageSize: number;
-  size: number;
-  total: number;
 }

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/connector/fetch_sync_jobs_api_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/connector/fetch_sync_jobs_api_logic.test.ts
@@ -24,18 +24,18 @@ describe('FetchSyncJobs', () => {
       await nextTick();
       expect(http.get).toHaveBeenCalledWith(
         '/internal/enterprise_search/connectors/connectorId1/sync_jobs',
-        { query: { page: 0, size: 10 } }
+        { query: { from: 0, size: 10 } }
       );
       await expect(result).resolves.toEqual('result');
     });
     it('appends query if specified', async () => {
       const promise = Promise.resolve('result');
       http.get.mockReturnValue(promise);
-      const result = fetchSyncJobs({ connectorId: 'connectorId1', page: 10, size: 20 });
+      const result = fetchSyncJobs({ connectorId: 'connectorId1', from: 10, size: 20 });
       await nextTick();
       expect(http.get).toHaveBeenCalledWith(
         '/internal/enterprise_search/connectors/connectorId1/sync_jobs',
-        { query: { page: 10, size: 20 } }
+        { query: { from: 10, size: 20 } }
       );
       await expect(result).resolves.toEqual('result');
     });

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/connector/fetch_sync_jobs_api_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/connector/fetch_sync_jobs_api_logic.ts
@@ -13,15 +13,15 @@ import { HttpLogic } from '../../../shared/http';
 
 export interface FetchSyncJobsArgs {
   connectorId: string;
-  page?: number;
+  from?: number;
   size?: number;
 }
 
 export type FetchSyncJobsResponse = Paginate<ConnectorSyncJob>;
 
-export const fetchSyncJobs = async ({ connectorId, page = 0, size = 10 }: FetchSyncJobsArgs) => {
+export const fetchSyncJobs = async ({ connectorId, from = 0, size = 10 }: FetchSyncJobsArgs) => {
   const route = `/internal/enterprise_search/connectors/${connectorId}/sync_jobs`;
-  const query = { page, size };
+  const query = { from, size };
   return await HttpLogic.values.http.get<Paginate<ConnectorSyncJob>>(route, { query });
 };
 

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/engines/fetch_engines_api_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/engines/fetch_engines_api_logic.ts
@@ -6,14 +6,13 @@
  */
 
 import { EnterpriseSearchEnginesResponse } from '../../../../../common/types/engines';
+import { Page } from '../../../../../common/types/pagination';
 
 import { createApiLogic } from '../../../shared/api_logic/create_api_logic';
 import { HttpLogic } from '../../../shared/http';
 
-import { Meta } from '../../components/engines/types';
-
 export interface EnginesListAPIArguments {
-  meta: Meta;
+  meta: Page;
   searchQuery?: string;
 }
 

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engines/components/tables/engines_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engines/components/tables/engines_table.tsx
@@ -20,22 +20,23 @@ import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 
 import { EnterpriseSearchEngine } from '../../../../../../../common/types/engines';
+import { Page } from '../../../../../../../common/types/pagination';
+
 import { MANAGE_BUTTON_LABEL } from '../../../../../shared/constants';
 
 import { generateEncodedPath } from '../../../../../shared/encode_path_params';
 import { FormattedDateTime } from '../../../../../shared/formatted_date_time';
 import { KibanaLogic } from '../../../../../shared/kibana';
+import { pageToPagination } from '../../../../../shared/pagination/page_to_pagination';
 import { EuiLinkTo } from '../../../../../shared/react_router_helpers';
 
 import { ENGINE_PATH } from '../../../../routes';
-
-import { convertMetaToPagination, Meta } from '../../types';
 
 interface EnginesListTableProps {
   enginesList: EnterpriseSearchEngine[];
   isLoading?: boolean;
   loading: boolean;
-  meta: Meta;
+  meta: Page;
   onChange: (criteria: CriteriaWithPagination<EnterpriseSearchEngine>) => void;
   onDelete: (engine: EnterpriseSearchEngine) => void;
   viewEngineIndices: (engineName: string) => void;
@@ -157,7 +158,7 @@ export const EnginesListTable: React.FC<EnginesListTableProps> = ({
     <EuiBasicTable
       items={enginesList}
       columns={columns}
-      pagination={{ ...convertMetaToPagination(meta), showPerPageOptions: false }}
+      pagination={{ ...pageToPagination(meta), showPerPageOptions: false }}
       onChange={onChange}
       loading={isLoading}
     />

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engines/engines_list_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engines/engines_list_logic.ts
@@ -13,6 +13,7 @@ import {
   EnterpriseSearchEngine,
   EnterpriseSearchEnginesResponse,
 } from '../../../../../common/types/engines';
+import { Page } from '../../../../../common/types/pagination';
 
 import { Actions } from '../../../shared/api_logic/create_api_logic';
 
@@ -26,7 +27,7 @@ import {
   FetchEnginesAPILogic,
 } from '../../api/engines/fetch_engines_api_logic';
 
-import { DEFAULT_META, Meta, updateMetaPageIndex } from './types';
+import { DEFAULT_META, updateMetaPageIndex } from './types';
 
 interface EuiBasicTableOnChange {
   page: { index: number };
@@ -58,8 +59,8 @@ interface EngineListValues {
   isDeleteLoading: boolean;
   isDeleteModalVisible: boolean;
   isLoading: boolean;
-  meta: Meta;
-  parameters: { meta: Meta; searchQuery?: string }; // Added this variable to store to the search Query value as well
+  meta: Page;
+  parameters: { meta: Page; searchQuery?: string }; // Added this variable to store to the search Query value as well
   results: EnterpriseSearchEngine[]; // stores engine list value from data
   searchQuery: string;
   status: typeof FetchEnginesAPILogic.values.status;

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engines/types.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engines/types.ts
@@ -5,11 +5,7 @@
  * 2.0.
  */
 
-export interface Meta {
-  from: number;
-  size: number;
-  total: number;
-}
+import { Page } from '../../../../../common/types/pagination';
 
 export const DEFAULT_META = {
   from: 0,
@@ -17,13 +13,6 @@ export const DEFAULT_META = {
   total: 0,
 };
 
-export const convertMetaToPagination = (meta: Meta) => {
-  return {
-    pageIndex: meta.from / meta.size,
-    pageSize: meta.size,
-    totalItemCount: meta.total,
-  };
-};
-export const updateMetaPageIndex = (oldState: Meta, newPageIndex: number) => {
+export const updateMetaPageIndex = (oldState: Page, newPageIndex: number) => {
   return { ...oldState, from: newPageIndex * oldState.size };
 };

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/sync_jobs/sync_jobs.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/sync_jobs/sync_jobs.tsx
@@ -16,6 +16,7 @@ import { i18n } from '@kbn/i18n';
 import { SyncStatus } from '../../../../../../common/types/connectors';
 
 import { FormattedDateTime } from '../../../../shared/formatted_date_time';
+import { pageToPagination } from '../../../../shared/pagination/page_to_pagination';
 import { durationToText } from '../../../utils/duration_to_text';
 
 import { syncStatusToColor, syncStatusToText } from '../../../utils/sync_status_to_text';
@@ -35,8 +36,8 @@ export const SyncJobs: React.FC = () => {
     if (connectorId) {
       fetchSyncJobs({
         connectorId,
-        page: syncJobsPagination.pageIndex ?? 0,
-        size: syncJobsPagination.pageSize ?? 10,
+        from: syncJobsPagination.from ?? 0,
+        size: syncJobsPagination.size ?? 10,
       });
     }
   }, [connectorId]);
@@ -119,13 +120,10 @@ export const SyncJobs: React.FC = () => {
         hasActions
         onChange={({ page: { index, size } }: { page: { index: number; size: number } }) => {
           if (connectorId) {
-            fetchSyncJobs({ connectorId, page: index, size });
+            fetchSyncJobs({ connectorId, from: index * size, size });
           }
         }}
-        pagination={{
-          ...syncJobsPagination,
-          totalItemCount: syncJobsPagination.total,
-        }}
+        pagination={pageToPagination(syncJobsPagination)}
         tableLayout="fixed"
         loading={syncJobsLoading}
       />

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/sync_jobs/sync_jobs_view_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/sync_jobs/sync_jobs_view_logic.test.ts
@@ -32,11 +32,9 @@ const DEFAULT_VALUES = {
   syncJobsData: undefined,
   syncJobsLoading: true,
   syncJobsPagination: {
-    data: [],
+    from: 0,
     has_more_hits_than_total: false,
-    pageIndex: 0,
-    pageSize: 10,
-    size: 0,
+    size: 10,
     total: 0,
   },
   syncJobsStatus: Status.IDLE,
@@ -93,30 +91,35 @@ describe('SyncJobsViewLogic', () => {
       };
       it('should update values', async () => {
         FetchSyncJobsApiLogic.actions.apiSuccess({
+          _meta: {
+            page: {
+              from: 40,
+              has_more_hits_than_total: false,
+              size: 20,
+              total: 50,
+            },
+          },
           data: [syncJob],
-          has_more_hits_than_total: false,
-          pageIndex: 3,
-          pageSize: 20,
-          size: 20,
-          total: 50,
         });
         await nextTick();
         expect(SyncJobsViewLogic.values).toEqual({
           ...DEFAULT_VALUES,
           syncJobs: [syncJobView],
           syncJobsData: {
+            _meta: {
+              page: {
+                from: 40,
+                has_more_hits_than_total: false,
+                size: 20,
+                total: 50,
+              },
+            },
             data: [syncJob],
-            has_more_hits_than_total: false,
-            pageIndex: 3,
-            pageSize: 20,
-            size: 20,
-            total: 50,
           },
           syncJobsLoading: false,
           syncJobsPagination: {
+            from: 40,
             has_more_hits_than_total: false,
-            pageIndex: 3,
-            pageSize: 20,
             size: 20,
             total: 50,
           },
@@ -125,6 +128,14 @@ describe('SyncJobsViewLogic', () => {
       });
       it('should update values for incomplete job', async () => {
         FetchSyncJobsApiLogic.actions.apiSuccess({
+          _meta: {
+            page: {
+              from: 40,
+              has_more_hits_than_total: false,
+              size: 20,
+              total: 50,
+            },
+          },
           data: [
             {
               ...syncJob,
@@ -133,11 +144,6 @@ describe('SyncJobsViewLogic', () => {
               status: SyncStatus.IN_PROGRESS,
             },
           ],
-          has_more_hits_than_total: false,
-          pageIndex: 3,
-          pageSize: 20,
-          size: 20,
-          total: 50,
         });
         await nextTick();
         expect(SyncJobsViewLogic.values).toEqual({
@@ -153,6 +159,14 @@ describe('SyncJobsViewLogic', () => {
             },
           ],
           syncJobsData: {
+            _meta: {
+              page: {
+                from: 40,
+                has_more_hits_than_total: false,
+                size: 20,
+                total: 50,
+              },
+            },
             data: [
               {
                 ...syncJob,
@@ -161,17 +175,11 @@ describe('SyncJobsViewLogic', () => {
                 status: SyncStatus.IN_PROGRESS,
               },
             ],
-            has_more_hits_than_total: false,
-            pageIndex: 3,
-            pageSize: 20,
-            size: 20,
-            total: 50,
           },
           syncJobsLoading: false,
           syncJobsPagination: {
+            from: 40,
             has_more_hits_than_total: false,
-            pageIndex: 3,
-            pageSize: 20,
             size: 20,
             total: 50,
           },

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/sync_jobs/sync_jobs_view_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/sync_jobs/sync_jobs_view_logic.ts
@@ -12,7 +12,7 @@ import moment from 'moment';
 import { Status } from '../../../../../../common/types/api';
 
 import { ConnectorSyncJob } from '../../../../../../common/types/connectors';
-import { Paginate } from '../../../../../../common/types/pagination';
+import { Page, Paginate } from '../../../../../../common/types/pagination';
 import { Actions } from '../../../../shared/api_logic/create_api_logic';
 import {
   FetchSyncJobsApiLogic,
@@ -37,7 +37,7 @@ export interface IndexViewValues {
   syncJobs: SyncJobView[];
   syncJobsData: Paginate<ConnectorSyncJob> | null;
   syncJobsLoading: boolean;
-  syncJobsPagination: Paginate<undefined>;
+  syncJobsPagination: Page;
   syncJobsStatus: Status;
 }
 
@@ -85,13 +85,11 @@ export const SyncJobsViewLogic = kea<MakeLogicType<IndexViewValues, IndexViewAct
       () => [selectors.syncJobsData],
       (data?: Paginate<ConnectorSyncJob>) =>
         data
-          ? { ...data, data: undefined }
+          ? data._meta.page
           : {
-              data: [],
+              from: 0,
               has_more_hits_than_total: false,
-              pageIndex: 0,
-              pageSize: 10,
-              size: 0,
+              size: 10,
               total: 0,
             },
     ],

--- a/x-pack/plugins/enterprise_search/public/applications/shared/pagination/page_to_pagination.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/pagination/page_to_pagination.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { Page } from '../../../../common/types/pagination';
+
+export function pageToPagination(page: Page) {
+  // Prevent divide-by-zero-error
+  const pageIndex = page.size ? Math.trunc(page.from / page.size) : 0;
+  return {
+    pageIndex,
+    pageSize: page.size,
+    totalItemCount: page.total,
+  };
+}

--- a/x-pack/plugins/enterprise_search/server/lib/connectors/fetch_sync_jobs.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/connectors/fetch_sync_jobs.test.ts
@@ -31,12 +31,15 @@ describe('fetchSyncJobs lib', () => {
         Promise.resolve({ hits: { hits: ['result1', 'result2'] }, total: 2 })
       );
       await expect(fetchSyncJobsByConnectorId(mockClient as any, 'id', 0, 10)).resolves.toEqual({
+        _meta: {
+          page: {
+            from: 0,
+            has_more_hits_than_total: false,
+            size: 10,
+            total: 0,
+          },
+        },
         data: [],
-        has_more_hits_than_total: false,
-        pageIndex: 0,
-        pageSize: 10,
-        size: 0,
-        total: 0,
       });
       expect(mockClient.asCurrentUser.search).toHaveBeenCalledWith({
         from: 0,
@@ -56,12 +59,15 @@ describe('fetchSyncJobs lib', () => {
     });
     it('should return empty result if size is 0', async () => {
       await expect(fetchSyncJobsByConnectorId(mockClient as any, 'id', 0, 0)).resolves.toEqual({
+        _meta: {
+          page: {
+            from: 0,
+            has_more_hits_than_total: false,
+            size: 10,
+            total: 0,
+          },
+        },
         data: [],
-        has_more_hits_than_total: false,
-        pageIndex: 0,
-        pageSize: 0,
-        size: 0,
-        total: 0,
       });
       expect(mockClient.asCurrentUser.search).not.toHaveBeenCalled();
     });
@@ -78,12 +84,15 @@ describe('fetchSyncJobs lib', () => {
         })
       );
       await expect(fetchSyncJobsByConnectorId(mockClient as any, 'id', 0, 10)).resolves.toEqual({
+        _meta: {
+          page: {
+            from: 0,
+            has_more_hits_than_total: false,
+            size: 10,
+            total: 0,
+          },
+        },
         data: [],
-        has_more_hits_than_total: false,
-        pageIndex: 0,
-        pageSize: 10,
-        size: 0,
-        total: 0,
       });
       expect(mockClient.asCurrentUser.search).toHaveBeenCalledWith({
         from: 0,
@@ -114,13 +123,14 @@ describe('fetchSyncJobs lib', () => {
           },
         })
       );
-      await expect(fetchSyncJobsByConnectorId(mockClient as any, 'id', 0, 10)).resolves.toEqual({
-        data: [],
-        has_more_hits_than_total: false,
-        pageIndex: 0,
-        pageSize: 10,
-        size: 0,
-        total: 0,
+      await expect(fetchSyncJobsByConnectorId(mockClient as any, 'id', 0, 10)).rejects.toEqual({
+        meta: {
+          body: {
+            error: {
+              type: 'other error',
+            },
+          },
+        },
       });
       expect(mockClient.asCurrentUser.search).toHaveBeenCalledWith({
         from: 0,

--- a/x-pack/plugins/enterprise_search/server/utils/fetch_with_pagination.test.ts
+++ b/x-pack/plugins/enterprise_search/server/utils/fetch_with_pagination.test.ts
@@ -1,0 +1,124 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { SearchResponse } from '@elastic/elasticsearch/lib/api/types';
+
+import { fetchWithPagination } from './fetch_with_pagination';
+
+describe('fetchWithPagination util', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  describe('fetchWithPagination', () => {
+    it('should fetch mock data with pagination', async () => {
+      const mockFn = jest.fn();
+      mockFn.mockImplementation(() =>
+        Promise.resolve({
+          hits: { hits: ['result1', 'result2'], total: 2 },
+        } as any as SearchResponse<string>)
+      );
+      await expect(fetchWithPagination(mockFn, 0, 10)).resolves.toEqual({
+        _meta: {
+          page: {
+            from: 0,
+            has_more_hits_than_total: false,
+            size: 10,
+            total: 2,
+          },
+        },
+        data: ['result1', 'result2'],
+      });
+    });
+    it('should return empty result if size is 0', async () => {
+      const mockFn = jest.fn();
+      mockFn.mockImplementation(() =>
+        Promise.resolve({
+          hits: { hits: [], total: 0 },
+        } as any as SearchResponse<string>)
+      );
+      await expect(fetchWithPagination(mockFn, 0, 0)).resolves.toEqual({
+        _meta: {
+          page: {
+            from: 0,
+            has_more_hits_than_total: false,
+            size: 10,
+            total: 0,
+          },
+        },
+        data: [],
+      });
+    });
+    it('should handle total as an object correctly', async () => {
+      const mockFn = jest.fn();
+      mockFn.mockImplementation(() =>
+        Promise.resolve({
+          hits: {
+            hits: [],
+            total: {
+              relation: 'lte',
+              value: 555,
+            },
+          },
+        } as any as SearchResponse<string>)
+      );
+      await expect(fetchWithPagination(mockFn, 0, 10)).resolves.toEqual({
+        _meta: {
+          page: {
+            from: 0,
+            has_more_hits_than_total: false,
+            size: 10,
+            total: 555,
+          },
+        },
+        data: [],
+      });
+    });
+
+    it('should handle undefined total correctly', async () => {
+      const mockFn = jest.fn();
+      mockFn.mockImplementation(() =>
+        Promise.resolve({
+          hits: {
+            hits: [],
+            total: undefined,
+          },
+        } as any as SearchResponse<string>)
+      );
+      await expect(fetchWithPagination(mockFn, 0, 10)).resolves.toEqual({
+        _meta: {
+          page: {
+            from: 0,
+            has_more_hits_than_total: false,
+            size: 10,
+            total: 0,
+          },
+        },
+        data: [],
+      });
+    });
+
+    it('should handle has_more_hits_than_total correctly', async () => {
+      const mockFn = jest.fn();
+      mockFn.mockImplementation(() =>
+        Promise.resolve({
+          hits: { hits: ['result1', 'result2'], total: { relation: 'gte', value: 10000 } },
+        } as any as SearchResponse<string>)
+      );
+      await expect(fetchWithPagination(mockFn, 50, 10)).resolves.toEqual({
+        _meta: {
+          page: {
+            from: 50,
+            has_more_hits_than_total: true,
+            size: 10,
+            total: 10000,
+          },
+        },
+        data: ['result1', 'result2'],
+      });
+    });
+  });
+});

--- a/x-pack/plugins/enterprise_search/server/utils/fetch_with_pagination.ts
+++ b/x-pack/plugins/enterprise_search/server/utils/fetch_with_pagination.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { SearchHit, SearchResponse, SearchTotalHits } from '@elastic/elasticsearch/lib/api/types';
+
+import { Paginate } from '../../common/types/pagination';
+
+const defaultResult = <T>(data: T[]) => ({
+  _meta: {
+    page: {
+      from: 0,
+      has_more_hits_than_total: false,
+      size: 10,
+      total: 0,
+    },
+  },
+  data,
+});
+
+export const fetchWithPagination = async <T>(
+  fetchFunction: () => Promise<SearchResponse<T>>,
+  from: number,
+  size: number
+): Promise<Paginate<SearchHit<T>>> => {
+  if (size === 0) {
+    return defaultResult<SearchHit<T>>([]);
+  }
+  const result = await fetchFunction();
+  const total = totalToPaginateTotal(result.hits.total);
+  return {
+    _meta: {
+      page: {
+        from,
+        size,
+        ...total,
+      },
+    },
+    data: result.hits.hits,
+  };
+};
+
+function totalToPaginateTotal(input: number | SearchTotalHits | undefined): {
+  has_more_hits_than_total: boolean;
+  total: number;
+} {
+  if (typeof input === 'number') {
+    return { has_more_hits_than_total: false, total: input };
+  }
+
+  return input
+    ? {
+        has_more_hits_than_total: input.relation === 'gte' ? true : false,
+        total: input.value,
+      }
+    : { has_more_hits_than_total: false, total: 0 };
+}


### PR DESCRIPTION
## Summary

This standardizes the Enterprise Search pagination on the Elasticsearch standard of using

Addressing the indices APIs is left as an exercise for the reader (or anyone else), as those are significantly more complicated to change.