### PR TITLE
Fix: Set fittingFunction to 'Zero'

### DIFF
--- a/x-pack/plugins/infra/public/common/visualizations/lens/utils.ts
+++ b/x-pack/plugins/infra/public/common/visualizations/lens/utils.ts
@@ -70,7 +70,7 @@ export const getXYVisualizationState = (
     showSingleSeries: false,
   },
   valueLabels: 'show',
-  fittingFunction: 'None',
+  fittingFunction: 'Zero',
   curveType: 'LINEAR',
   yLeftScale: 'linear',
   axisTitlesVisibilitySettings: {


### PR DESCRIPTION
Closes #149685 
## Summary

This PR fixes the issue with the lens charts stopped showing data when the date range is shorter than 5 minutes

## Testing
1. Open Host View (enable it if it's not enabled)
   - It's better to check with a remote cluster because with slingshot test data some of the data is missing
3. Select a time range < 5 minutes
4. The charts should show the data: 
![image](https://user-images.githubusercontent.com/14139027/215551342-94f745c4-a713-48b4-9900-89ccbd00810d.png)
