### PR TITLE
[DOCS] Fixes formatting in the Osquery manager APIs

### DIFF
--- a/docs/api/osquery-manager/live-queries/get-all.asciidoc
+++ b/docs/api/osquery-manager/live-queries/get-all.asciidoc
@@ -22,7 +22,8 @@ experimental[] Get live queries.
 (Optional, string) An identifier for the space. When `space_id` is not provided in the URL, the default space is used.
 
 
-=== Query parameters
+[[osquery-manager-live-queries-api-get-all-query-params]]
+==== Query parameters
 
 `page`::
 (Optional, integer) The page number to return. The default is `1`.

--- a/docs/api/osquery-manager/packs/delete.asciidoc
+++ b/docs/api/osquery-manager/packs/delete.asciidoc
@@ -33,7 +33,7 @@ WARNING: Once you delete a pack, _it cannot be recovered_.
 `200`::
   Indicates that the pack is deleted. Returns an empty response body. 
 
-
+[[osquery-manager-packs-api-delete-example]]
 ==== Example
 
 Delete a pack object with the `bbe5b070-0c51-11ed-b0f8-ad31b008e832` ID:

--- a/docs/api/osquery-manager/packs/get-all.asciidoc
+++ b/docs/api/osquery-manager/packs/get-all.asciidoc
@@ -21,8 +21,8 @@ experimental[] Get packs.
 `space_id`::
 (Optional, string) The space identifier. When `space_id` is not provided in the URL, the default space is used.
 
-
-=== Query parameters
+[[osquery-manager-packs-api-get-all-query-params]]
+==== Query parameters
 
 `page`::
 (Optional, integer) The page number to return. The default is `1`.

--- a/docs/api/osquery-manager/saved-queries/delete.asciidoc
+++ b/docs/api/osquery-manager/saved-queries/delete.asciidoc
@@ -33,7 +33,7 @@ WARNING: Once you delete a saved query, _it cannot be recovered_.
 `200`::
   Indicates the saved query is deleted. Returns an empty response body. 
 
-
+[[osquery-manager-saved-queries-api-delete-example]]
 ==== Example
 
 Delete a saved query object with the `42ba9c50-0cc5-11ed-aa1d-2b27890bc90d` ID:

--- a/docs/api/osquery-manager/saved-queries/get-all.asciidoc
+++ b/docs/api/osquery-manager/saved-queries/get-all.asciidoc
@@ -21,8 +21,8 @@ experimental[] Get saved queries.
 `space_id`::
 (Optional, string) The space identifier. When `space_id` is not provided in the URL, the default space is used.
 
-
-=== Query parameters
+[[osquery-manager-saved-queries-api-get-all-query-params]]
+==== Query parameters
 
 `page`::
 (Optional, integer) The page number to return. The default is `1`.


### PR DESCRIPTION
## Summary

Fixes the formatting of the rogue `Query parameters` sections.

<!--ONMERGE {"backportTargets":["8.4","8.5","8.6"]} ONMERGE-->