### PR TITLE
[build] Build canvas runtime before copying source files

### DIFF
--- a/src/dev/build/build_distributables.ts
+++ b/src/dev/build/build_distributables.ts
@@ -64,6 +64,7 @@ export async function buildDistributables(log: ToolingLog, options: BuildOptions
    * run platform-generic build tasks
    */
   if (options.createGenericFolders) {
+    // Build before copying source files
     if (options.buildCanvasShareableRuntime) {
       await run(Tasks.BuildCanvasShareableRuntime);
     }

--- a/src/dev/build/build_distributables.ts
+++ b/src/dev/build/build_distributables.ts
@@ -64,6 +64,10 @@ export async function buildDistributables(log: ToolingLog, options: BuildOptions
    * run platform-generic build tasks
    */
   if (options.createGenericFolders) {
+    if (options.buildCanvasShareableRuntime) {
+      await run(Tasks.BuildCanvasShareableRuntime);
+    }
+
     await run(Tasks.CopySource);
     await run(Tasks.CopyBinScripts);
 
@@ -71,9 +75,6 @@ export async function buildDistributables(log: ToolingLog, options: BuildOptions
     await run(Tasks.CreateReadme);
     await run(Tasks.BuildBazelPackages);
     await run(Tasks.ReplaceFavicon);
-    if (options.buildCanvasShareableRuntime) {
-      await run(Tasks.BuildCanvasShareableRuntime);
-    }
     await run(Tasks.BuildKibanaPlatformPlugins);
     if (options.buildExamplePlugins) {
       await run(Tasks.BuildKibanaExamplePlugins);


### PR DESCRIPTION
The canvas runtime build needs to be completed before source files are copied so that it's available in the final distribution.

<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->