### PR TITLE
unskip Failing test: Chrome UI Functional Tests.test/functional/apps/dashboard/group4/dashboard_empty·ts

### DIFF
--- a/test/functional/apps/dashboard/group4/dashboard_empty.ts
+++ b/test/functional/apps/dashboard/group4/dashboard_empty.ts
@@ -26,8 +26,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     await testSubjects.click('saveIndexPatternButton');
   };
 
-  // FLAKY: https://github.com/elastic/kibana/issues/149256
-  describe.skip('dashboard empty state', () => {
+  describe('dashboard empty state', () => {
     const kbnDirectory = 'test/functional/fixtures/kbn_archiver/dashboard/current/kibana';
 
     before(async function () {


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/149256

Flaky test runner https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/1824

Fix in https://github.com/elastic/kibana/pull/149582. `await kibanaServer.importExport.unload(kbnDirectory);` is getting the `error ECONNRESET`. Underlining cause determined to be @pgayvallet "Yeah, so apparently it's related to the fact that kibanaServer.importExport.unload calls bulkDelete with the summary from the import file, which is not a valid SO. Not sure why it doesn't constantly crashes on master though, as my changes in https://github.com/elastic/kibana/pull/149582 makes it quite obvious"
