### PR TITLE
APM: Update documentation of PHP APM agent support for service maps (#149584)

### DIFF
--- a/docs/apm/service-maps.asciidoc
+++ b/docs/apm/service-maps.asciidoc
@@ -112,7 +112,7 @@ iOS agent:: _Not yet supported_
 Java agent:: ≥ v1.13.0
 .NET agent:: ≥ v1.3.0
 Node.js agent:: ≥ v3.6.0
-PHP agent:: _Not yet supported_
+PHP agent:: ≥ v1.2.0
 Python agent:: ≥ v5.5.0
 Ruby agent:: ≥ v3.6.0
 Real User Monitoring (RUM) agent:: ≥ v4.7.0


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.6` to `main`:
 - [Update documentation of PHP APM agent support for service maps (#149584)](https://github.com/elastic/kibana/pull/149584)

<!--- Backport version: 8.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT {commits} BACKPORT-->