### PR TITLE
docs: remove `xpack.apm.searchAggregatedTransactions`

### DIFF
--- a/docs/settings/apm-settings.asciidoc
+++ b/docs/settings/apm-settings.asciidoc
@@ -74,11 +74,6 @@ Maximum number of child items displayed when viewing trace details. Defaults to 
 `xpack.observability.annotations.index` {ess-icon}::
 Index name where Observability annotations are stored. Defaults to `observability-annotations`.
 
-`xpack.apm.searchAggregatedTransactions` {ess-icon}::
-Enables Transaction histogram metrics. Defaults to `auto` so the UI will use metric indices over transaction indices for transactions if aggregated transactions are found. When set to `always`, additional configuration in APM Server is required. When set to `never` and aggregated transactions are not used.
-+
-See {apm-guide-ref}/transaction-metrics.html[Configure transaction metrics] for more information.
-
 `xpack.apm.metricsInterval` {ess-icon}::
 Sets a `fixed_interval` for date histograms in metrics aggregations. Defaults to `30`.
 


### PR DESCRIPTION
### Summary

This PR reverts https://github.com/elastic/kibana/pull/82379 and removes `xpack.apm.searchAggregatedTransactions` from the documentation. This is for https://github.com/elastic/apm-server/pull/10140:

> Removing transaction metrics config as they are not officially supported.

<!--ONMERGE {"backportTargets":["7.17","8.6"]} ONMERGE-->