### PR TITLE
[7.17] docs: remove `xpack.apm.searchAggregatedTransactions` (#149896)

### DIFF
--- a/docs/settings/apm-settings.asciidoc
+++ b/docs/settings/apm-settings.asciidoc
@@ -80,11 +80,6 @@ Maximum number of child items displayed when viewing trace details. Defaults to 
 `xpack.observability.annotations.index` {ess-icon}::
 Index name where Observability annotations are stored. Defaults to `observability-annotations`.
 
-`xpack.apm.searchAggregatedTransactions` {ess-icon}::
-Enables Transaction histogram metrics. Defaults to `auto` so the UI will use metric indices over transaction indices for transactions if aggregated transactions are found. When set to `always`, additional configuration in APM Server is required. When set to `never` and aggregated transactions are not used. 
-+
-See {apm-guide-ref}/transaction-metrics.html[Configure transaction metrics] for more information.
-
 `xpack.apm.metricsInterval` {ess-icon}::
 Sets a `fixed_interval` for date histograms in metrics aggregations. Defaults to `30`.
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [docs: remove `xpack.apm.searchAggregatedTransactions` (#149896)](https://github.com/elastic/kibana/pull/149896)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Brandon Morelli","email":"brandon.morelli@elastic.co"},"sourceCommit":{"committedDate":"2023-01-30T22:33:03Z","message":"docs: remove `xpack.apm.searchAggregatedTransactions` (#149896)\n\n### Summary\r\n\r\nThis PR reverts https://github.com/elastic/kibana/pull/82379 and removes\r\n`xpack.apm.searchAggregatedTransactions` from the documentation. This is\r\nfor https://github.com/elastic/apm-server/pull/10140:\r\n\r\n> Removing transaction metrics config as they are not officially\r\nsupported.","sha":"b90ddba88244fdf81593737cbdb5211664090a0c","branchLabelMapping":{"^v8.7.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:APM","release_note:skip","v8.7.0","v7.17.9","v8.6.2"],"number":149896,"url":"https://github.com/elastic/kibana/pull/149896","mergeCommit":{"message":"docs: remove `xpack.apm.searchAggregatedTransactions` (#149896)\n\n### Summary\r\n\r\nThis PR reverts https://github.com/elastic/kibana/pull/82379 and removes\r\n`xpack.apm.searchAggregatedTransactions` from the documentation. This is\r\nfor https://github.com/elastic/apm-server/pull/10140:\r\n\r\n> Removing transaction metrics config as they are not officially\r\nsupported.","sha":"b90ddba88244fdf81593737cbdb5211664090a0c"}},"sourceBranch":"main","suggestedTargetBranches":["7.17"],"targetPullRequestStates":[{"branch":"main","label":"v8.7.0","labelRegex":"^v8.7.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/149896","number":149896,"mergeCommit":{"message":"docs: remove `xpack.apm.searchAggregatedTransactions` (#149896)\n\n### Summary\r\n\r\nThis PR reverts https://github.com/elastic/kibana/pull/82379 and removes\r\n`xpack.apm.searchAggregatedTransactions` from the documentation. This is\r\nfor https://github.com/elastic/apm-server/pull/10140:\r\n\r\n> Removing transaction metrics config as they are not officially\r\nsupported.","sha":"b90ddba88244fdf81593737cbdb5211664090a0c"}},{"branch":"7.17","label":"v7.17.9","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.6","label":"v8.6.2","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/149901","number":149901,"state":"OPEN"}]}] BACKPORT-->