### PR TITLE
[Lens] Unskips share tests

### DIFF
--- a/x-pack/test/functional/apps/lens/group2/share.ts
+++ b/x-pack/test/functional/apps/lens/group2/share.ts
@@ -14,8 +14,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const filterBarService = getService('filterBar');
   const queryBar = getService('queryBar');
 
-  // Failing: See https://github.com/elastic/kibana/issues/149163
-  describe.skip('lens share tests', () => {
+  describe('lens share tests', () => {
     before(async () => {
       await PageObjects.visualize.gotoVisualizationLandingPage();
     });
@@ -73,7 +72,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       await browser.navigateTo(url);
       // check that it's the same configuration in the new URL when ready
-      await PageObjects.header.waitUntilLoadingHasFinished();
+      await PageObjects.lens.waitForVisualization('xyVisChart');
       expect(await PageObjects.lens.getDimensionTriggerText('lnsXY_yDimensionPanel')).to.eql(
         'Average of bytes'
       );
@@ -93,7 +92,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await filterBarService.addFilter({ field: 'bytes', operation: 'is', value: '1' });
       await queryBar.setQuery('host.keyword www.elastic.co');
       await queryBar.submitQuery();
-      await PageObjects.header.waitUntilLoadingHasFinished();
+      await PageObjects.lens.waitForVisualization('xyVisChart');
 
       const url = await PageObjects.lens.getUrl('snapshot');
       await browser.openNewTab();
@@ -102,7 +101,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       await browser.navigateTo(url);
       // check that it's the same configuration in the new URL when ready
-      await PageObjects.header.waitUntilLoadingHasFinished();
+      await PageObjects.lens.waitForVisualization('xyVisChart');
       expect(await filterBarService.getFiltersLabel()).to.eql(['bytes: 1']);
       expect(await queryBar.getQueryString()).to.be('host.keyword www.elastic.co');
       await browser.closeCurrentWindow();


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/149163

We have seen this before. We should use the Lens wait for chart rendering function and not the global one. This stabilizes the tests

Run 100 times https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/1827

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios