### PR TITLE
[Fleet] remove `totalInactive` from get agents by kuery API

### DIFF
--- a/x-pack/plugins/fleet/common/types/rest_spec/agent.ts
+++ b/x-pack/plugins/fleet/common/types/rest_spec/agent.ts
@@ -27,7 +27,6 @@ export interface GetAgentsRequest {
 }
 
 export interface GetAgentsResponse extends ListResult<Agent> {
-  totalInactive: number;
   // deprecated in 8.x
   list?: Agent[];
 }

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/hooks/use_last_seen_inactive_agents_count.ts
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/hooks/use_last_seen_inactive_agents_count.ts
@@ -11,7 +11,6 @@ const LOCAL_STORAGE_KEY = 'fleet.lastSeenInactiveAgentsCount';
 
 export const useLastSeenInactiveAgentsCount = (): [number, (val: number) => void] => {
   const [lastSeenInactiveAgentsCount, setLastSeenInactiveAgentsCount] = useState(0);
-
   useEffect(() => {
     const storageValue = localStorage.getItem(LOCAL_STORAGE_KEY);
     if (storageValue) {

--- a/x-pack/plugins/fleet/server/routes/agent/handlers.ts
+++ b/x-pack/plugins/fleet/server/routes/agent/handlers.ts
@@ -186,10 +186,9 @@ export const getAgentsHandler: RequestHandler<
       kuery: request.query.kuery,
       sortField: request.query.sortField,
       sortOrder: request.query.sortOrder,
-      getTotalInactive: request.query.showInactive,
     });
 
-    const { total, page, perPage, totalInactive = 0 } = agentRes;
+    const { total, page, perPage } = agentRes;
     let { agents } = agentRes;
 
     // Assign metrics
@@ -201,7 +200,6 @@ export const getAgentsHandler: RequestHandler<
       list: agents, // deprecated
       items: agents,
       total,
-      totalInactive,
       page,
       perPage,
     };

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/store/mock_endpoint_result_list.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/store/mock_endpoint_result_list.ts
@@ -156,7 +156,6 @@ const endpointListApiPathHandlerMocks = ({
       return {
         total: totalAgentsUsingEndpoint,
         items: [],
-        totalInactive: 0,
         page: 1,
         perPage: 10,
       };


### PR DESCRIPTION
## Summary

`totalInactive` is now no longer used after I merged https://github.com/elastic/kibana/pull/149925

It contains the total number of inactive agents if you provide the `showInactive` query param.

it is an undocumented response field so I think we can safely remove it. I am going to make it so that you can optionally return a full status summary in the response in a following PR.
