### PR TITLE
[Security Solution] Fix last rule execution timestamp

### DIFF
--- a/x-pack/plugins/alerting/server/lib/index.ts
+++ b/x-pack/plugins/alerting/server/lib/index.ts
@@ -27,7 +27,7 @@ export {
 } from './rule_execution_status';
 export { lastRunFromState, lastRunFromError, lastRunToRaw } from './last_run_status';
 export {
-  updateMonitoring,
+  resetMonitoringLastRun,
   getDefaultMonitoring,
   convertMonitoringFromRawAndVerify,
 } from './monitoring';

--- a/x-pack/plugins/alerting/server/lib/monitoring.test.ts
+++ b/x-pack/plugins/alerting/server/lib/monitoring.test.ts
@@ -111,18 +111,19 @@ describe('resetMonitoringLastRun', () => {
   });
 
   it('preserves last run timestamp', () => {
+    const expectedTimestamp = mockRuleMonitoring.run.last_run.timestamp;
     const result = resetMonitoringLastRun(mockRuleMonitoring);
-    expect(result.run.last_run.timestamp).toEqual(mockRuleMonitoring.run.last_run.timestamp);
+    expect(result.run.last_run.timestamp).toEqual(expectedTimestamp);
   });
 
   it('preserves other monitoring properties', () => {
+    const { run: originalRun, ...originalRestOfMonitoringObject } = mockRuleMonitoring;
+    const { last_run: originalLastRun, ...originalRestOfRunObject } = originalRun;
+
     const result = resetMonitoringLastRun(mockRuleMonitoring);
 
     const { run: actualRun, ...actualRestOfMonitoringObject } = result;
-    const { run: originalRun, ...originalRestOfMonitoringObject } = mockRuleMonitoring;
-
     const { last_run: actualLastRun, ...actualRestOfRunObject } = actualRun;
-    const { last_run: originalLastRun, ...originalRestOfRunObject } = originalRun;
 
     expect(actualRestOfMonitoringObject).toEqual(originalRestOfMonitoringObject);
     expect(actualRestOfRunObject).toEqual(originalRestOfRunObject);

--- a/x-pack/plugins/alerting/server/lib/monitoring.test.ts
+++ b/x-pack/plugins/alerting/server/lib/monitoring.test.ts
@@ -5,47 +5,56 @@
  * 2.0.
  */
 
+import { RuleMonitoring, RuleMonitoringHistory } from '../types';
 import {
   getExecutionDurationPercentiles,
   updateMonitoring,
   convertMonitoringFromRawAndVerify,
+  resetMonitoringLastRun,
 } from './monitoring';
-import { RuleMonitoring } from '../types';
 
-const mockHistory = [
+const mockHistory: RuleMonitoringHistory[] = [
   {
+    timestamp: 1655427600000,
     success: true,
     duration: 100,
   },
   {
+    timestamp: 1655427900000,
     success: true,
     duration: 200,
   },
   {
+    timestamp: 1655428200000,
     success: false,
     duration: 300,
   },
   {
+    timestamp: 1655428500000,
     success: false,
     duration: 100,
   },
   {
+    timestamp: 1655428800000,
     success: false,
   },
   {
+    timestamp: 1655429100000,
     success: true,
   },
   {
+    timestamp: 1655429400000,
     success: true,
     duration: 400,
   },
   {
+    timestamp: 1655429700000,
     success: true,
     duration: 500,
   },
 ];
 
-const mockRuleMonitoring = {
+const mockRuleMonitoring: RuleMonitoring = {
   run: {
     history: mockHistory,
     calculated_metrics: {
@@ -58,7 +67,7 @@ const mockRuleMonitoring = {
       },
     },
   },
-} as RuleMonitoring;
+};
 
 describe('getExecutionDurationPercentiles', () => {
   it('Calculates the percentile given partly undefined durations', () => {
@@ -70,20 +79,53 @@ describe('getExecutionDurationPercentiles', () => {
 
   it('Returns empty object when given all undefined durations', () => {
     // remove all duration fields
-    const nullDurationHistory = mockHistory.map((history) => ({
+    const nullDurationHistory: RuleMonitoringHistory[] = mockHistory.map((history) => ({
+      timestamp: history.timestamp,
       success: history.success,
     }));
 
-    const newMockRuleMonitoring = {
+    const newMockRuleMonitoring: RuleMonitoring = {
       ...mockRuleMonitoring,
       run: {
         ...mockRuleMonitoring.run,
         history: nullDurationHistory,
       },
-    } as RuleMonitoring;
+    };
 
     const percentiles = getExecutionDurationPercentiles(newMockRuleMonitoring.run.history);
     expect(Object.keys(percentiles).length).toEqual(0);
+  });
+});
+
+describe('resetMonitoringLastRun', () => {
+  it('resets last run metrics to the initial default value', () => {
+    const result = resetMonitoringLastRun(mockRuleMonitoring);
+    expect(result.run.last_run.metrics).toEqual({
+      duration: 0,
+      total_search_duration_ms: null,
+      total_indexing_duration_ms: null,
+      total_alerts_detected: null,
+      total_alerts_created: null,
+      gap_duration_s: null,
+    });
+  });
+
+  it('preserves last run timestamp', () => {
+    const result = resetMonitoringLastRun(mockRuleMonitoring);
+    expect(result.run.last_run.timestamp).toEqual(mockRuleMonitoring.run.last_run.timestamp);
+  });
+
+  it('preserves other monitoring properties', () => {
+    const result = resetMonitoringLastRun(mockRuleMonitoring);
+
+    const { run: actualRun, ...actualRestOfMonitoringObject } = result;
+    const { run: originalRun, ...originalRestOfMonitoringObject } = mockRuleMonitoring;
+
+    const { last_run: actualLastRun, ...actualRestOfRunObject } = actualRun;
+    const { last_run: originalLastRun, ...originalRestOfRunObject } = originalRun;
+
+    expect(actualRestOfMonitoringObject).toEqual(originalRestOfMonitoringObject);
+    expect(actualRestOfRunObject).toEqual(originalRestOfRunObject);
   });
 });
 

--- a/x-pack/plugins/alerting/server/rules_client/methods/enable.ts
+++ b/x-pack/plugins/alerting/server/rules_client/methods/enable.ts
@@ -6,7 +6,7 @@
  */
 
 import { RawRule, IntervalSchedule } from '../../types';
-import { updateMonitoring, getNextRun } from '../../lib';
+import { resetMonitoringLastRun, getNextRun } from '../../lib';
 import { WriteOperations, AlertingAuthorizationEntity } from '../../authorization';
 import { retryIfConflicts } from '../../lib/retry_if_conflicts';
 import { ruleAuditEvent, RuleAuditAction } from '../common/audit_events';
@@ -84,11 +84,7 @@ async function enableWithOCC(context: RulesClientContext, { id }: { id: string }
       ...attributes,
       ...(!existingApiKey && (await createNewAPIKeySet(context, { attributes, username }))),
       ...(attributes.monitoring && {
-        monitoring: updateMonitoring({
-          monitoring: attributes.monitoring,
-          timestamp: now.toISOString(),
-          duration: 0,
-        }),
+        monitoring: resetMonitoringLastRun(attributes.monitoring),
       }),
       nextRun: getNextRun({ interval: schedule.interval }),
       enabled: true,

--- a/x-pack/plugins/alerting/server/rules_client/tests/create.test.ts
+++ b/x-pack/plugins/alerting/server/rules_client/tests/create.test.ts
@@ -439,6 +439,7 @@ describe('create()', () => {
             "history": Array [],
             "last_run": Object {
               "metrics": Object {
+                "duration": 0,
                 "gap_duration_s": null,
                 "total_alerts_created": null,
                 "total_alerts_detected": null,
@@ -658,6 +659,7 @@ describe('create()', () => {
             "history": Array [],
             "last_run": Object {
               "metrics": Object {
+                "duration": 0,
                 "gap_duration_s": null,
                 "total_alerts_created": null,
                 "total_alerts_detected": null,
@@ -2097,6 +2099,7 @@ describe('create()', () => {
             last_run: {
               timestamp: '2019-02-12T21:01:22.479Z',
               metrics: {
+                duration: 0,
                 gap_duration_s: null,
                 total_alerts_created: null,
                 total_alerts_detected: null,

--- a/x-pack/plugins/alerting/server/task_runner/fixtures.ts
+++ b/x-pack/plugins/alerting/server/task_runner/fixtures.ts
@@ -101,6 +101,7 @@ export const generateSavedObjectParams = ({
         last_run: {
           timestamp: '1970-01-01T00:00:00.000Z',
           metrics: {
+            duration: 0,
             gap_duration_s: null,
             total_alerts_created: null,
             total_alerts_detected: null,
@@ -281,6 +282,7 @@ export const generateRunnerResult = ({
         history: history.map((success) => ({ success, timestamp: 0 })),
         last_run: {
           metrics: {
+            duration: 0,
             gap_duration_s: null,
             total_alerts_created: null,
             total_alerts_detected: null,

--- a/x-pack/plugins/alerting/server/task_runner/task_runner_cancel.test.ts
+++ b/x-pack/plugins/alerting/server/task_runner/task_runner_cancel.test.ts
@@ -246,6 +246,7 @@ describe('Task Runner Cancel', () => {
             history: [],
             last_run: {
               metrics: {
+                duration: 0,
                 gap_duration_s: null,
                 total_alerts_created: null,
                 total_alerts_detected: null,

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/create_rule_execution_summary.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/create_rule_execution_summary.ts
@@ -27,7 +27,12 @@ export const createRuleExecutionSummary = (
     return null;
   }
 
+  // Data that we need to create rule execution summary is stored in two different "last run" objects within a rule.
+
+  // This last run object is internal to Kibana server and is not exposed via any public HTTP API.
+  // Alerting Framework keeps it for itself and provides via the RulesClient for solutions.
   const lastRunInternal = rule.monitoring.run.last_run;
+  // This last run object is public - it is exposed via the public Alerting HTTP API.
   const lastRunPublic = rule.lastRun;
 
   if (rule.running) {

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/create_rule_execution_summary.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/create_rule_execution_summary.ts
@@ -13,41 +13,51 @@ import {
   ruleExecutionStatusToNumber,
   RuleExecutionStatus,
 } from '../../../../../../common/detection_engine/rule_monitoring';
+
 import type { RuleParams } from '../../../rule_schema';
 
 export const createRuleExecutionSummary = (
   rule: SanitizedRule<RuleParams> | ResolvedSanitizedRule<RuleParams>
 ): RuleExecutionSummary | null => {
+  if (!rule.monitoring) {
+    // In the rule type the monitoring object is optional because in some cases rules client returns a rule without it.
+    // For instance, when we call RulesClient.create(). Despite the fact that it's always in the rule saved object,
+    // even when it was just created:
+    // https://github.com/elastic/kibana/blob/26eddec70844ffb65e5d3521a7adb52e643c4534/x-pack/plugins/alerting/server/rules_client/methods/create.ts#L155
+    return null;
+  }
+
+  const lastRunInternal = rule.monitoring.run.last_run;
+  const lastRunPublic = rule.lastRun;
+
   if (rule.running) {
     return {
       last_execution: {
-        date: new Date().toISOString(),
-        message: '',
-        metrics: {},
+        date: lastRunInternal.timestamp,
         status: RuleExecutionStatus.running,
         status_order: ruleExecutionStatusToNumber(RuleExecutionStatus.running),
+        message: '',
+        metrics: {},
       },
     };
   }
 
-  if (!rule.lastRun) {
+  if (!lastRunPublic) {
     return null;
   }
 
-  const ruleExecutionStatus = ruleLastRunOutcomeToExecutionStatus(rule.lastRun.outcome);
+  const ruleExecutionStatus = ruleLastRunOutcomeToExecutionStatus(lastRunPublic.outcome);
 
   return {
     last_execution: {
-      date: rule.monitoring?.run.last_run?.timestamp ?? new Date().toISOString(),
+      date: lastRunInternal.timestamp,
       status: ruleExecutionStatus,
       status_order: ruleExecutionStatusToNumber(ruleExecutionStatus),
-      message: rule.lastRun?.outcomeMsg?.join(' \n') ?? '',
+      message: lastRunPublic.outcomeMsg?.join(' \n') ?? '',
       metrics: {
-        total_indexing_duration_ms:
-          rule.monitoring?.run.last_run.metrics.total_indexing_duration_ms ?? undefined,
-        total_search_duration_ms:
-          rule.monitoring?.run.last_run.metrics.total_search_duration_ms ?? undefined,
-        execution_gap_duration_s: rule.monitoring?.run.last_run.metrics.gap_duration_s ?? undefined,
+        total_indexing_duration_ms: lastRunInternal.metrics.total_indexing_duration_ms ?? undefined,
+        total_search_duration_ms: lastRunInternal.metrics.total_search_duration_ms ?? undefined,
+        execution_gap_duration_s: lastRunInternal.metrics.gap_duration_s ?? undefined,
       },
     },
   };


### PR DESCRIPTION
## Summary

This PR introduces a few fixes in order to make rule execution timestamps more reliable and less dynamic. Rule execution timestamp is a timestamp of the last rule execution, for a given rule. The timestamp is:

- returned from Security APIs as `rule.execution_summary.last_execution.date`
- stored in the rule object in the `rule.monitoring.run.last_run.timestamp` field

The fixes are:

- When the user enables a rule:
  - don't reset its `rule.monitoring.run.last_run.timestamp` to now
  - only reset its metrics to the default empty value
- When a rule is running:
  - return the timestamp of its previous execution instead of `now`

## Background

Issue found by @marshallmain when working on new integration tests that enable and disable a rule a few times:

I'm working on some tests that disable and re-enable a rule to trigger a rule execution, and the test watches the rule status to determine when the alerts should show up. However, I'm seeing the rule status get updated with a new succeeded status before the rule actually executes. The metrics in the new status are also identical to the previous status (2 separate examples below).

```
ruleExecutionSummary: {"last_execution":{"date":"2023-01-27T19:02:47.149Z","status":"succeeded","status_order":0,"message":"Rule execution completed successfully","metrics":{"total_indexing_duration_ms":184,"total_search_duration_ms":4}}}
ruleExecutionSummary: {"last_execution":{"date":"2023-01-27T19:02:51.014Z","status":"succeeded","status_order":0,"message":"Rule execution completed successfully","metrics":{"total_indexing_duration_ms":184,"total_search_duration_ms":4}}}

ruleExecutionSummary: {"last_execution":{"date":"2023-01-27T19:13:05.242Z","status":"succeeded","status_order":0,"message":"Rule execution completed successfully","metrics":{"total_indexing_duration_ms":189,"total_search_duration_ms":4}}}
ruleExecutionSummary: {"last_execution":{"date":"2023-01-27T19:13:09.237Z","status":"succeeded","status_order":0,"message":"Rule execution completed successfully","metrics":{"total_indexing_duration_ms":189,"total_search_duration_ms":4}}}
```

Since the metrics are identical, I was wondering if something changed that could be updating the status timestamp without updating anything else in the status.

After tracking it down more the timestamp on the status only gets updated incorrectly if the rule is disabled and re-enabled, and I found [these lines](https://github.com/elastic/kibana/blob/main/x-pack/plugins/alerting/server/rules_client/methods/enable.ts#L86-L92) in the enable logic that, when commented out, fix my test logic because the rule status timestamp [comes from the monitoring section](https://github.com/elastic/kibana/blob/main/x-pack/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/create_rule_execution_summary.ts#L41).

I was able to fix the test on my end by simply making a checkpoint timestamp after re-enabling the rule instead of making the checkpoint after the first rule execution but before disabling and re-enabling to trigger the second execution. But, it seems odd still to update the monitoring timestamp on enable and set the duration to 0 without updating any other metrics in the rule monitoring.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->