### PR TITLE
[Fleet] Bugfix: Apply namespace from agent policy if there is one when adding integration

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/form.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/form.tsx
@@ -204,7 +204,7 @@ export function useOnSubmit({
         packageToPackagePolicy(
           packageInfo,
           agentPolicy?.id || '',
-          DEFAULT_PACKAGE_POLICY.namespace,
+          agentPolicy?.namespace || DEFAULT_PACKAGE_POLICY.namespace,
           DEFAULT_PACKAGE_POLICY.name || incrementedName,
           DEFAULT_PACKAGE_POLICY.description,
           integrationToEnable


### PR DESCRIPTION
## Summary

Closes #149919 

Apply the default namespace of the agent policy if there is one when adding an integration to a policy.

https://user-images.githubusercontent.com/3315046/215801897-60754173-167e-4522-91ab-0566e6c83eb5.mp4

