### PR TITLE
Add dynamic:false to both connector index mappings

### DIFF
--- a/x-pack/plugins/enterprise_search/server/index_management/setup_indices.test.ts
+++ b/x-pack/plugins/enterprise_search/server/index_management/setup_indices.test.ts
@@ -31,6 +31,7 @@ describe('Setup Indices', () => {
       version: CONNECTORS_VERSION,
       pipeline: defaultConnectorsPipelineMeta,
     },
+    dynamic: false,
     properties: {
       api_key_id: {
         type: 'keyword',
@@ -161,6 +162,7 @@ describe('Setup Indices', () => {
     _meta: {
       version: CONNECTORS_VERSION,
     },
+    dynamic: false,
     properties: {
       cancelation_requested_at: { type: 'date' },
       canceled_at: { type: 'date' },

--- a/x-pack/plugins/enterprise_search/server/index_management/setup_indices.ts
+++ b/x-pack/plugins/enterprise_search/server/index_management/setup_indices.ts
@@ -174,6 +174,7 @@ const indices: IndexDefinition[] = [
         pipeline: defaultConnectorsPipelineMeta,
         version: 1,
       },
+      dynamic: false,
       properties: connectorMappingsProperties,
     },
     name: '.elastic-connectors-v1',
@@ -185,6 +186,7 @@ const indices: IndexDefinition[] = [
       _meta: {
         version: 1,
       },
+      dynamic: false,
       properties: {
         cancelation_requested_at: { type: 'date' },
         canceled_at: { type: 'date' },


### PR DESCRIPTION
## Summary

Part of the changes for https://github.com/elastic/enterprise-search-team/issues/3729.

This change updates the mappings for `.elastic-connectors-v1` and `.elastic-connector-sync-jobs-v1` to include `dynamic: false` for both.

Other PRs are:
https://github.com/elastic/ent-search/pull/7272
https://github.com/elastic/connectors-ruby/pull/526


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
