### PR TITLE
[Docs] Adds authentication providers sync to load balancing documentation

### DIFF
--- a/docs/user/production-considerations/production.asciidoc
+++ b/docs/user/production-considerations/production.asciidoc
@@ -51,7 +51,8 @@ Settings that must be the same:
 [source,js]
 --------
 xpack.security.encryptionKey //decrypting session information
-xpack.security.authc.providers // authentication providers
+xpack.security.authc.* // authentication configuration
+xpack.security.session.* // session configuration
 xpack.reporting.encryptionKey //decrypting reports
 xpack.encryptedSavedObjects.encryptionKey // decrypting saved objects
 xpack.encryptedSavedObjects.keyRotation.decryptionOnlyKeys // saved objects encryption key rotation, if any
@@ -59,7 +60,7 @@ xpack.encryptedSavedObjects.keyRotation.decryptionOnlyKeys // saved objects encr
 
 [WARNING]
 ====
-If authentication providers do not match, sessions from unrecognized providers in each {kib} instance will be deleted during that instance's cleanup. This also applies to any {kib} instances that are backed by the same {es} instance and share the same kibana.index, even if they are not behind the same load balancer.
+If the authentication configuration does not match, sessions from unrecognized providers in each {kib} instance will be deleted during that instance's regular session cleanup. Similarly, inconsistencies in session configuration can also lead to undesired session logouts. For example, if one {kib} instance is configured with a session lifespan, it will remove sessions created by other {kib} instances during session cleanup. This also applies to any {kib} instances that are backed by the same {es} instance and share the same kibana.index, even if they are not behind the same load balancer.
 ====
 
 Separate configuration files can be used from the command line by using the `-c` flag:

--- a/docs/user/production-considerations/production.asciidoc
+++ b/docs/user/production-considerations/production.asciidoc
@@ -51,10 +51,16 @@ Settings that must be the same:
 [source,js]
 --------
 xpack.security.encryptionKey //decrypting session information
+xpack.security.authc.providers // authentication providers
 xpack.reporting.encryptionKey //decrypting reports
 xpack.encryptedSavedObjects.encryptionKey // decrypting saved objects
 xpack.encryptedSavedObjects.keyRotation.decryptionOnlyKeys // saved objects encryption key rotation, if any
 --------
+
+[WARNING]
+====
+If authentication providers do not match, sessions from unrecognized providers in each {kib} instance will be deleted during that instance's cleanup. This also applies to any {kib} instances that are backed by the same {es} instance and share the same kibana.index, even if they are not behind the same load balancer.
+====
 
 Separate configuration files can be used from the command line by using the `-c` flag:
 [source,js]

--- a/docs/user/production-considerations/production.asciidoc
+++ b/docs/user/production-considerations/production.asciidoc
@@ -60,7 +60,7 @@ xpack.encryptedSavedObjects.keyRotation.decryptionOnlyKeys // saved objects encr
 
 [WARNING]
 ====
-If the authentication configuration does not match, sessions from unrecognized providers in each {kib} instance will be deleted during that instance's regular session cleanup. Similarly, inconsistencies in session configuration can also lead to undesired session logouts. For example, if one {kib} instance is configured with a session lifespan, it will remove sessions created by other {kib} instances during session cleanup. This also applies to any {kib} instances that are backed by the same {es} instance and share the same kibana.index, even if they are not behind the same load balancer.
+If the authentication configuration does not match, sessions from unrecognized providers in each {kib} instance will be deleted during that instance's regular session cleanup. Similarly, inconsistencies in session configuration can also lead to undesired session logouts. This also applies to any {kib} instances that are backed by the same {es} instance and share the same kibana.index, even if they are not behind the same load balancer.
 ====
 
 Separate configuration files can be used from the command line by using the `-c` flag:


### PR DESCRIPTION
Closes #113928

## Summary

- Adds 'xpack.security.authc.providers' to the list of settings that must be the same across all Kibana instances behind a load balancer.
- Adds a warning block explaining why the authentication providers need to match, and an additional configuration case where this applies (Kibana instances that are backed by the same ES instance and share the same kibana.index).

<!--ONMERGE {"backportTargets":["7.17","8.6"]} ONMERGE-->