### PR TITLE
[Fleet] Add `getStatusSummary` query parameter to `GET /api/fleet/agents` API

### DIFF
--- a/x-pack/plugins/fleet/common/openapi/bundled.json
+++ b/x-pack/plugins/fleet/common/openapi/bundled.json
@@ -1372,6 +1372,14 @@
           },
           {
             "$ref": "#/components/parameters/with_metrics"
+          },
+          {
+            "name": "getStatusSummary",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "security": [
@@ -5399,11 +5407,11 @@
             "properties": {
               "cpu_avg": {
                 "type": "number",
-                "description": "Average agent CPU usage during the last 5 minute, number between 0-1"
+                "description": "Average agent CPU usage during the last 5 minutes, number between 0-1"
               },
               "memory_size_byte_avg": {
                 "type": "number",
-                "description": "Average agent memory consumption during the last 5 minute"
+                "description": "Average agent memory consumption during the last 5 minutes"
               }
             }
           }
@@ -5441,6 +5449,38 @@
           },
           "perPage": {
             "type": "number"
+          },
+          "statusSummary": {
+            "type": "object",
+            "properties": {
+              "offline": {
+                "type": "number"
+              },
+              "error": {
+                "type": "number"
+              },
+              "online": {
+                "type": "number"
+              },
+              "inactive": {
+                "type": "number"
+              },
+              "enrolling": {
+                "type": "number"
+              },
+              "unenrolling": {
+                "type": "number"
+              },
+              "unenrolled": {
+                "type": "number"
+              },
+              "updating": {
+                "type": "number"
+              },
+              "degraded'": {
+                "type": "number"
+              }
+            }
           }
         },
         "required": [

--- a/x-pack/plugins/fleet/common/openapi/bundled.yaml
+++ b/x-pack/plugins/fleet/common/openapi/bundled.yaml
@@ -857,6 +857,11 @@ paths:
         - $ref: '#/components/parameters/sort_field'
         - $ref: '#/components/parameters/sort_order'
         - $ref: '#/components/parameters/with_metrics'
+        - name: getStatusSummary
+          in: query
+          required: false
+          schema:
+            type: boolean
       security:
         - basicAuth: []
   /agents/bulk_upgrade:
@@ -3421,11 +3426,11 @@ components:
             cpu_avg:
               type: number
               description: >-
-                Average agent CPU usage during the last 5 minute, number between
-                0-1
+                Average agent CPU usage during the last 5 minutes, number
+                between 0-1
             memory_size_byte_avg:
               type: number
-              description: Average agent memory consumption during the last 5 minute
+              description: Average agent memory consumption during the last 5 minutes
       required:
         - type
         - active
@@ -3451,6 +3456,27 @@ components:
           type: number
         perPage:
           type: number
+        statusSummary:
+          type: object
+          properties:
+            offline:
+              type: number
+            error:
+              type: number
+            online:
+              type: number
+            inactive:
+              type: number
+            enrolling:
+              type: number
+            unenrolling:
+              type: number
+            unenrolled:
+              type: number
+            updating:
+              type: number
+            degraded':
+              type: number
       required:
         - items
         - total

--- a/x-pack/plugins/fleet/common/openapi/components/schemas/get_agents_response.yaml
+++ b/x-pack/plugins/fleet/common/openapi/components/schemas/get_agents_response.yaml
@@ -16,6 +16,27 @@ properties:
     type: number
   perPage:
     type: number
+  statusSummary:
+    type: object
+    properties:
+        offline: 
+          type: number
+        error: 
+          type: number
+        online : 
+          type: number
+        inactive : 
+          type: number
+        enrolling: 
+          type: number
+        unenrolling: 
+          type: number
+        unenrolled : 
+          type: number
+        updating : 
+          type: number
+        degraded': 
+          type: number
 required:
   - items
   - total

--- a/x-pack/plugins/fleet/common/openapi/paths/agents.yaml
+++ b/x-pack/plugins/fleet/common/openapi/paths/agents.yaml
@@ -18,5 +18,10 @@ get:
     - $ref: ../components/parameters/sort_field.yaml
     - $ref: ../components/parameters/sort_order.yaml
     - $ref: ../components/parameters/with_metrics.yaml
+    - name: getStatusSummary
+      in: query
+      required: false
+      schema:
+        type: boolean
   security:
     - basicAuth: []

--- a/x-pack/plugins/fleet/common/services/agent_statuses_to_summary.test.ts
+++ b/x-pack/plugins/fleet/common/services/agent_statuses_to_summary.test.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { agentStatusesToSummary } from './agent_statuses_to_summary';
+
+describe('agentStatusesToSummary', () => {
+  it('should return the correct summary', () => {
+    expect(
+      agentStatusesToSummary({
+        online: 1,
+        error: 2,
+        degraded: 3,
+        inactive: 4,
+        offline: 5,
+        updating: 6,
+        enrolling: 7,
+        unenrolling: 8,
+        unenrolled: 9,
+      })
+    ).toEqual({
+      healthy: 1,
+      unhealthy: 5,
+      inactive: 4,
+      offline: 5,
+      updating: 21,
+      unenrolled: 9,
+    });
+  });
+});

--- a/x-pack/plugins/fleet/common/services/agent_statuses_to_summary.ts
+++ b/x-pack/plugins/fleet/common/services/agent_statuses_to_summary.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { AgentStatus, SimplifiedAgentStatus } from '../types';
+
+export function agentStatusesToSummary(
+  statuses: Record<AgentStatus, number>
+): Record<SimplifiedAgentStatus, number> {
+  return {
+    healthy: statuses.online,
+    unhealthy: statuses.error + statuses.degraded,
+    inactive: statuses.inactive,
+    offline: statuses.offline,
+    updating: statuses.updating + statuses.enrolling + statuses.unenrolling,
+    unenrolled: statuses.unenrolled,
+  };
+}

--- a/x-pack/plugins/fleet/common/services/index.ts
+++ b/x-pack/plugins/fleet/common/services/index.ts
@@ -58,3 +58,4 @@ export {
 } from './package_prerelease';
 
 export { getAllowedOutputTypeForPolicy } from './output_helpers';
+export { agentStatusesToSummary } from './agent_statuses_to_summary';

--- a/x-pack/plugins/fleet/common/types/rest_spec/agent.ts
+++ b/x-pack/plugins/fleet/common/types/rest_spec/agent.ts
@@ -14,6 +14,7 @@ import type {
   CurrentUpgrade,
   NewAgentAction,
   AgentDiagnostics,
+  AgentStatus,
 } from '../models';
 
 import type { ListResult, ListWithKuery } from './common';
@@ -29,6 +30,7 @@ export interface GetAgentsRequest {
 export interface GetAgentsResponse extends ListResult<Agent> {
   // deprecated in 8.x
   list?: Agent[];
+  statusSummary?: Record<AgentStatus, number>;
 }
 
 export interface GetAgentTagsResponse {

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/index.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/index.test.tsx
@@ -100,14 +100,18 @@ describe('agent_list_page', () => {
         data: {
           items: mapAgents(['agent1', 'agent2', 'agent3', 'agent4', 'agent5']),
           total: 6,
-          totalInactive: 0,
+          statusSummary: {
+            online: 6,
+          },
         },
       })
       .mockResolvedValueOnce({
         data: {
           items: mapAgents(['agent1', 'agent2', 'agent3', 'agent4', 'agent6']),
           total: 6,
-          totalInactive: 0,
+          statusSummary: {
+            online: 6,
+          },
         },
       });
     jest.useFakeTimers({ legacyFakeTimers: true });
@@ -128,12 +132,8 @@ describe('agent_list_page', () => {
       return {
         data: {
           results: {
-            online: 6,
-            error: 0,
-            offline: 0,
-            updating: 0,
+            inactive: 0,
           },
-          totalInactive: 0,
         },
       };
     });
@@ -143,9 +143,7 @@ describe('agent_list_page', () => {
       jest.advanceTimersByTime(65000);
     });
 
-    // we call the status endpoint twice on page load,
-    // once for all inactive agents and one for the current kuery
-    expect(mockedSendGetAgentStatus).toHaveBeenCalledTimes(2);
+    expect(mockedSendGetAgentStatus).toHaveBeenCalledTimes(1);
   });
 
   describe('selection change', () => {
@@ -153,10 +151,7 @@ describe('agent_list_page', () => {
       mockedSendGetAgentStatus.mockResolvedValue({
         data: {
           results: {
-            online: 6,
-            error: 0,
-            offline: 0,
-            updating: 0,
+            inactive: 0,
           },
           totalInactive: 0,
         },

--- a/x-pack/plugins/fleet/server/routes/agent/handlers.ts
+++ b/x-pack/plugins/fleet/server/routes/agent/handlers.ts
@@ -186,9 +186,10 @@ export const getAgentsHandler: RequestHandler<
       kuery: request.query.kuery,
       sortField: request.query.sortField,
       sortOrder: request.query.sortOrder,
+      getStatusSummary: request.query.getStatusSummary,
     });
 
-    const { total, page, perPage } = agentRes;
+    const { total, page, perPage, statusSummary } = agentRes;
     let { agents } = agentRes;
 
     // Assign metrics
@@ -202,6 +203,7 @@ export const getAgentsHandler: RequestHandler<
       total,
       page,
       perPage,
+      ...(statusSummary ? { statusSummary } : {}),
     };
     return response.ok({ body });
   } catch (error) {

--- a/x-pack/plugins/fleet/server/services/agents/status.ts
+++ b/x-pack/plugins/fleet/server/services/agents/status.ts
@@ -16,6 +16,8 @@ import type {
   QueryDslQueryContainer,
 } from '@elastic/elasticsearch/lib/api/types';
 
+import { agentStatusesToSummary } from '../../../common/services';
+
 import { AGENTS_INDEX } from '../../constants';
 import type { AgentStatus } from '../../types';
 import { FleetUnauthorizedError } from '../../errors';
@@ -122,15 +124,8 @@ export async function getAgentStatusForAgentPolicy(
     }
   });
 
-  const combinedStatuses = {
-    online: statuses.online,
-    error: statuses.error + statuses.degraded,
-    inactive: statuses.inactive,
-    offline: statuses.offline,
-    updating: statuses.updating + statuses.enrolling + statuses.unenrolling,
-    unenrolled: statuses.unenrolled,
-  };
-
+  const { healthy: online, unhealthy: error, ...otherStatuses } = agentStatusesToSummary(statuses);
+  const combinedStatuses = { online, error, ...otherStatuses };
   return {
     ...combinedStatuses,
     /* @deprecated no agents will have other status */

--- a/x-pack/plugins/fleet/server/types/rest_spec/agent.ts
+++ b/x-pack/plugins/fleet/server/types/rest_spec/agent.ts
@@ -22,6 +22,7 @@ export const GetAgentsRequestSchema = {
       showInactive: schema.boolean({ defaultValue: false }),
       withMetrics: schema.boolean({ defaultValue: false }),
       showUpgradeable: schema.boolean({ defaultValue: false }),
+      getStatusSummary: schema.boolean({ defaultValue: false }),
       sortField: schema.maybe(schema.string()),
       sortOrder: schema.maybe(schema.oneOf([schema.literal('asc'), schema.literal('desc')])),
     },

--- a/x-pack/test/fleet_api_integration/apis/agents/list.ts
+++ b/x-pack/test/fleet_api_integration/apis/agents/list.ts
@@ -197,5 +197,25 @@ export default function ({ getService }: FtrProviderContext) {
       expect(agent2.metrics?.memory_size_byte_avg).equal(undefined);
       expect(agent2.metrics?.cpu_avg).equal(undefined);
     });
+
+    it('should return a status summary if getStatusSummary provided', async () => {
+      const { body: apiResponse } = await supertest
+        .get('/api/fleet/agents?getStatusSummary=true&perPage=0')
+        .expect(200);
+
+      expect(apiResponse.items).to.eql([]);
+
+      expect(apiResponse.statusSummary).to.eql({
+        degraded: 0,
+        enrolling: 0,
+        error: 0,
+        inactive: 0,
+        offline: 4,
+        online: 0,
+        unenrolled: 0,
+        unenrolling: 0,
+        updating: 0,
+      });
+    });
   });
 }


### PR DESCRIPTION
## Summary

`getAgentStatus` will return a status breakdown for the given `kuery`. The breakdown is returned in the `statusSummary` response key. 

This allows us to remove an API call on the agents list page, I also think this kind of facet is a good thing to have for our API. 

We seem to have a mix of camel case and snake case in our API responses, for this API all the response params are camel case so I kept consistent

- integration test added
- API docs updated


Example request and response:

```
GET  kbn:/api/fleet/agents?getStatusSummary=true&showInactive=true&perPage=0

{
  "list": [],
  "items": [],
  "total": 1001,
  "page": 1,
  "perPage": 0,
  "statusSummary": {
    "online": 1,
    "error": 0,
    "inactive": 500,
    "offline": 0,
    "updating": 0,
    "unenrolled": 500,
    "degraded": 0,
    "enrolling": 0,
    "unenrolling": 0
  }
}
```