### PR TITLE
[Maps] fix Kibana Maps UI upload geojson failure should be received as such

### DIFF
--- a/x-pack/plugins/file_upload/public/components/__snapshots__/import_complete_view.test.tsx.snap
+++ b/x-pack/plugins/file_upload/public/components/__snapshots__/import_complete_view.test.tsx.snap
@@ -362,7 +362,7 @@ exports[`Should render warning when some features failed import 1`] = `
     title="File upload complete with failures"
   >
     <p>
-      Indexed 10 features. Unable to index 1 features.
+      Unable to index 1 of 10 features.
     </p>
   </EuiCallOut>
   <EuiFlexGroup

--- a/x-pack/plugins/file_upload/public/components/__snapshots__/import_complete_view.test.tsx.snap
+++ b/x-pack/plugins/file_upload/public/components/__snapshots__/import_complete_view.test.tsx.snap
@@ -1,0 +1,519 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Should render error when upload fails from elasticsearch request failure 1`] = `
+<Provider
+  services={
+    Object {
+      "uiSettings": Object {
+        "get": [MockFunction],
+      },
+    }
+  }
+>
+  <EuiCallOut
+    color="danger"
+    data-test-subj="fileUploadStatusCallout"
+    iconType="alert"
+    title="Unable to upload file"
+  >
+    <p>
+      Error: simulated elasticsearch request failure
+    </p>
+  </EuiCallOut>
+  <EuiFlexGroup
+    alignItems="flexEnd"
+    justifyContent="spaceBetween"
+  >
+    <EuiFlexItem
+      grow={false}
+    >
+      <EuiTitle
+        size="xxs"
+      >
+        <h4>
+          Import response
+        </h4>
+      </EuiTitle>
+    </EuiFlexItem>
+    <EuiFlexItem
+      grow={false}
+    >
+      <EuiCopy
+        afterMessage="Copied"
+        textToCopy="{
+  \\"success\\": false,
+  \\"docCount\\": 10,
+  \\"error\\": {
+    \\"error\\": {
+      \\"reason\\": \\"simulated elasticsearch request failure\\"
+    }
+  }
+}"
+      >
+        <Component />
+      </EuiCopy>
+    </EuiFlexItem>
+  </EuiFlexGroup>
+  <div
+    style={
+      Object {
+        "height": "200px",
+      }
+    }
+  >
+    <CodeEditor
+      languageId="json"
+      options={
+        Object {
+          "automaticLayout": true,
+          "fontSize": 12,
+          "lineNumbers": "off",
+          "minimap": Object {
+            "enabled": false,
+          },
+          "readOnly": true,
+          "scrollBeyondLastLine": false,
+          "wordWrap": "on",
+          "wrappingIndent": "indent",
+        }
+      }
+      value="{
+  \\"success\\": false,
+  \\"docCount\\": 10,
+  \\"error\\": {
+    \\"error\\": {
+      \\"reason\\": \\"simulated elasticsearch request failure\\"
+    }
+  }
+}"
+    />
+  </div>
+  <EuiSpacer
+    size="m"
+  />
+</Provider>
+`;
+
+exports[`Should render error when upload fails from http request timeout 1`] = `
+<Provider
+  services={
+    Object {
+      "uiSettings": Object {
+        "get": [MockFunction],
+      },
+    }
+  }
+>
+  <EuiCallOut
+    color="danger"
+    data-test-subj="fileUploadStatusCallout"
+    iconType="alert"
+    title="Unable to upload file"
+  >
+    <p>
+      Error: simulated http request timeout
+    </p>
+  </EuiCallOut>
+  <EuiFlexGroup
+    alignItems="flexEnd"
+    justifyContent="spaceBetween"
+  >
+    <EuiFlexItem
+      grow={false}
+    >
+      <EuiTitle
+        size="xxs"
+      >
+        <h4>
+          Import response
+        </h4>
+      </EuiTitle>
+    </EuiFlexItem>
+    <EuiFlexItem
+      grow={false}
+    >
+      <EuiCopy
+        afterMessage="Copied"
+        textToCopy="{
+  \\"success\\": false,
+  \\"docCount\\": 10,
+  \\"error\\": {
+    \\"body\\": {
+      \\"message\\": \\"simulated http request timeout\\"
+    }
+  }
+}"
+      >
+        <Component />
+      </EuiCopy>
+    </EuiFlexItem>
+  </EuiFlexGroup>
+  <div
+    style={
+      Object {
+        "height": "200px",
+      }
+    }
+  >
+    <CodeEditor
+      languageId="json"
+      options={
+        Object {
+          "automaticLayout": true,
+          "fontSize": 12,
+          "lineNumbers": "off",
+          "minimap": Object {
+            "enabled": false,
+          },
+          "readOnly": true,
+          "scrollBeyondLastLine": false,
+          "wordWrap": "on",
+          "wrappingIndent": "indent",
+        }
+      }
+      value="{
+  \\"success\\": false,
+  \\"docCount\\": 10,
+  \\"error\\": {
+    \\"body\\": {
+      \\"message\\": \\"simulated http request timeout\\"
+    }
+  }
+}"
+    />
+  </div>
+  <EuiSpacer
+    size="m"
+  />
+</Provider>
+`;
+
+exports[`Should render success 1`] = `
+<Provider
+  services={
+    Object {
+      "uiSettings": Object {
+        "get": [MockFunction],
+      },
+    }
+  }
+>
+  <EuiCallOut
+    data-test-subj="fileUploadStatusCallout"
+    title="File upload complete"
+  >
+    <p>
+      Indexed 10 features.
+    </p>
+  </EuiCallOut>
+  <EuiFlexGroup
+    alignItems="flexEnd"
+    justifyContent="spaceBetween"
+  >
+    <EuiFlexItem
+      grow={false}
+    >
+      <EuiTitle
+        size="xxs"
+      >
+        <h4>
+          Import response
+        </h4>
+      </EuiTitle>
+    </EuiFlexItem>
+    <EuiFlexItem
+      grow={false}
+    >
+      <EuiCopy
+        afterMessage="Copied"
+        textToCopy="{
+  \\"success\\": true,
+  \\"docCount\\": 10
+}"
+      >
+        <Component />
+      </EuiCopy>
+    </EuiFlexItem>
+  </EuiFlexGroup>
+  <div
+    style={
+      Object {
+        "height": "200px",
+      }
+    }
+  >
+    <CodeEditor
+      languageId="json"
+      options={
+        Object {
+          "automaticLayout": true,
+          "fontSize": 12,
+          "lineNumbers": "off",
+          "minimap": Object {
+            "enabled": false,
+          },
+          "readOnly": true,
+          "scrollBeyondLastLine": false,
+          "wordWrap": "on",
+          "wrappingIndent": "indent",
+        }
+      }
+      value="{
+  \\"success\\": true,
+  \\"docCount\\": 10
+}"
+    />
+  </div>
+  <EuiSpacer
+    size="m"
+  />
+  <EuiFlexGroup
+    alignItems="flexEnd"
+    justifyContent="spaceBetween"
+  >
+    <EuiFlexItem
+      grow={false}
+    >
+      <EuiTitle
+        size="xxs"
+      >
+        <h4>
+          Data view response
+        </h4>
+      </EuiTitle>
+    </EuiFlexItem>
+    <EuiFlexItem
+      grow={false}
+    >
+      <EuiCopy
+        afterMessage="Copied"
+        textToCopy="{}"
+      >
+        <Component />
+      </EuiCopy>
+    </EuiFlexItem>
+  </EuiFlexGroup>
+  <div
+    style={
+      Object {
+        "height": "200px",
+      }
+    }
+  >
+    <CodeEditor
+      languageId="json"
+      options={
+        Object {
+          "automaticLayout": true,
+          "fontSize": 12,
+          "lineNumbers": "off",
+          "minimap": Object {
+            "enabled": false,
+          },
+          "readOnly": true,
+          "scrollBeyondLastLine": false,
+          "wordWrap": "on",
+          "wrappingIndent": "indent",
+        }
+      }
+      value="{}"
+    />
+  </div>
+  <EuiSpacer
+    size="m"
+  />
+  <EuiText>
+    <p>
+      <FormattedMessage
+        defaultMessage="To modify the index, go to "
+        id="xpack.fileUpload.importComplete.indexModsMsg"
+        values={Object {}}
+      />
+      <a
+        data-test-subj="indexManagementNewIndexLink"
+        href="abc/app/management/kibana/dataViews"
+        target="_blank"
+      >
+        <FormattedMessage
+          defaultMessage="Index Management."
+          id="xpack.fileUpload.importComplete.indexMgmtLink"
+          values={Object {}}
+        />
+      </a>
+    </p>
+  </EuiText>
+</Provider>
+`;
+
+exports[`Should render warning when some features failed import 1`] = `
+<Provider
+  services={
+    Object {
+      "uiSettings": Object {
+        "get": [MockFunction],
+      },
+    }
+  }
+>
+  <EuiCallOut
+    color="warning"
+    data-test-subj="fileUploadStatusCallout"
+    iconType="help"
+    title="File upload complete with failures"
+  >
+    <p>
+      Indexed 10 features. Unable to index 1 features.
+    </p>
+  </EuiCallOut>
+  <EuiFlexGroup
+    alignItems="flexEnd"
+    justifyContent="spaceBetween"
+  >
+    <EuiFlexItem
+      grow={false}
+    >
+      <EuiTitle
+        size="xxs"
+      >
+        <h4>
+          Import response
+        </h4>
+      </EuiTitle>
+    </EuiFlexItem>
+    <EuiFlexItem
+      grow={false}
+    >
+      <EuiCopy
+        afterMessage="Copied"
+        textToCopy="{
+  \\"success\\": true,
+  \\"docCount\\": 10,
+  \\"failures\\": [
+    {
+      \\"item\\": 1,
+      \\"reason\\": \\"simulated feature import failure\\",
+      \\"doc\\": {}
+    }
+  ]
+}"
+      >
+        <Component />
+      </EuiCopy>
+    </EuiFlexItem>
+  </EuiFlexGroup>
+  <div
+    style={
+      Object {
+        "height": "200px",
+      }
+    }
+  >
+    <CodeEditor
+      languageId="json"
+      options={
+        Object {
+          "automaticLayout": true,
+          "fontSize": 12,
+          "lineNumbers": "off",
+          "minimap": Object {
+            "enabled": false,
+          },
+          "readOnly": true,
+          "scrollBeyondLastLine": false,
+          "wordWrap": "on",
+          "wrappingIndent": "indent",
+        }
+      }
+      value="{
+  \\"success\\": true,
+  \\"docCount\\": 10,
+  \\"failures\\": [
+    {
+      \\"item\\": 1,
+      \\"reason\\": \\"simulated feature import failure\\",
+      \\"doc\\": {}
+    }
+  ]
+}"
+    />
+  </div>
+  <EuiSpacer
+    size="m"
+  />
+  <EuiFlexGroup
+    alignItems="flexEnd"
+    justifyContent="spaceBetween"
+  >
+    <EuiFlexItem
+      grow={false}
+    >
+      <EuiTitle
+        size="xxs"
+      >
+        <h4>
+          Data view response
+        </h4>
+      </EuiTitle>
+    </EuiFlexItem>
+    <EuiFlexItem
+      grow={false}
+    >
+      <EuiCopy
+        afterMessage="Copied"
+        textToCopy="{}"
+      >
+        <Component />
+      </EuiCopy>
+    </EuiFlexItem>
+  </EuiFlexGroup>
+  <div
+    style={
+      Object {
+        "height": "200px",
+      }
+    }
+  >
+    <CodeEditor
+      languageId="json"
+      options={
+        Object {
+          "automaticLayout": true,
+          "fontSize": 12,
+          "lineNumbers": "off",
+          "minimap": Object {
+            "enabled": false,
+          },
+          "readOnly": true,
+          "scrollBeyondLastLine": false,
+          "wordWrap": "on",
+          "wrappingIndent": "indent",
+        }
+      }
+      value="{}"
+    />
+  </div>
+  <EuiSpacer
+    size="m"
+  />
+  <EuiText>
+    <p>
+      <FormattedMessage
+        defaultMessage="To modify the index, go to "
+        id="xpack.fileUpload.importComplete.indexModsMsg"
+        values={Object {}}
+      />
+      <a
+        data-test-subj="indexManagementNewIndexLink"
+        href="abc/app/management/kibana/dataViews"
+        target="_blank"
+      >
+        <FormattedMessage
+          defaultMessage="Index Management."
+          id="xpack.fileUpload.importComplete.indexMgmtLink"
+          values={Object {}}
+        />
+      </a>
+    </p>
+  </EuiText>
+</Provider>
+`;

--- a/x-pack/plugins/file_upload/public/components/geo_upload_wizard.tsx
+++ b/x-pack/plugins/file_upload/public/components/geo_upload_wizard.tsx
@@ -187,7 +187,7 @@ export class GeoUploadWizard extends Component<FileUploadComponentProps, State> 
                 defaultMessage: 'Unable to index {numFailures} of {featureCount} features.',
                 values: {
                   featureCount: importResults.docCount,
-                  numFailures: importResults.failures.length,
+                  numFailures: importResults.failures!.length,
                 },
               }),
             },

--- a/x-pack/plugins/file_upload/public/components/geo_upload_wizard.tsx
+++ b/x-pack/plugins/file_upload/public/components/geo_upload_wizard.tsx
@@ -17,6 +17,7 @@ import { ImportResults } from '../importer';
 import { GeoFileImporter } from '../importer/geo';
 import type { Settings } from '../../common/types';
 import { hasImportPermission } from '../api';
+import { getPartialImportMessage } from './utils';
 
 enum PHASE {
   CONFIGURE = 'CONFIGURE',
@@ -183,13 +184,10 @@ export class GeoUploadWizard extends Component<FileUploadComponentProps, State> 
           success: false,
           error: {
             error: {
-              reason: i18n.translate('xpack.fileUpload.geoUploadWizard.allFeaturesFailedIndexing', {
-                defaultMessage: 'Unable to index {numFailures} of {featureCount} features.',
-                values: {
-                  featureCount: importResults.docCount,
-                  numFailures: importResults.failures!.length,
-                },
-              }),
+              reason: getPartialImportMessage(
+                importResults.failures!.length,
+                importResults.docCount
+              ),
             },
           },
         },

--- a/x-pack/plugins/file_upload/public/components/geo_upload_wizard.tsx
+++ b/x-pack/plugins/file_upload/public/components/geo_upload_wizard.tsx
@@ -175,6 +175,28 @@ export class GeoUploadWizard extends Component<FileUploadComponentProps, State> 
       });
       this.props.onUploadError();
       return;
+    } else if (importResults.docCount === importResults.failures?.length) {
+      this.setState({
+        // Force importResults into failure shape when no features are indexed
+        importResults: {
+          ...importResults,
+          success: false,
+          error: {
+            error: {
+              reason: i18n.translate('xpack.fileUpload.geoUploadWizard.allFeaturesFailedIndexing', {
+                defaultMessage: 'Unable to index {numFailures} of {featureCount} features.',
+                values: {
+                  featureCount: importResults.docCount,
+                  numFailures: importResults.failures.length,
+                },
+              })
+            }
+          }
+        },
+        phase: PHASE.COMPLETE,
+      });
+      this.props.onUploadError();
+      return;
     }
 
     //

--- a/x-pack/plugins/file_upload/public/components/geo_upload_wizard.tsx
+++ b/x-pack/plugins/file_upload/public/components/geo_upload_wizard.tsx
@@ -189,9 +189,9 @@ export class GeoUploadWizard extends Component<FileUploadComponentProps, State> 
                   featureCount: importResults.docCount,
                   numFailures: importResults.failures.length,
                 },
-              })
-            }
-          }
+              }),
+            },
+          },
         },
         phase: PHASE.COMPLETE,
       });

--- a/x-pack/plugins/file_upload/public/components/import_complete_view.test.tsx
+++ b/x-pack/plugins/file_upload/public/components/import_complete_view.test.tsx
@@ -16,7 +16,7 @@ jest.mock('../kibana_services', () => ({
     return {
       links: {
         maps: {
-          importGeospatialPrivileges: 'linkToPrvilegesDocs'
+          importGeospatialPrivileges: 'linkToPrvilegesDocs',
         },
       },
     };
@@ -45,7 +45,8 @@ test('Should render success', () => {
       }}
       dataViewResp={{}}
       indexName="myIndex"
-    />);
+    />
+  );
 
   expect(component).toMatchSnapshot();
 });
@@ -67,7 +68,8 @@ test('Should render warning when some features failed import', () => {
       }}
       dataViewResp={{}}
       indexName="myIndex"
-    />);
+    />
+  );
 
   expect(component).toMatchSnapshot();
 });
@@ -86,7 +88,8 @@ test('Should render error when upload fails from http request timeout', () => {
         },
       }}
       indexName="myIndex"
-    />);
+    />
+  );
 
   expect(component).toMatchSnapshot();
 });
@@ -105,7 +108,8 @@ test('Should render error when upload fails from elasticsearch request failure',
         },
       }}
       indexName="myIndex"
-    />);
+    />
+  );
 
   expect(component).toMatchSnapshot();
 });

--- a/x-pack/plugins/file_upload/public/components/import_complete_view.test.tsx
+++ b/x-pack/plugins/file_upload/public/components/import_complete_view.test.tsx
@@ -24,7 +24,7 @@ jest.mock('../kibana_services', () => ({
   getHttp: () => {
     return {
       basePath: {
-        prepend: (path) => `abc${path}`,
+        prepend: (path: string) => `abc${path}`,
       },
     };
   },

--- a/x-pack/plugins/file_upload/public/components/import_complete_view.test.tsx
+++ b/x-pack/plugins/file_upload/public/components/import_complete_view.test.tsx
@@ -1,0 +1,111 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { ImportCompleteView } from './import_complete_view';
+
+jest.mock('../kibana_services', () => ({
+  get: jest.fn(),
+  getDocLinks: () => {
+    return {
+      links: {
+        maps: {
+          importGeospatialPrivileges: 'linkToPrvilegesDocs'
+        },
+      },
+    };
+  },
+  getHttp: () => {
+    return {
+      basePath: {
+        prepend: (path) => `abc${path}`,
+      },
+    };
+  },
+  getUiSettings: () => {
+    return {
+      get: jest.fn(),
+    };
+  },
+}));
+
+test('Should render success', () => {
+  const component = shallow(
+    <ImportCompleteView
+      failedPermissionCheck={false}
+      importResults={{
+        success: true,
+        docCount: 10,
+      }}
+      dataViewResp={{}}
+      indexName="myIndex"
+    />);
+
+  expect(component).toMatchSnapshot();
+});
+
+test('Should render warning when some features failed import', () => {
+  const component = shallow(
+    <ImportCompleteView
+      failedPermissionCheck={false}
+      importResults={{
+        success: true,
+        docCount: 10,
+        failures: [
+          {
+            item: 1,
+            reason: 'simulated feature import failure',
+            doc: {},
+          },
+        ],
+      }}
+      dataViewResp={{}}
+      indexName="myIndex"
+    />);
+
+  expect(component).toMatchSnapshot();
+});
+
+test('Should render error when upload fails from http request timeout', () => {
+  const component = shallow(
+    <ImportCompleteView
+      failedPermissionCheck={false}
+      importResults={{
+        success: false,
+        docCount: 10,
+        error: {
+          body: {
+            message: 'simulated http request timeout',
+          },
+        },
+      }}
+      indexName="myIndex"
+    />);
+
+  expect(component).toMatchSnapshot();
+});
+
+test('Should render error when upload fails from elasticsearch request failure', () => {
+  const component = shallow(
+    <ImportCompleteView
+      failedPermissionCheck={false}
+      importResults={{
+        success: false,
+        docCount: 10,
+        error: {
+          error: {
+            reason: 'simulated elasticsearch request failure',
+          },
+        },
+      }}
+      indexName="myIndex"
+    />);
+
+  expect(component).toMatchSnapshot();
+});

--- a/x-pack/plugins/file_upload/public/components/import_complete_view.tsx
+++ b/x-pack/plugins/file_upload/public/components/import_complete_view.tsx
@@ -169,7 +169,7 @@ export class ImportCompleteView extends Component<Props, {}> {
         >
           <p>
             {getPartialImportMessage(
-              this.props.importResults.failures.length,
+              this.props.importResults.failures!.length,
               this.props.importResults.docCount
             )}
           </p>

--- a/x-pack/plugins/file_upload/public/components/import_complete_view.tsx
+++ b/x-pack/plugins/file_upload/public/components/import_complete_view.tsx
@@ -22,6 +22,7 @@ import {
 import { CodeEditor, KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
 import { getDocLinks, getHttp, getUiSettings } from '../kibana_services';
 import { ImportResults } from '../importer';
+import { getPartialImportMessage } from './utils';
 
 const services = {
   uiSettings: getUiSettings(),
@@ -156,23 +157,7 @@ export class ImportCompleteView extends Component<Props, {}> {
       );
     }
 
-    const successMsg = i18n.translate('xpack.fileUpload.importComplete.uploadSuccessMsg', {
-      defaultMessage: 'Indexed {numFeatures} features.',
-      values: {
-        numFeatures: this.props.importResults.docCount,
-      },
-    });
-
     if (this.props.importResults.failures?.length) {
-      const failedFeaturesMsg = i18n.translate(
-        'xpack.fileUpload.importComplete.failedFeaturesMsg',
-        {
-          defaultMessage: 'Unable to index {numFailures} features.',
-          values: {
-            numFailures: this.props.importResults.failures.length,
-          },
-        }
-      );
       return (
         <EuiCallOut
           title={i18n.translate('xpack.fileUpload.importComplete.uploadSuccessWithFailuresTitle', {
@@ -182,7 +167,12 @@ export class ImportCompleteView extends Component<Props, {}> {
           iconType="help"
           data-test-subj={STATUS_CALLOUT_DATA_TEST_SUBJ}
         >
-          <p>{`${successMsg} ${failedFeaturesMsg}`}</p>
+          <p>
+            {getPartialImportMessage(
+              this.props.importResults.failures.length,
+              this.props.importResults.docCount
+            )}
+          </p>
         </EuiCallOut>
       );
     }
@@ -194,7 +184,14 @@ export class ImportCompleteView extends Component<Props, {}> {
         })}
         data-test-subj={STATUS_CALLOUT_DATA_TEST_SUBJ}
       >
-        <p>{successMsg}</p>
+        <p>
+          {i18n.translate('xpack.fileUpload.importComplete.uploadSuccessMsg', {
+            defaultMessage: 'Indexed {numFeatures} features.',
+            values: {
+              numFeatures: this.props.importResults.docCount,
+            },
+          })}
+        </p>
       </EuiCallOut>
     );
   }

--- a/x-pack/plugins/file_upload/public/components/import_complete_view.tsx
+++ b/x-pack/plugins/file_upload/public/components/import_complete_view.tsx
@@ -133,7 +133,7 @@ export class ImportCompleteView extends Component<Props, {}> {
         // Display http request error message
         reason = this.props.importResults.error.body.message;
       } else if (this.props.importResults?.error?.error?.reason) {
-        // Display elasticxsearch request error message
+        // Display elasticsearch request error message
         reason = this.props.importResults.error.error.reason;
       }
       const errorMsg = reason
@@ -163,14 +163,26 @@ export class ImportCompleteView extends Component<Props, {}> {
       },
     });
 
-    const failedFeaturesMsg = this.props.importResults.failures?.length
-      ? i18n.translate('xpack.fileUpload.importComplete.failedFeaturesMsg', {
-          defaultMessage: 'Unable to index {numFailures} features.',
-          values: {
-            numFailures: this.props.importResults.failures.length,
-          },
-        })
-      : '';
+    if (this.props.importResults.failures?.length) {
+      const failedFeaturesMsg = i18n.translate('xpack.fileUpload.importComplete.failedFeaturesMsg', {
+        defaultMessage: 'Unable to index {numFailures} features.',
+        values: {
+          numFailures: this.props.importResults.failures.length,
+        },
+      });
+      return (
+        <EuiCallOut
+          title={i18n.translate('xpack.fileUpload.importComplete.uploadSuccessWithFailuresTitle', {
+            defaultMessage: 'File upload complete with failures',
+          })}
+          color="warning"
+          iconType="help"
+          data-test-subj={STATUS_CALLOUT_DATA_TEST_SUBJ}
+        >
+          <p>{`${successMsg} ${failedFeaturesMsg}`}</p>
+        </EuiCallOut>
+      );
+    }
 
     return (
       <EuiCallOut
@@ -179,7 +191,7 @@ export class ImportCompleteView extends Component<Props, {}> {
         })}
         data-test-subj={STATUS_CALLOUT_DATA_TEST_SUBJ}
       >
-        <p>{`${successMsg} ${failedFeaturesMsg}`}</p>
+        <p>{successMsg}</p>
       </EuiCallOut>
     );
   }

--- a/x-pack/plugins/file_upload/public/components/import_complete_view.tsx
+++ b/x-pack/plugins/file_upload/public/components/import_complete_view.tsx
@@ -164,12 +164,15 @@ export class ImportCompleteView extends Component<Props, {}> {
     });
 
     if (this.props.importResults.failures?.length) {
-      const failedFeaturesMsg = i18n.translate('xpack.fileUpload.importComplete.failedFeaturesMsg', {
-        defaultMessage: 'Unable to index {numFailures} features.',
-        values: {
-          numFailures: this.props.importResults.failures.length,
-        },
-      });
+      const failedFeaturesMsg = i18n.translate(
+        'xpack.fileUpload.importComplete.failedFeaturesMsg',
+        {
+          defaultMessage: 'Unable to index {numFailures} features.',
+          values: {
+            numFailures: this.props.importResults.failures.length,
+          },
+        }
+      );
       return (
         <EuiCallOut
           title={i18n.translate('xpack.fileUpload.importComplete.uploadSuccessWithFailuresTitle', {

--- a/x-pack/plugins/file_upload/public/components/utils.ts
+++ b/x-pack/plugins/file_upload/public/components/utils.ts
@@ -7,12 +7,21 @@
 
 import { i18n } from '@kbn/i18n';
 
-export function getPartialImportMessage(failedFeaturesCount: number, totalFeaturesCount: number) {
+export function getPartialImportMessage(failedFeaturesCount: number, totalFeaturesCount?: number) {
+  const outOfTotalMsg =
+    typeof totalFeaturesCount === 'number'
+      ? i18n.translate('xpack.fileUpload.geoUploadWizard.outOfTotalMsg', {
+          defaultMessage: 'of {totalFeaturesCount}',
+          values: {
+            totalFeaturesCount,
+          },
+        })
+      : '';
   return i18n.translate('xpack.fileUpload.geoUploadWizard.partialImportMsg', {
-    defaultMessage: 'Unable to index {failedFeaturesCount} of {totalFeaturesCount} features.',
+    defaultMessage: 'Unable to index {failedFeaturesCount} {outOfTotalMsg} features.',
     values: {
       failedFeaturesCount,
-      totalFeaturesCount,
+      outOfTotalMsg,
     },
   });
 }

--- a/x-pack/plugins/file_upload/public/components/utils.ts
+++ b/x-pack/plugins/file_upload/public/components/utils.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export function getPartialImportMessage(failedFeaturesCount: number, totalFeaturesCount: number) {
+  return i18n.translate('xpack.fileUpload.geoUploadWizard.partialImportMsg', {
+    defaultMessage: 'Unable to index {failedFeaturesCount} of {totalFeaturesCount} features.',
+    values: {
+      failedFeaturesCount,
+      totalFeaturesCount,
+    },
+  });
+}

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -13248,7 +13248,6 @@
     "xpack.fileUpload.geoUploadWizard.creatingDataView": "正在创建数据视图：{indexName}",
     "xpack.fileUpload.geoUploadWizard.dataIndexingStarted": "正在创建索引：{indexName}",
     "xpack.fileUpload.geoUploadWizard.writingToIndex": "正在写入索引：已完成 {progress}%",
-    "xpack.fileUpload.importComplete.failedFeaturesMsg": "无法索引 {numFailures} 个特征。",
     "xpack.fileUpload.importComplete.permissionFailureMsg": "您无权创建或将数据导入索引“{indexName}”。",
     "xpack.fileUpload.importComplete.uploadFailureMsgErrorBlock": "错误：{reason}",
     "xpack.fileUpload.importComplete.uploadSuccessMsg": "已索引 {numFeatures} 个特征。",


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/138122

PR updates geo spatial file upload to show error callout if all features fail indexing. PR updates geo spatial file upload to show warning callout if some features fail indexing.

<img width="150" alt="Screen Shot 2023-01-31 at 11 34 49 AM" src="https://user-images.githubusercontent.com/373691/215851548-11cf9fa8-7c59-4d21-9257-664ab00f418d.png">

<img width="150" alt="Screen Shot 2023-01-31 at 11 34 32 AM" src="https://user-images.githubusercontent.com/373691/215851557-09dfbef3-ae0e-4ddd-b617-9c70a66fa712.png">

To test save the following geojson samples as a file with the name `<filename>.geojson`. Then upload the files in kibana. Verify errors are displayed as expected

all invalid features
```
{
  "type" : "FeatureCollection",
  "features" : [{ 
    "type" : "Feature", 
    "geometry" : { 
      "type" : "Point", 
      "coordinates" : [ 100000, 42.417500 ] 
    }
  }]
}
```

some invalid features
```
{
  "type" : "FeatureCollection",
  "features" : [{ 
    "type" : "Feature", 
    "geometry" : { 
      "type" : "Point", 
      "coordinates" : [ 0, 0 ] 
    }
  },
  { 
    "type" : "Feature", 
    "geometry" : { 
      "type" : "Point", 
      "coordinates" : [ 100000, 0 ] 
    }
  }]
}
```
