### PR TITLE
Use `auto_expand_replicas` to dynamically adjust number of replicas for apm-source-map index

### DIFF
--- a/x-pack/plugins/apm/server/routes/source_maps/create_apm_source_map_index_template.ts
+++ b/x-pack/plugins/apm/server/routes/source_maps/create_apm_source_map_index_template.ts
@@ -17,9 +17,9 @@ const indexTemplate: IndicesPutIndexTemplateRequest = {
     index_patterns: [APM_SOURCE_MAP_INDEX],
     template: {
       settings: {
-        number_of_shards: 1,
-        auto_expand_replicas: '0-1',
         index: {
+          number_of_shards: 2,
+          auto_expand_replicas: '0-2',
           hidden: true,
         },
       },

--- a/x-pack/plugins/apm/server/routes/source_maps/create_apm_source_map_index_template.ts
+++ b/x-pack/plugins/apm/server/routes/source_maps/create_apm_source_map_index_template.ts
@@ -18,7 +18,7 @@ const indexTemplate: IndicesPutIndexTemplateRequest = {
     template: {
       settings: {
         index: {
-          number_of_shards: 2,
+          number_of_shards: 1,
           auto_expand_replicas: '0-2',
           hidden: true,
         },

--- a/x-pack/plugins/apm/server/routes/source_maps/create_apm_source_map_index_template.ts
+++ b/x-pack/plugins/apm/server/routes/source_maps/create_apm_source_map_index_template.ts
@@ -18,6 +18,7 @@ const indexTemplate: IndicesPutIndexTemplateRequest = {
     template: {
       settings: {
         number_of_shards: 1,
+        auto_expand_replicas: '0-1',
         index: {
           hidden: true,
         },


### PR DESCRIPTION
By default the apm-source-map index has `number_of_replicas: 1`. This causes problems for single-node ES clusters where the health will be yellow. With `auto_expand_replicas` the number of replicas will automatically be adjusted depending on the number of nodes in the cluster