### PR TITLE
[Enterprise Search] Engines Overview with indices and documents count stats

### DIFF
--- a/x-pack/plugins/enterprise_search/common/types/engines.ts
+++ b/x-pack/plugins/enterprise_search/common/types/engines.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { HealthStatus } from '@elastic/elasticsearch/lib/api/types';
+import { HealthStatus, FieldCapsResponse } from '@elastic/elasticsearch/lib/api/types';
 
 export interface EnterpriseSearchEnginesResponse {
   meta: {
@@ -36,4 +36,11 @@ export interface EnterpriseSearchEngineIndex {
   health: HealthStatus | 'unknown';
   name: string;
   source: 'api' | 'connector' | 'crawler';
+}
+
+export interface EnterpriseSearchEngineFieldCapabilities {
+  created: string;
+  field_capabilities: FieldCapsResponse;
+  name: string;
+  updated: string;
 }

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/engines/fetch_engine_field_capabilities_api_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/engines/fetch_engine_field_capabilities_api_logic.test.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { mockHttpValues } from '../../../__mocks__/kea_logic';
+
+import { nextTick } from '@kbn/test-jest-helpers';
+
+import { fetchEngineFieldCapabilities } from './fetch_engine_field_capabilities_api_logic';
+
+describe('FetchEngineFieldCapabilitiesApiLogic', () => {
+  const { http } = mockHttpValues;
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  describe('fetchEngineFieldCapabilities', () => {
+    it('requests the field_capabilities api', async () => {
+      const promise = Promise.resolve({ result: 'result' });
+      http.get.mockReturnValue(promise);
+      const result = fetchEngineFieldCapabilities({ engineName: 'foobar' });
+      await nextTick();
+      expect(http.get).toHaveBeenCalledWith(
+        '/internal/enterprise_search/engines/foobar/field_capabilities'
+      );
+      await expect(result).resolves.toEqual({ result: 'result' });
+    });
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/engines/fetch_engine_field_capabilities_api_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/engines/fetch_engine_field_capabilities_api_logic.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EnterpriseSearchEngineFieldCapabilities } from '../../../../../common/types/engines';
+import { Actions, createApiLogic } from '../../../shared/api_logic/create_api_logic';
+import { HttpLogic } from '../../../shared/http';
+
+export interface FetchEngineFieldCapabilitiesApiParams {
+  engineName: string;
+}
+
+export type FetchEngineFieldCapabilitiesApiResponse = EnterpriseSearchEngineFieldCapabilities;
+
+export const fetchEngineFieldCapabilities = async ({
+  engineName,
+}: FetchEngineFieldCapabilitiesApiParams): Promise<FetchEngineFieldCapabilitiesApiResponse> => {
+  const route = `/internal/enterprise_search/engines/${engineName}/field_capabilities`;
+
+  return await HttpLogic.values.http.get<EnterpriseSearchEngineFieldCapabilities>(route);
+};
+
+export const FetchEngineFieldCapabilitiesApiLogic = createApiLogic(
+  ['fetch_engine_field_capabilities_api_logic'],
+  fetchEngineFieldCapabilities
+);
+
+export type FetchEngineFieldCapabilitiesApiLogicActions = Actions<
+  FetchEngineFieldCapabilitiesApiParams,
+  FetchEngineFieldCapabilitiesApiResponse
+>;

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_overview.tsx
@@ -21,9 +21,9 @@ import { EngineViewLogic } from './engine_view_logic';
 export const EngineOverview: React.FC = () => {
   const { engineName, engineData, isLoadingEngine } = useValues(EngineViewLogic);
 
-  const indicesCount = engineData?.indices?.length;
+  const indicesCount = engineData?.indices?.length ?? 0;
   const documentsCount = useMemo(
-    () => engineData?.indices?.reduce((sum, { count }) => sum + count, 0),
+    () => engineData?.indices?.reduce((sum, { count }) => sum + count, 0) ?? 0,
     [engineData]
   );
 
@@ -49,7 +49,7 @@ export const EngineOverview: React.FC = () => {
                 <EuiStat
                   titleSize="l"
                   isLoading={isLoadingEngine}
-                  title={`${indicesCount}`}
+                  title={indicesCount.toLocaleString()}
                   description={i18n.translate(
                     'xpack.enterpriseSearch.content.engine.overview.indicesDescription',
                     { defaultMessage: 'Indices' }
@@ -64,7 +64,7 @@ export const EngineOverview: React.FC = () => {
                 <EuiStat
                   titleSize="l"
                   isLoading={isLoadingEngine}
-                  title={`${documentsCount}`}
+                  title={documentsCount.toLocaleString()}
                   description={i18n.translate(
                     'xpack.enterpriseSearch.content.engine.overview.documentsDescription',
                     { defaultMessage: 'Documents' }

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_overview.tsx
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { useValues } from 'kea';
+
+import { i18n } from '@kbn/i18n';
+
+import { EngineViewTabs } from '../../routes';
+import { EnterpriseSearchEnginesPageTemplate } from '../layout/engines_page_template';
+
+import { EngineViewHeaderActions } from './engine_view_header_actions';
+import { EngineViewLogic } from './engine_view_logic';
+
+export const EngineOverview: React.FC = () => {
+  const { engineName, isLoadingEngine } = useValues(EngineViewLogic);
+
+  return (
+    <EnterpriseSearchEnginesPageTemplate
+      pageChrome={[engineName]}
+      pageViewTelemetry={EngineViewTabs.OVERVIEW}
+      isLoading={isLoadingEngine}
+      pageHeader={{
+        pageTitle: i18n.translate('xpack.enterpriseSearch.content.engine.overview.pageTitle', {
+          defaultMessage: 'Overview',
+        }),
+        rightSideItems: [<EngineViewHeaderActions />],
+      }}
+      engineName={engineName}
+    />
+  );
+};

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_overview.tsx
@@ -5,10 +5,11 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { useMemo } from 'react';
 
 import { useValues } from 'kea';
 
+import { EuiFlexGroup, EuiFlexItem, EuiIcon, EuiPanel, EuiStat } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
 import { EngineViewTabs } from '../../routes';
@@ -18,7 +19,13 @@ import { EngineViewHeaderActions } from './engine_view_header_actions';
 import { EngineViewLogic } from './engine_view_logic';
 
 export const EngineOverview: React.FC = () => {
-  const { engineName, isLoadingEngine } = useValues(EngineViewLogic);
+  const { engineName, engineData, isLoadingEngine } = useValues(EngineViewLogic);
+
+  const indicesCount = engineData?.indices?.length;
+  const documentsCount = useMemo(
+    () => engineData?.indices?.reduce((sum, { count }) => sum + count, 0),
+    [engineData]
+  );
 
   return (
     <EnterpriseSearchEnginesPageTemplate
@@ -32,6 +39,57 @@ export const EngineOverview: React.FC = () => {
         rightSideItems: [<EngineViewHeaderActions />],
       }}
       engineName={engineName}
-    />
+    >
+      <>
+        <EuiPanel hasShadow={false} hasBorder paddingSize="l">
+          <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
+            <EuiFlexItem>
+              <EuiFlexGroup alignItems="center">
+                <EuiIcon size="xxl" type="visTable" color="#98A2B3" />
+                <EuiStat
+                  titleSize="l"
+                  isLoading={!engineData}
+                  title={`${indicesCount}`}
+                  description={i18n.translate(
+                    'xpack.enterpriseSearch.content.engine.overview.indicesDescription',
+                    { defaultMessage: 'Indices' }
+                  )}
+                  titleColor="primary"
+                />
+              </EuiFlexGroup>
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiFlexGroup alignItems="center">
+                <EuiIcon size="xxl" type="documents" color="#98A2B3" />
+                <EuiStat
+                  titleSize="l"
+                  isLoading={!engineData}
+                  title={`${documentsCount}`}
+                  description={i18n.translate(
+                    'xpack.enterpriseSearch.content.engine.overview.documentsDescription',
+                    { defaultMessage: 'Documents' }
+                  )}
+                  titleColor="primary"
+                />
+              </EuiFlexGroup>
+            </EuiFlexItem>
+            {/* <EuiFlexItem>
+              <EuiFlexGroup alignItems="center">
+                <EuiIcon size="xxl" type="kqlField" color="#98A2B3" />
+                <EuiStat
+                  titleSize="l"
+                  isLoading
+                  description={i18n.translate(
+                    'xpack.enterpriseSearch.content.engine.overview.fieldsDescription',
+                    { defaultMessage: 'Fields' }
+                  )}
+                  titleColor="primary"
+                />
+              </EuiFlexGroup>
+            </EuiFlexItem> */}
+          </EuiFlexGroup>
+        </EuiPanel>
+      </>
+    </EnterpriseSearchEnginesPageTemplate>
   );
 };

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_overview.tsx
@@ -64,27 +64,19 @@ export const EngineOverview: React.FC = () => {
               </EuiLinkTo>
             </EuiFlexItem>
             <EuiFlexItem>
-              <EuiLinkTo
-                to={generateEncodedPath(ENGINE_TAB_PATH, {
-                  engineName,
-                  tabId: EngineViewTabs.PREVIEW,
-                })}
-                color="text"
-              >
-                <EuiFlexGroup alignItems="center">
-                  <EuiIcon size="xxl" type="documents" color="#98A2B3" />
-                  <EuiStat
-                    titleSize="l"
-                    isLoading={isLoadingEngine}
-                    title={documentsCount.toLocaleString()}
-                    description={i18n.translate(
-                      'xpack.enterpriseSearch.content.engine.overview.documentsDescription',
-                      { defaultMessage: 'Documents' }
-                    )}
-                    titleColor="primary"
-                  />
-                </EuiFlexGroup>
-              </EuiLinkTo>
+              <EuiFlexGroup alignItems="center">
+                <EuiIcon size="xxl" type="documents" color="#98A2B3" />
+                <EuiStat
+                  titleSize="l"
+                  isLoading={isLoadingEngine}
+                  title={documentsCount.toLocaleString()}
+                  description={i18n.translate(
+                    'xpack.enterpriseSearch.content.engine.overview.documentsDescription',
+                    { defaultMessage: 'Documents' }
+                  )}
+                  titleColor="primary"
+                />
+              </EuiFlexGroup>
             </EuiFlexItem>
             <EuiFlexItem>
               <EuiLinkTo

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_overview.tsx
@@ -12,7 +12,9 @@ import { useValues } from 'kea';
 import { EuiFlexGroup, EuiFlexItem, EuiIcon, EuiPanel, EuiStat } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
-import { EngineViewTabs } from '../../routes';
+import { generateEncodedPath } from '../../../shared/encode_path_params';
+import { EuiLinkTo } from '../../../shared/react_router_helpers';
+import { EngineViewTabs, ENGINE_TAB_PATH } from '../../routes';
 import { EnterpriseSearchEnginesPageTemplate } from '../layout/engines_page_template';
 
 import { EngineOverviewLogic } from './engine_overview_logic';
@@ -39,49 +41,73 @@ export const EngineOverview: React.FC = () => {
         <EuiPanel hasShadow={false} hasBorder paddingSize="l">
           <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
             <EuiFlexItem>
-              <EuiFlexGroup alignItems="center">
-                <EuiIcon size="xxl" type="visTable" color="#98A2B3" />
-                <EuiStat
-                  titleSize="l"
-                  isLoading={isLoadingEngine}
-                  title={indicesCount.toLocaleString()}
-                  description={i18n.translate(
-                    'xpack.enterpriseSearch.content.engine.overview.indicesDescription',
-                    { defaultMessage: 'Indices' }
-                  )}
-                  titleColor="primary"
-                />
-              </EuiFlexGroup>
+              <EuiLinkTo
+                to={generateEncodedPath(ENGINE_TAB_PATH, {
+                  engineName,
+                  tabId: EngineViewTabs.INDICES,
+                })}
+                color="text"
+              >
+                <EuiFlexGroup alignItems="center">
+                  <EuiIcon size="xxl" type="visTable" color="#98A2B3" />
+                  <EuiStat
+                    titleSize="l"
+                    isLoading={isLoadingEngine}
+                    title={indicesCount.toLocaleString()}
+                    description={i18n.translate(
+                      'xpack.enterpriseSearch.content.engine.overview.indicesDescription',
+                      { defaultMessage: 'Indices' }
+                    )}
+                    titleColor="primary"
+                  />
+                </EuiFlexGroup>
+              </EuiLinkTo>
             </EuiFlexItem>
             <EuiFlexItem>
-              <EuiFlexGroup alignItems="center">
-                <EuiIcon size="xxl" type="documents" color="#98A2B3" />
-                <EuiStat
-                  titleSize="l"
-                  isLoading={isLoadingEngine}
-                  title={documentsCount.toLocaleString()}
-                  description={i18n.translate(
-                    'xpack.enterpriseSearch.content.engine.overview.documentsDescription',
-                    { defaultMessage: 'Documents' }
-                  )}
-                  titleColor="primary"
-                />
-              </EuiFlexGroup>
+              <EuiLinkTo
+                to={generateEncodedPath(ENGINE_TAB_PATH, {
+                  engineName,
+                  tabId: EngineViewTabs.PREVIEW,
+                })}
+                color="text"
+              >
+                <EuiFlexGroup alignItems="center">
+                  <EuiIcon size="xxl" type="documents" color="#98A2B3" />
+                  <EuiStat
+                    titleSize="l"
+                    isLoading={isLoadingEngine}
+                    title={documentsCount.toLocaleString()}
+                    description={i18n.translate(
+                      'xpack.enterpriseSearch.content.engine.overview.documentsDescription',
+                      { defaultMessage: 'Documents' }
+                    )}
+                    titleColor="primary"
+                  />
+                </EuiFlexGroup>
+              </EuiLinkTo>
             </EuiFlexItem>
             <EuiFlexItem>
-              <EuiFlexGroup alignItems="center">
-                <EuiIcon size="xxl" type="documents" color="#98A2B3" />
-                <EuiStat
-                  titleSize="l"
-                  isLoading={false}
-                  title={fieldsCount.toLocaleString()}
-                  description={i18n.translate(
-                    'xpack.enterpriseSearch.content.engine.overview.fieldsDescription',
-                    { defaultMessage: 'Fields' }
-                  )}
-                  titleColor="primary"
-                />
-              </EuiFlexGroup>
+              <EuiLinkTo
+                to={generateEncodedPath(ENGINE_TAB_PATH, {
+                  engineName,
+                  tabId: EngineViewTabs.SCHEMA,
+                })}
+                color="text"
+              >
+                <EuiFlexGroup alignItems="center">
+                  <EuiIcon size="xxl" type="documents" color="#98A2B3" />
+                  <EuiStat
+                    titleSize="l"
+                    isLoading={false}
+                    title={fieldsCount.toLocaleString()}
+                    description={i18n.translate(
+                      'xpack.enterpriseSearch.content.engine.overview.fieldsDescription',
+                      { defaultMessage: 'Fields' }
+                    )}
+                    titleColor="primary"
+                  />
+                </EuiFlexGroup>
+              </EuiLinkTo>
             </EuiFlexItem>
           </EuiFlexGroup>
         </EuiPanel>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_overview.tsx
@@ -48,7 +48,7 @@ export const EngineOverview: React.FC = () => {
                 <EuiIcon size="xxl" type="visTable" color="#98A2B3" />
                 <EuiStat
                   titleSize="l"
-                  isLoading={!engineData}
+                  isLoading={isLoadingEngine}
                   title={`${indicesCount}`}
                   description={i18n.translate(
                     'xpack.enterpriseSearch.content.engine.overview.indicesDescription',
@@ -63,7 +63,7 @@ export const EngineOverview: React.FC = () => {
                 <EuiIcon size="xxl" type="documents" color="#98A2B3" />
                 <EuiStat
                   titleSize="l"
-                  isLoading={!engineData}
+                  isLoading={isLoadingEngine}
                   title={`${documentsCount}`}
                   description={i18n.translate(
                     'xpack.enterpriseSearch.content.engine.overview.documentsDescription',
@@ -73,20 +73,6 @@ export const EngineOverview: React.FC = () => {
                 />
               </EuiFlexGroup>
             </EuiFlexItem>
-            {/* <EuiFlexItem>
-              <EuiFlexGroup alignItems="center">
-                <EuiIcon size="xxl" type="kqlField" color="#98A2B3" />
-                <EuiStat
-                  titleSize="l"
-                  isLoading
-                  description={i18n.translate(
-                    'xpack.enterpriseSearch.content.engine.overview.fieldsDescription',
-                    { defaultMessage: 'Fields' }
-                  )}
-                  titleColor="primary"
-                />
-              </EuiFlexGroup>
-            </EuiFlexItem> */}
           </EuiFlexGroup>
         </EuiPanel>
       </>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_overview.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useMemo } from 'react';
+import React from 'react';
 
 import { useValues } from 'kea';
 
@@ -15,17 +15,12 @@ import { i18n } from '@kbn/i18n';
 import { EngineViewTabs } from '../../routes';
 import { EnterpriseSearchEnginesPageTemplate } from '../layout/engines_page_template';
 
+import { EngineOverviewLogic } from './engine_overview_logic';
 import { EngineViewHeaderActions } from './engine_view_header_actions';
-import { EngineViewLogic } from './engine_view_logic';
 
 export const EngineOverview: React.FC = () => {
-  const { engineName, engineData, isLoadingEngine } = useValues(EngineViewLogic);
-
-  const indicesCount = engineData?.indices?.length ?? 0;
-  const documentsCount = useMemo(
-    () => engineData?.indices?.reduce((sum, { count }) => sum + count, 0) ?? 0,
-    [engineData]
-  );
+  const { engineName, indicesCount, documentsCount, fieldsCount, isLoadingEngine } =
+    useValues(EngineOverviewLogic);
 
   return (
     <EnterpriseSearchEnginesPageTemplate
@@ -68,6 +63,21 @@ export const EngineOverview: React.FC = () => {
                   description={i18n.translate(
                     'xpack.enterpriseSearch.content.engine.overview.documentsDescription',
                     { defaultMessage: 'Documents' }
+                  )}
+                  titleColor="primary"
+                />
+              </EuiFlexGroup>
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiFlexGroup alignItems="center">
+                <EuiIcon size="xxl" type="documents" color="#98A2B3" />
+                <EuiStat
+                  titleSize="l"
+                  isLoading={false}
+                  title={fieldsCount.toLocaleString()}
+                  description={i18n.translate(
+                    'xpack.enterpriseSearch.content.engine.overview.fieldsDescription',
+                    { defaultMessage: 'Fields' }
                   )}
                   titleColor="primary"
                 />

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_overview_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_overview_logic.test.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { LogicMounter } from '../../../__mocks__/kea_logic';
+
+import { Status } from '../../../../../common/types/api';
+
+import { EngineOverviewLogic, EngineOverviewValues } from './engine_overview_logic';
+
+const DEFAULT_VALUES: EngineOverviewValues = {
+  documentsCount: 0,
+  engineData: undefined,
+  engineFieldCapabilitiesApiStatus: Status.IDLE,
+  engineFieldCapabilitiesData: undefined,
+  engineName: '',
+  fieldsCount: 0,
+  indices: [],
+  indicesCount: 0,
+  isLoadingEngine: true,
+};
+
+describe('EngineOverviewLogic', () => {
+  const { mount } = new LogicMounter(EngineOverviewLogic);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useRealTimers();
+
+    mount();
+  });
+
+  it('has expected default values', () => {
+    expect(EngineOverviewLogic.values).toEqual(DEFAULT_VALUES);
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_overview_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_overview_logic.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { kea, MakeLogicType } from 'kea';
+
+import { Status } from '../../../../../common/types/api';
+import { EnterpriseSearchEngineIndex } from '../../../../../common/types/engines';
+
+import { FetchEngineFieldCapabilitiesApiLogic } from '../../api/engines/fetch_engine_field_capabilities_api_logic';
+
+import { EngineNameLogic } from './engine_name_logic';
+import { EngineViewLogic } from './engine_view_logic';
+
+export interface EngineOverviewActions {
+  fetchEngineFieldCapabilities: typeof FetchEngineFieldCapabilitiesApiLogic.actions.makeRequest;
+}
+export interface EngineOverviewValues {
+  documentsCount: number;
+  engineData: typeof EngineViewLogic.values.engineData;
+  engineFieldCapabilitiesApiStatus: typeof FetchEngineFieldCapabilitiesApiLogic.values.status;
+  engineFieldCapabilitiesData: typeof FetchEngineFieldCapabilitiesApiLogic.values.data;
+  engineName: typeof EngineNameLogic.values.engineName;
+  fieldsCount: number;
+  indices: EnterpriseSearchEngineIndex[];
+  indicesCount: number;
+  isLoadingEngine: typeof EngineViewLogic.values.isLoadingEngine;
+}
+
+export const EngineOverviewLogic = kea<MakeLogicType<EngineOverviewValues, EngineOverviewActions>>({
+  actions: {},
+  connect: {
+    actions: [
+      EngineNameLogic,
+      ['setEngineName'],
+      FetchEngineFieldCapabilitiesApiLogic,
+      ['makeRequest as fetchEngineFieldCapabilities'],
+    ],
+    values: [
+      EngineNameLogic,
+      ['engineName'],
+      EngineViewLogic,
+      ['engineData', 'isLoadingEngine'],
+      FetchEngineFieldCapabilitiesApiLogic,
+      ['data as engineFieldCapabilitiesData', 'status as engineFieldCapabilitiesApiStatus'],
+    ],
+  },
+  events: ({ actions, values }) => ({
+    afterMount: () => {
+      if (values.engineFieldCapabilitiesApiStatus !== Status.SUCCESS && !!values.engineName) {
+        actions.fetchEngineFieldCapabilities({
+          engineName: values.engineName,
+        });
+      }
+    },
+  }),
+  listeners: ({ actions }) => ({
+    setEngineName: ({ engineName }) => {
+      actions.fetchEngineFieldCapabilities({ engineName });
+    },
+  }),
+  path: ['enterprise_search', 'content', 'engine_overview_logic'],
+  reducers: {},
+  selectors: ({ selectors }) => ({
+    documentsCount: [
+      () => [selectors.indices],
+      (indices: EngineOverviewValues['indices']) =>
+        indices.reduce((sum, { count }) => sum + count, 0),
+    ],
+    fieldsCount: [
+      () => [selectors.engineFieldCapabilitiesData],
+      (engineFieldCapabilitiesData: EngineOverviewValues['engineFieldCapabilitiesData']) =>
+        Object.values(engineFieldCapabilitiesData?.field_capabilities?.fields ?? {}).filter(
+          (value) => !Object.values(value).some((field) => !!field.metadata_field)
+        ).length,
+    ],
+    indices: [
+      () => [selectors.engineData],
+      (engineData: EngineOverviewValues['engineData']) => engineData?.indices ?? [],
+    ],
+    indicesCount: [
+      () => [selectors.indices],
+      (indices: EngineOverviewValues['indices']) => indices.length,
+    ],
+  }),
+});

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_view.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_view.tsx
@@ -21,6 +21,7 @@ import { EnterpriseSearchEnginesPageTemplate } from '../layout/engines_page_temp
 import { EngineAPI } from './engine_api/engine_api';
 import { EngineError } from './engine_error';
 import { EngineIndices } from './engine_indices';
+import { EngineOverview } from './engine_overview';
 import { EngineViewHeaderActions } from './engine_view_header_actions';
 import { EngineViewLogic } from './engine_view_logic';
 import { EngineHeaderDocsAction } from './header_docs_action';
@@ -66,6 +67,11 @@ export const EngineView: React.FC = () => {
         <DeleteEngineModal engineName={engineName} onClose={closeDeleteEngineModal} />
       ) : null}
       <Switch>
+        <Route
+          exact
+          path={`${ENGINE_PATH}/${EngineViewTabs.OVERVIEW}`}
+          component={EngineOverview}
+        />
         <Route exact path={`${ENGINE_PATH}/${EngineViewTabs.INDICES}`} component={EngineIndices} />
         <Route exact path={`${ENGINE_PATH}/${EngineViewTabs.API}`} component={EngineAPI} />
         <Route // TODO: remove this route when all engine view routes are implemented, replace with a 404 route

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_view_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_view_logic.ts
@@ -39,6 +39,10 @@ export interface EngineViewValues {
 }
 
 export const EngineViewLogic = kea<MakeLogicType<EngineViewValues, EngineViewActions>>({
+  actions: {
+    closeDeleteEngineModal: true,
+    openDeleteEngineModal: true,
+  },
   connect: {
     actions: [
       FetchEngineApiLogic,
@@ -52,10 +56,6 @@ export const EngineViewLogic = kea<MakeLogicType<EngineViewValues, EngineViewAct
       FetchEngineApiLogic,
       ['data as engineData', 'status as fetchEngineApiStatus', 'error as fetchEngineApiError'],
     ],
-  },
-  actions: {
-    closeDeleteEngineModal: true,
-    openDeleteEngineModal: true,
   },
   listeners: ({ actions }) => ({
     deleteSuccess: () => {

--- a/x-pack/plugins/enterprise_search/server/routes/enterprise_search/engines.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/enterprise_search/engines.ts
@@ -128,4 +128,14 @@ export function registerEnginesRoutes({
       path: '/api/engines/:engine_name/_search',
     })
   );
+
+  router.get(
+    {
+      path: '/internal/enterprise_search/engines/{engine_name}/field_capabilities',
+      validate: { params: schema.object({ engine_name: schema.string() }) },
+    },
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/api/engines/:engine_name/field_capabilities',
+    })
+  );
 }


### PR DESCRIPTION
## Summary

Adds Engine overview page. Includes panel with document and index counts in stats components

<img width="1501" alt="image" src="https://user-images.githubusercontent.com/1699281/216103567-84b8e4f6-d234-4ba1-b346-01e681505caa.png">




### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)



### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
