### PR TITLE
Remove unused/obsolete source type field from frames metadata

### DIFF
--- a/x-pack/plugins/profiling/common/__fixtures__/stacktraces.ts
+++ b/x-pack/plugins/profiling/common/__fixtures__/stacktraces.ts
@@ -143,7 +143,6 @@ const defaultStackFrame = {
   FunctionName: '',
   FunctionOffset: 0,
   LineNumber: 0,
-  SourceType: 0,
 };
 
 export const stackFrames = new Map([
@@ -154,12 +153,11 @@ export const stackFrames = new Map([
       FunctionName: 'java.lang.Runnable java.util.concurrent.ThreadPoolExecutor.getTask()',
       FunctionOffset: 26,
       LineNumber: 1061,
-      SourceType: 5,
     },
   ],
   [
     frameID.B,
-    { FileName: '', FunctionName: 'sock_sendmsg', FunctionOffset: 0, LineNumber: 0, SourceType: 0 },
+    { FileName: '', FunctionName: 'sock_sendmsg', FunctionOffset: 0, LineNumber: 0},
   ],
   [frameID.C, defaultStackFrame],
   [frameID.D, defaultStackFrame],
@@ -172,7 +170,7 @@ export const stackFrames = new Map([
   [frameID.K, defaultStackFrame],
   [
     frameID.L,
-    { FileName: '', FunctionName: 'udp_sendmsg', FunctionOffset: 0, LineNumber: 0, SourceType: 0 },
+    { FileName: '', FunctionName: 'udp_sendmsg', FunctionOffset: 0, LineNumber: 0},
   ],
   [frameID.M, defaultStackFrame],
   [frameID.N, defaultStackFrame],

--- a/x-pack/plugins/profiling/common/__fixtures__/stacktraces.ts
+++ b/x-pack/plugins/profiling/common/__fixtures__/stacktraces.ts
@@ -155,10 +155,7 @@ export const stackFrames = new Map([
       LineNumber: 1061,
     },
   ],
-  [
-    frameID.B,
-    { FileName: '', FunctionName: 'sock_sendmsg', FunctionOffset: 0, LineNumber: 0},
-  ],
+  [frameID.B, { FileName: '', FunctionName: 'sock_sendmsg', FunctionOffset: 0, LineNumber: 0 }],
   [frameID.C, defaultStackFrame],
   [frameID.D, defaultStackFrame],
   [frameID.E, defaultStackFrame],
@@ -168,10 +165,7 @@ export const stackFrames = new Map([
   [frameID.I, defaultStackFrame],
   [frameID.J, defaultStackFrame],
   [frameID.K, defaultStackFrame],
-  [
-    frameID.L,
-    { FileName: '', FunctionName: 'udp_sendmsg', FunctionOffset: 0, LineNumber: 0},
-  ],
+  [frameID.L, { FileName: '', FunctionName: 'udp_sendmsg', FunctionOffset: 0, LineNumber: 0 }],
   [frameID.M, defaultStackFrame],
   [frameID.N, defaultStackFrame],
   [frameID.O, defaultStackFrame],

--- a/x-pack/plugins/profiling/common/elasticsearch.ts
+++ b/x-pack/plugins/profiling/common/elasticsearch.ts
@@ -24,7 +24,6 @@ export enum ProfilingESField {
   StackframeFunctionName = 'Stackframe.function.name',
   StackframeLineNumber = 'Stackframe.line.number',
   StackframeFunctionOffset = 'Stackframe.function.offset',
-  StackframeSourceType = 'Stackframe.source.type',
   ExecutableBuildID = 'Executable.build.id',
   ExecutableFileName = 'Executable.file.name',
 }
@@ -83,7 +82,6 @@ export type ProfilingStackFrame = DedotObject<{
   [ProfilingESField.StackframeFunctionName]: string;
   [ProfilingESField.StackframeLineNumber]: number;
   [ProfilingESField.StackframeFunctionOffset]: number;
-  [ProfilingESField.StackframeSourceType]: number;
 }>;
 
 export type ProfilingExecutable = DedotObject<{

--- a/x-pack/plugins/profiling/common/profiling.ts
+++ b/x-pack/plugins/profiling/common/profiling.ts
@@ -103,7 +103,6 @@ export interface StackFrame {
   FunctionName: string;
   FunctionOffset: number;
   LineNumber: number;
-  SourceType: number;
 }
 
 export const emptyStackFrame: StackFrame = {
@@ -111,7 +110,6 @@ export const emptyStackFrame: StackFrame = {
   FunctionName: '',
   FunctionOffset: 0,
   LineNumber: 0,
-  SourceType: 0,
 };
 
 export interface Executable {
@@ -157,7 +155,6 @@ export interface StackFrameMetadata {
   // unused atm due to lack of symbolization metadata
   SourcePackageURL: string;
   // unused atm due to lack of symbolization metadata
-  SourceType: number;
 }
 
 export function createStackFrameMetadata(
@@ -179,7 +176,6 @@ export function createStackFrameMetadata(
   metadata.SourceFilename = options.SourceFilename ?? '';
   metadata.SourcePackageHash = options.SourcePackageHash ?? '';
   metadata.SourcePackageURL = options.SourcePackageURL ?? '';
-  metadata.SourceType = options.SourceType ?? 0;
 
   // Unknown/invalid offsets are currently set to 0.
   //

--- a/x-pack/plugins/profiling/common/stack_traces.ts
+++ b/x-pack/plugins/profiling/common/stack_traces.ts
@@ -27,7 +27,6 @@ interface ProfilingStackFrame {
   ['function_name']: string;
   ['function_offset']: number | undefined;
   ['line_number']: number | undefined;
-  ['source_type']: number | undefined;
 }
 
 interface ProfilingStackFrames {

--- a/x-pack/plugins/profiling/server/routes/search_stacktraces.test.ts
+++ b/x-pack/plugins/profiling/server/routes/search_stacktraces.test.ts
@@ -59,7 +59,6 @@ describe('Stack trace response operations', () => {
           function_name: 'pthread_create',
           function_offset: 0,
           line_number: 0,
-          source_type: 5,
         },
       },
       executables: {
@@ -89,7 +88,6 @@ describe('Stack trace response operations', () => {
             FunctionName: 'pthread_create',
             FunctionOffset: 0,
             LineNumber: 0,
-            SourceType: 5,
           },
         ],
       ]),
@@ -134,7 +132,6 @@ describe('Stack trace response operations', () => {
           function_name: 'pthread_create',
           function_offset: undefined,
           line_number: undefined,
-          source_type: undefined,
         },
       },
       executables: {
@@ -164,7 +161,6 @@ describe('Stack trace response operations', () => {
             FunctionName: 'pthread_create',
             FunctionOffset: null,
             LineNumber: null,
-            SourceType: null,
           },
         ],
       ]),

--- a/x-pack/plugins/profiling/server/routes/search_stacktraces.ts
+++ b/x-pack/plugins/profiling/server/routes/search_stacktraces.ts
@@ -40,7 +40,6 @@ export function decodeStackTraceResponse(response: StackTraceResponse) {
       FunctionName: value.function_name,
       FunctionOffset: value.function_offset,
       LineNumber: value.line_number,
-      SourceType: value.source_type,
     } as StackFrame);
   }
 

--- a/x-pack/plugins/profiling/server/routes/stacktrace.ts
+++ b/x-pack/plugins/profiling/server/routes/stacktrace.ts
@@ -334,7 +334,6 @@ export async function mgetStackFrames({
         FunctionName: frame._source!.Stackframe.function?.name,
         FunctionOffset: frame._source!.Stackframe.function?.offset,
         LineNumber: frame._source!.Stackframe.line?.number,
-        SourceType: frame._source!.Stackframe.source?.type,
       };
       stackFrames.set(frame._id, stackFrame);
       frameLRU.set(frame._id, stackFrame);


### PR DESCRIPTION
## Summary
We don't use the source type for frames, but parse it from the query response.

In the near future, we remove this field completely from the `profiling-stackframes` index, because we have no reliable way to determine the type of source code for a frame of type 'native' or 'kernel'.
For interpreted languages we have this information stored in the `profiling-stacktraces` index.

Issue: https://github.com/elastic/prodfiler/issues/2944

<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->