### PR TITLE
[TIP] Ensure non-primitive values are not rendered

### DIFF
--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/utils/unwrap_value.test.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/utils/unwrap_value.test.ts
@@ -17,5 +17,9 @@ describe('unwrapValue()', () => {
     expect(
       unwrapValue({ fields: { [RawIndicatorFieldId.Type]: ['ip'] } }, RawIndicatorFieldId.Type)
     ).toEqual('ip');
+
+    expect(
+      unwrapValue({ fields: { [RawIndicatorFieldId.Type]: [{}] } }, RawIndicatorFieldId.Type)
+    ).toEqual(null);
   });
 });

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/utils/unwrap_value.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/utils/unwrap_value.ts
@@ -5,20 +5,24 @@
  * 2.0.
  */
 
-import { Indicator, RawIndicatorFieldId } from '../../../../common/types/indicator';
+type IndicatorLike = Record<'fields', Record<string, unknown>> | null | undefined;
 
 /**
  * Unpacks field value from raw indicator fields. Will return null if fields are missing entirely
  * or there is no record for given `fieldId`
  */
-export const unwrapValue = <T = string>(
-  indicator: Partial<Indicator> | null | undefined,
-  fieldId: RawIndicatorFieldId
-): T | null => {
+export const unwrapValue = <T = string>(indicator: IndicatorLike, fieldId: string): T | null => {
   if (!indicator) {
     return null;
   }
 
-  const valueArray = indicator.fields?.[fieldId];
-  return Array.isArray(valueArray) ? (valueArray[0] as T) : null;
+  const fieldValues = indicator.fields?.[fieldId];
+
+  if (!Array.isArray(fieldValues)) {
+    return null;
+  }
+
+  const firstValue = fieldValues[0];
+
+  return typeof firstValue === 'object' ? null : (firstValue as T);
 };


### PR DESCRIPTION
## Summary

Should fix https://github.com/elastic/security-team/issues/5856

Right now, it will just render the complex fields as empty. Should these be ommited or something?

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->