### PR TITLE
Define/encapsulate guide states a little more distinctly

### DIFF
--- a/examples/guided_onboarding_example/public/components/main.tsx
+++ b/examples/guided_onboarding_example/public/components/main.tsx
@@ -75,8 +75,8 @@ export const Main = (props: MainProps) => {
     }
   }, [guidesState, setActiveGuide]);
 
-  const activateGuide = async (guideId: GuideId, guideState?: GuideState) => {
-    const response = await guidedOnboardingApi?.activateGuide(guideId, guideState);
+  const activateGuideDefaultState = async (guideId: GuideId, guideState?: GuideState) => {
+    const response = await guidedOnboardingApi?.activateGuideDefaultState(guideId, guideState);
 
     if (response) {
       notifications.toasts.addSuccess(
@@ -225,7 +225,7 @@ export const Main = (props: MainProps) => {
             return (
               <EuiFlexItem>
                 <EuiButton
-                  onClick={() => activateGuide(guideId, guideState)}
+                  onClick={() => activateGuideDefaultState(guideId, guideState)}
                   fill
                   disabled={guideState?.status === 'complete'}
                 >

--- a/packages/kbn-guided-onboarding/src/components/landing_page/__snapshots__/guide_card.test.tsx.snap
+++ b/packages/kbn-guided-onboarding/src/components/landing_page/__snapshots__/guide_card.test.tsx.snap
@@ -1,0 +1,51 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`guide cards snapshots should render card 1`] = `
+<EuiCard
+  betaBadgeProps={
+    Object {
+      "label": "search",
+    }
+  }
+  css={
+    Object {
+      "map": undefined,
+      "name": "9w6uxv",
+      "next": undefined,
+      "styles": "
+  position: relative;
+  min-height: 110px;
+  width: 380px;
+  .euiCard__content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+  }
+",
+      "toString": [Function],
+    }
+  }
+  description={<React.Fragment />}
+  hasBorder={false}
+  isDisabled={false}
+  onClick={[Function]}
+  title={
+    <React.Fragment>
+      <EuiSpacer
+        size="s"
+      />
+      <h3
+        style={
+          Object {
+            "fontWeight": 600,
+          }
+        }
+      >
+        test_title
+      </h3>
+    </React.Fragment>
+  }
+  titleSize="xs"
+/>
+`;

--- a/packages/kbn-guided-onboarding/src/components/landing_page/__snapshots__/guide_card.test.tsx.snap
+++ b/packages/kbn-guided-onboarding/src/components/landing_page/__snapshots__/guide_card.test.tsx.snap
@@ -26,6 +26,7 @@ exports[`guide cards snapshots should render card 1`] = `
       "toString": [Function],
     }
   }
+  data-test-subj="test_telemetry_id"
   description={<React.Fragment />}
   hasBorder={false}
   isDisabled={false}

--- a/packages/kbn-guided-onboarding/src/components/landing_page/__snapshots__/guide_cards.test.tsx.snap
+++ b/packages/kbn-guided-onboarding/src/components/landing_page/__snapshots__/guide_cards.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`guide cards snapshots should render all cards 1`] = `
     key="0"
   >
     <GuideCard
-      activateGuide={[MockFunction]}
+      activateGuideDefaultState={[MockFunction]}
       activeFilter="all"
       card={
         Object {
@@ -42,7 +42,7 @@ exports[`guide cards snapshots should render all cards 1`] = `
     key="1"
   >
     <GuideCard
-      activateGuide={[MockFunction]}
+      activateGuideDefaultState={[MockFunction]}
       activeFilter="all"
       card={
         Object {
@@ -68,7 +68,7 @@ exports[`guide cards snapshots should render all cards 1`] = `
     key="2"
   >
     <GuideCard
-      activateGuide={[MockFunction]}
+      activateGuideDefaultState={[MockFunction]}
       activeFilter="all"
       card={
         Object {
@@ -99,7 +99,7 @@ exports[`guide cards snapshots should render all cards 1`] = `
     key="3"
   >
     <GuideCard
-      activateGuide={[MockFunction]}
+      activateGuideDefaultState={[MockFunction]}
       activeFilter="all"
       card={
         Object {
@@ -122,7 +122,7 @@ exports[`guide cards snapshots should render all cards 1`] = `
     key="4"
   >
     <GuideCard
-      activateGuide={[MockFunction]}
+      activateGuideDefaultState={[MockFunction]}
       activeFilter="all"
       card={
         Object {
@@ -156,7 +156,7 @@ exports[`guide cards snapshots should render all cards 1`] = `
     key="5"
   >
     <GuideCard
-      activateGuide={[MockFunction]}
+      activateGuideDefaultState={[MockFunction]}
       activeFilter="all"
       card={
         Object {
@@ -190,7 +190,7 @@ exports[`guide cards snapshots should render all cards 1`] = `
     key="6"
   >
     <GuideCard
-      activateGuide={[MockFunction]}
+      activateGuideDefaultState={[MockFunction]}
       activeFilter="all"
       card={
         Object {
@@ -221,7 +221,7 @@ exports[`guide cards snapshots should render all cards 1`] = `
     key="7"
   >
     <GuideCard
-      activateGuide={[MockFunction]}
+      activateGuideDefaultState={[MockFunction]}
       activeFilter="all"
       card={
         Object {
@@ -247,7 +247,7 @@ exports[`guide cards snapshots should render all cards 1`] = `
     key="8"
   >
     <GuideCard
-      activateGuide={[MockFunction]}
+      activateGuideDefaultState={[MockFunction]}
       activeFilter="all"
       card={
         Object {
@@ -281,7 +281,7 @@ exports[`guide cards snapshots should render all cards 1`] = `
     key="9"
   >
     <GuideCard
-      activateGuide={[MockFunction]}
+      activateGuideDefaultState={[MockFunction]}
       activeFilter="all"
       card={
         Object {

--- a/packages/kbn-guided-onboarding/src/components/landing_page/guide_card.test.tsx
+++ b/packages/kbn-guided-onboarding/src/components/landing_page/guide_card.test.tsx
@@ -1,0 +1,69 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+import { mount, shallow } from 'enzyme';
+
+import { GuideCard } from './guide_card';
+import { EuiCard } from '@elastic/eui';
+import { act } from 'react-dom/test-utils';
+import { activateGuideMock, navigateToAppGuideMock } from '../../mocks';
+
+describe('guide cards', () => {
+  describe('snapshots', () => {
+    test('should render card', async () => {
+      const component = await shallow(<GuideCard {...activateGuideMock} />);
+      expect(component).toMatchSnapshot();
+    });
+  });
+
+  describe('Navigation', () => {
+    test('Should activate guide default state if has guide ID', async () => {
+      const props = {
+        ...activateGuideMock,
+        activateGuideDefaultState: jest.fn(),
+      };
+      const component = await mount(<GuideCard {...props} />);
+      const { activateGuideDefaultState, guidesState } = props;
+      const card = component.find(EuiCard);
+
+      await act(async () => {
+        // @ts-ignore
+        card.props().onClick({});
+      });
+      component.update();
+
+      expect(activateGuideDefaultState).toHaveBeenCalledTimes(1);
+      expect(activateGuideDefaultState).toBeCalledWith(guidesState[0].guideId, guidesState[0]);
+    });
+
+    test('Should navigate to guide path if navigation path provided', async () => {
+      const props = {
+        ...navigateToAppGuideMock,
+        activateGuideDefaultState: jest.fn(),
+      };
+      const component = await mount(<GuideCard {...props} />);
+      const card = component.find(EuiCard);
+
+      await act(async () => {
+        // @ts-ignore
+        card.props().onClick({});
+      });
+      component.update();
+
+      const { activateGuideDefaultState } = props;
+      const {
+        navigateToApp,
+        card: { navigateTo },
+      } = navigateToAppGuideMock;
+      expect(activateGuideDefaultState).toHaveBeenCalledTimes(0);
+      expect(navigateToApp).toHaveBeenCalledTimes(1);
+      expect(navigateToApp).toBeCalledWith(navigateTo?.appId, { path: navigateTo?.path });
+    });
+  });
+});

--- a/packages/kbn-guided-onboarding/src/components/landing_page/guide_card.tsx
+++ b/packages/kbn-guided-onboarding/src/components/landing_page/guide_card.tsx
@@ -58,7 +58,7 @@ const getProgressLabel = (guideState: GuideState | undefined): string | undefine
 export const GuideCard = ({
   card,
   guidesState,
-  activateGuide,
+  activateGuideDefaultState,
   navigateToApp,
   activeFilter,
 }: GuideCardsProps & { card: GuideCardConstants }) => {
@@ -72,14 +72,14 @@ export const GuideCard = ({
   const onClick = useCallback(async () => {
     setIsLoading(true);
     if (card.guideId) {
-      await activateGuide(card.guideId, guideState);
+      await activateGuideDefaultState(card.guideId, guideState);
     } else if (card.navigateTo) {
       await navigateToApp(card.navigateTo?.appId, {
         path: card.navigateTo.path,
       });
     }
     setIsLoading(false);
-  }, [activateGuide, card.guideId, card.navigateTo, guideState, navigateToApp]);
+  }, [activateGuideDefaultState, card.guideId, card.navigateTo, guideState, navigateToApp]);
 
   const isHighlighted = activeFilter === 'all' || activeFilter === card.solution;
   const isComplete = guideState && guideState.status === 'complete';

--- a/packages/kbn-guided-onboarding/src/components/landing_page/guide_cards.test.tsx
+++ b/packages/kbn-guided-onboarding/src/components/landing_page/guide_cards.test.tsx
@@ -12,7 +12,7 @@ import { shallow } from 'enzyme';
 import { GuideCards, GuideCardsProps } from './guide_cards';
 
 const defaultProps: GuideCardsProps = {
-  activateGuide: jest.fn(),
+  activateGuideDefaultState: jest.fn(),
   navigateToApp: jest.fn(),
   activeFilter: 'all',
   guidesState: [],

--- a/packages/kbn-guided-onboarding/src/components/landing_page/guide_cards.tsx
+++ b/packages/kbn-guided-onboarding/src/components/landing_page/guide_cards.tsx
@@ -20,7 +20,7 @@ import { GuideCard } from './guide_card';
 export type GuideCardSolutions = 'search' | 'observability' | 'security';
 
 export interface GuideCardsProps {
-  activateGuide: (guideId: GuideId, guideState?: GuideState) => Promise<void>;
+  activateGuideDefaultState: (guideId: GuideId, guideState?: GuideState) => Promise<void>;
   navigateToApp: ApplicationStart['navigateToApp'];
   activeFilter: GuideFilterValues;
   guidesState: GuideState[];

--- a/packages/kbn-guided-onboarding/src/mocks.ts
+++ b/packages/kbn-guided-onboarding/src/mocks.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { GuideCardSolutions, GuideCardsProps } from './components/landing_page/guide_cards';
+import { GuideCardConstants } from './components/landing_page/guide_cards.constants';
+import { GuideId, GuideStatus, GuideStepIds, StepStatus } from '..';
+
+const guideId: GuideId = 'testGuide';
+const status: GuideStatus = 'not_started';
+const stepStatus: StepStatus = 'inactive';
+const testGuideId: GuideStepIds = 'step1';
+
+export const activateGuideMock: GuideCardsProps & { card: GuideCardConstants } = {
+  activateGuideDefaultState: jest.fn(),
+  navigateToApp: jest.fn(),
+  activeFilter: 'all',
+  guidesState: [
+    {
+      guideId,
+      status,
+      isActive: false,
+      steps: [
+        {
+          id: testGuideId,
+          status: stepStatus,
+        },
+      ],
+    },
+  ],
+  card: {
+    solution: 'search' as GuideCardSolutions,
+    title: 'test_title',
+    guideId: 'testGuide',
+    telemetryId: 'test_telemetry_id',
+    order: 1,
+  },
+};
+
+export const navigateToAppGuideMock: GuideCardsProps & { card: GuideCardConstants } = {
+  ...activateGuideMock,
+  card: {
+    solution: 'search' as GuideCardSolutions,
+    title: 'test_title',
+    telemetryId: 'test_telemetry_id',
+    order: 1,
+    navigateTo: {
+      appId: 'test_appId',
+      path: 'path/to/app',
+    },
+  },
+};

--- a/src/plugins/guided_onboarding/public/components/guide_button.tsx
+++ b/src/plugins/guided_onboarding/public/components/guide_button.tsx
@@ -74,24 +74,34 @@ export const GuideButton = ({
           })}
     </EuiButton>
   );
+
+  const isGuideInActiveState = (): boolean => {
+    if (pluginState && pluginState.activeGuide) {
+      const { status, isActive } = pluginState.activeGuide;
+
+      if (!isActive || status === 'not_started') {
+        return false;
+      }
+
+      const { steps } = pluginState.activeGuide;
+
+      return (
+        steps.filter((step) => {
+          return step.status === 'inactive';
+        }).length !== steps.length
+      );
+    }
+
+    return false;
+  };
+
   // if there is no active guide
-  if (
-    !pluginState ||
-    !pluginState.activeGuide ||
-    !pluginState.activeGuide.isActive ||
-    // the guide has not started yet when the user just looks at the guide
-    // see https://github.com/elastic/kibana/issues/148912 for more context
-    pluginState.activeGuide.status === 'not_started'
-  ) {
+  if (!isGuideInActiveState()) {
     // if still active period and the user has not started a guide or skipped the guide,
     // display the button that redirects to the landing page
     if (
       pluginState?.isActivePeriod &&
-      (pluginState?.status === 'not_started' ||
-        pluginState?.status === 'skipped' ||
-        // plugin state 'in_progress' without an active guide is when the guide has not started yet
-        // see https://github.com/elastic/kibana/issues/148912 for context
-        pluginState.status === 'in_progress')
+      (pluginState?.status === 'not_started' || pluginState?.status === 'skipped')
     ) {
       return (
         <EuiButton

--- a/src/plugins/guided_onboarding/public/components/guide_panel.test.tsx
+++ b/src/plugins/guided_onboarding/public/components/guide_panel.test.tsx
@@ -95,7 +95,7 @@ describe('Guided setup', () => {
 
   describe('Button component', () => {
     describe('when a guide is in default state', () => {
-      it('button is enabled', async () => {
+      it('redirect button is enabled', async () => {
         const { exists, find } = await setupComponentWithPluginStateMock(
           httpClient,
           mockPluginStateInDefaultGuideState

--- a/src/plugins/guided_onboarding/public/components/guide_panel.test.tsx
+++ b/src/plugins/guided_onboarding/public/components/guide_panel.test.tsx
@@ -184,7 +184,7 @@ describe('Guided setup', () => {
 
         test('shows redirect button when a guide has been viewed but not started', async () => {
           const { exists } = await setupComponentWithPluginStateMock(httpClient, {
-            status: 'in_progress',
+            status: 'not_started',
             isActivePeriod: true,
             activeGuide: { ...testGuideStep1InProgressState, status: 'not_started' },
           });
@@ -453,6 +453,7 @@ describe('Guided setup', () => {
         // The guide panel should remain open after marking a step done
         expect(exists('guidePanel')).toBe(true);
         // Dependent on the Test guide config, which expects step 3 to start
+        // expect(component.debug()).toBe(0)
         expect(find('onboarding--stepButton--testGuide--step3').text()).toEqual('Start');
       });
 

--- a/src/plugins/guided_onboarding/public/components/guide_panel.test.tsx
+++ b/src/plugins/guided_onboarding/public/components/guide_panel.test.tsx
@@ -29,6 +29,8 @@ import {
   readyToCompleteGuideState,
   mockPluginStateNotStarted,
   mockPluginStateInProgress,
+  mockPluginStateInDefaultGuideState,
+  testGuideDefaultState,
 } from '../services/api.mocks';
 import { GuidePanel } from './guide_panel';
 import { IUiSettingsClient } from '@kbn/core/public';
@@ -92,6 +94,18 @@ describe('Guided setup', () => {
   });
 
   describe('Button component', () => {
+    describe('when a guide is in default state', () => {
+      it('button is enabled', async () => {
+        const { exists, find } = await setupComponentWithPluginStateMock(
+          httpClient,
+          mockPluginStateInDefaultGuideState
+        );
+        expect(exists('guideButton')).toBe(false);
+        expect(exists('guideButtonRedirect')).toBe(true);
+        expect(find('guideButtonRedirect').text()).toEqual('Setup guides');
+      });
+    });
+
     describe('when a guide is active', () => {
       it('button is enabled', async () => {
         const { exists, find } = await setupComponentWithPluginStateMock(
@@ -377,11 +391,7 @@ describe('Guided setup', () => {
 
       test('can start a step if step has not been started', async () => {
         httpClient.put.mockResolvedValueOnce({
-          pluginState: {
-            status: 'in_progress',
-            isActivePeriod: true,
-            activeGuide: testGuideStep1InProgressState,
-          },
+          pluginState: testGuideDefaultState,
         });
         testBed = await setupComponentWithPluginStateMock(httpClient, mockPluginStateInProgress);
         const { exists, find, component } = testBed;

--- a/src/plugins/guided_onboarding/public/components/guide_panel.tsx
+++ b/src/plugins/guided_onboarding/public/components/guide_panel.tsx
@@ -111,8 +111,27 @@ export const GuidePanel = ({ api, application, notifications, uiSettings }: Guid
   const isDarkTheme = uiSettings.get('theme:darkMode');
   const styles = getGuidePanelStyles({ euiTheme, isDarkTheme });
 
+  const hasActiveStep = (steps: GuideStepStatus[]) => {
+    return (
+      steps.filter((step) => {
+        return step.status === 'active';
+      }).length < 0
+    );
+  };
+
   const toggleGuide = () => {
-    setIsGuideOpen((prevIsGuideOpen) => !prevIsGuideOpen);
+    setIsGuideOpen((prevIsGuideOpen) => {
+      if (pluginState && pluginState.activeGuide) {
+        const { steps, status } = pluginState.activeGuide;
+
+        if (status === 'not_started' && !hasActiveStep(steps) && !prevIsGuideOpen) {
+          navigateToLandingPage();
+          return false;
+        }
+      }
+
+      return !prevIsGuideOpen;
+    });
   };
 
   const handleStepButtonClick = useCallback(
@@ -120,13 +139,18 @@ export const GuidePanel = ({ api, application, notifications, uiSettings }: Guid
       if (pluginState) {
         const { id, status } = step;
         const guideId: GuideId = pluginState!.activeGuide!.guideId!;
+        const steps = pluginState.activeGuide!.steps;
 
         try {
           if (status === 'ready_to_complete') {
             return await api.completeGuideStep(guideId, id);
           }
 
-          if (status === 'active' || status === 'in_progress') {
+          if (
+            status === 'active' ||
+            status === 'in_progress' ||
+            (status === 'inactive' && !hasActiveStep(steps))
+          ) {
             await api.startGuideStep(guideId, id);
 
             if (stepConfig.location) {

--- a/src/plugins/guided_onboarding/public/components/guide_panel.tsx
+++ b/src/plugins/guided_onboarding/public/components/guide_panel.tsx
@@ -111,27 +111,8 @@ export const GuidePanel = ({ api, application, notifications, uiSettings }: Guid
   const isDarkTheme = uiSettings.get('theme:darkMode');
   const styles = getGuidePanelStyles({ euiTheme, isDarkTheme });
 
-  const hasActiveStep = (steps: GuideStepStatus[]) => {
-    return (
-      steps.filter((step) => {
-        return step.status === 'active';
-      }).length < 0
-    );
-  };
-
   const toggleGuide = () => {
-    setIsGuideOpen((prevIsGuideOpen) => {
-      if (pluginState && pluginState.activeGuide) {
-        const { steps, status } = pluginState.activeGuide;
-
-        if (status === 'not_started' && !hasActiveStep(steps) && !prevIsGuideOpen) {
-          navigateToLandingPage();
-          return false;
-        }
-      }
-
-      return !prevIsGuideOpen;
-    });
+    setIsGuideOpen((prevIsGuideOpen) => !prevIsGuideOpen);
   };
 
   const handleStepButtonClick = useCallback(
@@ -139,18 +120,13 @@ export const GuidePanel = ({ api, application, notifications, uiSettings }: Guid
       if (pluginState) {
         const { id, status } = step;
         const guideId: GuideId = pluginState!.activeGuide!.guideId!;
-        const steps = pluginState.activeGuide!.steps;
 
         try {
           if (status === 'ready_to_complete') {
             return await api.completeGuideStep(guideId, id);
           }
 
-          if (
-            status === 'active' ||
-            status === 'in_progress' ||
-            (status === 'inactive' && !hasActiveStep(steps))
-          ) {
+          if (status === 'inactive' || status === 'active' || status === 'in_progress') {
             await api.startGuideStep(guideId, id);
 
             if (stepConfig.location) {

--- a/src/plugins/guided_onboarding/public/components/guide_panel_step.tsx
+++ b/src/plugins/guided_onboarding/public/components/guide_panel_step.tsx
@@ -83,14 +83,27 @@ export const GuideStep = ({
     </EuiFlexGroup>
   );
   const isAccordionOpen =
-    stepStatus === 'in_progress' || stepStatus === 'active' || stepStatus === 'ready_to_complete';
+    stepStatus === 'in_progress' ||
+    stepStatus === 'active' ||
+    stepNumber === 1 ||
+    stepStatus === 'ready_to_complete';
+
+  const getStartStepButtonLabel = ({ isInactive }: { isInactive: boolean }) => {
+    if (!isInactive || (isInactive && stepNumber === 1)) {
+      return i18n.translate('guidedOnboarding.dropdownPanel.startStepButtonLabel', {
+        defaultMessage: 'Start',
+      });
+    }
+
+    return '';
+  };
 
   const getStepButtonLabel = (): string => {
     switch (stepStatus) {
+      case 'inactive':
+        return getStartStepButtonLabel({ isInactive: true });
       case 'active':
-        return i18n.translate('guidedOnboarding.dropdownPanel.startStepButtonLabel', {
-          defaultMessage: 'Start',
-        });
+        return getStartStepButtonLabel({ isInactive: false });
       case 'in_progress':
         return i18n.translate('guidedOnboarding.dropdownPanel.continueStepButtonLabel', {
           defaultMessage: 'Continue',

--- a/src/plugins/guided_onboarding/public/mocks.ts
+++ b/src/plugins/guided_onboarding/public/mocks.ts
@@ -15,6 +15,7 @@ const apiServiceMock: jest.Mocked<GuidedOnboardingPluginStart> = {
     fetchPluginState$: () => new BehaviorSubject(undefined),
     fetchAllGuidesState: jest.fn(),
     updatePluginState: jest.fn(),
+    activateGuideDefaultState: jest.fn(),
     activateGuide: jest.fn(),
     deactivateGuide: jest.fn(),
     completeGuide: jest.fn(),

--- a/src/plugins/guided_onboarding/public/services/api.mocks.ts
+++ b/src/plugins/guided_onboarding/public/services/api.mocks.ts
@@ -19,7 +19,7 @@ export const wrongIntegration = 'notTestIntegration';
 export const testGuideDefaultState: GuideState = {
   guideId: 'testGuide',
   isActive: true,
-  status: 'in_progress',
+  status: 'not_started',
   steps: [
     {
       id: 'step1',
@@ -38,6 +38,7 @@ export const testGuideDefaultState: GuideState = {
 
 export const testGuideStep1ActiveState: GuideState = {
   ...testGuideDefaultState,
+  status: 'in_progress',
   steps: [
     {
       id: testGuideDefaultState.steps[0].id,
@@ -149,6 +150,12 @@ export const testGuideNotActiveState: GuideState = {
 export const mockPluginStateNotStarted: PluginState = {
   status: 'not_started',
   isActivePeriod: true,
+};
+
+export const mockPluginStateInDefaultGuideState: PluginState = {
+  status: 'not_started',
+  isActivePeriod: true,
+  activeGuide: testGuideDefaultState,
 };
 
 export const mockPluginStateInProgress: PluginState = {

--- a/src/plugins/guided_onboarding/public/services/api.mocks.ts
+++ b/src/plugins/guided_onboarding/public/services/api.mocks.ts
@@ -16,14 +16,14 @@ export const testGuideLastStep: GuideStepIds = 'step3';
 export const testIntegration = 'testIntegration';
 export const wrongIntegration = 'notTestIntegration';
 
-export const testGuideStep1ActiveState: GuideState = {
+export const testGuideDefaultState: GuideState = {
   guideId: 'testGuide',
   isActive: true,
   status: 'in_progress',
   steps: [
     {
       id: 'step1',
-      status: 'active',
+      status: 'inactive',
     },
     {
       id: 'step2',
@@ -33,6 +33,18 @@ export const testGuideStep1ActiveState: GuideState = {
       id: 'step3',
       status: 'inactive',
     },
+  ],
+};
+
+export const testGuideStep1ActiveState: GuideState = {
+  ...testGuideDefaultState,
+  steps: [
+    {
+      id: testGuideDefaultState.steps[0].id,
+      status: 'active', // update the first step status
+    },
+    testGuideDefaultState.steps[1],
+    testGuideDefaultState.steps[2],
   ],
 };
 

--- a/src/plugins/guided_onboarding/public/services/api.mocks.ts
+++ b/src/plugins/guided_onboarding/public/services/api.mocks.ts
@@ -163,3 +163,9 @@ export const mockPluginStateInProgress: PluginState = {
   isActivePeriod: true,
   activeGuide: testGuideStep1ActiveState,
 };
+
+export const mockPluginStateStartedAndQuit: PluginState = {
+  status: 'quit',
+  isActivePeriod: false,
+  activeGuide: testGuideStep1ActiveState,
+};

--- a/src/plugins/guided_onboarding/public/services/api.service.ts
+++ b/src/plugins/guided_onboarding/public/services/api.service.ts
@@ -169,31 +169,16 @@ export class ApiService implements GuidedOnboardingApi {
   }
 
   /**
-   * Activates a guide by guideId.
-   * This is useful for the onboarding landing page, when a user selects a guide to start or continue.
+   * Activates a guide's default state by guideId.
+   * This is useful for defining an initial state for a guide.
    * @param {GuideId} guideId the id of the guide (one of search, kubernetes, siem)
    * @param {GuideState} guide (optional) the selected guide state, if it exists (i.e., if a user is continuing a guide)
    * @return {Promise} a promise with the updated plugin state
    */
-  public async activateGuide(
+  public async activateGuideDefaultState(
     guideId: GuideId,
     guide?: GuideState
   ): Promise<{ pluginState: PluginState } | undefined> {
-    // If we already have the guide state (i.e., user has already started the guide at some point),
-    // simply pass it through so they can continue where they left off, and update the guide to active
-    if (guide) {
-      return await this.updatePluginState(
-        {
-          status: 'in_progress',
-          guide: {
-            ...guide,
-            isActive: true,
-          },
-        },
-        true
-      );
-    }
-
     // If this is the 1st-time attempt, we need to create the default state
     const guideConfig = await this.configService.getGuideConfig(guideId);
 
@@ -215,8 +200,35 @@ export class ApiService implements GuidedOnboardingApi {
 
       return await this.updatePluginState(
         {
-          status: 'in_progress',
+          status: 'not_started',
           guide: updatedGuide,
+        },
+        true
+      );
+    }
+  }
+
+  /**
+   * Activates a guide by guideId.
+   * This is useful for the onboarding landing page, when a user selects a guide to start or continue.
+   * @param {GuideId} guideId the id of the guide (one of search, kubernetes, siem)
+   * @param {GuideState} guide (optional) the selected guide state, if it exists (i.e., if a user is continuing a guide)
+   * @return {Promise} a promise with the updated plugin state
+   */
+  public async activateGuide(
+    guideId: GuideId,
+    guide?: GuideState
+  ): Promise<{ pluginState: PluginState } | undefined> {
+    // If we already have the guide state (i.e., user has already started the guide at some point),
+    // simply pass it through so they can continue where they left off, and update the guide to active
+    if (guide) {
+      return await this.updatePluginState(
+        {
+          status: 'in_progress',
+          guide: {
+            ...guide,
+            isActive: true,
+          },
         },
         true
       );
@@ -347,7 +359,7 @@ export class ApiService implements GuidedOnboardingApi {
       steps: updatedSteps,
     };
 
-    return await this.updatePluginState({ guide: currentGuide }, false);
+    return await this.updatePluginState({ status: 'in_progress', guide: currentGuide }, false);
   }
 
   /**

--- a/src/plugins/guided_onboarding/public/services/api.service.ts
+++ b/src/plugins/guided_onboarding/public/services/api.service.ts
@@ -186,7 +186,7 @@ export class ApiService implements GuidedOnboardingApi {
       const pluginState = await firstValueFrom(this.fetchPluginState$());
 
       // If guide was previously started and subsequently quit, activate progress state
-      if (!pluginState?.isActivePeriod && pluginState?.status === 'quit') {
+      if (pluginState?.status === 'quit') {
         return this.activateGuide(guideId, guide);
       }
 

--- a/src/plugins/guided_onboarding/public/services/api.service.ts
+++ b/src/plugins/guided_onboarding/public/services/api.service.ts
@@ -183,6 +183,13 @@ export class ApiService implements GuidedOnboardingApi {
     const guideConfig = await this.configService.getGuideConfig(guideId);
 
     if (guideConfig) {
+      const pluginState = await firstValueFrom(this.fetchPluginState$());
+
+      // If guide was previously started and subsequently quit, activate progress state
+      if (!pluginState?.isActivePeriod && pluginState?.status === 'quit') {
+        return this.activateGuide(guideId, guide);
+      }
+
       const updatedSteps: GuideStep[] = guideConfig.steps.map((step) => {
         return {
           id: step.id,

--- a/src/plugins/guided_onboarding/public/services/api.service.ts
+++ b/src/plugins/guided_onboarding/public/services/api.service.ts
@@ -198,12 +198,11 @@ export class ApiService implements GuidedOnboardingApi {
     const guideConfig = await this.configService.getGuideConfig(guideId);
 
     if (guideConfig) {
-      const updatedSteps: GuideStep[] = guideConfig.steps.map((step, stepIndex) => {
-        const isFirstStep = stepIndex === 0;
+      const updatedSteps: GuideStep[] = guideConfig.steps.map((step) => {
         return {
           id: step.id,
-          // Only the first step should be activated when activating a new guide
-          status: isFirstStep ? 'active' : 'inactive',
+          // Set all steps to inactive by default when activating a new guide
+          status: 'inactive',
         };
       });
 

--- a/src/plugins/guided_onboarding/public/services/api.test.ts
+++ b/src/plugins/guided_onboarding/public/services/api.test.ts
@@ -31,6 +31,7 @@ import {
   mockPluginStateNotStarted,
   testGuideStep3ActiveState,
   testGuideStep2ReadyToCompleteState,
+  mockPluginStateStartedAndQuit,
 } from './api.mocks';
 
 describe('GuidedOnboarding ApiService', () => {
@@ -174,6 +175,23 @@ describe('GuidedOnboarding ApiService', () => {
         body: JSON.stringify({
           status: 'not_started',
           guide: { ...testGuideDefaultState, status: 'not_started' },
+        }),
+      });
+    });
+
+    it.skip('activates a guide that was previously quit', async () => {
+      httpClient.get.mockResolvedValueOnce({
+        pluginState: mockPluginStateStartedAndQuit,
+      });
+      apiService.setup(httpClient, true);
+
+      await apiService.activateGuideDefaultState(testGuideId);
+
+      expect(httpClient.put).toHaveBeenCalledTimes(1);
+      expect(httpClient.put).toHaveBeenCalledWith(`${API_BASE_PATH}/state`, {
+        body: JSON.stringify({
+          status: 'in_progress',
+          guide: testGuideStep1ActiveState,
         }),
       });
     });

--- a/src/plugins/guided_onboarding/public/services/api.test.ts
+++ b/src/plugins/guided_onboarding/public/services/api.test.ts
@@ -179,13 +179,14 @@ describe('GuidedOnboarding ApiService', () => {
       });
     });
 
-    it.skip('activates a guide that was previously quit', async () => {
-      httpClient.get.mockResolvedValueOnce({
+    it('activates a guide that was previously quit', async () => {
+      httpClient.get.mockResolvedValue({
+        config: testGuideConfig,
         pluginState: mockPluginStateStartedAndQuit,
       });
       apiService.setup(httpClient, true);
 
-      await apiService.activateGuideDefaultState(testGuideId);
+      await apiService.activateGuideDefaultState(testGuideId, testGuideStep1ActiveState);
 
       expect(httpClient.put).toHaveBeenCalledTimes(1);
       expect(httpClient.put).toHaveBeenCalledWith(`${API_BASE_PATH}/state`, {

--- a/src/plugins/guided_onboarding/public/services/api.test.ts
+++ b/src/plugins/guided_onboarding/public/services/api.test.ts
@@ -167,12 +167,12 @@ describe('GuidedOnboarding ApiService', () => {
       });
       apiService.setup(httpClient, true);
 
-      await apiService.activateGuide(testGuideId);
+      await apiService.activateGuideDefaultState(testGuideId);
 
       expect(httpClient.put).toHaveBeenCalledTimes(1);
       expect(httpClient.put).toHaveBeenCalledWith(`${API_BASE_PATH}/state`, {
         body: JSON.stringify({
-          status: 'in_progress',
+          status: 'not_started',
           guide: { ...testGuideDefaultState, status: 'not_started' },
         }),
       });
@@ -370,7 +370,7 @@ describe('GuidedOnboarding ApiService', () => {
       await apiService.startGuideStep(testGuideId, testGuideFirstStep);
 
       expect(httpClient.put).toHaveBeenCalledWith(`${API_BASE_PATH}/state`, {
-        body: JSON.stringify({ guide: testGuideStep1InProgressState }),
+        body: JSON.stringify({ status: 'in_progress', guide: testGuideStep1InProgressState }),
       });
     });
 

--- a/src/plugins/guided_onboarding/public/services/api.test.ts
+++ b/src/plugins/guided_onboarding/public/services/api.test.ts
@@ -18,6 +18,7 @@ import {
   testGuideFirstStep,
   testGuideLastStep,
   testGuideManualCompletionStep,
+  testGuideDefaultState,
   testGuideStep1ActiveState,
   testGuideStep1InProgressState,
   testGuideStep2ActiveState,
@@ -172,7 +173,7 @@ describe('GuidedOnboarding ApiService', () => {
       expect(httpClient.put).toHaveBeenCalledWith(`${API_BASE_PATH}/state`, {
         body: JSON.stringify({
           status: 'in_progress',
-          guide: { ...testGuideStep1ActiveState, status: 'not_started' },
+          guide: { ...testGuideDefaultState, status: 'not_started' },
         }),
       });
     });

--- a/src/plugins/guided_onboarding/public/services/helpers.ts
+++ b/src/plugins/guided_onboarding/public/services/helpers.ts
@@ -78,9 +78,14 @@ export const getInProgressStepConfig = (
 export const isGuideActive = (pluginState?: PluginState, guideId?: GuideId): boolean => {
   // false if pluginState is undefined or plugin state is not in progress
   // or active guide is undefined
-  if (!pluginState || pluginState.status !== 'in_progress' || !pluginState.activeGuide) {
+  if (!pluginState || !pluginState.activeGuide) {
     return false;
   }
+
+  if (!pluginState.activeGuide.isActive) {
+    return false;
+  }
+
   // guideId is passed, check that it's the id of the active guide
   if (guideId) {
     const { activeGuide } = pluginState;

--- a/src/plugins/guided_onboarding/public/types.ts
+++ b/src/plugins/guided_onboarding/public/types.ts
@@ -31,6 +31,10 @@ export interface GuidedOnboardingApi {
     state: { status?: PluginStatus; guide?: GuideState },
     panelState: boolean
   ) => Promise<{ pluginState: PluginState } | undefined>;
+  activateGuideDefaultState: (
+    guideId: GuideId,
+    guide?: GuideState
+  ) => Promise<{ pluginState: PluginState } | undefined>;
   activateGuide: (
     guideId: GuideId,
     guide?: GuideState

--- a/src/plugins/home/public/application/components/guided_onboarding/__snapshots__/getting_started.test.tsx.snap
+++ b/src/plugins/home/public/application/components/guided_onboarding/__snapshots__/getting_started.test.tsx.snap
@@ -53,7 +53,7 @@ exports[`getting started should render getting started component 1`] = `
       size="xxl"
     />
     <GuideCards
-      activateGuide={[Function]}
+      activateGuideDefaultState={[Function]}
       activeFilter="all"
       guidesState={Array []}
       navigateToApp={[MockFunction]}

--- a/src/plugins/home/public/application/components/guided_onboarding/getting_started.tsx
+++ b/src/plugins/home/public/application/components/guided_onboarding/getting_started.tsx
@@ -111,10 +111,10 @@ export const GettingStarted = () => {
     padding: calc(${euiTheme.size.base}*3) calc(${euiTheme.size.base}*4);
   `;
 
-  const activateGuide = useCallback(
+  const activateGuideDefaultState = useCallback(
     async (guideId: GuideId, guideState?: GuideState) => {
       try {
-        await guidedOnboardingService?.activateGuide(guideId, guideState);
+        await guidedOnboardingService?.activateGuideDefaultState(guideId, guideState);
       } catch (err) {
         getServices().toastNotifications.addDanger({
           title: i18n.translate('home.guidedOnboarding.gettingStarted.activateGuide.errorMessage', {
@@ -199,7 +199,7 @@ export const GettingStarted = () => {
         <GuideFilters activeFilter={filter} setActiveFilter={setFilter} />
         <EuiSpacer size="xxl" />
         <GuideCards
-          activateGuide={activateGuide}
+          activateGuideDefaultState={activateGuideDefaultState}
           navigateToApp={application.navigateToApp}
           activeFilter={filter}
           guidesState={guidesState}

--- a/x-pack/plugins/spaces/public/space_selector/__snapshots__/space_selector.test.tsx.snap
+++ b/x-pack/plugins/spaces/public/space_selector/__snapshots__/space_selector.test.tsx.snap
@@ -6,8 +6,9 @@ exports[`it renders with custom logo 1`] = `
   data-test-subj="kibanaSpaceSelector"
   panelled={true}
 >
-  <_EuiPageEmptyPrompt
+  <_EuiPageSection
     className="spcSpaceSelector__pageContent"
+    color="transparent"
   >
     <EuiText
       size="s"
@@ -24,19 +25,19 @@ exports[`it renders with custom logo 1`] = `
       <EuiSpacer
         size="xxl"
       />
-      <h1
-        className="eui spcSpaceSelector__pageHeader"
-        tabIndex={0}
-      >
-        <FormattedMessage
-          defaultMessage="Select your space"
-          id="xpack.spaces.spaceSelector.selectSpacesTitle"
-          values={Object {}}
-        />
-      </h1>
       <EuiTextColor
         color="subdued"
       >
+        <h1
+          className="eui spcSpaceSelector__pageHeader"
+          tabIndex={0}
+        >
+          <FormattedMessage
+            defaultMessage="Select your space"
+            id="xpack.spaces.spaceSelector.selectSpacesTitle"
+            values={Object {}}
+          />
+        </h1>
         <p>
           <FormattedMessage
             defaultMessage="You can change your space at anytime."
@@ -52,7 +53,7 @@ exports[`it renders with custom logo 1`] = `
     <EuiLoadingSpinner
       size="xl"
     />
-  </_EuiPageEmptyPrompt>
+  </_EuiPageSection>
 </_KibanaPageTemplate>
 `;
 


### PR DESCRIPTION
Rel: #148912
Follow up to https://github.com/elastic/kibana/pull/149528 

This PR refactors guided onboarding such that it's required states are more distinctly defined as follows;

- `default - not_started`
-  `in_progress` 
- `completed` 
- `quit`

The intention being - assuming the codebase grows, and in directions we don't yet know, and to a size we don't yet know, reasoning in terms of states clearly defined and having the code encapsulate each specifically, will make things easier in the long run. e.g. less need for new if/else conditions anytime we need to cater to a new (or combined) state behaviour.

