### PR TITLE
Prepare to enable GitHub Code Scanning on the 7.17 branch

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,25 @@
+paths-ignore:
+  - '**/*.test.*'
+  - packages/elastic-datemath/npm_module_types
+  - packages/kbn-babel-code-parser
+  - packages/kbn-babel-preset
+  - packages/kbn-cli-dev-mode
+  - packages/kbn-dev-utils
+  - packages/kbn-docs-utils
+  - packages/kbn-es
+  - packages/kbn-es-archiver
+  - packages/kbn-eslint-config
+  - packages/kbn-eslint-import-resolver-kibana
+  - packages/kbn-eslint-plugin-eslint
+  - packages/kbn-expect
+  - packages/kbn-optimizer
+  - packages/kbn-plugin-generator
+  - packages/kbn-plugin-helpers
+  - packages/kbn-pm
+  - packages/kbn-spec-to-console
+  - packages/kbn-storybook
+  - packages/kbn-telemetry-tools
+  - packages/kbn-test
+  - packages/kbn-test-subj-selector
+  - test
+  - x-pack/test


### PR DESCRIPTION
PR 2 out of 3 for issue #148542 in which we prepare to enable GitHub Code Scanning on the `7.17` branch.

For reference here's the previous PR: #148318

Once this PR is merged we need to enable scanning of the `7.17` within the `main` branch by modifying `.github/workflows/codeql.yml`