### PR TITLE
Enable GitHub Code Scanning on the 7.17 branch

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,14 +17,13 @@ jobs:
       fail-fast: false
       matrix:
         language: [ 'javascript' ]
-        # branch: [ 'main', '7.17' ]
+        branch: [ 'main', '7.17' ]
 
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
-      # TODO: Enable once a `.github/codeql/codeql-config.yml` file has been committed to 7.17
-      # with:
-      #   ref: ${{ matrix.branch }}
+      with:
+        ref: ${{ matrix.branch }}
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2


### PR DESCRIPTION
PR 3 out of 3 for issue #148542 in which we enables GitHub Code Scanning on the `7.17` branch.

For reference here's the two previous PRs: #148318, #150020

Closes #148542

### Blockers:
- [x] #150020