### PR TITLE
Fix escaping of double quote

### DIFF
--- a/x-pack/plugins/fleet/server/services/saved_object.test.ts
+++ b/x-pack/plugins/fleet/server/services/saved_object.test.ts
@@ -18,7 +18,7 @@ describe('Saved object service', () => {
     it('should escape quotes', () => {
       const res = escapeSearchQueryPhrase('test1"test2');
 
-      expect(res).toEqual(`"test1\"test2"`);
+      expect(res).toEqual(`"test1\\"test2"`);
     });
   });
 });

--- a/x-pack/plugins/fleet/server/services/saved_object.ts
+++ b/x-pack/plugins/fleet/server/services/saved_object.ts
@@ -16,7 +16,7 @@ import type { ListWithKuery } from '../types';
  * @param val
  */
 export function escapeSearchQueryPhrase(val: string): string {
-  return `"${val.replace(/["]/g, '"')}"`;
+  return `"${val.replace(/["]/g, '\\"')}"`;
 }
 
 // Adds `.attributes` to any kuery strings that are missing it, this comes from


### PR DESCRIPTION
The previous version of `escapeSearchQueryPhrase` didn't escape anything.

This was discovered automatically by GitHub Code Scanning:
- [ ] https://github.com/elastic/kibana/security/code-scanning/20

<!--ONMERGE {"backportTargets":["7.17","8.6"]} ONMERGE-->