### PR TITLE
Improve script URL detection logic

### DIFF
--- a/src/plugins/vis_types/timeseries/public/application/components/vis_types/table/vis.js
+++ b/src/plugins/vis_types/timeseries/public/application/components/vis_types/table/vis.js
@@ -46,8 +46,9 @@ function getColor(rules, colorKey, value) {
 }
 
 function sanitizeUrl(url) {
+  const { protocol } = parseUrl(url);
   // eslint-disable-next-line no-script-url
-  if (parseUrl(url).protocol === 'javascript:') {
+  if (protocol === 'javascript:' || protocol === 'data:' || protocol === 'vbscript:') {
     return '';
   }
   return url;


### PR DESCRIPTION
I'm pretty sure we don't need to allow the `data:` URL and would be very surprised if `vbscript:` was allowed.

This was discovered automatically by GitHub Code Scanning:
- [ ] https://github.com/elastic/kibana/security/code-scanning/28

<!--ONMERGE {"backportTargets":["7.17","8.6"]} ONMERGE-->