### PR TITLE
Improve security of links using target=_blank

### DIFF
--- a/packages/core/apps/core-apps-browser-internal/src/errors/public_base_url.tsx
+++ b/packages/core/apps/core-apps-browser-internal/src/errors/public_base_url.tsx
@@ -58,7 +58,11 @@ export const setupPublicBaseUrlConfigWarning = ({
               configKey: <code>server.publicBaseUrl</code>,
             }}
           />{' '}
-          <a href={`${docLinks.links.settings}#server-publicBaseUrl`} target="_blank">
+          <a
+            href={`${docLinks.links.settings}#server-publicBaseUrl`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             <FormattedMessage
               id="core.ui.publicBaseUrlWarning.learnMoreLinkLabel"
               defaultMessage="Learn more."

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/components/configuration_form/source_field_section/source_field_section.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/components/configuration_form/source_field_section/source_field_section.tsx
@@ -44,7 +44,11 @@ export const SourceFieldSection = () => {
       </p>
 
       <p>
-        <a href={documentationService.getDisablingMappingSourceFieldLink()} target="_blank">
+        <a
+          href={documentationService.getDisablingMappingSourceFieldLink()}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
           <FormattedMessage
             id="xpack.idxMgmt.mappingsEditor.disabledSourceFieldCallOutDescription2"
             defaultMessage="Learn more about alternatives to disabling the {source} field."


### PR DESCRIPTION
Background: https://www.elegantthemes.com/blog/wordpress/rel-noopener-noreferrer-nofollow

This was discovered automatically by GitHub Code Scanning:
- [ ] https://github.com/elastic/kibana/security/code-scanning/1
- [ ] https://github.com/elastic/kibana/security/code-scanning/3

<!--ONMERGE {"backportTargets":["7.17","8.6"]} ONMERGE-->