### PR TITLE
[performance] unskip journey

### DIFF
--- a/x-pack/performance/journeys/ecommerce_dashboard_saved_search_only.ts
+++ b/x-pack/performance/journeys/ecommerce_dashboard_saved_search_only.ts
@@ -10,8 +10,6 @@ import { subj } from '@kbn/test-subj-selector';
 import { waitForVisualizations } from '../utils';
 
 export const journey = new Journey({
-  // FAILING: https://github.com/elastic/kibana/issues/148221
-  skipped: true,
   esArchives: ['x-pack/performance/es_archives/sample_data_ecommerce'],
   kbnArchives: ['x-pack/performance/kbn_archives/ecommerce_saved_search_only_dashboard'],
 })


### PR DESCRIPTION
## Summary

Closes #148221

This test failure was caused by Chrome binary not been found and probably related to agent, not the test inself.