### PR TITLE
[8.6] [Security Solution][Endpoint] Fix and unskip flaky test (#149841)

### DIFF
--- a/x-pack/plugins/security_solution/public/management/pages/integration_tests/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/integration_tests/index.test.tsx
@@ -14,7 +14,6 @@ import { createAppRootMockRenderer } from '../../../common/mock/endpoint';
 import { useUserPrivileges } from '../../../common/components/user_privileges';
 import { useCanSeeHostIsolationExceptionsMenu } from '../host_isolation_exceptions/view/hooks';
 import { endpointPageHttpMock } from '../endpoint_hosts/mocks';
-import { getUserPrivilegesMockDefaultValue } from '../../../common/components/user_privileges/__mocks__';
 
 jest.mock('../../../common/components/user_privileges');
 jest.mock('../host_isolation_exceptions/view/hooks');
@@ -33,8 +32,8 @@ describe('when in the Administration tab', () => {
   });
 
   afterEach(() => {
-    useUserPrivilegesMock.mockImplementation(getUserPrivilegesMockDefaultValue);
     useCanSeeHostIsolationExceptionsMenuMock.mockReset();
+    useUserPrivilegesMock.mockReset();
   });
 
   describe('when the user has no permissions', () => {
@@ -101,8 +100,7 @@ describe('when in the Administration tab', () => {
     });
   });
 
-  // FLAKY: https://github.com/elastic/kibana/issues/145204
-  describe.skip('when the user has permissions', () => {
+  describe('when the user has permissions', () => {
     it('should display the Management view if user has privileges', async () => {
       useUserPrivilegesMock.mockReturnValue({
         endpointPrivileges: { loading: false, canReadEndpointList: true },


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.6`:
 - [[Security Solution][Endpoint] Fix and unskip flaky test (#149841)](https://github.com/elastic/kibana/pull/149841)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Ashokaditya","email":"1849116+ashokaditya@users.noreply.github.com"},"sourceCommit":{"committedDate":"2023-02-01T14:57:05Z","message":"[Security Solution][Endpoint] Fix and unskip flaky test (#149841)\n\n> **Note**\r\n> **Merge after elastic/kibana/pull/149839**\r\n\r\n## Summary\r\n\r\nFixes flaky test elastic/kibana/issues/145204\r\n\r\nflaky test runners \r\n-\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/1817\r\nx 50 (failed on a single [unrelated\r\n](https://github.com/ashokaditya/kibana/blob/92cb000a2f5116fc7408f52794cea06ad40de4bb/x-pack/test/security_solution_endpoint/apps/endpoint/artifact_entries_list.ts#L75)flaky\r\ntest)\r\n-\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/1826\r\nx 150 (failed on a single run for an\r\n[unrelated](https://github.com/ashokaditya/kibana/blob/92cb000a2f5116fc7408f52794cea06ad40de4bb/x-pack/test/security_solution_endpoint/apps/endpoint/artifact_entries_list.ts#L87)\r\nflaky test)\r\n-\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/1834\r\nx 200 (successful on all runs)\r\n-\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/1847\r\nx 100 (successful on all runs)\r\n\r\n### Checklist\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"9b85acb49e821f16b886c608787b285d813198b6","branchLabelMapping":{"^v8.7.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","test-failure-flaky","Team:Defend Workflows","OLM Sprint","v8.6.0","v8.7.0"],"number":149841,"url":"https://github.com/elastic/kibana/pull/149841","mergeCommit":{"message":"[Security Solution][Endpoint] Fix and unskip flaky test (#149841)\n\n> **Note**\r\n> **Merge after elastic/kibana/pull/149839**\r\n\r\n## Summary\r\n\r\nFixes flaky test elastic/kibana/issues/145204\r\n\r\nflaky test runners \r\n-\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/1817\r\nx 50 (failed on a single [unrelated\r\n](https://github.com/ashokaditya/kibana/blob/92cb000a2f5116fc7408f52794cea06ad40de4bb/x-pack/test/security_solution_endpoint/apps/endpoint/artifact_entries_list.ts#L75)flaky\r\ntest)\r\n-\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/1826\r\nx 150 (failed on a single run for an\r\n[unrelated](https://github.com/ashokaditya/kibana/blob/92cb000a2f5116fc7408f52794cea06ad40de4bb/x-pack/test/security_solution_endpoint/apps/endpoint/artifact_entries_list.ts#L87)\r\nflaky test)\r\n-\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/1834\r\nx 200 (successful on all runs)\r\n-\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/1847\r\nx 100 (successful on all runs)\r\n\r\n### Checklist\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"9b85acb49e821f16b886c608787b285d813198b6"}},"sourceBranch":"main","suggestedTargetBranches":["8.6"],"targetPullRequestStates":[{"branch":"8.6","label":"v8.6.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.7.0","labelRegex":"^v8.7.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/149841","number":149841,"mergeCommit":{"message":"[Security Solution][Endpoint] Fix and unskip flaky test (#149841)\n\n> **Note**\r\n> **Merge after elastic/kibana/pull/149839**\r\n\r\n## Summary\r\n\r\nFixes flaky test elastic/kibana/issues/145204\r\n\r\nflaky test runners \r\n-\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/1817\r\nx 50 (failed on a single [unrelated\r\n](https://github.com/ashokaditya/kibana/blob/92cb000a2f5116fc7408f52794cea06ad40de4bb/x-pack/test/security_solution_endpoint/apps/endpoint/artifact_entries_list.ts#L75)flaky\r\ntest)\r\n-\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/1826\r\nx 150 (failed on a single run for an\r\n[unrelated](https://github.com/ashokaditya/kibana/blob/92cb000a2f5116fc7408f52794cea06ad40de4bb/x-pack/test/security_solution_endpoint/apps/endpoint/artifact_entries_list.ts#L87)\r\nflaky test)\r\n-\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/1834\r\nx 200 (successful on all runs)\r\n-\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/1847\r\nx 100 (successful on all runs)\r\n\r\n### Checklist\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"9b85acb49e821f16b886c608787b285d813198b6"}}]}] BACKPORT-->