### PR TITLE
fix Failing test: Chrome X-Pack UI Functional Tests.x-pack/test/functional/apps/dashboard/group2/sync_colors·ts

### DIFF
--- a/test/functional/services/dashboard/add_panel.ts
+++ b/test/functional/services/dashboard/add_panel.ts
@@ -25,9 +25,14 @@ export class DashboardAddPanelService extends FtrService {
 
   async clickCreateNewLink() {
     this.log.debug('DashboardAddPanel.clickAddNewPanelButton');
-    await this.testSubjects.click('dashboardAddNewPanelButton');
-    // Give some time for the animation to complete
-    await this.common.sleep(500);
+    await this.retry.try(async () => {
+      await this.testSubjects.click('dashboardAddNewPanelButton');
+      await this.testSubjects.waitForDeleted('dashboardAddNewPanelButton');
+      await this.header.waitUntilLoadingHasFinished();
+      await this.testSubjects.existOrFail('lnsApp', {
+        timeout: 5000,
+      });
+    });
   }
 
   async clickQuickButton(visType: string) {

--- a/x-pack/test/functional/apps/dashboard/group2/sync_colors.ts
+++ b/x-pack/test/functional/apps/dashboard/group2/sync_colors.ts
@@ -54,7 +54,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await elasticChart.setNewChartUiDebugFlag(true);
       await PageObjects.dashboard.clickCreateDashboardPrompt();
       await dashboardAddPanel.clickCreateNewLink();
-      await PageObjects.header.waitUntilLoadingHasFinished();
       await PageObjects.lens.goToTimeRange();
 
       await PageObjects.lens.configureDimension({
@@ -72,7 +71,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await PageObjects.lens.save('vis1', false, true);
       await PageObjects.header.waitUntilLoadingHasFinished();
       await dashboardAddPanel.clickCreateNewLink();
-      await PageObjects.header.waitUntilLoadingHasFinished();
 
       await PageObjects.lens.configureDimension({
         dimension: 'lnsXY_yDimensionPanel > lns-empty-dimension',


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/148557 and https://github.com/elastic/kibana/issues/148558

Flaky test runner https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/1854

See https://github.com/elastic/kibana/issues/148557#issuecomment-1412415539 for explanation of failure. PR resolves flakiness by adding retry in clickCreateNewLink, ensuring clickCreateNewLink opens lens or else retries.