### PR TITLE
[Security Solution] Avoid exporting execution_summary field

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/logic/export/get_export_by_object_ids.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/logic/export/get_export_by_object_ids.ts
@@ -118,9 +118,14 @@ export const getRulesFromObjects = async (
       isAlertType(matchingRule) &&
       matchingRule.params.immutable !== true
     ) {
+      const rule = internalRuleToAPIResponse(matchingRule, legacyActions[matchingRule.id]);
+
+      // Fields containing runtime information shouldn't be exported. It causes import failures.
+      delete rule.execution_summary;
+
       return {
         statusCode: 200,
-        rule: internalRuleToAPIResponse(matchingRule, legacyActions[matchingRule.id]),
+        rule,
       };
     } else {
       return {


### PR DESCRIPTION
## Summary

It fixes a problem of exporting `execution_summary` field while exporting detection rules which was introduce in https://github.com/elastic/kibana/pull/147035. Presence of that field make importing of just exported rule failing.

Tests to cover this fix will come in a separate PR.

