### PR TITLE
[ML] Data Frame Analytics: adds functional test for scatterplot chart link to custom visualization

### DIFF
--- a/x-pack/plugins/ml/public/application/components/scatterplot_matrix/scatterplot_matrix.tsx
+++ b/x-pack/plugins/ml/public/application/components/scatterplot_matrix/scatterplot_matrix.tsx
@@ -532,7 +532,7 @@ export const ScatterplotMatrix: FC<ScatterplotMatrixProps> = ({
                       openInNewTab: false,
                     });
                   }}
-                  data-test-subj="mlSplomoExploreInCustomVisualizationLink"
+                  data-test-subj="mlSplomExploreInCustomVisualizationLink"
                 >
                   <EuiIconTip
                     content={i18n.translate('xpack.ml.splom.exploreInCustomVisualizationLabel', {

--- a/x-pack/test/functional/apps/ml/data_frame_analytics/results_view_content.ts
+++ b/x-pack/test/functional/apps/ml/data_frame_analytics/results_view_content.ts
@@ -322,6 +322,10 @@ export default function ({ getService }: FtrProviderContext) {
           await ml.dataFrameAnalyticsResults.showAllResultsTableColumns();
           await ml.dataFrameAnalyticsResults.hideAllResultsTableColumns();
         });
+
+        it('should link to custom visualization UI from scatterplot charts', async () => {
+          await ml.dataFrameAnalyticsResults.assertOpensExploreInCustomVisualization();
+        });
       });
     }
   });

--- a/x-pack/test/functional/services/ml/data_frame_analytics_results.ts
+++ b/x-pack/test/functional/services/ml/data_frame_analytics_results.ts
@@ -20,6 +20,7 @@ export function MachineLearningDataFrameAnalyticsResultsProvider(
   const headerPage = getPageObject('header');
   const retry = getService('retry');
   const testSubjects = getService('testSubjects');
+  const find = getService('find');
 
   return {
     async assertRegressionEvaluatePanelElementsExists() {
@@ -72,6 +73,26 @@ export function MachineLearningDataFrameAnalyticsResultsProvider(
         expectedCheckState,
         `Chart histogram button check state should be '${expectedCheckState}' (got '${actualCheckState}')`
       );
+    },
+
+    async getViewContainer() {
+      return find.byCssSelector('div.vgaVis__view');
+    },
+
+    async assertOpensExploreInCustomVisualization() {
+      await testSubjects.existOrFail('mlSplomExploreInCustomVisualizationLink', {
+        timeout: 5000,
+      });
+      await testSubjects.click('mlSplomExploreInCustomVisualizationLink');
+      await testSubjects.existOrFail('visualizationLoader');
+
+      const view = await this.getViewContainer();
+      expect(view).to.be.ok();
+      const size = await view.getSize();
+      expect(size).to.have.property('width');
+      expect(size).to.have.property('height');
+      expect(size.width).to.be.above(0);
+      expect(size.height).to.be.above(0);
     },
 
     async enableResultsTablePreviewHistogramCharts(expectedButtonState: boolean) {


### PR DESCRIPTION
## Summary

Follow up to https://github.com/elastic/kibana/pull/149647
Link to flaky test runner: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/1856

This PR adds a functional test for the scatterplot matrix link in the DFA results view to custom visualizations UI.


### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios




