### PR TITLE
[ML] Data Frame Analytics creation wizard: ensure includes table is populated correctly on job type change

### DIFF
--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/components/shared/fetch_explain_data.ts
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/components/shared/fetch_explain_data.ts
@@ -28,6 +28,7 @@ export const fetchExplainData = async (formState: State['form']) => {
   try {
     delete jobConfig.dest;
     delete jobConfig.model_memory_limit;
+    delete jobConfig.analyzed_fields;
     const resp: DfAnalyticsExplainResponse = await ml.dataFrameAnalytics.explainDataFrameAnalytics(
       jobConfig
     );


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/147824

Fixes the request body sent to the explain api - no longer sends unnecessary `analyzed_fields` property. This ensures the explain api call is successful and the includes table is populated correctly with the new job type and dependent variable.

Before:

![dfa_wizard_fields_error](https://user-images.githubusercontent.com/6446462/208556732-d1ae37f0-c3eb-4983-945b-62de0af45833.gif)

After:

https://user-images.githubusercontent.com/6446462/216168208-a68a590d-5a45-4b4b-80eb-18b811218a00.mp4



### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios




