### PR TITLE
[Fleet] Fix metrics flaky test

### DIFF
--- a/x-pack/test/fleet_api_integration/apis/agents/list.ts
+++ b/x-pack/test/fleet_api_integration/apis/agents/list.ts
@@ -17,7 +17,6 @@ export default function ({ getService }: FtrProviderContext) {
   const supertest = getService('supertest');
   const es = getService('es');
   let elasticAgentpkgVersion: string;
-  // FLAKY: https://github.com/elastic/kibana/issues/149937
   describe('fleet_list_agent', () => {
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/fleet/agents');
@@ -130,7 +129,7 @@ export default function ({ getService }: FtrProviderContext) {
       expect(apiResponse.items).to.eql(['existingTag', 'tag1']);
     });
 
-    it.only('should return metrics if available and called with withMetrics', async () => {
+    it('should return metrics if available and called with withMetrics', async () => {
       const now = Date.now();
       await es.index({
         index: 'metrics-elastic_agent.elastic_agent-default',

--- a/x-pack/test/fleet_api_integration/apis/agents/list.ts
+++ b/x-pack/test/fleet_api_integration/apis/agents/list.ts
@@ -18,7 +18,7 @@ export default function ({ getService }: FtrProviderContext) {
   const es = getService('es');
   let elasticAgentpkgVersion: string;
   // FLAKY: https://github.com/elastic/kibana/issues/149937
-  describe.skip('fleet_list_agent', () => {
+  describe('fleet_list_agent', () => {
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/fleet/agents');
       const getPkRes = await supertest

--- a/x-pack/test/fleet_api_integration/apis/agents/list.ts
+++ b/x-pack/test/fleet_api_integration/apis/agents/list.ts
@@ -130,12 +130,13 @@ export default function ({ getService }: FtrProviderContext) {
       expect(apiResponse.items).to.eql(['existingTag', 'tag1']);
     });
 
-    it('should return metrics if available and called with withMetrics', async () => {
+    it.only('should return metrics if available and called with withMetrics', async () => {
+      const now = Date.now();
       await es.index({
         index: 'metrics-elastic_agent.elastic_agent-default',
         refresh: 'wait_for',
         document: {
-          '@timestamp': new Date(Date.now() - 3 * 60 * 1000).toISOString(),
+          '@timestamp': new Date(now - 2 * 60 * 1000).toISOString(),
           data_stream: {
             namespace: 'default',
             type: 'metrics',
@@ -160,7 +161,7 @@ export default function ({ getService }: FtrProviderContext) {
         index: 'metrics-elastic_agent.elastic_agent-default',
         refresh: 'wait_for',
         document: {
-          '@timestamp': new Date(Date.now() - 2 * 60 * 1000).toISOString(),
+          '@timestamp': new Date(now - 1 * 60 * 1000).toISOString(),
           elastic_agent: { id: 'agent1', process: 'elastic_agent' },
           data_stream: {
             namespace: 'default',


### PR DESCRIPTION
## Summary

Resolve #149937

The new test we added seems to be some time flaky, we rely on metrics document and timestamp to build these metrics, so the only things I think about was to improve this here.

I launched the flaky runner with success https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/1859#01860f62-7181-4111-9f95-4a70ce1de5fe