### PR TITLE
[APM] Add missing `IntlProvider` to unit test

### DIFF
--- a/x-pack/plugins/apm/public/components/app/transaction_overview/transaction_overview.test.tsx
+++ b/x-pack/plugins/apm/public/components/app/transaction_overview/transaction_overview.test.tsx
@@ -23,6 +23,7 @@ import {
 } from '../../../utils/test_helpers';
 import { fromQuery } from '../../shared/links/url_helpers';
 import { TransactionOverview } from '.';
+import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
 
 const KibanaReactContext = createKibanaReactContext({
   uiSettings: { get: () => true },
@@ -64,15 +65,17 @@ function setup({
   jest.spyOn(useFetcherHook, 'useFetcher').mockReturnValue({} as any);
 
   return renderWithTheme(
-    <KibanaReactContext.Provider>
-      <MockApmPluginContextWrapper history={history}>
-        <UrlParamsProvider>
-          <ApmServiceContextProvider>
-            <TransactionOverview />
-          </ApmServiceContextProvider>
-        </UrlParamsProvider>
-      </MockApmPluginContextWrapper>
-    </KibanaReactContext.Provider>
+    <IntlProvider locale="en">
+      <KibanaReactContext.Provider>
+        <MockApmPluginContextWrapper history={history}>
+          <UrlParamsProvider>
+            <ApmServiceContextProvider>
+              <TransactionOverview />
+            </ApmServiceContextProvider>
+          </UrlParamsProvider>
+        </MockApmPluginContextWrapper>
+      </KibanaReactContext.Provider>
+    </IntlProvider>
   );
 }
 


### PR DESCRIPTION
Jest tests in APM are currently failing with:

```
Error: Uncaught [Error: [React Intl] Could not find required `intl` object. <IntlProvider> needs to exist in the component ancestry. Using default message as fallback.]
```

Adding the `IntlProvider` fixes the problem