### PR TITLE
[Security Solution] Add an enable or disabled state rules filter

### DIFF
--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/logic/types.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/logic/types.ts
@@ -244,6 +244,7 @@ export interface FilterOptions {
   showElasticRules: boolean;
   tags: string[];
   excludeRuleTypes?: Type[];
+  enabled?: boolean; // undefined is to display all the rules
 }
 
 export interface FetchRulesResponse {

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/logic/utils.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/logic/utils.ts
@@ -32,6 +32,7 @@ export const convertRulesFilterToKQL = ({
   filter,
   tags,
   excludeRuleTypes = [],
+  enabled,
 }: FilterOptions): string => {
   const filters: string[] = [];
 
@@ -41,6 +42,10 @@ export const convertRulesFilterToKQL = ({
     filters.push('alert.attributes.params.immutable: true');
   } else if (showCustomRules) {
     filters.push('alert.attributes.params.immutable: false');
+  }
+
+  if (enabled !== undefined) {
+    filters.push(`alert.attributes.enabled: ${enabled ? 'true' : 'false'}`);
   }
 
   if (tags.length > 0) {

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table/rules_table_saved_state.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table/rules_table_saved_state.ts
@@ -19,6 +19,7 @@ export const RulesTableSavedFilter = t.partial({
   searchTerm: t.string,
   source: enumeration('RuleSource', RuleSource),
   tags: t.array(t.string),
+  enabled: t.boolean,
 });
 
 export type RulesTableSavedSorting = t.TypeOf<typeof RulesTableSavedSorting>;

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table/use_initialize_rules_table_saved_state.test.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table/use_initialize_rules_table_saved_state.test.ts
@@ -31,6 +31,7 @@ describe('useInitializeRulesTableSavedState', () => {
     order: 'asc',
     page: 2,
     perPage: 10,
+    enabled: true,
   };
   const storageSavedState: RulesTableStorageSavedState = {
     searchTerm: 'test',
@@ -39,6 +40,7 @@ describe('useInitializeRulesTableSavedState', () => {
     field: 'name',
     order: 'asc',
     perPage: 20,
+    enabled: false,
   };
   const rulesTableContext = useRulesTableContextMock.create();
   const actions = rulesTableContext.actions;
@@ -76,6 +78,7 @@ describe('useInitializeRulesTableSavedState', () => {
         showCustomRules: urlSavedState.source === RuleSource.Custom,
         showElasticRules: urlSavedState.source === RuleSource.Prebuilt,
         tags: urlSavedState.tags,
+        enabled: urlSavedState.enabled,
       });
       expect(actions.setSortingOptions).toHaveBeenCalledWith({
         field: urlSavedState.field,
@@ -168,6 +171,20 @@ describe('useInitializeRulesTableSavedState', () => {
       expect(actions.setPerPage).not.toHaveBeenCalled();
     });
 
+    it('restores only enabled state filter', () => {
+      mockRulesTablePersistedState({ urlState: { enabled: true }, storageState: null });
+
+      renderHook(() => useInitializeRulesTableSavedState());
+
+      expect(actions.setFilterOptions).toHaveBeenCalledWith({
+        ...DEFAULT_FILTER_OPTIONS,
+        enabled: true,
+      });
+      expect(actions.setSortingOptions).not.toHaveBeenCalled();
+      expect(actions.setPage).not.toHaveBeenCalled();
+      expect(actions.setPerPage).not.toHaveBeenCalled();
+    });
+
     it('restores only sorting field', () => {
       mockRulesTablePersistedState({ urlState: { field: 'name' }, storageState: null });
 
@@ -232,6 +249,7 @@ describe('useInitializeRulesTableSavedState', () => {
         showCustomRules: storageSavedState.source === RuleSource.Custom,
         showElasticRules: storageSavedState.source === RuleSource.Prebuilt,
         tags: storageSavedState.tags,
+        enabled: storageSavedState.enabled,
       });
       expect(actions.setSortingOptions).toHaveBeenCalledWith({
         field: storageSavedState.field,
@@ -324,6 +342,20 @@ describe('useInitializeRulesTableSavedState', () => {
       expect(actions.setPerPage).not.toHaveBeenCalled();
     });
 
+    it('restores only enabled state filter', () => {
+      mockRulesTablePersistedState({ urlState: null, storageState: { enabled: true } });
+
+      renderHook(() => useInitializeRulesTableSavedState());
+
+      expect(actions.setFilterOptions).toHaveBeenCalledWith({
+        ...DEFAULT_FILTER_OPTIONS,
+        enabled: true,
+      });
+      expect(actions.setSortingOptions).not.toHaveBeenCalled();
+      expect(actions.setPage).not.toHaveBeenCalled();
+      expect(actions.setPerPage).not.toHaveBeenCalled();
+    });
+
     it('restores only sorting field', () => {
       mockRulesTablePersistedState({ urlState: null, storageState: { field: 'name' } });
 
@@ -392,6 +424,7 @@ describe('useInitializeRulesTableSavedState', () => {
         showCustomRules: urlSavedState.source === RuleSource.Custom,
         showElasticRules: urlSavedState.source === RuleSource.Prebuilt,
         tags: urlSavedState.tags,
+        enabled: urlSavedState.enabled,
       });
       expect(actions.setSortingOptions).toHaveBeenCalledWith({
         field: urlSavedState.field,

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table/use_initialize_rules_table_saved_state.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table/use_initialize_rules_table_saved_state.ts
@@ -76,6 +76,7 @@ export function useInitializeRulesTableSavedState(): void {
       showElasticRules: filter.source === RuleSource.Prebuilt,
       showCustomRules: filter.source === RuleSource.Custom,
       tags: Array.isArray(filter.tags) ? filter.tags : DEFAULT_FILTER_OPTIONS.tags,
+      enabled: filter.enabled,
     });
 
     if (sorting.field || sorting.order) {

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table/use_sync_rules_table_saved_state.test.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table/use_sync_rules_table_saved_state.test.tsx
@@ -105,6 +105,7 @@ describe('useSyncRulesTableSavedState', () => {
         tags: ['test'],
         showCustomRules: true,
         showElasticRules: false,
+        enabled: true,
       },
       sortingOptions: {
         field: 'name',
@@ -124,6 +125,7 @@ describe('useSyncRulesTableSavedState', () => {
       order: 'asc',
       page: 3,
       perPage: 10,
+      enabled: true,
     };
     const expectedStorageState: RulesTableStorageSavedState = omit(expectedUrlState, 'page');
 
@@ -172,6 +174,16 @@ describe('useSyncRulesTableSavedState', () => {
           filterOptions: { ...defaultState.filterOptions, tags: ['test'] },
         },
         { tags: ['test'] }
+      );
+    });
+
+    it('syncs only the enabled state filter', () => {
+      expectStateToSyncWithUrl(
+        {
+          ...defaultState,
+          filterOptions: { ...defaultState.filterOptions, enabled: true },
+        },
+        { enabled: true }
       );
     });
 
@@ -257,6 +269,16 @@ describe('useSyncRulesTableSavedState', () => {
           filterOptions: { ...defaultState.filterOptions, tags: ['test'] },
         },
         { tags: ['test'] }
+      );
+    });
+
+    it('syncs only the enabled state filter', () => {
+      expectStateToSyncWithStorage(
+        {
+          ...defaultState,
+          filterOptions: { ...defaultState.filterOptions, enabled: true },
+        },
+        { enabled: true }
       );
     });
 

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table/use_sync_rules_table_saved_state.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table/use_sync_rules_table_saved_state.ts
@@ -50,6 +50,11 @@ export function useSyncRulesTableSavedState(): void {
       storageStateToSave.tags = state.filterOptions.tags;
     }
 
+    if (state.filterOptions.enabled !== undefined) {
+      urlStateToSave.enabled = state.filterOptions.enabled;
+      storageStateToSave.enabled = state.filterOptions.enabled;
+    }
+
     if (state.sortingOptions.field !== DEFAULT_SORTING_OPTIONS.field) {
       urlStateToSave.field = state.sortingOptions.field;
       storageStateToSave.field = state.sortingOptions.field;

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table_filters/rule_search_field.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table_filters/rule_search_field.tsx
@@ -13,6 +13,7 @@ import { SEARCH_FIRST_RULE_ANCHOR } from '../rules_table/guided_onboarding/rules
 import * as i18n from '../../../../../detections/pages/detection_engine/rules/translations';
 
 const SearchBarWrapper = styled(EuiFlexItem)`
+  min-width: 200px;
   & .euiPopover,
   & .euiPopover__anchor {
     // This is needed to "cancel" styles passed down from EuiTourStep that

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table_filters/rules_table_filters.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table_filters/rules_table_filters.tsx
@@ -77,7 +77,7 @@ const RulesTableFiltersComponent = () => {
   );
 
   return (
-    <FilterWrapper gutterSize="m" justifyContent="flexEnd">
+    <FilterWrapper gutterSize="m" justifyContent="flexEnd" wrap>
       <RuleSearchField initialValue={filterOptions.filter} onSearch={handleOnSearch} />
       <EuiFlexItem grow={false}>
         <EuiFilterGroup>

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table_filters/rules_table_filters.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table_filters/rules_table_filters.tsx
@@ -36,7 +36,7 @@ const RulesTableFiltersComponent = () => {
   const rulesCustomCount = ruleManagementFields?.rules_summary.custom_count;
   const rulesPrebuiltInstalledCount = ruleManagementFields?.rules_summary.prebuilt_installed_count;
 
-  const { showCustomRules, showElasticRules, tags: selectedTags } = filterOptions;
+  const { showCustomRules, showElasticRules, tags: selectedTags, enabled } = filterOptions;
 
   const handleOnSearch = useCallback(
     (filterString) => {
@@ -55,6 +55,16 @@ const RulesTableFiltersComponent = () => {
     startTransaction({ name: RULES_TABLE_ACTIONS.FILTER });
     setFilterOptions({ showCustomRules: !showCustomRules, showElasticRules: false });
   }, [setFilterOptions, showCustomRules, startTransaction]);
+
+  const handleShowEnabledRulesClick = useCallback(() => {
+    startTransaction({ name: RULES_TABLE_ACTIONS.FILTER });
+    setFilterOptions(enabled === true ? { enabled: undefined } : { enabled: true });
+  }, [setFilterOptions, enabled, startTransaction]);
+
+  const handleShowDisabledRulesClick = useCallback(() => {
+    startTransaction({ name: RULES_TABLE_ACTIONS.FILTER });
+    setFilterOptions(enabled === false ? { enabled: undefined } : { enabled: false });
+  }, [setFilterOptions, enabled, startTransaction]);
 
   const handleSelectedTags = useCallback(
     (newTags: string[]) => {
@@ -98,6 +108,26 @@ const RulesTableFiltersComponent = () => {
           >
             {i18n.CUSTOM_RULES}
             {rulesCustomCount != null ? ` (${rulesCustomCount})` : ''}
+          </EuiFilterButton>
+        </EuiFilterGroup>
+      </EuiFlexItem>
+
+      <EuiFlexItem grow={false}>
+        <EuiFilterGroup>
+          <EuiFilterButton
+            hasActiveFilters={enabled === true}
+            onClick={handleShowEnabledRulesClick}
+            data-test-subj="showEnabledRulesFilterButton"
+            withNext
+          >
+            {i18n.ENABLED_RULES}
+          </EuiFilterButton>
+          <EuiFilterButton
+            hasActiveFilters={enabled === false}
+            onClick={handleShowDisabledRulesClick}
+            data-test-subj="showDisabledRulesFilterButton"
+          >
+            {i18n.DISABLED_RULES}
           </EuiFilterButton>
         </EuiFilterGroup>
       </EuiFlexItem>

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/translations.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/translations.ts
@@ -638,6 +638,20 @@ export const MONITORING_TAB = i18n.translate(
   }
 );
 
+export const ENABLED_RULES = i18n.translate(
+  'xpack.securitySolution.detectionEngine.rules.allRules.filters.enabledRulesTitle',
+  {
+    defaultMessage: 'Enabled rules',
+  }
+);
+
+export const DISABLED_RULES = i18n.translate(
+  'xpack.securitySolution.detectionEngine.rules.allRules.filters.disabledRulesTitle',
+  {
+    defaultMessage: 'Disabled rules',
+  }
+);
+
 export const CUSTOM_RULES = i18n.translate(
   'xpack.securitySolution.detectionEngine.rules.allRules.filters.customRulesTitle',
   {


### PR DESCRIPTION
**Addresses:** https://github.com/elastic/kibana/issues/132497

## Summary

This PR adds a rules table filter for the enabled and disabled state.

*Filter in action*:

https://user-images.githubusercontent.com/3775283/216316405-27ad8b21-6392-4705-8af8-53c746a00acf.mov

Since the added filter occupies some space the search field may shrink too much. To address this issue wrapping was enabled for the filter row.

*Layout responsiveness:*

https://user-images.githubusercontent.com/3775283/216380837-3bda2072-4f5b-4754-8e57-8978c5e2b0d5.mov

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

