### PR TITLE
[Security Solution] Fix prebuilt rules installation when the detection engine package is missing

### DIFF
--- a/x-pack/plugins/security_solution/common/detection_engine/constants.ts
+++ b/x-pack/plugins/security_solution/common/detection_engine/constants.ts
@@ -25,3 +25,5 @@ export enum RULE_PREVIEW_FROM {
   WEEK = 'now-65m',
   MONTH = 'now-25h',
 }
+
+export const PREBUILT_RULES_PACKAGE_NAME = 'security_detection_engine';

--- a/x-pack/plugins/security_solution/public/common/hooks/use_upgrade_security_packages.ts
+++ b/x-pack/plugins/security_solution/public/common/hooks/use_upgrade_security_packages.ts
@@ -12,6 +12,7 @@ import { epmRouteService } from '@kbn/fleet-plugin/common';
 import type { InstallPackageResponse } from '@kbn/fleet-plugin/common/types';
 import { KibanaServices, useKibana } from '../lib/kibana';
 import { useUserPrivileges } from '../components/user_privileges';
+import { PREBUILT_RULES_PACKAGE_NAME } from '../../../common/detection_engine/constants';
 
 /**
  * Requests that the endpoint and security_detection_engine package be upgraded to the latest version
@@ -25,16 +26,16 @@ const sendUpgradeSecurityPackages = async (
   options: HttpFetchOptions = {},
   prebuiltRulesPackageVersion?: string
 ): Promise<void> => {
-  const packages = ['endpoint', 'security_detection_engine'];
+  const packages = ['endpoint', PREBUILT_RULES_PACKAGE_NAME];
   const requests: Array<Promise<InstallPackageResponse | BulkInstallPackagesResponse>> = [];
 
   // If `prebuiltRulesPackageVersion` is provided, try to install that version
   // Must be done as two separate requests as bulk API doesn't support versions
   if (prebuiltRulesPackageVersion != null) {
-    packages.splice(packages.indexOf('security_detection_engine'), 1);
+    packages.splice(packages.indexOf(PREBUILT_RULES_PACKAGE_NAME), 1);
     requests.push(
       http.post<InstallPackageResponse>(
-        epmRouteService.getInstallPath('security_detection_engine', prebuiltRulesPackageVersion),
+        epmRouteService.getInstallPath(PREBUILT_RULES_PACKAGE_NAME, prebuiltRulesPackageVersion),
         {
           ...options,
           body: JSON.stringify({

--- a/x-pack/plugins/security_solution/server/client/client.test.ts
+++ b/x-pack/plugins/security_solution/server/client/client.test.ts
@@ -17,7 +17,7 @@ describe('SiemClient', () => {
         [SIGNALS_INDEX_KEY]: 'mockSignalsIndex',
       };
       const spaceId = 'fooSpace';
-      const client = new AppClient(spaceId, mockConfig);
+      const client = new AppClient(spaceId, mockConfig, '8.7', 'main');
 
       expect(client.getSignalsIndex()).toEqual('mockSignalsIndex-fooSpace');
     });

--- a/x-pack/plugins/security_solution/server/client/client.ts
+++ b/x-pack/plugins/security_solution/server/client/client.ts
@@ -13,18 +13,24 @@ export class AppClient {
   private readonly spaceId: string;
   private readonly previewIndex: string;
   private readonly sourcererDataViewId: string;
+  private readonly kibanaVersion: string;
+  private readonly kibanaBranch: string;
 
-  constructor(_spaceId: string, private config: ConfigType) {
-    const configuredSignalsIndex = this.config.signalsIndex;
+  constructor(spaceId: string, config: ConfigType, kibanaVersion: string, kibanaBranch: string) {
+    const configuredSignalsIndex = config.signalsIndex;
 
-    this.signalsIndex = `${configuredSignalsIndex}-${_spaceId}`;
-    this.previewIndex = `${DEFAULT_PREVIEW_INDEX}-${_spaceId}`;
-    this.sourcererDataViewId = `${DEFAULT_DATA_VIEW_ID}-${_spaceId}`;
-    this.spaceId = _spaceId;
+    this.signalsIndex = `${configuredSignalsIndex}-${spaceId}`;
+    this.previewIndex = `${DEFAULT_PREVIEW_INDEX}-${spaceId}`;
+    this.sourcererDataViewId = `${DEFAULT_DATA_VIEW_ID}-${spaceId}`;
+    this.spaceId = spaceId;
+    this.kibanaVersion = kibanaVersion;
+    this.kibanaBranch = kibanaBranch;
   }
 
   public getSignalsIndex = (): string => this.signalsIndex;
   public getPreviewIndex = (): string => this.previewIndex;
   public getSourcererDataViewId = (): string => this.sourcererDataViewId;
   public getSpaceId = (): string => this.spaceId;
+  public getKibanaVersion = (): string => this.kibanaVersion;
+  public getKibanaBranch = (): string => this.kibanaBranch;
 }

--- a/x-pack/plugins/security_solution/server/client/factory.test.ts
+++ b/x-pack/plugins/security_solution/server/client/factory.test.ts
@@ -18,19 +18,39 @@ describe('AppClientFactory', () => {
     it('constructs a client with the current spaceId', () => {
       const factory = new AppClientFactory();
       const mockRequest = httpServerMock.createKibanaRequest();
-      factory.setup({ getSpaceId: () => 'mockSpace', config: createMockConfig() });
+      factory.setup({
+        getSpaceId: () => 'mockSpace',
+        config: createMockConfig(),
+        kibanaVersion: '8.7',
+        kibanaBranch: 'main',
+      });
       factory.create(mockRequest);
 
-      expect(mockClient).toHaveBeenCalledWith('mockSpace', expect.anything());
+      expect(mockClient).toHaveBeenCalledWith(
+        'mockSpace',
+        expect.anything(),
+        expect.anything(),
+        expect.anything()
+      );
     });
 
     it('constructs a client with the default spaceId if spaces are disabled', () => {
       const factory = new AppClientFactory();
       const mockRequest = httpServerMock.createKibanaRequest();
-      factory.setup({ getSpaceId: undefined, config: createMockConfig() });
+      factory.setup({
+        getSpaceId: undefined,
+        config: createMockConfig(),
+        kibanaVersion: '8.7',
+        kibanaBranch: 'main',
+      });
       factory.create(mockRequest);
 
-      expect(mockClient).toHaveBeenCalledWith('default', expect.anything());
+      expect(mockClient).toHaveBeenCalledWith(
+        'default',
+        expect.anything(),
+        expect.anything(),
+        expect.anything()
+      );
     });
 
     it('cannot call create without calling setup first', () => {

--- a/x-pack/plugins/security_solution/server/client/factory.ts
+++ b/x-pack/plugins/security_solution/server/client/factory.ts
@@ -8,29 +8,43 @@
 import type { KibanaRequest } from '@kbn/core/server';
 import { AppClient } from './client';
 import type { ConfigType } from '../config';
+import { invariant } from '../../common/utils/invariant';
 
 interface SetupDependencies {
   getSpaceId?: (request: KibanaRequest) => string | undefined;
   config: ConfigType;
+  kibanaVersion: string;
+  kibanaBranch: string;
 }
 
 export class AppClientFactory {
   private getSpaceId?: SetupDependencies['getSpaceId'];
   private config?: SetupDependencies['config'];
+  private kibanaVersion?: string;
+  private kibanaBranch?: string;
 
-  public setup({ getSpaceId, config }: SetupDependencies) {
+  public setup({ getSpaceId, config, kibanaBranch, kibanaVersion }: SetupDependencies) {
     this.getSpaceId = getSpaceId;
     this.config = config;
+    this.kibanaVersion = kibanaVersion;
+    this.kibanaBranch = kibanaBranch;
   }
 
   public create(request: KibanaRequest): AppClient {
-    if (this.config == null) {
-      throw new Error(
-        'Cannot create AppClient as config is not present. Did you forget to call setup()?'
-      );
-    }
+    invariant(
+      this.config != null,
+      'Cannot create AppClient as config is not present. Did you forget to call setup()?'
+    );
+    invariant(
+      this.kibanaVersion != null,
+      'Cannot create AppClient as kibanaVersion is not present. Did you forget to call setup()?'
+    );
+    invariant(
+      this.kibanaBranch != null,
+      'Cannot create AppClient as kibanaBranch is not present. Did you forget to call setup()?'
+    );
 
     const spaceId = this.getSpaceId?.(request) ?? 'default';
-    return new AppClient(spaceId, this.config);
+    return new AppClient(spaceId, this.config, this.kibanaVersion, this.kibanaBranch);
   }
 }

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/install_prebuilt_rules_and_timelines/install_prebuilt_rules_package.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/install_prebuilt_rules_and_timelines/install_prebuilt_rules_package.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SecuritySolutionApiRequestHandlerContext } from '../../../../../types';
+import { PREBUILT_RULES_PACKAGE_NAME } from '../../../../../../common/detection_engine/constants';
+import type { ConfigType } from '../../../../../config';
+
+/**
+ * Installs the prebuilt rules package of the config's specified or latest version.
+ *
+ * @param config Kibana config
+ * @param context Request handler context
+ */
+export async function installPrebuiltRulesPackage(
+  config: ConfigType,
+  context: SecuritySolutionApiRequestHandlerContext
+) {
+  // Get package version from the config
+  let pkgVersion = config.prebuiltRulesPackageVersion;
+
+  // Find latest package if the version isn't specified in the config
+  if (!pkgVersion) {
+    // Use prerelease versions in dev environment
+    const isPrerelease =
+      context.getAppClient().getKibanaVersion().includes('-SNAPSHOT') ||
+      context.getAppClient().getKibanaBranch() === 'main';
+
+    const result = await context
+      .getInternalFleetServices()
+      .packages.fetchFindLatestPackage(PREBUILT_RULES_PACKAGE_NAME, { prerelease: isPrerelease });
+    pkgVersion = result.version;
+  }
+
+  // Install the package
+  await context
+    .getInternalFleetServices()
+    .packages.ensureInstalledPackage({ pkgName: PREBUILT_RULES_PACKAGE_NAME, pkgVersion });
+}

--- a/x-pack/plugins/security_solution/server/lib/telemetry/receiver.ts
+++ b/x-pack/plugins/security_solution/server/lib/telemetry/receiver.ts
@@ -63,6 +63,7 @@ import type {
 } from './types';
 import { telemetryConfiguration } from './configuration';
 import { ENDPOINT_METRICS_INDEX } from '../../../common/constants';
+import { PREBUILT_RULES_PACKAGE_NAME } from '../../../common/detection_engine/constants';
 
 export interface ITelemetryReceiver {
   start(
@@ -220,7 +221,7 @@ export class TelemetryReceiver implements ITelemetryReceiver {
   }
 
   public async fetchDetectionRulesPackageVersion(): Promise<Installation | undefined> {
-    return this.packageService?.asInternalUser.getInstallation('security_detection_engine');
+    return this.packageService?.asInternalUser.getInstallation(PREBUILT_RULES_PACKAGE_NAME);
   }
 
   public async fetchFleetAgents() {

--- a/x-pack/plugins/security_solution/server/plugin.ts
+++ b/x-pack/plugins/security_solution/server/plugin.ts
@@ -171,6 +171,8 @@ export class Plugin implements ISecuritySolutionPlugin {
       plugins,
       endpointAppContextService: this.endpointAppContextService,
       ruleExecutionLogService,
+      kibanaVersion: pluginContext.env.packageInfo.version,
+      kibanaBranch: pluginContext.env.packageInfo.branch,
     });
 
     const router = core.http.createRouter<SecuritySolutionRequestHandlerContext>();
@@ -357,6 +359,8 @@ export class Plugin implements ISecuritySolutionPlugin {
       appClientFactory.setup({
         getSpaceId: depsStart.spaces?.spacesService?.getSpaceId,
         config,
+        kibanaVersion: pluginContext.env.packageInfo.version,
+        kibanaBranch: pluginContext.env.packageInfo.branch,
       });
 
       const endpointFieldsStrategy = endpointFieldsProvider(

--- a/x-pack/plugins/security_solution/server/request_context_factory.ts
+++ b/x-pack/plugins/security_solution/server/request_context_factory.ts
@@ -40,6 +40,8 @@ interface ConstructorOptions {
   plugins: SecuritySolutionPluginSetupDependencies;
   endpointAppContextService: EndpointAppContextService;
   ruleExecutionLogService: IRuleExecutionLogService;
+  kibanaVersion: string;
+  kibanaBranch: string;
 }
 
 export class RequestContextFactory implements IRequestContextFactory {
@@ -64,6 +66,8 @@ export class RequestContextFactory implements IRequestContextFactory {
     appClientFactory.setup({
       getSpaceId: startPlugins.spaces?.spacesService?.getSpaceId,
       config,
+      kibanaVersion: options.kibanaVersion,
+      kibanaBranch: options.kibanaBranch,
     });
 
     // List of endpoint authz for the current request's user. Will be initialized the first


### PR DESCRIPTION
**Resolves: https://github.com/elastic/kibana/issues/150067**

## Summary

After removing the detection rules [distributed via the filesystem](https://github.com/elastic/kibana/pull/143839), the prepackaged rules installation endpoint started to behave a bit differently. Previously, `PUT detection_engine/rules/prepackaged` calls were installing rules regardless of the detection engine Fleet package installation status because there always were rules on the filesystem. Some integrations, like Elastic Defend, relied on that behavior. But currently, if users have never visited a detection engine page in kibana, all attempts to install detection rules via API will result in zero rules installed. That could lead to issues like this one reproducible when users follow the guided onboarding:
- https://github.com/elastic/kibana/issues/150067/

This PR tries to replicate previous behavior as closely as possible. I've added a check to the rules installation method, and if there are no detection rules assets in Kibana, we're trying to install the `security_detection_engine` package first. So that a `PUT detection_engine/rules/prepackaged` call will install rules even if users never visited any detection engine page.