### PR TITLE
[Fleet] Add ability to show FQDN of agents 

### DIFF
--- a/src/core/server/integration_tests/saved_objects/migrations/check_registered_types.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/check_registered_types.test.ts
@@ -101,7 +101,7 @@ describe('checking migration metadata changes on all registered SO types', () =>
         "index-pattern": "48e77ca393c254e93256f11a7cdc0232dd754c08",
         "infrastructure-monitoring-log-view": "e2c78c1076bd35e57d7c5fa1b410e5c126d12327",
         "infrastructure-ui-source": "7c8dbbc0a608911f1b683a944f4a65383f6153ed",
-        "ingest-agent-policies": "bb5141304409d3faafd6647494d36727f4dc77ea",
+        "ingest-agent-policies": "a94bd53b8f81ca883de8a75386db04e27dda973e",
         "ingest-download-sources": "1e69dabd6db5e320fe08c5bda8f35f29bafc6b54",
         "ingest-outputs": "29181ecfdc7723f544325ecef7266bccbc691a54",
         "ingest-package-policies": "0335a28af793ce25b4969d2156cfaf1dae2ef812",

--- a/src/core/server/integration_tests/saved_objects/migrations/check_registered_types.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/check_registered_types.test.ts
@@ -101,7 +101,7 @@ describe('checking migration metadata changes on all registered SO types', () =>
         "index-pattern": "48e77ca393c254e93256f11a7cdc0232dd754c08",
         "infrastructure-monitoring-log-view": "e2c78c1076bd35e57d7c5fa1b410e5c126d12327",
         "infrastructure-ui-source": "7c8dbbc0a608911f1b683a944f4a65383f6153ed",
-        "ingest-agent-policies": "54d586fdafae83ba326e47d1a3727b0d9c910a12",
+        "ingest-agent-policies": "bb5141304409d3faafd6647494d36727f4dc77ea",
         "ingest-download-sources": "1e69dabd6db5e320fe08c5bda8f35f29bafc6b54",
         "ingest-outputs": "29181ecfdc7723f544325ecef7266bccbc691a54",
         "ingest-package-policies": "0335a28af793ce25b4969d2156cfaf1dae2ef812",

--- a/x-pack/plugins/fleet/common/openapi/bundled.json
+++ b/x-pack/plugins/fleet/common/openapi/bundled.json
@@ -5807,6 +5807,25 @@
               },
               "agents": {
                 "type": "number"
+              },
+              "agent_features": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "enabled": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "enabled"
+                  ]
+                }
               }
             },
             "required": [

--- a/x-pack/plugins/fleet/common/openapi/bundled.json
+++ b/x-pack/plugins/fleet/common/openapi/bundled.json
@@ -5812,7 +5812,6 @@
                 "type": "array",
                 "items": {
                   "type": "object",
-                  "additionalProperties": true,
                   "properties": {
                     "name": {
                       "type": "string"

--- a/x-pack/plugins/fleet/common/openapi/bundled.yaml
+++ b/x-pack/plugins/fleet/common/openapi/bundled.yaml
@@ -3708,7 +3708,6 @@ components:
               type: array
               items:
                 type: object
-                additionalProperties: true
                 properties:
                   name:
                     type: string

--- a/x-pack/plugins/fleet/common/openapi/bundled.yaml
+++ b/x-pack/plugins/fleet/common/openapi/bundled.yaml
@@ -3704,6 +3704,19 @@ components:
               type: number
             agents:
               type: number
+            agent_features:
+              type: array
+              items:
+                type: object
+                additionalProperties: true
+                properties:
+                  name:
+                    type: string
+                  enabled:
+                    type: boolean
+                required:
+                  - name
+                  - enabled
           required:
             - id
             - status

--- a/x-pack/plugins/fleet/common/openapi/components/schemas/agent_policy.yaml
+++ b/x-pack/plugins/fleet/common/openapi/components/schemas/agent_policy.yaml
@@ -39,7 +39,6 @@ allOf:
         type: array
         items: 
           type: object
-          additionalProperties: true
           properties:
             name: 
               type: string

--- a/x-pack/plugins/fleet/common/openapi/components/schemas/agent_policy.yaml
+++ b/x-pack/plugins/fleet/common/openapi/components/schemas/agent_policy.yaml
@@ -35,6 +35,19 @@ allOf:
         type: number
       agents:
         type: number
+      agent_features:
+        type: array
+        items: 
+          type: object
+          additionalProperties: true
+          properties:
+            name: 
+              type: string
+            enabled: 
+              type: boolean
+          required:
+            - name
+            - enabled
     required:
       - id
       - status

--- a/x-pack/plugins/fleet/common/types/models/agent_policy.ts
+++ b/x-pack/plugins/fleet/common/types/models/agent_policy.ts
@@ -113,6 +113,7 @@ export interface FullAgentPolicy {
       logs: boolean;
     };
     download: { sourceURI: string };
+    features: Record<string, { enabled: boolean; [key: string]: any }>;
   };
 }
 

--- a/x-pack/plugins/fleet/common/types/models/agent_policy.ts
+++ b/x-pack/plugins/fleet/common/types/models/agent_policy.ts
@@ -32,6 +32,7 @@ export interface NewAgentPolicy {
   download_source_id?: string | null;
   fleet_server_host_id?: string | null;
   schema_version?: string;
+  agent_features?: Array<{ name: string; enabled: boolean; [key: string]: any }>;
 }
 
 export interface AgentPolicy extends Omit<NewAgentPolicy, 'id'> {

--- a/x-pack/plugins/fleet/common/types/models/agent_policy.ts
+++ b/x-pack/plugins/fleet/common/types/models/agent_policy.ts
@@ -32,7 +32,7 @@ export interface NewAgentPolicy {
   download_source_id?: string | null;
   fleet_server_host_id?: string | null;
   schema_version?: string;
-  agent_features?: Array<{ name: string; enabled: boolean; [key: string]: any }>;
+  agent_features?: Array<{ name: string; enabled: boolean }>;
 }
 
 export interface AgentPolicy extends Omit<NewAgentPolicy, 'id'> {
@@ -113,7 +113,7 @@ export interface FullAgentPolicy {
       logs: boolean;
     };
     download: { sourceURI: string };
-    features: Record<string, { enabled: boolean; [key: string]: any }>;
+    features: Record<string, { enabled: boolean }>;
   };
 }
 

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_advanced_fields/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_advanced_fields/index.tsx
@@ -20,6 +20,10 @@ import {
   EuiSuperSelect,
   EuiToolTip,
   EuiBadge,
+  EuiRadioGroup,
+  EuiText,
+  EuiFlexGroup,
+  EuiFlexItem,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
@@ -514,6 +518,89 @@ export const AgentPolicyAdvancedOptionsContent: React.FunctionComponent<Props> =
             }}
             isInvalid={Boolean(touchedFields.unenroll_timeout && validation.unenroll_timeout)}
             onBlur={() => setTouchedFields({ ...touchedFields, unenroll_timeout: true })}
+          />
+        </EuiFormRow>
+      </EuiDescribedFormGroup>
+      <EuiDescribedFormGroup
+        title={
+          <h4>
+            <FormattedMessage
+              id="xpack.fleet.agentPolicyForm.hostnameFormatLabel"
+              defaultMessage="Host name format"
+            />
+          </h4>
+        }
+        description={
+          <FormattedMessage
+            id="xpack.fleet.agentPolicyForm.hostnameFormatLabelDescription"
+            defaultMessage="Select how you would like agent domain names to be displayed."
+          />
+        }
+      >
+        <EuiFormRow fullWidth>
+          <EuiRadioGroup
+            options={[
+              {
+                id: 'hostname',
+                label: (
+                  <>
+                    <EuiFlexGroup gutterSize="xs" direction="column">
+                      <EuiFlexItem grow={false}>
+                        <EuiText size="s">
+                          <b>
+                            <FormattedMessage
+                              id="xpack.fleet.agentPolicyForm.hostnameFormatOptionHostname"
+                              defaultMessage="Hostname"
+                            />
+                          </b>
+                        </EuiText>
+                      </EuiFlexItem>
+                      <EuiFlexItem grow={false}>
+                        <EuiText size="s" color="subdued">
+                          <FormattedMessage
+                            id="xpack.fleet.agentPolicyForm.hostnameFormatOptionHostnameExample"
+                            defaultMessage="ex: My-Laptop"
+                          />
+                        </EuiText>
+                      </EuiFlexItem>
+                    </EuiFlexGroup>
+                    <EuiSpacer size="s" />
+                  </>
+                ),
+              },
+              {
+                id: 'fqdn',
+                label: (
+                  <EuiFlexGroup gutterSize="xs" direction="column">
+                    <EuiFlexItem grow={false}>
+                      <EuiText size="s">
+                        <b>
+                          <FormattedMessage
+                            id="xpack.fleet.agentPolicyForm.hostnameFormatOptionFqdn"
+                            defaultMessage="Fully Qualified Domain Name (FQDN)"
+                          />
+                        </b>
+                      </EuiText>
+                    </EuiFlexItem>
+                    <EuiFlexItem grow={false}>
+                      <EuiText size="s" color="subdued">
+                        <FormattedMessage
+                          id="xpack.fleet.agentPolicyForm.hostnameFormatOptionFqdnExample"
+                          defaultMessage="ex: My-Laptop.admin.acme.co"
+                        />
+                      </EuiText>
+                    </EuiFlexItem>
+                  </EuiFlexGroup>
+                ),
+              },
+            ]}
+            idSelected={agentPolicy.agent_features?.length ? 'fqdn' : 'hostname'}
+            onChange={(id: string) => {
+              updateAgentPolicy({
+                agent_features: id === 'hostname' ? [] : [{ name: 'fqdn', enabled: true }],
+              });
+            }}
+            name="radio group"
           />
         </EuiFormRow>
       </EuiDescribedFormGroup>

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/details_page/components/settings/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/details_page/components/settings/index.tsx
@@ -40,6 +40,21 @@ import { DevtoolsRequestFlyoutButton } from '../../../../../components';
 import { ExperimentalFeaturesService } from '../../../../../services';
 import { generateUpdateAgentPolicyDevToolsRequest } from '../../../services';
 
+const pickAgentPolicyKeysToSend = (agentPolicy: AgentPolicy) =>
+  pick(agentPolicy, [
+    'name',
+    'description',
+    'namespace',
+    'monitoring_enabled',
+    'unenroll_timeout',
+    'inactivity_timeout',
+    'data_output_id',
+    'monitoring_output_id',
+    'download_source_id',
+    'fleet_server_host_id',
+    'agent_features',
+  ]);
+
 const FormWrapper = styled.div`
   max-width: 800px;
   margin-right: auto;
@@ -77,37 +92,10 @@ export const SettingsView = memo<{ agentPolicy: AgentPolicy }>(
     const submitUpdateAgentPolicy = async () => {
       setIsLoading(true);
       try {
-        const {
-          name,
-          description,
-          namespace,
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          monitoring_enabled,
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          unenroll_timeout,
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          inactivity_timeout,
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          data_output_id,
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          monitoring_output_id,
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          download_source_id,
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          fleet_server_host_id,
-        } = agentPolicy;
-        const { data, error } = await sendUpdateAgentPolicy(agentPolicy.id, {
-          name,
-          description,
-          namespace,
-          monitoring_enabled,
-          unenroll_timeout,
-          inactivity_timeout,
-          data_output_id,
-          monitoring_output_id,
-          download_source_id,
-          fleet_server_host_id,
-        });
+        const { data, error } = await sendUpdateAgentPolicy(
+          agentPolicy.id,
+          pickAgentPolicyKeysToSend(agentPolicy)
+        );
         if (data) {
           notifications.toasts.addSuccess(
             i18n.translate('xpack.fleet.editAgentPolicy.successNotificationTitle', {
@@ -141,19 +129,7 @@ export const SettingsView = memo<{ agentPolicy: AgentPolicy }>(
       () =>
         generateUpdateAgentPolicyDevToolsRequest(
           agentPolicy.id,
-          pick(
-            agentPolicy,
-            'name',
-            'description',
-            'namespace',
-            'monitoring_enabled',
-            'unenroll_timeout',
-            'inactivity_timeout',
-            'data_output_id',
-            'monitoring_output_id',
-            'download_source_id',
-            'fleet_server_host_id'
-          )
+          pickAgentPolicyKeysToSend(agentPolicy)
         ),
       [agentPolicy]
     );

--- a/x-pack/plugins/fleet/server/saved_objects/index.ts
+++ b/x-pack/plugins/fleet/server/saved_objects/index.ts
@@ -114,7 +114,6 @@ const getSavedObjectTypes = (
         download_source_id: { type: 'keyword' },
         fleet_server_host_id: { type: 'keyword' },
         agent_features: {
-          dynamic: false,
           properties: {
             name: { type: 'keyword' },
             enabled: { type: 'boolean' },

--- a/x-pack/plugins/fleet/server/saved_objects/index.ts
+++ b/x-pack/plugins/fleet/server/saved_objects/index.ts
@@ -113,6 +113,11 @@ const getSavedObjectTypes = (
         monitoring_output_id: { type: 'keyword' },
         download_source_id: { type: 'keyword' },
         fleet_server_host_id: { type: 'keyword' },
+        agent_features: {
+          properties: {
+            name: { type: 'keyword' },
+            enabled: { type: 'boolean' },
+        }
       },
     },
     migrations: {

--- a/x-pack/plugins/fleet/server/saved_objects/index.ts
+++ b/x-pack/plugins/fleet/server/saved_objects/index.ts
@@ -114,6 +114,7 @@ const getSavedObjectTypes = (
         download_source_id: { type: 'keyword' },
         fleet_server_host_id: { type: 'keyword' },
         agent_features: {
+          dynamic: false,
           properties: {
             name: { type: 'keyword' },
             enabled: { type: 'boolean' },

--- a/x-pack/plugins/fleet/server/saved_objects/index.ts
+++ b/x-pack/plugins/fleet/server/saved_objects/index.ts
@@ -117,7 +117,8 @@ const getSavedObjectTypes = (
           properties: {
             name: { type: 'keyword' },
             enabled: { type: 'boolean' },
-        }
+          },
+        },
       },
     },
     migrations: {

--- a/x-pack/plugins/fleet/server/services/agent_policies/__snapshots__/full_agent_policy.test.ts.snap
+++ b/x-pack/plugins/fleet/server/services/agent_policies/__snapshots__/full_agent_policy.test.ts.snap
@@ -6,6 +6,7 @@ Object {
     "download": Object {
       "sourceURI": "http://default-registry.co",
     },
+    "features": Object {},
     "monitoring": Object {
       "enabled": true,
       "logs": false,
@@ -71,6 +72,7 @@ Object {
     "download": Object {
       "sourceURI": "http://default-registry.co",
     },
+    "features": Object {},
     "monitoring": Object {
       "enabled": true,
       "logs": false,
@@ -136,6 +138,7 @@ Object {
     "download": Object {
       "sourceURI": "http://default-registry.co",
     },
+    "features": Object {},
     "monitoring": Object {
       "enabled": true,
       "logs": false,

--- a/x-pack/plugins/fleet/server/services/agent_policies/full_agent_policy.test.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policies/full_agent_policy.test.ts
@@ -388,6 +388,53 @@ describe('getFullAgentPolicy', () => {
       },
     });
   });
+
+  it('should add + transform agent features', async () => {
+    mockAgentPolicy({
+      namespace: 'default',
+      revision: 1,
+      monitoring_enabled: ['metrics'],
+      agent_features: [
+        { name: 'fqdn', enabled: true, config_1: 'something' },
+        { name: 'feature2', enabled: true, config_2: 'something' },
+      ],
+    });
+    const agentPolicy = await getFullAgentPolicy(savedObjectsClientMock.create(), 'agent-policy');
+
+    expect(agentPolicy).toMatchObject({
+      id: 'agent-policy',
+      outputs: {
+        default: {
+          type: 'elasticsearch',
+          hosts: ['http://127.0.0.1:9201'],
+        },
+      },
+      inputs: [],
+      revision: 1,
+      fleet: {
+        hosts: ['http://fleetserver:8220'],
+      },
+      agent: {
+        monitoring: {
+          namespace: 'default',
+          use_output: 'default',
+          enabled: true,
+          logs: false,
+          metrics: true,
+        },
+        features: {
+          fqdn: {
+            enabled: true,
+            config_1: 'something',
+          },
+          feature2: {
+            enabled: true,
+            config_2: 'something',
+          },
+        },
+      },
+    });
+  });
 });
 
 describe('transformOutputToFullPolicyOutput', () => {

--- a/x-pack/plugins/fleet/server/services/agent_policies/full_agent_policy.test.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policies/full_agent_policy.test.ts
@@ -395,8 +395,8 @@ describe('getFullAgentPolicy', () => {
       revision: 1,
       monitoring_enabled: ['metrics'],
       agent_features: [
-        { name: 'fqdn', enabled: true, config_1: 'something' },
-        { name: 'feature2', enabled: true, config_2: 'something' },
+        { name: 'fqdn', enabled: true },
+        { name: 'feature2', enabled: true },
       ],
     });
     const agentPolicy = await getFullAgentPolicy(savedObjectsClientMock.create(), 'agent-policy');
@@ -425,11 +425,9 @@ describe('getFullAgentPolicy', () => {
         features: {
           fqdn: {
             enabled: true,
-            config_1: 'something',
           },
           feature2: {
             enabled: true,
-            config_2: 'something',
           },
         },
       },

--- a/x-pack/plugins/fleet/server/services/agent_policies/full_agent_policy.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policies/full_agent_policy.ts
@@ -120,6 +120,10 @@ export async function getFullAgentPolicy(
               metrics: agentPolicy.monitoring_enabled.includes(dataTypes.Metrics),
             }
           : { enabled: false, logs: false, metrics: false },
+      features: (agentPolicy.agent_features || []).reduce((acc, { name, ...featureConfig }) => {
+        acc[name] = featureConfig;
+        return acc;
+      }, {} as NonNullable<FullAgentPolicy['agent']>['features']),
     },
   };
 

--- a/x-pack/plugins/fleet/server/types/models/agent_policy.ts
+++ b/x-pack/plugins/fleet/server/types/models/agent_policy.ts
@@ -41,13 +41,10 @@ export const AgentPolicyBaseSchema = {
   fleet_server_host_id: schema.maybe(schema.nullable(schema.string())),
   agent_features: schema.maybe(
     schema.arrayOf(
-      schema.object(
-        {
-          name: schema.string(),
-          enabled: schema.boolean(),
-        },
-        { unknowns: 'allow' }
-      )
+      schema.object({
+        name: schema.string(),
+        enabled: schema.boolean(),
+      })
     )
   ),
 };

--- a/x-pack/plugins/fleet/server/types/models/agent_policy.ts
+++ b/x-pack/plugins/fleet/server/types/models/agent_policy.ts
@@ -39,6 +39,17 @@ export const AgentPolicyBaseSchema = {
   monitoring_output_id: schema.maybe(schema.nullable(schema.string())),
   download_source_id: schema.maybe(schema.nullable(schema.string())),
   fleet_server_host_id: schema.maybe(schema.nullable(schema.string())),
+  agent_features: schema.maybe(
+    schema.arrayOf(
+      schema.object(
+        {
+          name: schema.string(),
+          enabled: schema.boolean(),
+        },
+        { unknowns: 'allow' }
+      )
+    )
+  ),
 };
 
 export const NewAgentPolicySchema = schema.object({

--- a/x-pack/test/fleet_api_integration/apis/agent_policy/agent_policy.ts
+++ b/x-pack/test/fleet_api_integration/apis/agent_policy/agent_policy.ts
@@ -97,6 +97,24 @@ export default function (providerContext: FtrProviderContext) {
         expect(policy2.is_managed).to.equal(false);
       });
 
+      it('does not allow arbitrary config in agent_features value', async () => {
+        await supertest
+          .post(`/api/fleet/agent_policies`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({
+            name: 'test-agent-features',
+            namespace: 'default',
+            agent_features: [
+              {
+                name: 'fqdn',
+                enabled: true,
+                config: "I'm not allowed yet",
+              },
+            ],
+          })
+          .expect(400);
+      });
+
       it('sets given agent_features value', async () => {
         const {
           body: { item: createdPolicy },
@@ -110,7 +128,6 @@ export default function (providerContext: FtrProviderContext) {
               {
                 name: 'fqdn',
                 enabled: true,
-                config_1: 'config_1',
               },
             ],
           })
@@ -121,7 +138,6 @@ export default function (providerContext: FtrProviderContext) {
           {
             name: 'fqdn',
             enabled: true,
-            config_1: 'config_1',
           },
         ]);
 
@@ -138,7 +154,6 @@ export default function (providerContext: FtrProviderContext) {
         expect(policyDocRes?.hits?.hits[0]?._source?.data?.agent?.features).to.eql({
           fqdn: {
             enabled: true,
-            config_1: 'config_1',
           },
         });
       });

--- a/x-pack/test/fleet_api_integration/apis/agent_policy/agent_policy.ts
+++ b/x-pack/test/fleet_api_integration/apis/agent_policy/agent_policy.ts
@@ -104,7 +104,7 @@ export default function (providerContext: FtrProviderContext) {
           .post(`/api/fleet/agent_policies`)
           .set('kbn-xsrf', 'xxxx')
           .send({
-            name: 'TEST2',
+            name: 'test-agent-features',
             namespace: 'default',
             agent_features: [
               {

--- a/x-pack/test/fleet_api_integration/apis/agent_policy/agent_policy.ts
+++ b/x-pack/test/fleet_api_integration/apis/agent_policy/agent_policy.ts
@@ -97,7 +97,7 @@ export default function (providerContext: FtrProviderContext) {
         expect(policy2.is_managed).to.equal(false);
       });
 
-      it.only('sets given agent_features value', async () => {
+      it('sets given agent_features value', async () => {
         const {
           body: { item: createdPolicy },
         } = await supertest


### PR DESCRIPTION
## Summary

Closes #149059 

Adds the `agent_features` agent policy field which is an array of feature flags. As part of this allow the FQDN feature to be configured in the agent policy settings.

<img width="1049" alt="Screenshot 2023-02-02 at 23 59 17" src="https://user-images.githubusercontent.com/3315046/216478081-c6316798-bcc6-422a-85b1-fa5d717a229d.png">
