### PR TITLE
[Security Solution] Alert page charts new layout and chart collapse

### DIFF
--- a/x-pack/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/plugins/security_solution/common/experimental_features.ts
@@ -89,7 +89,7 @@ export const allowedExperimentalValues = Object.freeze({
   /**
    * Enables top charts on Alerts Page
    */
-  alertsPageChartsEnabled: false,
+  alertsPageChartsEnabled: true,
 
   /**
    * Keep DEPRECATED experimental flags that are documented to prevent failed upgrades.

--- a/x-pack/plugins/security_solution/cypress/screens/alerts.ts
+++ b/x-pack/plugins/security_solution/cypress/screens/alerts.ts
@@ -90,7 +90,7 @@ export const RULE_NAME = '[data-test-subj^=formatted-field][data-test-subj$=rule
 
 export const SELECTED_ALERTS = '[data-test-subj="selectedShowBulkActionsButton"]';
 
-export const SELECT_TABLE = '[data-test-subj="chart-select-table"]';
+export const SELECT_AGGREGATION_CHART = '[data-test-subj="chart-select-table"]';
 
 export const SEND_ALERT_TO_TIMELINE_BTN = '[data-test-subj="send-alert-to-timeline-button"]';
 

--- a/x-pack/plugins/security_solution/cypress/screens/alerts.ts
+++ b/x-pack/plugins/security_solution/cypress/screens/alerts.ts
@@ -32,8 +32,6 @@ export const ALERTS_COUNT =
 export const ALERTS_TREND_SIGNAL_RULE_NAME_PANEL =
   '[data-test-subj="render-content-kibana.alert.rule.name"]';
 
-export const CHART_SELECT = '[data-test-subj="chartSelect"]';
-
 export const CLOSE_ALERT_BTN = '[data-test-subj="close-alert-status"]';
 
 export const CLOSE_SELECTED_ALERTS_BTN = '[data-test-subj="close-alert-status"]';
@@ -92,7 +90,7 @@ export const RULE_NAME = '[data-test-subj^=formatted-field][data-test-subj$=rule
 
 export const SELECTED_ALERTS = '[data-test-subj="selectedShowBulkActionsButton"]';
 
-export const SELECT_TABLE = '[data-test-subj="table"]';
+export const SELECT_TABLE = '[data-test-subj="chart-select-table"]';
 
 export const SEND_ALERT_TO_TIMELINE_BTN = '[data-test-subj="send-alert-to-timeline-button"]';
 

--- a/x-pack/plugins/security_solution/cypress/tasks/alerts.ts
+++ b/x-pack/plugins/security_solution/cypress/tasks/alerts.ts
@@ -17,7 +17,7 @@ import {
   MARK_ALERT_ACKNOWLEDGED_BTN,
   OPEN_ALERT_BTN,
   SEND_ALERT_TO_TIMELINE_BTN,
-  SELECT_TABLE,
+  SELECT_AGGREGATION_CHART,
   TAKE_ACTION_POPOVER_BTN,
   TIMELINE_CONTEXT_MENU_BTN,
   CLOSE_FLYOUT,
@@ -256,7 +256,7 @@ export const openAlerts = () => {
 };
 
 export const selectCountTable = () => {
-  cy.get(SELECT_TABLE).click({ force: true });
+  cy.get(SELECT_AGGREGATION_CHART).click({ force: true });
 };
 
 export const clearGroupByTopInput = () => {

--- a/x-pack/plugins/security_solution/cypress/tasks/alerts.ts
+++ b/x-pack/plugins/security_solution/cypress/tasks/alerts.ts
@@ -8,7 +8,6 @@
 import {
   ADD_EXCEPTION_BTN,
   ALERT_CHECKBOX,
-  CHART_SELECT,
   CLOSE_ALERT_BTN,
   CLOSE_SELECTED_ALERTS_BTN,
   EXPAND_ALERT_BTN,
@@ -257,8 +256,7 @@ export const openAlerts = () => {
 };
 
 export const selectCountTable = () => {
-  cy.get(CHART_SELECT).click({ force: true });
-  cy.get(SELECT_TABLE).click();
+  cy.get(SELECT_TABLE).click({ force: true });
 };
 
 export const clearGroupByTopInput = () => {

--- a/x-pack/plugins/security_solution/public/common/components/alerts_treemap/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/alerts_treemap/index.test.tsx
@@ -49,7 +49,7 @@ describe('AlertsTreemap', () => {
     });
 
     test('it renders the treemap', () => {
-      expect(screen.getByTestId('treemap').querySelector('.echChart')).toBeInTheDocument();
+      expect(screen.getByTestId('alerts-treemap').querySelector('.echChart')).toBeInTheDocument();
     });
 
     test('it renders the legend with the expected overflow-y style', () => {
@@ -71,7 +71,7 @@ describe('AlertsTreemap', () => {
     });
 
     test('it does NOT render the treemap', () => {
-      expect(screen.queryByTestId('treemap')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('alerts-treemap')).not.toBeInTheDocument();
     });
 
     test('it does NOT render the legend', () => {
@@ -127,7 +127,7 @@ describe('AlertsTreemap', () => {
     });
 
     test('it renders the treemap', () => {
-      expect(screen.getByTestId('treemap').querySelector('.echChart')).toBeInTheDocument();
+      expect(screen.getByTestId('alerts-treemap').querySelector('.echChart')).toBeInTheDocument();
     });
 
     test('it does NOT render the "no data" message', () => {

--- a/x-pack/plugins/security_solution/public/common/components/alerts_treemap/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/alerts_treemap/index.tsx
@@ -165,7 +165,7 @@ const AlertsTreemapComponent: React.FC<Props> = ({
   }
 
   return (
-    <div data-test-subj="treemap">
+    <div data-test-subj="alerts-treemap">
       <EuiFlexGroup gutterSize="none">
         <ChartFlexItem grow={true} $minChartHeight={minChartHeight}>
           {stackByField1 != null && !isEmpty(stackByField1) && normalizedData.length === 0 ? (

--- a/x-pack/plugins/security_solution/public/common/components/alerts_treemap_panel/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/alerts_treemap_panel/index.test.tsx
@@ -214,7 +214,7 @@ describe('AlertsTreemapPanel', () => {
       </TestProviders>
     );
 
-    await waitFor(() => expect(screen.getByTestId('chartSelect')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByTestId('chart-select-tabs')).toBeInTheDocument());
   });
 
   it('renders field selection when `isPanelExpanded` is true', async () => {
@@ -305,6 +305,6 @@ describe('AlertsTreemapPanel', () => {
       </TestProviders>
     );
 
-    await waitFor(() => expect(screen.getByTestId('treemap')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByTestId('alerts-treemap')).toBeInTheDocument());
   });
 });

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/alerts_by_type_panel/helpers.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/alerts_by_type_panel/helpers.tsx
@@ -59,11 +59,11 @@ const getAggregateAlerts = (
   return ret;
 };
 
-export const isAlertsTypeData = (data: SummaryChartsData[]): data is AlertsTypeData[] => {
+export const getIsAlertsTypeData = (data: SummaryChartsData[]): data is AlertsTypeData[] => {
   return data?.every((x) => has(x, 'type'));
 };
 
-export const isAlertsByTypeAgg = (
+export const getIsAlertsByTypeAgg = (
   data: AlertSearchResponse<{}, SummaryChartsAgg>
 ): data is AlertSearchResponse<{}, AlertsByTypeAgg> => {
   return has(data, 'aggregations.alertsByRule');

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/alerts_by_type_panel/helpers.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/alerts_by_type_panel/helpers.tsx
@@ -7,7 +7,7 @@
 import { has } from 'lodash';
 import type { AlertType, AlertsByTypeAgg, AlertsTypeData } from './types';
 import type { AlertSearchResponse } from '../../../containers/detection_engine/alerts/types';
-import type { SummaryChartsData } from '../alerts_summary_charts_panel/types';
+import type { SummaryChartsData, SummaryChartsAgg } from '../alerts_summary_charts_panel/types';
 
 export const ALERT_TYPE_COLOR = {
   Detection: '#D36086',
@@ -61,4 +61,10 @@ const getAggregateAlerts = (
 
 export const isAlertsTypeData = (data: SummaryChartsData[]): data is AlertsTypeData[] => {
   return data?.every((x) => has(x, 'type'));
+};
+
+export const isAlertsByTypeAgg = (
+  data: AlertSearchResponse<{}, SummaryChartsAgg>
+): data is AlertSearchResponse<{}, AlertsByTypeAgg> => {
+  return has(data, 'aggregations.alertsByRule');
 };

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/alerts_by_type_panel/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/alerts_by_type_panel/index.tsx
@@ -14,7 +14,7 @@ import { HeaderSection } from '../../../../common/components/header_section';
 import { InspectButtonContainer } from '../../../../common/components/inspect';
 import { useSummaryChartData } from '../alerts_summary_charts_panel/use_summary_chart_data';
 import { alertTypeAggregations } from '../alerts_summary_charts_panel/aggregations';
-import { isAlertsTypeData } from './helpers';
+import { getIsAlertsTypeData } from './helpers';
 import * as i18n from './translations';
 
 const ALERTS_BY_TYPE_CHART_ID = 'alerts-summary-alert_by_type';
@@ -37,7 +37,7 @@ export const AlertsByTypePanel: React.FC<ChartsPanelProps> = ({
     skip,
     uniqueQueryId,
   });
-  const data = useMemo(() => (isAlertsTypeData(items) ? items : []), [items]);
+  const data = useMemo(() => (getIsAlertsTypeData(items) ? items : []), [items]);
 
   return (
     <InspectButtonContainer>

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/alerts_count_panel/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/alerts_count_panel/index.tsx
@@ -84,6 +84,7 @@ export const AlertsCountPanel = memo<AlertsCountPanelProps>(
     setIsExpanded,
   }) => {
     const { to, from, deleteQuery, setQuery } = useGlobalTime(false);
+    const isChartEmbeddablesEnabled = useIsExperimentalFeatureEnabled('chartEmbeddablesEnabled');
     const isAlertsPageChartsEnabled = useIsExperimentalFeatureEnabled('alertsPageChartsEnabled');
     // create a unique, but stable (across re-renders) query id
     const uniqueQueryId = useMemo(() => `${DETECTIONS_ALERTS_COUNT_ID}-${uuidv4()}`, []);
@@ -130,7 +131,6 @@ export const AlertsCountPanel = memo<AlertsCountPanelProps>(
       [setQuerySkip, setToggleStatus, setIsExpanded, isAlertsPageChartsEnabled]
     );
 
-    const isChartEmbeddablesEnabled = useIsExperimentalFeatureEnabled('chartEmbeddablesEnabled');
     const timerange = useMemo(() => ({ from, to }), [from, to]);
 
     const extraVisualizationOptions = useMemo(
@@ -234,7 +234,7 @@ export const AlertsCountPanel = memo<AlertsCountPanelProps>(
           (!isAlertsPageChartsEnabled && toggleStatus) ? (
             <ChartContent
               alertsData={alertsData}
-              data-test-subj="embeddable-matrix-histogram"
+              data-test-subj="embeddable-count-table"
               extraActions={extraActions}
               extraOptions={extraVisualizationOptions}
               getLensAttributes={getLensAttributes}

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/alerts_histogram_panel/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/alerts_histogram_panel/index.test.tsx
@@ -109,24 +109,23 @@ jest.mock('../common/hooks', () => {
   };
 });
 
+const mockUseIsExperimentalFeatureEnabled = useIsExperimentalFeatureEnabled as jest.Mock;
+jest.mock('../../../../common/hooks/use_experimental_features');
+
+const defaultProps = {
+  setQuery: jest.fn(),
+  showBuildingBlockAlerts: false,
+  showOnlyThreatIndicatorAlerts: false,
+  signalIndexName: 'signalIndexName',
+  updateDateRange: jest.fn(),
+};
+const mockSetToggle = jest.fn();
+const mockUseQueryToggle = useQueryToggle as jest.Mock;
+
 describe('AlertsHistogramPanel', () => {
-  const defaultProps = {
-    setQuery: jest.fn(),
-    showBuildingBlockAlerts: false,
-    showOnlyThreatIndicatorAlerts: false,
-    signalIndexName: 'signalIndexName',
-    updateDateRange: jest.fn(),
-  };
-
-  const mockSetToggle = jest.fn();
-  const mockUseQueryToggle = useQueryToggle as jest.Mock;
   beforeEach(() => {
-    mockUseQueryToggle.mockReturnValue({ toggleStatus: true, setToggleStatus: mockSetToggle });
-  });
-
-  afterEach(() => {
     jest.clearAllMocks();
-    jest.restoreAllMocks();
+    mockUseQueryToggle.mockReturnValue({ toggleStatus: true, setToggleStatus: mockSetToggle });
   });
 
   it('renders correctly', () => {
@@ -690,26 +689,85 @@ describe('AlertsHistogramPanel', () => {
         expect(mockSetToggle).toBeCalledWith(false);
       });
     });
-    it('toggleStatus=true, render', async () => {
-      await act(async () => {
-        const wrapper = mount(
-          <TestProviders>
-            <AlertsHistogramPanel {...defaultProps} />
-          </TestProviders>
-        );
 
-        expect(wrapper.find(MatrixLoader).exists()).toEqual(true);
+    describe('when alertsPageChartsEnabled = false', () => {
+      beforeEach(() => {
+        jest.clearAllMocks();
+        mockUseIsExperimentalFeatureEnabled.mockReturnValueOnce(false); // for chartEmbeddablesEnabled flag
+        mockUseIsExperimentalFeatureEnabled.mockReturnValueOnce(false); // for alertsPageChartsEnabled flag
+      });
+
+      it('toggleStatus=true, render', async () => {
+        await act(async () => {
+          const wrapper = mount(
+            <TestProviders>
+              <AlertsHistogramPanel {...defaultProps} />
+            </TestProviders>
+          );
+
+          expect(wrapper.find(MatrixLoader).exists()).toEqual(true);
+        });
+      });
+      it('toggleStatus=false, hide', async () => {
+        mockUseQueryToggle.mockReturnValue({ toggleStatus: false, setToggleStatus: mockSetToggle });
+        await act(async () => {
+          const wrapper = mount(
+            <TestProviders>
+              <AlertsHistogramPanel {...defaultProps} />
+            </TestProviders>
+          );
+          expect(wrapper.find(MatrixLoader).exists()).toEqual(false);
+        });
       });
     });
-    it('toggleStatus=false, hide', async () => {
-      mockUseQueryToggle.mockReturnValue({ toggleStatus: false, setToggleStatus: mockSetToggle });
-      await act(async () => {
-        const wrapper = mount(
-          <TestProviders>
-            <AlertsHistogramPanel {...defaultProps} />
-          </TestProviders>
-        );
-        expect(wrapper.find(MatrixLoader).exists()).toEqual(false);
+
+    describe('when alertsPageChartsEnabled = true', () => {
+      beforeEach(() => {
+        jest.clearAllMocks();
+        mockUseIsExperimentalFeatureEnabled.mockReturnValueOnce(false); // for chartEmbeddablesEnabled flag
+        mockUseIsExperimentalFeatureEnabled.mockReturnValueOnce(true); // for alertsPageChartsEnabled flag
+      });
+
+      it('isExpanded=true, render', async () => {
+        await act(async () => {
+          const wrapper = mount(
+            <TestProviders>
+              <AlertsHistogramPanel {...defaultProps} isExpanded={true} />
+            </TestProviders>
+          );
+          expect(wrapper.find(MatrixLoader).exists()).toEqual(true);
+        });
+      });
+      it('isExpanded=false, hide', async () => {
+        await act(async () => {
+          const wrapper = mount(
+            <TestProviders>
+              <AlertsHistogramPanel {...defaultProps} isExpanded={false} />
+            </TestProviders>
+          );
+          expect(wrapper.find(MatrixLoader).exists()).toEqual(false);
+        });
+      });
+      it('isExpanded is not passed in and toggleStatus =true, render', async () => {
+        await act(async () => {
+          const wrapper = mount(
+            <TestProviders>
+              <AlertsHistogramPanel {...defaultProps} />
+            </TestProviders>
+          );
+          expect(wrapper.find(MatrixLoader).exists()).toEqual(true);
+        });
+      });
+      it('isExpanded is not passed in and toggleStatus =false, hide', async () => {
+        mockUseQueryToggle.mockReturnValue({ toggleStatus: false, setToggleStatus: mockSetToggle });
+        await act(async () => {
+          const wrapper = mount(
+            <TestProviders>
+              <AlertsHistogramPanel {...defaultProps} />
+            </TestProviders>
+          );
+          expect(wrapper.find(MatrixLoader).exists()).toEqual(false);
+        });
       });
     });
   });
@@ -717,10 +775,9 @@ describe('AlertsHistogramPanel', () => {
   describe('when isChartEmbeddablesEnabled = true', () => {
     beforeEach(() => {
       jest.clearAllMocks();
-
       mockUseQueryToggle.mockReturnValue({ toggleStatus: true, setToggleStatus: mockSetToggle });
-
-      (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(true);
+      mockUseIsExperimentalFeatureEnabled.mockReturnValueOnce(true); // for chartEmbeddablesEnabled flag
+      mockUseIsExperimentalFeatureEnabled.mockReturnValueOnce(false); // for alertsPageChartsEnabled flag
     });
 
     it('renders LensEmbeddable', async () => {
@@ -730,7 +787,9 @@ describe('AlertsHistogramPanel', () => {
             <AlertsHistogramPanel {...defaultProps} />
           </TestProviders>
         );
-        expect(wrapper.find('[data-test-subj="lens-embeddable"]').exists()).toBeTruthy();
+        expect(
+          wrapper.find('[data-test-subj="embeddable-matrix-histogram"]').exists()
+        ).toBeTruthy();
       });
     });
 

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/alerts_progress_bar_panel/alerts_progress_bar.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/alerts_progress_bar_panel/alerts_progress_bar.test.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 import { TestProviders } from '../../../../common/mock';
 import { AlertsProgressBar } from './alerts_progress_bar';
 import { parsedAlerts } from './mock_data';
+import type { GroupBySelection } from './types';
 
 jest.mock('../../../../common/lib/kibana');
 
@@ -21,7 +22,7 @@ describe('Alert by grouping', () => {
   const defaultProps = {
     data: [],
     isLoading: false,
-    stackByField: 'host.name',
+    groupBySelection: 'host.name' as GroupBySelection,
   };
 
   afterEach(() => {
@@ -38,7 +39,7 @@ describe('Alert by grouping', () => {
       );
       expect(
         container.querySelector(`[data-test-subj="alerts-progress-bar-title"]`)?.textContent
-      ).toEqual(defaultProps.stackByField);
+      ).toEqual(defaultProps.groupBySelection);
       expect(container.querySelector(`[data-test-subj="empty-proress-bar"]`)).toBeInTheDocument();
       expect(container.querySelector(`[data-test-subj="empty-proress-bar"]`)?.textContent).toEqual(
         'No items found'
@@ -50,7 +51,7 @@ describe('Alert by grouping', () => {
     act(() => {
       const { container } = render(
         <TestProviders>
-          <AlertsProgressBar data={parsedAlerts} isLoading={false} stackByField={'host.name'} />
+          <AlertsProgressBar data={parsedAlerts} isLoading={false} groupBySelection={'host.name'} />
         </TestProviders>
       );
       expect(

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/alerts_progress_bar_panel/alerts_progress_bar.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/alerts_progress_bar_panel/alerts_progress_bar.tsx
@@ -7,7 +7,7 @@
 import { EuiProgress, EuiSpacer, EuiText, EuiHorizontalRule } from '@elastic/eui';
 import React from 'react';
 import styled from 'styled-components';
-import type { AlertsProgressBarData } from './types';
+import type { AlertsProgressBarData, GroupBySelection } from './types';
 import { DefaultDraggable } from '../../../../common/components/draggables';
 import * as i18n from './translations';
 
@@ -22,19 +22,19 @@ const StyledEuiText = styled(EuiText)`
 export interface AlertsProcessBarProps {
   data: AlertsProgressBarData[];
   isLoading: boolean;
-  stackByField: string;
   addFilter?: ({ field, value }: { field: string; value: string | number }) => void;
+  groupBySelection: GroupBySelection;
 }
 
 export const AlertsProgressBar: React.FC<AlertsProcessBarProps> = ({
   data,
   isLoading,
-  stackByField,
+  groupBySelection,
 }) => {
   return (
     <>
       <StyledEuiText size="s" data-test-subj="alerts-progress-bar-title">
-        <h5>{stackByField}</h5>
+        <h5>{groupBySelection}</h5>
       </StyledEuiText>
       <EuiHorizontalRule margin="xs" />
       {!isLoading && data.length === 0 ? (
@@ -64,7 +64,7 @@ export const AlertsProgressBar: React.FC<AlertsProcessBarProps> = ({
                   ) : (
                     <DefaultDraggable
                       isDraggable={false}
-                      field={stackByField}
+                      field={groupBySelection}
                       hideTopN={true}
                       id={`top-alerts-${item.key}`}
                       value={item.key}

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/alerts_progress_bar_panel/helpers.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/alerts_progress_bar_panel/helpers.tsx
@@ -6,10 +6,10 @@
  */
 
 import { has } from 'lodash';
-import type { AlertsByGroupingAgg, AlertsProgressBarData } from './types';
+import type { AlertsByGroupingAgg, AlertsProgressBarData, GroupBySelection } from './types';
 import type { AlertSearchResponse } from '../../../containers/detection_engine/alerts/types';
 import type { BucketItem } from '../../../../../common/search_strategy/security_solution/cti';
-import type { SummaryChartsData } from '../alerts_summary_charts_panel/types';
+import type { SummaryChartsData, SummaryChartsAgg } from '../alerts_summary_charts_panel/types';
 import * as i18n from './translations';
 
 export const parseAlertsGroupingData = (
@@ -47,4 +47,21 @@ export const isAlertsProgressBarData = (
   data: SummaryChartsData[]
 ): data is AlertsProgressBarData[] => {
   return data?.every((x) => has(x, 'percentage'));
+};
+
+export const isAlertsByGroupingAgg = (
+  data: AlertSearchResponse<{}, SummaryChartsAgg>
+): data is AlertSearchResponse<{}, AlertsByGroupingAgg> => {
+  return has(data, 'aggregations.alertsByGrouping');
+};
+
+const labels = {
+  'host.name': i18n.HOST_NAME_LABEL,
+  'user.name': i18n.USER_NAME_LABEL,
+  'source.ip': i18n.SOURCE_LABEL,
+  'destination.ip': i18n.DESTINATION_LABEL,
+};
+
+export const getGroupByLabel = (option: GroupBySelection): string => {
+  return labels[option];
 };

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/alerts_progress_bar_panel/helpers.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/alerts_progress_bar_panel/helpers.tsx
@@ -43,13 +43,13 @@ export const parseAlertsGroupingData = (
   return topAlerts;
 };
 
-export const isAlertsProgressBarData = (
+export const getIsAlertsProgressBarData = (
   data: SummaryChartsData[]
 ): data is AlertsProgressBarData[] => {
   return data?.every((x) => has(x, 'percentage'));
 };
 
-export const isAlertsByGroupingAgg = (
+export const getIsAlertsByGroupingAgg = (
   data: AlertSearchResponse<{}, SummaryChartsAgg>
 ): data is AlertSearchResponse<{}, AlertsByGroupingAgg> => {
   return has(data, 'aggregations.alertsByGrouping');

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/alerts_progress_bar_panel/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/alerts_progress_bar_panel/index.tsx
@@ -7,7 +7,8 @@
 import { EuiPanel, EuiLoadingSpinner } from '@elastic/eui';
 import React, { useEffect, useState, useCallback, useMemo } from 'react';
 import { v4 as uuid } from 'uuid';
-import type { ChartsPanelProps } from '../alerts_summary_charts_panel/types';
+import type { MappingRuntimeFields } from '@elastic/elasticsearch/lib/api/types';
+import type { Filter, Query } from '@kbn/es-query';
 import { HeaderSection } from '../../../../common/components/header_section';
 import { InspectButtonContainer } from '../../../../common/components/inspect';
 import { StackByComboBox } from '../common/components';
@@ -17,28 +18,45 @@ import { alertsGroupingAggregations } from '../alerts_summary_charts_panel/aggre
 import { showInitialLoadingSpinner } from '../alerts_histogram_panel/helpers';
 import { isAlertsProgressBarData } from './helpers';
 import * as i18n from './translations';
+import type { GroupBySelection } from './types';
 
 const TOP_ALERTS_CHART_ID = 'alerts-summary-top-alerts';
 const DEFAULT_COMBOBOX_WIDTH = 150;
 const DEFAULT_OPTIONS = ['host.name', 'user.name', 'source.ip', 'destination.ip'];
 
-export const AlertsProgressBarPanel: React.FC<ChartsPanelProps> = ({
+interface Props {
+  filters?: Filter[];
+  query?: Query;
+  signalIndexName: string | null;
+  runtimeMappings?: MappingRuntimeFields;
+  skip?: boolean;
+  groupBySelection: GroupBySelection;
+  setGroupBySelection: (groupBySelection: GroupBySelection) => void;
+}
+export const AlertsProgressBarPanel: React.FC<Props> = ({
   filters,
   query,
   signalIndexName,
   runtimeMappings,
   skip,
+  groupBySelection,
+  setGroupBySelection,
 }) => {
-  const [stackByField, setStackByField] = useState('host.name');
   const [isInitialLoading, setIsInitialLoading] = useState(true);
   const uniqueQueryId = useMemo(() => `${TOP_ALERTS_CHART_ID}-${uuid()}`, []);
   const dropDownOptions = DEFAULT_OPTIONS.map((field) => {
     return { value: field, label: field };
   });
-  const aggregations = useMemo(() => alertsGroupingAggregations(stackByField), [stackByField]);
-  const onSelect = useCallback((field: string) => {
-    setStackByField(field);
-  }, []);
+  const aggregations = useMemo(
+    () => alertsGroupingAggregations(groupBySelection),
+    [groupBySelection]
+  );
+  const onSelect = useCallback(
+    (field: string) => {
+      setGroupBySelection(field as GroupBySelection);
+    },
+    [setGroupBySelection]
+  );
 
   const { items, isLoading } = useSummaryChartData({
     aggregations,
@@ -61,7 +79,7 @@ export const AlertsProgressBarPanel: React.FC<ChartsPanelProps> = ({
       <EuiPanel hasBorder hasShadow={false} data-test-subj="alerts-progress-bar-panel">
         <HeaderSection
           id={uniqueQueryId}
-          inspectTitle={`${i18n.ALERT_BY_TITLE} ${stackByField}`}
+          inspectTitle={`${i18n.ALERT_BY_TITLE} ${groupBySelection}`}
           outerDirection="row"
           title={i18n.ALERT_BY_TITLE}
           titleSize="xs"
@@ -69,7 +87,7 @@ export const AlertsProgressBarPanel: React.FC<ChartsPanelProps> = ({
         >
           <StackByComboBox
             data-test-subj="stackByComboBox"
-            selected={stackByField}
+            selected={groupBySelection}
             onSelect={onSelect}
             prepend={''}
             width={DEFAULT_COMBOBOX_WIDTH}
@@ -79,7 +97,11 @@ export const AlertsProgressBarPanel: React.FC<ChartsPanelProps> = ({
         {isInitialLoading ? (
           <EuiLoadingSpinner size="l" />
         ) : (
-          <AlertsProgressBar data={data} isLoading={isLoading} stackByField={stackByField} />
+          <AlertsProgressBar
+            data={data}
+            isLoading={isLoading}
+            groupBySelection={groupBySelection}
+          />
         )}
       </EuiPanel>
     </InspectButtonContainer>

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/alerts_progress_bar_panel/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/alerts_progress_bar_panel/index.tsx
@@ -16,7 +16,7 @@ import { AlertsProgressBar } from './alerts_progress_bar';
 import { useSummaryChartData } from '../alerts_summary_charts_panel/use_summary_chart_data';
 import { alertsGroupingAggregations } from '../alerts_summary_charts_panel/aggregations';
 import { showInitialLoadingSpinner } from '../alerts_histogram_panel/helpers';
-import { isAlertsProgressBarData } from './helpers';
+import { getIsAlertsProgressBarData } from './helpers';
 import * as i18n from './translations';
 import type { GroupBySelection } from './types';
 
@@ -67,7 +67,7 @@ export const AlertsProgressBarPanel: React.FC<Props> = ({
     skip,
     uniqueQueryId,
   });
-  const data = useMemo(() => (isAlertsProgressBarData(items) ? items : []), [items]);
+  const data = useMemo(() => (getIsAlertsProgressBarData(items) ? items : []), [items]);
   useEffect(() => {
     if (!showInitialLoadingSpinner({ isInitialLoading, isLoadingAlerts: isLoading })) {
       setIsInitialLoading(false);

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/alerts_progress_bar_panel/translations.ts
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/alerts_progress_bar_panel/translations.ts
@@ -26,3 +26,28 @@ export const OTHER = i18n.translate(
     defaultMessage: 'Other',
   }
 );
+
+export const HOST_NAME_LABEL = i18n.translate(
+  'xpack.securitySolution.detectionEngine.alerts.alertsByGrouping.hostNameLabel',
+  {
+    defaultMessage: 'host',
+  }
+);
+export const USER_NAME_LABEL = i18n.translate(
+  'xpack.securitySolution.detectionEngine.alerts.alertsByGrouping.userNameLabel',
+  {
+    defaultMessage: 'user',
+  }
+);
+export const DESTINATION_LABEL = i18n.translate(
+  'xpack.securitySolution.detectionEngine.alerts.alertsByGrouping.destinationLabel',
+  {
+    defaultMessage: 'destination',
+  }
+);
+export const SOURCE_LABEL = i18n.translate(
+  'xpack.securitySolution.detectionEngine.alerts.alertsByGrouping.sourceLabel',
+  {
+    defaultMessage: 'source',
+  }
+);

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/alerts_progress_bar_panel/types.ts
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/alerts_progress_bar_panel/types.ts
@@ -6,6 +6,7 @@
  */
 import type { BucketItem } from '../../../../../common/search_strategy/security_solution/cti';
 
+export type GroupBySelection = 'host.name' | 'user.name' | 'source.ip' | 'destination.ip';
 export interface AlertsByGroupingAgg {
   alertsByGrouping: {
     doc_count_error_upper_bound: number;

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/alerts_summary_charts_panel/aggregations.ts
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/alerts_summary_charts_panel/aggregations.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 import { ALERT_SEVERITY, ALERT_RULE_NAME } from '@kbn/rule-data-utils';
+import type { GroupBySelection } from '../alerts_progress_bar_panel/types';
 
 const DEFAULT_QUERY_SIZE = 1000;
 
@@ -33,7 +34,7 @@ export const alertTypeAggregations = {
   },
 };
 
-export const alertsGroupingAggregations = (stackByField: string) => {
+export const alertsGroupingAggregations = (stackByField: GroupBySelection) => {
   return {
     alertsByGrouping: {
       terms: {

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/alerts_summary_charts_panel/helpers.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/alerts_summary_charts_panel/helpers.tsx
@@ -4,12 +4,18 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { isAlertsBySeverityAgg, isAlertsByTypeAgg, isAlertsByGroupingAgg } from './types';
 import type { SummaryChartsAgg } from './types';
 import type { AlertSearchResponse } from '../../../containers/detection_engine/alerts/types';
-import { parseSeverityData } from '../severity_level_panel/helpers';
-import { parseAlertsTypeData } from '../alerts_by_type_panel/helpers';
-import { parseAlertsGroupingData } from '../alerts_progress_bar_panel/helpers';
+import { parseSeverityData, isAlertsBySeverityAgg } from '../severity_level_panel/helpers';
+import { parseAlertsTypeData, isAlertsByTypeAgg } from '../alerts_by_type_panel/helpers';
+import {
+  parseAlertsGroupingData,
+  isAlertsByGroupingAgg,
+} from '../alerts_progress_bar_panel/helpers';
+import {
+  parseChartCollapseData,
+  isChartCollapseAgg,
+} from '../../../pages/detection_engine/chart_panels/chart_collapse/helpers';
 
 export const parseData = (data: AlertSearchResponse<{}, SummaryChartsAgg>) => {
   if (isAlertsBySeverityAgg(data)) {
@@ -20,6 +26,9 @@ export const parseData = (data: AlertSearchResponse<{}, SummaryChartsAgg>) => {
   }
   if (isAlertsByGroupingAgg(data)) {
     return parseAlertsGroupingData(data);
+  }
+  if (isChartCollapseAgg(data)) {
+    return parseChartCollapseData(data);
   }
   return [];
 };

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/alerts_summary_charts_panel/helpers.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/alerts_summary_charts_panel/helpers.tsx
@@ -6,28 +6,28 @@
  */
 import type { SummaryChartsAgg } from './types';
 import type { AlertSearchResponse } from '../../../containers/detection_engine/alerts/types';
-import { parseSeverityData, isAlertsBySeverityAgg } from '../severity_level_panel/helpers';
-import { parseAlertsTypeData, isAlertsByTypeAgg } from '../alerts_by_type_panel/helpers';
+import { parseSeverityData, getIsAlertsBySeverityAgg } from '../severity_level_panel/helpers';
+import { parseAlertsTypeData, getIsAlertsByTypeAgg } from '../alerts_by_type_panel/helpers';
 import {
   parseAlertsGroupingData,
-  isAlertsByGroupingAgg,
+  getIsAlertsByGroupingAgg,
 } from '../alerts_progress_bar_panel/helpers';
 import {
   parseChartCollapseData,
-  isChartCollapseAgg,
+  getIsChartCollapseAgg,
 } from '../../../pages/detection_engine/chart_panels/chart_collapse/helpers';
 
 export const parseData = (data: AlertSearchResponse<{}, SummaryChartsAgg>) => {
-  if (isAlertsBySeverityAgg(data)) {
+  if (getIsAlertsBySeverityAgg(data)) {
     return parseSeverityData(data);
   }
-  if (isAlertsByTypeAgg(data)) {
+  if (getIsAlertsByTypeAgg(data)) {
     return parseAlertsTypeData(data);
   }
-  if (isAlertsByGroupingAgg(data)) {
+  if (getIsAlertsByGroupingAgg(data)) {
     return parseAlertsGroupingData(data);
   }
-  if (isChartCollapseAgg(data)) {
+  if (getIsChartCollapseAgg(data)) {
     return parseChartCollapseData(data);
   }
   return [];

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/alerts_summary_charts_panel/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/alerts_summary_charts_panel/index.test.tsx
@@ -9,6 +9,8 @@ import React from 'react';
 import { useQueryToggle } from '../../../../common/containers/query_toggle';
 import { TestProviders } from '../../../../common/mock';
 import { AlertsSummaryChartsPanel } from '.';
+import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
+import type { GroupBySelection } from '../alerts_progress_bar_panel/types';
 
 jest.mock('../../../../common/lib/kibana');
 jest.mock('../../../../common/containers/query_toggle');
@@ -18,14 +20,22 @@ jest.mock('react-router-dom', () => {
   return { ...actual, useLocation: jest.fn().mockReturnValue({ pathname: '' }) };
 });
 
+const mockUseIsExperimentalFeatureEnabled = useIsExperimentalFeatureEnabled as jest.Mock;
+jest.mock('../../../../common/hooks/use_experimental_features');
+
 describe('AlertsSummaryChartsPanel', () => {
   const defaultProps = {
     signalIndexName: 'signalIndexName',
+    isExpanded: true,
+    setIsExpanded: jest.fn(),
+    groupBySelection: 'host.name' as GroupBySelection,
+    setGroupBySelection: jest.fn(),
   };
   const mockSetToggle = jest.fn();
   const mockUseQueryToggle = useQueryToggle as jest.Mock;
   beforeEach(() => {
     mockUseQueryToggle.mockReturnValue({ toggleStatus: true, setToggleStatus: mockSetToggle });
+    mockUseIsExperimentalFeatureEnabled.mockReturnValue(false);
   });
 
   test('renders correctly', async () => {
@@ -89,7 +99,7 @@ describe('AlertsSummaryChartsPanel', () => {
       });
     });
 
-    test('toggleStatus=true, render', async () => {
+    it('alertsPageChartsEnabled is false and toggleStatus=true, render', async () => {
       await act(async () => {
         const { container } = render(
           <TestProviders>
@@ -102,12 +112,39 @@ describe('AlertsSummaryChartsPanel', () => {
       });
     });
 
-    test('toggleStatus=false, hide', async () => {
+    it('alertsPageChartsEnabled is false and toggleStatus=false, hide', async () => {
       mockUseQueryToggle.mockReturnValue({ toggleStatus: false, setToggleStatus: mockSetToggle });
       await act(async () => {
         const { container } = render(
           <TestProviders>
             <AlertsSummaryChartsPanel {...defaultProps} />
+          </TestProviders>
+        );
+        expect(
+          container.querySelector('[data-test-subj="alerts-charts-container"]')
+        ).not.toBeInTheDocument();
+      });
+    });
+
+    it('alertsPageChartsEnabled is true and isExpanded=true, render', async () => {
+      mockUseIsExperimentalFeatureEnabled.mockReturnValue(true);
+      await act(async () => {
+        const { container } = render(
+          <TestProviders>
+            <AlertsSummaryChartsPanel {...defaultProps} />
+          </TestProviders>
+        );
+        expect(
+          container.querySelector('[data-test-subj="alerts-charts-container"]')
+        ).toBeInTheDocument();
+      });
+    });
+    it('alertsPageChartsEnabled is true and isExpanded=false, hide', async () => {
+      mockUseIsExperimentalFeatureEnabled.mockReturnValue(true);
+      await act(async () => {
+        const { container } = render(
+          <TestProviders>
+            <AlertsSummaryChartsPanel {...defaultProps} isExpanded={false} />
           </TestProviders>
         );
         expect(

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/alerts_summary_charts_panel/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/alerts_summary_charts_panel/index.tsx
@@ -17,6 +17,7 @@ import { AlertsByTypePanel } from '../alerts_by_type_panel';
 import { AlertsProgressBarPanel } from '../alerts_progress_bar_panel';
 import { useQueryToggle } from '../../../../common/containers/query_toggle';
 import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
+import type { GroupBySelection } from '../alerts_progress_bar_panel/types';
 
 const StyledFlexGroup = styled(EuiFlexGroup)`
   @media only screen and (min-width: ${({ theme }) => theme.eui.euiBreakpoints.l});
@@ -39,6 +40,8 @@ interface Props {
   runtimeMappings?: MappingRuntimeFields;
   isExpanded?: boolean;
   setIsExpanded?: (status: boolean) => void;
+  groupBySelection: GroupBySelection;
+  setGroupBySelection: (groupBySelection: GroupBySelection) => void;
 }
 
 export const AlertsSummaryChartsPanel: React.FC<Props> = ({
@@ -52,6 +55,8 @@ export const AlertsSummaryChartsPanel: React.FC<Props> = ({
   title = i18n.CHARTS_TITLE,
   isExpanded,
   setIsExpanded,
+  groupBySelection,
+  setGroupBySelection,
 }: Props) => {
   const isAlertsPageChartsEnabled = useIsExperimentalFeatureEnabled('alertsPageChartsEnabled');
 
@@ -137,12 +142,13 @@ export const AlertsSummaryChartsPanel: React.FC<Props> = ({
           </StyledFlexItem>
           <StyledFlexItem>
             <AlertsProgressBarPanel
-              addFilter={addFilter}
               filters={filters}
               query={query}
               signalIndexName={signalIndexName}
               runtimeMappings={runtimeMappings}
               skip={querySkip}
+              groupBySelection={groupBySelection}
+              setGroupBySelection={setGroupBySelection}
             />
           </StyledFlexItem>
         </StyledFlexGroup>

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/alerts_summary_charts_panel/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/alerts_summary_charts_panel/index.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
-import React, { useCallback, useState, useEffect } from 'react';
+import React, { useCallback, useState, useEffect, useMemo } from 'react';
 import type { MappingRuntimeFields } from '@elastic/elasticsearch/lib/api/types';
 import type { Filter, Query } from '@kbn/es-query';
 import styled from 'styled-components';
@@ -16,6 +16,7 @@ import { SeverityLevelPanel } from '../severity_level_panel';
 import { AlertsByTypePanel } from '../alerts_by_type_panel';
 import { AlertsProgressBarPanel } from '../alerts_progress_bar_panel';
 import { useQueryToggle } from '../../../../common/containers/query_toggle';
+import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 
 const StyledFlexGroup = styled(EuiFlexGroup)`
   @media only screen and (min-width: ${({ theme }) => theme.eui.euiBreakpoints.l});
@@ -36,6 +37,8 @@ interface Props {
   signalIndexName: string | null;
   title?: React.ReactNode;
   runtimeMappings?: MappingRuntimeFields;
+  isExpanded?: boolean;
+  setIsExpanded?: (status: boolean) => void;
 }
 
 export const AlertsSummaryChartsPanel: React.FC<Props> = ({
@@ -47,25 +50,51 @@ export const AlertsSummaryChartsPanel: React.FC<Props> = ({
   runtimeMappings,
   signalIndexName,
   title = i18n.CHARTS_TITLE,
+  isExpanded,
+  setIsExpanded,
 }: Props) => {
-  const { toggleStatus, setToggleStatus } = useQueryToggle(DETECTIONS_ALERTS_CHARTS_ID);
-  const [querySkip, setQuerySkip] = useState(!toggleStatus);
+  const isAlertsPageChartsEnabled = useIsExperimentalFeatureEnabled('alertsPageChartsEnabled');
 
+  const { toggleStatus, setToggleStatus } = useQueryToggle(DETECTIONS_ALERTS_CHARTS_ID);
+  const [querySkip, setQuerySkip] = useState(
+    isAlertsPageChartsEnabled ? !isExpanded : !toggleStatus
+  );
   useEffect(() => {
-    setQuerySkip(!toggleStatus);
-  }, [toggleStatus]);
+    if (isAlertsPageChartsEnabled) {
+      setQuerySkip(!isExpanded);
+    } else {
+      setQuerySkip(!toggleStatus);
+    }
+  }, [toggleStatus, isAlertsPageChartsEnabled, isExpanded]);
+
   const toggleQuery = useCallback(
     (status: boolean) => {
-      setToggleStatus(status);
+      if (isAlertsPageChartsEnabled && setIsExpanded) {
+        setIsExpanded(status);
+      } else {
+        setToggleStatus(status);
+      }
       // toggle on = skipQuery false
       setQuerySkip(!status);
     },
-    [setQuerySkip, setToggleStatus]
+    [setQuerySkip, setToggleStatus, setIsExpanded, isAlertsPageChartsEnabled]
   );
+
+  const status: boolean = useMemo(() => {
+    if (isAlertsPageChartsEnabled && isExpanded) {
+      return true;
+    }
+    if (!isAlertsPageChartsEnabled && toggleStatus) {
+      return true;
+    }
+    return false;
+  }, [isAlertsPageChartsEnabled, isExpanded, toggleStatus]);
 
   return (
     <KpiPanel
-      $toggleStatus={toggleStatus}
+      $toggleStatus={
+        isAlertsPageChartsEnabled && isExpanded !== undefined ? isExpanded : toggleStatus
+      }
       data-test-subj="alerts-charts-panel"
       hasBorder
       height={panelHeight}
@@ -77,10 +106,10 @@ export const AlertsSummaryChartsPanel: React.FC<Props> = ({
         titleSize="s"
         hideSubtitle
         showInspectButton={false}
-        toggleStatus={toggleStatus}
+        toggleStatus={isAlertsPageChartsEnabled ? isExpanded : toggleStatus}
         toggleQuery={toggleQuery}
       />
-      {toggleStatus && (
+      {status && (
         <StyledFlexGroup
           data-test-subj="alerts-charts-container"
           className="eui-yScroll"

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/alerts_summary_charts_panel/types.ts
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/alerts_summary_charts_panel/types.ts
@@ -6,8 +6,6 @@
  */
 import type { MappingRuntimeFields } from '@elastic/elasticsearch/lib/api/types';
 import type { Filter, Query } from '@kbn/es-query';
-import { has } from 'lodash';
-import type { AlertSearchResponse } from '../../../containers/detection_engine/alerts/types';
 import type { SeverityBuckets as SeverityData } from '../../../../overview/components/detection_response/alerts_by_status/types';
 import type { AlertsBySeverityAgg } from '../severity_level_panel/types';
 import type { AlertsByTypeAgg, AlertsTypeData } from '../alerts_by_type_panel/types';
@@ -15,10 +13,20 @@ import type {
   AlertsByGroupingAgg,
   AlertsProgressBarData,
 } from '../alerts_progress_bar_panel/types';
+import type {
+  ChartCollapseAgg,
+  ChartCollapseData,
+} from '../../../pages/detection_engine/chart_panels/chart_collapse/types';
 
-export type SummaryChartsAgg = Partial<AlertsBySeverityAgg | AlertsByTypeAgg | AlertsByGroupingAgg>;
+export type SummaryChartsAgg = Partial<
+  AlertsBySeverityAgg | AlertsByTypeAgg | AlertsByGroupingAgg | ChartCollapseAgg
+>;
 
-export type SummaryChartsData = SeverityData | AlertsTypeData | AlertsProgressBarData;
+export type SummaryChartsData =
+  | SeverityData
+  | AlertsTypeData
+  | AlertsProgressBarData
+  | ChartCollapseData;
 
 export interface ChartsPanelProps {
   filters?: Filter[];
@@ -28,21 +36,3 @@ export interface ChartsPanelProps {
   skip?: boolean;
   addFilter?: ({ field, value }: { field: string; value: string | number }) => void;
 }
-
-export const isAlertsBySeverityAgg = (
-  data: AlertSearchResponse<{}, SummaryChartsAgg>
-): data is AlertSearchResponse<{}, AlertsBySeverityAgg> => {
-  return has(data, 'aggregations.statusBySeverity');
-};
-
-export const isAlertsByTypeAgg = (
-  data: AlertSearchResponse<{}, SummaryChartsAgg>
-): data is AlertSearchResponse<{}, AlertsByTypeAgg> => {
-  return has(data, 'aggregations.alertsByRule');
-};
-
-export const isAlertsByGroupingAgg = (
-  data: AlertSearchResponse<{}, SummaryChartsAgg>
-): data is AlertSearchResponse<{}, AlertsByGroupingAgg> => {
-  return has(data, 'aggregations.alertsByGrouping');
-};

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/severity_level_panel/helpers.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/severity_level_panel/helpers.tsx
@@ -9,7 +9,7 @@ import { has } from 'lodash';
 import type { AlertsBySeverityAgg } from './types';
 import type { AlertSearchResponse } from '../../../containers/detection_engine/alerts/types';
 import type { SeverityBuckets as SeverityData } from '../../../../overview/components/detection_response/alerts_by_status/types';
-import type { SummaryChartsData } from '../alerts_summary_charts_panel/types';
+import type { SummaryChartsData, SummaryChartsAgg } from '../alerts_summary_charts_panel/types';
 import { severityLabels } from '../../../../overview/components/detection_response/alerts_by_status/use_alerts_by_status';
 import { emptyDonutColor } from '../../../../common/components/charts/donutchart_empty';
 import { SEVERITY_COLOR } from '../../../../overview/components/detection_response/utils';
@@ -37,4 +37,10 @@ export const parseSeverityData = (
 
 export const isAlertsBySeverityData = (data: SummaryChartsData[]): data is SeverityData[] => {
   return data?.every((x) => has(x, 'key'));
+};
+
+export const isAlertsBySeverityAgg = (
+  data: AlertSearchResponse<{}, SummaryChartsAgg>
+): data is AlertSearchResponse<{}, AlertsBySeverityAgg> => {
+  return has(data, 'aggregations.statusBySeverity');
 };

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/severity_level_panel/helpers.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/severity_level_panel/helpers.tsx
@@ -35,11 +35,11 @@ export const parseSeverityData = (
       });
 };
 
-export const isAlertsBySeverityData = (data: SummaryChartsData[]): data is SeverityData[] => {
+export const getIsAlertsBySeverityData = (data: SummaryChartsData[]): data is SeverityData[] => {
   return data?.every((x) => has(x, 'key'));
 };
 
-export const isAlertsBySeverityAgg = (
+export const getIsAlertsBySeverityAgg = (
   data: AlertSearchResponse<{}, SummaryChartsAgg>
 ): data is AlertSearchResponse<{}, AlertsBySeverityAgg> => {
   return has(data, 'aggregations.statusBySeverity');

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/severity_level_panel/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/severity_level_panel/index.tsx
@@ -13,7 +13,7 @@ import { HeaderSection } from '../../../../common/components/header_section';
 import { InspectButtonContainer } from '../../../../common/components/inspect';
 import { useSummaryChartData } from '../alerts_summary_charts_panel/use_summary_chart_data';
 import { severityAggregations } from '../alerts_summary_charts_panel/aggregations';
-import { isAlertsBySeverityData } from './helpers';
+import { getIsAlertsBySeverityData } from './helpers';
 import { SeverityLevelChart } from './severity_level_chart';
 import * as i18n from './translations';
 
@@ -38,7 +38,7 @@ export const SeverityLevelPanel: React.FC<ChartsPanelProps> = ({
     skip,
     uniqueQueryId,
   });
-  const data = useMemo(() => (isAlertsBySeverityData(items) ? items : []), [items]);
+  const data = useMemo(() => (getIsAlertsBySeverityData(items) ? items : []), [items]);
   return (
     <InspectButtonContainer>
       <EuiPanel hasBorder hasShadow={false} data-test-subj="severty-level-panel">

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/chart_panels/alerts_local_storage/constants.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/chart_panels/alerts_local_storage/constants.ts
@@ -34,3 +34,6 @@ export const TREND_CHART_CATEGORY = 'trend';
 
 /** settings for view selection are grouped under this category */
 export const VIEW_CATEGORY = 'view';
+
+/** settings for group by selection on summary tab */
+export const GROUP_BY_SETTING_NAME = 'group-by';

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/chart_panels/alerts_local_storage/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/chart_panels/alerts_local_storage/index.test.tsx
@@ -27,6 +27,7 @@ describe('useAlertsLocalStorage', () => {
       alertViewSelection: 'trend', // default to the trend chart
       countTableStackBy0: 'kibana.alert.rule.name',
       countTableStackBy1: 'host.name',
+      groupBySelection: 'host.name',
       isTreemapPanelExpanded: true,
       riskChartStackBy0: 'kibana.alert.rule.name',
       riskChartStackBy1: 'host.name',

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/chart_panels/alerts_local_storage/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/chart_panels/alerts_local_storage/index.tsx
@@ -22,6 +22,7 @@ import {
   STACK_BY_SETTING_NAME,
   TREND_CHART_CATEGORY,
   VIEW_CATEGORY,
+  GROUP_BY_SETTING_NAME,
 } from './constants';
 import {
   DEFAULT_STACK_BY_FIELD,
@@ -30,6 +31,7 @@ import {
 import type { AlertsSettings } from './types';
 import type { AlertViewSelection } from '../chart_select/helpers';
 import { TREND_ID } from '../chart_select/helpers';
+import type { GroupBySelection } from '../../../../components/alerts_kpis/alerts_progress_bar_panel/types';
 
 export const useAlertsLocalStorage = (): AlertsSettings => {
   const [alertViewSelection, setAlertViewSelection] = useLocalStorage<AlertViewSelection>({
@@ -38,6 +40,16 @@ export const useAlertsLocalStorage = (): AlertsSettings => {
       category: VIEW_CATEGORY,
       page: ALERTS_PAGE,
       setting: ALERT_VIEW_SELECTION_SETTING_NAME,
+    }),
+    isInvalidDefault: isDefaultWhenEmptyString,
+  });
+
+  const [groupBySelection, setGroupBySelection] = useLocalStorage<GroupBySelection>({
+    defaultValue: 'host.name',
+    key: getSettingKey({
+      category: VIEW_CATEGORY,
+      page: ALERTS_PAGE,
+      setting: GROUP_BY_SETTING_NAME,
     }),
     isInvalidDefault: isDefaultWhenEmptyString,
   });
@@ -103,12 +115,14 @@ export const useAlertsLocalStorage = (): AlertsSettings => {
     alertViewSelection,
     countTableStackBy0,
     countTableStackBy1,
+    groupBySelection,
     isTreemapPanelExpanded,
     riskChartStackBy0,
     riskChartStackBy1,
     setAlertViewSelection,
     setCountTableStackBy0,
     setCountTableStackBy1,
+    setGroupBySelection,
     setIsTreemapPanelExpanded,
     setRiskChartStackBy0,
     setRiskChartStackBy1,

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/chart_panels/alerts_local_storage/types.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/chart_panels/alerts_local_storage/types.ts
@@ -6,17 +6,19 @@
  */
 
 import type { AlertViewSelection } from '../chart_select/helpers';
-
+import type { GroupBySelection } from '../../../../components/alerts_kpis/alerts_progress_bar_panel/types';
 export interface AlertsSettings {
   alertViewSelection: AlertViewSelection;
   countTableStackBy0: string;
   countTableStackBy1: string | undefined;
+  groupBySelection: GroupBySelection;
   isTreemapPanelExpanded: boolean;
   riskChartStackBy0: string;
   riskChartStackBy1: string | undefined;
   setAlertViewSelection: (alertViewSelection: AlertViewSelection) => void;
   setCountTableStackBy0: (value: string) => void;
   setCountTableStackBy1: (value: string | undefined) => void;
+  setGroupBySelection: (groupBySelection: GroupBySelection) => void;
   setIsTreemapPanelExpanded: (value: boolean) => void;
   setRiskChartStackBy0: (value: string) => void;
   setRiskChartStackBy1: (value: string | undefined) => void;

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/chart_panels/chart_collapse/helpers.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/chart_panels/chart_collapse/helpers.test.tsx
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { parseChartCollapseData } from './helpers';
+import * as mock from './mock_data';
+import type { ChartCollapseAgg } from './types';
+import type { AlertSearchResponse } from '../../../../containers/detection_engine/alerts/types';
+import { getGroupByLabel } from '../../../../components/alerts_kpis/alerts_progress_bar_panel/helpers';
+import * as i18n from '../../../../components/alerts_kpis/alerts_progress_bar_panel/translations';
+
+describe('parse chart collapse data', () => {
+  test('parse alerts with data', () => {
+    const res = parseChartCollapseData(
+      mock.mockAlertsData as AlertSearchResponse<{}, ChartCollapseAgg>
+    );
+    expect(res).toEqual(mock.parsedAlerts);
+  });
+
+  test('parse alerts without data', () => {
+    const res = parseChartCollapseData(
+      mock.mockAlertsEmptyData as AlertSearchResponse<{}, ChartCollapseAgg>
+    );
+    expect(res).toEqual([]);
+  });
+});
+
+describe('get group by label', () => {
+  test('should return correct label for group by selections', () => {
+    expect(getGroupByLabel('host.name')).toEqual(i18n.HOST_NAME_LABEL);
+    expect(getGroupByLabel('user.name')).toEqual(i18n.USER_NAME_LABEL);
+    expect(getGroupByLabel('source.ip')).toEqual(i18n.SOURCE_LABEL);
+    expect(getGroupByLabel('destination.ip')).toEqual(i18n.DESTINATION_LABEL);
+  });
+});

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/chart_panels/chart_collapse/helpers.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/chart_panels/chart_collapse/helpers.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { has } from 'lodash';
+import type { ChartCollapseAgg, ChartCollapseData } from './types';
+import type { AlertSearchResponse } from '../../../../containers/detection_engine/alerts/types';
+import type {
+  SummaryChartsData,
+  SummaryChartsAgg,
+} from '../../../../components/alerts_kpis/alerts_summary_charts_panel/types';
+import { severityLabels } from '../../../../../overview/components/detection_response/alerts_by_status/use_alerts_by_status';
+import { UNKNOWN_SEVERITY } from '../../../../components/alerts_kpis/severity_level_panel/translations';
+
+export const parseChartCollapseData = (
+  response: AlertSearchResponse<{}, ChartCollapseAgg>
+): ChartCollapseData[] => {
+  const ret: ChartCollapseData = { rule: null, group: null, severities: [] };
+  ret.rule = response?.aggregations?.topRule?.buckets?.at(0)?.key ?? null;
+  ret.group = response?.aggregations?.topGrouping?.buckets?.at(0)?.key ?? null;
+
+  const severityBuckets = response?.aggregations?.severities?.buckets ?? [];
+  if (severityBuckets.length > 0) {
+    ret.severities = severityBuckets.map((severity) => {
+      return {
+        key: severity.key,
+        value: severity.doc_count,
+        label: severityLabels[severity.key] ?? UNKNOWN_SEVERITY,
+      };
+    });
+    return [ret];
+  }
+  return [];
+};
+
+export const isChartCollapseData = (data: SummaryChartsData[]): data is ChartCollapseData[] => {
+  return data?.every((x) => has(x, 'rule') && has(x, 'group') && has(x, 'severities'));
+};
+
+export const isChartCollapseAgg = (
+  data: AlertSearchResponse<{}, SummaryChartsAgg>
+): data is AlertSearchResponse<{}, ChartCollapseAgg> => {
+  return (
+    has(data, 'aggregations.severities') &&
+    has(data, 'aggregations.topRule') &&
+    has(data, 'aggregations.topGrouping')
+  );
+};

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/chart_panels/chart_collapse/helpers.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/chart_panels/chart_collapse/helpers.tsx
@@ -36,11 +36,11 @@ export const parseChartCollapseData = (
   return [];
 };
 
-export const isChartCollapseData = (data: SummaryChartsData[]): data is ChartCollapseData[] => {
+export const getIsChartCollapseData = (data: SummaryChartsData[]): data is ChartCollapseData[] => {
   return data?.every((x) => has(x, 'rule') && has(x, 'group') && has(x, 'severities'));
 };
 
-export const isChartCollapseAgg = (
+export const getIsChartCollapseAgg = (
   data: AlertSearchResponse<{}, SummaryChartsAgg>
 ): data is AlertSearchResponse<{}, ChartCollapseAgg> => {
   return (

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/chart_panels/chart_collapse/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/chart_panels/chart_collapse/index.test.tsx
@@ -1,0 +1,95 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { render } from '@testing-library/react';
+import React from 'react';
+import type { GroupBySelection } from '../../../../components/alerts_kpis/alerts_progress_bar_panel/types';
+import { TestProviders } from '../../../../../common/mock';
+import { ChartCollapse } from '.';
+import { useSummaryChartData } from '../../../../components/alerts_kpis/alerts_summary_charts_panel/use_summary_chart_data';
+import * as mock from './mock_data';
+
+jest.mock('../../../../../common/lib/kibana');
+
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return { ...actual, useLocation: jest.fn().mockReturnValue({ pathname: '' }) };
+});
+jest.mock('../../../../components/alerts_kpis/alerts_summary_charts_panel/use_summary_chart_data');
+
+const defaultProps = {
+  groupBySelection: 'host.name' as GroupBySelection,
+  signalIndexName: 'signalIndexName',
+};
+
+const severitiesId = '[data-test-subj="chart-collapse-severities"]';
+const ruleId = '[data-test-subj="chart-collapse-top-rule"]';
+const groupId = '[data-test-subj="chart-collapse-top-group"]';
+
+describe('ChartCollapse', () => {
+  const mockUseSummaryChartData = useSummaryChartData as jest.Mock;
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+  });
+
+  test('it renders the chart collapse panel and the 3 summary componenets', () => {
+    mockUseSummaryChartData.mockReturnValue({ items: [], isLoading: false });
+    const { container } = render(
+      <TestProviders>
+        <ChartCollapse {...defaultProps} />
+      </TestProviders>
+    );
+    expect(container.querySelector('[data-test-subj="chart-collapse"]')).toBeInTheDocument();
+
+    expect(container.querySelector(severitiesId)).toBeInTheDocument();
+    expect(container.querySelector(ruleId)).toBeInTheDocument();
+    expect(container.querySelector(groupId)).toBeInTheDocument();
+  });
+
+  test('it renders chart collapse with data', () => {
+    mockUseSummaryChartData.mockReturnValue({ items: mock.parsedAlerts, isLoading: false });
+    const { container } = render(
+      <TestProviders>
+        <ChartCollapse {...defaultProps} />
+      </TestProviders>
+    );
+
+    mock.parsedAlerts.at(0)?.severities.forEach((severity) => {
+      expect(container.querySelector(severitiesId)).toHaveTextContent(
+        `${severity.label}: ${severity.value}`
+      );
+    });
+    expect(container.querySelector(ruleId)).toHaveTextContent('Top alerted rule: Test rule');
+    expect(container.querySelector(groupId)).toHaveTextContent('Top alerted host: Test group');
+  });
+
+  test('it renders chart collapse without data', () => {
+    mockUseSummaryChartData.mockReturnValue({ items: [], isLoading: false });
+    const { container } = render(
+      <TestProviders>
+        <ChartCollapse {...defaultProps} />
+      </TestProviders>
+    );
+    mock.parsedAlerts.at(0)?.severities.forEach((severity) => {
+      expect(container.querySelector(severitiesId)).toHaveTextContent(`${severity.label}: 0`);
+    });
+    expect(container.querySelector(ruleId)).toHaveTextContent('Top alerted rule: None');
+    expect(container.querySelector(groupId)).toHaveTextContent('Top alerted host: None');
+  });
+
+  test('it renders group by label correctly', () => {
+    mockUseSummaryChartData.mockReturnValue({ items: [], isLoading: false });
+    const { container } = render(
+      <TestProviders>
+        <ChartCollapse {...defaultProps} groupBySelection={'user.name'} />
+      </TestProviders>
+    );
+    expect(container.querySelector(groupId)).toHaveTextContent('Top alerted user: None');
+  });
+});

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/chart_panels/chart_collapse/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/chart_panels/chart_collapse/index.tsx
@@ -1,0 +1,104 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { EuiFlexGroup, EuiFlexItem, EuiHealth, EuiText } from '@elastic/eui';
+import type { MappingRuntimeFields } from '@elastic/elasticsearch/lib/api/types';
+import type { Filter, Query } from '@kbn/es-query';
+import { v4 as uuid } from 'uuid';
+import React, { useMemo } from 'react';
+import { ALERT_SEVERITY, ALERT_RULE_NAME } from '@kbn/rule-data-utils';
+import styled from 'styled-components';
+import { useSummaryChartData } from '../../../../components/alerts_kpis/alerts_summary_charts_panel/use_summary_chart_data';
+import {
+  isAlertsBySeverityData,
+  getSeverityColor,
+} from '../../../../components/alerts_kpis/alerts_summary_charts_panel/severity_level_panel/helpers';
+import { FormattedCount } from '../../../../../common/components/formatted_number';
+
+const DETECTIONS_ALERTS_COLLAPSED_CHART_ID = 'detectioin-alerts-collapsed-chart';
+
+const combinedAggregations = (stackByValue: string) => {
+  return {
+    statusBySeverity: {
+      terms: {
+        field: ALERT_SEVERITY,
+      },
+    },
+    topRule: {
+      terms: {
+        field: ALERT_RULE_NAME,
+        size: 1,
+      },
+    },
+    topGrouping: {
+      terms: {
+        field: stackByValue,
+        size: 1,
+      },
+    },
+  };
+};
+
+const ChartCollapseWrapper = styled.div`
+  margin: ${({ theme }) => theme.eui.euiSizeS};
+`;
+
+interface Props {
+  stackByValue: string;
+  filters?: Filter[];
+  query?: Query;
+  signalIndexName: string | null;
+  runtimeMappings?: MappingRuntimeFields;
+}
+
+export const ChartCollapse: React.FC<Props> = ({
+  stackByValue,
+  filters,
+  query,
+  signalIndexName,
+  runtimeMappings,
+}: Props) => {
+  const uniqueQueryId = useMemo(() => `${DETECTIONS_ALERTS_COLLAPSED_CHART_ID}-${uuid()}`, []);
+
+  const { items } = useSummaryChartData({
+    aggregations: combinedAggregations,
+    filters,
+    query,
+    signalIndexName,
+    runtimeMappings,
+    uniqueQueryId,
+  });
+  const data = useMemo(() => (isAlertsBySeverityData(items) ? items : []), [items]);
+
+  return (
+    <ChartCollapseWrapper>
+      <EuiFlexGroup alignItems="center" component="span">
+        <EuiFlexItem>
+          <EuiFlexGroup>
+            {data.map((severity) => (
+              <EuiFlexItem key={severity.key} grow={false}>
+                <EuiFlexGroup gutterSize="xs">
+                  <EuiFlexItem grow={false}>
+                    <EuiHealth className="eui-alignMiddle" color={getSeverityColor(severity.key)}>
+                      <EuiText size="xs">{`${severity.label}:`}</EuiText>
+                    </EuiHealth>
+                  </EuiFlexItem>
+                  <EuiFlexItem grow={false}>
+                    <EuiText size="xs">
+                      <FormattedCount count={severity.value || 0} />
+                    </EuiText>
+                  </EuiFlexItem>
+                </EuiFlexGroup>
+              </EuiFlexItem>
+            ))}
+          </EuiFlexGroup>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </ChartCollapseWrapper>
+  );
+};
+
+ChartCollapse.displayName = 'ChartCollapse';

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/chart_panels/chart_collapse/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/chart_panels/chart_collapse/index.tsx
@@ -5,26 +5,32 @@
  * 2.0.
  */
 import { EuiFlexGroup, EuiFlexItem, EuiHealth, EuiText } from '@elastic/eui';
+import { ALERT_SEVERITY, ALERT_RULE_NAME } from '@kbn/rule-data-utils';
 import type { MappingRuntimeFields } from '@elastic/elasticsearch/lib/api/types';
 import type { Filter, Query } from '@kbn/es-query';
 import { v4 as uuid } from 'uuid';
+import { capitalize } from 'lodash';
 import React, { useMemo } from 'react';
-import { ALERT_SEVERITY, ALERT_RULE_NAME } from '@kbn/rule-data-utils';
 import styled from 'styled-components';
+import type { GroupBySelection } from '../../../../components/alerts_kpis/alerts_progress_bar_panel/types';
+import { getGroupByLabel } from '../../../../components/alerts_kpis/alerts_progress_bar_panel/helpers';
+import { InspectButton, InspectButtonContainer } from '../../../../../common/components/inspect';
 import { useSummaryChartData } from '../../../../components/alerts_kpis/alerts_summary_charts_panel/use_summary_chart_data';
-import {
-  isAlertsBySeverityData,
-  getSeverityColor,
-} from '../../../../components/alerts_kpis/alerts_summary_charts_panel/severity_level_panel/helpers';
+import { getSeverityColor } from '../../../../components/alerts_kpis/severity_level_panel/helpers';
 import { FormattedCount } from '../../../../../common/components/formatted_number';
+import { isChartCollapseData } from './helpers';
+import * as i18n from './translations';
+
+import { SEVERITY_COLOR } from '../../../../../overview/components/detection_response/utils';
 
 const DETECTIONS_ALERTS_COLLAPSED_CHART_ID = 'detectioin-alerts-collapsed-chart';
 
-const combinedAggregations = (stackByValue: string) => {
+const combinedAggregations = (groupBySelection: GroupBySelection) => {
   return {
-    statusBySeverity: {
+    severities: {
       terms: {
         field: ALERT_SEVERITY,
+        min_doc_count: 0,
       },
     },
     topRule: {
@@ -35,19 +41,29 @@ const combinedAggregations = (stackByValue: string) => {
     },
     topGrouping: {
       terms: {
-        field: stackByValue,
+        field: groupBySelection,
         size: 1,
       },
     },
   };
 };
 
-const ChartCollapseWrapper = styled.div`
-  margin: ${({ theme }) => theme.eui.euiSizeS};
+const StyledEuiFlexGroup = styled(EuiFlexGroup)`
+  margin-top: ${({ theme }) => theme.eui.euiSizeXS};
+  @media only screen and (min-width: ${({ theme }) => theme.eui.euiBreakpoints.l});
 `;
 
+const SeverityWrapper = styled(EuiFlexItem)`
+  min-width: 380px;
+`;
+
+const StyledEuiText = styled(EuiText)`
+  border-left: 1px solid ${({ theme }) => theme.eui.euiColorLightShade};
+  padding-left: ${({ theme }) => theme.eui.euiSizeL};
+  white-space: nowrap;
+`;
 interface Props {
-  stackByValue: string;
+  groupBySelection: GroupBySelection;
   filters?: Filter[];
   query?: Query;
   signalIndexName: string | null;
@@ -55,49 +71,78 @@ interface Props {
 }
 
 export const ChartCollapse: React.FC<Props> = ({
-  stackByValue,
+  groupBySelection,
   filters,
   query,
   signalIndexName,
   runtimeMappings,
 }: Props) => {
   const uniqueQueryId = useMemo(() => `${DETECTIONS_ALERTS_COLLAPSED_CHART_ID}-${uuid()}`, []);
+  const aggregations = useMemo(() => combinedAggregations(groupBySelection), [groupBySelection]);
 
-  const { items } = useSummaryChartData({
-    aggregations: combinedAggregations,
+  const { items, isLoading } = useSummaryChartData({
+    aggregations,
     filters,
     query,
     signalIndexName,
     runtimeMappings,
     uniqueQueryId,
   });
-  const data = useMemo(() => (isAlertsBySeverityData(items) ? items : []), [items]);
+  const data = useMemo(() => (isChartCollapseData(items) ? items : []), [items]);
 
+  const topRule = useMemo(() => data.at(0)?.rule ?? i18n.NO_RESULT_MESSAGE, [data]);
+  const topGroup = useMemo(() => data.at(0)?.group ?? i18n.NO_RESULT_MESSAGE, [data]);
+  const severities = useMemo(() => {
+    const severityData = data.at(0)?.severities ?? [];
+    return Object.keys(SEVERITY_COLOR).map((severity) => {
+      const obj = severityData.find((s) => s.key === severity);
+      if (obj) {
+        return { key: obj.key, label: obj.label, value: obj.value };
+      } else {
+        return { key: severity, label: capitalize(severity), value: 0 };
+      }
+    });
+  }, [data]);
+  const groupBy = useMemo(() => getGroupByLabel(groupBySelection), [groupBySelection]);
+  // className="eui-alignMiddle"
   return (
-    <ChartCollapseWrapper>
-      <EuiFlexGroup alignItems="center" component="span">
-        <EuiFlexItem>
-          <EuiFlexGroup>
-            {data.map((severity) => (
-              <EuiFlexItem key={severity.key} grow={false}>
-                <EuiFlexGroup gutterSize="xs">
-                  <EuiFlexItem grow={false}>
-                    <EuiHealth className="eui-alignMiddle" color={getSeverityColor(severity.key)}>
-                      <EuiText size="xs">{`${severity.label}:`}</EuiText>
-                    </EuiHealth>
-                  </EuiFlexItem>
-                  <EuiFlexItem grow={false}>
+    <InspectButtonContainer>
+      {!isLoading && (
+        <StyledEuiFlexGroup alignItems="center" data-test-subj="chart-collapse" wrap>
+          <SeverityWrapper grow={false}>
+            <EuiFlexGroup data-test-subj="chart-collapse-severities">
+              {severities.map((severity) => (
+                <EuiFlexItem key={severity.key} grow={false}>
+                  <EuiHealth color={getSeverityColor(severity.key)}>
                     <EuiText size="xs">
+                      {`${severity.label}: `}
                       <FormattedCount count={severity.value || 0} />
                     </EuiText>
-                  </EuiFlexItem>
-                </EuiFlexGroup>
-              </EuiFlexItem>
-            ))}
+                  </EuiHealth>
+                </EuiFlexItem>
+              ))}
+            </EuiFlexGroup>
+          </SeverityWrapper>
+          <EuiFlexItem grow={false}>
+            <StyledEuiText size="xs" data-test-subj="chart-collapse-top-rule">
+              <strong>{i18n.TOP_RULE_TITLE}</strong>
+              {topRule}
+            </StyledEuiText>
+          </EuiFlexItem>
+          <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
+            <EuiFlexItem grow={false}>
+              <StyledEuiText size="xs" data-test-subj="chart-collapse-top-group">
+                <strong>{`${i18n.TOP_GROUP_TITLE} ${groupBy}: `}</strong>
+                {topGroup}
+              </StyledEuiText>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <InspectButton isDisabled={false} queryId={uniqueQueryId} title={'chart collapse'} />
+            </EuiFlexItem>
           </EuiFlexGroup>
-        </EuiFlexItem>
-      </EuiFlexGroup>
-    </ChartCollapseWrapper>
+        </StyledEuiFlexGroup>
+      )}
+    </InspectButtonContainer>
   );
 };
 

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/chart_panels/chart_collapse/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/chart_panels/chart_collapse/index.tsx
@@ -18,7 +18,7 @@ import { InspectButton, InspectButtonContainer } from '../../../../../common/com
 import { useSummaryChartData } from '../../../../components/alerts_kpis/alerts_summary_charts_panel/use_summary_chart_data';
 import { getSeverityColor } from '../../../../components/alerts_kpis/severity_level_panel/helpers';
 import { FormattedCount } from '../../../../../common/components/formatted_number';
-import { isChartCollapseData } from './helpers';
+import { getIsChartCollapseData } from './helpers';
 import * as i18n from './translations';
 
 import { SEVERITY_COLOR } from '../../../../../overview/components/detection_response/utils';
@@ -88,7 +88,7 @@ export const ChartCollapse: React.FC<Props> = ({
     runtimeMappings,
     uniqueQueryId,
   });
-  const data = useMemo(() => (isChartCollapseData(items) ? items : []), [items]);
+  const data = useMemo(() => (getIsChartCollapseData(items) ? items : []), [items]);
 
   const topRule = useMemo(() => data.at(0)?.rule ?? i18n.NO_RESULT_MESSAGE, [data]);
   const topGroup = useMemo(() => data.at(0)?.group ?? i18n.NO_RESULT_MESSAGE, [data]);

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/chart_panels/chart_collapse/mock_data.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/chart_panels/chart_collapse/mock_data.ts
@@ -1,0 +1,152 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+const from = '2022-04-05T12:00:00.000Z';
+const to = '2022-04-08T12:00:00.000Z';
+
+export const mockAlertsData = {
+  took: 0,
+  timeout: false,
+  _shards: {
+    total: 1,
+    successful: 1,
+    skipped: 0,
+    failed: 0,
+  },
+  hits: {
+    total: {
+      value: 570,
+      relation: 'eq',
+    },
+    max_score: null,
+    hits: [],
+  },
+  aggregations: {
+    severities: {
+      doc_count_error_upper_bound: 0,
+      sum_other_doc_count: 0,
+      buckets: [
+        {
+          key: 'high',
+          doc_count: 78,
+        },
+        {
+          key: 'low',
+          doc_count: 46,
+        },
+        {
+          key: 'medium',
+          doc_count: 32,
+        },
+        {
+          key: 'critical',
+          doc_count: 21,
+        },
+      ],
+    },
+    topRule: {
+      doc_count_error_upper_bound: 0,
+      sum_other_doc_count: 0,
+      buckets: [
+        {
+          key: 'Test rule',
+          doc_count: 234,
+        },
+      ],
+    },
+    topGrouping: {
+      doc_count_error_upper_bound: 0,
+      sum_other_doc_count: 0,
+      buckets: [
+        {
+          key: 'Test group',
+          doc_count: 100,
+        },
+      ],
+    },
+  },
+};
+
+export const mockAlertsEmptyData = {
+  took: 0,
+  timeout: false,
+  _shards: {
+    total: 1,
+    successful: 1,
+    skipped: 0,
+    failed: 0,
+  },
+  hits: {
+    total: {
+      value: 0,
+      relation: 'eq',
+    },
+    max_score: null,
+    hits: [],
+  },
+  aggregations: {
+    severities: {
+      doc_count_error_upper_bound: 0,
+      sum_other_doc_count: 0,
+      buckets: [],
+    },
+    topRule: {
+      doc_count_error_upper_bound: 0,
+      sum_other_doc_count: 0,
+      buckets: [],
+    },
+    topGrouping: {
+      doc_count_error_upper_bound: 0,
+      sum_other_doc_count: 0,
+      buckets: [],
+    },
+  },
+};
+
+export const query = {
+  size: 0,
+  query: {
+    bool: {
+      filter: [
+        { bool: { filter: [], must: [], must_not: [], should: [] } },
+        { range: { '@timestamp': { gte: from, lte: to } } },
+      ],
+    },
+  },
+  aggs: {
+    severities: {
+      terms: {
+        field: 'kibana.alert.severity',
+      },
+    },
+    topRule: {
+      terms: {
+        field: 'kibana.alert.rule.name',
+        size: 1000,
+      },
+    },
+    topGrouping: {
+      terms: {
+        field: 'host.name',
+        size: 1,
+      },
+    },
+  },
+  runtime_mappings: undefined,
+};
+
+export const parsedAlerts = [
+  {
+    rule: 'Test rule',
+    group: 'Test group',
+    severities: [
+      { key: 'high', value: 78, label: 'High' },
+      { key: 'low', value: 46, label: 'Low' },
+      { key: 'medium', value: 32, label: 'Medium' },
+      { key: 'critical', value: 21, label: 'Critical' },
+    ],
+  },
+];

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/chart_panels/chart_collapse/translations.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/chart_panels/chart_collapse/translations.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export const TOP_RULE_TITLE = i18n.translate(
+  'xpack.securitySolution.components.chartCollapse.topRule',
+  {
+    defaultMessage: 'Top alerted rule: ',
+  }
+);
+
+export const TOP_GROUP_TITLE = i18n.translate(
+  'xpack.securitySolution.components.chartCollapse.topGroup',
+  {
+    defaultMessage: 'Top alerted',
+  }
+);
+
+export const NO_RESULT_MESSAGE = i18n.translate(
+  'xpack.securitySolution.components.chartCollapse.noResultMessage',
+  {
+    defaultMessage: 'None',
+  }
+);

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/chart_panels/chart_collapse/types.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/chart_panels/chart_collapse/types.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import type { BucketItem } from '../../../../../../common/search_strategy/security_solution/cti';
+import type { SeverityBucket } from '../../../../../overview/components/detection_response/alerts_by_status/types';
+
+export interface ChartCollapseAgg {
+  statusBySeverity: {
+    doc_count_error_upper_bound: number;
+    sum_other_doc_count: number;
+    buckets: SeverityBucket[];
+  };
+  topRule: {
+    doc_count_error_upper_bound: number;
+    sum_other_doc_count: number;
+    buckets: BucketItem[];
+  };
+  topGrouping: {
+    doc_count_error_upper_bound: number;
+    sum_other_doc_count: number;
+    buckets: BucketItem[];
+  };
+}
+export interface ChartCollapseData {
+  key: string;
+  value: number;
+  percentage: number;
+  label: string;
+}

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/chart_panels/chart_collapse/types.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/chart_panels/chart_collapse/types.ts
@@ -5,10 +5,13 @@
  * 2.0.
  */
 import type { BucketItem } from '../../../../../../common/search_strategy/security_solution/cti';
-import type { SeverityBucket } from '../../../../../overview/components/detection_response/alerts_by_status/types';
+import type {
+  SeverityBucket,
+  SeverityBuckets as SeverityData,
+} from '../../../../../overview/components/detection_response/alerts_by_status/types';
 
 export interface ChartCollapseAgg {
-  statusBySeverity: {
+  severities: {
     doc_count_error_upper_bound: number;
     sum_other_doc_count: number;
     buckets: SeverityBucket[];
@@ -25,8 +28,7 @@ export interface ChartCollapseAgg {
   };
 }
 export interface ChartCollapseData {
-  key: string;
-  value: number;
-  percentage: number;
-  label: string;
+  rule: string | null;
+  group: string | null;
+  severities: SeverityData[];
 }

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/chart_panels/chart_select/helpers.test.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/chart_panels/chart_select/helpers.test.ts
@@ -104,33 +104,37 @@ describe('helpers', () => {
   describe('getOptionProperties', () => {
     test('it returns the expected properties when alertViewSelection is Trend', () => {
       expect(getOptionProperties(TREND_ID)).toEqual({
-        id: CHARTS_ID,
-        'data-test-subj': TREND_ID,
+        id: TREND_ID,
+        'data-test-subj': `chart-select-${TREND_ID}`,
         label: i18n.TREND_TITLE,
+        value: TREND_ID,
       });
     });
 
     test('it returns the expected properties when alertViewSelection is Table', () => {
       expect(getOptionProperties(TABLE_ID)).toEqual({
         id: TABLE_ID,
-        'data-test-subj': TABLE_ID,
-        label: i18n.TABLE,
+        'data-test-subj': `chart-select-${TABLE_ID}`,
+        label: i18n.TABLE_TITLE,
+        value: TABLE_ID,
       });
     });
 
     test('it returns the expected properties when alertViewSelection is Treemap', () => {
       expect(getOptionProperties(TREEMAP_ID)).toEqual({
         id: TREEMAP_ID,
-        'data-test-subj': TREEMAP_ID,
-        label: i18n.TREEMAP,
+        'data-test-subj': `chart-select-${TREEMAP_ID}`,
+        label: i18n.TREEMAP_TITLE,
+        value: TREEMAP_ID,
       });
     });
 
     test('it returns the expected properties when alertViewSelection is charts', () => {
       expect(getOptionProperties(CHARTS_ID)).toEqual({
         id: CHARTS_ID,
-        'data-test-subj': CHARTS_ID,
-        label: i18n.CHARTS,
+        'data-test-subj': `chart-select-${CHARTS_ID}`,
+        label: i18n.CHARTS_TITLE,
+        value: CHARTS_ID,
       });
     });
   });

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/chart_panels/chart_select/helpers.test.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/chart_panels/chart_select/helpers.test.ts
@@ -9,6 +9,7 @@ import type { AlertViewSelection } from './helpers';
 import {
   getButtonProperties,
   getContextMenuPanels,
+  getOptionProperties,
   TABLE_ID,
   TREEMAP_ID,
   TREND_ID,
@@ -96,6 +97,40 @@ describe('helpers', () => {
         (item?.onClick as () => void)();
 
         expect(closePopover).toBeCalled();
+      });
+    });
+  });
+
+  describe('getOptionProperties', () => {
+    test('it returns the expected properties when alertViewSelection is Trend', () => {
+      expect(getOptionProperties(TREND_ID)).toEqual({
+        id: CHARTS_ID,
+        'data-test-subj': TREND_ID,
+        label: i18n.TREND_TITLE,
+      });
+    });
+
+    test('it returns the expected properties when alertViewSelection is Table', () => {
+      expect(getOptionProperties(TABLE_ID)).toEqual({
+        id: TABLE_ID,
+        'data-test-subj': TABLE_ID,
+        label: i18n.TABLE,
+      });
+    });
+
+    test('it returns the expected properties when alertViewSelection is Treemap', () => {
+      expect(getOptionProperties(TREEMAP_ID)).toEqual({
+        id: TREEMAP_ID,
+        'data-test-subj': TREEMAP_ID,
+        label: i18n.TREEMAP,
+      });
+    });
+
+    test('it returns the expected properties when alertViewSelection is charts', () => {
+      expect(getOptionProperties(CHARTS_ID)).toEqual({
+        id: CHARTS_ID,
+        'data-test-subj': CHARTS_ID,
+        label: i18n.CHARTS,
       });
     });
   });

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/chart_panels/chart_select/helpers.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/chart_panels/chart_select/helpers.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { EuiContextMenuPanelDescriptor } from '@elastic/eui';
+import type { EuiContextMenuPanelDescriptor, EuiButtonGroupOptionProps } from '@elastic/eui';
 
 import * as i18n from './translations';
 
@@ -92,3 +92,26 @@ export const getContextMenuPanels = ({
     ],
   },
 ];
+
+export const getOptionProperties = (
+  alertViewSelection: AlertViewSelection
+): EuiButtonGroupOptionProps => {
+  const charts = { id: CHARTS_ID, 'data-test-subj': alertViewSelection, label: i18n.CHARTS_TITLE };
+
+  switch (alertViewSelection) {
+    case TABLE_ID:
+      return { id: TABLE_ID, 'data-test-subj': alertViewSelection, label: i18n.TABLE_TITLE };
+    case TREND_ID:
+      return {
+        id: TREND_ID,
+        'data-test-subj': alertViewSelection,
+        label: i18n.TREND_TITLE,
+      };
+    case TREEMAP_ID:
+      return { id: TREEMAP_ID, 'data-test-subj': alertViewSelection, label: i18n.TREEMAP_TITLE };
+    case CHARTS_ID:
+      return charts;
+    default:
+      return charts;
+  }
+};

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/chart_panels/chart_select/helpers.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/chart_panels/chart_select/helpers.ts
@@ -96,19 +96,35 @@ export const getContextMenuPanels = ({
 export const getOptionProperties = (
   alertViewSelection: AlertViewSelection
 ): EuiButtonGroupOptionProps => {
-  const charts = { id: CHARTS_ID, 'data-test-subj': alertViewSelection, label: i18n.CHARTS_TITLE };
+  const charts = {
+    id: CHARTS_ID,
+    'data-test-subj': `chart-select-${CHARTS_ID}`,
+    label: i18n.CHARTS_TITLE,
+    value: CHARTS_ID,
+  };
 
   switch (alertViewSelection) {
     case TABLE_ID:
-      return { id: TABLE_ID, 'data-test-subj': alertViewSelection, label: i18n.TABLE_TITLE };
+      return {
+        id: TABLE_ID,
+        'data-test-subj': `chart-select-${TABLE_ID}`,
+        label: i18n.TABLE_TITLE,
+        value: TABLE_ID,
+      };
     case TREND_ID:
       return {
         id: TREND_ID,
-        'data-test-subj': alertViewSelection,
+        'data-test-subj': `chart-select-${TREND_ID}`,
         label: i18n.TREND_TITLE,
+        value: TREND_ID,
       };
     case TREEMAP_ID:
-      return { id: TREEMAP_ID, 'data-test-subj': alertViewSelection, label: i18n.TREEMAP_TITLE };
+      return {
+        id: TREEMAP_ID,
+        'data-test-subj': `chart-select-${TREEMAP_ID}`,
+        label: i18n.TREEMAP_TITLE,
+        value: TREEMAP_ID,
+      };
     case CHARTS_ID:
       return charts;
     default:

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/chart_panels/chart_select/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/chart_panels/chart_select/index.test.tsx
@@ -4,42 +4,82 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { waitForEuiPopoverOpen } from '@elastic/eui/lib/test/rtl';
 import React from 'react';
 
 import { TestProviders } from '../../../../../common/mock';
-import { SELECT_A_CHART_ARIA_LABEL, TREEMAP } from './translations';
+import * as i18n from './translations';
 import { ChartSelect } from '.';
+import { useIsExperimentalFeatureEnabled } from '../../../../../common/hooks/use_experimental_features';
+
+const mockUseIsExperimentalFeatureEnabled = useIsExperimentalFeatureEnabled as jest.Mock;
+jest.mock('../../../../../common/hooks/use_experimental_features');
 
 describe('ChartSelect', () => {
-  test('it renders the chart select button', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+  });
+
+  test('it renders the chart select button when alertsPageChartsEnabled is false', () => {
+    mockUseIsExperimentalFeatureEnabled.mockReturnValue(false);
     render(
       <TestProviders>
         <ChartSelect alertViewSelection="trend" setAlertViewSelection={jest.fn()} />
       </TestProviders>
     );
 
-    expect(screen.getByRole('button', { name: SELECT_A_CHART_ARIA_LABEL })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: i18n.SELECT_A_CHART_ARIA_LABEL })
+    ).toBeInTheDocument();
   });
 
-  test('it invokes `setAlertViewSelection` with the expected value when a chart is selected', async () => {
+  test('it invokes `setAlertViewSelection` with the expected value when a chart is selected and alertsPageChartsEnabled is false', async () => {
+    mockUseIsExperimentalFeatureEnabled.mockReturnValue(false);
     const setAlertViewSelection = jest.fn();
-
     render(
       <TestProviders>
         <ChartSelect alertViewSelection="trend" setAlertViewSelection={setAlertViewSelection} />
       </TestProviders>
     );
 
-    const selectButton = screen.getByRole('button', { name: SELECT_A_CHART_ARIA_LABEL });
+    const selectButton = screen.getByRole('button', { name: i18n.SELECT_A_CHART_ARIA_LABEL });
     selectButton.click();
     await waitForEuiPopoverOpen();
 
-    const treemapMenuItem = screen.getByRole('button', { name: TREEMAP });
+    const treemapMenuItem = screen.getByRole('button', { name: i18n.TREEMAP });
     treemapMenuItem.click();
 
     expect(setAlertViewSelection).toBeCalledWith('treemap');
+  });
+
+  test('it renders the chart select tabs when alertsPageChartsEnabled is true', () => {
+    mockUseIsExperimentalFeatureEnabled.mockReturnValue(true);
+    render(
+      <TestProviders>
+        <ChartSelect alertViewSelection="trend" setAlertViewSelection={jest.fn()} />
+      </TestProviders>
+    );
+
+    expect(screen.getByTestId('chart-select-tabs')).toBeInTheDocument();
+    expect(screen.getByTestId('trend')).toBeChecked();
+  });
+
+  test('changing selection render correctly when alertsPageChartsEnabled is true', async () => {
+    mockUseIsExperimentalFeatureEnabled.mockReturnValue(true);
+    const setAlertViewSelection = jest.fn();
+    const { container } = render(
+      <TestProviders>
+        <ChartSelect alertViewSelection="trend" setAlertViewSelection={setAlertViewSelection} />
+      </TestProviders>
+    );
+
+    const button = container.querySelector('input[value="treemap"]');
+    if (button) {
+      fireEvent.change(button, { target: { checked: true, type: 'radio' } });
+    }
+    expect(screen.getByTestId('treemap')).toBeChecked();
+    expect(screen.getByTestId('trend')).not.toBeChecked();
   });
 });

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/chart_panels/chart_select/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/chart_panels/chart_select/index.tsx
@@ -70,13 +70,14 @@ const ChartSelectComponent: React.FC<Props> = ({
     <>
       {isAlertsPageChartsEnabled ? (
         <EuiButtonGroup
-          name="coarsness"
-          legend="This is a basic group"
+          name="chart-select"
+          legend={i18n.LEGEND_TITLE}
           options={options}
           idSelected={alertViewSelection}
           onChange={(id) => setAlertViewSelection(id as AlertViewSelection)}
           buttonSize="compressed"
           color="primary"
+          data-test-subj="chart-select-tabs"
         />
       ) : (
         <EuiPopover

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/chart_panels/chart_select/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/chart_panels/chart_select/index.tsx
@@ -6,12 +6,12 @@
  */
 
 import type { EuiContextMenuPanelDescriptor } from '@elastic/eui';
-import { EuiButton, EuiContextMenu, EuiIcon, EuiPopover } from '@elastic/eui';
+import { EuiButton, EuiContextMenu, EuiIcon, EuiPopover, EuiButtonGroup } from '@elastic/eui';
 import React, { useCallback, useMemo, useState } from 'react';
 import styled from 'styled-components';
 
 import type { AlertViewSelection } from './helpers';
-import { getButtonProperties, getContextMenuPanels } from './helpers';
+import { getButtonProperties, getContextMenuPanels, getOptionProperties } from './helpers';
 import * as i18n from './translations';
 import { useIsExperimentalFeatureEnabled } from '../../../../../common/hooks/use_experimental_features';
 interface Props {
@@ -22,6 +22,7 @@ interface Props {
 const ChartTypeIcon = styled(EuiIcon)`
   margin-right: ${({ theme }) => theme.eui.euiSizeS};
 `;
+const AlertViewOptions: AlertViewSelection[] = ['charts', 'trend', 'table', 'treemap'];
 
 const ChartSelectComponent: React.FC<Props> = ({
   alertViewSelection,
@@ -50,6 +51,10 @@ const ChartSelectComponent: React.FC<Props> = ({
     );
   }, [alertViewSelection, onButtonClick]);
   const isAlertsPageChartsEnabled = useIsExperimentalFeatureEnabled('alertsPageChartsEnabled');
+  const options = useMemo(() => {
+    return AlertViewOptions.map((option: AlertViewSelection) => getOptionProperties(option));
+  }, []);
+
   const panels: EuiContextMenuPanelDescriptor[] = useMemo(
     () =>
       getContextMenuPanels({
@@ -62,15 +67,29 @@ const ChartSelectComponent: React.FC<Props> = ({
   );
 
   return (
-    <EuiPopover
-      anchorPosition="downLeft"
-      button={button}
-      closePopover={closePopover}
-      isOpen={isPopoverOpen}
-      panelPaddingSize="none"
-    >
-      <EuiContextMenu initialPanelId={0} panels={panels} />
-    </EuiPopover>
+    <>
+      {isAlertsPageChartsEnabled ? (
+        <EuiButtonGroup
+          name="coarsness"
+          legend="This is a basic group"
+          options={options}
+          idSelected={alertViewSelection}
+          onChange={(id) => setAlertViewSelection(id as AlertViewSelection)}
+          buttonSize="compressed"
+          color="primary"
+        />
+      ) : (
+        <EuiPopover
+          anchorPosition="downLeft"
+          button={button}
+          closePopover={closePopover}
+          isOpen={isPopoverOpen}
+          panelPaddingSize="none"
+        >
+          <EuiContextMenu initialPanelId={0} panels={panels} />
+        </EuiPopover>
+      )}
+    </>
   );
 };
 

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/chart_panels/chart_select/translations.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/chart_panels/chart_select/translations.ts
@@ -32,3 +32,31 @@ export const TREEMAP = i18n.translate(
 export const CHARTS = i18n.translate('xpack.securitySolution.components.chartSelect.chartsOption', {
   defaultMessage: 'Charts',
 });
+
+export const TABLE_TITLE = i18n.translate(
+  'xpack.securitySolution.components.chartSelect.tableOption',
+  {
+    defaultMessage: 'Aggregations',
+  }
+);
+
+export const TREND_TITLE = i18n.translate(
+  'xpack.securitySolution.components.chartSelect.trendOption',
+  {
+    defaultMessage: 'Trend Analysis',
+  }
+);
+
+export const TREEMAP_TITLE = i18n.translate(
+  'xpack.securitySolution.components.chartSelect.treemapOption',
+  {
+    defaultMessage: 'Multi-dimensional',
+  }
+);
+
+export const CHARTS_TITLE = i18n.translate(
+  'xpack.securitySolution.components.chartSelect.chartsOption',
+  {
+    defaultMessage: 'Summary',
+  }
+);

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/chart_panels/chart_select/translations.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/chart_panels/chart_select/translations.ts
@@ -60,3 +60,10 @@ export const CHARTS_TITLE = i18n.translate(
     defaultMessage: 'Summary',
   }
 );
+
+export const LEGEND_TITLE = i18n.translate(
+  'xpack.securitySolution.components.chartSelect.legendTitle',
+  {
+    defaultMessage: 'Select a tab',
+  }
+);

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/detection_engine.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/detection_engine.tsx
@@ -217,7 +217,7 @@ const DetectionEnginePageComponent: React.FC<DetectionEngineComponentProps> = ({
     [formatUrl, navigateToUrl]
   );
 
-  const alertsHistogramDefaultFilters = useMemo(
+  const alertsDefaultFilters = useMemo(
     () => [
       ...filters,
       ...buildShowBuildingBlockFilter(showBuildingBlockAlerts),
@@ -437,7 +437,7 @@ const DetectionEnginePageComponent: React.FC<DetectionEngineComponentProps> = ({
               <EuiSpacer size="l" />
               <ChartPanels
                 addFilter={addFilter}
-                alertsHistogramDefaultFilters={alertsHistogramDefaultFilters}
+                alertsDefaultFilters={alertsDefaultFilters}
                 isLoadingIndexPattern={isChartPanelLoading}
                 query={query}
                 runtimeMappings={runtimeMappings}


### PR DESCRIPTION
## Summary

This PR is part 3 of https://github.com/elastic/kibana/pull/149173 and https://github.com/elastic/kibana/pull/146938 that add additional KPI visualizations to the Alerts page.

#### Capabilities added

Charts menu: changed from a drop down selection to tabs format, with wording that better describe the usage of each charts
Chart collapse: when the toggle is collapsed, instead of showing the same menu options, a summary of the KPIs are shown.

Feature flag: `alertsPageChartsEnabled` is set to true by default

#### Changes from previous PR
Before this PR, each chart (trend, tree map etc.) keeps its own state of toggle status. This is no longer suitable because the new layout does not show options when collapsed. This PR also moves the toggle status to be at the chart panel's level, and be passed down to each chart component. 

One exception is the histogram (trend analysis), it is currently being used in alerts detail page and overview dashboard, hence it needs to keep track of toggle state on its own. 

#### When charts are expanded
![image](https://user-images.githubusercontent.com/18648970/216714087-a872cdeb-5d69-40fd-a392-4130ad6c925c.png)

#### When collapsed and has data
![image](https://user-images.githubusercontent.com/18648970/216714168-e4d72ca2-b214-48d8-9182-932927c0b473.png)

#### When collapsed with no data
![image](https://user-images.githubusercontent.com/18648970/216714250-628b96d2-6380-4999-a2a6-ed22eb0d8791.png)


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)
