### PR TITLE
[docs] SDH is an internal only reference/term

### DIFF
--- a/docs/developer/best-practices/stability.asciidoc
+++ b/docs/developer/best-practices/stability.asciidoc
@@ -29,7 +29,7 @@ access.
 *** We need to make sure security is set up in a specific way for
 non-standard {kib} indices. (create their own custom roles)
 * {kib} running behind a reverse proxy or load balancer, without sticky
-sessions. (we have had many discuss/SDH tickets around this)
+sessions. (we have had many discuss/support cases around this)
 * If a proxy/loadbalancer is running between ES and {kib}
 
 [discrete]


### PR DESCRIPTION
Use "support cases" in place of "SDHs" for public facing docs.


