### PR TITLE
[Enterprise Search] Fix painless script bug cancelling syncs

### DIFF
--- a/x-pack/plugins/enterprise_search/server/lib/connectors/post_cancel_syncs.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/connectors/post_cancel_syncs.test.ts
@@ -55,12 +55,10 @@ describe('addConnector lib function', () => {
       refresh: true,
       script: {
         lang: 'painless',
-        source: `
-      ctx._source['status'] = '${SyncStatus.CANCELED}';
-      ctx._source['cancelation_requested_at'] = '${new Date(Date.now()).toISOString()}';
-      ctx._source['canceled_at'] = '${new Date(Date.now()).toISOString()}';
-      ctx._source['completed_at'] = '${new Date(Date.now()).toISOString()}';
-`,
+        source: `ctx._source['status'] = '${SyncStatus.CANCELED}';
+ctx._source['cancelation_requested_at'] = '${new Date(Date.now()).toISOString()}';
+ctx._source['canceled_at'] = '${new Date(Date.now()).toISOString()}';
+ctx._source['completed_at'] = '${new Date(Date.now()).toISOString()}';`,
       },
     });
     expect(mockClient.asCurrentUser.updateByQuery).toHaveBeenCalledWith({
@@ -84,10 +82,8 @@ describe('addConnector lib function', () => {
       refresh: true,
       script: {
         lang: 'painless',
-        source: `
-        ctx._source['status'] = '${SyncStatus.CANCELING}'
-        ctx._source['cancelation_requested_at'] = '${new Date(Date.now()).toISOString()}';
-`,
+        source: `ctx._source['status'] = '${SyncStatus.CANCELING}';
+ctx._source['cancelation_requested_at'] = '${new Date(Date.now()).toISOString()}';`,
       },
     });
     await expect(mockClient.asCurrentUser.update).toHaveBeenCalledWith({

--- a/x-pack/plugins/enterprise_search/server/lib/connectors/post_cancel_syncs.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/connectors/post_cancel_syncs.ts
@@ -35,12 +35,10 @@ export const cancelSyncs = async (
     refresh: true,
     script: {
       lang: 'painless',
-      source: `
-      ctx._source['status'] = '${SyncStatus.CANCELED}';
-      ctx._source['cancelation_requested_at'] = '${new Date(Date.now()).toISOString()}';
-      ctx._source['canceled_at'] = '${new Date(Date.now()).toISOString()}';
-      ctx._source['completed_at'] = '${new Date(Date.now()).toISOString()}';
-`,
+      source: `ctx._source['status'] = '${SyncStatus.CANCELED}';
+ctx._source['cancelation_requested_at'] = '${new Date(Date.now()).toISOString()}';
+ctx._source['canceled_at'] = '${new Date(Date.now()).toISOString()}';
+ctx._source['completed_at'] = '${new Date(Date.now()).toISOString()}';`,
     },
   });
   await client.asCurrentUser.updateByQuery({
@@ -64,10 +62,8 @@ export const cancelSyncs = async (
     refresh: true,
     script: {
       lang: 'painless',
-      source: `
-        ctx._source['status'] = '${SyncStatus.CANCELING}'
-        ctx._source['cancelation_requested_at'] = '${new Date(Date.now()).toISOString()}';
-`,
+      source: `ctx._source['status'] = '${SyncStatus.CANCELING}';
+ctx._source['cancelation_requested_at'] = '${new Date(Date.now()).toISOString()}';`,
     },
   });
   await client.asCurrentUser.update({


### PR DESCRIPTION
## Summary

Fixes a formatting bug causing a painless script to cancel syncs to break.

<!--ONMERGE {"backportTargets":["8.6"]} ONMERGE-->