### PR TITLE
API docs: Add deprecation warning to all deprecated Saved Object APIs

### DIFF
--- a/docs/api/saved-objects.asciidoc
+++ b/docs/api/saved-objects.asciidoc
@@ -7,6 +7,7 @@ WARNING: Do not write documents directly to the `.kibana` index. When you write 
 to the `.kibana` index, the data becomes corrupted and permanently breaks future {kib} versions.
 
 The following saved objects APIs are available: 
+
 * <<saved-objects-api-export, Export objects API>> to retrieve sets of saved objects that you want to import into {kib}
 
 * <<saved-objects-api-import, Import objects API>> to create sets of {kib} saved objects from a file created by the export API
@@ -43,7 +44,6 @@ include::saved-objects/export.asciidoc[]
 include::saved-objects/import.asciidoc[]
 include::saved-objects/resolve_import_errors.asciidoc[]
 include::saved-objects/rotate_encryption_key.asciidoc[]
-
 include::saved-objects/get.asciidoc[]
 include::saved-objects/bulk_get.asciidoc[]
 include::saved-objects/find.asciidoc[]

--- a/docs/api/saved-objects/bulk_create.asciidoc
+++ b/docs/api/saved-objects/bulk_create.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Bulk create saved objects</titleabbrev>
 ++++
 
-deprecated::[8.7.0, to be removed in an uncomming version]
+deprecated::[8.7.0, To be removed in an upcoming version]
 
 Create multiple {kib} saved objects.
 

--- a/docs/api/saved-objects/bulk_create.asciidoc
+++ b/docs/api/saved-objects/bulk_create.asciidoc
@@ -4,7 +4,9 @@
 <titleabbrev>Bulk create saved objects</titleabbrev>
 ++++
 
-experimental[] Create multiple {kib} saved objects.
+deprecated::[8.7.0, to be removed in an uncomming version]
+
+Create multiple {kib} saved objects.
 
 [[saved-objects-api-bulk-create-request]]
 ==== Request

--- a/docs/api/saved-objects/bulk_delete.asciidoc
+++ b/docs/api/saved-objects/bulk_delete.asciidoc
@@ -4,7 +4,9 @@
 <titleabbrev>Bulk delete objects</titleabbrev>
 ++++
 
-experimental[] Remove multiple {kib} saved objects.
+deprecated::[8.7.0, to be removed in an uncomming version]
+
+Remove multiple {kib} saved objects.
 
 WARNING: Once you delete a saved object, _it cannot be recovered_.
 

--- a/docs/api/saved-objects/bulk_delete.asciidoc
+++ b/docs/api/saved-objects/bulk_delete.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Bulk delete objects</titleabbrev>
 ++++
 
-deprecated::[8.7.0, to be removed in an uncomming version]
+deprecated::[8.7.0, To be removed in an upcoming version]
 
 Remove multiple {kib} saved objects.
 

--- a/docs/api/saved-objects/bulk_get.asciidoc
+++ b/docs/api/saved-objects/bulk_get.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Bulk get objects</titleabbrev>
 ++++
 
-deprecated::[8.7.0, to be removed in an uncomming version]
+deprecated::[8.7.0, To be removed in an upcoming version]
 
 Retrieve multiple {kib} saved objects by ID.
 

--- a/docs/api/saved-objects/bulk_get.asciidoc
+++ b/docs/api/saved-objects/bulk_get.asciidoc
@@ -4,7 +4,9 @@
 <titleabbrev>Bulk get objects</titleabbrev>
 ++++
 
-experimental[] Retrieve multiple {kib} saved objects by ID.
+deprecated::[8.7.0, to be removed in an uncomming version]
+
+Retrieve multiple {kib} saved objects by ID.
 
 [[saved-objects-api-bulk-get-request]]
 ==== Request

--- a/docs/api/saved-objects/bulk_resolve.asciidoc
+++ b/docs/api/saved-objects/bulk_resolve.asciidoc
@@ -4,7 +4,9 @@
 <titleabbrev>Bulk resolve objects</titleabbrev>
 ++++
 
-experimental[] Retrieve multiple {kib} saved objects by ID, using any legacy URL aliases if they exist.
+deprecated::[8.7.0, to be removed in an uncomming version]
+
+Retrieve multiple {kib} saved objects by ID, using any legacy URL aliases if they exist.
 
 Under certain circumstances, when Kibana is upgraded, saved object migrations may necessitate regenerating some object IDs to enable new
 features. When an object's ID is regenerated, a legacy URL alias is created for that object, preserving its old ID. In such a scenario, that

--- a/docs/api/saved-objects/bulk_resolve.asciidoc
+++ b/docs/api/saved-objects/bulk_resolve.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Bulk resolve objects</titleabbrev>
 ++++
 
-deprecated::[8.7.0, to be removed in an uncomming version]
+deprecated::[8.7.0, To be removed in an upcoming version]
 
 Retrieve multiple {kib} saved objects by ID, using any legacy URL aliases if they exist.
 

--- a/docs/api/saved-objects/bulk_update.asciidoc
+++ b/docs/api/saved-objects/bulk_update.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Bulk update objects</titleabbrev>
 ++++
 
-deprecated::[8.7.0, to be removed in an uncomming version]
+deprecated::[8.7.0, To be removed in an upcoming version]
 
 Update the attributes for multiple existing {kib} saved objects.
 

--- a/docs/api/saved-objects/bulk_update.asciidoc
+++ b/docs/api/saved-objects/bulk_update.asciidoc
@@ -4,7 +4,9 @@
 <titleabbrev>Bulk update objects</titleabbrev>
 ++++
 
-experimental[] Update the attributes for multiple existing {kib} saved objects.
+deprecated::[8.7.0, to be removed in an uncomming version]
+
+Update the attributes for multiple existing {kib} saved objects.
 
 [[saved-objects-api-bulk-update-request]]
 ==== Request

--- a/docs/api/saved-objects/create.asciidoc
+++ b/docs/api/saved-objects/create.asciidoc
@@ -4,7 +4,9 @@
 <titleabbrev>Create saved objects</titleabbrev>
 ++++
 
-experimental[] Create {kib} saved objects.
+deprecated::[8.7.0, to be removed in an uncomming version]
+
+Create {kib} saved objects.
 
 [[saved-objects-api-create-request]]
 ==== Request

--- a/docs/api/saved-objects/create.asciidoc
+++ b/docs/api/saved-objects/create.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Create saved objects</titleabbrev>
 ++++
 
-deprecated::[8.7.0, to be removed in an uncomming version]
+deprecated::[8.7.0, To be removed in an upcoming version]
 
 Create {kib} saved objects.
 

--- a/docs/api/saved-objects/delete.asciidoc
+++ b/docs/api/saved-objects/delete.asciidoc
@@ -4,7 +4,9 @@
 <titleabbrev>Delete object</titleabbrev>
 ++++
 
-experimental[] Remove {kib} saved objects.
+deprecated::[8.7.0, to be removed in an uncomming version]
+
+Remove {kib} saved objects.
 
 WARNING: Once you delete a saved object, _it cannot be recovered_.
 

--- a/docs/api/saved-objects/delete.asciidoc
+++ b/docs/api/saved-objects/delete.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Delete object</titleabbrev>
 ++++
 
-deprecated::[8.7.0, to be removed in an uncomming version]
+deprecated::[8.7.0, To be removed in an upcoming version]
 
 Remove {kib} saved objects.
 

--- a/docs/api/saved-objects/find.asciidoc
+++ b/docs/api/saved-objects/find.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Find objects</titleabbrev>
 ++++
 
-deprecated::[8.7.0, to be removed in an uncomming version]
+deprecated::[8.7.0, To be removed in an upcoming version]
 
 Retrieve a paginated set of {kib} saved objects by various conditions.
 

--- a/docs/api/saved-objects/find.asciidoc
+++ b/docs/api/saved-objects/find.asciidoc
@@ -4,7 +4,9 @@
 <titleabbrev>Find objects</titleabbrev>
 ++++
 
-experimental[] Retrieve a paginated set of {kib} saved objects by various conditions.
+deprecated::[8.7.0, to be removed in an uncomming version]
+
+Retrieve a paginated set of {kib} saved objects by various conditions.
 
 [[saved-objects-api-find-request]]
 ==== Request

--- a/docs/api/saved-objects/get.asciidoc
+++ b/docs/api/saved-objects/get.asciidoc
@@ -4,7 +4,9 @@
 <titleabbrev>Get object</titleabbrev>
 ++++
 
-experimental[] Retrieve a single {kib} saved object by ID.
+deprecated::[8.7.0, to be removed in an uncomming version]
+
+Retrieve a single {kib} saved object by ID.
 
 [[saved-objects-api-get-request]]
 ==== Request

--- a/docs/api/saved-objects/get.asciidoc
+++ b/docs/api/saved-objects/get.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Get object</titleabbrev>
 ++++
 
-deprecated::[8.7.0, to be removed in an uncomming version]
+deprecated::[8.7.0, To be removed in an upcoming version]
 
 Retrieve a single {kib} saved object by ID.
 

--- a/docs/api/saved-objects/resolve.asciidoc
+++ b/docs/api/saved-objects/resolve.asciidoc
@@ -4,7 +4,9 @@
 <titleabbrev>Resolve object</titleabbrev>
 ++++
 
-experimental[] Retrieve a single {kib} saved object by ID, using any legacy URL alias if it exists.
+deprecated::[8.7.0, to be removed in an uncomming version]
+
+Retrieve a single {kib} saved object by ID, using any legacy URL alias if it exists.
 
 Under certain circumstances, when Kibana is upgraded, saved object migrations may necessitate regenerating some object IDs to enable new
 features. When an object's ID is regenerated, a legacy URL alias is created for that object, preserving its old ID. In such a scenario, that

--- a/docs/api/saved-objects/resolve.asciidoc
+++ b/docs/api/saved-objects/resolve.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Resolve object</titleabbrev>
 ++++
 
-deprecated::[8.7.0, to be removed in an uncomming version]
+deprecated::[8.7.0, To be removed in an upcoming version]
 
 Retrieve a single {kib} saved object by ID, using any legacy URL alias if it exists.
 

--- a/docs/api/saved-objects/update.asciidoc
+++ b/docs/api/saved-objects/update.asciidoc
@@ -4,7 +4,8 @@
 <titleabbrev>Update object</titleabbrev>
 ++++
 
-deprecated::[8.7.0, to be removed in an uncomming version]
+deprecated::[8.7.0, To be removed in an upcoming version]
+
 Update the attributes for existing {kib} saved objects.
 
 [[saved-objects-api-update-request]]

--- a/docs/api/saved-objects/update.asciidoc
+++ b/docs/api/saved-objects/update.asciidoc
@@ -4,7 +4,8 @@
 <titleabbrev>Update object</titleabbrev>
 ++++
 
-experimental[] Update the attributes for existing {kib} saved objects.
+deprecated::[8.7.0, to be removed in an uncomming version]
+Update the attributes for existing {kib} saved objects.
 
 [[saved-objects-api-update-request]]
 ==== Request

--- a/docs/management/saved-objects/saved-object-ids.asciidoc
+++ b/docs/management/saved-objects/saved-object-ids.asciidoc
@@ -77,6 +77,8 @@ be broken. For more information, refer to {kibana-ref-all}/8.0/release-notes-8.0
 
 If you are using the saved objects APIs directly, you should be aware of these changes:
 
+WARNING: Some of the saved objects APIs are deprecated in 8.7.0. For more information, refer to the <<saved-objects-api, API docs>>
+
 * When using the <<saved-objects-api-create,create>> or <<saved-objects-api-bulk-create,bulk create>> API, you may encounter
   <<saved-objects-api-bulk-create-conflict-errors,conflict errors>> that **cannot** be overridden using the `overwrite: true`
   option. This can occur if there is already a saved object with this ID in a _different_ space, or if there is a legacy URL alias for this


### PR DESCRIPTION
Follow up to https://github.com/elastic/kibana/pull/150124

Part of https://github.com/elastic/kibana/issues/149287

This PR does the following:
- Adds deprecation warning to API-specific docs and other docs where needed.
- Fixes the formatting issue with the API lost starting mid-sentence in [Saved Objects APIs](https://www.elastic.co/guide/en/kibana/current/saved-objects-api.html)

**Note to reviewers**
See the documentation preview for what has changed.