### PR TITLE
[Vega] Stabilize the vega custom expressions tests

### DIFF
--- a/test/functional/apps/visualize/group6/_vega_chart.ts
+++ b/test/functional/apps/visualize/group6/_vega_chart.ts
@@ -224,6 +224,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
         if (filtersCount > 0) {
           await filterBar.removeAllFilters();
         }
+        await PageObjects.visChart.waitForVisualizationRenderingStabilized();
       });
 
       const fillSpecAndGo = async (newSpec: string) => {


### PR DESCRIPTION
## Summary
Closes https://github.com/elastic/kibana/issues/150208

The problem is that it adds the filter badge twice. I think that it doesn't remove the previous one so a new is added. I think that waiting the chart to be rendered after the clearing of the filters will stabilize it.

Runner 100 times

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios