### PR TITLE
Improve alert summary data fetching in Alerts and Overview pages

### DIFF
--- a/x-pack/plugins/observability/public/pages/alerts/containers/alerts_page/alerts_page.tsx
+++ b/x-pack/plugins/observability/public/pages/alerts/containers/alerts_page/alerts_page.tsx
@@ -5,15 +5,12 @@
  * 2.0.
  */
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { BoolQuery } from '@kbn/es-query';
 import { i18n } from '@kbn/i18n';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
-import {
-  loadRuleAggregations,
-  AlertSummaryTimeRange,
-} from '@kbn/triggers-actions-ui-plugin/public';
+import { loadRuleAggregations } from '@kbn/triggers-actions-ui-plugin/public';
 import { AlertConsumers } from '@kbn/rule-data-utils';
 import { useToasts } from '../../../../hooks/use_toast';
 import {
@@ -80,12 +77,16 @@ function InternalAlertsPage() {
   const { hasAnyData, isAllRequestsComplete } = useHasData();
   const [esQuery, setEsQuery] = useState<{ bool: BoolQuery }>();
   const timeBuckets = useTimeBuckets();
-  const alertSummaryTimeRange: AlertSummaryTimeRange = getAlertSummaryTimeRange(
-    {
-      from: alertSearchBarStateProps.rangeFrom,
-      to: alertSearchBarStateProps.rangeTo,
-    },
-    timeBuckets
+  const alertSummaryTimeRange = useMemo(
+    () =>
+      getAlertSummaryTimeRange(
+        {
+          from: alertSearchBarStateProps.rangeFrom,
+          to: alertSearchBarStateProps.rangeTo,
+        },
+        timeBuckets
+      ),
+    [alertSearchBarStateProps.rangeFrom, alertSearchBarStateProps.rangeTo, timeBuckets]
   );
 
   useBreadcrumbs([

--- a/x-pack/plugins/observability/public/pages/overview/containers/overview_page/overview_page.tsx
+++ b/x-pack/plugins/observability/public/pages/overview/containers/overview_page/overview_page.tsx
@@ -92,12 +92,16 @@ export function OverviewPage() {
     })
   );
   const timeBuckets = useTimeBuckets();
-  const alertSummaryTimeRange = getAlertSummaryTimeRange(
-    {
-      from: relativeStart,
-      to: relativeEnd,
-    },
-    timeBuckets
+  const alertSummaryTimeRange = useMemo(
+    () =>
+      getAlertSummaryTimeRange(
+        {
+          from: relativeStart,
+          to: relativeEnd,
+        },
+        timeBuckets
+      ),
+    [relativeEnd, relativeStart, timeBuckets]
   );
 
   const chartThemes = {


### PR DESCRIPTION
## Summary

Use useMemo to avoid extra fetching of alert summary data.

|Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/12370520/216947059-71e52c83-e72f-4061-9f4a-91b9e7e83335.png)|![image](https://user-images.githubusercontent.com/12370520/216947089-ef669157-70aa-4ef0-800b-c3f659055fdd.png)|