### PR TITLE
Fix Nested other bucket for empty string

### DIFF
--- a/src/plugins/data/common/search/aggs/buckets/_terms_other_bucket_helper.test.ts
+++ b/src/plugins/data/common/search/aggs/buckets/_terms_other_bucket_helper.test.ts
@@ -646,6 +646,73 @@ describe('Terms Agg Other bucket helper', () => {
           expect((topAgg['1'] as any).buckets[1]['2'].buckets[3].key).toEqual('__other__');
         }
       });
+
+      test('correctly merges other bucket with nested terms agg with empty string', () => {
+        const response = {
+          ...nestedTermResponse,
+          aggregations: {
+            ...nestedTermResponse.aggregations,
+            '1': {
+              ...nestedTermResponse.aggregations['1'],
+              buckets: [
+                ...nestedTermResponse.aggregations['1'].buckets,
+                {
+                  '2': {
+                    doc_count_error_upper_bound: 0,
+                    sum_other_doc_count: 8325,
+                    buckets: [
+                      { key: 'ios', doc_count: 1850 },
+                      { key: 'win xp', doc_count: 1830 },
+                      { key: '__missing__', doc_count: 130 },
+                    ],
+                  },
+                  key: '',
+                  doc_count: 2830,
+                },
+              ],
+            },
+          },
+        };
+
+        const otherResponse = {
+          took: 3,
+          timed_out: false,
+          _shards: { total: 1, successful: 1, skipped: 0, failed: 0 },
+          hits: { total: 14005, max_score: 0, hits: [] },
+          aggregations: {
+            'other-filter': {
+              buckets: {
+                [`${SEP}US-with-dash`]: { doc_count: 2805 },
+                [`${SEP}IN-with-dash`]: { doc_count: 2804 },
+                [`${SEP}`]: { doc_count: 2804 },
+              },
+            },
+          },
+          status: 200,
+        };
+        const aggConfigs = getAggConfigs(nestedTerm.aggs);
+        const otherAggConfig = buildOtherBucketAgg(
+          aggConfigs,
+          aggConfigs.aggs[1] as IBucketAggConfig,
+          enrichResponseWithSampling(response)
+        );
+
+        expect(otherAggConfig).toBeDefined();
+        if (otherAggConfig) {
+          const mergedResponse = mergeOtherBucketAggResponse(
+            aggConfigs,
+            enrichResponseWithSampling(response),
+            enrichResponseWithSampling(otherResponse),
+            aggConfigs.aggs[1] as IBucketAggConfig,
+            otherAggConfig(),
+            constructSingleTermOtherFilter
+          );
+
+          const topAgg = getTopAggregations(mergedResponse);
+          expect((topAgg['1'] as any).buckets[2].key).toEqual('');
+          expect((topAgg['1'] as any).buckets[2]['2'].buckets[3].key).toEqual('__other__');
+        }
+      });
     });
 
     describe(`updateMissingBucket${getTitlePostfix()}`, () => {

--- a/src/plugins/data/common/search/aggs/buckets/_terms_other_bucket_helper.ts
+++ b/src/plugins/data/common/search/aggs/buckets/_terms_other_bucket_helper.ts
@@ -209,7 +209,7 @@ export const buildOtherBucketAgg = (
       exhaustiveBuckets = false;
     }
     if (aggIndex < index) {
-      each(agg?.buckets, (bucket: any, bucketObjKey) => {
+      each(agg.buckets, (bucket: any, bucketObjKey) => {
         const bucketKey = currentAgg.getKey(
           bucket,
           isNumber(bucketObjKey) ? undefined : bucketObjKey

--- a/src/plugins/data/common/search/aggs/buckets/_terms_other_bucket_helper.ts
+++ b/src/plugins/data/common/search/aggs/buckets/_terms_other_bucket_helper.ts
@@ -59,7 +59,7 @@ const getAggResultBuckets = (
   const keyParts = key.split(OTHER_BUCKET_SEPARATOR);
   let responseAgg = response;
   for (const i in keyParts) {
-    if (keyParts[i]) {
+    if (keyParts[i] || keyParts[i] === '') {
       const responseAggs: Array<Record<string, any>> = values(responseAgg);
       // If you have multi aggs, we cannot just assume the first one is the `other` bucket,
       // so we need to loop over each agg until we find it.
@@ -209,7 +209,7 @@ export const buildOtherBucketAgg = (
       exhaustiveBuckets = false;
     }
     if (aggIndex < index) {
-      each(agg.buckets, (bucket: any, bucketObjKey) => {
+      each(agg?.buckets, (bucket: any, bucketObjKey) => {
         const bucketKey = currentAgg.getKey(
           bucket,
           isNumber(bucketObjKey) ? undefined : bucketObjKey


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/123723

Fixes the bug mentioned in the issue. With this change now the Other for the empty string bucket is displayed correctly.

<img width="1480" alt="image" src="https://user-images.githubusercontent.com/17003240/216982740-de97e151-7221-47b0-bbb5-9a23d6548795.png">


### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios