### PR TITLE
[Fleet] return uploaded packages that are not in registry

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/packages/get.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/get.test.ts
@@ -24,7 +24,7 @@ import { PackageNotFoundError } from '../../../errors';
 
 import { getSettings } from '../../settings';
 
-import { getPackageInfo, getPackageUsageStats } from './get';
+import { getPackageInfo, getPackages, getPackageUsageStats } from './get';
 
 const MockRegistry = Registry as jest.Mocked<typeof Registry>;
 
@@ -183,6 +183,65 @@ describe('When using EPM `get` services', () => {
       ).toEqual({
         agent_policy_count: 3,
       });
+    });
+  });
+
+  describe('getPackages', () => {
+    beforeEach(() => {
+      const mockContract = createAppContextStartContractMock();
+      appContextService.start(mockContract);
+      jest.clearAllMocks();
+      MockRegistry.fetchList.mockResolvedValue([
+        {
+          name: 'nginx',
+          version: '1.0.0',
+          title: 'Nginx',
+        } as any,
+      ]);
+    });
+
+    it('should return installed package that is not in registry', async () => {
+      const soClient = savedObjectsClientMock.create();
+      soClient.find.mockResolvedValue({
+        saved_objects: [
+          {
+            id: 'elasticsearch',
+            attributes: {
+              name: 'elasticsearch',
+              version: '0.0.1',
+              install_status: 'upload',
+            },
+          },
+        ],
+      } as any);
+
+      await expect(
+        getPackages({
+          savedObjectsClient: soClient,
+        })
+      ).resolves.toMatchObject([
+        {
+          name: 'elasticsearch',
+          version: '0.0.1',
+          title: 'Elasticsearch',
+          status: 'upload',
+          savedObject: {
+            id: 'elasticsearch',
+            attributes: {
+              name: 'elasticsearch',
+              version: '0.0.1',
+              install_status: 'upload',
+            },
+          },
+        },
+        {
+          name: 'nginx',
+          version: '1.0.0',
+          title: 'Nginx',
+          id: 'nginx',
+          status: 'not_installed',
+        },
+      ]);
     });
   });
 


### PR DESCRIPTION
## Summary

Related to https://github.com/elastic/kibana/issues/148599
Fixes https://github.com/elastic/kibana/issues/81995

Changed `GET /epm/packages` API to list uploaded packages as well that are not in registry.

Testing steps:
- Built a test package that is not in registry from kibana repo:
```
cd x-pack/test/fleet_api_integration/apis/fixtures/package_verification/packages/src/verified-1.0.0
elastic-package build --zip -v
```
- Uploaded the resulting zip [verified-1.0.0.zip](https://github.com/elastic/kibana/files/10664094/verified-1.0.0.zip)
```
curl -XPOST -H 'content-type: application/zip' -H 'kbn-xsrf: true' http://localhost:5601/julia/api/fleet/epm/packages -u elastic:changeme --data-binary @verified-1.0.0.zip
```
- Navigate to `Integrations` page, verify that the `Verified` package is displayed under `Browse` / `Installed` integrations, and the details are visible when clicking on the package.

<img width="639" alt="image" src="https://user-images.githubusercontent.com/90178898/217000305-90c28293-bdfa-42d5-b30b-50f7a63aad11.png">
<img width="757" alt="image" src="https://user-images.githubusercontent.com/90178898/217000420-208d3b90-5341-4f1f-8ab8-554f78821bbf.png">
<img width="1147" alt="image" src="https://user-images.githubusercontent.com/90178898/217000541-06324345-4204-43cc-8411-6c961ec37d17.png">


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->