### PR TITLE
Make "for each alert" option default for all the rule types

### DIFF
--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/action_form.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/action_form.tsx
@@ -36,7 +36,6 @@ import { AddConnectorInline } from './connector_add_inline';
 import { actionTypeCompare } from '../../lib/action_type_compare';
 import { checkActionFormActionTypeEnabled } from '../../lib/check_action_type_enabled';
 import {
-  DEFAULT_FREQUENCY_WITH_SUMMARY,
   DEFAULT_FREQUENCY_WITHOUT_SUMMARY,
   VIEW_LICENSE_OPTIONS_LINK,
 } from '../../../common/constants';
@@ -224,7 +223,7 @@ export const ActionForm = ({
         actionTypeId: actionTypeModel.id,
         group: defaultActionGroupId,
         params: {},
-        frequency: hasSummary ? DEFAULT_FREQUENCY_WITH_SUMMARY : DEFAULT_FREQUENCY_WITHOUT_SUMMARY,
+        frequency: DEFAULT_FREQUENCY_WITHOUT_SUMMARY,
       });
       setActionIdByIndex(actionTypeConnectors[0].id, actions.length - 1);
     }
@@ -236,7 +235,7 @@ export const ActionForm = ({
         actionTypeId: actionTypeModel.id,
         group: defaultActionGroupId,
         params: {},
-        frequency: hasSummary ? DEFAULT_FREQUENCY_WITH_SUMMARY : DEFAULT_FREQUENCY_WITHOUT_SUMMARY,
+        frequency: DEFAULT_FREQUENCY_WITHOUT_SUMMARY,
       });
       setActionIdByIndex(actions.length.toString(), actions.length - 1);
       setEmptyActionsIds([...emptyActionsIds, actions.length.toString()]);

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/action_form.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/action_form.tsx
@@ -35,10 +35,7 @@ import { ActionTypeForm } from './action_type_form';
 import { AddConnectorInline } from './connector_add_inline';
 import { actionTypeCompare } from '../../lib/action_type_compare';
 import { checkActionFormActionTypeEnabled } from '../../lib/check_action_type_enabled';
-import {
-  DEFAULT_FREQUENCY_WITHOUT_SUMMARY,
-  VIEW_LICENSE_OPTIONS_LINK,
-} from '../../../common/constants';
+import { DEFAULT_FREQUENCY, VIEW_LICENSE_OPTIONS_LINK } from '../../../common/constants';
 import { useKibana } from '../../../common/lib/kibana';
 import { ConnectorAddModal } from '.';
 import { suspendedComponentWithProps } from '../../lib/suspended_component_with_props';
@@ -223,7 +220,7 @@ export const ActionForm = ({
         actionTypeId: actionTypeModel.id,
         group: defaultActionGroupId,
         params: {},
-        frequency: DEFAULT_FREQUENCY_WITHOUT_SUMMARY,
+        frequency: DEFAULT_FREQUENCY,
       });
       setActionIdByIndex(actionTypeConnectors[0].id, actions.length - 1);
     }
@@ -235,7 +232,7 @@ export const ActionForm = ({
         actionTypeId: actionTypeModel.id,
         group: defaultActionGroupId,
         params: {},
-        frequency: DEFAULT_FREQUENCY_WITHOUT_SUMMARY,
+        frequency: DEFAULT_FREQUENCY,
       });
       setActionIdByIndex(actions.length.toString(), actions.length - 1);
       setEmptyActionsIds([...emptyActionsIds, actions.length.toString()]);

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/action_notify_when.test.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/action_notify_when.test.tsx
@@ -12,14 +12,11 @@ import { act } from 'react-dom/test-utils';
 import { RuleAction } from '../../../types';
 import { ActionNotifyWhen } from './action_notify_when';
 import { RuleNotifyWhen } from '@kbn/alerting-plugin/common';
-import {
-  DEFAULT_FREQUENCY_WITHOUT_SUMMARY,
-  DEFAULT_FREQUENCY_WITH_SUMMARY,
-} from '../../../common/constants';
+import { DEFAULT_FREQUENCY } from '../../../common/constants';
 
 describe('action_notify_when', () => {
   async function setup(
-    frequency: RuleAction['frequency'] = DEFAULT_FREQUENCY_WITH_SUMMARY,
+    frequency: RuleAction['frequency'] = DEFAULT_FREQUENCY,
     hasSummary: boolean = true
   ) {
     const wrapper = mountWithIntl(
@@ -50,15 +47,15 @@ describe('action_notify_when', () => {
         '[data-test-subj="summaryOrPerRuleSelect"]'
       );
       expect(summaryOrPerRuleSelect.exists()).toBeTruthy();
-      expect(summaryOrPerRuleSelect.first().props()['aria-label']).toEqual('Summary of alerts');
+      expect(summaryOrPerRuleSelect.first().props()['aria-label']).toEqual('For each alert');
 
       const notifyWhenSelect = wrapperDefault.find('[data-test-subj="notifyWhenSelect"]');
       expect(notifyWhenSelect.exists()).toBeTruthy();
       expect((notifyWhenSelect.first().props() as EuiSuperSelectProps<''>).valueOfSelected).toEqual(
-        RuleNotifyWhen.ACTIVE
+        RuleNotifyWhen.CHANGE
       );
     }
-    const wrapperForEach = await setup(DEFAULT_FREQUENCY_WITHOUT_SUMMARY);
+    const wrapperForEach = await setup(DEFAULT_FREQUENCY);
     {
       const summaryOrPerRuleSelect = wrapperForEach.find(
         '[data-test-subj="summaryOrPerRuleSelect"]'
@@ -73,7 +70,7 @@ describe('action_notify_when', () => {
       );
     }
     const wrapperSummaryThrottle = await setup({
-      ...DEFAULT_FREQUENCY_WITH_SUMMARY,
+      ...DEFAULT_FREQUENCY,
       throttle: '5h',
       notifyWhen: RuleNotifyWhen.THROTTLE,
     });
@@ -82,7 +79,7 @@ describe('action_notify_when', () => {
         '[data-test-subj="summaryOrPerRuleSelect"]'
       );
       expect(summaryOrPerRuleSelect.exists()).toBeTruthy();
-      expect(summaryOrPerRuleSelect.first().props()['aria-label']).toEqual('Summary of alerts');
+      expect(summaryOrPerRuleSelect.first().props()['aria-label']).toEqual('For each alert');
 
       const notifyWhenSelect = wrapperSummaryThrottle.find('[data-test-subj="notifyWhenSelect"]');
       expect(notifyWhenSelect.exists()).toBeTruthy();
@@ -99,7 +96,7 @@ describe('action_notify_when', () => {
   });
 
   it('hides the summary selector when hasSummary is false', async () => {
-    const wrapper = await setup(DEFAULT_FREQUENCY_WITHOUT_SUMMARY, false);
+    const wrapper = await setup(DEFAULT_FREQUENCY, false);
     const summaryOrPerRuleSelect = wrapper.find('[data-test-subj="summaryOrPerRuleSelect"]');
     expect(summaryOrPerRuleSelect.exists()).toBeFalsy();
   });

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/action_notify_when.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/action_notify_when.tsx
@@ -29,10 +29,7 @@ import { some, filter, map } from 'fp-ts/lib/Option';
 import { pipe } from 'fp-ts/lib/pipeable';
 import { getTimeOptions } from '../../../common/lib/get_time_options';
 import { RuleNotifyWhenType, RuleAction } from '../../../types';
-import {
-  DEFAULT_FREQUENCY_WITH_SUMMARY,
-  DEFAULT_FREQUENCY_WITHOUT_SUMMARY,
-} from '../../../common/constants';
+import { DEFAULT_FREQUENCY } from '../../../common/constants';
 
 export const NOTIFY_WHEN_OPTIONS: Array<EuiSuperSelectOption<RuleNotifyWhenType>> = [
   {
@@ -135,7 +132,7 @@ interface ActionNotifyWhenProps {
 
 export const ActionNotifyWhen = ({
   hasSummary,
-  frequency = DEFAULT_FREQUENCY_WITHOUT_SUMMARY,
+  frequency = DEFAULT_FREQUENCY,
   throttle,
   throttleUnit,
   onNotifyWhenChange,
@@ -146,9 +143,7 @@ export const ActionNotifyWhen = ({
 }: ActionNotifyWhenProps) => {
   const [showCustomThrottleOpts, setShowCustomThrottleOpts] = useState<boolean>(false);
   const [notifyWhenValue, setNotifyWhenValue] = useState<RuleNotifyWhenType>(
-    frequency.summary
-      ? DEFAULT_FREQUENCY_WITH_SUMMARY.notifyWhen
-      : DEFAULT_FREQUENCY_WITHOUT_SUMMARY.notifyWhen
+    DEFAULT_FREQUENCY.notifyWhen
   );
 
   const [summaryMenuOpen, setSummaryMenuOpen] = useState(false);

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/action_notify_when.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/action_notify_when.tsx
@@ -135,7 +135,7 @@ interface ActionNotifyWhenProps {
 
 export const ActionNotifyWhen = ({
   hasSummary,
-  frequency = hasSummary ? DEFAULT_FREQUENCY_WITH_SUMMARY : DEFAULT_FREQUENCY_WITHOUT_SUMMARY,
+  frequency = DEFAULT_FREQUENCY_WITHOUT_SUMMARY,
   throttle,
   throttleUnit,
   onNotifyWhenChange,
@@ -146,32 +146,9 @@ export const ActionNotifyWhen = ({
 }: ActionNotifyWhenProps) => {
   const [showCustomThrottleOpts, setShowCustomThrottleOpts] = useState<boolean>(false);
   const [notifyWhenValue, setNotifyWhenValue] = useState<RuleNotifyWhenType>(
-    hasSummary
+    frequency.summary
       ? DEFAULT_FREQUENCY_WITH_SUMMARY.notifyWhen
       : DEFAULT_FREQUENCY_WITHOUT_SUMMARY.notifyWhen
-  );
-
-  // Track whether the user has changed the notify when value from default. This is necessary because the
-  // "default" notifyWhen value for summary: true is the second menu item for summary: false. We want the UX to be:
-  // Case A
-  // - User opens the form with summary: false, notifyWhen: CHANGE
-  // - User switches to summary: true, necessitating a switch to notifyWhen: ACTIVE
-  // - User doesn't touch notifyWhen: ACTIVE, switches back to summary: false. notifyWhen should switch to CHANGE, the 1st menu option
-  // Case B
-  // - User opens the form with summary: false, notifyWhen: ACTIVE (not the "default")
-  // - User switches to summary: true
-  // - User switches back to summary: false. notifyWhen stays ACTIVE
-  // Case C
-  // - User opens the form with summary: true, notifyWhen: ACTIVE (the "default")
-  // - User doesn't change notifyWhen, just sets summary: false. notifyWhen should switch to CHANGE
-  // Case D
-  // - User opens the form with summary: true, notifyWhen: THROTTLE, or summary: false, notifyWhen: !CHANGE
-  // - When user changes summary, leave notifyWhen unchanged
-  const [notifyWhenValueChangedFromDefault, setNotifyWhenValueChangedFromDefault] = useState(
-    // Check if the initial notifyWhen value is different from the default value for its summary type
-    frequency.summary
-      ? frequency.notifyWhen !== DEFAULT_FREQUENCY_WITH_SUMMARY.notifyWhen
-      : frequency.notifyWhen !== DEFAULT_FREQUENCY_WITHOUT_SUMMARY.notifyWhen
   );
 
   const [summaryMenuOpen, setSummaryMenuOpen] = useState(false);
@@ -193,7 +170,6 @@ export const ActionNotifyWhen = ({
     (newValue: RuleNotifyWhenType) => {
       onNotifyWhenChange(newValue);
       setNotifyWhenValue(newValue);
-      setNotifyWhenValueChangedFromDefault(true);
       // Calling onNotifyWhenChange and onThrottleChange at the same time interferes with the React state lifecycle
       // so wait for onNotifyWhenChange to process before calling onThrottleChange
       setTimeout(
@@ -213,24 +189,10 @@ export const ActionNotifyWhen = ({
       onSummaryChange(summary);
       setSummaryMenuOpen(false);
       if (summary && frequency.notifyWhen === RuleNotifyWhen.CHANGE) {
-        // Call onNotifyWhenChange DIRECTLY to bypass setNotifyWhenValueChangedFromDefault
         onNotifyWhenChange(RuleNotifyWhen.ACTIVE);
-        // In cases like this:
-        // 1. User opens form with notifyWhen: THROTTLE
-        // 2. User sets notifyWhen: CHANGE, notifyWhenValueChangedFromDefault is now true
-        // 3. User sets summary: true, notifyWhen gets set to CHANGE
-        // 4. User sets summary: false, notifyWhen should probably get set back to CHANGE
-        // To make step 4 possible, we have to reset notifyWhenValueChangedFromDefault:
-        setNotifyWhenValueChangedFromDefault(false);
-      } else if (
-        !summary &&
-        frequency.notifyWhen === RuleNotifyWhen.ACTIVE &&
-        !notifyWhenValueChangedFromDefault
-      ) {
-        onNotifyWhenChange(RuleNotifyWhen.CHANGE);
       }
     },
-    [onSummaryChange, frequency.notifyWhen, onNotifyWhenChange, notifyWhenValueChangedFromDefault]
+    [onSummaryChange, frequency.notifyWhen, onNotifyWhenChange]
   );
 
   const summaryOptions = useMemo(

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/action_type_form.test.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/action_type_form.test.tsx
@@ -20,11 +20,9 @@ import { act } from 'react-dom/test-utils';
 import { EuiFieldText } from '@elastic/eui';
 import { I18nProvider, __IntlProvider as IntlProvider } from '@kbn/i18n-react';
 import { render, waitFor, screen } from '@testing-library/react';
-import {
-  DEFAULT_FREQUENCY_WITHOUT_SUMMARY,
-  DEFAULT_FREQUENCY_WITH_SUMMARY,
-} from '../../../common/constants';
+import { DEFAULT_FREQUENCY } from '../../../common/constants';
 import { transformActionVariables } from '../../lib/action_variables';
+import { RuleNotifyWhen } from '@kbn/alerting-plugin/common';
 
 jest.mock('../../../common/lib/kibana');
 const actionTypeRegistry = actionTypeRegistryMock.create();
@@ -312,7 +310,7 @@ describe('action_type_form', () => {
       actionTypeId: '.pagerduty',
       group: 'default',
       params: {},
-      frequency: DEFAULT_FREQUENCY_WITHOUT_SUMMARY,
+      frequency: DEFAULT_FREQUENCY,
     };
     const wrapper = render(
       <IntlProvider locale="en">
@@ -320,7 +318,11 @@ describe('action_type_form', () => {
           index: 1,
           actionItem,
           setActionFrequencyProperty: () => {
-            actionItem.frequency = DEFAULT_FREQUENCY_WITH_SUMMARY;
+            actionItem.frequency = {
+              notifyWhen: RuleNotifyWhen.ACTIVE,
+              throttle: null,
+              summary: true,
+            };
           },
         })}
       </IntlProvider>

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/rule_form/rule_reducer.ts
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/rule_form/rule_reducer.ts
@@ -10,7 +10,7 @@ import { isEqual } from 'lodash';
 import { Reducer } from 'react';
 import { RuleActionParam, IntervalSchedule } from '@kbn/alerting-plugin/common';
 import { Rule, RuleAction } from '../../../types';
-import { DEFAULT_FREQUENCY_WITHOUT_SUMMARY } from '../../../common/constants';
+import { DEFAULT_FREQUENCY } from '../../../common/constants';
 
 export type InitialRule = Partial<Rule> &
   Pick<Rule, 'params' | 'consumer' | 'schedule' | 'actions' | 'tags'>;
@@ -201,7 +201,7 @@ export const ruleReducer = <RulePhase extends InitialRule | Rule>(
         const updatedAction = {
           ...oldAction,
           frequency: {
-            ...(oldAction.frequency ?? DEFAULT_FREQUENCY_WITHOUT_SUMMARY),
+            ...(oldAction.frequency ?? DEFAULT_FREQUENCY),
             [key]: value,
           },
         };

--- a/x-pack/plugins/triggers_actions_ui/public/common/constants/action_frequency_types.ts
+++ b/x-pack/plugins/triggers_actions_ui/public/common/constants/action_frequency_types.ts
@@ -7,13 +7,7 @@
 
 import { RuleNotifyWhen } from '@kbn/alerting-plugin/common';
 
-export const DEFAULT_FREQUENCY_WITH_SUMMARY = {
-  notifyWhen: RuleNotifyWhen.ACTIVE,
-  throttle: null,
-  summary: true,
-};
-
-export const DEFAULT_FREQUENCY_WITHOUT_SUMMARY = {
+export const DEFAULT_FREQUENCY = {
   notifyWhen: RuleNotifyWhen.CHANGE,
   throttle: null,
   summary: false,


### PR DESCRIPTION
As some of the users are using a template to fill out the message input with `for each alert` params, having `summary of alerts` option default causes some problems.

Therefore, this PR intends to make "for each alert" option default for all the rule types.