### PR TITLE
[Lens] suppress missing index toasts

### DIFF
--- a/x-pack/plugins/lens/public/data_views_service/loader.ts
+++ b/x-pack/plugins/lens/public/data_views_service/loader.ts
@@ -176,7 +176,9 @@ export async function loadIndexPatterns({
   }
   indexPatterns.push(
     ...(await Promise.all(
-      Object.values(adHocDataViews || {}).map((spec) => dataViews.create(spec, false, false))
+      Object.values(adHocDataViews || {}).map((spec) =>
+        dataViews.create({ ...spec, allowNoIndex: true })
+      )
     ))
   );
 

--- a/x-pack/plugins/lens/public/data_views_service/loader.ts
+++ b/x-pack/plugins/lens/public/data_views_service/loader.ts
@@ -176,7 +176,7 @@ export async function loadIndexPatterns({
   }
   indexPatterns.push(
     ...(await Promise.all(
-      Object.values(adHocDataViews || {}).map((spec) => dataViews.create(spec))
+      Object.values(adHocDataViews || {}).map((spec) => dataViews.create(spec, false, false))
     ))
   );
 


### PR DESCRIPTION
## Summary

Part of https://github.com/elastic/kibana/issues/149836. We will surface this missing index message in Lens later, but for now we're getting rid of the toasts without replacement. Missing field errors still alert the user that something is wrong.

Before:
<img width="1920" alt="Screenshot 2023-02-06 at 12 19 11 PM" src="https://user-images.githubusercontent.com/315764/217053333-4bb22754-7dc2-4846-a0ed-66732c1742f1.png">


After:
<img width="1918" alt="Screenshot 2023-02-06 at 12 18 14 PM" src="https://user-images.githubusercontent.com/315764/217053359-e1d21e8b-5ac9-49ea-b781-c3d54ab82791.png">


