### PR TITLE
[Security Solution][Endpoint] Remove `ENDPOINTS_ACTION_LIST_ROUTE` const and replace it with `BASE_ENDPOINT_ACTION_ROUTE`

### DIFF
--- a/x-pack/plugins/security_solution/common/endpoint/constants.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/constants.ts
@@ -69,6 +69,7 @@ export const ISOLATE_HOST_ROUTE = `${BASE_ENDPOINT_ROUTE}/isolate`;
 /** @deprecated use `ISOLATE_HOST_ROUTE_V2` instead */
 export const UNISOLATE_HOST_ROUTE = `${BASE_ENDPOINT_ROUTE}/unisolate`;
 
+/** Base Actions route. Used to get a list of all actions and is root to other action related routes */
 export const BASE_ENDPOINT_ACTION_ROUTE = `${BASE_ENDPOINT_ROUTE}/action`;
 
 export const ISOLATE_HOST_ROUTE_V2 = `${BASE_ENDPOINT_ACTION_ROUTE}/isolate`;

--- a/x-pack/plugins/security_solution/common/endpoint/constants.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/constants.ts
@@ -60,13 +60,17 @@ export const AGENT_POLICY_SUMMARY_ROUTE = `${BASE_POLICY_ROUTE}/summaries`;
 /** Suggestions routes */
 export const SUGGESTIONS_ROUTE = `${BASE_ENDPOINT_ROUTE}/suggestions/{suggestion_type}`;
 
-/** Host Isolation Routes */
+/**
+ * Action Response Routes
+ */
+
+/** @deprecated use `ISOLATE_HOST_ROUTE_V2` instead */
 export const ISOLATE_HOST_ROUTE = `${BASE_ENDPOINT_ROUTE}/isolate`;
+/** @deprecated use `ISOLATE_HOST_ROUTE_V2` instead */
 export const UNISOLATE_HOST_ROUTE = `${BASE_ENDPOINT_ROUTE}/unisolate`;
 
-const BASE_ENDPOINT_ACTION_ROUTE = `${BASE_ENDPOINT_ROUTE}/action`;
+export const BASE_ENDPOINT_ACTION_ROUTE = `${BASE_ENDPOINT_ROUTE}/action`;
 
-/** Action Response Routes */
 export const ISOLATE_HOST_ROUTE_V2 = `${BASE_ENDPOINT_ACTION_ROUTE}/isolate`;
 export const UNISOLATE_HOST_ROUTE_V2 = `${BASE_ENDPOINT_ACTION_ROUTE}/unisolate`;
 export const GET_PROCESSES_ROUTE = `${BASE_ENDPOINT_ACTION_ROUTE}/running_procs`;
@@ -81,9 +85,6 @@ export const ACTION_STATUS_ROUTE = `${BASE_ENDPOINT_ROUTE}/action_status`;
 export const ACTION_DETAILS_ROUTE = `${BASE_ENDPOINT_ACTION_ROUTE}/{action_id}`;
 export const ACTION_AGENT_FILE_INFO_ROUTE = `${BASE_ENDPOINT_ACTION_ROUTE}/{action_id}/file/{file_id}`;
 export const ACTION_AGENT_FILE_DOWNLOAD_ROUTE = `${BASE_ENDPOINT_ACTION_ROUTE}/{action_id}/file/{file_id}/download`;
-
-// FIXME:PT `const` below seem like a duplicate. Delete it
-export const ENDPOINTS_ACTION_LIST_ROUTE = `${BASE_ENDPOINT_ROUTE}/action`;
 
 export const failedFleetActionErrorCode = '424';
 

--- a/x-pack/plugins/security_solution/public/management/hooks/response_actions/use_get_endpoint_action_list.test.ts
+++ b/x-pack/plugins/security_solution/public/management/hooks/response_actions/use_get_endpoint_action_list.test.ts
@@ -8,7 +8,7 @@
 import type { AppContextTestRender, ReactQueryHookRenderer } from '../../../common/mock/endpoint';
 import { createAppRootMockRenderer } from '../../../common/mock/endpoint';
 import { useGetEndpointActionList } from './use_get_endpoint_action_list';
-import { ENDPOINTS_ACTION_LIST_ROUTE } from '../../../../common/endpoint/constants';
+import { BASE_ENDPOINT_ACTION_ROUTE } from '../../../../common/endpoint/constants';
 import { useQuery as _useQuery } from '@tanstack/react-query';
 import { responseActionsHttpMocks } from '../../mocks/response_actions_http_mocks';
 
@@ -55,7 +55,7 @@ describe('useGetEndpointActionList hook', () => {
     );
 
     expect(apiMocks.responseProvider.actionList).toHaveBeenCalledWith({
-      path: `${ENDPOINTS_ACTION_LIST_ROUTE}`,
+      path: BASE_ENDPOINT_ACTION_ROUTE,
       query: {
         agentIds: ['123', '456'],
         commands: ['isolate', 'unisolate'],

--- a/x-pack/plugins/security_solution/public/management/hooks/response_actions/use_get_endpoint_action_list.ts
+++ b/x-pack/plugins/security_solution/public/management/hooks/response_actions/use_get_endpoint_action_list.ts
@@ -10,7 +10,7 @@ import type { IHttpFetchError } from '@kbn/core-http-browser';
 import { useQuery } from '@tanstack/react-query';
 import type { EndpointActionListRequestQuery } from '../../../../common/endpoint/schema/actions';
 import { useHttp } from '../../../common/lib/kibana';
-import { ENDPOINTS_ACTION_LIST_ROUTE } from '../../../../common/endpoint/constants';
+import { BASE_ENDPOINT_ACTION_ROUTE } from '../../../../common/endpoint/constants';
 import type { ActionListApiResponse } from '../../../../common/endpoint/types';
 
 interface ErrorType {
@@ -36,7 +36,7 @@ export const useGetEndpointActionList = (
     queryKey: ['get-action-list', query],
     ...options,
     queryFn: async () => {
-      return http.get<ActionListApiResponse>(ENDPOINTS_ACTION_LIST_ROUTE, {
+      return http.get<ActionListApiResponse>(BASE_ENDPOINT_ACTION_ROUTE, {
         query: {
           agentIds: query.agentIds,
           commands: query.commands,

--- a/x-pack/plugins/security_solution/public/management/mocks/response_actions_http_mocks.ts
+++ b/x-pack/plugins/security_solution/public/management/mocks/response_actions_http_mocks.ts
@@ -11,7 +11,7 @@ import {
   ACTION_DETAILS_ROUTE,
   ACTION_STATUS_ROUTE,
   GET_PROCESSES_ROUTE,
-  ENDPOINTS_ACTION_LIST_ROUTE,
+  BASE_ENDPOINT_ACTION_ROUTE,
   ISOLATE_HOST_ROUTE,
   UNISOLATE_HOST_ROUTE,
   KILL_PROCESS_ROUTE,
@@ -107,7 +107,7 @@ export const responseActionsHttpMocks = httpHandlerMockFactory<ResponseActionsHt
   },
   {
     id: 'actionList',
-    path: ENDPOINTS_ACTION_LIST_ROUTE,
+    path: BASE_ENDPOINT_ACTION_ROUTE,
     method: 'get',
     handler: (): ActionListApiResponse => {
       const response = new EndpointActionGenerator('seed').generateActionDetails();

--- a/x-pack/plugins/security_solution/scripts/endpoint/agent_emulator/services/endpoint_response_actions.ts
+++ b/x-pack/plugins/security_solution/scripts/endpoint/agent_emulator/services/endpoint_response_actions.ts
@@ -17,7 +17,7 @@ import { sendEndpointMetadataUpdate } from '../../common/endpoint_metadata_servi
 import { FleetActionGenerator } from '../../../../common/endpoint/data_generators/fleet_action_generator';
 import {
   ENDPOINT_ACTION_RESPONSES_INDEX,
-  ENDPOINTS_ACTION_LIST_ROUTE,
+  BASE_ENDPOINT_ACTION_ROUTE,
   FILE_STORAGE_DATA_INDEX,
   FILE_STORAGE_METADATA_INDEX,
 } from '../../../../common/endpoint/constants';
@@ -51,7 +51,7 @@ export const fetchEndpointActionList = async (
     return (
       await kbn.request<ActionListApiResponse>({
         method: 'GET',
-        path: ENDPOINTS_ACTION_LIST_ROUTE,
+        path: BASE_ENDPOINT_ACTION_ROUTE,
         query: options,
       })
     ).data;

--- a/x-pack/plugins/security_solution/server/endpoint/routes/actions/list.test.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/routes/actions/list.test.ts
@@ -23,7 +23,7 @@ import {
   savedObjectsClientMock,
 } from '@kbn/core/server/mocks';
 import type { KibanaResponseFactory, RequestHandler, RouteConfig } from '@kbn/core/server';
-import { ENDPOINTS_ACTION_LIST_ROUTE } from '../../../../common/endpoint/constants';
+import { BASE_ENDPOINT_ACTION_ROUTE } from '../../../../common/endpoint/constants';
 import { EndpointAppContextService } from '../../endpoint_app_context_services';
 import { createMockConfig } from '../../../lib/detection_engine/routes/__mocks__';
 import { LicenseService } from '../../../../common/license';
@@ -136,35 +136,35 @@ describe('Action List Route', () => {
 
   describe('User auth level', () => {
     it('allows user with `canReadActionsLogManagement` access for API requests', async () => {
-      await callApiRoute(ENDPOINTS_ACTION_LIST_ROUTE, {
+      await callApiRoute(BASE_ENDPOINT_ACTION_ROUTE, {
         authz: { canReadActionsLogManagement: true },
       });
       expect(mockResponse.ok).toBeCalled();
     });
 
     it('allows user with `canAccessEndpointActionsLogManagement` access for API requests', async () => {
-      await callApiRoute(ENDPOINTS_ACTION_LIST_ROUTE, {
+      await callApiRoute(BASE_ENDPOINT_ACTION_ROUTE, {
         authz: { canAccessEndpointActionsLogManagement: true },
       });
       expect(mockResponse.ok).toBeCalled();
     });
 
     it('does not allow user without `canReadActionsLogManagement` or `canAccessEndpointActionsLogManagement` access for API requests', async () => {
-      await callApiRoute(ENDPOINTS_ACTION_LIST_ROUTE, {
+      await callApiRoute(BASE_ENDPOINT_ACTION_ROUTE, {
         authz: { canReadActionsLogManagement: false, canAccessEndpointActionsLogManagement: false },
       });
       expect(mockResponse.forbidden).toBeCalled();
     });
 
     it('does allow user access to API requests if license is at least platinum', async () => {
-      await callApiRoute(ENDPOINTS_ACTION_LIST_ROUTE, {
+      await callApiRoute(BASE_ENDPOINT_ACTION_ROUTE, {
         license: Platinum,
       });
       expect(mockResponse.ok).toBeCalled();
     });
 
     it('does not allow user access to API requests if license is below platinum', async () => {
-      await callApiRoute(ENDPOINTS_ACTION_LIST_ROUTE, {
+      await callApiRoute(BASE_ENDPOINT_ACTION_ROUTE, {
         license: Gold,
       });
       expect(mockResponse.forbidden).toBeCalled();

--- a/x-pack/plugins/security_solution/server/endpoint/routes/actions/list.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/routes/actions/list.ts
@@ -11,7 +11,7 @@
  * 2.0.
  */
 
-import { ENDPOINTS_ACTION_LIST_ROUTE } from '../../../../common/endpoint/constants';
+import { BASE_ENDPOINT_ACTION_ROUTE } from '../../../../common/endpoint/constants';
 import { EndpointActionListRequestSchema } from '../../../../common/endpoint/schema/actions';
 import { actionListHandler } from './list_handler';
 
@@ -28,7 +28,7 @@ export function registerActionListRoutes(
 ) {
   router.get(
     {
-      path: ENDPOINTS_ACTION_LIST_ROUTE,
+      path: BASE_ENDPOINT_ACTION_ROUTE,
       validate: EndpointActionListRequestSchema,
       options: { authRequired: true, tags: ['access:securitySolution'] },
     },

--- a/x-pack/plugins/security_solution/server/endpoint/routes/actions/list_handler.test.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/routes/actions/list_handler.test.ts
@@ -17,7 +17,7 @@ import {
   savedObjectsClientMock,
 } from '@kbn/core/server/mocks';
 import type { EndpointActionListRequestQuery } from '../../../../common/endpoint/schema/actions';
-import { ENDPOINTS_ACTION_LIST_ROUTE } from '../../../../common/endpoint/constants';
+import { BASE_ENDPOINT_ACTION_ROUTE } from '../../../../common/endpoint/constants';
 import { parseExperimentalConfigValue } from '../../../../common/experimental_features';
 import { createMockConfig } from '../../../lib/detection_engine/routes/__mocks__';
 import { EndpointAppContextService } from '../../endpoint_app_context_services';
@@ -77,7 +77,7 @@ describe('Action List Handler', () => {
           SecuritySolutionRequestHandlerContext
         >
       ] = routerMock.get.mock.calls.find(([{ path }]) =>
-        path.startsWith(ENDPOINTS_ACTION_LIST_ROUTE)
+        path.startsWith(BASE_ENDPOINT_ACTION_ROUTE)
       )!;
       await routeHandler(
         coreMock.createCustomRequestHandlerContext(

--- a/x-pack/test/security_solution_endpoint_api_int/apis/endpoint_authz.ts
+++ b/x-pack/test/security_solution_endpoint_api_int/apis/endpoint_authz.ts
@@ -11,7 +11,7 @@ import {
   ACTION_STATUS_ROUTE,
   AGENT_POLICY_SUMMARY_ROUTE,
   BASE_POLICY_RESPONSE_ROUTE,
-  ENDPOINTS_ACTION_LIST_ROUTE,
+  BASE_ENDPOINT_ACTION_ROUTE,
   GET_PROCESSES_ROUTE,
   GET_FILE_ROUTE,
   HOST_METADATA_GET_ROUTE,
@@ -79,7 +79,7 @@ export default function ({ getService }: FtrProviderContext) {
     const canReadActionsLogManagementApiList: ApiCallsInterface[] = [
       {
         method: 'get',
-        path: ENDPOINTS_ACTION_LIST_ROUTE,
+        path: BASE_ENDPOINT_ACTION_ROUTE,
         body: undefined,
       },
     ];


### PR DESCRIPTION
## Summary

- Removes duplicate `const` `ENDPOINTS_ACTION_LIST_ROUTE` and replace it with `BASE_ENDPOINT_ACTION_ROUTE`

