### PR TITLE
[Enterprise Search] Add toggle for HTML extraction

### DIFF
--- a/x-pack/plugins/enterprise_search/common/types/connectors.ts
+++ b/x-pack/plugins/enterprise_search/common/types/connectors.ts
@@ -10,7 +10,9 @@ export interface KeyValuePair {
   value: string | null;
 }
 
-export type ConnectorConfiguration = Record<string, KeyValuePair | null>;
+export type ConnectorConfiguration = Record<string, KeyValuePair | null> & {
+  extract_full_html?: { label: string; value: boolean };
+};
 
 export interface ConnectorScheduling {
   enabled: boolean;

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/crawler/update_html_extraction_api_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/crawler/update_html_extraction_api_logic.test.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { mockHttpValues } from '../../../__mocks__/kea_logic';
+
+import { updateHtmlExtraction } from './update_html_extraction_api_logic';
+
+describe('UpdateHtmlExtractionApiLogic', () => {
+  const { http } = mockHttpValues;
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  describe('updateHtmlExtraction', () => {
+    it('calls correct api', async () => {
+      const indexName = 'elastic-co-crawler';
+
+      http.get.mockReturnValue(Promise.resolve());
+
+      const result = updateHtmlExtraction({ htmlExtraction: true, indexName });
+
+      expect(http.put).toHaveBeenCalledWith(
+        `/internal/enterprise_search/indices/${indexName}/crawler/html_extraction`,
+        {
+          body: JSON.stringify({
+            extract_full_html: true,
+          }),
+        }
+      );
+      await expect(result).resolves.toEqual({ htmlExtraction: true });
+    });
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/crawler/update_html_extraction_api_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/crawler/update_html_extraction_api_logic.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { Actions } from '../../../shared/api_logic/create_api_logic';
+
+import { createApiLogic } from '../../../shared/api_logic/create_api_logic';
+import { HttpLogic } from '../../../shared/http';
+
+export interface UpdateHtmlExtractionArgs {
+  htmlExtraction: boolean;
+  indexName: string;
+}
+
+export interface UpdateHtmlExtractionResponse {
+  htmlExtraction: boolean;
+}
+
+export const updateHtmlExtraction = async ({
+  htmlExtraction,
+  indexName,
+}: UpdateHtmlExtractionArgs) => {
+  const route = `/internal/enterprise_search/indices/${indexName}/crawler/html_extraction`;
+
+  const params = { extract_full_html: htmlExtraction };
+
+  await HttpLogic.values.http.put(route, {
+    body: JSON.stringify(params),
+  });
+  return { htmlExtraction };
+};
+
+export const UpdateHtmlExtractionApiLogic = createApiLogic(
+  ['update_html_extraction_api_logic'],
+  updateHtmlExtraction
+);
+
+export type UpdateHtmlExtractionActions = Actions<
+  UpdateHtmlExtractionArgs,
+  UpdateHtmlExtractionResponse
+>;

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/crawler_configuration/crawler_configuration.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/crawler_configuration/crawler_configuration.tsx
@@ -87,7 +87,10 @@ export const CrawlerConfiguration: React.FC = () => {
               />
             </EuiFlexItem>
             <EuiFlexItem>
-              <EuiLink>
+              <EuiLink
+                href="TODO"
+                data-telemetry-id="entSearchContent-crawler-configuration-learnMoreExtraction"
+              >
                 {i18n.translate(
                   'xpack.enterpriseSearch.content.crawler.crawlerConfiguration.extractHTML.learnMoreLink',
                   {

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/crawler_configuration/crawler_configuration.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/crawler_configuration/crawler_configuration.tsx
@@ -1,0 +1,103 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { useActions, useValues } from 'kea';
+
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiLink,
+  EuiSpacer,
+  EuiSplitPanel,
+  EuiSwitch,
+  EuiText,
+  EuiTitle,
+} from '@elastic/eui';
+
+import { i18n } from '@kbn/i18n';
+
+import { Status } from '../../../../../../../common/types/api';
+
+import { IndexViewLogic } from '../../index_view_logic';
+
+import { CrawlerConfigurationLogic } from './crawler_configuration_logic';
+
+export const CrawlerConfiguration: React.FC = () => {
+  const { htmlExtraction } = useValues(IndexViewLogic);
+  const { status } = useValues(CrawlerConfigurationLogic);
+  const { updateHtmlExtraction } = useActions(CrawlerConfigurationLogic);
+  return (
+    <>
+      <EuiSpacer />
+      <EuiSplitPanel.Outer hasBorder hasShadow={false}>
+        <EuiSplitPanel.Inner>
+          <EuiTitle size="s">
+            <h3>
+              {i18n.translate(
+                'xpack.enterpriseSearch.content.crawler.crawlerConfiguration.extractHTML.title',
+                { defaultMessage: 'Store full HTML' }
+              )}
+            </h3>
+          </EuiTitle>
+          <EuiSpacer />
+          <EuiText size="s">
+            <p>
+              {i18n.translate(
+                'xpack.enterpriseSearch.content.crawler.crawlerConfiguration.extractHTML.addExtraFieldDescription',
+                {
+                  defaultMessage:
+                    'Add an extra field in all documents with the value of the full HTML of the page being crawled.',
+                }
+              )}
+            </p>
+          </EuiText>
+          <EuiSpacer />
+          <EuiText size="s">
+            <p>
+              {i18n.translate(
+                'xpack.enterpriseSearch.content.crawler.crawlerConfiguration.extractHTML.increasedSizeWarning',
+                {
+                  defaultMessage:
+                    'This may dramatically increase the index size if the site being crawled is large.',
+                }
+              )}
+            </p>
+          </EuiText>
+        </EuiSplitPanel.Inner>
+        <EuiSplitPanel.Inner color="subdued">
+          <EuiFlexGroup>
+            <EuiFlexItem grow={false}>
+              <EuiSwitch
+                label={i18n.translate(
+                  'xpack.enterpriseSearch.content.crawler.crawlerConfiguration.extractHTML.extractionSwitchLabel',
+                  {
+                    defaultMessage: 'Content extraction.',
+                  }
+                )}
+                disabled={status === Status.LOADING}
+                checked={htmlExtraction ?? false}
+                onChange={(event) => updateHtmlExtraction(event.target.checked)}
+              />
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiLink>
+                {i18n.translate(
+                  'xpack.enterpriseSearch.content.crawler.crawlerConfiguration.extractHTML.learnMoreLink',
+                  {
+                    defaultMessage: 'Learn more about storing full HTML.',
+                  }
+                )}
+              </EuiLink>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiSplitPanel.Inner>
+      </EuiSplitPanel.Outer>
+    </>
+  );
+};

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/crawler_configuration/crawler_configuration.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/crawler_configuration/crawler_configuration.tsx
@@ -74,6 +74,7 @@ export const CrawlerConfiguration: React.FC = () => {
           <EuiFlexGroup>
             <EuiFlexItem grow={false}>
               <EuiSwitch
+                data-telemetry-id="entSearchContent-crawler-configuration-extractHtml"
                 label={i18n.translate(
                   'xpack.enterpriseSearch.content.crawler.crawlerConfiguration.extractHTML.extractionSwitchLabel',
                   {

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/crawler_configuration/crawler_configuration_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/crawler_configuration/crawler_configuration_logic.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { kea, MakeLogicType } from 'kea';
+
+import { Status } from '../../../../../../../common/types/api';
+import { Connector } from '../../../../../../../common/types/connectors';
+
+import {
+  UpdateHtmlExtractionActions,
+  UpdateHtmlExtractionApiLogic,
+} from '../../../../api/crawler/update_html_extraction_api_logic';
+import { CachedFetchIndexApiLogicActions } from '../../../../api/index/cached_fetch_index_api_logic';
+import { isCrawlerIndex } from '../../../../utils/indices';
+import { IndexViewLogic } from '../../index_view_logic';
+
+interface CrawlerConfigurationLogicActions {
+  apiError: UpdateHtmlExtractionActions['apiError'];
+  apiSuccess: UpdateHtmlExtractionActions['apiSuccess'];
+  fetchIndex: () => void;
+  fetchIndexApiSuccess: CachedFetchIndexApiLogicActions['apiSuccess'];
+  htmlExtraction: boolean;
+  makeRequest: UpdateHtmlExtractionActions['makeRequest'];
+  updateHtmlExtraction(htmlExtraction: boolean): { htmlExtraction: boolean };
+}
+
+interface CrawlerConfigurationLogicValues {
+  connector: Connector | undefined;
+  indexName: string;
+  localHtmlExtraction: boolean | null;
+  status: Status;
+}
+
+export const CrawlerConfigurationLogic = kea<
+  MakeLogicType<CrawlerConfigurationLogicValues, CrawlerConfigurationLogicActions>
+>({
+  actions: {
+    updateHtmlExtraction: (htmlExtraction) => ({ htmlExtraction }),
+  },
+  connect: {
+    actions: [
+      IndexViewLogic,
+      ['fetchIndex', 'fetchIndexApiSuccess'],
+      UpdateHtmlExtractionApiLogic,
+      ['apiSuccess', 'makeRequest'],
+    ],
+    values: [IndexViewLogic, ['connector', 'indexName'], UpdateHtmlExtractionApiLogic, ['status']],
+  },
+  listeners: ({ actions, values }) => ({
+    apiSuccess: () => {
+      actions.fetchIndex();
+    },
+    updateHtmlExtraction: ({ htmlExtraction }) => {
+      actions.makeRequest({ htmlExtraction, indexName: values.indexName });
+    },
+  }),
+  path: ['enterprise_search', 'search_index', 'crawler', 'configuration'],
+  reducers: {
+    localHtmlExtraction: [
+      null,
+      {
+        apiSuccess: (_, { htmlExtraction }) => htmlExtraction,
+        fetchIndexApiSuccess: (_, index) => {
+          if (isCrawlerIndex(index)) {
+            return index.connector.configuration.extract_full_html?.value ?? null;
+          }
+          return null;
+        },
+      },
+    ],
+  },
+  selectors: ({ selectors }) => ({
+    htmlExtraction: [
+      () => [selectors.connector, selectors.localHtmlExtraction],
+      (connector: Connector | null, localHtmlExtraction: boolean | null) =>
+        localHtmlExtraction !== null
+          ? localHtmlExtraction
+          : connector?.configuration.extract_full_html?.value ?? false,
+    ],
+  }),
+});

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/index_view_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/index_view_logic.ts
@@ -70,6 +70,7 @@ export interface IndexViewValues {
   hasAdvancedFilteringFeature: boolean;
   hasBasicFilteringFeature: boolean;
   hasFilteringFeature: boolean;
+  htmlExtraction: boolean | undefined;
   index: ElasticsearchViewIndex | undefined;
   indexData: typeof CachedFetchIndexApiLogic.values.indexData;
   indexName: string;
@@ -213,6 +214,11 @@ export const IndexViewLogic = kea<MakeLogicType<IndexViewValues, IndexViewAction
     hasFilteringFeature: [
       () => [selectors.hasAdvancedFilteringFeature, selectors.hasBasicFilteringFeature],
       (advancedFeature: boolean, basicFeature: boolean) => advancedFeature || basicFeature,
+    ],
+    htmlExtraction: [
+      () => [selectors.connector],
+      (connector: Connector | undefined) =>
+        connector?.configuration.extract_full_html?.value ?? undefined,
     ],
     index: [
       () => [selectors.indexData],

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/search_index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/search_index.tsx
@@ -36,6 +36,7 @@ import { ConnectorSchedulingComponent } from './connector/connector_scheduling';
 import { ConnectorSyncRules } from './connector/sync_rules/connector_rules';
 import { AutomaticCrawlScheduler } from './crawler/automatic_crawl_scheduler/automatic_crawl_scheduler';
 import { CrawlCustomSettingsFlyout } from './crawler/crawl_custom_settings_flyout/crawl_custom_settings_flyout';
+import { CrawlerConfiguration } from './crawler/crawler_configuration/crawler_configuration';
 import { SearchIndexDomainManagement } from './crawler/domain_management/domain_management';
 import { SearchIndexDocuments } from './documents';
 import { SearchIndexIndexMappings } from './index_mappings';
@@ -56,6 +57,7 @@ export enum SearchIndexTabId {
   SCHEDULING = 'scheduling',
   // crawler indices
   DOMAIN_MANAGEMENT = 'domain_management',
+  CRAWLER_CONFIGURATION = 'crawler_configuration',
 }
 
 export const SearchIndex: React.FC = () => {
@@ -152,6 +154,16 @@ export const SearchIndex: React.FC = () => {
       name: i18n.translate('xpack.enterpriseSearch.content.searchIndex.domainManagementTabLabel', {
         defaultMessage: 'Manage Domains',
       }),
+    },
+    {
+      content: <CrawlerConfiguration />,
+      id: SearchIndexTabId.CRAWLER_CONFIGURATION,
+      name: i18n.translate(
+        'xpack.enterpriseSearch.content.searchIndex.crawlerConfigurationTabLabel',
+        {
+          defaultMessage: 'Configuration',
+        }
+      ),
     },
     {
       content: <AutomaticCrawlScheduler />,

--- a/x-pack/plugins/enterprise_search/server/lib/crawler/put_html_extraction.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/crawler/put_html_extraction.test.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { IScopedClusterClient } from '@kbn/core/server';
+
+import { CONNECTORS_INDEX } from '../..';
+import { Connector } from '../../../common/types/connectors';
+
+import { updateHtmlExtraction } from './put_html_extraction';
+
+describe('updateHtmlExtraction lib function', () => {
+  const mockClient = {
+    asCurrentUser: {
+      update: jest.fn(),
+    },
+    asInternalUser: {},
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should update connector configuration', async () => {
+    mockClient.asCurrentUser.update.mockResolvedValue(true);
+    const mockConnector = {
+      configuration: { test: { label: 'haha', value: 'this' } },
+      id: 'connectorId',
+    };
+
+    await updateHtmlExtraction(
+      mockClient as unknown as IScopedClusterClient,
+      true,
+      mockConnector as any as Connector
+    );
+    expect(mockClient.asCurrentUser.update).toHaveBeenCalledWith({
+      doc: {
+        configuration: {
+          ...mockConnector.configuration,
+          extract_full_html: { label: 'Extract full HTML', value: true },
+        },
+      },
+      id: 'connectorId',
+      index: CONNECTORS_INDEX,
+      refresh: 'wait_for',
+    });
+  });
+});

--- a/x-pack/plugins/enterprise_search/server/lib/crawler/put_html_extraction.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/crawler/put_html_extraction.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { IScopedClusterClient } from '@kbn/core-elasticsearch-server';
+
+import { CONNECTORS_INDEX } from '../..';
+import { Connector } from '../../../common/types/connectors';
+
+export async function updateHtmlExtraction(
+  client: IScopedClusterClient,
+  htmlExtraction: boolean,
+  connector: Connector
+) {
+  return await client.asCurrentUser.update({
+    doc: {
+      configuration: {
+        ...connector.configuration,
+        extract_full_html: {
+          label: 'Extract full HTML',
+          value: htmlExtraction,
+        },
+      },
+    },
+    id: connector.id,
+    index: CONNECTORS_INDEX,
+    refresh: 'wait_for',
+  });
+}


### PR DESCRIPTION
## Summary
This adds a toggle to enable/disable full html extraction for Elastic crawlers.

https://user-images.githubusercontent.com/94373878/217030130-8b377aad-dbbf-4b55-87ae-b0a94ac060a6.mov

