### PR TITLE
[Lens] don't block render on missing sort field

### DIFF
--- a/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/last_value.test.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/last_value.test.tsx
@@ -981,9 +981,6 @@ describe('last_value', () => {
                 "id": "dimensionButton",
               },
               Object {
-                "id": "visualization",
-              },
-              Object {
                 "id": "embeddableBadge",
               },
             ],

--- a/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/last_value.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/last_value.tsx
@@ -86,7 +86,6 @@ function getInvalidSortFieldMessage(
       displayLocations: [
         { id: 'toolbar' },
         { id: 'dimensionButton', dimensionId: columnId },
-        { id: 'visualization' },
         { id: 'embeddableBadge' },
       ],
     };


### PR DESCRIPTION
## Summary

part of https://github.com/elastic/kibana/issues/143673

In the case where only the sort field is missing, you'll get an Elasticsearch error displayed in place of the visualization. So we thought we should have the missing field error shown in the workspace instead since that's the real problem.

However, doing this can cause the integration dashboards to suffer from the same issue that https://github.com/elastic/kibana/pull/149262 was trying to resolve since many of them have last-value operations with sort fields.

<img width="1915" alt="Screenshot 2023-02-06 at 11 28 09 AM" src="https://user-images.githubusercontent.com/315764/217042121-ae57e1c6-20e2-4b51-8427-648190bc1994.png">

The lesser of the evils is just to not block the render no matter what. In the scenario where only the sort field is missing from a configuration, they will see the elasticsearch error in the workspace, but will still see the missing field error in the messages list and the error dimension. This scenario also seems like an edge case, while the integration dashboards are installed every day.

