### PR TITLE
[ML] Transforms: Health status information in transform list.

### DIFF
--- a/x-pack/plugins/transform/common/constants.ts
+++ b/x-pack/plugins/transform/common/constants.ts
@@ -98,6 +98,39 @@ export const TRANSFORM_STATE = {
 const transformStates = Object.values(TRANSFORM_STATE);
 export type TransformState = typeof transformStates[number];
 
+export const TRANSFORM_HEALTH = {
+  GREEN: 'green',
+  UNKNOWN: 'unknown',
+  YELLOW: 'yellow',
+  RED: 'red',
+} as const;
+
+const transformHealth = Object.values(TRANSFORM_HEALTH);
+export type TransformHealth = typeof transformHealth[number];
+
+export const TRANSFORM_HEALTH_COLOR = {
+  green: 'success',
+  unknown: 'subdued',
+  yellow: 'warning',
+  red: 'danger',
+} as const;
+
+export const TRANSFORM_HEALTH_DESCRIPTION = {
+  green: i18n.translate('xpack.transform.transformHealth.greenDescription', {
+    defaultMessage: 'The transform is healthy.',
+  }),
+  unknown: i18n.translate('xpack.transform.transformHealth.unknownDescription', {
+    defaultMessage: 'The health of the transform could not be determined.',
+  }),
+  yellow: i18n.translate('xpack.transform.transformHealth.yellowDescription', {
+    defaultMessage:
+      'The functionality of the transform is in a degraded state and may need remediation to avoid the health becoming red.',
+  }),
+  red: i18n.translate('xpack.transform.transformHealth.redDescription', {
+    defaultMessage: 'The transform is experiencing an outage or is unavailable for use.',
+  }),
+} as const;
+
 export const TRANSFORM_MODE = {
   BATCH: 'batch',
   CONTINUOUS: 'continuous',

--- a/x-pack/plugins/transform/common/constants.ts
+++ b/x-pack/plugins/transform/common/constants.ts
@@ -95,8 +95,7 @@ export const TRANSFORM_STATE = {
   WAITING: 'waiting',
 } as const;
 
-const transformStates = Object.values(TRANSFORM_STATE);
-export type TransformState = typeof transformStates[number];
+export type TransformState = typeof TRANSFORM_STATE[keyof typeof TRANSFORM_STATE];
 
 export const TRANSFORM_HEALTH = {
   GREEN: 'green',
@@ -105,8 +104,7 @@ export const TRANSFORM_HEALTH = {
   RED: 'red',
 } as const;
 
-const transformHealth = Object.values(TRANSFORM_HEALTH);
-export type TransformHealth = typeof transformHealth[number];
+export type TransformHealth = typeof TRANSFORM_HEALTH[keyof typeof TRANSFORM_HEALTH];
 
 export const TRANSFORM_HEALTH_COLOR = {
   green: 'success',
@@ -136,8 +134,7 @@ export const TRANSFORM_MODE = {
   CONTINUOUS: 'continuous',
 } as const;
 
-const transformModes = Object.values(TRANSFORM_MODE);
-export type TransformMode = typeof transformModes[number];
+export type TransformMode = typeof TRANSFORM_MODE[keyof typeof TRANSFORM_MODE];
 
 export const TRANSFORM_FUNCTION = {
   PIVOT: 'pivot',

--- a/x-pack/plugins/transform/common/constants.ts
+++ b/x-pack/plugins/transform/common/constants.ts
@@ -113,6 +113,21 @@ export const TRANSFORM_HEALTH_COLOR = {
   red: 'danger',
 } as const;
 
+export const TRANSFORM_HEALTH_LABEL = {
+  green: i18n.translate('xpack.transform.transformHealth.greenLabel', {
+    defaultMessage: 'Healthy',
+  }),
+  unknown: i18n.translate('xpack.transform.transformHealth.unknownLabel', {
+    defaultMessage: 'Unknown',
+  }),
+  yellow: i18n.translate('xpack.transform.transformHealth.yellowLabel', {
+    defaultMessage: 'Degraded',
+  }),
+  red: i18n.translate('xpack.transform.transformHealth.redLabel', {
+    defaultMessage: 'Outage',
+  }),
+} as const;
+
 export const TRANSFORM_HEALTH_DESCRIPTION = {
   green: i18n.translate('xpack.transform.transformHealth.greenDescription', {
     defaultMessage: 'The transform is healthy.',

--- a/x-pack/plugins/transform/common/types/transform_stats.ts
+++ b/x-pack/plugins/transform/common/types/transform_stats.ts
@@ -7,7 +7,7 @@
 
 import { isPopulatedObject } from '@kbn/ml-is-populated-object';
 
-import { TransformState, TRANSFORM_STATE } from '../constants';
+import { type TransformHealth, type TransformState, TRANSFORM_STATE } from '../constants';
 import { TransformId } from './transform';
 
 export interface TransformStats {
@@ -26,6 +26,15 @@ export interface TransformStats {
       };
     };
     operations_behind: number;
+  };
+  health: {
+    status: TransformHealth;
+    issues?: Array<{
+      issue: string;
+      details?: string;
+      count: number;
+      first_occurrence?: number;
+    }>;
   };
   node?: {
     id: string;

--- a/x-pack/plugins/transform/public/app/common/transform_list.ts
+++ b/x-pack/plugins/transform/public/app/common/transform_list.ts
@@ -19,7 +19,6 @@ export enum TRANSFORM_LIST_COLUMN {
 export interface TransformListRow {
   id: TransformId;
   config: TransformConfigUnion;
-  health?: string; // added property on client side to allow filtering by this field
   mode?: string; // added property on client side to allow filtering by this field
   stats: TransformStats;
   alerting_rules?: TransformHealthAlertRule[];

--- a/x-pack/plugins/transform/public/app/common/transform_list.ts
+++ b/x-pack/plugins/transform/public/app/common/transform_list.ts
@@ -19,6 +19,7 @@ export enum TRANSFORM_LIST_COLUMN {
 export interface TransformListRow {
   id: TransformId;
   config: TransformConfigUnion;
+  health?: string; // added property on client side to allow filtering by this field
   mode?: string; // added property on client side to allow filtering by this field
   stats: TransformStats;
   alerting_rules?: TransformHealthAlertRule[];

--- a/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/expanded_row.tsx
+++ b/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/expanded_row.tsx
@@ -6,21 +6,26 @@
  */
 
 import React, { FC, useMemo } from 'react';
+import moment from 'moment-timezone';
 
 import { EuiButtonEmpty, EuiTabbedContent } from '@elastic/eui';
+
 import { Optional } from '@kbn/utility-types';
 import { i18n } from '@kbn/i18n';
 import { stringHash } from '@kbn/ml-string-hash';
 
-import moment from 'moment-timezone';
 import { isDefined } from '@kbn/ml-is-defined';
+
+import { TransformHealthAlertRule } from '../../../../../../common/types/alerting';
+
 import { TransformListRow } from '../../../../common';
 import { useAppDependencies } from '../../../../app_dependencies';
+
 import { ExpandedRowDetailsPane, SectionConfig, SectionItem } from './expanded_row_details_pane';
 import { ExpandedRowJsonPane } from './expanded_row_json_pane';
 import { ExpandedRowMessagesPane } from './expanded_row_messages_pane';
 import { ExpandedRowPreviewPane } from './expanded_row_preview_pane';
-import { TransformHealthAlertRule } from '../../../../../../common/types/alerting';
+import { TransformHealthColoredDot } from './transform_health_colored_dot';
 
 function getItemDescription(value: any) {
   if (typeof value === 'object') {
@@ -62,6 +67,12 @@ export const ExpandedRow: FC<Props> = ({ item, onAlertEdit }) => {
     stateItems.push({
       title: 'node.name',
       description: item.stats.node.name,
+    });
+  }
+  if (item.stats.health !== undefined) {
+    stateItems.push({
+      title: 'health',
+      description: <TransformHealthColoredDot healthStatus={item.stats.health.status} />,
     });
   }
 

--- a/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/transform_health_colored_dot.tsx
+++ b/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/transform_health_colored_dot.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { type FC } from 'react';
+
+import { EuiHealth, EuiToolTip } from '@elastic/eui';
+
+import {
+  type TransformHealth,
+  TRANSFORM_HEALTH_COLOR,
+  TRANSFORM_HEALTH_DESCRIPTION,
+} from '../../../../../../common/constants';
+
+interface TransformHealthProps {
+  healthStatus: TransformHealth;
+}
+
+export const TransformHealthColoredDot: FC<TransformHealthProps> = ({ healthStatus }) => {
+  return (
+    <EuiToolTip content={TRANSFORM_HEALTH_DESCRIPTION[healthStatus]}>
+      <EuiHealth color={TRANSFORM_HEALTH_COLOR[healthStatus]} />
+    </EuiToolTip>
+  );
+};

--- a/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/transform_health_colored_dot.tsx
+++ b/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/transform_health_colored_dot.tsx
@@ -13,6 +13,7 @@ import {
   type TransformHealth,
   TRANSFORM_HEALTH_COLOR,
   TRANSFORM_HEALTH_DESCRIPTION,
+  TRANSFORM_HEALTH_LABEL,
 } from '../../../../../../common/constants';
 
 interface TransformHealthProps {
@@ -22,7 +23,9 @@ interface TransformHealthProps {
 export const TransformHealthColoredDot: FC<TransformHealthProps> = ({ healthStatus }) => {
   return (
     <EuiToolTip content={TRANSFORM_HEALTH_DESCRIPTION[healthStatus]}>
-      <EuiHealth color={TRANSFORM_HEALTH_COLOR[healthStatus]} />
+      <EuiHealth color={TRANSFORM_HEALTH_COLOR[healthStatus]}>
+        <small>{TRANSFORM_HEALTH_LABEL[healthStatus]}</small>
+      </EuiHealth>
     </EuiToolTip>
   );
 };

--- a/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/transform_search_bar_filters.tsx
+++ b/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/transform_search_bar_filters.tsx
@@ -13,6 +13,8 @@ import {
   TRANSFORM_FUNCTION,
   TRANSFORM_MODE,
   TRANSFORM_STATE,
+  TRANSFORM_HEALTH,
+  TRANSFORM_HEALTH_COLOR,
 } from '../../../../../../common/constants';
 import { isLatestTransform, isPivotTransform } from '../../../../../../common/types/transform';
 import { TransformListRow } from '../../../../common';
@@ -40,6 +42,25 @@ export const transformFilters: SearchFilterConfig[] = [
       name: val,
       view: (
         <EuiBadge className="transform__TaskModeBadge" color="hollow">
+          {val}
+        </EuiBadge>
+      ),
+    })),
+  },
+  {
+    type: 'field_value_selection',
+    field: 'health',
+    name: i18n.translate('xpack.transform.healthFilter', { defaultMessage: 'Health' }),
+    multiSelect: false,
+    options: Object.values(TRANSFORM_HEALTH).map((val) => ({
+      value: val,
+      name: val,
+      view: (
+        <EuiBadge
+          className="transform__TaskHealthBadge"
+          // For the color icon 'subdued' is used but for the badge we need 'hollow' instead.
+          color={TRANSFORM_HEALTH_COLOR[val] === 'subdued' ? 'hollow' : TRANSFORM_HEALTH_COLOR[val]}
+        >
           {val}
         </EuiBadge>
       ),
@@ -96,6 +117,9 @@ export const filterTransforms = (transforms: TransformListRow[], clauses: Clause
         ts = transforms.filter((transform) => (c.value as Value[]).includes(transform.stats.state));
       } else {
         ts = transforms.filter((transform) => {
+          if (c.type === 'field' && c.field === 'health') {
+            return transform.stats.health?.status === c.value;
+          }
           if (c.type === 'field' && c.field === 'mode') {
             return transform.mode === c.value;
           }

--- a/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/transform_search_bar_filters.tsx
+++ b/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/transform_search_bar_filters.tsx
@@ -16,7 +16,7 @@ import {
 } from '../../../../../../common/constants';
 import { isLatestTransform, isPivotTransform } from '../../../../../../common/types/transform';
 import { TransformListRow } from '../../../../common';
-import { getTaskStateBadge } from './use_columns';
+import { TransformTaskStateBadge } from './transform_task_state_badge';
 
 export const transformFilters: SearchFilterConfig[] = [
   {
@@ -27,7 +27,7 @@ export const transformFilters: SearchFilterConfig[] = [
     options: Object.values(TRANSFORM_STATE).map((val) => ({
       value: val,
       name: val,
-      view: getTaskStateBadge(val),
+      view: <TransformTaskStateBadge state={val} />,
     })),
   },
   {

--- a/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/transform_search_bar_filters.tsx
+++ b/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/transform_search_bar_filters.tsx
@@ -15,6 +15,7 @@ import {
   TRANSFORM_STATE,
   TRANSFORM_HEALTH,
   TRANSFORM_HEALTH_COLOR,
+  TRANSFORM_HEALTH_LABEL,
 } from '../../../../../../common/constants';
 import { isLatestTransform, isPivotTransform } from '../../../../../../common/types/transform';
 import { TransformListRow } from '../../../../common';
@@ -61,7 +62,7 @@ export const transformFilters: SearchFilterConfig[] = [
           // For the color icon 'subdued' is used but for the badge we need 'hollow' instead.
           color={TRANSFORM_HEALTH_COLOR[val] === 'subdued' ? 'hollow' : TRANSFORM_HEALTH_COLOR[val]}
         >
-          {val}
+          {TRANSFORM_HEALTH_LABEL[val]}
         </EuiBadge>
       ),
     })),

--- a/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/transform_task_state_badge.tsx
+++ b/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/transform_task_state_badge.tsx
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { type FC } from 'react';
+
+import { EuiBadge, EuiToolTip } from '@elastic/eui';
+
+import { TransformStats } from '../../../../../../common/types/transform_stats';
+import { TRANSFORM_STATE } from '../../../../../../common/constants';
+
+// reflects https://github.com/elastic/elasticsearch/blob/master/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformStats.java#L250
+const STATE_COLOR = {
+  aborting: 'warning',
+  failed: 'danger',
+  indexing: 'primary',
+  started: 'primary',
+  stopped: 'hollow',
+  stopping: 'hollow',
+  waiting: 'hollow',
+} as const;
+
+interface TransformTaskStateBadgeProps {
+  state: TransformStats['state'];
+  reason?: TransformStats['reason'];
+}
+
+export const TransformTaskStateBadge: FC<TransformTaskStateBadgeProps> = ({ state, reason }) => {
+  const color = STATE_COLOR[state];
+
+  if (state === TRANSFORM_STATE.FAILED && reason !== undefined) {
+    return (
+      <EuiToolTip content={reason}>
+        <EuiBadge className="transform__TaskStateBadge" color={color}>
+          {state}
+        </EuiBadge>
+      </EuiToolTip>
+    );
+  }
+
+  return (
+    <EuiBadge className="transform__TaskStateBadge" color={color}>
+      {state}
+    </EuiBadge>
+  );
+};

--- a/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/use_columns.test.tsx
+++ b/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/use_columns.test.tsx
@@ -20,7 +20,7 @@ describe('Transform: Job List Columns', () => {
 
     const columns: ReturnType<typeof useColumns>['columns'] = result.current.columns;
 
-    expect(columns).toHaveLength(9);
+    expect(columns).toHaveLength(10);
     expect(columns[0].isExpander).toBeTruthy();
     expect(columns[1].name).toBe('ID');
     expect(columns[2].id).toBe('alertRule');
@@ -29,6 +29,7 @@ describe('Transform: Job List Columns', () => {
     expect(columns[5].name).toBe('Status');
     expect(columns[6].name).toBe('Mode');
     expect(columns[7].name).toBe('Progress');
-    expect(columns[8].name).toBe('Actions');
+    expect(columns[8].name).toBe('Health');
+    expect(columns[9].name).toBe('Actions');
   });
 });

--- a/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/use_columns.tsx
+++ b/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/use_columns.tsx
@@ -16,6 +16,7 @@ import {
   EuiButtonIcon,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiHealth,
   EuiProgress,
   EuiScreenReaderOnly,
   EuiText,
@@ -30,7 +31,11 @@ import {
   TransformId,
 } from '../../../../../../common/types/transform';
 import { TransformStats } from '../../../../../../common/types/transform_stats';
-import { TRANSFORM_STATE } from '../../../../../../common/constants';
+import {
+  TRANSFORM_HEALTH_COLOR,
+  TRANSFORM_HEALTH_DESCRIPTION,
+  TRANSFORM_STATE,
+} from '../../../../../../common/constants';
 
 import { getTransformProgress, TransformListRow, TRANSFORM_LIST_COLUMN } from '../../../../common';
 import { useActions } from './use_actions';
@@ -99,6 +104,7 @@ export const useColumns = (
     EuiTableFieldDataColumnType<TransformListRow>,
     EuiTableComputedColumnType<TransformListRow>,
     EuiTableFieldDataColumnType<TransformListRow>,
+    EuiTableComputedColumnType<TransformListRow>,
     EuiTableComputedColumnType<TransformListRow>,
     EuiTableComputedColumnType<TransformListRow>,
     EuiTableComputedColumnType<TransformListRow>,
@@ -308,6 +314,20 @@ export const useColumns = (
         );
       },
       width: '100px',
+    },
+    {
+      name: i18n.translate('xpack.transform.health', { defaultMessage: 'Health' }),
+      'data-test-subj': 'transformListColumnHealth',
+      sortable: (item: TransformListRow) => item.stats.health.status,
+      truncateText: true,
+      render(item: TransformListRow) {
+        return (
+          <EuiToolTip content={TRANSFORM_HEALTH_DESCRIPTION[item.stats.health.status]}>
+            <EuiHealth color={TRANSFORM_HEALTH_COLOR[item.stats.health.status]} />
+          </EuiToolTip>
+        );
+      },
+      width: '60px',
     },
     {
       name: i18n.translate('xpack.transform.tableActionLabel', { defaultMessage: 'Actions' }),

--- a/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/use_columns.tsx
+++ b/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/use_columns.tsx
@@ -16,7 +16,6 @@ import {
   EuiButtonIcon,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiHealth,
   EuiProgress,
   EuiScreenReaderOnly,
   EuiText,
@@ -30,50 +29,14 @@ import {
   isPivotTransform,
   TransformId,
 } from '../../../../../../common/types/transform';
-import { TransformStats } from '../../../../../../common/types/transform_stats';
-import {
-  TRANSFORM_HEALTH_COLOR,
-  TRANSFORM_HEALTH_DESCRIPTION,
-  TRANSFORM_STATE,
-} from '../../../../../../common/constants';
+import { TRANSFORM_STATE } from '../../../../../../common/constants';
 
 import { getTransformProgress, TransformListRow, TRANSFORM_LIST_COLUMN } from '../../../../common';
 import { useActions } from './use_actions';
 import { isManagedTransform } from '../../../../common/managed_transforms_utils';
 
-// reflects https://github.com/elastic/elasticsearch/blob/master/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformStats.java#L250
-const STATE_COLOR = {
-  aborting: 'warning',
-  failed: 'danger',
-  indexing: 'primary',
-  started: 'primary',
-  stopped: 'hollow',
-  stopping: 'hollow',
-  waiting: 'hollow',
-} as const;
-
-export const getTaskStateBadge = (
-  state: TransformStats['state'],
-  reason?: TransformStats['reason']
-) => {
-  const color = STATE_COLOR[state];
-
-  if (state === TRANSFORM_STATE.FAILED && reason !== undefined) {
-    return (
-      <EuiToolTip content={reason}>
-        <EuiBadge className="transform__TaskStateBadge" color={color}>
-          {state}
-        </EuiBadge>
-      </EuiToolTip>
-    );
-  }
-
-  return (
-    <EuiBadge className="transform__TaskStateBadge" color={color}>
-      {state}
-    </EuiBadge>
-  );
-};
+import { TransformHealthColoredDot } from './transform_health_colored_dot';
+import { TransformTaskStateBadge } from './transform_task_state_badge';
 
 export const useColumns = (
   expandedRowItemIds: TransformId[],
@@ -239,7 +202,7 @@ export const useColumns = (
       sortable: (item: TransformListRow) => item.stats.state,
       truncateText: true,
       render(item: TransformListRow) {
-        return getTaskStateBadge(item.stats.state, item.stats.reason);
+        return <TransformTaskStateBadge state={item.stats.state} reason={item.stats.reason} />;
       },
       width: '100px',
     },
@@ -321,11 +284,7 @@ export const useColumns = (
       sortable: (item: TransformListRow) => item.stats.health.status,
       truncateText: true,
       render(item: TransformListRow) {
-        return (
-          <EuiToolTip content={TRANSFORM_HEALTH_DESCRIPTION[item.stats.health.status]}>
-            <EuiHealth color={TRANSFORM_HEALTH_COLOR[item.stats.health.status]} />
-          </EuiToolTip>
-        );
+        return <TransformHealthColoredDot healthStatus={item.stats.health.status} />;
       },
       width: '60px',
     },

--- a/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/use_columns.tsx
+++ b/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/use_columns.tsx
@@ -286,7 +286,7 @@ export const useColumns = (
       render(item: TransformListRow) {
         return <TransformHealthColoredDot healthStatus={item.stats.health.status} />;
       },
-      width: '60px',
+      width: '100px',
     },
     {
       name: i18n.translate('xpack.transform.tableActionLabel', { defaultMessage: 'Actions' }),


### PR DESCRIPTION
## Summary

Part of #144157.

Adds health status information to the transform list.

- Column "Health" in the list with `EuiHealth` based colored dot and tooltip
- Health information in expanded row as part of stats output.
- Search filter option for health status.

<img width="1007" alt="image" src="https://user-images.githubusercontent.com/230104/217270541-1af74b3c-7b21-41ab-a9e2-235bdd643d6c.png">

<img width="988" alt="image" src="https://user-images.githubusercontent.com/230104/217270642-846213ed-9ec6-4f1e-82fb-ca68b049369c.png">

<img width="1007" alt="image" src="https://user-images.githubusercontent.com/230104/217270731-cb5eb7e8-672c-4716-af22-505836694e1c.png">

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
