### PR TITLE
[Docs] Documents constraints of space id in create space API

### DIFF
--- a/docs/api/spaces-management/post.asciidoc
+++ b/docs/api/spaces-management/post.asciidoc
@@ -15,7 +15,7 @@ experimental[] Create a {kib} space.
 ==== Request body
 
 `id`::
-  (Required, string) The space ID that is part of the Kibana URL when inside the space. You are unable to change the ID with the update operation.
+  (Required, string) The space ID that is part of the Kibana URL when inside the space. Space IDs are limited to lowercase alphanumeric, underscore, and hyphen characters (a-z, 0-9, '_', and '-'). You are unable to change the ID with the update operation.
 
 `name`::
   (Required, string) The display name for the space.


### PR DESCRIPTION
closes #150311

Adds wording to clarify that the space ID must be lowercase alphanumeric, but can include underscores and hyphens. Previously this restriction was not documented, but if these requirements are not met the API will respond with a 400.

<!--ONMERGE {"backportTargets":["7.17","8.6"]} ONMERGE-->