### PR TITLE
[Maps] fix grid resolution ticks without labels not visible

### DIFF
--- a/x-pack/plugins/maps/public/classes/sources/es_geo_grid_source/__snapshots__/resolution_editor.test.tsx.snap
+++ b/x-pack/plugins/maps/public/classes/sources/es_geo_grid_source/__snapshots__/resolution_editor.test.tsx.snap
@@ -24,7 +24,9 @@ exports[`should render 3 tick slider when renderAs is HEX 1`] = `
             "value": 1,
           },
           Object {
-            "label": "",
+            "label": <span>
+               
+            </span>,
             "value": 2,
           },
           Object {
@@ -63,11 +65,15 @@ exports[`should render 4 tick slider when renderAs is GRID 1`] = `
             "value": 1,
           },
           Object {
-            "label": "",
+            "label": <span>
+               
+            </span>,
             "value": 2,
           },
           Object {
-            "label": "",
+            "label": <span>
+               
+            </span>,
             "value": 3,
           },
           Object {
@@ -106,11 +112,15 @@ exports[`should render 4 tick slider when renderAs is HEATMAP 1`] = `
             "value": 1,
           },
           Object {
-            "label": "",
+            "label": <span>
+               
+            </span>,
             "value": 2,
           },
           Object {
-            "label": "",
+            "label": <span>
+               
+            </span>,
             "value": 3,
           },
           Object {
@@ -149,11 +159,15 @@ exports[`should render 4 tick slider when renderAs is POINT 1`] = `
             "value": 1,
           },
           Object {
-            "label": "",
+            "label": <span>
+               
+            </span>,
             "value": 2,
           },
           Object {
-            "label": "",
+            "label": <span>
+               
+            </span>,
             "value": 3,
           },
           Object {

--- a/x-pack/plugins/maps/public/classes/sources/es_geo_grid_source/resolution_editor.tsx
+++ b/x-pack/plugins/maps/public/classes/sources/es_geo_grid_source/resolution_editor.tsx
@@ -53,13 +53,13 @@ export class ResolutionEditor extends Component<Props, State> {
     const scale = this._getScale();
     const unlabeledTicks = [
       {
-        label: '',
+        label: <span>&nbsp;</span>,
         value: scale[GRID_RESOLUTION.FINE],
       },
     ];
     if (scale[GRID_RESOLUTION.FINE] !== scale[GRID_RESOLUTION.MOST_FINE]) {
       unlabeledTicks.push({
-        label: '',
+        label: <span>&nbsp;</span>,
         value: scale[GRID_RESOLUTION.MOST_FINE],
       });
     }


### PR DESCRIPTION
To view problem
1) create new map and add "Clusters" layer. Configure layer and click "Add layer"
2) Under the clusters section, notice that there are no ticks in the middle of "Resolution" slider. This makes it difficult for users to see the available selections.
    <img width="200" alt="Screen Shot 2023-02-06 at 1 42 25 PM" src="https://user-images.githubusercontent.com/373691/217081316-2cdfd50b-1a7a-4c1e-9037-349f124466a7.png">
    <img width="200" alt="Screen Shot 2023-02-06 at 1 42 19 PM" src="https://user-images.githubusercontent.com/373691/217081350-7bda07ad-1431-4801-96f7-2235e610ed17.png">

The problem is that empty string does not render the tick mark. This PR adds a react element that renders an empty string, making the tick mark visible and providing visual context to users about selectable areas.
<img width="200" alt="Screen Shot 2023-02-06 at 1 41 49 PM" src="https://user-images.githubusercontent.com/373691/217081507-391ebb4c-d9a4-422f-85e1-61982c2604eb.png">
<img width="200" alt="Screen Shot 2023-02-06 at 1 41 43 PM" src="https://user-images.githubusercontent.com/373691/217081524-a799d435-99b5-46c0-82d3-b15a913594a1.png">


