### PR TITLE
[Security Solution] Add File operation RBAC switch description text to role creation

### DIFF
--- a/x-pack/plugins/security_solution/server/features.ts
+++ b/x-pack/plugins/security_solution/server/features.ts
@@ -234,6 +234,12 @@ const responseActionSubFeatures: SubFeatureConfig[] = [
     name: i18n.translate('xpack.securitySolution.featureRegistry.subFeatures.fileOperations', {
       defaultMessage: 'File Operations',
     }),
+    description: i18n.translate(
+      'xpack.securitySolution.featureRegistry.subFeatures.fileOperations.description',
+      {
+        defaultMessage: 'Perform file-related response actions in the response console.',
+      }
+    ),
     privilegeGroups: [
       {
         groupType: 'mutually_exclusive',


### PR DESCRIPTION
## Summary

Adds description text for the file operations RBAC switch

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/56395104/217087523-3d9fa27d-e582-4be2-90a2-7522bc96e6b7.png">

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
