### PR TITLE
[Dashboard] Retain maximized panel  on link/unlink from library

### DIFF
--- a/src/plugins/dashboard/public/dashboard_actions/add_to_library_action.tsx
+++ b/src/plugins/dashboard/public/dashboard_actions/add_to_library_action.tsx
@@ -92,14 +92,16 @@ export class AddToLibraryAction implements Action<AddToLibraryActionContext> {
       type: embeddable.type,
       explicitInput: { ...newInput },
     };
-    dashboard.replacePanel(panelToReplace, newPanel, true);
+    const replacedPanelId = await dashboard.replacePanel(panelToReplace, newPanel, true);
 
     const title = dashboardAddToLibraryActionStrings.getSuccessMessage(
       embeddable.getTitle() ? `'${embeddable.getTitle()}'` : ''
     );
+
     if (dashboard.getExpandedPanelId() !== undefined) {
-      dashboard.setExpandedPanelId(undefined);
+      dashboard.setExpandedPanelId(replacedPanelId);
     }
+
     this.toastsService.addSuccess({
       title,
       'data-test-subj': 'addPanelToLibrarySuccess',

--- a/src/plugins/dashboard/public/dashboard_actions/unlink_from_library_action.tsx
+++ b/src/plugins/dashboard/public/dashboard_actions/unlink_from_library_action.tsx
@@ -86,13 +86,14 @@ export class UnlinkFromLibraryAction implements Action<UnlinkFromLibraryActionCo
       type: embeddable.type,
       explicitInput: { ...newInput, title: embeddable.getTitle() },
     };
-    dashboard.replacePanel(panelToReplace, newPanel, true);
+    const replacedPanelId = await dashboard.replacePanel(panelToReplace, newPanel, true);
 
     const title = dashboardUnlinkFromLibraryActionStrings.getSuccessMessage(
       embeddable.getTitle() ? `'${embeddable.getTitle()}'` : ''
     );
+
     if (dashboard.getExpandedPanelId() !== undefined) {
-      dashboard.setExpandedPanelId(undefined);
+      dashboard.setExpandedPanelId(replacedPanelId);
     }
 
     this.toastsService.addSuccess({

--- a/src/plugins/dashboard/public/dashboard_container/embeddable/api/panel_management.ts
+++ b/src/plugins/dashboard/public/dashboard_container/embeddable/api/panel_management.ts
@@ -46,30 +46,33 @@ export async function replacePanel(
   previousPanelState: DashboardPanelState<EmbeddableInput>,
   newPanelState: Partial<PanelState>,
   generateNewId?: boolean
-) {
+): Promise<string> {
   let panels;
+  let panelId;
+
   if (generateNewId) {
     // replace panel can be called with generateNewId in order to totally destroy and recreate the embeddable
+    panelId = uuidv4();
     panels = { ...this.input.panels };
     delete panels[previousPanelState.explicitInput.id];
-    const newId = uuidv4();
-    panels[newId] = {
+    panels[panelId] = {
       ...previousPanelState,
       ...newPanelState,
       gridData: {
         ...previousPanelState.gridData,
-        i: newId,
+        i: panelId,
       },
       explicitInput: {
         ...newPanelState.explicitInput,
-        id: newId,
+        id: panelId,
       },
     };
   } else {
     // Because the embeddable type can change, we have to operate at the container level here
+    panelId = previousPanelState.explicitInput.id;
     panels = {
       ...this.input.panels,
-      [previousPanelState.explicitInput.id]: {
+      [panelId]: {
         ...previousPanelState,
         ...newPanelState,
         gridData: {
@@ -77,16 +80,18 @@ export async function replacePanel(
         },
         explicitInput: {
           ...newPanelState.explicitInput,
-          id: previousPanelState.explicitInput.id,
+          id: panelId,
         },
       },
     };
   }
 
-  return this.updateInput({
+  await this.updateInput({
     panels,
     lastReloadRequestTime: new Date().getTime(),
   });
+
+  return panelId;
 }
 
 export function showPlaceholderUntil<TPlacementMethodArgs extends IPanelPlacementArgs>(


### PR DESCRIPTION
## Summary

Follow up to #150338.
Closes #150460.

This updates the expanded panel to the newly generated ID when linking/unlinking a panel from the library to keep the panel maximized.


https://user-images.githubusercontent.com/1697105/217161308-3f953f6e-7a1b-4baa-a243-f9636f04a81d.mp4

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
