### PR TITLE
[Lens] Fixes problem with timeshift in formula and breakdown

### DIFF
--- a/src/plugins/data/common/search/aggs/buckets/_terms_other_bucket_helper.test.ts
+++ b/src/plugins/data/common/search/aggs/buckets/_terms_other_bucket_helper.test.ts
@@ -344,11 +344,6 @@ describe('Terms Agg Other bucket helper', () => {
             2: {
               doc_count_error_upper_bound: 0,
               sum_other_doc_count: 8325,
-              buckets: [
-                { key: 'ios', doc_count: 2850 },
-                { key: 'win xp', doc_count: 2830 },
-                { key: '__missing__', doc_count: 1430 },
-              ],
             },
           },
           status: 200,

--- a/src/plugins/data/common/search/aggs/buckets/_terms_other_bucket_helper.test.ts
+++ b/src/plugins/data/common/search/aggs/buckets/_terms_other_bucket_helper.test.ts
@@ -325,6 +325,43 @@ describe('Terms Agg Other bucket helper', () => {
         expect(typeof agg).toBe('function');
       });
 
+      test('returns a function for undefined agg buckets', () => {
+        const response = {
+          took: 10,
+          timed_out: false,
+          _shards: {
+            total: 1,
+            successful: 1,
+            skipped: 0,
+            failed: 0,
+          },
+          hits: {
+            total: 14005,
+            max_score: 0,
+            hits: [],
+          },
+          aggregations: {
+            2: {
+              doc_count_error_upper_bound: 0,
+              sum_other_doc_count: 8325,
+              buckets: [
+                { key: 'ios', doc_count: 2850 },
+                { key: 'win xp', doc_count: 2830 },
+                { key: '__missing__', doc_count: 1430 },
+              ],
+            },
+          },
+          status: 200,
+        };
+        const aggConfigs = getAggConfigs(nestedTerm.aggs);
+        const agg = buildOtherBucketAgg(
+          aggConfigs,
+          aggConfigs.aggs[1] as IBucketAggConfig,
+          enrichResponseWithSampling(response)
+        );
+        expect(agg).toBe(false);
+      });
+
       test('correctly builds query with single terms agg', () => {
         const aggConfigs = getAggConfigs(singleTerm.aggs);
         const agg = buildOtherBucketAgg(

--- a/src/plugins/data/common/search/aggs/buckets/_terms_other_bucket_helper.ts
+++ b/src/plugins/data/common/search/aggs/buckets/_terms_other_bucket_helper.ts
@@ -196,7 +196,8 @@ export const buildOtherBucketAgg = (
     key: string
   ) => {
     // make sure there are actually results for the buckets
-    if (aggregations[aggId]?.buckets.length < 1) {
+    const aggregation = aggregations[aggId];
+    if (!aggregation || !aggregation.buckets.length) {
       noAggBucketResults = true;
       return;
     }

--- a/src/plugins/data/common/search/aggs/buckets/_terms_other_bucket_helper.ts
+++ b/src/plugins/data/common/search/aggs/buckets/_terms_other_bucket_helper.ts
@@ -209,7 +209,7 @@ export const buildOtherBucketAgg = (
       exhaustiveBuckets = false;
     }
     if (aggIndex < index) {
-      each(agg.buckets, (bucket: any, bucketObjKey) => {
+      each(agg?.buckets, (bucket: any, bucketObjKey) => {
         const bucketKey = currentAgg.getKey(
           bucket,
           isNumber(bucketObjKey) ? undefined : bucketObjKey

--- a/src/plugins/data/common/search/aggs/buckets/_terms_other_bucket_helper.ts
+++ b/src/plugins/data/common/search/aggs/buckets/_terms_other_bucket_helper.ts
@@ -196,13 +196,11 @@ export const buildOtherBucketAgg = (
     key: string
   ) => {
     // make sure there are actually results for the buckets
-    const aggregation = aggregations[aggId];
-    if (!aggregation || !aggregation.buckets.length) {
+    const agg = aggregations[aggId];
+    if (!agg || !agg.buckets.length) {
       noAggBucketResults = true;
       return;
     }
-
-    const agg = aggregations[aggId];
     const newAggIndex = aggIndex + 1;
     const newAgg = bucketAggs[newAggIndex];
     const currentAgg = bucketAggs[aggIndex];


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/146200

This bug can easily be replicated with the following scenario:
1. Add a date histogram on the x axis
2. Add a formula with shift (use different timeshifts) i.e. count() - count(shift=1d)
3. Add a terms breakdown and switch off the Aggregate by this function first

The fi is easy, it fails on the each look as it requires the agg to have buckets but it doesnt at this scenario. I also added a test.

How it looks now
<img width="1049" alt="image" src="https://user-images.githubusercontent.com/17003240/217195447-3b6edb8d-0814-4148-888d-9bd64e924c76.png">


### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios