### PR TITLE
[Lens] Always use resolved time range when computing Top values order agg with timeshifts

### DIFF
--- a/src/plugins/data/common/search/aggs/buckets/_terms_order_helper.ts
+++ b/src/plugins/data/common/search/aggs/buckets/_terms_order_helper.ts
@@ -67,6 +67,9 @@ export const termsOrderAggParamDefinition: Partial<BucketAggParam<IBucketAggConf
 
     if (aggs?.hasTimeShifts() && Object.keys(aggs?.getTimeShifts()).length > 1 && aggs.timeRange) {
       const shift = orderAgg.getTimeShift();
+      // The timeRange can be either absolute or relative
+      // We need the absolute/resolved one for moment, so use the helper method
+      const timeRange = aggs.getResolvedTimeRange();
       orderAgg = aggs.createAggConfig(
         {
           type: 'filtered_metric',
@@ -84,11 +87,11 @@ export const termsOrderAggParamDefinition: Partial<BucketAggParam<IBucketAggConf
                         range: {
                           [aggs.timeFields![0]]: {
                             gte: moment
-                              .tz(aggs.timeRange.from, aggs.timeZone)
+                              .tz(timeRange?.min, aggs.timeZone)
                               .subtract(shift || 0)
                               .toISOString(),
                             lte: moment
-                              .tz(aggs.timeRange.to, aggs.timeZone)
+                              .tz(timeRange?.max, aggs.timeZone)
                               .subtract(shift || 0)
                               .toISOString(),
                           },


### PR DESCRIPTION
## Summary

Fix #150313 

This was a very tricky bug to discover but with a relative "easy" solution: the main difference here between Lens and Dashboard was that the former is always converting timeRange data into absolute dates, while the latter keeps the original date format.
This difference in how dates are handled by the app triggers the bug when a specific Lens configuration is used, as `moment` could not handle a relative time range, as it's not an ISO format, which makes it fallback into the `Date` constructor therefore a final `null` value: this `null` is passed underneath to the aggs logic which 💥 when traversing the object and find a `null` value where a timestamp was expected instead.

As an example think of:

```ts
moment.tz("now-15m", "Europe/Rome").subtract(undefined || 0).toISOString();
```

this will produce a `new Date("now-15m")` and the `toISOString()` method translates it into a `null` value.

All this to give some more debugging context of the work behind this simple one-line fix. :)

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
