### PR TITLE
[Defend Workflows] Lack of sort field when sortOrder was provided caused 500 server…

### DIFF
--- a/x-pack/plugins/osquery/server/routes/saved_query/find_saved_query_route.ts
+++ b/x-pack/plugins/osquery/server/routes/saved_query/find_saved_query_route.ts
@@ -50,7 +50,7 @@ export const findSavedQueryRoute = (router: IRouter, osqueryContext: OsqueryAppC
         type: savedQuerySavedObjectType,
         page: request.query.page ?? 1,
         perPage: request.query.pageSize,
-        sortField: request.query.sort,
+        sortField: request.query.sort ?? 'id',
         sortOrder: (request.query.sortOrder as SortOrder) ?? 'desc',
       });
 


### PR DESCRIPTION
Querying `localhost:5601/api/osquery/saved_queries?sortOrder=asc` would throw 500 because `sort` field has to be specified when using `sortOrder` param.

Couldn't reproduce 500 neither on `/api/osquery/packs` nor `/api/osquery/live_queries` 

`schema.conditional` logic:

if `schema.siblingRef('sort')` is of `schema.string()` then `schema.oneOf([schema.literal('asc'), schema.literal('desc')])` else throw verbose error by failing validation `schema.string({validate: () => 'sort has to be specified when using sortOrder',})` 