### PR TITLE
[Fleet] Hide cancel button in agent activity panel when upgrade starts immediately

### DIFF
--- a/x-pack/plugins/fleet/common/types/models/agent.ts
+++ b/x-pack/plugins/fleet/common/types/models/agent.ts
@@ -154,6 +154,7 @@ export interface ActionStatus {
   cancellationTime?: string;
   newPolicyId?: string;
   creationTime: string;
+  hasRolloutPeriod?: boolean;
 }
 
 export interface AgentDiagnostics {

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agent_activity_flyout.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agent_activity_flyout.test.tsx
@@ -79,6 +79,7 @@ describe('AgentActivityFlyout', () => {
         expiration: '2099-09-16T10:00:00.000Z',
         creationTime: '2022-09-15T10:00:00.000Z',
         nbAgentsFailed: 0,
+        hasRolloutPeriod: true,
       },
     ];
     mockUseActionStatus.mockReturnValue({
@@ -105,6 +106,45 @@ describe('AgentActivityFlyout', () => {
     });
 
     expect(mockAbortUpgrade).toHaveBeenCalled();
+  });
+
+  it('should not render cancel button if the upgrade is set to happen immediately', () => {
+    const mockActionStatuses = [
+      {
+        actionId: 'action2',
+        nbAgentsActionCreated: 5,
+        nbAgentsAck: 0,
+        version: '8.5.0',
+        startTime: '2022-09-15T10:00:00.000Z',
+        type: 'UPGRADE',
+        nbAgentsActioned: 5,
+        status: 'IN_PROGRESS',
+        expiration: '2099-09-16T10:00:00.000Z',
+        creationTime: '2022-09-15T10:00:00.000Z',
+        nbAgentsFailed: 0,
+        hasRolloutPeriod: false,
+      },
+    ];
+    mockUseActionStatus.mockReturnValue({
+      currentActions: mockActionStatuses,
+      abortUpgrade: mockAbortUpgrade,
+      isFirstLoading: true,
+    });
+    const result = renderComponent();
+
+    expect(result.getByText('Agent activity')).toBeInTheDocument();
+
+    expect(
+      result.container.querySelector('[data-test-subj="upgradeInProgressTitle"]')!.textContent
+    ).toEqual('Upgrading 5 agents to version 8.5.0');
+    // compare without whitespace, &nbsp; doesn't match
+    expect(
+      result.container
+        .querySelector('[data-test-subj="upgradeInProgressDescription"]')!
+        .textContent?.replace(/\s/g, '')
+    ).toContain('Started on Sep 15, 2022 10:00 AM. Learn more'.replace(/\s/g, ''));
+
+    expect(result.queryByText('Cancel')).not.toBeInTheDocument();
   });
 
   it('should render agent activity for scheduled upgrade', () => {

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agent_activity_flyout.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agent_activity_flyout.tsx
@@ -532,6 +532,10 @@ export const UpgradeInProgressActivityItem: React.FunctionComponent<{
     return startDate > now;
   }, [action]);
 
+  const showCancelButton = useMemo(() => {
+    return isScheduled || action.hasRolloutPeriod;
+  }, [action, isScheduled]);
+
   return (
     <EuiPanel hasBorder={true} borderRadius="none">
       <EuiFlexGroup direction="column" gutterSize="m">
@@ -592,17 +596,19 @@ export const UpgradeInProgressActivityItem: React.FunctionComponent<{
               </EuiText>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiButton
-                size="s"
-                onClick={onClickAbortUpgrade}
-                isLoading={isAborting}
-                data-test-subj="abortBtn"
-              >
-                <FormattedMessage
-                  id="xpack.fleet.agentActivityFlyout.abortUpgradeButtom"
-                  defaultMessage="Cancel"
-                />
-              </EuiButton>
+              {showCancelButton ? (
+                <EuiButton
+                  size="s"
+                  onClick={onClickAbortUpgrade}
+                  isLoading={isAborting}
+                  data-test-subj="abortBtn"
+                >
+                  <FormattedMessage
+                    id="xpack.fleet.agentActivityFlyout.abortUpgradeButtom"
+                    defaultMessage="Cancel"
+                  />
+                </EuiButton>
+              ) : null}
             </EuiFlexItem>
           </EuiFlexGroup>
         </EuiFlexItem>

--- a/x-pack/plugins/fleet/server/services/agents/action_status.ts
+++ b/x-pack/plugins/fleet/server/services/agents/action_status.ts
@@ -216,6 +216,7 @@ async function _getActions(
           newPolicyId: source.data?.policy_id as string,
           creationTime: source['@timestamp']!,
           nbAgentsFailed: 0,
+          hasRolloutPeriod: !!source.rollout_duration_seconds,
         };
       }
 

--- a/x-pack/test/fleet_api_integration/apis/agents/action_status.ts
+++ b/x-pack/test/fleet_api_integration/apis/agents/action_status.ts
@@ -195,6 +195,7 @@ export default function (providerContext: FtrProviderContext) {
             status: 'IN_PROGRESS',
             creationTime: '2022-09-15T10:00:00.000Z',
             nbAgentsFailed: 0,
+            hasRolloutPeriod: false,
           },
           {
             actionId: 'action3',
@@ -207,6 +208,7 @@ export default function (providerContext: FtrProviderContext) {
             creationTime: '2022-09-15T10:00:00.000Z',
             nbAgentsFailed: 0,
             completionTime: '2022-09-15T12:00:00.000Z',
+            hasRolloutPeriod: false,
           },
           {
             actionId: 'action4',
@@ -218,6 +220,7 @@ export default function (providerContext: FtrProviderContext) {
             expiration: '2022-09-14T10:00:00.000Z',
             creationTime: '2022-09-15T10:00:00.000Z',
             nbAgentsFailed: 0,
+            hasRolloutPeriod: false,
           },
           {
             actionId: 'action5',
@@ -231,6 +234,7 @@ export default function (providerContext: FtrProviderContext) {
             creationTime: '2022-09-15T10:00:00.000Z',
             nbAgentsFailed: 0,
             cancellationTime: '2022-09-15T11:00:00.000Z',
+            hasRolloutPeriod: false,
           },
           {
             actionId: 'action7',
@@ -244,6 +248,7 @@ export default function (providerContext: FtrProviderContext) {
             creationTime: '2022-09-15T10:00:00.000Z',
             nbAgentsFailed: 1,
             completionTime: '2022-09-15T11:00:00.000Z',
+            hasRolloutPeriod: false,
           },
         ]);
       });


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/146112

## Summary
When upgrading agents with upgrade set to "immediately", the cancel button on agent activity panel is now hidden.

To determine whether the upgrade action is set to immediately or not I added a parameter `hasRolloutPeriod` to the `ActionStatus` response, so that this information is easily available in the activity panel.

### Before

<img width="1004" alt="Screenshot 2023-02-07 at 13 04 19" src="https://user-images.githubusercontent.com/16084106/217240273-d5b69edf-1ac7-48c0-bdd5-d44ab8f3c6aa.png">

### After
<img width="1002" alt="Screenshot 2023-02-07 at 13 03 29" src="https://user-images.githubusercontent.com/16084106/217240298-37eb4a7e-7f15-4864-ab84-c0b245091ecd.png">


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

