### PR TITLE
[Guided onboarding] Fix requests not firing

### DIFF
--- a/src/plugins/guided_onboarding/public/services/api.service.ts
+++ b/src/plugins/guided_onboarding/public/services/api.service.ts
@@ -148,10 +148,6 @@ export class ApiService implements GuidedOnboardingApi {
     if (!this.client) {
       throw new Error('ApiService has not be initialized.');
     }
-    // don't send a request if a request is already in flight
-    if (this.isLoading$.value) {
-      return undefined;
-    }
 
     try {
       this.isLoading$.next(true);
@@ -473,10 +469,6 @@ export class ApiService implements GuidedOnboardingApi {
     }
     if (!this.client) {
       throw new Error('ApiService has not be initialized.');
-    }
-    // don't send a request if a request is already in flight
-    if (this.isLoading$.value) {
-      return undefined;
     }
     this.isLoading$.next(true);
     const config = await this.configService.getGuideConfig(guideId);

--- a/src/plugins/guided_onboarding/public/services/api.service.ts
+++ b/src/plugins/guided_onboarding/public/services/api.service.ts
@@ -123,18 +123,10 @@ export class ApiService implements GuidedOnboardingApi {
     if (!this.client) {
       throw new Error('ApiService has not be initialized.');
     }
-    // don't send a request if a request is already in flight
-    if (this.isLoading$.value) {
-      return undefined;
-    }
 
     try {
-      this.isLoading$.next(true);
-      const response = await this.client.get<{ state: GuideState[] }>(`${API_BASE_PATH}/guides`);
-      this.isLoading$.next(false);
-      return response;
+      return await this.client.get<{ state: GuideState[] }>(`${API_BASE_PATH}/guides`);
     } catch (error) {
-      this.isLoading$.next(false);
       throw error;
     }
   }

--- a/src/plugins/guided_onboarding/public/services/api.test.ts
+++ b/src/plugins/guided_onboarding/public/services/api.test.ts
@@ -115,7 +115,7 @@ describe('GuidedOnboarding ApiService', () => {
       expect(httpClient.get).toHaveBeenCalledWith(`${API_BASE_PATH}/guides`);
     });
 
-    it('sends a request even if another request is in flight', async () => {
+    it('a request to all guides state API is sent even when a fetch plugin state request is in flight at the same time', async () => {
       httpClient.get.mockImplementationOnce(() => {
         return new Promise((resolve) => setTimeout(resolve));
       });
@@ -144,13 +144,12 @@ describe('GuidedOnboarding ApiService', () => {
       });
     });
 
-    it('sends a request even if another request is in flight', async () => {
+    it('a request to update plugin state API is sent even when a fetch plugin state request is in flight at the same time', async () => {
       httpClient.get.mockImplementationOnce(() => {
         return new Promise((resolve) => setTimeout(resolve));
       });
       await apiService.fetchPluginState$().subscribe();
       expect(apiService.isLoading$.value).toBe(true);
-      await apiService.getGuideConfig(testGuideId);
       await apiService.updatePluginState({ guide: testGuideStep1InProgressState }, false);
       expect(httpClient.put).toHaveBeenCalledTimes(1);
       expect(httpClient.put).toHaveBeenCalledWith(`${API_BASE_PATH}/state`, {
@@ -750,7 +749,7 @@ describe('GuidedOnboarding ApiService', () => {
       expect(httpClient.get).toHaveBeenLastCalledWith(`${API_BASE_PATH}/configs/${testGuideId}`);
     });
 
-    it('sends a request even if another request is in flight', async () => {
+    it('a request to config API is sent even when a fetch plugin state request is in flight at the same time', async () => {
       httpClient.get.mockImplementationOnce(() => {
         return new Promise((resolve) => setTimeout(resolve));
       });


### PR DESCRIPTION
## Summary
I introduced a bug in https://github.com/elastic/kibana/pull/149528 that prevents some requests from being sent if other guided onboarding requests are in flight. That should not be the case, because it's intended that some requests will be sent at the same time. For example, the guide panel needs to load the plugin state and a config of the guide. At the same time, if the user is on the landing page, its needs to load the state of all guides. 

### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
