### PR TITLE
[canvas] Run tests against @kbn/handlebars compileAST function

### DIFF
--- a/x-pack/plugins/canvas/common/lib/handlebars.test.js
+++ b/x-pack/plugins/canvas/common/lib/handlebars.test.js
@@ -10,11 +10,11 @@ import { Handlebars } from './handlebars';
 
 describe('handlebars', () => {
   it('registers math function and returns argument error', () => {
-    const template = Handlebars.compile("test math: {{math rows 'mean(price * quantity)' 2}}");
+    const template = Handlebars.compileAST("test math: {{math rows 'mean(price * quantity)' 2}}");
     expect(template()).toBe('test math: MATH ERROR: first argument must be an array');
   });
   it('evaluates math function successfully', () => {
-    const template = Handlebars.compile("test math: {{math rows 'mean(price * quantity)' 2}}");
+    const template = Handlebars.compileAST("test math: {{math rows 'mean(price * quantity)' 2}}");
     expect(template(testTable)).toBe('test math: 82164.33');
   });
 });


### PR DESCRIPTION
The `Handlebars` object exposed by the tested file (`x-pack/plugins/canvas/common/lib/handlebars.js`) is primarily meant to have its `compileAST` function called and not the `compile` function. This PR just updates the tests to reflect that.