### PR TITLE
[Fleet] Add feature flag for FQDN toggle

### DIFF
--- a/x-pack/plugins/fleet/common/experimental_features.ts
+++ b/x-pack/plugins/fleet/common/experimental_features.ts
@@ -19,6 +19,7 @@ export const allowedExperimentalValues = Object.freeze({
   experimentalDataStreamSettings: false,
   displayAgentMetrics: true,
   showIntegrationsSubcategories: false,
+  agentFqdnMode: true,
 });
 
 type ExperimentalConfigKeys = Array<keyof ExperimentalFeatures>;

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_advanced_fields/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_advanced_fields/index.tsx
@@ -39,7 +39,7 @@ import { AgentPolicyPackageBadge } from '../../../../components';
 import { AgentPolicyDeleteProvider } from '../agent_policy_delete_provider';
 import type { ValidationResults } from '../agent_policy_validation';
 
-import { policyHasFleetServer } from '../../../../services';
+import { ExperimentalFeaturesService, policyHasFleetServer } from '../../../../services';
 
 import {
   useOutputOptions,
@@ -67,6 +67,7 @@ export const AgentPolicyAdvancedOptionsContent: React.FunctionComponent<Props> =
   isEditing = false,
   onDelete = () => {},
 }) => {
+  const { agentFqdnMode: agentFqdnModeEnabled } = ExperimentalFeaturesService.get();
   const { docLinks } = useStartServices();
   const [touchedFields, setTouchedFields] = useState<{ [key: string]: boolean }>({});
   const {
@@ -521,36 +522,64 @@ export const AgentPolicyAdvancedOptionsContent: React.FunctionComponent<Props> =
           />
         </EuiFormRow>
       </EuiDescribedFormGroup>
-      <EuiDescribedFormGroup
-        title={
-          <h4>
+      {agentFqdnModeEnabled && (
+        <EuiDescribedFormGroup
+          title={
+            <h4>
+              <FormattedMessage
+                id="xpack.fleet.agentPolicyForm.hostnameFormatLabel"
+                defaultMessage="Host name format"
+              />
+            </h4>
+          }
+          description={
             <FormattedMessage
-              id="xpack.fleet.agentPolicyForm.hostnameFormatLabel"
-              defaultMessage="Host name format"
+              id="xpack.fleet.agentPolicyForm.hostnameFormatLabelDescription"
+              defaultMessage="Select how you would like agent domain names to be displayed."
             />
-          </h4>
-        }
-        description={
-          <FormattedMessage
-            id="xpack.fleet.agentPolicyForm.hostnameFormatLabelDescription"
-            defaultMessage="Select how you would like agent domain names to be displayed."
-          />
-        }
-      >
-        <EuiFormRow fullWidth>
-          <EuiRadioGroup
-            options={[
-              {
-                id: 'hostname',
-                label: (
-                  <>
+          }
+        >
+          <EuiFormRow fullWidth>
+            <EuiRadioGroup
+              options={[
+                {
+                  id: 'hostname',
+                  label: (
+                    <>
+                      <EuiFlexGroup gutterSize="xs" direction="column">
+                        <EuiFlexItem grow={false}>
+                          <EuiText size="s">
+                            <b>
+                              <FormattedMessage
+                                id="xpack.fleet.agentPolicyForm.hostnameFormatOptionHostname"
+                                defaultMessage="Hostname"
+                              />
+                            </b>
+                          </EuiText>
+                        </EuiFlexItem>
+                        <EuiFlexItem grow={false}>
+                          <EuiText size="s" color="subdued">
+                            <FormattedMessage
+                              id="xpack.fleet.agentPolicyForm.hostnameFormatOptionHostnameExample"
+                              defaultMessage="ex: My-Laptop"
+                            />
+                          </EuiText>
+                        </EuiFlexItem>
+                      </EuiFlexGroup>
+                      <EuiSpacer size="s" />
+                    </>
+                  ),
+                },
+                {
+                  id: 'fqdn',
+                  label: (
                     <EuiFlexGroup gutterSize="xs" direction="column">
                       <EuiFlexItem grow={false}>
                         <EuiText size="s">
                           <b>
                             <FormattedMessage
-                              id="xpack.fleet.agentPolicyForm.hostnameFormatOptionHostname"
-                              defaultMessage="Hostname"
+                              id="xpack.fleet.agentPolicyForm.hostnameFormatOptionFqdn"
+                              defaultMessage="Fully Qualified Domain Name (FQDN)"
                             />
                           </b>
                         </EuiText>
@@ -558,52 +587,26 @@ export const AgentPolicyAdvancedOptionsContent: React.FunctionComponent<Props> =
                       <EuiFlexItem grow={false}>
                         <EuiText size="s" color="subdued">
                           <FormattedMessage
-                            id="xpack.fleet.agentPolicyForm.hostnameFormatOptionHostnameExample"
-                            defaultMessage="ex: My-Laptop"
+                            id="xpack.fleet.agentPolicyForm.hostnameFormatOptionFqdnExample"
+                            defaultMessage="ex: My-Laptop.admin.acme.co"
                           />
                         </EuiText>
                       </EuiFlexItem>
                     </EuiFlexGroup>
-                    <EuiSpacer size="s" />
-                  </>
-                ),
-              },
-              {
-                id: 'fqdn',
-                label: (
-                  <EuiFlexGroup gutterSize="xs" direction="column">
-                    <EuiFlexItem grow={false}>
-                      <EuiText size="s">
-                        <b>
-                          <FormattedMessage
-                            id="xpack.fleet.agentPolicyForm.hostnameFormatOptionFqdn"
-                            defaultMessage="Fully Qualified Domain Name (FQDN)"
-                          />
-                        </b>
-                      </EuiText>
-                    </EuiFlexItem>
-                    <EuiFlexItem grow={false}>
-                      <EuiText size="s" color="subdued">
-                        <FormattedMessage
-                          id="xpack.fleet.agentPolicyForm.hostnameFormatOptionFqdnExample"
-                          defaultMessage="ex: My-Laptop.admin.acme.co"
-                        />
-                      </EuiText>
-                    </EuiFlexItem>
-                  </EuiFlexGroup>
-                ),
-              },
-            ]}
-            idSelected={agentPolicy.agent_features?.length ? 'fqdn' : 'hostname'}
-            onChange={(id: string) => {
-              updateAgentPolicy({
-                agent_features: id === 'hostname' ? [] : [{ name: 'fqdn', enabled: true }],
-              });
-            }}
-            name="radio group"
-          />
-        </EuiFormRow>
-      </EuiDescribedFormGroup>
+                  ),
+                },
+              ]}
+              idSelected={agentPolicy.agent_features?.length ? 'fqdn' : 'hostname'}
+              onChange={(id: string) => {
+                updateAgentPolicy({
+                  agent_features: id === 'hostname' ? [] : [{ name: 'fqdn', enabled: true }],
+                });
+              }}
+              name="radio group"
+            />
+          </EuiFormRow>
+        </EuiDescribedFormGroup>
+      )}
       {isEditing && 'id' in agentPolicy && !agentPolicy.is_managed ? (
         <EuiDescribedFormGroup
           title={


### PR DESCRIPTION
Part of #149059 

Add a feature flag which will remove the hostname toggle from the UI if we need to remove it at the last minute (e.g the agent work doesn't make it into 8.7)