### PR TITLE
[8.6] [Cases] Improve functional tests (#150117)

### DIFF
--- a/x-pack/plugins/cases/public/components/case_action_bar/actions.test.tsx
+++ b/x-pack/plugins/cases/public/components/case_action_bar/actions.test.tsx
@@ -50,8 +50,11 @@ describe('CaseView actions', () => {
     );
 
     expect(wrapper.find('[data-test-subj="confirm-delete-case-modal"]').exists()).toBeFalsy();
-    wrapper.find('button[data-test-subj="property-actions-ellipses"]').first().simulate('click');
-    wrapper.find('button[data-test-subj="property-actions-trash"]').simulate('click');
+    wrapper
+      .find('button[data-test-subj="property-actions-case-ellipses"]')
+      .first()
+      .simulate('click');
+    wrapper.find('button[data-test-subj="property-actions-case-trash"]').simulate('click');
     expect(wrapper.find('[data-test-subj="confirm-delete-case-modal"]').exists()).toBeTruthy();
   });
 
@@ -63,7 +66,7 @@ describe('CaseView actions', () => {
     );
 
     expect(wrapper.find('[data-test-subj="confirm-delete-case-modal"]').exists()).toBeFalsy();
-    expect(wrapper.find('button[data-test-subj="property-actions-ellipses"]').exists()).toBeFalsy();
+    expect(wrapper.find('button[data-test-subj="property-actions-case-ellipses"]').exists()).toBeFalsy();
   });
 
   it('toggle delete modal and confirm', async () => {
@@ -77,8 +80,11 @@ describe('CaseView actions', () => {
       </TestProviders>
     );
 
-    wrapper.find('button[data-test-subj="property-actions-ellipses"]').first().simulate('click');
-    wrapper.find('button[data-test-subj="property-actions-trash"]').simulate('click');
+    wrapper
+      .find('button[data-test-subj="property-actions-case-ellipses"]')
+      .first()
+      .simulate('click');
+    wrapper.find('button[data-test-subj="property-actions-case-trash"]').simulate('click');
 
     expect(wrapper.find('[data-test-subj="confirm-delete-case-modal"]').exists()).toBeTruthy();
     wrapper.find('button[data-test-subj="confirmModalConfirmButton"]').simulate('click');
@@ -106,9 +112,12 @@ describe('CaseView actions', () => {
 
     expect(wrapper.find('[data-test-subj="confirm-delete-case-modal"]').exists()).toBeFalsy();
 
-    wrapper.find('button[data-test-subj="property-actions-ellipses"]').first().simulate('click');
+    wrapper
+      .find('button[data-test-subj="property-actions-case-ellipses"]')
+      .first()
+      .simulate('click');
     expect(
-      wrapper.find('[data-test-subj="property-actions-popout"]').first().prop('aria-label')
+      wrapper.find('[data-test-subj="property-actions-case-popout"]').first().prop('aria-label')
     ).toEqual(i18n.VIEW_INCIDENT(basicPush.externalTitle));
   });
 });

--- a/x-pack/plugins/cases/public/components/case_action_bar/actions.test.tsx
+++ b/x-pack/plugins/cases/public/components/case_action_bar/actions.test.tsx
@@ -66,7 +66,9 @@ describe('CaseView actions', () => {
     );
 
     expect(wrapper.find('[data-test-subj="confirm-delete-case-modal"]').exists()).toBeFalsy();
-    expect(wrapper.find('button[data-test-subj="property-actions-case-ellipses"]').exists()).toBeFalsy();
+    expect(
+      wrapper.find('button[data-test-subj="property-actions-case-ellipses"]').exists()
+    ).toBeFalsy();
   });
 
   it('toggle delete modal and confirm', async () => {

--- a/x-pack/plugins/cases/public/components/case_action_bar/actions.tsx
+++ b/x-pack/plugins/cases/public/components/case_action_bar/actions.tsx
@@ -74,7 +74,7 @@ const ActionsComponent: React.FC<CaseViewActions> = ({ caseData, currentExternal
 
   return (
     <EuiFlexItem grow={false} data-test-subj="case-view-actions">
-      <PropertyActions propertyActions={propertyActions} />
+      <PropertyActions propertyActions={propertyActions} customDataTestSubj={'case'} />
       {isModalVisible ? (
         <ConfirmDeleteCaseModal
           totalCasesToBeDeleted={1}

--- a/x-pack/plugins/cases/public/components/case_action_bar/index.test.tsx
+++ b/x-pack/plugins/cases/public/components/case_action_bar/index.test.tsx
@@ -233,7 +233,7 @@ describe('CaseActionBar', () => {
       </TestProviders>
     );
 
-    expect(queryByTestId('property-actions-ellipses')).not.toBeInTheDocument();
+    expect(queryByTestId('property-actions-case-ellipses')).not.toBeInTheDocument();
     expect(queryByText('Delete case')).not.toBeInTheDocument();
   });
 
@@ -244,7 +244,7 @@ describe('CaseActionBar', () => {
       </TestProviders>
     );
 
-    userEvent.click(screen.getByTestId('property-actions-ellipses'));
+    userEvent.click(screen.getByTestId('property-actions-case-ellipses'));
     expect(queryByText('Delete case')).toBeInTheDocument();
   });
 });

--- a/x-pack/plugins/cases/public/components/property_actions/index.tsx
+++ b/x-pack/plugins/cases/public/components/property_actions/index.tsx
@@ -24,17 +24,19 @@ const PropertyActionButton = React.memo<PropertyActionButtonProps>(
   ({ disabled = false, onClick, iconType, label, customDataTestSubj }) => {
     const dataTestSubjPrepend = makeDataTestSubjPrepend(customDataTestSubj);
 
-    return (<EuiButtonEmpty
-      aria-label={label}
-      color="text"
-      data-test-subj={`${dataTestSubjPrepend}-${iconType}`}
-      iconSide="left"
-      iconType={iconType}
-      isDisabled={disabled}
-      onClick={onClick}
-    >
-      {label}
-    </EuiButtonEmpty>)
+    return (
+      <EuiButtonEmpty
+        aria-label={label}
+        color="text"
+        data-test-subj={`${dataTestSubjPrepend}-${iconType}`}
+        iconSide="left"
+        iconType={iconType}
+        isDisabled={disabled}
+        onClick={onClick}
+      >
+        {label}
+      </EuiButtonEmpty>
+    );
   }
 );
 
@@ -80,23 +82,30 @@ export const PropertyActions = React.memo<PropertyActionsProps>(
         closePopover={onClosePopover}
         repositionOnScroll
       >
-        {propertyActions.map((action, key) => (
-          <EuiFlexItem grow={false} key={`${action.label}${key}`}>
-            <span>
-              <PropertyActionButton
-                disabled={action.disabled}
-                iconType={action.iconType}
-                label={action.label}
-                onClick={() => onClosePopover(action.onClick)}
-                customDataTestSubj={customDataTestSubj}
-              />
-            </span>
-          </EuiFlexItem>
-        ))}
-      </EuiFlexGroup>
-    </EuiPopover>
-  );
-});
+        <EuiFlexGroup
+          alignItems="flexStart"
+          data-test-subj={`${dataTestSubjPrepend}-group`}
+          direction="column"
+          gutterSize="none"
+        >
+          {propertyActions.map((action, key) => (
+            <EuiFlexItem grow={false} key={`${action.label}${key}`}>
+              <span>
+                <PropertyActionButton
+                  disabled={action.disabled}
+                  iconType={action.iconType}
+                  label={action.label}
+                  onClick={() => onClosePopover(action.onClick)}
+                  customDataTestSubj={customDataTestSubj}
+                />
+              </span>
+            </EuiFlexItem>
+          ))}
+        </EuiFlexGroup>
+      </EuiPopover>
+    );
+  }
+);
 
 PropertyActions.displayName = 'PropertyActions';
 

--- a/x-pack/plugins/cases/public/components/property_actions/index.tsx
+++ b/x-pack/plugins/cases/public/components/property_actions/index.tsx
@@ -15,69 +15,70 @@ export interface PropertyActionButtonProps {
   onClick: () => void;
   iconType: string;
   label: string;
+  customDataTestSubj?: string;
 }
 
 const ComponentId = 'property-actions';
 
 const PropertyActionButton = React.memo<PropertyActionButtonProps>(
-  ({ disabled = false, onClick, iconType, label }) => (
-    <EuiButtonEmpty
+  ({ disabled = false, onClick, iconType, label, customDataTestSubj }) => {
+    const dataTestSubjPrepend = makeDataTestSubjPrepend(customDataTestSubj);
+
+    return (<EuiButtonEmpty
       aria-label={label}
       color="text"
-      data-test-subj={`${ComponentId}-${iconType}`}
+      data-test-subj={`${dataTestSubjPrepend}-${iconType}`}
       iconSide="left"
       iconType={iconType}
       isDisabled={disabled}
       onClick={onClick}
     >
       {label}
-    </EuiButtonEmpty>
-  )
+    </EuiButtonEmpty>)
+  }
 );
 
 PropertyActionButton.displayName = 'PropertyActionButton';
 
 export interface PropertyActionsProps {
   propertyActions: PropertyActionButtonProps[];
+  customDataTestSubj?: string;
 }
 
-export const PropertyActions = React.memo<PropertyActionsProps>(({ propertyActions }) => {
-  const [showActions, setShowActions] = useState(false);
+export const PropertyActions = React.memo<PropertyActionsProps>(
+  ({ propertyActions, customDataTestSubj }) => {
+    const [showActions, setShowActions] = useState(false);
 
-  const onButtonClick = useCallback(() => {
-    setShowActions((prevShowActions) => !prevShowActions);
-  }, []);
+    const onButtonClick = useCallback(() => {
+      setShowActions((prevShowActions) => !prevShowActions);
+    }, []);
 
-  const onClosePopover = useCallback((cb?: () => void) => {
-    setShowActions(false);
-    if (cb != null) {
-      cb();
-    }
-  }, []);
-
-  return (
-    <EuiPopover
-      anchorPosition="downRight"
-      data-test-subj={ComponentId}
-      ownFocus
-      button={
-        <EuiButtonIcon
-          data-test-subj={`${ComponentId}-ellipses`}
-          aria-label={i18n.ACTIONS_ARIA}
-          iconType="boxesHorizontal"
-          onClick={onButtonClick}
-        />
+    const onClosePopover = useCallback((cb?: () => void) => {
+      setShowActions(false);
+      if (cb != null) {
+        cb();
       }
-      id="settingsPopover"
-      isOpen={showActions}
-      closePopover={onClosePopover}
-      repositionOnScroll
-    >
-      <EuiFlexGroup
-        alignItems="flexStart"
-        data-test-subj={`${ComponentId}-group`}
-        direction="column"
-        gutterSize="none"
+    }, []);
+
+    const dataTestSubjPrepend = makeDataTestSubjPrepend(customDataTestSubj);
+
+    return (
+      <EuiPopover
+        anchorPosition="downRight"
+        data-test-subj={dataTestSubjPrepend}
+        ownFocus
+        button={
+          <EuiButtonIcon
+            data-test-subj={`${dataTestSubjPrepend}-ellipses`}
+            aria-label={i18n.ACTIONS_ARIA}
+            iconType="boxesHorizontal"
+            onClick={onButtonClick}
+          />
+        }
+        id="settingsPopover"
+        isOpen={showActions}
+        closePopover={onClosePopover}
+        repositionOnScroll
       >
         {propertyActions.map((action, key) => (
           <EuiFlexItem grow={false} key={`${action.label}${key}`}>
@@ -87,6 +88,7 @@ export const PropertyActions = React.memo<PropertyActionsProps>(({ propertyActio
                 iconType={action.iconType}
                 label={action.label}
                 onClick={() => onClosePopover(action.onClick)}
+                customDataTestSubj={customDataTestSubj}
               />
             </span>
           </EuiFlexItem>
@@ -97,3 +99,7 @@ export const PropertyActions = React.memo<PropertyActionsProps>(({ propertyActio
 });
 
 PropertyActions.displayName = 'PropertyActions';
+
+const makeDataTestSubjPrepend = (customDataTestSubj?: string) => {
+  return customDataTestSubj == null ? ComponentId : `${ComponentId}-${customDataTestSubj}`;
+};

--- a/x-pack/plugins/cases/public/components/user_actions/comment/comment.test.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/comment/comment.test.tsx
@@ -223,13 +223,13 @@ describe('createCommentUserActionBuilder', () => {
       );
 
       expect(result.getByText('Solve this fast!')).toBeInTheDocument();
-      expect(result.getByTestId('property-actions')).toBeInTheDocument();
+      expect(result.getByTestId('property-actions-user-action')).toBeInTheDocument();
 
-      userEvent.click(result.getByTestId('property-actions-ellipses'));
+      userEvent.click(result.getByTestId('property-actions-user-action-ellipses'));
       await waitForEuiPopoverOpen();
 
-      expect(result.queryByTestId('property-actions-pencil')).toBeInTheDocument();
-      userEvent.click(result.getByTestId('property-actions-pencil'));
+      expect(result.queryByTestId('property-actions-user-action-pencil')).toBeInTheDocument();
+      userEvent.click(result.getByTestId('property-actions-user-action-pencil'));
 
       await waitFor(() => {
         expect(builderArgs.handleManageMarkdownEditId).toHaveBeenCalledWith('basic-comment-id');
@@ -254,13 +254,13 @@ describe('createCommentUserActionBuilder', () => {
       );
 
       expect(result.getByText('Solve this fast!')).toBeInTheDocument();
-      expect(result.getByTestId('property-actions')).toBeInTheDocument();
+      expect(result.getByTestId('property-actions-user-action')).toBeInTheDocument();
 
-      userEvent.click(result.getByTestId('property-actions-ellipses'));
+      userEvent.click(result.getByTestId('property-actions-user-action-ellipses'));
       await waitForEuiPopoverOpen();
 
-      expect(result.queryByTestId('property-actions-quote')).toBeInTheDocument();
-      userEvent.click(result.getByTestId('property-actions-quote'));
+      expect(result.queryByTestId('property-actions-user-action-quote')).toBeInTheDocument();
+      userEvent.click(result.getByTestId('property-actions-user-action-quote'));
 
       await waitFor(() => {
         expect(builderArgs.handleManageQuote).toHaveBeenCalledWith('Solve this fast!');
@@ -769,14 +769,14 @@ describe('createCommentUserActionBuilder', () => {
 });
 
 const deleteAttachment = async (result: RenderResult, deleteIcon: string, buttonLabel: string) => {
-  expect(result.getByTestId('property-actions')).toBeInTheDocument();
+  expect(result.getByTestId('property-actions-user-action')).toBeInTheDocument();
 
-  userEvent.click(result.getByTestId('property-actions-ellipses'));
+  userEvent.click(result.getByTestId('property-actions-user-action-ellipses'));
   await waitForEuiPopoverOpen();
 
-  expect(result.queryByTestId(`property-actions-${deleteIcon}`)).toBeInTheDocument();
+  expect(result.queryByTestId(`property-actions-user-action-${deleteIcon}`)).toBeInTheDocument();
 
-  userEvent.click(result.getByTestId(`property-actions-${deleteIcon}`));
+  userEvent.click(result.getByTestId(`property-actions-user-action-${deleteIcon}`));
 
   await waitFor(() => {
     expect(result.queryByTestId('property-actions-confirm-modal')).toBeInTheDocument();

--- a/x-pack/plugins/cases/public/components/user_actions/description.test.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/description.test.tsx
@@ -58,13 +58,13 @@ describe('createDescriptionUserActionBuilder ', () => {
       </TestProviders>
     );
 
-    expect(res.getByTestId('property-actions')).toBeInTheDocument();
+    expect(res.getByTestId('property-actions-description')).toBeInTheDocument();
 
-    userEvent.click(res.getByTestId('property-actions-ellipses'));
+    userEvent.click(res.getByTestId('property-actions-description-ellipses'));
     await waitForEuiPopoverOpen();
 
-    expect(res.queryByTestId('property-actions-pencil')).toBeInTheDocument();
-    userEvent.click(res.getByTestId('property-actions-pencil'));
+    expect(res.queryByTestId('property-actions-description-pencil')).toBeInTheDocument();
+    userEvent.click(res.getByTestId('property-actions-description-pencil'));
 
     await waitFor(() => {
       expect(builderArgs.handleManageMarkdownEditId).toHaveBeenCalledWith('description');
@@ -84,13 +84,13 @@ describe('createDescriptionUserActionBuilder ', () => {
       </TestProviders>
     );
 
-    expect(res.getByTestId('property-actions')).toBeInTheDocument();
+    expect(res.getByTestId('property-actions-description')).toBeInTheDocument();
 
-    userEvent.click(res.getByTestId('property-actions-ellipses'));
+    userEvent.click(res.getByTestId('property-actions-description-ellipses'));
     await waitForEuiPopoverOpen();
 
-    expect(res.queryByTestId('property-actions-quote')).toBeInTheDocument();
-    userEvent.click(res.getByTestId('property-actions-quote'));
+    expect(res.queryByTestId('property-actions-description-quote')).toBeInTheDocument();
+    userEvent.click(res.getByTestId('property-actions-description-quote'));
 
     await waitFor(() => {
       expect(builderArgs.handleManageQuote).toHaveBeenCalledWith('Security banana Issue');

--- a/x-pack/plugins/cases/public/components/user_actions/index.test.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/index.test.tsx
@@ -203,13 +203,13 @@ describe(`UserActions`, () => {
 
     wrapper
       .find(
-        `[data-test-subj="comment-create-action-${props.data.comments[0].id}"] [data-test-subj="property-actions-ellipses"]`
+        `[data-test-subj="comment-create-action-${props.data.comments[0].id}"] [data-test-subj="property-actions-user-action-ellipses"]`
       )
       .first()
       .simulate('click');
     wrapper
       .find(
-        `[data-test-subj="comment-create-action-${props.data.comments[0].id}"] [data-test-subj="property-actions-pencil"]`
+        `[data-test-subj="comment-create-action-${props.data.comments[0].id}"] [data-test-subj="property-actions-user-action-pencil"]`
       )
       .first()
       .simulate('click');
@@ -247,14 +247,14 @@ describe(`UserActions`, () => {
 
     wrapper
       .find(
-        `[data-test-subj="comment-create-action-${props.data.comments[0].id}"] [data-test-subj="property-actions-ellipses"]`
+        `[data-test-subj="comment-create-action-${props.data.comments[0].id}"] [data-test-subj="property-actions-user-action-ellipses"]`
       )
       .first()
       .simulate('click');
 
     wrapper
       .find(
-        `[data-test-subj="comment-create-action-${props.data.comments[0].id}"] [data-test-subj="property-actions-pencil"]`
+        `[data-test-subj="comment-create-action-${props.data.comments[0].id}"] [data-test-subj="property-actions-user-action-pencil"]`
       )
       .first()
       .simulate('click');
@@ -299,12 +299,16 @@ describe(`UserActions`, () => {
     );
 
     wrapper
-      .find(`[data-test-subj="description-action"] [data-test-subj="property-actions-ellipses"]`)
+      .find(
+        `[data-test-subj="description-action"] [data-test-subj="property-actions-description-ellipses"]`
+      )
       .first()
       .simulate('click');
 
     wrapper
-      .find(`[data-test-subj="description-action"] [data-test-subj="property-actions-pencil"]`)
+      .find(
+        `[data-test-subj="description-action"] [data-test-subj="property-actions-description-pencil"]`
+      )
       .first()
       .simulate('click');
 
@@ -347,12 +351,16 @@ describe(`UserActions`, () => {
     expect(wrapper.find(`.euiMarkdownEditorTextArea`).text()).not.toContain(quoteableText);
 
     wrapper
-      .find(`[data-test-subj="description-action"] [data-test-subj="property-actions-ellipses"]`)
+      .find(
+        `[data-test-subj="description-action"] [data-test-subj="property-actions-description-ellipses"]`
+      )
       .first()
       .simulate('click');
 
     wrapper
-      .find(`[data-test-subj="description-action"] [data-test-subj="property-actions-quote"]`)
+      .find(
+        `[data-test-subj="description-action"] [data-test-subj="property-actions-description-quote"]`
+      )
       .first()
       .simulate('click');
 

--- a/x-pack/plugins/cases/public/components/user_actions/property_actions/alert_property_actions.test.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/property_actions/alert_property_actions.test.tsx
@@ -34,26 +34,26 @@ describe('AlertPropertyActions', () => {
   it('renders the correct number of actions', async () => {
     const result = appMock.render(<AlertPropertyActions {...props} />);
 
-    expect(result.getByTestId('property-actions')).toBeInTheDocument();
+    expect(result.getByTestId('property-actions-user-action')).toBeInTheDocument();
 
-    userEvent.click(result.getByTestId('property-actions-ellipses'));
+    userEvent.click(result.getByTestId('property-actions-user-action-ellipses'));
     await waitForEuiPopoverOpen();
 
-    expect(result.getByTestId('property-actions-group').children.length).toBe(1);
-    expect(result.queryByTestId('property-actions-minusInCircle')).toBeInTheDocument();
+    expect(result.getByTestId('property-actions-user-action-group').children.length).toBe(1);
+    expect(result.queryByTestId('property-actions-user-action-minusInCircle')).toBeInTheDocument();
   });
 
   it('renders the modal info correctly for one alert', async () => {
     const result = appMock.render(<AlertPropertyActions {...props} />);
 
-    expect(result.getByTestId('property-actions')).toBeInTheDocument();
+    expect(result.getByTestId('property-actions-user-action')).toBeInTheDocument();
 
-    userEvent.click(result.getByTestId('property-actions-ellipses'));
+    userEvent.click(result.getByTestId('property-actions-user-action-ellipses'));
     await waitForEuiPopoverOpen();
 
-    expect(result.queryByTestId('property-actions-minusInCircle')).toBeInTheDocument();
+    expect(result.queryByTestId('property-actions-user-action-minusInCircle')).toBeInTheDocument();
 
-    userEvent.click(result.getByTestId('property-actions-minusInCircle'));
+    userEvent.click(result.getByTestId('property-actions-user-action-minusInCircle'));
 
     await waitFor(() => {
       expect(result.queryByTestId('property-actions-confirm-modal')).toBeInTheDocument();
@@ -66,14 +66,14 @@ describe('AlertPropertyActions', () => {
   it('renders the modal info correctly for multiple alert', async () => {
     const result = appMock.render(<AlertPropertyActions {...props} totalAlerts={2} />);
 
-    expect(result.getByTestId('property-actions')).toBeInTheDocument();
+    expect(result.getByTestId('property-actions-user-action')).toBeInTheDocument();
 
-    userEvent.click(result.getByTestId('property-actions-ellipses'));
+    userEvent.click(result.getByTestId('property-actions-user-action-ellipses'));
     await waitForEuiPopoverOpen();
 
-    expect(result.queryByTestId('property-actions-minusInCircle')).toBeInTheDocument();
+    expect(result.queryByTestId('property-actions-user-action-minusInCircle')).toBeInTheDocument();
 
-    userEvent.click(result.getByTestId('property-actions-minusInCircle'));
+    userEvent.click(result.getByTestId('property-actions-user-action-minusInCircle'));
 
     await waitFor(() => {
       expect(result.queryByTestId('property-actions-confirm-modal')).toBeInTheDocument();
@@ -86,14 +86,14 @@ describe('AlertPropertyActions', () => {
   it('remove alerts correctly', async () => {
     const result = appMock.render(<AlertPropertyActions {...props} />);
 
-    expect(result.getByTestId('property-actions')).toBeInTheDocument();
+    expect(result.getByTestId('property-actions-user-action')).toBeInTheDocument();
 
-    userEvent.click(result.getByTestId('property-actions-ellipses'));
+    userEvent.click(result.getByTestId('property-actions-user-action-ellipses'));
     await waitForEuiPopoverOpen();
 
-    expect(result.queryByTestId('property-actions-minusInCircle')).toBeInTheDocument();
+    expect(result.queryByTestId('property-actions-user-action-minusInCircle')).toBeInTheDocument();
 
-    userEvent.click(result.getByTestId('property-actions-minusInCircle'));
+    userEvent.click(result.getByTestId('property-actions-user-action-minusInCircle'));
 
     await waitFor(() => {
       expect(result.queryByTestId('property-actions-confirm-modal')).toBeInTheDocument();
@@ -107,13 +107,13 @@ describe('AlertPropertyActions', () => {
     appMock = createAppMockRenderer({ permissions: noCasesPermissions() });
     const result = appMock.render(<AlertPropertyActions {...props} />);
 
-    expect(result.queryByTestId('property-actions')).not.toBeInTheDocument();
+    expect(result.queryByTestId('property-actions-user-action')).not.toBeInTheDocument();
   });
 
   it('does show the property actions with only delete permissions', async () => {
     appMock = createAppMockRenderer({ permissions: onlyDeleteCasesPermission() });
     const result = appMock.render(<AlertPropertyActions {...props} />);
 
-    expect(result.getByTestId('property-actions')).toBeInTheDocument();
+    expect(result.getByTestId('property-actions-user-action')).toBeInTheDocument();
   });
 });

--- a/x-pack/plugins/cases/public/components/user_actions/property_actions/description_property_actions.test.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/property_actions/description_property_actions.test.tsx
@@ -29,27 +29,27 @@ describe('DescriptionPropertyActions', () => {
   it('renders the correct number of actions', async () => {
     const result = appMock.render(<DescriptionPropertyActions {...props} />);
 
-    expect(result.getByTestId('property-actions')).toBeInTheDocument();
+    expect(result.getByTestId('property-actions-description')).toBeInTheDocument();
 
-    userEvent.click(result.getByTestId('property-actions-ellipses'));
+    userEvent.click(result.getByTestId('property-actions-description-ellipses'));
     await waitForEuiPopoverOpen();
 
-    expect(result.getByTestId('property-actions-group').children.length).toBe(2);
-    expect(result.queryByTestId('property-actions-pencil')).toBeInTheDocument();
-    expect(result.queryByTestId('property-actions-quote')).toBeInTheDocument();
+    expect(result.getByTestId('property-actions-description-group').children.length).toBe(2);
+    expect(result.queryByTestId('property-actions-description-pencil')).toBeInTheDocument();
+    expect(result.queryByTestId('property-actions-description-quote')).toBeInTheDocument();
   });
 
   it('edits the description correctly', async () => {
     const result = appMock.render(<DescriptionPropertyActions {...props} />);
 
-    expect(result.getByTestId('property-actions')).toBeInTheDocument();
+    expect(result.getByTestId('property-actions-description')).toBeInTheDocument();
 
-    userEvent.click(result.getByTestId('property-actions-ellipses'));
+    userEvent.click(result.getByTestId('property-actions-description-ellipses'));
     await waitForEuiPopoverOpen();
 
-    expect(result.queryByTestId('property-actions-pencil')).toBeInTheDocument();
+    expect(result.queryByTestId('property-actions-description-pencil')).toBeInTheDocument();
 
-    userEvent.click(result.getByTestId('property-actions-pencil'));
+    userEvent.click(result.getByTestId('property-actions-description-pencil'));
 
     expect(props.onEdit).toHaveBeenCalled();
   });
@@ -57,14 +57,14 @@ describe('DescriptionPropertyActions', () => {
   it('quotes the description correctly', async () => {
     const result = appMock.render(<DescriptionPropertyActions {...props} />);
 
-    expect(result.getByTestId('property-actions')).toBeInTheDocument();
+    expect(result.getByTestId('property-actions-description')).toBeInTheDocument();
 
-    userEvent.click(result.getByTestId('property-actions-ellipses'));
+    userEvent.click(result.getByTestId('property-actions-description-ellipses'));
     await waitForEuiPopoverOpen();
 
-    expect(result.queryByTestId('property-actions-quote')).toBeInTheDocument();
+    expect(result.queryByTestId('property-actions-description-quote')).toBeInTheDocument();
 
-    userEvent.click(result.getByTestId('property-actions-quote'));
+    userEvent.click(result.getByTestId('property-actions-description-quote'));
 
     expect(props.onQuote).toHaveBeenCalled();
   });
@@ -73,6 +73,6 @@ describe('DescriptionPropertyActions', () => {
     appMock = createAppMockRenderer({ permissions: noCasesPermissions() });
     const result = appMock.render(<DescriptionPropertyActions {...props} />);
 
-    expect(result.queryByTestId('property-actions')).not.toBeInTheDocument();
+    expect(result.queryByTestId('property-actions-description')).not.toBeInTheDocument();
   });
 });

--- a/x-pack/plugins/cases/public/components/user_actions/property_actions/description_property_actions.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/property_actions/description_property_actions.tsx
@@ -45,7 +45,13 @@ const DescriptionPropertyActionsComponent: React.FC<Props> = ({ isLoading, onEdi
     ];
   }, [permissions.update, permissions.create, onEdit, onQuote]);
 
-  return <UserActionPropertyActions isLoading={isLoading} propertyActions={propertyActions} />;
+  return (
+    <UserActionPropertyActions
+      isLoading={isLoading}
+      propertyActions={propertyActions}
+      customDataTestSubj={'description'}
+    />
+  );
 };
 
 DescriptionPropertyActionsComponent.displayName = 'DescriptionPropertyActions';

--- a/x-pack/plugins/cases/public/components/user_actions/property_actions/property_actions.test.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/property_actions/property_actions.test.tsx
@@ -36,19 +36,19 @@ describe('UserActionPropertyActions', () => {
     const result = appMock.render(<UserActionPropertyActions {...props} isLoading={true} />);
 
     expect(result.getByTestId('user-action-title-loading')).toBeInTheDocument();
-    expect(result.queryByTestId('property-actions')).not.toBeInTheDocument();
+    expect(result.queryByTestId('property-actions-user-action')).not.toBeInTheDocument();
   });
 
   it('renders the property actions', async () => {
     const result = appMock.render(<UserActionPropertyActions {...props} isLoading={false} />);
 
-    expect(result.getByTestId('property-actions')).toBeInTheDocument();
+    expect(result.getByTestId('property-actions-user-action')).toBeInTheDocument();
 
-    userEvent.click(result.getByTestId('property-actions-ellipses'));
+    userEvent.click(result.getByTestId('property-actions-user-action-ellipses'));
     await waitForEuiPopoverOpen();
 
-    expect(result.getByTestId('property-actions-group').children.length).toBe(1);
-    expect(result.queryByTestId('property-actions-pencil')).toBeInTheDocument();
+    expect(result.getByTestId('property-actions-user-action-group').children.length).toBe(1);
+    expect(result.queryByTestId('property-actions-user-action-pencil')).toBeInTheDocument();
   });
 
   it('does not render if properties are empty', async () => {
@@ -56,7 +56,7 @@ describe('UserActionPropertyActions', () => {
       <UserActionPropertyActions {...props} isLoading={false} propertyActions={[]} />
     );
 
-    expect(result.queryByTestId('property-actions')).not.toBeInTheDocument();
+    expect(result.queryByTestId('property-actions-user-action')).not.toBeInTheDocument();
     expect(result.queryByTestId('user-action-title-loading')).not.toBeInTheDocument();
   });
 });

--- a/x-pack/plugins/cases/public/components/user_actions/property_actions/property_actions.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/property_actions/property_actions.tsx
@@ -13,9 +13,14 @@ import { PropertyActions } from '../../property_actions';
 interface Props {
   isLoading: boolean;
   propertyActions: PropertyActionButtonProps[];
+  customDataTestSubj?: string;
 }
 
-const UserActionPropertyActionsComponent: React.FC<Props> = ({ isLoading, propertyActions }) => {
+const UserActionPropertyActionsComponent: React.FC<Props> = ({
+  isLoading,
+  propertyActions,
+  customDataTestSubj = 'user-action',
+}) => {
   if (propertyActions.length === 0) {
     return null;
   }
@@ -25,7 +30,10 @@ const UserActionPropertyActionsComponent: React.FC<Props> = ({ isLoading, proper
       {isLoading ? (
         <EuiLoadingSpinner data-test-subj="user-action-title-loading" />
       ) : (
-        <PropertyActions propertyActions={propertyActions} />
+        <PropertyActions
+          propertyActions={propertyActions}
+          customDataTestSubj={customDataTestSubj}
+        />
       )}
     </EuiFlexItem>
   );

--- a/x-pack/plugins/cases/public/components/user_actions/property_actions/registered_attachments_property_actions.test.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/property_actions/registered_attachments_property_actions.test.tsx
@@ -33,26 +33,26 @@ describe('RegisteredAttachmentsPropertyActions', () => {
   it('renders the correct number of actions', async () => {
     const result = appMock.render(<RegisteredAttachmentsPropertyActions {...props} />);
 
-    expect(result.getByTestId('property-actions')).toBeInTheDocument();
+    expect(result.getByTestId('property-actions-user-action')).toBeInTheDocument();
 
-    userEvent.click(result.getByTestId('property-actions-ellipses'));
+    userEvent.click(result.getByTestId('property-actions-user-action-ellipses'));
     await waitForEuiPopoverOpen();
 
-    expect(result.getByTestId('property-actions-group').children.length).toBe(1);
-    expect(result.queryByTestId('property-actions-trash')).toBeInTheDocument();
+    expect(result.getByTestId('property-actions-user-action-group').children.length).toBe(1);
+    expect(result.queryByTestId('property-actions-user-action-trash')).toBeInTheDocument();
   });
 
   it('renders the modal info correctly', async () => {
     const result = appMock.render(<RegisteredAttachmentsPropertyActions {...props} />);
 
-    expect(result.getByTestId('property-actions')).toBeInTheDocument();
+    expect(result.getByTestId('property-actions-user-action')).toBeInTheDocument();
 
-    userEvent.click(result.getByTestId('property-actions-ellipses'));
+    userEvent.click(result.getByTestId('property-actions-user-action-ellipses'));
     await waitForEuiPopoverOpen();
 
-    expect(result.queryByTestId('property-actions-trash')).toBeInTheDocument();
+    expect(result.queryByTestId('property-actions-user-action-trash')).toBeInTheDocument();
 
-    userEvent.click(result.getByTestId('property-actions-trash'));
+    userEvent.click(result.getByTestId('property-actions-user-action-trash'));
 
     await waitFor(() => {
       expect(result.queryByTestId('property-actions-confirm-modal')).toBeInTheDocument();
@@ -65,14 +65,14 @@ describe('RegisteredAttachmentsPropertyActions', () => {
   it('remove attachments correctly', async () => {
     const result = appMock.render(<RegisteredAttachmentsPropertyActions {...props} />);
 
-    expect(result.getByTestId('property-actions')).toBeInTheDocument();
+    expect(result.getByTestId('property-actions-user-action')).toBeInTheDocument();
 
-    userEvent.click(result.getByTestId('property-actions-ellipses'));
+    userEvent.click(result.getByTestId('property-actions-user-action-ellipses'));
     await waitForEuiPopoverOpen();
 
-    expect(result.queryByTestId('property-actions-trash')).toBeInTheDocument();
+    expect(result.queryByTestId('property-actions-user-action-trash')).toBeInTheDocument();
 
-    userEvent.click(result.getByTestId('property-actions-trash'));
+    userEvent.click(result.getByTestId('property-actions-user-action-trash'));
 
     await waitFor(() => {
       expect(result.queryByTestId('property-actions-confirm-modal')).toBeInTheDocument();
@@ -86,13 +86,13 @@ describe('RegisteredAttachmentsPropertyActions', () => {
     appMock = createAppMockRenderer({ permissions: noCasesPermissions() });
     const result = appMock.render(<RegisteredAttachmentsPropertyActions {...props} />);
 
-    expect(result.queryByTestId('property-actions')).not.toBeInTheDocument();
+    expect(result.queryByTestId('property-actions-user-action')).not.toBeInTheDocument();
   });
 
   it('does show the property actions with only delete permissions', async () => {
     appMock = createAppMockRenderer({ permissions: onlyDeleteCasesPermission() });
     const result = appMock.render(<RegisteredAttachmentsPropertyActions {...props} />);
 
-    expect(result.getByTestId('property-actions')).toBeInTheDocument();
+    expect(result.getByTestId('property-actions-user-action')).toBeInTheDocument();
   });
 });

--- a/x-pack/plugins/cases/public/components/user_actions/property_actions/user_comment_property_actions.test.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/property_actions/user_comment_property_actions.test.tsx
@@ -35,28 +35,28 @@ describe('UserCommentPropertyActions', () => {
   it('renders the correct number of actions', async () => {
     const result = appMock.render(<UserCommentPropertyActions {...props} />);
 
-    expect(result.getByTestId('property-actions')).toBeInTheDocument();
+    expect(result.getByTestId('property-actions-user-action')).toBeInTheDocument();
 
-    userEvent.click(result.getByTestId('property-actions-ellipses'));
+    userEvent.click(result.getByTestId('property-actions-user-action-ellipses'));
     await waitForEuiPopoverOpen();
 
-    expect(result.getByTestId('property-actions-group').children.length).toBe(3);
-    expect(result.queryByTestId('property-actions-pencil')).toBeInTheDocument();
-    expect(result.queryByTestId('property-actions-trash')).toBeInTheDocument();
-    expect(result.queryByTestId('property-actions-quote')).toBeInTheDocument();
+    expect(result.getByTestId('property-actions-user-action-group').children.length).toBe(3);
+    expect(result.queryByTestId('property-actions-user-action-pencil')).toBeInTheDocument();
+    expect(result.queryByTestId('property-actions-user-action-trash')).toBeInTheDocument();
+    expect(result.queryByTestId('property-actions-user-action-quote')).toBeInTheDocument();
   });
 
   it('edits the comment correctly', async () => {
     const result = appMock.render(<UserCommentPropertyActions {...props} />);
 
-    expect(result.getByTestId('property-actions')).toBeInTheDocument();
+    expect(result.getByTestId('property-actions-user-action')).toBeInTheDocument();
 
-    userEvent.click(result.getByTestId('property-actions-ellipses'));
+    userEvent.click(result.getByTestId('property-actions-user-action-ellipses'));
     await waitForEuiPopoverOpen();
 
-    expect(result.queryByTestId('property-actions-pencil')).toBeInTheDocument();
+    expect(result.queryByTestId('property-actions-user-action-pencil')).toBeInTheDocument();
 
-    userEvent.click(result.getByTestId('property-actions-pencil'));
+    userEvent.click(result.getByTestId('property-actions-user-action-pencil'));
 
     expect(props.onEdit).toHaveBeenCalled();
   });
@@ -64,14 +64,14 @@ describe('UserCommentPropertyActions', () => {
   it('quotes the comment correctly', async () => {
     const result = appMock.render(<UserCommentPropertyActions {...props} />);
 
-    expect(result.getByTestId('property-actions')).toBeInTheDocument();
+    expect(result.getByTestId('property-actions-user-action')).toBeInTheDocument();
 
-    userEvent.click(result.getByTestId('property-actions-ellipses'));
+    userEvent.click(result.getByTestId('property-actions-user-action-ellipses'));
     await waitForEuiPopoverOpen();
 
-    expect(result.queryByTestId('property-actions-quote')).toBeInTheDocument();
+    expect(result.queryByTestId('property-actions-user-action-quote')).toBeInTheDocument();
 
-    userEvent.click(result.getByTestId('property-actions-quote'));
+    userEvent.click(result.getByTestId('property-actions-user-action-quote'));
 
     expect(props.onQuote).toHaveBeenCalled();
   });
@@ -79,14 +79,14 @@ describe('UserCommentPropertyActions', () => {
   it('deletes the comment correctly', async () => {
     const result = appMock.render(<UserCommentPropertyActions {...props} />);
 
-    expect(result.getByTestId('property-actions')).toBeInTheDocument();
+    expect(result.getByTestId('property-actions-user-action')).toBeInTheDocument();
 
-    userEvent.click(result.getByTestId('property-actions-ellipses'));
+    userEvent.click(result.getByTestId('property-actions-user-action-ellipses'));
     await waitForEuiPopoverOpen();
 
-    expect(result.queryByTestId('property-actions-trash')).toBeInTheDocument();
+    expect(result.queryByTestId('property-actions-user-action-trash')).toBeInTheDocument();
 
-    userEvent.click(result.getByTestId('property-actions-trash'));
+    userEvent.click(result.getByTestId('property-actions-user-action-trash'));
 
     await waitFor(() => {
       expect(result.queryByTestId('property-actions-confirm-modal')).toBeInTheDocument();
@@ -100,13 +100,13 @@ describe('UserCommentPropertyActions', () => {
     appMock = createAppMockRenderer({ permissions: noCasesPermissions() });
     const result = appMock.render(<UserCommentPropertyActions {...props} />);
 
-    expect(result.queryByTestId('property-actions')).not.toBeInTheDocument();
+    expect(result.queryByTestId('property-actions-user-action')).not.toBeInTheDocument();
   });
 
   it('does show the property actions with only delete permissions', async () => {
     appMock = createAppMockRenderer({ permissions: onlyDeleteCasesPermission() });
     const result = appMock.render(<UserCommentPropertyActions {...props} />);
 
-    expect(result.getByTestId('property-actions')).toBeInTheDocument();
+    expect(result.getByTestId('property-actions-user-action')).toBeInTheDocument();
   });
 });

--- a/x-pack/test/functional/services/cases/list.ts
+++ b/x-pack/test/functional/services/cases/list.ts
@@ -81,9 +81,6 @@ export function CasesTableServiceProvider(
         rows = await find.allByCssSelector('[data-test-subj*="cases-table-row-"', 100);
         if (rows.length > 0) {
           await this.bulkDeleteAllCases();
-          // wait for a second
-          await new Promise((r) => setTimeout(r, 1000));
-          await header.waitUntilLoadingHasFinished();
         }
       } while (rows.length > 0);
     },

--- a/x-pack/test/functional/services/cases/single_case_view.ts
+++ b/x-pack/test/functional/services/cases/single_case_view.ts
@@ -20,14 +20,12 @@ export function CasesSingleViewServiceProvider({ getService, getPageObject }: Ft
 
   return {
     async deleteCase() {
-      const caseActions = await testSubjects.findDescendant(
-        'property-actions-ellipses',
-        await testSubjects.find('case-view-actions')
-      );
+      await retry.try(async () => {
+        await testSubjects.click('property-actions-case-ellipses');
+        await testSubjects.existOrFail('property-actions-case-trash', { timeout: 100 });
+      });
 
-      await caseActions.click();
-      await testSubjects.existOrFail('property-actions-trash');
-      await common.clickAndValidate('property-actions-trash', 'confirmModalConfirmButton');
+      await common.clickAndValidate('property-actions-case-trash', 'confirmModalConfirmButton');
       await testSubjects.click('confirmModalConfirmButton');
       await header.waitUntilLoadingHasFinished();
     },

--- a/x-pack/test/functional_with_es_ssl/apps/cases/deletion.ts
+++ b/x-pack/test/functional_with_es_ssl/apps/cases/deletion.ts
@@ -17,8 +17,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
   const testSubjects = getService('testSubjects');
   const cases = getService('cases');
 
-  // Failing: See https://github.com/elastic/kibana/issues/145271
-  describe.skip('cases deletion sub privilege', () => {
+  describe('cases deletion sub privilege', () => {
     before(async () => {
       await createUsersAndRoles(getService, users, roles);
       await PageObjects.security.forceLogout();
@@ -101,7 +100,8 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
             });
 
             it(`User ${user.username} cannot delete a case while on a specific case page`, async () => {
-              await testSubjects.missingOrFail('case-view-actions');
+              await testSubjects.click('property-actions-case-ellipses');
+              await testSubjects.missingOrFail('property-actions-case-trash');
             });
           });
 

--- a/x-pack/test/functional_with_es_ssl/apps/cases/deletion.ts
+++ b/x-pack/test/functional_with_es_ssl/apps/cases/deletion.ts
@@ -100,7 +100,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
             });
 
             it(`User ${user.username} cannot delete a case while on a specific case page`, async () => {
-              await testSubjects.click('property-actions-case-ellipses');
+              await testSubjects.missingOrFail('property-actions-case-ellipses');
               await testSubjects.missingOrFail('property-actions-case-trash');
             });
           });

--- a/x-pack/test/functional_with_es_ssl/apps/cases/view_case.ts
+++ b/x-pack/test/functional_with_es_ssl/apps/cases/view_case.ts
@@ -14,7 +14,7 @@ import {
   createUsersAndRoles,
   deleteUsersAndRoles,
 } from '../../../cases_api_integration/common/lib/authentication';
-import { users, roles, casesAllUser } from './common';
+import { users, roles, casesAllUser, casesAllUser2 } from './common';
 
 export default ({ getPageObject, getService }: FtrProviderContext) => {
   const header = getPageObject('header');
@@ -213,7 +213,7 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
     describe('Assignees field', () => {
       before(async () => {
         await createUsersAndRoles(getService, users, roles);
-        await cases.api.activateUserProfiles([casesAllUser]);
+        await cases.api.activateUserProfiles([casesAllUser, casesAllUser2]);
       });
 
       after(async () => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.6`:
 - [[Cases] Improve functional tests (#150117)](https://github.com/elastic/kibana/pull/150117)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Jonathan Buttner","email":"56361221+jonathan-buttner@users.noreply.github.com"},"sourceCommit":{"committedDate":"2023-02-06T20:38:36Z","message":"[Cases] Improve functional tests (#150117)\n\nThis PR tries to improve how often our functional tests succeeds. I also\r\ntried cleaning up a few things that seemed to be slowing the tests down\r\nand also causing errors when the tests were run individually.\r\n\r\nFixes: https://github.com/elastic/kibana/issues/145271\r\n\r\nNotable changes:\r\n- I added a value to the `property-actions*` in most places so that the\r\nfunctional tests can distinguish between a description, comment, or the\r\ncase ellipses this seems to work consistently where other methods have\r\nnot\r\n\r\nFlaky test run:\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/1871","sha":"c3ea5e5b3a2f0e13e743eea059404c81a07576c1","branchLabelMapping":{"^v8.7.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","Team:ResponseOps","Feature:Cases","v8.7.0"],"number":150117,"url":"https://github.com/elastic/kibana/pull/150117","mergeCommit":{"message":"[Cases] Improve functional tests (#150117)\n\nThis PR tries to improve how often our functional tests succeeds. I also\r\ntried cleaning up a few things that seemed to be slowing the tests down\r\nand also causing errors when the tests were run individually.\r\n\r\nFixes: https://github.com/elastic/kibana/issues/145271\r\n\r\nNotable changes:\r\n- I added a value to the `property-actions*` in most places so that the\r\nfunctional tests can distinguish between a description, comment, or the\r\ncase ellipses this seems to work consistently where other methods have\r\nnot\r\n\r\nFlaky test run:\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/1871","sha":"c3ea5e5b3a2f0e13e743eea059404c81a07576c1"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.7.0","labelRegex":"^v8.7.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/150117","number":150117,"mergeCommit":{"message":"[Cases] Improve functional tests (#150117)\n\nThis PR tries to improve how often our functional tests succeeds. I also\r\ntried cleaning up a few things that seemed to be slowing the tests down\r\nand also causing errors when the tests were run individually.\r\n\r\nFixes: https://github.com/elastic/kibana/issues/145271\r\n\r\nNotable changes:\r\n- I added a value to the `property-actions*` in most places so that the\r\nfunctional tests can distinguish between a description, comment, or the\r\ncase ellipses this seems to work consistently where other methods have\r\nnot\r\n\r\nFlaky test run:\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/1871","sha":"c3ea5e5b3a2f0e13e743eea059404c81a07576c1"}}]}] BACKPORT-->