### PR TITLE
Making maxTransactionGroupsExceeded false by default

### DIFF
--- a/x-pack/plugins/apm/public/components/shared/transactions_table/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/transactions_table/index.tsx
@@ -49,7 +49,7 @@ const INITIAL_STATE: InitialState = {
   requestId: '',
   mainStatisticsData: {
     transactionGroups: [],
-    maxTransactionGroupsExceeded: true,
+    maxTransactionGroupsExceeded: false,
     transactionOverflowCount: 0,
     transactionGroupsTotalItems: 0,
   },


### PR DESCRIPTION
Relates to https://github.com/elastic/kibana/issues/146648.

`maxTransactionGroupsExceeded` is currently `true` by default which is causing a flickering in transactions page specifically for the table, where we can see the callout for some milliseconds and then, after getting results from endpoint, disappears.

### before this change

https://user-images.githubusercontent.com/1313018/217316916-e6434f4a-c4e6-4e12-ba2b-5f5ab0011984.mov

