### PR TITLE
[TIP] fix broken cypress tests after change made in cases plugin

### DIFF
--- a/x-pack/plugins/threat_intelligence/cypress/screens/indicators.ts
+++ b/x-pack/plugins/threat_intelligence/cypress/screens/indicators.ts
@@ -191,9 +191,9 @@ export const CASE_COMMENT_EXTERNAL_REFERENCE = `[data-test-subj="comment-externa
 
 export const CASE_ACTION_WRAPPER = `[data-test-subj="case-action-bar-wrapper"]`;
 
-export const CASE_ELLIPSE_BUTTON = `[data-test-subj="property-actions-ellipses"]`;
+export const CASE_ELLIPSE_BUTTON = `[data-test-subj="property-actions-case-ellipses"]`;
 
-export const CASE_ELLIPSE_DELETE_CASE_OPTION = `[data-test-subj="property-actions-trash"]`;
+export const CASE_ELLIPSE_DELETE_CASE_OPTION = `[data-test-subj="property-actions-case-trash"]`;
 
 export const CASE_ELLIPSE_DELETE_CASE_CONFIRMATION_BUTTON = `[data-test-subj="confirmModalConfirmButton"]`;
 


### PR DESCRIPTION
## Summary
 
This [commit](https://github.com/elastic/kibana/commit/c3ea5e5b3a2f0e13e743eea059404c81a07576c1) updated some of the `data-test-subj` values in the Cases plugin. The Threat Intelligence plugin was using a couple of these and now the Cypress tests are failing.
This PR fixes that!