### PR TITLE
[RAM] Allow alert table to show new alert status on apm

### DIFF
--- a/x-pack/plugins/apm/public/components/app/alerts_overview/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/alerts_overview/index.tsx
@@ -103,6 +103,7 @@ export function AlertsOverview() {
               configurationId={AlertConsumers.OBSERVABILITY}
               featureIds={[AlertConsumers.APM]}
               query={esQuery}
+              showAlertStatusWithFlapping
               showExpandToDetails={false}
             />
           )}


### PR DESCRIPTION
## Summary

Add new alert status on APM alerts table

Before:
<img width="1318" alt="image" src="https://user-images.githubusercontent.com/189600/217375931-167777fb-b71c-4bfb-9c34-cbebb3d69a89.png">


After:
<img width="1310" alt="image" src="https://user-images.githubusercontent.com/189600/217375668-6e9ee5af-1163-4f3e-aded-b83ac12b0b8f.png">

