### PR TITLE
[7.17] [DOCS] Fix incorrect alt text for images (#149371)

### DIFF
--- a/docs/management/rollups/create_and_manage_rollups.asciidoc
+++ b/docs/management/rollups/create_and_manage_rollups.asciidoc
@@ -12,7 +12,7 @@ data for use in visualizations and reports.
 To get started, open the main menu, then click *Stack Management > Rollup Jobs*.
 
 [role="screenshot"]
-image::images/management_rollup_list.png[][List of currently active rollup jobs]
+image::images/management_rollup_list.png[List of currently active rollup jobs]
 
 Before using this feature, you should be familiar with how rollups work.
 {ref}/xpack-rollup.html[Rolling up historical data] is a good source for more detailed information.
@@ -39,21 +39,21 @@ will attempt to capture the data in the rollup index. For example, if your index
 you can name your rollup index `rollup-metricbeat`, but not `metricbeat-rollup`.
 
 [role="screenshot"]
-image::images/management_create_rollup_job.png[][Wizard that walks you through creation of a rollup job]
+image::images/management_create_rollup_job.png[Wizard that walks you through creation of a rollup job]
 
 [float]
 [[manage-rollup-job]]
 === Start, stop, and delete rollup jobs
 
-Once you’ve saved a rollup job, you’ll see it the *Rollup Jobs* overview page,
+Once you've saved a rollup job, you'll see it the *Rollup Jobs* overview page,
 where you can drill down for further investigation. The *Manage* menu enables
 you to start, stop, and delete the rollup job.
 You must first stop a rollup job before deleting it.
 
 [role="screenshot"]
-image::images/management_rollup_job_details.png[][Rollup job details]
+image::images/management_rollup_job_details.png[Rollup job details]
 
-You can’t change a rollup job after you’ve created it. To select additional fields
+You can't change a rollup job after you've created it. To select additional fields
 or redefine terms, you must delete the existing job, and then create a new one
 with the updated specifications. Be sure to use a different name for the new rollup
 job&mdash;reusing the same name can lead to problems with mismatched job configurations.
@@ -64,10 +64,10 @@ You can read more at {ref}/rollup-job-config.html[rollup job configuration].
 === Try it: Create and visualize rolled up data
 
 This example creates a rollup job to capture log data from sample web logs.
-Before you start, <<add-sample-data, add the web logs sample data set>>.
+Before you start, <<add-sample-data,add the web logs sample data set>>.
 
 In this example, you want data that is older than 7 days in the target index pattern `kibana_sample_data_logs`
-to roll up into the `rollup_logstash` index. You’ll bucket the
+to roll up into the `rollup_logstash` index. You'll bucket the
 rolled up data on an hourly basis, using 60m for the time bucket configuration.
 This allows for more granular queries, such as 2h and 12h.
 
@@ -164,7 +164,7 @@ pattern for raw data.
 as your source to see both the raw and rolled up data.
 +
 [role="screenshot"]
-image::images/management-create-rollup-bar-chart.png[][Create visualization of rolled up data]
+image::images/management-create-rollup-bar-chart.png[Create visualization of rolled up data]
 
 . Select *Bar vertical stacked* in the chart type dropdown.
 
@@ -177,4 +177,4 @@ bytes`.
 to zoom in.
 +
 [role="screenshot"]
-image::images/management_rollup_job_dashboard.png[][Dashboard with rolled up data]
+image::images/management_rollup_job_dashboard.png[Dashboard with rolled up data]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [[DOCS] Fix incorrect alt text for images (#149371)](https://github.com/elastic/kibana/pull/149371)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Lisa Cawley","email":"lcawley@elastic.co"},"sourceCommit":{"committedDate":"2023-01-24T20:49:33Z","message":"[DOCS] Fix incorrect alt text for images (#149371)","sha":"4c9a76cabdb6774e8f721b744cc264148c67aa40","branchLabelMapping":{"^v8.7.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Docs","release_note:skip","Feature:Rollups","backport missing","docs","backport:all-open","v8.7.0"],"number":149371,"url":"https://github.com/elastic/kibana/pull/149371","mergeCommit":{"message":"[DOCS] Fix incorrect alt text for images (#149371)","sha":"4c9a76cabdb6774e8f721b744cc264148c67aa40"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.7.0","labelRegex":"^v8.7.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/149371","number":149371,"mergeCommit":{"message":"[DOCS] Fix incorrect alt text for images (#149371)","sha":"4c9a76cabdb6774e8f721b744cc264148c67aa40"}},{"url":"https://github.com/elastic/kibana/pull/149452","number":149452,"branch":"8.6","state":"OPEN"}]}] BACKPORT-->