### PR TITLE
[Convert2Lens] Do not carry filters/query from dashboard to the converted embeddable

### DIFF
--- a/x-pack/plugins/lens/public/app_plugin/mounter.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/mounter.tsx
@@ -310,6 +310,12 @@ export async function mountApp(
         if (!initialContext) {
           data.query.filterManager.setAppFilters([]);
         }
+        // if user comes from a dashboard to convert a legacy viz to a Lens chart
+        // we clear up the dashboard filters and query
+        if (initialContext && 'isEmbeddable' in initialContext && initialContext.isEmbeddable) {
+          data.query.filterManager.setAppFilters([]);
+          data.query.queryString.clearQuery();
+        }
         lensStore.dispatch(setState(getPreloadedState(storeDeps) as LensAppState));
         lensStore.dispatch(loadInitial({ redirectCallback, initialInput, history: props.history }));
       }, [initialInput, props.history, redirectCallback]);

--- a/x-pack/test/functional/apps/lens/open_in_lens/dashboard/dashboard.ts
+++ b/x-pack/test/functional/apps/lens/open_in_lens/dashboard/dashboard.ts
@@ -22,6 +22,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const retry = getService('retry');
   const panelActions = getService('dashboardPanelActions');
   const dashboardAddPanel = getService('dashboardAddPanel');
+  const filterBar = getService('filterBar');
 
   describe('Convert to Lens action on dashboard', function describeIndexTests() {
     before(async () => {
@@ -37,6 +38,9 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       await testSubjects.exists('visualizesaveAndReturnButton');
       await testSubjects.click('visualizesaveAndReturnButton');
       await dashboard.waitForRenderComplete();
+      // define a filter
+      await filterBar.addFilter({ field: 'geo.src', operation: 'is', value: 'CN' });
+      await dashboard.waitForRenderComplete();
       expect(await dashboard.isNotificationExists(0)).to.be(true);
     });
 
@@ -46,6 +50,8 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       await lens.waitForVisualization('xyVisChart');
       const lastBreadcrumbdcrumb = await testSubjects.getVisibleText('breadcrumb last');
       expect(lastBreadcrumbdcrumb).to.be('Converting Area visualization');
+      const filterCount = await filterBar.getFilterCount();
+      expect(filterCount).to.equal(0);
       await lens.replaceInDashboard();
 
       await retry.try(async () => {


### PR DESCRIPTION

## Summary

Closes https://github.com/elastic/kibana/issues/150283

When a user navigates from another app to Lens with context (Discover, legacy editors, dashboard convert to Lens action) then the filters and query from the originating app are carried to Lens. This makes sense for the first 2 but not for the latter as we don't want to carry the dahsboard search context to the Lens editor.

![lens](https://user-images.githubusercontent.com/17003240/217473766-afe827a1-81db-4093-800f-450d33932507.gif)


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios