### PR TITLE
[Fleet] disable reinstall with tooltip for uploaded packages

### DIFF
--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/settings/settings.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/settings/settings.tsx
@@ -407,7 +407,14 @@ export const SettingsPage: React.FC<Props> = memo(({ packageInfo, theme$ }: Prop
                     </EuiFlexItem>
                     <EuiFlexItem grow={false}>
                       <div>
-                        <ReinstallButton {...packageInfo} />
+                        <ReinstallButton
+                          {...packageInfo}
+                          installSource={
+                            'savedObject' in packageInfo
+                              ? packageInfo.savedObject.attributes.install_source
+                              : ''
+                          }
+                        />
                       </div>
                     </EuiFlexItem>
                   </EuiFlexGroup>


### PR DESCRIPTION
## Summary

Disable Reinstall button and added tooltip to prevent clicking Reinstall for uploaded packages.

Related to https://github.com/elastic/kibana/issues/148599#issuecomment-1420869104

<img width="731" alt="image" src="https://user-images.githubusercontent.com/90178898/217497440-e36bad4d-d4dc-4d1c-b434-b17f0a4ead0a.png">



### Checklist


- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
