### PR TITLE
Changing the Anomaly detection icon on APM

### DIFF
--- a/x-pack/plugins/apm/public/components/shared/apm_header_action_menu/anomaly_detection_setup_link.tsx
+++ b/x-pack/plugins/apm/public/components/shared/apm_header_action_menu/anomaly_detection_setup_link.tsx
@@ -46,7 +46,7 @@ export function AnomalyDetectionSetupLink() {
         defaultMessage: 'Could not determine state of anomaly detection setup.',
       }
     );
-    icon = 'alert';
+    icon = 'machineLearningApp';
   } else if (
     anomalyDetectionSetupState === AnomalyDetectionSetupState.NoJobs ||
     anomalyDetectionSetupState ===
@@ -54,7 +54,7 @@ export function AnomalyDetectionSetupLink() {
   ) {
     color = 'warning';
     tooltipText = getNoJobsMessage(anomalyDetectionSetupState, environment);
-    icon = 'alert';
+    icon = 'machineLearningApp';
   } else if (
     anomalyDetectionSetupState === AnomalyDetectionSetupState.UpgradeableJobs
   ) {


### PR DESCRIPTION
## Summary

We use `alert` icon to communicate when Anomaly detection is not enabled. This conflicts with the usage of the icon for alerting. So in this small PR I'm swapping the icons with the `machineLearning` icon to make the visual connection stronger. The ML icon is also used in their app so things would make more sense that way. 
<img width="250" alt="image" src="https://user-images.githubusercontent.com/13353203/217507328-e5927f3c-d7cd-4671-88d1-ed4743470d77.png">


After / Before

![image](https://user-images.githubusercontent.com/13353203/217507185-44b7cb94-45d8-4c4e-824c-8ce0fb7adc7c.png)
