### PR TITLE
Accept additional dynamic field values for index template

### DIFF
--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/constants/parameters_definition.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/constants/parameters_definition.tsx
@@ -683,7 +683,13 @@ export const PARAMETERS_DEFINITION: { [key in ParameterName]: ParameterDefinitio
     fieldConfig: {
       defaultValue: true,
     },
-    schema: t.union([t.boolean, t.literal('strict')]),
+    schema: t.union([
+      t.boolean,
+      t.literal('strict'),
+      t.literal('true'),
+      t.literal('false'),
+      t.literal('runtime'),
+    ]),
   },
   dynamic_toggle: {
     fieldConfig: {

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/lib/mappings_validator.test.ts
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/lib/mappings_validator.test.ts
@@ -329,7 +329,7 @@ describe('Properties validator', () => {
         orientation: 'ccw',
         boost: 1.5,
         scaling_factor: 2.5,
-        dynamic: 'strict', // true | false | 'strict' are allowed
+        dynamic: 'strict', // true | false | 'strict' | 'true' | 'false' | 'runtime' are allowed
         enabled: true,
         format: 'strict_date_optional_time',
         analyzer: 'standard',
@@ -367,16 +367,39 @@ describe('Properties validator', () => {
         type: 'object',
         dynamic: false,
       },
+      goodField4: {
+        type: 'object',
+        dynamic: 'true',
+      },
+      goodField5: {
+        type: 'object',
+        dynamic: 'false',
+      },
+      goodField6: {
+        type: 'object',
+        dynamic: 'runtime',
+      },
     };
 
     const { value, errors } = validateProperties(properties as any);
 
-    expect(Object.keys(value)).toEqual(['wrongField', 'goodField', 'goodField2', 'goodField3']);
+    expect(Object.keys(value)).toEqual([
+      'wrongField',
+      'goodField',
+      'goodField2',
+      'goodField3',
+      'goodField4',
+      'goodField5',
+      'goodField6',
+    ]);
 
     expect(value.wrongField).toEqual({ type: 'text' }); // All parameters have been stripped out but the "type".
     expect(value.goodField).toEqual(properties.goodField); // All parameters are stil there.
     expect(value.goodField2).toEqual(properties.goodField2);
     expect(value.goodField3).toEqual(properties.goodField3);
+    expect(value.goodField4).toEqual(properties.goodField4);
+    expect(value.goodField5).toEqual(properties.goodField5);
+    expect(value.goodField6).toEqual(properties.goodField6);
 
     const allWrongParameters = Object.keys(properties.wrongField).filter((v) => v !== 'type');
     expect(errors).toEqual(

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/lib/mappings_validator.ts
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/lib/mappings_validator.ts
@@ -207,7 +207,14 @@ export const mappingsConfigurationSchema = t.exact(
   t.partial({
     properties: t.UnknownRecord,
     runtime: t.UnknownRecord,
-    dynamic: t.union([t.literal(true), t.literal(false), t.literal('strict')]),
+    dynamic: t.union([
+      t.literal(true),
+      t.literal(false),
+      t.literal('strict'),
+      t.literal('true'),
+      t.literal('false'),
+      t.literal('runtime'),
+    ]),
     date_detection: t.boolean,
     numeric_detection: t.boolean,
     dynamic_date_formats: t.array(t.string),


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/123809

## Summary

This PR adds support for the `'true'`, `'false'`, and `'runtime'` values for the `dynamic` field of index templates as they are [supported by Elasticsearch](https://www.elastic.co/guide/en/elasticsearch/reference/8.6/dynamic.html#dynamic-parameters). Before these changes, setting one of these values for the `dynamic` field would cause a `MultipleMappingsWarning` message when editing the Mappings section as described in the scenario in https://github.com/elastic/kibana/issues/123809.

Regarding the string values `'true'` and `'false'`, according to https://github.com/elastic/elasticsearch-java/issues/139, "Elasticsearch is lenient and happily accepts a string for boolean values", which is why we need to add support for these two values in Kibana.


https://user-images.githubusercontent.com/59341489/217516509-88679c38-271c-4c7d-9145-27c7f9cfa8ca.mov



### Checklist

- [X] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
