### PR TITLE
[TIP] fix add to blocklist flyout not showing current IoC id

### DIFF
--- a/x-pack/plugins/threat_intelligence/cypress/e2e/block_list.cy.ts
+++ b/x-pack/plugins/threat_intelligence/cypress/e2e/block_list.cy.ts
@@ -8,8 +8,10 @@
 import {
   BLOCK_LIST_ADD_BUTTON,
   BLOCK_LIST_DESCRIPTION,
+  BLOCK_LIST_FLYOUT_CLOSE_BUTTON,
   BLOCK_LIST_NAME,
   BLOCK_LIST_TOAST_LIST,
+  BLOCK_LIST_VALUE_INPUT,
   FLYOUT_ADD_TO_BLOCK_LIST_ITEM,
   FLYOUT_TAKE_ACTION_BUTTON,
   INDICATORS_TABLE_ADD_TO_BLOCK_LIST_BUTTON_ICON,
@@ -88,5 +90,23 @@ describe('Block list interactions', () => {
     cy.get(FLYOUT_ADD_TO_BLOCK_LIST_ITEM).first().click();
 
     fillBlocklistForm();
+  });
+
+  it('add to blocklist flyout should have the correct IoC id', () => {
+    // first indicator is a valid indicator for add to blocklist feature
+    const firstIndicatorId = 'd86e656455f985357df3063dff6637f7f3b95bb27d1769a6b88c7adecaf7763f';
+    cy.get(INDICATORS_TABLE_MORE_ACTION_BUTTON_ICON).first().click();
+    cy.get(INDICATORS_TABLE_ADD_TO_BLOCK_LIST_BUTTON_ICON).first().click();
+
+    cy.get(BLOCK_LIST_VALUE_INPUT(firstIndicatorId)).should('exist');
+
+    cy.get(BLOCK_LIST_FLYOUT_CLOSE_BUTTON).click();
+
+    // second indicator is a valid indicator for add to blocklist feature
+    const secondIndicatorId = 'd3e2cf87eabf84ef929aaf8dad1431b3387f5a26de8ffb7a0c3c2a13f973c0ab';
+    cy.get(INDICATORS_TABLE_MORE_ACTION_BUTTON_ICON).eq(1).click();
+    cy.get(INDICATORS_TABLE_ADD_TO_BLOCK_LIST_BUTTON_ICON).first().click();
+
+    cy.get(BLOCK_LIST_VALUE_INPUT(secondIndicatorId)).should('exist');
   });
 });

--- a/x-pack/plugins/threat_intelligence/cypress/screens/indicators.ts
+++ b/x-pack/plugins/threat_intelligence/cypress/screens/indicators.ts
@@ -211,7 +211,12 @@ export const BLOCK_LIST_DESCRIPTION = `[data-test-subj="blocklist-form-descripti
 
 export const BLOCK_LIST_ADD_BUTTON = `[class="eui-textTruncate"]`;
 
+export const BLOCK_LIST_FLYOUT_CLOSE_BUTTON = `[data-test-subj="euiFlyoutCloseButton"]`;
+
 export const BLOCK_LIST_TOAST_LIST = `[data-test-subj="globalToastList"]`;
+
+export const BLOCK_LIST_VALUE_INPUT = (iocId: string) =>
+  `[data-test-subj="blocklist-form-values-input-${iocId}"]`;
 
 /* Miscellaneous */
 

--- a/x-pack/plugins/threat_intelligence/public/modules/block_list/containers/flyout.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/block_list/containers/flyout.tsx
@@ -10,6 +10,7 @@ import {
   CreateExceptionListItemSchema,
   EntriesArray,
 } from '@kbn/securitysolution-io-ts-list-types';
+import { useBlockListContext } from '../../indicators/hooks/use_block_list_context';
 import { ADD_TO_BLOCKLIST_FLYOUT_TITLE } from './translations';
 import { useSecurityContext } from '../../../hooks/use_security_context';
 
@@ -27,6 +28,7 @@ export interface BlockListFlyoutProps {
  * - the form component: https://github.com/elastic/kibana/blob/main/x-pack/plugins/security_solution/public/management/pages/blocklist/view/components/blocklist_form.tsx
  */
 export const BlockListFlyout: VFC<BlockListFlyoutProps> = ({ indicatorFileHash }) => {
+  const { setBlockListIndicatorValue } = useBlockListContext();
   const { blockList } = useSecurityContext();
   const Component = blockList.getFlyoutComponent();
   const exceptionListApiClient = blockList.exceptionListApiClient;
@@ -59,13 +61,15 @@ export const BlockListFlyout: VFC<BlockListFlyoutProps> = ({ indicatorFileHash }
     flyoutCreateTitle: ADD_TO_BLOCKLIST_FLYOUT_TITLE,
   };
 
+  const clearBlockListIndicatorValue = () => setBlockListIndicatorValue('');
+
   const props = {
     apiClient: exceptionListApiClient,
     labels,
     item,
     policies: [],
     FormComponent,
-    onClose: () => {},
+    onClose: clearBlockListIndicatorValue,
   };
 
   return <Component {...props} />;


### PR DESCRIPTION
## Summary

This PR fixes a bug in the add to blocklist functionality within the Threat Intelligence plugin:
- user opens the add to blocklist flyout for an IoC (from the main Indicators table or the Indicator flyout)
- then closes this flyout (either bu closing the flyout, canceling or add to blocklist)
- then opens a new flyout for a different IoC
=> the id of the previous IoC is still in the value input

The IoC value is now cleared when the flyout closes.

https://user-images.githubusercontent.com/17276605/217638634-0a94a645-7e0c-42d6-825d-fa71f122bf10.mov

https://github.com/elastic/security-team/issues/5933

### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->