### PR TITLE
[Security Solution] fix flaky endpoint tests

### DIFF
--- a/x-pack/plugins/security_solution/server/plugin.ts
+++ b/x-pack/plugins/security_solution/server/plugin.ts
@@ -529,11 +529,13 @@ export class Plugin implements ISecuritySolutionPlugin {
       this.telemetryReceiver
     );
 
-    if (plugins.taskManager) {
-      this.checkMetadataTransformsTask?.start({
-        taskManager: plugins.taskManager,
-      });
-    }
+    plugins.fleet?.fleetSetupCompleted().then(() => {
+      if (plugins.taskManager) {
+        this.checkMetadataTransformsTask?.start({
+          taskManager: plugins.taskManager,
+        });
+      }
+    });
 
     return {};
   }


### PR DESCRIPTION
## Summary

Fix flaky endpoint tests. Start transform health check task after fleet plugin setup is completed to prevent package install conflicts.

Fixes: https://github.com/elastic/kibana/issues/72874

Flaky test runner:
* https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/1896 x200 ✅ 
* https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/1897 x200 ✅ 


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
