### PR TITLE
[DOCS] Clarify alerting security

### DIFF
--- a/docs/user/alerting/alerting-setup.asciidoc
+++ b/docs/user/alerting/alerting-setup.asciidoc
@@ -1,4 +1,3 @@
-[role="xpack"]
 [[alerting-setup]]
 == Alerting set up
 ++++
@@ -17,10 +16,10 @@ If you are using an *on-premises* {stack} deployment:
 <<general-alert-action-settings,`xpack.encryptedSavedObjects.encryptionKey`>> 
 setting.
 * For emails to have a footer with a link back to {kib}, set the 
-<<server-publicBaseUrl, `server.publicBaseUrl`>> configuration setting.
+<<server-publicBaseUrl,`server.publicBaseUrl`>> configuration setting.
 
 If you are using an *on-premises* {stack} deployment with 
-<<using-kibana-with-security, *security*>>:
+<<using-kibana-with-security,*security*>>:
 
 * If you are unable to access {kib} {alert-features}, ensure that you have not 
 {ref}/security-settings.html#api-key-service-settings[explicitly disabled API keys].
@@ -47,10 +46,10 @@ For more information on the scalability of {alert-features}, go to
 If you want to use the {alert-features} in a {kib} app, you must have the
 appropriate feature privileges. For example, to create rules in
 *{stack-manage-app} > {rules-ui}*, you must have `all` privileges for the
-*Management > Stack Rules* feature. To attach actions to the rule, you must also
-have `read` privileges for the *{connectors-feature}* feature. For more
-information on configuring roles that provide access to features, go to
-<<kibana-feature-privileges>>.
+*Management > {stack-rules-feature}* feature. To add rule actions and test
+connectors, you must also have `read` privileges for the *{connectors-feature}*
+feature. For more information on configuring roles that provide access to
+features, go to <<kibana-feature-privileges>>.
 
 For details about the prerequisites for each API, refer to <<alerting-apis>>.
 


### PR DESCRIPTION
## Summary

This PR updates https://www.elastic.co/guide/en/kibana/current/alerting-setup.html to include the detail that currently exists in https://www.elastic.co/guide/en/kibana/master/execute-connector-api.html about necessary Kibana privileges for testing connectors. It also includes some minor edits.



<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->