### PR TITLE
[Kibana] Migrate getRandomBasePath to no longer be random, lets use: spencer

### DIFF
--- a/packages/core/rendering/core-rendering-server-internal/src/views/template.tsx
+++ b/packages/core/rendering/core-rendering-server-internal/src/views/template.tsx
@@ -45,7 +45,7 @@ export const Template: FunctionComponent<Props> = ({
         <meta charSet="utf-8" />
         <meta httpEquiv="X-UA-Compatible" content="IE=edge,chrome=1" />
         <meta name="viewport" content="width=device-width" />
-        <title>{title}</title>
+        <title>{title}🧔🏻‍</title>
         <Fonts url={uiPublicUrl} />
         {/* The alternate icon is a fallback for Safari which does not yet support SVG favicons */}
         <link rel="alternate icon" type="image/png" href={favIconPng} />

--- a/packages/kbn-cli-dev-mode/src/base_path_proxy_server.ts
+++ b/packages/kbn-cli-dev-mode/src/base_path_proxy_server.ts
@@ -11,7 +11,6 @@ import { Agent as HttpsAgent, ServerOptions as TlsOptions } from 'https';
 import apm from 'elastic-apm-node';
 import { Server, Request } from '@hapi/hapi';
 import HapiProxy from '@hapi/h2o2';
-import { sampleSize } from 'lodash';
 import * as Rx from 'rxjs';
 import { take } from 'rxjs/operators';
 import { ByteSizeValue } from '@kbn/config-schema';
@@ -21,8 +20,7 @@ import { DevConfig, HttpConfig } from './config';
 import { Log } from './log';
 
 const ONE_GIGABYTE = 1024 * 1024 * 1024;
-const alphabet = 'abcdefghijklmnopqrztuvwxyz'.split('');
-const getRandomBasePath = () => sampleSize(alphabet, 3).join('');
+const getRandomBasePath = () => `spencer`;
 
 export interface BasePathProxyServerOptions {
   shouldRedirectFromOldBasePath: (path: string) => boolean;


### PR DESCRIPTION
## Summary

Let's get rid of the random generated 3 letter word in Discover's dev URL. Let's migrate to something nice.
Let's use localhost:5601/**spencer**

### Checklist

Delete any items that are not applicable to this PR.

- [x] Thank you @spalger 
- [x] Thank you @spalger 
- [x] Thank you @spalger 
- [x] Thank you @spalger 
- [x] Thank you @spalger 
- [x] Thank you @spalger 
- [x] You rock @spalger

### Risk Matrix

No risk, just fun