### PR TITLE
[ML] Transforms: Health status functional tests, expanded row tab.

### DIFF
--- a/x-pack/plugins/transform/common/api_schemas/transforms.ts
+++ b/x-pack/plugins/transform/common/api_schemas/transforms.ts
@@ -72,6 +72,8 @@ export const settingsSchema = schema.object({
   docs_per_second: schema.maybe(schema.nullable(schema.number())),
   // Optional value that takes precedence over cluster's setting.
   num_failure_retries: schema.maybe(schema.nullable(schema.number())),
+  // Unattended mode flag
+  unattended: schema.maybe(schema.boolean()),
 });
 
 export const sourceSchema = schema.object({

--- a/x-pack/plugins/transform/common/constants.ts
+++ b/x-pack/plugins/transform/common/constants.ts
@@ -130,7 +130,7 @@ export const TRANSFORM_HEALTH_LABEL = {
 
 export const TRANSFORM_HEALTH_DESCRIPTION = {
   green: i18n.translate('xpack.transform.transformHealth.greenDescription', {
-    defaultMessage: 'The transform is healthy.',
+    defaultMessage: 'The transform is running as expected.',
   }),
   unknown: i18n.translate('xpack.transform.transformHealth.unknownDescription', {
     defaultMessage: 'The health of the transform could not be determined.',

--- a/x-pack/plugins/transform/common/constants.ts
+++ b/x-pack/plugins/transform/common/constants.ts
@@ -197,3 +197,6 @@ export const DEFAULT_CONTINUOUS_MODE_DELAY = '60s';
 export const DEFAULT_TRANSFORM_FREQUENCY = '1m';
 export const DEFAULT_TRANSFORM_SETTINGS_DOCS_PER_SECOND = null;
 export const DEFAULT_TRANSFORM_SETTINGS_MAX_PAGE_SEARCH_SIZE = 500;
+
+// Used in the transform list's expanded row for the messages and issues table.
+export const TIME_FORMAT = 'YYYY-MM-DD HH:mm:ss';

--- a/x-pack/plugins/transform/common/types/transform_stats.ts
+++ b/x-pack/plugins/transform/common/types/transform_stats.ts
@@ -10,6 +10,13 @@ import { isPopulatedObject } from '@kbn/ml-is-populated-object';
 import { type TransformHealth, type TransformState, TRANSFORM_STATE } from '../constants';
 import { TransformId } from './transform';
 
+export interface TransformHealthIssue {
+  issue: string;
+  details?: string;
+  count: number;
+  first_occurrence?: number;
+}
+
 export interface TransformStats {
   id: TransformId;
   checkpointing: {
@@ -29,12 +36,7 @@ export interface TransformStats {
   };
   health: {
     status: TransformHealth;
-    issues?: Array<{
-      issue: string;
-      details?: string;
-      count: number;
-      first_occurrence?: number;
-    }>;
+    issues?: TransformHealthIssue[];
   };
   node?: {
     id: string;

--- a/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/expanded_row.tsx
+++ b/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/expanded_row.tsx
@@ -25,6 +25,7 @@ import { ExpandedRowDetailsPane, SectionConfig, SectionItem } from './expanded_r
 import { ExpandedRowJsonPane } from './expanded_row_json_pane';
 import { ExpandedRowMessagesPane } from './expanded_row_messages_pane';
 import { ExpandedRowPreviewPane } from './expanded_row_preview_pane';
+import { ExpandedRowHealthPane } from './expanded_row_health_pane';
 import { TransformHealthColoredDot } from './transform_health_colored_dot';
 
 function getItemDescription(value: any) {
@@ -281,6 +282,20 @@ export const ExpandedRow: FC<Props> = ({ item, onAlertEdit }) => {
       content: <ExpandedRowPreviewPane transformConfig={item.config} />,
     },
   ];
+
+  if (item.stats.health) {
+    tabs.push({
+      id: `transform-health-tab-${tabId}`,
+      'data-test-subj': 'transformHealthTab',
+      name: i18n.translate(
+        'xpack.transform.transformList.transformDetails.tabs.transformHealthLabel',
+        {
+          defaultMessage: 'Health',
+        }
+      ),
+      content: <ExpandedRowHealthPane health={item.stats.health} />,
+    });
+  }
 
   // Using `expand=false` here so the tabs themselves don't spread
   // across the full width. The 100% width is used so the bottom line

--- a/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/expanded_row.tsx
+++ b/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/expanded_row.tsx
@@ -259,6 +259,21 @@ export const ExpandedRow: FC<Props> = ({ item, onAlertEdit }) => {
       name: 'JSON',
       content: <ExpandedRowJsonPane json={item.config} />,
     },
+    ...(item.stats.health
+      ? [
+          {
+            id: `transform-health-tab-${tabId}`,
+            'data-test-subj': 'transformHealthTab',
+            name: i18n.translate(
+              'xpack.transform.transformList.transformDetails.tabs.transformHealthLabel',
+              {
+                defaultMessage: 'Health',
+              }
+            ),
+            content: <ExpandedRowHealthPane health={item.stats.health} />,
+          },
+        ]
+      : []),
     {
       id: `transform-messages-tab-${tabId}`,
       'data-test-subj': 'transformMessagesTab',
@@ -282,20 +297,6 @@ export const ExpandedRow: FC<Props> = ({ item, onAlertEdit }) => {
       content: <ExpandedRowPreviewPane transformConfig={item.config} />,
     },
   ];
-
-  if (item.stats.health) {
-    tabs.push({
-      id: `transform-health-tab-${tabId}`,
-      'data-test-subj': 'transformHealthTab',
-      name: i18n.translate(
-        'xpack.transform.transformList.transformDetails.tabs.transformHealthLabel',
-        {
-          defaultMessage: 'Health',
-        }
-      ),
-      content: <ExpandedRowHealthPane health={item.stats.health} />,
-    });
-  }
 
   // Using `expand=false` here so the tabs themselves don't spread
   // across the full width. The 100% width is used so the bottom line

--- a/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/expanded_row.tsx
+++ b/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/expanded_row.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, { FC, useMemo } from 'react';
+import { css } from '@emotion/react';
 import moment from 'moment-timezone';
 
 import { EuiButtonEmpty, EuiTabbedContent } from '@elastic/eui';
@@ -309,7 +310,13 @@ export const ExpandedRow: FC<Props> = ({ item, onAlertEdit }) => {
       initialSelectedTab={tabs[0]}
       onTabClick={() => {}}
       expand={false}
-      style={{ width: '100%' }}
+      css={css`
+        width: 100%;
+
+        .euiTable {
+          background-color: transparent;
+        }
+      `}
       data-test-subj="transformExpandedRowTabbedContent"
     />
   );

--- a/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/expanded_row_health_pane.tsx
+++ b/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/expanded_row_health_pane.tsx
@@ -83,7 +83,7 @@ export const ExpandedRowHealthPane: FC<ExpandedRowHealthPaneProps> = ({ health }
             items={issues}
             columns={columns}
             compressed={true}
-            pagination={true}
+            pagination={issues.length > 10}
             sorting={sorting}
           />
         </>

--- a/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/expanded_row_health_pane.tsx
+++ b/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/expanded_row_health_pane.tsx
@@ -79,6 +79,7 @@ export const ExpandedRowHealthPane: FC<ExpandedRowHealthPaneProps> = ({ health }
         <>
           <EuiSpacer size="s" />
           <EuiInMemoryTable<TransformHealthIssue>
+            data-test-subj="transformHealthTabContentIssueTable"
             items={issues}
             columns={columns}
             compressed={true}

--- a/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/expanded_row_health_pane.tsx
+++ b/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/expanded_row_health_pane.tsx
@@ -38,7 +38,7 @@ export const ExpandedRowHealthPane: FC<ExpandedRowHealthPaneProps> = ({ health }
       name: i18n.translate(
         'xpack.transform.transformList.transformDetails.healthPane.firstOccurrenceLabel',
         {
-          defaultMessage: 'First Occurrence',
+          defaultMessage: 'First occurrence',
         }
       ),
       render: (firstOccurrence: number) => formatDate(firstOccurrence, TIME_FORMAT),

--- a/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/expanded_row_health_pane.tsx
+++ b/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/expanded_row_health_pane.tsx
@@ -7,7 +7,7 @@
 
 import React, { type FC } from 'react';
 
-import { formatDate, EuiSpacer, EuiInMemoryTable } from '@elastic/eui';
+import { formatDate, EuiPanel, EuiSpacer, EuiInMemoryTable } from '@elastic/eui';
 
 import { i18n } from '@kbn/i18n';
 
@@ -72,7 +72,12 @@ export const ExpandedRowHealthPane: FC<ExpandedRowHealthPaneProps> = ({ health }
   ];
 
   return (
-    <div data-test-subj="transformHealthTabContent">
+    <EuiPanel
+      color="transparent"
+      hasBorder={false}
+      paddingSize="s"
+      data-test-subj="transformHealthTabContent"
+    >
       <EuiSpacer size="s" />
       <TransformHealthColoredDot healthStatus={status} compact={false} />
       {Array.isArray(issues) && issues.length > 0 && (
@@ -88,6 +93,6 @@ export const ExpandedRowHealthPane: FC<ExpandedRowHealthPaneProps> = ({ health }
           />
         </>
       )}
-    </div>
+    </EuiPanel>
   );
 };

--- a/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/expanded_row_health_pane.tsx
+++ b/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/expanded_row_health_pane.tsx
@@ -1,0 +1,98 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { type FC } from 'react';
+
+import { formatDate, EuiSpacer, EuiInMemoryTable } from '@elastic/eui';
+
+import { i18n } from '@kbn/i18n';
+
+import type { TransformHealthIssue } from '../../../../../../common/types/transform_stats';
+
+import { TransformListRow } from '../../../../common';
+
+import { TransformHealthColoredDot } from './transform_health_colored_dot';
+
+const TIME_FORMAT = 'YYYY-MM-DD HH:mm:ss';
+
+interface ExpandedRowHealthPaneProps {
+  health: TransformListRow['stats']['health'];
+}
+
+export const ExpandedRowHealthPane: FC<ExpandedRowHealthPaneProps> = ({ health }) => {
+  const sorting = {
+    sort: {
+      field: 'first_occurrence' as const,
+      direction: 'desc' as const,
+    },
+  };
+
+  const { status, issues } = health;
+
+  if (issues === undefined) {
+    return (
+      <>
+        <EuiSpacer size="s" />
+        <TransformHealthColoredDot healthStatus={status} compact={false} />
+      </>
+    );
+  }
+
+  const columns = [
+    {
+      field: 'first_occurrence',
+      name: i18n.translate(
+        'xpack.transform.transformList.transformDetails.healthPane.firstOccurrenceLabel',
+        {
+          defaultMessage: 'First Occurrence',
+        }
+      ),
+      render: (firstOccurrence: number) => formatDate(firstOccurrence, TIME_FORMAT),
+      sortable: true,
+    },
+    {
+      field: 'count',
+      name: i18n.translate('xpack.transform.transformList.transformDetails.healthPane.countLabel', {
+        defaultMessage: 'count',
+      }),
+      sortable: true,
+      width: '60px',
+    },
+    {
+      field: 'issue',
+      name: i18n.translate('xpack.transform.transformList.transformDetails.healthPane.issueLabel', {
+        defaultMessage: 'Issue',
+      }),
+      sortable: true,
+    },
+    {
+      field: 'details',
+      name: i18n.translate(
+        'xpack.transform.transformList.transformDetails.healthPane.detailsLabel',
+        {
+          defaultMessage: 'Details',
+        }
+      ),
+      width: '50%',
+    },
+  ];
+
+  return (
+    <div data-test-subj="transformHealthTabContent">
+      <EuiSpacer size="s" />
+      <TransformHealthColoredDot healthStatus={status} compact={false} />
+      <EuiSpacer size="s" />
+      <EuiInMemoryTable<TransformHealthIssue>
+        items={issues}
+        columns={columns}
+        compressed={true}
+        pagination={true}
+        sorting={sorting}
+      />
+    </div>
+  );
+};

--- a/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/expanded_row_health_pane.tsx
+++ b/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/expanded_row_health_pane.tsx
@@ -11,36 +11,26 @@ import { formatDate, EuiSpacer, EuiInMemoryTable } from '@elastic/eui';
 
 import { i18n } from '@kbn/i18n';
 
+import { TIME_FORMAT } from '../../../../../../common/constants';
 import type { TransformHealthIssue } from '../../../../../../common/types/transform_stats';
 
 import { TransformListRow } from '../../../../common';
 
 import { TransformHealthColoredDot } from './transform_health_colored_dot';
 
-const TIME_FORMAT = 'YYYY-MM-DD HH:mm:ss';
-
 interface ExpandedRowHealthPaneProps {
   health: TransformListRow['stats']['health'];
 }
 
 export const ExpandedRowHealthPane: FC<ExpandedRowHealthPaneProps> = ({ health }) => {
+  const { status, issues } = health;
+
   const sorting = {
     sort: {
       field: 'first_occurrence' as const,
       direction: 'desc' as const,
     },
   };
-
-  const { status, issues } = health;
-
-  if (issues === undefined) {
-    return (
-      <>
-        <EuiSpacer size="s" />
-        <TransformHealthColoredDot healthStatus={status} compact={false} />
-      </>
-    );
-  }
 
   const columns = [
     {
@@ -85,14 +75,18 @@ export const ExpandedRowHealthPane: FC<ExpandedRowHealthPaneProps> = ({ health }
     <div data-test-subj="transformHealthTabContent">
       <EuiSpacer size="s" />
       <TransformHealthColoredDot healthStatus={status} compact={false} />
-      <EuiSpacer size="s" />
-      <EuiInMemoryTable<TransformHealthIssue>
-        items={issues}
-        columns={columns}
-        compressed={true}
-        pagination={true}
-        sorting={sorting}
-      />
+      {Array.isArray(issues) && issues.length > 0 && (
+        <>
+          <EuiSpacer size="s" />
+          <EuiInMemoryTable<TransformHealthIssue>
+            items={issues}
+            columns={columns}
+            compressed={true}
+            pagination={true}
+            sorting={sorting}
+          />
+        </>
+      )}
     </div>
   );
 };

--- a/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/expanded_row_messages_pane.tsx
+++ b/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/expanded_row_messages_pane.tsx
@@ -19,15 +19,13 @@ import { euiLightVars as theme } from '@kbn/ui-theme';
 
 import { i18n } from '@kbn/i18n';
 
-import { DEFAULT_MAX_AUDIT_MESSAGE_SIZE } from '../../../../../../common/constants';
+import { DEFAULT_MAX_AUDIT_MESSAGE_SIZE, TIME_FORMAT } from '../../../../../../common/constants';
 import { isGetTransformsAuditMessagesResponseSchema } from '../../../../../../common/api_schemas/type_guards';
 import { TransformMessage } from '../../../../../../common/types/messages';
 
 import { useApi } from '../../../../hooks/use_api';
 import { JobIcon } from '../../../../components/job_icon';
 import { useRefreshTransformList } from '../../../../common';
-
-const TIME_FORMAT = 'YYYY-MM-DD HH:mm:ss';
 
 interface ExpandedRowMessagesPaneProps {
   transformId: string;

--- a/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/expanded_row_messages_pane.tsx
+++ b/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/expanded_row_messages_pane.tsx
@@ -9,7 +9,7 @@ import React, { MouseEvent, useState, type FC } from 'react';
 
 import {
   formatDate,
-  EuiSpacer,
+  EuiPanel,
   EuiBasicTable,
   EuiBasicTableProps,
   EuiToolTip,
@@ -215,8 +215,12 @@ export const ExpandedRowMessagesPane: FC<ExpandedRowMessagesPaneProps> = ({ tran
   };
 
   return (
-    <div data-test-subj="transformMessagesTabContent">
-      <EuiSpacer size="s" />
+    <EuiPanel
+      color="transparent"
+      hasBorder={false}
+      paddingSize="s"
+      data-test-subj="transformMessagesTabContent"
+    >
       <EuiBasicTable
         className="transform__TransformTable__messagesPaneTable"
         items={pageOfMessages}
@@ -228,6 +232,6 @@ export const ExpandedRowMessagesPane: FC<ExpandedRowMessagesPaneProps> = ({ tran
         onChange={onChange}
         sorting={sorting}
       />
-    </div>
+    </EuiPanel>
   );
 };

--- a/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/expanded_row_messages_pane.tsx
+++ b/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/expanded_row_messages_pane.tsx
@@ -5,17 +5,16 @@
  * 2.0.
  */
 
-import React, { MouseEvent, useState } from 'react';
+import React, { MouseEvent, useState, type FC } from 'react';
 
 import {
+  formatDate,
   EuiSpacer,
   EuiBasicTable,
   EuiBasicTableProps,
   EuiToolTip,
   EuiButtonIcon,
 } from '@elastic/eui';
-// @ts-ignore
-import { formatDate } from '@elastic/eui/lib/services/format';
 import { euiLightVars as theme } from '@kbn/ui-theme';
 
 import { i18n } from '@kbn/i18n';
@@ -30,7 +29,7 @@ import { useRefreshTransformList } from '../../../../common';
 
 const TIME_FORMAT = 'YYYY-MM-DD HH:mm:ss';
 
-interface Props {
+interface ExpandedRowMessagesPaneProps {
   transformId: string;
 }
 
@@ -39,7 +38,7 @@ interface Sorting {
   direction: 'asc' | 'desc';
 }
 
-export const ExpandedRowMessagesPane: React.FC<Props> = ({ transformId }) => {
+export const ExpandedRowMessagesPane: FC<ExpandedRowMessagesPaneProps> = ({ transformId }) => {
   const [messages, setMessages] = useState<any[]>([]);
   const [msgCount, setMsgCount] = useState<number>(0);
 

--- a/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/transform_health_colored_dot.tsx
+++ b/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/transform_health_colored_dot.tsx
@@ -18,14 +18,22 @@ import {
 
 interface TransformHealthProps {
   healthStatus: TransformHealth;
+  compact?: boolean;
 }
 
-export const TransformHealthColoredDot: FC<TransformHealthProps> = ({ healthStatus }) => {
-  return (
+export const TransformHealthColoredDot: FC<TransformHealthProps> = ({
+  healthStatus,
+  compact = true,
+}) => {
+  return compact ? (
     <EuiToolTip content={TRANSFORM_HEALTH_DESCRIPTION[healthStatus]}>
       <EuiHealth color={TRANSFORM_HEALTH_COLOR[healthStatus]}>
         <small>{TRANSFORM_HEALTH_LABEL[healthStatus]}</small>
       </EuiHealth>
     </EuiToolTip>
+  ) : (
+    <EuiHealth color={TRANSFORM_HEALTH_COLOR[healthStatus]}>
+      {TRANSFORM_HEALTH_DESCRIPTION[healthStatus]}
+    </EuiHealth>
   );
 };

--- a/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/transform_health_colored_dot.tsx
+++ b/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/transform_health_colored_dot.tsx
@@ -33,7 +33,7 @@ export const TransformHealthColoredDot: FC<TransformHealthProps> = ({
     </EuiToolTip>
   ) : (
     <EuiHealth color={TRANSFORM_HEALTH_COLOR[healthStatus]}>
-      {TRANSFORM_HEALTH_DESCRIPTION[healthStatus]}
+      {TRANSFORM_HEALTH_LABEL[healthStatus]} {TRANSFORM_HEALTH_DESCRIPTION[healthStatus]}
     </EuiHealth>
   );
 };

--- a/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/transform_health_colored_dot.tsx
+++ b/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/transform_health_colored_dot.tsx
@@ -28,7 +28,7 @@ export const TransformHealthColoredDot: FC<TransformHealthProps> = ({
   return compact ? (
     <EuiToolTip content={TRANSFORM_HEALTH_DESCRIPTION[healthStatus]}>
       <EuiHealth color={TRANSFORM_HEALTH_COLOR[healthStatus]}>
-        <small>{TRANSFORM_HEALTH_LABEL[healthStatus]}</small>
+        <small data-test-subj="transformListHealth">{TRANSFORM_HEALTH_LABEL[healthStatus]}</small>
       </EuiHealth>
     </EuiToolTip>
   ) : (

--- a/x-pack/test/functional/apps/transform/creation/index_pattern/creation_index_pattern.ts
+++ b/x-pack/test/functional/apps/transform/creation/index_pattern/creation_index_pattern.ts
@@ -159,6 +159,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
             status: TRANSFORM_STATE.STOPPED,
             mode: 'batch',
             progress: '100',
+            health: 'Healthy',
           },
           indexPreview: {
             columns: 10,
@@ -342,6 +343,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
             status: TRANSFORM_STATE.STOPPED,
             mode: 'batch',
             progress: '100',
+            health: 'Healthy',
           },
           indexPreview: {
             columns: 10,
@@ -406,6 +408,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
             status: TRANSFORM_STATE.STOPPED,
             mode: 'batch',
             progress: '100',
+            health: 'Healthy',
           },
           indexPreview: {
             columns: 10,
@@ -452,6 +455,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
             status: TRANSFORM_STATE.STOPPED,
             mode: 'batch',
             progress: '100',
+            health: 'Healthy',
           },
           indexPreview: {
             columns: 10,
@@ -736,6 +740,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
             status: testData.expected.row.status,
             mode: testData.expected.row.mode,
             progress: testData.expected.row.progress,
+            health: testData.expected.row.health,
           });
         });
 

--- a/x-pack/test/functional/apps/transform/creation/runtime_mappings_saved_search/creation_saved_search.ts
+++ b/x-pack/test/functional/apps/transform/creation/runtime_mappings_saved_search/creation_saved_search.ts
@@ -68,6 +68,7 @@ export default function ({ getService }: FtrProviderContext) {
             status: TRANSFORM_STATE.STOPPED,
             mode: 'batch',
             progress: '100',
+            health: 'Healthy',
           },
           sourceIndex: 'ft_farequote',
           indexPreview: {
@@ -105,6 +106,7 @@ export default function ({ getService }: FtrProviderContext) {
             status: TRANSFORM_STATE.STOPPED,
             mode: 'batch',
             progress: '100',
+            health: 'Healthy',
           },
           sourceIndex: 'ft_farequote',
           indexPreview: {
@@ -297,6 +299,7 @@ export default function ({ getService }: FtrProviderContext) {
             status: testData.expected.row.status,
             mode: testData.expected.row.mode,
             progress: testData.expected.row.progress,
+            health: testData.expected.row.health,
           });
 
           await transform.testExecution.logTestStep(

--- a/x-pack/test/functional/apps/transform/edit_clone/editing.ts
+++ b/x-pack/test/functional/apps/transform/edit_clone/editing.ts
@@ -73,6 +73,7 @@ export default function ({ getService }: FtrProviderContext) {
             type: 'pivot',
             mode: 'batch',
             progress: '100',
+            health: 'Healthy',
           },
         },
       },
@@ -95,6 +96,7 @@ export default function ({ getService }: FtrProviderContext) {
             type: 'latest',
             mode: 'batch',
             progress: '100',
+            health: 'Healthy',
           },
         },
       },
@@ -231,6 +233,7 @@ export default function ({ getService }: FtrProviderContext) {
             status: testData.expected.row.status,
             mode: testData.expected.row.mode,
             progress: testData.expected.row.progress,
+            health: testData.expected.row.health,
           });
 
           await transform.testExecution.logTestStep(

--- a/x-pack/test/functional/apps/transform/helpers.ts
+++ b/x-pack/test/functional/apps/transform/helpers.ts
@@ -52,11 +52,14 @@ export function isLatestTransformTestData(arg: any): arg is LatestTransformTestD
 
 export function getPivotTransformConfig(
   prefix: string,
-  continuous?: boolean
+  continuous?: boolean,
+  unattended?: boolean
 ): TransformPivotConfig {
   const timestamp = Date.now();
   return {
-    id: `ec_${prefix}_pivot_${timestamp}_${continuous ? 'cont' : 'batch'}`,
+    id: `ec_${prefix}_pivot_${timestamp}_${continuous ? 'cont' : 'batch'}${
+      unattended ? '_unattended' : ''
+    }`,
     source: { index: ['ft_ecommerce'] },
     pivot: {
       group_by: { category: { terms: { field: 'category.keyword' } } },
@@ -67,6 +70,7 @@ export function getPivotTransformConfig(
     } transform with avg(products.base_price) grouped by terms(category.keyword)`,
     dest: { index: `user-ec_2_${timestamp}` },
     ...(continuous ? { sync: { time: { field: 'order_date', delay: '60s' } } } : {}),
+    ...(unattended ? { settings: { unattended: true } } : {}),
   };
 }
 

--- a/x-pack/test/functional/apps/transform/start_reset_delete/deleting.ts
+++ b/x-pack/test/functional/apps/transform/start_reset_delete/deleting.ts
@@ -27,6 +27,7 @@ export default function ({ getService }: FtrProviderContext) {
             type: 'pivot',
             mode: 'batch',
             progress: 100,
+            health: 'Healthy',
           },
         },
       },
@@ -39,6 +40,7 @@ export default function ({ getService }: FtrProviderContext) {
             type: 'pivot',
             mode: 'continuous',
             progress: undefined,
+            health: 'Healthy',
           },
         },
       },
@@ -55,6 +57,7 @@ export default function ({ getService }: FtrProviderContext) {
             type: 'latest',
             mode: 'batch',
             progress: 100,
+            health: 'Healthy',
           },
         },
       },
@@ -114,6 +117,7 @@ export default function ({ getService }: FtrProviderContext) {
             status: testData.expected.row.status,
             mode: testData.expected.row.mode,
             progress: testData.expected.row.progress,
+            health: testData.expected.row.health,
           });
 
           await transform.testExecution.logTestStep('should show the delete modal');

--- a/x-pack/test/functional/apps/transform/start_reset_delete/resetting.ts
+++ b/x-pack/test/functional/apps/transform/start_reset_delete/resetting.ts
@@ -28,6 +28,7 @@ export default function ({ getService }: FtrProviderContext) {
             type: 'pivot',
             mode: 'batch',
             progress: 100,
+            health: 'Healthy',
           },
         },
       },
@@ -41,6 +42,7 @@ export default function ({ getService }: FtrProviderContext) {
             type: 'pivot',
             mode: 'continuous',
             progress: undefined,
+            health: 'Healthy',
           },
         },
       },
@@ -57,6 +59,7 @@ export default function ({ getService }: FtrProviderContext) {
             type: 'latest',
             mode: 'batch',
             progress: 100,
+            health: 'Healthy',
           },
         },
       },
@@ -116,6 +119,7 @@ export default function ({ getService }: FtrProviderContext) {
             status: testData.expected.row.status,
             mode: testData.expected.row.mode,
             progress: testData.expected.row.progress,
+            health: testData.expected.row.health,
           });
 
           await transform.testExecution.logTestStep('should show the reset modal');

--- a/x-pack/test/functional/apps/transform/start_reset_delete/starting.ts
+++ b/x-pack/test/functional/apps/transform/start_reset_delete/starting.ts
@@ -9,6 +9,7 @@ import {
   TRANSFORM_STATE,
   TRANSFORM_HEALTH,
   TRANSFORM_HEALTH_LABEL,
+  TRANSFORM_HEALTH_DESCRIPTION,
 } from '@kbn/transform-plugin/common/constants';
 import {
   TransformLatestConfig,
@@ -23,6 +24,7 @@ interface TestDataPivot {
   mode: 'batch' | 'continuous';
   type: 'pivot';
   expected: {
+    healthDescription: string;
     healthLabel: string;
     healthStatus: string;
   };
@@ -34,6 +36,7 @@ interface TestDataLatest {
   mode: 'batch' | 'continuous';
   type: 'latest';
   expected: {
+    healthDescription: string;
     healthLabel: string;
     healthStatus: string;
   };
@@ -54,6 +57,7 @@ export default function ({ getService }: FtrProviderContext) {
         mode: 'batch',
         type: 'pivot',
         expected: {
+          healthDescription: TRANSFORM_HEALTH_DESCRIPTION.green,
           healthLabel: TRANSFORM_HEALTH_LABEL.green,
           healthStatus: TRANSFORM_HEALTH.GREEN,
         },
@@ -64,6 +68,7 @@ export default function ({ getService }: FtrProviderContext) {
         mode: 'continuous',
         type: 'pivot',
         expected: {
+          healthDescription: TRANSFORM_HEALTH_DESCRIPTION.green,
           healthLabel: TRANSFORM_HEALTH_LABEL.green,
           healthStatus: TRANSFORM_HEALTH.GREEN,
         },
@@ -74,6 +79,7 @@ export default function ({ getService }: FtrProviderContext) {
         mode: 'continuous',
         type: 'pivot',
         expected: {
+          healthDescription: TRANSFORM_HEALTH_DESCRIPTION.yellow,
           healthLabel: TRANSFORM_HEALTH_LABEL.yellow,
           healthStatus: TRANSFORM_HEALTH.YELLOW,
         },
@@ -84,6 +90,7 @@ export default function ({ getService }: FtrProviderContext) {
         mode: 'batch',
         type: 'latest',
         expected: {
+          healthDescription: TRANSFORM_HEALTH_DESCRIPTION.green,
           healthLabel: TRANSFORM_HEALTH_LABEL.green,
           healthStatus: TRANSFORM_HEALTH.GREEN,
         },
@@ -94,6 +101,7 @@ export default function ({ getService }: FtrProviderContext) {
         mode: 'continuous',
         type: 'latest',
         expected: {
+          healthDescription: TRANSFORM_HEALTH_DESCRIPTION.green,
           healthLabel: TRANSFORM_HEALTH_LABEL.green,
           healthStatus: TRANSFORM_HEALTH.GREEN,
         },
@@ -158,6 +166,12 @@ export default function ({ getService }: FtrProviderContext) {
           await transform.table.assertTransformRowActionEnabled(transformId, 'Start', true);
           await transform.table.clickTransformRowAction(transformId, 'Start');
           await transform.table.confirmStartTransform();
+
+          await transform.table.assertTransformExpandedRowHealth(
+            testData.expected.healthDescription,
+            testData.expected.healthStatus !== TRANSFORM_HEALTH.GREEN
+          );
+
           await transform.table.clearSearchString(testDataList.length);
 
           if (testData.mode === 'continuous') {

--- a/x-pack/test/functional/apps/transform/start_reset_delete/starting.ts
+++ b/x-pack/test/functional/apps/transform/start_reset_delete/starting.ts
@@ -5,9 +5,41 @@
  * 2.0.
  */
 
-import { TRANSFORM_STATE } from '@kbn/transform-plugin/common/constants';
+import {
+  TRANSFORM_STATE,
+  TRANSFORM_HEALTH,
+  TRANSFORM_HEALTH_LABEL,
+} from '@kbn/transform-plugin/common/constants';
+import {
+  TransformLatestConfig,
+  TransformPivotConfig,
+} from '@kbn/transform-plugin/common/types/transform';
 import { FtrProviderContext } from '../../../ftr_provider_context';
 import { getLatestTransformConfig, getPivotTransformConfig } from '../helpers';
+
+interface TestDataPivot {
+  suiteTitle: string;
+  originalConfig: TransformPivotConfig;
+  mode: 'batch' | 'continuous';
+  type: 'pivot';
+  expected: {
+    healthLabel: string;
+    healthStatus: string;
+  };
+}
+
+interface TestDataLatest {
+  suiteTitle: string;
+  originalConfig: TransformLatestConfig;
+  mode: 'batch' | 'continuous';
+  type: 'latest';
+  expected: {
+    healthLabel: string;
+    healthStatus: string;
+  };
+}
+
+type TestData = TestDataPivot | TestDataLatest;
 
 export default function ({ getService }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');
@@ -15,26 +47,56 @@ export default function ({ getService }: FtrProviderContext) {
 
   describe('starting', function () {
     const PREFIX = 'starting';
-    const testDataList = [
+    const testDataList: TestData[] = [
       {
         suiteTitle: 'batch transform with pivot configuration',
         originalConfig: getPivotTransformConfig(PREFIX, false),
         mode: 'batch',
+        type: 'pivot',
+        expected: {
+          healthLabel: TRANSFORM_HEALTH_LABEL.green,
+          healthStatus: TRANSFORM_HEALTH.GREEN,
+        },
       },
       {
         suiteTitle: 'continuous transform with pivot configuration',
         originalConfig: getPivotTransformConfig(PREFIX, true),
         mode: 'continuous',
+        type: 'pivot',
+        expected: {
+          healthLabel: TRANSFORM_HEALTH_LABEL.green,
+          healthStatus: TRANSFORM_HEALTH.GREEN,
+        },
+      },
+      {
+        suiteTitle: 'non healthy continuous transform with pivot configuration',
+        originalConfig: getPivotTransformConfig(PREFIX, true, true),
+        mode: 'continuous',
+        type: 'pivot',
+        expected: {
+          healthLabel: TRANSFORM_HEALTH_LABEL.yellow,
+          healthStatus: TRANSFORM_HEALTH.YELLOW,
+        },
       },
       {
         suiteTitle: 'batch transform with latest configuration',
         originalConfig: getLatestTransformConfig(PREFIX, false),
         mode: 'batch',
+        type: 'latest',
+        expected: {
+          healthLabel: TRANSFORM_HEALTH_LABEL.green,
+          healthStatus: TRANSFORM_HEALTH.GREEN,
+        },
       },
       {
         suiteTitle: 'continuous transform with latest configuration',
         originalConfig: getLatestTransformConfig(PREFIX, true),
         mode: 'continuous',
+        type: 'latest',
+        expected: {
+          healthLabel: TRANSFORM_HEALTH_LABEL.green,
+          healthStatus: TRANSFORM_HEALTH.GREEN,
+        },
       },
     ];
 
@@ -43,7 +105,23 @@ export default function ({ getService }: FtrProviderContext) {
       await transform.testResources.createIndexPatternIfNeeded('ft_ecommerce', 'order_date');
 
       for (const testData of testDataList) {
-        await transform.api.createTransform(testData.originalConfig.id, testData.originalConfig);
+        if (
+          testData.expected.healthStatus === TRANSFORM_HEALTH.YELLOW &&
+          testData.type === 'pivot'
+        ) {
+          testData.originalConfig.pivot.aggregations['products.base_price.fail'] = {
+            avg: {
+              script: {
+                source: "def a = doc['non_existing'].value",
+              },
+            },
+          };
+        }
+        await transform.api.createTransform(
+          testData.originalConfig.id,
+          testData.originalConfig,
+          testData.expected.healthStatus === TRANSFORM_HEALTH.YELLOW
+        );
       }
       await transform.testResources.setKibanaTimeZoneToUTC();
       await transform.securityUI.loginAsTransformPowerUser();
@@ -88,9 +166,15 @@ export default function ({ getService }: FtrProviderContext) {
               testData.originalConfig.id,
               TRANSFORM_STATE.STOPPED
             );
-          } else {
+          } else if (testData.mode === 'batch') {
+            await transform.testExecution.logTestStep('should display a healthy status');
             await transform.table.assertTransformRowProgressGreaterThan(transformId, 0);
           }
+
+          await transform.table.assertTransformRowHealth(
+            testData.originalConfig.id,
+            testData.expected.healthLabel
+          );
 
           await transform.table.assertTransformRowStatusNotEql(
             testData.originalConfig.id,

--- a/x-pack/test/functional/services/transform/api.ts
+++ b/x-pack/test/functional/services/transform/api.ts
@@ -215,10 +215,14 @@ export function TransformAPIProvider({ getService }: FtrProviderContext) {
       return body as TransformPivotConfig;
     },
 
-    async createTransform(transformId: string, transformConfig: PutTransformsRequestSchema) {
+    async createTransform(
+      transformId: string,
+      transformConfig: PutTransformsRequestSchema,
+      deferValidation?: boolean
+    ) {
       log.debug(`Creating transform with id '${transformId}'...`);
       const { body, status } = await esSupertest
-        .put(`/_transform/${transformId}`)
+        .put(`/_transform/${transformId}${deferValidation ? '?defer_validation=true' : ''}`)
         .send(transformConfig);
       this.assertResponseStatusCode(200, status, body);
 

--- a/x-pack/test/functional/services/transform/transform_table.ts
+++ b/x-pack/test/functional/services/transform/transform_table.ts
@@ -57,6 +57,11 @@ export function TransformTableProvider({ getService }: FtrProviderContext) {
             .findTestSubject('transformListColumnProgress')
             .findTestSubject('transformListProgress')
             .attr('value'),
+          health: $tr
+            .findTestSubject('transformListColumnHealth')
+            .findTestSubject('transformListHealth')
+            .text()
+            .trim(),
         });
       }
 
@@ -136,6 +141,18 @@ export function TransformTableProvider({ getService }: FtrProviderContext) {
         expect(transformRow.progress).to.greaterThan(
           0,
           `Expected transform row progress to be greater than '${expectedProgress}' (got '${transformRow.progress}')`
+        );
+      });
+    }
+
+    public async assertTransformRowHealth(transformId: string, health: string) {
+      await retry.tryForTime(30 * 1000, async () => {
+        await this.refreshTransformList();
+        const rows = await this.parseTransformTable();
+        const transformRow = rows.filter((row) => row.id === transformId)[0];
+        expect(transformRow.health).to.eql(
+          health,
+          `Expected transform row status to not be '${health}' (got '${transformRow.health}')`
         );
       });
     }

--- a/x-pack/test/functional/services/transform/transform_table.ts
+++ b/x-pack/test/functional/services/transform/transform_table.ts
@@ -204,6 +204,7 @@ export function TransformTableProvider({ getService }: FtrProviderContext) {
 
       // Walk through the rest of the tabs and check if the corresponding content shows up
       await this.switchToExpandedRowTab('transformJsonTab', '~transformJsonTabContent');
+      await this.switchToExpandedRowTab('transformHealthTab', '~transformHealthTabContent');
       await this.switchToExpandedRowTab('transformMessagesTab', '~transformMessagesTabContent');
       await this.switchToExpandedRowTab('transformPreviewTab', '~transformPivotPreview');
     }
@@ -252,6 +253,36 @@ export function TransformTableProvider({ getService }: FtrProviderContext) {
           `Expected transform messages text to include '${expectedText}'`
         );
       });
+
+      // Switch back to details tab
+      await this.switchToExpandedRowTab('transformDetailsTab', '~transformDetailsTabContent');
+    }
+
+    public async assertTransformExpandedRowHealth(
+      expectedText: string,
+      expectIssueTableToExist: boolean
+    ) {
+      await this.ensureDetailsOpen();
+
+      // The expanded row should show the details tab content by default
+      await testSubjects.existOrFail('transformDetailsTab');
+      await testSubjects.existOrFail('~transformDetailsTabContent');
+
+      // Click on the messages tab and assert the messages
+      await this.switchToExpandedRowTab('transformHealthTab', '~transformHealthTabContent');
+      await retry.tryForTime(30 * 1000, async () => {
+        const actualText = await testSubjects.getVisibleText('~transformHealthTabContent');
+        expect(actualText.toLowerCase()).to.contain(
+          expectedText.toLowerCase(),
+          `Expected transform messages text to include '${expectedText}'`
+        );
+      });
+
+      if (expectIssueTableToExist) {
+        await testSubjects.existOrFail('transformHealthTabContentIssueTable');
+      } else {
+        await testSubjects.missingOrFail('transformHealthTabContentIssueTable');
+      }
 
       // Switch back to details tab
       await this.switchToExpandedRowTab('transformDetailsTab', '~transformDetailsTabContent');


### PR DESCRIPTION
## Summary

Part of #144157.

Adds functional tests for transform health status and expanded row tab.

<img width="900" alt="image" src="https://user-images.githubusercontent.com/230104/217835924-c46eb070-7925-4e7a-b7ab-dc62666d7227.png">

For testing, one can create a failing transform with this command in Dev Tools:

```
PUT _transform/tr_fail_01?defer_validation=true
{
  "source": {
    "index": [
      "farequote-2019"
    ],
    "query": {
      "bool": {
        "filter": []
      }
    }
  },
  "pivot": {
    "group_by": {
      "airline": {
        "terms": {
          "field": "airline"
        }
      }
    },
    "aggregations": {
      "avg_hour_of_day": {
        "avg": {
          "script": {
            "source": "def a = doc['non_existing'].value"
          }
        }
      },
      "avg_responsetime": {
        "avg": {
          "field": "responsetime"
        }
      }
    }
  },
  "dest": {
    "index": "tr_fail_01"
  },
  "settings":  {
    "unattended": true
  }
}
```

The `unattended` setting will "allow" to create a problematic config, otherwise validation on create/start will kick in and disallow creating a failing transform. Once the transform is started, it should first get into a `yellow/degrading` health status and after some retries get into a `red/outage` health status.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->