### PR TITLE
[Fleet] Ensure react-query devtools `initialIsOpen` is false

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/app.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/app.tsx
@@ -262,7 +262,7 @@ export const FleetAppContext: React.FC<{
                   <KibanaThemeProvider theme$={theme$}>
                     <EuiThemeProvider darkMode={isDarkMode}>
                       <QueryClientProvider client={queryClient}>
-                        <ReactQueryDevtools initialIsOpen={true} />
+                        <ReactQueryDevtools initialIsOpen={false} />
                         <UIExtensionsContext.Provider value={extensions}>
                           <FleetStatusProvider>
                             <Router history={history}>

--- a/x-pack/plugins/fleet/public/applications/integrations/app.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/app.tsx
@@ -84,7 +84,7 @@ export const IntegrationsAppContext: React.FC<{
                   <KibanaThemeProvider theme$={theme$}>
                     <EuiThemeProvider darkMode={isDarkMode}>
                       <QueryClientProvider client={queryClient}>
-                        <ReactQueryDevtools initialIsOpen={true} />
+                        <ReactQueryDevtools initialIsOpen={false} />
                         <UIExtensionsContext.Provider value={extensions}>
                           <FleetStatusProvider>
                             <startServices.customIntegrations.ContextProvider>


### PR DESCRIPTION
## Summary

Left a bit of testing code here where I had devtools open all the time - this PR ensures they're closed by default on Fleet/Integrations pages.



<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->