### PR TITLE
[UA] skip system indices migration status check if `featureSet.migrateSystemIndices` is set to `false`

### DIFF
--- a/x-pack/plugins/upgrade_assistant/server/routes/status.test.ts
+++ b/x-pack/plugins/upgrade_assistant/server/routes/status.test.ts
@@ -86,7 +86,7 @@ const systemIndicesNoMigrationResponse = {
   features: [],
 };
 
-describe('Status API', () => {  
+describe('Status API', () => {
   const registerRoutes = (featureSetOverrides: Partial<FeatureSet> = {}) => {
     const mockRouter = createMockRouter();
     const routeDependencies: any = {
@@ -95,7 +95,7 @@ describe('Status API', () => {
           mlSnapshots: true,
           migrateSystemIndices: true,
           reindexCorrectiveActions: true,
-          ...featureSetOverrides
+          ...featureSetOverrides,
         },
       },
       router: mockRouter,
@@ -209,7 +209,7 @@ describe('Status API', () => {
     it('skips ES system indices migration check when featureSet.migrateSystemIndices is set to false', async () => {
       const { routeDependencies } = registerRoutes({ migrateSystemIndices: false });
       getESUpgradeStatusMock.mockResolvedValue(esNoDeprecationsResponse);
-      
+
       getKibanaUpgradeStatusMock.mockResolvedValue({
         totalCriticalDeprecations: 0,
       });
@@ -226,7 +226,7 @@ describe('Status API', () => {
         readyForUpgrade: true,
         details: 'All deprecation warnings have been resolved.',
       });
-    })
+    });
 
     it('returns an error if it throws', async () => {
       const { routeDependencies } = registerRoutes();

--- a/x-pack/plugins/upgrade_assistant/server/routes/status.test.ts
+++ b/x-pack/plugins/upgrade_assistant/server/routes/status.test.ts
@@ -107,7 +107,6 @@ describe('Status API', () => {
     return { mockRouter, routeDependencies };
   };
 
-  
   describe('GET /api/upgrade_assistant/status', () => {
     afterEach(() => {
       jest.resetAllMocks();
@@ -122,7 +121,7 @@ describe('Status API', () => {
       });
 
       getESSystemIndicesMigrationStatusMock.mockResolvedValue(systemIndicesNoMigrationResponse);
-      
+
       const resp = await routeDependencies.router.getHandler({
         method: 'get',
         pathPattern: '/api/upgrade_assistant/status',
@@ -170,7 +169,7 @@ describe('Status API', () => {
       });
 
       getESSystemIndicesMigrationStatusMock.mockResolvedValue(systemIndicesMigrationResponse);
-      
+
       const resp = await routeDependencies.router.getHandler({
         method: 'get',
         pathPattern: '/api/upgrade_assistant/status',

--- a/x-pack/plugins/upgrade_assistant/server/routes/status.ts
+++ b/x-pack/plugins/upgrade_assistant/server/routes/status.ts
@@ -37,9 +37,27 @@ export function registerUpgradeStatusRoute({
           esClient,
           featureSet
         );
-        // Fetch system indices migration status
+
+        const getSystemIndicesMigrationStatus = async () => {
+          /**
+           * Skip system indices migration status check if `featureSet.migrateSystemIndices`
+           * is set to `false`. This flag is enabled from configs for major version stack ugprades.
+           * returns `migration_status: 'NO_MIGRATION_NEEDED'` to indicate no migation needed.
+           */
+          if (!featureSet.migrateSystemIndices) {
+            return {
+              migration_status: 'NO_MIGRATION_NEEDED',
+              features: [],
+            }
+          }
+
+          // Fetch system indices migration status from ES
+          return await getESSystemIndicesMigrationStatus(esClient.asCurrentUser);
+        }
+
         const { migration_status: systemIndicesMigrationStatus, features } =
-          await getESSystemIndicesMigrationStatus(esClient.asCurrentUser);
+          await getSystemIndicesMigrationStatus();
+
         const notMigratedSystemIndices = features.filter(
           (feature) => feature.migration_status !== 'NO_MIGRATION_NEEDED'
         ).length;

--- a/x-pack/plugins/upgrade_assistant/server/routes/status.ts
+++ b/x-pack/plugins/upgrade_assistant/server/routes/status.ts
@@ -48,12 +48,12 @@ export function registerUpgradeStatusRoute({
             return {
               migration_status: 'NO_MIGRATION_NEEDED',
               features: [],
-            }
+            };
           }
 
           // Fetch system indices migration status from ES
           return await getESSystemIndicesMigrationStatus(esClient.asCurrentUser);
-        }
+        };
 
         const { migration_status: systemIndicesMigrationStatus, features } =
           await getSystemIndicesMigrationStatus();


### PR DESCRIPTION
## Summary
In the UA `status` route, we need to skip the ES system indices migration status check if `featureSet.migrateSystemIndices`
is set to `false`. This flag is enabled from configs for major version stack upgrades.

Ideally, ES API would work as intended for non-minor versions, but for now, we'd have to skip hitting the API from Kibana's side when we are not upgrading to a major.

Context: https://github.com/elastic/cloud/issues/112124

<!--ONMERGE {"backportTargets":["8.6","8.7"]} ONMERGE-->