### PR TITLE
[Data Views] Support "namespaces" param in create data view API

### DIFF
--- a/src/plugins/data_views/common/data_views/data_views.ts
+++ b/src/plugins/data_views/common/data_views/data_views.ts
@@ -1011,6 +1011,7 @@ export class DataViewsService {
       body,
       {
         id: dataView.id,
+        initialNamespaces: dataView.namespaces.length > 0 ? dataView.namespaces : undefined,
       }
     )) as SavedObject<DataViewAttributes>;
 

--- a/src/plugins/data_views/common/types.ts
+++ b/src/plugins/data_views/common/types.ts
@@ -296,7 +296,7 @@ export interface SavedObjectsClientCommon {
   create: (
     type: string,
     attributes: DataViewAttributes,
-    options: SavedObjectsCreateOptions
+    options: SavedObjectsCreateOptions & { initialNamespaces?: string[] }
   ) => Promise<SavedObject>;
   /**
    * Delete a saved object by id

--- a/src/plugins/data_views/server/rest_api_routes/create_data_view.ts
+++ b/src/plugins/data_views/server/rest_api_routes/create_data_view.ts
@@ -70,6 +70,7 @@ const dataViewSpecSchema = schema.object({
   allowNoIndex: schema.maybe(schema.boolean()),
   runtimeFieldMap: schema.maybe(schema.recordOf(schema.string(), runtimeFieldSchema)),
   name: schema.maybe(schema.string()),
+  namespaces: schema.maybe(schema.arrayOf(schema.string())),
 });
 
 const registerCreateDataViewRouteFactory =
@@ -125,6 +126,7 @@ const registerCreateDataViewRouteFactory =
             },
             body: {
               [serviceKey]: dataView.toSpec(),
+              namespaces: dataView.namespaces,
             },
           });
         })

--- a/src/plugins/data_views/server/rest_api_routes/create_data_view.ts
+++ b/src/plugins/data_views/server/rest_api_routes/create_data_view.ts
@@ -125,8 +125,10 @@ const registerCreateDataViewRouteFactory =
               'content-type': 'application/json',
             },
             body: {
-              [serviceKey]: dataView.toSpec(),
-              namespaces: dataView.namespaces,
+              [serviceKey]: {
+                ...dataView.toSpec(),
+                namespaces: dataView.namespaces,
+              },
             },
           });
         })


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/140426

## Summary

This PR adds support for `namespaces` param in create data view API as per docs https://www.elastic.co/guide/en/kibana/current/data-views-api-create.html#data-views-api-properties

<img width="300" alt="Screenshot 2023-02-09 at 15 04 55" src="https://user-images.githubusercontent.com/1415710/217835577-fa4286ff-89f4-4de2-97b0-62c04f756858.png">

Previous functionality is still in place:
* setting "default" space if "namespaces" param is not provided
<img width="300" alt="Screenshot 2023-02-09 at 15 06 55" src="https://user-images.githubusercontent.com/1415710/217835951-d274c8ba-5bd9-4c36-9487-c2dbd5ce42de.png">

* setting the specified in URL space ID if "namespaces" param is not provided
<img width="300" alt="Screenshot 2023-02-09 at 15 06 34" src="https://user-images.githubusercontent.com/1415710/217836019-81f36a16-157f-4ce9-9d19-c5685d633acc.png">

