### PR TITLE
[BUG] [AO] - Fix alert evaluation value format in the alert flyout 

### DIFF
--- a/x-pack/plugins/observability/public/pages/alerts/components/alerts_flyout/alerts_flyout_body.tsx
+++ b/x-pack/plugins/observability/public/pages/alerts/components/alerts_flyout/alerts_flyout_body.tsx
@@ -21,6 +21,7 @@ import {
   ALERT_EVALUATION_VALUE,
   ALERT_FLAPPING,
   ALERT_RULE_CATEGORY,
+  ALERT_RULE_TYPE_ID,
   ALERT_RULE_UUID,
   ALERT_STATUS_ACTIVE,
   ALERT_STATUS_RECOVERED,
@@ -32,6 +33,7 @@ import { RULE_DETAILS_PAGE_ID } from '../../../rule_details/constants';
 import { asDuration } from '../../../../../common/utils/formatters';
 import { translations, paths } from '../../../../config';
 import { FlyoutProps } from './types';
+import { formatAlertEvaluationValue } from '../../../../utils/format_alert_evaluation_value';
 
 // eslint-disable-next-line import/no-default-export
 export default function AlertsFlyoutBody({ alert, id: pageId }: FlyoutProps) {
@@ -74,11 +76,15 @@ export default function AlertsFlyoutBody({ alert, id: pageId }: FlyoutProps) {
     },
     {
       title: translations.alertsFlyout.expectedValueLabel,
-      description: alert.fields[ALERT_EVALUATION_THRESHOLD] ?? '-',
+      description: formatAlertEvaluationValue(
+        alert.fields[ALERT_RULE_TYPE_ID],
+        alert.fields[ALERT_EVALUATION_THRESHOLD]),
     },
     {
       title: translations.alertsFlyout.actualValueLabel,
-      description: alert.fields[ALERT_EVALUATION_VALUE] ?? '-',
+      description: formatAlertEvaluationValue(
+        alert.fields[ALERT_RULE_TYPE_ID],
+        alert.fields[ALERT_EVALUATION_VALUE]),
     },
     {
       title: translations.alertsFlyout.ruleTypeLabel,

--- a/x-pack/plugins/observability/public/pages/alerts/components/alerts_flyout/alerts_flyout_body.tsx
+++ b/x-pack/plugins/observability/public/pages/alerts/components/alerts_flyout/alerts_flyout_body.tsx
@@ -78,13 +78,15 @@ export default function AlertsFlyoutBody({ alert, id: pageId }: FlyoutProps) {
       title: translations.alertsFlyout.expectedValueLabel,
       description: formatAlertEvaluationValue(
         alert.fields[ALERT_RULE_TYPE_ID],
-        alert.fields[ALERT_EVALUATION_THRESHOLD]),
+        alert.fields[ALERT_EVALUATION_THRESHOLD]
+      ),
     },
     {
       title: translations.alertsFlyout.actualValueLabel,
       description: formatAlertEvaluationValue(
         alert.fields[ALERT_RULE_TYPE_ID],
-        alert.fields[ALERT_EVALUATION_VALUE]),
+        alert.fields[ALERT_EVALUATION_VALUE]
+      ),
     },
     {
       title: translations.alertsFlyout.ruleTypeLabel,

--- a/x-pack/test/observability_functional/apps/observability/pages/alerts/index.ts
+++ b/x-pack/test/observability_functional/apps/observability/pages/alerts/index.ts
@@ -171,7 +171,7 @@ export default ({ getService }: FtrProviderContext) => {
               'Oct 19, 2021 @ 15:20:38.749',
               '20 minutes',
               '5.0%',
-              '30.73',
+              '31%',
               'Failed transaction rate threshold',
             ];
 

--- a/x-pack/test/observability_functional/apps/observability/pages/alerts/index.ts
+++ b/x-pack/test/observability_functional/apps/observability/pages/alerts/index.ts
@@ -170,7 +170,7 @@ export default ({ getService }: FtrProviderContext) => {
               'Oct 19, 2021 @ 15:00:41.555',
               'Oct 19, 2021 @ 15:20:38.749',
               '20 minutes',
-              '5',
+              '5%',
               '30.73',
               'Failed transaction rate threshold',
             ];

--- a/x-pack/test/observability_functional/apps/observability/pages/alerts/index.ts
+++ b/x-pack/test/observability_functional/apps/observability/pages/alerts/index.ts
@@ -170,7 +170,7 @@ export default ({ getService }: FtrProviderContext) => {
               'Oct 19, 2021 @ 15:00:41.555',
               'Oct 19, 2021 @ 15:20:38.749',
               '20 minutes',
-              '5%',
+              '5.0%',
               '30.73',
               'Failed transaction rate threshold',
             ];


### PR DESCRIPTION
## Summary

It closes #101945 
It closes #150857
by using the formatter from the Observability plugin. 


### Before
### ms
<img width="644" alt="Screenshot 2023-02-09 at 15 49 12" src="https://user-images.githubusercontent.com/6838659/217846452-de9b1440-ec60-4700-a3eb-71c6e9a81e08.png">

### %
<img width="643" alt="Screenshot 2023-02-10 at 12 28 34" src="https://user-images.githubusercontent.com/6838659/218090682-af90e158-7e97-4c7f-a813-356213ec1322.png">

### After

### ms
<img width="641" alt="Screenshot 2023-02-09 at 15 48 58" src="https://user-images.githubusercontent.com/6838659/217846507-13d21e3c-43a6-4bf9-bb3c-e559aa5b1905.png">

### %
<img width="626" alt="Screenshot 2023-02-10 at 13 17 20" src="https://user-images.githubusercontent.com/6838659/218090805-93c39c82-2ec5-4911-9b92-c935053a056e.png">


<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->