### PR TITLE
chore(bug): remove hover effects from kpi charts

### DIFF
--- a/x-pack/plugins/infra/public/pages/metrics/hosts/components/kpi_charts/kpi_chart.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/hosts/components/kpi_charts/kpi_chart.tsx
@@ -121,11 +121,6 @@ export const KPIChart = ({
 const KPIChartStyled = styled(Chart)`
   .echMetric {
     border-radius: ${(p) => p.theme.eui.euiBorderRadius};
-  }
-  button {
-    cursor: default;
-  }
-  div {
     pointer-events: none;
   }
 `;

--- a/x-pack/plugins/infra/public/pages/metrics/hosts/components/kpi_charts/kpi_chart.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/hosts/components/kpi_charts/kpi_chart.tsx
@@ -95,7 +95,7 @@ export const KPIChart = ({
   };
 
   return (
-    <EuiPanel paddingSize="none" {...props}>
+    <EuiPanel hasShadow={false} paddingSize="none" {...props}>
       {loading ? (
         <EuiFlexGroup style={{ minHeight: MIN_HEIGHT }} justifyContent="center" alignItems="center">
           <EuiFlexItem grow={false}>
@@ -121,5 +121,11 @@ export const KPIChart = ({
 const KPIChartStyled = styled(Chart)`
   .echMetric {
     border-radius: ${(p) => p.theme.eui.euiBorderRadius};
+  }
+  button {
+    cursor: default;
+  }
+  div {
+    pointer-events: none;
   }
 `;


### PR DESCRIPTION
## Summary

This PR targets removing hover effect from the KPI charts in the hosts view
closes #150532 

### Checklist

- [x] Remove the chart hover effect
- [x] Remove the hover on the title which shows the pointer cursor
- [x] Remove the drop-shadow from the containing panels


### Testing


https://user-images.githubusercontent.com/11225826/217870637-2842ad64-25f4-4b2e-928b-d969f3e6cc55.mov



<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->