### PR TITLE
[Security Solution] Fixes bulk close alerts from exception flyout type bug

### DIFF
--- a/x-pack/plugins/security_solution/public/detection_engine/rule_exceptions/utils/helpers.test.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_exceptions/utils/helpers.test.tsx
@@ -386,7 +386,10 @@ describe('Exception helpers', () => {
     });
 
     test("should strip out any comments in the exceptions for bulk close'", () => {
-      const exceptionItemWithComment = {...getExceptionListItemSchemaMock(), comments: getCommentsArrayMock()}
+      const exceptionItemWithComment = {
+        ...getExceptionListItemSchemaMock(),
+        comments: getCommentsArrayMock(),
+      };
       const payload = [exceptionItemWithComment];
       const result = prepareExceptionItemsForBulkClose(payload);
       expect(result).toEqual([getExceptionListItemSchemaMock()]);

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_exceptions/utils/helpers.test.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_exceptions/utils/helpers.test.tsx
@@ -384,6 +384,13 @@ describe('Exception helpers', () => {
       const result = prepareExceptionItemsForBulkClose(payload);
       expect(result).toEqual(expected);
     });
+
+    test("should strip out any comments in the exceptions for bulk close'", () => {
+      const exceptionItemWithComment = {...getExceptionListItemSchemaMock(), comments: getCommentsArrayMock()}
+      const payload = [exceptionItemWithComment];
+      const result = prepareExceptionItemsForBulkClose(payload);
+      expect(result).toEqual([getExceptionListItemSchemaMock()]);
+    });
   });
 
   describe('#lowercaseHashValues', () => {

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_exceptions/utils/helpers.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_exceptions/utils/helpers.tsx
@@ -154,9 +154,10 @@ export const prepareExceptionItemsForBulkClose = (
       return {
         ...item,
         entries: newEntries,
+        comments: [], // Strips out unneeded comments attribute for bulk close as they are not needed and are throwing type errors
       };
     } else {
-      return item;
+      return {...item, comments: []};
     }
   });
 };

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_exceptions/utils/helpers.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_exceptions/utils/helpers.tsx
@@ -157,7 +157,7 @@ export const prepareExceptionItemsForBulkClose = (
         comments: [], // Strips out unneeded comments attribute for bulk close as they are not needed and are throwing type errors
       };
     } else {
-      return {...item, comments: []};
+      return { ...item, comments: [] };
     }
   });
 };


### PR DESCRIPTION
## Summary

Addresses https://github.com/elastic/kibana/issues/149971 which was stopping users from bulk closing alerts from the exception flyout when they added new comments to the exception item

This strips out unneeded attributes before that api call thus fixing the type errors without changing the final return value


### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.6","8.7"]} ONMERGE-->