### PR TITLE
fixes Failing ES Promotion: X-Pack API Integration Tests x-pack/test/api_integration/apis/maps/get_grid_tile.js

### DIFF
--- a/x-pack/test/api_integration/apis/maps/get_grid_tile.js
+++ b/x-pack/test/api_integration/apis/maps/get_grid_tile.js
@@ -21,8 +21,7 @@ function findFeature(layer, callbackFn) {
 export default function ({ getService }) {
   const supertest = getService('supertest');
 
-  // FAILING ES PROMOTION: https://github.com/elastic/kibana/issues/149068
-  describe.skip('getGridTile', () => {
+  describe('getGridTile', () => {
     const URL = `/api/maps/mvt/getGridTile/3/2/3.pbf\
 ?geometryFieldName=geo.coordinates\
 &hasLabels=false\
@@ -152,13 +151,13 @@ export default function ({ getService }) {
       // assert feature geometry is hex
       expect(gridFeature.loadGeometry()).to.eql([
         [
-          { x: 111, y: 698 },
           { x: 89, y: 710 },
           { x: 67, y: 696 },
           { x: 67, y: 669 },
           { x: 89, y: 657 },
           { x: 112, y: 672 },
           { x: 111, y: 698 },
+          { x: 89, y: 710 },
         ],
       ]);
     });


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/149068

Order of the vertices changed as side effect of https://github.com/elastic/elasticsearch/pull/92883. PR updates expects clause for new order