### PR TITLE
[Discover] Fix time filter visibility after editing a data view

### DIFF
--- a/src/plugins/discover/public/application/context/context_app_content.tsx
+++ b/src/plugins/discover/public/application/context/context_app_content.tsx
@@ -86,9 +86,10 @@ export function ContextAppContent({
   const areSuccessorsLoading =
     successorsStatus === LoadingStatus.LOADING || successorsStatus === LoadingStatus.UNINITIALIZED;
 
+  const timeFieldName = dataView.timeFieldName;
   const showTimeCol = useMemo(
-    () => !config.get(DOC_HIDE_TIME_COLUMN_SETTING, false) && !!dataView.timeFieldName,
-    [config, dataView]
+    () => !config.get(DOC_HIDE_TIME_COLUMN_SETTING, false) && !!timeFieldName,
+    [config, timeFieldName]
   );
   const defaultStepSize = useMemo(() => parseInt(config.get(CONTEXT_STEP_SETTING), 10), [config]);
 
@@ -111,8 +112,8 @@ export function ContextAppContent({
     [setAppState]
   );
   const sort = useMemo(() => {
-    return [[dataView.timeFieldName!, SortDirection.desc]];
-  }, [dataView]);
+    return [[timeFieldName!, SortDirection.desc]];
+  }, [timeFieldName]);
 
   return (
     <Fragment>

--- a/src/plugins/discover/public/application/main/components/layout/discover_documents.tsx
+++ b/src/plugins/discover/public/application/main/components/layout/discover_documents.tsx
@@ -155,12 +155,10 @@ function DiscoverDocumentsComponent({
     [stateContainer]
   );
 
+  const timeFieldName = dataView.timeFieldName;
   const showTimeCol = useMemo(
-    () =>
-      !isPlainRecord &&
-      !uiSettings.get(DOC_HIDE_TIME_COLUMN_SETTING, false) &&
-      !!dataView.timeFieldName,
-    [isPlainRecord, uiSettings, dataView.timeFieldName]
+    () => !isPlainRecord && !uiSettings.get(DOC_HIDE_TIME_COLUMN_SETTING, false) && !!timeFieldName,
+    [isPlainRecord, timeFieldName, uiSettings]
   );
 
   if (isDataViewLoading || (isEmptyDataResult && isDataLoading)) {

--- a/src/plugins/discover/public/application/main/components/layout/discover_layout.tsx
+++ b/src/plugins/discover/public/application/main/components/layout/discover_layout.tsx
@@ -107,9 +107,10 @@ export function DiscoverLayout({
   // in a non time based way using the regular _search API, since the internal
   // representation of those documents does not have the time field that _field_caps
   // reports us.
+  const dataViewIsTimeBased = dataView.isTimeBased();
   const isTimeBased = useMemo(() => {
-    return dataView.type !== DataViewType.ROLLUP && dataView.isTimeBased();
-  }, [dataView]);
+    return dataView.type !== DataViewType.ROLLUP && dataViewIsTimeBased;
+  }, [dataView.type, dataViewIsTimeBased]);
 
   const initialSidebarClosed = Boolean(storage.get(SIDEBAR_CLOSED_KEY));
   const [isSidebarClosed, setIsSidebarClosed] = useState(initialSidebarClosed);

--- a/src/plugins/discover/public/application/main/components/top_nav/discover_topnav.tsx
+++ b/src/plugins/discover/public/application/main/components/top_nav/discover_topnav.tsx
@@ -65,9 +65,10 @@ export const DiscoverTopNav = ({
   const adHocDataViews = useInternalStateSelector((state) => state.adHocDataViews);
   const dataView = useInternalStateSelector((state) => state.dataView!);
   const savedDataViews = useInternalStateSelector((state) => state.savedDataViews);
+  const dataViewIsTimeBased = dataView.isTimeBased();
   const showDatePicker = useMemo(
-    () => dataView.isTimeBased() && dataView.type !== DataViewType.ROLLUP,
-    [dataView]
+    () => dataViewIsTimeBased && dataView.type !== DataViewType.ROLLUP,
+    [dataView.type, dataViewIsTimeBased]
   );
   const services = useDiscoverServices();
   const { dataViewEditor, navigation, dataViewFieldEditor, data, uiSettings, dataViews } = services;

--- a/src/plugins/discover/public/application/main/hooks/use_discover_state.ts
+++ b/src/plugins/discover/public/application/main/hooks/use_discover_state.ts
@@ -303,11 +303,13 @@ export function useDiscoverState({
    * We need to make sure the auto refresh interval is disabled for
    * non-time series data or rollups since we don't show the date picker
    */
+  const dataViewIsTimeBased = dataView.isTimeBased();
+
   useEffect(() => {
-    if (dataView && (!dataView.isTimeBased() || dataView.type === DataViewType.ROLLUP)) {
+    if (dataView && (!dataViewIsTimeBased || dataView.type === DataViewType.ROLLUP)) {
       stateContainer.pauseAutoRefreshInterval();
     }
-  }, [dataView, stateContainer]);
+  }, [dataView, dataViewIsTimeBased, stateContainer]);
 
   return {
     inspectorAdapters,


### PR DESCRIPTION
## Summary

WIP

Fixes #150740.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)