### PR TITLE
[Fleet] Fix max 20 installed integrations returned from Fleet API

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/packages/get.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/get.ts
@@ -12,6 +12,7 @@ import type { Logger } from '@kbn/core/server';
 import {
   installationStatuses,
   PACKAGE_POLICY_SAVED_OBJECT_TYPE,
+  SO_SEARCH_LIMIT,
 } from '../../../../common/constants';
 import { isPackageLimited } from '../../../../common/services';
 import type {
@@ -137,6 +138,7 @@ export async function getPackageSavedObjects(
   return savedObjectsClient.find<Installation>({
     ...(options || {}),
     type: PACKAGES_SAVED_OBJECT_TYPE,
+    perPage: SO_SEARCH_LIMIT,
   });
 }
 


### PR DESCRIPTION
## Summary

Fix an (old) bug where Fleet's "list packages" API endpoint would only ever return 20 installed integrations at most. 

I haven't included a test case here because I'm not sure we have 20 test packages that can reasonably be installed at the same time. Also feels like an arbitrary number to introduce a "lists all packages even if there are more N" test case. Open to feedback on testing.

## Before

23 installed integrations, only 20 in UI

![image](https://user-images.githubusercontent.com/6766512/217930020-f6dafe56-191a-48c0-acb4-c567810a6dad.png)

![image](https://user-images.githubusercontent.com/6766512/217930126-441e78a8-d484-4c5d-b5df-00179d930e4a.png)

## After

23 installed integrations, 23 in UI

![image](https://user-images.githubusercontent.com/6766512/217930384-21506d77-7244-42c1-93bd-97025a8ec86e.png)


<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->