### PR TITLE
fix test/functional/apps/dashboard/group3/dashboard_time_picker·ts

### DIFF
--- a/test/functional/apps/dashboard/group3/dashboard_time_picker.ts
+++ b/test/functional/apps/dashboard/group3/dashboard_time_picker.ts
@@ -118,6 +118,9 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await browser.refresh();
       const alert = await browser.getAlert();
       await alert?.accept();
+
+      await elasticChart.setNewChartUiDebugFlag(true);
+
       await PageObjects.dashboard.gotoDashboardLandingPage();
       await PageObjects.dashboard.clickNewDashboard();
       await PageObjects.dashboard.addVisualizations([PIE_CHART_VIS_NAME]);
@@ -126,7 +129,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         '2015-09-19 06:31:44.000',
         '2015-09-23 18:31:44.000'
       );
-      await elasticChart.setNewChartUiDebugFlag(true);
       await pieChart.expectPieSliceCount(10);
     });
   });


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/148736

flaky test runner https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/1901

Flakiness caused because `window._echDebugStateFlag` flag is not always getting set before panel renders. PR resolves flakiness by moving `await elasticChart.setNewChartUiDebugFlag(true);` call to be before dashboard panel is rendered, removing the race condition. 

Flakiness caused by same issue as https://github.com/elastic/kibana/issues/132865. 