### PR TITLE
[codeowners] allow overrides to take higher precedence

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,509 +1,8 @@
-# GitHub CODEOWNERS definition
-# Identify which groups will be pinged by changes to different parts of the codebase.
-# For more info, see https://help.github.com/articles/about-codeowners/
-
-# The #CC# prefix delineates Code Coverage,
-# used for the 'team' designator within Kibana Stats
-
-# Data Discovery
-/x-pack/test/functional/apps/discover/ @elastic/kibana-data-discovery
-/x-pack/test/functional_with_es_ssl/apps/discover_ml_uptime/discover/ @elastic/kibana-data-discovery
-/test/functional/apps/discover/ @elastic/kibana-data-discovery
-/test/functional/apps/context/ @elastic/kibana-data-discovery
-/test/api_integration/apis/unified_field_list/ @elastic/kibana-data-discovery
-/x-pack/test/search_sessions_integration/ @elastic/kibana-data-discovery
-/test/plugin_functional/test_suites/data_plugin @elastic/kibana-data-discovery
-/examples/demo_search/ @elastic/kibana-data-discovery
-
-# Vis Editors
-/src/plugins/visualize/ @elastic/kibana-visualizations
-/x-pack/test/functional/apps/lens @elastic/kibana-visualizations
-/x-pack/test/api_integration/apis/lens/ @elastic/kibana-visualizations
-/test/functional/apps/visualize/ @elastic/kibana-visualizations
-/x-pack/test/functional/apps/graph @elastic/kibana-visualizations
-
-# Global Experience
-
-### Global Experience Reporting
-/x-pack/test/functional/apps/dashboard/reporting/ @elastic/appex-sharedux
-/x-pack/test/functional/apps/reporting/ @elastic/appex-sharedux
-/x-pack/test/functional/apps/reporting_management/ @elastic/appex-sharedux
-/x-pack/test/examples/screenshotting/ @elastic/appex-sharedux
-/x-pack/test/functional/es_archives/lens/reporting/ @elastic/appex-sharedux
-/x-pack/test/functional/es_archives/reporting/ @elastic/appex-sharedux
-/x-pack/test/functional/fixtures/kbn_archiver/reporting/ @elastic/appex-sharedux
-/x-pack/test/reporting_api_integration/ @elastic/appex-sharedux
-/x-pack/test/reporting_functional/ @elastic/appex-sharedux
-/x-pack/test/stack_functional_integration/apps/reporting/ @elastic/appex-sharedux
-/docs/user/reporting @elastic/appex-sharedux
-/docs/settings/reporting-settings.asciidoc @elastic/appex-sharedux
-/docs/setup/configuring-reporting.asciidoc @elastic/appex-sharedux
-
-### Global Experience Tagging
-/x-pack/test/saved_object_tagging/ @elastic/appex-sharedux
-
-### Kibana React (to be deprecated)
-/src/plugins/kibana_react/public/@elastic/appex-sharedux @elastic/kibana-presentation
-
-### Home Plugin and Packages
-/src/plugins/home/public @elastic/appex-sharedux
-/src/plugins/home/server/*.ts @elastic/appex-sharedux
-/src/plugins/home/server/services/ @elastic/appex-sharedux
-
-### Code Coverage
-#CC# /src/plugins/home/public @elastic/appex-sharedux
-#CC# /src/plugins/home/server/services/ @elastic/appex-sharedux
-#CC# /src/plugins/home/ @elastic/appex-sharedux
-#CC# /x-pack/plugins/reporting/ @elastic/appex-sharedux
-
-### Observability Plugins
-
-# Observability Shared
-/x-pack/plugins/observability/public/components/shared/date_picker/ @elastic/uptime
-
-# Unified Observability - on hold due to team capacity shortage
-# For now, if you're changing these pages, get a review from someone who understand the changes
-# /x-pack/plugins/observability/public/context @elastic/unified-observability
-# /x-pack/test/observability_functional @elastic/unified-observability
-
-# Home/Overview/Landing Pages
-/x-pack/plugins/observability/public/pages/home @elastic/observability-design
-/x-pack/plugins/observability/public/pages/landing @elastic/observability-design
-/x-pack/plugins/observability/public/pages/overview @elastic/observability-design @elastic/actionable-observability
-
-# Actionable Observability
-/x-pack/plugins/observability/common/rules @elastic/actionable-observability
-/x-pack/plugins/observability/public/rules @elastic/actionable-observability
-/x-pack/plugins/observability/public/pages/alerts @elastic/actionable-observability
-/x-pack/plugins/observability/public/pages/cases  @elastic/actionable-observability
-/x-pack/plugins/observability/public/pages/rules  @elastic/actionable-observability
-/x-pack/plugins/observability/public/pages/rule_details  @elastic/actionable-observability
-/x-pack/test/observability_functional @elastic/actionable-observability
-
-# Infra Monitoring
-/x-pack/test/functional/apps/infra @elastic/infra-monitoring-ui
-/x-pack/test/api_integration/apis/infra @elastic/infra-monitoring-ui
-
-# Elastic Stack Monitoring
-/x-pack/test/functional/apps/monitoring @elastic/infra-monitoring-ui
-/x-pack/test/api_integration/apis/monitoring @elastic/infra-monitoring-ui
-/x-pack/test/api_integration/apis/monitoring_collection @elastic/infra-monitoring-ui
-
-# Fleet
-/fleet_packages.json @elastic/fleet
-/x-pack/test/fleet_api_integration @elastic/fleet
-/x-pack/test/fleet_cypress @elastic/fleet
-/x-pack/test/fleet_functional @elastic/fleet
-/src/dev/build/tasks/bundle_fleet_packages.ts @elastic/fleet @elastic/kibana-operations
-
-# APM
-/x-pack/test/functional/apps/apm/  @elastic/apm-ui
-/x-pack/test/apm_api_integration/ @elastic/apm-ui
-/src/apm.js @elastic/kibana-core @vigneshshanmugam
-/src/core/types/elasticsearch @elastic/apm-ui
-/packages/kbn-utility-types/src/dot.ts @dgieselaar
-/packages/kbn-utility-types/src/dot_test.ts @dgieselaar
-#CC# /src/plugins/apm_oss/ @elastic/apm-ui
-#CC# /x-pack/plugins/observability/ @elastic/apm-ui
-
-# Uptime
-/x-pack/test/functional_with_es_ssl/apps/discover_ml_uptime/uptime/ @elastic/uptime
-/x-pack/test/functional/apps/uptime @elastic/uptime
-/x-pack/test/functional/es_archives/uptime @elastic/uptime
-/x-pack/test/functional/services/uptime @elastic/uptime
-/x-pack/test/api_integration/apis/uptime @elastic/uptime
-/x-pack/plugins/observability/public/components/shared/exploratory_view @elastic/uptime
-
-
-# Client Side Monitoring / Uptime (lives in APM directories but owned by Uptime)
-/x-pack/plugins/apm/public/application/uxApp.tsx @elastic/uptime
-/x-pack/plugins/apm/public/components/app/rum_dashboard @elastic/uptime
-/x-pack/test/apm_api_integration/tests/csm/ @elastic/uptime
-
-# Observability onboarding tour
-/x-pack/plugins/observability/public/components/shared/tour @elastic/platform-onboarding
-/x-pack/test/functional/apps/infra/tour.ts @elastic/platform-onboarding
-
-### END Observability Plugins
-
-# Presentation
-/test/functional/apps/dashboard/  @elastic/kibana-presentation
-/test/functional/apps/dashboard_elements/  @elastic/kibana-presentation
-/test/functional/services/dashboard/  @elastic/kibana-presentation
-/x-pack/test/functional/apps/canvas/ @elastic/kibana-presentation
-/test/plugin_functional/test_suites/panel_actions @elastic/kibana-presentation
-#CC# /src/plugins/kibana_react/public/code_editor/ @elastic/kibana-presentation
-
-# Machine Learning
-/x-pack/plugins/ml/common/openapi/ @elastic/mlr-docs
-/x-pack/test/accessibility/apps/ml.ts  @elastic/ml-ui
-/x-pack/test/accessibility/apps/ml_embeddables_in_dashboard.ts  @elastic/ml-ui
-/x-pack/test/api_integration/apis/ml/ @elastic/ml-ui
-/x-pack/test/api_integration_basic/apis/ml/ @elastic/ml-ui
-/x-pack/test/functional/apps/ml/  @elastic/ml-ui
-/x-pack/test/functional/es_archives/ml/  @elastic/ml-ui
-/x-pack/test/functional/services/ml/  @elastic/ml-ui
-/x-pack/test/functional_basic/apps/ml/ @elastic/ml-ui
-/x-pack/test/functional_with_es_ssl/apps/discover_ml_uptime/ml/ @elastic/ml-ui
-/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/ml_rule_types/ @elastic/ml-ui
-/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/transform_rule_types/ @elastic/ml-ui
-/x-pack/test/screenshot_creation/apps/ml_docs @elastic/ml-ui
-/x-pack/test/screenshot_creation/services/ml_screenshots.ts @elastic/ml-ui
-/docs/api/machine-learning/ @elastic/mlr-docs
-
-# Additional plugins and packages maintained by the ML team.
-/x-pack/test/accessibility/apps/transform.ts  @elastic/ml-ui
-/x-pack/test/api_integration/apis/transform/ @elastic/ml-ui
-/x-pack/test/api_integration_basic/apis/transform/ @elastic/ml-ui
-/x-pack/test/functional/apps/transform/ @elastic/ml-ui
-/x-pack/test/functional/services/transform/ @elastic/ml-ui
-/x-pack/test/functional_basic/apps/transform/ @elastic/ml-ui
-
-# Maps
-#CC# /x-pack/plugins/maps/ @elastic/kibana-gis
-/x-pack/test/api_integration/apis/maps/ @elastic/kibana-gis
-/x-pack/test/functional/apps/maps/ @elastic/kibana-gis
-/x-pack/test/functional/es_archives/maps/ @elastic/kibana-gis
-/x-pack/plugins/stack_alerts/server/rule_types/geo_containment @elastic/kibana-gis
-/x-pack/plugins/stack_alerts/public/rule_types/geo_containment @elastic/kibana-gis
-#CC# /x-pack/plugins/file_upload @elastic/kibana-gis
-
-# Operations
-/src/dev/license_checker/config.ts @elastic/kibana-operations
-/src/dev/ @elastic/kibana-operations
-/src/setup_node_env/ @elastic/kibana-operations
-/src/cli/keystore/ @elastic/kibana-operations
-/.ci/es-snapshots/ @elastic/kibana-operations
-/.github/workflows/ @elastic/kibana-operations
-/vars/ @elastic/kibana-operations
-/.bazelignore @elastic/kibana-operations
-/.bazeliskversion @elastic/kibana-operations
-/.bazelrc @elastic/kibana-operations
-/.bazelrc.common @elastic/kibana-operations
-/.bazelversion @elastic/kibana-operations
-/WORKSPACE.bazel @elastic/kibana-operations
-/.buildkite/ @elastic/kibana-operations
-/kbn_pm/ @elastic/kibana-operations
-
-# Quality Assurance
-/src/dev/code_coverage @elastic/kibana-qa
-/vars/*Coverage.groovy @elastic/kibana-qa
-/test/functional/services/common @elastic/kibana-qa
-/test/functional/services/lib @elastic/kibana-qa
-/test/functional/services/remote @elastic/kibana-qa
-/test/visual_regression @elastic/kibana-qa
-/x-pack/test/visual_regression @elastic/kibana-qa
-
-# Core
-/config/kibana.yml @elastic/kibana-core
-/typings/ @elastic/kibana-core
-/x-pack/test/saved_objects_field_count/ @elastic/kibana-core
-/test/analytics @elastic/kibana-core
-#CC# /src/core/server/csp/ @elastic/kibana-core
-#CC# /src/plugins/saved_objects/ @elastic/kibana-core
-#CC# /x-pack/plugins/cloud/ @elastic/kibana-core
-#CC# /x-pack/plugins/features/ @elastic/kibana-core
-#CC# /x-pack/plugins/global_search/ @elastic/kibana-core
-#CC# /src/plugins/newsfeed @elastic/kibana-core
-#CC# /x-pack/plugins/global_search_providers/ @elastic/kibana-core
-
-# Kibana Telemetry
-/.telemetryrc.json @elastic/kibana-core
-/x-pack/.telemetryrc.json @elastic/kibana-core
-/src/plugins/telemetry/schema/ @elastic/kibana-core @elastic/kibana-telemetry
-/x-pack/plugins/telemetry_collection_xpack/schema/ @elastic/kibana-core @elastic/kibana-telemetry
-
-# Kibana Localization
-/src/dev/i18n/  @elastic/kibana-localization @elastic/kibana-core
-/src/core/public/i18n/  @elastic/kibana-localization @elastic/kibana-core
-#CC# /x-pack/plugins/translations/ @elastic/kibana-localization @elastic/kibana-core
-
-# Kibana Platform Security
-/src/plugins/telemetry/server/config/telemetry_labels.ts @elastic/kibana-security
-/test/interactive_setup_api_integration/ @elastic/kibana-security
-/test/interactive_setup_functional/ @elastic/kibana-security
-/test/plugin_functional/test_suites/core_plugins/rendering.ts @elastic/kibana-security
-/x-pack/test/api_integration/apis/security/ @elastic/kibana-security
-/x-pack/test/api_integration/apis/spaces/ @elastic/kibana-security
-/x-pack/test/ui_capabilities/ @elastic/kibana-security
-/x-pack/test/encrypted_saved_objects_api_integration/ @elastic/kibana-security
-/x-pack/test/functional/apps/security/ @elastic/kibana-security
-/x-pack/test/functional/apps/spaces/ @elastic/kibana-security
-/x-pack/test/security_api_integration/ @elastic/kibana-security
-/x-pack/test/security_functional/ @elastic/kibana-security
-/x-pack/test/spaces_api_integration/ @elastic/kibana-security
-/x-pack/test/saved_object_api_integration/ @elastic/kibana-security
-#CC# /x-pack/plugins/security/ @elastic/kibana-security
-
-# Response Ops team
-/x-pack/test/alerting_api_integration/ @elastic/response-ops
-/x-pack/test/plugin_api_integration/test_suites/task_manager/ @elastic/response-ops
-/x-pack/test/functional_with_es_ssl/apps/triggers_actions_ui/ @elastic/response-ops
-/docs/user/alerting/ @elastic/response-ops
-/docs/management/connectors/ @elastic/response-ops
-/x-pack/test/cases_api_integration/ @elastic/response-ops
-/x-pack/test/functional/services/cases/ @elastic/response-ops
-/x-pack/test/functional_with_es_ssl/apps/cases/ @elastic/response-ops
-/x-pack/test/api_integration/apis/cases/ @elastic/response-ops
-/docs/api/actions-and-connectors @elastic/mlr-docs
-/docs/api/alerting @elastic/mlr-docs
-/docs/api/cases @elastic/mlr-docs
-/x-pack/plugins/cases/docs/openapi @elastic/mlr-docs
-
-# Enterprise Search
-/x-pack/test/functional_enterprise_search/ @elastic/enterprise-search-frontend
-/x-pack/plugins/enterprise_search/public/applications/shared/doc_links @elastic/ent-search-docs-team
-
-# Management Experience - Deployment Management
-#CC# /x-pack/plugins/cross_cluster_replication/ @elastic/platform-deployment-management
-
-# Security Solution
-/x-pack/test/endpoint_api_integration_no_ingest/ @elastic/security-solution
-/x-pack/test/security_solution_endpoint/ @elastic/security-solution
-/x-pack/test/functional/es_archives/endpoint/ @elastic/security-solution
-/x-pack/test/plugin_functional/test_suites/resolver/ @elastic/security-solution
-/x-pack/test/detection_engine_api_integration @elastic/security-solution
-/x-pack/test/lists_api_integration @elastic/security-solution
-/x-pack/test/api_integration/apis/security_solution @elastic/security-solution
-#CC# /x-pack/plugins/security_solution/ @elastic/security-solution
-
-# Security Solution sub teams
-
-## Security Solution sub teams - Threat Hunting Investigations
-
-/x-pack/plugins/security_solution/common/search_strategy/timeline @elastic/security-threat-hunting-investigations
-/x-pack/plugins/security_solution/common/types/timeline @elastic/security-threat-hunting-investigations
-
-/x-pack/plugins/security_solution/cypress/e2e/timeline_templates @elastic/security-threat-hunting-investigations
-/x-pack/plugins/security_solution/cypress/e2e/timeline @elastic/security-threat-hunting-investigations
-/x-pack/plugins/security_solution/cypress/e2e/detection_alerts @elastic/security-threat-hunting-investigations
-/x-pack/plugins/security_solution/cypress/e2e/urls @elastic/security-threat-hunting-investigations
-
-/x-pack/plugins/security_solution/public/common/components/alerts_viewer @elastic/security-threat-hunting-investigations
-/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_action @elastic/security-threat-hunting-investigations
-/x-pack/plugins/security_solution/public/common/components/event_details @elastic/security-threat-hunting-investigations
-/x-pack/plugins/security_solution/public/common/components/events_viewer @elastic/security-threat-hunting-investigations
-/x-pack/plugins/security_solution/public/common/components/markdown_editor @elastic/security-threat-hunting-investigations
-/x-pack/plugins/security_solution/public/detections/components/alerts_kpis @elastic/security-threat-hunting-investigations
-/x-pack/plugins/security_solution/public/detections/components/alerts_table @elastic/security-threat-hunting-investigations
-/x-pack/plugins/security_solution/public/detections/components/alerts_info @elastic/security-threat-hunting-investigations
-/x-pack/plugins/security_solution/public/resolver @elastic/security-threat-hunting-investigations
-/x-pack/plugins/security_solution/public/timelines @elastic/security-threat-hunting-investigations
-
-/x-pack/plugins/security_solution/server/lib/timeline @elastic/security-threat-hunting-investigations
-
-## Security Solution sub teams - Threat Hunting Explore
-/x-pack/plugins/security_solution/common/search_strategy/security_solution/hosts @elastic/security-threat-hunting-explore
-/x-pack/plugins/security_solution/common/search_strategy/security_solution/matrix_histogram @elastic/security-threat-hunting-explore
-/x-pack/plugins/security_solution/common/search_strategy/security_solution/network @elastic/security-threat-hunting-explore
-/x-pack/plugins/security_solution/common/search_strategy/security_solution/user @elastic/security-threat-hunting-explore
-
-/x-pack/plugins/security_solution/cypress/e2e/cases @elastic/security-threat-hunting-explore
-/x-pack/plugins/security_solution/cypress/e2e/filters @elastic/security-threat-hunting-explore
-/x-pack/plugins/security_solution/cypress/e2e/host_details @elastic/security-threat-hunting-explore
-/x-pack/plugins/security_solution/cypress/e2e/hosts @elastic/security-threat-hunting-explore
-/x-pack/plugins/security_solution/cypress/e2e/network @elastic/security-threat-hunting-explore
-/x-pack/plugins/security_solution/cypress/e2e/overview @elastic/security-threat-hunting-explore
-/x-pack/plugins/security_solution/cypress/e2e/pagination @elastic/security-threat-hunting-explore
-/x-pack/plugins/security_solution/cypress/e2e/users @elastic/security-threat-hunting-explore
-/x-pack/plugins/security_solution/cypress/screens/hosts @elastic/security-threat-hunting-explore
-/x-pack/plugins/security_solution/cypress/screens/network @elastic/security-threat-hunting-explore
-/x-pack/plugins/security_solution/cypress/tasks/hosts @elastic/security-threat-hunting-explore
-/x-pack/plugins/security_solution/cypress/tasks/network @elastic/security-threat-hunting-explore
-/x-pack/plugins/security_solution/cypress/upgrade_e2e/threat_hunting/cases @elastic/security-threat-hunting-explore
-
-/x-pack/plugins/security_solution/public/common/components/guided_onboarding_tour @elastic/security-threat-hunting-explore
-/x-pack/plugins/security_solution/public/common/components/charts @elastic/security-threat-hunting-explore
-/x-pack/plugins/security_solution/public/common/components/header_page @elastic/security-threat-hunting-explore
-/x-pack/plugins/security_solution/public/common/components/header_section @elastic/security-threat-hunting-explore
-/x-pack/plugins/security_solution/public/common/components/inspect @elastic/security-threat-hunting-explore
-/x-pack/plugins/security_solution/public/common/components/last_event_time @elastic/security-threat-hunting-explore
-/x-pack/plugins/security_solution/public/common/components/links @elastic/security-threat-hunting-explore
-/x-pack/plugins/security_solution/public/common/components/matrix_histogram @elastic/security-threat-hunting-explore
-/x-pack/plugins/security_solution/public/common/components/navigation @elastic/security-threat-hunting-explore
-/x-pack/plugins/security_solution/public/common/components/news_feed @elastic/security-threat-hunting-explore
-/x-pack/plugins/security_solution/public/common/components/overview_description_list @elastic/security-threat-hunting-explore
-/x-pack/plugins/security_solution/public/common/components/page @elastic/security-threat-hunting-explore
-/x-pack/plugins/security_solution/public/common/components/sidebar_header @elastic/security-threat-hunting-explore
-/x-pack/plugins/security_solution/public/common/components/tables @elastic/security-threat-hunting-explore
-/x-pack/plugins/security_solution/public/common/components/top_n @elastic/security-threat-hunting-explore
-/x-pack/plugins/security_solution/public/common/components/with_hover_actions @elastic/security-threat-hunting-explore
-/x-pack/plugins/security_solution/public/common/containers/matrix_histogram @elastic/security-threat-hunting-explore
-/x-pack/plugins/security_solution/public/common/lib/cell_actions @elastic/security-threat-hunting-explore
-/x-pack/plugins/security_solution/public/cases @elastic/security-threat-hunting-explore
-/x-pack/plugins/security_solution/public/explore @elastic/security-threat-hunting-explore
-/x-pack/plugins/security_solution/public/overview @elastic/security-threat-hunting-explore
-
-/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts @elastic/security-threat-hunting-explore
-/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram @elastic/security-threat-hunting-explore
-/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network @elastic/security-threat-hunting-explore
-/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/users @elastic/security-threat-hunting-explore
-
-## Security Solution sub teams - Detections and Response Alerts
-/x-pack/plugins/security_solution/common/detection_engine/schemas/alerts @elastic/security-detections-response-alerts
-/x-pack/plugins/security_solution/common/field_maps @elastic/security-detections-response-alerts
-
-/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui @elastic/security-detections-response-alerts
-/x-pack/plugins/security_solution/public/detections/pages/alerts @elastic/security-detections-response-alerts
-
-/x-pack/plugins/security_solution/server/lib/detection_engine/migrations @elastic/security-detections-response-alerts
-/x-pack/plugins/security_solution/server/lib/detection_engine/rule_preview @elastic/security-detections-response-alerts
-/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types @elastic/security-detections-response-alerts
-/x-pack/plugins/security_solution/server/lib/detection_engine/signals @elastic/security-detections-response-alerts
-/x-pack/plugins/security_solution/server/lib/detection_engine/routes/index @elastic/security-detections-response-alerts
-/x-pack/plugins/security_solution/server/lib/detection_engine/routes/signals @elastic/security-detections-response-alerts
-
-## Security Solution sub teams - Detections and Response Rules
-/x-pack/plugins/security_solution/common/detection_engine/fleet_integrations @elastic/security-detections-response-rules
-/x-pack/plugins/security_solution/common/detection_engine/prebuilt_rules @elastic/security-detections-response-rules
-/x-pack/plugins/security_solution/common/detection_engine/rule_management @elastic/security-detections-response-rules
-/x-pack/plugins/security_solution/common/detection_engine/rule_monitoring @elastic/security-detections-response-rules
-/x-pack/plugins/security_solution/common/detection_engine/rule_schema @elastic/security-detections-response-rules @elastic/security-detections-response-alerts
-
-/x-pack/plugins/security_solution/public/common/components/health_truncate_text @elastic/security-detections-response-rules
-/x-pack/plugins/security_solution/public/common/components/links_to_docs @elastic/security-detections-response-rules
-/x-pack/plugins/security_solution/public/common/components/ml_popover @elastic/security-detections-response-rules
-/x-pack/plugins/security_solution/public/common/components/popover_items @elastic/security-detections-response-rules
-/x-pack/plugins/security_solution/public/detection_engine/fleet_integrations @elastic/security-detections-response-rules
-/x-pack/plugins/security_solution/public/detection_engine/rule_details_ui @elastic/security-detections-response-rules
-/x-pack/plugins/security_solution/public/detection_engine/rule_management @elastic/security-detections-response-rules
-/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui @elastic/security-detections-response-rules
-/x-pack/plugins/security_solution/public/detection_engine/rule_monitoring @elastic/security-detections-response-rules
-/x-pack/plugins/security_solution/public/detections/components/callouts @elastic/security-detections-response-rules
-/x-pack/plugins/security_solution/public/detections/components/modals/ml_job_upgrade_modal @elastic/security-detections-response-rules
-/x-pack/plugins/security_solution/public/detections/components/rules @elastic/security-detections-response-rules
-/x-pack/plugins/security_solution/public/detections/components/rules/rule_preview @elastic/security-detections-response-alerts
-/x-pack/plugins/security_solution/public/detections/containers/detection_engine/rules @elastic/security-detections-response-rules
-/x-pack/plugins/security_solution/public/detections/mitre @elastic/security-detections-response-rules
-/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules @elastic/security-detections-response-rules
-/x-pack/plugins/security_solution/public/rules @elastic/security-detections-response-rules
-
-/x-pack/plugins/security_solution/server/lib/detection_engine/fleet_integrations @elastic/security-detections-response-rules
-/x-pack/plugins/security_solution/server/lib/detection_engine/prebuilt_rules @elastic/security-detections-response-rules
-/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management @elastic/security-detections-response-rules
-/x-pack/plugins/security_solution/server/lib/detection_engine/rule_monitoring @elastic/security-detections-response-rules
-/x-pack/plugins/security_solution/server/lib/detection_engine/rule_schema @elastic/security-detections-response-rules @elastic/security-detections-response-alerts
-
-/x-pack/plugins/security_solution/server/utils @elastic/security-detections-response-rules
-
-## Security Solution sub teams - Security Platform
-
-/x-pack/plugins/security_solution/cypress/e2e/data_sources @elastic/security-solution-platform
-/x-pack/plugins/security_solution/cypress/e2e/exceptions @elastic/security-solution-platform
-/x-pack/plugins/security_solution/cypress/e2e/value_lists @elastic/security-solution-platform
-
-/x-pack/plugins/security_solution/common/detection_engine/rule_exceptions @elastic/security-solution-platform
-
-/x-pack/plugins/security_solution/public/detection_engine/rule_exceptions @elastic/security-solution-platform
-/x-pack/plugins/security_solution/public/detection_engine/rule_exceptions_ui @elastic/security-solution-platform
-/x-pack/plugins/security_solution/public/common/components/exceptions @elastic/security-solution-platform
-/x-pack/plugins/security_solution/public/exceptions @elastic/security-solution-platform
-/x-pack/plugins/security_solution/public/detections/containers/detection_engine/lists @elastic/security-solution-platform
-/x-pack/plugins/security_solution/public/common/components/sourcerer @elastic/security-solution-platform
-
-/x-pack/plugins/security_solution/server/lib/detection_engine/rule_actions_legacy @elastic/security-solution-platform
-/x-pack/plugins/security_solution/server/lib/detection_engine/rule_exceptions @elastic/security-solution-platform
-/x-pack/plugins/security_solution/server/lib/sourcerer @elastic/security-solution-platform
-
-## Security Threat Intelligence - Under Security Platform
-/x-pack/plugins/security_solution/public/common/components/threat_match @elastic/security-solution-platform
-
-## Security Solution cross teams ownership
-/x-pack/plugins/security_solution/cypress/fixtures @elastic/security-detections-response @elastic/security-threat-hunting
-/x-pack/plugins/security_solution/cypress/helpers @elastic/security-detections-response @elastic/security-threat-hunting
-/x-pack/plugins/security_solution/cypress/e2e/detection_rules @elastic/security-detections-response-rules @elastic/security-detections-response-alerts
-/x-pack/plugins/security_solution/cypress/objects @elastic/security-detections-response @elastic/security-threat-hunting
-/x-pack/plugins/security_solution/cypress/plugins @elastic/security-detections-response @elastic/security-threat-hunting
-/x-pack/plugins/security_solution/cypress/screens/common @elastic/security-detections-response @elastic/security-threat-hunting
-/x-pack/plugins/security_solution/cypress/support @elastic/security-detections-response @elastic/security-threat-hunting
-/x-pack/plugins/security_solution/cypress/urls @elastic/security-threat-hunting-investigations @elastic/security-solution-platform
-
-/x-pack/plugins/security_solution/common/ecs @elastic/security-threat-hunting-investigations
-/x-pack/plugins/security_solution/common/test @elastic/security-detections-response-rules @elastic/security-detections-response-alerts
-
-/x-pack/plugins/security_solution/public/common/components/callouts @elastic/security-detections-response
-/x-pack/plugins/security_solution/public/common/components/hover_actions @elastic/security-threat-hunting-explore @elastic/security-threat-hunting-investigations
-
-/x-pack/plugins/security_solution/server/lib/detection_engine/rule_actions @elastic/security-solution-platform @elastic/security-detections-response-rules
-/x-pack/plugins/security_solution/server/routes @elastic/security-detections-response @elastic/security-threat-hunting
-
-## Security Solution sub teams - security-defend-workflows
-/x-pack/plugins/security_solution/public/management/ @elastic/security-defend-workflows
-/x-pack/plugins/security_solution/public/common/lib/endpoint*/ @elastic/security-defend-workflows
-/x-pack/plugins/security_solution/public/common/components/endpoint/ @elastic/security-defend-workflows
-/x-pack/plugins/security_solution/common/endpoint/ @elastic/security-defend-workflows
-/x-pack/plugins/security_solution/server/endpoint/ @elastic/security-defend-workflows
-/x-pack/plugins/security_solution/server/lists_integration/endpoint/ @elastic/security-defend-workflows
-/x-pack/plugins/security_solution/server/lib/license/ @elastic/security-defend-workflows
-/x-pack/plugins/security_solution/server/fleet_integration/ @elastic/security-defend-workflows
-/x-pack/plugins/security_solution/scripts/endpoint/event_filters/ @elastic/security-defend-workflows
-/x-pack/plugins/security_solution/scripts/endpoint/trusted_apps/ @elastic/security-defend-workflows
-/x-pack/test/security_solution_endpoint/apps/endpoint/ @elastic/security-defend-workflows
-/x-pack/test/security_solution_endpoint_api_int/ @elastic/security-defend-workflows
-
-## Security Solution sub teams - security-telemetry (Data Engineering)
-x-pack/plugins/security_solution/server/usage/ @elastic/security-data-analytics
-x-pack/plugins/security_solution/server/lib/telemetry/ @elastic/security-data-analytics
-
-## Security Solution sub teams - security-engineering-productivity
-x-pack/plugins/security_solution/cypress/ccs_e2e @elastic/security-engineering-productivity
-x-pack/plugins/security_solution/cypress/upgrade_e2e @elastic/security-engineering-productivity
-x-pack/plugins/security_solution/cypress/README.md @elastic/security-engineering-productivity
-x-pack/test/security_solution_cypress @elastic/security-engineering-productivity
-
-## Security Solution sub teams - adaptive-workload-protection
-x-pack/plugins/security_solution/public/common/components/sessions_viewer @elastic/awp-viz
-x-pack/plugins/security_solution/public/kubernetes @elastic/awp-viz
-
-## Security Solution sub teams - Protections Experience
-x-pack/plugins/security_solution/public/threat_intelligence @elastic/protections-experience
-x-pack/test/threat_intelligence_cypress @elastic/protections-experience
-
-# Security Defend Workflows - OSQuery Ownership
-/x-pack/plugins/security_solution/common/detection_engine/rule_response_actions @elastic/security-defend-workflows
-/x-pack/plugins/security_solution/public/detection_engine/rule_response_actions @elastic/security-defend-workflows
-/x-pack/plugins/security_solution/server/lib/detection_engine/rule_response_actions @elastic/security-defend-workflows
-
-# Cloud Security Posture
-/x-pack/plugins/security_solution/public/cloud_security_posture @elastic/kibana-cloud-security-posture
-/x-pack/test/api_integration/apis/cloud_security_posture/ @elastic/kibana-cloud-security-posture
-/x-pack/test/cloud_security_posture_functional/ @elastic/kibana-cloud-security-posture
-
-
-# Security Solution onboarding tour
-/x-pack/plugins/security_solution/public/common/components/guided_onboarding @elastic/security-threat-hunting-explore
-/x-pack/plugins/security_solution/cypress/e2e/guided_onboarding @elastic/security-threat-hunting-explore
-
-# Design (at the bottom for specificity of SASS files)
-**/*.scss  @elastic/kibana-design
-
-# Observability design
-/x-pack/plugins/apm/**/*.scss @elastic/observability-design
-/x-pack/plugins/infra/**/*.scss @elastic/observability-design
-/x-pack/plugins/fleet/**/*.scss @elastic/observability-design
-/x-pack/plugins/observability/**/*.scss @elastic/observability-design
-/x-pack/plugins/monitoring/**/*.scss @elastic/observability-design
-
-# Ent. Search design
-/x-pack/plugins/enterprise_search/**/*.scss @elastic/ent-search-design
-
-# Security design
-/x-pack/plugins/endpoint/**/*.scss @elastic/security-design
-/x-pack/plugins/security_solution/**/*.scss @elastic/security-design
-
-# Logstash
-#CC# /x-pack/plugins/logstash/ @elastic/logstash
-
-# EUI design
-/src/plugins/kibana_react/public/page_template/ @elastic/eui-design @elastic/appex-sharedux
-
-# Landing page for guided onboarding in Home plugin
-/src/plugins/home/public/application/components/guided_onboarding @elastic/platform-onboarding
-
 ####
-## Everything below this comment is automatically generated based on kibana.jsonc
-## "owner" fields. This file is automatically updated by CI or can be updated locally
-## by running `node scripts/generate codeowners`.
+## Everything at the top of the codeowners file is auto generated based on the
+## "owner" fields in the kibana.jsonc files at the root of each package. This
+## file is automatically updated by CI or can be updated locally by running
+## `node scripts/generate codeowners`.
 ####
 
 x-pack/test/alerting_api_integration/common/plugins/aad @elastic/response-ops
@@ -1188,9 +687,523 @@ x-pack/plugins/watcher @elastic/platform-deployment-management
 packages/kbn-web-worker-stub @elastic/kibana-operations
 packages/kbn-whereis-pkg-cli @elastic/kibana-operations
 packages/kbn-yarn-lock-validator @elastic/kibana-operations
+####
+## Everything below this line overrides the default assignments for each package.
+## Items lower in the file have higher precedence:
+##  https://help.github.com/articles/about-codeowners/
+####
+
+# The #CC# prefix delineates Code Coverage,
+# used for the 'team' designator within Kibana Stats
+
+# Data Discovery
+/x-pack/test/functional/apps/discover/ @elastic/kibana-data-discovery
+/x-pack/test/functional_with_es_ssl/apps/discover_ml_uptime/discover/ @elastic/kibana-data-discovery
+/test/functional/apps/discover/ @elastic/kibana-data-discovery
+/test/functional/apps/context/ @elastic/kibana-data-discovery
+/test/api_integration/apis/unified_field_list/ @elastic/kibana-data-discovery
+/x-pack/test/search_sessions_integration/ @elastic/kibana-data-discovery
+/test/plugin_functional/test_suites/data_plugin @elastic/kibana-data-discovery
+/examples/demo_search/ @elastic/kibana-data-discovery
+
+# Vis Editors
+/src/plugins/visualize/ @elastic/kibana-visualizations
+/x-pack/test/functional/apps/lens @elastic/kibana-visualizations
+/x-pack/test/api_integration/apis/lens/ @elastic/kibana-visualizations
+/test/functional/apps/visualize/ @elastic/kibana-visualizations
+/x-pack/test/functional/apps/graph @elastic/kibana-visualizations
+
+# Global Experience
+
+### Global Experience Reporting
+/x-pack/test/functional/apps/dashboard/reporting/ @elastic/appex-sharedux
+/x-pack/test/functional/apps/reporting/ @elastic/appex-sharedux
+/x-pack/test/functional/apps/reporting_management/ @elastic/appex-sharedux
+/x-pack/test/examples/screenshotting/ @elastic/appex-sharedux
+/x-pack/test/functional/es_archives/lens/reporting/ @elastic/appex-sharedux
+/x-pack/test/functional/es_archives/reporting/ @elastic/appex-sharedux
+/x-pack/test/functional/fixtures/kbn_archiver/reporting/ @elastic/appex-sharedux
+/x-pack/test/reporting_api_integration/ @elastic/appex-sharedux
+/x-pack/test/reporting_functional/ @elastic/appex-sharedux
+/x-pack/test/stack_functional_integration/apps/reporting/ @elastic/appex-sharedux
+/docs/user/reporting @elastic/appex-sharedux
+/docs/settings/reporting-settings.asciidoc @elastic/appex-sharedux
+/docs/setup/configuring-reporting.asciidoc @elastic/appex-sharedux
+
+### Global Experience Tagging
+/x-pack/test/saved_object_tagging/ @elastic/appex-sharedux
+
+### Kibana React (to be deprecated)
+/src/plugins/kibana_react/public/@elastic/appex-sharedux @elastic/kibana-presentation
+
+### Home Plugin and Packages
+/src/plugins/home/public @elastic/appex-sharedux
+/src/plugins/home/server/*.ts @elastic/appex-sharedux
+/src/plugins/home/server/services/ @elastic/appex-sharedux
+
+### Code Coverage
+#CC# /src/plugins/home/public @elastic/appex-sharedux
+#CC# /src/plugins/home/server/services/ @elastic/appex-sharedux
+#CC# /src/plugins/home/ @elastic/appex-sharedux
+#CC# /x-pack/plugins/reporting/ @elastic/appex-sharedux
+
+### Observability Plugins
+
+# Observability Shared
+/x-pack/plugins/observability/public/components/shared/date_picker/ @elastic/uptime
+
+# Unified Observability - on hold due to team capacity shortage
+# For now, if you're changing these pages, get a review from someone who understand the changes
+# /x-pack/plugins/observability/public/context @elastic/unified-observability
+# /x-pack/test/observability_functional @elastic/unified-observability
+
+# Home/Overview/Landing Pages
+/x-pack/plugins/observability/public/pages/home @elastic/observability-design
+/x-pack/plugins/observability/public/pages/landing @elastic/observability-design
+/x-pack/plugins/observability/public/pages/overview @elastic/observability-design @elastic/actionable-observability
+
+# Actionable Observability
+/x-pack/plugins/observability/common/rules @elastic/actionable-observability
+/x-pack/plugins/observability/public/rules @elastic/actionable-observability
+/x-pack/plugins/observability/public/pages/alerts @elastic/actionable-observability
+/x-pack/plugins/observability/public/pages/cases  @elastic/actionable-observability
+/x-pack/plugins/observability/public/pages/rules  @elastic/actionable-observability
+/x-pack/plugins/observability/public/pages/rule_details  @elastic/actionable-observability
+/x-pack/test/observability_functional @elastic/actionable-observability
+
+# Infra Monitoring
+/x-pack/test/functional/apps/infra @elastic/infra-monitoring-ui
+/x-pack/test/api_integration/apis/infra @elastic/infra-monitoring-ui
+
+# Elastic Stack Monitoring
+/x-pack/test/functional/apps/monitoring @elastic/infra-monitoring-ui
+/x-pack/test/api_integration/apis/monitoring @elastic/infra-monitoring-ui
+/x-pack/test/api_integration/apis/monitoring_collection @elastic/infra-monitoring-ui
+
+# Fleet
+/fleet_packages.json @elastic/fleet
+/x-pack/test/fleet_api_integration @elastic/fleet
+/x-pack/test/fleet_cypress @elastic/fleet
+/x-pack/test/fleet_functional @elastic/fleet
+/src/dev/build/tasks/bundle_fleet_packages.ts @elastic/fleet @elastic/kibana-operations
+
+# APM
+/x-pack/test/functional/apps/apm/  @elastic/apm-ui
+/x-pack/test/apm_api_integration/ @elastic/apm-ui
+/src/apm.js @elastic/kibana-core @vigneshshanmugam
+/src/core/types/elasticsearch @elastic/apm-ui
+/packages/kbn-utility-types/src/dot.ts @dgieselaar
+/packages/kbn-utility-types/src/dot_test.ts @dgieselaar
+#CC# /src/plugins/apm_oss/ @elastic/apm-ui
+#CC# /x-pack/plugins/observability/ @elastic/apm-ui
+
+# Uptime
+/x-pack/test/functional_with_es_ssl/apps/discover_ml_uptime/uptime/ @elastic/uptime
+/x-pack/test/functional/apps/uptime @elastic/uptime
+/x-pack/test/functional/es_archives/uptime @elastic/uptime
+/x-pack/test/functional/services/uptime @elastic/uptime
+/x-pack/test/api_integration/apis/uptime @elastic/uptime
+/x-pack/plugins/observability/public/components/shared/exploratory_view @elastic/uptime
+
+
+# Client Side Monitoring / Uptime (lives in APM directories but owned by Uptime)
+/x-pack/plugins/apm/public/application/uxApp.tsx @elastic/uptime
+/x-pack/plugins/apm/public/components/app/rum_dashboard @elastic/uptime
+/x-pack/test/apm_api_integration/tests/csm/ @elastic/uptime
+
+# Observability onboarding tour
+/x-pack/plugins/observability/public/components/shared/tour @elastic/platform-onboarding
+/x-pack/test/functional/apps/infra/tour.ts @elastic/platform-onboarding
+
+### END Observability Plugins
+
+# Presentation
+/test/functional/apps/dashboard/  @elastic/kibana-presentation
+/test/functional/apps/dashboard_elements/  @elastic/kibana-presentation
+/test/functional/services/dashboard/  @elastic/kibana-presentation
+/x-pack/test/functional/apps/canvas/ @elastic/kibana-presentation
+/test/plugin_functional/test_suites/panel_actions @elastic/kibana-presentation
+#CC# /src/plugins/kibana_react/public/code_editor/ @elastic/kibana-presentation
+
+# Machine Learning
+/x-pack/plugins/ml/common/openapi/ @elastic/mlr-docs
+/x-pack/test/accessibility/apps/ml.ts  @elastic/ml-ui
+/x-pack/test/accessibility/apps/ml_embeddables_in_dashboard.ts  @elastic/ml-ui
+/x-pack/test/api_integration/apis/ml/ @elastic/ml-ui
+/x-pack/test/api_integration_basic/apis/ml/ @elastic/ml-ui
+/x-pack/test/functional/apps/ml/  @elastic/ml-ui
+/x-pack/test/functional/es_archives/ml/  @elastic/ml-ui
+/x-pack/test/functional/services/ml/  @elastic/ml-ui
+/x-pack/test/functional_basic/apps/ml/ @elastic/ml-ui
+/x-pack/test/functional_with_es_ssl/apps/discover_ml_uptime/ml/ @elastic/ml-ui
+/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/ml_rule_types/ @elastic/ml-ui
+/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/transform_rule_types/ @elastic/ml-ui
+/x-pack/test/screenshot_creation/apps/ml_docs @elastic/ml-ui
+/x-pack/test/screenshot_creation/services/ml_screenshots.ts @elastic/ml-ui
+/docs/api/machine-learning/ @elastic/mlr-docs
+
+# Additional plugins and packages maintained by the ML team.
+/x-pack/test/accessibility/apps/transform.ts  @elastic/ml-ui
+/x-pack/test/api_integration/apis/transform/ @elastic/ml-ui
+/x-pack/test/api_integration_basic/apis/transform/ @elastic/ml-ui
+/x-pack/test/functional/apps/transform/ @elastic/ml-ui
+/x-pack/test/functional/services/transform/ @elastic/ml-ui
+/x-pack/test/functional_basic/apps/transform/ @elastic/ml-ui
+
+# Maps
+#CC# /x-pack/plugins/maps/ @elastic/kibana-gis
+/x-pack/test/api_integration/apis/maps/ @elastic/kibana-gis
+/x-pack/test/functional/apps/maps/ @elastic/kibana-gis
+/x-pack/test/functional/es_archives/maps/ @elastic/kibana-gis
+/x-pack/plugins/stack_alerts/server/rule_types/geo_containment @elastic/kibana-gis
+/x-pack/plugins/stack_alerts/public/rule_types/geo_containment @elastic/kibana-gis
+#CC# /x-pack/plugins/file_upload @elastic/kibana-gis
+
+# Operations
+/src/dev/license_checker/config.ts @elastic/kibana-operations
+/src/dev/ @elastic/kibana-operations
+/src/setup_node_env/ @elastic/kibana-operations
+/src/cli/keystore/ @elastic/kibana-operations
+/.ci/es-snapshots/ @elastic/kibana-operations
+/.github/workflows/ @elastic/kibana-operations
+/vars/ @elastic/kibana-operations
+/.bazelignore @elastic/kibana-operations
+/.bazeliskversion @elastic/kibana-operations
+/.bazelrc @elastic/kibana-operations
+/.bazelrc.common @elastic/kibana-operations
+/.bazelversion @elastic/kibana-operations
+/WORKSPACE.bazel @elastic/kibana-operations
+/.buildkite/ @elastic/kibana-operations
+/kbn_pm/ @elastic/kibana-operations
+
+# Quality Assurance
+/src/dev/code_coverage @elastic/kibana-qa
+/vars/*Coverage.groovy @elastic/kibana-qa
+/test/functional/services/common @elastic/kibana-qa
+/test/functional/services/lib @elastic/kibana-qa
+/test/functional/services/remote @elastic/kibana-qa
+/test/visual_regression @elastic/kibana-qa
+/x-pack/test/visual_regression @elastic/kibana-qa
+
+# Core
+/config/kibana.yml @elastic/kibana-core
+/typings/ @elastic/kibana-core
+/x-pack/test/saved_objects_field_count/ @elastic/kibana-core
+/test/analytics @elastic/kibana-core
+#CC# /src/core/server/csp/ @elastic/kibana-core
+#CC# /src/plugins/saved_objects/ @elastic/kibana-core
+#CC# /x-pack/plugins/cloud/ @elastic/kibana-core
+#CC# /x-pack/plugins/features/ @elastic/kibana-core
+#CC# /x-pack/plugins/global_search/ @elastic/kibana-core
+#CC# /src/plugins/newsfeed @elastic/kibana-core
+#CC# /x-pack/plugins/global_search_providers/ @elastic/kibana-core
+
+# Kibana Telemetry
+/.telemetryrc.json @elastic/kibana-core
+/x-pack/.telemetryrc.json @elastic/kibana-core
+/src/plugins/telemetry/schema/ @elastic/kibana-core @elastic/kibana-telemetry
+/x-pack/plugins/telemetry_collection_xpack/schema/ @elastic/kibana-core @elastic/kibana-telemetry
+
+# Kibana Localization
+/src/dev/i18n/  @elastic/kibana-localization @elastic/kibana-core
+/src/core/public/i18n/  @elastic/kibana-localization @elastic/kibana-core
+#CC# /x-pack/plugins/translations/ @elastic/kibana-localization @elastic/kibana-core
+
+# Kibana Platform Security
+/src/plugins/telemetry/server/config/telemetry_labels.ts @elastic/kibana-security
+/test/interactive_setup_api_integration/ @elastic/kibana-security
+/test/interactive_setup_functional/ @elastic/kibana-security
+/test/plugin_functional/test_suites/core_plugins/rendering.ts @elastic/kibana-security
+/x-pack/test/api_integration/apis/security/ @elastic/kibana-security
+/x-pack/test/api_integration/apis/spaces/ @elastic/kibana-security
+/x-pack/test/ui_capabilities/ @elastic/kibana-security
+/x-pack/test/encrypted_saved_objects_api_integration/ @elastic/kibana-security
+/x-pack/test/functional/apps/security/ @elastic/kibana-security
+/x-pack/test/functional/apps/spaces/ @elastic/kibana-security
+/x-pack/test/security_api_integration/ @elastic/kibana-security
+/x-pack/test/security_functional/ @elastic/kibana-security
+/x-pack/test/spaces_api_integration/ @elastic/kibana-security
+/x-pack/test/saved_object_api_integration/ @elastic/kibana-security
+#CC# /x-pack/plugins/security/ @elastic/kibana-security
+
+# Response Ops team
+/x-pack/test/alerting_api_integration/ @elastic/response-ops
+/x-pack/test/plugin_api_integration/test_suites/task_manager/ @elastic/response-ops
+/x-pack/test/functional_with_es_ssl/apps/triggers_actions_ui/ @elastic/response-ops
+/docs/user/alerting/ @elastic/response-ops
+/docs/management/connectors/ @elastic/response-ops
+/x-pack/test/cases_api_integration/ @elastic/response-ops
+/x-pack/test/functional/services/cases/ @elastic/response-ops
+/x-pack/test/functional_with_es_ssl/apps/cases/ @elastic/response-ops
+/x-pack/test/api_integration/apis/cases/ @elastic/response-ops
+/docs/api/actions-and-connectors @elastic/mlr-docs
+/docs/api/alerting @elastic/mlr-docs
+/docs/api/cases @elastic/mlr-docs
+/x-pack/plugins/cases/docs/openapi @elastic/mlr-docs
+
+# Enterprise Search
+/x-pack/test/functional_enterprise_search/ @elastic/enterprise-search-frontend
+/x-pack/plugins/enterprise_search/public/applications/shared/doc_links @elastic/ent-search-docs-team
+
+# Management Experience - Deployment Management
+#CC# /x-pack/plugins/cross_cluster_replication/ @elastic/platform-deployment-management
+
+# Security Solution
+/x-pack/test/endpoint_api_integration_no_ingest/ @elastic/security-solution
+/x-pack/test/security_solution_endpoint/ @elastic/security-solution
+/x-pack/test/functional/es_archives/endpoint/ @elastic/security-solution
+/x-pack/test/plugin_functional/test_suites/resolver/ @elastic/security-solution
+/x-pack/test/detection_engine_api_integration @elastic/security-solution
+/x-pack/test/lists_api_integration @elastic/security-solution
+/x-pack/test/api_integration/apis/security_solution @elastic/security-solution
+#CC# /x-pack/plugins/security_solution/ @elastic/security-solution
+
+# Security Solution sub teams
+
+## Security Solution sub teams - Threat Hunting Investigations
+
+/x-pack/plugins/security_solution/common/search_strategy/timeline @elastic/security-threat-hunting-investigations
+/x-pack/plugins/security_solution/common/types/timeline @elastic/security-threat-hunting-investigations
+
+/x-pack/plugins/security_solution/cypress/e2e/timeline_templates @elastic/security-threat-hunting-investigations
+/x-pack/plugins/security_solution/cypress/e2e/timeline @elastic/security-threat-hunting-investigations
+/x-pack/plugins/security_solution/cypress/e2e/detection_alerts @elastic/security-threat-hunting-investigations
+/x-pack/plugins/security_solution/cypress/e2e/urls @elastic/security-threat-hunting-investigations
+
+/x-pack/plugins/security_solution/public/common/components/alerts_viewer @elastic/security-threat-hunting-investigations
+/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_action @elastic/security-threat-hunting-investigations
+/x-pack/plugins/security_solution/public/common/components/event_details @elastic/security-threat-hunting-investigations
+/x-pack/plugins/security_solution/public/common/components/events_viewer @elastic/security-threat-hunting-investigations
+/x-pack/plugins/security_solution/public/common/components/markdown_editor @elastic/security-threat-hunting-investigations
+/x-pack/plugins/security_solution/public/detections/components/alerts_kpis @elastic/security-threat-hunting-investigations
+/x-pack/plugins/security_solution/public/detections/components/alerts_table @elastic/security-threat-hunting-investigations
+/x-pack/plugins/security_solution/public/detections/components/alerts_info @elastic/security-threat-hunting-investigations
+/x-pack/plugins/security_solution/public/resolver @elastic/security-threat-hunting-investigations
+/x-pack/plugins/security_solution/public/timelines @elastic/security-threat-hunting-investigations
+
+/x-pack/plugins/security_solution/server/lib/timeline @elastic/security-threat-hunting-investigations
+
+## Security Solution sub teams - Threat Hunting Explore
+/x-pack/plugins/security_solution/common/search_strategy/security_solution/hosts @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/common/search_strategy/security_solution/matrix_histogram @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/common/search_strategy/security_solution/network @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/common/search_strategy/security_solution/user @elastic/security-threat-hunting-explore
+
+/x-pack/plugins/security_solution/cypress/e2e/cases @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/cypress/e2e/filters @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/cypress/e2e/host_details @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/cypress/e2e/hosts @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/cypress/e2e/network @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/cypress/e2e/overview @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/cypress/e2e/pagination @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/cypress/e2e/users @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/cypress/screens/hosts @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/cypress/screens/network @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/cypress/tasks/hosts @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/cypress/tasks/network @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/cypress/upgrade_e2e/threat_hunting/cases @elastic/security-threat-hunting-explore
+
+/x-pack/plugins/security_solution/public/common/components/guided_onboarding_tour @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/public/common/components/charts @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/public/common/components/header_page @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/public/common/components/header_section @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/public/common/components/inspect @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/public/common/components/last_event_time @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/public/common/components/links @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/public/common/components/matrix_histogram @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/public/common/components/navigation @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/public/common/components/news_feed @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/public/common/components/overview_description_list @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/public/common/components/page @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/public/common/components/sidebar_header @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/public/common/components/tables @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/public/common/components/top_n @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/public/common/components/with_hover_actions @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/public/common/containers/matrix_histogram @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/public/common/lib/cell_actions @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/public/cases @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/public/explore @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/public/overview @elastic/security-threat-hunting-explore
+
+/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/users @elastic/security-threat-hunting-explore
+
+## Security Solution sub teams - Detections and Response Alerts
+/x-pack/plugins/security_solution/common/detection_engine/schemas/alerts @elastic/security-detections-response-alerts
+/x-pack/plugins/security_solution/common/field_maps @elastic/security-detections-response-alerts
+
+/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui @elastic/security-detections-response-alerts
+/x-pack/plugins/security_solution/public/detections/pages/alerts @elastic/security-detections-response-alerts
+
+/x-pack/plugins/security_solution/server/lib/detection_engine/migrations @elastic/security-detections-response-alerts
+/x-pack/plugins/security_solution/server/lib/detection_engine/rule_preview @elastic/security-detections-response-alerts
+/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types @elastic/security-detections-response-alerts
+/x-pack/plugins/security_solution/server/lib/detection_engine/signals @elastic/security-detections-response-alerts
+/x-pack/plugins/security_solution/server/lib/detection_engine/routes/index @elastic/security-detections-response-alerts
+/x-pack/plugins/security_solution/server/lib/detection_engine/routes/signals @elastic/security-detections-response-alerts
+
+## Security Solution sub teams - Detections and Response Rules
+/x-pack/plugins/security_solution/common/detection_engine/fleet_integrations @elastic/security-detections-response-rules
+/x-pack/plugins/security_solution/common/detection_engine/prebuilt_rules @elastic/security-detections-response-rules
+/x-pack/plugins/security_solution/common/detection_engine/rule_management @elastic/security-detections-response-rules
+/x-pack/plugins/security_solution/common/detection_engine/rule_monitoring @elastic/security-detections-response-rules
+/x-pack/plugins/security_solution/common/detection_engine/rule_schema @elastic/security-detections-response-rules @elastic/security-detections-response-alerts
+
+/x-pack/plugins/security_solution/public/common/components/health_truncate_text @elastic/security-detections-response-rules
+/x-pack/plugins/security_solution/public/common/components/links_to_docs @elastic/security-detections-response-rules
+/x-pack/plugins/security_solution/public/common/components/ml_popover @elastic/security-detections-response-rules
+/x-pack/plugins/security_solution/public/common/components/popover_items @elastic/security-detections-response-rules
+/x-pack/plugins/security_solution/public/detection_engine/fleet_integrations @elastic/security-detections-response-rules
+/x-pack/plugins/security_solution/public/detection_engine/rule_details_ui @elastic/security-detections-response-rules
+/x-pack/plugins/security_solution/public/detection_engine/rule_management @elastic/security-detections-response-rules
+/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui @elastic/security-detections-response-rules
+/x-pack/plugins/security_solution/public/detection_engine/rule_monitoring @elastic/security-detections-response-rules
+/x-pack/plugins/security_solution/public/detections/components/callouts @elastic/security-detections-response-rules
+/x-pack/plugins/security_solution/public/detections/components/modals/ml_job_upgrade_modal @elastic/security-detections-response-rules
+/x-pack/plugins/security_solution/public/detections/components/rules @elastic/security-detections-response-rules
+/x-pack/plugins/security_solution/public/detections/components/rules/rule_preview @elastic/security-detections-response-alerts
+/x-pack/plugins/security_solution/public/detections/containers/detection_engine/rules @elastic/security-detections-response-rules
+/x-pack/plugins/security_solution/public/detections/mitre @elastic/security-detections-response-rules
+/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules @elastic/security-detections-response-rules
+/x-pack/plugins/security_solution/public/rules @elastic/security-detections-response-rules
+
+/x-pack/plugins/security_solution/server/lib/detection_engine/fleet_integrations @elastic/security-detections-response-rules
+/x-pack/plugins/security_solution/server/lib/detection_engine/prebuilt_rules @elastic/security-detections-response-rules
+/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management @elastic/security-detections-response-rules
+/x-pack/plugins/security_solution/server/lib/detection_engine/rule_monitoring @elastic/security-detections-response-rules
+/x-pack/plugins/security_solution/server/lib/detection_engine/rule_schema @elastic/security-detections-response-rules @elastic/security-detections-response-alerts
+
+/x-pack/plugins/security_solution/server/utils @elastic/security-detections-response-rules
+
+## Security Solution sub teams - Security Platform
+
+/x-pack/plugins/security_solution/cypress/e2e/data_sources @elastic/security-solution-platform
+/x-pack/plugins/security_solution/cypress/e2e/exceptions @elastic/security-solution-platform
+/x-pack/plugins/security_solution/cypress/e2e/value_lists @elastic/security-solution-platform
+
+/x-pack/plugins/security_solution/common/detection_engine/rule_exceptions @elastic/security-solution-platform
+
+/x-pack/plugins/security_solution/public/detection_engine/rule_exceptions @elastic/security-solution-platform
+/x-pack/plugins/security_solution/public/detection_engine/rule_exceptions_ui @elastic/security-solution-platform
+/x-pack/plugins/security_solution/public/common/components/exceptions @elastic/security-solution-platform
+/x-pack/plugins/security_solution/public/exceptions @elastic/security-solution-platform
+/x-pack/plugins/security_solution/public/detections/containers/detection_engine/lists @elastic/security-solution-platform
+/x-pack/plugins/security_solution/public/common/components/sourcerer @elastic/security-solution-platform
+
+/x-pack/plugins/security_solution/server/lib/detection_engine/rule_actions_legacy @elastic/security-solution-platform
+/x-pack/plugins/security_solution/server/lib/detection_engine/rule_exceptions @elastic/security-solution-platform
+/x-pack/plugins/security_solution/server/lib/sourcerer @elastic/security-solution-platform
+
+## Security Threat Intelligence - Under Security Platform
+/x-pack/plugins/security_solution/public/common/components/threat_match @elastic/security-solution-platform
+
+## Security Solution cross teams ownership
+/x-pack/plugins/security_solution/cypress/fixtures @elastic/security-detections-response @elastic/security-threat-hunting
+/x-pack/plugins/security_solution/cypress/helpers @elastic/security-detections-response @elastic/security-threat-hunting
+/x-pack/plugins/security_solution/cypress/e2e/detection_rules @elastic/security-detections-response-rules @elastic/security-detections-response-alerts
+/x-pack/plugins/security_solution/cypress/objects @elastic/security-detections-response @elastic/security-threat-hunting
+/x-pack/plugins/security_solution/cypress/plugins @elastic/security-detections-response @elastic/security-threat-hunting
+/x-pack/plugins/security_solution/cypress/screens/common @elastic/security-detections-response @elastic/security-threat-hunting
+/x-pack/plugins/security_solution/cypress/support @elastic/security-detections-response @elastic/security-threat-hunting
+/x-pack/plugins/security_solution/cypress/urls @elastic/security-threat-hunting-investigations @elastic/security-solution-platform
+
+/x-pack/plugins/security_solution/common/ecs @elastic/security-threat-hunting-investigations
+/x-pack/plugins/security_solution/common/test @elastic/security-detections-response-rules @elastic/security-detections-response-alerts
+
+/x-pack/plugins/security_solution/public/common/components/callouts @elastic/security-detections-response
+/x-pack/plugins/security_solution/public/common/components/hover_actions @elastic/security-threat-hunting-explore @elastic/security-threat-hunting-investigations
+
+/x-pack/plugins/security_solution/server/lib/detection_engine/rule_actions @elastic/security-solution-platform @elastic/security-detections-response-rules
+/x-pack/plugins/security_solution/server/routes @elastic/security-detections-response @elastic/security-threat-hunting
+
+## Security Solution sub teams - security-defend-workflows
+/x-pack/plugins/security_solution/public/management/ @elastic/security-defend-workflows
+/x-pack/plugins/security_solution/public/common/lib/endpoint*/ @elastic/security-defend-workflows
+/x-pack/plugins/security_solution/public/common/components/endpoint/ @elastic/security-defend-workflows
+/x-pack/plugins/security_solution/common/endpoint/ @elastic/security-defend-workflows
+/x-pack/plugins/security_solution/server/endpoint/ @elastic/security-defend-workflows
+/x-pack/plugins/security_solution/server/lists_integration/endpoint/ @elastic/security-defend-workflows
+/x-pack/plugins/security_solution/server/lib/license/ @elastic/security-defend-workflows
+/x-pack/plugins/security_solution/server/fleet_integration/ @elastic/security-defend-workflows
+/x-pack/plugins/security_solution/scripts/endpoint/event_filters/ @elastic/security-defend-workflows
+/x-pack/plugins/security_solution/scripts/endpoint/trusted_apps/ @elastic/security-defend-workflows
+/x-pack/test/security_solution_endpoint/apps/endpoint/ @elastic/security-defend-workflows
+/x-pack/test/security_solution_endpoint_api_int/ @elastic/security-defend-workflows
+
+## Security Solution sub teams - security-telemetry (Data Engineering)
+x-pack/plugins/security_solution/server/usage/ @elastic/security-data-analytics
+x-pack/plugins/security_solution/server/lib/telemetry/ @elastic/security-data-analytics
+
+## Security Solution sub teams - security-engineering-productivity
+x-pack/plugins/security_solution/cypress/ccs_e2e @elastic/security-engineering-productivity
+x-pack/plugins/security_solution/cypress/upgrade_e2e @elastic/security-engineering-productivity
+x-pack/plugins/security_solution/cypress/README.md @elastic/security-engineering-productivity
+x-pack/test/security_solution_cypress @elastic/security-engineering-productivity
+
+## Security Solution sub teams - adaptive-workload-protection
+x-pack/plugins/security_solution/public/common/components/sessions_viewer @elastic/awp-viz
+x-pack/plugins/security_solution/public/kubernetes @elastic/awp-viz
+
+## Security Solution sub teams - Protections Experience
+x-pack/plugins/security_solution/public/threat_intelligence @elastic/protections-experience
+x-pack/test/threat_intelligence_cypress @elastic/protections-experience
+
+# Security Defend Workflows - OSQuery Ownership
+/x-pack/plugins/security_solution/common/detection_engine/rule_response_actions @elastic/security-defend-workflows
+/x-pack/plugins/security_solution/public/detection_engine/rule_response_actions @elastic/security-defend-workflows
+/x-pack/plugins/security_solution/server/lib/detection_engine/rule_response_actions @elastic/security-defend-workflows
+
+# Cloud Security Posture
+/x-pack/plugins/security_solution/public/cloud_security_posture @elastic/kibana-cloud-security-posture
+/x-pack/test/api_integration/apis/cloud_security_posture/ @elastic/kibana-cloud-security-posture
+/x-pack/test/cloud_security_posture_functional/ @elastic/kibana-cloud-security-posture
+
+
+# Security Solution onboarding tour
+/x-pack/plugins/security_solution/public/common/components/guided_onboarding @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/cypress/e2e/guided_onboarding @elastic/security-threat-hunting-explore
 
 # Design (at the bottom for specificity of SASS files)
 **/*.scss  @elastic/kibana-design
 
+# Observability design
+/x-pack/plugins/apm/**/*.scss @elastic/observability-design
+/x-pack/plugins/infra/**/*.scss @elastic/observability-design
+/x-pack/plugins/fleet/**/*.scss @elastic/observability-design
+/x-pack/plugins/observability/**/*.scss @elastic/observability-design
+/x-pack/plugins/monitoring/**/*.scss @elastic/observability-design
+
+# Ent. Search design
+/x-pack/plugins/enterprise_search/**/*.scss @elastic/ent-search-design
+
+# Security design
+/x-pack/plugins/endpoint/**/*.scss @elastic/security-design
+/x-pack/plugins/security_solution/**/*.scss @elastic/security-design
+
+# Logstash
+#CC# /x-pack/plugins/logstash/ @elastic/logstash
+
+# EUI design
+/src/plugins/kibana_react/public/page_template/ @elastic/eui-design @elastic/appex-sharedux
+
+# Landing page for guided onboarding in Home plugin
+/src/plugins/home/public/application/components/guided_onboarding @elastic/platform-onboarding
+
 # Changes to translation files should not ping code reviewers
 x-pack/plugins/translations/translations
+
+####
+## These rules are always last so they take ultimate priority over everything else
+####
+
+
+# Design (at the bottom for specificity of SASS files)
+**/*.scss  @elastic/kibana-design
+
+####
+## These rules are always last so they take ultimate priority over everything else
+####
+
+**/*.scss  @elastic/kibana-design

--- a/packages/kbn-generate/src/commands/codeowners_command.ts
+++ b/packages/kbn-generate/src/commands/codeowners_command.ts
@@ -16,37 +16,30 @@ import type { GenerateCommand } from '../generate_command';
 
 const REL = '.github/CODEOWNERS';
 
-const GENERATED_START = `
-
-####
-## Everything below this comment is automatically generated based on kibana.jsonc
-## "owner" fields. This file is automatically updated by CI or can be updated locally
-## by running \`node scripts/generate codeowners\`.
+const GENERATED_START = `####
+## Everything at the top of the codeowners file is auto generated based on the
+## "owner" fields in the kibana.jsonc files at the root of each package. This
+## file is automatically updated by CI or can be updated locally by running
+## \`node scripts/generate codeowners\`.
 ####
 
 `;
 
-const GENERATED_TRAILER = `
+const GENERATED_END = `
+####
+## Everything below this line overrides the default assignments for each package.
+## Items lower in the file have higher precedence:
+##  https://help.github.com/articles/about-codeowners/
+####
+`;
 
-# Design (at the bottom for specificity of SASS files)
+const ULTIMATE_PRIORITY_RULES = `
+####
+## These rules are always last so they take ultimate priority over everything else
+####
+
 **/*.scss  @elastic/kibana-design
-
-# Changes to translation files should not ping code reviewers
-x-pack/plugins/translations/translations
 `;
-
-function normalizeDir(dirish: string): string {
-  const trim = dirish.trim();
-  if (trim.startsWith('/')) {
-    return normalizeDir(trim.slice(1));
-  }
-
-  if (trim.endsWith('/')) {
-    return normalizeDir(trim.slice(0, -1));
-  }
-
-  return trim;
-}
 
 export const CodeownersCommand: GenerateCommand = {
   name: 'codeowners',
@@ -54,39 +47,32 @@ export const CodeownersCommand: GenerateCommand = {
   usage: 'node scripts/generate codeowners',
   async run({ log }) {
     const pkgs = getPackages(REPO_ROOT);
-    const coPath = Path.resolve(REPO_ROOT, REL);
-    const codeowners = await Fsp.readFile(coPath, 'utf8');
-    let genStart: number | undefined = codeowners.indexOf(GENERATED_START);
-    if (genStart === -1) {
-      genStart = undefined;
-      log.warning(`${REL} doesn't include the expected start-marker for injecting generated text`);
+    const path = Path.resolve(REPO_ROOT, REL);
+    const oldCodeowners = await Fsp.readFile(path, 'utf8');
+    let content = oldCodeowners;
+
+    // strip the old generated output
+    const genEnd = content.indexOf(GENERATED_END);
+    if (genEnd !== -1) {
+      content = content.slice(genEnd + GENERATED_END.length);
     }
 
-    const pkgDirs = new Set(pkgs.map((pkg) => pkg.normalizedRepoRelativeDir));
-    const lines = [];
-
-    for (const line of codeowners.slice(0, genStart).split('\n')) {
-      if (line.startsWith('#') || !line.trim()) {
-        lines.push(line);
-        continue;
-      }
-
-      const dir = normalizeDir(line.split('@')[0]);
-      if (!pkgDirs.has(dir)) {
-        lines.push(line);
-      }
+    // strip the old ultimate rules
+    const ultStart = content.indexOf(ULTIMATE_PRIORITY_RULES);
+    if (ultStart !== -1) {
+      content = content.slice(0, ultStart);
     }
 
-    const newCodeowners = `${lines.join('\n')}${GENERATED_START}${pkgs
+    const newCodeowners = `${GENERATED_START}${pkgs
       .map((pkg) => `${pkg.normalizedRepoRelativeDir} ${pkg.manifest.owner.join(' ')}`)
-      .join('\n')}${GENERATED_TRAILER}`;
+      .join('\n')}${GENERATED_END}${content}${ULTIMATE_PRIORITY_RULES}`;
 
-    if (codeowners === newCodeowners) {
+    if (newCodeowners === oldCodeowners) {
       log.success(`${REL} is already up-to-date`);
       return;
     }
 
-    await Fsp.writeFile(coPath, newCodeowners);
+    await Fsp.writeFile(path, newCodeowners);
     log.info(`${REL} updated`);
   },
 };


### PR DESCRIPTION
With #149344 the codeowners has many more entries in it, and these entries are taking precedence because in codeowner files:

https://help.github.com/articles/about-codeowners/
> Order is important; the last matching pattern takes the most precedence.

This reverses the order of the codeowners file, placing all of the auto-generated codeowners at the top of the file, followed by the manually managed overrides, and finally followed by the "ultimate priority" rules which gives design codeowners over all .scss files in the repo.