### PR TITLE
[Discover] Fix issue where editing a data view causes the UI to become out of sync

### DIFF
--- a/src/plugins/discover/public/application/main/components/top_nav/discover_topnav.tsx
+++ b/src/plugins/discover/public/application/main/components/top_nav/discover_topnav.tsx
@@ -186,10 +186,13 @@ export const DiscoverTopNav = ({
   );
 
   const onEditDataView = async (editedDataView: DataView) => {
-    if (!editedDataView.isPersisted()) {
-      await updateAdHocDataViewId(editedDataView);
+    if (editedDataView.isPersisted()) {
+      // Clear the current data view from the cache and create a new instance
+      // of it, ensuring we have a new object reference to trigger a re-render
+      dataViews.clearInstanceCache(editedDataView.id);
+      stateContainer.actions.setDataView(await dataViews.create(editedDataView.toSpec(), true));
     } else {
-      stateContainer.actions.setDataView(editedDataView);
+      await updateAdHocDataViewId(editedDataView);
     }
     stateContainer.actions.loadDataViewList();
     stateContainer.dataState.fetch();

--- a/test/functional/page_objects/unified_search_page.ts
+++ b/test/functional/page_objects/unified_search_page.ts
@@ -12,6 +12,7 @@ export class UnifiedSearchPageObject extends FtrService {
   private readonly retry = this.ctx.getService('retry');
   private readonly testSubjects = this.ctx.getService('testSubjects');
   private readonly find = this.ctx.getService('find');
+  private readonly comboBox = this.ctx.getService('comboBox');
 
   public async switchDataView(
     switchButtonSelector: string,
@@ -90,13 +91,21 @@ export class UnifiedSearchPageObject extends FtrService {
     await this.testSubjects.click(adHoc ? 'exploreIndexPatternButton' : 'saveIndexPatternButton');
   }
 
-  public async editDataView(newPattern: string) {
-    await this.clickCreateNewDataView();
-    await this.testSubjects.setValue('createIndexPatternTitleInput', newPattern, {
-      clearWithKeyboard: true,
-      typeCharByChar: true,
-    });
+  public async editDataView(newPattern?: string, newTimeField?: string) {
+    await this.clickEditDataView();
+    if (newPattern) {
+      await this.testSubjects.setValue('createIndexPatternTitleInput', newPattern, {
+        clearWithKeyboard: true,
+        typeCharByChar: true,
+      });
+    }
+    if (newTimeField) {
+      await this.comboBox.set('timestampField', newTimeField);
+    }
     await this.testSubjects.click('saveIndexPatternButton');
+    if (await this.testSubjects.exists('confirmModalConfirmButton')) {
+      await this.testSubjects.click('confirmModalConfirmButton');
+    }
   }
 
   public async isAdHocDataView() {


### PR DESCRIPTION
## Summary

Let's try this again with a simpler and hopefully more robust approach. This PR fixes the issue where editing a data view in Discover causes the UI to become out of sync with the current data view due to the stable object identity.

Fixes #149857.
Fixes #150740.

### Checklist

- [ ] ~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)~
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] ~Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))~
- [ ] ~Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))~
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))~
- [ ] ~This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)~

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->