### PR TITLE
[Space selector] Fix failing test

### DIFF
--- a/x-pack/plugins/spaces/public/space_selector/__snapshots__/space_selector.test.tsx.snap
+++ b/x-pack/plugins/spaces/public/space_selector/__snapshots__/space_selector.test.tsx.snap
@@ -6,8 +6,9 @@ exports[`it renders with custom logo 1`] = `
   data-test-subj="kibanaSpaceSelector"
   panelled={true}
 >
-  <_EuiPageEmptyPrompt
+  <_EuiPageSection
     className="spcSpaceSelector__pageContent"
+    color="transparent"
   >
     <EuiText
       size="s"
@@ -24,19 +25,19 @@ exports[`it renders with custom logo 1`] = `
       <EuiSpacer
         size="xxl"
       />
-      <h1
-        className="eui spcSpaceSelector__pageHeader"
-        tabIndex={0}
-      >
-        <FormattedMessage
-          defaultMessage="Select your space"
-          id="xpack.spaces.spaceSelector.selectSpacesTitle"
-          values={Object {}}
-        />
-      </h1>
       <EuiTextColor
         color="subdued"
       >
+        <h1
+          className="eui spcSpaceSelector__pageHeader"
+          tabIndex={0}
+        >
+          <FormattedMessage
+            defaultMessage="Select your space"
+            id="xpack.spaces.spaceSelector.selectSpacesTitle"
+            values={Object {}}
+          />
+        </h1>
         <p>
           <FormattedMessage
             defaultMessage="You can change your space at anytime."
@@ -52,7 +53,7 @@ exports[`it renders with custom logo 1`] = `
     <EuiLoadingSpinner
       size="xl"
     />
-  </_EuiPageEmptyPrompt>
+  </_EuiPageSection>
 </_KibanaPageTemplate>
 `;
 


### PR DESCRIPTION
## Summary

This PR updates the snapshot for `space_selector_test`, so the test can pass normally. Discrepancy occurred after two PRs changing the `space_selector` were merged around the same time.
https://github.com/elastic/kibana/pull/150284
https://github.com/elastic/kibana/pull/150503

__Fixes: https://github.com/elastic/kibana/issues/150834__

### Checklist

Delete any items that are not applicable to this PR.

~- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)~
~- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [X] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
~- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))~
~- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))~
~- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
~- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))~
~- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)~


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
