### PR TITLE
[Fleet] Add beta badge to host name format agent policy setting

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_advanced_fields/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_advanced_fields/index.tsx
@@ -19,16 +19,15 @@ import {
   EuiFieldText,
   EuiSuperSelect,
   EuiToolTip,
-  EuiBadge,
   EuiRadioGroup,
   EuiText,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiBetaBadge,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
 
-import styled from 'styled-components';
 
 import { dataTypes } from '../../../../../../../common/constants';
 import type { NewAgentPolicy, AgentPolicy } from '../../../../types';
@@ -48,9 +47,6 @@ import {
   useFleetServerHostsOptions,
 } from './hooks';
 
-const LeftPaddedEUIBadge = styled(EuiBadge)`
-  margin-left: 5px;
-`;
 
 interface Props {
   agentPolicy: Partial<NewAgentPolicy | AgentPolicy>;
@@ -476,18 +472,19 @@ export const AgentPolicyAdvancedOptionsContent: React.FunctionComponent<Props> =
               id="xpack.fleet.agentPolicyForm.unenrollmentTimeoutLabel"
               defaultMessage="Unenrollment timeout"
             />
+            &nbsp;
             <EuiToolTip
               content={i18n.translate('xpack.fleet.agentPolicyForm.unenrollmentTimeoutTooltip', {
                 defaultMessage:
                   'This setting is deprecated and will be removed in a future release. Consider using inactivity timeout instead',
               })}
             >
-              <LeftPaddedEUIBadge color="hollow">
-                <FormattedMessage
-                  id="xpack.fleet.agentPolicyForm.unenrollmentTimeoutDeprecatedLabel"
-                  defaultMessage="Deprecated"
-                />
-              </LeftPaddedEUIBadge>
+              <EuiBetaBadge label={i18n.translate(
+                  "xpack.fleet.agentPolicyForm.unenrollmentTimeoutDeprecatedLabel",
+                  {defaultMessage: "Deprecated"}
+                )} size="s">
+
+              </EuiBetaBadge>
             </EuiToolTip>
           </h4>
         }
@@ -530,6 +527,8 @@ export const AgentPolicyAdvancedOptionsContent: React.FunctionComponent<Props> =
                 id="xpack.fleet.agentPolicyForm.hostnameFormatLabel"
                 defaultMessage="Host name format"
               />
+              &nbsp;
+              <EuiBetaBadge label="beta" size="s" color="accent" />
             </h4>
           }
           description={

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_advanced_fields/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_advanced_fields/index.tsx
@@ -28,7 +28,6 @@ import {
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
 
-
 import { dataTypes } from '../../../../../../../common/constants';
 import type { NewAgentPolicy, AgentPolicy } from '../../../../types';
 import { useStartServices } from '../../../../hooks';
@@ -46,7 +45,6 @@ import {
   DEFAULT_SELECT_VALUE,
   useFleetServerHostsOptions,
 } from './hooks';
-
 
 interface Props {
   agentPolicy: Partial<NewAgentPolicy | AgentPolicy>;
@@ -479,12 +477,13 @@ export const AgentPolicyAdvancedOptionsContent: React.FunctionComponent<Props> =
                   'This setting is deprecated and will be removed in a future release. Consider using inactivity timeout instead',
               })}
             >
-              <EuiBetaBadge label={i18n.translate(
-                  "xpack.fleet.agentPolicyForm.unenrollmentTimeoutDeprecatedLabel",
-                  {defaultMessage: "Deprecated"}
-                )} size="s">
-
-              </EuiBetaBadge>
+              <EuiBetaBadge
+                label={i18n.translate(
+                  'xpack.fleet.agentPolicyForm.unenrollmentTimeoutDeprecatedLabel',
+                  { defaultMessage: 'Deprecated' }
+                )}
+                size="s"
+              />
             </EuiToolTip>
           </h4>
         }


### PR DESCRIPTION
Add a beta badge to the host name format agent policy setting. As asked here https://github.com/elastic/kibana/issues/149059#issuecomment-1424490013

I have changed ther deprecated badge to be rounded too as it looked really odd having two different types of badge next to each other. I have used accent color on the beta badge too to differentiate it from the deprecated badge. 

### Before
<img width="850" alt="Screenshot 2023-02-10 at 11 05 36" src="https://user-images.githubusercontent.com/3315046/218077728-f5ea600b-d0ae-4284-bc90-4e323646f44d.png">


### After
<img width="942" alt="Screenshot 2023-02-10 at 11 05 13" src="https://user-images.githubusercontent.com/3315046/218077762-f90b7a76-b5f7-483f-8118-751c345bbc67.png">


<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->