### PR TITLE
[Discover] Fix a11y description for the search input in fields sidebar

### DIFF
--- a/src/plugins/discover/public/application/main/components/sidebar/discover_sidebar.tsx
+++ b/src/plugins/discover/public/application/main/components/sidebar/discover_sidebar.tsx
@@ -14,7 +14,6 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiPageSideBar_Deprecated as EuiPageSideBar,
-  htmlIdGenerator,
 } from '@elastic/eui';
 import { isOfAggregateQueryType } from '@kbn/es-query';
 import { DataViewPicker } from '@kbn/unified-search-plugin/public';
@@ -44,8 +43,6 @@ import { DiscoverSidebarResponsiveProps } from './discover_sidebar_responsive';
 import { getUiActions } from '../../../../kibana_services';
 import { getRawRecordType } from '../../utils/get_raw_record_type';
 import { RecordRawType } from '../../services/discover_data_state_container';
-
-const fieldSearchDescriptionId = htmlIdGenerator()();
 
 export interface DiscoverSidebarProps extends DiscoverSidebarResponsiveProps {
   /**
@@ -326,7 +323,6 @@ export function DiscoverSidebarComponent({
               <FieldListGrouped
                 {...fieldListGroupedProps}
                 renderFieldItem={renderFieldItem}
-                screenReaderDescriptionId={fieldSearchDescriptionId}
                 localStorageKeyPrefix="discover"
               />
             ) : (

--- a/src/plugins/discover/public/application/main/components/sidebar/discover_sidebar_responsive.test.tsx
+++ b/src/plugins/discover/public/application/main/components/sidebar/discover_sidebar_responsive.test.tsx
@@ -294,13 +294,13 @@ describe('discover responsive sidebar', function () {
     const comp = await mountComponent(props);
 
     const a11yDescription = findTestSubject(comp, 'fieldListGrouped__ariaDescription');
+    expect(a11yDescription.prop('aria-live')).toBe('polite');
     expect(a11yDescription.text()).toBe(
       '1 selected field. 4 popular fields. 3 available fields. 20 empty fields. 2 meta fields.'
     );
 
     const searchInput = findTestSubject(comp, 'fieldListFiltersFieldSearch');
     expect(searchInput.first().prop('aria-describedby')).toBe(a11yDescription.prop('id'));
-    expect(a11yDescription.prop('aria-live')).toBe('polite');
   });
 
   it('should not have selected fields if no columns selected', async function () {

--- a/src/plugins/discover/public/application/main/components/sidebar/discover_sidebar_responsive.test.tsx
+++ b/src/plugins/discover/public/application/main/components/sidebar/discover_sidebar_responsive.test.tsx
@@ -290,6 +290,19 @@ describe('discover responsive sidebar', function () {
     expect(ExistingFieldsServiceApi.loadFieldExisting).toHaveBeenCalledTimes(1);
   });
 
+  it('should set a11y attributes for the search input in the field list', async function () {
+    const comp = await mountComponent(props);
+
+    const a11yDescription = findTestSubject(comp, 'fieldListGrouped__ariaDescription');
+    expect(a11yDescription.text()).toBe(
+      '1 selected field. 4 popular fields. 3 available fields. 20 empty fields. 2 meta fields.'
+    );
+
+    const searchInput = findTestSubject(comp, 'fieldListFiltersFieldSearch');
+    expect(searchInput.first().prop('aria-describedby')).toBe(a11yDescription.prop('id'));
+    expect(a11yDescription.prop('aria-live')).toBe('polite');
+  });
+
   it('should not have selected fields if no columns selected', async function () {
     const propsWithoutColumns = {
       ...props,


### PR DESCRIPTION
Missed cleaning that up in https://github.com/elastic/kibana/pull/148547

<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->