### PR TITLE
[8.6] [Fleet] Fix max 20 installed integrations returned from Fleet API (#150780)

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/packages/get.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/get.ts
@@ -12,6 +12,7 @@ import type { Logger } from '@kbn/core/server';
 import {
   installationStatuses,
   PACKAGE_POLICY_SAVED_OBJECT_TYPE,
+  SO_SEARCH_LIMIT,
 } from '../../../../common/constants';
 import { isPackageLimited } from '../../../../common/services';
 import type { PackageUsageStats, PackagePolicySOAttributes } from '../../../../common/types';
@@ -127,6 +128,7 @@ export async function getPackageSavedObjects(
   return savedObjectsClient.find<Installation>({
     ...(options || {}),
     type: PACKAGES_SAVED_OBJECT_TYPE,
+    perPage: SO_SEARCH_LIMIT,
   });
 }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.6`:
 - [[Fleet] Fix max 20 installed integrations returned from Fleet API (#150780)](https://github.com/elastic/kibana/pull/150780)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Kyle Pollich","email":"kyle.pollich@elastic.co"},"sourceCommit":{"committedDate":"2023-02-09T21:41:15Z","message":"[Fleet] Fix max 20 installed integrations returned from Fleet API (#150780)\n\n## Summary\r\n\r\nFix an (old) bug where Fleet's \"list packages\" API endpoint would only\r\never return 20 installed integrations at most.\r\n\r\nI haven't included a test case here because I'm not sure we have 20 test\r\npackages that can reasonably be installed at the same time. Also feels\r\nlike an arbitrary number to introduce a \"lists all packages even if\r\nthere are more N\" test case. Open to feedback on testing.\r\n\r\n## Before\r\n\r\n23 installed integrations, only 20 in UI\r\n\r\n\r\n![image](https://user-images.githubusercontent.com/6766512/217930020-f6dafe56-191a-48c0-acb4-c567810a6dad.png)\r\n\r\n\r\n![image](https://user-images.githubusercontent.com/6766512/217930126-441e78a8-d484-4c5d-b5df-00179d930e4a.png)\r\n\r\n## After\r\n\r\n23 installed integrations, 23 in UI\r\n\r\n\r\n![image](https://user-images.githubusercontent.com/6766512/217930384-21506d77-7244-42c1-93bd-97025a8ec86e.png)","sha":"e7209f52a91170ce3e53d2bd27bafaecf6195d54","branchLabelMapping":{"^v8.8.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Fleet","backport:prev-minor","v8.7.0","v8.8.0"],"number":150780,"url":"https://github.com/elastic/kibana/pull/150780","mergeCommit":{"message":"[Fleet] Fix max 20 installed integrations returned from Fleet API (#150780)\n\n## Summary\r\n\r\nFix an (old) bug where Fleet's \"list packages\" API endpoint would only\r\never return 20 installed integrations at most.\r\n\r\nI haven't included a test case here because I'm not sure we have 20 test\r\npackages that can reasonably be installed at the same time. Also feels\r\nlike an arbitrary number to introduce a \"lists all packages even if\r\nthere are more N\" test case. Open to feedback on testing.\r\n\r\n## Before\r\n\r\n23 installed integrations, only 20 in UI\r\n\r\n\r\n![image](https://user-images.githubusercontent.com/6766512/217930020-f6dafe56-191a-48c0-acb4-c567810a6dad.png)\r\n\r\n\r\n![image](https://user-images.githubusercontent.com/6766512/217930126-441e78a8-d484-4c5d-b5df-00179d930e4a.png)\r\n\r\n## After\r\n\r\n23 installed integrations, 23 in UI\r\n\r\n\r\n![image](https://user-images.githubusercontent.com/6766512/217930384-21506d77-7244-42c1-93bd-97025a8ec86e.png)","sha":"e7209f52a91170ce3e53d2bd27bafaecf6195d54"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"8.7","label":"v8.7.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/150795","number":150795,"state":"MERGED","mergeCommit":{"sha":"84c92b53dc446e92a1a5cd7ed7a33cbf9913141d","message":"[8.7] [Fleet] Fix max 20 installed integrations returned from Fleet API (#150780) (#150795)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.7`:\n- [[Fleet] Fix max 20 installed integrations returned from Fleet API\n(#150780)](https://github.com/elastic/kibana/pull/150780)\n\n<!--- Backport version: 8.9.7 -->\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n<!--BACKPORT [{\"author\":{\"name\":\"Kyle\nPollich\",\"email\":\"kyle.pollich@elastic.co\"},\"sourceCommit\":{\"committedDate\":\"2023-02-09T21:41:15Z\",\"message\":\"[Fleet]\nFix max 20 installed integrations returned from Fleet API\n(#150780)\\n\\n## Summary\\r\\n\\r\\nFix an (old) bug where Fleet's \\\"list\npackages\\\" API endpoint would only\\r\\never return 20 installed\nintegrations at most.\\r\\n\\r\\nI haven't included a test case here because\nI'm not sure we have 20 test\\r\\npackages that can reasonably be\ninstalled at the same time. Also feels\\r\\nlike an arbitrary number to\nintroduce a \\\"lists all packages even if\\r\\nthere are more N\\\" test\ncase. Open to feedback on testing.\\r\\n\\r\\n## Before\\r\\n\\r\\n23 installed\nintegrations, only 20 in\nUI\\r\\n\\r\\n\\r\\n![image](https://user-images.githubusercontent.com/6766512/217930020-f6dafe56-191a-48c0-acb4-c567810a6dad.png)\\r\\n\\r\\n\\r\\n![image](https://user-images.githubusercontent.com/6766512/217930126-441e78a8-d484-4c5d-b5df-00179d930e4a.png)\\r\\n\\r\\n##\nAfter\\r\\n\\r\\n23 installed integrations, 23 in\nUI\\r\\n\\r\\n\\r\\n![image](https://user-images.githubusercontent.com/6766512/217930384-21506d77-7244-42c1-93bd-97025a8ec86e.png)\",\"sha\":\"e7209f52a91170ce3e53d2bd27bafaecf6195d54\",\"branchLabelMapping\":{\"^v8.8.0$\":\"main\",\"^v(\\\\d+).(\\\\d+).\\\\d+$\":\"$1.$2\"}},\"sourcePullRequest\":{\"labels\":[\"release_note:fix\",\"Team:Fleet\",\"backport:prev-minor\",\"v8.8.0\"],\"number\":150780,\"url\":\"https://github.com/elastic/kibana/pull/150780\",\"mergeCommit\":{\"message\":\"[Fleet]\nFix max 20 installed integrations returned from Fleet API\n(#150780)\\n\\n## Summary\\r\\n\\r\\nFix an (old) bug where Fleet's \\\"list\npackages\\\" API endpoint would only\\r\\never return 20 installed\nintegrations at most.\\r\\n\\r\\nI haven't included a test case here because\nI'm not sure we have 20 test\\r\\npackages that can reasonably be\ninstalled at the same time. Also feels\\r\\nlike an arbitrary number to\nintroduce a \\\"lists all packages even if\\r\\nthere are more N\\\" test\ncase. Open to feedback on testing.\\r\\n\\r\\n## Before\\r\\n\\r\\n23 installed\nintegrations, only 20 in\nUI\\r\\n\\r\\n\\r\\n![image](https://user-images.githubusercontent.com/6766512/217930020-f6dafe56-191a-48c0-acb4-c567810a6dad.png)\\r\\n\\r\\n\\r\\n![image](https://user-images.githubusercontent.com/6766512/217930126-441e78a8-d484-4c5d-b5df-00179d930e4a.png)\\r\\n\\r\\n##\nAfter\\r\\n\\r\\n23 installed integrations, 23 in\nUI\\r\\n\\r\\n\\r\\n![image](https://user-images.githubusercontent.com/6766512/217930384-21506d77-7244-42c1-93bd-97025a8ec86e.png)\",\"sha\":\"e7209f52a91170ce3e53d2bd27bafaecf6195d54\"}},\"sourceBranch\":\"main\",\"suggestedTargetBranches\":[],\"targetPullRequestStates\":[{\"branch\":\"main\",\"label\":\"v8.8.0\",\"labelRegex\":\"^v8.8.0$\",\"isSourceBranch\":true,\"state\":\"MERGED\",\"url\":\"https://github.com/elastic/kibana/pull/150780\",\"number\":150780,\"mergeCommit\":{\"message\":\"[Fleet]\nFix max 20 installed integrations returned from Fleet API\n(#150780)\\n\\n## Summary\\r\\n\\r\\nFix an (old) bug where Fleet's \\\"list\npackages\\\" API endpoint would only\\r\\never return 20 installed\nintegrations at most.\\r\\n\\r\\nI haven't included a test case here because\nI'm not sure we have 20 test\\r\\npackages that can reasonably be\ninstalled at the same time. Also feels\\r\\nlike an arbitrary number to\nintroduce a \\\"lists all packages even if\\r\\nthere are more N\\\" test\ncase. Open to feedback on testing.\\r\\n\\r\\n## Before\\r\\n\\r\\n23 installed\nintegrations, only 20 in\nUI\\r\\n\\r\\n\\r\\n![image](https://user-images.githubusercontent.com/6766512/217930020-f6dafe56-191a-48c0-acb4-c567810a6dad.png)\\r\\n\\r\\n\\r\\n![image](https://user-images.githubusercontent.com/6766512/217930126-441e78a8-d484-4c5d-b5df-00179d930e4a.png)\\r\\n\\r\\n##\nAfter\\r\\n\\r\\n23 installed integrations, 23 in\nUI\\r\\n\\r\\n\\r\\n![image](https://user-images.githubusercontent.com/6766512/217930384-21506d77-7244-42c1-93bd-97025a8ec86e.png)\",\"sha\":\"e7209f52a91170ce3e53d2bd27bafaecf6195d54\"}}]}]\nBACKPORT-->\n\nCo-authored-by: Kyle Pollich <kyle.pollich@elastic.co>"}},{"branch":"main","label":"v8.8.0","labelRegex":"^v8.8.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/150780","number":150780,"mergeCommit":{"message":"[Fleet] Fix max 20 installed integrations returned from Fleet API (#150780)\n\n## Summary\r\n\r\nFix an (old) bug where Fleet's \"list packages\" API endpoint would only\r\never return 20 installed integrations at most.\r\n\r\nI haven't included a test case here because I'm not sure we have 20 test\r\npackages that can reasonably be installed at the same time. Also feels\r\nlike an arbitrary number to introduce a \"lists all packages even if\r\nthere are more N\" test case. Open to feedback on testing.\r\n\r\n## Before\r\n\r\n23 installed integrations, only 20 in UI\r\n\r\n\r\n![image](https://user-images.githubusercontent.com/6766512/217930020-f6dafe56-191a-48c0-acb4-c567810a6dad.png)\r\n\r\n\r\n![image](https://user-images.githubusercontent.com/6766512/217930126-441e78a8-d484-4c5d-b5df-00179d930e4a.png)\r\n\r\n## After\r\n\r\n23 installed integrations, 23 in UI\r\n\r\n\r\n![image](https://user-images.githubusercontent.com/6766512/217930384-21506d77-7244-42c1-93bd-97025a8ec86e.png)","sha":"e7209f52a91170ce3e53d2bd27bafaecf6195d54"}}]}] BACKPORT-->