### PR TITLE
[TIP] fix add to blocklist flyout title

### DIFF
--- a/x-pack/plugins/threat_intelligence/cypress/screens/indicators.ts
+++ b/x-pack/plugins/threat_intelligence/cypress/screens/indicators.ts
@@ -205,13 +205,13 @@ export const NEW_CASE_CREATE_BUTTON = `[data-test-subj="create-case-submit"]`;
 
 /* Block list */
 
-export const BLOCK_LIST_NAME = '[data-test-subj="blocklist-form-name-input"]';
+export const BLOCK_LIST_NAME = `[data-test-subj="blocklist-form-name-input"]`;
 
-export const BLOCK_LIST_DESCRIPTION = '[data-test-subj="blocklist-form-description-input"]';
+export const BLOCK_LIST_DESCRIPTION = `[data-test-subj="blocklist-form-description-input"]`;
 
-export const BLOCK_LIST_ADD_BUTTON = '[class="eui-textTruncate"]';
+export const BLOCK_LIST_ADD_BUTTON = `[class="eui-textTruncate"]`;
 
-export const BLOCK_LIST_TOAST_LIST = '[data-test-subj="globalToastList"]';
+export const BLOCK_LIST_TOAST_LIST = `[data-test-subj="globalToastList"]`;
 
 /* Miscellaneous */
 

--- a/x-pack/plugins/threat_intelligence/public/modules/block_list/containers/flyout.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/block_list/containers/flyout.tsx
@@ -10,6 +10,7 @@ import {
   CreateExceptionListItemSchema,
   EntriesArray,
 } from '@kbn/securitysolution-io-ts-list-types';
+import { ADD_TO_BLOCKLIST_FLYOUT_TITLE } from './translations';
 import { useSecurityContext } from '../../../hooks/use_security_context';
 
 export interface BlockListFlyoutProps {
@@ -53,8 +54,14 @@ export const BlockListFlyout: VFC<BlockListFlyoutProps> = ({ indicatorFileHash }
     type: 'simple',
   };
 
+  // texts to customize the flyout
+  const labels = {
+    flyoutCreateTitle: ADD_TO_BLOCKLIST_FLYOUT_TITLE,
+  };
+
   const props = {
     apiClient: exceptionListApiClient,
+    labels,
     item,
     policies: [],
     FormComponent,

--- a/x-pack/plugins/threat_intelligence/public/modules/block_list/containers/translations.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/block_list/containers/translations.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export const ADD_TO_BLOCKLIST_FLYOUT_TITLE = i18n.translate(
+  'xpack.threatIntelligence.blocklist.flyoutTitle',
+  {
+    defaultMessage: 'Add blocklist',
+  }
+);


### PR DESCRIPTION
## Summary

The add to blocklist flyout title was showing `Create Artifact` which is the default value for the `ArtifactFlyout` component the Threat Intelligence plugin uses from the Security Solution plugin.
There is a `labels` property we can customize. This PR leverages this to show `Add blocklist` in the flyout header.

![Screenshot 2023-02-10 at 8 57 26 AM](https://user-images.githubusercontent.com/17276605/218123112-2013c653-17d7-4415-985a-0cd77cc82948.png)

https://github.com/elastic/kibana/issues/150845

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)

<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->