### PR TITLE
[APM] Add more APM paths to paths-labeller.yml

### DIFF
--- a/.github/paths-labeller.yml
+++ b/.github/paths-labeller.yml
@@ -10,6 +10,10 @@
     - "src/plugins/bfetch/**/*.*"
   - "Team:apm":
     - "x-pack/plugins/apm/**/*.*"
+    - "x-pack/test/apm_api_integration/**/*.*"
+    - "packages/kbn-apm-synthtrace/**/*.*"
+    - "packages/kbn-apm-synthtrace-client/**/*.*"
+    - "packages/kbn-apm-utils/**/*.*"
   - "Team:Fleet":
     - "x-pack/plugins/fleet/**/*.*"
     - "x-pack/test/fleet_api_integration/**/*.*"


### PR DESCRIPTION
## Summary
Add more APM paths so the `team:APM` label is added to the PRs