### PR TITLE
[Security Solution] [Exceptions] fixes download from list details page

### DIFF
--- a/x-pack/plugins/security_solution/public/exceptions/hooks/use_list_detail_view/index.ts
+++ b/x-pack/plugins/security_solution/public/exceptions/hooks/use_list_detail_view/index.ts
@@ -190,6 +190,10 @@ export const useListDetailsView = (exceptionListId: string) => {
     [list, exportExceptionList, handleErrorStatus, toasts]
   );
 
+  const handleOnDownload = useCallback(() => {
+    setExportedList(undefined);
+  }, []);
+
   // #region DeleteList
 
   const handleDeleteSuccess = useCallback(
@@ -366,6 +370,7 @@ export const useListDetailsView = (exceptionListId: string) => {
     canUserEditList,
     linkedRules,
     exportedList,
+    handleOnDownload,
     viewerStatus,
     showManageRulesFlyout,
     headerBackOptions,

--- a/x-pack/plugins/security_solution/public/exceptions/pages/list_detail_view/index.tsx
+++ b/x-pack/plugins/security_solution/public/exceptions/pages/list_detail_view/index.tsx
@@ -39,6 +39,7 @@ export const ListsDetailViewComponent: FC = () => {
     listId,
     linkedRules,
     exportedList,
+    handleOnDownload,
     viewerStatus,
     listName,
     listDescription,
@@ -91,7 +92,7 @@ export const ListsDetailViewComponent: FC = () => {
           onManageRules={onManageRules}
         />
 
-        <AutoDownload blob={exportedList} name={listId} />
+        <AutoDownload blob={exportedList} name={`${listId}.ndjson`} onDownload={handleOnDownload} />
         <ListWithSearch list={list} refreshExceptions={refreshExceptions} isReadOnly={isReadOnly} />
         <ReferenceErrorModal
           cancelText={i18n.REFERENCE_MODAL_CANCEL_BUTTON}
@@ -126,6 +127,7 @@ export const ListsDetailViewComponent: FC = () => {
     canUserEditList,
     disableManageButton,
     exportedList,
+    handleOnDownload,
     headerBackOptions,
     invalidListId,
     isLoading,


### PR DESCRIPTION
## Summary

Fixes: https://github.com/elastic/kibana/issues/148139

When exporting a shared exception list from that lists' detailed view, the exported file would not have the `.ndjson` extension appended to it. I think we should update this to be a single hook used between the two views.

<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->