### PR TITLE
[Investigations] - Fix extra space in details flyout

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/event_details/event_details.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/event_details.tsx
@@ -132,6 +132,7 @@ const RendererContainer = styled.div`
 `;
 
 const ThreatTacticContainer = styled(EuiFlexGroup)`
+  flex-grow: 0;
   flex-wrap: nowrap;
   & .euiFlexGroup {
     flex-wrap: nowrap;
@@ -232,8 +233,13 @@ const EventDetailsComponent: React.FC<Props> = ({
                   isReadOnly={isReadOnly}
                 />
                 <EuiSpacer size="l" />
-                <ThreatTacticContainer direction="column" wrap={false} gutterSize="none">
-                  {threatDetails && threatDetails[0] && (
+                {threatDetails && threatDetails[0] && (
+                  <ThreatTacticContainer
+                    alignItems="flexStart"
+                    direction="column"
+                    wrap={false}
+                    gutterSize="none"
+                  >
                     <>
                       <EuiTitle size="xxs">
                         <h5>{threatDetails[0].title}</h5>
@@ -242,8 +248,8 @@ const EventDetailsComponent: React.FC<Props> = ({
                         {threatDetails[0].description}
                       </ThreatTacticDescription>
                     </>
-                  )}
-                </ThreatTacticContainer>
+                  </ThreatTacticContainer>
+                )}
                 <EuiSpacer size="l" />
                 {renderer != null && detailsEcsData != null && (
                   <div>


### PR DESCRIPTION
## Summary

Small bug fix. On larger screens the space meant for MITRE information grows to fill the height of the window. The space without this data shows an unnecessary large empty space. This PR updates the code to only show the MITRE section when MITRE information is present, but also prevent that section from filling window height.

The bug (resized via dev tools):

https://user-images.githubusercontent.com/17211684/218170000-569c0a27-2ff4-4be1-a07d-7cae2b5b02ee.mov

The fix:

https://user-images.githubusercontent.com/17211684/218170652-a4fae457-a895-42e8-95c9-98ee84792c8e.mov




<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->