### PR TITLE
[Enterprise Search] fix: search experiences plugin name

### DIFF
--- a/x-pack/plugins/enterprise_search/common/constants.ts
+++ b/x-pack/plugins/enterprise_search/common/constants.ts
@@ -100,10 +100,10 @@ export const WORKPLACE_SEARCH_PLUGIN = {
 export const SEARCH_EXPERIENCES_PLUGIN = {
   ID: 'searchExperiences',
   NAME: i18n.translate('xpack.enterpriseSearch.searchExperiences.productName', {
-    defaultMessage: 'Enterprise Search',
+    defaultMessage: 'Search Experiences',
   }),
   NAV_TITLE: i18n.translate('xpack.enterpriseSearch.searchExperiences.navTitle', {
-    defaultMessage: 'Search experiences',
+    defaultMessage: 'Search Experiences',
   }),
   DESCRIPTION: i18n.translate('xpack.enterpriseSearch.searchExperiences.productDescription', {
     defaultMessage: 'Build an intuitive, engaging search experience without reinventing the wheel.',

--- a/x-pack/plugins/enterprise_search/public/applications/search_experiences/components/layout/page_template.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/search_experiences/components/layout/page_template.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 
-import { SEARCH_EXPERIENCES_PLUGIN } from '../../../../../common/constants';
+import { ENTERPRISE_SEARCH_CONTENT_PLUGIN } from '../../../../../common/constants';
 import { SetSearchExperiencesChrome } from '../../../shared/kibana_chrome';
 import { EnterpriseSearchPageTemplateWrapper, PageTemplateProps } from '../../../shared/layout';
 import { useEnterpriseSearchNav } from '../../../shared/layout';
@@ -23,7 +23,7 @@ export const EnterpriseSearchSearchExperiencesPageTemplate: React.FC<PageTemplat
     <EnterpriseSearchPageTemplateWrapper
       {...pageTemplateProps}
       solutionNav={{
-        name: SEARCH_EXPERIENCES_PLUGIN.NAME,
+        name: ENTERPRISE_SEARCH_CONTENT_PLUGIN.NAME,
         items: useEnterpriseSearchNav(),
       }}
       setPageChrome={pageChrome && <SetSearchExperiencesChrome trail={pageChrome} />}


### PR DESCRIPTION
## Summary

Updated the Search experiences navigation shortcut to be "Search Experiences" instead of "Enterprise Search"

### Screenshot
![image](https://user-images.githubusercontent.com/1972968/218199866-6a78a1e8-861f-4ca7-9c8f-6e514642ec52.png)




<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->