### PR TITLE
[codeql] Do not run GitHub CodeQL Action on forks

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,6 +12,7 @@ jobs:
       actions: read
       contents: read
       security-events: write
+    if: github.repository == 'elastic/kibana' # Hack: Do not run on forks
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
It turned out that the CodeQL action also runs on forks which generate a lot of noise in the form of security e-mails to the owners of those forks.

As far as I know there's no way to completely disable a GitHub Action to run on forks, but this is the next best thing: Simply having an if-statement that aborts the action before it can get going. This approach was borrowed from: https://github.com/orgs/community/discussions/26684

A feature request to have scheduled actions not run on forks al together exists, but there's no activity on it from GitHubs side: https://github.com/community/community/discussions/16109

<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->