### PR TITLE
[Fleet] fixed bug where installed beta integration was visible multiple times

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/packages/get.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/get.test.ts
@@ -221,6 +221,7 @@ describe('When using EPM `get` services', () => {
         })
       ).resolves.toMatchObject([
         {
+          id: 'elasticsearch',
           name: 'elasticsearch',
           version: '0.0.1',
           title: 'Elasticsearch',

--- a/x-pack/plugins/fleet/server/services/epm/packages/get.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/get.test.ts
@@ -209,7 +209,7 @@ describe('When using EPM `get` services', () => {
             attributes: {
               name: 'elasticsearch',
               version: '0.0.1',
-              install_status: 'upload',
+              install_source: 'upload',
             },
           },
         ],
@@ -224,13 +224,12 @@ describe('When using EPM `get` services', () => {
           name: 'elasticsearch',
           version: '0.0.1',
           title: 'Elasticsearch',
-          status: 'upload',
           savedObject: {
             id: 'elasticsearch',
             attributes: {
               name: 'elasticsearch',
               version: '0.0.1',
-              install_status: 'upload',
+              install_source: 'upload',
             },
           },
         },

--- a/x-pack/plugins/fleet/server/services/epm/packages/get.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/get.ts
@@ -74,8 +74,12 @@ export async function getPackages(
   // get the installed packages
   const packageSavedObjects = await getPackageSavedObjects(savedObjectsClient);
 
-  const packagesNotInRegistry = packageSavedObjects.saved_objects
-    .filter((pkg) => !registryItems.some((item) => item.name === pkg.id))
+  const uploadedPackagesNotInRegistry = packageSavedObjects.saved_objects
+    .filter(
+      (pkg) =>
+        pkg.attributes.install_source === 'upload' &&
+        !registryItems.some((item) => item.name === pkg.id)
+    )
     .map((pkg) => createInstallableFrom({ ...pkg.attributes, title: nameAsTitle(pkg.id) }, pkg));
 
   const packageList = registryItems
@@ -85,7 +89,7 @@ export async function getPackages(
         packageSavedObjects.saved_objects.find(({ id }) => id === item.name)
       )
     )
-    .concat(packagesNotInRegistry as Installable<any>)
+    .concat(uploadedPackagesNotInRegistry as Installable<any>)
     .sort(sortByName);
 
   if (!excludeInstallStatus) {

--- a/x-pack/plugins/fleet/server/services/epm/packages/get.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/get.ts
@@ -75,12 +75,10 @@ export async function getPackages(
   const packageSavedObjects = await getPackageSavedObjects(savedObjectsClient);
 
   const uploadedPackagesNotInRegistry = packageSavedObjects.saved_objects
-    .filter(
-      (pkg) =>
-        pkg.attributes.install_source === 'upload' &&
-        !registryItems.some((item) => item.name === pkg.id)
-    )
-    .map((pkg) => createInstallableFrom({ ...pkg.attributes, title: nameAsTitle(pkg.id) }, pkg));
+    .filter((pkg) => !registryItems.some((item) => item.name === pkg.id))
+    .map((pkg) =>
+      createInstallableFrom({ ...pkg.attributes, title: nameAsTitle(pkg.id), id: pkg.id }, pkg)
+    );
 
   const packageList = registryItems
     .map((item) =>


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/150969

Filtering for only uploaded packages that are not in registry.
This fixes of bug of linux integration showing up multiple times when the `/packages` call with `prerelease:false` and `prerelease:true` options are quickly following each other.

To verify:
- Navigate to Integrations, search `linux`.
- Add linux integration to agent policy.
- Repeat the same process again.
- Navigate back to Integrations and search `linux`.
- Only one Linux metrics integration card should be visible.

<img width="1009" alt="image" src="https://user-images.githubusercontent.com/90178898/218418246-ffd8f9ed-796b-4ba9-97d2-5a93165c384b.png">

Uploaded integrations are still visible:
<img width="1006" alt="image" src="https://user-images.githubusercontent.com/90178898/218418791-82d41523-b8ec-4a37-9e14-cfd67e889ba7.png">



### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->