### PR TITLE
[Security Solution] Get rid of rule description's fade in/out effect

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_about_rule_details/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_about_rule_details/index.tsx
@@ -17,8 +17,8 @@ import {
   EuiResizeObserver,
 } from '@elastic/eui';
 import { isEmpty } from 'lodash';
+import type { PropsWithChildren } from 'react';
 import React, { memo, useCallback, useMemo, useState } from 'react';
-import styled from 'styled-components';
 
 import { HeaderSection } from '../../../../common/components/header_section';
 import { MarkdownRenderer } from '../../../../common/components/markdown_editor';
@@ -28,28 +28,6 @@ import type {
 } from '../../../pages/detection_engine/rules/types';
 import * as i18n from './translations';
 import { StepAboutRule } from '../step_about_rule';
-
-const MyPanel = styled(EuiPanel)`
-  position: relative;
-`;
-
-const FlexGroupFullHeight = styled(EuiFlexGroup)`
-  height: 100%;
-`;
-
-const VerticalOverflowContainer = styled.div((props: { maxHeight: number }) => ({
-  'max-height': `${props.maxHeight}px`,
-  'overflow-y': 'hidden',
-  'word-break': 'break-word',
-}));
-
-const VerticalOverflowContent = styled.div((props: { maxHeight: number }) => ({
-  'max-height': `${props.maxHeight}px`,
-}));
-
-const AboutContent = styled.div`
-  height: 100%;
-`;
 
 const detailsOption: EuiButtonGroupOptionProps = {
   id: 'details',
@@ -99,7 +77,12 @@ const StepAboutRuleToggleDetailsComponent: React.FC<StepPanelProps> = ({
   }, [stepDataDetails]);
 
   return (
-    <MyPanel hasBorder>
+    <EuiPanel
+      hasBorder
+      css={`
+        position: relative;
+      `}
+    >
       {loading && (
         <>
           <EuiProgress size="xs" color="accent" position="absolute" />
@@ -107,7 +90,13 @@ const StepAboutRuleToggleDetailsComponent: React.FC<StepPanelProps> = ({
         </>
       )}
       {stepData != null && stepDataDetails != null && (
-        <FlexGroupFullHeight gutterSize="xs" direction="column">
+        <EuiFlexGroup
+          gutterSize="xs"
+          direction="column"
+          css={`
+            height: 100%;
+          `}
+        >
           <EuiFlexItem grow={false} key="header">
             <HeaderSection title={i18n.ABOUT_TEXT}>
               {toggleOptions.length > 0 && (
@@ -127,7 +116,7 @@ const StepAboutRuleToggleDetailsComponent: React.FC<StepPanelProps> = ({
             {selectedToggleOption === 'details' && (
               <EuiResizeObserver data-test-subj="stepAboutDetailsContent" onResize={onResize}>
                 {(resizeRef) => (
-                  <AboutContent ref={resizeRef}>
+                  <div ref={resizeRef} css={{ height: '100%' }}>
                     <VerticalOverflowContainer maxHeight={120}>
                       <VerticalOverflowContent maxHeight={120}>
                         <EuiText
@@ -145,7 +134,7 @@ const StepAboutRuleToggleDetailsComponent: React.FC<StepPanelProps> = ({
                       isLoading={false}
                       defaultValues={stepData}
                     />
-                  </AboutContent>
+                  </div>
                 )}
               </EuiResizeObserver>
             )}
@@ -170,13 +159,35 @@ const StepAboutRuleToggleDetailsComponent: React.FC<StepPanelProps> = ({
               </VerticalOverflowContainer>
             )}
           </EuiFlexItem>
-        </FlexGroupFullHeight>
+        </EuiFlexGroup>
       )}
-    </MyPanel>
+    </EuiPanel>
   );
 };
 
 export const StepAboutRuleToggleDetails = memo(StepAboutRuleToggleDetailsComponent);
+
+interface VerticalOverflowContainerProps {
+  maxHeight: number;
+}
+
+function VerticalOverflowContainer({
+  maxHeight,
+  children,
+}: PropsWithChildren<VerticalOverflowContainerProps>): JSX.Element {
+  return (
+    <div
+      className="eui-yScroll"
+      css={{
+        maxHeight,
+        'overflow-y': 'hidden',
+        'word-break': 'break-word',
+      }}
+    >
+      {children}
+    </div>
+  );
+}
 
 interface VerticalOverflowContentProps {
   maxHeight: number;

--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_about_rule_details/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_about_rule_details/index.tsx
@@ -79,9 +79,9 @@ const StepAboutRuleToggleDetailsComponent: React.FC<StepPanelProps> = ({
   return (
     <EuiPanel
       hasBorder
-      css={`
-        position: relative;
-      `}
+      css={{
+        position: 'relative',
+      }}
     >
       {loading && (
         <>
@@ -93,9 +93,9 @@ const StepAboutRuleToggleDetailsComponent: React.FC<StepPanelProps> = ({
         <EuiFlexGroup
           gutterSize="xs"
           direction="column"
-          css={`
-            height: 100%;
-          `}
+          css={{
+            height: '100%',
+          }}
         >
           <EuiFlexItem grow={false} key="header">
             <HeaderSection title={i18n.ABOUT_TEXT}>

--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_about_rule_details/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_about_rule_details/index.tsx
@@ -29,6 +29,7 @@ import type {
 } from '../../../pages/detection_engine/rules/types';
 import * as i18n from './translations';
 import { StepAboutRule } from '../step_about_rule';
+import { fullHeight } from './styles';
 
 const detailsOption: EuiButtonGroupOptionProps = {
   id: 'details',
@@ -91,13 +92,7 @@ const StepAboutRuleToggleDetailsComponent: React.FC<StepPanelProps> = ({
         </>
       )}
       {stepData != null && stepDataDetails != null && (
-        <EuiFlexGroup
-          gutterSize="xs"
-          direction="column"
-          css={css`
-            height: 100%;
-          `}
-        >
+        <EuiFlexGroup gutterSize="xs" direction="column" css={fullHeight}>
           <EuiFlexItem grow={false} key="header">
             <HeaderSection title={i18n.ABOUT_TEXT}>
               {toggleOptions.length > 0 && (
@@ -117,12 +112,7 @@ const StepAboutRuleToggleDetailsComponent: React.FC<StepPanelProps> = ({
             {selectedToggleOption === 'details' && (
               <EuiResizeObserver data-test-subj="stepAboutDetailsContent" onResize={onResize}>
                 {(resizeRef) => (
-                  <div
-                    ref={resizeRef}
-                    css={css`
-                      height: 100%;
-                    `}
-                  >
+                  <div ref={resizeRef} css={fullHeight}>
                     <VerticalOverflowContainer maxHeight={120}>
                       <VerticalOverflowContent maxHeight={120}>
                         <EuiText
@@ -175,20 +165,22 @@ export const StepAboutRuleToggleDetails = memo(StepAboutRuleToggleDetailsCompone
 
 interface VerticalOverflowContainerProps {
   maxHeight: number;
+  'data-test-subj'?: string;
 }
 
 function VerticalOverflowContainer({
   maxHeight,
+  'data-test-subj': dataTestSubject,
   children,
 }: PropsWithChildren<VerticalOverflowContainerProps>): JSX.Element {
   return (
     <div
-      className="eui-yScroll"
       css={css`
         max-height: ${maxHeight};
         overflow-y: 'hidden';
         word-break: 'break-word';
       `}
+      data-test-subj={dataTestSubject}
     >
       {children}
     </div>
@@ -201,6 +193,7 @@ interface VerticalOverflowContentProps {
 
 function VerticalOverflowContent({
   maxHeight,
+
   children,
 }: PropsWithChildren<VerticalOverflowContentProps>): JSX.Element {
   return (

--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_about_rule_details/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_about_rule_details/index.tsx
@@ -129,7 +129,7 @@ const StepAboutRuleToggleDetailsComponent: React.FC<StepPanelProps> = ({
                 {(resizeRef) => (
                   <AboutContent ref={resizeRef}>
                     <VerticalOverflowContainer maxHeight={120}>
-                      <VerticalOverflowContent maxHeight={120} className="eui-yScrollWithShadows">
+                      <VerticalOverflowContent maxHeight={120} className="eui-yScroll">
                         <EuiText
                           size="s"
                           data-test-subj="stepAboutRuleDetailsToggleDescriptionText"
@@ -154,10 +154,7 @@ const StepAboutRuleToggleDetailsComponent: React.FC<StepPanelProps> = ({
                 data-test-subj="stepAboutDetailsNoteContent"
                 maxHeight={aboutPanelHeight}
               >
-                <VerticalOverflowContent
-                  maxHeight={aboutPanelHeight}
-                  className="eui-yScrollWithShadows"
-                >
+                <VerticalOverflowContent maxHeight={aboutPanelHeight} className="eui-yScroll">
                   <MarkdownRenderer>{stepDataDetails.note}</MarkdownRenderer>
                 </VerticalOverflowContent>
               </VerticalOverflowContainer>
@@ -167,10 +164,7 @@ const StepAboutRuleToggleDetailsComponent: React.FC<StepPanelProps> = ({
                 data-test-subj="stepAboutDetailsSetupContent"
                 maxHeight={aboutPanelHeight}
               >
-                <VerticalOverflowContent
-                  maxHeight={aboutPanelHeight}
-                  className="eui-yScrollWithShadows"
-                >
+                <VerticalOverflowContent maxHeight={aboutPanelHeight} className="eui-yScroll">
                   <MarkdownRenderer>{stepDataDetails.setup}</MarkdownRenderer>
                 </VerticalOverflowContent>
               </VerticalOverflowContainer>

--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_about_rule_details/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_about_rule_details/index.tsx
@@ -20,6 +20,7 @@ import { isEmpty } from 'lodash';
 import type { PropsWithChildren } from 'react';
 import React, { memo, useCallback, useMemo, useState } from 'react';
 
+import { css } from '@emotion/react';
 import { HeaderSection } from '../../../../common/components/header_section';
 import { MarkdownRenderer } from '../../../../common/components/markdown_editor';
 import type {
@@ -79,9 +80,9 @@ const StepAboutRuleToggleDetailsComponent: React.FC<StepPanelProps> = ({
   return (
     <EuiPanel
       hasBorder
-      css={{
-        position: 'relative',
-      }}
+      css={css`
+        position: 'relative';
+      `}
     >
       {loading && (
         <>
@@ -93,9 +94,9 @@ const StepAboutRuleToggleDetailsComponent: React.FC<StepPanelProps> = ({
         <EuiFlexGroup
           gutterSize="xs"
           direction="column"
-          css={{
-            height: '100%',
-          }}
+          css={css`
+            height: 100%;
+          `}
         >
           <EuiFlexItem grow={false} key="header">
             <HeaderSection title={i18n.ABOUT_TEXT}>
@@ -116,7 +117,12 @@ const StepAboutRuleToggleDetailsComponent: React.FC<StepPanelProps> = ({
             {selectedToggleOption === 'details' && (
               <EuiResizeObserver data-test-subj="stepAboutDetailsContent" onResize={onResize}>
                 {(resizeRef) => (
-                  <div ref={resizeRef} css={{ height: '100%' }}>
+                  <div
+                    ref={resizeRef}
+                    css={css`
+                      height: 100%;
+                    `}
+                  >
                     <VerticalOverflowContainer maxHeight={120}>
                       <VerticalOverflowContent maxHeight={120}>
                         <EuiText
@@ -178,11 +184,11 @@ function VerticalOverflowContainer({
   return (
     <div
       className="eui-yScroll"
-      css={{
-        maxHeight,
-        'overflow-y': 'hidden',
-        'word-break': 'break-word',
-      }}
+      css={css`
+        max-height: ${maxHeight};
+        overflow-y: 'hidden';
+        word-break: 'break-word';
+      `}
     >
       {children}
     </div>
@@ -200,9 +206,9 @@ function VerticalOverflowContent({
   return (
     <div
       className="eui-yScroll"
-      css={{
-        maxHeight,
-      }}
+      css={css`
+        max-height: ${maxHeight};
+      `}
     >
       {children}
     </div>

--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_about_rule_details/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_about_rule_details/index.tsx
@@ -129,7 +129,7 @@ const StepAboutRuleToggleDetailsComponent: React.FC<StepPanelProps> = ({
                 {(resizeRef) => (
                   <AboutContent ref={resizeRef}>
                     <VerticalOverflowContainer maxHeight={120}>
-                      <VerticalOverflowContent maxHeight={120} className="eui-yScroll">
+                      <VerticalOverflowContent maxHeight={120}>
                         <EuiText
                           size="s"
                           data-test-subj="stepAboutRuleDetailsToggleDescriptionText"
@@ -154,7 +154,7 @@ const StepAboutRuleToggleDetailsComponent: React.FC<StepPanelProps> = ({
                 data-test-subj="stepAboutDetailsNoteContent"
                 maxHeight={aboutPanelHeight}
               >
-                <VerticalOverflowContent maxHeight={aboutPanelHeight} className="eui-yScroll">
+                <VerticalOverflowContent maxHeight={aboutPanelHeight}>
                   <MarkdownRenderer>{stepDataDetails.note}</MarkdownRenderer>
                 </VerticalOverflowContent>
               </VerticalOverflowContainer>
@@ -164,7 +164,7 @@ const StepAboutRuleToggleDetailsComponent: React.FC<StepPanelProps> = ({
                 data-test-subj="stepAboutDetailsSetupContent"
                 maxHeight={aboutPanelHeight}
               >
-                <VerticalOverflowContent maxHeight={aboutPanelHeight} className="eui-yScroll">
+                <VerticalOverflowContent maxHeight={aboutPanelHeight}>
                   <MarkdownRenderer>{stepDataDetails.setup}</MarkdownRenderer>
                 </VerticalOverflowContent>
               </VerticalOverflowContainer>
@@ -177,3 +177,23 @@ const StepAboutRuleToggleDetailsComponent: React.FC<StepPanelProps> = ({
 };
 
 export const StepAboutRuleToggleDetails = memo(StepAboutRuleToggleDetailsComponent);
+
+interface VerticalOverflowContentProps {
+  maxHeight: number;
+}
+
+function VerticalOverflowContent({
+  maxHeight,
+  children,
+}: PropsWithChildren<VerticalOverflowContentProps>): JSX.Element {
+  return (
+    <div
+      className="eui-yScroll"
+      css={{
+        maxHeight,
+      }}
+    >
+      {children}
+    </div>
+  );
+}

--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_about_rule_details/styles.ts
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_about_rule_details/styles.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { css } from '@emotion/react';
+
+export const fullHeight = css`
+  height: 100%;
+`;


### PR DESCRIPTION
**Addresses:** https://github.com/elastic/kibana/issues/150997

## Summary

It removed rule details description's fade in and out effect which was added by scrolling EUI styles.

*Before:*

![Screenshot 2023-02-13 at 13 30 02](https://user-images.githubusercontent.com/3775283/218459498-28dd50ce-94eb-427f-865c-279f611b4049.png)

![Screenshot 2023-02-13 at 13 30 11](https://user-images.githubusercontent.com/3775283/218459532-56072024-8e8b-4ee1-89be-ffece60d31a7.png)

*After:*

![Screenshot 2023-02-13 at 13 27 49](https://user-images.githubusercontent.com/3775283/218459699-8da6f5c3-e05d-4c9f-8122-392f3bfd6846.png)

![Screenshot 2023-02-13 at 13 28 00](https://user-images.githubusercontent.com/3775283/218459735-1c522e19-573f-47c4-9490-5828373ac5ac.png)


<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->