### PR TITLE
[SecuritySolutions] Update ML modules installation to be space aware

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/ml/anomaly/helpers.ts
+++ b/x-pack/plugins/security_solution/public/common/components/ml/anomaly/helpers.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * From version 8.8, jobs installed using security solution have the spaceId in their name.
+ */
+export const matchJobId = (jobId: string, moduleJobId: string, spaceId: string | undefined) =>
+  jobId === uninstalledJobIdToInstalledJobId(moduleJobId, spaceId) || jobId === moduleJobId;
+
+export const installedJobPrefix = (spaceId: string | undefined) => `${spaceId ?? 'default'}_`;
+
+export const uninstalledJobIdToInstalledJobId = (
+  moduleJobId: string,
+  spaceId: string | undefined
+) => `${installedJobPrefix(spaceId)}${moduleJobId}`;

--- a/x-pack/plugins/security_solution/public/common/components/ml/anomaly/use_anomalies_search.ts
+++ b/x-pack/plugins/security_solution/public/common/components/ml/anomaly/use_anomalies_search.ts
@@ -161,7 +161,6 @@ export const uninstalledJobIdToInstalledJobId = (
 
 /**
  * From version 8.8, jobs installed using security solution have the spaceId in their name.
- * Jobs installed using security solution on versions older than 8.8 don't have the spaceId in their name.
  */
 const matchJobId = (
   jobId: string,

--- a/x-pack/plugins/security_solution/public/common/components/ml/anomaly/use_anomalies_search.ts
+++ b/x-pack/plugins/security_solution/public/common/components/ml/anomaly/use_anomalies_search.ts
@@ -20,6 +20,7 @@ import type { inputsModel } from '../../../store';
 import { useSecurityJobs } from '../../ml_popover/hooks/use_security_jobs';
 import type { SecurityJob } from '../../ml_popover/types';
 import { useSpaceId } from '../../../hooks/use_space_id';
+import { matchJobId } from './helpers';
 
 export enum AnomalyEntity {
   User,
@@ -151,19 +152,3 @@ function formatResultData(
   });
   return sortBy(['name'], unsortedAnomalies);
 }
-
-export const installedJobPrefix = (spaceId: string | undefined) => `${spaceId ?? 'default'}_`;
-
-export const uninstalledJobIdToInstalledJobId = (
-  moduleJobId: string,
-  spaceId: string | undefined
-) => `${installedJobPrefix(spaceId)}${moduleJobId}`;
-
-/**
- * From version 8.8, jobs installed using security solution have the spaceId in their name.
- */
-const matchJobId = (
-  jobId: string,
-  notableJobId: NotableAnomaliesJobId,
-  spaceId: string | undefined
-) => jobId === uninstalledJobIdToInstalledJobId(notableJobId, spaceId) || jobId === notableJobId;

--- a/x-pack/plugins/security_solution/public/common/components/ml_popover/api.ts
+++ b/x-pack/plugins/security_solution/public/common/components/ml_popover/api.ts
@@ -84,7 +84,6 @@ export const setupMlJob = async ({
         indexPatternName,
         startDatafeed: false,
         useDedicatedIndex: true,
-        applyToAllSpaces: true,
       }),
       asSystemRequest: true,
     }

--- a/x-pack/plugins/security_solution/public/common/components/ml_popover/hooks/use_enable_data_feed.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/ml_popover/hooks/use_enable_data_feed.test.tsx
@@ -132,7 +132,7 @@ describe('useSecurityJobsHelpers', () => {
       await result.current.enableDatafeed(JOB, TIMESTAMP, true);
     });
     expect(mockStartDatafeeds).toBeCalledWith({
-      datafeedIds: [`datafeed-undefined`],
+      datafeedIds: [`datafeed-default_undefined`],
       start: new Date('1989-02-21').getTime(),
     });
   });

--- a/x-pack/plugins/security_solution/public/common/components/ml_popover/hooks/use_enable_data_feed.ts
+++ b/x-pack/plugins/security_solution/public/common/components/ml_popover/hooks/use_enable_data_feed.ts
@@ -9,10 +9,7 @@ import { useCallback, useState } from 'react';
 import { useAppToasts } from '../../../hooks/use_app_toasts';
 import { useSpaceId } from '../../../hooks/use_space_id';
 import { METRIC_TYPE, TELEMETRY_EVENT, track } from '../../../lib/telemetry';
-import {
-  installedJobPrefix,
-  uninstalledJobIdToInstalledJobId,
-} from '../../ml/anomaly/use_anomalies_search';
+import { installedJobPrefix, uninstalledJobIdToInstalledJobId } from '../../ml/anomaly/helpers';
 import { setupMlJob, startDatafeeds, stopDatafeeds } from '../api';
 import type { SecurityJob } from '../types';
 import * as i18n from './translations';

--- a/x-pack/plugins/security_solution/public/common/components/ml_popover/hooks/use_enable_data_feed.ts
+++ b/x-pack/plugins/security_solution/public/common/components/ml_popover/hooks/use_enable_data_feed.ts
@@ -25,6 +25,7 @@ export const useEnableDataFeed = () => {
 
   const enableDatafeed = useCallback(
     async (job: SecurityJob, latestTimestampMs: number, enable: boolean) => {
+      let enabledJobId: string;
       submitTelemetry(job, enable);
 
       if (!job.isInstalled) {
@@ -37,12 +38,15 @@ export const useEnableDataFeed = () => {
             groups: job.groups,
             prefix: installedJobPrefix(spaceId),
           });
+          enabledJobId = uninstalledJobIdToInstalledJobId(job.id, spaceId);
           setIsLoading(false);
         } catch (error) {
           addError(error, { title: i18n.CREATE_JOB_FAILURE });
           setIsLoading(false);
-          return;
+          return { enabledJobId: job.id };
         }
+      } else {
+        enabledJobId = job.id;
       }
 
       // Max start time for job is no more than two weeks ago to ensure job performance
@@ -74,6 +78,8 @@ export const useEnableDataFeed = () => {
         }
       }
       setIsLoading(false);
+
+      return { enabledJobId };
     },
     [addError, spaceId]
   );

--- a/x-pack/plugins/security_solution/public/common/components/ml_popover/hooks/use_enable_data_feed.ts
+++ b/x-pack/plugins/security_solution/public/common/components/ml_popover/hooks/use_enable_data_feed.ts
@@ -58,11 +58,7 @@ export const useEnableDataFeed = () => {
         const startTime = Math.max(latestTimestampMs, maxStartTime);
         try {
           await startDatafeeds({
-            datafeedIds: [
-              job.isInstalled
-                ? `datafeed-${job.id}` // When the job is installed the job.id already contains the prefix.
-                : `datafeed-${uninstalledJobIdToInstalledJobId(job.id, spaceId)}`,
-            ],
+            datafeedIds: [`datafeed-${enabledJobId}`],
             start: startTime,
           });
         } catch (error) {

--- a/x-pack/plugins/security_solution/public/common/components/ml_popover/hooks/use_security_jobs.ts
+++ b/x-pack/plugins/security_solution/public/common/components/ml_popover/hooks/use_security_jobs.ts
@@ -20,6 +20,7 @@ import { useMlCapabilities } from '../../ml/hooks/use_ml_capabilities';
 import * as i18n from '../../ml/translations';
 import { getJobsSummary } from '../../ml/api/get_jobs_summary';
 import type { inputsModel } from '../../../store';
+import { useSpaceId } from '../../../hooks/use_space_id';
 
 export interface UseSecurityJobsReturn {
   loading: boolean;
@@ -49,6 +50,7 @@ export const useSecurityJobs = (): UseSecurityJobsReturn => {
   const refetch = useRef<inputsModel.Refetch>(noop);
   const isMlAdmin = hasMlAdminPermissions(mlCapabilities);
   const isLicensed = hasMlLicense(mlCapabilities);
+  const spaceId = useSpaceId();
 
   useEffect(() => {
     let isSubscribed = true;
@@ -71,7 +73,8 @@ export const useSecurityJobs = (): UseSecurityJobsReturn => {
           const compositeSecurityJobs = createSecurityJobs(
             jobSummaryData,
             modulesData,
-            compatibleModules
+            compatibleModules,
+            spaceId
           );
 
           if (isSubscribed) {
@@ -95,7 +98,7 @@ export const useSecurityJobs = (): UseSecurityJobsReturn => {
       isSubscribed = false;
       abortCtrl.abort();
     };
-  }, [isMlAdmin, isLicensed, securitySolutionDefaultIndex, addError, http]);
+  }, [isMlAdmin, isLicensed, securitySolutionDefaultIndex, addError, http, spaceId]);
 
   return { isLicensed, isMlAdmin, jobs, loading, refetch: refetch.current };
 };

--- a/x-pack/plugins/security_solution/public/common/components/ml_popover/hooks/use_security_jobs_helpers.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/ml_popover/hooks/use_security_jobs_helpers.test.tsx
@@ -79,11 +79,31 @@ describe('useSecurityJobsHelpers', () => {
     });
 
     describe('getAugmentedFields', () => {
-      test('return correct augmented fields for given matching compatible modules', () => {
+      test('return correct augmented fields for global ml jobs', () => {
         const moduleJobs = getModuleJobs(mockGetModuleResponse, ['security_linux_v3']);
-        const augmentedFields = getAugmentedFields('rare_process_by_host_linux', moduleJobs, [
-          'security_linux_v3',
-        ]);
+        const augmentedFields = getAugmentedFields(
+          'rare_process_by_host_linux',
+          moduleJobs,
+          ['security_linux_v3'],
+          'space-id'
+        );
+        expect(augmentedFields).toEqual({
+          defaultIndexPattern: 'auditbeat-*',
+          isCompatible: true,
+          isElasticJob: true,
+          moduleId: 'security_linux_v3',
+        });
+      });
+
+      test('return correct augmented fields for space aware jobs', () => {
+        const spaceId = 'test-space-id';
+        const moduleJobs = getModuleJobs(mockGetModuleResponse, ['security_linux_v3']);
+        const augmentedFields = getAugmentedFields(
+          `${spaceId}_rare_process_by_host_linux`,
+          moduleJobs,
+          ['security_linux_v3'],
+          spaceId
+        );
         expect(augmentedFields).toEqual({
           defaultIndexPattern: 'auditbeat-*',
           isCompatible: true,
@@ -103,9 +123,12 @@ describe('useSecurityJobsHelpers', () => {
     describe('getInstalledJobs', () => {
       test('returns all jobs from jobSummary for a compatible moduleId', () => {
         const moduleJobs = getModuleJobs(mockGetModuleResponse, ['security_linux_v3']);
-        const installedJobs = getInstalledJobs(mockJobsSummaryResponse, moduleJobs, [
-          'security_linux_v3',
-        ]);
+        const installedJobs = getInstalledJobs(
+          mockJobsSummaryResponse,
+          moduleJobs,
+          ['security_linux_v3'],
+          'spaceId'
+        );
         expect(installedJobs.length).toEqual(3);
       });
     });
@@ -113,9 +136,12 @@ describe('useSecurityJobsHelpers', () => {
     describe('composeModuleAndInstalledJobs', () => {
       test('returns correct number of jobs when composing separate module and installed jobs', () => {
         const moduleJobs = getModuleJobs(mockGetModuleResponse, ['security_linux_v3']);
-        const installedJobs = getInstalledJobs(mockJobsSummaryResponse, moduleJobs, [
-          'security_linux_v3',
-        ]);
+        const installedJobs = getInstalledJobs(
+          mockJobsSummaryResponse,
+          moduleJobs,
+          ['security_linux_v3'],
+          'spaceId'
+        );
         const securityJobs = composeModuleAndInstalledJobs(
           installedJobs,
           moduleJobs,

--- a/x-pack/plugins/security_solution/public/common/components/ml_popover/hooks/use_security_jobs_helpers.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/ml_popover/hooks/use_security_jobs_helpers.test.tsx
@@ -18,6 +18,7 @@ import {
   mockGetModuleResponse,
   mockJobsSummaryResponse,
 } from '../api.mock';
+import type { SecurityJob } from '../types';
 
 // TODO: Expand test coverage
 
@@ -115,8 +116,34 @@ describe('useSecurityJobsHelpers', () => {
         const installedJobs = getInstalledJobs(mockJobsSummaryResponse, moduleJobs, [
           'security_linux_v3',
         ]);
-        const securityJobs = composeModuleAndInstalledJobs(installedJobs, moduleJobs);
+        const securityJobs = composeModuleAndInstalledJobs(
+          installedJobs,
+          moduleJobs,
+          'testSpaceId'
+        );
         expect(securityJobs.length).toEqual(6);
+      });
+
+      test('filters out module job when the job id matches a installed job id (jobs installed before 8.8)', () => {
+        const installedJob = mockJob('test_job');
+        const moduleJob = mockJob('test_job');
+        const securityJobs = composeModuleAndInstalledJobs(
+          [installedJob],
+          [moduleJob],
+          'testSpaceId'
+        );
+        expect(securityJobs.length).toEqual(1);
+      });
+
+      test('filters out module job when the job id matches a installed job id (jobs installed after 8.8)', () => {
+        const installedJob = mockJob('testSpaceId_test_job');
+        const moduleJob = mockJob('test_job');
+        const securityJobs = composeModuleAndInstalledJobs(
+          [installedJob],
+          [moduleJob],
+          'testSpaceId'
+        );
+        expect(securityJobs.length).toEqual(1);
       });
     });
 
@@ -125,10 +152,31 @@ describe('useSecurityJobsHelpers', () => {
         const securityJobs = createSecurityJobs(
           mockJobsSummaryResponse,
           mockGetModuleResponse,
-          checkRecognizerSuccess
+          checkRecognizerSuccess,
+          'testSpaceId'
         );
         expect(securityJobs.length).toEqual(6);
       });
     });
   });
+});
+
+const mockJob = (id: string): SecurityJob => ({
+  moduleId: '',
+  defaultIndexPattern: '',
+  isCompatible: false,
+  isInstalled: false,
+  isElasticJob: false,
+  id,
+  description: '',
+  groups: [],
+  jobState: 'closed',
+  datafeedIndices: [],
+  hasDatafeed: false,
+  datafeedId: '',
+  datafeedState: '',
+  isSingleMetricViewerJob: false,
+  awaitingNodeAssignment: false,
+  jobTags: {},
+  bucketSpanSeconds: 0,
 });

--- a/x-pack/plugins/security_solution/public/common/components/ml_popover/ml_popover.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/ml_popover/ml_popover.tsx
@@ -62,9 +62,8 @@ export const MlPopover = React.memo(() => {
   const { enableDatafeed, isLoading: isLoadingEnableDataFeed } = useEnableDataFeed();
   const handleJobStateChange = useCallback(
     async (job: SecurityJob, latestTimestampMs: number, enable: boolean) => {
-      const result = await enableDatafeed(job, latestTimestampMs, enable);
+      await enableDatafeed(job, latestTimestampMs, enable);
       refreshJobs();
-      return result;
     },
     [refreshJobs, enableDatafeed]
   );

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/pages/rule_creation/index.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/pages/rule_creation/index.tsx
@@ -294,19 +294,19 @@ const CreateRulePageComponent: React.FC = () => {
               if (!isMlRule(defineStep.data.ruleType) || !actionsStep.data.enabled) {
                 return;
               }
-              await startMlJobs(defineStep.data.machineLearningJobId);
+              return startMlJobs(defineStep.data.machineLearningJobId);
             };
-            const [, createdRule] = await Promise.all([
-              startMlJobsIfNeeded(),
-              createRule(
-                formatRule<RuleCreateProps>(
-                  defineStep.data,
-                  aboutStep.data,
-                  scheduleStep.data,
-                  actionsStep.data
-                )
-              ),
-            ]);
+            // Update machineLearningJobId because after created they receive the space prefix
+            const createdJobIds = await startMlJobsIfNeeded();
+
+            const createdRule = await createRule(
+              formatRule<RuleCreateProps>(
+                { ...defineStep.data, machineLearningJobId: createdJobIds ?? [] },
+                aboutStep.data,
+                scheduleStep.data,
+                actionsStep.data
+              )
+            );
 
             addSuccess(i18n.SUCCESSFULLY_CREATED_RULES(createdRule.name));
 
@@ -447,6 +447,7 @@ const CreateRulePageComponent: React.FC = () => {
                             onSubmit={() => submitStep(RuleStep.defineRule)}
                             kibanaDataViews={dataViewOptions}
                             descriptionColumns="singleSplit"
+                            jobInstallationDisabled
                             // We need a key to make this component remount when edit/view mode is toggled
                             // https://github.com/elastic/kibana/pull/132834#discussion_r881705566
                             key={isShouldRerenderStep(RuleStep.defineRule, activeStep)}

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/pages/rule_creation/index.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/pages/rule_creation/index.tsx
@@ -301,7 +301,10 @@ const CreateRulePageComponent: React.FC = () => {
 
             const createdRule = await createRule(
               formatRule<RuleCreateProps>(
-                { ...defineStep.data, machineLearningJobId: createdJobIds ?? [] },
+                {
+                  ...defineStep.data,
+                  machineLearningJobId: createdJobIds ?? defineStep.data.machineLearningJobId,
+                },
                 aboutStep.data,
                 scheduleStep.data,
                 actionsStep.data
@@ -318,7 +321,7 @@ const CreateRulePageComponent: React.FC = () => {
         }
       }
     },
-    [updateCurrentDataState, goToStep, createRule, navigateToApp, startMlJobs, addSuccess]
+    [updateCurrentDataState, goToStep, createRule, addSuccess, navigateToApp, startMlJobs]
   );
 
   const getAccordionType = useCallback(
@@ -447,7 +450,6 @@ const CreateRulePageComponent: React.FC = () => {
                             onSubmit={() => submitStep(RuleStep.defineRule)}
                             kibanaDataViews={dataViewOptions}
                             descriptionColumns="singleSplit"
-                            jobInstallationDisabled
                             // We need a key to make this component remount when edit/view mode is toggled
                             // https://github.com/elastic/kibana/pull/132834#discussion_r881705566
                             key={isShouldRerenderStep(RuleStep.defineRule, activeStep)}

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/pages/rule_editing/index.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/pages/rule_editing/index.tsx
@@ -19,9 +19,9 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import type { FC } from 'react';
 import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
+import type { DataViewListItem } from '@kbn/data-views-plugin/common';
 import { noop } from 'lodash';
 
-import type { DataViewListItem } from '@kbn/data-views-plugin/common';
 import { RulePreview } from '../../../../detections/components/rules/rule_preview';
 import type { RuleUpdateProps } from '../../../../../common/detection_engine/rule_schema';
 import { useRule, useUpdateRule } from '../../../rule_management/logic';
@@ -98,7 +98,9 @@ const EditRulePageComponent: FC = () => {
   const { navigateToApp } = useKibana().services.application;
 
   const { detailName: ruleId } = useParams<{ detailName: string }>();
+  // HERE aqui que eu vou
   const { data: rule, isLoading: ruleLoading } = useRule(ruleId);
+
   const loading = ruleLoading || userInfoLoading || listsConfigLoading;
 
   const { isSavedQueryLoading, savedQueryBar, savedQuery } = useGetSavedQuery(rule?.saved_id, {
@@ -237,6 +239,7 @@ const EditRulePageComponent: FC = () => {
                   onRuleDataChange={onDataChange}
                   onPreviewDisabledStateChange={setIsPreviewDisabled}
                   defaultSavedQuery={savedQuery}
+                  // updateMachineLearningJob={updateMachineLearningJob}
                 />
               )}
               <EuiSpacer />
@@ -322,20 +325,20 @@ const EditRulePageComponent: FC = () => {
       rule?.immutable,
       rule?.type,
       loading,
-      defineStep.data,
-      isLoading,
       isSavedQueryLoading,
       defineStepDataWithSavedQuery,
+      isLoading,
       setFormHook,
       dataViewOptions,
       indicesConfig,
       threatIndicesConfig,
       onDataChange,
+      savedQuery,
       aboutStep.data,
+      defineStep.data,
       scheduleStep.data,
       actionsStep.data,
       actionMessageParams,
-      savedQuery,
     ]
   );
 

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/index.test.tsx
@@ -126,6 +126,7 @@ jest.mock('../../../../common/lib/kibana', () => {
             components: { getLegacyUrlConflict: mockGetLegacyUrlConflict },
             redirectLegacyUrl: mockRedirectLegacyUrl,
           },
+          getActiveSpace: jest.fn().mockResolvedValue('test-space'),
         },
       },
     }),

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/index.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/index.tsx
@@ -246,9 +246,10 @@ const RuleDetailsPageComponent: React.FC<DetectionEngineComponentProps> = ({
   const isLoading = ruleLoading && rule == null;
 
   const { starting: isStartingJobs, startMlJobs } = useStartMlJobs();
-  const startMlJobsIfNeeded = useCallback(async () => {
-    await startMlJobs(rule?.machine_learning_job_id);
-  }, [rule, startMlJobs]);
+  const startMlJobsIfNeeded = useCallback(
+    () => startMlJobs(rule?.machine_learning_job_id),
+    [rule, startMlJobs]
+  );
 
   const ruleDetailTabs = useMemo(
     (): Record<RuleDetailTabs, NavTab> => ({

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/translations.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/translations.ts
@@ -69,3 +69,10 @@ export const DELETED_RULE = i18n.translate(
     defaultMessage: 'Deleted rule',
   }
 );
+
+export const UPDATE_MACHINE_LEARNING_JOB_ERROR = i18n.translate(
+  'xpack.securitySolution.detectionEngine.ruleDetails.updateMachineLearningJobError',
+  {
+    defaultMessage: 'Error updating machine learning job',
+  }
+);

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/use_columns.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/use_columns.tsx
@@ -52,7 +52,7 @@ interface ColumnsProps {
   hasCRUDPermissions: boolean;
   isLoadingJobs: boolean;
   mlJobs: SecurityJob[];
-  startMlJobs: (jobIds: string[] | undefined) => Promise<string[] | undefined>;
+  startMlJobs: (rule: Rule) => Promise<string[] | undefined>;
 }
 
 interface ActionColumnsProps {
@@ -89,7 +89,7 @@ const useEnabledColumn = ({ hasCRUDPermissions, startMlJobs }: ColumnsProps): Ta
           <RuleSwitch
             id={rule.id}
             enabled={rule.enabled}
-            startMlJobsIfNeeded={() => startMlJobs(rule.machine_learning_job_id)}
+            startMlJobsIfNeeded={() => startMlJobs(rule)}
             isDisabled={
               !canEditRuleWithActions(rule, hasActionsPrivileges) ||
               !hasCRUDPermissions ||

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/use_columns.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/use_columns.tsx
@@ -52,7 +52,7 @@ interface ColumnsProps {
   hasCRUDPermissions: boolean;
   isLoadingJobs: boolean;
   mlJobs: SecurityJob[];
-  startMlJobs: (jobIds: string[] | undefined) => Promise<void>;
+  startMlJobs: (jobIds: string[] | undefined) => Promise<string[] | undefined>;
 }
 
 interface ActionColumnsProps {

--- a/x-pack/plugins/security_solution/public/detections/components/rules/description_step/build_ml_jobs_description.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/description_step/build_ml_jobs_description.tsx
@@ -8,7 +8,11 @@ import React from 'react';
 import type { ListItems } from './types';
 import { MlJobsDescription } from '../ml_jobs_description';
 
-export const buildMlJobsDescription = (jobIds: string[], label: string): ListItems => ({
+export const buildMlJobsDescription = (
+  jobIds: string[],
+  label: string,
+  readOnly: boolean
+): ListItems => ({
   title: label,
-  description: <MlJobsDescription jobIds={jobIds} />,
+  description: <MlJobsDescription jobIds={jobIds} readOnly={readOnly} />,
 });

--- a/x-pack/plugins/security_solution/public/detections/components/rules/description_step/build_ml_jobs_description.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/description_step/build_ml_jobs_description.tsx
@@ -7,12 +7,15 @@
 import React from 'react';
 import type { ListItems } from './types';
 import { MlJobsDescription } from '../ml_jobs_description';
+import type { UpdateMachineLearningJob } from '../ml_jobs_description/admin/ml_admin_jobs_description';
 
 export const buildMlJobsDescription = (
   jobIds: string[],
   label: string,
-  readOnly: boolean
+  updateMachineLearningJob?: UpdateMachineLearningJob
 ): ListItems => ({
   title: label,
-  description: <MlJobsDescription jobIds={jobIds} readOnly={readOnly} />,
+  description: (
+    <MlJobsDescription jobIds={jobIds} updateMachineLearningJob={updateMachineLearningJob} />
+  ),
 });

--- a/x-pack/plugins/security_solution/public/detections/components/rules/description_step/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/description_step/index.tsx
@@ -6,7 +6,6 @@
  */
 
 import { EuiDescriptionList, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
-import { isEmpty, chunk, get, pick, isNumber } from 'lodash/fp';
 import React, { memo, useState } from 'react';
 import styled from 'styled-components';
 
@@ -14,6 +13,7 @@ import type { ThreatMapping, Threats, Type } from '@kbn/securitysolution-io-ts-a
 import type { DataViewBase, Filter } from '@kbn/es-query';
 import { FilterStateStore } from '@kbn/es-query';
 import { FilterManager } from '@kbn/data-plugin/public';
+import { isEmpty, chunk, get, pick, isNumber } from 'lodash/fp';
 import { buildRelatedIntegrationsDescription } from '../related_integrations/integrations_description';
 import type {
   RelatedIntegrationArray,
@@ -54,6 +54,7 @@ import { THREAT_QUERY_LABEL } from './translations';
 import { filterEmptyThreats } from '../../../../detection_engine/rule_creation_ui/pages/rule_creation/helpers';
 import { useLicense } from '../../../../common/hooks/use_license';
 import type { LicenseService } from '../../../../../common/license';
+import type { UpdateMachineLearningJob } from '../ml_jobs_description/admin/ml_admin_jobs_description';
 
 const DescriptionListContainer = styled(EuiDescriptionList)`
   &.euiDescriptionList--column .euiDescriptionList__title {
@@ -70,7 +71,7 @@ interface StepRuleDescriptionProps<T> {
   data: unknown;
   indexPatterns?: DataViewBase;
   schema: FormSchema<T>;
-  jobInstallationDisabled?: boolean;
+  updateMachineLearningJob?: UpdateMachineLearningJob;
 }
 
 export const StepRuleDescriptionComponent = <T,>({
@@ -78,7 +79,7 @@ export const StepRuleDescriptionComponent = <T,>({
   columns = 'multi',
   indexPatterns,
   schema,
-  jobInstallationDisabled,
+  updateMachineLearningJob,
 }: StepRuleDescriptionProps<T>) => {
   const kibana = useKibana();
   const license = useLicense();
@@ -92,7 +93,7 @@ export const StepRuleDescriptionComponent = <T,>({
         buildMlJobsDescription(
           get(key, data) as string[],
           (get(key, schema) as { label: string }).label,
-          !!jobInstallationDisabled
+          updateMachineLearningJob
         ),
       ];
     }

--- a/x-pack/plugins/security_solution/public/detections/components/rules/description_step/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/description_step/index.tsx
@@ -70,6 +70,7 @@ interface StepRuleDescriptionProps<T> {
   data: unknown;
   indexPatterns?: DataViewBase;
   schema: FormSchema<T>;
+  jobInstallationDisabled?: boolean;
 }
 
 export const StepRuleDescriptionComponent = <T,>({
@@ -77,6 +78,7 @@ export const StepRuleDescriptionComponent = <T,>({
   columns = 'multi',
   indexPatterns,
   schema,
+  jobInstallationDisabled,
 }: StepRuleDescriptionProps<T>) => {
   const kibana = useKibana();
   const license = useLicense();
@@ -89,7 +91,8 @@ export const StepRuleDescriptionComponent = <T,>({
         ...acc,
         buildMlJobsDescription(
           get(key, data) as string[],
-          (get(key, schema) as { label: string }).label
+          (get(key, schema) as { label: string }).label,
+          !!jobInstallationDisabled
         ),
       ];
     }

--- a/x-pack/plugins/security_solution/public/detections/components/rules/ml_jobs_description/admin/ml_admin_job_description.integration.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/ml_jobs_description/admin/ml_admin_job_description.integration.test.tsx
@@ -47,6 +47,7 @@ describe('MlAdminJobDescription', () => {
         job={securityJobNotStarted}
         refreshJob={refreshJobSpy}
         loading={false}
+        readOnly={false}
       />,
       {
         wrapper: TestProviders,
@@ -71,7 +72,12 @@ describe('MlAdminJobDescription', () => {
     });
 
     render(
-      <MlAdminJobDescription job={securityJobNotStarted} refreshJob={noop} loading={false} />,
+      <MlAdminJobDescription
+        job={securityJobNotStarted}
+        refreshJob={noop}
+        loading={false}
+        readOnly={false}
+      />,
       {
         wrapper: TestProviders,
       }
@@ -84,9 +90,17 @@ describe('MlAdminJobDescription', () => {
   });
 
   it('should render loading spinner when loading property passed', async () => {
-    render(<MlAdminJobDescription job={securityJobNotStarted} refreshJob={noop} loading />, {
-      wrapper: TestProviders,
-    });
+    render(
+      <MlAdminJobDescription
+        job={securityJobNotStarted}
+        refreshJob={noop}
+        loading
+        readOnly={false}
+      />,
+      {
+        wrapper: TestProviders,
+      }
+    );
 
     expect(screen.getByTestId('job-switch-loader')).toBeInTheDocument();
     await waitFor(() => {
@@ -95,9 +109,17 @@ describe('MlAdminJobDescription', () => {
   });
 
   it('should render job details correctly', async () => {
-    render(<MlAdminJobDescription job={securityJobNotStarted} refreshJob={noop} loading />, {
-      wrapper: TestProviders,
-    });
+    render(
+      <MlAdminJobDescription
+        job={securityJobNotStarted}
+        refreshJob={noop}
+        loading
+        readOnly={false}
+      />,
+      {
+        wrapper: TestProviders,
+      }
+    );
 
     // link to job
     const linkElement = screen.getByTestId('machineLearningJobLink');
@@ -116,6 +138,27 @@ describe('MlAdminJobDescription', () => {
     // job action label
     await waitFor(() => {
       expect(screen.getByTestId('mlJobActionLabel')).toHaveTextContent('Run job');
+    });
+  });
+
+  it('should not render toggle if readOnly is true', async () => {
+    useEnableDataFeedMock.mockReturnValueOnce({
+      enableDatafeed: noop,
+    });
+
+    render(
+      <MlAdminJobDescription
+        job={securityJobNotStarted}
+        refreshJob={noop}
+        loading={false}
+        readOnly
+      />,
+      {
+        wrapper: TestProviders,
+      }
+    );
+    await waitFor(() => {
+      expect(screen.queryByTestId('job-switch')).not.toBeInTheDocument();
     });
   });
 });

--- a/x-pack/plugins/security_solution/public/detections/components/rules/ml_jobs_description/admin/ml_admin_job_description.integration.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/ml_jobs_description/admin/ml_admin_job_description.integration.test.tsx
@@ -37,7 +37,7 @@ const useEnableDataFeedMock = (useEnableDataFeed as jest.Mock).mockReturnValue({
 describe('MlAdminJobDescription', () => {
   it('should enable datafeed and call refreshJob when enabling job', async () => {
     const refreshJobSpy = jest.fn();
-    const enableDatafeedSpy = jest.fn();
+    const enableDatafeedSpy = jest.fn().mockReturnValue({});
     useEnableDataFeedMock.mockReturnValueOnce({
       enableDatafeed: enableDatafeedSpy,
     });

--- a/x-pack/plugins/security_solution/public/detections/components/rules/ml_jobs_description/admin/ml_admin_job_description.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/ml_jobs_description/admin/ml_admin_job_description.tsx
@@ -18,12 +18,14 @@ interface MlAdminJobDescriptionProps {
   job: SecurityJob;
   loading: boolean;
   refreshJob: (job: SecurityJob) => void;
+  readOnly: boolean;
 }
 
 const MlAdminJobDescriptionComponent: FC<MlAdminJobDescriptionProps> = ({
   job,
   loading,
   refreshJob,
+  readOnly,
 }) => {
   const { enableDatafeed, isLoading: isLoadingEnableDataFeed } = useEnableDataFeed();
 
@@ -46,7 +48,7 @@ const MlAdminJobDescriptionComponent: FC<MlAdminJobDescriptionProps> = ({
     [handleJobStateChange, isLoadingEnableDataFeed, job, loading]
   );
 
-  return <MlJobItem job={job} switchComponent={switchComponent} />;
+  return <MlJobItem job={job} switchComponent={readOnly ? undefined : switchComponent} />;
 };
 
 export const MlAdminJobDescription = memo(MlAdminJobDescriptionComponent);

--- a/x-pack/plugins/security_solution/public/detections/components/rules/ml_jobs_description/admin/ml_admin_jobs_description.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/ml_jobs_description/admin/ml_admin_jobs_description.test.tsx
@@ -29,7 +29,7 @@ const useSecurityJobsMock = useSecurityJobs as jest.Mock;
 describe('MlAdminJobsDescription', () => {
   it('should render null if admin permissions absent', () => {
     useSecurityJobsMock.mockReturnValueOnce({ jobs: [], isMlAdmin: false });
-    const { container } = render(<MlAdminJobsDescription jobIds={['mock-1']} readOnly={false} />);
+    const { container } = render(<MlAdminJobsDescription jobIds={['mock-1']} />);
 
     expect(container.firstChild).toBeNull();
   });
@@ -39,7 +39,7 @@ describe('MlAdminJobsDescription', () => {
       jobs: [{ id: 'mock-1' }, { id: 'mock-2' }, { id: 'mock-3' }],
       isMlAdmin: true,
     });
-    render(<MlAdminJobsDescription jobIds={['mock-1', 'mock-2', 'mock-4']} readOnly={false} />);
+    render(<MlAdminJobsDescription jobIds={['mock-1', 'mock-2', 'mock-4']} />);
     const expectedJobs = screen.getAllByTestId('adminMock');
 
     expect(expectedJobs).toHaveLength(2);

--- a/x-pack/plugins/security_solution/public/detections/components/rules/ml_jobs_description/admin/ml_admin_jobs_description.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/ml_jobs_description/admin/ml_admin_jobs_description.test.tsx
@@ -29,7 +29,7 @@ const useSecurityJobsMock = useSecurityJobs as jest.Mock;
 describe('MlAdminJobsDescription', () => {
   it('should render null if admin permissions absent', () => {
     useSecurityJobsMock.mockReturnValueOnce({ jobs: [], isMlAdmin: false });
-    const { container } = render(<MlAdminJobsDescription jobIds={['mock-1']} />);
+    const { container } = render(<MlAdminJobsDescription jobIds={['mock-1']} readOnly={false} />);
 
     expect(container.firstChild).toBeNull();
   });
@@ -39,7 +39,7 @@ describe('MlAdminJobsDescription', () => {
       jobs: [{ id: 'mock-1' }, { id: 'mock-2' }, { id: 'mock-3' }],
       isMlAdmin: true,
     });
-    render(<MlAdminJobsDescription jobIds={['mock-1', 'mock-2', 'mock-4']} />);
+    render(<MlAdminJobsDescription jobIds={['mock-1', 'mock-2', 'mock-4']} readOnly={false} />);
     const expectedJobs = screen.getAllByTestId('adminMock');
 
     expect(expectedJobs).toHaveLength(2);

--- a/x-pack/plugins/security_solution/public/detections/components/rules/ml_jobs_description/admin/ml_admin_jobs_description.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/ml_jobs_description/admin/ml_admin_jobs_description.tsx
@@ -14,9 +14,10 @@ import { MlAdminJobDescription } from './ml_admin_job_description';
 
 interface MlAdminJobsDescriptionProps {
   jobIds: string[];
+  readOnly: boolean;
 }
 
-const MlAdminJobsDescriptionComponent: FC<MlAdminJobsDescriptionProps> = ({ jobIds }) => {
+const MlAdminJobsDescriptionComponent: FC<MlAdminJobsDescriptionProps> = ({ jobIds, readOnly }) => {
   const { loading, jobs, refetch: refreshJobs, isMlAdmin } = useSecurityJobs();
 
   if (!isMlAdmin) {
@@ -28,7 +29,13 @@ const MlAdminJobsDescriptionComponent: FC<MlAdminJobsDescriptionProps> = ({ jobI
   return (
     <>
       {relevantJobs.map((job) => (
-        <MlAdminJobDescription key={job.id} job={job} loading={loading} refreshJob={refreshJobs} />
+        <MlAdminJobDescription
+          key={job.id}
+          job={job}
+          loading={loading}
+          refreshJob={refreshJobs}
+          readOnly={readOnly}
+        />
       ))}
     </>
   );

--- a/x-pack/plugins/security_solution/public/detections/components/rules/ml_jobs_description/admin/ml_admin_jobs_description.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/ml_jobs_description/admin/ml_admin_jobs_description.tsx
@@ -5,38 +5,64 @@
  * 2.0.
  */
 
+import { EuiLoadingSpinner } from '@elastic/eui';
 import type { FC } from 'react';
 import React, { memo } from 'react';
-
+import { matchJobId } from '../../../../../common/components/ml/anomaly/helpers';
+import * as i18n from '../translations';
 import { useSecurityJobs } from '../../../../../common/components/ml_popover/hooks/use_security_jobs';
+import { useSpaceId } from '../../../../../common/hooks/use_space_id';
 
 import { MlAdminJobDescription } from './ml_admin_job_description';
 
+// TODO MOVE IT TO TYPES
+export type UpdateMachineLearningJob = (
+  originalJobId: string,
+  updatedJobId: string
+) => Promise<void>;
+
 interface MlAdminJobsDescriptionProps {
   jobIds: string[];
-  readOnly: boolean;
+  updateMachineLearningJob?: UpdateMachineLearningJob;
 }
 
-const MlAdminJobsDescriptionComponent: FC<MlAdminJobsDescriptionProps> = ({ jobIds, readOnly }) => {
+const MlAdminJobsDescriptionComponent: FC<MlAdminJobsDescriptionProps> = ({
+  jobIds,
+  updateMachineLearningJob,
+}) => {
+  const spaceId = useSpaceId();
   const { loading, jobs, refetch: refreshJobs, isMlAdmin } = useSecurityJobs();
 
   if (!isMlAdmin) {
     return null;
   }
 
-  const relevantJobs = jobs.filter((job) => jobIds.includes(job.id));
+  if (loading) {
+    return <EuiLoadingSpinner size="m" />;
+  }
+
+  const relevantJobs = jobIds.map((ruleJobId) => ({
+    job: jobs.find((job) => matchJobId(job.id, ruleJobId, spaceId)),
+    ruleJobId,
+  }));
 
   return (
     <>
-      {relevantJobs.map((job) => (
-        <MlAdminJobDescription
-          key={job.id}
-          job={job}
-          loading={loading}
-          refreshJob={refreshJobs}
-          readOnly={readOnly}
-        />
-      ))}
+      {relevantJobs.map(({ job, ruleJobId }) =>
+        job ? (
+          <MlAdminJobDescription
+            key={ruleJobId}
+            job={job}
+            ruleJobId={ruleJobId}
+            loading={loading}
+            refreshJob={refreshJobs}
+            readOnly={!updateMachineLearningJob}
+            onUpdateJobId={updateMachineLearningJob}
+          />
+        ) : (
+          <span>{i18n.JOB_NOT_FOUND}</span>
+        )
+      )}
     </>
   );
 };

--- a/x-pack/plugins/security_solution/public/detections/components/rules/ml_jobs_description/ml_job_item.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/ml_jobs_description/ml_job_item.tsx
@@ -25,7 +25,7 @@ const Wrapper = styled.div`
 
 const MlJobItemComponent: FC<{
   job: MlSummaryJob;
-  switchComponent: ReactNode;
+  switchComponent?: ReactNode;
 }> = ({ job, switchComponent, ...props }) => {
   const isStarted = isJobStarted(job.jobState, job.datafeedState);
 
@@ -39,10 +39,14 @@ const MlJobItemComponent: FC<{
         <EuiFlexItem grow={false} style={{ marginRight: '0' }}>
           <MlJobStatusBadge job={job} />
         </EuiFlexItem>
-        <EuiFlexItem grow={false}>{switchComponent}</EuiFlexItem>
-        <EuiFlexItem grow={false} style={{ marginLeft: '0' }} data-test-subj="mlJobActionLabel">
-          {isStarted ? i18n.ML_STOP_JOB_LABEL : i18n.ML_RUN_JOB_LABEL}
-        </EuiFlexItem>
+        {switchComponent ? (
+          <>
+            <EuiFlexItem grow={false}>{switchComponent}</EuiFlexItem>
+            <EuiFlexItem grow={false} style={{ marginLeft: '0' }} data-test-subj="mlJobActionLabel">
+              {isStarted ? i18n.ML_STOP_JOB_LABEL : i18n.ML_RUN_JOB_LABEL}
+            </EuiFlexItem>
+          </>
+        ) : null}
       </EuiFlexGroup>
     </Wrapper>
   );

--- a/x-pack/plugins/security_solution/public/detections/components/rules/ml_jobs_description/ml_jobs_description.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/ml_jobs_description/ml_jobs_description.test.tsx
@@ -26,14 +26,14 @@ const hasMlUserPermissionsMock = hasMlUserPermissions as jest.Mock;
 
 describe('MlUserJobDescription', () => {
   it('should render null if no ML permissions available', () => {
-    const { container } = render(<MlJobsDescription jobIds={[]} readOnly={false} />);
+    const { container } = render(<MlJobsDescription jobIds={[]} />);
 
     expect(container.firstChild).toBeNull();
   });
 
   it('should render user jobs component if ML permissions is for user only', () => {
     hasMlUserPermissionsMock.mockReturnValueOnce(true);
-    render(<MlJobsDescription jobIds={[]} readOnly={false} />);
+    render(<MlJobsDescription jobIds={[]} />);
 
     expect(screen.getByTestId('userJobs')).toBeInTheDocument();
     expect(screen.queryByTestId('adminJobs')).not.toBeInTheDocument();
@@ -41,7 +41,7 @@ describe('MlUserJobDescription', () => {
 
   it('should render admin jobs component if ML permissions is for admin', () => {
     (hasMlAdminPermissions as jest.Mock).mockReturnValueOnce(true);
-    render(<MlJobsDescription jobIds={[]} readOnly={false} />);
+    render(<MlJobsDescription jobIds={[]} />);
 
     expect(screen.getByTestId('adminJobs')).toBeInTheDocument();
     expect(screen.queryByTestId('userJobs')).not.toBeInTheDocument();

--- a/x-pack/plugins/security_solution/public/detections/components/rules/ml_jobs_description/ml_jobs_description.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/ml_jobs_description/ml_jobs_description.test.tsx
@@ -26,14 +26,14 @@ const hasMlUserPermissionsMock = hasMlUserPermissions as jest.Mock;
 
 describe('MlUserJobDescription', () => {
   it('should render null if no ML permissions available', () => {
-    const { container } = render(<MlJobsDescription jobIds={[]} />);
+    const { container } = render(<MlJobsDescription jobIds={[]} readOnly={false} />);
 
     expect(container.firstChild).toBeNull();
   });
 
   it('should render user jobs component if ML permissions is for user only', () => {
     hasMlUserPermissionsMock.mockReturnValueOnce(true);
-    render(<MlJobsDescription jobIds={[]} />);
+    render(<MlJobsDescription jobIds={[]} readOnly={false} />);
 
     expect(screen.getByTestId('userJobs')).toBeInTheDocument();
     expect(screen.queryByTestId('adminJobs')).not.toBeInTheDocument();
@@ -41,7 +41,7 @@ describe('MlUserJobDescription', () => {
 
   it('should render admin jobs component if ML permissions is for admin', () => {
     (hasMlAdminPermissions as jest.Mock).mockReturnValueOnce(true);
-    render(<MlJobsDescription jobIds={[]} />);
+    render(<MlJobsDescription jobIds={[]} readOnly={false} />);
 
     expect(screen.getByTestId('adminJobs')).toBeInTheDocument();
     expect(screen.queryByTestId('userJobs')).not.toBeInTheDocument();

--- a/x-pack/plugins/security_solution/public/detections/components/rules/ml_jobs_description/ml_jobs_description.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/ml_jobs_description/ml_jobs_description.tsx
@@ -12,26 +12,32 @@ import { useMlCapabilities } from '../../../../common/components/ml/hooks/use_ml
 import { hasMlAdminPermissions } from '../../../../../common/machine_learning/has_ml_admin_permissions';
 import { hasMlUserPermissions } from '../../../../../common/machine_learning/has_ml_user_permissions';
 
+import type { UpdateMachineLearningJob } from './admin/ml_admin_jobs_description';
 import { MlAdminJobsDescription } from './admin/ml_admin_jobs_description';
 import { MlUserJobsDescription } from './user/ml_user_jobs_description';
 
 interface MlJobsDescriptionProps {
   jobIds: string[];
-  readOnly: boolean;
+  updateMachineLearningJob?: UpdateMachineLearningJob;
 }
 
-const MlJobsDescriptionComponent: FC<MlJobsDescriptionProps> = ({ jobIds, readOnly }) => {
+const MlJobsDescriptionComponent: FC<MlJobsDescriptionProps> = ({
+  jobIds,
+  updateMachineLearningJob,
+}) => {
   const mlCapabilities = useMlCapabilities();
 
   const isMlUser = hasMlUserPermissions(mlCapabilities);
   const isMlAdmin = hasMlAdminPermissions(mlCapabilities);
 
   if (isMlAdmin) {
-    return <MlAdminJobsDescription jobIds={jobIds} readOnly={readOnly} />;
+    return (
+      <MlAdminJobsDescription jobIds={jobIds} updateMachineLearningJob={updateMachineLearningJob} />
+    );
   }
 
   if (isMlUser) {
-    return <MlUserJobsDescription jobIds={jobIds} readOnly={readOnly} />;
+    return <MlUserJobsDescription jobIds={jobIds} readOnly={!updateMachineLearningJob} />;
   }
 
   return null;

--- a/x-pack/plugins/security_solution/public/detections/components/rules/ml_jobs_description/ml_jobs_description.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/ml_jobs_description/ml_jobs_description.tsx
@@ -17,20 +17,21 @@ import { MlUserJobsDescription } from './user/ml_user_jobs_description';
 
 interface MlJobsDescriptionProps {
   jobIds: string[];
+  readOnly: boolean;
 }
 
-const MlJobsDescriptionComponent: FC<MlJobsDescriptionProps> = ({ jobIds }) => {
+const MlJobsDescriptionComponent: FC<MlJobsDescriptionProps> = ({ jobIds, readOnly }) => {
   const mlCapabilities = useMlCapabilities();
 
   const isMlUser = hasMlUserPermissions(mlCapabilities);
   const isMlAdmin = hasMlAdminPermissions(mlCapabilities);
 
   if (isMlAdmin) {
-    return <MlAdminJobsDescription jobIds={jobIds} />;
+    return <MlAdminJobsDescription jobIds={jobIds} readOnly={readOnly} />;
   }
 
   if (isMlUser) {
-    return <MlUserJobsDescription jobIds={jobIds} />;
+    return <MlUserJobsDescription jobIds={jobIds} readOnly={readOnly} />;
   }
 
   return null;

--- a/x-pack/plugins/security_solution/public/detections/components/rules/ml_jobs_description/translations.ts
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/ml_jobs_description/translations.ts
@@ -33,3 +33,14 @@ export const ML_ADMIN_REQUIRED = i18n.translate(
     defaultMessage: 'ML Admin Permissions required to perform this action',
   }
 );
+
+export const JOB_NOT_FOUND = (jobId: number) =>
+  i18n.translate(
+    'xpack.securitySolution.detectionEngine.ruleDescription.mlAdminPermissionsRequiredDescription',
+    {
+      defaultMessage: 'Job {id} not found',
+      values: {
+        id: jobId,
+      },
+    }
+  );

--- a/x-pack/plugins/security_solution/public/detections/components/rules/ml_jobs_description/user/ml_user_job_description.integration.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/ml_jobs_description/user/ml_user_job_description.integration.test.tsx
@@ -18,14 +18,18 @@ import { mockOpenedJob } from '../../../../../common/components/ml_popover/api.m
 
 describe('MlUserJobDescription', () => {
   it('should render switch component disabled', async () => {
-    render(<MlUserJobDescription job={mockOpenedJob} />, { wrapper: TestProviders });
+    render(<MlUserJobDescription job={mockOpenedJob} readOnly={false} />, {
+      wrapper: TestProviders,
+    });
     await waitFor(() => {
       expect(screen.getByTestId('mlUserJobSwitch')).toBeDisabled();
     });
   });
 
   it('should render toast that shows admin permissions required', async () => {
-    render(<MlUserJobDescription job={mockOpenedJob} />, { wrapper: TestProviders });
+    render(<MlUserJobDescription job={mockOpenedJob} readOnly={false} />, {
+      wrapper: TestProviders,
+    });
 
     userEvent.hover(screen.getByTestId('mlUserJobSwitch').parentNode as Element);
 
@@ -37,7 +41,7 @@ describe('MlUserJobDescription', () => {
   });
 
   it('should render job details correctly', async () => {
-    render(<MlUserJobDescription job={mockOpenedJob} />, {
+    render(<MlUserJobDescription job={mockOpenedJob} readOnly={false} />, {
       wrapper: TestProviders,
     });
 
@@ -56,6 +60,16 @@ describe('MlUserJobDescription', () => {
     // job action label
     await waitFor(() => {
       expect(screen.getByTestId('mlJobActionLabel')).toHaveTextContent('Stop job');
+    });
+  });
+
+  it('should not render switch if readOnly is true', async () => {
+    render(<MlUserJobDescription job={mockOpenedJob} readOnly={true} />, {
+      wrapper: TestProviders,
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('mlUserJobSwitch')).not.toBeInTheDocument();
     });
   });
 });

--- a/x-pack/plugins/security_solution/public/detections/components/rules/ml_jobs_description/user/ml_user_job_description.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/ml_jobs_description/user/ml_user_job_description.tsx
@@ -19,7 +19,8 @@ import { MlJobItem } from '../ml_job_item';
 
 const MlUserJobDescriptionComponent: FC<{
   job: MlSummaryJob;
-}> = ({ job }) => {
+  readOnly: boolean;
+}> = ({ job, readOnly }) => {
   const switchComponent = useMemo(
     () => (
       <EuiToolTip content={i18n.ML_ADMIN_REQUIRED}>
@@ -36,7 +37,7 @@ const MlUserJobDescriptionComponent: FC<{
     [job]
   );
 
-  return <MlJobItem job={job} switchComponent={switchComponent} />;
+  return <MlJobItem job={job} switchComponent={readOnly ? undefined : switchComponent} />;
 };
 
 export const MlUserJobDescription = memo(MlUserJobDescriptionComponent);

--- a/x-pack/plugins/security_solution/public/detections/components/rules/ml_jobs_description/user/ml_user_jobs_description.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/ml_jobs_description/user/ml_user_jobs_description.test.tsx
@@ -29,7 +29,7 @@ const useInstalledSecurityJobsMock = useInstalledSecurityJobs as jest.Mock;
 describe('MlUsersJobDescription', () => {
   it('should render null if user permissions absent', () => {
     useInstalledSecurityJobsMock.mockReturnValueOnce({ jobs: [], isMlUser: false });
-    const { container } = render(<MlUserJobsDescription jobIds={['mock-1']} />);
+    const { container } = render(<MlUserJobsDescription jobIds={['mock-1']} readOnly={false} />);
 
     expect(container.firstChild).toBeNull();
   });
@@ -39,7 +39,7 @@ describe('MlUsersJobDescription', () => {
       jobs: [{ id: 'mock-1' }, { id: 'mock-2' }, { id: 'mock-3' }],
       isMlUser: true,
     });
-    render(<MlUserJobsDescription jobIds={['mock-1', 'mock-2', 'mock-4']} />);
+    render(<MlUserJobsDescription jobIds={['mock-1', 'mock-2', 'mock-4']} readOnly={false} />);
 
     const expectedJobs = screen.getAllByTestId('userMock');
     expect(expectedJobs).toHaveLength(2);

--- a/x-pack/plugins/security_solution/public/detections/components/rules/ml_jobs_description/user/ml_user_jobs_description.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/ml_jobs_description/user/ml_user_jobs_description.tsx
@@ -14,9 +14,10 @@ import { MlUserJobDescription } from './ml_user_job_description';
 
 interface MlUserJobsDescriptionProps {
   jobIds: string[];
+  readOnly: boolean;
 }
 
-const MlUserJobsDescriptionComponent: FC<MlUserJobsDescriptionProps> = ({ jobIds }) => {
+const MlUserJobsDescriptionComponent: FC<MlUserJobsDescriptionProps> = ({ jobIds, readOnly }) => {
   const { isMlUser, jobs } = useInstalledSecurityJobs();
 
   if (!isMlUser) {
@@ -28,7 +29,7 @@ const MlUserJobsDescriptionComponent: FC<MlUserJobsDescriptionProps> = ({ jobIds
   return (
     <>
       {relevantJobs.map((job) => (
-        <MlUserJobDescription key={job.id} job={job} />
+        <MlUserJobDescription key={job.id} job={job} readOnly={readOnly} />
       ))}
     </>
   );

--- a/x-pack/plugins/security_solution/public/detections/components/rules/rule_switch/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/rule_switch/index.tsx
@@ -29,7 +29,7 @@ export interface RuleSwitchProps {
   enabled: boolean;
   isDisabled?: boolean;
   isLoading?: boolean;
-  startMlJobsIfNeeded?: () => Promise<void>;
+  startMlJobsIfNeeded?: () => Promise<string[] | undefined>;
   onChange?: (enabled: boolean) => void;
 }
 

--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_define_rule/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_define_rule/index.tsx
@@ -103,6 +103,7 @@ interface StepDefineRuleProps extends RuleStepProps {
   onRuleDataChange?: (data: DefineStepRule) => void;
   onPreviewDisabledStateChange?: (isDisabled: boolean) => void;
   defaultSavedQuery?: SavedQuery;
+  jobInstallationDisabled?: boolean;
 }
 
 export const MyLabelButton = styled(EuiButtonEmpty)`
@@ -140,6 +141,7 @@ const StepDefineRuleComponent: FC<StepDefineRuleProps> = ({
   onRuleDataChange,
   onPreviewDisabledStateChange,
   defaultSavedQuery,
+  jobInstallationDisabled,
 }) => {
   const mlCapabilities = useMlCapabilities();
   const [openTimelineSearch, setOpenTimelineSearch] = useState(false);
@@ -781,6 +783,7 @@ const StepDefineRuleComponent: FC<StepDefineRuleProps> = ({
         indexPatterns={indexPattern}
         schema={filterRuleFieldsForType(schema, ruleType)}
         data={filterRuleFieldsForType(dataForDescription, ruleType)}
+        jobInstallationDisabled={jobInstallationDisabled}
       />
     </StepContentWrapper>
   ) : (

--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_define_rule/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_define_rule/index.tsx
@@ -22,13 +22,13 @@ import React, { memo, useCallback, useState, useEffect, useMemo } from 'react';
 
 import styled from 'styled-components';
 import { i18n as i18nCore } from '@kbn/i18n';
-import { isEqual, isEmpty, omit } from 'lodash';
 import type { FieldSpec } from '@kbn/data-views-plugin/common';
 import usePrevious from 'react-use/lib/usePrevious';
 
 import type { SavedQuery } from '@kbn/data-plugin/public';
 import type { DataViewBase } from '@kbn/es-query';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { isEqual, isEmpty, omit } from 'lodash';
 import { useSetFieldValueWithCallback } from '../../../../common/utils/use_set_field_value_cb';
 import { useRuleFromTimeline } from '../../../containers/detection_engine/rules/use_rule_from_timeline';
 import { isMlRule } from '../../../../../common/machine_learning/helpers';
@@ -90,6 +90,7 @@ import { GroupByFields } from '../group_by_fields';
 import { useLicense } from '../../../../common/hooks/use_license';
 import { minimumLicenseForSuppression } from '../../../../../common/detection_engine/rule_schema';
 import { DurationInput } from '../duration_input';
+import type { UpdateMachineLearningJob } from '../ml_jobs_description/admin/ml_admin_jobs_description';
 
 const CommonUseField = getUseField({ component: Field });
 
@@ -103,7 +104,7 @@ interface StepDefineRuleProps extends RuleStepProps {
   onRuleDataChange?: (data: DefineStepRule) => void;
   onPreviewDisabledStateChange?: (isDisabled: boolean) => void;
   defaultSavedQuery?: SavedQuery;
-  jobInstallationDisabled?: boolean;
+  updateMachineLearningJob?: UpdateMachineLearningJob;
 }
 
 export const MyLabelButton = styled(EuiButtonEmpty)`
@@ -141,7 +142,7 @@ const StepDefineRuleComponent: FC<StepDefineRuleProps> = ({
   onRuleDataChange,
   onPreviewDisabledStateChange,
   defaultSavedQuery,
-  jobInstallationDisabled,
+  updateMachineLearningJob,
 }) => {
   const mlCapabilities = useMlCapabilities();
   const [openTimelineSearch, setOpenTimelineSearch] = useState(false);
@@ -783,7 +784,7 @@ const StepDefineRuleComponent: FC<StepDefineRuleProps> = ({
         indexPatterns={indexPattern}
         schema={filterRuleFieldsForType(schema, ruleType)}
         data={filterRuleFieldsForType(dataForDescription, ruleType)}
-        jobInstallationDisabled={jobInstallationDisabled}
+        updateMachineLearningJob={updateMachineLearningJob}
       />
     </StepContentWrapper>
   ) : (

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/translations.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/translations.ts
@@ -1133,3 +1133,10 @@ export const SAVED_QUERY_LOAD_ERROR_TOAST = i18n.translate(
     defaultMessage: 'Failed to load the saved query',
   }
 );
+
+export const UPDATE_MACHINE_LEARNING_JOB_ERROR = i18n.translate(
+  'xpack.securitySolution.detectionEngine.ruleDetails.updateMachineLearningJobError',
+  {
+    defaultMessage: 'Error updating machine learning job',
+  }
+);

--- a/x-pack/plugins/security_solution/public/overview/components/entity_analytics/anomalies/columns.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/entity_analytics/anomalies/columns.tsx
@@ -35,7 +35,7 @@ const MediumShadeText = styled.span`
 
 export const useAnomaliesColumns = (
   loading: boolean,
-  onJobStateChange: (job: SecurityJob) => Promise<void>
+  onJobStateChange: (job: SecurityJob) => Promise<{ enabledJobId: string }>
 ): AnomaliesColumns => {
   const columns: AnomaliesColumns = useMemo(
     () => [
@@ -101,7 +101,7 @@ const EnableJob = ({
 }: {
   job: SecurityJob;
   isLoading: boolean;
-  onJobStateChange: (job: SecurityJob) => Promise<void>;
+  onJobStateChange: (job: SecurityJob) => Promise<{ enabledJobId: string }>;
 }) => {
   const handleChange = useCallback(() => onJobStateChange(job), [job, onJobStateChange]);
 

--- a/x-pack/plugins/security_solution/public/overview/components/entity_analytics/anomalies/columns.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/entity_analytics/anomalies/columns.tsx
@@ -7,7 +7,7 @@
 import React, { useCallback, useMemo } from 'react';
 import styled from 'styled-components';
 import type { EuiBasicTableColumn } from '@elastic/eui';
-import { EuiIcon, EuiLoadingSpinner } from '@elastic/eui';
+import { EuiIcon, EuiLoadingSpinner, EuiToolTip } from '@elastic/eui';
 import { useDispatch } from 'react-redux';
 
 import * as i18n from './translations';
@@ -45,13 +45,15 @@ export const useAnomaliesColumns = (
         truncateText: true,
         mobileOptions: { show: true },
         'data-test-subj': 'anomalies-table-column-name',
-        render: (jobName, { count, job }) => {
-          if (count > 0 || (job && isJobStarted(job.jobState, job.datafeedState))) {
-            return jobName;
-          } else {
-            return <MediumShadeText>{jobName}</MediumShadeText>;
-          }
-        },
+        render: (jobName, { count, job }) => (
+          <EuiToolTip content={job?.id ?? jobName}>
+            {count > 0 || (job && isJobStarted(job.jobState, job.datafeedState)) ? (
+              <span>{jobName}</span>
+            ) : (
+              <MediumShadeText>{jobName}</MediumShadeText>
+            )}
+          </EuiToolTip>
+        ),
       },
       {
         field: 'count',

--- a/x-pack/plugins/security_solution/public/overview/components/entity_analytics/risk_score/columns.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/entity_analytics/risk_score/columns.tsx
@@ -8,8 +8,8 @@
 import React from 'react';
 import type { EuiBasicTableColumn } from '@elastic/eui';
 import { EuiLink, EuiIcon, EuiToolTip } from '@elastic/eui';
-import { get } from 'lodash/fp';
 import styled from 'styled-components';
+import { get } from 'lodash/fp';
 import { UsersTableType } from '../../../../explore/users/store/model';
 import { getEmptyTagValue } from '../../../../common/components/empty_value';
 import { HostDetailsLink, UserDetailsLink } from '../../../../common/components/links';


### PR DESCRIPTION
issue: https://github.com/elastic/kibana/issues/146662
## Summary

This PR removes `applyToAllSpaces: true` flag from security ML job creation, which makes all jobs installed using security solution UI only visible on the current space.


### Job id change:
The machine learning module requires job ids to be unique. Therefore, I had to add the space id to the job id prefix.

### Rule creation change
I had to change the rule creation because it used to store the job id returned by the Select component. But now, the job id will change and include the prefix. So I updated the rule creation code to wait for the job creation and replace the ids.
I also disable the feature that allowed users to install jobs from the rule creation page, which doesn't work with the new flow. Users are still allowed to create/enable jobs from the rule details page.

### Quirks:
The inclusion of the space as a job id prefix might bring a weird user experience for users with jobs installed in older versions of kibana (without the prefix). When those users install the same job on 8.8, they will see two versions of it. That is an uncommon user flow but I updated the UI to display both jobs and added a tooltip to the Entity Analytics page so that users can differentiate them.

**The user that installs all their security jobs in the same version of kibana won't notice any unexpected behavior.**



**Security warning**: Because Elastic search doesn't know about spaces, users can query elastic search directly and access information of jobs installed on spaces to which they don't have permission. 

### All job installed on the same version
<img width="1498" alt="jobs" src="https://user-images.githubusercontent.com/1490444/218490574-e6d55777-d0cd-43ab-996b-ace83d30d4c1.png">


### Jobs installed on different versions
<img width="1502" alt="jobs different versions" src="https://user-images.githubusercontent.com/1490444/218491802-ea215091-ef1c-4ec8-849f-2d5bf39cff0d.png">


### New tooltip

<img width="455" alt="tooltip" src="https://user-images.githubusercontent.com/1490444/218491289-fa23bf1a-8da7-4e17-9237-4e715dbe28da.png">


### TODO

- [ ] Dedupliacte some code by extracting functions/hooks
- [ ] Add untit tests
- [ ] Call an extra API to fetch spaces where jobs are installed https://docs.elastic.dev/ml-team/docs/ui/rest-api/ml-api#-get-all-jobs-and-their-spaces
- [ ] Create a global job tooltip [mockups?]
- [ ] Blocked by https://github.com/elastic/security-team/issues/1974
- [ ] proactively notify to the user (via help text/ tooltip/ job creation status dialog) that the 'rules details -> job_id' value is pending refresh following the initial enablement?

### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
