### PR TITLE
[Profiling] Fix TopN diff functions title text

### DIFF
--- a/x-pack/plugins/profiling/public/components/primary_and_comparison_search_bar.tsx
+++ b/x-pack/plugins/profiling/public/components/primary_and_comparison_search_bar.tsx
@@ -61,18 +61,29 @@ export function PrimaryAndComparisonSearchBar() {
     }
   }
 
+  let baselineTitle: string;
+  let comparisonTitle: string;
+
+  if (routePath === '/flamegraphs/differential') {
+    baselineTitle = i18n.translate('xpack.profiling.comparisonSearch.baselineTitleFlamegraph', {
+      defaultMessage: 'Baseline flamegraph',
+    });
+    comparisonTitle = i18n.translate('xpack.profiling.comparisonSearch.comparisonTitleFlamegraph', {
+      defaultMessage: 'Comparison flamegraph',
+    });
+  } else {
+    baselineTitle = i18n.translate('xpack.profiling.comparisonSearch.baselineTitleFunctions', {
+      defaultMessage: 'Baseline functions',
+    });
+    comparisonTitle = i18n.translate('xpack.profiling.comparisonSearch.comparisonTitleFunctions', {
+      defaultMessage: 'Comparison functions',
+    });
+  }
   return (
     <EuiFlexGroup direction="row" gutterSize="xs" alignItems="flexEnd">
       <EuiFlexItem>
         <EuiTitle size="xxs">
-          <h3>
-            {i18n.translate('xpack.profiling.comparisonSearch.baselineTitle', {
-              defaultMessage:
-                routePath === '/flamegraphs/differential'
-                  ? 'Baseline flamegraph'
-                  : 'Baseline functions',
-            })}
-          </h3>
+          <h3>{baselineTitle}</h3>
         </EuiTitle>
         <EuiSpacer size="s" />
         <PrimaryProfilingSearchBar showSubmitButton={false} />
@@ -110,14 +121,7 @@ export function PrimaryAndComparisonSearchBar() {
       </EuiFlexItem>
       <EuiFlexItem>
         <EuiTitle size="xxs">
-          <h3>
-            {i18n.translate('xpack.profiling.comparisonSearch.comparisonTitle', {
-              defaultMessage:
-                routePath === '/flamegraphs/differential'
-                  ? 'Comparison flamegraph'
-                  : 'Comparison functions',
-            })}
-          </h3>
+          <h3>{comparisonTitle}</h3>
         </EuiTitle>
         <EuiSpacer size="s" />
         <ProfilingSearchBar

--- a/x-pack/plugins/profiling/public/components/primary_and_comparison_search_bar.tsx
+++ b/x-pack/plugins/profiling/public/components/primary_and_comparison_search_bar.tsx
@@ -67,7 +67,10 @@ export function PrimaryAndComparisonSearchBar() {
         <EuiTitle size="xxs">
           <h3>
             {i18n.translate('xpack.profiling.comparisonSearch.baselineTitle', {
-              defaultMessage: 'Baseline flamegraph',
+              defaultMessage:
+                routePath === '/flamegraphs/differential'
+                  ? 'Baseline flamegraph'
+                  : 'Baseline functions',
             })}
           </h3>
         </EuiTitle>
@@ -109,7 +112,10 @@ export function PrimaryAndComparisonSearchBar() {
         <EuiTitle size="xxs">
           <h3>
             {i18n.translate('xpack.profiling.comparisonSearch.comparisonTitle', {
-              defaultMessage: 'Comparison flamegraph',
+              defaultMessage:
+                routePath === '/flamegraphs/differential'
+                  ? 'Comparison flamegraph'
+                  : 'Comparison functions',
             })}
           </h3>
         </EuiTitle>


### PR DESCRIPTION
## Summary

Fixes the title texts in the differential TopN functions view (turning 'flamegraph' into 'functions').

Fixes https://github.com/elastic/prodfiler/issues/3000

**Before**
![Screenshot_20230213_171123](https://user-images.githubusercontent.com/2087964/218511062-f1ff5c83-b59e-4aa6-a69b-0c1e273e9d95.png)

**After**
![Screenshot_20230213_170955](https://user-images.githubusercontent.com/2087964/218510925-8d23850f-2bea-494e-9408-aa9ad33d1f3c.png)


<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->