### PR TITLE
[artifacts/container image] Only trigger on main branch

### DIFF
--- a/.buildkite/scripts/steps/artifacts/docker_image_trigger.sh
+++ b/.buildkite/scripts/steps/artifacts/docker_image_trigger.sh
@@ -2,4 +2,7 @@
 
 set -euo pipefail
 
-ts-node .buildkite/scripts/steps/trigger_pipeline.ts kibana-artifacts-container-image "$BUILDKITE_BRANCH" "$BUILDKITE_COMMIT"
+if [[ "$BUILDKITE_BRANCH" == "main" ]]; then
+  echo "--- Trigger artifacts container image pipeline"
+  ts-node .buildkite/scripts/steps/trigger_pipeline.ts kibana-artifacts-container-image "$BUILDKITE_BRANCH" "$BUILDKITE_COMMIT"
+fi


### PR DESCRIPTION
We only need to product container images for the most recent commit.  This updates the trigger to only run on `main`.

note: `skip-ci` label, this only runs on-merge and is a no-op from pull requests.

<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->