### PR TITLE
[build] Fix config argument order

### DIFF
--- a/src/dev/build/lib/config.test.ts
+++ b/src/dev/build/lib/config.test.ts
@@ -25,9 +25,12 @@ const versionInfo = jest.requireMock('./version_info').getVersionInfo();
 
 expect.addSnapshotSerializer(createAbsolutePathSerializer());
 
-const setup = async ({ targetAllPlatforms = true }: { targetAllPlatforms?: boolean } = {}) => {
+const setup = async ({
+  targetAllPlatforms = true,
+  isRelease = true,
+}: { targetAllPlatforms?: boolean; isRelease?: boolean } = {}) => {
   return await Config.create({
-    isRelease: true,
+    isRelease,
     targetAllPlatforms,
     dockerContextUseLocalArtifact: false,
     dockerCrossCompile: false,
@@ -189,6 +192,17 @@ describe('#getBuildSha()', () => {
   it('returns the sha from the build info', async () => {
     const config = await setup();
     expect(config.getBuildSha()).toBe(versionInfo.buildSha);
+  });
+});
+
+describe('#isRelease()', () => {
+  it('returns true when marked as a release', async () => {
+    const config = await setup({ isRelease: true });
+    expect(config.isRelease).toBe(true);
+  });
+  it('returns false when not marked as a release', async () => {
+    const config = await setup({ isRelease: false });
+    expect(config.isRelease).toBe(false);
   });
 });
 

--- a/src/dev/build/lib/config.ts
+++ b/src/dev/build/lib/config.ts
@@ -82,8 +82,8 @@ export class Config {
     private readonly dockerTag: string | null,
     private readonly dockerTagQualifier: string | null,
     private readonly dockerPush: boolean,
-    public readonly downloadFreshNode: boolean,
     public readonly isRelease: boolean,
+    public readonly downloadFreshNode: boolean,
     public readonly pluginSelector: PluginSelector
   ) {
     this.pluginFilter = getPluginPackagesFilter(this.pluginSelector);


### PR DESCRIPTION
Snapshot builds are currently being marked as release builds in the config service.  This impacts the release property in package.json snapshot builds and pull request deployments.

This was introduced in https://github.com/elastic/kibana/commit/1b8581540295fde746dae6b4a09d74fb5821bfef#diff-dbea24da2a777429d025c1da037dd966d65bff2c97a7b78b82a33532f3ad06d9R63