### PR TITLE
[Cases] Adding refreshes to fix failed test

### DIFF
--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/trial/cases/push_case.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/trial/cases/push_case.ts
@@ -616,8 +616,7 @@ export default ({ getService }: FtrProviderContext): void => {
         });
       });
 
-      // FLAKY: https://github.com/elastic/kibana/issues/150962
-      describe.skip('alerts', () => {
+      describe('alerts', () => {
         const defaultSignalsIndex = '.siem-signals-default-000001';
         const signalID = '4679431ee0ba3209b6fcd60a255a696886fe0a7d18f5375de510ff5b68fa6b78';
         const signalID2 = '1023bcfea939643c5e51fd8df53797e0ea693cee547db579ab56d96402365c1e';
@@ -656,6 +655,8 @@ export default ({ getService }: FtrProviderContext): void => {
             },
           });
 
+          await es.indices.refresh({ index: defaultSignalsIndex });
+
           await createComment({
             supertest,
             caseId: postedCase.id,
@@ -667,6 +668,8 @@ export default ({ getService }: FtrProviderContext): void => {
               owner: 'securitySolutionFixture',
             },
           });
+
+          await es.indices.refresh({ index: defaultSignalsIndex });
 
           await pushCase({
             supertest,


### PR DESCRIPTION
Fixes: https://github.com/elastic/kibana/issues/150962

This PR adds some index refreshes to fix tests that were running into index conflicts.

Flaky test run: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/1907