### PR TITLE
[maps] include vector tile layers in geoShapeAggLayersCount telemetry

### DIFF
--- a/x-pack/plugins/maps/server/maps_telemetry/index_pattern_stats/index_pattern_stats_collector.ts
+++ b/x-pack/plugins/maps/server/maps_telemetry/index_pattern_stats/index_pattern_stats_collector.ts
@@ -9,7 +9,7 @@ import type { SavedObject } from '@kbn/core/server';
 import { asyncForEach } from '@kbn/std';
 import { KBN_FIELD_TYPES } from '@kbn/field-types';
 import { DataViewsService } from '@kbn/data-views-plugin/common';
-import { LAYER_TYPE, SCALING_TYPES, SOURCE_TYPES } from '../../../common/constants';
+import { SCALING_TYPES, SOURCE_TYPES } from '../../../common/constants';
 import { injectReferences } from '../../../common/migrations/references';
 import {
   ESGeoGridSourceDescriptor,

--- a/x-pack/plugins/maps/server/maps_telemetry/index_pattern_stats/index_pattern_stats_collector.ts
+++ b/x-pack/plugins/maps/server/maps_telemetry/index_pattern_stats/index_pattern_stats_collector.ts
@@ -107,14 +107,6 @@ export class IndexPatternStatsCollector {
       return false;
     }
 
-    if (
-      layer.type !== LAYER_TYPE.GEOJSON_VECTOR &&
-      layer.type !== LAYER_TYPE.BLENDED_VECTOR &&
-      layer.type !== LAYER_TYPE.HEATMAP
-    ) {
-      return false;
-    }
-
     const sourceDescriptor = layer.sourceDescriptor;
     if (sourceDescriptor.type === SOURCE_TYPES.ES_GEO_GRID) {
       return await this._isFieldGeoShape(


### PR DESCRIPTION
While investigating https://github.com/elastic/kibana/issues/151064, I found a problem with IndexPatternStatsCollector where geo_shape aggregation usage with vector tile layers are not counted.

Steps to view problem:
* Download [world countries geojson](https://vector.maps.elastic.co/files/world_countries_v7.geo.json?elastic_tile_service_tos=agree&my_app_name=ems-landing-page&my_app_version=8.6.0&license=643c1faf-80fc-4ab0-9323-4d9bd11f4bbc)
* use file upload to upload world countries into your Elastic stack
* add a new cluster layer to your map. 
    * Select world countries index
    * Select **Hexagons**
    * Click **Add layer**
    * Save map
* Open borwser dev tools and switch to network tab
* Open Kibana dev tools and run 
    ```
    POST kbn:api/telemetry/v2/clusters/_stats
    { "unencrypted": true }
    ```
* Copy response for `_stats` request. Search for `geoShapeAggLayersCount`. Notice how the value is zero but it should be one since you have one map using geo shape aggregation
    <img width="600" alt="Screen Shot 2023-02-13 at 1 14 34 PM" src="https://user-images.githubusercontent.com/373691/218565153-0060dd4b-e422-477f-8b07-9f4dabd73064.png">


PR resolves the problem by removing layer type guard. The guard is error prone and easy to not update with new layer types. The guard does not provide any value, since the logic is really concerned with source types and the source type guards provide the correct protections.

Steps to test:
Follow steps above and verify `geoShapeAggLayersCount` is one