### PR TITLE
[Security Solution]Alert page chart selection default to summary

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/chart_panels/alerts_local_storage/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/chart_panels/alerts_local_storage/index.test.tsx
@@ -10,13 +10,18 @@ import React from 'react';
 
 import { useAlertsLocalStorage } from '.';
 import { TestProviders } from '../../../../../common/mock';
+import { useIsExperimentalFeatureEnabled } from '../../../../../common/hooks/use_experimental_features';
+
+const mockUseIsExperimentalFeatureEnabled = useIsExperimentalFeatureEnabled as jest.Mock;
+jest.mock('../../../../../common/hooks/use_experimental_features');
 
 describe('useAlertsLocalStorage', () => {
   const wrapper = ({ children }: { children: React.ReactNode }) => (
     <TestProviders>{children}</TestProviders>
   );
 
-  test('it returns the expected defaults', () => {
+  test('it returns the expected defaults when isAlertsPageCharts is disabled', () => {
+    mockUseIsExperimentalFeatureEnabled.mockReturnValue(false);
     const { result } = renderHook(() => useAlertsLocalStorage(), { wrapper });
 
     const defaults = Object.fromEntries(
@@ -25,6 +30,26 @@ describe('useAlertsLocalStorage', () => {
 
     expect(defaults).toEqual({
       alertViewSelection: 'trend', // default to the trend chart
+      countTableStackBy0: 'kibana.alert.rule.name',
+      countTableStackBy1: 'host.name',
+      groupBySelection: 'host.name',
+      isTreemapPanelExpanded: true,
+      riskChartStackBy0: 'kibana.alert.rule.name',
+      riskChartStackBy1: 'host.name',
+      trendChartStackBy: 'kibana.alert.rule.name',
+    });
+  });
+
+  test('it returns the expected defaults when isAlertsPageCharts is enaabled', () => {
+    mockUseIsExperimentalFeatureEnabled.mockReturnValue(true);
+    const { result } = renderHook(() => useAlertsLocalStorage(), { wrapper });
+
+    const defaults = Object.fromEntries(
+      Object.entries(result.current).filter((x) => typeof x[1] !== 'function')
+    );
+
+    expect(defaults).toEqual({
+      alertViewSelection: 'charts', // default to the summary
       countTableStackBy0: 'kibana.alert.rule.name',
       countTableStackBy1: 'host.name',
       groupBySelection: 'host.name',

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/chart_panels/alerts_local_storage/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/chart_panels/alerts_local_storage/index.tsx
@@ -30,12 +30,14 @@ import {
 } from '../../../../components/alerts_kpis/common/config';
 import type { AlertsSettings } from './types';
 import type { AlertViewSelection } from '../chart_select/helpers';
-import { TREND_ID } from '../chart_select/helpers';
+import { CHARTS_ID, TREND_ID } from '../chart_select/helpers';
 import type { GroupBySelection } from '../../../../components/alerts_kpis/alerts_progress_bar_panel/types';
+import { useIsExperimentalFeatureEnabled } from '../../../../../common/hooks/use_experimental_features';
 
 export const useAlertsLocalStorage = (): AlertsSettings => {
+  const isAlertsPageChartsEnabled = useIsExperimentalFeatureEnabled('alertsPageChartsEnabled');
   const [alertViewSelection, setAlertViewSelection] = useLocalStorage<AlertViewSelection>({
-    defaultValue: TREND_ID,
+    defaultValue: isAlertsPageChartsEnabled ? CHARTS_ID : TREND_ID,
     key: getSettingKey({
       category: VIEW_CATEGORY,
       page: ALERTS_PAGE,


### PR DESCRIPTION
## Summary

This PR addresses a visual bug mentioned in https://github.com/elastic/kibana/issues/151044. Before implementing the `Summary` option, the charts defaults to `Trend`, this PR changes the default to `Summary` when `isAlertsPageCharts` is enabled. 

**Before**
![image](https://user-images.githubusercontent.com/18648970/218564106-fba96942-cb11-4f57-97ba-a06afccd2d15.png)

**After**
![image](https://user-images.githubusercontent.com/18648970/218564231-3103f39f-7d33-43f9-b435-92470491b7ef.png)

### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### Note for desk testing
Desk testing can be tricky because the selection is stored in local storage. The fastest way I found to test is to use a browser you don't use often (like Safari), clear all browsing data, cache etc., and then open kibana. 


<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->