### PR TITLE
[TIP] fix policies not shown in add to blocklist flyout

### DIFF
--- a/x-pack/plugins/threat_intelligence/public/modules/block_list/containers/flyout.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/block_list/containers/flyout.tsx
@@ -10,6 +10,7 @@ import {
   CreateExceptionListItemSchema,
   EntriesArray,
 } from '@kbn/securitysolution-io-ts-list-types';
+import { usePolicies } from '../hooks/use_policies';
 import { useBlockListContext } from '../../indicators/hooks/use_block_list_context';
 import { ADD_TO_BLOCKLIST_FLYOUT_TITLE } from './translations';
 import { useSecurityContext } from '../../../hooks/use_security_context';
@@ -33,6 +34,7 @@ export const BlockListFlyout: VFC<BlockListFlyoutProps> = ({ indicatorFileHash }
   const Component = blockList.getFlyoutComponent();
   const exceptionListApiClient = blockList.exceptionListApiClient;
   const FormComponent = blockList.getFormComponent();
+  const { isLoading: policiesIsLoading, data: policies } = usePolicies();
 
   // prepopulate the for with the indicator file hash
   const entries: EntriesArray = [
@@ -67,7 +69,8 @@ export const BlockListFlyout: VFC<BlockListFlyoutProps> = ({ indicatorFileHash }
     apiClient: exceptionListApiClient,
     labels,
     item,
-    policies: [],
+    policies: policies || [],
+    policiesIsLoading,
     FormComponent,
     onClose: clearBlockListIndicatorValue,
   };

--- a/x-pack/plugins/threat_intelligence/public/modules/block_list/hooks/use_policies.test.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/block_list/hooks/use_policies.test.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+import { QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-query';
+
+const createWrapper = () => {
+  const queryClient = new QueryClient();
+  return ({ children }: { children: any }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};
+
+const renderUseQuery = (result: { items: any[] }) =>
+  renderHook(() => useQuery(['policies'], () => result), {
+    wrapper: createWrapper(),
+  });
+
+describe('usePolicies', () => {
+  it('should have undefined data during loading state', async () => {
+    const mockPolicies = { items: [] };
+    const { result, waitFor } = renderUseQuery(mockPolicies);
+
+    await waitFor(() => result.current.isLoading);
+
+    expect(result.current.isLoading).toBeTruthy();
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it('should return policies on success', async () => {
+    const mockPolicies = {
+      items: [
+        {
+          id: '123',
+          name: 'MyPolicy',
+        },
+      ],
+    };
+    const { result, waitFor } = renderUseQuery(mockPolicies);
+
+    await waitFor(() => result.current.isSuccess);
+
+    expect(result.current.isLoading).toBeFalsy();
+    expect(result.current.data).toEqual(mockPolicies);
+  });
+});

--- a/x-pack/plugins/threat_intelligence/public/modules/block_list/hooks/use_policies.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/block_list/hooks/use_policies.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useQuery } from '@tanstack/react-query';
+import { useKibana } from '../../../hooks';
+
+const POLICIES_URL = '/api/fleet/package_policies';
+const PACKAGE_POLICY_SAVED_OBJECT_TYPE = 'ingest-package-policies';
+
+export interface PolicyResponse {
+  items: Policy[];
+}
+
+export interface Policy {
+  id: string;
+  name: string;
+}
+
+export function usePolicies() {
+  const { http } = useKibana().services;
+  const queryKey = ['policies'];
+
+  const fetchPolicies = () =>
+    http.get<PolicyResponse>(POLICIES_URL, {
+      query: {
+        withAgentCount: true,
+        kuery: `${PACKAGE_POLICY_SAVED_OBJECT_TYPE}.package.name: endpoint`,
+      },
+    });
+
+  return useQuery(queryKey, fetchPolicies, {
+    select: (data: PolicyResponse) => data.items,
+  });
+}

--- a/x-pack/plugins/threat_intelligence/public/types.ts
+++ b/x-pack/plugins/threat_intelligence/public/types.ts
@@ -23,6 +23,7 @@ import { DataProvider } from '@kbn/timelines-plugin/common';
 import { Start as InspectorPluginStart } from '@kbn/inspector-plugin/public';
 import { CasesUiSetup, CasesUiStart } from '@kbn/cases-plugin/public/types';
 import { CreateExceptionListItemSchema } from '@kbn/securitysolution-io-ts-list-types';
+import { Policy } from './modules/block_list/hooks/use_policies';
 
 export interface SecuritySolutionDataViewBase extends DataViewBase {
   fields: Array<FieldSpec & DataViewField>;
@@ -79,7 +80,8 @@ export interface UseInvestigateInTimelineProps {
 export interface BlockListFlyoutProps {
   apiClient: unknown;
   item: CreateExceptionListItemSchema;
-  policies: unknown[];
+  policies: Policy[];
+  policiesIsLoading: boolean;
   FormComponent: NamedExoticComponent<BlockListFormProps>;
   onClose: () => void;
 }


### PR DESCRIPTION
## Summary

This PR fixes the issues in the add to blocklist flyout not showing the policies.
We're now calling the `/api/fleet/package_policies` similarly to how the Add to Blocklist page does it [here](https://github.com/elastic/kibana/blob/main/x-pack/plugins/security_solution/public/management/components/artifact_list_page/artifact_list_page.tsx#L165).

![Screenshot 2023-02-13 at 4 47 03 PM](https://user-images.githubusercontent.com/17276605/218592300-9afc1125-0733-4500-b2d1-53ec4d6a4ec6.png)

https://github.com/elastic/kibana/issues/150848

### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->