### PR TITLE
[8.7] [Security Solution] Fix all rules list is not present , when user manage rules from a shared exception list (#151079)

### DIFF
--- a/x-pack/plugins/security_solution/public/detection_engine/rule_exceptions/components/flyout_components/add_to_rules_table/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_exceptions/components/flyout_components/add_to_rules_table/index.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { mountWithIntl } from '@kbn/test-jest-helpers';
+import { fireEvent, render, within } from '@testing-library/react';
 
 import { ExceptionsAddToRulesTable } from '.';
 import { TestProviders } from '../../../../../common/mock';
@@ -17,23 +17,19 @@ import type { Rule } from '../../../../rule_management/logic/types';
 jest.mock('../../../../rule_management/logic/use_find_rules');
 
 describe('ExceptionsAddToRulesTable', () => {
-  it('it displays loading state while fetching rules', () => {
+  it('should display the loading state while fetching rules', () => {
     (useFindRules as jest.Mock).mockReturnValue({
       data: { rules: [], total: 0 },
       isFetched: false,
     });
-    const wrapper = mountWithIntl(
-      <TestProviders>
-        <ExceptionsAddToRulesTable initiallySelectedRules={[]} onRuleSelectionChange={jest.fn()} />
-      </TestProviders>
+    const wrapper = render(
+      <ExceptionsAddToRulesTable initiallySelectedRules={[]} onRuleSelectionChange={jest.fn()} />
     );
 
-    expect(
-      wrapper.find('[data-test-subj="exceptionItemViewerEmptyPrompts-loading"]').exists()
-    ).toBeTruthy();
+    expect(wrapper.getByTestId('exceptionItemViewerEmptyPromptsLoading')).toBeInTheDocument();
   });
 
-  it.skip('it displays fetched rules', () => {
+  it('should display the fetched rule selected', () => {
     (useFindRules as jest.Mock).mockReturnValue({
       data: {
         rules: [getRulesSchemaMock(), { ...getRulesSchemaMock(), id: '345', name: 'My rule' }],
@@ -41,7 +37,7 @@ describe('ExceptionsAddToRulesTable', () => {
       },
       isFetched: true,
     });
-    const wrapper = mountWithIntl(
+    const wrapper = render(
       <TestProviders>
         <ExceptionsAddToRulesTable
           initiallySelectedRules={[{ ...getRulesSchemaMock(), id: '345', name: 'My rule' } as Rule]}
@@ -49,12 +45,34 @@ describe('ExceptionsAddToRulesTable', () => {
         />
       </TestProviders>
     );
+    expect(wrapper.queryByTestId('exceptionItemViewerEmptyPromptsLoading')).toBeFalsy();
+    const selectedRow = wrapper.getByText('My rule').closest('tr') as HTMLTableRowElement;
+    const selectedSwitch = within(selectedRow).getByRole('switch');
+    expect(selectedSwitch).toBeChecked();
+  });
 
-    expect(
-      wrapper.find('[data-test-subj="exceptionItemViewerEmptyPrompts-loading"]').exists()
-    ).toBeFalsy();
-    expect(
-      wrapper.find('.euiTableRow-isSelected td[data-test-subj="ruleNameCell"]').text()
-    ).toEqual('NameMy rule');
+  it('should invoke the onRuleSelectionChange when link switch is clicked', () => {
+    (useFindRules as jest.Mock).mockReturnValue({
+      data: {
+        rules: [getRulesSchemaMock(), { ...getRulesSchemaMock(), id: '345', name: 'My rule' }],
+        total: 0,
+      },
+      isFetched: true,
+    });
+    const onRuleSelectionChangeMock = jest.fn();
+    const rule = { ...getRulesSchemaMock(), id: '345', name: 'My rule' };
+    const { queryByTestId, getByText } = render(
+      <TestProviders>
+        <ExceptionsAddToRulesTable
+          initiallySelectedRules={[rule as Rule]}
+          onRuleSelectionChange={onRuleSelectionChangeMock}
+        />
+      </TestProviders>
+    );
+    expect(queryByTestId('exceptionItemViewerEmptyPromptsLoading')).toBeFalsy();
+    const selectedRow = getByText('My rule').closest('tr') as HTMLTableRowElement;
+    const selectedSwitch = within(selectedRow).getByRole('switch');
+    fireEvent.click(selectedSwitch);
+    expect(onRuleSelectionChangeMock).toBeCalledWith([rule]);
   });
 });

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_exceptions/components/flyout_components/add_to_rules_table/index.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_exceptions/components/flyout_components/add_to_rules_table/index.tsx
@@ -50,7 +50,7 @@ const ExceptionsAddToRulesTableComponent: React.FC<ExceptionsAddToRulesComponent
             isLoading ? (
               <EuiLoadingContent
                 lines={4}
-                data-test-subj="exceptionItemViewerEmptyPrompts-loading"
+                data-test-subj="exceptionItemViewerEmptyPromptsLoading"
               />
             ) : undefined
           }

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_exceptions/components/flyout_components/add_to_rules_table/link_rule_switch/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_exceptions/components/flyout_components/add_to_rules_table/link_rule_switch/index.test.tsx
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react';
+import { getRulesSchemaMock } from '../../../../../../../common/detection_engine/rule_schema/mocks';
+
+import { LinkRuleSwitch } from '.';
+
+const mockedRule = getRulesSchemaMock();
+const linkedRules = Array(3).fill(mockedRule);
+const onRuleLinkChangeMock = jest.fn();
+describe('LinkRuleSwitch', () => {
+  it('should render the switch checked if rule is linked', () => {
+    const { getByRole } = render(
+      <LinkRuleSwitch
+        rule={linkedRules[0]}
+        linkedRules={linkedRules}
+        onRuleLinkChange={onRuleLinkChangeMock}
+      />
+    );
+    const switchComponent = getByRole('switch');
+    expect(switchComponent).toBeChecked();
+  });
+  it('should render the switch unchecked if rule is unlinked', () => {
+    const { getByRole } = render(
+      <LinkRuleSwitch
+        rule={linkedRules[0]}
+        linkedRules={[]}
+        onRuleLinkChange={onRuleLinkChangeMock}
+      />
+    );
+    const switchComponent = getByRole('switch');
+    expect(switchComponent).not.toBeChecked();
+  });
+  it('should link rule if not linked before', () => {
+    const { getByRole } = render(
+      <LinkRuleSwitch
+        rule={linkedRules[0]}
+        linkedRules={[]}
+        onRuleLinkChange={onRuleLinkChangeMock}
+      />
+    );
+    const switchComponent = getByRole('switch');
+    expect(switchComponent).not.toBeChecked();
+    fireEvent.click(switchComponent);
+    expect(onRuleLinkChangeMock).toBeCalledWith([linkedRules[0]]);
+  });
+  it('should unlink rule if it was linked before', () => {
+    const { getByRole } = render(
+      <LinkRuleSwitch
+        rule={linkedRules[0]}
+        linkedRules={linkedRules}
+        onRuleLinkChange={onRuleLinkChangeMock}
+      />
+    );
+    const switchComponent = getByRole('switch');
+    expect(switchComponent).toBeChecked();
+    fireEvent.click(switchComponent);
+    expect(onRuleLinkChangeMock).toBeCalledWith([]);
+  });
+});

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_exceptions/components/flyout_components/add_to_rules_table/use_add_to_rules_table.test.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_exceptions/components/flyout_components/add_to_rules_table/use_add_to_rules_table.test.tsx
@@ -1,0 +1,222 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { fireEvent, render as rTLRender } from '@testing-library/react';
+import { waitFor } from '@testing-library/dom';
+import { act, renderHook } from '@testing-library/react-hooks';
+import type { EuiTableFieldDataColumnType } from '@elastic/eui';
+import type { Rule } from '../../../../rule_management/logic/types';
+import { getRulesSchemaMock } from '../../../../../../common/detection_engine/rule_schema/mocks';
+import { useFindRules } from '../../../../rule_management/logic/use_find_rules';
+import { useAddToRulesTable } from './use_add_to_rules_table';
+
+jest.mock('../../../../rule_management/logic/use_find_rules');
+
+const mockedRule = getRulesSchemaMock();
+const onRuleSelectionChangeMock = jest.fn();
+const initiallySelectedRules = [{ ...mockedRule, id: '345', name: 'My rule' }] as Rule[];
+
+describe('useAddToRulesTable', () => {
+  it('should call the useFindRules with the correct parameters', () => {
+    (useFindRules as jest.Mock).mockReturnValue({
+      data: {
+        rules: [mockedRule],
+        total: 0,
+      },
+      isFetched: true,
+    });
+    renderHook(() =>
+      useAddToRulesTable({
+        initiallySelectedRules,
+        onRuleSelectionChange: onRuleSelectionChangeMock,
+      })
+    );
+    expect(useFindRules as jest.Mock).toBeCalledWith({
+      filterOptions: {
+        filter: '',
+        showCustomRules: false,
+        showElasticRules: false,
+        tags: [],
+      },
+      sortingOptions: undefined,
+      pagination: {
+        page: 1,
+        perPage: 10000,
+      },
+    });
+  });
+  it('should return all stored rule if less than 10000 when calling the useFindRules', () => {
+    (useFindRules as jest.Mock).mockReturnValue({
+      data: {
+        rules: Array(30).fill(mockedRule),
+        total: 0,
+      },
+      isFetched: true,
+    });
+    const {
+      result: { current },
+    } = renderHook(() =>
+      useAddToRulesTable({
+        initiallySelectedRules,
+        onRuleSelectionChange: onRuleSelectionChangeMock,
+      })
+    );
+    const { sortedRulesByLinkedRulesOnTop, isLoading } = current;
+    expect(sortedRulesByLinkedRulesOnTop.length).toEqual(30);
+    expect(isLoading).toBeFalsy();
+  });
+  it('should return isLoading true and pagination as default if useFindRules is fetching', () => {
+    (useFindRules as jest.Mock).mockReturnValue({
+      data: {
+        rules: [],
+        total: 0,
+      },
+      isFetched: false,
+    });
+    const {
+      result: { current },
+    } = renderHook(() =>
+      useAddToRulesTable({
+        initiallySelectedRules,
+        onRuleSelectionChange: onRuleSelectionChangeMock,
+      })
+    );
+    const {
+      sortedRulesByLinkedRulesOnTop,
+      isLoading,
+      pagination,
+      searchOptions,
+      addToSelectedRulesDescription,
+    } = current;
+    expect(sortedRulesByLinkedRulesOnTop.length).toEqual(0);
+    expect(isLoading).toBeTruthy();
+    expect(pagination).toEqual({ pageIndex: 0, initialPageSize: 5, showPerPageOptions: false });
+    expect(searchOptions.filters[0].name).toEqual('Tags');
+    expect(addToSelectedRulesDescription).toEqual(
+      'After you create the exception, it is added to the rules you link. '
+    );
+  });
+  it('should sort initially selected rules on top', () => {
+    (useFindRules as jest.Mock).mockReturnValue({
+      data: {
+        rules: [mockedRule, { ...mockedRule, id: '345', name: 'My rule' }],
+        total: 0,
+      },
+      isFetched: true,
+    });
+    const {
+      result: { current },
+    } = renderHook(() =>
+      useAddToRulesTable({
+        initiallySelectedRules,
+        onRuleSelectionChange: onRuleSelectionChangeMock,
+      })
+    );
+    const { sortedRulesByLinkedRulesOnTop } = current;
+    expect(sortedRulesByLinkedRulesOnTop[0]).toEqual(
+      expect.objectContaining({ id: '345', name: 'My rule' })
+    );
+  });
+  it('should filter out duplicated tags from tag options', () => {
+    (useFindRules as jest.Mock).mockReturnValue({
+      data: {
+        rules: [
+          { ...mockedRule, tags: ['some fake tag 1'] },
+          { ...mockedRule, tags: ['some fake tag 1'], id: '345', name: 'My rule' },
+        ],
+        total: 0,
+      },
+      isFetched: true,
+    });
+    const {
+      result: { current },
+    } = renderHook(() =>
+      useAddToRulesTable({
+        initiallySelectedRules,
+        onRuleSelectionChange: onRuleSelectionChangeMock,
+      })
+    );
+    const { searchOptions } = current;
+    const { filters } = searchOptions;
+    const { options } = filters[0];
+    expect(options).toEqual([
+      {
+        name: 'some fake tag 1',
+        value: 'some fake tag 1',
+      },
+    ]);
+  });
+  it('should call onRuleLinkChange when switch of a rule is clicked', () => {
+    (useFindRules as jest.Mock).mockReturnValue({
+      data: {
+        rules: [
+          mockedRule,
+          { ...mockedRule, tags: ['some fake tag 1'], id: '345', name: 'My rule' },
+        ],
+        total: 0,
+      },
+      isFetched: true,
+    });
+
+    const {
+      result: { current },
+    } = renderHook(() =>
+      useAddToRulesTable({
+        initiallySelectedRules,
+        onRuleSelectionChange: onRuleSelectionChangeMock,
+      })
+    );
+    const { rulesTableColumnsWithLinkSwitch } = current;
+    const { name, render } =
+      rulesTableColumnsWithLinkSwitch[0] as EuiTableFieldDataColumnType<Rule>;
+    expect(name).toEqual('Link');
+
+    const LinkColumn = (render ? render(null, mockedRule as Rule) : <></>) as JSX.Element;
+    const { getByRole } = rTLRender(<div>{LinkColumn}</div>);
+    const selectedSwitch = getByRole('switch');
+    fireEvent.click(selectedSwitch);
+
+    expect(onRuleSelectionChangeMock).toBeCalledWith([
+      expect.objectContaining({ id: '345', name: 'My rule' }),
+    ]);
+  });
+  it('should change the pagination when onTableChange is called', () => {
+    (useFindRules as jest.Mock).mockReturnValue({
+      data: {
+        rules: [
+          mockedRule,
+          { ...mockedRule, tags: ['some fake tag 1'], id: '345', name: 'My rule' },
+        ],
+        total: 0,
+      },
+      isFetched: true,
+    });
+
+    const {
+      result: { current },
+    } = renderHook(() =>
+      useAddToRulesTable({
+        initiallySelectedRules,
+        onRuleSelectionChange: onRuleSelectionChangeMock,
+      })
+    );
+
+    const { onTableChange, pagination } = current;
+    act(() => {
+      onTableChange({ page: { index: 2, size: 10 } });
+    });
+    waitFor(() =>
+      expect(pagination).toEqual({
+        initialPageSize: 5,
+        pageIndex: 2,
+        size: 10,
+        showPerPageOptions: false,
+      })
+    );
+  });
+});

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_exceptions/components/flyout_components/add_to_rules_table/use_add_to_rules_table.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_exceptions/components/flyout_components/add_to_rules_table/use_add_to_rules_table.tsx
@@ -36,7 +36,10 @@ export const useAddToRulesTable = ({
       tags: [],
     },
     sortingOptions: undefined,
-    pagination: undefined,
+    pagination: {
+      page: 1,
+      perPage: 10000,
+    },
   });
 
   const [pagination, setPagination] = useState({


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.7`:
 - [[Security Solution] Fix all rules list is not present , when user manage rules from a shared exception list (#151079)](https://github.com/elastic/kibana/pull/151079)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Wafaa Nasr","email":"wafaa.nasr@elastic.co"},"sourceCommit":{"committedDate":"2023-02-14T10:00:15Z","message":"[Security Solution] Fix all rules list is not present , when user manage rules from a shared exception list (#151079)\n\n## Summary\r\n\r\n- Addresses https://github.com/elastic/kibana/issues/150989\r\n- Pass pagination equals to `10000` to `fetchRules` api to get all\r\nuser's rules as the old\r\n[use_find_rules_in_memory.ts](https://github.com/elastic/kibana/pull/149840/files#diff-c45bbe9560f22294e32a1c0a68fe374b1e360b3df01060efed93acb9153a6e72)\r\nwas removed\r\n- Adding unit tests\r\n\r\n### Checklist\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n\r\n---------\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"3ae7d70c803dbc091cafc5d561625893ae1afacc","branchLabelMapping":{"^v8.8.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Security Solution Platform","8.7 candidate","backport:prev-minor","v8.8.0"],"number":151079,"url":"https://github.com/elastic/kibana/pull/151079","mergeCommit":{"message":"[Security Solution] Fix all rules list is not present , when user manage rules from a shared exception list (#151079)\n\n## Summary\r\n\r\n- Addresses https://github.com/elastic/kibana/issues/150989\r\n- Pass pagination equals to `10000` to `fetchRules` api to get all\r\nuser's rules as the old\r\n[use_find_rules_in_memory.ts](https://github.com/elastic/kibana/pull/149840/files#diff-c45bbe9560f22294e32a1c0a68fe374b1e360b3df01060efed93acb9153a6e72)\r\nwas removed\r\n- Adding unit tests\r\n\r\n### Checklist\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n\r\n---------\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"3ae7d70c803dbc091cafc5d561625893ae1afacc"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.8.0","labelRegex":"^v8.8.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/151079","number":151079,"mergeCommit":{"message":"[Security Solution] Fix all rules list is not present , when user manage rules from a shared exception list (#151079)\n\n## Summary\r\n\r\n- Addresses https://github.com/elastic/kibana/issues/150989\r\n- Pass pagination equals to `10000` to `fetchRules` api to get all\r\nuser's rules as the old\r\n[use_find_rules_in_memory.ts](https://github.com/elastic/kibana/pull/149840/files#diff-c45bbe9560f22294e32a1c0a68fe374b1e360b3df01060efed93acb9153a6e72)\r\nwas removed\r\n- Adding unit tests\r\n\r\n### Checklist\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n\r\n---------\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"3ae7d70c803dbc091cafc5d561625893ae1afacc"}}]}] BACKPORT-->