### PR TITLE
[Fleet] Fix agent policy selection and creation when there are a large number of agent policies ( > 1k)

### DIFF
--- a/x-pack/plugins/fleet/common/openapi/bundled.json
+++ b/x-pack/plugins/fleet/common/openapi/bundled.json
@@ -2522,6 +2522,14 @@
             "in": "query",
             "name": "full",
             "description": "When set to true, retrieve the related package policies for each agent policy."
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "noAgentCount",
+            "description": "When set to true, do not count how many agents are in the agent policy, this can improve performance if you are searching over a large number of agent policies. The \"agents\" property will always be 0 if set to true."
           }
         ],
         "description": ""

--- a/x-pack/plugins/fleet/common/openapi/bundled.yaml
+++ b/x-pack/plugins/fleet/common/openapi/bundled.yaml
@@ -1558,6 +1558,15 @@ paths:
           description: >-
             When set to true, retrieve the related package policies for each
             agent policy.
+        - schema:
+            type: boolean
+          in: query
+          name: noAgentCount
+          description: >-
+            When set to true, do not count how many agents are in the agent
+            policy, this can improve performance if you are searching over a
+            large number of agent policies. The "agents" property will always be
+            0 if set to true.
       description: ''
     post:
       summary: Agent policy - Create

--- a/x-pack/plugins/fleet/common/openapi/paths/agent_policies.yaml
+++ b/x-pack/plugins/fleet/common/openapi/paths/agent_policies.yaml
@@ -34,6 +34,11 @@ get:
       in: query
       name: full
       description: When set to true, retrieve the related package policies for each agent policy.
+    - schema:
+        type: boolean
+      in: query
+      name: noAgentCount
+      description: When set to true, do not count how many agents are in the agent policy, this can improve performance if you are searching over a large number of agent policies. The "agents" property will always be 0 if set to true. 
 
   description: ''
 post:

--- a/x-pack/plugins/fleet/common/types/rest_spec/agent_policy.ts
+++ b/x-pack/plugins/fleet/common/types/rest_spec/agent_policy.ts
@@ -11,6 +11,7 @@ import type { ListResult, ListWithKuery, BulkGetResult } from './common';
 
 export interface GetAgentPoliciesRequest {
   query: ListWithKuery & {
+    noAgentCount?: boolean;
     full?: boolean;
   };
 }

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_select_hosts.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_select_hosts.tsx
@@ -64,7 +64,8 @@ export const StepSelectHosts: React.FunctionComponent<Props> = ({
     perPage: SO_SEARCH_LIMIT,
     sortField: 'name',
     sortOrder: 'asc',
-    full: true,
+    full: false, // package_policies will always be empty
+    noAgentCount: true, // agentPolicy.agents will always be 0
   });
   if (err) {
     // eslint-disable-next-line no-console

--- a/x-pack/plugins/fleet/server/routes/agent_policy/handlers.ts
+++ b/x-pack/plugins/fleet/server/routes/agent_policy/handlers.ts
@@ -75,7 +75,7 @@ export const getAgentPoliciesHandler: FleetRequestHandler<
   const fleetContext = await context.fleet;
   const soClient = fleetContext.internalSoClient;
   const esClient = coreContext.elasticsearch.client.asInternalUser;
-  const { full: withPackagePolicies = false, ...restOfQuery } = request.query;
+  const { full: withPackagePolicies = false, noAgentCount = false, ...restOfQuery } = request.query;
   try {
     const { items, total, page, perPage } = await agentPolicyService.list(soClient, {
       withPackagePolicies,
@@ -88,9 +88,11 @@ export const getAgentPoliciesHandler: FleetRequestHandler<
       page,
       perPage,
     };
-
-    await populateAssignedAgentsCount(esClient, soClient, items);
-
+    if (!noAgentCount) {
+      await populateAssignedAgentsCount(esClient, soClient, items);
+    } else {
+      items.forEach((item) => (item.agents = 0));
+    }
     return response.ok({ body });
   } catch (error) {
     return defaultFleetErrorHandler({ error, response });
@@ -136,10 +138,12 @@ export const getOneAgentPolicyHandler: RequestHandler<
   TypeOf<typeof GetOneAgentPolicyRequestSchema.params>
 > = async (context, request, response) => {
   const coreContext = await context.core;
+  const esClient = coreContext.elasticsearch.client.asInternalUser;
   const soClient = coreContext.savedObjects.client;
   try {
     const agentPolicy = await agentPolicyService.get(soClient, request.params.agentPolicyId);
     if (agentPolicy) {
+      await populateAssignedAgentsCount(esClient, soClient, [agentPolicy]);
       const body: GetOneAgentPolicyResponse = {
         item: agentPolicy,
       };

--- a/x-pack/plugins/fleet/server/types/rest_spec/agent_policy.ts
+++ b/x-pack/plugins/fleet/server/types/rest_spec/agent_policy.ts
@@ -13,6 +13,7 @@ import { ListWithKuerySchema, BulkRequestBodySchema } from './common';
 
 export const GetAgentPoliciesRequestSchema = {
   query: ListWithKuerySchema.extends({
+    noAgentCount: schema.maybe(schema.boolean()),
     full: schema.maybe(schema.boolean()),
   }),
 };


### PR DESCRIPTION
## Summary

Closes #150605

When adding an integration, the agent policy selector (create or select existing agent policy) does not work if there are too many agent policies.

In an environment with a large number of agent policies (e.g 1000+) the following API request times out or takes 30 - 60 seconds to respond:

```
http://localhost:5601/mark/api/fleet/agent_policies?page=1&perPage=10000&sortField=name&sortOrder=asc&full=true
```

That is because for each agent policy we get the saved object twice, get ALL package policies, and count the agents, so for 1000 agents we fun 4000 queries using `pmap` in some places. 

this PR changes it so that we do not get the agent count or `full` agent policy for every agent policy when populating the agent policy select, instead we only get the selected agent policy.

This has meant that I have to separately query package policies in order to do the limited packages and APM output checks, but the component now loads instantly on an environment with 3k agent policies.

Key changes:

- add `noAgentCount` query param to agent policies API, to not count the agents for all agent policies
- populate `agents` in the get one agent policy API, this was an inconsistency in our agent policy API
- when selecting an existing agent policy, only get the full agent policy for the selected agent policy


###Testing

No behaviour should have changed for the agent policy select, some niche behaviour of the selector:

- if adding the APM integration, any agent policy with a logstash output configured for integration data should be disabled
- if adding a limited integration e.g apm or defend, any agent policy already containing that integration should be disabled

<img width="1052" alt="Screenshot 2023-02-14 at 10 45 03" src="https://user-images.githubusercontent.com/3315046/218745430-4a8f0ded-1e0b-4319-bc2c-cc5253b4cdd2.png">


<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->