### PR TITLE
[Fleet] Input packages: Use policy template name for default dataset

### DIFF
--- a/x-pack/plugins/fleet/common/services/policy_template.ts
+++ b/x-pack/plugins/fleet/common/services/policy_template.ts
@@ -79,7 +79,7 @@ export const getNormalizedDataStreams = (
       streams: [
         {
           input: policyTemplate.input,
-          vars: addDatasetVarIfNotPresent(policyTemplate.vars),
+          vars: addDatasetVarIfNotPresent(policyTemplate.vars, policyTemplate.name),
           template_path: policyTemplate.template_path,
           title: policyTemplate.title,
           description: policyTemplate.title,
@@ -94,7 +94,10 @@ export const getNormalizedDataStreams = (
 
 // Input only packages must provide a dataset name in order to differentiate their data streams
 // here we add the dataset var if it is not defined in the package already.
-const addDatasetVarIfNotPresent = (vars?: RegistryVarsEntry[]): RegistryVarsEntry[] => {
+const addDatasetVarIfNotPresent = (
+  vars?: RegistryVarsEntry[],
+  datasetName?: string
+): RegistryVarsEntry[] => {
   const newVars = vars ?? [];
 
   const isDatasetAlreadyAdded = newVars.find(
@@ -104,7 +107,10 @@ const addDatasetVarIfNotPresent = (vars?: RegistryVarsEntry[]): RegistryVarsEntr
   if (isDatasetAlreadyAdded) {
     return newVars;
   } else {
-    return [...newVars, DATA_STREAM_DATASET_VAR];
+    return [
+      ...newVars,
+      { ...DATA_STREAM_DATASET_VAR, ...(datasetName && { default: datasetName }) },
+    ];
   }
 };
 

--- a/x-pack/test/fleet_api_integration/apis/package_policy/create.ts
+++ b/x-pack/test/fleet_api_integration/apis/package_policy/create.ts
@@ -447,7 +447,7 @@ export default function (providerContext: FtrProviderContext) {
     });
 
     describe('input only packages', () => {
-      it('should return 400 if dataset not provided for input only pkg', async function () {
+      it('should default dataset if not provided for input only pkg', async function () {
         await supertest
           .post(`/api/fleet/package_policies`)
           .set('kbn-xsrf', 'xxxx')
@@ -476,7 +476,7 @@ export default function (providerContext: FtrProviderContext) {
               },
             },
           })
-          .expect(400);
+          .expect(200);
       });
       it('should successfully create an input only package policy with all required vars', async function () {
         await supertest


### PR DESCRIPTION
## Summary

Closes #151137 

We were using "generic" as the dataset name for all input packages which was a bad UX. I have moved to using the policy template name e.g for jolokia we now create metrics-jolokia datastream by default instead of metrics-generic

<img width="856" alt="Screenshot 2023-02-14 at 14 25 18" src="https://user-images.githubusercontent.com/3315046/218766481-8c230341-ef6c-4317-beb5-473d8917e908.png">


<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->