### PR TITLE
[Enterprise Search] Fix full HTML toggle label

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/crawler_configuration/crawler_configuration.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/crawler_configuration/crawler_configuration.tsx
@@ -79,7 +79,7 @@ export const CrawlerConfiguration: React.FC = () => {
                 label={i18n.translate(
                   'xpack.enterpriseSearch.content.crawler.crawlerConfiguration.extractHTML.extractionSwitchLabel',
                   {
-                    defaultMessage: 'Content extraction.',
+                    defaultMessage: 'Store full HTML',
                   }
                 )}
                 disabled={status === Status.LOADING}


### PR DESCRIPTION
## Summary

The label should be `Store full HTML` rather than `Content extraction`. This is to lower ambiguity between this feature and extraction rules.

[Slack thread link](https://elastic.slack.com/archives/C01795T48LQ/p1676339384256619)

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
