### PR TITLE
[Lens] Fix reference line label rendering

### DIFF
--- a/src/plugins/chart_expressions/expression_xy/common/expression_functions/reference_line.test.ts
+++ b/src/plugins/chart_expressions/expression_xy/common/expression_functions/reference_line.test.ts
@@ -16,6 +16,7 @@ describe('referenceLine', () => {
       value: 100,
       fill: 'above',
       position: 'bottom',
+      forAccessor: '',
     };
 
     const result = referenceLineFunction.fn(null, args, createMockExecutionContext());
@@ -47,6 +48,7 @@ describe('referenceLine', () => {
       color: '#fff',
       fill: 'below',
       textVisibility: true,
+      forAccessor: '',
     };
 
     const result = referenceLineFunction.fn(null, args, createMockExecutionContext());
@@ -71,6 +73,7 @@ describe('referenceLine', () => {
       value: 100,
       fill: 'none',
       position: 'bottom',
+      forAccessor: '',
     };
 
     const result = referenceLineFunction.fn(null, args, createMockExecutionContext());
@@ -96,6 +99,7 @@ describe('referenceLine', () => {
       textVisibility: true,
       fill: 'none',
       position: 'bottom',
+      forAccessor: '',
     };
 
     const result = referenceLineFunction.fn(null, args, createMockExecutionContext());
@@ -123,6 +127,7 @@ describe('referenceLine', () => {
         textVisibility,
         fill: 'none',
         position: 'bottom',
+        forAccessor: '',
       };
 
       const result = referenceLineFunction.fn(null, args, createMockExecutionContext());

--- a/src/plugins/chart_expressions/expression_xy/common/expression_functions/reference_line.ts
+++ b/src/plugins/chart_expressions/expression_xy/common/expression_functions/reference_line.ts
@@ -105,6 +105,11 @@ export const referenceLineFunction: ReferenceLineFn = {
       default: FillStyles.NONE,
       strict: true,
     },
+    forAccessor: {
+      types: ['string'],
+      help: '',
+      default: '',
+    },
   },
   fn(table, args) {
     const textVisibility =

--- a/src/plugins/chart_expressions/expression_xy/common/types/expression_functions.ts
+++ b/src/plugins/chart_expressions/expression_xy/common/types/expression_functions.ts
@@ -329,8 +329,7 @@ export type ExtendedAnnotationLayerConfigResult = ExtendedAnnotationLayerArgs & 
   layerType: typeof LayerTypes.ANNOTATIONS;
 };
 
-export interface ReferenceLineArgs
-  extends Omit<ReferenceLineDecorationConfig, 'forAccessor' | 'fill'> {
+export interface ReferenceLineArgs extends Omit<ReferenceLineDecorationConfig, 'fill'> {
   name?: string;
   value: number;
   fill: FillStyle;
@@ -365,6 +364,7 @@ export interface ReferenceLineConfigResult {
   type: typeof REFERENCE_LINE;
   layerType: typeof LayerTypes.REFERENCELINE;
   lineLength: number;
+  columnToLabel?: string;
   decorations: [ExtendedReferenceLineDecorationConfig];
 }
 

--- a/src/plugins/chart_expressions/expression_xy/public/components/reference_lines/reference_line.tsx
+++ b/src/plugins/chart_expressions/expression_xy/public/components/reference_lines/reference_line.tsx
@@ -35,6 +35,7 @@ export const ReferenceLine: FC<ReferenceLineProps> = ({
 }) => {
   const {
     decorations: [decorationConfig],
+    columnToLabel,
   } = layer;
 
   if (!decorationConfig) {
@@ -42,15 +43,19 @@ export const ReferenceLine: FC<ReferenceLineProps> = ({
   }
 
   const { value } = decorationConfig;
+  const columnToLabelMap: Record<string, string> = columnToLabel ? JSON.parse(columnToLabel) : {};
 
   const axisGroup = getAxisGroupForReferenceLine(axesConfiguration, decorationConfig, isHorizontal);
 
   const formatter = axisGroup?.formatter || xAxisFormatter;
   const id = `${layer.layerId}-${value}`;
+  const name = decorationConfig.textVisibility
+    ? columnToLabelMap[decorationConfig.forAccessor]
+    : undefined;
 
   return (
     <ReferenceLineAnnotations
-      config={{ id, ...decorationConfig, nextValue, axisGroup }}
+      config={{ id, ...decorationConfig, name, nextValue, axisGroup }}
       paddingMap={paddingMap}
       axesMap={yAxesMap}
       formatter={formatter}

--- a/src/plugins/chart_expressions/expression_xy/public/components/reference_lines/reference_line_annotations.tsx
+++ b/src/plugins/chart_expressions/expression_xy/public/components/reference_lines/reference_line_annotations.tsx
@@ -75,7 +75,7 @@ export const ReferenceLineAnnotations: FC<Props> = ({
   paddingMap,
   isHorizontal,
 }) => {
-  const { id, axisGroup, iconPosition, name, textVisibility, value, fill, color } = config;
+  const { id, axisGroup, iconPosition, name, value, fill, color } = config;
 
   const defaultColor = euiLightVars.euiColorDarkShade;
   // get the position for vertical chart
@@ -85,18 +85,9 @@ export const ReferenceLineAnnotations: FC<Props> = ({
     getOriginalAxisPosition(axisGroup?.position ?? Position.Bottom, isHorizontal)
   );
   // the padding map is built for vertical chart
-  const hasReducedPadding = paddingMap[markerPositionVertical] === LINES_MARKER_SIZE;
+  const isTextOnlyMarker = paddingMap[markerPositionVertical] === LINES_MARKER_SIZE;
 
-  const props = getLineAnnotationProps(
-    config,
-    {
-      markerLabel: name,
-      markerBodyLabel: textVisibility && !hasReducedPadding ? name : undefined,
-    },
-    axesMap,
-    paddingMap,
-    isHorizontal
-  );
+  const props = getLineAnnotationProps(config, name, axesMap, isHorizontal, isTextOnlyMarker);
 
   const sharedStyle = getSharedStyle(config);
 

--- a/src/plugins/chart_expressions/expression_xy/public/components/reference_lines/reference_lines.test.tsx
+++ b/src/plugins/chart_expressions/expression_xy/public/components/reference_lines/reference_lines.test.tsx
@@ -536,6 +536,7 @@ describe('ReferenceLines', () => {
                 lineStyle: 'solid',
                 fill,
                 value,
+                forAccessor: '',
               }),
             ]}
           />
@@ -576,6 +577,7 @@ describe('ReferenceLines', () => {
                 lineStyle: 'solid',
                 fill,
                 value,
+                forAccessor: '',
               }),
             ]}
           />
@@ -617,12 +619,14 @@ describe('ReferenceLines', () => {
                 lineStyle: 'solid',
                 fill,
                 value,
+                forAccessor: '',
               }),
               createReferenceLine(layerPrefix, 10, {
                 position,
                 lineStyle: 'solid',
                 fill,
                 value,
+                forAccessor: '',
               }),
             ]}
           />
@@ -667,12 +671,14 @@ describe('ReferenceLines', () => {
                 lineStyle: 'solid',
                 fill,
                 value,
+                forAccessor: '',
               }),
               createReferenceLine(layerPrefix, 10, {
                 position: 'bottom',
                 lineStyle: 'solid',
                 fill,
                 value,
+                forAccessor: '',
               }),
             ]}
           />
@@ -720,12 +726,14 @@ describe('ReferenceLines', () => {
                 lineStyle: 'solid',
                 fill: 'above',
                 value: value1,
+                forAccessor: '',
               }),
               createReferenceLine(layerPrefix, 10, {
                 position,
                 lineStyle: 'solid',
                 fill: 'below',
                 value: value2,
+                forAccessor: '',
               }),
             ]}
           />

--- a/src/plugins/chart_expressions/expression_xy/public/components/reference_lines/utils.test.tsx
+++ b/src/plugins/chart_expressions/expression_xy/public/components/reference_lines/utils.test.tsx
@@ -7,8 +7,11 @@
  */
 
 import { AxisTypeId, computeInputCombinations, PosType } from './_mocks';
-import { computeChartMargins } from './utils';
-import { AxisConfiguration } from '../../helpers';
+import { computeChartMargins, getLineAnnotationProps } from './utils';
+import { AxesMap, AxisConfiguration, Marker, MarkerBody } from '../../helpers';
+import { ReferenceLineAnnotationConfig } from './reference_line_annotations';
+import { Position } from '@elastic/charts';
+import React from 'react';
 
 describe('reference lines helpers', () => {
   describe('computeChartMargins', () => {
@@ -35,5 +38,123 @@ describe('reference lines helpers', () => {
         ).toEqual(result);
       }
     );
+  });
+
+  describe('getLineAnnotationProps', () => {
+    function getAxesMap({ left, right }: Partial<AxesMap> = {}): AxesMap {
+      return {
+        left: { groupId: 'yLeft', position: Position.Left, series: [], ...left },
+        right: { groupId: 'yRight', position: Position.Right, series: [], ...right },
+      };
+    }
+    function getConfig(
+      customPartialConfig: Partial<ReferenceLineAnnotationConfig> = {}
+    ): ReferenceLineAnnotationConfig {
+      return {
+        id: 'id',
+        value: 3,
+        lineWidth: 5,
+        textVisibility: false,
+        iconPosition: 'auto',
+        axisGroup: getAxesMap().left,
+        ...customPartialConfig,
+      };
+    }
+
+    it('should render only the line with no marker', () => {
+      const config = getConfig();
+      expect(getLineAnnotationProps(config, 'myLabel', getAxesMap(), false, false)).toEqual(
+        expect.objectContaining({
+          groupId: 'yLeft',
+          markerPosition: Position.Left,
+          marker: (
+            <Marker
+              config={config}
+              label={'myLabel'}
+              isHorizontal={false}
+              hasReducedPadding={false}
+            />
+          ),
+          markerBody: <MarkerBody label={undefined} isHorizontal={false} />,
+        })
+      );
+    });
+    it('should render an icon marker', () => {
+      const config = getConfig({ icon: 'triangle' });
+      expect(getLineAnnotationProps(config, 'myLabel', getAxesMap(), false, false)).toEqual(
+        expect.objectContaining({
+          groupId: 'yLeft',
+          markerPosition: Position.Left,
+          marker: (
+            <Marker
+              config={config}
+              label={'myLabel'}
+              isHorizontal={false}
+              hasReducedPadding={false}
+            />
+          ),
+          markerBody: <MarkerBody label={undefined} isHorizontal={false} />,
+        })
+      );
+    });
+    it('should render only the label', () => {
+      const config = getConfig({ textVisibility: true });
+      expect(getLineAnnotationProps(config, 'myLabel', getAxesMap(), false, true)).toEqual(
+        expect.objectContaining({
+          groupId: 'yLeft',
+          markerPosition: Position.Left,
+          marker: (
+            <Marker
+              config={config}
+              label={'myLabel'}
+              isHorizontal={false}
+              hasReducedPadding={true}
+            />
+          ),
+          markerBody: <MarkerBody label={undefined} isHorizontal={false} />,
+        })
+      );
+    });
+    it('should render both icon and text', () => {
+      const config = getConfig({ icon: 'triangle', textVisibility: true });
+      expect(getLineAnnotationProps(config, 'myLabel', getAxesMap(), false, false)).toEqual(
+        expect.objectContaining({
+          groupId: 'yLeft',
+          markerPosition: Position.Left,
+          marker: (
+            <Marker
+              config={config}
+              label={'myLabel'}
+              isHorizontal={false}
+              hasReducedPadding={false}
+            />
+          ),
+          markerBody: <MarkerBody label={'myLabel'} isHorizontal={false} />,
+        })
+      );
+    });
+
+    it('should handle marker rotated label', () => {
+      const config = getConfig({
+        icon: 'triangle',
+        textVisibility: true,
+        axisGroup: { groupId: 'x', position: Position.Bottom, series: [] },
+      });
+      expect(getLineAnnotationProps(config, 'myLabel', getAxesMap(), false, false)).toEqual(
+        expect.objectContaining({
+          groupId: 'x',
+          markerPosition: Position.Top,
+          marker: (
+            <Marker
+              config={config}
+              label={'myLabel'}
+              isHorizontal={true}
+              hasReducedPadding={false}
+            />
+          ),
+          markerBody: <MarkerBody label={'myLabel'} isHorizontal={true} />,
+        })
+      );
+    });
   });
 });

--- a/src/plugins/chart_expressions/expression_xy/public/components/reference_lines/utils.tsx
+++ b/src/plugins/chart_expressions/expression_xy/public/components/reference_lines/utils.tsx
@@ -21,7 +21,6 @@ import {
 import { FillStyles } from '../../../common/constants';
 import {
   GroupsConfiguration,
-  LINES_MARKER_SIZE,
   mapVerticalToHorizontalPlacement,
   Marker,
   MarkerBody,
@@ -29,7 +28,7 @@ import {
   getOriginalAxisPosition,
   AxesMap,
 } from '../../helpers';
-import { ReferenceLineAnnotationConfig } from './reference_line_annotations';
+import type { ReferenceLineAnnotationConfig } from './reference_line_annotations';
 
 // if there's just one axis, put it on the other one
 // otherwise use the same axis
@@ -84,10 +83,10 @@ export const getSharedStyle = (config: ReferenceLineAnnotationConfig) => ({
 
 export const getLineAnnotationProps = (
   config: ReferenceLineAnnotationConfig,
-  labels: { markerLabel?: string; markerBodyLabel?: string },
+  label: string | undefined,
   axesMap: AxesMap,
-  paddingMap: Partial<Record<Position, number>>,
-  isHorizontal: boolean
+  isHorizontal: boolean,
+  isTextOnlyMarker: boolean
 ) => {
   // get the position for vertical chart
   const markerPositionVertical = getBaseIconPlacement(
@@ -96,27 +95,27 @@ export const getLineAnnotationProps = (
     getOriginalAxisPosition(config.axisGroup?.position ?? Position.Bottom, isHorizontal)
   );
 
-  // the padding map is built for vertical chart
-  const hasReducedPadding = paddingMap[markerPositionVertical] === LINES_MARKER_SIZE;
-
   const markerPosition = isHorizontal
     ? mapVerticalToHorizontalPlacement(markerPositionVertical)
     : markerPositionVertical;
+
+  const isMarkerLabelHorizontal =
+    markerPosition === Position.Bottom || markerPosition === Position.Top;
 
   return {
     groupId: config.axisGroup?.groupId || 'bottom',
     marker: (
       <Marker
         config={config}
-        label={labels.markerLabel}
-        isHorizontal={isHorizontal}
-        hasReducedPadding={hasReducedPadding}
+        label={label}
+        isHorizontal={isMarkerLabelHorizontal}
+        hasReducedPadding={isTextOnlyMarker}
       />
     ),
     markerBody: (
       <MarkerBody
-        label={labels.markerBodyLabel}
-        isHorizontal={markerPosition === Position.Bottom || markerPosition === Position.Top}
+        label={config.textVisibility && !isTextOnlyMarker ? label : undefined}
+        isHorizontal={isMarkerLabelHorizontal}
       />
     ),
     // rotate the position if required

--- a/src/plugins/chart_expressions/expression_xy/public/helpers/annotations.tsx
+++ b/src/plugins/chart_expressions/expression_xy/public/helpers/annotations.tsx
@@ -29,13 +29,19 @@ type PartialReferenceLineDecorationConfig = Pick<
 
 type PartialMergedAnnotation = Pick<
   MergedAnnotation,
-  'position' | 'icon' | 'textVisibility' | 'label'
+  'position' | 'icon' | 'textVisibility' | 'label' | 'isGrouped'
 >;
 
 const isExtendedDecorationConfig = (
   config: PartialReferenceLineDecorationConfig | PartialMergedAnnotation | undefined
 ): config is PartialReferenceLineDecorationConfig =>
   (config as PartialReferenceLineDecorationConfig)?.iconPosition ? true : false;
+
+export const isAnnotationConfig = (
+  config: PartialReferenceLineDecorationConfig | PartialMergedAnnotation
+): config is PartialMergedAnnotation => {
+  return 'isGrouped' in config;
+};
 
 // Note: it does not take into consideration whether the reference line is in view or not
 export const getLinesCausedPaddings = (
@@ -52,8 +58,9 @@ export const getLinesCausedPaddings = (
     }
     const { position, icon, textVisibility } = config;
     const iconPosition = isExtendedDecorationConfig(config) ? config.iconPosition : undefined;
+    const isLabelVisible = textVisibility && (isAnnotationConfig(config) ? config.label : true);
 
-    if (position && (hasIcon(icon) || (textVisibility && 'label' in config))) {
+    if (position && (hasIcon(icon) || isLabelVisible)) {
       const placement = getBaseIconPlacement(
         iconPosition,
         axesMap,
@@ -61,7 +68,7 @@ export const getLinesCausedPaddings = (
       );
       paddings[placement] = Math.max(
         paddings[placement] || 0,
-        LINES_MARKER_SIZE * (textVisibility && 'label' in config && config.label ? 2 : 1) // double the padding size if there's text
+        LINES_MARKER_SIZE * (isLabelVisible ? 2 : 1) // double the padding size if there's text
       );
       icons[placement] = (icons[placement] || 0) + (hasIcon(icon) ? 1 : 0);
     }


### PR DESCRIPTION
## Summary

Fix #151101 

Refactored shared code between reference line and annotation rendering to restore label rendering on Reference line.

The root issue was a refactoring of the code who only considered the annotation configuration shape, which slightly differs from the reference lines one, and in particular a stricter check for the label configuration together with the assumption that an icon was always shown in the annotation marker.

I've added few new unit tests to detect changes in the future in some annotation logic, but it would be best to extend them in the future.

<img width="444" alt="Screenshot 2023-02-14 at 15 29 10" src="https://user-images.githubusercontent.com/924948/218792072-a56ece78-07fd-4c0b-ab63-017590281b18.png">
<img width="451" alt="Screenshot 2023-02-14 at 15 29 17" src="https://user-images.githubusercontent.com/924948/218792082-85630355-b003-4dea-86ca-3e90707c8293.png">

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->