### PR TITLE
[TIP] emable Cypress screenshot upload on CI for failing tests

### DIFF
--- a/.buildkite/pipelines/pull_request/threat_intelligence.yml
+++ b/.buildkite/pipelines/pull_request/threat_intelligence.yml
@@ -12,3 +12,5 @@ steps:
           limit: 3
         - exit_status: '*'
           limit: 1
+    artifact_paths:
+      - "target/kibana-threat-intelligence/**/*"


### PR DESCRIPTION
## Summary

The Threat Intelligence (TI) plugin is using Cypress for integration tests. Unlike some other plugins (like OSQuery for example), when tests are failing in Buildkite, no screenshots are uploaded and accessible for developers to look at.

This PR adds the configuration in the `.buildkite` folder to fix that.