### PR TITLE
[Fleet] Fetch package title, description for uploaded packages

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/packages/get.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/get.test.ts
@@ -198,9 +198,11 @@ describe('When using EPM `get` services', () => {
           title: 'Nginx',
         } as any,
       ]);
+      MockRegistry.fetchFindLatestPackageOrUndefined.mockResolvedValue(undefined);
+      MockRegistry.fetchInfo.mockResolvedValue({} as any);
     });
 
-    it('should return installed package that is not in registry', async () => {
+    it('should return installed package that is not in registry with package info', async () => {
       const soClient = savedObjectsClientMock.create();
       soClient.find.mockResolvedValue({
         saved_objects: [
@@ -210,10 +212,42 @@ describe('When using EPM `get` services', () => {
               name: 'elasticsearch',
               version: '0.0.1',
               install_source: 'upload',
+              install_version: '0.0.1',
             },
           },
         ],
       } as any);
+      soClient.get.mockImplementation((type) => {
+        if (type === 'epm-packages-assets') {
+          return Promise.resolve({
+            attributes: {
+              data_utf8: `
+name: elasticsearch
+version: 0.0.1
+title: Elastic
+description: Elasticsearch description`,
+            },
+          } as any);
+        } else {
+          return Promise.resolve({
+            id: 'elasticsearch',
+            attributes: {
+              name: 'elasticsearch',
+              version: '0.0.1',
+              install_source: 'upload',
+              package_assets: [],
+              data_utf8: `
+            name: elasticsearch
+            version: 0.0.1
+            title: Elastic
+            description: Elasticsearch description`,
+            },
+          });
+        }
+      });
+      soClient.bulkGet.mockResolvedValue({
+        saved_objects: [],
+      });
 
       await expect(
         getPackages({
@@ -224,7 +258,8 @@ describe('When using EPM `get` services', () => {
           id: 'elasticsearch',
           name: 'elasticsearch',
           version: '0.0.1',
-          title: 'Elasticsearch',
+          title: 'Elastic',
+          description: 'Elasticsearch description',
           savedObject: {
             id: 'elasticsearch',
             attributes: {
@@ -234,13 +269,7 @@ describe('When using EPM `get` services', () => {
             },
           },
         },
-        {
-          name: 'nginx',
-          version: '1.0.0',
-          title: 'Nginx',
-          id: 'nginx',
-          status: 'not_installed',
-        },
+        { id: 'nginx', name: 'nginx', title: 'Nginx', version: '1.0.0' },
       ]);
     });
   });


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/150409

Loading package title and description from package manifest for uploaded packages that are not in registry.
This is to enhance the UI so that the package card has the same information as registry packages.

Did some measurements and the `getPackageInfo` from `zip` file takes about 100-200ms per package, so limited this to 10 packages for a `/packages` API call.

Before (uploaded or installed beta packages showing up without description if beta integrations are off):
<img width="1075" alt="image" src="https://user-images.githubusercontent.com/90178898/218795984-70daf495-f996-470b-ab89-ce4829cc9d47.png">

After:
<img width="1041" alt="image" src="https://user-images.githubusercontent.com/90178898/218795455-17327313-e383-4220-a872-668473db1a4d.png">

If we plan to support use cases with more uploaded packages, we could look at further optimizing this logic, e.g. instead of using `getPackageInfo`, there could be a faster function which only loads the top level manifest file for the basic info. We could also look at adding more caching to speed up the fetching.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
