### PR TITLE
[Enterprise Search] Fix sync flyout

### DIFF
--- a/x-pack/plugins/enterprise_search/common/types/connectors.ts
+++ b/x-pack/plugins/enterprise_search/common/types/connectors.ts
@@ -170,7 +170,7 @@ export interface ConnectorSyncJob {
   completed_at: string | null;
   connector: {
     configuration: ConnectorConfiguration;
-    filtering: FilteringRules[] | null;
+    filtering: FilteringRules | FilteringRules[] | null;
     id: string;
     index_name: string;
     language: string;

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/sync_jobs/filtering_panel.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/sync_jobs/filtering_panel.tsx
@@ -35,7 +35,7 @@ export const FilteringPanel: React.FC<FilteringPanelProps> = ({
       >
         <FilteringRulesTable filteringRules={filteringRules} showOrder={false} />
       </FlyoutPanel>
-      {!!advancedSnippet?.value ? (
+      {!!advancedSnippet ? (
         <>
           <EuiSpacer />
           <FlyoutPanel
@@ -48,7 +48,7 @@ export const FilteringPanel: React.FC<FilteringPanelProps> = ({
           >
             <EuiPanel hasShadow={false}>
               <EuiCodeBlock transparentBackground language="json">
-                {JSON.stringify(advancedSnippet.value, undefined, 2)}
+                {JSON.stringify(advancedSnippet, undefined, 2)}
               </EuiCodeBlock>
             </EuiPanel>
           </FlyoutPanel>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/sync_jobs/filtering_panel.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/sync_jobs/filtering_panel.tsx
@@ -35,7 +35,7 @@ export const FilteringPanel: React.FC<FilteringPanelProps> = ({
       >
         <FilteringRulesTable filteringRules={filteringRules} showOrder={false} />
       </FlyoutPanel>
-      {!!advancedSnippet ? (
+      {!!advancedSnippet?.value ? (
         <>
           <EuiSpacer />
           <FlyoutPanel
@@ -48,7 +48,7 @@ export const FilteringPanel: React.FC<FilteringPanelProps> = ({
           >
             <EuiPanel hasShadow={false}>
               <EuiCodeBlock transparentBackground language="json">
-                {JSON.stringify(advancedSnippet, undefined, 2)}
+                {JSON.stringify(advancedSnippet.value, undefined, 2)}
               </EuiCodeBlock>
             </EuiPanel>
           </FlyoutPanel>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/sync_jobs/sync_job_flyout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/sync_jobs/sync_job_flyout.tsx
@@ -33,7 +33,11 @@ interface SyncJobFlyoutProps {
 }
 
 export const SyncJobFlyout: React.FC<SyncJobFlyoutProps> = ({ onClose, syncJob }) => {
-  const filtering = syncJob?.connector.filtering ? (Array.isArray(syncJob?.connector.filtering) ? syncJob?.connector.filtering?.[0] : syncJob?.connector.filtering) : null;
+  const filtering = syncJob?.connector.filtering
+    ? Array.isArray(syncJob?.connector.filtering)
+      ? syncJob?.connector.filtering?.[0]
+      : syncJob?.connector.filtering
+    : null;
   const visible = !!syncJob;
   return visible ? (
     <EuiFlyout onClose={onClose}>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/sync_jobs/sync_job_flyout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/sync_jobs/sync_job_flyout.tsx
@@ -33,7 +33,7 @@ interface SyncJobFlyoutProps {
 }
 
 export const SyncJobFlyout: React.FC<SyncJobFlyoutProps> = ({ onClose, syncJob }) => {
-  const filtering = syncJob?.connector.filtering ? syncJob.connector.filtering[0] : null;
+  const filtering = syncJob?.connector.filtering ? (Array.isArray(syncJob?.connector.filtering) ? syncJob?.connector.filtering?.[0] : syncJob?.connector.filtering) : null;
   const visible = !!syncJob;
   return visible ? (
     <EuiFlyout onClose={onClose}>


### PR DESCRIPTION
### Closes https://github.com/elastic/enterprise-search-team/issues/3949

## Summary

As ES stores a single filter instance as object directly we need to make sure to also handle this case by allowing a single filter instance directly not wrapped inside an array.

### Checklist


<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->