### PR TITLE
[ML] Fix tooltip for full-width annotations in the Single Metric Viewer

### DIFF
--- a/x-pack/plugins/ml/public/application/components/chart_tooltip/chart_tooltip.tsx
+++ b/x-pack/plugins/ml/public/application/components/chart_tooltip/chart_tooltip.tsx
@@ -129,11 +129,11 @@ const Tooltip: FC<{ service: ChartTooltipService }> = React.memo(({ service }) =
         {
           name: 'preventOverflow',
           options: {
-            rootBoundary: 'window',
+            rootBoundary: 'viewport',
           },
         },
       ]}
-      placement="right-start"
+      placement="top-start"
       trigger="none"
       tooltipShown={isTooltipShown}
       tooltip={tooltipCallback}

--- a/x-pack/plugins/ml/public/application/timeseriesexplorer/components/timeseries_chart/timeseries_chart_annotations.ts
+++ b/x-pack/plugins/ml/public/application/timeseriesexplorer/components/timeseries_chart/timeseries_chart_annotations.ts
@@ -165,7 +165,7 @@ export function renderAnnotations(
   rects
     .attr('x', (d: Annotation) => {
       const date = moment(d.timestamp);
-      return focusXScale(date);
+      return Math.max(focusXScale(date), 0);
     })
     .attr('y', (d: Annotation) => {
       const level = d.key !== undefined ? levels[d.key] : ANNOTATION_DEFAULT_LEVEL;


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/141612

- Prevents settings a negative value for `x` attribute for annotation `rect` element 
- Improves tooltip positioning by placing it on top of the chart 

<img width="1091" alt="image" src="https://user-images.githubusercontent.com/5236598/218806266-a85717bd-3c88-430a-a6e5-71ae2ed9beda.png">


<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->