### PR TITLE
[kbn-ecs] Adds security solution threat hunting investigations as co-owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -309,7 +309,7 @@ src/plugins/discover @elastic/kibana-data-discovery
 packages/kbn-doc-links @elastic/kibana-docs
 packages/kbn-docs-utils @elastic/kibana-operations
 packages/kbn-ebt-tools @elastic/kibana-core
-packages/kbn-ecs @elastic/kibana-core
+packages/kbn-ecs @elastic/kibana-core @elastic/security-threat-hunting-investigations
 x-pack/packages/kbn-ecs-data-quality-dashboard @elastic/security-threat-hunting-investigations
 x-pack/plugins/ecs_data_quality_dashboard @elastic/security-threat-hunting-investigations
 test/plugin_functional/plugins/elasticsearch_client_plugin @elastic/kibana-core

--- a/packages/kbn-ecs/kibana.jsonc
+++ b/packages/kbn-ecs/kibana.jsonc
@@ -1,5 +1,5 @@
 {
   "type": "shared-common",
   "id": "@kbn/ecs",
-  "owner": "@elastic/kibana-core"
+  "owner": ["@elastic/kibana-core", "@elastic/security-threat-hunting-investigations"]
 }

--- a/packages/kbn-ecs/package.json
+++ b/packages/kbn-ecs/package.json
@@ -2,6 +2,5 @@
   "name": "@kbn/ecs",
   "version": "1.0.0",
   "private": true,
-  "author": "Kibana Core",
   "license": "SSPL-1.0 OR Elastic License 2.0"
 }


### PR DESCRIPTION
Due to shifting priorities, the Core team cannot dedicate time to actively maintain the package.
As agreed to offline, maintenance will mostly fall on the team with the highest stake in keeping the types up to date.

This PR adds the security threat hunting investigations as a co-owner of the `kbn-ecs` package.