### PR TITLE
Upgrade EUI to v75.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "@elastic/datemath": "5.0.3",
     "@elastic/elasticsearch": "npm:@elastic/elasticsearch-canary@8.6.0-canary.3",
     "@elastic/ems-client": "8.4.0",
-    "@elastic/eui": "75.0.0",
+    "@elastic/eui": "75.1.0",
     "@elastic/filesaver": "1.1.2",
     "@elastic/node-crypto": "1.2.1",
     "@elastic/numeral": "^2.5.1",

--- a/packages/core/i18n/core-i18n-browser-internal/src/__snapshots__/i18n_service.test.tsx.snap
+++ b/packages/core/i18n/core-i18n-browser-internal/src/__snapshots__/i18n_service.test.tsx.snap
@@ -27,6 +27,7 @@ exports[`#start() returns \`Context\` component 1`] = `
           "euiCardSelect.select": "Select",
           "euiCardSelect.selected": "Selected",
           "euiCardSelect.unavailable": "Unavailable",
+          "euiCodeBlockAnnotations.ariaLabel": [Function],
           "euiCodeBlockCopy.copy": "Copy",
           "euiCodeBlockFullScreen.fullscreenCollapse": "Collapse",
           "euiCodeBlockFullScreen.fullscreenExpand": "Expand",

--- a/packages/core/i18n/core-i18n-browser-internal/src/i18n_eui_mapping.tsx
+++ b/packages/core/i18n/core-i18n-browser-internal/src/i18n_eui_mapping.tsx
@@ -125,6 +125,13 @@ export const getEuiContextMapping = (): EuiTokensObject => {
       defaultMessage: 'Unavailable',
       description: 'Displayed button text when a card option is unavailable.',
     }),
+    'euiCodeBlockAnnotations.ariaLabel': ({ lineNumber }: EuiValues) =>
+      i18n.translate('core.euiCodeBlockAnnotations.ariaLabel', {
+        defaultMessage: 'Click to view a code annotation for line {lineNumber}',
+        values: { lineNumber },
+        description:
+          'ARIA label for a button icon that toggles a popover annotation for a specific code line',
+      }),
     'euiCodeBlockCopy.copy': i18n.translate('core.euiCodeBlockCopy.copy', {
       defaultMessage: 'Copy',
       description: 'ARIA label for a button that copies source code text to the clipboard',

--- a/src/dev/license_checker/config.ts
+++ b/src/dev/license_checker/config.ts
@@ -84,6 +84,6 @@ export const LICENSE_OVERRIDES = {
   'jsts@1.6.2': ['Eclipse Distribution License - v 1.0'], // cf. https://github.com/bjornharrtell/jsts
   '@mapbox/jsonlint-lines-primitives@2.0.2': ['MIT'], // license in readme https://github.com/tmcw/jsonlint
   '@elastic/ems-client@8.4.0': ['Elastic License 2.0'],
-  '@elastic/eui@75.0.0': ['SSPL-1.0 OR Elastic License 2.0'],
+  '@elastic/eui@75.1.0': ['SSPL-1.0 OR Elastic License 2.0'],
   'language-subtag-registry@0.3.21': ['CC-BY-4.0'], // retired ODC‑By license https://github.com/mattcg/language-subtag-registry
 };

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/multi_page_layout/components/horizontal_page_steps.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/multi_page_layout/components/horizontal_page_steps.tsx
@@ -28,7 +28,7 @@ const NumberlessHorizontalSteps = styled(EuiStepsHorizontal)`
   .euiStepHorizontal {
     padding: 25px 16px 16px;
   }
-  .euiStepHorizontal-isIncomplete .euiStepHorizontal__title {
+  .euiStepHorizontal[data-step-status='incomplete'] .euiStepHorizontal__title {
     color: #69707d;
   }
 `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1539,10 +1539,10 @@
   resolved "https://registry.yarnpkg.com/@elastic/eslint-plugin-eui/-/eslint-plugin-eui-0.0.2.tgz#56b9ef03984a05cc213772ae3713ea8ef47b0314"
   integrity sha512-IoxURM5zraoQ7C8f+mJb9HYSENiZGgRVcG4tLQxE61yHNNRDXtGDWTZh8N1KIHcsqN1CEPETjuzBXkJYF/fDiQ==
 
-"@elastic/eui@75.0.0":
-  version "75.0.0"
-  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-75.0.0.tgz#06f1d41181327d91d6531f240372c01c34505bee"
-  integrity sha512-fgjpF4l+YuMVepnYbiddpVZHkzEVrgwvsmJokaf0OZZ34UCh+OB2z4n01yAhmhQXhrFEKv8+LmQt+OMIpTBevA==
+"@elastic/eui@75.1.0":
+  version "75.1.0"
+  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-75.1.0.tgz#6bdb2a12e5dd503258e74d5585803f52b826b83e"
+  integrity sha512-HJgoARNsXeYDIGO9sKV+wwfmFA2IKL9hjOMj8B0PZ4fA6Euprw7KPLkakUbwjTCm0rqYUf/6zmXRafvzvdKLmA==
   dependencies:
     "@types/chroma-js" "^2.0.0"
     "@types/lodash" "^4.14.160"


### PR DESCRIPTION
## Summary

`eui@75.0.0` ⏩ `eui@75.1.0`

---

## [`75.1.0`](https://github.com/elastic/eui/tree/v75.1.0)

- Added padding to `EuiStep` title to better align with icon ([#6555](https://github.com/elastic/eui/pull/6555))
- Added a new `lineNumbers.annotations` API to `EuiCodeBlock`. This new feature displays an informational icon next to the specified line number(s), providing more context via popover ([#6580](https://github.com/elastic/eui/pull/6580))

**Bug fixes**

- Fixed bug in `EuiRange` where styles were applied incorrectly when custom ticks were passed but `showTicks` were false ([#6588](https://github.com/elastic/eui/pull/6588))
- Fixed `fleetApp` and `agentApp` icons that were swapped ([#6590](https://github.com/elastic/eui/pull/6590))

**CSS-in-JS conversions**

- Converted `EuiSteps` to Emotion; Removed `$euiStepStatusColorsToFade`, `$euiStepNumberSize`, `$euiStepNumberSmallSize`, and `$euiStepNumberMargin` ([#6555](https://github.com/elastic/eui/pull/6555))
