### PR TITLE
[Maps] fix Map crashes on field edit when hitting backspace key

### DIFF
--- a/x-pack/plugins/maps/public/classes/joins/inner_join.test.js
+++ b/x-pack/plugins/maps/public/classes/joins/inner_join.test.js
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { InnerJoin } from './inner_join';
+import { createJoinTermSource, InnerJoin } from './inner_join';
 import { SOURCE_TYPES } from '../../../common/constants';
 
 jest.mock('../../kibana_services', () => {});
@@ -38,8 +38,48 @@ const leftJoin = new InnerJoin(
 );
 const COUNT_PROPERTY_NAME = '__kbnjoin__count__d3625663-5b34-4d50-a784-0d743f676a0c';
 
+describe('createJoinTermSource', () => {
+  test('Should return undefined when descriptor is not provided', () => {
+    expect(createJoinTermSource(undefined)).toBe(undefined);
+  });
+
+  test('Should return undefined with unmatched source type', () => {
+    expect(createJoinTermSource({
+      type: SOURCE_TYPES.WMS,
+    })).toBe(undefined);
+  });
+
+  describe('EsTermSource', () => {
+    test('Should return EsTermSource', () => {
+      expect(createJoinTermSource(rightSource).constructor.name).toBe('ESTermSource');
+    });
+
+    test('Should return undefined when indexPatternId is undefined', () => {
+      expect(createJoinTermSource({
+        ...rightSource,
+        indexPatternId: undefined,
+      })).toBe(undefined);
+    });
+
+    test('Should return undefined when term is undefined', () => {
+      expect(createJoinTermSource({
+        ...rightSource,
+        term: undefined,
+      })).toBe(undefined);
+    });
+  });
+
+  describe('TableSource', () => {
+    test('Should return TableSource', () => {
+      expect(createJoinTermSource({
+        type: SOURCE_TYPES.TABLE_SOURCE
+      }).constructor.name).toBe('TableSource');
+    });
+  });
+});
+
 describe('joinPropertiesToFeature', () => {
-  it('Should add join property to features in feature collection', () => {
+  test('Should add join property to features in feature collection', () => {
     const feature = {
       properties: {
         iso2: 'CN',
@@ -59,7 +99,7 @@ describe('joinPropertiesToFeature', () => {
     });
   });
 
-  it('Should delete previous join property values from feature', () => {
+  test('Should delete previous join property values from feature', () => {
     const feature = {
       properties: {
         iso2: 'CN',
@@ -79,7 +119,7 @@ describe('joinPropertiesToFeature', () => {
     });
   });
 
-  it('Should coerce to string before joining', () => {
+  test('Should coerce to string before joining', () => {
     const leftJoin = new InnerJoin(
       {
         leftField: 'zipcode',
@@ -107,7 +147,7 @@ describe('joinPropertiesToFeature', () => {
     });
   });
 
-  it('Should handle undefined values', () => {
+  test('Should handle undefined values', () => {
     const feature = {
       //this feature does not have the iso2 field
       properties: {
@@ -127,7 +167,7 @@ describe('joinPropertiesToFeature', () => {
     });
   });
 
-  it('Should handle falsy values', () => {
+  test('Should handle falsy values', () => {
     const leftJoin = new InnerJoin(
       {
         leftField: 'code',

--- a/x-pack/plugins/maps/public/classes/joins/inner_join.test.js
+++ b/x-pack/plugins/maps/public/classes/joins/inner_join.test.js
@@ -44,9 +44,11 @@ describe('createJoinTermSource', () => {
   });
 
   test('Should return undefined with unmatched source type', () => {
-    expect(createJoinTermSource({
-      type: SOURCE_TYPES.WMS,
-    })).toBe(undefined);
+    expect(
+      createJoinTermSource({
+        type: SOURCE_TYPES.WMS,
+      })
+    ).toBe(undefined);
   });
 
   describe('EsTermSource', () => {
@@ -55,25 +57,31 @@ describe('createJoinTermSource', () => {
     });
 
     test('Should return undefined when indexPatternId is undefined', () => {
-      expect(createJoinTermSource({
-        ...rightSource,
-        indexPatternId: undefined,
-      })).toBe(undefined);
+      expect(
+        createJoinTermSource({
+          ...rightSource,
+          indexPatternId: undefined,
+        })
+      ).toBe(undefined);
     });
 
     test('Should return undefined when term is undefined', () => {
-      expect(createJoinTermSource({
-        ...rightSource,
-        term: undefined,
-      })).toBe(undefined);
+      expect(
+        createJoinTermSource({
+          ...rightSource,
+          term: undefined,
+        })
+      ).toBe(undefined);
     });
   });
 
   describe('TableSource', () => {
     test('Should return TableSource', () => {
-      expect(createJoinTermSource({
-        type: SOURCE_TYPES.TABLE_SOURCE
-      }).constructor.name).toBe('TableSource');
+      expect(
+        createJoinTermSource({
+          type: SOURCE_TYPES.TABLE_SOURCE,
+        }).constructor.name
+      ).toBe('TableSource');
     });
   });
 });

--- a/x-pack/plugins/maps/public/classes/joins/inner_join.ts
+++ b/x-pack/plugins/maps/public/classes/joins/inner_join.ts
@@ -26,7 +26,7 @@ import { PropertiesMap } from '../../../common/elasticsearch_util';
 import { ITermJoinSource } from '../sources/term_join_source';
 import { TableSource } from '../sources/table_source';
 
-function createJoinTermSource(
+export function createJoinTermSource(
   descriptor: Partial<TermJoinSourceDescriptor> | undefined
 ): ITermJoinSource | undefined {
   if (!descriptor) {
@@ -35,8 +35,8 @@ function createJoinTermSource(
 
   if (
     descriptor.type === SOURCE_TYPES.ES_TERM_SOURCE &&
-    'indexPatternId' in descriptor &&
-    'term' in descriptor
+    descriptor.indexPatternId !== undefined &&
+    descriptor.term !== undefined
   ) {
     return new ESTermSource(descriptor as ESTermSourceDescriptor);
   } else if (descriptor.type === SOURCE_TYPES.TABLE_SOURCE) {

--- a/x-pack/plugins/maps/public/classes/sources/es_term_source/es_term_source.ts
+++ b/x-pack/plugins/maps/public/classes/sources/es_term_source/es_term_source.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import _ from 'lodash';
 import { i18n } from '@kbn/i18n';
 import type { Query } from '@kbn/es-query';
 import { ISearchSource } from '@kbn/data-plugin/public';
@@ -42,7 +41,7 @@ type ESTermSourceSyncMeta = Pick<ESTermSourceDescriptor, 'indexPatternId' | 'siz
 
 export function extractPropertiesMap(rawEsData: any, countPropertyName: string): PropertiesMap {
   const propertiesMap: PropertiesMap = new Map<string, BucketProperties>();
-  const buckets: any[] = _.get(rawEsData, ['aggregations', TERMS_AGG_NAME, 'buckets'], []);
+  const buckets: any[] = rawEsData?.aggregations?.[TERMS_AGG_NAME]?.buckets ?? [];
   buckets.forEach((termBucket: any) => {
     const properties = extractPropertiesFromBucket(termBucket, TERMS_BUCKET_KEYS_TO_IGNORE);
     if (countPropertyName) {
@@ -83,7 +82,7 @@ export class ESTermSource extends AbstractESAggSource implements ITermJoinSource
   }
 
   hasCompleteConfig(): boolean {
-    return _.has(this._descriptor, 'indexPatternId') && _.has(this._descriptor, 'term');
+    return this._descriptor.indexPatternId !== undefined && this._descriptor.term !== undefined;
   }
 
   getTermField(): ESDocField {

--- a/x-pack/plugins/maps/public/connected_components/edit_layer_panel/join_editor/resources/join_expression.tsx
+++ b/x-pack/plugins/maps/public/connected_components/edit_layer_panel/join_editor/resources/join_expression.tsx
@@ -84,6 +84,14 @@ export class JoinExpression extends Component<Props, State> {
     this.props.onLeftFieldChange(_.get(selectedFields, '[0].value.name', null));
   };
 
+  _onRightFieldChange = (term?: string) => {
+    if (!term || term.length === 0) {
+      return;
+    }
+
+    this.props.onRightFieldChange(term);
+  };
+
   _renderLeftFieldSelect() {
     const { leftValue, leftFields } = this.props;
 
@@ -167,7 +175,7 @@ export class JoinExpression extends Component<Props, State> {
         <SingleFieldSelect
           placeholder={getSelectFieldPlaceholder()}
           value={this.props.rightValue}
-          onChange={this.props.onRightFieldChange}
+          onChange={this._onRightFieldChange}
           fields={getTermsFields(this.props.rightFields)}
           isClearable={false}
         />


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/151121

There were 2 issues
1) user could delete right field, putting layer in non-working state. To fix this, update handler is not called when selected value is undefined
2) createJoinTermSource guard was not working for `{ term: undefined }`. PR updated guard to properly handle this case.