### PR TITLE
[Fleet] Deleting a FleetProxy should bump related agent policies

### DIFF
--- a/x-pack/plugins/fleet/server/routes/fleet_proxies/handler.ts
+++ b/x-pack/plugins/fleet/server/routes/fleet_proxies/handler.ts
@@ -6,7 +6,11 @@
  */
 
 import type { RequestHandler } from '@kbn/core/server';
-import { SavedObjectsErrorHelpers } from '@kbn/core/server';
+import {
+  SavedObjectsErrorHelpers,
+  type SavedObjectsClientContract,
+  type ElasticsearchClient,
+} from '@kbn/core/server';
 import type { TypeOf } from '@kbn/config-schema';
 import pMap from 'p-map';
 
@@ -16,15 +20,51 @@ import {
   deleteFleetProxy,
   getFleetProxy,
   updateFleetProxy,
+  getFleetProxyRelatedSavedObjects,
 } from '../../services/fleet_proxies';
 import { defaultFleetErrorHandler } from '../../errors';
 import type {
   GetOneFleetProxyRequestSchema,
   PostFleetProxyRequestSchema,
   PutFleetProxyRequestSchema,
+  FleetServerHost,
+  Output,
 } from '../../types';
-import { listFleetServerHostsForProxyId } from '../../services/fleet_server_host';
-import { agentPolicyService, outputService } from '../../services';
+import { agentPolicyService } from '../../services';
+
+async function bumpRelatedPolicies(
+  soClient: SavedObjectsClientContract,
+  esClient: ElasticsearchClient,
+  fleetServerHosts: FleetServerHost[],
+  outputs: Output[]
+) {
+  if (
+    fleetServerHosts.some((host) => host.is_default) ||
+    outputs.some((output) => output.is_default || output.is_default_monitoring)
+  ) {
+    await agentPolicyService.bumpAllAgentPolicies(soClient, esClient);
+  } else {
+    await pMap(
+      outputs,
+      (output) => agentPolicyService.bumpAllAgentPoliciesForOutput(soClient, esClient, output.id),
+      {
+        concurrency: 20,
+      }
+    );
+    await pMap(
+      fleetServerHosts,
+      (fleetServerHost) =>
+        agentPolicyService.bumpAllAgentPoliciesForFleetServerHosts(
+          soClient,
+          esClient,
+          fleetServerHost.id
+        ),
+      {
+        concurrency: 20,
+      }
+    );
+  }
+}
 
 export const postFleetProxyHandler: RequestHandler<
   undefined,
@@ -64,36 +104,8 @@ export const putFleetProxyHandler: RequestHandler<
     };
 
     // Bump all the agent policy that use that proxy
-    const [{ items: fleetServerHosts }, { items: outputs }] = await Promise.all([
-      listFleetServerHostsForProxyId(soClient, proxyId),
-      outputService.listAllForProxyId(soClient, proxyId),
-    ]);
-    if (
-      fleetServerHosts.some((host) => host.is_default) ||
-      outputs.some((output) => output.is_default || output.is_default_monitoring)
-    ) {
-      await agentPolicyService.bumpAllAgentPolicies(soClient, esClient);
-    } else {
-      await pMap(
-        outputs,
-        (output) => agentPolicyService.bumpAllAgentPoliciesForOutput(soClient, esClient, output.id),
-        {
-          concurrency: 20,
-        }
-      );
-      await pMap(
-        fleetServerHosts,
-        (fleetServerHost) =>
-          agentPolicyService.bumpAllAgentPoliciesForFleetServerHosts(
-            soClient,
-            esClient,
-            fleetServerHost.id
-          ),
-        {
-          concurrency: 20,
-        }
-      );
-    }
+    const { fleetServerHosts, outputs } = await getFleetProxyRelatedSavedObjects(soClient, proxyId);
+    await bumpRelatedPolicies(soClient, esClient, fleetServerHosts, outputs);
 
     return response.ok({ body });
   } catch (error) {
@@ -109,6 +121,7 @@ export const putFleetProxyHandler: RequestHandler<
 
 export const getAllFleetProxyHandler: RequestHandler = async (context, request, response) => {
   const soClient = (await context.core).savedObjects.client;
+
   try {
     const res = await listFleetProxies(soClient);
     const body = {
@@ -128,9 +141,17 @@ export const deleteFleetProxyHandler: RequestHandler<
   TypeOf<typeof GetOneFleetProxyRequestSchema.params>
 > = async (context, request, response) => {
   try {
+    const proxyId = request.params.itemId;
     const coreContext = await context.core;
     const soClient = coreContext.savedObjects.client;
+    const esClient = coreContext.elasticsearch.client.asInternalUser;
+
+    const { fleetServerHosts, outputs } = await getFleetProxyRelatedSavedObjects(soClient, proxyId);
+
     await deleteFleetProxy(soClient, request.params.itemId);
+
+    await bumpRelatedPolicies(soClient, esClient, fleetServerHosts, outputs);
+
     const body = {
       id: request.params.itemId,
     };

--- a/x-pack/plugins/fleet/server/services/fleet_proxies.test.ts
+++ b/x-pack/plugins/fleet/server/services/fleet_proxies.test.ts
@@ -1,0 +1,155 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { savedObjectsClientMock } from '@kbn/core/server/mocks';
+
+import { FLEET_PROXY_SAVED_OBJECT_TYPE } from '../constants';
+
+import { deleteFleetProxy } from './fleet_proxies';
+import { listFleetServerHostsForProxyId, updateFleetServerHost } from './fleet_server_host';
+import { outputService } from './output';
+
+jest.mock('./output');
+jest.mock('./fleet_server_host');
+
+const mockedListFleetServerHostsForProxyId = listFleetServerHostsForProxyId as jest.MockedFunction<
+  typeof listFleetServerHostsForProxyId
+>;
+
+const mockedUpdateFleetServerHost = updateFleetServerHost as jest.MockedFunction<
+  typeof updateFleetServerHost
+>;
+
+const mockedOutputService = outputService as jest.Mocked<typeof outputService>;
+
+const PROXY_IDS = {
+  PRECONFIGURED: 'test-preconfigured',
+  RELATED_PRECONFIGURED: 'test-related-preconfigured',
+};
+
+describe('Fleet proxies service', () => {
+  const soClientMock = savedObjectsClientMock.create();
+
+  beforeEach(() => {
+    mockedOutputService.update.mockReset();
+    soClientMock.delete.mockReset();
+    mockedUpdateFleetServerHost.mockReset();
+    mockedOutputService.listAllForProxyId.mockImplementation(async (_, proxyId) => {
+      if (proxyId === PROXY_IDS.RELATED_PRECONFIGURED) {
+        return {
+          items: [
+            {
+              id: 'test',
+              is_preconfigured: true,
+              type: 'elasticsearch',
+              name: 'test',
+              proxy_id: proxyId,
+              is_default: false,
+              is_default_monitoring: false,
+            },
+          ],
+          total: 1,
+          page: 1,
+          perPage: 10,
+        };
+      }
+
+      return {
+        items: [],
+        total: 0,
+        page: 1,
+        perPage: 10,
+      };
+    });
+    mockedListFleetServerHostsForProxyId.mockImplementation(async (_, proxyId) => {
+      if (proxyId === PROXY_IDS.RELATED_PRECONFIGURED) {
+        return {
+          items: [
+            {
+              id: 'test',
+              is_preconfigured: true,
+              host_urls: ['http://test.fr'],
+              is_default: false,
+              name: 'test',
+              proxy_id: proxyId,
+            },
+          ],
+          total: 1,
+          page: 1,
+          perPage: 10,
+        };
+      }
+
+      return {
+        items: [],
+        total: 0,
+        page: 1,
+        perPage: 10,
+      };
+    });
+    soClientMock.get.mockImplementation(async (type, id) => {
+      if (type !== FLEET_PROXY_SAVED_OBJECT_TYPE) {
+        throw new Error(`${type} not mocked in SO client`);
+      }
+
+      if (id === PROXY_IDS.PRECONFIGURED) {
+        return {
+          id,
+          type,
+          attributes: {
+            is_preconfigured: true,
+          },
+          references: [],
+        };
+      }
+
+      if (id === PROXY_IDS.RELATED_PRECONFIGURED) {
+        return {
+          id,
+          type,
+          attributes: {
+            is_preconfigured: false,
+          },
+          references: [],
+        };
+      }
+
+      throw new Error(`${id} not found`);
+    });
+  });
+
+  describe('delete', () => {
+    it('should not allow to delete preconfigured proxy', async () => {
+      await expect(() =>
+        deleteFleetProxy(soClientMock, PROXY_IDS.PRECONFIGURED)
+      ).rejects.toThrowError(/Cannot delete test-preconfigured preconfigured proxy/);
+    });
+
+    it('should allow to delete preconfigured proxy with option fromPreconfiguration:true', async () => {
+      await deleteFleetProxy(soClientMock, PROXY_IDS.PRECONFIGURED, { fromPreconfiguration: true });
+
+      expect(soClientMock.delete).toBeCalled();
+    });
+
+    it('should not allow to delete proxy wiht related preconfigured saved object', async () => {
+      await expect(() =>
+        deleteFleetProxy(soClientMock, PROXY_IDS.RELATED_PRECONFIGURED)
+      ).rejects.toThrowError(
+        /Cannot delete a proxy used in a preconfigured fleet server hosts or output./
+      );
+    });
+
+    it('should allow to delete proxy wiht related preconfigured saved object option fromPreconfiguration:true', async () => {
+      await deleteFleetProxy(soClientMock, PROXY_IDS.RELATED_PRECONFIGURED, {
+        fromPreconfiguration: true,
+      });
+      expect(mockedOutputService.update).toBeCalled();
+      expect(mockedUpdateFleetServerHost).toBeCalled();
+      expect(soClientMock.delete).toBeCalled();
+    });
+  });
+});

--- a/x-pack/plugins/fleet/server/services/fleet_proxies.ts
+++ b/x-pack/plugins/fleet/server/services/fleet_proxies.ts
@@ -6,10 +6,21 @@
  */
 
 import type { SavedObjectsClientContract, SavedObject } from '@kbn/core/server';
+import { omit } from 'lodash';
+import pMap from 'p-map';
 
 import { FLEET_PROXY_SAVED_OBJECT_TYPE, SO_SEARCH_LIMIT } from '../constants';
 import { FleetProxyUnauthorizedError } from '../errors';
-import type { FleetProxy, FleetProxySOAttributes, NewFleetProxy } from '../types';
+import type {
+  FleetProxy,
+  FleetProxySOAttributes,
+  FleetServerHost,
+  NewFleetProxy,
+  Output,
+} from '../types';
+
+import { listFleetServerHostsForProxyId, updateFleetServerHost } from './fleet_server_host';
+import { outputService } from './output';
 
 function savedObjectToFleetProxy(so: SavedObject<FleetProxySOAttributes>): FleetProxy {
   const { proxy_headers: proxyHeaders, ...rest } = so.attributes;
@@ -79,14 +90,25 @@ export async function deleteFleetProxy(
   id: string,
   options?: { fromPreconfiguration?: boolean }
 ) {
-  const fleetServerHost = await getFleetProxy(soClient, id);
+  const fleetProxy = await getFleetProxy(soClient, id);
 
-  if (fleetServerHost.is_preconfigured && !options?.fromPreconfiguration) {
+  if (fleetProxy.is_preconfigured && !options?.fromPreconfiguration) {
     throw new FleetProxyUnauthorizedError(`Cannot delete ${id} preconfigured proxy`);
   }
+  const { outputs, fleetServerHosts } = await getFleetProxyRelatedSavedObjects(soClient, id);
 
-  // TODO remove from all outputs and fleet server
-  // await agentPolicyService.removeFleetServerHostFromAll(soClient, esClient, id);
+  if (
+    [...fleetServerHosts, ...outputs].some(
+      (fleetServerHostOrOutput) => fleetServerHostOrOutput.is_preconfigured
+    ) &&
+    !options?.fromPreconfiguration
+  ) {
+    throw new FleetProxyUnauthorizedError(
+      'Cannot delete a proxy used in a preconfigured fleet server hosts or output.'
+    );
+  }
+
+  await updateRelatedSavedObject(soClient, fleetServerHosts, outputs);
 
   return await soClient.delete(FLEET_PROXY_SAVED_OBJECT_TYPE, id);
 }
@@ -146,4 +168,47 @@ export async function bulkGetFleetProxies(
       (fleetProxyOrUndefined): fleetProxyOrUndefined is FleetProxy =>
         typeof fleetProxyOrUndefined !== 'undefined'
     );
+}
+
+async function updateRelatedSavedObject(
+  soClient: SavedObjectsClientContract,
+  fleetServerHosts: FleetServerHost[],
+  outputs: Output[]
+) {
+  await pMap(
+    fleetServerHosts,
+    (fleetServerHost) => {
+      updateFleetServerHost(soClient, fleetServerHost.id, {
+        ...omit(fleetServerHost, 'id'),
+        proxy_id: null,
+      });
+    },
+    { concurrency: 20 }
+  );
+
+  await pMap(
+    outputs,
+    (output) => {
+      outputService.update(soClient, output.id, {
+        ...omit(output, 'id'),
+        proxy_id: null,
+      });
+    },
+    { concurrency: 20 }
+  );
+}
+
+export async function getFleetProxyRelatedSavedObjects(
+  soClient: SavedObjectsClientContract,
+  proxyId: string
+) {
+  const [{ items: fleetServerHosts }, { items: outputs }] = await Promise.all([
+    listFleetServerHostsForProxyId(soClient, proxyId),
+    outputService.listAllForProxyId(soClient, proxyId),
+  ]);
+
+  return {
+    fleetServerHosts,
+    outputs,
+  };
 }


### PR DESCRIPTION
## Summary

Resolve #151204

Deleting a FleetProxy should bump related agent policies, and update related saved object (outputs, and fleetServerHosts)

This was missed during the implementation that PR fix that.

## Tests

I added some API integration that verify the policy send to Fleet Servetr (`.fleet-policies`) contains the expected change.

<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->