### PR TITLE
[build] Fix chromium install path

### DIFF
--- a/src/dev/build/tasks/install_chromium.js
+++ b/src/dev/build/tasks/install_chromium.js
@@ -39,7 +39,10 @@ export const InstallChromium = {
         log: log.write.bind(log),
       };
 
-      const path = build.resolvePathForPlatform(platform, 'x-pack/plugins/screenshotting/chromium');
+      const path = build.resolvePathForPlatform(
+        platform,
+        'node_modules/@kbn/screenshotting-plugin/chromium'
+      );
       await install(logger, pkg, path);
     }
   },


### PR DESCRIPTION
Fixes an issue introduced in 1b8581540295fde746dae6b4a09d74fb5821bfef

Currently during builds chromium is installed to the `x-pack/reporting` directory.  Under the new package management system plugins are installed in node_modules, and the reporting plugin is not able to find the path of chromium.  This patches the path.

Ideally we could install chromium before the plugin is installed as a package, but plugin installation is run once for all platforms, and later reporting is run for each platform.

https://buildkite.com/elastic/kibana-artifacts-snapshot/builds/1222