### PR TITLE
Enterprise Search: include search experiences engines side nav

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/shared/layout/nav.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/layout/nav.test.tsx
@@ -258,6 +258,11 @@ describe('useEnterpriseSearchContentNav Engines feature flag', () => {
             name: 'Engines',
             href: '/app/enterprise_search/content/engines',
           },
+          {
+            id: 'searchExperiences',
+            name: 'Search Experiences',
+            href: '/app/enterprise_search/search_experiences',
+          },
         ],
       },
       {
@@ -398,6 +403,11 @@ describe('useEnterpriseSearchEngineNav', () => {
             id: 'enterpriseSearchEngines',
             name: 'Engines',
             href: '/app/enterprise_search/content/engines',
+          },
+          {
+            id: 'searchExperiences',
+            name: 'Search Experiences',
+            href: '/app/enterprise_search/search_experiences',
           },
         ],
       },

--- a/x-pack/plugins/enterprise_search/public/applications/shared/layout/nav.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/layout/nav.tsx
@@ -179,6 +179,16 @@ export const useEnterpriseSearchNav = () => {
               to: ENTERPRISE_SEARCH_CONTENT_PLUGIN.URL + ENGINES_PATH,
             }),
           },
+          {
+            id: 'searchExperiences',
+            name: i18n.translate('xpack.enterpriseSearch.nav.searchExperiencesTitle', {
+              defaultMessage: 'Search Experiences',
+            }),
+            ...generateNavLink({
+              shouldNotCreateHref: true,
+              to: SEARCH_EXPERIENCES_PLUGIN.URL,
+            }),
+          },
         ],
         name: i18n.translate('xpack.enterpriseSearch.nav.searchTitle', {
           defaultMessage: 'Search',


### PR DESCRIPTION
## Summary

When initially implementing the updates side nav with the feature flagged Engines feature, we did not include Search Experiences in the nav.

Upon learning more about this page I think its best we keep it included in the nav as long as it's still included in the shortcut nav and has a guided onboarding step. We may still remove this before engines is released in 8.8, but we can remove it with those other usages as well then.

### Screenshots

![image](https://user-images.githubusercontent.com/1972968/218875418-f7543f8d-cabf-4f7e-b2ad-c7f393e1d348.png)


<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->