### PR TITLE
[Security Solution] Skips failing cypress tests on main

### DIFF
--- a/x-pack/plugins/security_solution/cypress/e2e/detection_rules/rules_table_persistent_state.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_rules/rules_table_persistent_state.cy.ts
@@ -28,7 +28,8 @@ function createRule(id: string, name: string, tags?: string[]): void {
   createCustomRule(rule, id);
 }
 
-describe('Persistent rules table state', () => {
+// Failing on `main`, skipping for now, to be addressed by security-detection-rules-area
+describe.skip('Persistent rules table state', () => {
   before(() => {
     cleanKibana();
 

--- a/x-pack/plugins/security_solution/cypress/e2e/urls/state.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/urls/state.cy.ts
@@ -274,7 +274,8 @@ describe('url state', () => {
       );
   });
 
-  it('Do not clears kql when navigating to a new page', () => {
+  // Failing on `main`, skipping for now, to be addressed by security-detection-rules-area
+  it.skip('Do not clears kql when navigating to a new page', () => {
     visitWithoutDateRange(ABSOLUTE_DATE_RANGE.urlKqlHostsHosts);
     kqlSearch('source.ip: "10.142.0.9"{enter}');
     navigateFromHeaderTo(NETWORK);


### PR DESCRIPTION
## Summary

Failing Security cypress tests on main. Skipping to unblock and @elastic/security-detections-response-rules will investigate and unskip.

Example failure: https://buildkite.com/elastic/kibana-pull-request/builds/108068#_

<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->