### PR TITLE
[SecuritySolutions] Fix show-top-n not rendered for some security fields

### DIFF
--- a/x-pack/plugins/security_solution/public/actions/add_to_timeline/cell_action/add_to_timeline.ts
+++ b/x-pack/plugins/security_solution/public/actions/add_to_timeline/cell_action/add_to_timeline.ts
@@ -18,7 +18,7 @@ import {
   ADD_TO_TIMELINE_ICON,
   ADD_TO_TIMELINE_SUCCESS_TITLE,
 } from '../constants';
-import { createDataProviders } from '../data_provider';
+import { createDataProviders, isValidDataProviderField } from '../data_provider';
 import { SecurityCellActionType } from '../../constants';
 import type { StartServices } from '../../../types';
 import type { SecurityCellAction } from '../../types';
@@ -38,7 +38,8 @@ export const createAddToTimelineCellActionFactory = createCellActionFactory(
       getIconType: () => ADD_TO_TIMELINE_ICON,
       getDisplayName: () => ADD_TO_TIMELINE,
       getDisplayNameTooltip: () => ADD_TO_TIMELINE,
-      isCompatible: async ({ field }) => fieldHasCellActions(field.name),
+      isCompatible: async ({ field }) =>
+        fieldHasCellActions(field.name) && isValidDataProviderField(field.name, field.type),
       execute: async ({ field, metadata }) => {
         const dataProviders =
           createDataProviders({

--- a/x-pack/plugins/security_solution/public/actions/add_to_timeline/data_provider.ts
+++ b/x-pack/plugins/security_solution/public/actions/add_to_timeline/data_provider.ts
@@ -85,7 +85,7 @@ export const createDataProviders = ({
       value ? `-${value}` : ''
     }`;
 
-    if (fieldType === GEO_FIELD_TYPE || field === MESSAGE_FIELD_NAME) {
+    if (!isValidDataProviderField(field, fieldType)) {
       return dataProviders;
     }
 
@@ -130,6 +130,9 @@ export const createDataProviders = ({
     return dataProviders;
   }, []);
 };
+
+export const isValidDataProviderField = (fieldName: string, fieldType: string | undefined) =>
+  fieldType !== GEO_FIELD_TYPE && fieldName !== MESSAGE_FIELD_NAME;
 
 const getIdForField = ({
   field,

--- a/x-pack/plugins/security_solution/public/explore/hosts/components/host_risk_score_table/columns.tsx
+++ b/x-pack/plugins/security_solution/public/explore/hosts/components/host_risk_score_table/columns.tsx
@@ -44,6 +44,7 @@ export const getHostRiskScoreColumns = ({
               name: 'host.name',
               value: hostName,
               type: 'keyword',
+              aggregatable: true,
             }}
           >
             <HostDetailsLink hostName={hostName} hostTab={HostsTableType.risk} />

--- a/x-pack/plugins/security_solution/public/explore/hosts/components/hosts_table/columns.tsx
+++ b/x-pack/plugins/security_solution/public/explore/hosts/components/hosts_table/columns.tsx
@@ -44,6 +44,7 @@ export const getHostsColumns = (
                 name: 'host.name',
                 value: hostName[0],
                 type: 'keyword',
+                aggregatable: true,
               }}
             >
               <HostDetailsLink hostName={hostName[0]} />

--- a/x-pack/plugins/security_solution/public/explore/network/components/network_dns_table/columns.tsx
+++ b/x-pack/plugins/security_solution/public/explore/network/components/network_dns_table/columns.tsx
@@ -50,6 +50,7 @@ export const getNetworkDnsColumns = (): NetworkDnsColumns => [
               name: 'dns.question.registered_domain',
               value: dnsName,
               type: 'keyword',
+              aggregatable: true,
             }}
           >
             {defaultToEmptyTag(dnsName)}

--- a/x-pack/plugins/security_solution/public/explore/network/components/network_top_countries_table/columns.tsx
+++ b/x-pack/plugins/security_solution/public/explore/network/components/network_top_countries_table/columns.tsx
@@ -68,6 +68,7 @@ export const getNetworkTopCountriesColumns = (
               name: geoAttr,
               value: geo,
               type: 'keyword',
+              aggregatable: true,
             }}
           >
             <CountryFlagAndName countryCode={geo} />

--- a/x-pack/plugins/security_solution/public/explore/network/components/network_top_n_flow_table/columns.tsx
+++ b/x-pack/plugins/security_solution/public/explore/network/components/network_top_n_flow_table/columns.tsx
@@ -92,7 +92,7 @@ export const getNetworkTopNFlowColumns = (
                 field={{
                   name: geoAttrName,
                   value: geo,
-                  type: 'geo_point',
+                  type: 'keyword',
                   aggregatable: true,
                 }}
               >

--- a/x-pack/plugins/security_solution/public/explore/network/components/network_top_n_flow_table/columns.tsx
+++ b/x-pack/plugins/security_solution/public/explore/network/components/network_top_n_flow_table/columns.tsx
@@ -76,6 +76,7 @@ export const getNetworkTopNFlowColumns = (
                 name: ipAttr,
                 value: ip,
                 type: 'keyword',
+                aggregatable: true,
               }}
             >
               <NetworkDetailsLink ip={ip} flowTarget={flowTarget} />
@@ -92,6 +93,7 @@ export const getNetworkTopNFlowColumns = (
                   name: geoAttrName,
                   value: geo,
                   type: 'geo_point',
+                  aggregatable: true,
                 }}
               >
                 {' '}

--- a/x-pack/plugins/security_solution/public/explore/users/components/user_risk_score_table/columns.tsx
+++ b/x-pack/plugins/security_solution/public/explore/users/components/user_risk_score_table/columns.tsx
@@ -47,6 +47,7 @@ export const getUserRiskScoreColumns = ({
               name: 'user.name',
               value: userName,
               type: 'keyword',
+              aggregatable: true,
             }}
           >
             <UserDetailsLink userName={userName} userTab={UsersTableType.risk} />


### PR DESCRIPTION
I went through every usage of `CellActions` and added the `aggregatable` prop back to fields that previously had it.

### Why?
When I created CellActions I removed `isAgreggatable` from some fields because every field with an aggregatable type would automatically display `showTopN`. But later, I discovered that this approach didn't work for some edge cases. I reintroduced the `isAgreggatable` prop but forgot to add `isAgreggatable` back to those fields I had previously removed it.

### Extra
It also fixes the network page country flag type from`geo_point` to `keyword` to fix a bug.
It also adds an extra check to add_to_timeline `isCompatible` function so it doesn't show for `geo_point` and `message` fields.

![Screenshot 2023-02-15 at 11 53 35](https://user-images.githubusercontent.com/1490444/219011030-c3be4cc4-c095-4b89-8a64-5e29d0b3ba1b.png)


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->