### PR TITLE
[Unified search] Add locale to the date picker

### DIFF
--- a/src/plugins/unified_search/public/query_string_input/query_bar_top_row.tsx
+++ b/src/plugins/unified_search/public/query_string_input/query_bar_top_row.tsx
@@ -405,6 +405,7 @@ export const QueryBarTopRow = React.memo(
             onRefreshChange={props.onRefreshChange}
             showUpdateButton={false}
             recentlyUsedRanges={recentlyUsedRanges}
+            locale={i18n.getLocale()}
             commonlyUsedRanges={commonlyUsedRanges}
             dateFormat={uiSettings.get('dateFormat')}
             isAutoRefreshOnly={showAutoRefreshOnly}


### PR DESCRIPTION
## Summary

Part of https://github.com/elastic/kibana/issues/151051
Passes the locale to the Date Picker Component

<img width="479" alt="image" src="https://user-images.githubusercontent.com/17003240/218985020-82046718-15bf-4684-8445-29db6c50a8f7.png">

<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->