### PR TITLE
[Cloud Security] Center evaluation badge text

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/components/csp_evaluation_badge.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/csp_evaluation_badge.tsx
@@ -8,6 +8,7 @@
 import React from 'react';
 import { EuiBadge, type EuiBadgeProps } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { css } from '@emotion/react';
 
 interface Props {
   type: 'passed' | 'failed';
@@ -15,7 +16,7 @@ interface Props {
 
 // 'fail' / 'pass' are same chars length, but not same width size.
 // 46px is used to make sure the badge is always the same width.
-const BADGE_WIDTH = 46;
+const BADGE_WIDTH = '46px';
 
 const getColor = (type: Props['type']): EuiBadgeProps['color'] => {
   if (type === 'passed') return 'success';
@@ -26,7 +27,11 @@ const getColor = (type: Props['type']): EuiBadgeProps['color'] => {
 export const CspEvaluationBadge = ({ type }: Props) => (
   <EuiBadge
     color={getColor(type)}
-    style={{ width: BADGE_WIDTH, textAlign: 'center' }}
+    css={css`
+      width: ${BADGE_WIDTH};
+      display: flex;
+      justify-content: center;
+    `}
     data-test-subj={`${type}_finding`}
   >
     {type === 'failed' ? (


### PR DESCRIPTION
## Summary
Quick wins Issue https://github.com/elastic/security-team/issues/6026

- centered text in evaluation badge
- replaced `style` prop with `css`

### Before
<img width="62" alt="image" src="https://user-images.githubusercontent.com/51442161/218991997-68af2725-87b0-4286-82f5-2c1fcbc07398.png">

### After
<img width="81" alt="image" src="https://user-images.githubusercontent.com/51442161/218991799-a17a1e1e-2de6-43bb-b3a6-dd01076b591a.png">
