### PR TITLE
[Cloud Security] Showing full `cloud.account.id` for cspm accounts

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/dashboard_sections/cluster_details_box.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/dashboard_sections/cluster_details_box.tsx
@@ -37,7 +37,7 @@ const getClusterTitle = (cluster: Cluster) => {
 
 const getClusterId = (cluster: Cluster) => {
   const assetIdentifierId = cluster.meta.assetIdentifierId;
-  if (cluster.meta.benchmark.posture_type === 'cspm') return assetIdentifierId.slice(0, 6);
+  if (cluster.meta.benchmark.posture_type === 'cspm') return assetIdentifierId;
   return assetIdentifierId.slice(0, 6);
 };
 

--- a/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/dashboard_sections/cluster_details_box.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/dashboard_sections/cluster_details_box.tsx
@@ -32,14 +32,20 @@ const defaultClusterTitle = i18n.translate(
 
 const getClusterTitle = (cluster: Cluster) => {
   if (cluster.meta.benchmark.posture_type === 'cspm') return cluster.meta.cloud?.account.name;
-  if (cluster.meta.benchmark.posture_type === 'kspm') return cluster.meta.cluster?.name;
+  return cluster.meta.cluster?.name;
+};
+
+const getClusterId = (cluster: Cluster) => {
+  const assetIdentifierId = cluster.meta.assetIdentifierId;
+  if (cluster.meta.benchmark.posture_type === 'cspm') return assetIdentifierId;
+  return assetIdentifierId.slice(0, 6);
 };
 
 export const ClusterDetailsBox = ({ cluster }: { cluster: Cluster }) => {
   const { euiTheme } = useEuiTheme();
   const navToFindings = useNavigateFindings();
 
-  const shortId = cluster.meta.assetIdentifierId.slice(0, 6);
+  const shortId = getClusterId(cluster);
   const title = getClusterTitle(cluster) || defaultClusterTitle;
 
   const handleClusterTitleClick = () => {

--- a/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/dashboard_sections/cluster_details_box.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/dashboard_sections/cluster_details_box.tsx
@@ -37,7 +37,7 @@ const getClusterTitle = (cluster: Cluster) => {
 
 const getClusterId = (cluster: Cluster) => {
   const assetIdentifierId = cluster.meta.assetIdentifierId;
-  if (cluster.meta.benchmark.posture_type === 'cspm') return assetIdentifierId;
+  if (cluster.meta.benchmark.posture_type === 'cspm') return assetIdentifierId.slice(0, 6);
   return assetIdentifierId.slice(0, 6);
 };
 
@@ -45,7 +45,7 @@ export const ClusterDetailsBox = ({ cluster }: { cluster: Cluster }) => {
   const { euiTheme } = useEuiTheme();
   const navToFindings = useNavigateFindings();
 
-  const shortId = getClusterId(cluster);
+  const assetId = getClusterId(cluster);
   const title = getClusterTitle(cluster) || defaultClusterTitle;
 
   const handleClusterTitleClick = () => {
@@ -66,10 +66,10 @@ export const ClusterDetailsBox = ({ cluster }: { cluster: Cluster }) => {
               <strong>
                 <FormattedMessage
                   id="xpack.csp.dashboard.benchmarkSection.clusterTitleTooltip.clusterTitle"
-                  defaultMessage="{title} - {shortId}"
+                  defaultMessage="{title} - {assetId}"
                   values={{
                     title,
-                    shortId,
+                    assetId,
                   }}
                 />
               </strong>
@@ -81,10 +81,10 @@ export const ClusterDetailsBox = ({ cluster }: { cluster: Cluster }) => {
               <h5>
                 <FormattedMessage
                   id="xpack.csp.dashboard.benchmarkSection.clusterTitle"
-                  defaultMessage="{title} - {shortId}"
+                  defaultMessage="{title} - {assetId}"
                   values={{
                     title,
-                    shortId,
+                    assetId,
                   }}
                 />
               </h5>

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -10022,8 +10022,6 @@
     "xpack.csp.benchmarks.benchmarkEmptyState.integrationsNotFoundForNameTitle": " 对于“{name}”",
     "xpack.csp.benchmarks.totalIntegrationsCountMessage": "正在显示 {pageCount}/{totalCount, plural, other {# 个集成}}",
     "xpack.csp.cloudPosturePage.errorRenderer.errorDescription": "{error} {statusCode}：{body}",
-    "xpack.csp.dashboard.benchmarkSection.clusterTitle": "{title} - {shortId}",
-    "xpack.csp.dashboard.benchmarkSection.clusterTitleTooltip.clusterTitle": "{title} - {shortId}",
     "xpack.csp.dashboard.benchmarkSection.lastEvaluatedTitle": "上次评估于 {dateFromNow}",
     "xpack.csp.findings.distributionBar.showingPageOfTotalLabel": "正在显示第 {pageStart}-{pageEnd} 个（共 {total} 个）{type}",
     "xpack.csp.findings.findingsTableCell.addFilterButton": "添加 {field} 筛选",


### PR DESCRIPTION
## Summary
Quick wins Issue https://github.com/elastic/security-team/issues/6026

- now showing full `cloud.account.id` on cspm findings
- removed reliance on `posture_type === 'kspm'` for kspm findings (for this part only)
---
### Before
![image](https://user-images.githubusercontent.com/51442161/219003956-c605bf32-833f-4fd3-a5ca-0c64293cde00.png)
---
### After
![image](https://user-images.githubusercontent.com/51442161/219003867-77782e09-8e55-4186-aa33-95cbe05cf15a.png)