### PR TITLE
[ML] Fix module setup apply to all spaces

### DIFF
--- a/x-pack/plugins/ml/server/shared_services/providers/modules.ts
+++ b/x-pack/plugins/ml/server/shared_services/providers/modules.ts
@@ -112,7 +112,8 @@ export function getModulesProvider(
                 payload.end,
                 payload.jobOverrides,
                 payload.datafeedOverrides,
-                payload.estimateModelMemory
+                payload.estimateModelMemory,
+                payload.applyToAllSpaces
               );
             });
         },


### PR DESCRIPTION
The shared module setup function is not passing across the `applyToAllSpaces` parameter.
This only affects plugins calling `setup` via the server side shared function, not the ML plugin itself or any plugins calling the kibana endpoint.

<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->