### PR TITLE
[ftr/journeys] allow override ftr base config in journey

### DIFF
--- a/packages/kbn-journeys/journey/journey_config.ts
+++ b/packages/kbn-journeys/journey/journey_config.ts
@@ -71,6 +71,11 @@ export interface ScalabilitySetup {
 
 export interface JourneyConfigOptions<CtxExt> {
   /**
+   * Relative path to FTR config file. Use to override the default ones:
+   * 'x-pack/test/functional/config.base.js', 'test/functional/config.base.js'
+   */
+  ftrConfigPath?: string;
+  /**
    * Set to `true` to skip this journey. should probably be preceded
    * by a link to a Github issue where the reasoning for why this was
    * skipped and not just deleted is outlined.
@@ -120,6 +125,10 @@ export class JourneyConfig<CtxExt extends object> {
     this.#path = path;
     this.#name = Path.basename(this.#path, Path.extname(this.#path));
     this.#opts = opts;
+  }
+
+  getFtrConfigPath() {
+    return this.#opts.ftrConfigPath;
   }
 
   getEsArchives() {

--- a/packages/kbn-journeys/journey/journey_ftr_config.ts
+++ b/packages/kbn-journeys/journey/journey_ftr_config.ts
@@ -25,16 +25,12 @@ export function makeFtrConfigProvider(
   steps: AnyStep[]
 ): FtrConfigProvider {
   return async ({ readConfigFile }: FtrConfigProviderContext) => {
-    const baseConfig = (
-      await readConfigFile(
-        Path.resolve(
-          REPO_ROOT,
-          config.isXpack()
-            ? 'x-pack/test/functional/config.base.js'
-            : 'test/functional/config.base.js'
-        )
-      )
-    ).getAll();
+    const configPath = config.getFtrConfigPath();
+    const defaultConfigPath = config.isXpack()
+      ? 'x-pack/test/functional/config.base.js'
+      : 'test/functional/config.base.js';
+    const ftrConfigPath = configPath ?? defaultConfigPath;
+    const baseConfig = (await readConfigFile(Path.resolve(REPO_ROOT, ftrConfigPath))).getAll();
 
     const testBuildId = process.env.BUILDKITE_BUILD_ID ?? `local-${uuidV4()}`;
     const testJobId = process.env.BUILDKITE_JOB_ID ?? `local-${uuidV4()}`;


### PR DESCRIPTION
## Summary

Currently journeys use pre-defined base FTR config and there is no way to re-configure Kibana to be loaded with extras, e.g. Fleet plugin configuration.
https://github.com/elastic/kibana/blob/f443109eeae6af9873e39f16b53825941690c3be/packages/kbn-journeys/journey/journey_ftr_config.ts#L32-L34

Probably the easiest way to address it is to path custom FTR config directly in the journey.

```
export const journey = new Journey({
  ftrConfigPath: 'x-pack/test/cloud_security_posture_api/config.ts',
  ...
})
```


It can be also considered as a step towards using journeys as future alternative to Webdriver functional tests.

<!--ONMERGE {"backportTargets":["8.6","8.7"]} ONMERGE-->