### PR TITLE
[APM] Make `service.name` required in `AnnotationsContextProvider`

### DIFF
--- a/x-pack/plugins/apm/public/components/app/mobile/transaction_overview/transaction_charts.tsx
+++ b/x-pack/plugins/apm/public/components/app/mobile/transaction_overview/transaction_charts.tsx
@@ -36,6 +36,7 @@ export function MobileTransactionCharts({
 }) {
   return (
     <AnnotationsContextProvider
+      serviceName={serviceName}
       environment={environment}
       start={start}
       end={end}

--- a/x-pack/plugins/apm/public/components/app/transaction_details/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/transaction_details/index.tsx
@@ -35,8 +35,12 @@ export function TransactionDetails() {
   } = query;
   const { start, end } = useTimeRange({ rangeFrom, rangeTo });
   const apmRouter = useApmRouter();
-  const { transactionType, fallbackToTransactions, serverlessType } =
-    useApmServiceContext();
+  const {
+    transactionType,
+    fallbackToTransactions,
+    serverlessType,
+    serviceName,
+  } = useApmServiceContext();
 
   const history = useHistory();
 
@@ -71,6 +75,7 @@ export function TransactionDetails() {
 
       <ChartPointerEventContextProvider>
         <TransactionCharts
+          serviceName={serviceName}
           kuery={query.kuery}
           environment={query.environment}
           start={start}

--- a/x-pack/plugins/apm/public/components/app/transaction_overview/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/transaction_overview/index.tsx
@@ -32,8 +32,12 @@ export function TransactionOverview() {
 
   const { start, end } = useTimeRange({ rangeFrom, rangeTo });
 
-  const { transactionType, fallbackToTransactions, serverlessType } =
-    useApmServiceContext();
+  const {
+    transactionType,
+    fallbackToTransactions,
+    serverlessType,
+    serviceName,
+  } = useApmServiceContext();
 
   const history = useHistory();
 
@@ -57,6 +61,7 @@ export function TransactionOverview() {
         </>
       )}
       <TransactionCharts
+        serviceName={serviceName}
         kuery={kuery}
         environment={environment}
         start={start}

--- a/x-pack/plugins/apm/public/components/shared/charts/transaction_charts/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/charts/transaction_charts/index.tsx
@@ -28,6 +28,7 @@ export function TransactionCharts({
   environment,
   start,
   end,
+  serviceName,
   transactionName,
   isServerlessContext,
   comparisonEnabled,
@@ -37,6 +38,7 @@ export function TransactionCharts({
   environment: string;
   start: string;
   end: string;
+  serviceName: string;
   transactionName?: string;
   isServerlessContext?: boolean;
   comparisonEnabled?: boolean;
@@ -88,6 +90,7 @@ export function TransactionCharts({
   return (
     <>
       <AnnotationsContextProvider
+        serviceName={serviceName}
         environment={environment}
         start={start}
         end={end}

--- a/x-pack/plugins/apm/public/context/annotations/annotations_context.tsx
+++ b/x-pack/plugins/apm/public/context/annotations/annotations_context.tsx
@@ -17,16 +17,16 @@ const INITIAL_STATE = { annotations: [] };
 
 export function AnnotationsContextProvider({
   children,
+  serviceName,
   environment,
   start,
   end,
-  serviceName,
 }: {
   children: React.ReactNode;
+  serviceName: string;
   environment: string;
   start: string;
   end: string;
-  serviceName?: string;
 }) {
   const { data = INITIAL_STATE } = useFetcher(
     (callApmApi) => {


### PR DESCRIPTION
`service.name` was not being passed to `AnnotationsContextProvider` in the `TransactionCharts`. I don't think that was intentional (@dgieselaar?). Afaict `service.name` should be required so we don't forget to pass it.

The result of this change is that annotations will show up on transaction charts (they didn't show up before)