### PR TITLE
[Cloud Security] Fix CSP pages remount

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/plugin.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/plugin.tsx
@@ -67,19 +67,21 @@ export class CspPlugin
       Component: LazyCspCustomAssets,
     });
 
+    // Keep as constant to prevent remounts https://github.com/elastic/kibana/issues/146773
+    const App = (props: CspRouterProps) => (
+      <KibanaContextProvider services={{ ...core, ...plugins }}>
+        <RedirectAppLinks coreStart={core}>
+          <div style={{ width: '100%', height: '100%' }}>
+            <SetupContext.Provider value={{ isCloudEnabled: this.isCloudEnabled }}>
+              <CspRouter {...props} />
+            </SetupContext.Provider>
+          </div>
+        </RedirectAppLinks>
+      </KibanaContextProvider>
+    );
+
     return {
-      getCloudSecurityPostureRouter: () => (props: CspRouterProps) =>
-        (
-          <KibanaContextProvider services={{ ...core, ...plugins }}>
-            <RedirectAppLinks coreStart={core}>
-              <div style={{ width: '100%', height: '100%' }}>
-                <SetupContext.Provider value={{ isCloudEnabled: this.isCloudEnabled }}>
-                  <CspRouter {...props} />
-                </SetupContext.Provider>
-              </div>
-            </RedirectAppLinks>
-          </KibanaContextProvider>
-        ),
+      getCloudSecurityPostureRouter: () => App,
     };
   }
 


### PR DESCRIPTION
Resolves #146773
Quick wins Issue https://github.com/elastic/security-team/issues/6026

## Summary

All the needed details can be found in the issue, thank you @orouz for the research and solution, and also for even noticing it in the first place.

Please watch the video to see the impact, before the fix is applied our `useEffects` are essentially broken, getting called multiple times even though there are no variables in the dependency list. After the fix they are working as intended. Since we worked like that for quite some time, there might be some bugs that will start to show up now, might be better to wait for 8.8 to have a longer test period.

https://user-images.githubusercontent.com/51442161/219026109-a76b6d7d-4304-4ca2-b817-0880310c7c9b.mov

