### PR TITLE
[Security Solution] Fix rules filtering after enabling/disabling a rule

### DIFF
--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/api/hooks/use_bulk_action_mutation.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/api/hooks/use_bulk_action_mutation.ts
@@ -54,7 +54,13 @@ export const useBulkActionMutation = (
         case BulkActionType.enable:
         case BulkActionType.disable: {
           invalidateFetchRuleByIdQuery();
-          invalidateFindRulesQuery();
+          if (updatedRules) {
+            // We have a list of updated rules, no need to invalidate all
+            updateRulesCache(updatedRules);
+          } else {
+            // We failed to receive the list of update rules, invalidate all
+            invalidateFindRulesQuery();
+          }
           break;
         }
         case BulkActionType.delete:

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/api/hooks/use_bulk_action_mutation.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/api/hooks/use_bulk_action_mutation.ts
@@ -54,13 +54,7 @@ export const useBulkActionMutation = (
         case BulkActionType.enable:
         case BulkActionType.disable: {
           invalidateFetchRuleByIdQuery();
-          if (updatedRules) {
-            // We have a list of updated rules, no need to invalidate all
-            updateRulesCache(updatedRules);
-          } else {
-            // We failed to receive the list of update rules, invalidate all
-            invalidateFindRulesQuery();
-          }
+          invalidateFindRulesQuery();
           break;
         }
         case BulkActionType.delete:

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/api/hooks/use_fetch_rule_by_id_query.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/api/hooks/use_fetch_rule_by_id_query.ts
@@ -35,6 +35,9 @@ export const useFetchRuleByIdQuery = (id: string, options?: UseQueryOptions<Rule
     {
       ...DEFAULT_QUERY_OPTIONS,
       ...options,
+      // Mark this query as immediately stale helps to avoid problems related to filtering.
+      // e.g. enabled and disabled state filter require data update which happens at the backend side
+      staleTime: 0,
       enabled: !!id,
     }
   );

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/api/hooks/use_find_rules_query.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/api/hooks/use_find_rules_query.ts
@@ -54,6 +54,8 @@ export const useFindRulesQuery = (
     },
     {
       ...DEFAULT_QUERY_OPTIONS,
+      // Mark this query as immediately stale helps to avoid problems related to filtering.
+      // e.g. enabled and disabled state filter require data update which happens at the backend side
       staleTime: 0,
       ...queryOptions,
     }

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/api/hooks/use_find_rules_query.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/api/hooks/use_find_rules_query.ts
@@ -54,6 +54,7 @@ export const useFindRulesQuery = (
     },
     {
       ...DEFAULT_QUERY_OPTIONS,
+      staleTime: 0,
       ...queryOptions,
     }
   );


### PR DESCRIPTION
**Addresses:** https://github.com/elastic/kibana/issues/151151

## Summary

It fixes rules filtering after enabling or disabling a rule.

### Details

The problem is caused by improper cache invalidation. Rules cache used to be modified upon enabling or disabling one or more rules but it started causing troubles after introduction a filter by enabled or disabled state. Cached rules modification is  is complex and bug prone especially taking into account it will need to mirror backend logic and further plans on extending rule filers. So the simplest solution is invalidation of the whole rules cache. Though it may also lead to unfriendly UX when disabled or enabled rules "jump" in the table. The best approach is marking find rule request cached data as stale so data is refetched each time use changes filter state, sort by field or use pagination.

**Before:**

https://user-images.githubusercontent.com/1938181/218776621-f8903a88-1685-4a2c-9074-02fac0623dc4.mov

**After:**

https://user-images.githubusercontent.com/3775283/219630525-af109575-3a01-4988-bb6b-690473d33b80.mov


### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

