### PR TITLE
Remove unused react-syntax-highlighter resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,8 +86,6 @@
     "**/minimatch": "^3.1.2",
     "**/minimist": "^1.2.6",
     "**/pdfkit/crypto-js": "4.0.0",
-    "**/react-syntax-highlighter": "^15.3.1",
-    "**/react-syntax-highlighter/**/highlight.js": "^10.4.1",
     "**/refractor/prismjs": "~1.27.0",
     "**/trim": "1.0.1",
     "**/typescript": "4.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17089,7 +17089,7 @@ heap@^0.2.6:
   resolved "https://registry.yarnpkg.com/heap/-/heap-0.2.6.tgz#087e1f10b046932fc8594dd9e6d378afc9d1e5ac"
   integrity sha1-CH4fELBGky/IWU3Z5tN4r8nR5aw=
 
-highlight.js@^10.1.1, highlight.js@^10.4.1, highlight.js@~10.4.0:
+highlight.js@^10.1.1, highlight.js@~10.4.0:
   version "10.4.1"
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.4.1.tgz#d48fbcf4a9971c4361b3f95f302747afe19dbad0"
   integrity sha512-yR5lWvNz7c85OhVAEAeFhVCc/GV4C30Fjzc/rCP0aCWzc1UUOPUk55dK/qdwTZHBvMZo+eZ2jpk62ndX/xMFlg==


### PR DESCRIPTION
This resolution was no longer needed as all (sub)dependencies that required this had since been upgraded or removed.

<!--ONMERGE {"backportTargets":["7.17","8.7"]} ONMERGE-->