### PR TITLE
Render the correct form when edit extraction rules

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/crawler_domain_detail/extraction_rules/extraction_rules_logic.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/crawler_domain_detail/extraction_rules/extraction_rules_logic.tsx
@@ -294,7 +294,7 @@ export const ExtractionRulesLogic = kea<
       },
     ],
     fieldRuleToEditIsNew: [
-      true,
+      false,
       {
         closeEditRuleFlyout: () => true,
         openEditRuleFlyout: (_, { isNewRule }) => isNewRule,


### PR DESCRIPTION
## Summary

The wrong form (`create` instead of `edit`) is being rendered when I try to modify an extraction rule. 
