### PR TITLE
[Cloud Security] Close rule flyout on outside click

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_flyout.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_flyout.tsx
@@ -55,6 +55,7 @@ export const RuleFlyout = ({ onClose, rule }: RuleFlyoutProps) => {
       ownFocus={false}
       onClose={onClose}
       data-test-subj={TEST_SUBJECTS.CSP_RULES_FLYOUT_CONTAINER}
+      outsideClickCloses
     >
       <EuiFlyoutHeader>
         <EuiTitle size="l">


### PR DESCRIPTION
## Summary
Quick wins Issue https://github.com/elastic/security-team/issues/6026

- Rules flyout closes on outside click

https://user-images.githubusercontent.com/51442161/219057449-f243e521-a064-474b-a21e-ab30d7de28dc.mov

