### PR TITLE
[Osquery] Fix logic responsible for retrieving agent policies in Live…

### DIFF
--- a/x-pack/plugins/osquery/server/routes/fleet_wrapper/get_package_policies.ts
+++ b/x-pack/plugins/osquery/server/routes/fleet_wrapper/get_package_policies.ts
@@ -29,6 +29,7 @@ export const getPackagePoliciesRoute = (router: IRouter, osqueryContext: Osquery
       const packagePolicyService = osqueryContext.service.getPackagePolicyService();
       const policies = await packagePolicyService?.list(internalSavedObjectsClient, {
         kuery,
+        perPage: 1000,
       });
 
       return response.ok({


### PR DESCRIPTION
… query form

## Summary

> Agents dropdown menu non populating any fields when clicking on it .When reviewing the response we can see that it is limited to 20 items(check video) .The cause is due to customer  recently creating more than 20 agent policies with each a package policy. However there aren't any agents yet associated with those agent policies.Customer have tested removing the agent policies and this results in the Agents dropdown field being able to populate.
You don't need to delete all of the agent policies to enable the field to populate. You can delete just one and then it might work depending on the order of items returned. Customer have 40 agent policies with each their own package policy plus the additional 2 out of the box policies that contain an agent. When we look at the package_policies response in the dev tools I can see that the response contains 1 page with 20 items perPage. Depending on the returned response and if this response contains an agent sometimes the field will populate. When customer delete an agent policy's package  sometimes the package_policy will be on the first page and then the Agents dropdown field will populate.
It all depends on whether or not the package_policy which contains an agent is on the first page or not. The dropdown field doesn’t account for pages past the first one. Once customer  add back an agent_policy with a package_policy you can see that dropdown remains empty because the response doesn’t account for anything past the first page.

[osquery-bug.webm](https://user-images.githubusercontent.com/5188868/219403169-4acdd4a8-2b39-4249-8775-962a688f8cc0.webm)

![2023-02-01 16_42_46-New - Live queries - Osquery - Elastic](https://user-images.githubusercontent.com/5188868/219403579-eedaf424-a291-4db2-aa22-65d4f6c05afd.png)

![2023-02-01 16_49_04-New - Live queries - Osquery - Elastic](https://user-images.githubusercontent.com/5188868/219403630-4bf0cd57-e0ae-4a75-87f9-5121d57fadfb.png)



<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->