### PR TITLE
[Files] Add missing interface

### DIFF
--- a/packages/shared-ux/file/types/index.d.ts
+++ b/packages/shared-ux/file/types/index.d.ts
@@ -23,6 +23,19 @@ export type FileStatus = 'AWAITING_UPLOAD' | 'UPLOADING' | 'READY' | 'UPLOAD_ERR
  */
 export type FileCompression = 'br' | 'gzip' | 'deflate' | 'none';
 
+/** Definition for an endpoint that the File's service will generate */
+interface HttpEndpointDefinition {
+  /**
+   * Specify the tags for this endpoint.
+   *
+   * @example
+   * // This will enable access control to this endpoint for users that can access "myApp" only.
+   * { tags: ['access:myApp'] }
+   *
+   */
+  tags: string[];
+}
+
 /**
  * File metadata fields are defined per the ECS specification:
  *


### PR DESCRIPTION
## Summary

Part of https://github.com/elastic/kibana/pull/146284 it looks like the `HttpEndpointDefinition` interface was accidentally deleted. Due to the transient/cross file nature of `.d.ts` file this was not marked as an issue by TS.