### PR TITLE
[Cloud Security] Add CTA to `findings delayed` state

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/components/no_findings_states.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/no_findings_states.tsx
@@ -122,10 +122,7 @@ const IndexTimeout = () => (
           defaultMessage="Collecting findings is taking longer than expected, please review our {docs} or reach out to support"
           values={{
             docs: (
-              <EuiLink
-                href="https://www.elastic.co/guide/en/security/current/cloud-native-security-overview.html"
-                target="_blank"
-              >
+              <EuiLink href="https://ela.st/findings" target="_blank">
                 <FormattedMessage
                   id="xpack.csp.noFindingsStates.indexTimeout.indexTimeoutDocLink"
                   defaultMessage="docs"

--- a/x-pack/plugins/cloud_security_posture/public/components/no_findings_states.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/no_findings_states.tsx
@@ -122,7 +122,10 @@ const IndexTimeout = () => (
           defaultMessage="Collecting findings is taking longer than expected, please review our {docs} or reach out to support"
           values={{
             docs: (
-              <EuiLink href="https://ela.st/kspm" target="_blank">
+              <EuiLink
+                href="https://www.elastic.co/guide/en/security/current/cloud-native-security-overview.html"
+                target="_blank"
+              >
                 <FormattedMessage
                   id="xpack.csp.noFindingsStates.indexTimeout.indexTimeoutDocLink"
                   defaultMessage="docs"

--- a/x-pack/plugins/cloud_security_posture/public/components/no_findings_states.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/no_findings_states.tsx
@@ -12,6 +12,7 @@ import {
   EuiEmptyPrompt,
   EuiIcon,
   EuiMarkdownFormat,
+  EuiLink,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
@@ -118,7 +119,17 @@ const IndexTimeout = () => (
       <p>
         <FormattedMessage
           id="xpack.csp.noFindingsStates.indexTimeout.indexTimeoutDescription"
-          defaultMessage="Collecting findings is taking longer than expected, check back again soon"
+          defaultMessage="Collecting findings is taking longer than expected, please review our {docs} or reach out to support"
+          values={{
+            docs: (
+              <EuiLink href="https://ela.st/kspm" target="_blank">
+                <FormattedMessage
+                  id="xpack.csp.noFindingsStates.indexTimeout.indexTimeoutDocLink"
+                  defaultMessage="docs"
+                />
+              </EuiLink>
+            ),
+          }}
         />
       </p>
     }

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -10147,7 +10147,6 @@
     "xpack.csp.navigation.rulesNavItemLabel": "规则",
     "xpack.csp.noFindingsStates.indexing.indexingButtonTitle": "尚无结果",
     "xpack.csp.noFindingsStates.indexing.indexingDescription": "正在等待要收集和索引的数据。请稍后返回检查以查看结果",
-    "xpack.csp.noFindingsStates.indexTimeout.indexTimeoutDescription": "收集结果所需的时间长于预期，请稍后再回来检查",
     "xpack.csp.noFindingsStates.indexTimeout.indexTimeoutTitle": "已推迟结果",
     "xpack.csp.noFindingsStates.noAgentsDeployed.noAgentsDeployedButtonTitle": "安装代理",
     "xpack.csp.noFindingsStates.noAgentsDeployed.noAgentsDeployedDescription": "要查看结果，请通过在 Kubernetes 集群上安装 Elastic 代理来完成设置过程。",


### PR DESCRIPTION
## Summary
Quick wins Issue https://github.com/elastic/security-team/issues/6026

- Findings delayed prompt now has better text
- Added doc link, opens in a new window

https://user-images.githubusercontent.com/51442161/219067040-39389774-cdc7-4670-aee0-7c750e5e7ef9.mov

**NOTE:** link was changed from what is seen in the video.
linking to: https://ela.st/findings