### PR TITLE
[Security Solution] Remove unsafe cast in filter action

### DIFF
--- a/x-pack/plugins/security_solution/public/actions/filter/helpers.ts
+++ b/x-pack/plugins/security_solution/public/actions/filter/helpers.ts
@@ -34,9 +34,11 @@ export const createFilter = (
           },
         },
       }
-    : ({
-        exists: {
-          field: key,
+    : {
+        query: {
+          exists: {
+            field: key,
+          },
         },
         meta: {
           alias: null,
@@ -46,5 +48,5 @@ export const createFilter = (
           type: 'exists',
           value: 'exists',
         },
-      } as Filter);
+      };
 };


### PR DESCRIPTION
## Summary

This removes an unsafe cast, which I think would only be a problem in some esoteric scenarios where the values in Filter.meta do not match Filter.query, but which are a thing occasionally as mentioned in https://github.com/elastic/kibana/issues/149020



