### PR TITLE
[Cloud Security] Minor text fixes

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/pages/benchmarks/benchmarks.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/benchmarks/benchmarks.tsx
@@ -126,7 +126,7 @@ const BenchmarkSearchField = ({
           isLoading={isLoading}
           placeholder={i18n.translate(
             'xpack.csp.benchmarks.benchmarkSearchField.searchPlaceholder',
-            { defaultMessage: 'Search integration name' }
+            { defaultMessage: 'Search by Integration Name' }
           )}
           incremental
         />

--- a/x-pack/plugins/cloud_security_posture/public/pages/benchmarks/benchmarks_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/benchmarks/benchmarks_table.tsx
@@ -159,7 +159,7 @@ const BENCHMARKS_TABLE_COLUMNS: Array<EuiBasicTableColumn<Benchmark>> = [
   {
     field: 'package_policy.created_at',
     name: i18n.translate('xpack.csp.benchmarks.benchmarksTable.createdAtColumnTitle', {
-      defaultMessage: 'Created at',
+      defaultMessage: 'Created',
     }),
     dataType: 'date',
     truncateText: true,

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table_header.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table_header.tsx
@@ -36,7 +36,7 @@ const SearchField = ({
       <EuiFieldSearch
         isLoading={isSearching}
         placeholder={i18n.translate('xpack.csp.rules.rulesTable.searchPlaceholder', {
-          defaultMessage: 'Search for a specific rule name',
+          defaultMessage: 'Search by Rule Name',
         })}
         value={localValue}
         onChange={(e) => setLocalValue(e.target.value)}


### PR DESCRIPTION
## Summary

- Rule and Benchmark table now have that same placeholder structure: `Search by X`
- `Created At` column was renamed to `Created` at the Benchmarks table