### PR TITLE
[Draft] Fix flaky tests by not running registry in docker

### DIFF
--- a/.buildkite/pipelines/pull_request/security_solution.yml
+++ b/.buildkite/pipelines/pull_request/security_solution.yml
@@ -5,7 +5,7 @@ steps:
       queue: n2-4-spot
     depends_on: build
     timeout_in_minutes: 120
-    parallelism: 4
+    parallelism: 8
     retry:
       automatic:
         - exit_status: '-1'

--- a/.buildkite/scripts/pipelines/pull_request/pipeline.ts
+++ b/.buildkite/scripts/pipelines/pull_request/pipeline.ts
@@ -69,6 +69,8 @@ const uploadPipeline = (pipelineContent: string | object) => {
         /^x-pack\/test\/defend_workflows_cypress/,
         /^x-pack\/test\/security_solution_cypress/,
         /^fleet_packages\.json/, // It contains reference to prebuilt detection rules, we want to run security solution tests if it changes
+        /^package\.json/,
+        /^packages\/*/,
       ])) ||
       GITHUB_PR_LABELS.includes('ci:all-cypress-suites')
     ) {

--- a/x-pack/test/security_solution_endpoint/apps/endpoint/index.ts
+++ b/x-pack/test/security_solution_endpoint/apps/endpoint/index.ts
@@ -5,12 +5,7 @@
  * 2.0.
  */
 
-import { getRegistryUrl as getRegistryUrlFromIngest } from '@kbn/fleet-plugin/server';
 import { FtrProviderContext } from '../../ftr_provider_context';
-import {
-  isRegistryEnabled,
-  getRegistryUrlFromTestEnv,
-} from '../../../security_solution_endpoint_api_int/registry';
 
 export default function (providerContext: FtrProviderContext) {
   const { loadTestFile, getService } = providerContext;
@@ -19,13 +14,6 @@ export default function (providerContext: FtrProviderContext) {
     const ingestManager = getService('ingestManager');
     const log = getService('log');
     const endpointTestResources = getService('endpointTestResources');
-
-    if (!isRegistryEnabled()) {
-      log.warning('These tests are being run with an external package registry');
-    }
-
-    const registryUrl = getRegistryUrlFromTestEnv() ?? getRegistryUrlFromIngest();
-    log.info(`Package registry URL for tests: ${registryUrl}`);
 
     before(async () => {
       log.info('calling Fleet setup');

--- a/x-pack/test/security_solution_endpoint/config.ts
+++ b/x-pack/test/security_solution_endpoint/config.ts
@@ -9,10 +9,7 @@ import { resolve } from 'path';
 import { FtrConfigProviderContext } from '@kbn/test';
 import { pageObjects } from './page_objects';
 import { services } from './services';
-import {
-  getRegistryUrlAsArray,
-  createEndpointDockerConfig,
-} from '../security_solution_endpoint_api_int/registry';
+import { createEndpointDockerConfig } from '../security_solution_endpoint_api_int/registry';
 
 export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   const xpackFunctionalConfig = await readConfigFile(
@@ -45,14 +42,11 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
       serverArgs: [
         ...xpackFunctionalConfig.get('kbnTestServer.serverArgs'),
         // if you return an empty string here the kibana server will not start properly but an empty array works
-        ...getRegistryUrlAsArray(),
         // always install Endpoint package by default when Fleet sets up
         `--xpack.fleet.packages.0.name=endpoint`,
         `--xpack.fleet.packages.0.version=latest`,
         // set the packagerTaskInterval to 5s in order to speed up test executions when checking fleet artifacts
         '--xpack.securitySolution.packagerTaskInterval=5s',
-        // this will be removed in 8.7 when the file upload feature is released
-        `--xpack.fleet.enableExperimental.0=diagnosticFileUploadEnabled`,
       ],
     },
     layout: {

--- a/x-pack/test/security_solution_endpoint_api_int/apis/index.ts
+++ b/x-pack/test/security_solution_endpoint_api_int/apis/index.ts
@@ -5,9 +5,7 @@
  * 2.0.
  */
 
-import { getRegistryUrl as getRegistryUrlFromIngest } from '@kbn/fleet-plugin/server';
 import { FtrProviderContext } from '../ftr_provider_context';
-import { isRegistryEnabled, getRegistryUrlFromTestEnv } from '../registry';
 import { ROLE } from '../services/roles_users';
 
 export default function endpointAPIIntegrationTests(providerContext: FtrProviderContext) {
@@ -16,15 +14,6 @@ export default function endpointAPIIntegrationTests(providerContext: FtrProvider
   describe('Endpoint plugin', function () {
     const ingestManager = getService('ingestManager');
     const rolesUsersProvider = getService('rolesUsersProvider');
-
-    const log = getService('log');
-
-    if (!isRegistryEnabled()) {
-      log.warning('These tests are being run with an external package registry');
-    }
-
-    const registryUrl = getRegistryUrlFromTestEnv() ?? getRegistryUrlFromIngest();
-    log.info(`Package registry URL for tests: ${registryUrl}`);
 
     const roles = Object.values(ROLE);
     before(async () => {

--- a/x-pack/test/security_solution_endpoint_api_int/config.ts
+++ b/x-pack/test/security_solution_endpoint_api_int/config.ts
@@ -6,7 +6,7 @@
  */
 
 import { FtrConfigProviderContext } from '@kbn/test';
-import { createEndpointDockerConfig, getRegistryUrlAsArray } from './registry';
+import { createEndpointDockerConfig } from './registry';
 import { services } from './services';
 
 export default async function ({ readConfigFile }: FtrConfigProviderContext) {
@@ -24,8 +24,6 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
       ...xPackAPITestsConfig.get('kbnTestServer'),
       serverArgs: [
         ...xPackAPITestsConfig.get('kbnTestServer.serverArgs'),
-        // if you return an empty string here the kibana server will not start properly but an empty array works
-        ...getRegistryUrlAsArray(),
         // always install Endpoint package by default when Fleet sets up
         `--xpack.fleet.packages.0.name=endpoint`,
         `--xpack.fleet.packages.0.version=latest`,

--- a/x-pack/test/security_solution_endpoint_api_int/registry.ts
+++ b/x-pack/test/security_solution_endpoint_api_int/registry.ts
@@ -18,20 +18,6 @@ import { dockerImage as ingestDockerImage } from '../fleet_api_integration/confi
  */
 const dockerRegistryPort: string | undefined = process.env.FLEET_PACKAGE_REGISTRY_PORT;
 
-/**
- * If you don't want to use the docker image version pinned below and instead want to run your own
- * registry or use an external registry you can define this environment variable when running
- * the tests to use that registry url instead.
- *
- * This is particularly useful when a developer needs to test a new package against the kibana
- * integration or functional tests. Instead of having to publish a whole new docker image we
- * can set this environment variable which will point to the location of where your package registry
- * is serving the updated package.
- *
- * This variable will not and should not be used by CI. CI should always use the pinned docker image below.
- */
-const packageRegistryOverride: string | undefined = process.env.PACKAGE_REGISTRY_URL_OVERRIDE;
-
 const defaultRegistryConfigPath = path.join(
   __dirname,
   './apis/fixtures/package_registry_config.yml'
@@ -57,23 +43,4 @@ export function createEndpointDockerConfig(
       waitForLogLine: 'package manifests loaded',
     },
   });
-}
-
-export function getRegistryUrlFromTestEnv(): string | undefined {
-  let registryUrl: string | undefined;
-  if (dockerRegistryPort !== undefined) {
-    registryUrl = `--xpack.fleet.registryUrl=http://localhost:${dockerRegistryPort}`;
-  } else if (packageRegistryOverride !== undefined) {
-    registryUrl = `--xpack.fleet.registryUrl=${packageRegistryOverride}`;
-  }
-  return registryUrl;
-}
-
-export function getRegistryUrlAsArray(): string[] {
-  const registryUrl: string | undefined = getRegistryUrlFromTestEnv();
-  return registryUrl !== undefined ? [registryUrl] : [];
-}
-
-export function isRegistryEnabled() {
-  return getRegistryUrlFromTestEnv() !== undefined;
 }


### PR DESCRIPTION
## Summary

Test PR to run endpoint integration tests without a docker based registry, as this seems to be the cause of flakiness seen. 

https://github.com/elastic/kibana/issues/150814

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)



