### PR TITLE
Re-enable task management tests around bulk enable / disable

### DIFF
--- a/x-pack/test/plugin_api_integration/test_suites/task_manager/task_management.ts
+++ b/x-pack/test/plugin_api_integration/test_suites/task_manager/task_management.ts
@@ -54,8 +54,7 @@ export default function ({ getService }: FtrProviderContext) {
   const supertest = getService('supertest');
   const testHistoryIndex = '.kibana_task_manager_test_result';
 
-  // FLAKY: https://github.com/elastic/kibana/issues/141055
-  describe.skip('scheduling and running tasks', () => {
+  describe('scheduling and running tasks', () => {
     beforeEach(async () => {
       // clean up before each test
       return await supertest.delete('/api/sample_tasks').set('kbn-xsrf', 'xxx').expect(200);


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/141055.

Re-enabling task management's `scheduling and running tasks` test suite now that we've fixed some issues around bulk enable / disable of tasks in https://github.com/elastic/kibana/pull/148985.

Flaky test runner: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/1920.