### PR TITLE
fix(bug): fixed sorting on cluster list table

### DIFF
--- a/x-pack/plugins/monitoring/public/components/cluster/listing/listing.js
+++ b/x-pack/plugins/monitoring/public/components/cluster/listing/listing.js
@@ -389,17 +389,21 @@ const StandaloneClusterCallout = ({ changeCluster, storage }) => {
 };
 
 export const Listing = ({ angular, clusters, sorting, pagination, onTableChange }) => {
+  const { scope, globalState, storage, showLicenseExpiration } = angular;
+  const {
+    sort: { direction, field },
+  } = sorting;
   const { services } = useKibana();
 
-  const _changeCluster = partial(changeCluster, angular.scope, angular.globalState);
+  const _changeCluster = partial(changeCluster, scope, globalState);
   const _handleClickIncompatibleLicense = partial(
     handleClickIncompatibleLicense,
-    angular.scope,
+    scope,
     services.theme.theme$
   );
   const _handleClickInvalidLicense = partial(
     handleClickInvalidLicense,
-    angular.scope,
+    scope,
     services.theme.theme$
   );
   const hasStandaloneCluster = !!clusters.find(
@@ -411,13 +415,13 @@ export const Listing = ({ angular, clusters, sorting, pagination, onTableChange 
       <EuiPageBody>
         <EuiPageContent>
           {hasStandaloneCluster ? (
-            <StandaloneClusterCallout changeCluster={_changeCluster} storage={angular.storage} />
+            <StandaloneClusterCallout changeCluster={_changeCluster} storage={storage} />
           ) : null}
           <EuiMonitoringTable
             className="clusterTable"
             rows={clusters}
             columns={getColumns(
-              angular.showLicenseExpiration,
+              showLicenseExpiration,
               _changeCluster,
               _handleClickIncompatibleLicense,
               _handleClickInvalidLicense
@@ -428,17 +432,16 @@ export const Listing = ({ angular, clusters, sorting, pagination, onTableChange 
               };
             }}
             sorting={{
-              ...sorting,
               sort: {
-                ...sorting.sort,
-                field: 'cluster_name',
+                direction,
+                field: field || 'cluster_name',
               },
             }}
             pagination={pagination}
             search={{
               box: {
                 incremental: true,
-                placeholder: angular.scope.filterText,
+                placeholder: scope.filterText,
               },
             }}
             onTableChange={onTableChange}


### PR DESCRIPTION
## Summary

Going to Stack Monitoring in Kibana will bring you to the cluster list. Attempt to click one of the table headings to sort by that field.

Expected behavior: The table values are sorted by that field
Actual behavior: It changes the direction of the sort on Name

closes [#147273](https://github.com/elastic/kibana/issues/147273)

### Testing

https://user-images.githubusercontent.com/11225826/219131518-7a9b341a-3b6e-4a46-a680-a1d2a12b2bb1.mov




<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->