### PR TITLE
[DOCS] Removes tag from 8.6.2 release notes

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -45,8 +45,6 @@ Review important information about the {kib} 8.6.x releases.
 [[release-notes-8.6.2]]
 == {kib} 8.6.2
 
-coming::[8.6.2]
-
 Review the following information about the {kib} 8.6.2 release.
 
 [float]


### PR DESCRIPTION
## Summary

Removes the `coming` tag from the 8.6.2 release notes.

