### PR TITLE
[Cloud Posture] [Quick Wins] Update dashboard links Icon

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/components/csp_counter_card.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/csp_counter_card.tsx
@@ -18,6 +18,17 @@ export interface CspCounterCardProps {
   description: EuiStatProps['description'];
 }
 
+// Todo: remove when EuiIcon type="pivot" is available
+const PivotIcon = ({ ...props }) => (
+  <svg width="16" height="16" fill="none" viewBox="0 0 16 16" {...props}>
+    <path
+      fillRule="evenodd"
+      d="M2.89 13.847 11.239 5.5a.522.522 0 0 0-.737-.737L2.154 13.11a.522.522 0 0 0 .738.738ZM14 6.696a.522.522 0 1 1-1.043 0v-3.13a.522.522 0 0 0-.522-.523h-3.13a.522.522 0 1 1 0-1.043h3.13C13.299 2 14 2.7 14 3.565v3.13Z"
+      clipRule="evenodd"
+    />
+  </svg>
+);
+
 export const CspCounterCard = (counter: CspCounterCardProps) => {
   const { euiTheme } = useEuiTheme();
 
@@ -46,6 +57,7 @@ export const CspCounterCard = (counter: CspCounterCardProps) => {
           justifyContent: 'space-around',
           '.euiText h6': {
             textTransform: 'capitalize',
+            fontSize: euiTheme.size.m,
           },
         }}
         titleSize="s"
@@ -56,8 +68,10 @@ export const CspCounterCard = (counter: CspCounterCardProps) => {
       />
       {counter.onClick && (
         <EuiIcon
-          type="link"
+          // Todo: update when EuiIcon type="pivot" is available
+          type={PivotIcon}
           css={css`
+            color: ${euiTheme.colors.lightShade};
             position: absolute;
             top: ${euiTheme.size.s};
             right: ${euiTheme.size.s};


### PR DESCRIPTION
### Summary

This is part of a Quick Wins [Issue](https://github.com/elastic/security-team/issues/6026)

This PR replaces the chain link from the Posture dashboard with the `pivot` icon suggested by @r4zr32d3k1l, also added a todo to replace it once the Icon is added in the Eui Library ([PR](https://github.com/elastic/eui/pull/6605) is up)

_Note: Also increase the font size to `12px` for the cards as suggested in the mocks._

### Screenshot

![image](https://user-images.githubusercontent.com/19270322/219289933-aedbab32-13d0-4960-a663-6fc7115ba3b0.png)
