### PR TITLE
[8.7] [Infrastructure UI] Fix condition to show k8s dashboard link (#151279)

### DIFF
--- a/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/bottom_drawer.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/bottom_drawer.tsx
@@ -11,6 +11,7 @@ import { EuiFlexGroup, EuiFlexItem, EuiButtonEmpty, EuiPanel } from '@elastic/eu
 import { euiStyled } from '@kbn/kibana-react-plugin/common';
 import { useUiTracker } from '@kbn/observability-plugin/public';
 import useLocalStorage from 'react-use/lib/useLocalStorage';
+import { InventoryItemType } from '../../../../../common/inventory_models/types';
 import { TryItButton } from '../../../../components/try_it_button';
 import { useWaffleOptionsContext } from '../hooks/use_waffle_options';
 import { InfraFormatter } from '../../../../lib/lib';
@@ -27,6 +28,7 @@ interface Props {
   interval: string;
   formatter: InfraFormatter;
   view: string;
+  nodeType: InventoryItemType;
 }
 
 const LOCAL_STORAGE_KEY = 'inventoryUI:k8sDashboardClicked';
@@ -57,7 +59,7 @@ const KubernetesButton = () => {
     />
   );
 };
-export const BottomDrawer = ({ interval, formatter, view }: Props) => {
+export const BottomDrawer = ({ interval, formatter, view, nodeType }: Props) => {
   const { timelineOpen, changeTimelineOpen } = useWaffleOptionsContext();
 
   const [isOpen, setIsOpen] = useState(Boolean(timelineOpen));
@@ -73,11 +75,15 @@ export const BottomDrawer = ({ interval, formatter, view }: Props) => {
     changeTimelineOpen(!isOpen);
   }, [isOpen, trackDrawerOpen, changeTimelineOpen]);
 
-  return view === 'table' ? (
-    <BottomPanel hasBorder={false} hasShadow={false} borderRadius="none" paddingSize="s">
-      <KubernetesButton />
-    </BottomPanel>
-  ) : (
+  if (view === 'table') {
+    return nodeType === 'pod' ? (
+      <BottomPanel hasBorder={false} hasShadow={false} borderRadius="none" paddingSize="s">
+        <KubernetesButton />
+      </BottomPanel>
+    ) : null;
+  }
+
+  return (
     <BottomActionContainer>
       <StickyPanel borderRadius="none" paddingSize="s">
         <EuiFlexGroup responsive={false} justifyContent="flexStart" alignItems="center">
@@ -91,9 +97,11 @@ export const BottomDrawer = ({ interval, formatter, view }: Props) => {
               {isOpen ? hideHistory : showHistory}
             </EuiButtonEmpty>
           </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <KubernetesButton />
-          </EuiFlexItem>
+          {nodeType === 'pod' && (
+            <EuiFlexItem grow={false}>
+              <KubernetesButton />
+            </EuiFlexItem>
+          )}
         </EuiFlexGroup>
       </StickyPanel>
       <EuiFlexGroup

--- a/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/layout.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/layout.tsx
@@ -213,7 +213,7 @@ export const Layout = React.memo(
             </EuiFlexItem>
           </EuiFlexGroup>
         </PageContent>
-        <BottomDrawer interval={interval} formatter={formatter} view={view} />
+        <BottomDrawer interval={interval} formatter={formatter} view={view} nodeType={nodeType} />
       </>
     );
   }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.7`:
 - [[Infrastructure UI] Fix condition to show k8s dashboard link (#151279)](https://github.com/elastic/kibana/pull/151279)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Carlos Crespo","email":"crespocarlos@users.noreply.github.com"},"sourceCommit":{"committedDate":"2023-02-15T16:33:03Z","message":"[Infrastructure UI] Fix condition to show k8s dashboard link (#151279)\n\n## Summary\r\n\r\ncloses #151273 \r\n\r\nThis PR fixes a bug when the Kubernetes Dashboards link is displayed. It\r\nwill only show when Kubernetes Pods is selected\r\n\r\n\r\n![out](https://user-images.githubusercontent.com/2767137/219019027-2b6624e9-2396-4950-b34e-5090ff170577.gif)\r\n\r\n### How to test it\r\n- Connect your local kibana to an oblt cluster\r\n- Go to Observability > Inventory UI\r\n- Change \"Show\" and select Kubernetes Pods to see the link and any other\r\noption to hide it.\r\n\r\n---------\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"82b44b6399189542a9b50b57506eaef8d1ca774b","branchLabelMapping":{"^v8.8.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:fix","Team:Infra Monitoring UI","backport:skip","v8.7.0","v8.8.0"],"number":151279,"url":"https://github.com/elastic/kibana/pull/151279","mergeCommit":{"message":"[Infrastructure UI] Fix condition to show k8s dashboard link (#151279)\n\n## Summary\r\n\r\ncloses #151273 \r\n\r\nThis PR fixes a bug when the Kubernetes Dashboards link is displayed. It\r\nwill only show when Kubernetes Pods is selected\r\n\r\n\r\n![out](https://user-images.githubusercontent.com/2767137/219019027-2b6624e9-2396-4950-b34e-5090ff170577.gif)\r\n\r\n### How to test it\r\n- Connect your local kibana to an oblt cluster\r\n- Go to Observability > Inventory UI\r\n- Change \"Show\" and select Kubernetes Pods to see the link and any other\r\noption to hide it.\r\n\r\n---------\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"82b44b6399189542a9b50b57506eaef8d1ca774b"}},"sourceBranch":"main","suggestedTargetBranches":["8.7"],"targetPullRequestStates":[{"branch":"8.7","label":"v8.7.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.8.0","labelRegex":"^v8.8.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/151279","number":151279,"mergeCommit":{"message":"[Infrastructure UI] Fix condition to show k8s dashboard link (#151279)\n\n## Summary\r\n\r\ncloses #151273 \r\n\r\nThis PR fixes a bug when the Kubernetes Dashboards link is displayed. It\r\nwill only show when Kubernetes Pods is selected\r\n\r\n\r\n![out](https://user-images.githubusercontent.com/2767137/219019027-2b6624e9-2396-4950-b34e-5090ff170577.gif)\r\n\r\n### How to test it\r\n- Connect your local kibana to an oblt cluster\r\n- Go to Observability > Inventory UI\r\n- Change \"Show\" and select Kubernetes Pods to see the link and any other\r\noption to hide it.\r\n\r\n---------\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"82b44b6399189542a9b50b57506eaef8d1ca774b"}}]}] BACKPORT-->