### PR TITLE
[ML] Transforms: Fix health constants, styles and wording.

### DIFF
--- a/x-pack/plugins/transform/common/constants.ts
+++ b/x-pack/plugins/transform/common/constants.ts
@@ -98,10 +98,10 @@ export const TRANSFORM_STATE = {
 export type TransformState = typeof TRANSFORM_STATE[keyof typeof TRANSFORM_STATE];
 
 export const TRANSFORM_HEALTH = {
-  GREEN: 'green',
-  UNKNOWN: 'unknown',
-  YELLOW: 'yellow',
-  RED: 'red',
+  green: 'green',
+  unknown: 'unknown',
+  yellow: 'yellow',
+  red: 'red',
 } as const;
 
 export type TransformHealth = typeof TRANSFORM_HEALTH[keyof typeof TRANSFORM_HEALTH];

--- a/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/transform_health_colored_dot.tsx
+++ b/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/transform_health_colored_dot.tsx
@@ -19,21 +19,32 @@ import {
 interface TransformHealthProps {
   healthStatus: TransformHealth;
   compact?: boolean;
+  showToolTip?: boolean;
 }
 
 export const TransformHealthColoredDot: FC<TransformHealthProps> = ({
   healthStatus,
   compact = true,
+  showToolTip = true,
 }) => {
-  return compact ? (
-    <EuiToolTip content={TRANSFORM_HEALTH_DESCRIPTION[healthStatus]}>
-      <EuiHealth color={TRANSFORM_HEALTH_COLOR[healthStatus]}>
-        <small data-test-subj="transformListHealth">{TRANSFORM_HEALTH_LABEL[healthStatus]}</small>
-      </EuiHealth>
-    </EuiToolTip>
-  ) : (
-    <EuiHealth color={TRANSFORM_HEALTH_COLOR[healthStatus]}>
-      {TRANSFORM_HEALTH_LABEL[healthStatus]} {TRANSFORM_HEALTH_DESCRIPTION[healthStatus]}
+  const transformHealthDescription = TRANSFORM_HEALTH_DESCRIPTION[healthStatus];
+  const transformHealthColor = TRANSFORM_HEALTH_COLOR[healthStatus];
+  const transformHealthLabel = TRANSFORM_HEALTH_LABEL[healthStatus];
+
+  const health = (
+    <EuiHealth
+      color={transformHealthColor}
+      textSize={compact ? 'xs' : undefined}
+      data-test-subj="transformListHealth"
+    >
+      {transformHealthLabel}
+      {compact ? '' : `: ${transformHealthDescription}`}
     </EuiHealth>
   );
+
+  if (showToolTip) {
+    return <EuiToolTip content={transformHealthDescription}>{health}</EuiToolTip>;
+  }
+
+  return health;
 };

--- a/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/transform_search_bar_filters.tsx
+++ b/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/transform_search_bar_filters.tsx
@@ -55,7 +55,7 @@ export const transformFilters: SearchFilterConfig[] = [
     options: Object.values(TRANSFORM_HEALTH).map((val) => ({
       value: val,
       name: val,
-      view: <TransformHealthColoredDot compact={true} healthStatus={val} />,
+      view: <TransformHealthColoredDot compact={true} showToolTip={false} healthStatus={val} />,
     })),
   },
 ];

--- a/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/transform_search_bar_filters.tsx
+++ b/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/transform_search_bar_filters.tsx
@@ -14,12 +14,11 @@ import {
   TRANSFORM_MODE,
   TRANSFORM_STATE,
   TRANSFORM_HEALTH,
-  TRANSFORM_HEALTH_COLOR,
-  TRANSFORM_HEALTH_LABEL,
 } from '../../../../../../common/constants';
 import { isLatestTransform, isPivotTransform } from '../../../../../../common/types/transform';
 import { TransformListRow } from '../../../../common';
 import { TransformTaskStateBadge } from './transform_task_state_badge';
+import { TransformHealthColoredDot } from './transform_health_colored_dot';
 
 export const transformFilters: SearchFilterConfig[] = [
   {
@@ -56,15 +55,7 @@ export const transformFilters: SearchFilterConfig[] = [
     options: Object.values(TRANSFORM_HEALTH).map((val) => ({
       value: val,
       name: val,
-      view: (
-        <EuiBadge
-          className="transform__TaskHealthBadge"
-          // For the color icon 'subdued' is used but for the badge we need 'hollow' instead.
-          color={TRANSFORM_HEALTH_COLOR[val] === 'subdued' ? 'hollow' : TRANSFORM_HEALTH_COLOR[val]}
-        >
-          {TRANSFORM_HEALTH_LABEL[val]}
-        </EuiBadge>
-      ),
+      view: <TransformHealthColoredDot compact={true} healthStatus={val} />,
     })),
   },
 ];

--- a/x-pack/test/functional/apps/transform/start_reset_delete/starting.ts
+++ b/x-pack/test/functional/apps/transform/start_reset_delete/starting.ts
@@ -59,7 +59,7 @@ export default function ({ getService }: FtrProviderContext) {
         expected: {
           healthDescription: TRANSFORM_HEALTH_DESCRIPTION.green,
           healthLabel: TRANSFORM_HEALTH_LABEL.green,
-          healthStatus: TRANSFORM_HEALTH.GREEN,
+          healthStatus: TRANSFORM_HEALTH.green,
         },
       },
       {
@@ -70,7 +70,7 @@ export default function ({ getService }: FtrProviderContext) {
         expected: {
           healthDescription: TRANSFORM_HEALTH_DESCRIPTION.green,
           healthLabel: TRANSFORM_HEALTH_LABEL.green,
-          healthStatus: TRANSFORM_HEALTH.GREEN,
+          healthStatus: TRANSFORM_HEALTH.green,
         },
       },
       {
@@ -81,7 +81,7 @@ export default function ({ getService }: FtrProviderContext) {
         expected: {
           healthDescription: TRANSFORM_HEALTH_DESCRIPTION.yellow,
           healthLabel: TRANSFORM_HEALTH_LABEL.yellow,
-          healthStatus: TRANSFORM_HEALTH.YELLOW,
+          healthStatus: TRANSFORM_HEALTH.yellow,
         },
       },
       {
@@ -92,7 +92,7 @@ export default function ({ getService }: FtrProviderContext) {
         expected: {
           healthDescription: TRANSFORM_HEALTH_DESCRIPTION.green,
           healthLabel: TRANSFORM_HEALTH_LABEL.green,
-          healthStatus: TRANSFORM_HEALTH.GREEN,
+          healthStatus: TRANSFORM_HEALTH.green,
         },
       },
       {
@@ -103,7 +103,7 @@ export default function ({ getService }: FtrProviderContext) {
         expected: {
           healthDescription: TRANSFORM_HEALTH_DESCRIPTION.green,
           healthLabel: TRANSFORM_HEALTH_LABEL.green,
-          healthStatus: TRANSFORM_HEALTH.GREEN,
+          healthStatus: TRANSFORM_HEALTH.green,
         },
       },
     ];
@@ -114,7 +114,7 @@ export default function ({ getService }: FtrProviderContext) {
 
       for (const testData of testDataList) {
         if (
-          testData.expected.healthStatus === TRANSFORM_HEALTH.YELLOW &&
+          testData.expected.healthStatus === TRANSFORM_HEALTH.yellow &&
           testData.type === 'pivot'
         ) {
           testData.originalConfig.pivot.aggregations['products.base_price.fail'] = {
@@ -128,7 +128,7 @@ export default function ({ getService }: FtrProviderContext) {
         await transform.api.createTransform(
           testData.originalConfig.id,
           testData.originalConfig,
-          testData.expected.healthStatus === TRANSFORM_HEALTH.YELLOW
+          testData.expected.healthStatus === TRANSFORM_HEALTH.yellow
         );
       }
       await transform.testResources.setKibanaTimeZoneToUTC();
@@ -169,7 +169,7 @@ export default function ({ getService }: FtrProviderContext) {
 
           await transform.table.assertTransformExpandedRowHealth(
             testData.expected.healthDescription,
-            testData.expected.healthStatus !== TRANSFORM_HEALTH.GREEN
+            testData.expected.healthStatus !== TRANSFORM_HEALTH.green
           );
 
           await transform.table.clearSearchString(testDataList.length);


### PR DESCRIPTION
## Summary

Part of #144157.

- Fix to make all keys lower case across constants to match API texts.
- Fix styling to use `EuiHealth` instead of `EuiBadge` in the search bar filter dropdown.
- Fix text format in expanded row health tab.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->