### PR TITLE
[APM] Improve stack traces for internal server side errors

### DIFF
--- a/x-pack/plugins/apm/server/routes/apm_routes/register_apm_server_routes.ts
+++ b/x-pack/plugins/apm/server/routes/apm_routes/register_apm_server_routes.ts
@@ -6,6 +6,7 @@
  */
 
 import Boom from '@hapi/boom';
+import stringify from 'json-stable-stringify';
 import * as t from 'io-ts';
 import { KibanaRequest, RouteRegistrar } from '@kbn/core/server';
 import { errors } from '@elastic/elasticsearch';
@@ -19,6 +20,7 @@ import {
 } from '@kbn/server-route-repository';
 import { jsonRt, mergeRt } from '@kbn/io-ts-utils';
 import { InspectResponse } from '@kbn/observability-plugin/typings/common';
+import apm from 'elastic-apm-node';
 import { pickKeys } from '../../../common/utils/pick_keys';
 import { APMRouteHandlerResources, TelemetryUsageCounter } from '../typings';
 import type { ApmPluginRequestHandlerContext } from '../typings';
@@ -180,6 +182,9 @@ export function registerRoutes({
           if (Boom.isBoom(error)) {
             opts.statusCode = error.output.statusCode;
           }
+
+          // capture error with APM node agent
+          apm.captureError(error);
 
           return response.custom(opts);
         } finally {

--- a/x-pack/plugins/apm/server/routes/apm_routes/register_apm_server_routes.ts
+++ b/x-pack/plugins/apm/server/routes/apm_routes/register_apm_server_routes.ts
@@ -6,7 +6,6 @@
  */
 
 import Boom from '@hapi/boom';
-import stringify from 'json-stable-stringify';
 import * as t from 'io-ts';
 import { KibanaRequest, RouteRegistrar } from '@kbn/core/server';
 import { errors } from '@elastic/elasticsearch';


### PR DESCRIPTION
In the previous implementation the error message was missing and the stack trace was pointing to library frames which was not very useful.

In the new implementation we capture the error explicitly and thereby get a proper error message and stack trace pointing at application code where the error was thrown.

### Before

![image](https://user-images.githubusercontent.com/209966/219352662-1ff60078-1388-43f8-8428-39a42060696b.png)

### After
![image](https://user-images.githubusercontent.com/209966/219352677-d0072e52-7e45-48df-a831-3a48a09fa541.png)

### Before
![image](https://user-images.githubusercontent.com/209966/219352085-8b06e052-9571-4009-9727-e962bf5de20e.png)

### After
<img width="1096" alt="image" src="https://user-images.githubusercontent.com/209966/219352163-73e33435-0b72-4e85-a128-ec7ed6fc0cfc.png">



# Problems

- We are capturing the error twice
<img width="1267" alt="image" src="https://user-images.githubusercontent.com/209966/219352465-243bbe8f-d9f6-408b-b6aa-235542147646.png">
 - The summary shows status code 200, even though the actual status code is 500. I was unable to pass the `response` to `captureError` since only proper `ServerResponse` are allowed, and I only have access to the custom `KibanaResponseFactory` response

<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->