### PR TITLE
Update Fleet guide link in Agent enrollment

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_requirements_page/components/enrollment_recommendation.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_requirements_page/components/enrollment_recommendation.tsx
@@ -66,7 +66,7 @@ export const EnrollmentRecommendation: React.FunctionComponent<{
                   <EuiLink href={docLinks.links.fleet.guide} target="_blank" external>
                     <FormattedMessage
                       id="xpack.fleet.enrollment.fleetUserGuideLink"
-                      defaultMessage="Fleet User Guide"
+                      defaultMessage="Fleet and Elastic Agent Guide"
                     />
                   </EuiLink>
                 ),


### PR DESCRIPTION
## Summary

This PR follows up the renaming of Fleet User Guide to Fleet and Elastic User Guide reported in https://github.com/elastic/kibana/issues/122012. At the time of writing, all links have already been updated except the one in the Fleet -> Add Agent -> Enroll in Fleet panel (cf. screenshot).

### Screenshot

<img width="782" alt="Screenshot 2023-02-16 at 15 39 19" src="https://user-images.githubusercontent.com/23701614/219424219-ee79b000-bc40-4b54-9d4b-527d7f3a192f.png">
