### PR TITLE
[Fleet] remove private_key from encrypted attributes

### DIFF
--- a/x-pack/plugins/fleet/server/saved_objects/index.ts
+++ b/x-pack/plugins/fleet/server/saved_objects/index.ts
@@ -410,6 +410,6 @@ export function registerEncryptedSavedObjects(
   // Encrypted saved objects
   encryptedSavedObjects.registerType({
     type: MESSAGE_SIGNING_KEYS_SAVED_OBJECT_TYPE,
-    attributesToEncrypt: new Set(['private_key', 'passphrase']),
+    attributesToEncrypt: new Set(['passphrase']),
   });
 }


### PR DESCRIPTION
## Summary

Remove extra encryption on `private_key` attribute. This is already encrypted by the passphrase.


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
