### PR TITLE
[Cloud Security] Plugin Initialize - Updating `logs-cloud_security_posture.findings_latest-default` index mappings

### DIFF
--- a/x-pack/plugins/cloud_security_posture/server/create_indices/create_indices.ts
+++ b/x-pack/plugins/cloud_security_posture/server/create_indices/create_indices.ts
@@ -6,6 +6,7 @@
  */
 import type { ElasticsearchClient, Logger } from '@kbn/core/server';
 import { errors } from '@elastic/elasticsearch';
+import type { MappingTypeMapping } from '@elastic/elasticsearch/lib/api/types';
 import {
   BENCHMARK_SCORE_INDEX_DEFAULT_NS,
   BENCHMARK_SCORE_INDEX_PATTERN,
@@ -107,7 +108,21 @@ const createLatestFindingsIndex = async (esClient: ElasticsearchClient, logger: 
       composed_of,
     });
 
-    await createIndexSafe(esClient, logger, LATEST_FINDINGS_INDEX_DEFAULT_NS);
+    const result = await createIndexSafe(esClient, logger, LATEST_FINDINGS_INDEX_DEFAULT_NS);
+
+    if (result === 'already-exists') {
+      // Make sure mappings are up-to-date
+      const simulateResponse = await esClient.indices.simulateTemplate({
+        name: LATEST_FINDINGS_INDEX_TEMPLATE_NAME,
+      });
+
+      await updateIndexSafe(
+        esClient,
+        logger,
+        LATEST_FINDINGS_INDEX_DEFAULT_NS,
+        simulateResponse.template.mappings
+      );
+    }
   } catch (e) {
     logger.error(
       `Failed to upsert index template [Template: ${LATEST_FINDINGS_INDEX_TEMPLATE_NAME}]`
@@ -155,11 +170,32 @@ const createIndexSafe = async (esClient: ElasticsearchClient, logger: Logger, in
       });
 
       logger.info(`Created index successfully [Name: ${index}]`);
+      return 'success';
     } else {
       logger.trace(`Index already exists [Name: ${index}]`);
+      return 'already-exists';
     }
   } catch (e) {
     logger.error(`Failed to create index [Name: ${index}]`);
+    logger.error(e);
+    return 'fail';
+  }
+};
+
+const updateIndexSafe = async (
+  esClient: ElasticsearchClient,
+  logger: Logger,
+  index: string,
+  mappings: MappingTypeMapping
+) => {
+  try {
+    await esClient.indices.putMapping({
+      index,
+      properties: mappings.properties,
+    });
+    logger.info(`Updated index successfully [Name: ${index}]`);
+  } catch (e) {
+    logger.error(`Failed to update index [Name: ${index}]`);
     logger.error(e);
   }
 };


### PR DESCRIPTION
## Summary

fixes #151439

In the following video you can see a demonstration of the bug reproduction and how it is being fixed on the next plugin's initialize call (on kibana server start and on package installation)

The video shows:
1. bug reproduction (missing mappings for `posture_type` field causes the dashboard not to appear)
2. Simulating new package update by adding the mappings manually
3. Triggering `initialize` by server restart
4. Showing update mappings was called (highlighting the log message)
5. Waiting for new findings on the latest findings index
6. Problem is solved

https://user-images.githubusercontent.com/61654899/219409416-e8ed3d94-2e35-41f2-b217-b3cb3a2bef24.mp4



<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->