### PR TITLE
[Cloud Security] Updating policy deployment values

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/components/fleet_extensions/mocks.ts
+++ b/x-pack/plugins/cloud_security_posture/public/components/fleet_extensions/mocks.ts
@@ -15,11 +15,15 @@ import {
 } from '../../../common/constants';
 import type { PostureInput } from '../../../common/types';
 
-export const getMockPolicyAWS = () => getPolicyMock(CLOUDBEAT_AWS);
-export const getMockPolicyK8s = () => getPolicyMock(CLOUDBEAT_VANILLA);
-export const getMockPolicyEKS = () => getPolicyMock(CLOUDBEAT_EKS);
+export const getMockPolicyAWS = () => getPolicyMock(CLOUDBEAT_AWS, 'cspm', 'aws');
+export const getMockPolicyK8s = () => getPolicyMock(CLOUDBEAT_VANILLA, 'kspm', 'self_managed');
+export const getMockPolicyEKS = () => getPolicyMock(CLOUDBEAT_EKS, 'kspm', 'eks');
 
-const getPolicyMock = (type: PostureInput): NewPackagePolicy => {
+const getPolicyMock = (
+  type: PostureInput,
+  posture: string,
+  deployment: string
+): NewPackagePolicy => {
   const mockPackagePolicy = createNewPackagePolicyMock();
 
   const awsVarsMock = {
@@ -44,10 +48,10 @@ const getPolicyMock = (type: PostureInput): NewPackagePolicy => {
     },
     vars: {
       posture: {
-        value: type === CLOUDBEAT_VANILLA || type === CLOUDBEAT_EKS ? 'kspm' : 'cspm',
+        value: posture,
         type: 'text',
       },
-      deployment: { value: type, type: 'text' },
+      deployment: { value: deployment, type: 'text' },
     },
     inputs: [
       {

--- a/x-pack/plugins/cloud_security_posture/public/components/fleet_extensions/utils.test.ts
+++ b/x-pack/plugins/cloud_security_posture/public/components/fleet_extensions/utils.test.ts
@@ -35,7 +35,7 @@ describe('getPosturePolicy', () => {
 
     const policy = getPosturePolicy(mockCisAws, 'cloudbeat/cis_k8s');
     expect(policy.vars?.posture.value).toBe('kspm');
-    expect(policy.vars?.deployment.value).toBe('cloudbeat/cis_k8s');
+    expect(policy.vars?.deployment.value).toBe('self_managed');
 
     // Does not change extra vars
     expect(policy.vars?.extra.value).toBe('value');

--- a/x-pack/plugins/cloud_security_posture/public/components/fleet_extensions/utils.ts
+++ b/x-pack/plugins/cloud_security_posture/public/components/fleet_extensions/utils.ts
@@ -40,8 +40,36 @@ export const isPostureInput = (
   SUPPORTED_POLICY_TEMPLATES.includes(input.policy_template as PosturePolicyTemplate) &&
   SUPPORTED_CLOUDBEAT_INPUTS.includes(input.type as PostureInput);
 
-const getInputPolicyTemplate = (inputs: NewPackagePolicyInput[], inputType: PostureInput) =>
-  inputs.filter(isPostureInput).find((i) => i.type === inputType)!.policy_template;
+const getPostureType = (policyTemplateInput: PostureInput) => {
+  switch (policyTemplateInput) {
+    case CLOUDBEAT_AWS:
+    case CLOUDBEAT_AZURE:
+    case CLOUDBEAT_GCP:
+      return 'cspm';
+    case CLOUDBEAT_VANILLA:
+    case CLOUDBEAT_EKS:
+      return 'kspm';
+    default:
+      return 'n/a';
+  }
+};
+
+const getDeploymentType = (policyTemplateInput: PostureInput) => {
+  switch (policyTemplateInput) {
+    case CLOUDBEAT_AWS:
+      return 'aws';
+    case CLOUDBEAT_AZURE:
+      return 'azure';
+    case CLOUDBEAT_GCP:
+      return 'gcp';
+    case CLOUDBEAT_VANILLA:
+      return 'self_managed';
+    case CLOUDBEAT_EKS:
+      return 'eks';
+    default:
+      return 'n/a';
+  }
+};
 
 const getPostureInput = (
   input: NewPackagePolicyInput,
@@ -79,8 +107,8 @@ export const getPosturePolicy = (
   inputs: newPolicy.inputs.map((item) => getPostureInput(item, inputType, inputVars)),
   // Set hidden policy vars
   vars: merge({}, newPolicy.vars, {
-    deployment: { value: inputType },
-    posture: { value: getInputPolicyTemplate(newPolicy.inputs, inputType) },
+    deployment: { value: getDeploymentType(inputType) },
+    posture: { value: getPostureType(inputType) },
   }),
 });
 


### PR DESCRIPTION
## Summary

In this PR we fix the values of deployment to be one of the following: `aws`, `gcp`, `azure`, `self_managed` or `eks`

## Steps to check

- Create a new agent policy with cloud security posture
- Check agent policy generation 

```yaml
        config:
          v1:
            posture: kspm
            deployment: self_managed
            benchmark: cis_k8s
```