### PR TITLE
[dashboard] fix react-grid-layout GridItem displaying warning in console

### DIFF
--- a/src/plugins/dashboard/public/dashboard_container/component/grid/dashboard_grid_item.tsx
+++ b/src/plugins/dashboard/public/dashboard_container/component/grid/dashboard_grid_item.tsx
@@ -96,52 +96,48 @@ const Item = React.forwardRef<HTMLDivElement, Props>(
   }
 );
 
-export const ObservedItem = React.forwardRef<HTMLDivElement, Props>(
-  (props, panelRef) => {
-    const [intersection, updateIntersection] = useState<IntersectionObserverEntry>();
-    const [isRenderable, setIsRenderable] = useState(false);
+export const ObservedItem = React.forwardRef<HTMLDivElement, Props>((props, panelRef) => {
+  const [intersection, updateIntersection] = useState<IntersectionObserverEntry>();
+  const [isRenderable, setIsRenderable] = useState(false);
 
-    const observerRef = useRef(
-      new window.IntersectionObserver(([value]) => updateIntersection(value), {
-        root: (panelRef as React.RefObject<HTMLDivElement>).current,
-      })
-    );
+  const observerRef = useRef(
+    new window.IntersectionObserver(([value]) => updateIntersection(value), {
+      root: (panelRef as React.RefObject<HTMLDivElement>).current,
+    })
+  );
 
-    useEffect(() => {
-      const { current: currentObserver } = observerRef;
-      currentObserver.disconnect();
-      const { current } = panelRef as React.RefObject<HTMLDivElement>;
+  useEffect(() => {
+    const { current: currentObserver } = observerRef;
+    currentObserver.disconnect();
+    const { current } = panelRef as React.RefObject<HTMLDivElement>;
 
-      if (current) {
-        currentObserver.observe(current);
-      }
+    if (current) {
+      currentObserver.observe(current);
+    }
 
-      return () => currentObserver.disconnect();
-    }, [panelRef]);
+    return () => currentObserver.disconnect();
+  }, [panelRef]);
 
-    useEffect(() => {
-      if (intersection?.isIntersecting && !isRenderable) {
-        setIsRenderable(true);
-      }
-    }, [intersection, isRenderable]);
+  useEffect(() => {
+    if (intersection?.isIntersecting && !isRenderable) {
+      setIsRenderable(true);
+    }
+  }, [intersection, isRenderable]);
 
-    return <Item ref={panelRef} isRenderable={isRenderable} {...props} />;
-  }
-);
+  return <Item ref={panelRef} isRenderable={isRenderable} {...props} />;
+});
 
 // ReactGridLayout passes ref to children. Functional component children require forwardRef to avoid react warning
 // https://github.com/react-grid-layout/react-grid-layout#custom-child-components-and-draggable-handles
-export const DashboardGridItem = React.forwardRef<HTMLDivElement, Props>(
-  (props, ref) => {
-    const {
-      settings: { isProjectEnabledInLabs },
-    } = pluginServices.getServices();
+export const DashboardGridItem = React.forwardRef<HTMLDivElement, Props>((props, ref) => {
+  const {
+    settings: { isProjectEnabledInLabs },
+  } = pluginServices.getServices();
 
-    const { useEmbeddableSelector: select } = useDashboardContainerContext();
+  const { useEmbeddableSelector: select } = useDashboardContainerContext();
 
-    const isPrintMode = select((state) => state.explicitInput.viewMode) === ViewMode.PRINT;
-    const isEnabled = !isPrintMode && isProjectEnabledInLabs('labs:dashboard:deferBelowFold');
+  const isPrintMode = select((state) => state.explicitInput.viewMode) === ViewMode.PRINT;
+  const isEnabled = !isPrintMode && isProjectEnabledInLabs('labs:dashboard:deferBelowFold');
 
-    return isEnabled ? <ObservedItem ref={ref} {...props} /> : <Item ref={ref} {...props} />;
-  }
-);
+  return isEnabled ? <ObservedItem ref={ref} {...props} /> : <Item ref={ref} {...props} />;
+});

--- a/src/plugins/dashboard/public/dashboard_container/component/grid/dashboard_grid_item.tsx
+++ b/src/plugins/dashboard/public/dashboard_container/component/grid/dashboard_grid_item.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React, { useState, useRef, useEffect, FC } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { EuiLoadingChart } from '@elastic/eui';
 import classNames from 'classnames';
 
@@ -96,21 +96,21 @@ const Item = React.forwardRef<HTMLDivElement, Props>(
   }
 );
 
-export const ObservedItem: FC<Props> = React.forwardRef<HTMLDivElement, Props>(
+export const ObservedItem = React.forwardRef<HTMLDivElement, Props>(
   (props, panelRef) => {
     const [intersection, updateIntersection] = useState<IntersectionObserverEntry>();
     const [isRenderable, setIsRenderable] = useState(false);
 
     const observerRef = useRef(
       new window.IntersectionObserver(([value]) => updateIntersection(value), {
-        root: panelRef.current,
+        root: (panelRef as React.RefObject<HTMLDivElement>).current,
       })
     );
 
     useEffect(() => {
       const { current: currentObserver } = observerRef;
       currentObserver.disconnect();
-      const { current } = panelRef;
+      const { current } = panelRef as React.RefObject<HTMLDivElement>;
 
       if (current) {
         currentObserver.observe(current);
@@ -131,7 +131,7 @@ export const ObservedItem: FC<Props> = React.forwardRef<HTMLDivElement, Props>(
 
 // ReactGridLayout passes ref to children. Functional component children require forwardRef to avoid react warning
 // https://github.com/react-grid-layout/react-grid-layout#custom-child-components-and-draggable-handles
-export const DashboardGridItem: FC<Props> = React.forwardRef<HTMLDivElement, Props>(
+export const DashboardGridItem = React.forwardRef<HTMLDivElement, Props>(
   (props, ref) => {
     const {
       settings: { isProjectEnabledInLabs },

--- a/src/plugins/dashboard/public/dashboard_container/component/grid/dashboard_grid_item.tsx
+++ b/src/plugins/dashboard/public/dashboard_container/component/grid/dashboard_grid_item.tsx
@@ -96,47 +96,52 @@ const Item = React.forwardRef<HTMLDivElement, Props>(
   }
 );
 
-export const ObservedItem: FC<Props> = (props: Props) => {
-  const [intersection, updateIntersection] = useState<IntersectionObserverEntry>();
-  const [isRenderable, setIsRenderable] = useState(false);
-  const panelRef = useRef<HTMLDivElement>(null);
+export const ObservedItem: FC<Props> = React.forwardRef<HTMLDivElement, Props>(
+  (props, panelRef) => {
+    const [intersection, updateIntersection] = useState<IntersectionObserverEntry>();
+    const [isRenderable, setIsRenderable] = useState(false);
 
-  const observerRef = useRef(
-    new window.IntersectionObserver(([value]) => updateIntersection(value), {
-      root: panelRef.current,
-    })
-  );
+    const observerRef = useRef(
+      new window.IntersectionObserver(([value]) => updateIntersection(value), {
+        root: panelRef.current,
+      })
+    );
 
-  useEffect(() => {
-    const { current: currentObserver } = observerRef;
-    currentObserver.disconnect();
-    const { current } = panelRef;
+    useEffect(() => {
+      const { current: currentObserver } = observerRef;
+      currentObserver.disconnect();
+      const { current } = panelRef;
 
-    if (current) {
-      currentObserver.observe(current);
-    }
+      if (current) {
+        currentObserver.observe(current);
+      }
 
-    return () => currentObserver.disconnect();
-  }, [panelRef]);
+      return () => currentObserver.disconnect();
+    }, [panelRef]);
 
-  useEffect(() => {
-    if (intersection?.isIntersecting && !isRenderable) {
-      setIsRenderable(true);
-    }
-  }, [intersection, isRenderable]);
+    useEffect(() => {
+      if (intersection?.isIntersecting && !isRenderable) {
+        setIsRenderable(true);
+      }
+    }, [intersection, isRenderable]);
 
-  return <Item ref={panelRef} isRenderable={isRenderable} {...props} />;
-};
+    return <Item ref={panelRef} isRenderable={isRenderable} {...props} />;
+  }
+);
 
-export const DashboardGridItem: FC<Props> = (props: Props) => {
-  const {
-    settings: { isProjectEnabledInLabs },
-  } = pluginServices.getServices();
+// ReactGridLayout passes ref to children. Functional component children require forwardRef to avoid react warning
+// https://github.com/react-grid-layout/react-grid-layout#custom-child-components-and-draggable-handles
+export const DashboardGridItem: FC<Props> = React.forwardRef<HTMLDivElement, Props>(
+  (props, ref) => {
+    const {
+      settings: { isProjectEnabledInLabs },
+    } = pluginServices.getServices();
 
-  const { useEmbeddableSelector: select } = useDashboardContainerContext();
+    const { useEmbeddableSelector: select } = useDashboardContainerContext();
 
-  const isPrintMode = select((state) => state.explicitInput.viewMode) === ViewMode.PRINT;
-  const isEnabled = !isPrintMode && isProjectEnabledInLabs('labs:dashboard:deferBelowFold');
+    const isPrintMode = select((state) => state.explicitInput.viewMode) === ViewMode.PRINT;
+    const isEnabled = !isPrintMode && isProjectEnabledInLabs('labs:dashboard:deferBelowFold');
 
-  return isEnabled ? <ObservedItem {...props} /> : <Item {...props} />;
-};
+    return isEnabled ? <ObservedItem ref={ref} {...props} /> : <Item ref={ref} {...props} />;
+  }
+);


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/151487

PR updates DashboardGridItem to use forwardRef to resolve react warning caused when ReactGridLayout passes ref to functional component children. 