### PR TITLE
[APM] Fix side navigation breaks in APM on 404 page

### DIFF
--- a/x-pack/plugins/apm/public/components/routing/apm_error_boundary.tsx
+++ b/x-pack/plugins/apm/public/components/routing/apm_error_boundary.tsx
@@ -9,9 +9,15 @@ import { EuiErrorBoundary } from '@elastic/eui';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import React from 'react';
 import { NotFoundPrompt } from '@kbn/shared-ux-prompt-not-found';
+import { useLocation } from 'react-router-dom';
 import { ApmPluginStartDeps } from '../../plugin';
 
-export class ApmErrorBoundary extends React.Component<
+export function ApmErrorBoundary({ children }: { children?: React.ReactNode }) {
+  const location = useLocation();
+  return <ErrorBoundary key={location.pathname}>{children}</ErrorBoundary>;
+}
+
+class ErrorBoundary extends React.Component<
   { children?: React.ReactNode },
   { error?: Error },
   {}


### PR DESCRIPTION
https://user-images.githubusercontent.com/55978943/219460483-f7cf498e-f6f1-472c-bd86-cdd832b47a97.mov

Adds a `key` property with the current location, so when the URL is changed it invalidates the ErrorBoundary component.


<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->