### PR TITLE
[Enterprise Search] Engines Search Preview Document Flyout

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/document_context.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/document_context.test.tsx
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { act, renderHook } from '@testing-library/react-hooks';
+
+import { DocumentProvider, useSelectedDocument } from './document_context';
+
+const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <DocumentProvider>{children}</DocumentProvider>
+);
+
+describe('DocumentContext', () => {
+  it('defines `selectedDocument` and defaults to `null`', () => {
+    const { result } = renderHook(useSelectedDocument, { wrapper });
+    expect(result.current).toHaveProperty('selectedDocument', null);
+  });
+
+  it('defines `setSelectedDocument`', () => {
+    const { result } = renderHook(useSelectedDocument, { wrapper });
+    expect(result.current).toHaveProperty('setSelectedDocument');
+  });
+
+  it('sets the selected document using `setSelectedDocument`', () => {
+    const { result } = renderHook(useSelectedDocument, { wrapper });
+
+    act(() => {
+      result.current.setSelectedDocument({ foo: 'bar' });
+    });
+
+    expect(result.current.selectedDocument).toEqual({ foo: 'bar' });
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/document_context.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/document_context.tsx
@@ -7,13 +7,21 @@
 
 import React, { createContext, useMemo, useState, useContext } from 'react';
 
-export const DocumentContext = createContext({
+import { SearchResult } from '@elastic/search-ui';
+
+export type SelectedDocument = SearchResult;
+export interface DocumentContextType {
+  selectedDocument: null | SelectedDocument;
+  setSelectedDocument(select: null | SelectedDocument): void;
+}
+
+export const DocumentContext = createContext<DocumentContextType>({
   selectedDocument: null,
   setSelectedDocument: () => {},
 });
 
-export const DocumentProvider = ({ children }) => {
-  const [selectedDocument, setSelectedDocument] = useState(null);
+export const DocumentProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [selectedDocument, setSelectedDocument] = useState<SelectedDocument | null>(null);
   const value = useMemo(
     () => ({ selectedDocument, setSelectedDocument }),
     [selectedDocument, setSelectedDocument]

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/document_context.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/document_context.tsx
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { createContext, useMemo, useState, useContext } from 'react';
+
+export const DocumentContext = createContext({
+  selectedDocument: null,
+  setSelectedDocument: () => {},
+});
+
+export const DocumentProvider = ({ children }) => {
+  const [selectedDocument, setSelectedDocument] = useState(null);
+  const value = useMemo(
+    () => ({ selectedDocument, setSelectedDocument }),
+    [selectedDocument, setSelectedDocument]
+  );
+
+  return <DocumentContext.Provider value={value}>{children}</DocumentContext.Provider>;
+};
+
+export const useSelectedDocument = () => useContext(DocumentContext);

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/document_flyout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/document_flyout.tsx
@@ -40,7 +40,7 @@ export const DocumentFlyout: React.FC = () => {
     ...Object.entries(otherFields).map(([key, { raw: value }]) => ({ key, value })),
   ];
 
-  const columns: EuiBasicTableColumn = [
+  const columns: Array<EuiBasicTableColumn<{ key: string; value: string }>> = [
     {
       field: 'key',
       name: i18n.translate(

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/document_flyout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/document_flyout.tsx
@@ -54,7 +54,7 @@ export const DocumentFlyout: React.FC = () => {
           </EuiTextColor>
         </EuiText>
       ),
-      truncateText: true,
+      truncateText: false,
     },
     {
       field: 'value',
@@ -67,7 +67,7 @@ export const DocumentFlyout: React.FC = () => {
           <code>{key}</code>
         </EuiText>
       ),
-      truncateText: true,
+      truncateText: false,
     },
   ];
 

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/document_flyout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/document_flyout.tsx
@@ -7,7 +7,19 @@
 
 import React from 'react';
 
-import { EuiFlyout, EuiFlyoutBody, EuiFlyoutHeader, EuiText, EuiTitle } from '@elastic/eui';
+import {
+  EuiBasicTableColumn,
+  EuiFlexGroup,
+  EuiFlyout,
+  EuiFlyoutBody,
+  EuiFlyoutHeader,
+  EuiInMemoryTable,
+  EuiText,
+  EuiTextColor,
+  EuiTitle,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
 
 import { useSelectedDocument } from './document_context';
 
@@ -16,17 +28,73 @@ export const DocumentFlyout: React.FC = () => {
 
   if (selectedDocument === null) return null;
 
+  const {
+    _meta: { id: encodedId },
+    id: _id,
+    ...otherFields
+  } = selectedDocument;
+  const [, id] = JSON.parse(atob(encodedId));
+
+  const fields = [
+    { key: 'id', value: id },
+    ...Object.entries(otherFields).map(([key, { raw: value }]) => ({ key, value })),
+  ];
+
+  const columns: EuiBasicTableColumn = [
+    {
+      field: 'key',
+      name: i18n.translate(
+        'xpack.enterpriseSearch.content.engine.searchPreview.documentFlyout.fieldLabel',
+        { defaultMessage: 'Field' }
+      ),
+      render: (key: string) => (
+        <EuiText>
+          <EuiTextColor color="subdued">
+            <code>{key}</code>
+          </EuiTextColor>
+        </EuiText>
+      ),
+      truncateText: true,
+    },
+    {
+      field: 'value',
+      name: i18n.translate(
+        'xpack.enterpriseSearch.content.engine.searchPreview.documentFlyout.valueLabel',
+        { defaultMessage: 'Value' }
+      ),
+      render: (key: string) => (
+        <EuiText>
+          <code>{key}</code>
+        </EuiText>
+      ),
+      truncateText: true,
+    },
+  ];
+
   return (
     <EuiFlyout onClose={() => setSelectedDocument(null)}>
-      <EuiFlyoutHeader>
-        <EuiTitle size="m">
-          <h2>Document</h2>
-        </EuiTitle>
+      <EuiFlyoutHeader hasBorder>
+        <EuiFlexGroup direction="column" gutterSize="s">
+          <EuiTitle size="m">
+            <h2>
+              <FormattedMessage
+                id="xpack.enterpriseSearch.content.engine.searchPreview.documentFlyout.title"
+                defaultMessage="Document: {id}"
+                values={{ id }}
+              />
+            </h2>
+          </EuiTitle>
+          <EuiTextColor color="subdued">
+            <FormattedMessage
+              id="xpack.enterpriseSearch.content.engine.searchPreivew.documentFlyout.fieldCount"
+              defaultMessage="{fieldCount} {fieldCount, plural, one {Field} other {Fields}}"
+              values={{ fieldCount: fields.length }}
+            />
+          </EuiTextColor>
+        </EuiFlexGroup>
       </EuiFlyoutHeader>
       <EuiFlyoutBody>
-        <EuiText>
-          <code>{JSON.stringify(selectedDocument, null, 2)}</code>
-        </EuiText>
+        <EuiInMemoryTable columns={columns} items={fields} />
       </EuiFlyoutBody>
     </EuiFlyout>
   );

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/document_flyout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/document_flyout.tsx
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { EuiFlyout, EuiFlyoutBody, EuiFlyoutHeader, EuiText, EuiTitle } from '@elastic/eui';
+
+import { useSelectedDocument } from './document_context';
+
+export const DocumentFlyout: React.FC = () => {
+  const { selectedDocument, setSelectedDocument } = useSelectedDocument();
+
+  if (selectedDocument === null) return null;
+
+  return (
+    <EuiFlyout onClose={() => setSelectedDocument(null)}>
+      <EuiFlyoutHeader>
+        <EuiTitle size="m">
+          <h2>Document</h2>
+        </EuiTitle>
+      </EuiFlyoutHeader>
+      <EuiFlyoutBody>
+        <EuiText>
+          <code>{JSON.stringify(selectedDocument, null, 2)}</code>
+        </EuiText>
+      </EuiFlyoutBody>
+    </EuiFlyout>
+  );
+};

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/engine_search_preview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/engine_search_preview.tsx
@@ -9,20 +9,9 @@ import React from 'react';
 
 import { useValues } from 'kea';
 
-import {
-  EuiBadge,
-  EuiBasicTable,
-  EuiBasicTableColumn,
-  EuiButton,
-  EuiFieldSearch,
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiPanel,
-  EuiSpacer,
-} from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
 import { SearchProvider, SearchBox, Results } from '@elastic/react-search-ui';
-import { ResultsViewProps, ResultViewProps, InputViewProps } from '@elastic/react-search-ui-views';
-import { SearchDriverOptions, SearchResult } from '@elastic/search-ui';
+import { SearchDriverOptions } from '@elastic/search-ui';
 import EnginesAPIConnector, {
   Transporter,
   SearchRequest,
@@ -39,6 +28,8 @@ import { EngineIndicesLogic } from '../engine_indices_logic';
 import { EngineViewLogic } from '../engine_view_logic';
 
 import { EngineSearchPreviewLogic } from './engine_search_preview_logic';
+
+import { InputView, ResultView, ResultsView } from './search_ui_components';
 
 class InternalEngineTransporter implements Transporter {
   constructor(private http: HttpSetup, private engineName: string) {}
@@ -64,81 +55,6 @@ class InternalEngineTransporter implements Transporter {
     return withUniqueIds;
   }
 }
-
-const ResultsView: React.FC<ResultsViewProps> = ({ children }) => {
-  return <EuiFlexGroup direction="column">{children}</EuiFlexGroup>;
-};
-
-const ResultView: React.FC<ResultViewProps> = ({ result }) => {
-  const fields = Object.entries(result)
-    .filter(([key]) => !key.startsWith('_') && key !== 'id')
-    .map(([key, value]) => {
-      return {
-        name: key,
-        value: value.raw,
-      };
-    });
-
-  const {
-    _meta: {
-      id: encodedId,
-      rawHit: { _index: index },
-    },
-  } = result;
-
-  const [, id] = JSON.parse(atob(encodedId));
-
-  const columns: Array<EuiBasicTableColumn<SearchResult>> = [
-    {
-      field: 'name',
-      name: 'name',
-      render: (name: string) => {
-        return <code>&quot;{name}&quot;</code>;
-      },
-      truncateText: true,
-      width: '20%',
-    },
-    {
-      field: 'value',
-      name: 'value',
-      render: (value: string) => value,
-    },
-  ];
-
-  return (
-    <EuiPanel paddingSize="m">
-      <EuiFlexGroup direction="column">
-        <EuiFlexGroup justifyContent="spaceBetween">
-          <code>ID: {id}</code>
-          <EuiFlexItem grow={false}>
-            <EuiFlexGroup gutterSize="xs" alignItems="center">
-              <code>from</code>
-              <EuiBadge color="hollow">{index}</EuiBadge>
-            </EuiFlexGroup>
-          </EuiFlexItem>
-        </EuiFlexGroup>
-        <EuiBasicTable items={fields} columns={columns} />
-      </EuiFlexGroup>
-    </EuiPanel>
-  );
-};
-
-const InputView: React.FC<InputViewProps> = ({ getInputProps }) => {
-  return (
-    <EuiFlexGroup gutterSize="s">
-      <EuiFieldSearch
-        fullWidth
-        placeholder="search"
-        {...getInputProps({})}
-        isClearable
-        aria-label="Search Input"
-      />
-      <EuiButton type="submit" color="primary" fill>
-        Search
-      </EuiButton>
-    </EuiFlexGroup>
-  );
-};
 
 export const EngineSearchPreview: React.FC = () => {
   const { http } = useValues(HttpLogic);

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/engine_search_preview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/engine_search_preview.tsx
@@ -27,6 +27,8 @@ import { EnterpriseSearchEnginesPageTemplate } from '../../layout/engines_page_t
 import { EngineIndicesLogic } from '../engine_indices_logic';
 import { EngineViewLogic } from '../engine_view_logic';
 
+import { DocumentProvider } from './document_context';
+import { DocumentFlyout } from './document_flyout';
 import { EngineSearchPreviewLogic } from './engine_search_preview_logic';
 
 import { InputView, ResultView, ResultsView } from './search_ui_components';
@@ -91,20 +93,23 @@ export const EngineSearchPreview: React.FC = () => {
       }}
       engineName={engineName}
     >
-      <SearchProvider config={config}>
-        <EuiFlexGroup>
-          <EuiFlexItem>
-            <SearchBox inputView={InputView} />
-          </EuiFlexItem>
-        </EuiFlexGroup>
-        <EuiSpacer size="m" />
-        <EuiFlexGroup>
-          <EuiFlexItem grow={false} css={{ minWidth: '240px' }} />
-          <EuiFlexItem>
-            <Results view={ResultsView} resultView={ResultView} />
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      </SearchProvider>
+      <DocumentProvider>
+        <SearchProvider config={config}>
+          <EuiFlexGroup>
+            <EuiFlexItem>
+              <SearchBox inputView={InputView} />
+            </EuiFlexItem>
+          </EuiFlexGroup>
+          <EuiSpacer size="m" />
+          <EuiFlexGroup>
+            <EuiFlexItem grow={false} css={{ minWidth: '240px' }} />
+            <EuiFlexItem>
+              <Results view={ResultsView} resultView={ResultView} />
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </SearchProvider>
+        <DocumentFlyout />
+      </DocumentProvider>
     </EnterpriseSearchEnginesPageTemplate>
   );
 };

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/search_ui_components.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/search_ui_components.tsx
@@ -24,6 +24,8 @@ import type {
   ResultViewProps,
   ResultsViewProps,
 } from '@elastic/react-search-ui-views';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
 
 import { useSelectedDocument } from './document_context';
 
@@ -55,7 +57,10 @@ export const ResultView: React.FC<ResultViewProps> = ({ result }) => {
   const columns: Array<EuiBasicTableColumn<{ name: string; value: string }>> = [
     {
       field: 'name',
-      name: 'name',
+      name: i18n.translate(
+        'xpack.enterpriseSearch.content.engine.searchPreview.result.nameColumn',
+        { defaultMessage: 'Field' }
+      ),
       render: (name: string) => {
         return (
           <EuiText>
@@ -70,7 +75,10 @@ export const ResultView: React.FC<ResultViewProps> = ({ result }) => {
     },
     {
       field: 'value',
-      name: 'value',
+      name: i18n.translate(
+        'xpack.enterpriseSearch.content.engine.searchPreview.result.valueColumn',
+        { defaultMessage: 'Value' }
+      ),
       render: (value: string) => (
         <EuiText>
           <code>{value}</code>
@@ -84,10 +92,21 @@ export const ResultView: React.FC<ResultViewProps> = ({ result }) => {
       <EuiPanel paddingSize="m">
         <EuiFlexGroup direction="column">
           <EuiFlexGroup justifyContent="spaceBetween">
-            <code>ID: {id}</code>
+            <code>
+              <FormattedMessage
+                id="xpack.enterpriseSearch.content.engine.searchPreview.result.id"
+                defaultMessage="ID: {id}"
+                values={{ id }}
+              />
+            </code>
             <EuiFlexItem grow={false}>
               <EuiFlexGroup gutterSize="xs" alignItems="center">
-                <code>from</code>
+                <code>
+                  <FormattedMessage
+                    id="xpack.enterpriseSearch.content.engine.searchPreview.result.fromIndex"
+                    defaultMessage="from"
+                  />
+                </code>
                 <EuiBadge color="hollow">{index}</EuiBadge>
               </EuiFlexGroup>
             </EuiFlexItem>
@@ -104,10 +123,16 @@ export const InputView: React.FC<InputViewProps> = ({ getInputProps }) => {
     <EuiFlexGroup gutterSize="s">
       <EuiFieldSearch
         fullWidth
-        placeholder="search"
+        placeholder={i18n.translate(
+          'xpack.enterpriseSearch.content.engine.searchPreview.inputView.placeholder',
+          { defaultMessage: 'Search' }
+        )}
         {...getInputProps({})}
         isClearable
-        aria-label="Search Input"
+        aria-label={i18n.translate(
+          'xpack.enterpriseSearch.content.engine.searchPreview.inputView.label',
+          { defaultMessage: 'Search Input' }
+        )}
       />
       <EuiButton type="submit" color="primary" fill>
         Search

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/search_ui_components.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/search_ui_components.tsx
@@ -23,11 +23,15 @@ import type {
   ResultsViewProps,
 } from '@elastic/react-search-ui-views';
 
+import { useSelectedDocument } from './document_context';
+
 export const ResultsView: React.FC<ResultsViewProps> = ({ children }) => {
   return <EuiFlexGroup direction="column">{children}</EuiFlexGroup>;
 };
 
 export const ResultView: React.FC<ResultViewProps> = ({ result }) => {
+  const { setSelectedDocument } = useSelectedDocument();
+
   const fields = Object.entries(result)
     .filter(([key]) => !key.startsWith('_') && key !== 'id')
     .map(([key, value]) => {
@@ -64,20 +68,22 @@ export const ResultView: React.FC<ResultViewProps> = ({ result }) => {
   ];
 
   return (
-    <EuiPanel paddingSize="m">
-      <EuiFlexGroup direction="column">
-        <EuiFlexGroup justifyContent="spaceBetween">
-          <code>ID: {id}</code>
-          <EuiFlexItem grow={false}>
-            <EuiFlexGroup gutterSize="xs" alignItems="center">
-              <code>from</code>
-              <EuiBadge color="hollow">{index}</EuiBadge>
-            </EuiFlexGroup>
-          </EuiFlexItem>
+    <button type="button" onClick={() => setSelectedDocument(result)}>
+      <EuiPanel paddingSize="m">
+        <EuiFlexGroup direction="column">
+          <EuiFlexGroup justifyContent="spaceBetween">
+            <code>ID: {id}</code>
+            <EuiFlexItem grow={false}>
+              <EuiFlexGroup gutterSize="xs" alignItems="center">
+                <code>from</code>
+                <EuiBadge color="hollow">{index}</EuiBadge>
+              </EuiFlexGroup>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+          <EuiBasicTable items={fields} columns={columns} />
         </EuiFlexGroup>
-        <EuiBasicTable items={fields} columns={columns} />
-      </EuiFlexGroup>
-    </EuiPanel>
+      </EuiPanel>
+    </button>
   );
 };
 

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/search_ui_components.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/search_ui_components.tsx
@@ -15,6 +15,7 @@ import {
   EuiFieldSearch,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiIcon,
   EuiPanel,
   EuiText,
   EuiTextColor,
@@ -33,6 +34,8 @@ export const ResultsView: React.FC<ResultsViewProps> = ({ children }) => {
   return <EuiFlexGroup direction="column">{children}</EuiFlexGroup>;
 };
 
+const RESULT_FIELDS_TRUNCATE_AT = 4;
+
 export const ResultView: React.FC<ResultViewProps> = ({ result }) => {
   const { setSelectedDocument } = useSelectedDocument();
 
@@ -44,6 +47,9 @@ export const ResultView: React.FC<ResultViewProps> = ({ result }) => {
         value: value.raw,
       };
     });
+
+  const truncatedFields = fields.slice(0, RESULT_FIELDS_TRUNCATE_AT);
+  const hiddenFields = fields.length - truncatedFields.length;
 
   const {
     _meta: {
@@ -90,7 +96,7 @@ export const ResultView: React.FC<ResultViewProps> = ({ result }) => {
   return (
     <button type="button" onClick={() => setSelectedDocument(result)}>
       <EuiPanel paddingSize="m">
-        <EuiFlexGroup direction="column">
+        <EuiFlexGroup direction="column" gutterSize="m">
           <EuiFlexGroup justifyContent="spaceBetween">
             <code>
               <FormattedMessage
@@ -111,7 +117,21 @@ export const ResultView: React.FC<ResultViewProps> = ({ result }) => {
               </EuiFlexGroup>
             </EuiFlexItem>
           </EuiFlexGroup>
-          <EuiBasicTable items={fields} columns={columns} />
+          <EuiBasicTable items={truncatedFields} columns={columns} />
+          {hiddenFields > 0 && (
+            <EuiFlexGroup gutterSize="s" alignItems="center">
+              <EuiIcon type="arrowRight" color="subdued" />
+              <EuiTextColor color="subdued">
+                <code>
+                  <FormattedMessage
+                    id="xpack.enterpriseSearch.content.engine.searchPreview.result.moreFieldsButton"
+                    defaultMessage="{count} {count, plural, one {More Field} other {More Fields}}"
+                    values={{ count: hiddenFields }}
+                  />
+                </code>
+              </EuiTextColor>
+            </EuiFlexGroup>
+          )}
         </EuiFlexGroup>
       </EuiPanel>
     </button>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/search_ui_components.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/search_ui_components.tsx
@@ -8,14 +8,16 @@
 import React from 'react';
 
 import {
-  EuiFieldSearch,
   EuiBadge,
   EuiBasicTable,
   EuiBasicTableColumn,
   EuiButton,
+  EuiFieldSearch,
   EuiFlexGroup,
   EuiFlexItem,
   EuiPanel,
+  EuiText,
+  EuiTextColor,
 } from '@elastic/eui';
 import type {
   InputViewProps,
@@ -55,7 +57,13 @@ export const ResultView: React.FC<ResultViewProps> = ({ result }) => {
       field: 'name',
       name: 'name',
       render: (name: string) => {
-        return <code>&quot;{name}&quot;</code>;
+        return (
+          <EuiText>
+            <EuiTextColor color="subdued">
+              <code>&quot;{name}&quot;</code>
+            </EuiTextColor>
+          </EuiText>
+        );
       },
       truncateText: true,
       width: '20%',
@@ -63,7 +71,11 @@ export const ResultView: React.FC<ResultViewProps> = ({ result }) => {
     {
       field: 'value',
       name: 'value',
-      render: (value: string) => value,
+      render: (value: string) => (
+        <EuiText>
+          <code>{value}</code>
+        </EuiText>
+      ),
     },
   ];
 

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/search_ui_components.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/search_ui_components.tsx
@@ -52,7 +52,7 @@ export const ResultView: React.FC<ResultViewProps> = ({ result }) => {
 
   const [, id] = JSON.parse(atob(encodedId));
 
-  const columns: Array<EuiBasicTableColumn<SearchResult>> = [
+  const columns: Array<EuiBasicTableColumn<{ name: string; value: string }>> = [
     {
       field: 'name',
       name: 'name',

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/search_ui_components.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/search_ui_components.tsx
@@ -1,0 +1,99 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import {
+  EuiFieldSearch,
+  EuiBadge,
+  EuiBasicTable,
+  EuiBasicTableColumn,
+  EuiButton,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiPanel,
+} from '@elastic/eui';
+import type {
+  InputViewProps,
+  ResultViewProps,
+  ResultsViewProps,
+} from '@elastic/react-search-ui-views';
+
+export const ResultsView: React.FC<ResultsViewProps> = ({ children }) => {
+  return <EuiFlexGroup direction="column">{children}</EuiFlexGroup>;
+};
+
+export const ResultView: React.FC<ResultViewProps> = ({ result }) => {
+  const fields = Object.entries(result)
+    .filter(([key]) => !key.startsWith('_') && key !== 'id')
+    .map(([key, value]) => {
+      return {
+        name: key,
+        value: value.raw,
+      };
+    });
+
+  const {
+    _meta: {
+      id: encodedId,
+      rawHit: { _index: index },
+    },
+  } = result;
+
+  const [, id] = JSON.parse(atob(encodedId));
+
+  const columns: Array<EuiBasicTableColumn<SearchResult>> = [
+    {
+      field: 'name',
+      name: 'name',
+      render: (name: string) => {
+        return <code>&quot;{name}&quot;</code>;
+      },
+      truncateText: true,
+      width: '20%',
+    },
+    {
+      field: 'value',
+      name: 'value',
+      render: (value: string) => value,
+    },
+  ];
+
+  return (
+    <EuiPanel paddingSize="m">
+      <EuiFlexGroup direction="column">
+        <EuiFlexGroup justifyContent="spaceBetween">
+          <code>ID: {id}</code>
+          <EuiFlexItem grow={false}>
+            <EuiFlexGroup gutterSize="xs" alignItems="center">
+              <code>from</code>
+              <EuiBadge color="hollow">{index}</EuiBadge>
+            </EuiFlexGroup>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+        <EuiBasicTable items={fields} columns={columns} />
+      </EuiFlexGroup>
+    </EuiPanel>
+  );
+};
+
+export const InputView: React.FC<InputViewProps> = ({ getInputProps }) => {
+  return (
+    <EuiFlexGroup gutterSize="s">
+      <EuiFieldSearch
+        fullWidth
+        placeholder="search"
+        {...getInputProps({})}
+        isClearable
+        aria-label="Search Input"
+      />
+      <EuiButton type="submit" color="primary" fill>
+        Search
+      </EuiButton>
+    </EuiFlexGroup>
+  );
+};


### PR DESCRIPTION
## Summary

Adds a flyout to preview an entire document. Also cleans up some of the existing search preview code.

https://user-images.githubusercontent.com/1699281/219487342-4186cbbc-0da1-443c-bc98-dd20654d3049.mov

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

