### PR TITLE
[Controls] Discard control grow changes on cancel

### DIFF
--- a/src/plugins/controls/public/control_group/editor/edit_control.tsx
+++ b/src/plugins/controls/public/control_group/editor/edit_control.tsx
@@ -83,7 +83,8 @@ export const EditControlButton = ({ embeddableId }: { embeddableId: string }) =>
             ...panel.explicitInput,
             ...inputToReturn,
           }) &&
-            isEqual(latestPanelState.current.width, panel.width))
+            isEqual(latestPanelState.current.width, panel.width) &&
+            isEqual(latestPanelState.current.grow, panel.grow))
         ) {
           reject();
           ref.close();
@@ -97,6 +98,7 @@ export const EditControlButton = ({ embeddableId }: { embeddableId: string }) =>
         }).then((confirmed) => {
           if (confirmed) {
             dispatch(setControlWidth({ width: panel.width, embeddableId }));
+            dispatch(setControlGrow({ grow: panel.grow, embeddableId }));
             reject();
             ref.close();
           }


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/151206

## Summary

This PR ensures that changes to the control group `grow` property (a) triggers the `Discard changes` warning modal and (b) when the modal is confirmed, the changes are indeed discarded.

https://user-images.githubusercontent.com/8698078/220419614-4cac86d9-7fd3-40f5-8c39-ef5994b11947.mov

<br>

While this fixes the attached **bug**, it raises another issue on whether or not the behaviour of auto-applying changes to the control's width/grow properties is even desired - this can be tracked in https://github.com/elastic/kibana/issues/151767.

### Checklist

- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->