### PR TITLE
[Profiling] Restore show information window

### DIFF
--- a/x-pack/plugins/profiling/public/components/flame_graphs_view/index.tsx
+++ b/x-pack/plugins/profiling/public/components/flame_graphs_view/index.tsx
@@ -32,6 +32,24 @@ import { ProfilingAppPageTemplate } from '../profiling_app_page_template';
 import { RedirectTo } from '../redirect_to';
 import { FlameGraphNormalizationOptions, NormalizationMenu } from './normalization_menu';
 
+export function FlameGraphInformationWindowSwitch({
+  showInformationWindow,
+  onChange,
+}: {
+  showInformationWindow: boolean;
+  onChange: () => void;
+}) {
+  return (
+    <EuiSwitch
+      checked={showInformationWindow}
+      onChange={onChange}
+      label={i18n.translate('xpack.profiling.flameGraph.showInformationWindow', {
+        defaultMessage: 'Show information window',
+      })}
+    />
+  );
+}
+
 export function FlameGraphsView({ children }: { children: React.ReactElement }) {
   const {
     path,
@@ -132,6 +150,10 @@ export function FlameGraphsView({ children }: { children: React.ReactElement }) 
   if (routePath === '/flamegraphs') {
     return <RedirectTo pathname="/flamegraphs/flamegraph" />;
   }
+
+  const onInformationWindowChange = () => {
+    setShowInformationWindow((prev) => !prev);
+  };
 
   return (
     <ProfilingAppPageTemplate tabs={tabs} hideSearchBar={true}>
@@ -249,14 +271,9 @@ export function FlameGraphsView({ children }: { children: React.ReactElement }) 
                   </EuiFlexItem>
                 ) : undefined}
                 <EuiFlexItem grow style={{ alignItems: 'flex-end' }}>
-                  <EuiSwitch
-                    checked={showInformationWindow}
-                    onChange={() => {
-                      setShowInformationWindow((prev) => !prev);
-                    }}
-                    label={i18n.translate('xpack.profiling.flameGraph.showInformationWindow', {
-                      defaultMessage: 'Show information window',
-                    })}
+                  <FlameGraphInformationWindowSwitch
+                    showInformationWindow={showInformationWindow}
+                    onChange={onInformationWindowChange}
                   />
                 </EuiFlexItem>
               </EuiFlexGroup>
@@ -269,14 +286,9 @@ export function FlameGraphsView({ children }: { children: React.ReactElement }) 
               <EuiHorizontalRule />
               <EuiFlexGroup direction="row">
                 <EuiFlexItem grow style={{ alignItems: 'flex-end' }}>
-                  <EuiSwitch
-                    checked={showInformationWindow}
-                    onChange={() => {
-                      setShowInformationWindow((prev) => !prev);
-                    }}
-                    label={i18n.translate('xpack.profiling.flameGraph.showInformationWindow', {
-                      defaultMessage: 'Show information window',
-                    })}
+                  <FlameGraphInformationWindowSwitch
+                    showInformationWindow={showInformationWindow}
+                    onChange={onInformationWindowChange}
                   />
                 </EuiFlexItem>
               </EuiFlexGroup>

--- a/x-pack/plugins/profiling/public/components/flame_graphs_view/index.tsx
+++ b/x-pack/plugins/profiling/public/components/flame_graphs_view/index.tsx
@@ -27,6 +27,7 @@ import { AsyncComponent } from '../async_component';
 import { useProfilingDependencies } from '../contexts/profiling_dependencies/use_profiling_dependencies';
 import { FlameGraph } from '../flamegraph';
 import { PrimaryAndComparisonSearchBar } from '../primary_and_comparison_search_bar';
+import { PrimaryProfilingSearchBar } from '../profiling_app_page_template/primary_profiling_search_bar';
 import { ProfilingAppPageTemplate } from '../profiling_app_page_template';
 import { RedirectTo } from '../redirect_to';
 import { FlameGraphNormalizationOptions, NormalizationMenu } from './normalization_menu';
@@ -133,7 +134,7 @@ export function FlameGraphsView({ children }: { children: React.ReactElement }) 
   }
 
   return (
-    <ProfilingAppPageTemplate tabs={tabs} hideSearchBar={isDifferentialView}>
+    <ProfilingAppPageTemplate tabs={tabs} hideSearchBar={true}>
       <EuiFlexGroup direction="column">
         {isDifferentialView ? (
           <EuiFlexItem grow={false}>
@@ -261,7 +262,27 @@ export function FlameGraphsView({ children }: { children: React.ReactElement }) 
               </EuiFlexGroup>
             </EuiPanel>
           </EuiFlexItem>
-        ) : null}
+        ) : (
+          <EuiFlexItem grow={false}>
+            <EuiPanel hasShadow={false} color="subdued">
+              <PrimaryProfilingSearchBar />
+              <EuiHorizontalRule />
+              <EuiFlexGroup direction="row">
+                <EuiFlexItem grow style={{ alignItems: 'flex-end' }}>
+                  <EuiSwitch
+                    checked={showInformationWindow}
+                    onChange={() => {
+                      setShowInformationWindow((prev) => !prev);
+                    }}
+                    label={i18n.translate('xpack.profiling.flameGraph.showInformationWindow', {
+                      defaultMessage: 'Show information window',
+                    })}
+                  />
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            </EuiPanel>
+          </EuiFlexItem>
+        )}
         <EuiFlexItem>
           <AsyncComponent {...state} style={{ height: '100%' }} size="xl">
             <FlameGraph

--- a/x-pack/plugins/profiling/public/components/flame_graphs_view/index.tsx
+++ b/x-pack/plugins/profiling/public/components/flame_graphs_view/index.tsx
@@ -167,139 +167,139 @@ export function FlameGraphsView({ children }: { children: React.ReactElement }) 
     return <RedirectTo pathname="/flamegraphs/flamegraph" />;
   }
 
-  const onInformationWindowChange = () => {
-    setShowInformationWindow((prev) => !prev);
-  };
+  const searchBar = isDifferentialView ? (
+    <PrimaryAndComparisonSearchBar />
+  ) : (
+    <PrimaryProfilingSearchBar />
+  );
+
+  const differentialComparisonMode = (
+    <EuiFlexItem grow={false}>
+      <EuiFlexGroup direction="row" gutterSize="m" alignItems="center">
+        <EuiFlexItem grow={false}>
+          <EuiTitle size="xxs">
+            <h3>
+              {i18n.translate(
+                'xpack.profiling.flameGraphsView.differentialFlameGraphComparisonModeTitle',
+                { defaultMessage: 'Format' }
+              )}
+            </h3>
+          </EuiTitle>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiButtonGroup
+            legend={i18n.translate(
+              'xpack.profiling.flameGraphsView.differentialFlameGraphComparisonModeLegend',
+              {
+                defaultMessage:
+                  'This switch allows you to switch between an absolute and relative comparison between both graphs',
+              }
+            )}
+            type="single"
+            buttonSize="s"
+            idSelected={comparisonMode}
+            onChange={(nextComparisonMode) => {
+              if (!('comparisonRangeFrom' in query)) {
+                return;
+              }
+
+              profilingRouter.push(routePath, {
+                path,
+                query: {
+                  ...query,
+                  ...(nextComparisonMode === FlameGraphComparisonMode.Absolute
+                    ? {
+                        comparisonMode: FlameGraphComparisonMode.Absolute,
+                        normalizationMode: FlameGraphNormalizationMode.Time,
+                      }
+                    : { comparisonMode: FlameGraphComparisonMode.Relative }),
+                },
+              });
+            }}
+            options={[
+              {
+                id: FlameGraphComparisonMode.Absolute,
+                label: i18n.translate(
+                  'xpack.profiling.flameGraphsView.differentialFlameGraphComparisonModeAbsoluteButtonLabel',
+                  {
+                    defaultMessage: 'Abs',
+                  }
+                ),
+              },
+              {
+                id: FlameGraphComparisonMode.Relative,
+                label: i18n.translate(
+                  'xpack.profiling.flameGraphsView.differentialFlameGraphComparisonModeRelativeButtonLabel',
+                  {
+                    defaultMessage: 'Rel',
+                  }
+                ),
+              },
+            ]}
+          />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiFlexItem>
+  );
+
+  const differentialComparisonNormalization = (
+    <EuiFlexItem grow={false}>
+      <EuiFlexGroup direction="row" gutterSize="m" alignItems="center">
+        <EuiFlexItem grow={false}>
+          <NormalizationMenu
+            onChange={(options) => {
+              profilingRouter.push(routePath, {
+                path: routePath,
+                query: {
+                  ...query,
+                  ...pick(options, 'baseline', 'comparison'),
+                  normalizationMode: options.mode,
+                },
+              });
+            }}
+            totalSeconds={
+              (new Date(timeRange.end).getTime() - new Date(timeRange.start).getTime()) / 1000
+            }
+            comparisonTotalSeconds={
+              (new Date(comparisonTimeRange.end!).getTime() -
+                new Date(comparisonTimeRange.start!).getTime()) /
+              1000
+            }
+            options={
+              (normalizationMode === FlameGraphNormalizationMode.Time
+                ? { mode: FlameGraphNormalizationMode.Time }
+                : {
+                    mode: FlameGraphNormalizationMode.Scale,
+                    baseline,
+                    comparison,
+                  }) as FlameGraphNormalizationOptions
+            }
+          />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiFlexItem>
+  );
+
+  const informationWindowSwitch = (
+    <EuiFlexItem grow style={{ alignItems: 'flex-end' }}>
+      <FlameGraphInformationWindowSwitch
+        showInformationWindow={showInformationWindow}
+        onChange={() => setShowInformationWindow((prev) => !prev)}
+      />
+    </EuiFlexItem>
+  );
 
   return (
     <ProfilingAppPageTemplate tabs={tabs} hideSearchBar={true}>
       <EuiFlexGroup direction="column">
         <EuiFlexItem grow={false}>
-          {isDifferentialView ? (
-            <FlameGraphSearchPanel searchBar={<PrimaryAndComparisonSearchBar />}>
-              <EuiFlexItem grow={false}>
-                <EuiFlexGroup direction="row" gutterSize="m" alignItems="center">
-                  <EuiFlexItem grow={false}>
-                    <EuiTitle size="xxs">
-                      <h3>
-                        {i18n.translate(
-                          'xpack.profiling.flameGraphsView.differentialFlameGraphComparisonModeTitle',
-                          { defaultMessage: 'Format' }
-                        )}
-                      </h3>
-                    </EuiTitle>
-                  </EuiFlexItem>
-                  <EuiFlexItem grow={false}>
-                    <EuiButtonGroup
-                      legend={i18n.translate(
-                        'xpack.profiling.flameGraphsView.differentialFlameGraphComparisonModeLegend',
-                        {
-                          defaultMessage:
-                            'This switch allows you to switch between an absolute and relative comparison between both graphs',
-                        }
-                      )}
-                      type="single"
-                      buttonSize="s"
-                      idSelected={comparisonMode}
-                      onChange={(nextComparisonMode) => {
-                        if (!('comparisonRangeFrom' in query)) {
-                          return;
-                        }
-
-                        profilingRouter.push(routePath, {
-                          path,
-                          query: {
-                            ...query,
-                            ...(nextComparisonMode === FlameGraphComparisonMode.Absolute
-                              ? {
-                                  comparisonMode: FlameGraphComparisonMode.Absolute,
-                                  normalizationMode: FlameGraphNormalizationMode.Time,
-                                }
-                              : { comparisonMode: FlameGraphComparisonMode.Relative }),
-                          },
-                        });
-                      }}
-                      options={[
-                        {
-                          id: FlameGraphComparisonMode.Absolute,
-                          label: i18n.translate(
-                            'xpack.profiling.flameGraphsView.differentialFlameGraphComparisonModeAbsoluteButtonLabel',
-                            {
-                              defaultMessage: 'Abs',
-                            }
-                          ),
-                        },
-                        {
-                          id: FlameGraphComparisonMode.Relative,
-                          label: i18n.translate(
-                            'xpack.profiling.flameGraphsView.differentialFlameGraphComparisonModeRelativeButtonLabel',
-                            {
-                              defaultMessage: 'Rel',
-                            }
-                          ),
-                        },
-                      ]}
-                    />
-                  </EuiFlexItem>
-                </EuiFlexGroup>
-              </EuiFlexItem>
-              {comparisonMode === FlameGraphComparisonMode.Absolute ? (
-                <EuiFlexItem grow={false}>
-                  <EuiFlexGroup direction="row" gutterSize="m" alignItems="center">
-                    <EuiFlexItem grow={false}>
-                      <NormalizationMenu
-                        onChange={(options) => {
-                          profilingRouter.push(routePath, {
-                            path: routePath,
-                            // @ts-expect-error Code gets too complicated to satisfy TS constraints
-                            query: {
-                              ...query,
-                              ...pick(options, 'baseline', 'comparison'),
-                              normalizationMode: options.mode,
-                            },
-                          });
-                        }}
-                        totalSeconds={
-                          (new Date(timeRange.end).getTime() -
-                            new Date(timeRange.start).getTime()) /
-                          1000
-                        }
-                        comparisonTotalSeconds={
-                          (new Date(comparisonTimeRange.end!).getTime() -
-                            new Date(comparisonTimeRange.start!).getTime()) /
-                          1000
-                        }
-                        options={
-                          (normalizationMode === FlameGraphNormalizationMode.Time
-                            ? { mode: FlameGraphNormalizationMode.Time }
-                            : {
-                                mode: FlameGraphNormalizationMode.Scale,
-                                baseline,
-                                comparison,
-                              }) as FlameGraphNormalizationOptions
-                        }
-                      />
-                    </EuiFlexItem>
-                  </EuiFlexGroup>
-                </EuiFlexItem>
-              ) : undefined}
-              <EuiFlexItem grow style={{ alignItems: 'flex-end' }}>
-                <FlameGraphInformationWindowSwitch
-                  showInformationWindow={showInformationWindow}
-                  onChange={onInformationWindowChange}
-                />
-              </EuiFlexItem>
-            </FlameGraphSearchPanel>
-          ) : (
-            <FlameGraphSearchPanel searchBar={<PrimaryProfilingSearchBar />}>
-              <EuiFlexItem grow style={{ alignItems: 'flex-end' }}>
-                <FlameGraphInformationWindowSwitch
-                  showInformationWindow={showInformationWindow}
-                  onChange={onInformationWindowChange}
-                />
-              </EuiFlexItem>
-            </FlameGraphSearchPanel>
-          )}
+          <FlameGraphSearchPanel searchBar={searchBar}>
+            {isDifferentialView && differentialComparisonMode}
+            {isDifferentialView &&
+              comparisonMode === FlameGraphComparisonMode.Absolute &&
+              differentialComparisonNormalization}
+            {informationWindowSwitch}
+          </FlameGraphSearchPanel>
         </EuiFlexItem>
         <EuiFlexItem>
           <AsyncComponent {...state} style={{ height: '100%' }} size="xl">


### PR DESCRIPTION
## Summary

This PR returns the show information window to the flamegraph view.

We also added a minor UI improvement to keep the flamegraph view visually synced up with the differential flamegraph view.

Fixes https://github.com/elastic/prodfiler/issues/3009

### Screenshots

The "Show information window" toggle is visible and disabled.

![image](https://user-images.githubusercontent.com/6038/219519101-5e8a9797-faa4-4ffe-ab72-1281df7759dc.png)

The "Show information window" toggle is visible and enabled.

![image](https://user-images.githubusercontent.com/6038/219519115-8b9b5539-82f5-4eb9-b667-4b283e6f39d8.png)

<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->