### PR TITLE
[7.17] Fix eslint rule for restricting certain lodash imports (#151023)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -170,50 +170,49 @@ const DEV_PATTERNS = [
 const RESTRICTED_IMPORTS = [
   {
     name: 'lodash',
-    importNames: ['set', 'setWith'],
-    message: 'Please use @elastic/safer-lodash-set instead',
+    importNames: ['set', 'setWith', 'template'],
+    message:
+      'lodash.set/setWith: Please use @elastic/safer-lodash-set instead.\n' +
+      'lodash.template: Function is unsafe, and not compatible with our content security policy.',
   },
   {
     name: 'lodash.set',
-    message: 'Please use @elastic/safer-lodash-set instead',
+    message: 'Please use @elastic/safer-lodash-set/set instead',
   },
   {
     name: 'lodash.setwith',
-    message: 'Please use @elastic/safer-lodash-set instead',
+    message: 'Please use @elastic/safer-lodash-set/setWith instead',
   },
   {
     name: 'lodash/set',
-    message: 'Please use @elastic/safer-lodash-set instead',
+    message: 'Please use @elastic/safer-lodash-set/set instead',
   },
   {
     name: 'lodash/setWith',
-    message: 'Please use @elastic/safer-lodash-set instead',
+    message: 'Please use @elastic/safer-lodash-set/setWith instead',
   },
   {
     name: 'lodash/fp',
-    importNames: ['set', 'setWith', 'assoc', 'assocPath'],
-    message: 'Please use @elastic/safer-lodash-set instead',
+    importNames: ['set', 'setWith', 'assoc', 'assocPath', 'template'],
+    message:
+      'lodash.set/setWith/assoc/assocPath: Please use @elastic/safer-lodash-set/fp instead\n' +
+      'lodash.template: Function is unsafe, and not compatible with our content security policy.',
   },
   {
     name: 'lodash/fp/set',
-    message: 'Please use @elastic/safer-lodash-set instead',
+    message: 'Please use @elastic/safer-lodash-set/fp/set instead',
   },
   {
     name: 'lodash/fp/setWith',
-    message: 'Please use @elastic/safer-lodash-set instead',
+    message: 'Please use @elastic/safer-lodash-set/fp/setWith instead',
   },
   {
     name: 'lodash/fp/assoc',
-    message: 'Please use @elastic/safer-lodash-set instead',
+    message: 'Please use @elastic/safer-lodash-set/fp/assoc instead',
   },
   {
     name: 'lodash/fp/assocPath',
-    message: 'Please use @elastic/safer-lodash-set instead',
-  },
-  {
-    name: 'lodash',
-    importNames: ['template'],
-    message: 'lodash.template is unsafe, and not compatible with our content security policy.',
+    message: 'Please use @elastic/safer-lodash-set/fp/assocPath instead',
   },
   {
     name: 'lodash.template',
@@ -221,11 +220,6 @@ const RESTRICTED_IMPORTS = [
   },
   {
     name: 'lodash/template',
-    message: 'lodash.template is unsafe, and not compatible with our content security policy.',
-  },
-  {
-    name: 'lodash/fp',
-    importNames: ['template'],
     message: 'lodash.template is unsafe, and not compatible with our content security policy.',
   },
   {
@@ -787,47 +781,54 @@ module.exports = {
     {
       files: ['**/*.{js,mjs,ts,tsx}'],
       rules: {
-        'no-restricted-imports': [
-          2,
-          {
-            paths: RESTRICTED_IMPORTS,
-          },
-        ],
+        'no-restricted-imports': ['error', ...RESTRICTED_IMPORTS],
         'no-restricted-modules': [
-          2,
+          'error',
           {
-            paths: [
-              {
-                name: 'lodash.set',
-                message: 'Please use @elastic/safer-lodash-set instead',
-              },
-              {
-                name: 'lodash.setwith',
-                message: 'Please use @elastic/safer-lodash-set instead',
-              },
-              {
-                name: 'lodash.template',
-                message:
-                  'lodash.template is unsafe, and not compatible with our content security policy.',
-              },
-              {
-                name: 'lodash/set',
-                message: 'Please use @elastic/safer-lodash-set instead',
-              },
-              {
-                name: 'lodash/setWith',
-                message: 'Please use @elastic/safer-lodash-set instead',
-              },
-              {
-                name: 'lodash/template',
-                message:
-                  'lodash.template is unsafe, and not compatible with our content security policy.',
-              },
-            ],
+            name: 'lodash.set',
+            message: 'Please use @elastic/safer-lodash-set instead',
+          },
+          {
+            name: 'lodash.setwith',
+            message: 'Please use @elastic/safer-lodash-set instead',
+          },
+          {
+            name: 'lodash.template',
+            message:
+              'lodash.template is unsafe, and not compatible with our content security policy.',
+          },
+          {
+            name: 'lodash/set',
+            message: 'Please use @elastic/safer-lodash-set/set instead',
+          },
+          {
+            name: 'lodash/setWith',
+            message: 'Please use @elastic/safer-lodash-set/setWith instead',
+          },
+          {
+            name: 'lodash/fp/set',
+            message: 'Please use @elastic/safer-lodash-set/fp/set instead',
+          },
+          {
+            name: 'lodash/fp/setWith',
+            message: 'Please use @elastic/safer-lodash-set/fp/setWith instead',
+          },
+          {
+            name: 'lodash/fp/assoc',
+            message: 'Please use @elastic/safer-lodash-set/fp/assoc instead',
+          },
+          {
+            name: 'lodash/fp/assocPath',
+            message: 'Please use @elastic/safer-lodash-set/fp/assocPath instead',
+          },
+          {
+            name: 'lodash/template',
+            message:
+              'lodash.template is unsafe, and not compatible with our content security policy.',
           },
         ],
         'no-restricted-properties': [
-          2,
+          'error',
           {
             object: 'lodash',
             property: 'set',
@@ -837,18 +838,6 @@ module.exports = {
             object: '_',
             property: 'set',
             message: 'Please use @elastic/safer-lodash-set instead',
-          },
-          {
-            object: 'lodash',
-            property: 'template',
-            message:
-              'lodash.template is unsafe, and not compatible with our content security policy.',
-          },
-          {
-            object: '_',
-            property: 'template',
-            message:
-              'lodash.template is unsafe, and not compatible with our content security policy.',
           },
           {
             object: 'lodash',
@@ -879,6 +868,18 @@ module.exports = {
             object: '_',
             property: 'assocPath',
             message: 'Please use @elastic/safer-lodash-set instead',
+          },
+          {
+            object: 'lodash',
+            property: 'template',
+            message:
+              'lodash.template is unsafe, and not compatible with our content security policy.',
+          },
+          {
+            object: '_',
+            property: 'template',
+            message:
+              'lodash.template is unsafe, and not compatible with our content security policy.',
           },
         ],
       },
@@ -887,19 +888,15 @@ module.exports = {
       files: ['**/common/**/*.{js,mjs,ts,tsx}', '**/public/**/*.{js,mjs,ts,tsx}'],
       rules: {
         'no-restricted-imports': [
-          2,
+          'error',
+          ...RESTRICTED_IMPORTS,
           {
-            paths: [
-              ...RESTRICTED_IMPORTS,
-              {
-                name: 'semver',
-                message: 'Please use "semver/*/{function}" instead',
-              },
-              {
-                name: '@kbn/rule-data-utils',
-                message: `Import directly from @kbn/rule-data-utils/* submodules in public/common code`,
-              },
-            ],
+            name: 'semver',
+            message: 'Please use "semver/*/{function}" instead',
+          },
+          {
+            name: '@kbn/rule-data-utils',
+            message: `Import directly from @kbn/rule-data-utils/* submodules in public/common code`,
           },
         ],
       },

--- a/packages/elastic-apm-synthtrace/BUILD.bazel
+++ b/packages/elastic-apm-synthtrace/BUILD.bazel
@@ -26,6 +26,7 @@ NPM_MODULE_EXTRA_FILES = [
 
 RUNTIME_DEPS = [
   "//packages/elastic-datemath",
+  "//packages/elastic-safer-lodash-set",
   "@npm//@elastic/elasticsearch",
   "@npm//lodash",
   "@npm//moment",
@@ -38,6 +39,7 @@ RUNTIME_DEPS = [
 
 TYPES_DEPS = [
   "//packages/elastic-datemath:npm_module_types",
+  "//packages/elastic-safer-lodash-set",
   "@npm//@elastic/elasticsearch",
   "@npm//moment",
   "@npm//p-limit",

--- a/packages/elastic-apm-synthtrace/src/lib/output/to_elasticsearch_output.ts
+++ b/packages/elastic-apm-synthtrace/src/lib/output/to_elasticsearch_output.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { set } from 'lodash';
+import { set } from '@elastic/safer-lodash-set';
 import { getObserverDefaults } from '../..';
 import { Fields } from '../entity';
 

--- a/packages/elastic-safer-lodash-set/README.md
+++ b/packages/elastic-safer-lodash-set/README.md
@@ -7,7 +7,7 @@ Lodash v4.x.
 ## Example Usage
 
 ```js
-const { set } = require('@elastic/safer-loadsh-set');
+const { set } = require('@elastic/safer-lodash-set');
 
 const object = { a: [{ b: { c: 3 } }] };
 

--- a/packages/kbn-es-query/src/filters/build_filters/phrase_filter.test.ts
+++ b/packages/kbn-es-query/src/filters/build_filters/phrase_filter.test.ts
@@ -5,7 +5,7 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
-import { set } from 'lodash';
+import { set } from '@elastic/safer-lodash-set';
 import {
   buildInlineScriptForPhraseFilter,
   buildPhraseFilter,

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/suggested_documents_callout.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/suggested_documents_callout.test.tsx
@@ -11,7 +11,8 @@ import { setMockValues } from '../../../../__mocks__/kea_logic';
 import React from 'react';
 
 import { shallow } from 'enzyme';
-import { set } from 'lodash/fp';
+
+import { set } from '@elastic/safer-lodash-set/fp';
 
 import { SuggestionsCallout } from '../components/suggestions_callout';
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curations.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curations.test.tsx
@@ -14,9 +14,8 @@ import React from 'react';
 
 import { shallow } from 'enzyme';
 
-import { set } from 'lodash/fp';
-
 import { EuiTab } from '@elastic/eui';
+import { set } from '@elastic/safer-lodash-set/fp';
 
 import { getPageHeaderTabs, getPageTitle } from '../../../../test_helpers';
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curations_overview.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curations_overview.test.tsx
@@ -12,7 +12,8 @@ import '../../../__mocks__/engine_logic.mock';
 import React from 'react';
 
 import { shallow } from 'enzyme';
-import { set } from 'lodash/fp';
+
+import { set } from '@elastic/safer-lodash-set/fp';
 
 import { CurationsTable, EmptyState } from '../components';
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/components/suggested_curations_callout.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/components/suggested_curations_callout.test.tsx
@@ -11,7 +11,8 @@ import { setMockValues } from '../../../../__mocks__/kea_logic';
 import React from 'react';
 
 import { shallow } from 'enzyme';
-import { set } from 'lodash/fp';
+
+import { set } from '@elastic/safer-lodash-set/fp';
 
 import { SuggestionsCallout } from '../../curations/components/suggestions_callout';
 

--- a/x-pack/plugins/monitoring/server/lib/logstash/get_node_info.test.ts
+++ b/x-pack/plugins/monitoring/server/lib/logstash/get_node_info.test.ts
@@ -6,7 +6,8 @@
  */
 
 import moment from 'moment';
-import { set, unset } from 'lodash';
+import { set } from '@elastic/safer-lodash-set';
+import { unset } from 'lodash';
 import { STANDALONE_CLUSTER_CLUSTER_UUID } from '../../../common/constants';
 import { handleResponse, getNodeInfo } from './get_node_info';
 import { LegacyRequest } from '../../types';

--- a/x-pack/plugins/osquery/public/fleet_integration/osquery_managed_policy_create_import_extension.tsx
+++ b/x-pack/plugins/osquery/public/fleet_integration/osquery_managed_policy_create_import_extension.tsx
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { pickBy, get, isEmpty, isString, unset, set, intersection } from 'lodash';
+import { set } from '@elastic/safer-lodash-set';
+import { pickBy, get, isEmpty, isString, unset, intersection } from 'lodash';
 import satisfies from 'semver/functions/satisfies';
 import {
   EuiFlexGroup,

--- a/x-pack/plugins/osquery/server/routes/pack/create_pack_route.ts
+++ b/x-pack/plugins/osquery/server/routes/pack/create_pack_route.ts
@@ -6,7 +6,8 @@
  */
 
 import moment from 'moment-timezone';
-import { has, mapKeys, set, unset, find } from 'lodash';
+import { set } from '@elastic/safer-lodash-set';
+import { has, mapKeys, unset, find } from 'lodash';
 import { schema } from '@kbn/config-schema';
 import { produce } from 'immer';
 import {

--- a/x-pack/plugins/osquery/server/routes/pack/update_pack_route.ts
+++ b/x-pack/plugins/osquery/server/routes/pack/update_pack_route.ts
@@ -6,7 +6,8 @@
  */
 
 import moment from 'moment-timezone';
-import { set, unset, has, difference, filter, find, map, mapKeys, uniq } from 'lodash';
+import { set } from '@elastic/safer-lodash-set';
+import { unset, has, difference, filter, find, map, mapKeys, uniq } from 'lodash';
 import { schema } from '@kbn/config-schema';
 import { produce } from 'immer';
 import {

--- a/x-pack/plugins/osquery/server/routes/status/create_status_route.ts
+++ b/x-pack/plugins/osquery/server/routes/status/create_status_route.ts
@@ -7,7 +7,8 @@
 
 import { produce } from 'immer';
 import { satisfies } from 'semver';
-import { filter, reduce, mapKeys, each, set, unset, uniq, map, has } from 'lodash';
+import { set } from '@elastic/safer-lodash-set';
+import { filter, reduce, mapKeys, each, unset, uniq, map, has } from 'lodash';
 import { packSavedObjectType } from '../../../common/types';
 import {
   PACKAGE_POLICY_SAVED_OBJECT_TYPE,

--- a/x-pack/plugins/reporting/server/lib/content_stream.test.ts
+++ b/x-pack/plugins/reporting/server/lib/content_stream.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { set } from 'lodash';
+import { set } from '@elastic/safer-lodash-set';
 import { elasticsearchServiceMock } from 'src/core/server/mocks';
 import { createMockLevelLogger } from '../test_helpers';
 import { ContentStream } from './content_stream';

--- a/x-pack/plugins/reporting/server/lib/screenshots/get_number_of_items.test.ts
+++ b/x-pack/plugins/reporting/server/lib/screenshots/get_number_of_items.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { set } from 'lodash';
+import { set } from '@elastic/safer-lodash-set';
 import { durationToNumber } from '../../../common/schema_utils';
 import { HeadlessChromiumDriver } from '../../browsers';
 import {

--- a/x-pack/plugins/reporting/server/routes/lib/jobs_query.test.ts
+++ b/x-pack/plugins/reporting/server/routes/lib/jobs_query.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { UnwrapPromise } from '@kbn/utility-types';
-import { set } from 'lodash';
+import { set } from '@elastic/safer-lodash-set';
 import { ElasticsearchClient } from 'src/core/server';
 import { statuses } from '../../lib';
 import { createMockConfigSchema, createMockReportingCore } from '../../test_helpers';

--- a/x-pack/plugins/security/public/components/use_form.ts
+++ b/x-pack/plugins/security/public/components/use_form.ts
@@ -5,12 +5,11 @@
  * 2.0.
  */
 
+import { set } from '@elastic/safer-lodash-set';
 import { cloneDeep, cloneDeepWith, get } from 'lodash';
 import type { ChangeEventHandler, FocusEventHandler, ReactEventHandler } from 'react';
 import { useState } from 'react';
 import useAsyncFn from 'react-use/lib/useAsyncFn';
-
-import { set } from '@elastic/safer-lodash-set';
 
 export type FormReturnTuple<Values, Result> = [FormState<Values, Result>, FormProps];
 

--- a/x-pack/plugins/security/public/components/use_form.ts
+++ b/x-pack/plugins/security/public/components/use_form.ts
@@ -5,10 +5,12 @@
  * 2.0.
  */
 
-import { cloneDeep, cloneDeepWith, get, set } from 'lodash';
+import { cloneDeep, cloneDeepWith, get } from 'lodash';
 import type { ChangeEventHandler, FocusEventHandler, ReactEventHandler } from 'react';
 import { useState } from 'react';
 import useAsyncFn from 'react-use/lib/useAsyncFn';
+
+import { set } from '@elastic/safer-lodash-set';
 
 export type FormReturnTuple<Values, Result> = [FormState<Values, Result>, FormProps];
 

--- a/x-pack/plugins/timelines/public/components/t_grid/body/column_headers/helpers.test.tsx
+++ b/x-pack/plugins/timelines/public/components/t_grid/body/column_headers/helpers.test.tsx
@@ -6,7 +6,8 @@
  */
 import { euiThemeVars } from '@kbn/ui-shared-deps-src/theme';
 import { mount } from 'enzyme';
-import { omit, set } from 'lodash/fp';
+import { set } from '@elastic/safer-lodash-set/fp';
+import { omit } from 'lodash/fp';
 import React from 'react';
 
 import { defaultHeaders } from './default_headers';

--- a/x-pack/plugins/triggers_actions_ui/public/application/lib/value_validators.ts
+++ b/x-pack/plugins/triggers_actions_ui/public/application/lib/value_validators.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { constant, get, set } from 'lodash';
+import { set } from '@elastic/safer-lodash-set';
+import { constant, get } from 'lodash';
 import { UserConfiguredActionConnector, IErrorObject, Alert } from '../../types';
 
 export function throwIfAbsent<T>(message: string) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [Fix eslint rule for restricting certain lodash imports (#151023)](https://github.com/elastic/kibana/pull/151023)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Thomas Watson","email":"watson@elastic.co"},"sourceCommit":{"committedDate":"2023-02-16T15:35:09Z","message":"Fix eslint rule for restricting certain lodash imports (#151023)\n\nFixes #110422\r\n\r\nTL;DR: The `lodash.set` function is unsafe and shouldn't be called.\r\n\r\nCause of error: If you specify multiple `no-restricted-imports` paths\r\nfor the same module, only the last path is used. Instead you need to\r\ncombine them into a single path as I've done in this PR.\r\n\r\nThis regression was introduced in #100277","sha":"fbdeffb48fcc6c23ded1e84e62d3f33dc84de23d","branchLabelMapping":{"^v8.8.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:APM","Team:uptime","release_note:skip","backport:all-open","v8.8.0"],"number":151023,"url":"https://github.com/elastic/kibana/pull/151023","mergeCommit":{"message":"Fix eslint rule for restricting certain lodash imports (#151023)\n\nFixes #110422\r\n\r\nTL;DR: The `lodash.set` function is unsafe and shouldn't be called.\r\n\r\nCause of error: If you specify multiple `no-restricted-imports` paths\r\nfor the same module, only the last path is used. Instead you need to\r\ncombine them into a single path as I've done in this PR.\r\n\r\nThis regression was introduced in #100277","sha":"fbdeffb48fcc6c23ded1e84e62d3f33dc84de23d"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.8.0","labelRegex":"^v8.8.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/151023","number":151023,"mergeCommit":{"message":"Fix eslint rule for restricting certain lodash imports (#151023)\n\nFixes #110422\r\n\r\nTL;DR: The `lodash.set` function is unsafe and shouldn't be called.\r\n\r\nCause of error: If you specify multiple `no-restricted-imports` paths\r\nfor the same module, only the last path is used. Instead you need to\r\ncombine them into a single path as I've done in this PR.\r\n\r\nThis regression was introduced in #100277","sha":"fbdeffb48fcc6c23ded1e84e62d3f33dc84de23d"}}]}] BACKPORT-->