### PR TITLE
[Fleet] fix nullable timeout query params in agent_policies API

### DIFF
--- a/x-pack/plugins/fleet/common/openapi/bundled.json
+++ b/x-pack/plugins/fleet/common/openapi/bundled.json
@@ -5728,12 +5728,10 @@
             "nullable": true
           },
           "unenroll_timeout": {
-            "type": "number",
-            "nullable": true
+            "type": "number"
           },
           "inactivity_timeout": {
-            "type": "number",
-            "nullable": true
+            "type": "number"
           }
         },
         "required": [

--- a/x-pack/plugins/fleet/common/openapi/bundled.yaml
+++ b/x-pack/plugins/fleet/common/openapi/bundled.yaml
@@ -3647,10 +3647,8 @@ components:
           nullable: true
         unenroll_timeout:
           type: number
-          nullable: true
         inactivity_timeout:
           type: number
-          nullable: true
       required:
         - name
         - namespace

--- a/x-pack/plugins/fleet/common/openapi/components/schemas/new_agent_policy.yaml
+++ b/x-pack/plugins/fleet/common/openapi/components/schemas/new_agent_policy.yaml
@@ -30,10 +30,8 @@ properties:
     nullable: true
   unenroll_timeout:
     type: number
-    nullable: true
   inactivity_timeout:
     type: number
-    nullable: true
 required:
   - name
   - namespace

--- a/x-pack/plugins/fleet/common/types/models/agent_policy.ts
+++ b/x-pack/plugins/fleet/common/types/models/agent_policy.ts
@@ -23,8 +23,8 @@ export interface NewAgentPolicy {
   has_fleet_server?: boolean;
   is_managed?: boolean; // Optional when creating a policy
   monitoring_enabled?: MonitoringType;
-  unenroll_timeout?: number | null;
-  inactivity_timeout?: number | null;
+  unenroll_timeout?: number;
+  inactivity_timeout?: number;
   is_preconfigured?: boolean;
   // Nullable to allow user to reset to default outputs
   data_output_id?: string | null;

--- a/x-pack/plugins/fleet/common/types/models/agent_policy.ts
+++ b/x-pack/plugins/fleet/common/types/models/agent_policy.ts
@@ -23,8 +23,8 @@ export interface NewAgentPolicy {
   has_fleet_server?: boolean;
   is_managed?: boolean; // Optional when creating a policy
   monitoring_enabled?: MonitoringType;
-  unenroll_timeout?: number;
-  inactivity_timeout?: number;
+  unenroll_timeout?: number | null;
+  inactivity_timeout?: number | null;
   is_preconfigured?: boolean;
   // Nullable to allow user to reset to default outputs
   data_output_id?: string | null;

--- a/x-pack/plugins/fleet/server/types/models/agent_policy.ts
+++ b/x-pack/plugins/fleet/server/types/models/agent_policy.ts
@@ -28,8 +28,8 @@ export const AgentPolicyBaseSchema = {
   has_fleet_server: schema.maybe(schema.boolean()),
   is_default: schema.maybe(schema.boolean()),
   is_default_fleet_server: schema.maybe(schema.boolean()),
-  unenroll_timeout: schema.nullable(schema.number({ min: 0 })),
-  inactivity_timeout: schema.nullable(schema.number({ min: 0, defaultValue: TWO_WEEKS_SECONDS })),
+  unenroll_timeout: schema.maybe(schema.number({ min: 0 })),
+  inactivity_timeout: schema.number({ min: 0, defaultValue: TWO_WEEKS_SECONDS }),
   monitoring_enabled: schema.maybe(
     schema.arrayOf(
       schema.oneOf([schema.literal(dataTypes.Logs), schema.literal(dataTypes.Metrics)])

--- a/x-pack/plugins/fleet/server/types/models/agent_policy.ts
+++ b/x-pack/plugins/fleet/server/types/models/agent_policy.ts
@@ -28,8 +28,8 @@ export const AgentPolicyBaseSchema = {
   has_fleet_server: schema.maybe(schema.boolean()),
   is_default: schema.maybe(schema.boolean()),
   is_default_fleet_server: schema.maybe(schema.boolean()),
-  unenroll_timeout: schema.maybe(schema.number({ min: 0 })),
-  inactivity_timeout: schema.number({ min: 0, defaultValue: TWO_WEEKS_SECONDS }),
+  unenroll_timeout: schema.nullable(schema.number({ min: 0 })),
+  inactivity_timeout: schema.nullable(schema.number({ min: 0, defaultValue: TWO_WEEKS_SECONDS })),
   monitoring_enabled: schema.maybe(
     schema.arrayOf(
       schema.oneOf([schema.literal(dataTypes.Logs), schema.literal(dataTypes.Metrics)])


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/151525

OpenAPI was set to nullable for `unenroll_timeout` and `inactivity_timeout`, but the `null` values were not actually accepted.
Fixed that by changing `schema.maybe()` to `schema.nullable()`.

EDIT: On a second look, I think rather the OpenAPI should be updated, so that these are not nullable fields, but rather optional. Nullable doesn't work well with setting default values (which we want for `inactivity_timeout`).


```
POST kbn:/api/fleet/agent_policies
{
 "data_output_id": null,
 "description": "Collect windows event logs.",
 "download_source_id": null,
 "fleet_server_host_id": null,
 "monitoring_output_id": null,
 "name": "Windows4",
 "namespace": "default"
}

{
  "item": {
    "id": "c1ac4bf0-aea3-11ed-810e-a1ed2deae3ac",
    "data_output_id": null,
    "description": "Collect windows event logs.",
    "download_source_id": null,
    "fleet_server_host_id": null,
    "monitoring_output_id": null,
    "name": "Windows4",
    "namespace": "default",
    "inactivity_timeout": 1209600,
    "status": "active",
    "is_managed": false,
    "revision": 1,
    "updated_at": "2023-02-17T09:16:27.055Z",
    "updated_by": "elastic",
    "schema_version": "1.0.0"
  }
}
```


<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->