### PR TITLE
[APM] Add apm:fetcher transaction type

### DIFF
--- a/x-pack/plugins/apm/public/components/app/service_inventory/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_inventory/index.tsx
@@ -16,6 +16,7 @@ import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import React from 'react';
 import { v4 as uuidv4 } from 'uuid';
+import { useFetcherTransaction } from '../../../hooks/use_apm_api_transaction';
 import { ApmDocumentType } from '../../../../common/document_type';
 import { ServiceInventoryFieldName } from '../../../../common/service_inventory';
 import { useAnomalyDetectionJobsContext } from '../../../context/anomaly_detection_jobs/use_anomaly_detection_jobs_context';
@@ -248,6 +249,11 @@ export function ServiceInventory() {
     shouldDisplayMlCallout(anomalyDetectionSetupState);
 
   const isLoading = isPending(mainStatisticsFetch.status);
+
+  useFetcherTransaction('Service Inventory', [
+    mainStatisticsFetch,
+    comparisonFetch,
+  ]);
 
   const isFailure = mainStatisticsFetch.status === FETCH_STATUS.FAILURE;
   const noItemsMessage = (

--- a/x-pack/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/index.tsx
@@ -16,6 +16,10 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React, { useEffect, useState } from 'react';
+import {
+  useFetcherSpan,
+  useFetcherTransaction,
+} from '../../../../hooks/use_apm_api_transaction';
 import { TransactionSummary } from '../../../shared/summary/transaction_summary';
 import { TransactionActionMenu } from '../../../shared/transaction_action_menu/transaction_action_menu';
 import { MaybeViewTraceLink } from './maybe_view_trace_link';
@@ -63,6 +67,11 @@ export function WaterfallWithSummary<TSample extends {}>({
   const isSucceded =
     waterfallFetchResult.status === FETCH_STATUS.SUCCESS &&
     traceSamplesFetchStatus === FETCH_STATUS.SUCCESS;
+
+  useFetcherTransaction('Waterfall', [
+    useFetcherSpan('waterfall', waterfallFetchResult.status),
+    useFetcherSpan('trace samples', traceSamplesFetchStatus),
+  ]);
 
   useEffect(() => {
     if (!isControlled) {

--- a/x-pack/plugins/apm/public/context/url_params_context/helpers.ts
+++ b/x-pack/plugins/apm/public/context/url_params_context/helpers.ts
@@ -9,7 +9,7 @@ import datemath from '@kbn/datemath';
 import { pickBy } from 'lodash';
 import { UrlParams } from './types';
 
-function getParsedDate(rawDate?: string, options = {}) {
+export function getParsedDate(rawDate?: string, options = {}) {
   if (rawDate) {
     const parsed = datemath.parse(rawDate, options);
     if (parsed && parsed.isValid()) {

--- a/x-pack/plugins/apm/public/hooks/use_apm_api_transaction.tsx
+++ b/x-pack/plugins/apm/public/hooks/use_apm_api_transaction.tsx
@@ -1,0 +1,71 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { apm, Span } from '@elastic/apm-rum';
+import { useEffect, useMemo } from 'react';
+import { FETCH_STATUS } from './use_fetcher';
+
+export function useFetcherSpan(endpoint: string, status: FETCH_STATUS) {
+  return useMemo(() => ({ endpoint, status }), [endpoint, status]);
+}
+
+export function useFetcherTransaction(
+  name: string,
+  fetchResults: Array<{
+    endpoint?: string;
+    status: FETCH_STATUS;
+  }>
+) {
+  const { transaction, spans } = useMemo(() => {
+    return {
+      transaction: apm.startTransaction(name, 'apm:fetcher'),
+      spans: [] as Array<Span | undefined>,
+    };
+  }, [name]);
+
+  const didCompleteRequests = fetchResults.every(
+    ({ status }) =>
+      status === FETCH_STATUS.SUCCESS || status === FETCH_STATUS.FAILURE
+  );
+
+  useEffect(() => {
+    fetchResults.map(({ status, endpoint }, i) => {
+      // start span
+      if (status === FETCH_STATUS.LOADING && spans[i] === undefined) {
+        console.log('start span', endpoint);
+        spans[i] = transaction?.startSpan(endpoint, 'http');
+      }
+
+      // end span
+      const span = spans[i];
+      if (span !== undefined) {
+        if (status === FETCH_STATUS.SUCCESS) {
+          span.end();
+          // @ts-expect-error
+          span.outcome = 'success';
+        }
+
+        if (status === FETCH_STATUS.FAILURE) {
+          span.end();
+          // @ts-expect-error
+          span.outcome = 'failure';
+        }
+      }
+    });
+
+    // @ts-expect-error
+    const txEnded = transaction?.ended;
+    if (transaction && didCompleteRequests && !txEnded) {
+      transaction.end();
+      const isFailure = fetchResults.some(
+        ({ status }) => status === FETCH_STATUS.FAILURE
+      );
+      // @ts-expect-error
+      transaction.outcome = isFailure ? 'failure' : 'success';
+    }
+  }, [transaction, didCompleteRequests, fetchResults, spans]);
+}


### PR DESCRIPTION
This PR adds a new transaction type `apm:fetcher`. This is an alternative to the existing `route-change` and `app-change` transaction types that also capture client side performance. The advantage of `apm:fetcher` is that it focuses on the time it takes before specific parts of the content is available to interact with, where the existing transaction types are more generalised and don't distinguish between non-blocking background requests, and requests that directly block the UI from rendering. 

The `apm:fetcher` transaction will be captured for both full page loads, navigation between apps and client side route changes. The existing transaction types only capture specific flows. The `route-change` transaction type captures client side route changes. The `app-change`  transaction type captures full page loads and navigation between apps. This separation makes it harder to quantify overall numbers and `apm:fetcher` makes this easier.

## Examples

To create a custom transaction that measures a components rendering time, and waits for two specific http requests (main request and the spark lines):
```ts
useFetcherTransaction('Service Inventory', [
  mainStatisticsFetch,
  comparisonFetch,
]);
```
![image](https://user-images.githubusercontent.com/209966/219598279-8e937b3c-33a7-411d-b562-960c24ae2cf3.png)


It is also possible to only capture the primary request, which aligns more closely with user pain:

```ts
useFetcherTransaction('Service Inventory', [mainStatisticsFetch]);
```
<img width="1439" alt="image" src="https://user-images.githubusercontent.com/209966/219636771-ab5618ab-e4f5-442d-afe6-003d21602b87.png">


The exact same page load is captured with the `route-change` transaction type:
![image](https://user-images.githubusercontent.com/209966/219638633-4ffad13f-9282-40dd-a4a7-1cacf45b06ac.png)

Things to note:
- the `route-change` transaction is 5264m. 
- the `apm:fetch` transaction is 4153ms. 
- The `route-change` transaction is longer than the `apm:fetch` transaction because the former includes the span `GET http://localhost:5601/fix/api/index_patterns/_fields_for_wildcard`. This span is non-blocking, and doesn't affect the end user experience, so doesn't affect the time it takes to see the Service Inventory.
