### PR TITLE
[Fleet] added missing content type application/gzip to openapi

### DIFF
--- a/x-pack/plugins/fleet/common/openapi/bundled.json
+++ b/x-pack/plugins/fleet/common/openapi/bundled.json
@@ -435,6 +435,12 @@
                 "type": "string",
                 "format": "binary"
               }
+            },
+            "application/gzip": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
             }
           }
         }

--- a/x-pack/plugins/fleet/common/openapi/bundled.yaml
+++ b/x-pack/plugins/fleet/common/openapi/bundled.yaml
@@ -281,6 +281,10 @@ paths:
             schema:
               type: string
               format: binary
+          application/gzip:
+            schema:
+              type: string
+              format: binary
   /epm/packages/_bulk:
     post:
       summary: Packages - Bulk install

--- a/x-pack/plugins/fleet/common/openapi/paths/epm@packages.yaml
+++ b/x-pack/plugins/fleet/common/openapi/paths/epm@packages.yaml
@@ -83,3 +83,7 @@ post:
         schema:
           type: string
           format: binary
+      application/gzip:
+        schema:
+          type: string
+          format: binary


### PR DESCRIPTION
## Summary

Related to https://github.com/elastic/kibana/issues/148599

Added missing `application/gzip` content type to openapi for packages upload API.
