### PR TITLE
[Security Solution][C77175] E2E 👉🏽 Alert Table controls and renderers.

### DIFF
--- a/x-pack/plugins/security_solution/cypress/e2e/detection_alerts/alert_table_controls.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_alerts/alert_table_controls.cy.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getNewRule } from '../../objects/rule';
+import {
+  DATA_GRID_COLUMN_ORDER_BTN,
+  DATA_GRID_FIELDS,
+  DATA_GRID_FULL_SCREEN,
+  GET_DATA_GRID_HEADER,
+  GET_DATA_GRID_HEADER_CELL_ACTION_GROUP,
+} from '../../screens/common/data_grid';
+import { createCustomRuleEnabled } from '../../tasks/api_calls/rules';
+import { cleanKibana } from '../../tasks/common';
+import { waitForAlertsToPopulate } from '../../tasks/create_new_rule';
+import { login, visit } from '../../tasks/login';
+import { ALERTS_URL } from '../../urls/navigation';
+
+/*
+ *
+ * Alert table is third party component which cannot be easily tested by jest.
+ * This test main checks if Alert Table controls are rendered properly.
+ *
+ * */
+describe('Alert Table Contorls', () => {
+  before(() => {
+    cleanKibana();
+    login();
+    createCustomRuleEnabled(getNewRule());
+  });
+
+  beforeEach(() => {
+    visit(ALERTS_URL);
+    waitForAlertsToPopulate();
+  });
+
+  it('full screen, column sorting', () => {
+    cy.get(DATA_GRID_FULL_SCREEN)
+      .should('have.attr', 'aria-label', 'Enter fullscreen')
+      .trigger('click')
+      .should('have.attr', 'aria-label', 'Exit fullscreen')
+      .trigger('click');
+    cy.get(DATA_GRID_COLUMN_ORDER_BTN).should('be.visible');
+  });
+
+  context('Sorting', () => {
+    it('Date Column', () => {
+      const timestampField = DATA_GRID_FIELDS.TIMESTAMP.fieldName;
+      cy.get(GET_DATA_GRID_HEADER(timestampField)).trigger('click');
+      cy.get(GET_DATA_GRID_HEADER_CELL_ACTION_GROUP(timestampField))
+        .should('be.visible')
+        .should('contain.text', 'Sort Old-New');
+    });
+
+    it('Number column', () => {
+      const riskScoreField = DATA_GRID_FIELDS.RISK_SCORE.fieldName;
+      cy.get(GET_DATA_GRID_HEADER(riskScoreField)).trigger('click');
+      cy.get(GET_DATA_GRID_HEADER_CELL_ACTION_GROUP(riskScoreField))
+        .should('be.visible')
+        .should('contain.text', 'Sort Low-High');
+    });
+
+    it('Text Column', () => {
+      const ruleField = DATA_GRID_FIELDS.RULE.fieldName;
+      cy.get(GET_DATA_GRID_HEADER(ruleField)).trigger('click');
+      cy.get(GET_DATA_GRID_HEADER_CELL_ACTION_GROUP(ruleField))
+        .should('be.visible')
+        .should('contain.text', 'Sort A-Z');
+    });
+  });
+});

--- a/x-pack/plugins/security_solution/cypress/e2e/detection_alerts/event_rendered_view.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_alerts/event_rendered_view.cy.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getNewRule } from '../../objects/rule';
+import {
+  EVENT_SUMMARY_ALERT_RENDERER_CONTENT,
+  EVENT_SUMMARY_COLUMN,
+  ALERT_RENDERER_HOST_NAME,
+} from '../../screens/alerts';
+import { FIELDS_BROWSER_VIEW_BUTTON } from '../../screens/fields_browser';
+import {
+  DATA_GRID_COLUMN_ORDER_BTN,
+  DATA_GRID_FIELD_SORT_BTN,
+} from '../../screens/common/data_grid';
+import { HOVER_ACTIONS } from '../../screens/timeline';
+import {
+  switchAlertTableToEventRenderedView,
+  waitForAlerts,
+  waitForTopNHistogramToLoad,
+} from '../../tasks/alerts';
+import { createCustomRuleEnabled } from '../../tasks/api_calls/rules';
+import { cleanKibana } from '../../tasks/common';
+import { login, visit } from '../../tasks/login';
+import { ALERTS_URL } from '../../urls/navigation';
+import { TOP_N_ALERT_HISTOGRAM, TOP_N_CONTAINER_CLOSE_BTN } from '../../screens/shared';
+
+describe('Event Rendered View', { testIsolation: false }, () => {
+  before(() => {
+    cleanKibana();
+    login();
+    createCustomRuleEnabled(getNewRule(), 'new custom rule');
+    visit(ALERTS_URL);
+    waitForAlerts();
+    switchAlertTableToEventRenderedView();
+  });
+
+  it('Event Summary Column + Hover Actions', () => {
+    cy.get(EVENT_SUMMARY_COLUMN).should('be.visible');
+    cy.get(EVENT_SUMMARY_ALERT_RENDERER_CONTENT).should('be.visible');
+
+    cy.get(ALERT_RENDERER_HOST_NAME).first().trigger('mouseover');
+
+    cy.get(HOVER_ACTIONS.SHOW_TOP).trigger('click');
+    waitForTopNHistogramToLoad();
+    cy.get(TOP_N_ALERT_HISTOGRAM).should('be.visible');
+    cy.get(TOP_N_CONTAINER_CLOSE_BTN).trigger('click');
+  });
+
+  /*
+   *
+   * Alert table is third party component which cannot be easily tested by jest.
+   * This test main checks if Alert Table controls are rendered properly.
+   *
+   * */
+  it('Field Browser is not visible', () => {
+    cy.get(FIELDS_BROWSER_VIEW_BUTTON).should('not.exist');
+  });
+
+  it('Sorting control is not visible', () => {
+    cy.get(DATA_GRID_FIELD_SORT_BTN).should('not.be.visible');
+  });
+
+  it('Column Order button is not visible', () => {
+    cy.get(DATA_GRID_COLUMN_ORDER_BTN).should('not.exist');
+  });
+});

--- a/x-pack/plugins/security_solution/cypress/screens/alerts.ts
+++ b/x-pack/plugins/security_solution/cypress/screens/alerts.ts
@@ -152,3 +152,20 @@ export const ACTIONS_EXPAND_BUTTON = '[data-test-subj="euiDataGridCellExpandButt
 
 export const SHOW_TOP_N_HEADER =
   '[data-test-subj="topN-container"] [data-test-subj="header-section-title"]';
+
+export const ALERT_TABLE_SUMMARY_VIEW_SELECTABLE = '[data-test-subj="summary-view-selector"]';
+
+export const ALERT_TABLE_GRID_VIEW_OPTION = '[data-test-subj="gridView"]';
+
+export const EVENT_SUMMARY_COLUMN = '[data-gridcell-column-id="eventSummary"]';
+
+export const EVENT_SUMMARY_ALERT_RENDERER_CONTENT = '[data-test-subj="alertRenderer"]';
+
+export const ALERT_TABLE_EVENT_RENDERED_VIEW_OPTION = '[data-test-subj="eventRenderedView"]';
+
+export const ALERT_TABLE_ADDITIONAL_CONTROLS = '[data-test-subj="additionalFilters-popover"]';
+
+export const ALERT_RENDERER_CONTENT = '[data-test-subj="alertRenderer"]';
+
+export const ALERT_RENDERER_HOST_NAME =
+  '[data-test-subj="alertFieldBadge"] [data-test-subj="render-content-host.name"]';

--- a/x-pack/plugins/security_solution/cypress/screens/common/data_grid.ts
+++ b/x-pack/plugins/security_solution/cypress/screens/common/data_grid.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const GET_DATA_GRID_HEADER = (fieldName: string) => {
+  return `[data-test-subj="dataGridHeaderCell-${fieldName}"]`;
+};
+
+export const DATA_GRID_FIELDS = {
+  TIMESTAMP: {
+    fieldName: '@timestamp',
+    label: '@timestamp',
+  },
+  ID: {
+    fieldName: '_id',
+    label: '_id',
+  },
+  RISK_SCORE: {
+    fieldName: 'kibana.alert.risk_score',
+    label: 'Risk Score',
+  },
+
+  RULE: {
+    fieldName: 'kibana.alert.rule.name',
+    label: 'Rule',
+  },
+};
+
+export const GET_DATA_GRID_HEADER_CELL_ACTION_GROUP = (fieldName: string) => {
+  return `[data-test-subj="dataGridHeaderCellActionGroup-${fieldName}"]`;
+};
+
+export const DATA_GRID_FULL_SCREEN = '[data-test-subj="dataGridFullScreenButton"]';
+
+export const DATA_GRID_FIELD_SORT_BTN = '[data-test-subj="dataGridColumnSortingButton"]';
+
+export const DATA_GRID_COLUMN_ORDER_BTN = '[data-test-subj="dataGridColumnSelectorButton"]';
+
+export const DATA_GRID_COLUMNS = '.euiDataGridHeaderCell__content';
+
+export const COLUMN_ORDER_POPUP = {
+  TIMESTAMP: '[data-test-subj="dataGridColumnSelectorColumnItem-@timestamp"]',
+  REASON: '[data-test-subj="dataGridColumnSelectorColumnItem-kibana.alert.reason"]',
+};

--- a/x-pack/plugins/security_solution/cypress/screens/shared.ts
+++ b/x-pack/plugins/security_solution/cypress/screens/shared.ts
@@ -6,3 +6,11 @@
  */
 
 export const TOAST_ERROR = '.euiToast--danger';
+
+export const TOP_N_ALERT_HISTOGRAM =
+  '[data-test-subj="topN-container"] [data-test-subj="alerts-histogram-panel"]';
+
+export const TOP_N_CONTAINER = '[data-test-subj="topN-container"]';
+
+export const TOP_N_CONTAINER_CLOSE_BTN =
+  '[data-test-subj="topN-container"] [data-test-subj="close"]';

--- a/x-pack/plugins/security_solution/cypress/screens/timeline.ts
+++ b/x-pack/plugins/security_solution/cypress/screens/timeline.ts
@@ -315,5 +315,5 @@ export const HOVER_ACTIONS = {
   FILTER_FOR: '[data-test-subj="filter-for-value"]',
   FILTER_OUT: '[data-test-subj="filter-out-value"]',
   COPY: '[data-test-subj="clipboard"]',
-  SHOW_TOP: 'show-top-field',
+  SHOW_TOP: '[data-test-subj=show-top-field]',
 };

--- a/x-pack/plugins/security_solution/cypress/tasks/alerts.ts
+++ b/x-pack/plugins/security_solution/cypress/tasks/alerts.ts
@@ -36,6 +36,8 @@ import {
   CELL_FILTER_IN_BUTTON,
   CELL_SHOW_TOP_FIELD_BUTTON,
   ACTIONS_EXPAND_BUTTON,
+  ALERT_TABLE_SUMMARY_VIEW_SELECTABLE,
+  ALERT_TABLE_EVENT_RENDERED_VIEW_OPTION,
 } from '../screens/alerts';
 import { LOADING_INDICATOR, REFRESH_BUTTON } from '../screens/security_header';
 import { TIMELINE_COLUMN_SPINNER } from '../screens/timeline';
@@ -385,4 +387,14 @@ export const resetFilters = () => {
    * waitforpagefilters();
    *
    * */
+};
+
+export const waitForTopNHistogramToLoad = () => {
+  cy.get(ALERTS_HISTOGRAM_PANEL_LOADER).should('exist');
+  cy.get(ALERTS_HISTOGRAM_PANEL_LOADER).should('not.exist');
+};
+
+export const switchAlertTableToEventRenderedView = () => {
+  cy.get(ALERT_TABLE_SUMMARY_VIEW_SELECTABLE).should('be.visible').trigger('click');
+  cy.get(ALERT_TABLE_EVENT_RENDERED_VIEW_OPTION).should('be.visible').trigger('click');
 };

--- a/x-pack/plugins/security_solution/public/common/components/events_viewer/right_top_menu.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/events_viewer/right_top_menu.tsx
@@ -74,7 +74,7 @@ export const RightTopMenu = ({
       </UpdatedFlexItem>
       {tGridEventRenderedViewEnabled &&
         [TableId.alertsOnRuleDetailsPage, TableId.alertsOnAlertsPage].includes(tableId) && (
-          <UpdatedFlexItem grow={false} $show={!loading}>
+          <UpdatedFlexItem data-test-subj="summary-view-selector" grow={false} $show={!loading}>
             <SummaryViewSelector viewSelected={tableView} onViewChange={onViewChange} />
           </UpdatedFlexItem>
         )}

--- a/x-pack/plugins/security_solution/public/common/components/events_viewer/summary_view_select/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/events_viewer/summary_view_select/index.tsx
@@ -82,6 +82,7 @@ const SummaryViewSelectorComponent = ({ viewSelected, onViewChange }: SummaryVie
     () => [
       {
         label: gridView,
+        'data-test-subj': 'gridView',
         key: 'gridView',
         checked: (viewSelected === 'gridView' ? 'on' : undefined) as EuiSelectableOption['checked'],
         meta: [
@@ -99,6 +100,7 @@ const SummaryViewSelectorComponent = ({ viewSelected, onViewChange }: SummaryVie
       {
         label: eventRenderedView,
         key: 'eventRenderedView',
+        'data-test-subj': 'eventRenderedView',
         checked: (viewSelected === 'eventRenderedView'
           ? 'on'
           : undefined) as EuiSelectableOption['checked'],


### PR DESCRIPTION
## Summary

This PR adds only Cypress Tests in lieu of below Manual Regression tests. Complete list of regression tests that need to automated is given here: https://github.com/elastic/security-team/issues/5967

- [x] C77175 | Verify the customize columns, customize event renderers, full screen and sorting are working fine
- [x] C77179 | Verify that Sorting is working on all columns

