### PR TITLE
[8.7] [Security Solution] Rules column links back to popover action

### DIFF
--- a/x-pack/plugins/security_solution/public/common/lib/cell_actions/helpers.tsx
+++ b/x-pack/plugins/security_solution/public/common/lib/cell_actions/helpers.tsx
@@ -39,6 +39,11 @@ export const COLUMNS_WITH_LINKS = [
     label: i18n.VIEW_RULE_DETAILS,
     linkField: 'signal.rule.id',
   },
+  {
+    columnId: 'kibana.alert.rule.name',
+    label: i18n.VIEW_RULE_DETAILS,
+    linkField: 'kibana.alert.rule.uuid',
+  },
   ...PORT_NAMES.map((p) => ({
     columnId: p,
     label: i18n.VIEW_PORT_DETAILS,


### PR DESCRIPTION
## Summary

Due to changes in the cell renderers the `Rule` column cell value started showing as a link to the rule detail, instead of an action in the hover actions popover.

After discussing this with @paulewing, we decided we want to introduce values as links, but we want to change all the linkable (`user.name`, `host.name`, `source.ip` and `destination.ip`) columns at once, starting in 8.8.
 
For the 8.7 release, we'll keep the same old behavior, showing the option to open the details in the last popover action item.

In 8.8, with the introduction of the new `CellActions` framework, we'll start showing the values of all those columns as links.

### Screenshots

**Action link to summary (8.7)**

![action_column](https://user-images.githubusercontent.com/17747913/220077721-e764738a-1866-49ba-855f-23a4c0ee44d6.png)

**Value link to summary (8.8)**

![link_column](https://user-images.githubusercontent.com/17747913/220076477-813425f7-fa2f-474f-87d2-3a7a2a7f2c43.png)
