### PR TITLE
[ML] Fix trained model stats layout 

### DIFF
--- a/x-pack/plugins/ml/public/application/model_management/expanded_row.tsx
+++ b/x-pack/plugins/ml/public/application/model_management/expanded_row.tsx
@@ -313,23 +313,25 @@ export const ExpandedRow: FC<ExpandedRowProps> = ({ item }) => {
               <div data-test-subj={'mlTrainedModelStatsContent'}>
                 <EuiSpacer size={'s'} />
 
+                {!!modelItems?.length ? (
+                  <>
+                    <EuiPanel>
+                      <EuiTitle size={'xs'}>
+                        <h5>
+                          <FormattedMessage
+                            id="xpack.ml.trainedModels.modelsList.expandedRow.deploymentStatsTitle"
+                            defaultMessage="Deployment stats"
+                          />
+                        </h5>
+                      </EuiTitle>
+                      <EuiSpacer size={'m'} />
+                      <AllocatedModels models={modelItems} hideColumns={['model_id']} />
+                    </EuiPanel>
+                    <EuiSpacer size={'s'} />
+                  </>
+                ) : null}
+
                 <EuiFlexGrid columns={2} gutterSize={'m'}>
-                  {!!modelItems?.length ? (
-                    <EuiFlexItem grow={2}>
-                      <EuiPanel>
-                        <EuiTitle size={'xs'}>
-                          <h5>
-                            <FormattedMessage
-                              id="xpack.ml.trainedModels.modelsList.expandedRow.deploymentStatsTitle"
-                              defaultMessage="Deployment stats"
-                            />
-                          </h5>
-                        </EuiTitle>
-                        <EuiSpacer size={'m'} />
-                        <AllocatedModels models={modelItems} hideColumns={['model_id']} />
-                      </EuiPanel>
-                    </EuiFlexItem>
-                  ) : null}
                   {stats.inference_stats ? (
                     <EuiFlexItem>
                       <EuiPanel>


### PR DESCRIPTION
## Summary

Fixes the expanded row layout for trained model stats. 

Before: 
<img width="1241" alt="image" src="https://user-images.githubusercontent.com/5236598/220093818-7dc0a21a-2512-4b30-a7ef-abfb84eab799.png">


After: 
<img width="1247" alt="image" src="https://user-images.githubusercontent.com/5236598/220093615-c006473d-5e00-4902-a04f-0f9a581006fa.png">




<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->