### PR TITLE
[Fleet][Bugfix] Fix "dataset cannot be modified" error when editing input package policy

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/use_package_policy.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/use_package_policy.tsx
@@ -36,6 +36,7 @@ import {
 } from '../../create_package_policy_page/services';
 import type { PackagePolicyFormState } from '../../create_package_policy_page/types';
 import { fixApmDurationVars, hasUpgradeAvailable } from '../utils';
+import { prepareInputPackagePolicyDataset } from '../../create_package_policy_page/services/prepare_input_pkg_policy_dataset';
 
 function mergeVars(
   packageVars?: PackagePolicyConfigRecord,
@@ -94,7 +95,9 @@ export function usePackagePolicyWithRelatedData(
 
   const savePackagePolicy = async () => {
     setFormState('LOADING');
-    const { elasticsearch, ...restPackagePolicy } = packagePolicy; // ignore 'elasticsearch' property since it fails route validation
+    const {
+      policy: { elasticsearch, ...restPackagePolicy },
+    } = await prepareInputPackagePolicyDataset(packagePolicy);
     const result = await sendUpdatePackagePolicy(packagePolicyId, restPackagePolicy);
     setFormState('SUBMITTED');
     return result;

--- a/x-pack/plugins/fleet/server/services/package_policy.ts
+++ b/x-pack/plugins/fleet/server/services/package_policy.ts
@@ -2151,6 +2151,14 @@ export function _validateRestrictedFieldsNotModifiedOrThrow(opts: {
             oldStream?.vars['data_stream.dataset']?.value !==
               stream?.vars?.['data_stream.dataset']?.value
           ) {
+            // seeing this error in dev? Package policy must be called with prepareInputPackagePolicyDataset function first in UI code
+            appContextService
+              .getLogger()
+              .debug(
+                `Rejecting package policy update due to dataset change, old val '${
+                  oldStream?.vars['data_stream.dataset']?.value
+                }, new val '${JSON.stringify(stream?.vars?.['data_stream.dataset']?.value)}'`
+              );
             throw new PackagePolicyValidationError(
               i18n.translate('xpack.fleet.updatePackagePolicy.datasetCannotBeModified', {
                 defaultMessage:


### PR DESCRIPTION
## Summary

Originally reported by @ishleenk17, when editing a package policy we were always getting "Dataset cannot be modified".

The issue was the prepare function wasn't being called for the edit page, I have added some debug logs.

Skipping release ntoes as this bug was introduced in 8.7: https://github.com/elastic/kibana/pull/148772


<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->