### PR TITLE
[Cloud Security] Plugin Initialize - Updating `logs-cloud_security_posture.scores-default` index mappings

### DIFF
--- a/x-pack/plugins/cloud_security_posture/server/create_indices/create_indices.ts
+++ b/x-pack/plugins/cloud_security_posture/server/create_indices/create_indices.ts
@@ -65,7 +65,16 @@ const createBenchmarkScoreIndex = async (esClient: ElasticsearchClient, logger: 
       priority: 500,
     });
 
-    await createIndexSafe(esClient, logger, BENCHMARK_SCORE_INDEX_DEFAULT_NS);
+    const result = await createIndexSafe(esClient, logger, BENCHMARK_SCORE_INDEX_DEFAULT_NS);
+
+    if (result === 'already-exists') {
+      await updateIndexSafe(
+        esClient,
+        logger,
+        BENCHMARK_SCORE_INDEX_DEFAULT_NS,
+        benchmarkScoreMapping
+      );
+    }
   } catch (e) {
     logger.error(
       `Failed to upsert index template [Template: ${BENCHMARK_SCORE_INDEX_TEMPLATE_NAME}]`


### PR DESCRIPTION
## Summary

In https://github.com/elastic/kibana/pull/151460 we've found out we don't update the index's mappings.
It appears that on 8.7.0 we also changed the mappings to the score index template but didn't update index's mappings.

This PR makes sure we update the score index mappings

<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->