### PR TITLE
[Enterprise Search] Fix word wrapping on extraction rules table

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/crawler_domain_detail/extraction_rules/field_rules_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/crawler_domain_detail/extraction_rules/field_rules_table.tsx
@@ -7,7 +7,14 @@
 
 import React from 'react';
 
-import { EuiBasicTable, EuiBasicTableColumn, EuiCode, EuiFlexGroup, EuiText } from '@elastic/eui';
+import {
+  EuiBasicTable,
+  EuiBasicTableColumn,
+  EuiCode,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiText,
+} from '@elastic/eui';
 
 import { i18n } from '@kbn/i18n';
 
@@ -48,16 +55,20 @@ export const FieldRulesTable: React.FC<FieldRulesTableProps> = ({
       }),
       render: (rule: FieldRuleWithId) => (
         <EuiFlexGroup gutterSize="s" alignItems="center">
-          <EuiText size="s">
-            {rule.source_type === FieldType.HTML
-              ? i18n.translate('xpack.enterpriseSearch.crawler.fieldRulesTable.HTMLLabel', {
-                  defaultMessage: 'HTML: ',
-                })
-              : i18n.translate('xpack.enterpriseSearch.crawler.fieldRulesTable.UrlLabel', {
-                  defaultMessage: 'URL: ',
-                })}
-          </EuiText>
-          <EuiCode>{rule.selector}</EuiCode>
+          <EuiFlexItem grow={false}>
+            <EuiText size="s">
+              {rule.source_type === FieldType.HTML
+                ? i18n.translate('xpack.enterpriseSearch.crawler.fieldRulesTable.HTMLLabel', {
+                    defaultMessage: 'HTML: ',
+                  })
+                : i18n.translate('xpack.enterpriseSearch.crawler.fieldRulesTable.UrlLabel', {
+                    defaultMessage: 'URL: ',
+                  })}
+            </EuiText>
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <EuiCode>{rule.selector}</EuiCode>
+          </EuiFlexItem>
         </EuiFlexGroup>
       ),
     },
@@ -70,26 +81,30 @@ export const FieldRulesTable: React.FC<FieldRulesTableProps> = ({
         multiple_objects_handling: multipleObjectsHandling,
       }: FieldRuleWithId) => (
         <EuiFlexGroup gutterSize="s" alignItems="center">
-          <EuiText size="s">
-            {content.value_type === ContentFrom.EXTRACTED
-              ? i18n.translate('xpack.enterpriseSearch.crawler.fieldRulesTable.extractedLabel', {
-                  defaultMessage: 'Extracted as: ',
-                })
-              : i18n.translate('xpack.enterpriseSearch.crawler.fieldRulesTable.fixedLabel', {
-                  defaultMessage: 'Fixed value: ',
-                })}
-          </EuiText>
-          <EuiCode>
-            {content.value_type === ContentFrom.FIXED
-              ? content.value
-              : multipleObjectsHandling === MultipleObjectsHandling.ARRAY
-              ? i18n.translate('xpack.enterpriseSearch.crawler.fieldRulesTable.arrayLabel', {
-                  defaultMessage: 'array',
-                })
-              : i18n.translate('xpack.enterpriseSearch.crawler.fieldRulesTable.stringLabel', {
-                  defaultMessage: 'string',
-                })}
-          </EuiCode>
+          <EuiFlexItem grow={false}>
+            <EuiText size="s">
+              {content.value_type === ContentFrom.EXTRACTED
+                ? i18n.translate('xpack.enterpriseSearch.crawler.fieldRulesTable.extractedLabel', {
+                    defaultMessage: 'Extracted as: ',
+                  })
+                : i18n.translate('xpack.enterpriseSearch.crawler.fieldRulesTable.fixedLabel', {
+                    defaultMessage: 'Fixed value: ',
+                  })}
+            </EuiText>
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <EuiCode>
+              {content.value_type === ContentFrom.FIXED
+                ? content.value
+                : multipleObjectsHandling === MultipleObjectsHandling.ARRAY
+                ? i18n.translate('xpack.enterpriseSearch.crawler.fieldRulesTable.arrayLabel', {
+                    defaultMessage: 'array',
+                  })
+                : i18n.translate('xpack.enterpriseSearch.crawler.fieldRulesTable.stringLabel', {
+                    defaultMessage: 'string',
+                  })}
+            </EuiCode>
+          </EuiFlexItem>
         </EuiFlexGroup>
       ),
     },


### PR DESCRIPTION
## Summary

Use `EuiFlexItem` to fix table rendering.

Closes https://github.com/elastic/enterprise-search-team/issues/3957

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)
