### PR TITLE
[Monitoring] Add Version column to Cluster Listing table

### DIFF
--- a/x-pack/plugins/monitoring/public/components/cluster/listing/listing.js
+++ b/x-pack/plugins/monitoring/public/components/cluster/listing/listing.js
@@ -230,6 +230,14 @@ const getColumns = (
         );
       },
     },
+    {
+      name: i18n.translate('xpack.monitoring.cluster.listing.versionColumnTitle', {
+        defaultMessage: 'Version',
+      }),
+      field: 'version',
+      'data-test-subj': 'clusterVersion',
+      sortable: true,
+    },
   ];
 };
 


### PR DESCRIPTION
Fixes #151508 

<img width="1775" alt="Screenshot 2023-02-20 at 16 42 38" src="https://user-images.githubusercontent.com/2564140/220149715-26097b5c-601e-498d-8523-9db7d9d43891.png">

Using the data already provided by the API, I've added a new column to the cluster listing table to show the version there as well.