### PR TITLE
[Fleet] Fix kubernetes filename typo

### DIFF
--- a/x-pack/plugins/fleet/server/routes/agent_policy/handlers.ts
+++ b/x-pack/plugins/fleet/server/routes/agent_policy/handlers.ts
@@ -358,7 +358,7 @@ export const downloadFullAgentPolicy: FleetRequestHandler<
         const body = fullAgentConfigMap;
         const headers: ResponseHeaders = {
           'content-type': 'text/x-yaml',
-          'content-disposition': `attachment; filename="elastic-agent-standalone-kubernetes.yaml"`,
+          'content-disposition': `attachment; filename="elastic-agent-standalone-kubernetes.yml"`,
         };
         return response.ok({
           body,
@@ -438,7 +438,7 @@ export const downloadK8sManifest: FleetRequestHandler<
       const body = fullAgentManifest;
       const headers: ResponseHeaders = {
         'content-type': 'text/x-yaml',
-        'content-disposition': `attachment; filename="elastic-agent-managed-kubernetes.yaml"`,
+        'content-disposition': `attachment; filename="elastic-agent-managed-kubernetes.yml"`,
       };
       return response.ok({
         body,


### PR DESCRIPTION
## Summary
Fixes https://github.com/elastic/kibana/issues/151167 
This PR fixes the filename extension for the kubernetes manifest file: The commands in the UI assume the filename to be `elastic-agent-managed-kubernetes.yml` or `elastic-agent-standalone-kubernetes.yml`. The filename was previously using `.yaml` extension. 

Screenshots
<details>
<img width="806" alt="Screenshot 2023-02-20 at 17 33 52" src="https://user-images.githubusercontent.com/6585477/220160871-986c194f-b095-4621-b6c7-5942dc91ab64.png">


<img width="945" alt="Screenshot 2023-02-20 at 17 35 05" src="https://user-images.githubusercontent.com/6585477/220160889-b2d2d5a6-3d7e-4a2a-8a8c-374e3bf3df22.png">

</details>

<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->