### PR TITLE
[QA][Stack Functional Integration] Fix faling setText on subjectInput for Encryption key rotation test

### DIFF
--- a/x-pack/test/stack_functional_integration/apps/alerts/alerts_encryption_keys.js
+++ b/x-pack/test/stack_functional_integration/apps/alerts/alerts_encryption_keys.js
@@ -77,6 +77,8 @@ export default ({ getPageObjects, getService }) => {
     await testSubjects.setValue('comboBoxInput', toWayne(process.env.REPORTING_TEST_EMAILS));
     await testSubjects.setValue('subjectInput', name);
     await testSubjects.setValue('messageTextArea', name);
+    //timing issue sometimes happens with the combobox so we just try to set the subjectInput again
+    await testSubjects.setValue('subjectInput', name);
     await find.clickByCssSelector('[data-test-subj="executeActionButton"]:not(disabled)');
   }
 };


### PR DESCRIPTION
There seems to be a timing issue with setting this text field when the combobox updates so instead of adding a sleep we will just try to set it again near the end of the list. A retry would not work on this since this timing issue doesn't return a failure state on setText. There might be a better solution, but since it's not a critical part of the test (which is in maintenance mode anyways) this should be good enough.
