### PR TITLE
[ML] Transforms: Fix to retain existing query when there's no base filter criteria.

### DIFF
--- a/x-pack/plugins/transform/public/app/common/request.test.ts
+++ b/x-pack/plugins/transform/public/app/common/request.test.ts
@@ -11,11 +11,11 @@ import { PIVOT_SUPPORTED_AGGS } from '../../../common/types/pivot_aggs';
 
 import { PivotGroupByConfig } from '.';
 
-import { StepDefineExposedState } from '../sections/create_transform/components/step_define';
-import { StepDetailsExposedState } from '../sections/create_transform/components/step_details';
+import type { StepDefineExposedState } from '../sections/create_transform/components/step_define';
+import type { StepDetailsExposedState } from '../sections/create_transform/components/step_details';
 
 import { PIVOT_SUPPORTED_GROUP_BY_AGGS } from './pivot_group_by';
-import { PivotAggsConfig } from './pivot_aggs';
+import type { PivotAggsConfig } from './pivot_aggs';
 import {
   defaultQuery,
   getPreviewTransformRequestBody,
@@ -30,7 +30,7 @@ import {
   matchAllQuery,
   type TransformConfigQuery,
 } from './request';
-import { LatestFunctionConfigUI } from '../../../common/types/transform';
+import type { LatestFunctionConfigUI } from '../../../common/types/transform';
 import type { RuntimeField } from '@kbn/data-views-plugin/common';
 
 const simpleQuery: TransformConfigQuery = { query_string: { query: 'airline:AAL' } };
@@ -101,6 +101,34 @@ describe('Transform: Common', () => {
       source: {
         index: ['the-data-view-title'],
         query: { query_string: { default_operator: 'AND', query: 'the-query' } },
+      },
+    });
+  });
+
+  test('getPreviewTransformRequestBody() with time field and default query', () => {
+    const query = { query_string: { query: '*', default_operator: 'AND' } };
+
+    const request = getPreviewTransformRequestBody(
+      {
+        getIndexPattern: () => 'the-data-view-title',
+        timeFieldName: 'the-time-field-name',
+      } as DataView,
+      query,
+      {
+        pivot: {
+          aggregations: { 'the-agg-agg-name': { avg: { field: 'the-agg-field' } } },
+          group_by: { 'the-group-by-agg-name': { terms: { field: 'the-group-by-field' } } },
+        },
+      }
+    );
+
+    expect(request).toEqual({
+      pivot: {
+        aggregations: { 'the-agg-agg-name': { avg: { field: 'the-agg-field' } } },
+        group_by: { 'the-group-by-agg-name': { terms: { field: 'the-group-by-field' } } },
+      },
+      source: {
+        index: ['the-data-view-title'],
       },
     });
   });

--- a/x-pack/plugins/transform/public/app/common/request.ts
+++ b/x-pack/plugins/transform/public/app/common/request.ts
@@ -217,7 +217,10 @@ export function getPreviewTransformRequestBody(
     },
   };
 
-  const query = hasValidTimeField ? queryWithBaseFilterCriteria : transformConfigQuery;
+  const query =
+    hasValidTimeField && baseFilterCriteria.length > 0
+      ? queryWithBaseFilterCriteria
+      : transformConfigQuery;
 
   return {
     source: {


### PR DESCRIPTION
## Summary

Part of #146187.

When a data view had a time field, `getPreviewTransformRequestBody()` would even add an empty array of base filter criteria. The code later on would then not recognize that as a default query and add an empty bool filter query. This could even end up as nested empty bool filters when cloning a transform.

This fixes it by adding a check for an empty array of base filter criteria. A jest unit test was also added to cover the original problem.

### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->