### PR TITLE
[7.17] Replace remark-parse dependency with remark-parse-no-trim (#151431)

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "**/pdfkit/crypto-js": "4.0.0",
     "**/react-syntax-highlighter": "^15.3.1",
     "**/recursive-readdir/minimatch": "^3.1.2",
-    "**/trim": "1.0.1",
+    "**/remark-parse/trim": "1.0.1",
     "**/typescript": "4.1.3",
     "**/underscore": "^1.13.1",
     "globby/fast-glob": "3.2.5"
@@ -363,7 +363,7 @@
     "redux-thunk": "^2.3.0",
     "redux-thunks": "^1.0.0",
     "regenerator-runtime": "^0.13.3",
-    "remark-parse": "^8.0.3",
+    "remark-parse-no-trim": "^8.0.4",
     "remark-stringify": "^8.0.3",
     "require-in-the-middle": "^6.0.0",
     "reselect": "^4.0.0",

--- a/x-pack/plugins/cases/common/utils/markdown_plugins/utils.ts
+++ b/x-pack/plugins/cases/common/utils/markdown_plugins/utils.ts
@@ -7,7 +7,7 @@
 
 import { filter } from 'lodash';
 import type { Node } from 'unist';
-import markdown from 'remark-parse';
+import markdown from 'remark-parse-no-trim';
 import remarkStringify from 'remark-stringify';
 import unified from 'unified';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -24544,6 +24544,27 @@ remark-mdx@1.6.22:
     remark-parse "8.0.3"
     unified "9.2.0"
 
+remark-parse-no-trim@^8.0.4:
+  version "8.0.4"
+  resolved "https://registry.yarnpkg.com/remark-parse-no-trim/-/remark-parse-no-trim-8.0.4.tgz#f5c9531644284071d4a57a49e19a42ad4e8040bd"
+  integrity sha512-WtqeHNTZ0LSdyemmY1/G6y9WoEFblTtgckfKF5/NUnri919/0/dEu8RCDfvXtJvu96soMvT+mLWWgYVUaiHoag==
+  dependencies:
+    ccount "^1.0.0"
+    collapse-white-space "^1.0.2"
+    is-alphabetical "^1.0.0"
+    is-decimal "^1.0.0"
+    is-whitespace-character "^1.0.0"
+    is-word-character "^1.0.0"
+    markdown-escapes "^1.0.0"
+    parse-entities "^2.0.0"
+    repeat-string "^1.5.4"
+    state-toggle "^1.0.0"
+    trim-trailing-lines "^1.0.0"
+    unherit "^1.0.4"
+    unist-util-remove-position "^2.0.0"
+    vfile-location "^3.0.0"
+    xtend "^4.0.1"
+
 remark-parse@8.0.3, remark-parse@^8.0.3:
   version "8.0.3"
   resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-8.0.3.tgz#9c62aa3b35b79a486454c690472906075f40c7e1"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [Replace remark-parse dependency with remark-parse-no-trim (#151431)](https://github.com/elastic/kibana/pull/151431)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Thomas Watson","email":"watson@elastic.co"},"sourceCommit":{"committedDate":"2023-02-20T08:05:58Z","message":"Replace remark-parse dependency with remark-parse-no-trim (#151431)","sha":"6be491a12bf634f853a642db0527d4f277004284","branchLabelMapping":{"^v8.8.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","v8.8.0"],"number":151431,"url":"https://github.com/elastic/kibana/pull/151431","mergeCommit":{"message":"Replace remark-parse dependency with remark-parse-no-trim (#151431)","sha":"6be491a12bf634f853a642db0527d4f277004284"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.8.0","labelRegex":"^v8.8.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/151431","number":151431,"mergeCommit":{"message":"Replace remark-parse dependency with remark-parse-no-trim (#151431)","sha":"6be491a12bf634f853a642db0527d4f277004284"}},{"url":"https://github.com/elastic/kibana/pull/151582","number":151582,"branch":"8.7","state":"OPEN"}]}] BACKPORT-->