### PR TITLE
[ML] Date Picker: Fix to not trigger use full data button when changing frozen setting.

### DIFF
--- a/x-pack/packages/ml/date_picker/src/components/full_time_range_selector.tsx
+++ b/x-pack/packages/ml/date_picker/src/components/full_time_range_selector.tsx
@@ -123,10 +123,9 @@ export const FullTimeRangeSelector: FC<FullTimeRangeSelectorProps> = (props) => 
   const setPreference = useCallback(
     (id: string) => {
       setFrozenDataPreference(id as FrozenTierPreference);
-      setRange(dataView, query, id === FROZEN_TIER_PREFERENCE.EXCLUDE);
       closePopover();
     },
-    [dataView, query, setFrozenDataPreference, setRange]
+    [setFrozenDataPreference]
   );
 
   const onButtonClick = () => {

--- a/x-pack/packages/ml/date_picker/src/components/full_time_range_selector.tsx
+++ b/x-pack/packages/ml/date_picker/src/components/full_time_range_selector.tsx
@@ -90,33 +90,30 @@ export const FullTimeRangeSelector: FC<FullTimeRangeSelectorProps> = (props) => 
   } = useDatePickerContext();
 
   // wrapper around setFullTimeRange to allow for the calling of the optional callBack prop
-  const setRange = useCallback(
-    async (i: DataView, q?: QueryDslQueryContainer, excludeFrozenData?: boolean) => {
-      try {
-        const fullTimeRange = await setFullTimeRange(
-          timefilter,
-          i,
-          toasts,
-          http,
-          q,
-          excludeFrozenData
-        );
-        if (typeof callback === 'function') {
-          callback(fullTimeRange);
-        }
-      } catch (e) {
-        toasts.addDanger(
-          i18n.translate(
-            'xpack.ml.datePicker.fullTimeRangeSelector.errorSettingTimeRangeNotification',
-            {
-              defaultMessage: 'An error occurred setting the time range.',
-            }
-          )
-        );
+  const setRange = useCallback(async () => {
+    try {
+      const fullTimeRange = await setFullTimeRange(
+        timefilter,
+        dataView,
+        toasts,
+        http,
+        query,
+        frozenDataPreference === FROZEN_TIER_PREFERENCE.EXCLUDE
+      );
+      if (typeof callback === 'function') {
+        callback(fullTimeRange);
       }
-    },
-    [callback, http, timefilter, toasts]
-  );
+    } catch (e) {
+      toasts.addDanger(
+        i18n.translate(
+          'xpack.ml.datePicker.fullTimeRangeSelector.errorSettingTimeRangeNotification',
+          {
+            defaultMessage: 'An error occurred setting the time range.',
+          }
+        )
+      );
+    }
+  }, [callback, dataView, frozenDataPreference, http, query, timefilter, toasts]);
 
   const [isPopoverOpen, setPopover] = useState(false);
 
@@ -194,7 +191,7 @@ export const FullTimeRangeSelector: FC<FullTimeRangeSelectorProps> = (props) => 
       <EuiToolTip content={buttonTooltip}>
         <EuiButton
           isDisabled={disabled}
-          onClick={() => setRange(dataView, query, true)}
+          onClick={() => setRange()}
           data-test-subj="mlDatePickerButtonUseFullData"
         >
           <FormattedMessage


### PR DESCRIPTION
## Summary

Part of #146187.

Previously, when changing the frozen tier settings in the popover menu of the date picker, this would also trigger an action like you were clicking on the "Use full data" button at the same time. This PR fixes the behavior and only updates the frozen tier settings, to update the time range you now have to click "Use full data" separately.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->