### PR TITLE
[ML] Transforms: Fix label for red health status

### DIFF
--- a/x-pack/plugins/transform/common/constants.ts
+++ b/x-pack/plugins/transform/common/constants.ts
@@ -124,7 +124,7 @@ export const TRANSFORM_HEALTH_LABEL = {
     defaultMessage: 'Degraded',
   }),
   red: i18n.translate('xpack.transform.transformHealth.redLabel', {
-    defaultMessage: 'Outage',
+    defaultMessage: 'Unavailable',
   }),
 } as const;
 


### PR DESCRIPTION
## Summary

Part of #144157.

Fixes the label for the red health status.

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->