### PR TITLE
[8.7] [Fleet] Fix kubernetes filename typo (#151646)

### DIFF
--- a/x-pack/plugins/fleet/server/routes/agent_policy/handlers.ts
+++ b/x-pack/plugins/fleet/server/routes/agent_policy/handlers.ts
@@ -358,7 +358,7 @@ export const downloadFullAgentPolicy: FleetRequestHandler<
         const body = fullAgentConfigMap;
         const headers: ResponseHeaders = {
           'content-type': 'text/x-yaml',
-          'content-disposition': `attachment; filename="elastic-agent-standalone-kubernetes.yaml"`,
+          'content-disposition': `attachment; filename="elastic-agent-standalone-kubernetes.yml"`,
         };
         return response.ok({
           body,
@@ -438,7 +438,7 @@ export const downloadK8sManifest: FleetRequestHandler<
       const body = fullAgentManifest;
       const headers: ResponseHeaders = {
         'content-type': 'text/x-yaml',
-        'content-disposition': `attachment; filename="elastic-agent-managed-kubernetes.yaml"`,
+        'content-disposition': `attachment; filename="elastic-agent-managed-kubernetes.yml"`,
       };
       return response.ok({
         body,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.7`:
 - [[Fleet] Fix kubernetes filename typo (#151646)](https://github.com/elastic/kibana/pull/151646)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Yulia Čech","email":"6585477+yuliacech@users.noreply.github.com"},"sourceCommit":{"committedDate":"2023-02-21T10:39:58Z","message":"[Fleet] Fix kubernetes filename typo (#151646)\n\n## Summary\r\nFixes https://github.com/elastic/kibana/issues/151167 \r\nThis PR fixes the filename extension for the kubernetes manifest file:\r\nThe commands in the UI assume the filename to be\r\n`elastic-agent-managed-kubernetes.yml` or\r\n`elastic-agent-standalone-kubernetes.yml`. The filename was previously\r\nusing `.yaml` extension.\r\n\r\nScreenshots\r\n<details>\r\n<img width=\"806\" alt=\"Screenshot 2023-02-20 at 17 33 52\"\r\nsrc=\"https://user-images.githubusercontent.com/6585477/220160871-986c194f-b095-4621-b6c7-5942dc91ab64.png\">\r\n\r\n\r\n<img width=\"945\" alt=\"Screenshot 2023-02-20 at 17 35 05\"\r\nsrc=\"https://user-images.githubusercontent.com/6585477/220160889-b2d2d5a6-3d7e-4a2a-8a8c-374e3bf3df22.png\">\r\n\r\n</details>","sha":"a841cf86a3e2b942b507fa7b0dbb9339cc590bf2","branchLabelMapping":{"^v8.8.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","Team:Fleet","backport:prev-minor","v8.8.0"],"number":151646,"url":"https://github.com/elastic/kibana/pull/151646","mergeCommit":{"message":"[Fleet] Fix kubernetes filename typo (#151646)\n\n## Summary\r\nFixes https://github.com/elastic/kibana/issues/151167 \r\nThis PR fixes the filename extension for the kubernetes manifest file:\r\nThe commands in the UI assume the filename to be\r\n`elastic-agent-managed-kubernetes.yml` or\r\n`elastic-agent-standalone-kubernetes.yml`. The filename was previously\r\nusing `.yaml` extension.\r\n\r\nScreenshots\r\n<details>\r\n<img width=\"806\" alt=\"Screenshot 2023-02-20 at 17 33 52\"\r\nsrc=\"https://user-images.githubusercontent.com/6585477/220160871-986c194f-b095-4621-b6c7-5942dc91ab64.png\">\r\n\r\n\r\n<img width=\"945\" alt=\"Screenshot 2023-02-20 at 17 35 05\"\r\nsrc=\"https://user-images.githubusercontent.com/6585477/220160889-b2d2d5a6-3d7e-4a2a-8a8c-374e3bf3df22.png\">\r\n\r\n</details>","sha":"a841cf86a3e2b942b507fa7b0dbb9339cc590bf2"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.8.0","labelRegex":"^v8.8.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/151646","number":151646,"mergeCommit":{"message":"[Fleet] Fix kubernetes filename typo (#151646)\n\n## Summary\r\nFixes https://github.com/elastic/kibana/issues/151167 \r\nThis PR fixes the filename extension for the kubernetes manifest file:\r\nThe commands in the UI assume the filename to be\r\n`elastic-agent-managed-kubernetes.yml` or\r\n`elastic-agent-standalone-kubernetes.yml`. The filename was previously\r\nusing `.yaml` extension.\r\n\r\nScreenshots\r\n<details>\r\n<img width=\"806\" alt=\"Screenshot 2023-02-20 at 17 33 52\"\r\nsrc=\"https://user-images.githubusercontent.com/6585477/220160871-986c194f-b095-4621-b6c7-5942dc91ab64.png\">\r\n\r\n\r\n<img width=\"945\" alt=\"Screenshot 2023-02-20 at 17 35 05\"\r\nsrc=\"https://user-images.githubusercontent.com/6585477/220160889-b2d2d5a6-3d7e-4a2a-8a8c-374e3bf3df22.png\">\r\n\r\n</details>","sha":"a841cf86a3e2b942b507fa7b0dbb9339cc590bf2"}}]}] BACKPORT-->