### PR TITLE
Change field fetching behavior to automatically add allow_no_index=true when set to ES

### DIFF
--- a/src/plugins/data_views/common/data_views/__snapshots__/data_view.test.ts.snap
+++ b/src/plugins/data_views/common/data_views/__snapshots__/data_view.test.ts.snap
@@ -28,7 +28,7 @@ Object {
 
 exports[`IndexPattern toSpec can optionally exclude fields 1`] = `
 Object {
-  "allowNoIndex": false,
+  "allowNoIndex": true,
   "fieldAttrs": Object {},
   "fieldFormats": Object {},
   "id": "test-pattern",

--- a/src/plugins/data_views/common/data_views/__snapshots__/data_view.test.ts.snap
+++ b/src/plugins/data_views/common/data_views/__snapshots__/data_view.test.ts.snap
@@ -51,7 +51,7 @@ Object {
 
 exports[`IndexPattern toSpec should match snapshot 1`] = `
 Object {
-  "allowNoIndex": false,
+  "allowNoIndex": true,
   "fieldAttrs": Object {},
   "fieldFormats": Object {},
   "fields": Object {

--- a/src/plugins/data_views/common/data_views/data_view.ts
+++ b/src/plugins/data_views/common/data_views/data_view.ts
@@ -141,7 +141,7 @@ export class DataView implements DataViewBase {
   /**
    * Prevents errors when index pattern exists before indices
    */
-  public readonly allowNoIndex: boolean = false;
+  public readonly allowNoIndex: boolean = true;
   /**
    * Name of the data view. Human readable name used to differentiate data view.
    */
@@ -183,7 +183,7 @@ export class DataView implements DataViewBase {
     this.type = spec.type;
     this.typeMeta = spec.typeMeta;
     this.fieldAttrs = cloneDeep(spec.fieldAttrs) || {};
-    this.allowNoIndex = spec.allowNoIndex || false;
+    this.allowNoIndex = spec.allowNoIndex ?? true;
     this.runtimeFieldMap = cloneDeep(spec.runtimeFieldMap) || {};
     this.namespaces = spec.namespaces || [];
     this.name = spec.name || '';

--- a/src/plugins/data_views/common/data_views/data_views.ts
+++ b/src/plugins/data_views/common/data_views/data_views.ts
@@ -530,7 +530,7 @@ export class DataViewsService {
     return this.apiClient.getFieldsForWildcard({
       type: dataView.type,
       rollupIndex: dataView?.typeMeta?.params?.rollup_index,
-      allowNoIndex: dataView.allowNoIndex !== false,
+      allowNoIndex: dataView.allowNoIndex ?? true,
       pattern: dataView.getIndexPattern(),
       metaFields,
     });
@@ -543,7 +543,7 @@ export class DataViewsService {
       metaFields,
       type: options.type,
       rollupIndex: options.rollupIndex,
-      allowNoIndex: options.allowNoIndex !== false,
+      allowNoIndex: options.allowNoIndex ?? true,
       indexFilter: options.indexFilter,
     });
   };

--- a/src/plugins/data_views/common/data_views/data_views.ts
+++ b/src/plugins/data_views/common/data_views/data_views.ts
@@ -530,7 +530,7 @@ export class DataViewsService {
     return this.apiClient.getFieldsForWildcard({
       type: dataView.type,
       rollupIndex: dataView?.typeMeta?.params?.rollup_index,
-      allowNoIndex: dataView.allowNoIndex,
+      allowNoIndex: dataView.allowNoIndex !== false,
       pattern: dataView.getIndexPattern(),
       metaFields,
     });
@@ -543,7 +543,7 @@ export class DataViewsService {
       metaFields,
       type: options.type,
       rollupIndex: options.rollupIndex,
-      allowNoIndex: options.allowNoIndex,
+      allowNoIndex: options.allowNoIndex !== false,
       indexFilter: options.indexFilter,
     });
   };

--- a/src/plugins/data_views/server/fetcher/lib/field_capabilities/field_capabilities.ts
+++ b/src/plugins/data_views/server/fetcher/lib/field_capabilities/field_capabilities.ts
@@ -50,12 +50,13 @@ export async function getFieldCapabilities(params: FieldCapabilitiesParams) {
     indexFilter,
     fields,
   });
-  const fieldsFromFieldCapsByName = keyBy(readFieldCapsResponse(esFieldCaps.body), 'name');
+  const fieldCapsArr = readFieldCapsResponse(esFieldCaps.body);
+  const fieldsFromFieldCapsByName = keyBy(fieldCapsArr, 'name');
 
   const allFieldsUnsorted = Object.keys(fieldsFromFieldCapsByName)
     // not all meta fields are provided, so remove and manually add
     .filter((name) => !fieldsFromFieldCapsByName[name].metadata_field)
-    .concat(fieldsFromFieldCapsByName.length ? metaFields : [])
+    .concat(fieldCapsArr.length ? metaFields : [])
     .reduce<{ names: string[]; map: Map<string, string> }>(
       (agg, value) => {
         // This is intentionally using a Map to be highly optimized with very large indexes AND be safe for user provided data

--- a/src/plugins/data_views/server/fetcher/lib/field_capabilities/field_capabilities.ts
+++ b/src/plugins/data_views/server/fetcher/lib/field_capabilities/field_capabilities.ts
@@ -55,7 +55,7 @@ export async function getFieldCapabilities(params: FieldCapabilitiesParams) {
   const allFieldsUnsorted = Object.keys(fieldsFromFieldCapsByName)
     // not all meta fields are provided, so remove and manually add
     .filter((name) => !fieldsFromFieldCapsByName[name].metadata_field)
-    .concat(metaFields)
+    .concat(fieldsFromFieldCapsByName.length ? metaFields : [])
     .reduce<{ names: string[]; map: Map<string, string> }>(
       (agg, value) => {
         // This is intentionally using a Map to be highly optimized with very large indexes AND be safe for user provided data

--- a/test/functional/apps/discover/group1/_filter_editor.ts
+++ b/test/functional/apps/discover/group1/_filter_editor.ts
@@ -103,7 +103,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
             body: {
               version: '2.0.0',
             },
-            refresh: 'wait_for',
+            refresh: true,
           });
 
           await indexPatterns.create({ title: indexTitle }, { override: true });

--- a/test/functional/apps/discover/group1/_sidebar.ts
+++ b/test/functional/apps/discover/group1/_sidebar.ts
@@ -423,7 +423,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await PageObjects.discover.waitUntilSidebarHasLoaded();
 
         expect(await PageObjects.discover.getSidebarAriaDescription()).to.be(
-          '0 available fields. 0 meta fields.'
+          '0 available fields. 0 meta fields. 3 meta fields.'
         );
         await testSubjects.existOrFail(
           `${PageObjects.discover.getSidebarSectionSelector('available')}-fetchWarning`

--- a/test/functional/apps/discover/group1/_sidebar.ts
+++ b/test/functional/apps/discover/group1/_sidebar.ts
@@ -423,7 +423,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await PageObjects.discover.waitUntilSidebarHasLoaded();
 
         expect(await PageObjects.discover.getSidebarAriaDescription()).to.be(
-          '0 available fields. 0 meta fields. 3 meta fields.'
+          '0 available fields. 0 empty fields. 3 meta fields.'
         );
         await testSubjects.existOrFail(
           `${PageObjects.discover.getSidebarSectionSelector('available')}-fetchWarning`

--- a/x-pack/plugins/infra/server/services/log_views/log_views_client.test.ts
+++ b/x-pack/plugins/infra/server/services/log_views/log_views_client.test.ts
@@ -281,7 +281,7 @@ describe('LogViewsClient class', () => {
           },
         ],
         "dataViewReference": DataView {
-          "allowNoIndex": false,
+          "allowNoIndex": true,
           "deleteFieldFormat": [Function],
           "fieldAttrs": Object {},
           "fieldFormatMap": Object {},


### PR DESCRIPTION
## Summary

WIP to evaluate what happens when setting `allow_no_index` to true if not requested differently. In the UI this resolves the following toast storms, happening when the underlying indices are deleted
<img width="1140" alt="Bildschirmfoto 2023-02-21 um 11 05 31" src="https://user-images.githubusercontent.com/463851/220324587-de1f0cbc-6118-4d44-9c78-2e2af6e69dea.png">
<img width="1134" alt="Bildschirmfoto 2023-02-21 um 11 08 17" src="https://user-images.githubusercontent.com/463851/220324610-700cb3a7-dba2-4f30-80d0-786991fcf70c.png">




### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
