### PR TITLE
[Enterprise Search] Makes connector configuration entries wrap text

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_configuration_config.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_configuration_config.tsx
@@ -45,7 +45,7 @@ export const ConnectorConfigurationConfig: React.FC = ({ children }) => {
           displayList.length > 0 && (
             <EuiFlexGroup direction="column">
               <EuiFlexItem>
-                <EuiDescriptionList listItems={displayList} />
+                <EuiDescriptionList listItems={displayList} className="eui-textBreakWord" />
               </EuiFlexItem>
               <EuiFlexItem>
                 <EuiFlexGroup>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/select_connector/select_connector.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/select_connector/select_connector.tsx
@@ -125,9 +125,10 @@ export const SelectConnector: React.FC = () => {
           <EuiSpacer size="s" />
           <EuiFlexGroup direction="row">
             {NATIVE_CONNECTORS.map((nativeConnector) => (
-              <EuiFlexItem>
+              <EuiFlexItem key={nativeConnector.name}>
                 <ConnectorCheckable
-                  {...nativeConnector}
+                  name={nativeConnector.name}
+                  serviceType={nativeConnector.serviceType}
                   onChange={() => setSelectedConnector(nativeConnector)}
                   documentationUrl={nativeConnector.docsUrl}
                   checked={nativeConnector === selectedNativeConnector}


### PR DESCRIPTION
## Summary

This fixes a word wrap issue for connector configurations.

Before:
<img width="975" alt="Screenshot 2023-02-21 at 13 00 39" src="https://user-images.githubusercontent.com/94373878/220341403-57815e30-0119-4ff2-843d-5d0f5d424072.png">
After:
<img width="667" alt="Screenshot 2023-02-21 at 12 59 43" src="https://user-images.githubusercontent.com/94373878/220341426-e68541ff-979a-48b4-a734-48450c5635b0.png">



<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->