### PR TITLE
[controls] fix Time slider pin/unpin icons should be swaped

### DIFF
--- a/src/plugins/controls/public/time_slider/components/time_slider_popover_content.tsx
+++ b/src/plugins/controls/public/time_slider/components/time_slider_popover_content.tsx
@@ -82,7 +82,7 @@ export function TimeSliderPopoverContent(props: Props) {
       <EuiFlexItem grow={false}>
         <EuiToolTip content={anchorStartToggleButtonLabel}>
           <EuiButtonIcon
-            iconType={isAnchored ? 'pin' : 'pinFilled'}
+            iconType={isAnchored ? 'pinFilled' : 'pin'}
             onClick={() => {
               const nextIsAnchored = !isAnchored;
               if (nextIsAnchored) {


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/151309

PR swaps pin icon so icon shows state of pinning instead of showing the state of the action

Unpinned
<img width="400" alt="Screen Shot 2023-02-21 at 8 57 18 AM" src="https://user-images.githubusercontent.com/373691/220395461-d4786049-cd2c-4159-bb23-f3dda04f6a98.png">

Pinned
<img width="400" alt="Screen Shot 2023-02-21 at 8 57 25 AM" src="https://user-images.githubusercontent.com/373691/220395533-69b4e9ae-a14c-4b1b-af7f-ff3ece553f3c.png">
