### PR TITLE
[8.7] Add field to allow synchronization to prerelease versions in bundled packages (#151627)

### DIFF
--- a/fleet_packages.json
+++ b/fleet_packages.json
@@ -10,6 +10,10 @@
   will fetch the latest available version of the package from EPR (including prerelease versions),
   download that version, and rewrite its version to align with Kibana's.
 
+  The `allowSyncToPrerelease` option is available for packages who wish to opt into allowing sync
+  "bundled" packages whose version contain prerelease tags (e.g. 8.4.3-beta.1). By default, it just
+  updates to stable versions.
+
   Packages will be fetched from https://epr-snapshot.elastic.co by default. This can be overridden
   via the `--epr-registry=production` command line argument when building Kibana. Fetching from the
   snapshot registry allows Kibana to bundle packages that have yet to be published to production in
@@ -21,7 +25,8 @@
   {
     "name": "apm",
     "version": "8.7.0-preview-1675078021",
-    "forceAlignStackVersion": true
+    "forceAlignStackVersion": true,
+    "allowSyncToPrerelease": true
   },
   {
     "name": "elastic_agent",

--- a/src/dev/build/tasks/bundle_fleet_packages.ts
+++ b/src/dev/build/tasks/bundle_fleet_packages.ts
@@ -21,6 +21,7 @@ interface FleetPackage {
   name: string;
   version: string;
   forceAlignStackVersion?: boolean;
+  allowSyncToPrerelease?: boolean;
 }
 
 export const BundleFleetPackages: Task = {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.7`
- [Add field to allow synchronization to prerelease versions in bundled packages](https://github.com/elastic/kibana/pull/151627)
