### PR TITLE
[Fleet] Fix flaky package policy integration test

### DIFF
--- a/x-pack/test/fleet_api_integration/apis/package_policy/upgrade.ts
+++ b/x-pack/test/fleet_api_integration/apis/package_policy/upgrade.ts
@@ -1299,7 +1299,7 @@ export default function (providerContext: FtrProviderContext) {
                 },
               },
             });
-          if (!packagePolicyResponse.item.id) {
+          if (!packagePolicyResponse.item || !packagePolicyResponse.item.id) {
             throw new Error(
               'Package policy id is missing, response: ' +
                 JSON.stringify(packagePolicyResponse, null, 2)

--- a/x-pack/test/fleet_api_integration/apis/package_policy/upgrade.ts
+++ b/x-pack/test/fleet_api_integration/apis/package_policy/upgrade.ts
@@ -1299,7 +1299,12 @@ export default function (providerContext: FtrProviderContext) {
                 },
               },
             });
-
+          if (!packagePolicyResponse.item.id) {
+            throw new Error(
+              'Package policy id is missing, response: ' +
+                JSON.stringify(packagePolicyResponse, null, 2)
+            );
+          }
           packagePolicyIds.push(packagePolicyResponse.item.id);
           expectedAssets.push(
             { id: `logs-somedataset${id}-3.0.0`, type: 'ingest_pipeline' },

--- a/x-pack/test/fleet_api_integration/apis/package_policy/upgrade.ts
+++ b/x-pack/test/fleet_api_integration/apis/package_policy/upgrade.ts
@@ -1314,9 +1314,9 @@ export default function (providerContext: FtrProviderContext) {
           );
         };
 
-        await Promise.all(
-          new Array(POLICY_COUNT).fill(0).map((_, i) => createPackagePolicy(i.toString()))
-        );
+        for (let i = 0; i < POLICY_COUNT; i++) {
+          await createPackagePolicy(i.toString());
+        }
       });
 
       afterEach(async function () {


### PR DESCRIPTION
## Summary
Closes #151661
I think creating all of the package policies at once in this test is causing it to be flaky, reverting to creating them one by one.

```
TypeError: Cannot read properties of undefined (reading 'id')
    at createPackagePolicy (upgrade.ts:1303:60)
```

<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->