### PR TITLE
[Dashboard] [Controls] Unskip options list failed tests

### DIFF
--- a/test/functional/apps/dashboard_elements/controls/options_list/options_list_creation_and_editing.ts
+++ b/test/functional/apps/dashboard_elements/controls/options_list/options_list_creation_and_editing.ts
@@ -71,10 +71,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
     });
 
-    // Skip on cloud until issue is fixed
-    // Issue: https://github.com/elastic/kibana/issues/141280
     describe('Options List Control creation and editing experience', function () {
-      this.tags(['skipCloudFailedTest']);
       it('can add a new options list control from a blank state', async () => {
         await dashboardControls.createControl({
           controlType: OPTIONS_LIST_CONTROL,


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/141285

## Summary

Unskips the failed `options_list_creation_and_editing.ts` tests since the underlying [bug](https://github.com/elastic/kibana/issues/141280) is no longer present as of `v8.5.0`. 

**Flaky Test Runner**

<a href="https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/1930"><img src="https://user-images.githubusercontent.com/8698078/220448187-ca0605b4-8719-494a-ad82-7d3f969c609b.png"/></a>


### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
