### PR TITLE
[Elasticsearch Client] Limit Kibana's internal client's maxSockets

### DIFF
--- a/packages/core/elasticsearch/core-elasticsearch-server-internal/src/elasticsearch_config.ts
+++ b/packages/core/elasticsearch/core-elasticsearch-server-internal/src/elasticsearch_config.ts
@@ -37,6 +37,7 @@ export const configSchema = schema.object({
     defaultValue: 'http://localhost:9200',
   }),
   maxSockets: schema.number({ defaultValue: Infinity, min: 1 }),
+  internalClientMaxSockets: schema.number({ defaultValue: 500, min: 1 }),
   maxIdleSockets: schema.number({ defaultValue: 256, min: 1 }),
   idleSocketTimeout: schema.duration({ defaultValue: '60s' }),
   compression: schema.boolean({ defaultValue: false }),

--- a/x-pack/plugins/monitoring/server/config.test.ts
+++ b/x-pack/plugins/monitoring/server/config.test.ts
@@ -62,6 +62,7 @@ describe('config schema', () => {
             },
             "idleSocketTimeout": "PT1M",
             "ignoreVersionMismatch": false,
+            "internalClientMaxSockets": 500,
             "logFetchCount": 10,
             "logQueries": false,
             "maxIdleSockets": 256,


### PR DESCRIPTION
## Summary

While testing #151110, we noticed that most of the issues come from a sudden spike in the generation of requests to ES.

While Kibana should aim to scale as needed for any incoming HTTP requests, its background tasks should be limited from branching too many ES connections at once. When this happens, it's usually a sign of non-scalable code running in the background.

This PR wants to test if limiting the number of background connections in the Kibana Internal Elasticsearch Client improves the overall performance experienced by users. The motivation is: limiting the resources for background processes leaves extra capacity to process requests from actual users.

A promising starting point #151110's scalability tests show a big improvement:

| This PR | Baseline |
|--------|--------|
| <img width="1023" alt="image" src="https://user-images.githubusercontent.com/5469006/220435431-ac96b337-2818-4986-a655-0b4ac08c8fa6.png"> | <img width="1025" alt="image" src="https://user-images.githubusercontent.com/5469006/220435351-529a92b2-209a-4451-8b9b-985288835e61.png"> |

FWIW, mission-critical background processes like Alerts can create their own client using `core.elasticsearch.createClient()` to circumvent this limitation if deemed necessary.

TODO:

- [ ] Test other scenarios apart from telemetry endpoints: ~https://buildkite.com/elastic/kibana-apis-capacity-testing/builds/301~ TBD... waiting for @dmlemeshko to apply some changes to the runner so we can run from a branch
- [x] Any improvements found in Single-User benchmarks? => [Jobs](https://buildkite.com/elastic/kibana-single-user-performance/builds?branch=refs%2Fpull%2F151778%2Fhead): Roughly the same results.
- [ ] If agreed on this... document this behavior and scape-hatch for mission-critical apps.
- [ ] If we agree that creating too many sockets it's harmful to Kibana... should we revisit our default of `Infinity` even for user-triggered requests?

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Some background processes may consume other mission-critical ones | High | High | It is happening today: while we set `maxSockets: Infinity` by default, high event loop delays might block all services. Also, the mission-critical ones can create custom clients to have their dedicated connection pool. |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
