### PR TITLE
fix(slo): add width for error budget

### DIFF
--- a/x-pack/plugins/observability/public/pages/slos/components/slo_summary.tsx
+++ b/x-pack/plugins/observability/public/pages/slos/components/slo_summary.tsx
@@ -34,7 +34,7 @@ export function SloSummary({ slo, historicalSummary = [], historicalSummaryLoadi
 
   return (
     <EuiFlexGroup direction="row" justifyContent="spaceBetween" gutterSize="xl">
-      <EuiFlexItem grow={false} style={{ width: 210 }}>
+      <EuiFlexItem grow={false} style={{ width: 200 }}>
         <EuiFlexGroup direction="row" responsive={false} gutterSize="xs" alignItems="center">
           <EuiFlexItem grow={false} style={{ width: 120 }}>
             <EuiStat
@@ -64,9 +64,9 @@ export function SloSummary({ slo, historicalSummary = [], historicalSummaryLoadi
         </EuiFlexGroup>
       </EuiFlexItem>
 
-      <EuiFlexItem grow={false} style={{ width: 240 }}>
+      <EuiFlexItem grow={false} style={{ width: 260 }}>
         <EuiFlexGroup direction="row" responsive={false} gutterSize="xs" alignItems="center">
-          <EuiFlexItem grow={false} style={{ width: 160 }}>
+          <EuiFlexItem grow={false} style={{ width: 180 }}>
             <EuiStat
               description={i18n.translate('xpack.observability.slos.slo.stats.budgetRemaining', {
                 defaultMessage: 'Budget remaining',


### PR DESCRIPTION
## 📝 Summary

Small fix for improving the UI when the error budget is below `-10000.00%`


![image](https://user-images.githubusercontent.com/1376800/220439804-b9c91cfc-79dc-4437-8a3e-15b6578aedcd.png)
