### PR TITLE
[RAM] Fix Rules List Storybook Entries

### DIFF
--- a/x-pack/plugins/triggers_actions_ui/.storybook/context/http.ts
+++ b/x-pack/plugins/triggers_actions_ui/.storybook/context/http.ts
@@ -175,7 +175,7 @@ const baseRulesListGetResponse = (path: string) => {
   }
 };
 
-const emptyRulesListGetResponse = (path: string) => {
+const emptyRulesListResponse = (path: string) => {
   if (path === '/internal/alerting/rules/_find') {
     return {
       data: [],
@@ -189,7 +189,7 @@ const emptyRulesListGetResponse = (path: string) => {
   }
 };
 
-const rulesListGetResponse = (path: string) => {
+const rulesListResponse = (path: string) => {
   if (path === '/internal/alerting/rules/_find') {
     return {
       data: [getMockRule(), getMockRule(), getMockRule(), getMockRule()],
@@ -203,7 +203,7 @@ const rulesListGetResponse = (path: string) => {
   }
 };
 
-const rulesListGetPaginatedResponse = (path: string) => {
+const rulesListPaginatedResponse = (path: string) => {
   if (path === '/internal/alerting/rules/_find') {
     return {
       data: Array.from(Array(10), () => getMockRule()),
@@ -327,13 +327,13 @@ export const getHttp = (context: Parameters<DecoratorFn>[1]) => {
     post: (async (path: string, options: HttpFetchOptions) => {
       const { id } = context;
       if (id === 'app-ruleslist--empty') {
-        return emptyRulesListGetResponse(path);
+        return emptyRulesListResponse(path);
       }
       if (id === 'app-ruleslist--with-rules') {
-        return rulesListGetResponse(path);
+        return rulesListResponse(path);
       }
       if (id === 'app-ruleslist--with-paginated-rules') {
-        return rulesListGetPaginatedResponse(path);
+        return rulesListPaginatedResponse(path);
       }
       action('POST')(path, options);
       return Promise.resolve();

--- a/x-pack/plugins/triggers_actions_ui/.storybook/context/http.ts
+++ b/x-pack/plugins/triggers_actions_ui/.storybook/context/http.ts
@@ -108,7 +108,8 @@ const mockHealth = {
 };
 
 const mockAggregation = {
-  rule_execution_status: { ok: 0, active: 0, error: 0, pending: 0, unknown: 0, warning: 0 },
+  rule_execution_status: { ok: 5, active: 0, error: 0, pending: 0, unknown: 0, warning: 0 },
+  rule_last_run_outcome: { succeeded: 5, failed: 0, warning: 0 },
   rule_enabled_status: { enabled: 0, disabled: 0 },
   rule_muted_status: { muted: 0, unmuted: 0 },
   rule_snoozed_status: { snoozed: 0 },
@@ -183,7 +184,9 @@ const emptyRulesListGetResponse = (path: string) => {
       total: 0,
     };
   }
-  return baseRulesListGetResponse(path);
+  if (path === '/internal/alerting/rules/_aggregate') {
+    return mockAggregation;
+  }
 };
 
 const rulesListGetResponse = (path: string) => {
@@ -195,7 +198,9 @@ const rulesListGetResponse = (path: string) => {
       total: 4,
     };
   }
-  return baseRulesListGetResponse(path);
+  if (path === '/internal/alerting/rules/_aggregate') {
+    return mockAggregation;
+  }
 };
 
 const rulesListGetPaginatedResponse = (path: string) => {
@@ -207,7 +212,9 @@ const rulesListGetPaginatedResponse = (path: string) => {
       total: 50,
     };
   }
-  return baseRulesListGetResponse(path);
+  if (path === '/internal/alerting/rules/_aggregate') {
+    return mockAggregation;
+  }
 };
 
 const baseEventLogListGetResponse = (path: string) => {
@@ -291,9 +298,33 @@ const rulesSettingsIds = [
   'app-rulessettingslink--with-no-permission',
 ];
 
+const rulesListIds = [
+  'app-ruleslist--empty',
+  'app-ruleslist--with-rules',
+  'app-ruleslist--with-paginated-rules',
+];
+
 export const getHttp = (context: Parameters<DecoratorFn>[1]) => {
   return {
     get: (async (path: string, options: HttpFetchOptions) => {
+      const { id } = context;
+      if (id === 'app-ruleeventloglist--empty') {
+        return emptyEventLogListGetResponse(path);
+      }
+      if (id === 'app-ruleeventloglist--with-events') {
+        return eventLogListGetResponse(path);
+      }
+      if (id === 'app-ruleeventloglist--with-paginated-events') {
+        return paginatedEventLogListGetResponse(path);
+      }
+      if (rulesListIds.includes(id)) {
+        return baseRulesListGetResponse(path);
+      }
+      if (rulesSettingsIds.includes(id)) {
+        return rulesSettingsGetResponse(path);
+      }
+    }) as HttpHandler,
+    post: (async (path: string, options: HttpFetchOptions) => {
       const { id } = context;
       if (id === 'app-ruleslist--empty') {
         return emptyRulesListGetResponse(path);
@@ -304,20 +335,6 @@ export const getHttp = (context: Parameters<DecoratorFn>[1]) => {
       if (id === 'app-ruleslist--with-paginated-rules') {
         return rulesListGetPaginatedResponse(path);
       }
-      if (id === 'app-ruleeventloglist--empty') {
-        return emptyEventLogListGetResponse(path);
-      }
-      if (id === 'app-ruleeventloglist--with-events') {
-        return eventLogListGetResponse(path);
-      }
-      if (id === 'app-ruleeventloglist--with-paginated-events') {
-        return paginatedEventLogListGetResponse(path);
-      }
-      if (rulesSettingsIds.includes(id)) {
-        return rulesSettingsGetResponse(path);
-      }
-    }) as HttpHandler,
-    post: (async (path: string, options: HttpFetchOptions) => {
       action('POST')(path, options);
       return Promise.resolve();
     }) as HttpHandler,


### PR DESCRIPTION
## Summary
Resolves: https://github.com/elastic/kibana/issues/150366

When we changed the rules list `/_find` and `/_aggregate` endpoints to `POSTs` instead of `GETs`, it broke the rules list storybook entries. This PR fixes that.