### PR TITLE
Allow appex-qa team to skip failed tests using automation

### DIFF
--- a/.github/workflows/skip-failed-test.yml
+++ b/.github/workflows/skip-failed-test.yml
@@ -26,6 +26,7 @@ jobs:
         uses: ./actions/permission-check
         with:
           permission: admin
+          teams: appex-qa
           token: ${{secrets.GITHUB_TOKEN}}
 
       - name: Checkout kibana-operations


### PR DESCRIPTION
@dmlemeshko asked for this as @elastic/appex-qa will be taking over failed test monitoring.

See also the addition of `teams:` support: https://github.com/elastic/kibana-github-actions/commit/80487f90285d4f9136ad914bc78793d996532879