### PR TITLE
Migrate `reporting` FTRs from the Stats Usage API

### DIFF
--- a/src/plugins/telemetry_collection_manager/server/types.ts
+++ b/src/plugins/telemetry_collection_manager/server/types.ts
@@ -82,9 +82,7 @@ export interface BasicStatsPayload {
   version: string;
   cluster_stats: object;
   collection?: string;
-  // Needed for testing to make fields easier to access
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  stack_stats: Record<string, any>;
+  stack_stats: object;
 }
 
 export interface UsageStatsPayload extends BasicStatsPayload {

--- a/src/plugins/telemetry_collection_manager/server/types.ts
+++ b/src/plugins/telemetry_collection_manager/server/types.ts
@@ -82,7 +82,9 @@ export interface BasicStatsPayload {
   version: string;
   cluster_stats: object;
   collection?: string;
-  stack_stats: object;
+  // Needed for testing to make fields easier to access
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  stack_stats: Record<string, any>;
 }
 
 export interface UsageStatsPayload extends BasicStatsPayload {

--- a/x-pack/test/api_integration/services/usage_api.ts
+++ b/x-pack/test/api_integration/services/usage_api.ts
@@ -5,49 +5,39 @@
  * 2.0.
  */
 
-import { TelemetryCollectionManagerPlugin } from '@kbn/telemetry-collection-manager-plugin/server/plugin';
+import { UsageStatsPayload } from '@kbn/telemetry-collection-manager-plugin/server';
 import { FtrProviderContext } from '../ftr_provider_context';
 
 export function UsageAPIProvider({ getService }: FtrProviderContext) {
   const supertest = getService('supertest');
-  const supertestNoAuth = getService('supertestWithoutAuth');
+
+  async function getTelemetryStats(payload: {
+    unencrypted: true;
+    refreshCache?: boolean;
+  }): Promise<Array<{ clusterUuid: string; stats: UsageStatsPayload }>>;
+  async function getTelemetryStats(payload: {
+    unencrypted: false;
+    refreshCache?: boolean;
+  }): Promise<Array<{ clusterUuid: string; stats: string }>>;
+  async function getTelemetryStats(payload: {
+    unencrypted?: boolean;
+    refreshCache?: boolean;
+  }): Promise<Array<{ clusterUuid: string; stats: UsageStatsPayload | string }>> {
+    const { body } = await supertest
+      .post('/api/telemetry/v2/clusters/_stats')
+      .set('kbn-xsrf', 'xxx')
+      .send({ refreshCache: true, ...payload })
+      .expect(200);
+    return body;
+  }
 
   return {
-    async getUsageStatsNoAuth(): Promise<undefined> {
-      const { body } = await supertestNoAuth
-        .get('/api/stats?extended=true')
-        .set('kbn-xsrf', 'xxx')
-        .expect(401);
-      return body.usage;
-    },
-
-    /**
-     * Public stats API: it returns the usage in camelCase format
-     */
-    async getUsageStats() {
-      const { body } = await supertest
-        .get('/api/stats?extended=true')
-        .set('kbn-xsrf', 'xxx')
-        .expect(200);
-      return body.usage;
-    },
-
     /**
      * Retrieve the stats via the private telemetry API:
      * It returns the usage in as a string encrypted blob or the plain payload if `unencrypted: false`
      *
      * @param payload Request parameters to retrieve the telemetry stats
      */
-    async getTelemetryStats(payload: {
-      unencrypted?: boolean;
-      refreshCache?: boolean;
-    }): Promise<ReturnType<TelemetryCollectionManagerPlugin['getStats']>> {
-      const { body } = await supertest
-        .post('/api/telemetry/v2/clusters/_stats')
-        .set('kbn-xsrf', 'xxx')
-        .send({ refreshCache: true, ...payload })
-        .expect(200);
-      return body;
-    },
+    getTelemetryStats,
   };
 }

--- a/x-pack/test/api_integration/services/usage_api.ts
+++ b/x-pack/test/api_integration/services/usage_api.ts
@@ -8,13 +8,18 @@
 import { UsageStatsPayload } from '@kbn/telemetry-collection-manager-plugin/server';
 import { FtrProviderContext } from '../ftr_provider_context';
 
+export interface UsageStatsPayloadTestFriendly extends UsageStatsPayload {
+  // Overwriting the `object` type to a more test-friendly type
+  stack_stats: Record<string, any>;
+}
+
 export function UsageAPIProvider({ getService }: FtrProviderContext) {
   const supertest = getService('supertest');
 
   async function getTelemetryStats(payload: {
     unencrypted: true;
     refreshCache?: boolean;
-  }): Promise<Array<{ clusterUuid: string; stats: UsageStatsPayload }>>;
+  }): Promise<Array<{ clusterUuid: string; stats: UsageStatsPayloadTestFriendly }>>;
   async function getTelemetryStats(payload: {
     unencrypted: false;
     refreshCache?: boolean;
@@ -22,7 +27,7 @@ export function UsageAPIProvider({ getService }: FtrProviderContext) {
   async function getTelemetryStats(payload: {
     unencrypted?: boolean;
     refreshCache?: boolean;
-  }): Promise<Array<{ clusterUuid: string; stats: UsageStatsPayload | string }>> {
+  }): Promise<Array<{ clusterUuid: string; stats: UsageStatsPayloadTestFriendly | string }>> {
     const { body } = await supertest
       .post('/api/telemetry/v2/clusters/_stats')
       .set('kbn-xsrf', 'xxx')

--- a/x-pack/test/reporting_api_integration/reporting_and_security.config.ts
+++ b/x-pack/test/reporting_api_integration/reporting_and_security.config.ts
@@ -37,6 +37,8 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
         `--xpack.reporting.capture.maxAttempts=1`,
         `--xpack.reporting.csv.maxSizeBytes=6000`,
         '--xpack.reporting.roles.enabled=false', // Reporting access control is implemented by sub-feature application privileges
+        // for testing set buffer duration to 0 to immediately flush counters into saved objects.
+        '--usageCollection.usageCounters.bufferDuration=0',
       ],
     },
   };

--- a/x-pack/test/reporting_api_integration/reporting_and_security/usage/api_counters.ts
+++ b/x-pack/test/reporting_api_integration/reporting_and_security/usage/api_counters.ts
@@ -6,6 +6,7 @@
  */
 
 import expect from '@kbn/expect';
+import { BasicStatsPayload } from '@kbn/telemetry-collection-manager-plugin/server/types';
 import { createPdfV2Params, createPngV2Params } from '..';
 import { FtrProviderContext } from '../../ftr_provider_context';
 
@@ -35,10 +36,11 @@ export default function ({ getService }: FtrProviderContext) {
     describe('server', function () {
       this.tags('skipCloud');
       it('configuration settings of the tests_server', async () => {
-        const usage = await usageAPI.getUsageStats();
-        expect(usage.kibana_config_usage.xpack_reporting_capture_max_attempts).to.be(1);
-        expect(usage.kibana_config_usage.xpack_reporting_csv_max_size_bytes).to.be(6000);
-        expect(usage.kibana_config_usage.xpack_reporting_roles_enabled).to.be(false);
+        const [{ stats }] = await usageAPI.getTelemetryStats({ unencrypted: true });
+        const usage = stats.stack_stats.kibana.plugins;
+        expect(usage.kibana_config_usage['xpack.reporting.capture.maxAttempts']).to.be(1);
+        expect(usage.kibana_config_usage['xpack.reporting.csv.maxSizeBytes']).to.be(6000);
+        expect(usage.kibana_config_usage['xpack.reporting.roles.enabled']).to.be(false);
       });
     });
 
@@ -52,12 +54,12 @@ export default function ({ getService }: FtrProviderContext) {
         DIAG_SCREENSHOT = '/api/reporting/diagnose/screenshot',
       }
 
-      let initialStats: any;
-      let stats: any;
+      let initialStats: BasicStatsPayload;
+      let stats: BasicStatsPayload;
       const CALL_COUNT = 3;
 
       before('call APIs', async () => {
-        initialStats = await usageAPI.getUsageStats();
+        [{ stats: initialStats }] = await usageAPI.getTelemetryStats({ unencrypted: true });
 
         await Promise.all(
           Object.keys(paths).map(async (key) => {
@@ -73,30 +75,36 @@ export default function ({ getService }: FtrProviderContext) {
         await waitOnAggregation();
 
         // determine the result usage count
-        stats = await usageAPI.getUsageStats();
+        [{ stats }] = await usageAPI.getTelemetryStats({ unencrypted: true });
       });
 
       it('job listing', async () => {
-        expect(getUsageCount(initialStats, `get ${paths.LIST}`)).to.be(0);
-        expect(getUsageCount(stats, `get ${paths.LIST}`)).to.be(CALL_COUNT);
+        const initialCount = getUsageCount(initialStats, `get ${paths.LIST}`);
+        expect(getUsageCount(stats, `get ${paths.LIST}`)).to.be(CALL_COUNT + initialCount);
       });
 
       it('job count', async () => {
-        expect(getUsageCount(initialStats, `get ${paths.COUNT}`)).to.be(0);
-        expect(getUsageCount(stats, `get ${paths.COUNT}`)).to.be(CALL_COUNT);
+        const initialCount = getUsageCount(initialStats, `get ${paths.COUNT}`);
+        expect(getUsageCount(stats, `get ${paths.COUNT}`)).to.be(CALL_COUNT + initialCount);
       });
 
       it('job info', async () => {
-        expect(
-          getUsageCount(initialStats, `get /api/reporting/jobs/info/{docId}:printable_pdf`)
-        ).to.be(0);
+        const initialCount = getUsageCount(
+          initialStats,
+          `get /api/reporting/jobs/info/{docId}:printable_pdf`
+        );
         expect(getUsageCount(stats, `get /api/reporting/jobs/info/{docId}:printable_pdf`)).to.be(
-          CALL_COUNT
+          CALL_COUNT + initialCount
         );
       });
     });
 
     describe('downloading and deleting', () => {
+      let initialStats: BasicStatsPayload;
+      before('gather initial stats', async () => {
+        [{ stats: initialStats }] = await usageAPI.getTelemetryStats({ unencrypted: true });
+      });
+
       it('downloading', async () => {
         try {
           await Promise.all([
@@ -119,12 +127,14 @@ export default function ({ getService }: FtrProviderContext) {
         log.info(`waiting on aggregation completed.`);
 
         log.info(`calling getUsageStats...`);
+        const [{ stats }] = await usageAPI.getTelemetryStats({ unencrypted: true });
+        const initialCount = getUsageCount(
+          initialStats,
+          `get /api/reporting/jobs/download/{docId}:printable_pdf`
+        );
         expect(
-          getUsageCount(
-            await usageAPI.getUsageStats(),
-            `get /api/reporting/jobs/download/{docId}:printable_pdf`
-          )
-        ).to.be(3);
+          getUsageCount(stats, `get /api/reporting/jobs/download/{docId}:printable_pdf`)
+        ).to.be(3 + initialCount);
       });
 
       it('deleting', async () => {
@@ -145,17 +155,19 @@ export default function ({ getService }: FtrProviderContext) {
         log.info(`waiting on aggregation completed.`);
 
         log.info(`calling getUsageStats...`);
+        const [{ stats }] = await usageAPI.getTelemetryStats({ unencrypted: true });
+        const initialCount = getUsageCount(
+          initialStats,
+          `delete /api/reporting/jobs/delete/{docId}:csv_searchsource`
+        );
         expect(
-          getUsageCount(
-            await usageAPI.getUsageStats(),
-            `delete /api/reporting/jobs/delete/{docId}:csv_searchsource`
-          )
-        ).to.be(1);
+          getUsageCount(stats, `delete /api/reporting/jobs/delete/{docId}:csv_searchsource`)
+        ).to.be(1 + initialCount);
       });
     });
 
     describe('API counters: job generation', () => {
-      let stats: any;
+      let stats: BasicStatsPayload;
 
       before(async () => {
         // call generation APIs
@@ -172,7 +184,7 @@ export default function ({ getService }: FtrProviderContext) {
 
         await waitOnAggregation();
 
-        stats = await usageAPI.getUsageStats();
+        [{ stats }] = await usageAPI.getTelemetryStats({ unencrypted: true });
       });
 
       it('PNG', async () => {
@@ -201,10 +213,10 @@ export default function ({ getService }: FtrProviderContext) {
       });
     };
 
-    const getUsageCount = (checkUsage: any, counterName: string): number => {
+    const getUsageCount = (checkUsage: BasicStatsPayload, counterName: string): number => {
       return (
-        checkUsage.usage_counters.daily_events.find(
-          (item: any) => item.counter_name === counterName
+        checkUsage.stack_stats.kibana.plugins.usage_counters.dailyEvents.find(
+          (item: any) => item.counterName === counterName
         )?.total || 0
       );
     };

--- a/x-pack/test/reporting_api_integration/reporting_and_security/usage/api_counters.ts
+++ b/x-pack/test/reporting_api_integration/reporting_and_security/usage/api_counters.ts
@@ -6,9 +6,9 @@
  */
 
 import expect from '@kbn/expect';
-import { BasicStatsPayload } from '@kbn/telemetry-collection-manager-plugin/server/types';
 import { createPdfV2Params, createPngV2Params } from '..';
 import { FtrProviderContext } from '../../ftr_provider_context';
+import { UsageStatsPayloadTestFriendly } from '../../../api_integration/services/usage_api';
 
 // eslint-disable-next-line import/no-default-export
 export default function ({ getService }: FtrProviderContext) {
@@ -54,8 +54,8 @@ export default function ({ getService }: FtrProviderContext) {
         DIAG_SCREENSHOT = '/api/reporting/diagnose/screenshot',
       }
 
-      let initialStats: BasicStatsPayload;
-      let stats: BasicStatsPayload;
+      let initialStats: UsageStatsPayloadTestFriendly;
+      let stats: UsageStatsPayloadTestFriendly;
       const CALL_COUNT = 3;
 
       before('call APIs', async () => {
@@ -100,7 +100,7 @@ export default function ({ getService }: FtrProviderContext) {
     });
 
     describe('downloading and deleting', () => {
-      let initialStats: BasicStatsPayload;
+      let initialStats: UsageStatsPayloadTestFriendly;
       before('gather initial stats', async () => {
         [{ stats: initialStats }] = await usageAPI.getTelemetryStats({ unencrypted: true });
       });
@@ -167,7 +167,7 @@ export default function ({ getService }: FtrProviderContext) {
     });
 
     describe('API counters: job generation', () => {
-      let stats: BasicStatsPayload;
+      let stats: UsageStatsPayloadTestFriendly;
 
       before(async () => {
         // call generation APIs
@@ -213,7 +213,10 @@ export default function ({ getService }: FtrProviderContext) {
       });
     };
 
-    const getUsageCount = (checkUsage: BasicStatsPayload, counterName: string): number => {
+    const getUsageCount = (
+      checkUsage: UsageStatsPayloadTestFriendly,
+      counterName: string
+    ): number => {
       return (
         checkUsage.stack_stats.kibana.plugins.usage_counters.dailyEvents.find(
           (item: any) => item.counterName === counterName

--- a/x-pack/test/reporting_api_integration/reporting_and_security/usage/archived_data.ts
+++ b/x-pack/test/reporting_api_integration/reporting_and_security/usage/archived_data.ts
@@ -16,7 +16,8 @@ export default function ({ getService }: FtrProviderContext) {
   describe('from archive data', () => {
     it('generated from 6.2', async () => {
       await esArchiver.load('x-pack/test/functional/es_archives/reporting/bwc/6_2');
-      const usage = await usageAPI.getUsageStats();
+      const [{ stats }] = await usageAPI.getTelemetryStats({ unencrypted: true });
+      const usage = stats.stack_stats.kibana.plugins.reporting;
 
       reportingAPI.expectRecentJobTypeTotalStats(usage, 'printable_pdf', 0);
       reportingAPI.expectAllTimeJobTypeTotalStats(usage, 'printable_pdf', 7);
@@ -36,7 +37,8 @@ export default function ({ getService }: FtrProviderContext) {
 
     it('generated from 6.3', async () => {
       await esArchiver.load('x-pack/test/functional/es_archives/reporting/bwc/6_3');
-      const usage = await usageAPI.getUsageStats();
+      const [{ stats }] = await usageAPI.getTelemetryStats({ unencrypted: true });
+      const usage = stats.stack_stats.kibana.plugins.reporting;
 
       reportingAPI.expectRecentJobTypeTotalStats(usage, 'printable_pdf', 0);
       reportingAPI.expectRecentPdfAppStats(usage, 'visualization', 0);

--- a/x-pack/test/reporting_api_integration/reporting_and_security/usage/initial.ts
+++ b/x-pack/test/reporting_api_integration/reporting_and_security/usage/initial.ts
@@ -6,8 +6,8 @@
  */
 
 import expect from '@kbn/expect';
+import { ReportingUsageType } from '@kbn/reporting-plugin/server/usage/types';
 import { FtrProviderContext } from '../../ftr_provider_context';
-import { UsageStats } from '../../services/usage';
 
 // eslint-disable-next-line import/no-default-export
 export default function ({ getService }: FtrProviderContext) {
@@ -16,18 +16,19 @@ export default function ({ getService }: FtrProviderContext) {
   const usageAPI = getService('usageAPI');
 
   describe('initial state', () => {
-    let usage: UsageStats;
+    let usage: ReportingUsageType;
 
     before(async () => {
       await retry.try(async () => {
         // use retry for stability - usage API could return 503
-        usage = (await usageAPI.getUsageStats()) as UsageStats;
+        const [{ stats }] = await usageAPI.getTelemetryStats({ unencrypted: true });
+        usage = stats.stack_stats.kibana.plugins.reporting;
       });
     });
 
     it('shows reporting as available and enabled', async () => {
-      expect(usage.reporting.available).to.be(true);
-      expect(usage.reporting.enabled).to.be(true);
+      expect(usage.available).to.be(true);
+      expect(usage.enabled).to.be(true);
     });
 
     it('all counts are 0', async () => {

--- a/x-pack/test/reporting_api_integration/reporting_and_security/usage/new_jobs.ts
+++ b/x-pack/test/reporting_api_integration/reporting_and_security/usage/new_jobs.ts
@@ -37,7 +37,8 @@ export default function ({ getService }: FtrProviderContext) {
         await Promise.all([reportingAPI.postJob(urls.JOB_PARAMS_CSV_DEFAULT_SPACE)])
       );
 
-      const usage = await usageAPI.getUsageStats();
+      const [{ stats }] = await usageAPI.getTelemetryStats({ unencrypted: true });
+      const usage = stats.stack_stats.kibana.plugins.reporting;
       reportingAPI.expectRecentJobTypeTotalStats(usage, 'csv_searchsource', 1);
     });
 
@@ -49,7 +50,8 @@ export default function ({ getService }: FtrProviderContext) {
         ])
       );
 
-      const usage = await usageAPI.getUsageStats();
+      const [{ stats }] = await usageAPI.getTelemetryStats({ unencrypted: true });
+      const usage = stats.stack_stats.kibana.plugins.reporting;
       reportingAPI.expectRecentPdfLayoutStats(usage, 'preserve_layout', 2);
       reportingAPI.expectAllTimePdfLayoutStats(usage, 'preserve_layout', 2);
     });
@@ -62,7 +64,8 @@ export default function ({ getService }: FtrProviderContext) {
         ])
       );
 
-      const usage = await usageAPI.getUsageStats();
+      const [{ stats }] = await usageAPI.getTelemetryStats({ unencrypted: true });
+      const usage = stats.stack_stats.kibana.plugins.reporting;
       reportingAPI.expectRecentPdfLayoutStats(usage, 'print', 1);
       reportingAPI.expectAllTimePdfLayoutStats(usage, 'print', 1);
     });

--- a/x-pack/test/reporting_api_integration/services/usage.ts
+++ b/x-pack/test/reporting_api_integration/services/usage.ts
@@ -16,13 +16,6 @@ import {
 } from '@kbn/reporting-plugin/server/usage/types';
 import { FtrProviderContext } from '../ftr_provider_context';
 
-// NOTE: the usage stats come from an HTTP API, which converts key names to snake_case
-export interface UsageStats {
-  reporting: ReportingUsageType & {
-    last_7_days: ReportingUsageType['last7Days'];
-  };
-}
-
 export function createUsageServices({ getService }: FtrProviderContext) {
   const log = getService('log');
   const esSupertest = getService('esSupertest');
@@ -102,55 +95,53 @@ export function createUsageServices({ getService }: FtrProviderContext) {
       );
     },
 
-    expectRecentPdfAppStats(stats: UsageStats, app: string, count: number) {
-      const actual =
-        stats.reporting.last_7_days.printable_pdf.app![app as keyof AvailableTotal['app']];
+    expectRecentPdfAppStats(stats: ReportingUsageType, app: string, count: number) {
+      const actual = stats.last7Days.printable_pdf.app![app as keyof AvailableTotal['app']];
       log.info(`expecting recent ${app} stats to have ${count} printable pdfs (actual: ${actual})`);
       expect(actual).to.be(count);
     },
 
-    expectAllTimePdfAppStats(stats: UsageStats, app: string, count: number) {
-      const actual = stats.reporting.printable_pdf.app![app as keyof AvailableTotal['app']];
+    expectAllTimePdfAppStats(stats: ReportingUsageType, app: string, count: number) {
+      const actual = stats.printable_pdf.app![app as keyof AvailableTotal['app']];
       log.info(
         `expecting all time pdf ${app} stats to have ${count} printable pdfs (actual: ${actual})`
       );
       expect(actual).to.be(count);
     },
 
-    expectRecentPdfLayoutStats(stats: UsageStats, layout: string, count: number) {
-      const actual =
-        stats.reporting.last_7_days.printable_pdf.layout![layout as keyof LayoutCounts];
+    expectRecentPdfLayoutStats(stats: ReportingUsageType, layout: string, count: number) {
+      const actual = stats.last7Days.printable_pdf.layout![layout as keyof LayoutCounts];
       log.info(`expecting recent stats to report ${count} ${layout} layouts (actual: ${actual})`);
       expect(actual).to.be(count);
     },
 
-    expectAllTimePdfLayoutStats(stats: UsageStats, layout: string, count: number) {
-      const actual = stats.reporting.printable_pdf.layout![layout as keyof LayoutCounts];
+    expectAllTimePdfLayoutStats(stats: ReportingUsageType, layout: string, count: number) {
+      const actual = stats.printable_pdf.layout![layout as keyof LayoutCounts];
       log.info(`expecting all time stats to report ${count} ${layout} layouts (actual: ${actual})`);
       expect(actual).to.be(count);
     },
 
-    expectRecentJobTypeTotalStats(stats: UsageStats, jobType: string, count: number) {
-      const actual = stats.reporting.last_7_days[jobType as keyof JobTypes].total;
+    expectRecentJobTypeTotalStats(stats: ReportingUsageType, jobType: string, count: number) {
+      const actual = stats.last7Days[jobType as keyof JobTypes].total;
       log.info(
         `expecting recent stats to report ${count} ${jobType} job types (actual: ${actual})`
       );
       expect(actual).to.be(count);
     },
 
-    expectAllTimeJobTypeTotalStats(stats: UsageStats, jobType: string, count: number) {
-      const actual = stats.reporting[jobType as keyof JobTypes].total;
+    expectAllTimeJobTypeTotalStats(stats: ReportingUsageType, jobType: string, count: number) {
+      const actual = stats[jobType as keyof JobTypes].total;
       log.info(
         `expecting all time stats to report ${count} ${jobType} job types (actual: ${actual})`
       );
       expect(actual).to.be(count);
     },
 
-    getCompletedReportCount(stats: UsageStats) {
-      return stats.reporting.status.completed;
+    getCompletedReportCount(stats: ReportingUsageType) {
+      return stats.status.completed;
     },
 
-    expectCompletedReportCount(stats: UsageStats, count: number) {
+    expectCompletedReportCount(stats: ReportingUsageType, count: number) {
       expect(this.getCompletedReportCount(stats)).to.be(count);
     },
   };

--- a/x-pack/test/upgrade/services/reporting_upgrade_services.ts
+++ b/x-pack/test/upgrade/services/reporting_upgrade_services.ts
@@ -7,36 +7,15 @@
 
 import expect from '@kbn/expect';
 import { indexTimestamp } from '@kbn/reporting-plugin/server/lib/store/index_timestamp';
+import {
+  AppCounts,
+  JobTypes,
+  LayoutCounts,
+  ReportingUsageType,
+} from '@kbn/reporting-plugin/server/usage/types';
 import { services as xpackServices } from '../../functional/services';
 import { services as apiIntegrationServices } from '../../api_integration/services';
 import { FtrProviderContext } from '../ftr_provider_context';
-
-interface PDFAppCounts {
-  app: {
-    [appName: string]: number;
-  };
-  layout: {
-    [layoutType: string]: number;
-  };
-}
-
-export interface ReportingUsageStats {
-  available: boolean;
-  enabled: boolean;
-  total: number;
-  last_7_days: {
-    total: number;
-    printable_pdf: PDFAppCounts;
-    [jobType: string]: any;
-  };
-  printable_pdf: PDFAppCounts;
-  status: any;
-  [jobType: string]: any;
-}
-
-interface UsageStats {
-  reporting: ReportingUsageStats;
-}
 
 function removeWhitespace(str: string) {
   return str.replace(/\s/g, '');
@@ -148,60 +127,76 @@ export function ReportingAPIProvider({ getService }: FtrProviderContext) {
       });
     },
 
-    expectRecentPdfAppStats(stats: UsageStats, app: string, count: number) {
-      expect(stats.reporting.last_7_days.printable_pdf.app[app]).to.be(count);
+    expectRecentPdfAppStats(stats: ReportingUsageType, app: keyof AppCounts, count: number) {
+      expect(stats.last7Days.printable_pdf.app[app]).to.be(count);
     },
 
-    expectAllTimePdfAppStats(stats: UsageStats, app: string, count: number) {
-      expect(stats.reporting.printable_pdf.app[app]).to.be(count);
+    expectAllTimePdfAppStats(stats: ReportingUsageType, app: keyof AppCounts, count: number) {
+      expect(stats.printable_pdf.app[app]).to.be(count);
     },
 
-    expectRecentPdfLayoutStats(stats: UsageStats, layout: string, count: number) {
-      expect(stats.reporting.last_7_days.printable_pdf.layout[layout]).to.be(count);
+    expectRecentPdfLayoutStats(
+      stats: ReportingUsageType,
+      layout: keyof LayoutCounts,
+      count: number
+    ) {
+      expect(stats.last7Days.printable_pdf.layout[layout]).to.be(count);
     },
 
-    expectAllTimePdfLayoutStats(stats: UsageStats, layout: string, count: number) {
-      expect(stats.reporting.printable_pdf.layout[layout]).to.be(count);
+    expectAllTimePdfLayoutStats(
+      stats: ReportingUsageType,
+      layout: keyof LayoutCounts,
+      count: number
+    ) {
+      expect(stats.printable_pdf.layout[layout]).to.be(count);
     },
 
-    expectRecentJobTypeTotalStats(stats: UsageStats, jobType: string, count: number) {
-      expect(stats.reporting.last_7_days[jobType].total).to.be(count);
+    expectRecentJobTypeTotalStats(
+      stats: ReportingUsageType,
+      jobType: keyof JobTypes,
+      count: number
+    ) {
+      expect(stats.last7Days[jobType].total).to.be(count);
     },
 
-    expectAllTimeJobTypeTotalStats(stats: UsageStats, jobType: string, count: number) {
-      expect(stats.reporting[jobType].total).to.be(count);
+    expectAllTimeJobTypeTotalStats(
+      stats: ReportingUsageType,
+      jobType: keyof JobTypes,
+      count: number
+    ) {
+      expect(stats[jobType].total).to.be(count);
     },
 
-    getCompletedReportCount(stats: UsageStats) {
-      return stats.reporting.status.completed;
+    getCompletedReportCount(stats: ReportingUsageType) {
+      return stats.status.completed;
     },
 
-    expectCompletedReportCount(stats: UsageStats, count: number) {
+    expectCompletedReportCount(stats: ReportingUsageType, count: number) {
       expect(this.getCompletedReportCount(stats)).to.be(count);
     },
 
-    getRecentPdfAppStats(stats: UsageStats, app: string) {
-      return stats.reporting.last_7_days.printable_pdf.app[app];
+    getRecentPdfAppStats(stats: ReportingUsageType, app: keyof AppCounts) {
+      return stats.last7Days.printable_pdf.app[app];
     },
 
-    getAllTimePdfAppStats(stats: UsageStats, app: string) {
-      return stats.reporting.printable_pdf.app[app];
+    getAllTimePdfAppStats(stats: ReportingUsageType, app: keyof AppCounts) {
+      return stats.printable_pdf.app[app];
     },
 
-    getRecentPdfLayoutStats(stats: UsageStats, layout: string) {
-      return stats.reporting.last_7_days.printable_pdf.layout[layout];
+    getRecentPdfLayoutStats(stats: ReportingUsageType, layout: keyof LayoutCounts) {
+      return stats.last7Days.printable_pdf.layout[layout];
     },
 
-    getAllTimePdfLayoutStats(stats: UsageStats, layout: string) {
-      return stats.reporting.printable_pdf.layout[layout];
+    getAllTimePdfLayoutStats(stats: ReportingUsageType, layout: keyof LayoutCounts) {
+      return stats.printable_pdf.layout[layout];
     },
 
-    getRecentJobTypeTotalStats(stats: UsageStats, jobType: string) {
-      return stats.reporting.last_7_days[jobType].total;
+    getRecentJobTypeTotalStats(stats: ReportingUsageType, jobType: keyof JobTypes) {
+      return stats.last7Days[jobType].total;
     },
 
-    getAllTimeJobTypeTotalStats(stats: UsageStats, jobType: string) {
-      return stats.reporting[jobType].total;
+    getAllTimeJobTypeTotalStats(stats: ReportingUsageType, jobType: keyof JobTypes) {
+      return stats[jobType].total;
     },
   };
 }


### PR DESCRIPTION
## Summary

Part of https://github.com/elastic/kibana/issues/150429. To unblock #151082 we need to migrate the `reporting` FTRs away from the deprecated Stats API to use the actual telemetry API.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
