### PR TITLE
profiling: update copy in setup button

### DIFF
--- a/x-pack/plugins/profiling/public/components/check_setup.tsx
+++ b/x-pack/plugins/profiling/public/components/check_setup.tsx
@@ -179,7 +179,7 @@ export function CheckSetup({ children }: { children: React.ReactElement }) {
                 >
                   {!postSetupLoading
                     ? i18n.translate('xpack.profiling.noDataConfig.action.buttonLabel', {
-                        defaultMessage: 'Setup Universal Profiling',
+                        defaultMessage: 'Set up Universal Profiling',
                       })
                     : i18n.translate('xpack.profiling.noDataConfig.action.buttonLoadingLabel', {
                         defaultMessage: 'Setting up Universal Profiling...',


### PR DESCRIPTION
## Summary

Small update to copy in the Universal Profiling button, as mentioned in https://github.com/elastic/universal-profiling-documentation/pull/29#discussion_r1113257503

<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->