### PR TITLE
[8.6] [Security Solutions] Fix timeline not able to save on investigating alert from dashboard (#151616)

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/event_details/table/use_action_cell_data_provider.ts
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/table/use_action_cell_data_provider.ts
@@ -29,7 +29,7 @@ import { getDisplayValue } from '../../../../timelines/components/timeline/data_
 import { PORT_NAMES } from '../../../../network/components/port/helpers';
 import { INDICATOR_REFERENCE } from '../../../../../common/cti/constants';
 import type { BrowserField } from '../../../containers/source';
-import type { DataProvider, QueryOperator } from '../../../../../common/types';
+import type { DataProvider, DataProvidersAnd, QueryOperator } from '../../../../../common/types';
 import { IS_OPERATOR } from '../../../../../common/types';
 
 export interface UseActionCellDataProvider {
@@ -68,6 +68,16 @@ export const getDataProvider = (
     displayValue: getDisplayValue(value),
   },
 });
+
+export const getDataProviderAnd = (
+  field: string,
+  id: string,
+  value: string | string[],
+  operator: QueryOperator = IS_OPERATOR
+): DataProvidersAnd => {
+  const { and, ...dataProvider } = getDataProvider(field, id, value, operator);
+  return dataProvider;
+};
 
 export const useActionCellDataProvider = ({
   contextId,

--- a/x-pack/plugins/security_solution/public/overview/components/detection_response/hooks/mock_data.ts
+++ b/x-pack/plugins/security_solution/public/overview/components/detection_response/hooks/mock_data.ts
@@ -47,7 +47,6 @@ export const dataProviderWithAndFilters = [
   {
     and: [
       {
-        and: [],
         enabled: true,
         excluded: false,
         id: 'mock-id',
@@ -80,7 +79,6 @@ export const dataProviderWithOrFilters = [
   {
     and: [
       {
-        and: [],
         enabled: true,
         id: 'mock-id',
         name: 'kibana.alerts.workflow_status',
@@ -109,7 +107,6 @@ export const dataProviderWithOrFilters = [
   {
     and: [
       {
-        and: [],
         enabled: true,
         id: 'mock-id',
         name: 'kibana.alerts.workflow_status',
@@ -138,7 +135,6 @@ export const dataProviderWithOrFilters = [
   {
     and: [
       {
-        and: [],
         enabled: true,
         id: 'mock-id',
         name: 'kibana.alerts.workflow_status',

--- a/x-pack/plugins/security_solution/public/overview/components/detection_response/hooks/use_navigate_to_timeline.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/detection_response/hooks/use_navigate_to_timeline.tsx
@@ -12,7 +12,10 @@ import { v4 as uuid } from 'uuid';
 import { useDeepEqualSelector } from '../../../../common/hooks/use_selector';
 import { SourcererScopeName } from '../../../../common/store/sourcerer/model';
 import { sourcererActions } from '../../../../common/store/sourcerer';
-import { getDataProvider } from '../../../../common/components/event_details/table/use_action_cell_data_provider';
+import {
+  getDataProvider,
+  getDataProviderAnd,
+} from '../../../../common/components/event_details/table/use_action_cell_data_provider';
 import type { DataProvider, QueryOperator } from '../../../../../common/types/timeline';
 import { TimelineId, TimelineType } from '../../../../../common/types/timeline';
 import { useCreateTimeline } from '../../../../timelines/components/timeline/properties/use_create_timeline';
@@ -90,12 +93,13 @@ export const useNavigateToTimeline = () => {
 
           for (const filter of orFilterGroup.slice(1)) {
             dataProvider.and.push(
-              getDataProvider(filter.field, uuid(), filter.value, filter.operator)
+              getDataProviderAnd(filter.field, uuid(), filter.value, filter.operator)
             );
           }
           dataProviders.push(dataProvider);
         }
       }
+
       navigateToTimeline(dataProviders, timeRange);
     },
     [navigateToTimeline]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.6`:
 - [[Security Solutions] Fix timeline not able to save on investigating alert from dashboard (#151616)](https://github.com/elastic/kibana/pull/151616)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Pablo Machado","email":"pablo.nevesmachado@elastic.co"},"sourceCommit":{"committedDate":"2023-02-21T16:31:40Z","message":"[Security Solutions] Fix timeline not able to save on investigating alert from dashboard (#151616)\n\nissue: https://github.com/elastic/kibana/issues/149800\r\n\r\n## Summary\r\n\r\nThe timeline endpoint is returning an error everywhere we call\r\n`openTimelineWithFilters` (entity analytics and detections and response\r\npages)\r\n\r\nI compare a broken data provider with one that works and spotted the\r\nextra `and: []`\r\n<img width=\"1424\" alt=\"Screenshot 2023-02-20 at 13 54 19\"\r\nsrc=\"https://user-images.githubusercontent.com/1490444/220121799-9d33a0f8-d319-4161-95e2-c9c3fb324972.png\">\r\n\r\nAfter removing `and: []` it works.\r\n\r\n### How to test it?\r\n* On entity analytics and detections and response pages\r\n* Open the timeline from the alerts column \r\n* Check if the timeline HTTP call status code is 200\r\n* Save the timeline and check if it is saved\r\n\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"949c8c2fe0cf0fc5ca91b28e55559b4bfedd1460","branchLabelMapping":{"^v8.8.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:fix","Team:Threat Hunting","Team: SecuritySolution","Team:Threat Hunting:Explore","v8.7.0","v8.8.0","v8.6.3"],"number":151616,"url":"https://github.com/elastic/kibana/pull/151616","mergeCommit":{"message":"[Security Solutions] Fix timeline not able to save on investigating alert from dashboard (#151616)\n\nissue: https://github.com/elastic/kibana/issues/149800\r\n\r\n## Summary\r\n\r\nThe timeline endpoint is returning an error everywhere we call\r\n`openTimelineWithFilters` (entity analytics and detections and response\r\npages)\r\n\r\nI compare a broken data provider with one that works and spotted the\r\nextra `and: []`\r\n<img width=\"1424\" alt=\"Screenshot 2023-02-20 at 13 54 19\"\r\nsrc=\"https://user-images.githubusercontent.com/1490444/220121799-9d33a0f8-d319-4161-95e2-c9c3fb324972.png\">\r\n\r\nAfter removing `and: []` it works.\r\n\r\n### How to test it?\r\n* On entity analytics and detections and response pages\r\n* Open the timeline from the alerts column \r\n* Check if the timeline HTTP call status code is 200\r\n* Save the timeline and check if it is saved\r\n\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"949c8c2fe0cf0fc5ca91b28e55559b4bfedd1460"}},"sourceBranch":"main","suggestedTargetBranches":["8.6"],"targetPullRequestStates":[{"branch":"8.7","label":"v8.7.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/151744","number":151744,"state":"OPEN"},{"branch":"main","label":"v8.8.0","labelRegex":"^v8.8.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/151616","number":151616,"mergeCommit":{"message":"[Security Solutions] Fix timeline not able to save on investigating alert from dashboard (#151616)\n\nissue: https://github.com/elastic/kibana/issues/149800\r\n\r\n## Summary\r\n\r\nThe timeline endpoint is returning an error everywhere we call\r\n`openTimelineWithFilters` (entity analytics and detections and response\r\npages)\r\n\r\nI compare a broken data provider with one that works and spotted the\r\nextra `and: []`\r\n<img width=\"1424\" alt=\"Screenshot 2023-02-20 at 13 54 19\"\r\nsrc=\"https://user-images.githubusercontent.com/1490444/220121799-9d33a0f8-d319-4161-95e2-c9c3fb324972.png\">\r\n\r\nAfter removing `and: []` it works.\r\n\r\n### How to test it?\r\n* On entity analytics and detections and response pages\r\n* Open the timeline from the alerts column \r\n* Check if the timeline HTTP call status code is 200\r\n* Save the timeline and check if it is saved\r\n\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"949c8c2fe0cf0fc5ca91b28e55559b4bfedd1460"}},{"branch":"8.6","label":"v8.6.3","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->