### PR TITLE
[Security Solutions] Fix module name cut under beats overview dashboard

### DIFF
--- a/x-pack/plugins/security_solution/public/overview/components/overview_host_stats/index.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/overview_host_stats/index.tsx
@@ -262,7 +262,7 @@ const NoMarginTopFlexItem = styled(EuiFlexItem)`
 `;
 
 const AccordionContent = styled.div`
-  margin-top: 8px;
+  padding-top: 8px;
 `;
 
 const OverviewHostStatsComponent: React.FC<OverviewHostProps> = ({ data, loading }) => {

--- a/x-pack/plugins/security_solution/public/overview/components/overview_network_stats/index.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/overview_network_stats/index.tsx
@@ -175,7 +175,7 @@ const NoMarginTopFlexItem = styled(EuiFlexItem)`
 `;
 
 const AccordionContent = styled.div`
-  margin-top: 8px;
+  padding-top: 8px;
 `;
 
 const OverviewNetworkStatsComponent: React.FC<OverviewNetworkProps> = ({ data, loading }) => {


### PR DESCRIPTION
issue: https://github.com/elastic/kibana/issues/151663

## Summary
Probably due to some changes when converting `EuiAccordion` [from Sass to Emotion CSS](https://github.com/elastic/eui/commit/922a789ae204029a050f0bef79bf96d2438dab5a) `border-top` leaks and breaks the component height calculation.


### Before
<img width="1120" alt="Screenshot 2023-02-22 at 11 34 46" src="https://user-images.githubusercontent.com/1490444/220595311-d0abbdea-88eb-4403-b76a-a1c5f226a726.png">


### After
<img width="1109" alt="Screenshot 2023-02-22 at 11 33 20" src="https://user-images.githubusercontent.com/1490444/220595190-9ab66660-cebf-4589-84ad-a21449f816b9.png">



### Checklist



<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->