### PR TITLE
[Enterprise Search] Make stat titles smaller

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/api_total_stats.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/api_total_stats.tsx
@@ -53,7 +53,7 @@ export const ApiTotalStats: React.FC = () => {
       {stats.map((item, index) => (
         <EuiFlexItem key={index}>
           <EuiPanel color={index === 0 ? 'primary' : 'subdued'} hasShadow={false} paddingSize="l">
-            <EuiStat {...item} />
+            <EuiStat titleSize="m" {...item} />
           </EuiPanel>
         </EuiFlexItem>
       ))}

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_overview_panels.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_overview_panels.tsx
@@ -31,6 +31,7 @@ import { SearchIndexTabId } from '../search_index';
 const StatusPanel: React.FC<{ ingestionStatus: IngestionStatus }> = ({ ingestionStatus }) => (
   <EuiPanel color={ingestionStatusToColor(ingestionStatus)} hasShadow={false} paddingSize="l">
     <EuiStat
+      titleSize="m"
       description={i18n.translate('xpack.enterpriseSearch.connector.ingestionStatus.title', {
         defaultMessage: 'Ingestion status',
       })}
@@ -47,6 +48,7 @@ export const ConnectorOverviewPanels: React.FC = () => {
       <EuiFlexItem grow={1}>
         <EuiPanel color="primary" hasShadow={false} paddingSize="l">
           <EuiStat
+            titleSize="m"
             description={i18n.translate(
               'xpack.enterpriseSearch.content.searchIndex.totalStats.documentCountCardLabel',
               {

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector_total_stats.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector_total_stats.tsx
@@ -85,7 +85,7 @@ export const ConnectorTotalStats: React.FC = () => {
         {stats.map((item, index) => (
           <EuiFlexItem key={index}>
             <EuiPanel color="primary" hasShadow={false} paddingSize="l">
-              <EuiStat {...item} />
+              <EuiStat titleSize="m" {...item} />
             </EuiPanel>
           </EuiFlexItem>
         ))}

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler_total_stats.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler_total_stats.tsx
@@ -75,7 +75,7 @@ export const CrawlerTotalStats: React.FC = () => {
         {stats.map((item, index) => (
           <EuiFlexItem key={index}>
             <EuiPanel color={index === 0 ? 'primary' : 'subdued'} hasShadow={false} paddingSize="l">
-              <EuiStat {...item} />
+              <EuiStat titleSize="m" {...item} />
             </EuiPanel>
           </EuiFlexItem>
         ))}

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/name_and_description_stats.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/name_and_description_stats.tsx
@@ -72,7 +72,7 @@ export const NameAndDescriptionStats: React.FC = () => {
         {stats.map((item, index) => (
           <EuiFlexItem key={index}>
             <EuiPanel color={'subdued'} hasShadow={false} paddingSize="l">
-              <EuiStat {...item} />
+              <EuiStat titleSize="m" {...item} />
             </EuiPanel>
           </EuiFlexItem>
         ))}

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_indices/indices_stats.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_indices/indices_stats.tsx
@@ -42,6 +42,7 @@ export const IndicesStats: React.FC = () => {
               paddingSize="l"
             >
               <EuiStat
+                titleSize="m"
                 description={i18n.translate(
                   'xpack.enterpriseSearch.content.searchIndices.jobStats.connectedMethods',
                   {
@@ -60,6 +61,7 @@ export const IndicesStats: React.FC = () => {
               paddingSize="l"
             >
               <EuiStat
+                titleSize="m"
                 description={i18n.translate(
                   'xpack.enterpriseSearch.content.searchIndices.jobStats.incompleteMethods',
                   {
@@ -78,6 +80,7 @@ export const IndicesStats: React.FC = () => {
           <EuiFlexItem>
             <EuiPanel color="subdued" hasShadow={false} paddingSize="l">
               <EuiStat
+                titleSize="m"
                 description={i18n.translate(
                   'xpack.enterpriseSearch.content.searchIndices.jobStats.runningSyncs',
                   {
@@ -92,6 +95,7 @@ export const IndicesStats: React.FC = () => {
           <EuiFlexItem>
             <EuiPanel color={data?.idle ? 'warning' : 'subdued'} hasShadow={false} paddingSize="l">
               <EuiStat
+                titleSize="m"
                 description={i18n.translate(
                   'xpack.enterpriseSearch.content.searchIndices.jobStats.longRunningSyncs',
                   {
@@ -110,6 +114,7 @@ export const IndicesStats: React.FC = () => {
               paddingSize="l"
             >
               <EuiStat
+                titleSize="m"
                 description={i18n.translate(
                   'xpack.enterpriseSearch.content.searchIndices.jobStats.orphanedSyncs',
                   {
@@ -124,6 +129,7 @@ export const IndicesStats: React.FC = () => {
           <EuiFlexItem>
             <EuiPanel color={data?.errors ? 'danger' : 'subdued'} hasShadow={false} paddingSize="l">
               <EuiStat
+                titleSize="m"
                 description={i18n.translate(
                   'xpack.enterpriseSearch.content.searchIndices.jobStats.errorSyncs',
                   {


### PR DESCRIPTION
## Summary

This makes the stat components we use on indices and index overview pages use titleSize 'm'.

<img width="1003" alt="Screenshot 2023-02-22 at 12 11 21" src="https://user-images.githubusercontent.com/94373878/220605714-bcb9abb1-48a3-4be2-a6dd-96b8821f62f3.png">
<img width="1005" alt="Screenshot 2023-02-22 at 12 11 01" src="https://user-images.githubusercontent.com/94373878/220605722-5c50aa20-6aff-40f0-b440-c20faf8734dc.png">
<img width="991" alt="Screenshot 2023-02-22 at 12 10 50" src="https://user-images.githubusercontent.com/94373878/220605727-4cfa60da-7330-46e4-823a-65a35fb6a135.png">


<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->