### PR TITLE
[ML] Fix file upload ingest error handling

### DIFF
--- a/x-pack/plugins/data_visualizer/public/application/common/components/results_links/results_links.tsx
+++ b/x-pack/plugins/data_visualizer/public/application/common/components/results_links/results_links.tsx
@@ -268,7 +268,7 @@ export const ResultsLinks: FC<Props> = ({
       </EuiFlexItem>
       {Array.isArray(asyncHrefCards) &&
         asyncHrefCards.map((link) => (
-          <EuiFlexItem>
+          <EuiFlexItem key={link.title}>
             <EuiCard
               icon={<EuiIcon size="xxl" type={link.icon} />}
               data-test-subj="fileDataVisLink"

--- a/x-pack/plugins/data_visualizer/public/application/file_data_visualizer/components/import_errors/errors.tsx
+++ b/x-pack/plugins/data_visualizer/public/application/file_data_visualizer/components/import_errors/errors.tsx
@@ -128,17 +128,19 @@ function toString(error: any): ImportError {
       return { msg: error.msg };
     } else if (error.error !== undefined) {
       if (typeof error.error === 'object') {
-        if (error.error.reason !== undefined) {
-          // this will catch a bulk ingest failure
-          const errorObj: ImportError = { msg: error.error.reason };
-          if (error.error.root_cause !== undefined) {
-            errorObj.more = JSON.stringify(error.error.root_cause);
+        // this will catch a bulk ingest failure
+        const reason = error.error.reason ?? error.error.meta.body.error.reason;
+        if (reason !== undefined) {
+          const errorObj: ImportError = { msg: reason };
+          const rootCause = error.error.root_cause ?? error.error.meta.body.error.root_cause;
+          if (rootCause !== undefined) {
+            errorObj.more = JSON.stringify(rootCause);
           }
           return errorObj;
         }
 
+        // this will catch javascript errors such as JSON parsing issues
         if (error.error.message !== undefined) {
-          // this will catch javascript errors such as JSON parsing issues
           return { msg: error.error.message };
         }
       } else {


### PR DESCRIPTION
The errors thrown from the bulk ingest js client function have changed shape where the error information is now contained within a `meta` object.
This change supports this new object and also supports the previous error object shape, just in case there are situations where this is still thrown from the js client.

Errors are now correctly displayed on the UI:

![image](https://user-images.githubusercontent.com/22172091/220622631-9a3f0396-a02b-40d5-87b2-70d1928f9ce0.png)

Also adds a `key` prop to the results links list to fix the console error which is thrown in dev mode.


<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->