### PR TITLE
[Fleet] added `_meta` field `has_experimental_data_stream_indexing_features`

### DIFF
--- a/x-pack/plugins/fleet/server/services/package_policies/experimental_datastream_features.test.ts
+++ b/x-pack/plugins/fleet/server/services/package_policies/experimental_datastream_features.test.ts
@@ -239,6 +239,7 @@ describe('experimental_datastream_features', () => {
               mappings: expect.objectContaining({ _source: { mode: 'synthetic' } }),
             }),
           }),
+          _meta: { has_experimental_data_stream_indexing_features: true },
         })
       );
     });
@@ -268,6 +269,7 @@ describe('experimental_datastream_features', () => {
               }),
             }),
           }),
+          _meta: { has_experimental_data_stream_indexing_features: true },
         })
       );
     });
@@ -297,6 +299,7 @@ describe('experimental_datastream_features', () => {
               }),
             }),
           }),
+          _meta: { has_experimental_data_stream_indexing_features: true },
         })
       );
     });
@@ -325,6 +328,7 @@ describe('experimental_datastream_features', () => {
               }),
             }),
           }),
+          _meta: { has_experimental_data_stream_indexing_features: true },
         })
       );
     });
@@ -349,6 +353,7 @@ describe('experimental_datastream_features', () => {
               }),
             }),
           }),
+          _meta: { has_experimental_data_stream_indexing_features: true },
         })
       );
     });
@@ -446,6 +451,7 @@ describe('experimental_datastream_features', () => {
                 mappings: expect.objectContaining({ _source: { mode: 'synthetic' } }),
               }),
             }),
+            _meta: { has_experimental_data_stream_indexing_features: true },
           })
         );
       });
@@ -475,6 +481,7 @@ describe('experimental_datastream_features', () => {
                 }),
               }),
             }),
+            _meta: { has_experimental_data_stream_indexing_features: true },
           })
         );
       });
@@ -504,6 +511,7 @@ describe('experimental_datastream_features', () => {
                 }),
               }),
             }),
+            _meta: { has_experimental_data_stream_indexing_features: false },
           })
         );
       });
@@ -544,6 +552,7 @@ describe('experimental_datastream_features', () => {
                 }),
               }),
             }),
+            _meta: { has_experimental_data_stream_indexing_features: true },
           })
         );
       });

--- a/x-pack/plugins/fleet/server/services/package_policies/experimental_datastream_features.ts
+++ b/x-pack/plugins/fleet/server/services/package_policies/experimental_datastream_features.ts
@@ -159,9 +159,17 @@ export async function handleExperimentalDatastreamFeatureOptIn({
         },
       };
 
+      const hasExperimentalDataStreamIndexingFeatures =
+        featureMapEntry.features.synthetic_source ||
+        featureMapEntry.features.doc_value_only_numeric ||
+        featureMapEntry.features.doc_value_only_other;
+
       await esClient.cluster.putComponentTemplate({
         name: componentTemplateName,
         body,
+        _meta: {
+          has_experimental_data_stream_indexing_features: hasExperimentalDataStreamIndexingFeatures,
+        },
       });
     }
 
@@ -188,6 +196,9 @@ export async function handleExperimentalDatastreamFeatureOptIn({
         name: featureMapEntry.data_stream,
         // @ts-expect-error
         body: indexTemplateBody,
+        _meta: {
+          has_experimental_data_stream_indexing_features: featureMapEntry.features.tsdb,
+        },
       });
     }
 


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/150917

Added `has_experimental_data_stream_indexing_features` meta field to indicate that component/index template has these setting turned on.

The component template has this field set when `synthetic_source` or the `doc_value_only` settings are enabled.
The index template has the field set when `tsdb` setting is enabled. 

Open question:
- Alternatively we could move the meta field to only be in the component template, also for `tsdb`. I'm not sure which would be more intuitive (`tsdb` only makes changes to the index template, the other settings in component template).
@kpollich WDYT?

To test:
- enable `experimentalDataStreamSettings` feature flag
- add a System integration policy and enable one of the experimental features on one data stream e.g. Doc only value
- Check the corresponding component template in Stack Management that is has the new _meta field.

<img width="1413" alt="image" src="https://user-images.githubusercontent.com/90178898/220637550-3919ca2e-652b-4166-8353-cfced6b0deb9.png">
<img width="978" alt="image" src="https://user-images.githubusercontent.com/90178898/220637661-43c5d2fc-6a73-4afe-8280-b17dd020b589.png">


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
