### PR TITLE
[Enterprise Search] Use correct indexName to fetch domain list

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/domain_management/domain_management.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/domain_management/domain_management.tsx
@@ -5,18 +5,18 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import { useParams } from 'react-router-dom';
 
-import { useValues } from 'kea';
+import { useActions, useValues } from 'kea';
 
 import { EuiSpacer } from '@elastic/eui';
 
+import { DEFAULT_META } from '../../../../../shared/constants';
 import { Loading } from '../../../../../shared/loading';
 
 import { DeleteCrawlerDomainApiLogic } from '../../../../api/crawler/delete_crawler_domain_api_logic';
-import { GetCrawlerDomainsApiLogic } from '../../../../api/crawler/get_crawler_domains_api_logic';
 
 import { CrawlerDomainDetail } from '../crawler_domain_detail/crawler_domain_detail';
 
@@ -29,8 +29,12 @@ import { EmptyStatePanel } from './empty_state_panel';
 
 export const SearchIndexDomainManagement: React.FC = () => {
   DeleteCrawlerDomainApiLogic.mount();
-  GetCrawlerDomainsApiLogic.mount();
-  const { domains, isLoading } = useValues(DomainManagementLogic);
+  const { getDomains } = useActions(DomainManagementLogic);
+  const { domains, indexName, isLoading } = useValues(DomainManagementLogic);
+
+  useEffect(() => {
+    getDomains(DEFAULT_META);
+  }, [indexName]);
 
   const { detailId } = useParams<{
     detailId?: string;

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/domain_management/domain_management_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/domain_management/domain_management_logic.ts
@@ -103,9 +103,4 @@ export const DomainManagementLogic = kea<
         deleteStatus === Status.LOADING,
     ],
   }),
-  events: ({ actions, values }) => ({
-    afterMount: () => {
-      actions.getDomains(values.meta);
-    },
-  }),
 });

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/domain_management/domain_management_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/domain_management/domain_management_logic.ts
@@ -27,6 +27,7 @@ interface DomainManagementValues {
   domains: CrawlerDomain[];
   getData: CrawlerDomainsWithMeta | null;
   getStatus: Status;
+  indexName: string;
   isLoading: boolean;
   meta: Meta;
 }
@@ -54,6 +55,8 @@ export const DomainManagementLogic = kea<
       ['status as getStatus', 'data as getData'],
       DeleteCrawlerDomainApiLogic,
       ['status as deleteStatus'],
+      IndexNameLogic,
+      ['indexName'],
     ],
   },
   path: ['enterprise_search', 'domain_management'],
@@ -69,11 +72,11 @@ export const DomainManagementLogic = kea<
       actions.getDomains(values.meta);
     },
     deleteDomain: ({ domain }) => {
-      const { indexName } = IndexNameLogic.values;
+      const { indexName } = values;
       DeleteCrawlerDomainApiLogic.actions.makeRequest({ domain, indexName });
     },
     getDomains: ({ meta }) => {
-      const { indexName } = IndexNameLogic.values;
+      const { indexName } = values;
       GetCrawlerDomainsApiLogic.actions.makeRequest({ indexName, meta });
     },
     onPaginate: ({ newPageIndex }) => {


### PR DESCRIPTION
## Summary

This fixes the issue of domains from other crawlers appearing on a new crawler's domain list.
It ensures that the correct `indexName` is used to fetch the domain list in `DomainManagementLogic`.

No tests exist for these files so I haven't updated any tests.