### PR TITLE
[Fleet] Add featureFlag to support standalone fleet server

### DIFF
--- a/x-pack/plugins/fleet/common/experimental_features.ts
+++ b/x-pack/plugins/fleet/common/experimental_features.ts
@@ -21,6 +21,7 @@ export const allowedExperimentalValues = Object.freeze({
   showIntegrationsSubcategories: false,
   agentFqdnMode: true,
   showExperimentalShipperOptions: false,
+  fleetServerStandalone: false,
 });
 
 type ExperimentalConfigKeys = Array<keyof ExperimentalFeatures>;

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/index.tsx
@@ -27,6 +27,7 @@ import {
   useStartServices,
   useFlyoutContext,
   sendGetAgentTags,
+  useFleetServerStandalone,
 } from '../../../hooks';
 import { AgentEnrollmentFlyout } from '../../../components';
 import {
@@ -433,6 +434,9 @@ export const AgentListPage: React.FunctionComponent<{}> = () => {
 
   // Fleet server unhealthy status
   const { isUnhealthy: isFleetServerUnhealthy } = useFleetServerUnhealthy();
+  const { isFleetServerStandalone } = useFleetServerStandalone();
+  const showUnhealthyCallout = isFleetServerUnhealthy && !isFleetServerStandalone;
+
   const onClickAddFleetServer = useCallback(() => {
     flyoutContext.openFleetServerFlyout();
   }, [flyoutContext]);
@@ -558,7 +562,7 @@ export const AgentListPage: React.FunctionComponent<{}> = () => {
           }}
         />
       )}
-      {isFleetServerUnhealthy && (
+      {showUnhealthyCallout && (
         <>
           {cloud?.deploymentUrl ? (
             <FleetServerCloudUnhealthyCallout deploymentUrl={cloud.deploymentUrl} />

--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/agent_enrollment_flyout.test.mocks.ts
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/agent_enrollment_flyout.test.mocks.ts
@@ -13,6 +13,7 @@ jest.mock('../../hooks', () => {
   return {
     ...jest.requireActual('../../hooks'),
     useFleetStatus: jest.fn(),
+    useFleetServerStandalone: jest.fn(),
     useAgentEnrollmentFlyoutData: jest.fn(),
   };
 });

--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/agent_enrollment_flyout.test.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/agent_enrollment_flyout.test.tsx
@@ -27,6 +27,7 @@ import {
   useAgentEnrollmentFlyoutData,
   KibanaVersionContext,
   useFleetStatus,
+  useFleetServerStandalone,
 } from '../../hooks';
 
 import { useAdvancedForm } from '../../applications/fleet/components/fleet_server_instructions/hooks';
@@ -92,6 +93,7 @@ describe('<AgentEnrollmentFlyout />', () => {
         ],
       },
     });
+    jest.mocked(useFleetServerStandalone).mockReturnValue({ isFleetServerStandalone: false });
 
     (useFleetStatus as jest.Mock).mockReturnValue({ isReady: true });
     (useFleetServerUnhealthy as jest.Mock).mockReturnValue({

--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/instructions.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/instructions.tsx
@@ -9,22 +9,15 @@ import React, { useMemo, useEffect } from 'react';
 import { EuiText, EuiSpacer } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 
-import { useFleetStatus, useGetAgents } from '../../hooks';
-
+import { useFleetStatus, useGetAgents, useFleetServerStandalone } from '../../hooks';
 import { FleetServerRequirementPage } from '../../applications/fleet/sections/agents/agent_requirements_page';
-
 import { AGENTS_PREFIX, FLEET_SERVER_PACKAGE, SO_SEARCH_LIMIT } from '../../constants';
-
 import { useFleetServerUnhealthy } from '../../applications/fleet/sections/agents/hooks/use_fleet_server_unhealthy';
-
 import { Loading } from '..';
-
 import { policyHasFleetServer } from '../../services';
-
 import { AdvancedTab } from '../../applications/fleet/components/fleet_server_instructions/advanced_tab';
 
 import type { InstructionProps } from './types';
-
 import { ManagedSteps, StandaloneSteps } from './steps';
 import { DefaultMissingRequirements } from './default_missing_requirements';
 
@@ -44,6 +37,8 @@ export const Instructions = (props: InstructionProps) => {
   const fleetStatus = useFleetStatus();
   const { isUnhealthy: isFleetServerUnhealthy, isLoading: isLoadingFleetServerHealth } =
     useFleetServerUnhealthy();
+
+  const { isFleetServerStandalone } = useFleetServerStandalone();
 
   useEffect(() => {
     refreshAgentPolicies();
@@ -74,12 +69,14 @@ export const Instructions = (props: InstructionProps) => {
 
   const showAgentEnrollment =
     isFleetServerPolicySelected ||
+    isFleetServerStandalone ||
     (fleetStatus.isReady &&
       !isFleetServerUnhealthy &&
       fleetServers.length > 0 &&
       (fleetServerHosts?.length ?? 0) > 0);
 
   const showFleetServerEnrollment =
+    !isFleetServerStandalone &&
     !isFleetServerPolicySelected &&
     (fleetServers.length === 0 ||
       isFleetServerUnhealthy ||

--- a/x-pack/plugins/fleet/public/hooks/index.ts
+++ b/x-pack/plugins/fleet/public/hooks/index.ts
@@ -30,3 +30,4 @@ export * from './use_agent_enrollment_flyout_data';
 export * from './use_flyout_context';
 export * from './use_is_guided_onboarding_active';
 export * from './use_fleet_server_hosts_for_policy';
+export * from './use_fleet_server_standalone';

--- a/x-pack/plugins/fleet/public/hooks/use_fleet_server_standalone.tsx
+++ b/x-pack/plugins/fleet/public/hooks/use_fleet_server_standalone.tsx
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ExperimentalFeaturesService } from '../applications/fleet/services';
+
+export function useFleetServerStandalone() {
+  const isFleetServerStandalone = ExperimentalFeaturesService.get().fleetServerStandalone;
+
+  return { isFleetServerStandalone };
+}


### PR DESCRIPTION
## Summary

Related to https://github.com/elastic/fleet-server/pull/2359

Add a new experimental feature that allow to run the Fleet UI with a Fleet Server standalone that do not create a fake agent or checkin.
```
xpack.fleet.enableExperimental: ['fleetServerStandalone']
```

That flag will remove the need to get an healthy fleet-server to enroll an agent in the Fleet UI.

cc @michel-laterman @jsoriano 

## Implementation details

I created a new hook for that to be able to easily change the source of the config here and to enable it if Kibana is running in serverless for example