### PR TITLE
[Fleet] Add `date_format` support for date field type

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.test.ts
@@ -451,7 +451,7 @@ describe('EPM template', () => {
     const dateWithFormatYml = `
 - name: dateWithFormat
   type: date
-  format: yyyy-MM-dd
+  date_format: yyyy-MM-dd
 `;
 
     const dateWithMapping = {

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.test.ts
@@ -447,6 +447,27 @@ describe('EPM template', () => {
     expect(mappings).toEqual(keywordWithMultiFieldsMapping);
   });
 
+  it('tests processing date field with format', () => {
+    const dateWithFormatYml = `
+- name: dateWithFormat
+  type: date
+  format: yyyy-MM-dd
+`;
+
+    const dateWithMapping = {
+      properties: {
+        dateWithFormat: {
+          type: 'date',
+          format: 'yyyy-MM-dd',
+        },
+      },
+    };
+    const fields: Field[] = safeLoad(dateWithFormatYml);
+    const processedFields = processFields(fields);
+    const mappings = generateMappings(processedFields);
+    expect(mappings).toEqual(dateWithMapping);
+  });
+
   it('tests processing wildcard field with multi fields', () => {
     const keywordWithMultiFieldsLiteralYml = `
 - name: keywordWithMultiFields

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.ts
@@ -322,6 +322,10 @@ function _generateMappings(
             fieldProps.type = 'alias';
             fieldProps.path = field.path;
             break;
+          case 'date':
+            const dateMappings = generateDateMapping(field);
+            fieldProps = { ...fieldProps, ...dateMappings, type: 'date' };
+            break;
           default:
             fieldProps.type = type;
         }
@@ -419,6 +423,14 @@ function generateWildcardMapping(field: Field): IndexTemplateMapping {
   }
   if (field.ignore_above) {
     mapping.ignore_above = field.ignore_above;
+  }
+  return mapping;
+}
+
+function generateDateMapping(field: Field): IndexTemplateMapping {
+  const mapping: IndexTemplateMapping = {};
+  if (field.format) {
+    mapping.format = field.format;
   }
   return mapping;
 }

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.ts
@@ -429,8 +429,8 @@ function generateWildcardMapping(field: Field): IndexTemplateMapping {
 
 function generateDateMapping(field: Field): IndexTemplateMapping {
   const mapping: IndexTemplateMapping = {};
-  if (field.format) {
-    mapping.format = field.format;
+  if (field.date_format) {
+    mapping.format = field.date_format;
   }
   return mapping;
 }

--- a/x-pack/plugins/fleet/server/services/epm/fields/field.ts
+++ b/x-pack/plugins/fleet/server/services/epm/fields/field.ts
@@ -17,6 +17,7 @@ export interface Field {
   description?: string;
   value?: string;
   format?: string;
+  date_format?: string;
   fields?: Fields;
   enabled?: boolean;
   path?: string;


### PR DESCRIPTION
## Summary

fixes https://github.com/elastic/cloudbeat/issues/768
In this PR we allow using `date_format` for `date` fields when declaring the mappings.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
