### PR TITLE
[Defend workflows] Add Cypress tests for Endpoint reassignment functi…

### DIFF
--- a/packages/kbn-cypress-config/index.ts
+++ b/packages/kbn-cypress-config/index.ts
@@ -51,6 +51,8 @@ export function defineCypressConfig(options?: Cypress.ConfigOptions<any>) {
 
             on(event, task);
           }, config);
+
+          return config;
         }
       },
     },

--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/endpoint/endpoints.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/endpoint/endpoints.cy.ts
@@ -7,7 +7,11 @@
 
 import type { Agent } from '@kbn/fleet-plugin/common';
 import { ENDPOINT_VM_NAME } from '../../tasks/common';
-import { getAgentByHostName, reassignAgentPolicy } from '../../tasks/fleet';
+import {
+  getAgentByHostName,
+  getEndpointIntegrationVersion,
+  reassignAgentPolicy,
+} from '../../tasks/fleet';
 import type { IndexedFleetEndpointPolicyResponse } from '../../../../../common/endpoint/data_loaders/index_fleet_endpoint_policy';
 import { login } from '../../tasks/login';
 import {
@@ -42,10 +46,13 @@ describe('Endpoints page', () => {
       getAgentByHostName(endpointHostname).then((agentData) => {
         initialAgentData = agentData;
       });
-      cy.task<IndexedFleetEndpointPolicyResponse>('indexFleetEndpointPolicy', {
-        endpointPackageVersion: '8.7.0',
-      }).then((data) => {
-        response = data;
+      getEndpointIntegrationVersion().then((version) => {
+        cy.task<IndexedFleetEndpointPolicyResponse>('indexFleetEndpointPolicy', {
+          policyName: `Reassign ${Math.random().toString(36).substr(2, 5)}`,
+          endpointPackageVersion: version,
+        }).then((data) => {
+          response = data;
+        });
       });
     });
 

--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/endpoint/endpoints.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/endpoint/endpoints.cy.ts
@@ -5,9 +5,25 @@
  * 2.0.
  */
 
+import type { Agent } from '@kbn/fleet-plugin/common';
+import { ENDPOINT_VM_NAME } from '../../tasks/common';
+import { getAgentByHostName, reassignAgentPolicy } from '../../tasks/fleet';
+import type { IndexedFleetEndpointPolicyResponse } from '../../../../../common/endpoint/data_loaders/index_fleet_endpoint_policy';
 import { login } from '../../tasks/login';
+import {
+  AGENT_HOSTNAME_CELL,
+  TABLE_ROW_ACTIONS,
+  TABLE_ROW_ACTIONS_MENU,
+  AGENT_POLICY_CELL,
+} from '../../screens/endpoints';
+import {
+  FLEET_REASSIGN_POLICY_MODAL,
+  FLEET_REASSIGN_POLICY_MODAL_CONFIRM_BUTTON,
+} from '../../screens/fleet';
 
 describe('Endpoints page', () => {
+  const endpointHostname = Cypress.env(ENDPOINT_VM_NAME);
+
   beforeEach(() => {
     login();
   });
@@ -15,5 +31,57 @@ describe('Endpoints page', () => {
   it('Loads the endpoints page', () => {
     cy.visit('/app/security/administration/endpoints');
     cy.contains('Hosts running Elastic Defend').should('exist');
+    cy.getByTestId(AGENT_HOSTNAME_CELL).should('have.text', endpointHostname);
+  });
+
+  describe('Endpoint reassignment', () => {
+    let response: IndexedFleetEndpointPolicyResponse;
+    let initialAgentData: Agent;
+
+    before(() => {
+      getAgentByHostName(endpointHostname).then((agentData) => {
+        initialAgentData = agentData;
+      });
+      cy.task<IndexedFleetEndpointPolicyResponse>('indexFleetEndpointPolicy', {
+        endpointPackageVersion: '8.7.0',
+      }).then((data) => {
+        response = data;
+      });
+    });
+
+    beforeEach(() => {
+      login();
+    });
+
+    after(() => {
+      if (initialAgentData?.policy_id) {
+        reassignAgentPolicy(initialAgentData.id, initialAgentData.policy_id);
+      }
+      if (response) {
+        cy.task('deleteIndexedFleetEndpointPolicies', response);
+      }
+    });
+
+    it('User can reassign a single endpoint to a different Agent Configuration', () => {
+      cy.visit('/app/security/administration/endpoints');
+      const hostname = cy
+        .getByTestId(AGENT_HOSTNAME_CELL)
+        .filter(`:contains("${endpointHostname}")`);
+      const tableRow = hostname.parents('tr');
+      tableRow.getByTestId(TABLE_ROW_ACTIONS).click();
+      cy.getByTestId(TABLE_ROW_ACTIONS_MENU).contains('Reassign agent policy').click();
+      cy.getByTestId(FLEET_REASSIGN_POLICY_MODAL)
+        .find('select')
+        .select(response.agentPolicies[0].name);
+      cy.getByTestId(FLEET_REASSIGN_POLICY_MODAL_CONFIRM_BUTTON).click();
+      cy.getByTestId(AGENT_HOSTNAME_CELL)
+        .filter(`:contains("${endpointHostname}")`)
+        .should('exist');
+      cy.getByTestId(AGENT_HOSTNAME_CELL)
+        .filter(`:contains("${endpointHostname}")`)
+        .parents('tr')
+        .getByTestId(AGENT_POLICY_CELL)
+        .should('have.text', response.agentPolicies[0].name);
+    });
   });
 });

--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/endpoint/endpoints.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/endpoint/endpoints.cy.ts
@@ -13,6 +13,7 @@ import {
   reassignAgentPolicy,
 } from '../../tasks/fleet';
 import type { IndexedFleetEndpointPolicyResponse } from '../../../../../common/endpoint/data_loaders/index_fleet_endpoint_policy';
+import { getEndpointListPath } from '../../../common/routing';
 import { login } from '../../tasks/login';
 import {
   AGENT_HOSTNAME_CELL,
@@ -32,10 +33,10 @@ describe('Endpoints page', () => {
     login();
   });
 
-  it('Loads the endpoints page', () => {
-    cy.visit('/app/security/administration/endpoints');
+  it('Shows endpoint on the list', () => {
+    cy.visit(getEndpointListPath({ name: 'endpointList' }));
     cy.contains('Hosts running Elastic Defend').should('exist');
-    cy.getByTestId(AGENT_HOSTNAME_CELL).should('have.text', endpointHostname);
+    cy.getByTestSubj(AGENT_HOSTNAME_CELL).should('have.text', endpointHostname);
   });
 
   describe('Endpoint reassignment', () => {
@@ -70,24 +71,24 @@ describe('Endpoints page', () => {
     });
 
     it('User can reassign a single endpoint to a different Agent Configuration', () => {
-      cy.visit('/app/security/administration/endpoints');
+      cy.visit(getEndpointListPath({ name: 'endpointList' }));
       const hostname = cy
-        .getByTestId(AGENT_HOSTNAME_CELL)
+        .getByTestSubj(AGENT_HOSTNAME_CELL)
         .filter(`:contains("${endpointHostname}")`);
       const tableRow = hostname.parents('tr');
-      tableRow.getByTestId(TABLE_ROW_ACTIONS).click();
-      cy.getByTestId(TABLE_ROW_ACTIONS_MENU).contains('Reassign agent policy').click();
-      cy.getByTestId(FLEET_REASSIGN_POLICY_MODAL)
+      tableRow.getByTestSubj(TABLE_ROW_ACTIONS).click();
+      cy.getByTestSubj(TABLE_ROW_ACTIONS_MENU).contains('Reassign agent policy').click();
+      cy.getByTestSubj(FLEET_REASSIGN_POLICY_MODAL)
         .find('select')
         .select(response.agentPolicies[0].name);
-      cy.getByTestId(FLEET_REASSIGN_POLICY_MODAL_CONFIRM_BUTTON).click();
-      cy.getByTestId(AGENT_HOSTNAME_CELL)
+      cy.getByTestSubj(FLEET_REASSIGN_POLICY_MODAL_CONFIRM_BUTTON).click();
+      cy.getByTestSubj(AGENT_HOSTNAME_CELL)
         .filter(`:contains("${endpointHostname}")`)
         .should('exist');
-      cy.getByTestId(AGENT_HOSTNAME_CELL)
+      cy.getByTestSubj(AGENT_HOSTNAME_CELL)
         .filter(`:contains("${endpointHostname}")`)
         .parents('tr')
-        .getByTestId(AGENT_POLICY_CELL)
+        .getByTestSubj(AGENT_POLICY_CELL)
         .should('have.text', response.agentPolicies[0].name);
     });
   });

--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/mocked_data/artifact_tabs_in_policy_details.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/mocked_data/artifact_tabs_in_policy_details.cy.ts
@@ -64,8 +64,8 @@ const visitArtifactTab = (tabId: string) => {
 
 const visitPolicyDetailsPage = () => {
   cy.visit('/app/security/administration/policy');
-  cy.getBySel('policyNameCellLink').eq(0).click({ force: true });
-  cy.getBySel('policyDetailsPage').should('exist');
+  cy.getByTestId('policyNameCellLink').eq(0).click({ force: true });
+  cy.getByTestId('policyDetailsPage').should('exist');
   cy.get('#settings').should('exist'); // waiting for Policy Settings tab
 };
 
@@ -99,18 +99,18 @@ describe('Artifact tabs in Policy Details page', () => {
           loginWithPrivilegeRead(testData.privilegePrefix);
           visitArtifactTab(testData.tabId);
 
-          cy.getBySel('policy-artifacts-empty-unexisting').should('exist');
+          cy.getByTestId('policy-artifacts-empty-unexisting').should('exist');
 
-          cy.getBySel('unexisting-manage-artifacts-button').should('not.exist');
+          cy.getByTestId('unexisting-manage-artifacts-button').should('not.exist');
         });
 
         it(`[ALL] User can add ${testData.title} artifact`, () => {
           loginWithPrivilegeAll();
           visitArtifactTab(testData.tabId);
 
-          cy.getBySel('policy-artifacts-empty-unexisting').should('exist');
+          cy.getByTestId('policy-artifacts-empty-unexisting').should('exist');
 
-          cy.getBySel('unexisting-manage-artifacts-button').should('exist').click();
+          cy.getByTestId('unexisting-manage-artifacts-button').should('exist').click();
 
           const { formActions, checkResults } = testData.create;
 
@@ -118,18 +118,18 @@ describe('Artifact tabs in Policy Details page', () => {
 
           // Add a per policy artifact - but not assign it to any policy
           cy.get('[data-test-subj$="-perPolicy"]').click(); // test-subjects are generated in different formats, but all ends with -perPolicy
-          cy.getBySel(`${testData.pagePrefix}-flyout-submitButton`).click();
+          cy.getByTestId(`${testData.pagePrefix}-flyout-submitButton`).click();
 
           // Check new artifact is in the list
           for (const checkResult of checkResults) {
-            cy.getBySel(checkResult.selector).should('have.text', checkResult.value);
+            cy.getByTestId(checkResult.selector).should('have.text', checkResult.value);
           }
 
-          cy.getBySel('policyDetailsPage').should('not.exist');
-          cy.getBySel('backToOrigin').contains(/^Back to .+ policy$/);
+          cy.getByTestId('policyDetailsPage').should('not.exist');
+          cy.getByTestId('backToOrigin').contains(/^Back to .+ policy$/);
 
-          cy.getBySel('backToOrigin').click();
-          cy.getBySel('policyDetailsPage').should('exist');
+          cy.getByTestId('backToOrigin').click();
+          cy.getByTestId('policyDetailsPage').should('exist');
         });
       });
 
@@ -144,34 +144,34 @@ describe('Artifact tabs in Policy Details page', () => {
           loginWithPrivilegeRead(testData.privilegePrefix);
           visitArtifactTab(testData.tabId);
 
-          cy.getBySel('policy-artifacts-empty-unassigned').should('exist');
+          cy.getByTestId('policy-artifacts-empty-unassigned').should('exist');
 
-          cy.getBySel('unassigned-manage-artifacts-button').should('not.exist');
-          cy.getBySel('unassigned-assign-artifacts-button').should('not.exist');
+          cy.getByTestId('unassigned-manage-artifacts-button').should('not.exist');
+          cy.getByTestId('unassigned-assign-artifacts-button').should('not.exist');
         });
 
         it(`[ALL] User can Manage and Assign ${testData.title} artifacts`, () => {
           loginWithPrivilegeAll();
           visitArtifactTab(testData.tabId);
 
-          cy.getBySel('policy-artifacts-empty-unassigned').should('exist');
+          cy.getByTestId('policy-artifacts-empty-unassigned').should('exist');
 
           // Manage artifacts
-          cy.getBySel('unassigned-manage-artifacts-button').should('exist').click();
+          cy.getByTestId('unassigned-manage-artifacts-button').should('exist').click();
           cy.location('pathname').should(
             'equal',
             `/app/security/administration/${testData.urlPath}`
           );
-          cy.getBySel('backToOrigin').click();
+          cy.getByTestId('backToOrigin').click();
 
           // Assign artifacts
-          cy.getBySel('unassigned-assign-artifacts-button').should('exist').click();
+          cy.getByTestId('unassigned-assign-artifacts-button').should('exist').click();
 
-          cy.getBySel('artifacts-assign-flyout').should('exist');
-          cy.getBySel('artifacts-assign-confirm-button').should('be.disabled');
+          cy.getByTestId('artifacts-assign-flyout').should('exist');
+          cy.getByTestId('artifacts-assign-confirm-button').should('be.disabled');
 
-          cy.getBySel(`${testData.artifactName}_checkbox`).click();
-          cy.getBySel('artifacts-assign-confirm-button').click();
+          cy.getByTestId(`${testData.artifactName}_checkbox`).click();
+          cy.getByTestId('artifacts-assign-confirm-button').click();
         });
       });
 
@@ -189,17 +189,17 @@ describe('Artifact tabs in Policy Details page', () => {
           visitArtifactTab(testData.tabId);
 
           // List of artifacts
-          cy.getBySel('artifacts-collapsed-list-card').should('have.length', 1);
-          cy.getBySel('artifacts-collapsed-list-card-header-titleHolder').contains(
+          cy.getByTestId('artifacts-collapsed-list-card').should('have.length', 1);
+          cy.getByTestId('artifacts-collapsed-list-card-header-titleHolder').contains(
             testData.artifactName
           );
 
           // Cannot assign artifacts
-          cy.getBySel('artifacts-assign-button').should('not.exist');
+          cy.getByTestId('artifacts-assign-button').should('not.exist');
 
           // Cannot remove from policy
-          cy.getBySel('artifacts-collapsed-list-card-header-actions-button').click();
-          cy.getBySel('remove-from-policy-action').should('not.exist');
+          cy.getByTestId('artifacts-collapsed-list-card-header-actions-button').click();
+          cy.getByTestId('remove-from-policy-action').should('not.exist');
         });
 
         it(`[ALL] User can see ${testData.title} artifacts and can assign or remove artifacts from policy`, () => {
@@ -207,20 +207,20 @@ describe('Artifact tabs in Policy Details page', () => {
           visitArtifactTab(testData.tabId);
 
           // List of artifacts
-          cy.getBySel('artifacts-collapsed-list-card').should('have.length', 1);
-          cy.getBySel('artifacts-collapsed-list-card-header-titleHolder').contains(
+          cy.getByTestId('artifacts-collapsed-list-card').should('have.length', 1);
+          cy.getByTestId('artifacts-collapsed-list-card-header-titleHolder').contains(
             testData.artifactName
           );
 
           // Assign artifacts
-          cy.getBySel('artifacts-assign-button').should('exist').click();
-          cy.getBySel('artifacts-assign-flyout').should('exist');
-          cy.getBySel('artifacts-assign-cancel-button').click();
+          cy.getByTestId('artifacts-assign-button').should('exist').click();
+          cy.getByTestId('artifacts-assign-flyout').should('exist');
+          cy.getByTestId('artifacts-assign-cancel-button').click();
 
           // Remove from policy
-          cy.getBySel('artifacts-collapsed-list-card-header-actions-button').click();
-          cy.getBySel('remove-from-policy-action').click();
-          cy.getBySel('confirmModalConfirmButton').click();
+          cy.getByTestId('artifacts-collapsed-list-card-header-actions-button').click();
+          cy.getByTestId('remove-from-policy-action').click();
+          cy.getByTestId('confirmModalConfirmButton').click();
 
           cy.contains('Successfully removed');
         });

--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/mocked_data/artifact_tabs_in_policy_details.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/mocked_data/artifact_tabs_in_policy_details.cy.ts
@@ -64,8 +64,8 @@ const visitArtifactTab = (tabId: string) => {
 
 const visitPolicyDetailsPage = () => {
   cy.visit('/app/security/administration/policy');
-  cy.getByTestId('policyNameCellLink').eq(0).click({ force: true });
-  cy.getByTestId('policyDetailsPage').should('exist');
+  cy.getByTestSubj('policyNameCellLink').eq(0).click({ force: true });
+  cy.getByTestSubj('policyDetailsPage').should('exist');
   cy.get('#settings').should('exist'); // waiting for Policy Settings tab
 };
 
@@ -99,18 +99,18 @@ describe('Artifact tabs in Policy Details page', () => {
           loginWithPrivilegeRead(testData.privilegePrefix);
           visitArtifactTab(testData.tabId);
 
-          cy.getByTestId('policy-artifacts-empty-unexisting').should('exist');
+          cy.getByTestSubj('policy-artifacts-empty-unexisting').should('exist');
 
-          cy.getByTestId('unexisting-manage-artifacts-button').should('not.exist');
+          cy.getByTestSubj('unexisting-manage-artifacts-button').should('not.exist');
         });
 
         it(`[ALL] User can add ${testData.title} artifact`, () => {
           loginWithPrivilegeAll();
           visitArtifactTab(testData.tabId);
 
-          cy.getByTestId('policy-artifacts-empty-unexisting').should('exist');
+          cy.getByTestSubj('policy-artifacts-empty-unexisting').should('exist');
 
-          cy.getByTestId('unexisting-manage-artifacts-button').should('exist').click();
+          cy.getByTestSubj('unexisting-manage-artifacts-button').should('exist').click();
 
           const { formActions, checkResults } = testData.create;
 
@@ -118,18 +118,18 @@ describe('Artifact tabs in Policy Details page', () => {
 
           // Add a per policy artifact - but not assign it to any policy
           cy.get('[data-test-subj$="-perPolicy"]').click(); // test-subjects are generated in different formats, but all ends with -perPolicy
-          cy.getByTestId(`${testData.pagePrefix}-flyout-submitButton`).click();
+          cy.getByTestSubj(`${testData.pagePrefix}-flyout-submitButton`).click();
 
           // Check new artifact is in the list
           for (const checkResult of checkResults) {
-            cy.getByTestId(checkResult.selector).should('have.text', checkResult.value);
+            cy.getByTestSubj(checkResult.selector).should('have.text', checkResult.value);
           }
 
-          cy.getByTestId('policyDetailsPage').should('not.exist');
-          cy.getByTestId('backToOrigin').contains(/^Back to .+ policy$/);
+          cy.getByTestSubj('policyDetailsPage').should('not.exist');
+          cy.getByTestSubj('backToOrigin').contains(/^Back to .+ policy$/);
 
-          cy.getByTestId('backToOrigin').click();
-          cy.getByTestId('policyDetailsPage').should('exist');
+          cy.getByTestSubj('backToOrigin').click();
+          cy.getByTestSubj('policyDetailsPage').should('exist');
         });
       });
 
@@ -144,34 +144,34 @@ describe('Artifact tabs in Policy Details page', () => {
           loginWithPrivilegeRead(testData.privilegePrefix);
           visitArtifactTab(testData.tabId);
 
-          cy.getByTestId('policy-artifacts-empty-unassigned').should('exist');
+          cy.getByTestSubj('policy-artifacts-empty-unassigned').should('exist');
 
-          cy.getByTestId('unassigned-manage-artifacts-button').should('not.exist');
-          cy.getByTestId('unassigned-assign-artifacts-button').should('not.exist');
+          cy.getByTestSubj('unassigned-manage-artifacts-button').should('not.exist');
+          cy.getByTestSubj('unassigned-assign-artifacts-button').should('not.exist');
         });
 
         it(`[ALL] User can Manage and Assign ${testData.title} artifacts`, () => {
           loginWithPrivilegeAll();
           visitArtifactTab(testData.tabId);
 
-          cy.getByTestId('policy-artifacts-empty-unassigned').should('exist');
+          cy.getByTestSubj('policy-artifacts-empty-unassigned').should('exist');
 
           // Manage artifacts
-          cy.getByTestId('unassigned-manage-artifacts-button').should('exist').click();
+          cy.getByTestSubj('unassigned-manage-artifacts-button').should('exist').click();
           cy.location('pathname').should(
             'equal',
             `/app/security/administration/${testData.urlPath}`
           );
-          cy.getByTestId('backToOrigin').click();
+          cy.getByTestSubj('backToOrigin').click();
 
           // Assign artifacts
-          cy.getByTestId('unassigned-assign-artifacts-button').should('exist').click();
+          cy.getByTestSubj('unassigned-assign-artifacts-button').should('exist').click();
 
-          cy.getByTestId('artifacts-assign-flyout').should('exist');
-          cy.getByTestId('artifacts-assign-confirm-button').should('be.disabled');
+          cy.getByTestSubj('artifacts-assign-flyout').should('exist');
+          cy.getByTestSubj('artifacts-assign-confirm-button').should('be.disabled');
 
-          cy.getByTestId(`${testData.artifactName}_checkbox`).click();
-          cy.getByTestId('artifacts-assign-confirm-button').click();
+          cy.getByTestSubj(`${testData.artifactName}_checkbox`).click();
+          cy.getByTestSubj('artifacts-assign-confirm-button').click();
         });
       });
 
@@ -189,17 +189,17 @@ describe('Artifact tabs in Policy Details page', () => {
           visitArtifactTab(testData.tabId);
 
           // List of artifacts
-          cy.getByTestId('artifacts-collapsed-list-card').should('have.length', 1);
-          cy.getByTestId('artifacts-collapsed-list-card-header-titleHolder').contains(
+          cy.getByTestSubj('artifacts-collapsed-list-card').should('have.length', 1);
+          cy.getByTestSubj('artifacts-collapsed-list-card-header-titleHolder').contains(
             testData.artifactName
           );
 
           // Cannot assign artifacts
-          cy.getByTestId('artifacts-assign-button').should('not.exist');
+          cy.getByTestSubj('artifacts-assign-button').should('not.exist');
 
           // Cannot remove from policy
-          cy.getByTestId('artifacts-collapsed-list-card-header-actions-button').click();
-          cy.getByTestId('remove-from-policy-action').should('not.exist');
+          cy.getByTestSubj('artifacts-collapsed-list-card-header-actions-button').click();
+          cy.getByTestSubj('remove-from-policy-action').should('not.exist');
         });
 
         it(`[ALL] User can see ${testData.title} artifacts and can assign or remove artifacts from policy`, () => {
@@ -207,20 +207,20 @@ describe('Artifact tabs in Policy Details page', () => {
           visitArtifactTab(testData.tabId);
 
           // List of artifacts
-          cy.getByTestId('artifacts-collapsed-list-card').should('have.length', 1);
-          cy.getByTestId('artifacts-collapsed-list-card-header-titleHolder').contains(
+          cy.getByTestSubj('artifacts-collapsed-list-card').should('have.length', 1);
+          cy.getByTestSubj('artifacts-collapsed-list-card-header-titleHolder').contains(
             testData.artifactName
           );
 
           // Assign artifacts
-          cy.getByTestId('artifacts-assign-button').should('exist').click();
-          cy.getByTestId('artifacts-assign-flyout').should('exist');
-          cy.getByTestId('artifacts-assign-cancel-button').click();
+          cy.getByTestSubj('artifacts-assign-button').should('exist').click();
+          cy.getByTestSubj('artifacts-assign-flyout').should('exist');
+          cy.getByTestSubj('artifacts-assign-cancel-button').click();
 
           // Remove from policy
-          cy.getByTestId('artifacts-collapsed-list-card-header-actions-button').click();
-          cy.getByTestId('remove-from-policy-action').click();
-          cy.getByTestId('confirmModalConfirmButton').click();
+          cy.getByTestSubj('artifacts-collapsed-list-card-header-actions-button').click();
+          cy.getByTestSubj('remove-from-policy-action').click();
+          cy.getByTestSubj('confirmModalConfirmButton').click();
 
           cy.contains('Successfully removed');
         });

--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/mocked_data/artifacts.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/mocked_data/artifacts.cy.ts
@@ -51,10 +51,10 @@ describe('Artifacts pages', () => {
     describe(`When on the ${testData.title} entries list`, () => {
       it(`no access - should show no privileges callout`, () => {
         loginWithoutAccess(`/app/security/administration/${testData.urlPath}`);
-        cy.getByTestId('noPrivilegesPage').should('exist');
-        cy.getByTestId('empty-page-feature-action').should('exist');
-        cy.getByTestId(testData.emptyState).should('not.exist');
-        cy.getByTestId(`${testData.pagePrefix}-emptyState-addButton`).should('not.exist');
+        cy.getByTestSubj('noPrivilegesPage').should('exist');
+        cy.getByTestSubj('empty-page-feature-action').should('exist');
+        cy.getByTestSubj(testData.emptyState).should('not.exist');
+        cy.getByTestSubj(`${testData.pagePrefix}-emptyState-addButton`).should('not.exist');
       });
 
       it(`read - should show empty state page if there is no ${testData.title} entry and the add button does not exist`, () => {
@@ -62,33 +62,33 @@ describe('Artifacts pages', () => {
           testData.privilegePrefix,
           `/app/security/administration/${testData.urlPath}`
         );
-        cy.getByTestId(testData.emptyState).should('exist');
-        cy.getByTestId(`${testData.pagePrefix}-emptyState-addButton`).should('not.exist');
+        cy.getByTestSubj(testData.emptyState).should('exist');
+        cy.getByTestSubj(`${testData.pagePrefix}-emptyState-addButton`).should('not.exist');
       });
 
       it(`write - should show empty state page if there is no ${testData.title} entry and the add button exists`, () => {
         loginWithWriteAccess(`/app/security/administration/${testData.urlPath}`);
-        cy.getByTestId(testData.emptyState).should('exist');
-        cy.getByTestId(`${testData.pagePrefix}-emptyState-addButton`).should('exist');
+        cy.getByTestSubj(testData.emptyState).should('exist');
+        cy.getByTestSubj(`${testData.pagePrefix}-emptyState-addButton`).should('exist');
       });
 
       it(`write - should create new ${testData.title} entry`, () => {
         loginWithWriteAccess(`/app/security/administration/${testData.urlPath}`);
         // Opens add flyout
-        cy.getByTestId(`${testData.pagePrefix}-emptyState-addButton`).click();
+        cy.getByTestSubj(`${testData.pagePrefix}-emptyState-addButton`).click();
 
         performUserActions(testData.create.formActions);
 
         // Submit create artifact form
-        cy.getByTestId(`${testData.pagePrefix}-flyout-submitButton`).click();
+        cy.getByTestSubj(`${testData.pagePrefix}-flyout-submitButton`).click();
 
         // Check new artifact is in the list
         for (const checkResult of testData.create.checkResults) {
-          cy.getByTestId(checkResult.selector).should('have.text', checkResult.value);
+          cy.getByTestSubj(checkResult.selector).should('have.text', checkResult.value);
         }
 
         // Title is shown after adding an item
-        cy.getByTestId('header-page-title').contains(testData.title);
+        cy.getByTestSubj('header-page-title').contains(testData.title);
       });
 
       it(`read - should not be able to update/delete an existing ${testData.title} entry`, () => {
@@ -96,10 +96,10 @@ describe('Artifacts pages', () => {
           testData.privilegePrefix,
           `/app/security/administration/${testData.urlPath}`
         );
-        cy.getByTestId('header-page-title').contains(testData.title);
-        cy.getByTestId(`${testData.pagePrefix}-card-header-actions-button`).should('not.exist');
-        cy.getByTestId(`${testData.pagePrefix}-card-cardEditAction`).should('not.exist');
-        cy.getByTestId(`${testData.pagePrefix}-card-cardDeleteAction`).should('not.exist');
+        cy.getByTestSubj('header-page-title').contains(testData.title);
+        cy.getByTestSubj(`${testData.pagePrefix}-card-header-actions-button`).should('not.exist');
+        cy.getByTestSubj(`${testData.pagePrefix}-card-cardEditAction`).should('not.exist');
+        cy.getByTestSubj(`${testData.pagePrefix}-card-cardDeleteAction`).should('not.exist');
       });
 
       it(`read - should not be able to create a new ${testData.title} entry`, () => {
@@ -107,39 +107,39 @@ describe('Artifacts pages', () => {
           testData.privilegePrefix,
           `/app/security/administration/${testData.urlPath}`
         );
-        cy.getByTestId('header-page-title').contains(testData.title);
-        cy.getByTestId(`${testData.pagePrefix}-pageAddButton`).should('not.exist');
+        cy.getByTestSubj('header-page-title').contains(testData.title);
+        cy.getByTestSubj(`${testData.pagePrefix}-pageAddButton`).should('not.exist');
       });
 
       it(`write - should be able to update an existing ${testData.title} entry`, () => {
         loginWithWriteAccess(`/app/security/administration/${testData.urlPath}`);
         // Opens edit flyout
-        cy.getByTestId(`${testData.pagePrefix}-card-header-actions-button`).click();
-        cy.getByTestId(`${testData.pagePrefix}-card-cardEditAction`).click();
+        cy.getByTestSubj(`${testData.pagePrefix}-card-header-actions-button`).click();
+        cy.getByTestSubj(`${testData.pagePrefix}-card-cardEditAction`).click();
 
         performUserActions(testData.update.formActions);
 
         // Submit edit artifact form
-        cy.getByTestId(`${testData.pagePrefix}-flyout-submitButton`).click();
+        cy.getByTestSubj(`${testData.pagePrefix}-flyout-submitButton`).click();
 
         for (const checkResult of testData.create.checkResults) {
-          cy.getByTestId(checkResult.selector).should('have.text', checkResult.value);
+          cy.getByTestSubj(checkResult.selector).should('have.text', checkResult.value);
         }
 
         // Title still shown after editing an item
-        cy.getByTestId('header-page-title').contains(testData.title);
+        cy.getByTestSubj('header-page-title').contains(testData.title);
       });
 
       it(`write - should be able to delete the existing ${testData.title} entry`, () => {
         loginWithWriteAccess(`/app/security/administration/${testData.urlPath}`);
         // Remove it
-        cy.getByTestId(`${testData.pagePrefix}-card-header-actions-button`).click();
-        cy.getByTestId(`${testData.pagePrefix}-card-cardDeleteAction`).click();
-        cy.getByTestId(`${testData.pagePrefix}-deleteModal-submitButton`).click();
+        cy.getByTestSubj(`${testData.pagePrefix}-card-header-actions-button`).click();
+        cy.getByTestSubj(`${testData.pagePrefix}-card-cardDeleteAction`).click();
+        cy.getByTestSubj(`${testData.pagePrefix}-deleteModal-submitButton`).click();
         // No card visible after removing it
-        cy.getByTestId(testData.delete.card).should('not.exist');
+        cy.getByTestSubj(testData.delete.card).should('not.exist');
         // Empty state is displayed after removing last item
-        cy.getByTestId(testData.emptyState).should('exist');
+        cy.getByTestSubj(testData.emptyState).should('exist');
       });
     });
   }

--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/mocked_data/artifacts.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/mocked_data/artifacts.cy.ts
@@ -51,10 +51,10 @@ describe('Artifacts pages', () => {
     describe(`When on the ${testData.title} entries list`, () => {
       it(`no access - should show no privileges callout`, () => {
         loginWithoutAccess(`/app/security/administration/${testData.urlPath}`);
-        cy.getBySel('noPrivilegesPage').should('exist');
-        cy.getBySel('empty-page-feature-action').should('exist');
-        cy.getBySel(testData.emptyState).should('not.exist');
-        cy.getBySel(`${testData.pagePrefix}-emptyState-addButton`).should('not.exist');
+        cy.getByTestId('noPrivilegesPage').should('exist');
+        cy.getByTestId('empty-page-feature-action').should('exist');
+        cy.getByTestId(testData.emptyState).should('not.exist');
+        cy.getByTestId(`${testData.pagePrefix}-emptyState-addButton`).should('not.exist');
       });
 
       it(`read - should show empty state page if there is no ${testData.title} entry and the add button does not exist`, () => {
@@ -62,33 +62,33 @@ describe('Artifacts pages', () => {
           testData.privilegePrefix,
           `/app/security/administration/${testData.urlPath}`
         );
-        cy.getBySel(testData.emptyState).should('exist');
-        cy.getBySel(`${testData.pagePrefix}-emptyState-addButton`).should('not.exist');
+        cy.getByTestId(testData.emptyState).should('exist');
+        cy.getByTestId(`${testData.pagePrefix}-emptyState-addButton`).should('not.exist');
       });
 
       it(`write - should show empty state page if there is no ${testData.title} entry and the add button exists`, () => {
         loginWithWriteAccess(`/app/security/administration/${testData.urlPath}`);
-        cy.getBySel(testData.emptyState).should('exist');
-        cy.getBySel(`${testData.pagePrefix}-emptyState-addButton`).should('exist');
+        cy.getByTestId(testData.emptyState).should('exist');
+        cy.getByTestId(`${testData.pagePrefix}-emptyState-addButton`).should('exist');
       });
 
       it(`write - should create new ${testData.title} entry`, () => {
         loginWithWriteAccess(`/app/security/administration/${testData.urlPath}`);
         // Opens add flyout
-        cy.getBySel(`${testData.pagePrefix}-emptyState-addButton`).click();
+        cy.getByTestId(`${testData.pagePrefix}-emptyState-addButton`).click();
 
         performUserActions(testData.create.formActions);
 
         // Submit create artifact form
-        cy.getBySel(`${testData.pagePrefix}-flyout-submitButton`).click();
+        cy.getByTestId(`${testData.pagePrefix}-flyout-submitButton`).click();
 
         // Check new artifact is in the list
         for (const checkResult of testData.create.checkResults) {
-          cy.getBySel(checkResult.selector).should('have.text', checkResult.value);
+          cy.getByTestId(checkResult.selector).should('have.text', checkResult.value);
         }
 
         // Title is shown after adding an item
-        cy.getBySel('header-page-title').contains(testData.title);
+        cy.getByTestId('header-page-title').contains(testData.title);
       });
 
       it(`read - should not be able to update/delete an existing ${testData.title} entry`, () => {
@@ -96,10 +96,10 @@ describe('Artifacts pages', () => {
           testData.privilegePrefix,
           `/app/security/administration/${testData.urlPath}`
         );
-        cy.getBySel('header-page-title').contains(testData.title);
-        cy.getBySel(`${testData.pagePrefix}-card-header-actions-button`).should('not.exist');
-        cy.getBySel(`${testData.pagePrefix}-card-cardEditAction`).should('not.exist');
-        cy.getBySel(`${testData.pagePrefix}-card-cardDeleteAction`).should('not.exist');
+        cy.getByTestId('header-page-title').contains(testData.title);
+        cy.getByTestId(`${testData.pagePrefix}-card-header-actions-button`).should('not.exist');
+        cy.getByTestId(`${testData.pagePrefix}-card-cardEditAction`).should('not.exist');
+        cy.getByTestId(`${testData.pagePrefix}-card-cardDeleteAction`).should('not.exist');
       });
 
       it(`read - should not be able to create a new ${testData.title} entry`, () => {
@@ -107,39 +107,39 @@ describe('Artifacts pages', () => {
           testData.privilegePrefix,
           `/app/security/administration/${testData.urlPath}`
         );
-        cy.getBySel('header-page-title').contains(testData.title);
-        cy.getBySel(`${testData.pagePrefix}-pageAddButton`).should('not.exist');
+        cy.getByTestId('header-page-title').contains(testData.title);
+        cy.getByTestId(`${testData.pagePrefix}-pageAddButton`).should('not.exist');
       });
 
       it(`write - should be able to update an existing ${testData.title} entry`, () => {
         loginWithWriteAccess(`/app/security/administration/${testData.urlPath}`);
         // Opens edit flyout
-        cy.getBySel(`${testData.pagePrefix}-card-header-actions-button`).click();
-        cy.getBySel(`${testData.pagePrefix}-card-cardEditAction`).click();
+        cy.getByTestId(`${testData.pagePrefix}-card-header-actions-button`).click();
+        cy.getByTestId(`${testData.pagePrefix}-card-cardEditAction`).click();
 
         performUserActions(testData.update.formActions);
 
         // Submit edit artifact form
-        cy.getBySel(`${testData.pagePrefix}-flyout-submitButton`).click();
+        cy.getByTestId(`${testData.pagePrefix}-flyout-submitButton`).click();
 
         for (const checkResult of testData.create.checkResults) {
-          cy.getBySel(checkResult.selector).should('have.text', checkResult.value);
+          cy.getByTestId(checkResult.selector).should('have.text', checkResult.value);
         }
 
         // Title still shown after editing an item
-        cy.getBySel('header-page-title').contains(testData.title);
+        cy.getByTestId('header-page-title').contains(testData.title);
       });
 
       it(`write - should be able to delete the existing ${testData.title} entry`, () => {
         loginWithWriteAccess(`/app/security/administration/${testData.urlPath}`);
         // Remove it
-        cy.getBySel(`${testData.pagePrefix}-card-header-actions-button`).click();
-        cy.getBySel(`${testData.pagePrefix}-card-cardDeleteAction`).click();
-        cy.getBySel(`${testData.pagePrefix}-deleteModal-submitButton`).click();
+        cy.getByTestId(`${testData.pagePrefix}-card-header-actions-button`).click();
+        cy.getByTestId(`${testData.pagePrefix}-card-cardDeleteAction`).click();
+        cy.getByTestId(`${testData.pagePrefix}-deleteModal-submitButton`).click();
         // No card visible after removing it
-        cy.getBySel(testData.delete.card).should('not.exist');
+        cy.getByTestId(testData.delete.card).should('not.exist');
         // Empty state is displayed after removing last item
-        cy.getBySel(testData.emptyState).should('exist');
+        cy.getByTestId(testData.emptyState).should('exist');
       });
     });
   }

--- a/x-pack/plugins/security_solution/public/management/cypress/screens/endpoints.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/screens/endpoints.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const AGENT_HOSTNAME_CELL = 'hostnameCellLink';
+export const AGENT_POLICY_CELL = 'policyNameCellLink';
+export const TABLE_ROW_ACTIONS = 'endpointTableRowActions';
+export const TABLE_ROW_ACTIONS_MENU = 'tableRowActionsMenuPanel';

--- a/x-pack/plugins/security_solution/public/management/cypress/screens/fleet.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/screens/fleet.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const FLEET_REASSIGN_POLICY_MODAL = 'agentReassignPolicyModal';
+export const FLEET_REASSIGN_POLICY_MODAL_CONFIRM_BUTTON = 'confirmModalConfirmButton';

--- a/x-pack/plugins/security_solution/public/management/cypress/support/data_loaders.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/support/data_loaders.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createKbnClient } from '../../../../scripts/endpoint/common/stack_services';
+import {
+  indexFleetEndpointPolicy,
+  deleteIndexedFleetEndpointPolicies,
+} from '../../../../common/endpoint/data_loaders/index_fleet_endpoint_policy';
+
+export const dataLoaders = (on: Cypress.PluginEvents, config: Cypress.PluginConfigOptions) => {
+  const kbnClient = createKbnClient({
+    url: config.env.KIBANA_URL,
+    username: config.env.ELASTICSEARCH_USERNAME,
+    password: config.env.ELASTICSEARCH_PASSWORD,
+  });
+
+  on('task', {
+    indexFleetEndpointPolicy: async ({ policyName, endpointPackageVersion }) => {
+      return indexFleetEndpointPolicy(kbnClient, policyName, endpointPackageVersion);
+    },
+    deleteIndexedFleetEndpointPolicies: async (indexData) => {
+      return deleteIndexedFleetEndpointPolicies(kbnClient, indexData);
+    },
+  });
+};

--- a/x-pack/plugins/security_solution/public/management/cypress/support/data_loaders.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/support/data_loaders.ts
@@ -5,7 +5,10 @@
  * 2.0.
  */
 
+// / <reference types="cypress" />
+
 import { createKbnClient } from '../../../../scripts/endpoint/common/stack_services';
+import type { IndexedFleetEndpointPolicyResponse } from '../../../../common/endpoint/data_loaders/index_fleet_endpoint_policy';
 import {
   indexFleetEndpointPolicy,
   deleteIndexedFleetEndpointPolicies,
@@ -19,10 +22,16 @@ export const dataLoaders = (on: Cypress.PluginEvents, config: Cypress.PluginConf
   });
 
   on('task', {
-    indexFleetEndpointPolicy: async ({ policyName, endpointPackageVersion }) => {
+    indexFleetEndpointPolicy: async ({
+      policyName,
+      endpointPackageVersion,
+    }: {
+      policyName: string;
+      endpointPackageVersion: string;
+    }) => {
       return indexFleetEndpointPolicy(kbnClient, policyName, endpointPackageVersion);
     },
-    deleteIndexedFleetEndpointPolicies: async (indexData) => {
+    deleteIndexedFleetEndpointPolicies: async (indexData: IndexedFleetEndpointPolicyResponse) => {
       return deleteIndexedFleetEndpointPolicies(kbnClient, indexData);
     },
   });

--- a/x-pack/plugins/security_solution/public/management/cypress/support/e2e.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/support/e2e.ts
@@ -31,12 +31,12 @@ declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace Cypress {
     interface Chainable {
-      getBySel(...args: Parameters<Cypress.Chainable['get']>): Chainable<JQuery<HTMLElement>>;
+      getByTestId(...args: Parameters<Cypress.Chainable['get']>): Chainable<JQuery<HTMLElement>>;
     }
   }
 }
 
-Cypress.Commands.add('getBySel', (selector, ...args) =>
+Cypress.Commands.add('getByTestId', (selector, ...args) =>
   cy.get(`[data-test-subj="${selector}"]`, ...args)
 );
 

--- a/x-pack/plugins/security_solution/public/management/cypress/support/e2e.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/support/e2e.ts
@@ -31,13 +31,17 @@ declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace Cypress {
     interface Chainable {
-      getByTestId(...args: Parameters<Cypress.Chainable['get']>): Chainable<JQuery<HTMLElement>>;
+      getByTestSubj(...args: Parameters<Cypress.Chainable['get']>): Chainable<JQuery<HTMLElement>>;
     }
   }
 }
 
-Cypress.Commands.add('getByTestId', (selector, ...args) =>
-  cy.get(`[data-test-subj="${selector}"]`, ...args)
-);
+Cypress.Commands.addQuery('getByTestSubj', function getByTestSubj(selector, options) {
+  const getFn = cy.now('get', `[data-test-subj="${selector}"]`, options) as (
+    subject: Cypress.Chainable<JQuery<HTMLElement>>
+  ) => Cypress.Chainable<JQuery<HTMLElement>>;
+
+  return (subject) => getFn(subject);
+});
 
 Cypress.on('uncaught:exception', () => false);

--- a/x-pack/plugins/security_solution/public/management/cypress/tasks/artifacts.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/tasks/artifacts.ts
@@ -6,6 +6,10 @@
  */
 
 import { PACKAGE_POLICY_API_ROOT } from '@kbn/fleet-plugin/common';
+import type {
+  ExceptionListItemSchema,
+  ExceptionListSchema,
+} from '@kbn/securitysolution-io-ts-list-types';
 import { ExceptionListTypeEnum } from '@kbn/securitysolution-io-ts-list-types';
 import {
   ENDPOINT_ARTIFACT_LISTS,
@@ -13,8 +17,7 @@ import {
   EXCEPTION_LIST_ITEM_URL,
   EXCEPTION_LIST_URL,
 } from '@kbn/securitysolution-list-constants';
-
-const API_HEADER = { 'kbn-xsrf': 'kibana' };
+import { request } from './common';
 
 export const removeAllArtifacts = () => {
   for (const listId of ENDPOINT_ARTIFACT_LIST_IDS) {
@@ -23,10 +26,9 @@ export const removeAllArtifacts = () => {
 };
 
 export const removeExceptionsList = (listId: string) => {
-  cy.request({
+  request({
     method: 'DELETE',
     url: `${EXCEPTION_LIST_URL}?list_id=${listId}&namespace_type=agnostic`,
-    headers: API_HEADER,
     failOnStatusCode: false,
   }).then(({ status }) => {
     expect(status).to.be.oneOf([200, 404]); // should either be success or not found
@@ -42,10 +44,9 @@ const ENDPOINT_ARTIFACT_LIST_TYPES = {
 };
 
 export const createArtifactList = (listId: string) => {
-  cy.request({
+  request<ExceptionListSchema>({
     method: 'POST',
     url: EXCEPTION_LIST_URL,
-    headers: API_HEADER,
     body: {
       name: listId,
       description: 'This is a test list',
@@ -61,11 +62,9 @@ export const createArtifactList = (listId: string) => {
 };
 
 export const createPerPolicyArtifact = (name: string, body: object, policyId?: 'all' | string) => {
-  cy.request({
+  request<ExceptionListItemSchema>({
     method: 'POST',
     url: EXCEPTION_LIST_ITEM_URL,
-
-    headers: API_HEADER,
     body: {
       name,
       description: '',

--- a/x-pack/plugins/security_solution/public/management/cypress/tasks/common.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/tasks/common.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const ENDPOINT_VM_NAME = 'ENDPOINT_VM_NAME';
+
+export const API_AUTH = {
+  user: Cypress.env('ELASTICSEARCH_USERNAME'),
+  pass: Cypress.env('ELASTICSEARCH_PASSWORD'),
+};
+
+export const API_HEADERS = { 'kbn-xsrf': 'cypress' };
+
+export const request = <T = unknown>(options: Partial<Cypress.RequestOptions>) =>
+  cy.request<T>({
+    auth: API_AUTH,
+    headers: API_HEADERS,
+    ...options,
+  });

--- a/x-pack/plugins/security_solution/public/management/cypress/tasks/common.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/tasks/common.ts
@@ -14,7 +14,9 @@ export const API_AUTH = {
 
 export const API_HEADERS = { 'kbn-xsrf': 'cypress' };
 
-export const request = <T = unknown>(options: Partial<Cypress.RequestOptions>) =>
+export const request = <T = unknown>(
+  options: Partial<Cypress.RequestOptions>
+): Cypress.Chainable<Cypress.Response<T>> =>
   cy.request<T>({
     auth: API_AUTH,
     headers: API_HEADERS,

--- a/x-pack/plugins/security_solution/public/management/cypress/tasks/fleet.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/tasks/fleet.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { AgentPolicy, GetAgentsResponse, UpdatePackagePolicy } from '@kbn/fleet-plugin/common';
+import {
+  agentRouteService,
+  agentPolicyRouteService,
+  packagePolicyRouteService,
+} from '@kbn/fleet-plugin/common';
+import { request } from './common';
+
+export const getAgentByHostName = (hostname: string) => {
+  return request<GetAgentsResponse>({
+    url: agentRouteService.getListPath(),
+    method: 'GET',
+    qs: {
+      kuery: `local_metadata.host.hostname: "${hostname}"`,
+    },
+  }).then((response) => response.body.items[0]);
+};
+
+export const updatePackagePolicy = (packagePolicyId: string, packagePolicy: UpdatePackagePolicy) =>
+  request({
+    url: packagePolicyRouteService.getUpdatePath(packagePolicyId),
+    method: 'PUT',
+    body: packagePolicy,
+  });
+
+export const updateAgentPolicy = (agentPolicyId: string, agentPolicy: AgentPolicy) =>
+  request({
+    url: agentPolicyRouteService.getUpdatePath(agentPolicyId),
+    method: 'PUT',
+    body: agentPolicy,
+  });
+
+export const reassignAgentPolicy = (agentId: string, agentPolicyId: string) =>
+  request({
+    url: agentRouteService.getReassignPath(agentId),
+    method: 'PUT',
+    body: {
+      policy_id: agentPolicyId,
+    },
+  });

--- a/x-pack/plugins/security_solution/public/management/cypress/tasks/fleet.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/tasks/fleet.ts
@@ -5,23 +5,34 @@
  * 2.0.
  */
 
-import type { AgentPolicy, GetAgentsResponse, UpdatePackagePolicy } from '@kbn/fleet-plugin/common';
+import type {
+  AgentPolicy,
+  GetAgentsResponse,
+  GetInfoResponse,
+  UpdatePackagePolicy,
+} from '@kbn/fleet-plugin/common';
 import {
   agentRouteService,
   agentPolicyRouteService,
+  epmRouteService,
   packagePolicyRouteService,
 } from '@kbn/fleet-plugin/common';
 import { request } from './common';
 
-export const getAgentByHostName = (hostname: string) => {
-  return request<GetAgentsResponse>({
+export const getEndpointIntegrationVersion = () =>
+  request<GetInfoResponse>({
+    url: epmRouteService.getInfoPath('endpoint'),
+    method: 'GET',
+  }).then((response) => response.body.item.version);
+
+export const getAgentByHostName = (hostname: string) =>
+  request<GetAgentsResponse>({
     url: agentRouteService.getListPath(),
     method: 'GET',
     qs: {
       kuery: `local_metadata.host.hostname: "${hostname}"`,
     },
   }).then((response) => response.body.items[0]);
-};
 
 export const updatePackagePolicy = (packagePolicyId: string, packagePolicy: UpdatePackagePolicy) =>
   request({

--- a/x-pack/plugins/security_solution/public/management/cypress/tasks/fleet.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/tasks/fleet.ts
@@ -5,27 +5,18 @@
  * 2.0.
  */
 
-import type {
-  AgentPolicy,
-  GetAgentsResponse,
-  GetInfoResponse,
-  UpdatePackagePolicy,
-} from '@kbn/fleet-plugin/common';
-import {
-  agentRouteService,
-  agentPolicyRouteService,
-  epmRouteService,
-  packagePolicyRouteService,
-} from '@kbn/fleet-plugin/common';
+import type { Agent, GetAgentsResponse, GetInfoResponse } from '@kbn/fleet-plugin/common';
+import { agentRouteService, epmRouteService } from '@kbn/fleet-plugin/common';
+import type { PutAgentReassignResponse } from '@kbn/fleet-plugin/common/types';
 import { request } from './common';
 
-export const getEndpointIntegrationVersion = () =>
+export const getEndpointIntegrationVersion = (): Cypress.Chainable<string> =>
   request<GetInfoResponse>({
     url: epmRouteService.getInfoPath('endpoint'),
     method: 'GET',
   }).then((response) => response.body.item.version);
 
-export const getAgentByHostName = (hostname: string) =>
+export const getAgentByHostName = (hostname: string): Cypress.Chainable<Agent> =>
   request<GetAgentsResponse>({
     url: agentRouteService.getListPath(),
     method: 'GET',
@@ -34,22 +25,11 @@ export const getAgentByHostName = (hostname: string) =>
     },
   }).then((response) => response.body.items[0]);
 
-export const updatePackagePolicy = (packagePolicyId: string, packagePolicy: UpdatePackagePolicy) =>
-  request({
-    url: packagePolicyRouteService.getUpdatePath(packagePolicyId),
-    method: 'PUT',
-    body: packagePolicy,
-  });
-
-export const updateAgentPolicy = (agentPolicyId: string, agentPolicy: AgentPolicy) =>
-  request({
-    url: agentPolicyRouteService.getUpdatePath(agentPolicyId),
-    method: 'PUT',
-    body: agentPolicy,
-  });
-
-export const reassignAgentPolicy = (agentId: string, agentPolicyId: string) =>
-  request({
+export const reassignAgentPolicy = (
+  agentId: string,
+  agentPolicyId: string
+): Cypress.Chainable<Cypress.Response<PutAgentReassignResponse>> =>
+  request<PutAgentReassignResponse>({
     url: agentRouteService.getReassignPath(agentId),
     method: 'PUT',
     body: {

--- a/x-pack/plugins/security_solution/public/management/cypress/tasks/load_endpoint_data.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/tasks/load_endpoint_data.ts
@@ -8,17 +8,17 @@
 import { isEmpty } from 'lodash';
 import { BASE_ENDPOINT_ROUTE } from '../../../../common/endpoint/constants';
 import { runEndpointLoaderScript } from './run_endpoint_loader';
+import { request } from './common';
 
 // Checks for Endpoint data and creates it if needed
 export const loadEndpointDataForEventFiltersIfNeeded = () => {
-  cy.request({
+  request({
     method: 'POST',
     url: `${BASE_ENDPOINT_ROUTE}/suggestions/eventFilters`,
     body: {
       field: 'agent.type',
       query: '',
     },
-    headers: { 'kbn-xsrf': 'kibana' },
     failOnStatusCode: false,
   }).then(({ body }) => {
     if (isEmpty(body)) {

--- a/x-pack/plugins/security_solution/public/management/cypress/tasks/perform_user_actions.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/tasks/perform_user_actions.ts
@@ -25,7 +25,7 @@ const performAction = (action: FormAction) => {
   if (action.customSelector) {
     element = cy.get(action.customSelector);
   } else {
-    element = cy.getBySel(action.selector || '');
+    element = cy.getByTestId(action.selector || '');
   }
 
   if (action.type === 'click') {

--- a/x-pack/plugins/security_solution/public/management/cypress/tasks/perform_user_actions.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/tasks/perform_user_actions.ts
@@ -25,7 +25,7 @@ const performAction = (action: FormAction) => {
   if (action.customSelector) {
     element = cy.get(action.customSelector);
   } else {
-    element = cy.getByTestId(action.selector || '');
+    element = cy.getByTestSubj(action.selector || '');
   }
 
   if (action.type === 'click') {

--- a/x-pack/plugins/security_solution/public/management/cypress/tsconfig.json
+++ b/x-pack/plugins/security_solution/public/management/cypress/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../../../../../tsconfig.base.json",
   "include": [
-    "**/*"
+    "**/*",
+    "../cypress_endpoint.config.ts"
   ],
   "exclude": [
     "target/**/*"
@@ -26,5 +27,6 @@
     "@kbn/securitysolution-list-constants",
     "@kbn/fleet-plugin",
     "@kbn/securitysolution-io-ts-list-types",
+    "@kbn/cypress-config",
   ]
 }

--- a/x-pack/plugins/security_solution/public/management/cypress_endpoint.config.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress_endpoint.config.ts
@@ -6,6 +6,8 @@
  */
 
 import { defineCypressConfig } from '@kbn/cypress-config';
+// eslint-disable-next-line @kbn/imports/no_boundary_crossing
+import { dataLoaders } from './cypress/support/data_loaders';
 
 // eslint-disable-next-line import/no-default-export
 export default defineCypressConfig({
@@ -37,5 +39,8 @@ export default defineCypressConfig({
     supportFile: 'public/management/cypress/support/e2e.ts',
     specPattern: 'public/management/cypress/e2e/endpoint/*.cy.{js,jsx,ts,tsx}',
     experimentalRunAllSpecs: true,
+    setupNodeEvents(on, config) {
+      dataLoaders(on, config);
+    },
   },
 });

--- a/x-pack/plugins/security_solution/public/management/cypress_endpoint.config.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress_endpoint.config.ts
@@ -39,7 +39,7 @@ export default defineCypressConfig({
     supportFile: 'public/management/cypress/support/e2e.ts',
     specPattern: 'public/management/cypress/e2e/endpoint/*.cy.{js,jsx,ts,tsx}',
     experimentalRunAllSpecs: true,
-    setupNodeEvents(on, config) {
+    setupNodeEvents(on: Cypress.PluginEvents, config: Cypress.PluginConfigOptions) {
       dataLoaders(on, config);
     },
   },

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/hooks/use_endpoint_action_items.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/hooks/use_endpoint_action_items.tsx
@@ -12,7 +12,7 @@ import { useUserPrivileges } from '../../../../../common/components/user_privile
 import { useWithShowEndpointResponder } from '../../../../hooks';
 import { useIsExperimentalFeatureEnabled } from '../../../../../common/hooks/use_experimental_features';
 import { APP_UI_ID } from '../../../../../../common/constants';
-import { getEndpointDetailsPath } from '../../../../common/routing';
+import { getEndpointDetailsPath, getEndpointListPath } from '../../../../common/routing';
 import type { HostMetadata, MaybeImmutable } from '../../../../../../common/endpoint/types';
 import { useEndpointSelector } from './hooks';
 import { agentPolicies, uiQueryParams } from '../../store/selectors';
@@ -236,6 +236,12 @@ export const useEndpointActionItems = (
                       agentId: fleetAgentId,
                     })[1]
                   }?openReassignFlyout=true`,
+                  state: {
+                    onDoneNavigateTo: [
+                      APP_UI_ID,
+                      { path: getEndpointListPath({ name: 'endpointList' }) },
+                    ],
+                  },
                 },
                 href: `${getAppUrl({ appId: 'fleet' })}${
                   pagePathGetters.agent_details({

--- a/x-pack/plugins/security_solution/tsconfig.json
+++ b/x-pack/plugins/security_solution/tsconfig.json
@@ -16,7 +16,6 @@
   ],
   "exclude": [
     "target/**/*",
-    "**/cypress/**",
   ],
   "kbn_references": [
     "@kbn/core",

--- a/x-pack/plugins/security_solution/tsconfig.json
+++ b/x-pack/plugins/security_solution/tsconfig.json
@@ -16,6 +16,8 @@
   ],
   "exclude": [
     "target/**/*",
+    "**/cypress/**",
+    "public/management/cypress_endpoint.config.ts",
   ],
   "kbn_references": [
     "@kbn/core",

--- a/x-pack/test/defend_workflows_cypress/agent.ts
+++ b/x-pack/test/defend_workflows_cypress/agent.ts
@@ -21,6 +21,8 @@ export class AgentManager extends Manager {
 
   public async setup() {
     this.vmName = await enrollEndpointHost();
+
+    return this.vmName;
   }
 
   public cleanup() {

--- a/x-pack/test/defend_workflows_cypress/runner.ts
+++ b/x-pack/test/defend_workflows_cypress/runner.ts
@@ -14,9 +14,11 @@ import { AgentManager } from './agent';
 import { FleetManager } from './fleet_server';
 import { getLatestAvailableAgentVersion } from './utils';
 
+type RunnerEnv = Record<string, string | undefined>;
+
 async function withFleetAgent(
   { getService }: FtrProviderContext,
-  runner: (runnerEnv: Record<string, string>) => Promise<void>
+  runner: (runnerEnv: RunnerEnv) => Promise<void>
 ) {
   const log = getService('log');
   const config = getService('config');
@@ -40,9 +42,9 @@ async function withFleetAgent(
   const agentManager = new AgentManager(log);
 
   await fleetManager.setup();
-  await agentManager.setup();
+  const agentVmName = await agentManager.setup();
   try {
-    await runner({});
+    await runner({ agentVmName });
   } finally {
     agentManager.cleanup();
     fleetManager.cleanup();
@@ -58,10 +60,16 @@ export async function DefendWorkflowsCypressVisualTestRunner(context: FtrProvide
 }
 
 export async function DefendWorkflowsCypressEndpointTestRunner(context: FtrProviderContext) {
-  await withFleetAgent(context, () => startDefendWorkflowsCypress(context, 'dw:endpoint:open'));
+  await withFleetAgent(context, (runnerEnv) =>
+    startDefendWorkflowsCypress(context, 'dw:endpoint:open', runnerEnv)
+  );
 }
 
-function startDefendWorkflowsCypress(context: FtrProviderContext, cypressCommand: string) {
+function startDefendWorkflowsCypress(
+  context: FtrProviderContext,
+  cypressCommand: string,
+  runnerEnv?: RunnerEnv
+) {
   const log = context.getService('log');
   const config = context.getService('config');
   return withProcRunner(log, async (procs) => {
@@ -91,6 +99,7 @@ function startDefendWorkflowsCypress(context: FtrProviderContext, cypressCommand
           hostname: config.get('servers.kibana.hostname'),
           port: config.get('servers.kibana.port'),
         }),
+        CYPRESS_ENDPOINT_VM_NAME: runnerEnv?.agentVmName,
         ...process.env,
       },
       wait: true,

--- a/x-pack/test/defend_workflows_cypress/runner.ts
+++ b/x-pack/test/defend_workflows_cypress/runner.ts
@@ -67,7 +67,7 @@ export async function DefendWorkflowsCypressEndpointTestRunner(context: FtrProvi
 
 function startDefendWorkflowsCypress(
   context: FtrProviderContext,
-  cypressCommand: string,
+  cypressCommand: 'dw:endpoint:open' | 'dw:open' | 'dw:run',
   runnerEnv?: RunnerEnv
 ) {
   const log = context.getService('log');

--- a/x-pack/test/defend_workflows_cypress/utils.ts
+++ b/x-pack/test/defend_workflows_cypress/utils.ts
@@ -7,7 +7,7 @@
 
 import axios from 'axios';
 import semver from 'semver';
-import { filter } from 'lodash';
+import { map } from 'lodash';
 import { KbnClient } from '@kbn/test';
 
 /**
@@ -20,9 +20,7 @@ export const getLatestAvailableAgentVersion = async (kbnClient: KbnClient): Prom
   const kbnStatus = await kbnClient.status.get();
   const agentVersions = await axios
     .get('https://artifacts-api.elastic.co/v1/versions')
-    .then((response) =>
-      filter(response.data.versions, (versionString) => !versionString.includes('SNAPSHOT'))
-    );
+    .then((response) => map(response.data.versions, (version) => version.split('-SNAPSHOT')[0]));
 
   let version =
     semver.maxSatisfying(agentVersions, `<=${kbnStatus.version.number}`) ??


### PR DESCRIPTION
…onality

## Summary

Adds tests for Endpoint reassignment functionality using Multipass
Fixes bug related to the redirect after the agent was assigned to the new policy

Blocked on https://github.com/elastic/endpoint-dev/issues/12499