### PR TITLE
[Security Solution] Cypress alerts cell actions test improvement

### DIFF
--- a/x-pack/plugins/security_solution/cypress/e2e/detection_alerts/alerts_cell_actions.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_alerts/alerts_cell_actions.cy.ts
@@ -20,12 +20,13 @@ import {
   filterForAlertProperty,
   showTopNAlertProperty,
   clickExpandActions,
+  filterOutAlertProperty,
 } from '../../tasks/alerts';
 import { createCustomRuleEnabled } from '../../tasks/api_calls/rules';
 import { cleanKibana } from '../../tasks/common';
 import { waitForAlertsToPopulate } from '../../tasks/create_new_rule';
 import { login, visit } from '../../tasks/login';
-import { fillAddFilterForm, openAddFilterPopover } from '../../tasks/search_bar';
+import { fillAddFilterForm, fillKqlQueryBar, openAddFilterPopover } from '../../tasks/search_bar';
 import { openActiveTimeline } from '../../tasks/timeline';
 
 import { ALERTS_URL } from '../../urls/navigation';
@@ -60,12 +61,35 @@ describe('Alerts cell actions', () => {
       });
 
       it('should filter for an empty property', () => {
-        // add condition to make sure the field is empty
-        openAddFilterPopover();
-        fillAddFilterForm({ key: 'file.name', operator: 'does not exist' });
+        // add query condition to make sure the field is empty
+        fillKqlQueryBar('not file.name: *{enter}');
         scrollAlertTableColumnIntoView(ALERT_TABLE_FILE_NAME_HEADER);
         filterForAlertProperty(ALERT_TABLE_FILE_NAME_VALUES, 0);
+
         cy.get(FILTER_BADGE).first().should('have.text', 'NOT file.name: exists');
+      });
+
+      it('should filter out a non-empty property', () => {
+        cy.get(ALERT_TABLE_SEVERITY_VALUES)
+          .first()
+          .invoke('text')
+          .then((severityVal) => {
+            scrollAlertTableColumnIntoView(ALERT_TABLE_FILE_NAME_HEADER);
+            filterOutAlertProperty(ALERT_TABLE_SEVERITY_VALUES, 0);
+            cy.get(FILTER_BADGE)
+              .first()
+              .should('have.text', `NOT kibana.alert.severity: ${severityVal}`);
+          });
+      });
+
+      it('should filter out an empty property', () => {
+        // add query condition to make sure the field is empty
+        fillKqlQueryBar('not file.name: *{enter}');
+
+        scrollAlertTableColumnIntoView(ALERT_TABLE_FILE_NAME_HEADER);
+        filterOutAlertProperty(ALERT_TABLE_FILE_NAME_VALUES, 0);
+
+        cy.get(FILTER_BADGE).first().should('have.text', 'file.name: exists');
       });
     });
 

--- a/x-pack/plugins/security_solution/cypress/tasks/alerts.ts
+++ b/x-pack/plugins/security_solution/cypress/tasks/alerts.ts
@@ -37,6 +37,7 @@ import {
   CELL_SHOW_TOP_FIELD_BUTTON,
   ACTIONS_EXPAND_BUTTON,
   SELECT_HISTOGRAM,
+  CELL_FILTER_OUT_BUTTON,
 } from '../screens/alerts';
 import { LOADING_INDICATOR, REFRESH_BUTTON } from '../screens/security_header';
 import { TIMELINE_COLUMN_SPINNER } from '../screens/timeline';
@@ -317,6 +318,9 @@ export const addAlertPropertyToTimeline = (propertySelector: string, rowIndex: n
 };
 export const filterForAlertProperty = (propertySelector: string, rowIndex: number) => {
   clickAction(propertySelector, rowIndex, CELL_FILTER_IN_BUTTON);
+};
+export const filterOutAlertProperty = (propertySelector: string, rowIndex: number) => {
+  clickAction(propertySelector, rowIndex, CELL_FILTER_OUT_BUTTON);
 };
 export const showTopNAlertProperty = (propertySelector: string, rowIndex: number) => {
   clickExpandActions(propertySelector, rowIndex);


### PR DESCRIPTION
## Summary

Following @PhilippeOberti suggestions. This PR Improves the cell_actions test for the alerts page.

### problem
The main problem was in the `filterFor` action for the empty-value test case, which was not testing correctly that the action was working properly. 

This test was pre-setting the "not exists" filter manually to make sure the `filterFor` action was performed on an empty value, this action on an empty value also sets a "not exists" filter, so the action was adding the same filter we predefined manually.

The test has been improved to use the query bar to show empty values for the field in the table, so we can test that the `filterFor` action actually adds the "not exists"  filter itself.

### extra
Tests for the `filterOut` action, which were missing, have been also implemented.

