### PR TITLE
chore(slo): improve APM queries

### DIFF
--- a/x-pack/plugins/observability/server/plugin.ts
+++ b/x-pack/plugins/observability/server/plugin.ts
@@ -17,7 +17,6 @@ import { PluginSetupContract } from '@kbn/alerting-plugin/server';
 import { Dataset, RuleRegistryPluginSetupContract } from '@kbn/rule-registry-plugin/server';
 import { PluginSetupContract as FeaturesSetup } from '@kbn/features-plugin/server';
 import { createUICapabilities } from '@kbn/cases-plugin/common';
-import { SpacesPluginStart } from '@kbn/spaces-plugin/server';
 import { experimentalRuleFieldMap } from '@kbn/rule-registry-plugin/common/assets/field_maps/experimental_rule_field_map';
 import { mappingFromFieldMap } from '@kbn/rule-registry-plugin/common/mapping_from_field_map';
 import { ECS_COMPONENT_TEMPLATE_NAME } from '@kbn/rule-registry-plugin/common/assets';
@@ -51,7 +50,6 @@ interface PluginSetup {
   features: FeaturesSetup;
   guidedOnboarding: GuidedOnboardingPluginSetup;
   ruleRegistry: RuleRegistryPluginSetupContract;
-  spaces: SpacesPluginStart;
   usageCollection?: UsageCollectionSetup;
 }
 

--- a/x-pack/plugins/observability/server/plugin.ts
+++ b/x-pack/plugins/observability/server/plugin.ts
@@ -36,7 +36,7 @@ import {
 } from './lib/annotations/bootstrap_annotations';
 import { uiSettings } from './ui_settings';
 import { registerRoutes } from './routes/register_routes';
-import { getGlobalObservabilityServerRouteRepository } from './routes/get_global_observability_server_route_repository';
+import { getObservabilityServerRouteRepository } from './routes/get_global_observability_server_route_repository';
 import { casesFeatureId, observabilityFeatureId, sloFeatureId } from '../common';
 import { slo, SO_SLO_TYPE } from './saved_objects';
 import { SLO_RULE_REGISTRATION_CONTEXT } from './common/constants';
@@ -232,15 +232,12 @@ export class ObservabilityPlugin implements Plugin<ObservabilityPluginSetup> {
       registerSloUsageCollector(plugins.usageCollection);
     }
 
-    const start = () => core.getStartServices().then(([coreStart]) => coreStart);
-
     registerRoutes({
       core: {
         setup: core,
-        start,
       },
       logger: this.logger,
-      repository: getGlobalObservabilityServerRouteRepository(config),
+      repository: getObservabilityServerRouteRepository(config),
       ruleDataService,
     });
 

--- a/x-pack/plugins/observability/server/plugin.ts
+++ b/x-pack/plugins/observability/server/plugin.ts
@@ -233,12 +233,12 @@ export class ObservabilityPlugin implements Plugin<ObservabilityPluginSetup> {
     }
 
     registerRoutes({
-      core: {
-        setup: core,
+      core,
+      dependencies: {
+        ruleDataService,
       },
       logger: this.logger,
       repository: getObservabilityServerRouteRepository(config),
-      ruleDataService,
     });
 
     /**

--- a/x-pack/plugins/observability/server/plugin.ts
+++ b/x-pack/plugins/observability/server/plugin.ts
@@ -47,11 +47,11 @@ import { registerSloUsageCollector } from './lib/collectors/register';
 export type ObservabilityPluginSetup = ReturnType<ObservabilityPlugin['setup']>;
 
 interface PluginSetup {
+  alerting: PluginSetupContract;
   features: FeaturesSetup;
+  guidedOnboarding: GuidedOnboardingPluginSetup;
   ruleRegistry: RuleRegistryPluginSetupContract;
   spaces: SpacesPluginStart;
-  alerting: PluginSetupContract;
-  guidedOnboarding: GuidedOnboardingPluginSetup;
   usageCollection?: UsageCollectionSetup;
 }
 

--- a/x-pack/plugins/observability/server/routes/get_global_observability_server_route_repository.ts
+++ b/x-pack/plugins/observability/server/routes/get_global_observability_server_route_repository.ts
@@ -8,7 +8,7 @@ import { ObservabilityConfig } from '..';
 import { rulesRouteRepository } from './rules/route';
 import { slosRouteRepository } from './slo/route';
 
-export function getGlobalObservabilityServerRouteRepository(config: ObservabilityConfig) {
+export function getObservabilityServerRouteRepository(config: ObservabilityConfig) {
   const isSloFeatureEnabled = config.unsafe.slo.enabled;
 
   const repository = {
@@ -19,5 +19,5 @@ export function getGlobalObservabilityServerRouteRepository(config: Observabilit
 }
 
 export type ObservabilityServerRouteRepository = ReturnType<
-  typeof getGlobalObservabilityServerRouteRepository
+  typeof getObservabilityServerRouteRepository
 >;

--- a/x-pack/plugins/observability/server/routes/register_routes.ts
+++ b/x-pack/plugins/observability/server/routes/register_routes.ts
@@ -16,22 +16,22 @@ import { errors } from '@elastic/elasticsearch';
 import { RuleDataPluginService } from '@kbn/rule-registry-plugin/server';
 
 import { ObservabilityRequestHandlerContext } from '../types';
-import { ObservabilityServerRouteRepository } from './types';
+import { AbstractObservabilityServerRouteRepository } from './types';
 import { getHTTPResponseCode, ObservabilityError } from '../errors';
 
 interface RegisterRoutes {
-  core: {
-    setup: CoreSetup;
-  };
-  repository: ObservabilityServerRouteRepository;
+  core: CoreSetup;
+  repository: AbstractObservabilityServerRouteRepository;
   logger: Logger;
-  ruleDataService: RuleDataPluginService;
+  dependencies: {
+    ruleDataService: RuleDataPluginService;
+  };
 }
 
-export function registerRoutes({ repository, core, logger, ruleDataService }: RegisterRoutes) {
+export function registerRoutes({ repository, core, logger, dependencies }: RegisterRoutes) {
   const routes = Object.values(repository);
 
-  const router = core.setup.http.createRouter();
+  const router = core.http.createRouter();
 
   routes.forEach((route) => {
     const { endpoint, options, handler, params } = route;
@@ -59,7 +59,7 @@ export function registerRoutes({ repository, core, logger, ruleDataService }: Re
             request,
             logger,
             params: decodedParams,
-            ruleDataService,
+            ruleDataService: dependencies.ruleDataService,
           })) as any;
 
           if (data === undefined) {

--- a/x-pack/plugins/observability/server/routes/register_routes.ts
+++ b/x-pack/plugins/observability/server/routes/register_routes.ts
@@ -23,9 +23,11 @@ interface RegisterRoutes {
   core: CoreSetup;
   repository: AbstractObservabilityServerRouteRepository;
   logger: Logger;
-  dependencies: {
-    ruleDataService: RuleDataPluginService;
-  };
+  dependencies: RegisterRoutesDependencies;
+}
+
+export interface RegisterRoutesDependencies {
+  ruleDataService: RuleDataPluginService;
 }
 
 export function registerRoutes({ repository, core, logger, dependencies }: RegisterRoutes) {

--- a/x-pack/plugins/observability/server/routes/register_routes.ts
+++ b/x-pack/plugins/observability/server/routes/register_routes.ts
@@ -10,28 +10,25 @@ import {
   parseEndpoint,
   routeValidationObject,
 } from '@kbn/server-route-repository';
-import { CoreSetup, CoreStart, Logger, RouteRegistrar } from '@kbn/core/server';
+import { CoreSetup, Logger, RouteRegistrar } from '@kbn/core/server';
 import Boom from '@hapi/boom';
 import { errors } from '@elastic/elasticsearch';
 import { RuleDataPluginService } from '@kbn/rule-registry-plugin/server';
+
 import { ObservabilityRequestHandlerContext } from '../types';
-import { AbstractObservabilityServerRouteRepository } from './types';
+import { ObservabilityServerRouteRepository } from './types';
 import { getHTTPResponseCode, ObservabilityError } from '../errors';
 
-export function registerRoutes({
-  repository,
-  core,
-  logger,
-  ruleDataService,
-}: {
+interface RegisterRoutes {
   core: {
     setup: CoreSetup;
-    start: () => Promise<CoreStart>;
   };
-  repository: AbstractObservabilityServerRouteRepository;
+  repository: ObservabilityServerRouteRepository;
   logger: Logger;
   ruleDataService: RuleDataPluginService;
-}) {
+}
+
+export function registerRoutes({ repository, core, logger, ruleDataService }: RegisterRoutes) {
   const routes = Object.values(repository);
 
   const router = core.setup.http.createRouter();
@@ -60,7 +57,6 @@ export function registerRoutes({
           const data = (await handler({
             context,
             request,
-            core,
             logger,
             params: decodedParams,
             ruleDataService,

--- a/x-pack/plugins/observability/server/routes/register_routes.ts
+++ b/x-pack/plugins/observability/server/routes/register_routes.ts
@@ -59,7 +59,7 @@ export function registerRoutes({ repository, core, logger, dependencies }: Regis
             request,
             logger,
             params: decodedParams,
-            ruleDataService: dependencies.ruleDataService,
+            dependencies,
           })) as any;
 
           if (data === undefined) {

--- a/x-pack/plugins/observability/server/routes/rules/route.ts
+++ b/x-pack/plugins/observability/server/routes/rules/route.ts
@@ -20,8 +20,9 @@ const alertsDynamicIndexPatternRoute = createObservabilityServerRoute({
       namespace: t.string,
     }),
   }),
-  handler: async ({ ruleDataService, params }) => {
+  handler: async ({ dependencies, params }) => {
     const { namespace, registrationContexts } = params.query;
+    const { ruleDataService } = dependencies;
     const indexNames = registrationContexts.flatMap((registrationContext) => {
       const indexName = ruleDataService
         .findIndexByName(registrationContext, Dataset.alerts)

--- a/x-pack/plugins/observability/server/routes/types.ts
+++ b/x-pack/plugins/observability/server/routes/types.ts
@@ -6,18 +6,16 @@
  */
 import type { EndpointOf, ReturnOf, ServerRouteRepository } from '@kbn/server-route-repository';
 import { KibanaRequest, Logger } from '@kbn/core/server';
-import { RuleDataPluginService } from '@kbn/rule-registry-plugin/server';
 
 import { ObservabilityServerRouteRepository } from './get_global_observability_server_route_repository';
 import { ObservabilityRequestHandlerContext } from '../types';
+import { RegisterRoutesDependencies } from './register_routes';
 
 export type { ObservabilityServerRouteRepository };
 
 export interface ObservabilityRouteHandlerResources {
   context: ObservabilityRequestHandlerContext;
-  dependencies: {
-    ruleDataService: RuleDataPluginService;
-  };
+  dependencies: RegisterRoutesDependencies;
   logger: Logger;
   request: KibanaRequest;
 }

--- a/x-pack/plugins/observability/server/routes/types.ts
+++ b/x-pack/plugins/observability/server/routes/types.ts
@@ -8,18 +8,18 @@ import type { EndpointOf, ReturnOf, ServerRouteRepository } from '@kbn/server-ro
 import { KibanaRequest, Logger } from '@kbn/core/server';
 import { RuleDataPluginService } from '@kbn/rule-registry-plugin/server';
 
-import { SpacesServiceStart } from '@kbn/spaces-plugin/server';
 import { ObservabilityServerRouteRepository } from './get_global_observability_server_route_repository';
 import { ObservabilityRequestHandlerContext } from '../types';
 
 export type { ObservabilityServerRouteRepository };
 
 export interface ObservabilityRouteHandlerResources {
-  ruleDataService: RuleDataPluginService;
-  spacesService: SpacesServiceStart;
-  request: KibanaRequest;
   context: ObservabilityRequestHandlerContext;
+  dependencies: {
+    ruleDataService: RuleDataPluginService;
+  };
   logger: Logger;
+  request: KibanaRequest;
 }
 
 export interface ObservabilityRouteCreateOptions {

--- a/x-pack/plugins/observability/server/routes/types.ts
+++ b/x-pack/plugins/observability/server/routes/types.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 import type { EndpointOf, ReturnOf, ServerRouteRepository } from '@kbn/server-route-repository';
-import { CoreSetup, CoreStart, KibanaRequest, Logger } from '@kbn/core/server';
+import { KibanaRequest, Logger } from '@kbn/core/server';
 import { RuleDataPluginService } from '@kbn/rule-registry-plugin/server';
 
 import { SpacesServiceStart } from '@kbn/spaces-plugin/server';
@@ -15,10 +15,6 @@ import { ObservabilityRequestHandlerContext } from '../types';
 export type { ObservabilityServerRouteRepository };
 
 export interface ObservabilityRouteHandlerResources {
-  core: {
-    start: () => Promise<CoreStart>;
-    setup: CoreSetup;
-  };
   ruleDataService: RuleDataPluginService;
   spacesService: SpacesServiceStart;
   request: KibanaRequest;

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/apm_transaction_duration.test.ts.snap
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/apm_transaction_duration.test.ts.snap
@@ -5,8 +5,20 @@ Object {
   "bool": Object {
     "filter": Array [
       Object {
-        "match": Object {
-          "transaction.root": true,
+        "terms": Object {
+          "processor.event": Array [
+            "metric",
+          ],
+        },
+      },
+      Object {
+        "term": Object {
+          "metricset.name": "transaction",
+        },
+      },
+      Object {
+        "exists": Object {
+          "field": "transaction.duration.histogram",
         },
       },
       Object {
@@ -99,8 +111,20 @@ Object {
   "bool": Object {
     "filter": Array [
       Object {
-        "match": Object {
-          "transaction.root": true,
+        "terms": Object {
+          "processor.event": Array [
+            "metric",
+          ],
+        },
+      },
+      Object {
+        "term": Object {
+          "metricset.name": "transaction",
+        },
+      },
+      Object {
+        "exists": Object {
+          "field": "transaction.duration.histogram",
         },
       },
       Object {
@@ -189,8 +213,20 @@ Object {
       "bool": Object {
         "filter": Array [
           Object {
-            "match": Object {
-              "transaction.root": true,
+            "terms": Object {
+              "processor.event": Array [
+                "metric",
+              ],
+            },
+          },
+          Object {
+            "term": Object {
+              "metricset.name": "transaction",
+            },
+          },
+          Object {
+            "exists": Object {
+              "field": "transaction.duration.histogram",
             },
           },
           Object {
@@ -313,8 +349,20 @@ Object {
       "bool": Object {
         "filter": Array [
           Object {
-            "match": Object {
-              "transaction.root": true,
+            "terms": Object {
+              "processor.event": Array [
+                "metric",
+              ],
+            },
+          },
+          Object {
+            "term": Object {
+              "metricset.name": "transaction",
+            },
+          },
+          Object {
+            "exists": Object {
+              "field": "transaction.duration.histogram",
             },
           },
           Object {

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/apm_transaction_error_rate.test.ts.snap
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/apm_transaction_error_rate.test.ts.snap
@@ -5,8 +5,25 @@ Object {
   "bool": Object {
     "filter": Array [
       Object {
-        "match": Object {
-          "transaction.root": true,
+        "terms": Object {
+          "processor.event": Array [
+            "metric",
+          ],
+        },
+      },
+      Object {
+        "term": Object {
+          "metricset.name": "transaction",
+        },
+      },
+      Object {
+        "exists": Object {
+          "field": "transaction.duration.histogram",
+        },
+      },
+      Object {
+        "exists": Object {
+          "field": "transaction.result",
         },
       },
       Object {
@@ -99,8 +116,25 @@ Object {
   "bool": Object {
     "filter": Array [
       Object {
-        "match": Object {
-          "transaction.root": true,
+        "terms": Object {
+          "processor.event": Array [
+            "metric",
+          ],
+        },
+      },
+      Object {
+        "term": Object {
+          "metricset.name": "transaction",
+        },
+      },
+      Object {
+        "exists": Object {
+          "field": "transaction.duration.histogram",
+        },
+      },
+      Object {
+        "exists": Object {
+          "field": "transaction.result",
         },
       },
       Object {
@@ -194,8 +228,25 @@ Object {
       "bool": Object {
         "filter": Array [
           Object {
-            "match": Object {
-              "transaction.root": true,
+            "terms": Object {
+              "processor.event": Array [
+                "metric",
+              ],
+            },
+          },
+          Object {
+            "term": Object {
+              "metricset.name": "transaction",
+            },
+          },
+          Object {
+            "exists": Object {
+              "field": "transaction.duration.histogram",
+            },
+          },
+          Object {
+            "exists": Object {
+              "field": "transaction.result",
             },
           },
           Object {
@@ -323,8 +374,25 @@ Object {
       "bool": Object {
         "filter": Array [
           Object {
-            "match": Object {
-              "transaction.root": true,
+            "terms": Object {
+              "processor.event": Array [
+                "metric",
+              ],
+            },
+          },
+          Object {
+            "term": Object {
+              "metricset.name": "transaction",
+            },
+          },
+          Object {
+            "exists": Object {
+              "field": "transaction.duration.histogram",
+            },
+          },
+          Object {
+            "exists": Object {
+              "field": "transaction.result",
             },
           },
           Object {

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/apm_transaction_duration.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/apm_transaction_duration.ts
@@ -96,11 +96,8 @@ export class ApmTransactionDurationTransformGenerator extends TransformGenerator
       query: {
         bool: {
           filter: [
-            {
-              match: {
-                'transaction.root': true,
-              },
-            },
+            { terms: { 'processor.event': ['metric'] } },
+            { exists: { field: 'transaction.duration.histogram' } },
             ...queryFilter,
           ],
         },

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/apm_transaction_duration.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/apm_transaction_duration.ts
@@ -97,6 +97,7 @@ export class ApmTransactionDurationTransformGenerator extends TransformGenerator
         bool: {
           filter: [
             { terms: { 'processor.event': ['metric'] } },
+            { term: { 'metricset.name': 'transaction' } },
             { exists: { field: 'transaction.duration.histogram' } },
             ...queryFilter,
           ],

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/apm_transaction_error_rate.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/apm_transaction_error_rate.ts
@@ -101,8 +101,10 @@ export class ApmTransactionErrorRateTransformGenerator extends TransformGenerato
       query: {
         bool: {
           filter: [
-            { exists: { field: 'transaction.result' } },
+            { terms: { 'processor.event': ['metric'] } },
+            { term: { 'metricset.name': 'transaction' } },
             { exists: { field: 'transaction.duration.histogram' } },
+            { exists: { field: 'transaction.result' } },
             ...queryFilter,
           ],
         },

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/apm_transaction_error_rate.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/apm_transaction_error_rate.ts
@@ -101,11 +101,8 @@ export class ApmTransactionErrorRateTransformGenerator extends TransformGenerato
       query: {
         bool: {
           filter: [
-            {
-              match: {
-                'transaction.root': true,
-              },
-            },
+            { exists: { field: 'transaction.result' } },
+            { exists: { field: 'transaction.duration.histogram' } },
             ...queryFilter,
           ],
         },


### PR DESCRIPTION
## 📝 Summary

This PR uses the correct fields from the APM index. I've also refactored a bit the plugin dependencies logic, initially to use `getApmIndices` from apm plugin, but I can not require apm plugin from observability plugin (cyclic dependencies), but decided to keep the refactoring.

In a following PR, I'll update the FE to fetch the apm metrics index using the internal endpoint