### PR TITLE
[Enterprise Search] Search Preview API Call Flyout

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/api_call_flyout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/api_call_flyout.tsx
@@ -12,6 +12,7 @@ import {
   EuiFlexGroup,
   EuiFlyout,
   EuiFlyoutHeader,
+  EuiSpacer,
   EuiTab,
   EuiTabs,
   EuiTitle,
@@ -55,6 +56,7 @@ export const APICallFlyout: React.FC<APICallFlyoutProps> = ({
             />
           </h2>
         </EuiTitle>
+        <EuiSpacer size="s" />
         <EuiFlexGroup
           alignItems="center"
           justifyContent="spaceBetween"

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/api_call_flyout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/api_call_flyout.tsx
@@ -7,9 +7,22 @@
 
 import React, { useState } from 'react';
 
-import { EuiCodeBlock, EuiFlyout, EuiFlyoutHeader, EuiTitle, EuiTabs, EuiTab } from '@elastic/eui';
+import {
+  EuiCodeBlock,
+  EuiFlexGroup,
+  EuiFlyout,
+  EuiFlyoutHeader,
+  EuiTab,
+  EuiTabs,
+  EuiTitle,
+} from '@elastic/eui';
 import { SearchRequest, SearchResponse } from '@elastic/search-ui-engines-connector';
 import { FormattedMessage } from '@kbn/i18n-react';
+
+import { generateEncodedPath } from '../../../../shared/encode_path_params';
+import { EuiLinkTo } from '../../../../shared/react_router_helpers';
+
+import { EngineViewTabs, ENGINE_TAB_PATH } from '../../../routes';
 
 export interface APICallData {
   request: SearchRequest;
@@ -17,11 +30,16 @@ export interface APICallData {
 }
 
 export interface APICallFlyoutProps {
+  engineName: string;
   lastAPICall: APICallData;
   onClose: () => void;
 }
 
-export const APICallFlyout: React.FC<APICallFlyoutProps> = ({ onClose, lastAPICall }) => {
+export const APICallFlyout: React.FC<APICallFlyoutProps> = ({
+  engineName,
+  onClose,
+  lastAPICall,
+}) => {
   const [tab, setTab] = useState<'request' | 'response'>('request');
 
   const contents = JSON.stringify(lastAPICall[tab], null, 2);
@@ -37,20 +55,39 @@ export const APICallFlyout: React.FC<APICallFlyoutProps> = ({ onClose, lastAPICa
             />
           </h2>
         </EuiTitle>
-        <EuiTabs bottomBorder={false} style={{ marginBottom: '-24px' }}>
-          <EuiTab isSelected={tab === 'request'} onClick={() => setTab('request')}>
+        <EuiFlexGroup
+          alignItems="center"
+          justifyContent="spaceBetween"
+          style={{ marginBottom: '-24px' }}
+        >
+          <EuiTabs bottomBorder={false}>
+            <EuiTab isSelected={tab === 'request'} onClick={() => setTab('request')}>
+              <FormattedMessage
+                id="xpack.enterpriseSearch.content.engine.searchPreivew.apiCallFlyout.requestTab"
+                defaultMessage="Request"
+              />
+            </EuiTab>
+            <EuiTab isSelected={tab === 'response'} onClick={() => setTab('response')}>
+              <FormattedMessage
+                id="xpack.enterpriseSearch.content.engine.searchPreivew.apiCallFlyout.responseTab"
+                defaultMessage="Response"
+              />
+            </EuiTab>
+          </EuiTabs>
+          <EuiLinkTo
+            to={generateEncodedPath(ENGINE_TAB_PATH, {
+              engineName,
+              tabId: EngineViewTabs.API,
+            })}
+            color="primary"
+            target="_blank"
+          >
             <FormattedMessage
-              id="xpack.enterpriseSearch.content.engine.searchPreivew.apiCallFlyout.requestTab"
-              defaultMessage="Request"
+              id="xpack.enterpriseSearch.content.engine.searchPreivew.apiCallFlyout.searchEndpointLink"
+              defaultMessage="Search endpoint"
             />
-          </EuiTab>
-          <EuiTab isSelected={tab === 'response'} onClick={() => setTab('response')}>
-            <FormattedMessage
-              id="xpack.enterpriseSearch.content.engine.searchPreivew.apiCallFlyout.responseTab"
-              defaultMessage="Response"
-            />
-          </EuiTab>
-        </EuiTabs>
+          </EuiLinkTo>
+        </EuiFlexGroup>
       </EuiFlyoutHeader>
       <div style={{ blockSize: '100%' }}>
         <EuiCodeBlock overflowHeight="100%" isCopyable isVirtualized>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/api_call_flyout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/api_call_flyout.tsx
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useState } from 'react';
+
+import { EuiCodeBlock, EuiFlyout, EuiFlyoutHeader, EuiTitle, EuiTabs, EuiTab } from '@elastic/eui';
+import { SearchRequest, SearchResponse } from '@elastic/search-ui-engines-connector';
+import { FormattedMessage } from '@kbn/i18n-react';
+
+export interface APICallData {
+  request: SearchRequest;
+  response: SearchResponse;
+}
+
+export interface APICallFlyoutProps {
+  lastAPICall: APICallData;
+  onClose: () => void;
+}
+
+export const APICallFlyout: React.FC<APICallFlyoutProps> = ({ onClose, lastAPICall }) => {
+  const [tab, setTab] = useState<'request' | 'response'>('request');
+
+  const contents = JSON.stringify(lastAPICall[tab], null, 2);
+
+  return (
+    <EuiFlyout onClose={onClose} size="m">
+      <EuiFlyoutHeader hasBorder>
+        <EuiTitle>
+          <h2>
+            <FormattedMessage
+              id="xpack.enterpriseSearch.content.engine.searchPreivew.apiCallFlyout.title"
+              defaultMessage="API Call"
+            />
+          </h2>
+        </EuiTitle>
+        <EuiTabs bottomBorder={false} style={{ marginBottom: '-24px' }}>
+          <EuiTab isSelected={tab === 'request'} onClick={() => setTab('request')}>
+            <FormattedMessage
+              id="xpack.enterpriseSearch.content.engine.searchPreivew.apiCallFlyout.requestTab"
+              defaultMessage="Request"
+            />
+          </EuiTab>
+          <EuiTab isSelected={tab === 'response'} onClick={() => setTab('response')}>
+            <FormattedMessage
+              id="xpack.enterpriseSearch.content.engine.searchPreivew.apiCallFlyout.responseTab"
+              defaultMessage="Response"
+            />
+          </EuiTab>
+        </EuiTabs>
+      </EuiFlyoutHeader>
+      <div style={{ blockSize: '100%' }}>
+        <EuiCodeBlock overflowHeight="100%" isCopyable isVirtualized>
+          {contents}
+        </EuiCodeBlock>
+      </div>
+    </EuiFlyout>
+  );
+};

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/engine_search_preview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/engine_search_preview.tsx
@@ -131,7 +131,11 @@ export const EngineSearchPreview: React.FC = () => {
         </SearchProvider>
         <DocumentFlyout />
         {showAPICallFlyout && lastAPICall && (
-          <APICallFlyout onClose={() => setShowAPICallFlyout(false)} lastAPICall={lastAPICall} />
+          <APICallFlyout
+            onClose={() => setShowAPICallFlyout(false)}
+            lastAPICall={lastAPICall}
+            engineName={engineName}
+          />
         )}
       </DocumentProvider>
     </EnterpriseSearchEnginesPageTemplate>


### PR DESCRIPTION
## Summary

- hooks into `InternalEngineTransporter` to capture the last request and response
- adds a button to open a flyout containing tabs with a formatted request and response
- adds link to api page from the flyout


https://user-images.githubusercontent.com/1699281/220698535-c91f0e27-49c8-4133-b11e-c72fb89bb18b.mov



### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence 
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)
