### PR TITLE
[ML] Fixing missing date label in revert to model snapshot flyout

### DIFF
--- a/x-pack/plugins/ml/public/application/jobs/new_job/pages/components/charts/event_rate_chart/event_rate_chart.tsx
+++ b/x-pack/plugins/ml/public/application/jobs/new_job/pages/components/charts/event_rate_chart/event_rate_chart.tsx
@@ -70,7 +70,7 @@ export const EventRateChart: FC<Props> = ({
       data-test-subj={`mlEventRateChart ${eventRateChartData.length ? 'withData' : 'empty'}`}
     >
       <LoadingWrapper height={height} hasData={eventRateChartData.length > 0} loading={loading}>
-        <Chart css={cssOverride}>
+        <Chart css={overlayRanges !== undefined ? cssOverride : undefined}>
           {showAxis === true && <Axes />}
           <Settings
             tooltip={TooltipType.None}

--- a/x-pack/plugins/ml/public/application/jobs/new_job/pages/components/charts/event_rate_chart/event_rate_chart.tsx
+++ b/x-pack/plugins/ml/public/application/jobs/new_job/pages/components/charts/event_rate_chart/event_rate_chart.tsx
@@ -15,6 +15,7 @@ import {
   BrushEndListener,
   PartialTheme,
 } from '@elastic/charts';
+import { css } from '@emotion/react';
 import { Axes } from '../common/axes';
 import { LineChartPoint } from '../../../../common/chart_loader';
 import { Anomaly } from '../../../../common/results_loader';
@@ -58,13 +59,18 @@ export const EventRateChart: FC<Props> = ({
     scales: { histogramPadding: 0.2 },
   };
 
+  const cssOverride = css({
+    // fix for the annotation label being hidden inside the bounds of the chart container
+    '.echContainer': { overflow: 'visible' },
+  });
+
   return (
     <div
       style={{ width, height }}
       data-test-subj={`mlEventRateChart ${eventRateChartData.length ? 'withData' : 'empty'}`}
     >
       <LoadingWrapper height={height} hasData={eventRateChartData.length > 0} loading={loading}>
-        <Chart>
+        <Chart css={cssOverride}>
           {showAxis === true && <Axes />}
           <Settings
             tooltip={TooltipType.None}

--- a/x-pack/plugins/ml/public/application/jobs/new_job/pages/components/charts/event_rate_chart/overlay_range.tsx
+++ b/x-pack/plugins/ml/public/application/jobs/new_job/pages/components/charts/event_rate_chart/overlay_range.tsx
@@ -48,7 +48,6 @@ export const OverlayRange: FC<Props> = ({ overlayKey, start, end, color, showMar
         style={{
           line: {
             strokeWidth: 1,
-            stroke: '#343741',
             opacity: 0,
           },
         }}

--- a/x-pack/plugins/ml/server/lib/node_utils.ts
+++ b/x-pack/plugins/ml/server/lib/node_utils.ts
@@ -30,7 +30,6 @@ export async function getMlNodeCount(client: IScopedClusterClient): Promise<MlNo
 
   const lazyNodeCount = await getLazyMlNodeCount(client);
 
-  // return { count: 0, lazyNodeCount: 0 };
   return { count, lazyNodeCount };
 }
 

--- a/x-pack/plugins/ml/server/lib/node_utils.ts
+++ b/x-pack/plugins/ml/server/lib/node_utils.ts
@@ -30,6 +30,7 @@ export async function getMlNodeCount(client: IScopedClusterClient): Promise<MlNo
 
   const lazyNodeCount = await getLazyMlNodeCount(client);
 
+  // return { count: 0, lazyNodeCount: 0 };
   return { count, lazyNodeCount };
 }
 


### PR DESCRIPTION
The annotation label is being cut off by the bounds of the containing chart.
This PR overrides the overflow style so the label can be seen.
Attempts at altering the height, padding or margin of the chart did not fix this.

Before:
![image](https://user-images.githubusercontent.com/22172091/220707422-4d7395d2-7a38-4037-b887-2bea67f3357e.png)


After:
![image](https://user-images.githubusercontent.com/22172091/220707465-e4bf9dbf-bb5e-42cb-8919-7fd59fa857d0.png)



Fixes https://github.com/elastic/kibana/issues/147698


<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->