### PR TITLE
Split scalability pipelines

### DIFF
--- a/.buildkite/pipelines/scalability/api_capacity_testing_daily.yml
+++ b/.buildkite/pipelines/scalability/api_capacity_testing_daily.yml
@@ -1,0 +1,32 @@
+steps:
+  - label: 'Pre-Build'
+    command: .buildkite/scripts/lifecycle/pre_build.sh
+    agents:
+      queue: kibana-default
+
+  - wait
+
+  - label: 'Build Kibana Distribution and Plugins'
+    command: .buildkite/scripts/steps/build_kibana.sh
+    agents:
+      queue: c2-16
+    key: build
+    if: "build.env('KIBANA_BUILD_ID') == null || build.env('KIBANA_BUILD_ID') == ''"
+
+  - label: ':kibana: APIs Capacity Tests'
+    command: .buildkite/scripts/steps/scalability/api_capacity_testing.sh
+    agents:
+      queue: kb-static-scalability
+    timeout_in_minutes: 90
+    retry:
+      automatic:
+        - exit_status: '*'
+          limit: 1
+
+  - wait: ~
+    continue_on_failure: true
+
+  - label: 'Post-Build'
+    command: .buildkite/scripts/lifecycle/post_build.sh
+    agents:
+      queue: kibana-default

--- a/.buildkite/pipelines/scalability/api_capacity_testing_daily.yml
+++ b/.buildkite/pipelines/scalability/api_capacity_testing_daily.yml
@@ -17,6 +17,7 @@ steps:
     command: .buildkite/scripts/steps/scalability/api_capacity_testing.sh
     agents:
       queue: kb-static-scalability
+    depends_on: build
     timeout_in_minutes: 90
     retry:
       automatic:

--- a/.buildkite/pipelines/scalability/api_capacity_testing_daily.yml
+++ b/.buildkite/pipelines/scalability/api_capacity_testing_daily.yml
@@ -9,9 +9,14 @@ steps:
   - label: 'Build Kibana Distribution and Plugins'
     command: .buildkite/scripts/steps/build_kibana.sh
     agents:
-      queue: c2-16
+      queue: n2-16-spot
     key: build
     if: "build.env('KIBANA_BUILD_ID') == null || build.env('KIBANA_BUILD_ID') == ''"
+    timeout_in_minutes: 60
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 3
 
   - label: ':kibana: APIs Capacity Tests'
     command: .buildkite/scripts/steps/scalability/api_capacity_testing.sh

--- a/.buildkite/scripts/steps/scalability/api_capacity_testing.sh
+++ b/.buildkite/scripts/steps/scalability/api_capacity_testing.sh
@@ -8,15 +8,10 @@ source .buildkite/scripts/common/util.sh
 echo "--- yarn kbn reset && yarn kbn bootstrap"
 yarn kbn reset && yarn kbn bootstrap
 
-GCS_BUCKET="gs://kibana-performance/scalability-tests"
-GCS_ARTIFACTS_REL="gcs_artifacts"
-GCS_ARTIFACTS_DIR="${WORKSPACE}/${GCS_ARTIFACTS_REL}"
 KIBANA_LOAD_TESTING_DIR="${KIBANA_DIR}/kibana-load-testing"
-
 # These tests are running on static workers so we must delete previous build, load runner and scalability artifacts
 rm -rf "${KIBANA_BUILD_LOCATION}"
 rm -rf "${KIBANA_LOAD_TESTING_DIR}"
-rm -rf "${GCS_ARTIFACTS_DIR}"
 
 echo "--- Download the build artifacts"
 .buildkite/scripts/download_build_artifacts.sh
@@ -47,9 +42,6 @@ upload_test_results() {
   echo "--- Upload Gatling reports as build artifacts"
   tar -czf "scalability_test_report.tar.gz" --exclude=simulation.log -C kibana-load-testing/target gatling
   buildkite-agent artifact upload "scalability_test_report.tar.gz"
-  cd "${LATEST_RUN_ARTIFACTS_DIR}"
-  echo "Upload scalability traces as build artifacts"
-  buildkite-agent artifact upload "scalability_traces.tar.gz"
 }
 
 echo "--- Clone kibana-load-testing repo and compile project"

--- a/.buildkite/scripts/steps/scalability/api_capacity_testing.sh
+++ b/.buildkite/scripts/steps/scalability/api_capacity_testing.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source .buildkite/scripts/common/util.sh
+
+#.buildkite/scripts/bootstrap.sh
+echo "--- yarn kbn reset && yarn kbn bootstrap"
+yarn kbn reset && yarn kbn bootstrap
+
+GCS_BUCKET="gs://kibana-performance/scalability-tests"
+GCS_ARTIFACTS_REL="gcs_artifacts"
+GCS_ARTIFACTS_DIR="${WORKSPACE}/${GCS_ARTIFACTS_REL}"
+KIBANA_LOAD_TESTING_DIR="${KIBANA_DIR}/kibana-load-testing"
+
+# These tests are running on static workers so we must delete previous build, load runner and scalability artifacts
+rm -rf "${KIBANA_BUILD_LOCATION}"
+rm -rf "${KIBANA_LOAD_TESTING_DIR}"
+rm -rf "${GCS_ARTIFACTS_DIR}"
+
+checkout_and_compile_load_runner() {
+  mkdir -p "${KIBANA_LOAD_TESTING_DIR}" && cd "${KIBANA_LOAD_TESTING_DIR}"
+
+  if [[ ! -d .git ]]; then
+    git init
+    git remote add origin https://github.com/elastic/kibana-load-testing.git
+  fi
+  git fetch origin --depth 1 "main"
+  git reset --hard FETCH_HEAD
+
+  KIBANA_LOAD_TESTING_GIT_COMMIT="$(git rev-parse HEAD)"
+  export KIBANA_LOAD_TESTING_GIT_COMMIT
+
+  mvn -q test-compile
+  echo "Set 'GATLING_PROJECT_PATH' env var for ScalabilityTestRunner"
+  export GATLING_PROJECT_PATH="$(pwd)"
+}
+
+upload_test_results() {
+  cd "${KIBANA_DIR}"
+  echo "Upload server logs as build artifacts"
+  tar -czf server-logs.tar.gz data/ftr_servers_logs/**/*
+  buildkite-agent artifact upload server-logs.tar.gz
+  echo "--- Upload Gatling reports as build artifacts"
+  tar -czf "scalability_test_report.tar.gz" --exclude=simulation.log -C kibana-load-testing/target gatling
+  buildkite-agent artifact upload "scalability_test_report.tar.gz"
+  cd "${LATEST_RUN_ARTIFACTS_DIR}"
+  echo "Upload scalability traces as build artifacts"
+  buildkite-agent artifact upload "scalability_traces.tar.gz"
+}
+
+echo "--- Clone kibana-load-testing repo and compile project"
+checkout_and_compile_load_runner
+
+echo "--- Download the latest artifacts from single user performance pipeline"
+.buildkite/scripts/download_build_artifacts.sh
+
+echo "--- Run single apis capacity tests"
+node scripts/run_scalability --kibana-install-dir "$KIBANA_BUILD_LOCATION" --journey-path "x-pack/test/scalability/apis"
+
+echo "--- Upload test results"
+upload_test_results

--- a/.buildkite/scripts/steps/scalability/api_capacity_testing.sh
+++ b/.buildkite/scripts/steps/scalability/api_capacity_testing.sh
@@ -56,6 +56,7 @@ echo "--- Download the latest artifacts from single user performance pipeline"
 .buildkite/scripts/download_build_artifacts.sh
 
 echo "--- Run single apis capacity tests"
+cd "$KIBANA_DIR"
 node scripts/run_scalability --kibana-install-dir "$KIBANA_BUILD_LOCATION" --journey-path "x-pack/test/scalability/apis"
 
 echo "--- Upload test results"

--- a/.buildkite/scripts/steps/scalability/api_capacity_testing.sh
+++ b/.buildkite/scripts/steps/scalability/api_capacity_testing.sh
@@ -18,6 +18,9 @@ rm -rf "${KIBANA_BUILD_LOCATION}"
 rm -rf "${KIBANA_LOAD_TESTING_DIR}"
 rm -rf "${GCS_ARTIFACTS_DIR}"
 
+echo "--- Download the build artifacts"
+.buildkite/scripts/download_build_artifacts.sh
+
 checkout_and_compile_load_runner() {
   mkdir -p "${KIBANA_LOAD_TESTING_DIR}" && cd "${KIBANA_LOAD_TESTING_DIR}"
 
@@ -51,9 +54,6 @@ upload_test_results() {
 
 echo "--- Clone kibana-load-testing repo and compile project"
 checkout_and_compile_load_runner
-
-echo "--- Download the latest artifacts from single user performance pipeline"
-.buildkite/scripts/download_build_artifacts.sh
 
 echo "--- Run single apis capacity tests"
 cd "$KIBANA_DIR"

--- a/.buildkite/scripts/steps/scalability/api_capacity_testing.sh
+++ b/.buildkite/scripts/steps/scalability/api_capacity_testing.sh
@@ -6,9 +6,9 @@ source .buildkite/scripts/common/util.sh
 
 source .buildkite/scripts/steps/scalability/util.sh
 
-#.buildkite/scripts/bootstrap.sh
-echo "--- yarn kbn reset && yarn kbn bootstrap"
-yarn kbn reset && yarn kbn bootstrap
+.buildkite/scripts/bootstrap.sh
+#echo "--- yarn kbn reset && yarn kbn bootstrap"
+#yarn kbn reset && yarn kbn bootstrap
 
 KIBANA_LOAD_TESTING_DIR="${KIBANA_DIR}/kibana-load-testing"
 # These tests are running on static workers so we must delete previous build, load runner and scalability artifacts

--- a/.buildkite/scripts/steps/scalability/api_capacity_testing.sh
+++ b/.buildkite/scripts/steps/scalability/api_capacity_testing.sh
@@ -6,16 +6,7 @@ source .buildkite/scripts/common/util.sh
 
 source .buildkite/scripts/steps/scalability/util.sh
 
-echo "--- yarn kbn bootstrap  --force-install"
-if ! yarn kbn bootstrap  --force-install; then
-  echo "bootstrap failed, trying again in 15 seconds"
-  sleep 15
-
-  rm -rf node_modules
-
-  echo "--- yarn kbn reset && yarn kbn bootstrap, attempt 2"
-  yarn kbn reset && yarn kbn bootstrap
-fi
+bootstrap_kibana
 
 KIBANA_LOAD_TESTING_DIR="${KIBANA_DIR}/kibana-load-testing"
 # These tests are running on static workers so we must delete previous build, load runner and scalability artifacts

--- a/.buildkite/scripts/steps/scalability/api_capacity_testing.sh
+++ b/.buildkite/scripts/steps/scalability/api_capacity_testing.sh
@@ -6,9 +6,16 @@ source .buildkite/scripts/common/util.sh
 
 source .buildkite/scripts/steps/scalability/util.sh
 
-.buildkite/scripts/bootstrap.sh
-#echo "--- yarn kbn reset && yarn kbn bootstrap"
-#yarn kbn reset && yarn kbn bootstrap
+echo "--- yarn kbn bootstrap  --force-install"
+if ! yarn kbn bootstrap  --force-install; then
+  echo "bootstrap failed, trying again in 15 seconds"
+  sleep 15
+
+  rm -rf node_modules
+
+  echo "--- yarn kbn reset && yarn kbn bootstrap, attempt 2"
+  yarn kbn reset && yarn kbn bootstrap
+fi
 
 KIBANA_LOAD_TESTING_DIR="${KIBANA_DIR}/kibana-load-testing"
 # These tests are running on static workers so we must delete previous build, load runner and scalability artifacts

--- a/.buildkite/scripts/steps/scalability/api_capacity_testing.sh
+++ b/.buildkite/scripts/steps/scalability/api_capacity_testing.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 
 source .buildkite/scripts/common/util.sh
 
+source .buildkite/scripts/steps/scalability/util.sh
+
 #.buildkite/scripts/bootstrap.sh
 echo "--- yarn kbn reset && yarn kbn bootstrap"
 yarn kbn reset && yarn kbn bootstrap
@@ -16,35 +18,8 @@ rm -rf "${KIBANA_LOAD_TESTING_DIR}"
 echo "--- Download the build artifacts"
 .buildkite/scripts/download_build_artifacts.sh
 
-checkout_and_compile_load_runner() {
-  mkdir -p "${KIBANA_LOAD_TESTING_DIR}" && cd "${KIBANA_LOAD_TESTING_DIR}"
-
-  if [[ ! -d .git ]]; then
-    git init
-    git remote add origin https://github.com/elastic/kibana-load-testing.git
-  fi
-  git fetch origin --depth 1 "main"
-  git reset --hard FETCH_HEAD
-
-  KIBANA_LOAD_TESTING_GIT_COMMIT="$(git rev-parse HEAD)"
-  export KIBANA_LOAD_TESTING_GIT_COMMIT
-
-  mvn -q test-compile
-  echo "Set 'GATLING_PROJECT_PATH' env var for ScalabilityTestRunner"
-  export GATLING_PROJECT_PATH="$(pwd)"
-}
-
-upload_test_results() {
-  cd "${KIBANA_DIR}"
-  echo "Upload server logs as build artifacts"
-  tar -czf server-logs.tar.gz data/ftr_servers_logs/**/*
-  buildkite-agent artifact upload server-logs.tar.gz
-  echo "--- Upload Gatling reports as build artifacts"
-  tar -czf "scalability_test_report.tar.gz" --exclude=simulation.log -C kibana-load-testing/target gatling
-  buildkite-agent artifact upload "scalability_test_report.tar.gz"
-}
-
 echo "--- Clone kibana-load-testing repo and compile project"
+mkdir -p "${KIBANA_LOAD_TESTING_DIR}" && cd "${KIBANA_LOAD_TESTING_DIR}"
 checkout_and_compile_load_runner
 
 echo "--- Run single apis capacity tests"

--- a/.buildkite/scripts/steps/scalability/benchmarking.sh
+++ b/.buildkite/scripts/steps/scalability/benchmarking.sh
@@ -75,13 +75,8 @@ cd "$KIBANA_DIR"
 echo "--- Download the latest artifacts from single user performance pipeline"
 download_artifacts
 
-if [ "$BUILDKITE_PIPELINE_SLUG" == "kibana-scalability-benchmarking-1" ]; then
-  echo "--- Run journey scalability tests"
-  node scripts/run_scalability --kibana-install-dir "$KIBANA_BUILD_LOCATION" --journey-path "scalability_traces/server"
-else
-  echo "--- Run single apis capacity tests"
-  node scripts/run_scalability --kibana-install-dir "$KIBANA_BUILD_LOCATION" --journey-path "x-pack/test/scalability/apis"
-fi
+echo "--- Run journey scalability tests"
+node scripts/run_scalability --kibana-install-dir "$KIBANA_BUILD_LOCATION" --journey-path "scalability_traces/server"
 
 echo "--- Upload test results"
 upload_test_results

--- a/.buildkite/scripts/steps/scalability/benchmarking.sh
+++ b/.buildkite/scripts/steps/scalability/benchmarking.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 
 source .buildkite/scripts/common/util.sh
 
+source .buildkite/scripts/steps/scalability/util.sh
+
 #.buildkite/scripts/bootstrap.sh
 echo "--- yarn kbn reset && yarn kbn bootstrap"
 yarn kbn reset && yarn kbn bootstrap
@@ -37,38 +39,8 @@ download_artifacts() {
   tar -xzf "${LATEST_RUN_ARTIFACTS_DIR}/scalability_traces.tar.gz"
 }
 
-checkout_and_compile_load_runner() {
-  mkdir -p "${KIBANA_LOAD_TESTING_DIR}" && cd "${KIBANA_LOAD_TESTING_DIR}"
-
-  if [[ ! -d .git ]]; then
-    git init
-    git remote add origin https://github.com/elastic/kibana-load-testing.git
-  fi
-  git fetch origin --depth 1 "main"
-  git reset --hard FETCH_HEAD
-
-  KIBANA_LOAD_TESTING_GIT_COMMIT="$(git rev-parse HEAD)"
-  export KIBANA_LOAD_TESTING_GIT_COMMIT
-
-  mvn -q test-compile
-  echo "Set 'GATLING_PROJECT_PATH' env var for ScalabilityTestRunner"
-  export GATLING_PROJECT_PATH="$(pwd)"
-}
-
-upload_test_results() {
-  cd "${KIBANA_DIR}"
-  echo "Upload server logs as build artifacts"
-  tar -czf server-logs.tar.gz data/ftr_servers_logs/**/*
-  buildkite-agent artifact upload server-logs.tar.gz
-  echo "--- Upload Gatling reports as build artifacts"
-  tar -czf "scalability_test_report.tar.gz" --exclude=simulation.log -C kibana-load-testing/target gatling
-  buildkite-agent artifact upload "scalability_test_report.tar.gz"
-  cd "${LATEST_RUN_ARTIFACTS_DIR}"
-  echo "Upload scalability traces as build artifacts"
-  buildkite-agent artifact upload "scalability_traces.tar.gz"
-}
-
 echo "--- Clone kibana-load-testing repo and compile project"
+mkdir -p "${KIBANA_LOAD_TESTING_DIR}" && cd "${KIBANA_LOAD_TESTING_DIR}"
 checkout_and_compile_load_runner
 
 cd "$KIBANA_DIR"
@@ -80,3 +52,7 @@ node scripts/run_scalability --kibana-install-dir "$KIBANA_BUILD_LOCATION" --jou
 
 echo "--- Upload test results"
 upload_test_results
+
+cd "${LATEST_RUN_ARTIFACTS_DIR}"
+echo "Upload scalability traces as build artifacts"
+buildkite-agent artifact upload "scalability_traces.tar.gz"

--- a/.buildkite/scripts/steps/scalability/benchmarking.sh
+++ b/.buildkite/scripts/steps/scalability/benchmarking.sh
@@ -6,9 +6,7 @@ source .buildkite/scripts/common/util.sh
 
 source .buildkite/scripts/steps/scalability/util.sh
 
-#.buildkite/scripts/bootstrap.sh
-echo "--- yarn kbn reset && yarn kbn bootstrap"
-yarn kbn reset && yarn kbn bootstrap
+bootstrap_kibana
 
 GCS_BUCKET="gs://kibana-performance/scalability-tests"
 GCS_ARTIFACTS_REL="gcs_artifacts"

--- a/.buildkite/scripts/steps/scalability/util.sh
+++ b/.buildkite/scripts/steps/scalability/util.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+checkout_and_compile_load_runner() {
+  if [[ ! -d .git ]]; then
+    git init
+    git remote add origin https://github.com/elastic/kibana-load-testing.git
+  fi
+  git fetch origin --depth 1 "main"
+  git reset --hard FETCH_HEAD
+
+  KIBANA_LOAD_TESTING_GIT_COMMIT="$(git rev-parse HEAD)"
+  export KIBANA_LOAD_TESTING_GIT_COMMIT
+
+  mvn -q test-compile
+  echo "Set 'GATLING_PROJECT_PATH' env var for ScalabilityTestRunner"
+  export GATLING_PROJECT_PATH="$(pwd)"
+}
+
+upload_test_results() {
+  echo "Upload server logs as build artifacts"
+  tar -czf server-logs.tar.gz data/ftr_servers_logs/**/*
+  buildkite-agent artifact upload server-logs.tar.gz
+  echo "--- Upload Gatling reports as build artifacts"
+  tar -czf "scalability_test_report.tar.gz" --exclude=simulation.log -C kibana-load-testing/target gatling
+  buildkite-agent artifact upload "scalability_test_report.tar.gz"
+}

--- a/.buildkite/scripts/steps/scalability/util.sh
+++ b/.buildkite/scripts/steps/scalability/util.sh
@@ -24,3 +24,16 @@ upload_test_results() {
   tar -czf "scalability_test_report.tar.gz" --exclude=simulation.log -C kibana-load-testing/target gatling
   buildkite-agent artifact upload "scalability_test_report.tar.gz"
 }
+
+bootstrap_kibana() {
+  echo "--- yarn kbn bootstrap  --force-install"
+  if ! yarn kbn bootstrap  --force-install; then
+    echo "bootstrap failed, trying again in 15 seconds"
+    sleep 15
+
+    rm -rf node_modules
+
+    echo "--- yarn kbn reset && yarn kbn bootstrap, attempt 2"
+    yarn kbn reset && yarn kbn bootstrap
+  fi
+}


### PR DESCRIPTION
## Summary

As a POC single api capacity testing pipeline was sharing pipeline steps & main script with scalability journey.
This pipeline does not build Kibana sources, but downloads existing Kibana build and run tests against it.

This PR moves capacity testing in its own script and its own pipeline that includes building Kibana sources and testing your changes.

cc @afharo 

It should be possible to test your Kibana changes for apis performance improvements.

<!--ONMERGE {"backportTargets":["8.6","8.7"]} ONMERGE-->