### PR TITLE
feat(slo): use apm index

### DIFF
--- a/x-pack/plugins/observability/public/hooks/slo/__storybook_mocks__/use_fetch_apm_suggestions.ts
+++ b/x-pack/plugins/observability/public/hooks/slo/__storybook_mocks__/use_fetch_apm_suggestions.ts
@@ -10,12 +10,12 @@ import { Params, UseFetchApmSuggestions } from '../use_fetch_apm_suggestions';
 export const useFetchApmSuggestions = ({
   fieldName,
   search = '',
+  serviceName = '',
 }: Params): UseFetchApmSuggestions => {
   return {
     isLoading: false,
     isError: false,
     isSuccess: true,
     suggestions: ['apm-suggestion-1', 'apm-suggestion-2', 'apm-suggestion-3'],
-    refetch: function () {} as UseFetchApmSuggestions['refetch'],
   };
 };

--- a/x-pack/plugins/observability/public/hooks/slo/use_fetch_apm_indices.ts
+++ b/x-pack/plugins/observability/public/hooks/slo/use_fetch_apm_indices.ts
@@ -51,6 +51,7 @@ export function useFetchApmIndex(): UseFetchApmIndex {
         // ignore error
       }
     },
+    refetchOnWindowFocus: false,
   });
 
   return {

--- a/x-pack/plugins/observability/public/hooks/slo/use_fetch_apm_indices.ts
+++ b/x-pack/plugins/observability/public/hooks/slo/use_fetch_apm_indices.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { HttpSetup } from '@kbn/core-http-browser';
+import { useCallback } from 'react';
+import { useDataFetcher } from '../use_data_fetcher';
+
+type ApmIndex = string;
+
+export interface UseFetchApmIndex {
+  data: ApmIndex;
+  loading: boolean;
+  error: boolean;
+}
+
+interface ApiResponse {
+  apmIndexSettings: Array<{
+    configurationName: string;
+    defaultValue: string;
+    savedValue?: string;
+  }>;
+}
+
+export function useFetchApmIndex(): UseFetchApmIndex {
+  const shouldExecuteApiCall = useCallback(() => true, []);
+
+  const { data, loading, error } = useDataFetcher<null, ApmIndex>({
+    paramsForApiCall: null,
+    initialDataState: '',
+    executeApiCall: fetchApmIndices,
+    shouldExecuteApiCall,
+  });
+
+  return { data, loading, error };
+}
+
+const fetchApmIndices = async (
+  params: null,
+  abortController: AbortController,
+  http: HttpSetup
+): Promise<ApmIndex> => {
+  try {
+    const response = await http.get<ApiResponse>('/internal/apm/settings/apm-index-settings', {
+      signal: abortController.signal,
+    });
+
+    const metricSettings = response.apmIndexSettings.find(
+      (settings) => settings.configurationName === 'metric'
+    );
+
+    let index = '';
+    if (!!metricSettings) {
+      index = metricSettings.savedValue ?? metricSettings.defaultValue;
+    }
+
+    return index;
+  } catch (error) {
+    // ignore error
+  }
+
+  return '';
+};

--- a/x-pack/plugins/observability/public/hooks/slo/use_fetch_apm_suggestions.ts
+++ b/x-pack/plugins/observability/public/hooks/slo/use_fetch_apm_suggestions.ts
@@ -5,12 +5,7 @@
  * 2.0.
  */
 
-import {
-  QueryObserverResult,
-  RefetchOptions,
-  RefetchQueryFilters,
-  useQuery,
-} from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import moment from 'moment';
 
 import { useKibana } from '../../utils/kibana_react';
@@ -21,9 +16,6 @@ export interface UseFetchApmSuggestions {
   isLoading: boolean;
   isSuccess: boolean;
   isError: boolean;
-  refetch: <TPageData>(
-    options?: (RefetchOptions & RefetchQueryFilters<TPageData>) | undefined
-  ) => Promise<QueryObserverResult<string[] | undefined, unknown>>;
 }
 
 export interface Params {
@@ -45,35 +37,32 @@ export function useFetchApmSuggestions({
 }: Params): UseFetchApmSuggestions {
   const { http } = useKibana().services;
 
-  const { isInitialLoading, isLoading, isError, isSuccess, isRefetching, data, refetch } = useQuery(
-    {
-      queryKey: ['fetchApmSuggestions', fieldName, search, serviceName],
-      queryFn: async ({ signal }) => {
-        try {
-          const { terms = [] } = await http.get<ApiResponse>('/internal/apm/suggestions', {
-            query: {
-              fieldName,
-              start: moment().subtract(2, 'days').toISOString(),
-              end: moment().toISOString(),
-              fieldValue: search,
-              ...(!!serviceName && { serviceName }),
-            },
-            signal,
-          });
+  const { isInitialLoading, isLoading, isError, isSuccess, isRefetching, data } = useQuery({
+    queryKey: ['fetchApmSuggestions', fieldName, search, serviceName],
+    queryFn: async ({ signal }) => {
+      try {
+        const { terms = [] } = await http.get<ApiResponse>('/internal/apm/suggestions', {
+          query: {
+            fieldName,
+            start: moment().subtract(2, 'days').toISOString(),
+            end: moment().toISOString(),
+            fieldValue: search,
+            ...(!!serviceName && { serviceName }),
+          },
+          signal,
+        });
 
-          return terms;
-        } catch (error) {
-          // ignore error for retrieving slos
-        }
-      },
-    }
-  );
+        return terms;
+      } catch (error) {
+        // ignore error
+      }
+    },
+  });
 
   return {
     suggestions: isInitialLoading ? EMPTY_RESPONSE.terms : data ?? EMPTY_RESPONSE.terms,
     isLoading: isInitialLoading || isLoading || isRefetching,
     isSuccess,
     isError,
-    refetch,
   };
 }

--- a/x-pack/plugins/observability/public/hooks/slo/use_fetch_apm_suggestions.ts
+++ b/x-pack/plugins/observability/public/hooks/slo/use_fetch_apm_suggestions.ts
@@ -57,6 +57,7 @@ export function useFetchApmSuggestions({
         // ignore error
       }
     },
+    refetchOnWindowFocus: false,
   });
 
   return {

--- a/x-pack/plugins/observability/public/hooks/slo/use_fetch_apm_suggestions.ts
+++ b/x-pack/plugins/observability/public/hooks/slo/use_fetch_apm_suggestions.ts
@@ -12,6 +12,7 @@ import {
   useQuery,
 } from '@tanstack/react-query';
 import moment from 'moment';
+
 import { useKibana } from '../../utils/kibana_react';
 
 export type Suggestion = string;
@@ -27,7 +28,8 @@ export interface UseFetchApmSuggestions {
 
 export interface Params {
   fieldName: string;
-  search: string;
+  search?: string;
+  serviceName?: string;
 }
 
 interface ApiResponse {
@@ -36,12 +38,16 @@ interface ApiResponse {
 
 const EMPTY_RESPONSE: ApiResponse = { terms: [] };
 
-export function useFetchApmSuggestions({ fieldName, search = '' }: Params): UseFetchApmSuggestions {
+export function useFetchApmSuggestions({
+  fieldName,
+  search = '',
+  serviceName = '',
+}: Params): UseFetchApmSuggestions {
   const { http } = useKibana().services;
 
   const { isInitialLoading, isLoading, isError, isSuccess, isRefetching, data, refetch } = useQuery(
     {
-      queryKey: ['fetchApmSuggestions', fieldName, search],
+      queryKey: ['fetchApmSuggestions', fieldName, search, serviceName],
       queryFn: async ({ signal }) => {
         try {
           const { terms = [] } = await http.get<ApiResponse>('/internal/apm/suggestions', {
@@ -50,6 +56,7 @@ export function useFetchApmSuggestions({ fieldName, search = '' }: Params): UseF
               start: moment().subtract(2, 'days').toISOString(),
               end: moment().toISOString(),
               fieldValue: search,
+              ...(!!serviceName && { serviceName }),
             },
             signal,
           });

--- a/x-pack/plugins/observability/public/hooks/slo/use_fetch_slo_details.ts
+++ b/x-pack/plugins/observability/public/hooks/slo/use_fetch_slo_details.ts
@@ -43,6 +43,7 @@ export function useFetchSloDetails(sloId: string): UseFetchSloDetailsResponse {
         }
       },
       enabled: Boolean(sloId),
+      refetchOnWindowFocus: false,
     }
   );
 

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/apm_availability/apm_availability_indicator_type_form.stories.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/apm_availability/apm_availability_indicator_type_form.stories.tsx
@@ -10,10 +10,7 @@ import { ComponentStory } from '@storybook/react';
 import { FormProvider, useForm } from 'react-hook-form';
 
 import { KibanaReactStorybookDecorator } from '../../../../utils/kibana_react.storybook_decorator';
-import {
-  ApmAvailabilityIndicatorTypeForm as Component,
-  Props,
-} from './apm_availability_indicator_type_form';
+import { ApmAvailabilityIndicatorTypeForm as Component } from './apm_availability_indicator_type_form';
 import { SLO_EDIT_FORM_DEFAULT_VALUES } from '../../constants';
 
 export default {
@@ -22,11 +19,11 @@ export default {
   decorators: [KibanaReactStorybookDecorator],
 };
 
-const Template: ComponentStory<typeof Component> = (props: Props) => {
+const Template: ComponentStory<typeof Component> = () => {
   const methods = useForm({ defaultValues: SLO_EDIT_FORM_DEFAULT_VALUES });
   return (
     <FormProvider {...methods}>
-      <Component {...props} control={methods.control} />
+      <Component />
     </FormProvider>
   );
 };

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/apm_availability/apm_availability_indicator_type_form.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/apm_availability/apm_availability_indicator_type_form.tsx
@@ -13,20 +13,15 @@ import {
   EuiFlexItem,
   EuiFormLabel,
 } from '@elastic/eui';
-import { Control, Controller, UseFormSetValue, UseFormWatch } from 'react-hook-form';
+import { Controller, useFormContext } from 'react-hook-form';
 import { i18n } from '@kbn/i18n';
 import type { CreateSLOInput } from '@kbn/slo-schema';
 
 import { useFetchApmIndex } from '../../../../hooks/slo/use_fetch_apm_indices';
 import { FieldSelector } from '../common/field_selector';
 
-export interface Props {
-  control: Control<CreateSLOInput>;
-  setValue: UseFormSetValue<CreateSLOInput>;
-  watch: UseFormWatch<CreateSLOInput>;
-}
-
-export function ApmAvailabilityIndicatorTypeForm({ control, setValue, watch }: Props) {
+export function ApmAvailabilityIndicatorTypeForm() {
+  const { control, setValue } = useFormContext<CreateSLOInput>();
   const { data: apmIndex } = useFetchApmIndex();
   useEffect(() => {
     setValue('indicator.params.index', apmIndex);
@@ -48,7 +43,6 @@ export function ApmAvailabilityIndicatorTypeForm({ control, setValue, watch }: P
           )}
           fieldName="service.name"
           name="indicator.params.service"
-          control={control}
           dataTestSubj="apmAvailabilityServiceSelector"
         />
         <FieldSelector
@@ -66,9 +60,7 @@ export function ApmAvailabilityIndicatorTypeForm({ control, setValue, watch }: P
           )}
           fieldName="service.environment"
           name="indicator.params.environment"
-          control={control}
           dataTestSubj="apmAvailabilityEnvironmentSelector"
-          selectedServiceName={watch('indicator.params.service')}
         />
       </EuiFlexGroup>
 
@@ -88,9 +80,7 @@ export function ApmAvailabilityIndicatorTypeForm({ control, setValue, watch }: P
           )}
           fieldName="transaction.type"
           name="indicator.params.transactionType"
-          control={control}
           dataTestSubj="apmAvailabilityTransactionTypeSelector"
-          selectedServiceName={watch('indicator.params.service')}
         />
         <FieldSelector
           label={i18n.translate(
@@ -107,9 +97,7 @@ export function ApmAvailabilityIndicatorTypeForm({ control, setValue, watch }: P
           )}
           fieldName="transaction.name"
           name="indicator.params.transactionName"
-          control={control}
           dataTestSubj="apmAvailabilityTransactionNameSelector"
-          selectedServiceName={watch('indicator.params.service')}
         />
       </EuiFlexGroup>
 

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/apm_availability/apm_availability_indicator_type_form.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/apm_availability/apm_availability_indicator_type_form.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import {
   EuiComboBox,
   EuiComboBoxOptionOption,
@@ -13,17 +13,24 @@ import {
   EuiFlexItem,
   EuiFormLabel,
 } from '@elastic/eui';
-import { Control, Controller } from 'react-hook-form';
+import { Control, Controller, UseFormSetValue } from 'react-hook-form';
 import { i18n } from '@kbn/i18n';
 import type { CreateSLOInput } from '@kbn/slo-schema';
 
+import { useFetchApmIndex } from '../../../../hooks/slo/use_fetch_apm_indices';
 import { FieldSelector } from '../common/field_selector';
 
 export interface Props {
   control: Control<CreateSLOInput>;
+  setValue: UseFormSetValue<CreateSLOInput>;
 }
 
-export function ApmAvailabilityIndicatorTypeForm({ control }: Props) {
+export function ApmAvailabilityIndicatorTypeForm({ control, setValue }: Props) {
+  const { data: apmIndex } = useFetchApmIndex();
+  useEffect(() => {
+    setValue('indicator.params.index', apmIndex);
+  }, [apmIndex, setValue]);
+
   return (
     <EuiFlexGroup direction="column" gutterSize="l">
       <EuiFlexGroup direction="row" gutterSize="l">

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/apm_availability/apm_availability_indicator_type_form.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/apm_availability/apm_availability_indicator_type_form.tsx
@@ -13,7 +13,7 @@ import {
   EuiFlexItem,
   EuiFormLabel,
 } from '@elastic/eui';
-import { Control, Controller, UseFormSetValue } from 'react-hook-form';
+import { Control, Controller, UseFormSetValue, UseFormWatch } from 'react-hook-form';
 import { i18n } from '@kbn/i18n';
 import type { CreateSLOInput } from '@kbn/slo-schema';
 
@@ -23,9 +23,10 @@ import { FieldSelector } from '../common/field_selector';
 export interface Props {
   control: Control<CreateSLOInput>;
   setValue: UseFormSetValue<CreateSLOInput>;
+  watch: UseFormWatch<CreateSLOInput>;
 }
 
-export function ApmAvailabilityIndicatorTypeForm({ control, setValue }: Props) {
+export function ApmAvailabilityIndicatorTypeForm({ control, setValue, watch }: Props) {
   const { data: apmIndex } = useFetchApmIndex();
   useEffect(() => {
     setValue('indicator.params.index', apmIndex);
@@ -67,6 +68,7 @@ export function ApmAvailabilityIndicatorTypeForm({ control, setValue }: Props) {
           name="indicator.params.environment"
           control={control}
           dataTestSubj="apmAvailabilityEnvironmentSelector"
+          selectedServiceName={watch('indicator.params.service')}
         />
       </EuiFlexGroup>
 
@@ -88,6 +90,7 @@ export function ApmAvailabilityIndicatorTypeForm({ control, setValue }: Props) {
           name="indicator.params.transactionType"
           control={control}
           dataTestSubj="apmAvailabilityTransactionTypeSelector"
+          selectedServiceName={watch('indicator.params.service')}
         />
         <FieldSelector
           label={i18n.translate(
@@ -106,6 +109,7 @@ export function ApmAvailabilityIndicatorTypeForm({ control, setValue }: Props) {
           name="indicator.params.transactionName"
           control={control}
           dataTestSubj="apmAvailabilityTransactionNameSelector"
+          selectedServiceName={watch('indicator.params.service')}
         />
       </EuiFlexGroup>
 
@@ -138,10 +142,14 @@ export function ApmAvailabilityIndicatorTypeForm({ control, setValue }: Props) {
                   }
                 )}
                 isInvalid={!!fieldState.error}
-                options={generateStatusCodeOptions()}
+                options={generateStatusCodeOptions(['2xx', '3xx', '4xx', '5xx'])}
                 selectedOptions={generateStatusCodeOptions(field.value)}
                 onChange={(selected: EuiComboBoxOptionOption[]) => {
-                  field.onChange(selected.map((opts) => opts.value));
+                  if (selected.length) {
+                    return field.onChange(selected.map((opts) => opts.value));
+                  }
+
+                  field.onChange([]);
                 }}
                 isClearable={true}
                 data-test-subj="sloEditApmAvailabilityGoodStatusCodesSelector"
@@ -155,7 +163,7 @@ export function ApmAvailabilityIndicatorTypeForm({ control, setValue }: Props) {
   );
 }
 
-function generateStatusCodeOptions(codes: string[] = ['2xx', '3xx', '4xx', '5xx']) {
+function generateStatusCodeOptions(codes: string[] = []) {
   return codes.map((code) => ({
     label: code,
     value: code,

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/apm_latency/apm_latency_indicator_type_form.stories.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/apm_latency/apm_latency_indicator_type_form.stories.tsx
@@ -10,7 +10,7 @@ import { ComponentStory } from '@storybook/react';
 import { FormProvider, useForm } from 'react-hook-form';
 
 import { KibanaReactStorybookDecorator } from '../../../../utils/kibana_react.storybook_decorator';
-import { ApmLatencyIndicatorTypeForm as Component, Props } from './apm_latency_indicator_type_form';
+import { ApmLatencyIndicatorTypeForm as Component } from './apm_latency_indicator_type_form';
 import { SLO_EDIT_FORM_DEFAULT_VALUES } from '../../constants';
 
 export default {
@@ -19,11 +19,11 @@ export default {
   decorators: [KibanaReactStorybookDecorator],
 };
 
-const Template: ComponentStory<typeof Component> = (props: Props) => {
+const Template: ComponentStory<typeof Component> = () => {
   const methods = useForm({ defaultValues: SLO_EDIT_FORM_DEFAULT_VALUES });
   return (
     <FormProvider {...methods}>
-      <Component {...props} control={methods.control} />
+      <Component />
     </FormProvider>
   );
 };

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/apm_latency/apm_latency_indicator_type_form.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/apm_latency/apm_latency_indicator_type_form.tsx
@@ -7,7 +7,7 @@
 
 import React, { useEffect } from 'react';
 import { EuiFieldNumber, EuiFlexGroup, EuiFlexItem, EuiFormLabel } from '@elastic/eui';
-import { Control, Controller, UseFormSetValue } from 'react-hook-form';
+import { Control, Controller, UseFormSetValue, UseFormWatch } from 'react-hook-form';
 import { i18n } from '@kbn/i18n';
 import type { CreateSLOInput } from '@kbn/slo-schema';
 
@@ -17,9 +17,10 @@ import { FieldSelector } from '../common/field_selector';
 export interface Props {
   control: Control<CreateSLOInput>;
   setValue: UseFormSetValue<CreateSLOInput>;
+  watch: UseFormWatch<CreateSLOInput>;
 }
 
-export function ApmLatencyIndicatorTypeForm({ control, setValue }: Props) {
+export function ApmLatencyIndicatorTypeForm({ control, setValue, watch }: Props) {
   const { data: apmIndex } = useFetchApmIndex();
   useEffect(() => {
     setValue('indicator.params.index', apmIndex);
@@ -58,6 +59,7 @@ export function ApmLatencyIndicatorTypeForm({ control, setValue }: Props) {
           name="indicator.params.environment"
           control={control}
           dataTestSubj="apmLatencyEnvironmentSelector"
+          selectedServiceName={watch('indicator.params.service')}
         />
       </EuiFlexGroup>
 
@@ -76,6 +78,7 @@ export function ApmLatencyIndicatorTypeForm({ control, setValue }: Props) {
           name="indicator.params.transactionType"
           control={control}
           dataTestSubj="apmLatencyTransactionTypeSelector"
+          selectedServiceName={watch('indicator.params.service')}
         />
         <FieldSelector
           label={i18n.translate('xpack.observability.slos.sloEdit.apmLatency.transactionName', {
@@ -91,6 +94,7 @@ export function ApmLatencyIndicatorTypeForm({ control, setValue }: Props) {
           name="indicator.params.transactionName"
           control={control}
           dataTestSubj="apmLatencyTransactionNameSelector"
+          selectedServiceName={watch('indicator.params.service')}
         />
       </EuiFlexGroup>
 

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/apm_latency/apm_latency_indicator_type_form.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/apm_latency/apm_latency_indicator_type_form.tsx
@@ -5,19 +5,26 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import { EuiFieldNumber, EuiFlexGroup, EuiFlexItem, EuiFormLabel } from '@elastic/eui';
-import { Control, Controller } from 'react-hook-form';
+import { Control, Controller, UseFormSetValue } from 'react-hook-form';
 import { i18n } from '@kbn/i18n';
 import type { CreateSLOInput } from '@kbn/slo-schema';
 
+import { useFetchApmIndex } from '../../../../hooks/slo/use_fetch_apm_indices';
 import { FieldSelector } from '../common/field_selector';
 
 export interface Props {
   control: Control<CreateSLOInput>;
+  setValue: UseFormSetValue<CreateSLOInput>;
 }
 
-export function ApmLatencyIndicatorTypeForm({ control }: Props) {
+export function ApmLatencyIndicatorTypeForm({ control, setValue }: Props) {
+  const { data: apmIndex } = useFetchApmIndex();
+  useEffect(() => {
+    setValue('indicator.params.index', apmIndex);
+  }, [apmIndex, setValue]);
+
   return (
     <EuiFlexGroup direction="column" gutterSize="l">
       <EuiFlexGroup direction="row" gutterSize="l">

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/apm_latency/apm_latency_indicator_type_form.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/apm_latency/apm_latency_indicator_type_form.tsx
@@ -7,20 +7,15 @@
 
 import React, { useEffect } from 'react';
 import { EuiFieldNumber, EuiFlexGroup, EuiFlexItem, EuiFormLabel } from '@elastic/eui';
-import { Control, Controller, UseFormSetValue, UseFormWatch } from 'react-hook-form';
+import { Controller, useFormContext } from 'react-hook-form';
 import { i18n } from '@kbn/i18n';
 import type { CreateSLOInput } from '@kbn/slo-schema';
 
 import { useFetchApmIndex } from '../../../../hooks/slo/use_fetch_apm_indices';
 import { FieldSelector } from '../common/field_selector';
 
-export interface Props {
-  control: Control<CreateSLOInput>;
-  setValue: UseFormSetValue<CreateSLOInput>;
-  watch: UseFormWatch<CreateSLOInput>;
-}
-
-export function ApmLatencyIndicatorTypeForm({ control, setValue, watch }: Props) {
+export function ApmLatencyIndicatorTypeForm() {
+  const { control, setValue } = useFormContext<CreateSLOInput>();
   const { data: apmIndex } = useFetchApmIndex();
   useEffect(() => {
     setValue('indicator.params.index', apmIndex);
@@ -42,7 +37,6 @@ export function ApmLatencyIndicatorTypeForm({ control, setValue, watch }: Props)
           )}
           fieldName="service.name"
           name="indicator.params.service"
-          control={control}
           dataTestSubj="apmLatencyServiceSelector"
         />
         <FieldSelector
@@ -57,9 +51,7 @@ export function ApmLatencyIndicatorTypeForm({ control, setValue, watch }: Props)
           )}
           fieldName="service.environment"
           name="indicator.params.environment"
-          control={control}
           dataTestSubj="apmLatencyEnvironmentSelector"
-          selectedServiceName={watch('indicator.params.service')}
         />
       </EuiFlexGroup>
 
@@ -76,9 +68,7 @@ export function ApmLatencyIndicatorTypeForm({ control, setValue, watch }: Props)
           )}
           fieldName="transaction.type"
           name="indicator.params.transactionType"
-          control={control}
           dataTestSubj="apmLatencyTransactionTypeSelector"
-          selectedServiceName={watch('indicator.params.service')}
         />
         <FieldSelector
           label={i18n.translate('xpack.observability.slos.sloEdit.apmLatency.transactionName', {
@@ -92,9 +82,7 @@ export function ApmLatencyIndicatorTypeForm({ control, setValue, watch }: Props)
           )}
           fieldName="transaction.name"
           name="indicator.params.transactionName"
-          control={control}
           dataTestSubj="apmLatencyTransactionNameSelector"
-          selectedServiceName={watch('indicator.params.service')}
         />
       </EuiFlexGroup>
 

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/common/field_selector.stories.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/common/field_selector.stories.tsx
@@ -23,7 +23,7 @@ const Template: ComponentStory<typeof Component> = (props: Props) => {
   const methods = useForm({ defaultValues: SLO_EDIT_FORM_DEFAULT_VALUES });
   return (
     <FormProvider {...methods}>
-      <Component {...props} control={methods.control} />
+      <Component {...props} />
     </FormProvider>
   );
 };

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/common/field_selector.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/common/field_selector.tsx
@@ -5,9 +5,9 @@
  * 2.0.
  */
 
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { EuiComboBox, EuiComboBoxOptionOption, EuiFlexItem, EuiFormLabel } from '@elastic/eui';
-import { Control, Controller, FieldPath } from 'react-hook-form';
+import { Controller, FieldPath, useFormContext } from 'react-hook-form';
 import { CreateSLOInput } from '@kbn/slo-schema';
 import { i18n } from '@kbn/i18n';
 import {
@@ -22,50 +22,42 @@ interface Option {
 
 export interface Props {
   allowAllOption?: boolean;
-  control: Control<CreateSLOInput>;
   dataTestSubj: string;
   fieldName: string;
   label: string;
   name: FieldPath<CreateSLOInput>;
   placeholder: string;
-  selectedServiceName?: string;
 }
 
 export function FieldSelector({
   allowAllOption = true,
-  control,
   dataTestSubj,
   fieldName,
   label,
   name,
   placeholder,
-  selectedServiceName,
 }: Props) {
+  const { control, watch } = useFormContext<CreateSLOInput>();
+  const serviceName = watch('indicator.params.service');
   const [search, setSearch] = useState<string>('');
   const { suggestions, isLoading } = useFetchApmSuggestions({
     fieldName,
     search,
-    serviceName: selectedServiceName,
+    serviceName,
   });
-  const [options, setOptions] = useState<Option[]>([]);
 
-  useEffect(() => {
-    const opts = (
-      allowAllOption
-        ? [
-            {
-              value: '*',
-              label: i18n.translate('xpack.observability.slos.sloEdit.fieldSelector.all', {
-                defaultMessage: 'All',
-              }),
-            },
-          ]
-        : []
-    ).concat(createOptions(suggestions));
-
-    setOptions(opts);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [suggestions.length]);
+  const options = (
+    allowAllOption
+      ? [
+          {
+            value: '*',
+            label: i18n.translate('xpack.observability.slos.sloEdit.fieldSelector.all', {
+              defaultMessage: 'All',
+            }),
+          },
+        ]
+      : []
+  ).concat(createOptions(suggestions));
 
   return (
     <EuiFlexItem>
@@ -84,7 +76,7 @@ export function FieldSelector({
             async
             data-test-subj={dataTestSubj}
             isClearable={true}
-            isDisabled={name !== 'indicator.params.service' && !selectedServiceName}
+            isDisabled={name !== 'indicator.params.service' && !serviceName}
             isInvalid={!!fieldState.error}
             isLoading={isLoading}
             onChange={(selected: EuiComboBoxOptionOption[]) => {

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/common/field_selector.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/common/field_selector.tsx
@@ -28,6 +28,7 @@ export interface Props {
   label: string;
   name: FieldPath<CreateSLOInput>;
   placeholder: string;
+  selectedServiceName?: string;
 }
 
 export function FieldSelector({
@@ -38,11 +39,13 @@ export function FieldSelector({
   label,
   name,
   placeholder,
+  selectedServiceName,
 }: Props) {
   const [search, setSearch] = useState<string>('');
   const { suggestions, isLoading } = useFetchApmSuggestions({
     fieldName,
     search,
+    serviceName: selectedServiceName,
   });
   const [options, setOptions] = useState<Option[]>([]);
 
@@ -81,6 +84,7 @@ export function FieldSelector({
             async
             data-test-subj={dataTestSubj}
             isClearable={true}
+            isDisabled={name !== 'indicator.params.service' && !selectedServiceName}
             isInvalid={!!fieldState.error}
             isLoading={isLoading}
             onChange={(selected: EuiComboBoxOptionOption[]) => {

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/custom_kql/custom_kql_indicator_type_form.stories.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/custom_kql/custom_kql_indicator_type_form.stories.tsx
@@ -10,7 +10,7 @@ import { ComponentStory } from '@storybook/react';
 import { FormProvider, useForm } from 'react-hook-form';
 
 import { KibanaReactStorybookDecorator } from '../../../../utils/kibana_react.storybook_decorator';
-import { CustomKqlIndicatorTypeForm as Component, Props } from './custom_kql_indicator_type_form';
+import { CustomKqlIndicatorTypeForm as Component } from './custom_kql_indicator_type_form';
 import { SLO_EDIT_FORM_DEFAULT_VALUES } from '../../constants';
 
 export default {
@@ -19,11 +19,11 @@ export default {
   decorators: [KibanaReactStorybookDecorator],
 };
 
-const Template: ComponentStory<typeof Component> = (props: Props) => {
+const Template: ComponentStory<typeof Component> = () => {
   const methods = useForm({ defaultValues: SLO_EDIT_FORM_DEFAULT_VALUES });
   return (
     <FormProvider {...methods}>
-      <Component {...props} control={methods.control} watch={methods.watch} />
+      <Component />
     </FormProvider>
   );
 };

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/custom_kql/custom_kql_indicator_type_form.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/custom_kql/custom_kql_indicator_type_form.tsx
@@ -8,18 +8,14 @@
 import React from 'react';
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { Control, UseFormWatch } from 'react-hook-form';
-import type { CreateSLOInput } from '@kbn/slo-schema';
+import { useFormContext } from 'react-hook-form';
+import { CreateSLOInput } from '@kbn/slo-schema';
 
 import { IndexSelection } from './index_selection';
 import { QueryBuilder } from './query_builder';
 
-export interface Props {
-  control: Control<CreateSLOInput>;
-  watch: UseFormWatch<CreateSLOInput>;
-}
-
-export function CustomKqlIndicatorTypeForm({ control, watch }: Props) {
+export function CustomKqlIndicatorTypeForm() {
+  const { control, watch } = useFormContext<CreateSLOInput>();
   return (
     <EuiFlexGroup direction="column" gutterSize="l">
       <EuiFlexItem>

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/slo_edit_form.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/slo_edit_form.tsx
@@ -124,9 +124,11 @@ export function SloEditForm({ slo }: Props) {
       case 'sli.kql.custom':
         return <CustomKqlIndicatorTypeForm control={control} watch={watch} />;
       case 'sli.apm.transactionDuration':
-        return <ApmLatencyIndicatorTypeForm control={control} setValue={setValue} />;
+        return <ApmLatencyIndicatorTypeForm control={control} setValue={setValue} watch={watch} />;
       case 'sli.apm.transactionErrorRate':
-        return <ApmAvailabilityIndicatorTypeForm control={control} setValue={setValue} />;
+        return (
+          <ApmAvailabilityIndicatorTypeForm control={control} setValue={setValue} watch={watch} />
+        );
       default:
         return null;
     }

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/slo_edit_form.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/slo_edit_form.tsx
@@ -53,7 +53,7 @@ export function SloEditForm({ slo }: Props) {
     notifications: { toasts },
   } = useKibana().services;
 
-  const { control, watch, getFieldState, getValues, formState } = useForm({
+  const { control, watch, getFieldState, getValues, formState, setValue } = useForm({
     defaultValues: SLO_EDIT_FORM_DEFAULT_VALUES,
     values: transformSloResponseToCreateSloInput(slo),
     mode: 'all',
@@ -124,9 +124,9 @@ export function SloEditForm({ slo }: Props) {
       case 'sli.kql.custom':
         return <CustomKqlIndicatorTypeForm control={control} watch={watch} />;
       case 'sli.apm.transactionDuration':
-        return <ApmLatencyIndicatorTypeForm control={control} />;
+        return <ApmLatencyIndicatorTypeForm control={control} setValue={setValue} />;
       case 'sli.apm.transactionErrorRate':
-        return <ApmAvailabilityIndicatorTypeForm control={control} />;
+        return <ApmAvailabilityIndicatorTypeForm control={control} setValue={setValue} />;
       default:
         return null;
     }

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/slo_edit_form.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/slo_edit_form.tsx
@@ -20,7 +20,7 @@ import {
 } from '@elastic/eui';
 import { euiThemeVars } from '@kbn/ui-theme';
 import { i18n } from '@kbn/i18n';
-import { Controller, useForm } from 'react-hook-form';
+import { Controller, FormProvider, useForm } from 'react-hook-form';
 import type { SLOWithSummaryResponse } from '@kbn/slo-schema';
 
 import { useKibana } from '../../../utils/kibana_react';
@@ -53,11 +53,12 @@ export function SloEditForm({ slo }: Props) {
     notifications: { toasts },
   } = useKibana().services;
 
-  const { control, watch, getFieldState, getValues, formState, setValue } = useForm({
+  const methods = useForm({
     defaultValues: SLO_EDIT_FORM_DEFAULT_VALUES,
     values: transformSloResponseToCreateSloInput(slo),
     mode: 'all',
   });
+  const { control, watch, getFieldState, getValues, formState } = methods;
 
   const { isIndicatorSectionValid, isDescriptionSectionValid, isObjectiveSectionValid } =
     useSectionFormValidation({
@@ -122,161 +123,165 @@ export function SloEditForm({ slo }: Props) {
   const getIndicatorTypeForm = () => {
     switch (watch('indicator.type')) {
       case 'sli.kql.custom':
-        return <CustomKqlIndicatorTypeForm control={control} watch={watch} />;
+        return <CustomKqlIndicatorTypeForm />;
       case 'sli.apm.transactionDuration':
-        return <ApmLatencyIndicatorTypeForm control={control} setValue={setValue} watch={watch} />;
+        return <ApmLatencyIndicatorTypeForm />;
       case 'sli.apm.transactionErrorRate':
-        return (
-          <ApmAvailabilityIndicatorTypeForm control={control} setValue={setValue} watch={watch} />
-        );
+        return <ApmAvailabilityIndicatorTypeForm />;
       default:
         return null;
     }
   };
 
   return (
-    <EuiTimeline data-test-subj="sloForm">
-      <EuiTimelineItem
-        verticalAlign="top"
-        icon={
-          <EuiAvatar
-            color={
-              isIndicatorSectionValid ? euiThemeVars.euiColorSuccess : euiThemeVars.euiColorPrimary
-            }
-            iconType={isIndicatorSectionValid ? 'check' : ''}
-            name={isIndicatorSectionValid ? 'Check' : '1'}
-          />
-        }
-      >
-        <EuiPanel hasBorder={false} hasShadow={false} paddingSize="none" style={{ maxWidth }}>
-          <EuiTitle>
-            <h2>
-              {i18n.translate('xpack.observability.slos.sloEdit.definition.title', {
-                defaultMessage: 'Define SLI',
+    <FormProvider {...methods}>
+      <EuiTimeline data-test-subj="sloForm">
+        <EuiTimelineItem
+          verticalAlign="top"
+          icon={
+            <EuiAvatar
+              color={
+                isIndicatorSectionValid
+                  ? euiThemeVars.euiColorSuccess
+                  : euiThemeVars.euiColorPrimary
+              }
+              iconType={isIndicatorSectionValid ? 'check' : ''}
+              name={isIndicatorSectionValid ? 'Check' : '1'}
+            />
+          }
+        >
+          <EuiPanel hasBorder={false} hasShadow={false} paddingSize="none" style={{ maxWidth }}>
+            <EuiTitle>
+              <h2>
+                {i18n.translate('xpack.observability.slos.sloEdit.definition.title', {
+                  defaultMessage: 'Define SLI',
+                })}
+              </h2>
+            </EuiTitle>
+
+            <EuiSpacer size="xl" />
+
+            <EuiFormLabel>
+              {i18n.translate('xpack.observability.slos.sloEdit.definition.sliType', {
+                defaultMessage: 'SLI type',
               })}
-            </h2>
-          </EuiTitle>
+            </EuiFormLabel>
 
-          <EuiSpacer size="xl" />
+            <Controller
+              name="indicator.type"
+              control={control}
+              rules={{ required: true }}
+              render={({ field: { ref, ...field } }) => (
+                <EuiSelect
+                  data-test-subj="sloFormIndicatorTypeSelect"
+                  {...field}
+                  options={SLI_OPTIONS}
+                />
+              )}
+            />
 
-          <EuiFormLabel>
-            {i18n.translate('xpack.observability.slos.sloEdit.definition.sliType', {
-              defaultMessage: 'SLI type',
-            })}
-          </EuiFormLabel>
+            <EuiSpacer size="xxl" />
 
-          <Controller
-            name="indicator.type"
-            control={control}
-            rules={{ required: true }}
-            render={({ field: { ref, ...field } }) => (
-              <EuiSelect
-                data-test-subj="sloFormIndicatorTypeSelect"
-                {...field}
-                options={SLI_OPTIONS}
-              />
-            )}
-          />
+            {getIndicatorTypeForm()}
 
-          <EuiSpacer size="xxl" />
+            <EuiSpacer size="m" />
+          </EuiPanel>
+        </EuiTimelineItem>
 
-          {getIndicatorTypeForm()}
+        <EuiTimelineItem
+          icon={
+            <EuiAvatar
+              color={
+                isObjectiveSectionValid
+                  ? euiThemeVars.euiColorSuccess
+                  : euiThemeVars.euiColorPrimary
+              }
+              iconType={isObjectiveSectionValid ? 'check' : ''}
+              name={isObjectiveSectionValid ? 'Check' : '2'}
+            />
+          }
+          verticalAlign="top"
+        >
+          <EuiPanel hasBorder={false} hasShadow={false} paddingSize="none" style={{ maxWidth }}>
+            <EuiTitle>
+              <h2>
+                {i18n.translate('xpack.observability.slos.sloEdit.objectives.title', {
+                  defaultMessage: 'Set objectives',
+                })}
+              </h2>
+            </EuiTitle>
 
-          <EuiSpacer size="m" />
-        </EuiPanel>
-      </EuiTimelineItem>
+            <EuiSpacer size="xl" />
 
-      <EuiTimelineItem
-        icon={
-          <EuiAvatar
-            color={
-              isObjectiveSectionValid ? euiThemeVars.euiColorSuccess : euiThemeVars.euiColorPrimary
-            }
-            iconType={isObjectiveSectionValid ? 'check' : ''}
-            name={isObjectiveSectionValid ? 'Check' : '2'}
-          />
-        }
-        verticalAlign="top"
-      >
-        <EuiPanel hasBorder={false} hasShadow={false} paddingSize="none" style={{ maxWidth }}>
-          <EuiTitle>
-            <h2>
-              {i18n.translate('xpack.observability.slos.sloEdit.objectives.title', {
-                defaultMessage: 'Set objectives',
-              })}
-            </h2>
-          </EuiTitle>
+            <SloEditFormObjectives />
 
-          <EuiSpacer size="xl" />
+            <EuiSpacer size="xl" />
+          </EuiPanel>
+        </EuiTimelineItem>
 
-          <SloEditFormObjectives control={control} watch={watch} />
+        <EuiTimelineItem
+          verticalAlign="top"
+          icon={
+            <EuiAvatar
+              name={isDescriptionSectionValid ? 'Check' : '3'}
+              iconType={isDescriptionSectionValid ? 'check' : ''}
+              color={
+                isDescriptionSectionValid
+                  ? euiThemeVars.euiColorSuccess
+                  : euiThemeVars.euiColorPrimary
+              }
+            />
+          }
+        >
+          <EuiPanel hasBorder={false} hasShadow={false} paddingSize="none" style={{ maxWidth }}>
+            <EuiTitle>
+              <h2>
+                {i18n.translate('xpack.observability.slos.sloEdit.description.title', {
+                  defaultMessage: 'Describe SLO',
+                })}
+              </h2>
+            </EuiTitle>
 
-          <EuiSpacer size="xl" />
-        </EuiPanel>
-      </EuiTimelineItem>
+            <EuiSpacer size="xl" />
 
-      <EuiTimelineItem
-        verticalAlign="top"
-        icon={
-          <EuiAvatar
-            name={isDescriptionSectionValid ? 'Check' : '3'}
-            iconType={isDescriptionSectionValid ? 'check' : ''}
-            color={
-              isDescriptionSectionValid
-                ? euiThemeVars.euiColorSuccess
-                : euiThemeVars.euiColorPrimary
-            }
-          />
-        }
-      >
-        <EuiPanel hasBorder={false} hasShadow={false} paddingSize="none" style={{ maxWidth }}>
-          <EuiTitle>
-            <h2>
-              {i18n.translate('xpack.observability.slos.sloEdit.description.title', {
-                defaultMessage: 'Describe SLO',
-              })}
-            </h2>
-          </EuiTitle>
+            <SloEditFormDescription />
 
-          <EuiSpacer size="xl" />
+            <EuiSpacer size="xl" />
 
-          <SloEditFormDescription control={control} />
+            <EuiFlexGroup direction="row" gutterSize="s">
+              <EuiButton
+                color="primary"
+                data-test-subj="sloFormSubmitButton"
+                fill
+                disabled={!formState.isValid}
+                isLoading={isCreateSloLoading || isUpdateSloLoading}
+                onClick={handleSubmit}
+              >
+                {isEditMode
+                  ? i18n.translate('xpack.observability.slos.sloEdit.editSloButton', {
+                      defaultMessage: 'Update SLO',
+                    })
+                  : i18n.translate('xpack.observability.slos.sloEdit.createSloButton', {
+                      defaultMessage: 'Create SLO',
+                    })}
+              </EuiButton>
 
-          <EuiSpacer size="xl" />
+              <EuiButton
+                color="ghost"
+                data-test-subj="sloFormCancelButton"
+                fill
+                onClick={() => navigateToUrl(basePath.prepend(paths.observability.slos))}
+              >
+                {i18n.translate('xpack.observability.slos.sloEdit.cancelButton', {
+                  defaultMessage: 'Cancel',
+                })}
+              </EuiButton>
+            </EuiFlexGroup>
 
-          <EuiFlexGroup direction="row" gutterSize="s">
-            <EuiButton
-              color="primary"
-              data-test-subj="sloFormSubmitButton"
-              fill
-              disabled={!formState.isValid}
-              isLoading={isCreateSloLoading || isUpdateSloLoading}
-              onClick={handleSubmit}
-            >
-              {isEditMode
-                ? i18n.translate('xpack.observability.slos.sloEdit.editSloButton', {
-                    defaultMessage: 'Update SLO',
-                  })
-                : i18n.translate('xpack.observability.slos.sloEdit.createSloButton', {
-                    defaultMessage: 'Create SLO',
-                  })}
-            </EuiButton>
-
-            <EuiButton
-              color="ghost"
-              data-test-subj="sloFormCancelButton"
-              fill
-              onClick={() => navigateToUrl(basePath.prepend(paths.observability.slos))}
-            >
-              {i18n.translate('xpack.observability.slos.sloEdit.cancelButton', {
-                defaultMessage: 'Cancel',
-              })}
-            </EuiButton>
-          </EuiFlexGroup>
-
-          <EuiSpacer size="xl" />
-        </EuiPanel>
-      </EuiTimelineItem>
-    </EuiTimeline>
+            <EuiSpacer size="xl" />
+          </EuiPanel>
+        </EuiTimelineItem>
+      </EuiTimeline>
+    </FormProvider>
   );
 }

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/slo_edit_form_description.stories.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/slo_edit_form_description.stories.tsx
@@ -10,7 +10,7 @@ import { ComponentStory } from '@storybook/react';
 import { FormProvider, useForm } from 'react-hook-form';
 
 import { KibanaReactStorybookDecorator } from '../../../utils/kibana_react.storybook_decorator';
-import { SloEditFormDescription as Component, Props } from './slo_edit_form_description';
+import { SloEditFormDescription as Component } from './slo_edit_form_description';
 import { SLO_EDIT_FORM_DEFAULT_VALUES } from '../constants';
 
 export default {
@@ -19,11 +19,11 @@ export default {
   decorators: [KibanaReactStorybookDecorator],
 };
 
-const Template: ComponentStory<typeof Component> = (props: Props) => {
+const Template: ComponentStory<typeof Component> = () => {
   const methods = useForm({ defaultValues: SLO_EDIT_FORM_DEFAULT_VALUES });
   return (
     <FormProvider {...methods}>
-      <Component {...props} control={methods.control} />
+      <Component />
     </FormProvider>
   );
 };

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/slo_edit_form_description.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/slo_edit_form_description.tsx
@@ -15,14 +15,11 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
-import { Control, Controller } from 'react-hook-form';
+import { Controller, useFormContext } from 'react-hook-form';
 import type { CreateSLOInput } from '@kbn/slo-schema';
 
-export interface Props {
-  control: Control<CreateSLOInput>;
-}
-
-export function SloEditFormDescription({ control }: Props) {
+export function SloEditFormDescription() {
+  const { control } = useFormContext<CreateSLOInput>();
   const sloNameId = useGeneratedHtmlId({ prefix: 'sloName' });
   const descriptionId = useGeneratedHtmlId({ prefix: 'sloDescription' });
 

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/slo_edit_form_objectives.stories.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/slo_edit_form_objectives.stories.tsx
@@ -10,7 +10,7 @@ import { ComponentStory } from '@storybook/react';
 import { FormProvider, useForm } from 'react-hook-form';
 
 import { KibanaReactStorybookDecorator } from '../../../utils/kibana_react.storybook_decorator';
-import { SloEditFormObjectives as Component, Props } from './slo_edit_form_objectives';
+import { SloEditFormObjectives as Component } from './slo_edit_form_objectives';
 import { SLO_EDIT_FORM_DEFAULT_VALUES } from '../constants';
 
 export default {
@@ -19,11 +19,11 @@ export default {
   decorators: [KibanaReactStorybookDecorator],
 };
 
-const Template: ComponentStory<typeof Component> = (props: Props) => {
+const Template: ComponentStory<typeof Component> = () => {
   const methods = useForm({ defaultValues: SLO_EDIT_FORM_DEFAULT_VALUES });
   return (
     <FormProvider {...methods}>
-      <Component {...props} control={methods.control} watch={methods.watch} />
+      <Component />
     </FormProvider>
   );
 };

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/slo_edit_form_objectives.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/slo_edit_form_objectives.tsx
@@ -16,18 +16,14 @@ import {
   useGeneratedHtmlId,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { Control, Controller, UseFormWatch } from 'react-hook-form';
+import { Controller, useFormContext } from 'react-hook-form';
 import type { CreateSLOInput } from '@kbn/slo-schema';
 
 import { SloEditFormObjectivesTimeslices } from './slo_edit_form_objectives_timeslices';
 import { BUDGETING_METHOD_OPTIONS, TIMEWINDOW_OPTIONS } from '../constants';
 
-export interface Props {
-  control: Control<CreateSLOInput>;
-  watch: UseFormWatch<CreateSLOInput>;
-}
-
-export function SloEditFormObjectives({ control, watch }: Props) {
+export function SloEditFormObjectives() {
+  const { control, watch } = useFormContext<CreateSLOInput>();
   const budgetingSelect = useGeneratedHtmlId({ prefix: 'budgetingSelect' });
   const timeWindowSelect = useGeneratedHtmlId({ prefix: 'timeWindowSelect' });
 
@@ -112,7 +108,7 @@ export function SloEditFormObjectives({ control, watch }: Props) {
       {watch('budgetingMethod') === 'timeslices' ? (
         <>
           <EuiSpacer size="xl" />
-          <SloEditFormObjectivesTimeslices control={control} />
+          <SloEditFormObjectivesTimeslices />
         </>
       ) : null}
     </>

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/slo_edit_form_objectives_timeslices.stories.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/slo_edit_form_objectives_timeslices.stories.tsx
@@ -10,10 +10,7 @@ import { ComponentStory } from '@storybook/react';
 import { FormProvider, useForm } from 'react-hook-form';
 
 import { KibanaReactStorybookDecorator } from '../../../utils/kibana_react.storybook_decorator';
-import {
-  SloEditFormObjectivesTimeslices as Component,
-  Props,
-} from './slo_edit_form_objectives_timeslices';
+import { SloEditFormObjectivesTimeslices as Component } from './slo_edit_form_objectives_timeslices';
 import { SLO_EDIT_FORM_DEFAULT_VALUES } from '../constants';
 
 export default {
@@ -22,11 +19,11 @@ export default {
   decorators: [KibanaReactStorybookDecorator],
 };
 
-const Template: ComponentStory<typeof Component> = (props: Props) => {
+const Template: ComponentStory<typeof Component> = () => {
   const methods = useForm({ defaultValues: SLO_EDIT_FORM_DEFAULT_VALUES });
   return (
     <FormProvider {...methods}>
-      <Component {...props} control={methods.control} />
+      <Component />
     </FormProvider>
   );
 };

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/slo_edit_form_objectives_timeslices.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/slo_edit_form_objectives_timeslices.tsx
@@ -8,14 +8,11 @@
 import React from 'react';
 import { EuiFieldNumber, EuiFlexGrid, EuiFlexItem, EuiFormLabel } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { Control, Controller } from 'react-hook-form';
+import { Controller, useFormContext } from 'react-hook-form';
 import type { CreateSLOInput } from '@kbn/slo-schema';
 
-export interface Props {
-  control: Control<CreateSLOInput>;
-}
-
-export function SloEditFormObjectivesTimeslices({ control }: Props) {
+export function SloEditFormObjectivesTimeslices() {
+  const { control } = useFormContext<CreateSLOInput>();
   return (
     <EuiFlexGrid columns={3}>
       <EuiFlexItem>

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/apm_transaction_duration.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/apm_transaction_duration.ts
@@ -22,6 +22,7 @@ import { SLO, APMTransactionDurationIndicator } from '../../../domain/models';
 import { getElastichsearchQueryOrThrow, TransformGenerator } from '.';
 import { DEFAULT_APM_INDEX } from './constants';
 import { Query } from './types';
+import { parseIndex } from './common';
 
 export class ApmTransactionDurationTransformGenerator extends TransformGenerator {
   public getTransformParams(slo: SLO): TransformPutTransformRequest {
@@ -91,7 +92,7 @@ export class ApmTransactionDurationTransformGenerator extends TransformGenerator
     }
 
     return {
-      index: indicator.params.index ?? DEFAULT_APM_INDEX,
+      index: parseIndex(indicator.params.index ?? DEFAULT_APM_INDEX),
       runtime_mappings: this.buildCommonRuntimeMappings(slo),
       query: {
         bool: {

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/apm_transaction_error_rate.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/apm_transaction_error_rate.ts
@@ -23,6 +23,7 @@ import {
 import { APMTransactionErrorRateIndicator, SLO } from '../../../domain/models';
 import { DEFAULT_APM_INDEX } from './constants';
 import { Query } from './types';
+import { parseIndex } from './common';
 
 const ALLOWED_STATUS_CODES = ['2xx', '3xx', '4xx', '5xx'];
 const DEFAULT_GOOD_STATUS_CODES = ['2xx', '3xx', '4xx'];
@@ -96,7 +97,7 @@ export class ApmTransactionErrorRateTransformGenerator extends TransformGenerato
     }
 
     return {
-      index: indicator.params.index ?? DEFAULT_APM_INDEX,
+      index: parseIndex(indicator.params.index ?? DEFAULT_APM_INDEX),
       runtime_mappings: this.buildCommonRuntimeMappings(slo),
       query: {
         bool: {

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/common.test.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/common.test.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { parseIndex } from './common';
+
+describe('common', () => {
+  describe('parseIndex', () => {
+    it.each([
+      ['foo-*', 'foo-*'],
+      ['foo-*,bar-*', ['foo-*', 'bar-*']],
+      ['remote:foo-*', 'remote:foo-*'],
+      ['remote:foo*,bar-*', ['remote:foo*', 'remote:bar-*']],
+    ])("parses the index '%s' correctly", (index, expected) => {
+      expect(parseIndex(index)).toEqual(expected);
+    });
+  });
+});

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/common.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/common.ts
@@ -15,3 +15,17 @@ export function getElastichsearchQueryOrThrow(kuery: string) {
     throw new InvalidTransformError(`Invalid KQL: ${kuery}`);
   }
 }
+
+export function parseIndex(index: string): string | string[] {
+  if (index.indexOf(',') > -1) {
+    if (index.indexOf(':') > -1) {
+      const indexParts = index.split(':'); // "remote_name:foo-*,bar*"
+      const remoteName = indexParts[0];
+      return indexParts[1].split(',').map((idx) => `${remoteName}:${idx}`); // [ "remote_name:foo-*", "remote_name:bar-*"]
+    }
+
+    return index.split(',');
+  }
+
+  return index;
+}


### PR DESCRIPTION
## 📝  Summary

Resolves https://github.com/elastic/kibana/issues/150911

This PR uses the internal apm indices endpoint to fetch the metric apm index to use when creating/editing an SLO with APM indicator types.
It also filters the APM suggestions using the selected service name to avoid showing suggestions from other services.

I've also introduced the FormContext to remove the need to pass down the react form methods... Much simpler

## Screenshot

Title | Screenshot
-- | --
When no service is selected, disable other FieldSelector | ![image](https://user-images.githubusercontent.com/1376800/220761393-d8d85ad2-8b3b-4cc6-af39-acb31e551443.png)
Show suggestion related to selected service name | ![image](https://user-images.githubusercontent.com/1376800/220761554-c38346c7-3773-48b8-ad9b-b7a6b65f0ac0.png)

