### PR TITLE
[DOCS] Removes 8.7 tag

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -44,8 +44,6 @@ Review important information about the {kib} 8.7.0 release.
 [[release-notes-8.7.0]]
 == {kib} 8.7.0
 
-coming::[8.7.0]
-
 Review the following information about the {kib} 8.7.0 release.
 
 [float]


### PR DESCRIPTION
## Summary

Removes the `coming` tag from the 8.7.0 release notes.
