### PR TITLE
[RAM] Add strict_date_optional_time to excludeHitsFromPreviousRun time range query for ES query rule

### DIFF
--- a/x-pack/plugins/stack_alerts/server/rule_types/es_query/lib/fetch_search_source_query.test.ts
+++ b/x-pack/plugins/stack_alerts/server/rule_types/es_query/lib/fetch_search_source_query.test.ts
@@ -124,6 +124,7 @@ describe('fetchSearchSourceQuery', () => {
               Object {
                 "range": Object {
                   "time": Object {
+                    "format": "strict_date_optional_time",
                     "gt": "2020-02-09T23:12:41.941Z",
                   },
                 },

--- a/x-pack/plugins/stack_alerts/server/rule_types/es_query/lib/fetch_search_source_query.ts
+++ b/x-pack/plugins/stack_alerts/server/rule_types/es_query/lib/fetch_search_source_query.ts
@@ -122,7 +122,11 @@ export function updateSearchSource(
       // add additional filter for documents with a timestamp greater then
       // the timestamp of the previous run, so that those documents are not counted twice
       const field = index.fields.find((f) => f.name === timeFieldName);
-      const addTimeRangeField = buildRangeFilter(field!, { gt: latestTimestamp }, index);
+      const addTimeRangeField = buildRangeFilter(
+        field!,
+        { gt: latestTimestamp, format: 'strict_date_optional_time' },
+        index
+      );
       filters.push(addTimeRangeField);
     }
   }


### PR DESCRIPTION
## Summary
Resolves: https://github.com/elastic/kibana/issues/150448

Adds `strict_date_optional_time` to the `excludeHitsFromPreviousRun` last timestamp range query to allow querying data views with non-ISO `timefields`. This fixes the crash that occurred when we didn't have this field when the ES query ran consecutively to exclude previous hits for data views with non-iso time fields.

### To test:

##### 1. Create mapping with date with non-ISO format
```
PUT test-index
{
  "mappings": {
    "properties": {
      "date": {
        "type": "date",
        "format": "epoch_second"
      },
      "test_field": {
        "type": "keyword"
      }
    }
  }
}
```
##### 2. Insert test data
```
PUT test-index/_bulk?refresh
{ "index" : { "_id" : "1" } }
{ "date": 1677105176, "test_field": "hi"}
{ "index" : { "_id" : "2" } }
{ "date": 1677108776, "test_field": "bye"}
```

##### 3. Create data view with the `date` as the time field.

##### 4. Create a Elasticsearch query rule with KQL, making sure `Exclude matches from previous runs` is checked. Let rule run twice to generate alerts

##### 5. The rule should run without errors (especially after the first run). Before this fix, the rule would error after 1 run.

### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

<!--ONMERGE {"backportTargets":["8.6","8.7"]} ONMERGE-->