### PR TITLE
[8.7] [AO] Improve refreshing alert summary widget on the rule details page (#151645)

### DIFF
--- a/x-pack/plugins/observability/public/pages/rule_details/index.tsx
+++ b/x-pack/plugins/observability/public/pages/rule_details/index.tsx
@@ -39,7 +39,10 @@ import { ValidFeatureId } from '@kbn/rule-data-utils';
 import { RuleDefinitionProps } from '@kbn/triggers-actions-ui-plugin/public';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { fromQuery, toQuery } from '../../utils/url';
-import { getDefaultAlertSummaryTimeRange } from '../../utils/alert_summary_widget';
+import {
+  defaultTimeRange,
+  getDefaultAlertSummaryTimeRange,
+} from '../../utils/alert_summary_widget';
 import { ObservabilityAlertSearchbarWithUrlSync } from '../../components/shared/alert_search_bar';
 import { DeleteModalConfirmation } from './components/delete_modal_confirmation';
 import { CenterJustifiedSpinner } from './components/center_justified_spinner';
@@ -73,11 +76,11 @@ export function RuleDetailsPage() {
     triggersActionsUi: {
       alertsTableConfigurationRegistry,
       ruleTypeRegistry,
-      getEditAlertFlyout,
+      getEditAlertFlyout: EditAlertFlyout,
       getRuleEventLogList,
       getAlertsStateTable: AlertsStateTable,
       getAlertSummaryWidget: AlertSummaryWidget,
-      getRuleStatusPanel,
+      getRuleStatusPanel: RuleStatusPanel,
       getRuleDefinition,
     },
     application: { capabilities, navigateToUrl },
@@ -130,13 +133,16 @@ export function RuleDetailsPage() {
   });
   const tabsRef = useRef<HTMLDivElement>(null);
 
+  useEffect(() => {
+    setAlertSummaryWidgetTimeRange(getDefaultAlertSummaryTimeRange());
+  }, [esQuery]);
+
   const onAlertSummaryWidgetClick = async (status: AlertStatus = ALERT_STATUS_ALL) => {
-    const timeRange = getDefaultAlertSummaryTimeRange();
-    setAlertSummaryWidgetTimeRange(timeRange);
+    setAlertSummaryWidgetTimeRange(getDefaultAlertSummaryTimeRange());
     await locators.get(ruleDetailsLocatorID)?.navigate(
       {
-        rangeFrom: timeRange.utcFrom,
-        rangeTo: timeRange.utcTo,
+        rangeFrom: defaultTimeRange.from,
+        rangeTo: defaultTimeRange.to,
         ruleId,
         status,
         tabId: ALERTS_TAB,
@@ -387,13 +393,13 @@ export function RuleDetailsPage() {
     >
       <EuiFlexGroup wrap gutterSize="m">
         <EuiFlexItem style={{ minWidth: 350 }}>
-          {getRuleStatusPanel({
-            rule,
-            isEditable: hasEditButton,
-            requestRefresh: reloadRule,
-            healthColor: getHealthColor(rule.executionStatus.status),
-            statusMessage,
-          })}
+          <RuleStatusPanel
+            rule={rule}
+            isEditable={hasEditButton}
+            requestRefresh={reloadRule}
+            healthColor={getHealthColor(rule.executionStatus.status)}
+            statusMessage={statusMessage}
+          />
         </EuiFlexItem>
         <EuiFlexItem style={{ minWidth: 350 }}>
           <AlertSummaryWidget
@@ -417,14 +423,15 @@ export function RuleDetailsPage() {
           onTabIdChange(tab.id as TabId);
         }}
       />
-      {editFlyoutVisible &&
-        getEditAlertFlyout({
-          initialRule: rule,
-          onClose: () => {
+      {editFlyoutVisible && (
+        <EditAlertFlyout
+          initialRule={rule}
+          onClose={() => {
             setEditFlyoutVisible(false);
-          },
-          onSave: reloadRule,
-        })}
+          }}
+          onSave={reloadRule}
+        />
+      )}
       <DeleteModalConfirmation
         onDeleted={() => {
           setRuleToDelete([]);

--- a/x-pack/plugins/observability/public/utils/alert_summary_widget/constants.ts
+++ b/x-pack/plugins/observability/public/utils/alert_summary_widget/constants.ts
@@ -5,8 +5,7 @@
  * 2.0.
  */
 
-export { defaultTimeRange } from './constants';
-export {
-  getDefaultAlertSummaryTimeRange,
-  getAlertSummaryTimeRange,
-} from './get_alert_summary_time_range';
+export const defaultTimeRange = {
+  from: 'now-30d',
+  to: 'now',
+};

--- a/x-pack/plugins/observability/public/utils/alert_summary_widget/get_alert_summary_time_range.tsx
+++ b/x-pack/plugins/observability/public/utils/alert_summary_widget/get_alert_summary_time_range.tsx
@@ -10,12 +10,10 @@ import { getAbsoluteTimeRange } from '@kbn/data-plugin/common';
 import { TimeRange } from '@kbn/es-query';
 import { FormattedMessage } from '@kbn/i18n-react';
 import type { AlertSummaryTimeRange } from '@kbn/triggers-actions-ui-plugin/public';
+import { defaultTimeRange } from './constants';
 
 export const getDefaultAlertSummaryTimeRange = (): AlertSummaryTimeRange => {
-  const { to, from } = getAbsoluteTimeRange({
-    from: 'now-30d',
-    to: 'now',
-  });
+  const { to, from } = getAbsoluteTimeRange(defaultTimeRange);
 
   return {
     utcFrom: from,

--- a/x-pack/test/observability_functional/apps/observability/pages/rule_details_page.ts
+++ b/x-pack/test/observability_functional/apps/observability/pages/rule_details_page.ts
@@ -165,7 +165,8 @@ export default ({ getService }: FtrProviderContext) => {
         await activeAlerts.click();
 
         const url = await browser.getCurrentUrl();
-        const { from, to } = await observability.components.alertSearchBar.getAbsoluteTimeRange();
+        const from = 'rangeFrom:now-30d';
+        const to = 'rangeTo:now';
 
         expect(url.includes('tabId=alerts')).to.be(true);
         expect(url.includes('status%3Aactive')).to.be(true);
@@ -179,7 +180,8 @@ export default ({ getService }: FtrProviderContext) => {
         await compactWidget.click();
 
         const url = await browser.getCurrentUrl();
-        const { from, to } = await observability.components.alertSearchBar.getAbsoluteTimeRange();
+        const from = 'rangeFrom:now-30d';
+        const to = 'rangeTo:now';
 
         expect(url.includes('tabId=alerts')).to.be(true);
         expect(url.includes('status%3Aall')).to.be(true);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.7`:
 - [[AO] Improve refreshing alert summary widget on the rule details page (#151645)](https://github.com/elastic/kibana/pull/151645)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Maryam Saeidi","email":"maryam.saeidi@elastic.co"},"sourceCommit":{"committedDate":"2023-02-22T15:47:47Z","message":"[AO] Improve refreshing alert summary widget on the rule details page (#151645)\n\nFixes #147680\r\n\r\n## 📝 Summary\r\n\r\nThis PR improves the refreshing alert summary widget on the rule details\r\npage.\r\n\r\nRegarding the `execution history` tab, I didn't change the logic since,\r\nat the moment, we don't have a way to notify the parent component about\r\nrefreshing the `execution history` section, so I just focused on the\r\nalert summary widget in this PR.\r\n\r\n## 🧪 How to test\r\n- Create a rule and go to the rule details page\r\n- Select the alerts tab\r\n- When you refresh the table or change the status filter, you should see\r\na `_alert_summary` API call in the network tab of the browser console to\r\nindicate alert summary widget gets updated.\r\n\r\n\r\n![image](https://user-images.githubusercontent.com/12370520/220165203-c7ee780a-6a19-4b5c-9895-fb1ef6be1839.png)","sha":"0fd7d207ffc9cf339474ceafbf4feb2416b53260","branchLabelMapping":{"^v8.8.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team: Actionable Observability","v8.7.0","v8.8.0"],"number":151645,"url":"https://github.com/elastic/kibana/pull/151645","mergeCommit":{"message":"[AO] Improve refreshing alert summary widget on the rule details page (#151645)\n\nFixes #147680\r\n\r\n## 📝 Summary\r\n\r\nThis PR improves the refreshing alert summary widget on the rule details\r\npage.\r\n\r\nRegarding the `execution history` tab, I didn't change the logic since,\r\nat the moment, we don't have a way to notify the parent component about\r\nrefreshing the `execution history` section, so I just focused on the\r\nalert summary widget in this PR.\r\n\r\n## 🧪 How to test\r\n- Create a rule and go to the rule details page\r\n- Select the alerts tab\r\n- When you refresh the table or change the status filter, you should see\r\na `_alert_summary` API call in the network tab of the browser console to\r\nindicate alert summary widget gets updated.\r\n\r\n\r\n![image](https://user-images.githubusercontent.com/12370520/220165203-c7ee780a-6a19-4b5c-9895-fb1ef6be1839.png)","sha":"0fd7d207ffc9cf339474ceafbf4feb2416b53260"}},"sourceBranch":"main","suggestedTargetBranches":["8.7"],"targetPullRequestStates":[{"branch":"8.7","label":"v8.7.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.8.0","labelRegex":"^v8.8.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/151645","number":151645,"mergeCommit":{"message":"[AO] Improve refreshing alert summary widget on the rule details page (#151645)\n\nFixes #147680\r\n\r\n## 📝 Summary\r\n\r\nThis PR improves the refreshing alert summary widget on the rule details\r\npage.\r\n\r\nRegarding the `execution history` tab, I didn't change the logic since,\r\nat the moment, we don't have a way to notify the parent component about\r\nrefreshing the `execution history` section, so I just focused on the\r\nalert summary widget in this PR.\r\n\r\n## 🧪 How to test\r\n- Create a rule and go to the rule details page\r\n- Select the alerts tab\r\n- When you refresh the table or change the status filter, you should see\r\na `_alert_summary` API call in the network tab of the browser console to\r\nindicate alert summary widget gets updated.\r\n\r\n\r\n![image](https://user-images.githubusercontent.com/12370520/220165203-c7ee780a-6a19-4b5c-9895-fb1ef6be1839.png)","sha":"0fd7d207ffc9cf339474ceafbf4feb2416b53260"}}]}] BACKPORT-->