### PR TITLE
[Security Solution][Bug] Alert Table raises error when switchting to event rendered view

### DIFF
--- a/packages/kbn-cell-actions/src/hooks/use_load_actions.test.ts
+++ b/packages/kbn-cell-actions/src/hooks/use_load_actions.test.ts
@@ -195,6 +195,7 @@ describe('loadActions hooks', () => {
       await waitForNextUpdate();
       expect(mockGetActions).toHaveBeenCalledTimes(0);
 
+      expect(result.current.value).toBeInstanceOf(Array);
       expect(result.current.value).toHaveLength(0);
       expect(result.current.loading).toBe(false);
     });

--- a/packages/kbn-cell-actions/src/hooks/use_load_actions.test.ts
+++ b/packages/kbn-cell-actions/src/hooks/use_load_actions.test.ts
@@ -178,7 +178,7 @@ describe('loadActions hooks', () => {
     });
 
     it('should re-render when contexts is changed', async () => {
-      const { rerender, waitForNextUpdate } = renderHook(useBulkLoadActions, {
+      const { result, rerender, waitForNextUpdate } = renderHook(useBulkLoadActions, {
         initialProps: [actionContext],
       });
 
@@ -194,6 +194,9 @@ describe('loadActions hooks', () => {
       rerender([]);
       await waitForNextUpdate();
       expect(mockGetActions).toHaveBeenCalledTimes(0);
+
+      expect(result.current.value).toHaveLength(0);
+      expect(result.current.loading).toBe(false);
     });
   });
 });

--- a/packages/kbn-cell-actions/src/hooks/use_load_actions.test.ts
+++ b/packages/kbn-cell-actions/src/hooks/use_load_actions.test.ts
@@ -176,5 +176,24 @@ describe('loadActions hooks', () => {
 
       expect(result.current.value).toEqual([[actionEnabled], [actionEnabled]]);
     });
+
+    it('should re-render when contexts is changed', async () => {
+      const { rerender, waitForNextUpdate } = renderHook(useBulkLoadActions, {
+        initialProps: [actionContext],
+      });
+
+      await waitForNextUpdate();
+      expect(mockGetActions).toHaveBeenCalledWith(actionContext);
+
+      rerender([actionContext2]);
+      await waitForNextUpdate();
+      expect(mockGetActions).toHaveBeenCalledWith(actionContext2);
+
+      mockGetActions.mockClear();
+
+      rerender([]);
+      await waitForNextUpdate();
+      expect(mockGetActions).toHaveBeenCalledTimes(0);
+    });
   });
 });

--- a/packages/kbn-cell-actions/src/hooks/use_load_actions.ts
+++ b/packages/kbn-cell-actions/src/hooks/use_load_actions.ts
@@ -66,7 +66,7 @@ export const useBulkLoadActions = (
           )
         )
       ),
-    []
+    [contexts]
   );
   useThrowError(error);
   return actionsState;

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/index.tsx
@@ -282,8 +282,8 @@ export const AlertsTableComponent: FC<DetectionEngineAlertTableProps> = ({
         id: tableId,
         title: i18n.SESSIONS_TITLE,
         defaultColumns: finalColumns.map((c) => ({
-          ...c,
           initialWidth: DEFAULT_COLUMN_MIN_WIDTH,
+          ...c,
         })),
       })
     );

--- a/x-pack/plugins/security_solution/public/detections/hooks/trigger_actions_alert_table/use_cell_actions.tsx
+++ b/x-pack/plugins/security_solution/public/detections/hooks/trigger_actions_alert_table/use_cell_actions.tsx
@@ -13,7 +13,6 @@ import type { UseDataGridColumnsSecurityCellActionsProps } from '../../../common
 import { useDataGridColumnsSecurityCellActions } from '../../../common/components/cell_actions';
 import { SecurityCellActionsTrigger } from '../../../actions/constants';
 import { tableDefaults } from '../../../common/store/data_table/defaults';
-import { VIEW_SELECTION } from '../../../../common/constants';
 import { useSourcererDataView } from '../../../common/containers/sourcerer';
 import type { TableId } from '../../../../common/types';
 import { SourcererScopeName } from '../../../common/store/sourcerer/model';
@@ -63,20 +62,17 @@ export const getUseCellActionsHook = (tableId: TableId) => {
       tableDefaults.viewMode;
 
     const cellActionProps = useMemo<UseDataGridColumnsSecurityCellActionsProps>(() => {
-      const fields =
-        viewMode === VIEW_SELECTION.eventRenderedView
-          ? []
-          : columns.map((col) => {
-              const fieldMeta: Partial<BrowserField> | undefined = browserFieldsByName[col.id];
-              return {
-                name: col.id,
-                type: fieldMeta?.type ?? 'keyword',
-                values: (finalData as TimelineNonEcsData[][]).map(
-                  (row) => row.find((rowData) => rowData.field === col.id)?.value ?? []
-                ),
-                aggregatable: fieldMeta?.aggregatable ?? false,
-              };
-            });
+      const fields = columns.map((col) => {
+        const fieldMeta: Partial<BrowserField> | undefined = browserFieldsByName[col.id];
+        return {
+          name: col.id,
+          type: fieldMeta?.type ?? 'keyword',
+          values: (finalData as TimelineNonEcsData[][]).map(
+            (row) => row.find((rowData) => rowData.field === col.id)?.value ?? []
+          ),
+          aggregatable: fieldMeta?.aggregatable ?? false,
+        };
+      });
 
       return {
         triggerId: SecurityCellActionsTrigger.DEFAULT,
@@ -87,16 +83,16 @@ export const getUseCellActionsHook = (tableId: TableId) => {
         },
         dataGridRef,
       };
-    }, [viewMode, browserFieldsByName, columns, finalData, dataGridRef]);
+    }, [browserFieldsByName, columns, finalData, dataGridRef]);
 
     const cellActions = useDataGridColumnsSecurityCellActions(cellActionProps);
 
     const getCellActions = useCallback(
       (_columnId: string, columnIndex: number) => {
-        if (cellActions.length === 0) return [];
+        if (cellActions.length === 0 || viewMode === 'eventRenderedView') return [];
         return cellActions[columnIndex];
       },
-      [cellActions]
+      [cellActions, viewMode]
     );
 
     return {

--- a/x-pack/plugins/security_solution/public/detections/hooks/trigger_actions_alert_table/use_cell_actions.tsx
+++ b/x-pack/plugins/security_solution/public/detections/hooks/trigger_actions_alert_table/use_cell_actions.tsx
@@ -8,12 +8,12 @@
 import type { BrowserField, TimelineNonEcsData } from '@kbn/timelines-plugin/common';
 import type { AlertsTableConfigurationRegistry } from '@kbn/triggers-actions-ui-plugin/public/types';
 import { useCallback, useMemo } from 'react';
-import { VIEW_SELECTION } from '../../../../common/constants';
 import { getAllFieldsByName } from '../../../common/containers/source';
 import type { UseDataGridColumnsSecurityCellActionsProps } from '../../../common/components/cell_actions';
 import { useDataGridColumnsSecurityCellActions } from '../../../common/components/cell_actions';
 import { SecurityCellActionsTrigger } from '../../../actions/constants';
 import { tableDefaults } from '../../../common/store/data_table/defaults';
+import { VIEW_SELECTION } from '../../../../common/constants';
 import { useSourcererDataView } from '../../../common/containers/sourcerer';
 import type { TableId } from '../../../../common/types';
 import { SourcererScopeName } from '../../../common/store/sourcerer/model';
@@ -87,7 +87,7 @@ export const getUseCellActionsHook = (tableId: TableId) => {
         },
         dataGridRef,
       };
-    }, [browserFieldsByName, columns, finalData, dataGridRef, viewMode]);
+    }, [viewMode, browserFieldsByName, columns, finalData, dataGridRef]);
 
     const cellActions = useDataGridColumnsSecurityCellActions(cellActionProps);
 

--- a/x-pack/plugins/security_solution/public/detections/hooks/trigger_actions_alert_table/use_cell_actions.tsx
+++ b/x-pack/plugins/security_solution/public/detections/hooks/trigger_actions_alert_table/use_cell_actions.tsx
@@ -8,6 +8,7 @@
 import type { BrowserField, TimelineNonEcsData } from '@kbn/timelines-plugin/common';
 import type { AlertsTableConfigurationRegistry } from '@kbn/triggers-actions-ui-plugin/public/types';
 import { useCallback, useMemo } from 'react';
+import { VIEW_SELECTION } from '../../../../common/constants';
 import { getAllFieldsByName } from '../../../common/containers/source';
 import type { UseDataGridColumnsSecurityCellActionsProps } from '../../../common/components/cell_actions';
 import { useDataGridColumnsSecurityCellActions } from '../../../common/components/cell_actions';
@@ -62,17 +63,20 @@ export const getUseCellActionsHook = (tableId: TableId) => {
       tableDefaults.viewMode;
 
     const cellActionProps = useMemo<UseDataGridColumnsSecurityCellActionsProps>(() => {
-      const fields = columns.map((col) => {
-        const fieldMeta: Partial<BrowserField> | undefined = browserFieldsByName[col.id];
-        return {
-          name: col.id,
-          type: fieldMeta?.type ?? 'keyword',
-          values: (finalData as TimelineNonEcsData[][]).map(
-            (row) => row.find((rowData) => rowData.field === col.id)?.value ?? []
-          ),
-          aggregatable: fieldMeta?.aggregatable ?? false,
-        };
-      });
+      const fields =
+        viewMode === VIEW_SELECTION.eventRenderedView
+          ? []
+          : columns.map((col) => {
+              const fieldMeta: Partial<BrowserField> | undefined = browserFieldsByName[col.id];
+              return {
+                name: col.id,
+                type: fieldMeta?.type ?? 'keyword',
+                values: (finalData as TimelineNonEcsData[][]).map(
+                  (row) => row.find((rowData) => rowData.field === col.id)?.value ?? []
+                ),
+                aggregatable: fieldMeta?.aggregatable ?? false,
+              };
+            });
 
       return {
         triggerId: SecurityCellActionsTrigger.DEFAULT,
@@ -83,16 +87,16 @@ export const getUseCellActionsHook = (tableId: TableId) => {
         },
         dataGridRef,
       };
-    }, [browserFieldsByName, columns, finalData, dataGridRef]);
+    }, [browserFieldsByName, columns, finalData, dataGridRef, viewMode]);
 
     const cellActions = useDataGridColumnsSecurityCellActions(cellActionProps);
 
     const getCellActions = useCallback(
       (_columnId: string, columnIndex: number) => {
-        if (cellActions.length === 0 || viewMode === 'eventRenderedView') return [];
+        if (cellActions.length === 0) return [];
         return cellActions[columnIndex];
       },
-      [cellActions, viewMode]
+      [cellActions]
     );
 
     return {


### PR DESCRIPTION
## Summary

This PR handles: 

1.  #151992 [Security Solution] Alert Table raises error when switching to event rendered view. 
    - Issue was related `cellActions` package where changes in columns was not leading to re-calculation of cell actions on those new columns.
3. Minor table width issue - Sometime table is not expanded to the 100% of the container width.

## Before

https://user-images.githubusercontent.com/7485038/220914906-dcce7ba1-0318-44fd-a097-df86344f7727.mov

## After ( Resolved Issue 1 & 2)

https://user-images.githubusercontent.com/7485038/220921916-fa4b36ad-b8e1-4a8d-ad0d-a778c911bb5b.mov








