### PR TITLE
[Fleet] add proxy ssl key and certificate to agent policy

### DIFF
--- a/x-pack/plugins/fleet/common/openapi/bundled.json
+++ b/x-pack/plugins/fleet/common/openapi/bundled.json
@@ -6321,6 +6321,12 @@
                       "verification_mode": {
                         "type": "string"
                       },
+                      "certificate": {
+                        "type": "string"
+                      },
+                      "key": {
+                        "type": "string"
+                      },
                       "certificate_authorities": {
                         "type": "array",
                         "items": {

--- a/x-pack/plugins/fleet/common/openapi/bundled.yaml
+++ b/x-pack/plugins/fleet/common/openapi/bundled.yaml
@@ -4048,6 +4048,10 @@ components:
                   properties:
                     verification_mode:
                       type: string
+                    certificate:
+                      type: string
+                    key:
+                      type: string
                     certificate_authorities:
                       type: array
                       items:

--- a/x-pack/plugins/fleet/common/openapi/components/schemas/full_agent_policy.yaml
+++ b/x-pack/plugins/fleet/common/openapi/components/schemas/full_agent_policy.yaml
@@ -32,6 +32,10 @@ properties:
             properties:
               verification_mode:
                 type: string
+              certificate:
+                type: string
+              key:
+                type: string
               certificate_authorities:
                 type: array
                 items:

--- a/x-pack/plugins/fleet/common/types/models/agent_policy.ts
+++ b/x-pack/plugins/fleet/common/types/models/agent_policy.ts
@@ -134,6 +134,8 @@ export interface FullAgentPolicyFleetConfig {
     verification_mode?: string;
     certificate_authorities?: string[];
     renegotiation?: string;
+    certificate?: string;
+    key?: string;
   };
 }
 

--- a/x-pack/plugins/fleet/server/services/agent_policies/full_agent_policy.test.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policies/full_agent_policy.test.ts
@@ -675,3 +675,45 @@ describe('generateFleetConfig', () => {
     `);
   });
 });
+
+it('should work with proxy with headers and certificate authorities and certificate and key', () => {
+  const res = generateFleetConfig(
+    {
+      host_urls: ['https://test.fr'],
+      proxy_id: 'proxy-1',
+    } as any,
+    [
+      {
+        id: 'proxy-1',
+        url: 'https://proxy.fr',
+        certificate_authorities: ['/tmp/ssl/ca.crt'],
+        proxy_headers: { Authorization: 'xxx' },
+        certificate: 'my-cert',
+        certificate_key: 'my-key',
+      } as any,
+    ]
+  );
+
+  expect(res).toMatchInlineSnapshot(`
+    Object {
+      "hosts": Array [
+        "https://test.fr",
+      ],
+      "proxy_headers": Object {
+        "Authorization": "xxx",
+      },
+      "proxy_url": "https://proxy.fr",
+      "ssl": Object {
+        "certificate": "my-cert",
+        "certificate_authorities": Array [
+          Array [
+            "/tmp/ssl/ca.crt",
+          ],
+        ],
+        "key": "my-key",
+        "renegotiation": "never",
+        "verification_mode": "",
+      },
+    }
+  `);
+});

--- a/x-pack/plugins/fleet/server/services/agent_policies/full_agent_policy.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policies/full_agent_policy.ts
@@ -227,11 +227,19 @@ export function generateFleetConfig(
     if (fleetServerHostproxy.proxy_headers) {
       config.proxy_headers = fleetServerHostproxy.proxy_headers;
     }
-    if (fleetServerHostproxy.certificate_authorities) {
+    if (
+      fleetServerHostproxy.certificate_authorities ||
+      fleetServerHostproxy.certificate ||
+      fleetServerHostproxy.certificate_key
+    ) {
       config.ssl = {
-        certificate_authorities: [fleetServerHostproxy.certificate_authorities],
         renegotiation: 'never',
         verification_mode: '',
+        ...(fleetServerHostproxy.certificate_authorities && {
+          certificate_authorities: [fleetServerHostproxy.certificate_authorities],
+        }),
+        ...(fleetServerHostproxy.certificate && { certificate: fleetServerHostproxy.certificate }),
+        ...(fleetServerHostproxy.certificate_key && { key: fleetServerHostproxy.certificate_key }),
       };
     }
   }


### PR DESCRIPTION
## Summary

Closes #150709 

The proxy `certificate` and `certificate_key` properties already exist but were not being added to the agent policy.


To test:

- add certificate and key to your proxy
<img width="855" alt="Screenshot 2023-02-23 at 15 20 44" src="https://user-images.githubusercontent.com/3315046/220952651-ba83c4dd-2514-4ea8-a0af-2267396d2a5f.png">

- observe the fields in the agent policy yml:
<img width="935" alt="Screenshot 2023-02-23 at 15 20 20" src="https://user-images.githubusercontent.com/3315046/220952754-49d60170-f04e-41f0-b7bc-5d323623ce6d.png">

