### PR TITLE
[Security Solution] Remove beta tag from process ancestry insight component

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/event_details/insights/related_alerts_by_process_ancestry.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/insights/related_alerts_by_process_ancestry.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useMemo, useCallback, useEffect, useState } from 'react';
-import { EuiBetaBadge, EuiSpacer, EuiLoadingSpinner } from '@elastic/eui';
+import { EuiSpacer, EuiLoadingSpinner } from '@elastic/eui';
 
 import type { Filter } from '@kbn/es-query';
 import { isActiveTimeline } from '../../../../helpers';
@@ -25,7 +25,6 @@ import {
   PROCESS_ANCESTRY_ERROR,
   PROCESS_ANCESTRY_FILTER,
 } from './translations';
-import { BETA } from '../../../translations';
 
 interface Props {
   data: TimelineEventsDetailsItem;
@@ -102,8 +101,6 @@ export const RelatedAlertsByProcessAncestry = React.memo<Props>(
       );
     }, [showContent, cache.alertIds, data, index, originalDocumentId, eventId, scopeId]);
 
-    const betaBadge = useMemo(() => <EuiBetaBadge size="s" label={BETA} color="subdued" />, []);
-
     return (
       <InsightAccordion
         prefix="RelatedAlertsByProcessAncestry"
@@ -116,7 +113,6 @@ export const RelatedAlertsByProcessAncestry = React.memo<Props>(
         }
         renderContent={renderContent}
         onToggle={onToggle}
-        extraAction={betaBadge}
       />
     );
   }


### PR DESCRIPTION
## Summary

PR just removes the beta badge from the ancestry insight part of the alert flyout component. No change in functionality.
<img width="575" alt="whatev" src="https://user-images.githubusercontent.com/56408403/220963002-b9ccddb6-b195-4571-90eb-de741ab030d9.png">
<img width="597" alt="image" src="https://user-images.githubusercontent.com/56408403/220963149-fb379ed4-20a1-4480-9190-e307654126d7.png">





<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->