### PR TITLE
[8.7][Security Solution] Add correct Endpoint package for airgapped solution

### DIFF
--- a/fleet_packages.json
+++ b/fleet_packages.json
@@ -34,7 +34,7 @@
   },
   {
     "name": "endpoint",
-    "version": "8.7.0-next"
+    "version": "8.7.0"
   },
   {
     "name": "fleet_server",


### PR DESCRIPTION
## Summary

Adding the correct version for the Endpoint package to airgapped solutions for 8.7.

backport for: https://github.com/elastic/kibana/pull/150870

Adding this PR to be sure it gets into the release as the automatic backport failed