### PR TITLE
[8.7] Fixes render glitch on space selector screen (#151386)

### DIFF
--- a/x-pack/plugins/spaces/public/space_selector/__snapshots__/space_selector.test.tsx.snap
+++ b/x-pack/plugins/spaces/public/space_selector/__snapshots__/space_selector.test.tsx.snap
@@ -6,9 +6,15 @@ exports[`it renders without crashing 1`] = `
   data-test-subj="kibanaSpaceSelector"
   panelled={true}
 >
+  <EuiPortal>
+    <div
+      className="spcSelectorBackground"
+      role="presentation"
+    />
+  </EuiPortal>
   <_EuiPageSection
-    className="spcSpaceSelector__pageContent"
     color="transparent"
+    paddingSize="xl"
   >
     <EuiText
       size="s"

--- a/x-pack/plugins/spaces/public/space_selector/space_selector.scss
+++ b/x-pack/plugins/spaces/public/space_selector/space_selector.scss
@@ -1,10 +1,11 @@
 .spcSpaceSelector {
-  @include kibanaFullScreenGraphics;
+  background: transparent;
 }
 
-.spcSpaceSelector__pageContent {
-  position: relative;
-  z-index: 10;
+.spcSelectorBackground {
+  @include kibanaFullScreenGraphics;
+  z-index: -1;
+  pointer-events: none;
 }
 
 // Fix forced focus outline on text that isn't a link to just be an underline

--- a/x-pack/plugins/spaces/public/space_selector/space_selector.tsx
+++ b/x-pack/plugins/spaces/public/space_selector/space_selector.tsx
@@ -11,6 +11,7 @@ import {
   EuiFieldSearch,
   EuiLoadingSpinner,
   EuiPanel,
+  EuiPortal,
   EuiSpacer,
   EuiText,
   EuiTextColor,
@@ -107,7 +108,12 @@ export class SpaceSelector extends Component<Props, State> {
         data-test-subj="kibanaSpaceSelector"
         panelled
       >
-        <KibanaPageTemplate.Section className="spcSpaceSelector__pageContent" color="transparent">
+        {/* Portal the fixed background graphic so it doesn't affect page positioning or overlap on top of global banners */}
+        <EuiPortal>
+          <div className="spcSelectorBackground" role="presentation" />
+        </EuiPortal>
+
+        <KibanaPageTemplate.Section color="transparent" paddingSize="xl">
           <EuiText textAlign="center" size="s">
             <EuiSpacer size="xxl" />
             <KibanaSolutionAvatar name="Elastic" size="xl" />


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.7`:
 - [Fixes render glitch on space selector screen (#151386)](https://github.com/elastic/kibana/pull/151386)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Jeramy Soucy","email":"jeramy.soucy@elastic.co"},"sourceCommit":{"committedDate":"2023-02-22T19:19:02Z","message":"Fixes render glitch on space selector screen (#151386)\n\n## Summary\r\n\r\nWhen scrollbars are always on, the render of the background image on the\r\nspace selector screen was part\r\n<img width=\"663\" alt=\"Screenshot 2023-02-15 at 6 19 09 PM\"\r\nsrc=\"https://user-images.githubusercontent.com/103939324/219214315-529a38d8-3cf1-4ce7-8f1e-ca84ffc731bf.png\">\r\nially overlapping the scroll bar in Chrome and Firefox.\r\n\r\n\r\nThis was fixed by overriding the position setting of the\r\nkibanaFullScreenGraphics mixin in .spcSpaceSelector.\r\n<img width=\"669\" alt=\"Screenshot 2023-02-15 at 6 17 52 PM\"\r\nsrc=\"https://user-images.githubusercontent.com/103939324/219214099-b317fb53-28aa-4e60-b648-bb98757330c5.png\">\r\n\r\nAdditionally, it was noticed that the telemetry banner, if not\r\ndismissed, had been visually hidden in this screen when it should have\r\nbeen shown. This is now also resolved.\r\n\r\n### Test\r\n- Set scrollbars to always on (MacOS: Settings->Appearance->Show scroll\r\nbars->Always)\r\n- Start ES & Kibana - do NOT dismiss the telemetry banner\r\n- Add multiple spaces\r\n- Navigate to [base URL]/spaces/space_selector\r\n- Adjust window size to cause scrollbar to appear and background\r\ngraphics to align with it (reference above screenshot)\r\n- The background graphics should not render over the scroll bar\r\n- The telemetry banner should render in front and at the top of the\r\nwindow\r\n\r\n---------\r\n\r\nCo-authored-by: Constance Chen <constance.chen@elastic.co>\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"1a19148c1818b9af3b7735a0b6001bbb6bd8d7ba","branchLabelMapping":{"^v8.8.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Security","release_note:skip","v8.7.0","v8.8.0"],"number":151386,"url":"https://github.com/elastic/kibana/pull/151386","mergeCommit":{"message":"Fixes render glitch on space selector screen (#151386)\n\n## Summary\r\n\r\nWhen scrollbars are always on, the render of the background image on the\r\nspace selector screen was part\r\n<img width=\"663\" alt=\"Screenshot 2023-02-15 at 6 19 09 PM\"\r\nsrc=\"https://user-images.githubusercontent.com/103939324/219214315-529a38d8-3cf1-4ce7-8f1e-ca84ffc731bf.png\">\r\nially overlapping the scroll bar in Chrome and Firefox.\r\n\r\n\r\nThis was fixed by overriding the position setting of the\r\nkibanaFullScreenGraphics mixin in .spcSpaceSelector.\r\n<img width=\"669\" alt=\"Screenshot 2023-02-15 at 6 17 52 PM\"\r\nsrc=\"https://user-images.githubusercontent.com/103939324/219214099-b317fb53-28aa-4e60-b648-bb98757330c5.png\">\r\n\r\nAdditionally, it was noticed that the telemetry banner, if not\r\ndismissed, had been visually hidden in this screen when it should have\r\nbeen shown. This is now also resolved.\r\n\r\n### Test\r\n- Set scrollbars to always on (MacOS: Settings->Appearance->Show scroll\r\nbars->Always)\r\n- Start ES & Kibana - do NOT dismiss the telemetry banner\r\n- Add multiple spaces\r\n- Navigate to [base URL]/spaces/space_selector\r\n- Adjust window size to cause scrollbar to appear and background\r\ngraphics to align with it (reference above screenshot)\r\n- The background graphics should not render over the scroll bar\r\n- The telemetry banner should render in front and at the top of the\r\nwindow\r\n\r\n---------\r\n\r\nCo-authored-by: Constance Chen <constance.chen@elastic.co>\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"1a19148c1818b9af3b7735a0b6001bbb6bd8d7ba"}},"sourceBranch":"main","suggestedTargetBranches":["8.7"],"targetPullRequestStates":[{"branch":"8.7","label":"v8.7.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.8.0","labelRegex":"^v8.8.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/151386","number":151386,"mergeCommit":{"message":"Fixes render glitch on space selector screen (#151386)\n\n## Summary\r\n\r\nWhen scrollbars are always on, the render of the background image on the\r\nspace selector screen was part\r\n<img width=\"663\" alt=\"Screenshot 2023-02-15 at 6 19 09 PM\"\r\nsrc=\"https://user-images.githubusercontent.com/103939324/219214315-529a38d8-3cf1-4ce7-8f1e-ca84ffc731bf.png\">\r\nially overlapping the scroll bar in Chrome and Firefox.\r\n\r\n\r\nThis was fixed by overriding the position setting of the\r\nkibanaFullScreenGraphics mixin in .spcSpaceSelector.\r\n<img width=\"669\" alt=\"Screenshot 2023-02-15 at 6 17 52 PM\"\r\nsrc=\"https://user-images.githubusercontent.com/103939324/219214099-b317fb53-28aa-4e60-b648-bb98757330c5.png\">\r\n\r\nAdditionally, it was noticed that the telemetry banner, if not\r\ndismissed, had been visually hidden in this screen when it should have\r\nbeen shown. This is now also resolved.\r\n\r\n### Test\r\n- Set scrollbars to always on (MacOS: Settings->Appearance->Show scroll\r\nbars->Always)\r\n- Start ES & Kibana - do NOT dismiss the telemetry banner\r\n- Add multiple spaces\r\n- Navigate to [base URL]/spaces/space_selector\r\n- Adjust window size to cause scrollbar to appear and background\r\ngraphics to align with it (reference above screenshot)\r\n- The background graphics should not render over the scroll bar\r\n- The telemetry banner should render in front and at the top of the\r\nwindow\r\n\r\n---------\r\n\r\nCo-authored-by: Constance Chen <constance.chen@elastic.co>\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"1a19148c1818b9af3b7735a0b6001bbb6bd8d7ba"}}]}] BACKPORT-->