### PR TITLE
[Security Solution] Fix total count in alert grouping

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/grouping/container/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/grouping/container/index.test.tsx
@@ -94,14 +94,7 @@ const testProps = {
       ],
     },
     alertsCount: {
-      doc_count_error_upper_bound: 0,
-      sum_other_doc_count: 0,
-      buckets: [
-        {
-          key: 'siem',
-          doc_count: 2,
-        },
-      ],
+      value: 2,
     },
   },
   pagination: {
@@ -142,9 +135,7 @@ describe('grouping container', () => {
         buckets: [],
       },
       alertsCount: {
-        doc_count_error_upper_bound: 0,
-        sum_other_doc_count: 0,
-        buckets: [],
+        value: 0,
       },
     };
     const { getByTestId, queryByTestId } = render(

--- a/x-pack/plugins/security_solution/public/common/components/grouping/container/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/grouping/container/index.tsx
@@ -67,12 +67,9 @@ const GroupingContainerComponent = ({
 
   const groupsNumber = data?.groupsNumber?.value ?? 0;
   const unitCountText = useMemo(() => {
-    const count =
-      data?.alertsCount?.buckets && data?.alertsCount?.buckets.length > 0
-        ? data?.alertsCount?.buckets[0].doc_count ?? 0
-        : 0;
+    const count = data?.alertsCount?.value ?? 0;
     return `${count.toLocaleString()} ${unit && unit(count)}`;
-  }, [data?.alertsCount?.buckets, unit]);
+  }, [data?.alertsCount?.value, unit]);
 
   const unitGroupsCountText = useMemo(
     () => `${groupsNumber.toLocaleString()} ${GROUPS_UNIT(groupsNumber)}`,

--- a/x-pack/plugins/security_solution/public/common/components/grouping/query/index.ts
+++ b/x-pack/plugins/security_solution/public/common/components/grouping/query/index.ts
@@ -6,12 +6,7 @@
  */
 
 import { isEmpty } from 'lodash/fp';
-import type {
-  GroupingQueryArgs,
-  GroupingQuery,
-  SubAggregation,
-  TermsOrCardinalityAggregation,
-} from './types';
+import type { GroupingQueryArgs, GroupingQuery, NamedAggregation } from './types';
 /** The maximum number of items to render */
 export const DEFAULT_STACK_BY_FIELD0_SIZE = 10;
 export const DEFAULT_STACK_BY_FIELD1_SIZE = 10;
@@ -27,8 +22,8 @@ const getOptionalSubAggregation = ({
   stackByMultipleFields1Size: number;
   stackByMultipleFields1From?: number;
   stackByMultipleFields1Sort?: Array<{ [category: string]: { order: 'asc' | 'desc' } }>;
-  additionalStatsAggregationsFields1: TermsOrCardinalityAggregation[];
-}): SubAggregation | {} =>
+  additionalStatsAggregationsFields1: NamedAggregation[];
+}): NamedAggregation | {} =>
   stackByMultipleFields1 != null && !isEmpty(stackByMultipleFields1)
     ? {
         stackByMultipleFields1: {

--- a/x-pack/plugins/security_solution/public/common/components/grouping/query/types.ts
+++ b/x-pack/plugins/security_solution/public/common/components/grouping/query/types.ts
@@ -17,43 +17,31 @@ interface RangeAgg {
   range: { '@timestamp': { gte: string; lte: string } };
 }
 
-export interface TermsOrCardinalityAggregation {
-  [category: string]:
-    | {
-        cardinality: estypes.AggregationsAggregationContainer['cardinality'];
-      }
-    | {
-        terms: estypes.AggregationsAggregationContainer['terms'];
-      };
-}
+export type NamedAggregation = Record<string, estypes.AggregationsAggregationContainer>;
 
 export interface GroupingQueryArgs {
   additionalFilters: BoolAgg[];
   from: string;
   runtimeMappings?: MappingRuntimeFields;
-  additionalAggregationsRoot?: TermsOrCardinalityAggregation[];
+  additionalAggregationsRoot?: NamedAggregation[];
   stackByMultipleFields0: string[];
   stackByMultipleFields0Size?: number;
   stackByMultipleFields0From?: number;
   stackByMultipleFields0Sort?: Array<{ [category: string]: { order: 'asc' | 'desc' } }>;
-  additionalStatsAggregationsFields0: TermsOrCardinalityAggregation[];
+  additionalStatsAggregationsFields0: NamedAggregation[];
   stackByMultipleFields1: string[] | undefined;
   stackByMultipleFields1Size?: number;
   stackByMultipleFields1From?: number;
   stackByMultipleFields1Sort?: Array<{ [category: string]: { order: estypes.SortOrder } }>;
-  additionalStatsAggregationsFields1: TermsOrCardinalityAggregation[];
+  additionalStatsAggregationsFields1: NamedAggregation[];
   to: string;
 }
 
-export interface SubAggregation extends Record<string, estypes.AggregationsAggregationContainer> {
-  bucket_truncate: { bucket_sort: estypes.AggregationsAggregationContainer['bucket_sort'] };
-}
-
-export interface MainAggregation extends Record<string, estypes.AggregationsAggregationContainer> {
+export interface MainAggregation extends NamedAggregation {
   stackByMultipleFields0: {
     terms?: estypes.AggregationsAggregationContainer['terms'];
     multi_terms?: estypes.AggregationsAggregationContainer['multi_terms'];
-    aggs: SubAggregation;
+    aggs: NamedAggregation;
   };
 }
 

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/grouping_settings/query_builder.test.ts
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/grouping_settings/query_builder.test.ts
@@ -45,9 +45,8 @@ describe('getAlertsGroupingQuery', () => {
       _source: false,
       aggs: {
         alertsCount: {
-          terms: {
-            exclude: ['alerts'],
-            field: 'kibana.alert.rule.producer',
+          value_count: {
+            field: 'kibana.alert.rule.name',
           },
         },
         groupsNumber: {
@@ -183,9 +182,8 @@ describe('getAlertsGroupingQuery', () => {
       _source: false,
       aggs: {
         alertsCount: {
-          terms: {
-            exclude: ['alerts'],
-            field: 'kibana.alert.rule.producer',
+          value_count: {
+            field: 'process.name',
           },
         },
         groupsNumber: {

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/grouping_settings/query_builder.ts
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/grouping_settings/query_builder.ts
@@ -7,7 +7,7 @@
 
 import type { MappingRuntimeFields } from '@elastic/elasticsearch/lib/api/types';
 import type { BoolQuery } from '@kbn/es-query';
-import type { TermsOrCardinalityAggregation } from '../../../../common/components/grouping';
+import type { NamedAggregation } from '../../../../common/components/grouping';
 import { getGroupingQuery } from '../../../../common/components/grouping';
 
 const getGroupFields = (groupValue: string) => {
@@ -43,12 +43,7 @@ export const getAlertsGroupingQuery = ({
     additionalFilters,
     additionalAggregationsRoot: [
       {
-        alertsCount: {
-          terms: {
-            field: 'kibana.alert.rule.producer',
-            exclude: ['alerts'],
-          },
-        },
+        alertsCount: { value_count: { field: selectedGroup } },
       },
       ...(selectedGroup !== 'none'
         ? [
@@ -74,8 +69,8 @@ export const getAlertsGroupingQuery = ({
     stackByMultipleFields1: [],
   });
 
-const getAggregationsByGroupField = (field: string): TermsOrCardinalityAggregation[] => {
-  const aggMetrics: TermsOrCardinalityAggregation[] = [
+const getAggregationsByGroupField = (field: string): NamedAggregation[] => {
+  const aggMetrics: NamedAggregation[] = [
     {
       alertsCount: {
         cardinality: {


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/150840

The group filter was not applied to the aggregation for alert count for the alert grouping table. This resulted in the alert grouping table total count aligning with the just page query rather than the page query + grouping filter. I changed this aggregation to [`value_count`](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-valuecount-aggregation.html) with an argument of `field: selectedGroup`. This agg results in the correct total.


## Before
<img width="1019" alt="1" src="https://user-images.githubusercontent.com/6935300/221022355-05b758e0-11b6-4288-95ce-8da16f63d03f.png">

## After
<img width="1018" alt="2" src="https://user-images.githubusercontent.com/6935300/221022384-7c0c7639-17ff-4715-bd0c-b44be521c126.png">



<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->