### PR TITLE
Enterprise Search: implement engine field caps in kibana

### DIFF
--- a/x-pack/plugins/enterprise_search/common/types/error_codes.ts
+++ b/x-pack/plugins/enterprise_search/common/types/error_codes.ts
@@ -19,4 +19,5 @@ export enum ErrorCode {
   RESOURCE_NOT_FOUND = 'resource_not_found',
   UNAUTHORIZED = 'unauthorized',
   UNCAUGHT_EXCEPTION = 'uncaught_exception',
+  ENGINE_NOT_FOUND = 'engine_not_found',
 }

--- a/x-pack/plugins/enterprise_search/server/lib/engines/field_capabilities.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/engines/field_capabilities.test.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { FieldCapsResponse } from '@elastic/elasticsearch/lib/api/types';
+import { IScopedClusterClient } from '@kbn/core-elasticsearch-server';
+
+import { EnterpriseSearchEngineDetails } from '../../../common/types/engines';
+
+import { fetchEngineFieldCapabilities } from './field_capabilities';
+
+describe('engines field_capabilities', () => {
+  const mockClient = {
+    asCurrentUser: {
+      fieldCaps: jest.fn(),
+    },
+    asInternalUser: {},
+  };
+  const mockEngine: EnterpriseSearchEngineDetails = {
+    created: '1999-12-31T23:59:59.999Z',
+    indices: [],
+    name: 'unit-test-engine',
+    updated: '1999-12-31T23:59:59.999Z',
+  };
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('gets engine alias field capabilities', async () => {
+    const fieldCapsResponse = {} as FieldCapsResponse;
+
+    mockClient.asCurrentUser.fieldCaps.mockResolvedValueOnce(fieldCapsResponse);
+    await expect(
+      fetchEngineFieldCapabilities(mockClient as unknown as IScopedClusterClient, mockEngine)
+    ).resolves.toEqual({
+      created: mockEngine.created,
+      field_capabilities: fieldCapsResponse,
+      name: mockEngine.name,
+      updated: mockEngine.updated,
+    });
+
+    expect(mockClient.asCurrentUser.fieldCaps).toHaveBeenCalledTimes(1);
+    expect(mockClient.asCurrentUser.fieldCaps).toHaveBeenCalledWith({
+      fields: '*',
+      include_unmapped: true,
+      index: 'search-engine-unit-test-engine',
+    });
+  });
+});

--- a/x-pack/plugins/enterprise_search/server/lib/engines/field_capabilities.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/engines/field_capabilities.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { IScopedClusterClient } from '@kbn/core-elasticsearch-server';
+
+import {
+  EnterpriseSearchEngineDetails,
+  EnterpriseSearchEngineFieldCapabilities,
+} from '../../../common/types/engines';
+
+export const fetchEngineFieldCapabilities = async (
+  client: IScopedClusterClient,
+  engine: EnterpriseSearchEngineDetails
+): Promise<EnterpriseSearchEngineFieldCapabilities> => {
+  const { created, name, updated } = engine;
+  const fieldCapabilities = await client.asCurrentUser.fieldCaps({
+    fields: '*',
+    include_unmapped: true,
+    index: getEngineIndexAliasName(name),
+  });
+  return {
+    created,
+    field_capabilities: fieldCapabilities,
+    name,
+    updated,
+  };
+};
+
+// Note: This will likely need to be modified when engines move to es module
+const getEngineIndexAliasName = (engineName: string): string => `search-engine-${engineName}`;

--- a/x-pack/plugins/enterprise_search/server/routes/enterprise_search/engines.test.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/enterprise_search/engines.test.ts
@@ -7,6 +7,19 @@
 
 import { mockDependencies, mockRequestHandler, MockRouter } from '../../__mocks__';
 
+jest.mock('../../utils/fetch_enterprise_search', () => ({
+  ...jest.requireActual('../../utils/fetch_enterprise_search'),
+  fetchEnterpriseSearch: jest.fn(),
+}));
+jest.mock('../../lib/engines/field_capabilities', () => ({
+  fetchEngineFieldCapabilities: jest.fn(),
+}));
+
+import { RequestHandlerContext } from '@kbn/core/server';
+
+import { fetchEngineFieldCapabilities } from '../../lib/engines/field_capabilities';
+import { fetchEnterpriseSearch } from '../../utils/fetch_enterprise_search';
+
 import { registerEnginesRoutes } from './engines';
 
 describe('engines routes', () => {
@@ -296,6 +309,120 @@ describe('engines routes', () => {
       const request = { params: {} };
 
       mockRouter.shouldThrow(request);
+    });
+  });
+
+  describe('GET /internal/enterprise_search/engines/{engine_name}/field_capabilities', () => {
+    let mockRouter: MockRouter;
+    const mockClient = {
+      asCurrentUser: {},
+    };
+    const mockCore = {
+      elasticsearch: { client: mockClient },
+      savedObjects: { client: {} },
+    };
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+
+      const context = {
+        core: Promise.resolve(mockCore),
+      } as unknown as jest.Mocked<RequestHandlerContext>;
+
+      mockRouter = new MockRouter({
+        context,
+        method: 'get',
+        path: '/internal/enterprise_search/engines/{engine_name}/field_capabilities',
+      });
+
+      registerEnginesRoutes({
+        ...mockDependencies,
+        router: mockRouter.router,
+      });
+    });
+
+    it('fetches engine fields', async () => {
+      const engineResult = {
+        created: '1999-12-31T23:59:59.999Z',
+        indices: [],
+        name: 'unit-test',
+        updated: '1999-12-31T23:59:59.999Z',
+      };
+      const fieldCapabilitiesResult = {
+        name: 'unit-test',
+      };
+
+      (fetchEnterpriseSearch as jest.Mock).mockResolvedValueOnce(engineResult);
+      (fetchEngineFieldCapabilities as jest.Mock).mockResolvedValueOnce(fieldCapabilitiesResult);
+
+      await mockRouter.callRoute({
+        params: { engine_name: 'unit-test' },
+      });
+
+      expect(fetchEnterpriseSearch).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        '/api/engines/unit-test'
+      );
+      expect(fetchEngineFieldCapabilities).toHaveBeenCalledWith(mockClient, engineResult);
+      expect(mockRouter.response.ok).toHaveBeenCalledWith({
+        body: fieldCapabilitiesResult,
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+    it('returns 404 when fetch engine is undefined', async () => {
+      (fetchEnterpriseSearch as jest.Mock).mockResolvedValueOnce(undefined);
+      await mockRouter.callRoute({
+        params: { engine_name: 'unit-test' },
+      });
+
+      expect(mockRouter.response.customError).toHaveBeenCalledWith({
+        body: {
+          attributes: {
+            error_code: 'engine_not_found',
+          },
+          message: 'Could not find engine',
+        },
+        statusCode: 404,
+      });
+    });
+    it('returns 404 when fetch engine is returns 404', async () => {
+      (fetchEnterpriseSearch as jest.Mock).mockResolvedValueOnce({
+        responseStatus: 404,
+        responseStatusText: 'NOT_FOUND',
+      });
+      await mockRouter.callRoute({
+        params: { engine_name: 'unit-test' },
+      });
+
+      expect(mockRouter.response.customError).toHaveBeenCalledWith({
+        body: {
+          attributes: {
+            error_code: 'engine_not_found',
+          },
+          message: 'Could not find engine',
+        },
+        statusCode: 404,
+      });
+    });
+    it('returns error when fetch engine returns an error', async () => {
+      (fetchEnterpriseSearch as jest.Mock).mockResolvedValueOnce({
+        responseStatus: 500,
+        responseStatusText: 'INTERNAL_SERVER_ERROR',
+      });
+      await mockRouter.callRoute({
+        params: { engine_name: 'unit-test' },
+      });
+
+      expect(mockRouter.response.customError).toHaveBeenCalledWith({
+        body: {
+          attributes: {
+            error_code: 'uncaught_exception',
+          },
+          message: 'Error fetching engine',
+        },
+        statusCode: 500,
+      });
     });
   });
 });

--- a/x-pack/plugins/enterprise_search/server/utils/fetch_enterprise_search.test.ts
+++ b/x-pack/plugins/enterprise_search/server/utils/fetch_enterprise_search.test.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import '../__mocks__/http_agent.mock';
+
+jest.mock('node-fetch');
+import fetch from 'node-fetch';
+
+import { KibanaRequest } from '@kbn/core/server';
+
+import { ConfigType } from '..';
+
+import { fetchEnterpriseSearch, isResponseError } from './fetch_enterprise_search';
+
+describe('fetchEnterpriseSearch', () => {
+  const mockConfig = {
+    accessCheckTimeout: 200,
+    accessCheckTimeoutWarning: 100,
+    host: 'http://localhost:3002',
+  };
+  const mockRequest = {
+    headers: { authorization: '==someAuth' },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns json fetch response', async () => {
+    const response = { foo: 'bar' };
+    (fetch as unknown as jest.Mock).mockResolvedValueOnce({
+      json: jest.fn().mockResolvedValueOnce(response),
+      ok: true,
+    });
+    await expect(
+      fetchEnterpriseSearch(mockConfig as ConfigType, mockRequest as KibanaRequest, '/api/v1/test')
+    ).resolves.toBe(response);
+  });
+  it('calls expected endpoint', async () => {
+    (fetch as unknown as jest.Mock).mockResolvedValueOnce({
+      json: jest.fn().mockResolvedValueOnce({}),
+      ok: true,
+    });
+    await fetchEnterpriseSearch(
+      mockConfig as ConfigType,
+      mockRequest as KibanaRequest,
+      '/api/v1/test'
+    );
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledWith('http://localhost:3002/api/v1/test', expect.anything());
+  });
+  it('uses request auth header & config custom headers', async () => {
+    (fetch as unknown as jest.Mock).mockResolvedValueOnce({
+      json: jest.fn().mockResolvedValueOnce({}),
+      ok: true,
+    });
+    const config = {
+      ...mockConfig,
+      customHeaders: {
+        foo: 'bar',
+      },
+    };
+    await fetchEnterpriseSearch(
+      config as unknown as ConfigType,
+      mockRequest as KibanaRequest,
+      '/api/v1/test'
+    );
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledWith(expect.anything(), {
+      agent: expect.anything(),
+      headers: {
+        Authorization: mockRequest.headers.authorization,
+        foo: 'bar',
+      },
+    });
+  });
+  it('returns undefined when config.host is unavailable', async () => {
+    await expect(
+      fetchEnterpriseSearch(
+        { host: '' } as ConfigType,
+        mockRequest as KibanaRequest,
+        '/api/v1/test'
+      )
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe('isResponseError', () => {
+  it('returns true for ResponseError object', () => {
+    expect(isResponseError({ responseStatus: 404, responseStatusText: 'NOT_FOUND' })).toBe(true);
+  });
+  it('returns false for null/undefined', () => {
+    expect(isResponseError(null)).toBe(false);
+    expect(isResponseError(undefined)).toBe(false);
+  });
+  it('returns false for object without expected keys', () => {
+    expect(isResponseError({})).toBe(false);
+    expect(isResponseError({ responseStatusText: 'NOT_FOUND' })).toBe(false);
+    expect(isResponseError({ responseStatus: 404 })).toBe(false);
+    expect(isResponseError([])).toBe(false);
+  });
+  it('returns false for non-object', () => {
+    expect(isResponseError(100)).toBe(false);
+    expect(isResponseError('test')).toBe(false);
+  });
+});

--- a/x-pack/plugins/enterprise_search/server/utils/fetch_enterprise_search.ts
+++ b/x-pack/plugins/enterprise_search/server/utils/fetch_enterprise_search.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import fetch, { RequestInit } from 'node-fetch';
+
+import { KibanaRequest } from '@kbn/core/server';
+
+import { ConfigType } from '..';
+
+import { entSearchHttpAgent } from '../lib/enterprise_search_http_agent';
+
+export interface ResponseError {
+  responseStatus: number;
+  responseStatusText: string;
+}
+
+export function isResponseError(resp: unknown): resp is ResponseError {
+  if (typeof resp !== 'object') return false;
+  if (resp === null) return false;
+  if ('responseStatus' in resp && 'responseStatusText' in resp) return true;
+  return false;
+}
+
+export async function fetchEnterpriseSearch<T>(
+  config: ConfigType,
+  request: KibanaRequest,
+  endpoint: string
+): Promise<T | ResponseError | undefined> {
+  if (!config.host) return undefined;
+
+  const enterpriseSearchUrl = encodeURI(`${config.host}${endpoint}`);
+  const options: RequestInit = {
+    agent: entSearchHttpAgent.getHttpAgent(),
+    headers: {
+      Authorization: request.headers.authorization as string,
+      ...config.customHeaders,
+    },
+  };
+
+  const response = await fetch(enterpriseSearchUrl, options);
+
+  if (!response.ok) {
+    return {
+      responseStatus: response.status,
+      responseStatusText: response.statusText,
+    };
+  }
+
+  return await response.json();
+}


### PR DESCRIPTION
## Summary

migrated the fetching of engine field capabilities to be handled in Kibana server. This still required fetching the engine from the enterprise search server to fill out all the fields in the expected response. Which required writing a helper for fetching data from enterprise search without just doing a proxy request. I expect this helper will be removed and replaced with fetching the engine from the Elasticsearch once we migrate engines to the module.