### PR TITLE
[Synthetics] Fix popover action selected location id

### DIFF
--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/actions_popover.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/actions_popover.tsx
@@ -76,6 +76,7 @@ interface Props {
   position: PopoverPosition;
   iconHasPanel?: boolean;
   iconSize?: 's' | 'xs';
+  locationId?: string;
 }
 
 const CustomShadowPanel = styled(EuiPanel)<{ shadow: string }>`
@@ -107,6 +108,7 @@ export function ActionsPopover({
   position,
   iconHasPanel = true,
   iconSize = 's',
+  locationId,
 }: Props) {
   const euiShadow = useEuiShadow('l');
   const dispatch = useDispatch();
@@ -117,7 +119,7 @@ export function ActionsPopover({
 
   const detailUrl = useMonitorDetailLocator({
     configId: monitor.configId,
-    locationId: monitor.location.id,
+    locationId: locationId ?? monitor.location.id,
   });
   const editUrl = useEditMonitorLocator({ configId: monitor.configId });
 

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/monitor_detail_flyout.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/monitor_detail_flyout.tsx
@@ -306,6 +306,7 @@ export function MonitorDetailFlyout(props: Props) {
                       position="default"
                       iconHasPanel={false}
                       iconSize="xs"
+                      locationId={locationId}
                     />
                   )}
                 </EuiFlexItem>


### PR DESCRIPTION
## Summary
fixes https://github.com/elastic/kibana/issues/150919
Fix popover action selected location id

<img width="1775" alt="image" src="https://user-images.githubusercontent.com/3505601/221024200-0a815c93-8644-4908-8c4b-8476535cb039.png">


<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->