### PR TITLE
[DOCS] Add stub for find case activity API

### DIFF
--- a/docs/api/cases.asciidoc
+++ b/docs/api/cases.asciidoc
@@ -8,6 +8,7 @@ these APIs:
 * <<cases-api-create>>
 * <<cases-api-delete-cases>>
 * <<cases-api-delete-comments>>
+* <<cases-api-find-case-activity>>
 * <<cases-api-find-cases>>
 * <<cases-api-find-connectors>>
 * <<cases-api-get-alerts>>
@@ -33,6 +34,7 @@ include::cases/cases-api-create.asciidoc[leveloffset=+1]
 include::cases/cases-api-delete-cases.asciidoc[leveloffset=+1]
 include::cases/cases-api-delete-comments.asciidoc[leveloffset=+1]
 //FIND
+include::cases/cases-api-find-case-activity.asciidoc[leveloffset=+1]
 include::cases/cases-api-find-cases.asciidoc[leveloffset=+1]
 include::cases/cases-api-find-connectors.asciidoc[leveloffset=+1]
 //GET

--- a/docs/api/cases/cases-api-find-case-activity.asciidoc
+++ b/docs/api/cases/cases-api-find-case-activity.asciidoc
@@ -1,0 +1,20 @@
+[[cases-api-find-case-activity]]
+== Find case activity API
+++++
+<titleabbrev>Find case activity</titleabbrev>
+++++
+
+Finds user activity for a case.
+
+[NOTE]
+====
+For the most up-to-date API details, refer to the
+{kib-repo}/tree/{branch}/x-pack/plugins/cases/docs/openapi[open API specification]. For a preview, check out <<case-apis>>.
+====
+
+=== {api-request-title}
+
+`GET <kibana host>:<port>/api/cases/<case_id>/user_actions/_find`
+
+`GET <kibana host>:<port>/s/<space_id>/api/cases/<case_id>/user_actions/_find`
+

--- a/docs/api/cases/cases-api-get-case-activity.asciidoc
+++ b/docs/api/cases/cases-api-get-case-activity.asciidoc
@@ -6,7 +6,7 @@
 
 Returns all user activity for a case.
 
-deprecated::[8.1.0]
+deprecated::[8.1.0,Use <<cases-api-find-case-activity>> instead.]
 
 [NOTE]
 ====


### PR DESCRIPTION
## Summary

Relates to https://github.com/elastic/kibana/issues/134344

The open API specification for the new `GET /api/cases/<case_id>/user_actions/_find` endpoint exists. This PR adds a very brief placeholder page in https://www.elastic.co/guide/en/kibana/master/cases-api.html so that this API is searchable in our current docs and points to the specification as the source of truth.

### Preview

https://kibana_152041.docs-preview.app.elstc.co/guide/en/kibana/master/cases-api-find-case-activity.html

<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->