### PR TITLE
[Profiling] Fix missing comparison samples

### DIFF
--- a/x-pack/plugins/profiling/public/components/flame_graphs_view/index.tsx
+++ b/x-pack/plugins/profiling/public/components/flame_graphs_view/index.tsx
@@ -86,8 +86,8 @@ export function FlameGraphsView({ children }: { children: React.ReactElement }) 
     'comparisonMode' in query ? query.comparisonMode : FlameGraphComparisonMode.Absolute;
 
   const normalizationMode = 'normalizationMode' in query ? query.normalizationMode : undefined;
-  const baseline = 'baseline' in query ? query.baseline : undefined;
-  const comparison = 'comparison' in query ? query.comparison : undefined;
+  const baseline = 'baseline' in query ? query.baseline : 1;
+  const comparison = 'comparison' in query ? query.comparison : 1;
 
   const {
     services: { fetchElasticFlamechart },


### PR DESCRIPTION
## Summary

This PR fixes the bug in which the tooltip doesn't show the number of comparison samples after opening the differential flamegraph.

Fixes https://github.com/elastic/prodfiler/issues/3035

### Screenshot

![image](https://user-images.githubusercontent.com/6038/221075624-1b3dc14e-1c19-4bd2-b0a1-33afc07da17a.png)

<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->