### PR TITLE
[APM] Fix failing errors details e2e test

### DIFF
--- a/x-pack/plugins/apm/ftr_e2e/cypress/e2e/read_only_user/errors/error_details.cy.ts
+++ b/x-pack/plugins/apm/ftr_e2e/cypress/e2e/read_only_user/errors/error_details.cy.ts
@@ -48,7 +48,7 @@ describe('Error details', () => {
     });
 
     describe('when error has no occurrences', () => {
-      it('shows an empty message', () => {
+      it('shows zero occurrences', () => {
         cy.visitKibana(
           url.format({
             pathname:
@@ -60,7 +60,7 @@ describe('Error details', () => {
             },
           })
         );
-        cy.contains('No data to display');
+        cy.contains('0 occ');
       });
     });
 


### PR DESCRIPTION
The e2e test was failing because was expecting an empty message in the occurrences chart, after some updates in loading states and how we display empty messages now the chart is shown empty

BEFORE 

![image](https://user-images.githubusercontent.com/31922082/221141426-b239faa3-bb1a-49ce-ad8b-3313537afcda.png)

AFTER

![image](https://user-images.githubusercontent.com/31922082/221141483-a4b8e15b-31fc-4066-8dc7-096c22dd6003.png)



<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->