### PR TITLE
[Fleet] Add modal to display versions changelog

### DIFF
--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/settings/changelog_modal.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/settings/changelog_modal.tsx
@@ -1,0 +1,74 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import {
+  EuiCodeBlock,
+  EuiModal,
+  EuiModalBody,
+  EuiModalHeader,
+  EuiModalFooter,
+  EuiModalHeaderTitle,
+  EuiButton,
+  EuiSkeletonText,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
+
+import { useGetFileByPathQuery, useStartServices } from '../../../../../hooks';
+
+interface Props {
+  title?: string;
+  changelogPath: string;
+  onClose: () => void;
+}
+
+export const ChangelogModal: React.FunctionComponent<Props> = ({
+  title = 'Changelog',
+  changelogPath,
+  onClose,
+}) => {
+  const { notifications } = useStartServices();
+
+  const {
+    data: changelogResponse,
+    error: changelogError,
+    isLoading,
+  } = useGetFileByPathQuery(changelogPath);
+  const changelogText = changelogResponse?.data;
+
+  if (changelogError) {
+    notifications.toasts.addError(changelogError, {
+      title: i18n.translate('xpack.fleet.epm.errorLoadingChangelog', {
+        defaultMessage: 'Error loading changelog information',
+      }),
+    });
+  }
+
+  return (
+    <EuiModal maxWidth={true} onClose={onClose}>
+      <EuiModalHeader>
+        <EuiModalHeaderTitle>{title}</EuiModalHeaderTitle>
+      </EuiModalHeader>
+      <EuiModalBody>
+        <EuiSkeletonText
+          lines={10}
+          size="s"
+          isLoading={isLoading}
+          contentAriaLabel="changelog text"
+        >
+          <EuiCodeBlock overflowHeight={360}>{changelogText}</EuiCodeBlock>
+        </EuiSkeletonText>
+      </EuiModalBody>
+      <EuiModalFooter>
+        <EuiButton color="primary" fill onClick={onClose}>
+          <FormattedMessage id="xpack.fleet.epm.changelogModalCloseBtn" defaultMessage="Close" />
+        </EuiButton>
+      </EuiModalFooter>
+    </EuiModal>
+  );
+};

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/settings/changelog_modal.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/settings/changelog_modal.tsx
@@ -33,7 +33,6 @@ export interface ChangeLogParams {
 }
 
 interface Props {
-  title?: string;
   latestVersion: string;
   currentVersion: string;
   packageName: string;
@@ -41,7 +40,6 @@ interface Props {
 }
 
 export const ChangelogModal: React.FunctionComponent<Props> = ({
-  title = 'Changelog',
   latestVersion,
   currentVersion,
   packageName,
@@ -67,9 +65,9 @@ export const ChangelogModal: React.FunctionComponent<Props> = ({
   }
 
   return (
-    <EuiModal maxWidth={true} onClose={onClose}>
+    <EuiModal maxWidth={true} onClose={onClose} data-test-subj="integrations.changelogModal">
       <EuiModalHeader>
-        <EuiModalHeaderTitle>{title}</EuiModalHeaderTitle>
+        <EuiModalHeaderTitle>{'Changelog'}</EuiModalHeaderTitle>
       </EuiModalHeader>
       <EuiModalBody>
         <EuiSkeletonText

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/settings/changelog_modal.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/settings/changelog_modal.tsx
@@ -19,11 +19,11 @@ import {
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 
-import { safeLoad } from 'js-yaml';
-
 import { useGetFileByPathQuery, useStartServices } from '../../../../../hooks';
 
-interface ChangeLogParams {
+import { parseYamlChangelog } from '../utils';
+
+export interface ChangeLogParams {
   version: string;
   changes: Array<{
     description: string;
@@ -39,13 +39,6 @@ interface Props {
   packageName: string;
   onClose: () => void;
 }
-
-const formatChangelog = (parsedChangelog: ChangeLogParams[]) => {
-  return parsedChangelog.reduce((acc, val) => {
-    acc += `Version: ${val.version}\nChanges:\n  Type: ${val.changes[0].type}\n  Description: ${val.changes[0].description}\n  Link: ${val.changes[0].link}\n\n`;
-    return acc;
-  }, '');
-};
 
 export const ChangelogModal: React.FunctionComponent<Props> = ({
   title = 'Changelog',
@@ -63,12 +56,7 @@ export const ChangelogModal: React.FunctionComponent<Props> = ({
   } = useGetFileByPathQuery(`/package/${packageName}/${latestVersion}/changelog.yml`);
   const changelogText = changelogResponse?.data;
 
-  const parsedChangelog: ChangeLogParams[] = changelogText ? safeLoad(changelogText) : [];
-
-  const filtered = parsedChangelog.filter(
-    (e) => e.version === latestVersion || e.version === currentVersion
-  );
-  const finalChangelog = formatChangelog(filtered);
+  const finalChangelog = parseYamlChangelog(changelogText, currentVersion, latestVersion);
 
   if (changelogError) {
     notifications.toasts.addError(changelogError, {

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/settings/changelog_modal.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/settings/changelog_modal.tsx
@@ -21,7 +21,7 @@ import { FormattedMessage } from '@kbn/i18n-react';
 
 import { useGetFileByPathQuery, useStartServices } from '../../../../../hooks';
 
-import { parseYamlChangelog } from '../utils';
+import { getFormattedChangelog } from '../utils';
 
 export interface ChangeLogParams {
   version: string;
@@ -56,7 +56,7 @@ export const ChangelogModal: React.FunctionComponent<Props> = ({
   } = useGetFileByPathQuery(`/package/${packageName}/${latestVersion}/changelog.yml`);
   const changelogText = changelogResponse?.data;
 
-  const finalChangelog = parseYamlChangelog(changelogText, currentVersion, latestVersion);
+  const finalChangelog = getFormattedChangelog(changelogText, currentVersion, latestVersion);
 
   if (changelogError) {
     notifications.toasts.addError(changelogError, {

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/settings/settings.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/settings/settings.tsx
@@ -125,8 +125,6 @@ export const SettingsPage: React.FC<Props> = memo(({ packageInfo, theme$ }: Prop
   }, [isChangelogModalOpen]);
   const getPackageInstallStatus = useGetPackageInstallStatus();
 
-  const changelogPath = packageInfo?.licensePath?.replace('LICENSE.txt', 'changelog.yml');
-
   const { data: packagePoliciesData } = useGetPackagePoliciesQuery({
     perPage: SO_SEARCH_LIMIT,
     page: 1,
@@ -488,8 +486,13 @@ export const SettingsPage: React.FC<Props> = memo(({ packageInfo, theme$ }: Prop
         </EuiFlexItem>
       </EuiFlexGroup>
       <EuiPortal>
-        {isChangelogModalOpen && changelogPath && (
-          <ChangelogModal changelogPath={changelogPath} onClose={toggleChangelogModal} />
+        {isChangelogModalOpen && (
+          <ChangelogModal
+            currentVersion={version}
+            latestVersion={latestVersion}
+            packageName={name}
+            onClose={toggleChangelogModal}
+          />
         )}
       </EuiPortal>
     </>

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/settings/settings.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/settings/settings.tsx
@@ -18,6 +18,7 @@ import {
   EuiText,
   EuiSpacer,
   EuiLink,
+  EuiPortal,
 } from '@elastic/eui';
 
 import { i18n } from '@kbn/i18n';
@@ -48,6 +49,7 @@ import { InstallButton } from './install_button';
 import { ReinstallButton } from './reinstall_button';
 import { UpdateButton } from './update_button';
 import { UninstallButton } from './uninstall_button';
+import { ChangelogModal } from './changelog_modal';
 
 const SettingsTitleCell = styled.td`
   padding-right: ${(props) => props.theme.eui.euiSizeXL};
@@ -62,7 +64,13 @@ const NoteLabel = () => (
     />
   </strong>
 );
-const UpdatesAvailableMsg = ({ latestVersion }: { latestVersion: string }) => (
+const UpdatesAvailableMsg = ({
+  latestVersion,
+  toggleChangelogModal,
+}: {
+  latestVersion: string;
+  toggleChangelogModal: () => void;
+}) => (
   <EuiCallOut
     color="warning"
     iconType="alert"
@@ -70,11 +78,20 @@ const UpdatesAvailableMsg = ({ latestVersion }: { latestVersion: string }) => (
       defaultMessage: 'New version available',
     })}
   >
-    <FormattedMessage
-      id="xpack.fleet.integration.settings.versionInfo.updatesAvailableBody"
-      defaultMessage="Upgrade to version {latestVersion} to get the latest features"
-      values={{ latestVersion }}
-    />
+    <EuiFlexGroup gutterSize="xs">
+      <EuiFlexItem grow={false}>
+        <FormattedMessage
+          id="xpack.fleet.integration.settings.versionInfo.updatesAvailableBody"
+          defaultMessage="Upgrade to version {latestVersion} to get the latest features."
+          values={{ latestVersion }}
+        />
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <p>
+          <EuiLink onClick={toggleChangelogModal}>{'View changelog.'}</EuiLink>
+        </p>
+      </EuiFlexItem>
+    </EuiFlexGroup>
   </EuiCallOut>
 );
 
@@ -101,7 +118,14 @@ interface Props {
 export const SettingsPage: React.FC<Props> = memo(({ packageInfo, theme$ }: Props) => {
   const { name, title, latestVersion, version, keepPoliciesUpToDate } = packageInfo;
   const [isUpgradingPackagePolicies, setIsUpgradingPackagePolicies] = useState<boolean>(false);
+  const [isChangelogModalOpen, setIsChangelogModalOpen] = useState(false);
+
+  const toggleChangelogModal = useCallback(() => {
+    setIsChangelogModalOpen(!isChangelogModalOpen);
+  }, [isChangelogModalOpen]);
   const getPackageInstallStatus = useGetPackageInstallStatus();
+
+  const changelogPath = packageInfo?.licensePath?.replace('LICENSE.txt', 'changelog.yml');
 
   const { data: packagePoliciesData } = useGetPackagePoliciesQuery({
     perPage: SO_SEARCH_LIMIT,
@@ -220,98 +244,218 @@ export const SettingsPage: React.FC<Props> = memo(({ packageInfo, theme$ }: Prop
   );
 
   return (
-    <EuiFlexGroup alignItems="flexStart">
-      <EuiFlexItem grow={1} />
-      <EuiFlexItem grow={6}>
-        <EuiText>
-          <EuiTitle>
-            <h3>
-              <FormattedMessage
-                id="xpack.fleet.integrations.settings.packageSettingsTitle"
-                defaultMessage="Settings"
-              />
-            </h3>
-          </EuiTitle>
-          <EuiSpacer size="s" />
-          {installedVersion !== null && (
-            <div>
-              <EuiTitle>
-                <h4>
-                  <FormattedMessage
-                    id="xpack.fleet.integrations.settings.packageVersionTitle"
-                    defaultMessage="{title} version"
-                    values={{
-                      title,
-                    }}
-                  />
-                </h4>
-              </EuiTitle>
-              <EuiSpacer size="s" />
-              <table>
-                <tbody>
-                  <tr>
-                    <SettingsTitleCell>
-                      <FormattedMessage
-                        id="xpack.fleet.integrations.settings.versionInfo.installedVersion"
-                        defaultMessage="Installed version"
-                      />
-                    </SettingsTitleCell>
-                    <td>
-                      <EuiTitle size="xs" data-test-subj="epmSettings.installedVersionTitle">
-                        <span>{installedVersion}</span>
-                      </EuiTitle>
-                    </td>
-                  </tr>
-                  <tr>
-                    <SettingsTitleCell>
-                      <FormattedMessage
-                        id="xpack.fleet.integrations.settings.versionInfo.latestVersion"
-                        defaultMessage="Latest version"
-                      />
-                    </SettingsTitleCell>
-                    <td>
-                      <EuiTitle size="xs" data-test-subj="epmSettings.latestVersionTitle">
-                        <span>{latestVersion}</span>
-                      </EuiTitle>
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
-              {shouldShowKeepPoliciesUpToDateSwitch && (
-                <>
-                  <KeepPoliciesUpToDateSwitch
-                    checked={keepPoliciesUpToDateSwitchValue}
-                    onChange={handleKeepPoliciesUpToDateSwitchChange}
-                    disabled={isShowKeepPoliciesUpToDateSwitchDisabled}
-                  />
-                  <EuiSpacer size="l" />
-                </>
-              )}
-
-              {(updateAvailable || isUpgradingPackagePolicies) && (
-                <>
-                  <UpdatesAvailableMsg latestVersion={latestVersion} />
-                  <EuiSpacer size="l" />
-                  <p>
-                    <UpdateButton
-                      {...packageInfo}
-                      version={latestVersion}
-                      packagePolicyIds={packagePolicyIds}
-                      dryRunData={dryRunData}
-                      isUpgradingPackagePolicies={isUpgradingPackagePolicies}
-                      setIsUpgradingPackagePolicies={setIsUpgradingPackagePolicies}
-                      theme$={theme$}
+    <>
+      <EuiFlexGroup alignItems="flexStart">
+        <EuiFlexItem grow={1} />
+        <EuiFlexItem grow={6}>
+          <EuiText>
+            <EuiTitle>
+              <h3>
+                <FormattedMessage
+                  id="xpack.fleet.integrations.settings.packageSettingsTitle"
+                  defaultMessage="Settings"
+                />
+              </h3>
+            </EuiTitle>
+            <EuiSpacer size="s" />
+            {installedVersion !== null && (
+              <div>
+                <EuiTitle>
+                  <h4>
+                    <FormattedMessage
+                      id="xpack.fleet.integrations.settings.packageVersionTitle"
+                      defaultMessage="{title} version"
+                      values={{
+                        title,
+                      }}
                     />
-                  </p>
-                </>
-              )}
-            </div>
-          )}
-          {!hideInstallOptions && !isUpdating && (
-            <div>
-              <EuiSpacer size="s" />
-              {installationStatus === InstallStatus.notInstalled ||
-              installationStatus === InstallStatus.installing ? (
+                  </h4>
+                </EuiTitle>
+                <EuiSpacer size="s" />
+                <table>
+                  <tbody>
+                    <tr>
+                      <SettingsTitleCell>
+                        <FormattedMessage
+                          id="xpack.fleet.integrations.settings.versionInfo.installedVersion"
+                          defaultMessage="Installed version"
+                        />
+                      </SettingsTitleCell>
+                      <td>
+                        <EuiTitle size="xs" data-test-subj="epmSettings.installedVersionTitle">
+                          <span>{installedVersion}</span>
+                        </EuiTitle>
+                      </td>
+                    </tr>
+                    <tr>
+                      <SettingsTitleCell>
+                        <FormattedMessage
+                          id="xpack.fleet.integrations.settings.versionInfo.latestVersion"
+                          defaultMessage="Latest version"
+                        />
+                      </SettingsTitleCell>
+                      <td>
+                        <EuiTitle size="xs" data-test-subj="epmSettings.latestVersionTitle">
+                          <span>{latestVersion}</span>
+                        </EuiTitle>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+                {shouldShowKeepPoliciesUpToDateSwitch && (
+                  <>
+                    <KeepPoliciesUpToDateSwitch
+                      checked={keepPoliciesUpToDateSwitchValue}
+                      onChange={handleKeepPoliciesUpToDateSwitchChange}
+                      disabled={isShowKeepPoliciesUpToDateSwitchDisabled}
+                    />
+                    <EuiSpacer size="l" />
+                  </>
+                )}
+
+                {(updateAvailable || isUpgradingPackagePolicies) && (
+                  <>
+                    <UpdatesAvailableMsg
+                      latestVersion={latestVersion}
+                      toggleChangelogModal={toggleChangelogModal}
+                    />
+                    <EuiSpacer size="l" />
+                    <p>
+                      <UpdateButton
+                        {...packageInfo}
+                        version={latestVersion}
+                        packagePolicyIds={packagePolicyIds}
+                        dryRunData={dryRunData}
+                        isUpgradingPackagePolicies={isUpgradingPackagePolicies}
+                        setIsUpgradingPackagePolicies={setIsUpgradingPackagePolicies}
+                        theme$={theme$}
+                      />
+                    </p>
+                  </>
+                )}
+              </div>
+            )}
+            {!hideInstallOptions && !isUpdating && (
+              <div>
+                <EuiSpacer size="s" />
+                {installationStatus === InstallStatus.notInstalled ||
+                installationStatus === InstallStatus.installing ? (
+                  <div>
+                    <EuiTitle>
+                      <h4>
+                        <FormattedMessage
+                          id="xpack.fleet.integrations.settings.packageInstallTitle"
+                          defaultMessage="Install {title}"
+                          values={{
+                            title,
+                          }}
+                        />
+                      </h4>
+                    </EuiTitle>
+                    <EuiSpacer size="s" />
+                    <p>
+                      <FormattedMessage
+                        id="xpack.fleet.integrations.settings.packageInstallDescription"
+                        defaultMessage="Install this integration to setup Kibana and Elasticsearch assets designed for {title} data."
+                        values={{
+                          title,
+                        }}
+                      />
+                    </p>
+                    <EuiFlexGroup>
+                      <EuiFlexItem grow={false}>
+                        <p>
+                          <InstallButton
+                            {...packageInfo}
+                            numOfAssets={numOfAssets}
+                            disabled={!packagePoliciesData || packageHasUsages}
+                          />
+                        </p>
+                      </EuiFlexItem>
+                    </EuiFlexGroup>
+                  </div>
+                ) : (
+                  <>
+                    <EuiFlexGroup direction="column" gutterSize="m">
+                      <EuiFlexItem>
+                        <EuiTitle>
+                          <h4>
+                            <FormattedMessage
+                              id="xpack.fleet.integrations.settings.packageUninstallTitle"
+                              defaultMessage="Uninstall"
+                            />
+                          </h4>
+                        </EuiTitle>
+                      </EuiFlexItem>
+                      <EuiFlexItem>
+                        <FormattedMessage
+                          id="xpack.fleet.integrations.settings.packageUninstallDescription"
+                          defaultMessage="Remove Kibana and Elasticsearch assets that were installed by this integration."
+                        />
+                      </EuiFlexItem>
+                      <EuiFlexItem>
+                        <div>
+                          <UninstallButton
+                            {...packageInfo}
+                            numOfAssets={numOfAssets}
+                            latestVersion={latestVersion}
+                            disabled={!packagePoliciesData || packageHasUsages}
+                          />
+                        </div>
+                      </EuiFlexItem>
+                      {packageHasUsages && (
+                        <EuiFlexItem>
+                          <EuiText color="subdued" size="s">
+                            <FormattedMessage
+                              id="xpack.fleet.integrations.settings.packageUninstallNoteDescription.packageUninstallNoteDetail"
+                              defaultMessage="{strongNote} {title} cannot be uninstalled because there are active agents that use this integration. To uninstall, remove all {title} integrations from your agent policies."
+                              values={{
+                                title,
+                                strongNote: <NoteLabel />,
+                              }}
+                            />
+                          </EuiText>
+                        </EuiFlexItem>
+                      )}
+                    </EuiFlexGroup>
+                    <EuiSpacer size="l" />
+                    <EuiFlexGroup direction="column" gutterSize="m">
+                      <EuiFlexItem>
+                        <EuiTitle>
+                          <h4>
+                            <FormattedMessage
+                              id="xpack.fleet.integrations.settings.packageReinstallTitle"
+                              defaultMessage="Reinstall"
+                            />
+                          </h4>
+                        </EuiTitle>
+                      </EuiFlexItem>
+                      <EuiFlexItem>
+                        <FormattedMessage
+                          id="xpack.fleet.integrations.settings.packageReinstallDescription"
+                          defaultMessage="Reinstall Kibana and Elasticsearch assets for this integration."
+                        />
+                      </EuiFlexItem>
+                      <EuiFlexItem grow={false}>
+                        <div>
+                          <ReinstallButton
+                            {...packageInfo}
+                            installSource={
+                              'savedObject' in packageInfo
+                                ? packageInfo.savedObject.attributes.install_source
+                                : ''
+                            }
+                          />
+                        </div>
+                      </EuiFlexItem>
+                    </EuiFlexGroup>
+                  </>
+                )}
+              </div>
+            )}
+            {hideInstallOptions && isViewingOldPackage && !isUpdating && (
+              <div>
+                <EuiSpacer size="s" />
                 <div>
                   <EuiTitle>
                     <h4>
@@ -326,138 +470,28 @@ export const SettingsPage: React.FC<Props> = memo(({ packageInfo, theme$ }: Prop
                   </EuiTitle>
                   <EuiSpacer size="s" />
                   <p>
-                    <FormattedMessage
-                      id="xpack.fleet.integrations.settings.packageInstallDescription"
-                      defaultMessage="Install this integration to setup Kibana and Elasticsearch assets designed for {title} data."
-                      values={{
-                        title,
-                      }}
-                    />
+                    <EuiText color="subdued">
+                      <FormattedMessage
+                        id="xpack.fleet.integrations.settings.packageSettingsOldVersionMessage"
+                        defaultMessage="Version {version} is out of date. The {latestVersion} of this integration is available to be installed."
+                        values={{
+                          version,
+                          latestVersion: <LatestVersionLink name={name} version={latestVersion} />,
+                        }}
+                      />
+                    </EuiText>
                   </p>
-                  <EuiFlexGroup>
-                    <EuiFlexItem grow={false}>
-                      <p>
-                        <InstallButton
-                          {...packageInfo}
-                          numOfAssets={numOfAssets}
-                          disabled={!packagePoliciesData || packageHasUsages}
-                        />
-                      </p>
-                    </EuiFlexItem>
-                  </EuiFlexGroup>
                 </div>
-              ) : (
-                <>
-                  <EuiFlexGroup direction="column" gutterSize="m">
-                    <EuiFlexItem>
-                      <EuiTitle>
-                        <h4>
-                          <FormattedMessage
-                            id="xpack.fleet.integrations.settings.packageUninstallTitle"
-                            defaultMessage="Uninstall"
-                          />
-                        </h4>
-                      </EuiTitle>
-                    </EuiFlexItem>
-                    <EuiFlexItem>
-                      <FormattedMessage
-                        id="xpack.fleet.integrations.settings.packageUninstallDescription"
-                        defaultMessage="Remove Kibana and Elasticsearch assets that were installed by this integration."
-                      />
-                    </EuiFlexItem>
-                    <EuiFlexItem>
-                      <div>
-                        <UninstallButton
-                          {...packageInfo}
-                          numOfAssets={numOfAssets}
-                          latestVersion={latestVersion}
-                          disabled={!packagePoliciesData || packageHasUsages}
-                        />
-                      </div>
-                    </EuiFlexItem>
-                    {packageHasUsages && (
-                      <EuiFlexItem>
-                        <EuiText color="subdued" size="s">
-                          <FormattedMessage
-                            id="xpack.fleet.integrations.settings.packageUninstallNoteDescription.packageUninstallNoteDetail"
-                            defaultMessage="{strongNote} {title} cannot be uninstalled because there are active agents that use this integration. To uninstall, remove all {title} integrations from your agent policies."
-                            values={{
-                              title,
-                              strongNote: <NoteLabel />,
-                            }}
-                          />
-                        </EuiText>
-                      </EuiFlexItem>
-                    )}
-                  </EuiFlexGroup>
-                  <EuiSpacer size="l" />
-                  <EuiFlexGroup direction="column" gutterSize="m">
-                    <EuiFlexItem>
-                      <EuiTitle>
-                        <h4>
-                          <FormattedMessage
-                            id="xpack.fleet.integrations.settings.packageReinstallTitle"
-                            defaultMessage="Reinstall"
-                          />
-                        </h4>
-                      </EuiTitle>
-                    </EuiFlexItem>
-                    <EuiFlexItem>
-                      <FormattedMessage
-                        id="xpack.fleet.integrations.settings.packageReinstallDescription"
-                        defaultMessage="Reinstall Kibana and Elasticsearch assets for this integration."
-                      />
-                    </EuiFlexItem>
-                    <EuiFlexItem grow={false}>
-                      <div>
-                        <ReinstallButton
-                          {...packageInfo}
-                          installSource={
-                            'savedObject' in packageInfo
-                              ? packageInfo.savedObject.attributes.install_source
-                              : ''
-                          }
-                        />
-                      </div>
-                    </EuiFlexItem>
-                  </EuiFlexGroup>
-                </>
-              )}
-            </div>
-          )}
-          {hideInstallOptions && isViewingOldPackage && !isUpdating && (
-            <div>
-              <EuiSpacer size="s" />
-              <div>
-                <EuiTitle>
-                  <h4>
-                    <FormattedMessage
-                      id="xpack.fleet.integrations.settings.packageInstallTitle"
-                      defaultMessage="Install {title}"
-                      values={{
-                        title,
-                      }}
-                    />
-                  </h4>
-                </EuiTitle>
-                <EuiSpacer size="s" />
-                <p>
-                  <EuiText color="subdued">
-                    <FormattedMessage
-                      id="xpack.fleet.integrations.settings.packageSettingsOldVersionMessage"
-                      defaultMessage="Version {version} is out of date. The {latestVersion} of this integration is available to be installed."
-                      values={{
-                        version,
-                        latestVersion: <LatestVersionLink name={name} version={latestVersion} />,
-                      }}
-                    />
-                  </EuiText>
-                </p>
               </div>
-            </div>
-          )}
-        </EuiText>
-      </EuiFlexItem>
-    </EuiFlexGroup>
+            )}
+          </EuiText>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+      <EuiPortal>
+        {isChangelogModalOpen && changelogPath && (
+          <ChangelogModal changelogPath={changelogPath} onClose={toggleChangelogModal} />
+        )}
+      </EuiPortal>
+    </>
   );
 });

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/utils/changelog_utils.test.ts
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/utils/changelog_utils.test.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { filterYamlChangelog } from '.';
+
+describe('filterYamlChangelog', () => {
+  const changelogText = `
+- version: "2.4.0"
+  changes:
+    - description: Update package to ECS 8.6.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/4576
+- version: "2.3.0"
+  changes:
+    - description: Added support for GCS input.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/4728
+- version: "2.2.0"
+  changes:
+    - description: Update package to ECS 8.5.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/4285
+- version: "2.1.2"
+  changes:
+    - description: Remove duplicate fields.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/4399`;
+
+  it('should return the changelog from latest to current version', () => {
+    expect(filterYamlChangelog(changelogText, `2.2.0`, `2.4.0`)).toEqual([
+      {
+        version: '2.4.0',
+        changes: [
+          {
+            description: 'Update package to ECS 8.6.0.',
+            link: 'https://github.com/elastic/integrations/pull/4576',
+            type: 'enhancement',
+          },
+        ],
+      },
+      {
+        version: '2.3.0',
+        changes: [
+          {
+            description: 'Added support for GCS input.',
+            link: 'https://github.com/elastic/integrations/pull/4728',
+            type: 'enhancement',
+          },
+        ],
+      },
+      {
+        version: '2.2.0',
+        changes: [
+          {
+            description: 'Update package to ECS 8.5.0.',
+            link: 'https://github.com/elastic/integrations/pull/4285',
+            type: 'enhancement',
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('should return empty array if changelog text is undefined', () => {
+    expect(filterYamlChangelog(undefined, `2.2.0`, `2.4.0`)).toEqual([]);
+  });
+  it('should return empty array if changelog text is null', () => {
+    expect(filterYamlChangelog(null, `2.2.0`, `2.4.0`)).toEqual([]);
+  });
+});

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/utils/changelog_utils.ts
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/utils/changelog_utils.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { safeLoad } from 'js-yaml';
+
+import type { ChangeLogParams } from '../settings/changelog_modal';
+
+export const formatChangelog = (parsedChangelog: ChangeLogParams[]) => {
+  if (!parsedChangelog) return '';
+
+  return parsedChangelog.reduce((acc, val) => {
+    acc += `Version: ${val.version}\nChanges:\n  Type: ${val.changes[0].type}\n  Description: ${val.changes[0].description}\n  Link: ${val.changes[0].link}\n\n`;
+    return acc;
+  }, '');
+};
+
+export const parseYamlChangelog = (
+  changelogText: string | null | undefined,
+  currentVersion: string,
+  latestVersion: string
+) => {
+  const parsedChangelog: ChangeLogParams[] = changelogText ? safeLoad(changelogText) : [];
+
+  const filtered = parsedChangelog.filter(
+    (e) => e.version === latestVersion || e.version === currentVersion //TO DO: all the entries between the two versions
+  );
+  return formatChangelog(filtered);
+};

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/utils/changelog_utils.ts
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/utils/changelog_utils.ts
@@ -6,6 +6,9 @@
  */
 import { safeLoad } from 'js-yaml';
 
+import semverGte from 'semver/functions/gte';
+import semverLte from 'semver/functions/lte';
+
 import type { ChangeLogParams } from '../settings/changelog_modal';
 
 export const formatChangelog = (parsedChangelog: ChangeLogParams[]) => {
@@ -17,15 +20,24 @@ export const formatChangelog = (parsedChangelog: ChangeLogParams[]) => {
   }, '');
 };
 
-export const parseYamlChangelog = (
+// Exported for testing
+export const filterYamlChangelog = (
   changelogText: string | null | undefined,
   currentVersion: string,
   latestVersion: string
 ) => {
   const parsedChangelog: ChangeLogParams[] = changelogText ? safeLoad(changelogText) : [];
 
-  const filtered = parsedChangelog.filter(
-    (e) => e.version === latestVersion || e.version === currentVersion //TO DO: all the entries between the two versions
+  return parsedChangelog.filter(
+    (e) => semverLte(e.version, latestVersion) && semverGte(e.version, currentVersion)
   );
-  return formatChangelog(filtered);
+};
+
+export const getFormattedChangelog = (
+  changelogText: string | null | undefined,
+  currentVersion: string,
+  latestVersion: string
+) => {
+  const parsed = filterYamlChangelog(changelogText, currentVersion, latestVersion);
+  return formatChangelog(parsed);
 };

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/utils/index.ts
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/utils/index.ts
@@ -6,3 +6,4 @@
  */
 
 export { getInstallPkgRouteOptions } from './get_install_route_options';
+export { parseYamlChangelog } from './changelog_utils';

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/utils/index.ts
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/utils/index.ts
@@ -6,4 +6,4 @@
  */
 
 export { getInstallPkgRouteOptions } from './get_install_route_options';
-export { parseYamlChangelog } from './changelog_utils';
+export { getFormattedChangelog, filterYamlChangelog } from './changelog_utils';


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/150754

## Summary

When an integration upgrade is available, show the available changelog through a modal. 

The changelog is parsed and formatted so that it only shows the changes between the two versions. For instance, if the installed version is 2.1.0 and the latest version is 2.3.0, the modal will show the changelog for 2.1.0, 2.2.0 and 2.3.0, not the older versions.

<img width="1577" alt="Screenshot 2023-02-24 at 12 42 36" src="https://user-images.githubusercontent.com/16084106/221170961-66fcb4f5-f8ee-4cf3-aef4-bca148c536ce.png">

<img width="1607" alt="Screenshot 2023-02-24 at 11 29 09" src="https://user-images.githubusercontent.com/16084106/221170906-8bf70503-57e3-44a7-bfd2-f14816485d09.png">

### Testing

- Install old version of an integration. I tested with Akamai 2.2.0 (navigate to `http://localhost:5601/cri/app/fleet/integrations/akamai-2.2.0/add-integration` and the older version will install
- Navigate to Integration > Settings and click on "View Changelog"
- A modal with the changelog should appear.



