### PR TITLE
[Fleet] Do not show mappings and pipelines editor if integration allows dataset to be configured

### DIFF
--- a/x-pack/plugins/fleet/common/constants/epm.ts
+++ b/x-pack/plugins/fleet/common/constants/epm.ts
@@ -24,6 +24,8 @@ export const USER_SETTINGS_TEMPLATE_SUFFIX = '@custom';
 
 export const FLEET_ELASTIC_AGENT_DETAILS_DASHBOARD_ID =
   'elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395';
+
+export const DATASET_VAR_NAME = 'data_stream.dataset';
 /*
  Package rules:
 |               | autoUpdatePackages |

--- a/x-pack/plugins/fleet/common/services/policy_template.ts
+++ b/x-pack/plugins/fleet/common/services/policy_template.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { DATASET_VAR_NAME } from '../constants';
 import type {
   RegistryPolicyTemplate,
   RegistryPolicyInputOnlyTemplate,
@@ -17,7 +18,7 @@ import type {
 } from '../types';
 
 const DATA_STREAM_DATASET_VAR: RegistryVarsEntry = {
-  name: 'data_stream.dataset',
+  name: DATASET_VAR_NAME,
   type: 'text',
   title: 'Dataset name',
   description:

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_stream.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_stream.tsx
@@ -21,6 +21,8 @@ import {
 } from '@elastic/eui';
 import { useRouteMatch } from 'react-router-dom';
 
+import { DATASET_VAR_NAME } from '../../../../../../../../../common/constants';
+
 import { useConfig, useGetDataStreams } from '../../../../../../../../hooks';
 
 import { mapPackageReleaseToIntegrationCardRelease } from '../../../../../../../../../common/services';
@@ -90,6 +92,10 @@ export const PackagePolicyInputStreamConfig = memo<Props>(
     const isPackagePolicyEdit = !!packagePolicyId;
     const isInputOnlyPackage = packageInfo.type === 'input';
 
+    const hasDatasetVar = packageInputStream.vars?.some(
+      (varDef) => varDef.name === DATASET_VAR_NAME
+    );
+    const showPipelinesAndMappings = !isInputOnlyPackage && !hasDatasetVar;
     useEffect(() => {
       if (isDefaultDatastream && containerRef.current) {
         containerRef.current.scrollIntoView();
@@ -297,7 +303,7 @@ export const PackagePolicyInputStreamConfig = memo<Props>(
                       );
                     })}
                     {/* Only show datastream pipelines and mappings on edit and not for input packages*/}
-                    {isPackagePolicyEdit && !isInputOnlyPackage && (
+                    {isPackagePolicyEdit && showPipelinesAndMappings && (
                       <>
                         <EuiFlexItem>
                           <PackagePolicyEditorDatastreamPipelines

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_var_field.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_var_field.tsx
@@ -22,6 +22,8 @@ import styled from 'styled-components';
 
 import { CodeEditor } from '@kbn/kibana-react-plugin/public';
 
+import { DATASET_VAR_NAME } from '../../../../../../../../../common/constants';
+
 import type { DataStream, RegistryVarsEntry } from '../../../../../../types';
 
 import { MultiTextInput } from './multi_text_input';
@@ -72,7 +74,7 @@ export const PackagePolicyInputVarField: React.FunctionComponent<{
           />
         );
       }
-      if (name === 'data_stream.dataset' && packageType === 'input') {
+      if (name === DATASET_VAR_NAME && packageType === 'input') {
         return (
           <DatasetComboBox
             pkgName={packageName}

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/services/prepare_input_pkg_policy_dataset.ts
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/services/prepare_input_pkg_policy_dataset.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import { DATASET_VAR_NAME } from '../../../../../../../common/constants';
+
 import type { NewPackagePolicy } from '../../../../types';
 
 export function prepareInputPackagePolicyDataset(newPolicy: NewPackagePolicy): {
@@ -27,16 +29,16 @@ export function prepareInputPackagePolicyDataset(newPolicy: NewPackagePolicy): {
     const newStreams = streams.map((stream) => {
       if (
         !stream.vars ||
-        !stream.vars['data_stream.dataset'] ||
-        !stream.vars['data_stream.dataset'].value?.package
+        !stream.vars[DATASET_VAR_NAME] ||
+        !stream.vars[DATASET_VAR_NAME].value?.package
       ) {
         return stream;
       }
 
-      const datasetVar = stream.vars['data_stream.dataset'];
+      const datasetVar = stream.vars[DATASET_VAR_NAME];
 
       forceCreateNeeded = datasetVar.value?.package !== newPolicy?.package?.name;
-      stream.vars['data_stream.dataset'] = {
+      stream.vars[DATASET_VAR_NAME] = {
         ...datasetVar,
         value: datasetVar.value?.dataset,
       };

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/services/devtools_request.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/services/devtools_request.tsx
@@ -7,6 +7,8 @@
 
 import { omit } from 'lodash';
 
+import { DATASET_VAR_NAME } from '../../../../../../common/constants';
+
 import { agentPolicyRouteService, packagePolicyRouteService } from '../../../services';
 import { generateInputId } from '../../../../../../common/services/simplified_package_policy_helper';
 import type {
@@ -105,8 +107,8 @@ function formatVars(vars: NewPackagePolicy['inputs'][number]['vars']) {
   }
 
   return Object.entries(vars).reduce((acc, [varKey, varRecord]) => {
-    // the data_stream.dataset var uses an internal format before we send it
-    if (varKey === 'data_stream.dataset' && varRecord?.value?.dataset) {
+    // the dataset var uses an internal format before we send it
+    if (varKey === DATASET_VAR_NAME && varRecord?.value?.dataset) {
       acc[varKey] = varRecord?.value.dataset;
     } else {
       acc[varKey] = varRecord?.value;

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/constants.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/constants.tsx
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import { DATASET_VAR_NAME } from '../../../../../../../../common/constants';
+
 import type { AgentLogsState } from './agent_logs';
 
 export const AGENT_LOG_INDEX_PATTERN = 'logs-elastic_agent-*,logs-elastic_agent.*-*';
@@ -21,7 +23,7 @@ export const AGENT_ID_FIELD = {
   type: 'string',
 };
 export const DATASET_FIELD = {
-  name: 'data_stream.dataset',
+  name: DATASET_VAR_NAME,
   type: 'string',
   aggregatable: true,
   searchable: true,

--- a/x-pack/plugins/fleet/server/services/epm/packages/install.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/install.ts
@@ -45,7 +45,7 @@ import type {
   PackageVerificationResult,
   RegistryDataStream,
 } from '../../../types';
-import { AUTO_UPGRADE_POLICIES_PACKAGES } from '../../../../common/constants';
+import { AUTO_UPGRADE_POLICIES_PACKAGES, DATASET_VAR_NAME } from '../../../../common/constants';
 import { FleetError, PackageOutdatedError, PackagePolicyValidationError } from '../../../errors';
 import { PACKAGES_SAVED_OBJECT_TYPE, MAX_TIME_COMPLETE_INSTALL } from '../../../constants';
 import { dataStreamService, licenseService } from '../..';
@@ -1033,7 +1033,7 @@ export async function installAssetsForInputPackagePolicy(opts: {
   const paths = await getArchiveFilelist(pkgInfo);
   if (!paths) throw new Error('No paths found for ');
 
-  const datasetName = packagePolicy.inputs[0].streams[0].vars?.['data_stream.dataset']?.value;
+  const datasetName = packagePolicy.inputs[0].streams[0].vars?.[DATASET_VAR_NAME]?.value;
   const [dataStream] = getNormalizedDataStreams(pkgInfo, datasetName);
   const existingDataStreams = await dataStreamService.getMatchingDataStreams(esClient, {
     type: dataStream.type,

--- a/x-pack/plugins/fleet/server/services/package_policy.ts
+++ b/x-pack/plugins/fleet/server/services/package_policy.ts
@@ -42,6 +42,7 @@ import {
   FLEET_APM_PACKAGE,
   outputType,
   PACKAGES_SAVED_OBJECT_TYPE,
+  DATASET_VAR_NAME,
 } from '../../common/constants';
 import type {
   PostDeletePackagePoliciesResponse,
@@ -2147,17 +2148,16 @@ export function _validateRestrictedFieldsNotModifiedOrThrow(opts: {
           );
           if (
             oldStream &&
-            oldStream?.vars?.['data_stream.dataset'] &&
-            oldStream?.vars['data_stream.dataset']?.value !==
-              stream?.vars?.['data_stream.dataset']?.value
+            oldStream?.vars?.[DATASET_VAR_NAME] &&
+            oldStream?.vars[DATASET_VAR_NAME]?.value !== stream?.vars?.[DATASET_VAR_NAME]?.value
           ) {
             // seeing this error in dev? Package policy must be called with prepareInputPackagePolicyDataset function first in UI code
             appContextService
               .getLogger()
               .debug(
                 `Rejecting package policy update due to dataset change, old val '${
-                  oldStream?.vars['data_stream.dataset']?.value
-                }, new val '${JSON.stringify(stream?.vars?.['data_stream.dataset']?.value)}'`
+                  oldStream?.vars[DATASET_VAR_NAME]?.value
+                }, new val '${JSON.stringify(stream?.vars?.[DATASET_VAR_NAME]?.value)}'`
               );
             throw new PackagePolicyValidationError(
               i18n.translate('xpack.fleet.updatePackagePolicy.datasetCannotBeModified', {


### PR DESCRIPTION
Closes #144696

For packages which allow dataset to be configured (e.g custom logs, custom http) do not show the pipeline and mappings editor when editing a package policy. This is because the pipelines are only set up at install time so will not match the datastream if the user elects to change it.

Bonus change: I have moved the `data_stream.dataset` var to a constant as we use it in a lot of places

<img width="1265" alt="Screenshot 2023-02-24 at 12 12 19" src="https://user-images.githubusercontent.com/3315046/221176407-ab26b755-8cf4-4e4a-8ee3-83f947cfd4cb.png">


<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->