### PR TITLE
[8.7] [ResponseOps] [Flapping] actions scheduled while alert not active, but flapping (#151066)

### DIFF
--- a/x-pack/plugins/alerting/server/alerts_client/legacy_alerts_client.test.ts
+++ b/x-pack/plugins/alerting/server/alerts_client/legacy_alerts_client.test.ts
@@ -6,7 +6,7 @@
  */
 import { loggingSystemMock } from '@kbn/core/server/mocks';
 import { UntypedNormalizedRuleType } from '../rule_type_registry';
-import { AlertInstanceContext, RecoveredActionGroup } from '../types';
+import { AlertInstanceContext, RecoveredActionGroup, RuleNotifyWhen } from '../types';
 import { LegacyAlertsClient } from './legacy_alerts_client';
 import { createAlertFactory, getPublicAlertFactory } from '../alert/create_alert_factory';
 import { Alert } from '../alert/alert';
@@ -208,6 +208,10 @@ describe('Legacy Alerts Client', () => {
         '1': new Alert<AlertInstanceContext, AlertInstanceContext>('1', testAlert1),
         '2': new Alert<AlertInstanceContext, AlertInstanceContext>('2', testAlert2),
       },
+      currentActiveAlerts: {
+        '1': new Alert<AlertInstanceContext, AlertInstanceContext>('1', testAlert1),
+        '2': new Alert<AlertInstanceContext, AlertInstanceContext>('2', testAlert2),
+      },
       currentRecoveredAlerts: {},
       recoveredAlerts: {},
     });
@@ -231,6 +235,7 @@ describe('Legacy Alerts Client', () => {
       ruleRunMetricsStore,
       shouldLogAndScheduleActionsForAlerts: true,
       flappingSettings: DEFAULT_FLAPPING_SETTINGS,
+      notifyWhen: RuleNotifyWhen.CHANGE,
     });
 
     expect(processAlerts).toHaveBeenCalledWith({
@@ -268,6 +273,7 @@ describe('Legacy Alerts Client', () => {
         lookBackWindow: 20,
         statusChangeThreshold: 4,
       },
+      RuleNotifyWhen.CHANGE,
       'default',
       {},
       {

--- a/x-pack/plugins/alerting/server/alerts_client/legacy_alerts_client.ts
+++ b/x-pack/plugins/alerting/server/alerts_client/legacy_alerts_client.ts
@@ -28,6 +28,7 @@ import {
   AlertInstanceState,
   RawAlertInstance,
   WithoutReservedActionGroups,
+  RuleNotifyWhenType,
 } from '../types';
 import { RulesSettingsFlappingProperties } from '../../common/rules_settings';
 
@@ -49,6 +50,7 @@ export class LegacyAlertsClient<
   private processedAlerts: {
     new: Record<string, Alert<State, Context, ActionGroupIds>>;
     active: Record<string, Alert<State, Context, ActionGroupIds>>;
+    activeCurrent: Record<string, Alert<State, Context, ActionGroupIds>>;
     recovered: Record<string, Alert<State, Context, RecoveryActionGroupId>>;
     recoveredCurrent: Record<string, Alert<State, Context, RecoveryActionGroupId>>;
   };
@@ -65,6 +67,7 @@ export class LegacyAlertsClient<
     this.processedAlerts = {
       new: {},
       active: {},
+      activeCurrent: {},
       recovered: {},
       recoveredCurrent: {},
     };
@@ -113,12 +116,14 @@ export class LegacyAlertsClient<
     ruleRunMetricsStore,
     shouldLogAndScheduleActionsForAlerts,
     flappingSettings,
+    notifyWhen,
   }: {
     eventLogger: AlertingEventLogger;
     ruleLabel: string;
     shouldLogAndScheduleActionsForAlerts: boolean;
     ruleRunMetricsStore: RuleRunMetricsStore;
     flappingSettings: RulesSettingsFlappingProperties;
+    notifyWhen: RuleNotifyWhenType | null;
   }) {
     const {
       newAlerts: processedAlertsNew,
@@ -152,6 +157,7 @@ export class LegacyAlertsClient<
 
     const alerts = getAlertsForNotification<State, Context, ActionGroupIds, RecoveryActionGroupId>(
       flappingSettings,
+      notifyWhen,
       this.options.ruleType.defaultActionGroupId,
       processedAlertsNew,
       processedAlertsActive,
@@ -162,6 +168,7 @@ export class LegacyAlertsClient<
 
     this.processedAlerts.new = alerts.newAlerts;
     this.processedAlerts.active = alerts.activeAlerts;
+    this.processedAlerts.activeCurrent = alerts.currentActiveAlerts;
     this.processedAlerts.recovered = alerts.recoveredAlerts;
     this.processedAlerts.recoveredCurrent = alerts.currentRecoveredAlerts;
 
@@ -169,7 +176,7 @@ export class LegacyAlertsClient<
       logger: this.options.logger,
       alertingEventLogger: eventLogger,
       newAlerts: alerts.newAlerts,
-      activeAlerts: alerts.activeAlerts,
+      activeAlerts: alerts.currentActiveAlerts,
       recoveredAlerts: alerts.currentRecoveredAlerts,
       ruleLogPrefix: ruleLabel,
       ruleRunMetricsStore,
@@ -178,7 +185,9 @@ export class LegacyAlertsClient<
     });
   }
 
-  public getProcessedAlerts(type: 'new' | 'active' | 'recovered' | 'recoveredCurrent') {
+  public getProcessedAlerts(
+    type: 'new' | 'active' | 'activeCurrent' | 'recovered' | 'recoveredCurrent'
+  ) {
     if (this.processedAlerts.hasOwnProperty(type)) {
       return this.processedAlerts[type];
     }

--- a/x-pack/plugins/alerting/server/task_runner/task_runner.ts
+++ b/x-pack/plugins/alerting/server/task_runner/task_runner.ts
@@ -427,6 +427,7 @@ export class TaskRunner<
         ruleRunMetricsStore,
         shouldLogAndScheduleActionsForAlerts: this.shouldLogAndScheduleActionsForAlerts(),
         flappingSettings,
+        notifyWhen,
       });
     });
 
@@ -459,7 +460,7 @@ export class TaskRunner<
         this.countUsageOfActionExecutionAfterRuleCancellation();
       } else {
         executionHandlerRunResult = await executionHandler.run({
-          ...this.legacyAlertsClient.getProcessedAlerts('active'),
+          ...this.legacyAlertsClient.getProcessedAlerts('activeCurrent'),
           ...this.legacyAlertsClient.getProcessedAlerts('recoveredCurrent'),
         });
       }

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group1/event_log.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group1/event_log.ts
@@ -8,7 +8,7 @@
 import expect from '@kbn/expect';
 import { IValidatedEvent, nanosToMillis } from '@kbn/event-log-plugin/server';
 import { RuleNotifyWhen } from '@kbn/alerting-plugin/common';
-import { ES_TEST_INDEX_NAME, ESTestIndexTool } from '@kbn/alerting-api-integration-helpers';
+import { ESTestIndexTool } from '@kbn/alerting-api-integration-helpers';
 import { Spaces } from '../../../scenarios';
 import {
   getUrlPrefix,

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group1/event_log.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group1/event_log.ts
@@ -7,7 +7,8 @@
 
 import expect from '@kbn/expect';
 import { IValidatedEvent, nanosToMillis } from '@kbn/event-log-plugin/server';
-import { ESTestIndexTool } from '@kbn/alerting-api-integration-helpers';
+import { RuleNotifyWhen } from '@kbn/alerting-plugin/common';
+import { ES_TEST_INDEX_NAME, ESTestIndexTool } from '@kbn/alerting-api-integration-helpers';
 import { Spaces } from '../../../scenarios';
 import {
   getUrlPrefix,
@@ -585,6 +586,7 @@ export default function eventLogTests({ getService }: FtrProviderContext) {
                     params: {},
                   },
                 ],
+                notify_when: RuleNotifyWhen.CHANGE,
               })
             );
 
@@ -604,7 +606,7 @@ export default function eventLogTests({ getService }: FtrProviderContext) {
                 // make sure the counts of the # of events per type are as expected
                 ['execute-start', { gte: 6 }],
                 ['execute', { gte: 6 }],
-                ['execute-action', { equal: 7 }],
+                ['execute-action', { equal: 1 }],
                 ['new-instance', { equal: 1 }],
                 ['active-instance', { gte: 6 }],
                 ['recovered-instance', { equal: 1 }],
@@ -669,6 +671,90 @@ export default function eventLogTests({ getService }: FtrProviderContext) {
                     params: {},
                   },
                 ],
+                notify_when: RuleNotifyWhen.CHANGE,
+              })
+            );
+
+          expect(response.status).to.eql(200);
+          const alertId = response.body.id;
+          objectRemover.add(space.id, alertId, 'rule', 'alerting');
+
+          // get the events we're expecting
+          const events = await retry.try(async () => {
+            return await getEventLog({
+              getService,
+              spaceId: space.id,
+              type: 'alert',
+              id: alertId,
+              provider: 'alerting',
+              actions: new Map([
+                // make sure the counts of the # of events per type are as expected
+                ['execute-start', { gte: 6 }],
+                ['execute', { gte: 6 }],
+                ['execute-action', { equal: 2 }],
+                ['new-instance', { equal: 2 }],
+                ['active-instance', { gte: 6 }],
+                ['recovered-instance', { equal: 2 }],
+              ]),
+            });
+          });
+
+          const flapping = events
+            .filter(
+              (event) =>
+                event?.event?.action === 'active-instance' ||
+                event?.event?.action === 'recovered-instance'
+            )
+            .map((event) => event?.kibana?.alert?.flapping);
+          expect(flapping).to.eql([false, true, true, true, true, true, true, true]);
+        });
+
+        it('should generate expected events for flapping alerts that are mainly active with notifyWhen not set to "on status change"', async () => {
+          await supertest
+            .post(`${getUrlPrefix(space.id)}/internal/alerting/rules/settings/_flapping`)
+            .set('kbn-xsrf', 'foo')
+            .auth('superuser', 'superuser')
+            .send({
+              enabled: true,
+              look_back_window: 3,
+              status_change_threshold: 2,
+            })
+            .expect(200);
+          const { body: createdAction } = await supertest
+            .post(`${getUrlPrefix(space.id)}/api/actions/connector`)
+            .set('kbn-xsrf', 'foo')
+            .send({
+              name: 'MY action',
+              connector_type_id: 'test.noop',
+              config: {},
+              secrets: {},
+            })
+            .expect(200);
+
+          // pattern of when the alert should fire
+          const instance = [true, false, true, true, true, true, true];
+          const pattern = {
+            instance,
+          };
+
+          const response = await supertest
+            .post(`${getUrlPrefix(space.id)}/api/alerting/rule`)
+            .set('kbn-xsrf', 'foo')
+            .send(
+              getTestRuleData({
+                rule_type_id: 'test.patternFiring',
+                schedule: { interval: '1s' },
+                throttle: null,
+                params: {
+                  pattern,
+                },
+                actions: [
+                  {
+                    id: createdAction.id,
+                    group: 'default',
+                    params: {},
+                  },
+                ],
               })
             );
 
@@ -689,8 +775,92 @@ export default function eventLogTests({ getService }: FtrProviderContext) {
                 ['execute-start', { gte: 6 }],
                 ['execute', { gte: 6 }],
                 ['execute-action', { equal: 6 }],
-                ['new-instance', { equal: 2 }],
+                ['new-instance', { equal: 1 }],
                 ['active-instance', { gte: 6 }],
+                ['recovered-instance', { equal: 1 }],
+              ]),
+            });
+          });
+
+          const flapping = events
+            .filter(
+              (event) =>
+                event?.event?.action === 'active-instance' ||
+                event?.event?.action === 'recovered-instance'
+            )
+            .map((event) => event?.kibana?.alert?.flapping);
+          const result = [false, true, true, false, false, false, false];
+          expect(flapping).to.eql(result);
+        });
+
+        it('should generate expected events for flapping alerts that are mainly recovered with notifyWhen not set to "on status change"', async () => {
+          await supertest
+            .post(`${getUrlPrefix(space.id)}/internal/alerting/rules/settings/_flapping`)
+            .set('kbn-xsrf', 'foo')
+            .auth('superuser', 'superuser')
+            .send({
+              enabled: true,
+              look_back_window: 3,
+              status_change_threshold: 2,
+            })
+            .expect(200);
+          const { body: createdAction } = await supertest
+            .post(`${getUrlPrefix(space.id)}/api/actions/connector`)
+            .set('kbn-xsrf', 'foo')
+            .send({
+              name: 'MY action',
+              connector_type_id: 'test.noop',
+              config: {},
+              secrets: {},
+            })
+            .expect(200);
+
+          // pattern of when the alert should fire
+          const instance = [true, false, true, false, false, false, true];
+          const pattern = {
+            instance,
+          };
+
+          const response = await supertest
+            .post(`${getUrlPrefix(space.id)}/api/alerting/rule`)
+            .set('kbn-xsrf', 'foo')
+            .send(
+              getTestRuleData({
+                rule_type_id: 'test.patternFiring',
+                schedule: { interval: '1s' },
+                throttle: null,
+                params: {
+                  pattern,
+                },
+                actions: [
+                  {
+                    id: createdAction.id,
+                    group: 'default',
+                    params: {},
+                  },
+                ],
+              })
+            );
+
+          expect(response.status).to.eql(200);
+          const alertId = response.body.id;
+          objectRemover.add(space.id, alertId, 'rule', 'alerting');
+
+          // get the events we're expecting
+          const events = await retry.try(async () => {
+            return await getEventLog({
+              getService,
+              spaceId: space.id,
+              type: 'alert',
+              id: alertId,
+              provider: 'alerting',
+              actions: new Map([
+                // make sure the counts of the # of events per type are as expected
+                ['execute-start', { gte: 5 }],
+                ['execute', { gte: 5 }],
+                ['execute-action', { equal: 3 }],
+                ['new-instance', { equal: 2 }],
+                ['active-instance', { gte: 3 }],
                 ['recovered-instance', { equal: 2 }],
               ]),
             });
@@ -703,7 +873,7 @@ export default function eventLogTests({ getService }: FtrProviderContext) {
                 event?.event?.action === 'recovered-instance'
             )
             .map((event) => event?.kibana?.alert?.flapping);
-          expect(flapping).to.eql([false, true, true, true, true, true, true, true]);
+          expect(flapping).to.eql([false, true, true, true, true]);
         });
       });
     }

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/event_log_alerts.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/event_log_alerts.ts
@@ -58,7 +58,7 @@ export default function eventLogAlertTests({ getService }: FtrProviderContext) {
             // make sure the counts of the # of events per type are as expected
             ['execute', { gte: 12 }],
             ['new-instance', { equal: 2 }],
-            ['active-instance', { gte: 8 }],
+            ['active-instance', { gte: 5 }],
             ['recovered-instance', { equal: 2 }],
           ]),
         });
@@ -132,9 +132,7 @@ export default function eventLogAlertTests({ getService }: FtrProviderContext) {
             break;
         }
       }
-      expect(flapping).to.eql(
-        new Array(instanceEvents.length - 4).fill(false).concat([true, true, true, true])
-      );
+      expect(flapping).to.eql(new Array(instanceEvents.length - 1).fill(false).concat([true]));
     });
   });
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.7`:
 - [[ResponseOps] [Flapping] actions scheduled while alert not active, but flapping (#151066)](https://github.com/elastic/kibana/pull/151066)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Alexi Doak","email":"109488926+doakalexi@users.noreply.github.com"},"sourceCommit":{"committedDate":"2023-02-24T03:51:13Z","message":"[ResponseOps] [Flapping] actions scheduled while alert not active, but flapping (#151066)\n\nResolves https://github.com/elastic/kibana/issues/150115\r\n\r\n## Summary\r\n\r\nUpdates the `getAlertsForNotification` functions to only suppress\r\nflapping recovered alerts when `notifyWhen` is set to `on Status Change`\r\n\r\n\r\n### Checklist\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n\r\n\r\n### To verifu\r\n\r\n- Create an alert with `notifyWhen: on every run or throttle` and let it\r\nget in to a flapping state\r\n- Verify that recovered alerts notifications are skipped during the\r\npending recovered phase.","sha":"73cef597f1b6ed5f35d51d8fb24287bd7ffddf30","branchLabelMapping":{"^v8.8.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:ResponseOps","v8.7.0","v8.8.0"],"number":151066,"url":"https://github.com/elastic/kibana/pull/151066","mergeCommit":{"message":"[ResponseOps] [Flapping] actions scheduled while alert not active, but flapping (#151066)\n\nResolves https://github.com/elastic/kibana/issues/150115\r\n\r\n## Summary\r\n\r\nUpdates the `getAlertsForNotification` functions to only suppress\r\nflapping recovered alerts when `notifyWhen` is set to `on Status Change`\r\n\r\n\r\n### Checklist\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n\r\n\r\n### To verifu\r\n\r\n- Create an alert with `notifyWhen: on every run or throttle` and let it\r\nget in to a flapping state\r\n- Verify that recovered alerts notifications are skipped during the\r\npending recovered phase.","sha":"73cef597f1b6ed5f35d51d8fb24287bd7ffddf30"}},"sourceBranch":"main","suggestedTargetBranches":["8.7"],"targetPullRequestStates":[{"branch":"8.7","label":"v8.7.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.8.0","labelRegex":"^v8.8.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/151066","number":151066,"mergeCommit":{"message":"[ResponseOps] [Flapping] actions scheduled while alert not active, but flapping (#151066)\n\nResolves https://github.com/elastic/kibana/issues/150115\r\n\r\n## Summary\r\n\r\nUpdates the `getAlertsForNotification` functions to only suppress\r\nflapping recovered alerts when `notifyWhen` is set to `on Status Change`\r\n\r\n\r\n### Checklist\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n\r\n\r\n### To verifu\r\n\r\n- Create an alert with `notifyWhen: on every run or throttle` and let it\r\nget in to a flapping state\r\n- Verify that recovered alerts notifications are skipped during the\r\npending recovered phase.","sha":"73cef597f1b6ed5f35d51d8fb24287bd7ffddf30"}}]}] BACKPORT-->