### PR TITLE
[APM] Show prompt when service map is disabled

### DIFF
--- a/x-pack/plugins/apm/public/components/app/service_map/disabled_prompt.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_map/disabled_prompt.tsx
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiEmptyPrompt } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import React from 'react';
+
+export function DisabledPrompt() {
+  return (
+    <EuiEmptyPrompt
+      iconType="eyeClosed"
+      iconColor="subdued"
+      title={
+        <h2>
+          {i18n.translate('xpack.apm.serviceMap.disabledTitle', {
+            defaultMessage: 'Service map is disabled',
+          })}
+        </h2>
+      }
+      body={
+        <p>
+          {i18n.translate('xpack.apm.serviceMap.disabledDescription', {
+            defaultMessage:
+              'The service map has been disabled. It can be enabled via `xpack.apm.serviceMapEnabled`',
+          })}
+        </p>
+      }
+    />
+  );
+}


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/151971

It is possible to disable the service map via `xpack.apm.serviceMapEnabled: false`. Previously the UI would handle this very ungracefully by showing a 404 error toast when navigating to the service map.

This improves the situation by showing a more user friendly prompt:

![image](https://user-images.githubusercontent.com/209966/221195765-b4749886-1cb8-40a3-a6cb-333c0c9c6a87.png)


<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->