### PR TITLE
[Fleet] Add changelog modal to Integrations overview

### DIFF
--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/overview/details.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/overview/details.tsx
@@ -73,18 +73,18 @@ export const Details: React.FC<Props> = memo(({ packageInfo }) => {
 
   const [isNoticeModalOpen, setIsNoticeModalOpen] = useState(false);
   const toggleNoticeModal = useCallback(() => {
-    setIsNoticeModalOpen(!isNoticeModalOpen);
-  }, [isNoticeModalOpen]);
+    setIsNoticeModalOpen((currentState) => !currentState);
+  }, []);
 
   const [isLicenseModalOpen, setIsLicenseModalOpen] = useState(false);
   const toggleLicenseModal = useCallback(() => {
-    setIsLicenseModalOpen(!isLicenseModalOpen);
-  }, [isLicenseModalOpen]);
+    setIsLicenseModalOpen((currentState) => !currentState);
+  }, []);
 
   const [isChangelogModalOpen, setIsChangelogModalOpen] = useState(false);
   const toggleChangelogModal = useCallback(() => {
-    setIsChangelogModalOpen(!isChangelogModalOpen);
-  }, [isChangelogModalOpen]);
+    setIsChangelogModalOpen((currentState) => !currentState);
+  }, []);
 
   const listItems = useMemo(() => {
     // Base details: version and categories

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/overview/details.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/overview/details.tsx
@@ -32,6 +32,8 @@ import { entries } from '../../../../../types';
 import { useGetCategoriesQuery } from '../../../../../hooks';
 import { AssetTitleMap, DisplayedAssets, ServiceTitleMap } from '../../../constants';
 
+import { ChangelogModal } from '../settings/changelog_modal';
+
 import { NoticeModal } from './notice_modal';
 import { LicenseModal } from './license_modal';
 
@@ -78,6 +80,11 @@ export const Details: React.FC<Props> = memo(({ packageInfo }) => {
   const toggleLicenseModal = useCallback(() => {
     setIsLicenseModalOpen(!isLicenseModalOpen);
   }, [isLicenseModalOpen]);
+
+  const [isChangelogModalOpen, setIsChangelogModalOpen] = useState(false);
+  const toggleChangelogModal = useCallback(() => {
+    setIsChangelogModalOpen(!isChangelogModalOpen);
+  }, [isChangelogModalOpen]);
 
   const listItems = useMemo(() => {
     // Base details: version and categories
@@ -201,6 +208,21 @@ export const Details: React.FC<Props> = memo(({ packageInfo }) => {
       });
     }
 
+    items.push({
+      title: (
+        <EuiTextColor color="subdued">
+          <FormattedMessage id="xpack.fleet.epm.changelogLabel" defaultMessage="Changelog" />
+        </EuiTextColor>
+      ),
+      description: (
+        <>
+          <p>
+            <EuiLink onClick={toggleChangelogModal}>View Changelog</EuiLink>
+          </p>
+        </>
+      ),
+    });
+
     return items;
   }, [
     packageCategories,
@@ -214,6 +236,7 @@ export const Details: React.FC<Props> = memo(({ packageInfo }) => {
     packageInfo.version,
     toggleLicenseModal,
     toggleNoticeModal,
+    toggleChangelogModal,
   ]);
 
   return (
@@ -229,6 +252,15 @@ export const Details: React.FC<Props> = memo(({ packageInfo }) => {
             licenseName={packageInfo.source?.license}
             licensePath={packageInfo.licensePath}
             onClose={toggleLicenseModal}
+          />
+        )}
+      </EuiPortal>
+      <EuiPortal>
+        {isChangelogModalOpen && (
+          <ChangelogModal
+            latestVersion={packageInfo.version}
+            packageName={packageInfo.name}
+            onClose={toggleChangelogModal}
           />
         )}
       </EuiPortal>

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/settings/changelog_modal.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/settings/changelog_modal.tsx
@@ -34,7 +34,7 @@ export interface ChangeLogParams {
 
 interface Props {
   latestVersion: string;
-  currentVersion: string;
+  currentVersion?: string;
   packageName: string;
   onClose: () => void;
 }
@@ -54,7 +54,10 @@ export const ChangelogModal: React.FunctionComponent<Props> = ({
   } = useGetFileByPathQuery(`/package/${packageName}/${latestVersion}/changelog.yml`);
   const changelogText = changelogResponse?.data;
 
-  const finalChangelog = getFormattedChangelog(changelogText, currentVersion, latestVersion);
+  // currentVersion is used to display the changelog up to the current installed version, when there is a newer one available
+  const finalChangelog = currentVersion
+    ? getFormattedChangelog(changelogText, latestVersion, currentVersion)
+    : getFormattedChangelog(changelogText, latestVersion);
 
   if (changelogError) {
     notifications.toasts.addError(changelogError, {

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/utils/changelog_utils.test.ts
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/utils/changelog_utils.test.ts
@@ -31,7 +31,7 @@ describe('filterYamlChangelog', () => {
       link: https://github.com/elastic/integrations/pull/4399`;
 
   it('should return the changelog from latest to current version', () => {
-    expect(filterYamlChangelog(changelogText, `2.2.0`, `2.4.0`)).toEqual([
+    expect(filterYamlChangelog(changelogText, `2.4.0`, `2.2.0`)).toEqual([
       {
         version: '2.4.0',
         changes: [
@@ -65,10 +65,55 @@ describe('filterYamlChangelog', () => {
     ]);
   });
 
+  it('should return the changelog to latest version when there is no current version defined', () => {
+    expect(filterYamlChangelog(changelogText, `2.4.0`)).toEqual([
+      {
+        version: '2.4.0',
+        changes: [
+          {
+            description: 'Update package to ECS 8.6.0.',
+            link: 'https://github.com/elastic/integrations/pull/4576',
+            type: 'enhancement',
+          },
+        ],
+      },
+      {
+        version: '2.3.0',
+        changes: [
+          {
+            description: 'Added support for GCS input.',
+            link: 'https://github.com/elastic/integrations/pull/4728',
+            type: 'enhancement',
+          },
+        ],
+      },
+      {
+        version: '2.2.0',
+        changes: [
+          {
+            description: 'Update package to ECS 8.5.0.',
+            link: 'https://github.com/elastic/integrations/pull/4285',
+            type: 'enhancement',
+          },
+        ],
+      },
+      {
+        version: '2.1.2',
+        changes: [
+          {
+            description: 'Remove duplicate fields.',
+            link: 'https://github.com/elastic/integrations/pull/4399',
+            type: 'bugfix',
+          },
+        ],
+      },
+    ]);
+  });
+
   it('should return empty array if changelog text is undefined', () => {
-    expect(filterYamlChangelog(undefined, `2.2.0`, `2.4.0`)).toEqual([]);
+    expect(filterYamlChangelog(undefined, `2.4.0`, `2.2.0`)).toEqual([]);
   });
   it('should return empty array if changelog text is null', () => {
-    expect(filterYamlChangelog(null, `2.2.0`, `2.4.0`)).toEqual([]);
+    expect(filterYamlChangelog(null, `2.4.0`, `2.2.0`)).toEqual([]);
   });
 });

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/utils/changelog_utils.ts
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/utils/changelog_utils.ts
@@ -23,10 +23,12 @@ export const formatChangelog = (parsedChangelog: ChangeLogParams[]) => {
 // Exported for testing
 export const filterYamlChangelog = (
   changelogText: string | null | undefined,
-  currentVersion: string,
-  latestVersion: string
+  latestVersion: string,
+  currentVersion?: string
 ) => {
   const parsedChangelog: ChangeLogParams[] = changelogText ? safeLoad(changelogText) : [];
+
+  if (!currentVersion) return parsedChangelog.filter((e) => semverLte(e.version, latestVersion));
 
   return parsedChangelog.filter(
     (e) => semverLte(e.version, latestVersion) && semverGte(e.version, currentVersion)
@@ -35,9 +37,9 @@ export const filterYamlChangelog = (
 
 export const getFormattedChangelog = (
   changelogText: string | null | undefined,
-  currentVersion: string,
-  latestVersion: string
+  latestVersion: string,
+  currentVersion?: string
 ) => {
-  const parsed = filterYamlChangelog(changelogText, currentVersion, latestVersion);
+  const parsed = filterYamlChangelog(changelogText, latestVersion, currentVersion);
   return formatChangelog(parsed);
 };


### PR DESCRIPTION
Follow up for https://github.com/elastic/kibana/issues/150754

## Summary

Adding the changelog modal in integrations > overview. This a follow up of a [previous PR](https://github.com/elastic/kibana/pull/152082) to have a place in the UI where package integrations changelogs are easily accessible, not only at the time of the upgrade.

### Testing

- Install any integration
- In the overview tab there is a "View changelog" link on the right side column
- Clicking the link will open a modal with the changelog up to the installed version

### Screnshots

<img width="1548" alt="Screenshot 2023-02-24 at 15 22 52" src="https://user-images.githubusercontent.com/16084106/221204047-368b327c-5084-41fa-8389-c3d86e570bc1.png">

<img width="1498" alt="Screenshot 2023-02-24 at 15 22 59" src="https://user-images.githubusercontent.com/16084106/221204078-37b7c9b3-c880-45ba-ac67-5afc70a7f6b4.png">

### Checklist
- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
