### PR TITLE
[Fleet] Fix OpenAPI for agent policy

### DIFF
--- a/x-pack/plugins/fleet/common/openapi/bundled.json
+++ b/x-pack/plugins/fleet/common/openapi/bundled.json
@@ -2689,7 +2689,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/new_agent_policy"
+                "$ref": "#/components/schemas/agent_policy_create_request"
               }
             }
           }
@@ -2774,7 +2774,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/new_agent_policy"
+                "$ref": "#/components/schemas/agent_policy_update_request"
               }
             }
           }
@@ -5956,60 +5956,6 @@
           }
         }
       },
-      "new_agent_policy": {
-        "title": "New agent policy",
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "namespace": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "monitoring_enabled": {
-            "type": "array",
-            "items": {
-              "type": "string",
-              "enum": [
-                "metrics",
-                "logs"
-              ]
-            }
-          },
-          "data_output_id": {
-            "type": "string",
-            "nullable": true
-          },
-          "monitoring_output_id": {
-            "type": "string",
-            "nullable": true
-          },
-          "fleet_server_host_id": {
-            "type": "string",
-            "nullable": true
-          },
-          "download_source_id": {
-            "type": "string",
-            "nullable": true
-          },
-          "unenroll_timeout": {
-            "type": "number"
-          },
-          "inactivity_timeout": {
-            "type": "number"
-          }
-        },
-        "required": [
-          "name",
-          "namespace"
-        ]
-      },
       "new_package_policy": {
         "title": "New package policy",
         "type": "object",
@@ -6120,83 +6066,238 @@
         ]
       },
       "agent_policy": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/new_agent_policy"
+        "title": "Agent Policy",
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
           },
-          {
-            "type": "object",
-            "properties": {
-              "id": {
-                "type": "string"
-              },
-              "status": {
-                "type": "string",
-                "enum": [
-                  "active",
-                  "inactive"
-                ]
-              },
-              "package_policies": {
-                "description": "This field is present only when retrieving a single agent policy, or when retrieving a list of agent policy with the ?full=true parameter",
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/package_policy"
+          "name": {
+            "type": "string"
+          },
+          "namespace": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "monitoring_enabled": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "metrics",
+                "logs"
+              ]
+            }
+          },
+          "data_output_id": {
+            "type": "string",
+            "nullable": true
+          },
+          "monitoring_output_id": {
+            "type": "string",
+            "nullable": true
+          },
+          "fleet_server_host_id": {
+            "type": "string",
+            "nullable": true
+          },
+          "download_source_id": {
+            "type": "string",
+            "nullable": true
+          },
+          "unenroll_timeout": {
+            "type": "number"
+          },
+          "inactivity_timeout": {
+            "type": "number"
+          },
+          "package_policies": {
+            "description": "This field is present only when retrieving a single agent policy, or when retrieving a list of agent policy with the ?full=true parameter",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/package_policy"
+            }
+          },
+          "updated_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_by": {
+            "type": "string"
+          },
+          "revision": {
+            "type": "number"
+          },
+          "agents": {
+            "type": "number"
+          },
+          "agent_features": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "enabled": {
+                  "type": "boolean"
                 }
               },
-              "updated_on": {
-                "type": "string",
-                "format": "date-time"
-              },
-              "updated_by": {
-                "type": "string"
-              },
-              "data_output_id": {
-                "type": "string",
-                "nullable": true
-              },
-              "monitoring_output_id": {
-                "type": "string",
-                "nullable": true
-              },
-              "fleet_server_host_id": {
-                "type": "string",
-                "nullable": true
-              },
-              "download_source_id": {
-                "type": "string",
-                "nullable": true
-              },
-              "revision": {
-                "type": "number"
-              },
-              "agents": {
-                "type": "number"
-              },
-              "agent_features": {
-                "type": "array",
-                "items": {
-                  "type": "object",
-                  "properties": {
-                    "name": {
-                      "type": "string"
-                    },
-                    "enabled": {
-                      "type": "boolean"
-                    }
-                  },
-                  "required": [
-                    "name",
-                    "enabled"
-                  ]
-                }
-              }
-            },
-            "required": [
-              "id",
-              "status"
-            ]
+              "required": [
+                "name",
+                "enabled"
+              ]
+            }
           }
+        },
+        "required": [
+          "id",
+          "status",
+          "name",
+          "namespace"
+        ]
+      },
+      "agent_policy_create_request": {
+        "title": "Create agent policy request",
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "namespace": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "monitoring_enabled": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "metrics",
+                "logs"
+              ]
+            }
+          },
+          "data_output_id": {
+            "type": "string",
+            "nullable": true
+          },
+          "monitoring_output_id": {
+            "type": "string",
+            "nullable": true
+          },
+          "fleet_server_host_id": {
+            "type": "string",
+            "nullable": true
+          },
+          "download_source_id": {
+            "type": "string",
+            "nullable": true
+          },
+          "unenroll_timeout": {
+            "type": "number"
+          },
+          "inactivity_timeout": {
+            "type": "number"
+          },
+          "agent_features": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "enabled": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "name",
+                "enabled"
+              ]
+            }
+          }
+        },
+        "required": [
+          "name",
+          "namespace"
+        ]
+      },
+      "agent_policy_update_request": {
+        "title": "Update agent policy request",
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "namespace": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "monitoring_enabled": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "metrics",
+                "logs"
+              ]
+            }
+          },
+          "data_output_id": {
+            "type": "string",
+            "nullable": true
+          },
+          "monitoring_output_id": {
+            "type": "string",
+            "nullable": true
+          },
+          "fleet_server_host_id": {
+            "type": "string",
+            "nullable": true
+          },
+          "download_source_id": {
+            "type": "string",
+            "nullable": true
+          },
+          "unenroll_timeout": {
+            "type": "number"
+          },
+          "inactivity_timeout": {
+            "type": "number"
+          },
+          "agent_features": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "enabled": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "name",
+                "enabled"
+              ]
+            }
+          }
+        },
+        "required": [
+          "name",
+          "namespace"
         ]
       },
       "full_agent_policy_output": {

--- a/x-pack/plugins/fleet/common/openapi/bundled.yaml
+++ b/x-pack/plugins/fleet/common/openapi/bundled.yaml
@@ -1675,7 +1675,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/new_agent_policy'
+              $ref: '#/components/schemas/agent_policy_create_request'
       security: []
       parameters:
         - $ref: '#/components/parameters/kbn_xsrf'
@@ -1728,7 +1728,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/new_agent_policy'
+              $ref: '#/components/schemas/agent_policy_update_request'
       parameters:
         - $ref: '#/components/parameters/kbn_xsrf'
   /agent_policies/{agentPolicyId}/copy:
@@ -3797,44 +3797,6 @@ components:
           type: array
           items:
             type: string
-    new_agent_policy:
-      title: New agent policy
-      type: object
-      properties:
-        id:
-          type: string
-        name:
-          type: string
-        namespace:
-          type: string
-        description:
-          type: string
-        monitoring_enabled:
-          type: array
-          items:
-            type: string
-            enum:
-              - metrics
-              - logs
-        data_output_id:
-          type: string
-          nullable: true
-        monitoring_output_id:
-          type: string
-          nullable: true
-        fleet_server_host_id:
-          type: string
-          nullable: true
-        download_source_id:
-          type: string
-          nullable: true
-        unenroll_timeout:
-          type: number
-        inactivity_timeout:
-          type: number
-      required:
-        - name
-        - namespace
     new_package_policy:
       title: New package policy
       type: object
@@ -3908,61 +3870,171 @@ components:
             - revision
         - $ref: '#/components/schemas/new_package_policy'
     agent_policy:
-      allOf:
-        - $ref: '#/components/schemas/new_agent_policy'
-        - type: object
-          properties:
-            id:
-              type: string
-            status:
-              type: string
-              enum:
-                - active
-                - inactive
-            package_policies:
-              description: >-
-                This field is present only when retrieving a single agent
-                policy, or when retrieving a list of agent policy with the
-                ?full=true parameter
-              type: array
-              items:
-                $ref: '#/components/schemas/package_policy'
-            updated_on:
-              type: string
-              format: date-time
-            updated_by:
-              type: string
-            data_output_id:
-              type: string
-              nullable: true
-            monitoring_output_id:
-              type: string
-              nullable: true
-            fleet_server_host_id:
-              type: string
-              nullable: true
-            download_source_id:
-              type: string
-              nullable: true
-            revision:
-              type: number
-            agents:
-              type: number
-            agent_features:
-              type: array
-              items:
-                type: object
-                properties:
-                  name:
-                    type: string
-                  enabled:
-                    type: boolean
-                required:
-                  - name
-                  - enabled
-          required:
-            - id
-            - status
+      title: Agent Policy
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        namespace:
+          type: string
+        description:
+          type: string
+        monitoring_enabled:
+          type: array
+          items:
+            type: string
+            enum:
+              - metrics
+              - logs
+        data_output_id:
+          type: string
+          nullable: true
+        monitoring_output_id:
+          type: string
+          nullable: true
+        fleet_server_host_id:
+          type: string
+          nullable: true
+        download_source_id:
+          type: string
+          nullable: true
+        unenroll_timeout:
+          type: number
+        inactivity_timeout:
+          type: number
+        package_policies:
+          description: >-
+            This field is present only when retrieving a single agent policy, or
+            when retrieving a list of agent policy with the ?full=true parameter
+          type: array
+          items:
+            $ref: '#/components/schemas/package_policy'
+        updated_on:
+          type: string
+          format: date-time
+        updated_by:
+          type: string
+        revision:
+          type: number
+        agents:
+          type: number
+        agent_features:
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+              enabled:
+                type: boolean
+            required:
+              - name
+              - enabled
+      required:
+        - id
+        - status
+        - name
+        - namespace
+    agent_policy_create_request:
+      title: Create agent policy request
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        namespace:
+          type: string
+        description:
+          type: string
+        monitoring_enabled:
+          type: array
+          items:
+            type: string
+            enum:
+              - metrics
+              - logs
+        data_output_id:
+          type: string
+          nullable: true
+        monitoring_output_id:
+          type: string
+          nullable: true
+        fleet_server_host_id:
+          type: string
+          nullable: true
+        download_source_id:
+          type: string
+          nullable: true
+        unenroll_timeout:
+          type: number
+        inactivity_timeout:
+          type: number
+        agent_features:
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+              enabled:
+                type: boolean
+            required:
+              - name
+              - enabled
+      required:
+        - name
+        - namespace
+    agent_policy_update_request:
+      title: Update agent policy request
+      type: object
+      properties:
+        name:
+          type: string
+        namespace:
+          type: string
+        description:
+          type: string
+        monitoring_enabled:
+          type: array
+          items:
+            type: string
+            enum:
+              - metrics
+              - logs
+        data_output_id:
+          type: string
+          nullable: true
+        monitoring_output_id:
+          type: string
+          nullable: true
+        fleet_server_host_id:
+          type: string
+          nullable: true
+        download_source_id:
+          type: string
+          nullable: true
+        unenroll_timeout:
+          type: number
+        inactivity_timeout:
+          type: number
+        agent_features:
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+              enabled:
+                type: boolean
+            required:
+              - name
+              - enabled
+      required:
+        - name
+        - namespace
     full_agent_policy_output:
       title: Full agent policy
       type: object

--- a/x-pack/plugins/fleet/common/openapi/components/schemas/agent_policy_create_request.yaml
+++ b/x-pack/plugins/fleet/common/openapi/components/schemas/agent_policy_create_request.yaml
@@ -1,4 +1,4 @@
-title: Agent Policy
+title: Create agent policy request
 type: object
 properties:
   id:
@@ -32,20 +32,6 @@ properties:
     type: number
   inactivity_timeout:
     type: number
-  package_policies:
-    description: This field is present only when retrieving a single agent policy, or when retrieving a list of agent policy with the ?full=true parameter
-    type: array
-    items:
-      $ref: ./package_policy.yaml
-  updated_on:
-    type: string
-    format: date-time
-  updated_by:
-    type: string
-  revision:
-    type: number
-  agents:
-    type: number
   agent_features:
     type: array
     items:
@@ -59,7 +45,5 @@ properties:
         - name
         - enabled
 required:
-  - id
-  - status
   - name
   - namespace

--- a/x-pack/plugins/fleet/common/openapi/components/schemas/agent_policy_update_request.yaml
+++ b/x-pack/plugins/fleet/common/openapi/components/schemas/agent_policy_update_request.yaml
@@ -1,8 +1,6 @@
-title: New agent policy
+title: Update agent policy request
 type: object
 properties:
-  id:
-    type: string
   name:
     type: string
   namespace:
@@ -32,6 +30,18 @@ properties:
     type: number
   inactivity_timeout:
     type: number
+  agent_features:
+    type: array
+    items:
+      type: object
+      properties:
+        name:
+          type: string
+        enabled:
+          type: boolean
+      required:
+        - name
+        - enabled
 required:
   - name
   - namespace

--- a/x-pack/plugins/fleet/common/openapi/paths/agent_policies.yaml
+++ b/x-pack/plugins/fleet/common/openapi/paths/agent_policies.yaml
@@ -40,7 +40,7 @@ get:
         type: boolean
       in: query
       name: noAgentCount
-      description: When set to true, do not count how many agents are in the agent policy, this can improve performance if you are searching over a large number of agent policies. The "agents" property will always be 0 if set to true. 
+      description: When set to true, do not count how many agents are in the agent policy, this can improve performance if you are searching over a large number of agent policies. The "agents" property will always be 0 if set to true.
 
   description: ''
 post:
@@ -63,7 +63,7 @@ post:
     content:
       application/json:
         schema:
-          $ref: ../components/schemas/new_agent_policy.yaml
+          $ref: ../components/schemas/agent_policy_create_request.yaml
   security: []
   parameters:
     - $ref: ../components/headers/kbn_xsrf.yaml

--- a/x-pack/plugins/fleet/common/openapi/paths/agent_policies@{agent_policy_id}.yaml
+++ b/x-pack/plugins/fleet/common/openapi/paths/agent_policies@{agent_policy_id}.yaml
@@ -46,6 +46,6 @@ put:
     content:
       application/json:
         schema:
-          $ref: ../components/schemas/new_agent_policy.yaml
+          $ref: ../components/schemas/agent_policy_update_request.yaml
   parameters:
     - $ref: ../components/headers/kbn_xsrf.yaml


### PR DESCRIPTION
## Summary

Resolve #152062

Fix OpenAPI for agent policy, the schema for the update and create agent policy was not correct (`id` was allowed and `agent_features` was not present), that PR fix that by introducing two new file one for update and one for create.

## API doc changes

<img width="830" alt="Screenshot 2023-02-24 at 9 34 00 AM" src="https://user-images.githubusercontent.com/1336873/221204968-18092cfa-68a2-4a35-b634-13e9cc7bd998.png">


<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->