### PR TITLE
[Infrastructure UI] Enable Tooltip Sync Across All Host Metric Charts

### DIFF
--- a/x-pack/plugins/infra/public/pages/metrics/hosts/components/tabs/metrics/metric_chart.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/hosts/components/tabs/metrics/metric_chart.tsx
@@ -119,6 +119,7 @@ export const MetricChart = ({ title, type, breakdownSize }: MetricChartProps) =>
               name: `Hosts View ${type} Chart`,
             }}
             onBrushEnd={handleBrushEnd}
+            syncTooltips={true}
           />
         )
       )}


### PR DESCRIPTION
closes #152102
## Summary

This PR enables the tooltip sync flag across all Host metric charts.

### Testing

Go to the Hosts view page and hover over any of the charts you should see all 8 tooltips showing.


https://user-images.githubusercontent.com/11225826/221211687-b42dff02-04ab-44c2-9ef7-1206e46573cc.mov


