### PR TITLE
[Security Solution] fix flaky endpoint ftr tests

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/retry.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/retry.test.ts
@@ -85,4 +85,13 @@ describe('retryTransientErrors', () => {
     await expect(retryTransientEsErrors(esCallMock)).rejects.toThrow(error);
     expect(esCallMock).toHaveBeenCalledTimes(1);
   });
+
+  it('retries with additionalResponseStatuses', async () => {
+    const error = new EsErrors.ResponseError({ statusCode: 123, meta: {} as any, warnings: [] });
+    const esCallMock = jest.fn().mockRejectedValueOnce(error).mockResolvedValue('success');
+    expect(await retryTransientEsErrors(esCallMock, { additionalResponseStatuses: [123] })).toEqual(
+      'success'
+    );
+    expect(esCallMock).toHaveBeenCalledTimes(2);
+  });
 });

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/transform/install.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/transform/install.ts
@@ -703,9 +703,13 @@ async function handleTransformInstall({
   // start transform by default if not set in yml file
   // else, respect the setting
   if (startTransform === undefined || startTransform === true) {
-    await esClient.transform.startTransform(
-      { transform_id: transform.installationName },
-      { ignore: [409] }
+    await retryTransientEsErrors(
+      () =>
+        esClient.transform.startTransform(
+          { transform_id: transform.installationName },
+          { ignore: [409] }
+        ),
+      { logger, additionalResponseStatuses: [400] }
     );
     logger.debug(`Started transform: ${transform.installationName}`);
   }

--- a/x-pack/test/security_solution_endpoint/apps/endpoint/index.ts
+++ b/x-pack/test/security_solution_endpoint/apps/endpoint/index.ts
@@ -15,8 +15,7 @@ import {
 export default function (providerContext: FtrProviderContext) {
   const { loadTestFile, getService } = providerContext;
 
-  // FLAKY: https://github.com/elastic/kibana/issues/72874
-  describe.skip('endpoint', function () {
+  describe('endpoint', function () {
     const ingestManager = getService('ingestManager');
     const log = getService('log');
     const endpointTestResources = getService('endpointTestResources');


### PR DESCRIPTION
## Summary

Fixes flaky endpoint FTR tests.
- ~restrict `CheckMetadataTransformsTask` from running during tests so that it doesn't interfere with expected test transform setups~ will revisit in separate PR (see [comment](https://github.com/elastic/kibana/pull/152119#discussion_r1120215919))
- retry transform start during transform install

Flaky test runs:
- https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/1964 (200x ✅ )
- https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/1971 (200x ✅ )

Fixes: https://github.com/elastic/kibana/issues/72874


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
