### PR TITLE
[Enterprise Search] Engines Search Preview - Improve these results link

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/engine_search_preview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/engine_search_preview.tsx
@@ -9,7 +9,7 @@ import React, { useState, useMemo } from 'react';
 
 import { useValues } from 'kea';
 
-import { EuiButton, EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
+import { EuiButton, EuiFlexGroup, EuiFlexItem, EuiLink, EuiSpacer } from '@elastic/eui';
 import {
   PagingInfo,
   Results,
@@ -25,7 +25,9 @@ import EnginesAPIConnector, {
 } from '@elastic/search-ui-engines-connector';
 import { HttpSetup } from '@kbn/core-http-browser';
 import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
 
+import { docLinks } from '../../../../shared/doc_links';
 import { HttpLogic } from '../../../../shared/http';
 import { EngineViewTabs } from '../../../routes';
 import { EnterpriseSearchEnginesPageTemplate } from '../../layout/engines_page_template';
@@ -138,6 +140,13 @@ export const EngineSearchPreview: React.FC = () => {
           <EuiFlexGroup>
             <EuiFlexItem grow={false} css={{ minWidth: '240px' }}>
               <ResultsPerPage view={ResultsPerPageView} options={RESULTS_PER_PAGE_OPTIONS} />
+              <EuiSpacer size="m" />
+              <EuiLink href={docLinks.enterpriseSearchEngines} target="_blank">
+                <FormattedMessage
+                  id="xpack.enterpriseSearch.content.engine.searchPreview.improveResultsLink"
+                  defaultMessage="Improve these results"
+                />
+              </EuiLink>
             </EuiFlexItem>
             <EuiFlexItem>
               <PagingInfo view={PagingInfoView} />

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/search_ui_components.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/search_ui_components.tsx
@@ -197,7 +197,12 @@ export const ResultsPerPageView: React.FC<ResultsPerPageViewProps> = ({
   <EuiFlexItem grow={false}>
     <EuiFlexGroup direction="column" gutterSize="s">
       <EuiTitle size="xxxs">
-        <label htmlFor="results-per-page">Show</label>
+        <label htmlFor="results-per-page">
+          <FormattedMessage
+            id="xpack.enterpriseSearch.content.engine.searchPreview.resultsPerPage.label"
+            defaultMessage="Show"
+          />
+        </label>
       </EuiTitle>
       <EuiSelect
         id="results-per-page"

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/search_ui_components.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/search_ui_components.tsx
@@ -209,7 +209,7 @@ export const ResultsPerPageView: React.FC<ResultsPerPageViewProps> = ({
         options={
           options?.map((option) => ({
             text: i18n.translate(
-              'xpack.enterpriseSearch.content.engine.searchPreview.resultsPerPage.label',
+              'xpack.enterpriseSearch.content.engine.searchPreview.resultsPerPage.option.label',
               {
                 defaultMessage: '{value} {value, plural, one {Result} other {Results}}',
                 values: { value: option },

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/search_ui_components.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/search_ui_components.tsx
@@ -194,26 +194,28 @@ export const ResultsPerPageView: React.FC<ResultsPerPageViewProps> = ({
   options,
   value,
 }) => (
-  <EuiFlexGroup direction="column" gutterSize="s">
-    <EuiTitle size="xxxs">
-      <label htmlFor="results-per-page">Show</label>
-    </EuiTitle>
-    <EuiSelect
-      id="results-per-page"
-      options={
-        options?.map((option) => ({
-          text: i18n.translate(
-            'xpack.enterpriseSearch.content.engine.searchPreview.resultsPerPage.label',
-            {
-              defaultMessage: '{value} {value, plural, one {Result} other {Results}}',
-              values: { value: option },
-            }
-          ),
-          value: option,
-        })) ?? []
-      }
-      value={value}
-      onChange={(evt) => onChange(parseInt(evt.target.value, 10))}
-    />
-  </EuiFlexGroup>
+  <EuiFlexItem grow={false}>
+    <EuiFlexGroup direction="column" gutterSize="s">
+      <EuiTitle size="xxxs">
+        <label htmlFor="results-per-page">Show</label>
+      </EuiTitle>
+      <EuiSelect
+        id="results-per-page"
+        options={
+          options?.map((option) => ({
+            text: i18n.translate(
+              'xpack.enterpriseSearch.content.engine.searchPreview.resultsPerPage.label',
+              {
+                defaultMessage: '{value} {value, plural, one {Result} other {Results}}',
+                values: { value: option },
+              }
+            ),
+            value: option,
+          })) ?? []
+        }
+        value={value}
+        onChange={(evt) => onChange(parseInt(evt.target.value, 10))}
+      />
+    </EuiFlexGroup>
+  </EuiFlexItem>
 );


### PR DESCRIPTION
## Summary

<img width="368" alt="image" src="https://user-images.githubusercontent.com/1699281/221273950-17b400d8-15b0-4680-b438-5826c4e70703.png">

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

