### PR TITLE
[Cloud Posture] Ensure package policy namespace is always set to default

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/components/fleet_extensions/policy_template_form.test.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/fleet_extensions/policy_template_form.test.tsx
@@ -49,6 +49,23 @@ describe('<CspPolicyTemplateForm />', () => {
     onChange.mockClear();
   });
 
+  it('updates package policy namespace to default when it changes', () => {
+    const policy = getMockPolicyK8s();
+    const { rerender } = render(<WrappedComponent newPolicy={policy} />);
+
+    rerender(<WrappedComponent newPolicy={{ ...policy, namespace: 'some-namespace' }} />);
+
+    // Listen to the 2nd triggered by the test (re-render with new policy namespace)
+    // The 1st is done on mount to ensure initial state is valid.
+    expect(onChange).toHaveBeenNthCalledWith(2, {
+      isValid: true,
+      updatedPolicy: {
+        ...policy,
+        namespace: 'default',
+      },
+    });
+  });
+
   it('renders and updates name field', () => {
     const policy = getMockPolicyK8s();
     const { getByLabelText } = render(<WrappedComponent newPolicy={policy} />);

--- a/x-pack/plugins/cloud_security_posture/public/components/fleet_extensions/policy_template_form.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/fleet_extensions/policy_template_form.tsx
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import React, { memo, useEffect } from 'react';
+import React, { memo, useCallback, useEffect } from 'react';
 import { EuiFieldText, EuiFormRow, EuiSpacer, EuiTitle } from '@elastic/eui';
 import type { NewPackagePolicy } from '@kbn/fleet-plugin/public';
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -69,8 +69,10 @@ export const CspPolicyTemplateForm = memo<PackagePolicyReplaceDefineStepExtensio
     const { integration } = useParams<{ integration: CloudSecurityPolicyTemplate }>();
     const input = getEnabledPostureInput(newPolicy);
 
-    const updatePolicy = (updatedPolicy: NewPackagePolicy) =>
-      onChange({ isValid: true, updatedPolicy });
+    const updatePolicy = useCallback(
+      (updatedPolicy: NewPackagePolicy) => onChange({ isValid: true, updatedPolicy }),
+      [onChange]
+    );
 
     /**
      * - Updates policy inputs by user selection
@@ -118,6 +120,8 @@ export const CspPolicyTemplateForm = memo<PackagePolicyReplaceDefineStepExtensio
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [isEditPage]);
 
+    useEnsureDefaultNamespace({ newPolicy, input, updatePolicy });
+
     return (
       <div>
         {isEditPage && <EditScreenStepTitle />}
@@ -164,3 +168,14 @@ CspPolicyTemplateForm.displayName = 'CspPolicyTemplateForm';
 
 // eslint-disable-next-line import/no-default-export
 export { CspPolicyTemplateForm as default };
+
+const useEnsureDefaultNamespace = ({ newPolicy, input, updatePolicy }) => {
+  useEffect(() => {
+    if (newPolicy.namespace === 'default') return;
+
+    updatePolicy({
+      ...getPosturePolicy(newPolicy, input.type),
+      namespace: 'default',
+    });
+  }, [newPolicy, input, updatePolicy]);
+};

--- a/x-pack/plugins/cloud_security_posture/public/components/fleet_extensions/policy_template_form.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/fleet_extensions/policy_template_form.tsx
@@ -16,7 +16,13 @@ import {
   CLOUDBEAT_VANILLA,
   CLOUDBEAT_VULN_MGMT_AWS,
 } from '../../../common/constants';
-import { getPosturePolicy, getEnabledPostureInput, getPostureInputHiddenVars } from './utils';
+import {
+  getPosturePolicy,
+  getEnabledPostureInput,
+  getPostureInputHiddenVars,
+  POSTURE_NAMESPACE,
+  NewPackagePolicyPostureInput,
+} from './utils';
 import {
   PolicyTemplateInfo,
   PolicyTemplateInputSelector,
@@ -169,13 +175,19 @@ CspPolicyTemplateForm.displayName = 'CspPolicyTemplateForm';
 // eslint-disable-next-line import/no-default-export
 export { CspPolicyTemplateForm as default };
 
-const useEnsureDefaultNamespace = ({ newPolicy, input, updatePolicy }) => {
+const useEnsureDefaultNamespace = ({
+  newPolicy,
+  input,
+  updatePolicy,
+}: {
+  newPolicy: NewPackagePolicy;
+  input: NewPackagePolicyPostureInput;
+  updatePolicy: (policy: NewPackagePolicy) => void;
+}) => {
   useEffect(() => {
-    if (newPolicy.namespace === 'default') return;
+    if (newPolicy.namespace === POSTURE_NAMESPACE) return;
 
-    updatePolicy({
-      ...getPosturePolicy(newPolicy, input.type),
-      namespace: 'default',
-    });
+    const policy = { ...getPosturePolicy(newPolicy, input.type), namespace: POSTURE_NAMESPACE };
+    updatePolicy(policy);
   }, [newPolicy, input, updatePolicy]);
 };

--- a/x-pack/plugins/cloud_security_posture/public/components/fleet_extensions/utils.ts
+++ b/x-pack/plugins/cloud_security_posture/public/components/fleet_extensions/utils.ts
@@ -24,6 +24,9 @@ import type { PostureInput, CloudSecurityPolicyTemplate } from '../../../common/
 import { assert } from '../../../common/utils/helpers';
 import { cloudPostureIntegrations } from '../../common/constants';
 
+// Posture policies only support the default namespace
+export const POSTURE_NAMESPACE = 'default';
+
 type PosturePolicyInput =
   | { type: typeof CLOUDBEAT_AZURE; policy_template: 'cspm' }
   | { type: typeof CLOUDBEAT_GCP; policy_template: 'cspm' }

--- a/x-pack/plugins/cloud_security_posture/public/components/fleet_extensions/utils.ts
+++ b/x-pack/plugins/cloud_security_posture/public/components/fleet_extensions/utils.ts
@@ -75,6 +75,7 @@ export const getPosturePolicy = (
   inputVars?: Record<string, PackagePolicyConfigRecordEntry>
 ): NewPackagePolicy => ({
   ...newPolicy,
+  namespace: 'default',
   // Enable new policy input and disable all others
   inputs: newPolicy.inputs.map((item) => getPostureInput(item, inputType, inputVars)),
   // Set hidden policy vars


### PR DESCRIPTION
## Summary

once https://github.com/elastic/kibana/pull/151886 is merged, changes to agent policy will update the package policy id and also the namespace. in our case, we only support the `default` namespace (IIRC - to prevent confusion with k8s namespaces)

so this PR adds an effect to ensure the namespace is always set to default

<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->