### PR TITLE
[8.7] [Cloud Posture] Ensure package policy namespace is always set to default (#152168)

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/components/fleet_extensions/policy_template_form.test.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/fleet_extensions/policy_template_form.test.tsx
@@ -49,6 +49,23 @@ describe('<CspPolicyTemplateForm />', () => {
     onChange.mockClear();
   });
 
+  it('updates package policy namespace to default when it changes', () => {
+    const policy = getMockPolicyK8s();
+    const { rerender } = render(<WrappedComponent newPolicy={policy} />);
+
+    rerender(<WrappedComponent newPolicy={{ ...policy, namespace: 'some-namespace' }} />);
+
+    // Listen to the 2nd triggered by the test (re-render with new policy namespace)
+    // The 1st is done on mount to ensure initial state is valid.
+    expect(onChange).toHaveBeenNthCalledWith(2, {
+      isValid: true,
+      updatedPolicy: {
+        ...policy,
+        namespace: 'default',
+      },
+    });
+  });
+
   it('renders and updates name field', () => {
     const policy = getMockPolicyK8s();
     const { getByLabelText } = render(<WrappedComponent newPolicy={policy} />);

--- a/x-pack/plugins/cloud_security_posture/public/components/fleet_extensions/policy_template_form.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/fleet_extensions/policy_template_form.tsx
@@ -11,11 +11,7 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import type { PackagePolicyReplaceDefineStepExtensionComponentProps } from '@kbn/fleet-plugin/public/types';
 import { useParams } from 'react-router-dom';
 import type { PostureInput, PosturePolicyTemplate } from '../../../common/types';
-import {
-  CLOUDBEAT_AWS,
-  CLOUDBEAT_VANILLA,
-  CLOUDBEAT_VULN_MGMT_AWS,
-} from '../../../common/constants';
+import { CLOUDBEAT_AWS, CLOUDBEAT_VANILLA } from '../../../common/constants';
 import {
   getPosturePolicy,
   getEnabledPostureInput,

--- a/x-pack/plugins/cloud_security_posture/public/components/fleet_extensions/policy_template_form.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/fleet_extensions/policy_template_form.tsx
@@ -4,15 +4,25 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import React, { memo, useEffect } from 'react';
+import React, { memo, useCallback, useEffect } from 'react';
 import { EuiFieldText, EuiFormRow, EuiSpacer, EuiTitle } from '@elastic/eui';
 import type { NewPackagePolicy } from '@kbn/fleet-plugin/public';
 import { FormattedMessage } from '@kbn/i18n-react';
 import type { PackagePolicyReplaceDefineStepExtensionComponentProps } from '@kbn/fleet-plugin/public/types';
 import { useParams } from 'react-router-dom';
 import type { PostureInput, PosturePolicyTemplate } from '../../../common/types';
-import { CLOUDBEAT_AWS, CLOUDBEAT_VANILLA } from '../../../common/constants';
-import { getPosturePolicy, getEnabledPostureInput, getPostureInputHiddenVars } from './utils';
+import {
+  CLOUDBEAT_AWS,
+  CLOUDBEAT_VANILLA,
+  CLOUDBEAT_VULN_MGMT_AWS,
+} from '../../../common/constants';
+import {
+  getPosturePolicy,
+  getEnabledPostureInput,
+  getPostureInputHiddenVars,
+  POSTURE_NAMESPACE,
+  NewPackagePolicyPostureInput,
+} from './utils';
 import {
   PolicyTemplateInfo,
   PolicyTemplateInputSelector,
@@ -64,8 +74,10 @@ export const CspPolicyTemplateForm = memo<PackagePolicyReplaceDefineStepExtensio
     const { integration } = useParams<{ integration: PosturePolicyTemplate }>();
     const input = getEnabledPostureInput(newPolicy);
 
-    const updatePolicy = (updatedPolicy: NewPackagePolicy) =>
-      onChange({ isValid: true, updatedPolicy });
+    const updatePolicy = useCallback(
+      (updatedPolicy: NewPackagePolicy) => onChange({ isValid: true, updatedPolicy }),
+      [onChange]
+    );
 
     /**
      * - Updates policy inputs by user selection
@@ -113,6 +125,8 @@ export const CspPolicyTemplateForm = memo<PackagePolicyReplaceDefineStepExtensio
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [isEditPage]);
 
+    useEnsureDefaultNamespace({ newPolicy, input, updatePolicy });
+
     return (
       <div>
         {isEditPage && <EditScreenStepTitle />}
@@ -159,3 +173,20 @@ CspPolicyTemplateForm.displayName = 'CspPolicyTemplateForm';
 
 // eslint-disable-next-line import/no-default-export
 export { CspPolicyTemplateForm as default };
+
+const useEnsureDefaultNamespace = ({
+  newPolicy,
+  input,
+  updatePolicy,
+}: {
+  newPolicy: NewPackagePolicy;
+  input: NewPackagePolicyPostureInput;
+  updatePolicy: (policy: NewPackagePolicy) => void;
+}) => {
+  useEffect(() => {
+    if (newPolicy.namespace === POSTURE_NAMESPACE) return;
+
+    const policy = { ...getPosturePolicy(newPolicy, input.type), namespace: POSTURE_NAMESPACE };
+    updatePolicy(policy);
+  }, [newPolicy, input, updatePolicy]);
+};

--- a/x-pack/plugins/cloud_security_posture/public/components/fleet_extensions/utils.ts
+++ b/x-pack/plugins/cloud_security_posture/public/components/fleet_extensions/utils.ts
@@ -24,6 +24,9 @@ import type { PostureInput, PosturePolicyTemplate } from '../../../common/types'
 import { assert } from '../../../common/utils/helpers';
 import { cloudPostureIntegrations } from '../../common/constants';
 
+// Posture policies only support the default namespace
+export const POSTURE_NAMESPACE = 'default';
+
 type PosturePolicyInput =
   | { type: typeof CLOUDBEAT_AZURE; policy_template: 'cspm' }
   | { type: typeof CLOUDBEAT_GCP; policy_template: 'cspm' }
@@ -75,6 +78,7 @@ export const getPosturePolicy = (
   inputVars?: Record<string, PackagePolicyConfigRecordEntry>
 ): NewPackagePolicy => ({
   ...newPolicy,
+  namespace: 'default',
   // Enable new policy input and disable all others
   inputs: newPolicy.inputs.map((item) => getPostureInput(item, inputType, inputVars)),
   // Set hidden policy vars


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.7`:
 - [[Cloud Posture] Ensure package policy namespace is always set to default (#152168)](https://github.com/elastic/kibana/pull/152168)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Or Ouziel","email":"or.ouziel@elastic.co"},"sourceCommit":{"committedDate":"2023-02-27T05:26:14Z","message":"[Cloud Posture] Ensure package policy namespace is always set to default (#152168)","sha":"5d3d75fe83aa662d3b7d1acad282ab7a55fbce06","branchLabelMapping":{"^v8.8.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Cloud Security","v8.7.0","v8.8.0"],"number":152168,"url":"https://github.com/elastic/kibana/pull/152168","mergeCommit":{"message":"[Cloud Posture] Ensure package policy namespace is always set to default (#152168)","sha":"5d3d75fe83aa662d3b7d1acad282ab7a55fbce06"}},"sourceBranch":"main","suggestedTargetBranches":["8.7"],"targetPullRequestStates":[{"branch":"8.7","label":"v8.7.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.8.0","labelRegex":"^v8.8.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/152168","number":152168,"mergeCommit":{"message":"[Cloud Posture] Ensure package policy namespace is always set to default (#152168)","sha":"5d3d75fe83aa662d3b7d1acad282ab7a55fbce06"}}]}] BACKPORT-->