### PR TITLE
[Infrastucture UI] Use ECS fields in the rx and tx chart formulas

### DIFF
--- a/x-pack/plugins/infra/public/common/visualizations/lens/hosts/rx.ts
+++ b/x-pack/plugins/infra/public/common/visualizations/lens/hosts/rx.ts
@@ -53,8 +53,8 @@ export class RX implements ILensVisualization {
     const dataLayer = this.formula.insertOrReplaceFormulaColumn(
       'y_network_in_bytes',
       {
-        formula: 'average(host.network.ingress.bytes) * 8',
-        timeScale: 's',
+        formula:
+          "average(host.network.ingress.bytes) * 8 / (max(metricset.period, kql='host.network.ingress.bytes: *') / 1000)",
         format: {
           id: 'bits',
           params: {

--- a/x-pack/plugins/infra/public/common/visualizations/lens/hosts/rx.ts
+++ b/x-pack/plugins/infra/public/common/visualizations/lens/hosts/rx.ts
@@ -53,7 +53,7 @@ export class RX implements ILensVisualization {
     const dataLayer = this.formula.insertOrReplaceFormulaColumn(
       'y_network_in_bytes',
       {
-        formula: "counter_rate(max(system.network.in.bytes), kql='system.network.in.bytes: *') * 8",
+        formula: 'average(host.network.ingress.bytes) * 8',
         timeScale: 's',
         format: {
           id: 'bits',
@@ -95,13 +95,13 @@ export class RX implements ILensVisualization {
           negate: false,
           alias: null,
           index: '3be1e71b-4bc5-4462-a314-04539f877a19',
-          key: 'system.network.in.bytes',
+          key: 'host.network.ingress.bytes',
           value: 'exists',
           type: 'exists',
         },
         query: {
           exists: {
-            field: 'system.network.in.bytes',
+            field: 'host.network.ingress.bytes',
           },
         },
         $state: {

--- a/x-pack/plugins/infra/public/common/visualizations/lens/hosts/tx.ts
+++ b/x-pack/plugins/infra/public/common/visualizations/lens/hosts/tx.ts
@@ -53,8 +53,7 @@ export class TX implements ILensVisualization {
     const dataLayer = this.formula.insertOrReplaceFormulaColumn(
       'y_network_out_bytes',
       {
-        formula:
-          "counter_rate(max(system.network.out.bytes), kql='system.network.out.bytes: *') * 8",
+        formula: 'average(host.network.egress.bytes) * 8',
         timeScale: 's',
         format: {
           id: 'bits',
@@ -96,13 +95,13 @@ export class TX implements ILensVisualization {
           negate: false,
           alias: null,
           index: '3be1e71b-4bc5-4462-a314-04539f877a19',
-          key: 'system.network.out.bytes',
+          key: 'host.network.egress.bytes',
           value: 'exists',
           type: 'exists',
         },
         query: {
           exists: {
-            field: 'system.network.out.bytes',
+            field: 'host.network.egress.bytes',
           },
         },
         $state: {

--- a/x-pack/plugins/infra/public/common/visualizations/lens/hosts/tx.ts
+++ b/x-pack/plugins/infra/public/common/visualizations/lens/hosts/tx.ts
@@ -53,8 +53,8 @@ export class TX implements ILensVisualization {
     const dataLayer = this.formula.insertOrReplaceFormulaColumn(
       'y_network_out_bytes',
       {
-        formula: 'average(host.network.egress.bytes) * 8',
-        timeScale: 's',
+        formula:
+          "average(host.network.egress.bytes) * 8 / (max(metricset.period, kql='host.network.egress.bytes: *') / 1000)",
         format: {
           id: 'bits',
           params: {

--- a/x-pack/plugins/infra/public/pages/metrics/hosts/hooks/use_hosts_table.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/hosts/hooks/use_hosts_table.tsx
@@ -163,17 +163,17 @@ export const useHostsTable = (nodes: SnapshotNode[], { time }: HostTableParams) 
         align: 'right',
       },
       {
-        name: averageTXLabel,
-        field: 'tx.avg',
-        sortable: true,
-        render: (avg: number) => formatMetric('tx', avg),
-        align: 'right',
-      },
-      {
         name: averageRXLabel,
         field: 'rx.avg',
         sortable: true,
         render: (avg: number) => formatMetric('rx', avg),
+        align: 'right',
+      },
+      {
+        name: averageTXLabel,
+        field: 'tx.avg',
+        sortable: true,
+        render: (avg: number) => formatMetric('tx', avg),
         align: 'right',
       },
       {


### PR DESCRIPTION
## Summary

closes [#152010](https://github.com/elastic/kibana/issues/152010)

The RX and TX formulas were using `system.network.*` fields and their value didn't match with those of the Hosts table and KPI chart, which use the ECS `host.network.*` and `host.network.*` fields. This PR fixes the formulas to use the correct fields

<img width="353" alt="image" src="https://user-images.githubusercontent.com/2767137/221569527-ee65d96b-f0ea-403c-b0b7-3cc622f941a8.png">

<img width="868" alt="image" src="https://user-images.githubusercontent.com/2767137/221569654-018de4fb-f6fb-4a74-816f-ea5b5c0fcf78.png">



The values and the trend lines are similar or close to what's on the KPI and Table. RX ~5mb and TX with spikes of 800Pbit
<img width="869" alt="image" src="https://user-images.githubusercontent.com/2767137/221569490-f2125c2e-3533-487f-bc1c-c192ee1622db.png">



### How to test

- Make sure you have metrics data (either through enabling system module in metricbeat or connecting your local kibana to an oblt-cli cluster)
- Navigate to `Infrastructure` > `Hosts`
- Compare metric charts against the table and KPI tiles. Adjust the time range filter to check if the values in the charts continue to make sense



<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->