### PR TITLE
[Cloud Security] update transform max age

### DIFF
--- a/x-pack/plugins/cloud_security_posture/server/create_transforms/create_transforms.ts
+++ b/x-pack/plugins/cloud_security_posture/server/create_transforms/create_transforms.ts
@@ -118,10 +118,15 @@ const deletePreviousTransformsVersions = async (esClient: ElasticsearchClient, l
   }
 };
 
-const deleteTransformSafe = async (esClient: ElasticsearchClient, logger: Logger, name: string) => {
+const deleteTransformSafe = async (
+  esClient: ElasticsearchClient,
+  logger: Logger,
+  name: string
+): Promise<boolean> => {
   try {
     await esClient.transform.deleteTransform({ transform_id: name, force: true });
     logger.info(`Deleted transform successfully [Name: ${name}]`);
+    return true;
   } catch (e) {
     if (e instanceof errors.ResponseError && e.statusCode === 404) {
       logger.trace(`Transform not exists [Name: ${name}]`);

--- a/x-pack/plugins/cloud_security_posture/server/create_transforms/create_transforms.ts
+++ b/x-pack/plugins/cloud_security_posture/server/create_transforms/create_transforms.ts
@@ -10,14 +10,18 @@ import type { ElasticsearchClient, Logger } from '@kbn/core/server';
 import { errors } from '@elastic/elasticsearch';
 import { latestFindingsTransform } from './latest_findings_transform';
 
+const LATEST_TRANSFORM_V830 = 'cloud_security_posture.findings_latest-default-0.0.1';
+const LATEST_TRANSFORM_V840 = 'cloud_security_posture.findings_latest-default-8.4.0';
+
+const PREVIOUS_TRANSFORMS = [LATEST_TRANSFORM_V830, LATEST_TRANSFORM_V840];
+
 // TODO: Move transforms to integration package
 export const initializeCspTransforms = async (
   esClient: ElasticsearchClient,
   logger: Logger
 ): Promise<void> => {
   // Deletes old assets from previous versions as part of upgrade process
-  const LATEST_TRANSFORM_V830 = 'cloud_security_posture.findings_latest-default-0.0.1';
-  await deleteTransformSafe(esClient, logger, LATEST_TRANSFORM_V830);
+  await deletePreviousTransformsVersions(esClient, logger);
   await initializeTransform(esClient, latestFindingsTransform, logger);
 };
 
@@ -107,16 +111,25 @@ export const startTransformIfNotStarted = async (
   }
 };
 
+const deletePreviousTransformsVersions = async (esClient: ElasticsearchClient, logger: Logger) => {
+  for (const transform of PREVIOUS_TRANSFORMS) {
+    const response = await deleteTransformSafe(esClient, logger, transform);
+    if (response) return;
+  }
+};
+
 const deleteTransformSafe = async (esClient: ElasticsearchClient, logger: Logger, name: string) => {
   try {
     await esClient.transform.deleteTransform({ transform_id: name, force: true });
     logger.info(`Deleted transform successfully [Name: ${name}]`);
   } catch (e) {
     if (e instanceof errors.ResponseError && e.statusCode === 404) {
-      logger.trace(`Transform no longer exists [Name: ${name}]`);
+      logger.trace(`Transform not exists [Name: ${name}]`);
+      return false;
     } else {
       logger.error(`Failed to delete transform [Name: ${name}]`);
       logger.error(e);
+      return false;
     }
   }
 };

--- a/x-pack/plugins/cloud_security_posture/server/create_transforms/latest_findings_transform.ts
+++ b/x-pack/plugins/cloud_security_posture/server/create_transforms/latest_findings_transform.ts
@@ -12,7 +12,7 @@ import {
 } from '../../common/constants';
 
 export const latestFindingsTransform: TransformPutTransformRequest = {
-  transform_id: 'cloud_security_posture.findings_latest-default-8.4.0',
+  transform_id: 'cloud_security_posture.findings_latest-default-8.8.0',
   description: 'Defines findings transformation to view only the latest finding per resource',
   source: {
     index: FINDINGS_INDEX_PATTERN,
@@ -30,7 +30,7 @@ export const latestFindingsTransform: TransformPutTransformRequest = {
   retention_policy: {
     time: {
       field: '@timestamp',
-      max_age: '5h',
+      max_age: '26h',
     },
   },
   latest: {


### PR DESCRIPTION
- solves https://github.com/elastic/kibana/issues/151405

Update cloud security Transform's max age to 26h.
Support migration when upgrading Kibana.


https://user-images.githubusercontent.com/90558359/221597995-8c74b406-c62e-4998-9129-ceb652ab5055.mp4

