### PR TITLE
[Synthetics] fix icmp monitor to not trigger error boundary on edit

### DIFF
--- a/x-pack/plugins/synthetics/public/legacy_uptime/components/fleet_package/synthetics_policy_edit_extension_wrapper.tsx
+++ b/x-pack/plugins/synthetics/public/legacy_uptime/components/fleet_package/synthetics_policy_edit_extension_wrapper.tsx
@@ -14,8 +14,8 @@ import type {
 } from '@kbn/fleet-plugin/public';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { useEditMonitorLocator } from '../../../apps/synthetics/hooks';
-import { PolicyConfig, MonitorFields } from './types';
-import { ConfigKey, DataStream, TLSFields } from './types';
+import type { PolicyConfig, MonitorFields, TLSFields } from './types';
+import { ConfigKey, DataStream } from './types';
 import { SyntheticsPolicyEditExtension } from './synthetics_policy_edit_extension';
 import {
   PolicyConfigContextProvider,
@@ -80,10 +80,10 @@ export const SyntheticsPolicyEditExtensionWrapper = memo<PackagePolicyEditExtens
         };
 
         enableTLS =
-          formattedDefaultConfigForMonitorType[ConfigKey.METADATA].is_tls_enabled ??
+          formattedDefaultConfigForMonitorType[ConfigKey.METADATA]?.is_tls_enabled ??
           Boolean(vars?.[ConfigKey.TLS_VERIFICATION_MODE]?.value);
         enableZipUrlTLS =
-          formattedDefaultConfigForMonitorType[ConfigKey.METADATA].is_zip_url_tls_enabled ??
+          formattedDefaultConfigForMonitorType[ConfigKey.METADATA]?.is_zip_url_tls_enabled ??
           Boolean(vars?.[ConfigKey.ZIP_URL_TLS_VERIFICATION_MODE]?.value);
 
         const formattedDefaultConfig: Partial<PolicyConfig> = {

--- a/x-pack/plugins/synthetics/public/legacy_uptime/components/monitor_management/edit_monitor_config.tsx
+++ b/x-pack/plugins/synthetics/public/legacy_uptime/components/monitor_management/edit_monitor_config.tsx
@@ -52,8 +52,8 @@ export const EditMonitorConfig = ({ monitor, throttling }: Props) => {
         [ConfigKey.TLS_VERSION]: monitor[ConfigKey.TLS_VERSION],
       };
 
-      enableTLS = Boolean(monitor[ConfigKey.METADATA].is_tls_enabled);
-      enableZipUrlTLS = Boolean(monitor[ConfigKey.METADATA].is_zip_url_tls_enabled);
+      enableTLS = Boolean(monitor[ConfigKey.METADATA]?.is_tls_enabled);
+      enableZipUrlTLS = Boolean(monitor[ConfigKey.METADATA]?.is_zip_url_tls_enabled);
 
       const formattedDefaultConfig: Partial<PolicyConfig> = {
         [type]: monitor,


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/152239

Fixes error boundary in ICMP monitor.

Before
[Add-Monitor-Uptime---Kibana (1).webm](https://user-images.githubusercontent.com/11356435/221615611-12479071-c445-40dc-98fc-5e1268cdd07f.webm)

After
[Add-Monitor-Uptime---Kibana (2).webm](https://user-images.githubusercontent.com/11356435/221615727-3a5d40e1-b268-44e9-a821-319422f4ad6a.webm)

<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->