### PR TITLE
[Enterprise Search] Engines Search Preview - "Sort By"

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/engine_search_preview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/engine_search_preview.tsx
@@ -16,7 +16,6 @@ import {
   ResultsPerPage,
   SearchBox,
   SearchProvider,
-  Sorting,
 } from '@elastic/react-search-ui';
 import { SearchDriverOptions } from '@elastic/search-ui';
 import EnginesAPIConnector, {
@@ -87,7 +86,7 @@ export const EngineSearchPreview: React.FC = () => {
   const [showAPICallFlyout, setShowAPICallFlyout] = useState<boolean>(false);
   const [lastAPICall, setLastAPICall] = useState<null | APICallData>(null);
   const { engineName, isLoadingEngine } = useValues(EngineViewLogic);
-  const { resultFields, searchableFields, sortOptions } = useValues(EngineSearchPreviewLogic);
+  const { resultFields, searchableFields, sortableFields } = useValues(EngineSearchPreviewLogic);
   const { engineData } = useValues(EngineIndicesLogic);
 
   const config: SearchDriverOptions = useMemo(() => {
@@ -143,7 +142,8 @@ export const EngineSearchPreview: React.FC = () => {
             <EuiFlexItem grow={false} css={{ minWidth: '240px' }}>
               <ResultsPerPage view={ResultsPerPageView} options={RESULTS_PER_PAGE_OPTIONS} />
               <EuiSpacer size="m" />
-              <Sorting
+              <SortingView sortableFields={sortableFields} />
+              {/* <Sorting
                 view={SortingView}
                 sortOptions={[
                   {
@@ -155,7 +155,7 @@ export const EngineSearchPreview: React.FC = () => {
                   },
                   ...sortOptions,
                 ]}
-              />
+              /> */}
               <EuiSpacer size="m" />
               <EuiLink href={docLinks.enterpriseSearchEngines} target="_blank">
                 <FormattedMessage

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/engine_search_preview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/engine_search_preview.tsx
@@ -87,7 +87,7 @@ export const EngineSearchPreview: React.FC = () => {
   const [showAPICallFlyout, setShowAPICallFlyout] = useState<boolean>(false);
   const [lastAPICall, setLastAPICall] = useState<null | APICallData>(null);
   const { engineName, isLoadingEngine } = useValues(EngineViewLogic);
-  const { resultFields, searchableFields } = useValues(EngineSearchPreviewLogic);
+  const { resultFields, searchableFields, sortOptions } = useValues(EngineSearchPreviewLogic);
   const { engineData } = useValues(EngineIndicesLogic);
 
   const config: SearchDriverOptions = useMemo(() => {
@@ -147,25 +147,13 @@ export const EngineSearchPreview: React.FC = () => {
                 view={SortingView}
                 sortOptions={[
                   {
-                    name: 'Relevance',
+                    name: i18n.translate(
+                      'xpack.enterpriseSearch.content.engine.searchPreview.relevanceLabel',
+                      { defaultMessage: 'Relevance' }
+                    ),
                     value: [],
                   },
-                  {
-                    name: 'Color (Asc)',
-                    value: [{ field: 'color', direction: 'asc' }],
-                  },
-                  {
-                    name: 'Color (Desc)',
-                    value: [{ field: 'color', direction: 'desc' }],
-                  },
-                  {
-                    name: 'Age (Asc)',
-                    value: [{ field: 'age', direction: 'asc' }],
-                  },
-                  {
-                    name: 'Age (Desc)',
-                    value: [{ field: 'age', direction: 'desc' }],
-                  },
+                  ...sortOptions,
                 ]}
               />
               <EuiSpacer size="m" />

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/engine_search_preview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/engine_search_preview.tsx
@@ -47,7 +47,7 @@ import {
   ResultView,
   ResultsPerPageView,
   ResultsView,
-  SortingView,
+  Sorting,
 } from './search_ui_components';
 
 class InternalEngineTransporter implements Transporter {
@@ -142,20 +142,7 @@ export const EngineSearchPreview: React.FC = () => {
             <EuiFlexItem grow={false} css={{ minWidth: '240px' }}>
               <ResultsPerPage view={ResultsPerPageView} options={RESULTS_PER_PAGE_OPTIONS} />
               <EuiSpacer size="m" />
-              <SortingView sortableFields={sortableFields} />
-              {/* <Sorting
-                view={SortingView}
-                sortOptions={[
-                  {
-                    name: i18n.translate(
-                      'xpack.enterpriseSearch.content.engine.searchPreview.relevanceLabel',
-                      { defaultMessage: 'Relevance' }
-                    ),
-                    value: [],
-                  },
-                  ...sortOptions,
-                ]}
-              /> */}
+              <Sorting sortableFields={sortableFields} />
               <EuiSpacer size="m" />
               <EuiLink href={docLinks.enterpriseSearchEngines} target="_blank">
                 <FormattedMessage

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/engine_search_preview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/engine_search_preview.tsx
@@ -16,6 +16,7 @@ import {
   ResultsPerPage,
   SearchBox,
   SearchProvider,
+  Sorting,
 } from '@elastic/react-search-ui';
 import { SearchDriverOptions } from '@elastic/search-ui';
 import EnginesAPIConnector, {
@@ -47,6 +48,7 @@ import {
   ResultView,
   ResultsPerPageView,
   ResultsView,
+  SortingView,
 } from './search_ui_components';
 
 class InternalEngineTransporter implements Transporter {
@@ -140,6 +142,32 @@ export const EngineSearchPreview: React.FC = () => {
           <EuiFlexGroup>
             <EuiFlexItem grow={false} css={{ minWidth: '240px' }}>
               <ResultsPerPage view={ResultsPerPageView} options={RESULTS_PER_PAGE_OPTIONS} />
+              <EuiSpacer size="m" />
+              <Sorting
+                view={SortingView}
+                sortOptions={[
+                  {
+                    name: 'Relevance',
+                    value: [],
+                  },
+                  {
+                    name: 'Color (Asc)',
+                    value: [{ field: 'color', direction: 'asc' }],
+                  },
+                  {
+                    name: 'Color (Desc)',
+                    value: [{ field: 'color', direction: 'desc' }],
+                  },
+                  {
+                    name: 'Age (Asc)',
+                    value: [{ field: 'age', direction: 'asc' }],
+                  },
+                  {
+                    name: 'Age (Desc)',
+                    value: [{ field: 'age', direction: 'desc' }],
+                  },
+                ]}
+              />
               <EuiSpacer size="m" />
               <EuiLink href={docLinks.enterpriseSearchEngines} target="_blank">
                 <FormattedMessage

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/engine_search_preview_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/engine_search_preview_logic.ts
@@ -7,7 +7,7 @@
 
 import { kea, MakeLogicType } from 'kea';
 
-import { SortOption, FieldConfiguration, SearchFieldConfiguration } from '@elastic/search-ui';
+import { FieldConfiguration, SearchFieldConfiguration } from '@elastic/search-ui';
 
 import { FetchEngineFieldCapabilitiesApiLogic } from '../../../api/engines/fetch_engine_field_capabilities_api_logic';
 import { EngineNameLogic } from '../engine_name_logic';
@@ -21,10 +21,7 @@ export interface EngineSearchPreviewValues {
   engineName: typeof EngineNameLogic.values.engineName;
   resultFields: Record<string, FieldConfiguration>;
   searchableFields: Record<string, SearchFieldConfiguration>;
-  sortOptions: Array<{
-    name: string;
-    value: SortOption[];
-  }>;
+  sortableFields: string[];
 }
 
 export const EngineSearchPreviewLogic = kea<
@@ -90,7 +87,7 @@ export const EngineSearchPreviewLogic = kea<
         return searchableFields;
       },
     ],
-    sortOptions: [
+    sortableFields: [
       () => [selectors.engineFieldCapabilitiesData],
       (data: EngineSearchPreviewValues['engineFieldCapabilitiesData']) => {
         if (!data) return [];
@@ -103,10 +100,7 @@ export const EngineSearchPreviewLogic = kea<
                 aggregatable && !isMeta
             )
           )
-          .flatMap(([field]) => [
-            { name: `${field} (asc)`, value: [{ direction: 'asc', field }] },
-            { name: `${field} (desc)`, value: [{ direction: 'desc', field }] },
-          ]);
+          .map(([field]) => field);
       },
     ],
   }),

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/search_ui_components.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/search_ui_components.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useState } from 'react';
+import React from 'react';
 
 import { useValues } from 'kea';
 
@@ -25,6 +25,7 @@ import {
   EuiTextColor,
   EuiTitle,
 } from '@elastic/eui';
+import { withSearch } from '@elastic/react-search-ui';
 import type {
   InputViewProps,
   PagingInfoViewProps,
@@ -226,14 +227,10 @@ export const ResultsPerPageView: React.FC<ResultsPerPageViewProps> = ({
   </EuiFlexItem>
 );
 
-export const SortingView: React.FC<SortingViewProps> = (
-  {
-    // onChange,
-    // options,
-    // value,
-  }
-) => {
-  const [value, setValue] = useState(null);
+export const SortingView: React.FC<SortingViewProps> = withSearch(({ setSort, sortList }) => ({
+  setSort,
+  sortList: sortList.length === 0 ? [{ direction: '', field: '' }] : sortList,
+}))(({ sortableFields, sortList: [{ direction, field }], setSort }) => {
   return (
     <EuiFlexItem grow={false}>
       <EuiFlexGroup direction="column" gutterSize="s">
@@ -245,19 +242,25 @@ export const SortingView: React.FC<SortingViewProps> = (
           isClearable={false}
           singleSelection={{ asPlainText: true }}
           options={[
-            { value: 'foo', label: 'Foo' },
-            { value: 'bar', label: 'Bar' },
+            { label: 'Relevance', value: '' },
+            ...sortableFields.map((f) => ({ label: f, value: f })),
           ]}
-          selectedOptions={value === null ? [] : [{ value, label: value }]}
-          onChange={(options) => {
-            if (options.length === 0) return;
-
-            const [{ value: newValue }] = options;
-
-            setValue(newValue);
-          }}
+          selectedOptions={[{ label: !!field ? field : 'Relevance', value: field }]}
+          onChange={([{ value }]) =>
+            setSort(value === '' ? [] : [{ direction: 'asc', field: value }])
+          }
         />
+        {field !== '' && (
+          <EuiSelect
+            onChange={(evt) => setSort([{ direction: evt.target.value, field }])}
+            value={direction}
+            options={[
+              { label: 'Ascending', value: 'asc' },
+              { label: 'Descending', value: 'desc' },
+            ]}
+          />
+        )}
       </EuiFlexGroup>
     </EuiFlexItem>
   );
-};
+});

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/search_ui_components.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/search_ui_components.tsx
@@ -224,3 +224,21 @@ export const ResultsPerPageView: React.FC<ResultsPerPageViewProps> = ({
     </EuiFlexGroup>
   </EuiFlexItem>
 );
+
+export const SortingView: React.FC<SortingViewProps> = ({ onChange, options, value }) => {
+  return (
+    <EuiFlexItem grow={false}>
+      <EuiFlexGroup direction="column" gutterSize="s">
+        <EuiTitle size="xxxs">
+          <label htmlFor="sorting">Sort By</label>
+        </EuiTitle>
+        <EuiSelect
+          id="sorting"
+          options={options?.map((o) => ({ text: o.label, value: o.value }))}
+          value={value}
+          onChange={(evt) => onChange(evt.target.value)}
+        />
+      </EuiFlexGroup>
+    </EuiFlexItem>
+  );
+};

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/search_ui_components.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/search_ui_components.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 
 import { useValues } from 'kea';
 
@@ -14,6 +14,7 @@ import {
   EuiBasicTable,
   EuiBasicTableColumn,
   EuiButton,
+  EuiComboBox,
   EuiFieldSearch,
   EuiFlexGroup,
   EuiFlexItem,
@@ -225,18 +226,36 @@ export const ResultsPerPageView: React.FC<ResultsPerPageViewProps> = ({
   </EuiFlexItem>
 );
 
-export const SortingView: React.FC<SortingViewProps> = ({ onChange, options, value }) => {
+export const SortingView: React.FC<SortingViewProps> = (
+  {
+    // onChange,
+    // options,
+    // value,
+  }
+) => {
+  const [value, setValue] = useState(null);
   return (
     <EuiFlexItem grow={false}>
       <EuiFlexGroup direction="column" gutterSize="s">
         <EuiTitle size="xxxs">
           <label htmlFor="sorting">Sort By</label>
         </EuiTitle>
-        <EuiSelect
+        <EuiComboBox
           id="sorting"
-          options={options?.map((o) => ({ text: o.label, value: o.value }))}
-          value={value}
-          onChange={(evt) => onChange(evt.target.value)}
+          isClearable={false}
+          singleSelection={{ asPlainText: true }}
+          options={[
+            { value: 'foo', label: 'Foo' },
+            { value: 'bar', label: 'Bar' },
+          ]}
+          selectedOptions={value === null ? [] : [{ value, label: value }]}
+          onChange={(options) => {
+            if (options.length === 0) return;
+
+            const [{ value: newValue }] = options;
+
+            setValue(newValue);
+          }}
         />
       </EuiFlexGroup>
     </EuiFlexItem>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/search_ui_components.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/search_ui_components.tsx
@@ -232,21 +232,31 @@ export const SortingView: React.FC<SortingViewProps> = withSearch(({ setSort, so
   setSort,
   sortList: sortList.length === 0 ? [{ direction: '', field: '' }] : sortList,
 }))(({ sortableFields, sortList: [{ direction, field }], setSort }) => {
+  const relevance = i18n.translate(
+    'xpack.enterpriseSearch.content.engine.searchPreivew.sortingView.relevanceLabel',
+    { defaultMessage: 'Relevance' }
+  );
+
   return (
     <EuiFlexItem grow={false}>
       <EuiFlexGroup direction="column" gutterSize="s">
         <EuiTitle size="xxxs">
-          <label htmlFor="sorting-field">Sort By</label>
+          <label htmlFor="sorting-field">
+            <FormattedMessage
+              id="xpack.enterpriseSearch.content.engine.searchPreview.sortingView.fieldLabel"
+              defaultMessage="Sort By"
+            />
+          </label>
         </EuiTitle>
         <EuiComboBox
           id="sorting-field"
           isClearable={false}
           singleSelection={{ asPlainText: true }}
           options={[
-            { label: 'Relevance', value: '' },
+            { label: relevance, value: '' },
             ...sortableFields.map((f) => ({ label: f, value: f })),
           ]}
-          selectedOptions={[{ label: !!field ? field : 'Relevance', value: field }]}
+          selectedOptions={[{ label: !!field ? field : relevance, value: field }]}
           onChange={([{ value }]) =>
             setSort(value === '' ? [] : [{ direction: 'asc', field: value }])
           }
@@ -257,15 +267,32 @@ export const SortingView: React.FC<SortingViewProps> = withSearch(({ setSort, so
           <EuiSpacer size="m" />
           <EuiFlexGroup direction="column" gutterSize="s">
             <EuiTitle size="xxxs">
-              <label htmlFor="sorting-direction">Order By</label>
+              <label htmlFor="sorting-direction">
+                <FormattedMessage
+                  id="xpack.enterpriseSearch.content.engine.searchPreview.sortingView.directionLabel"
+                  defaultMessage="Order By"
+                />
+              </label>
             </EuiTitle>
             <EuiSelect
               id="sorting-direction"
               onChange={(evt) => setSort([{ direction: evt.target.value, field }])}
               value={direction}
               options={[
-                { label: 'Ascending', value: 'asc' },
-                { label: 'Descending', value: 'desc' },
+                {
+                  label: i18n.translate(
+                    'xpack.enterpriseSearch.content.engine.searchPreview.sortingView.ascLabel',
+                    { defaultMessage: 'Ascending' }
+                  ),
+                  value: 'asc',
+                },
+                {
+                  label: i18n.translate(
+                    'xpack.enterpriseSearch.content.engine.searchPreview.sortingView.descLabel',
+                    { defaultMessage: 'Descending' }
+                  ),
+                  value: 'desc',
+                },
               ]}
             />
           </EuiFlexGroup>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/search_ui_components.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/search_ui_components.tsx
@@ -21,6 +21,7 @@ import {
   EuiIcon,
   EuiPanel,
   EuiSelect,
+  EuiSpacer,
   EuiText,
   EuiTextColor,
   EuiTitle,
@@ -235,10 +236,10 @@ export const SortingView: React.FC<SortingViewProps> = withSearch(({ setSort, so
     <EuiFlexItem grow={false}>
       <EuiFlexGroup direction="column" gutterSize="s">
         <EuiTitle size="xxxs">
-          <label htmlFor="sorting">Sort By</label>
+          <label htmlFor="sorting-field">Sort By</label>
         </EuiTitle>
         <EuiComboBox
-          id="sorting"
+          id="sorting-field"
           isClearable={false}
           singleSelection={{ asPlainText: true }}
           options={[
@@ -250,17 +251,26 @@ export const SortingView: React.FC<SortingViewProps> = withSearch(({ setSort, so
             setSort(value === '' ? [] : [{ direction: 'asc', field: value }])
           }
         />
-        {field !== '' && (
-          <EuiSelect
-            onChange={(evt) => setSort([{ direction: evt.target.value, field }])}
-            value={direction}
-            options={[
-              { label: 'Ascending', value: 'asc' },
-              { label: 'Descending', value: 'desc' },
-            ]}
-          />
-        )}
       </EuiFlexGroup>
+      {field !== '' && (
+        <>
+          <EuiSpacer size="m" />
+          <EuiFlexGroup direction="column" gutterSize="s">
+            <EuiTitle size="xxxs">
+              <label htmlFor="sorting-direction">Order By</label>
+            </EuiTitle>
+            <EuiSelect
+              id="sorting-direction"
+              onChange={(evt) => setSort([{ direction: evt.target.value, field }])}
+              value={direction}
+              options={[
+                { label: 'Ascending', value: 'asc' },
+                { label: 'Descending', value: 'desc' },
+              ]}
+            />
+          </EuiFlexGroup>
+        </>
+      )}
     </EuiFlexItem>
   );
 });


### PR DESCRIPTION
## Summary

https://user-images.githubusercontent.com/1699281/222561456-55666a32-0508-4c49-b721-4bd71afb0d72.mov

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
