### PR TITLE
[Security Solution] Fix bug where isolate fails on Alert associated with 0 Cases

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/components/host_isolation/isolate.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/host_isolation/isolate.tsx
@@ -38,7 +38,11 @@ export const IsolateHost = React.memo(
       return caseInfo.id;
     });
 
-    const { loading, isolateHost } = useHostIsolation({ endpointId, comment, caseIds });
+    const { loading, isolateHost } = useHostIsolation({
+      endpointId,
+      comment,
+      caseIds: caseIds.length > 0 ? caseIds : undefined,
+    });
 
     const confirmHostIsolation = useCallback(async () => {
       const hostIsolated = await isolateHost();


### PR DESCRIPTION
## Summary

Fixes a bug where Isolate was failing in the isolate flyout from an Alert associated with 0 cases.  The bug was that an empty array was being passed to `case_ids` parameter and it requires that there is at least 1 cases in the array.  This PR makes sure that the flyout does not pass an empty array.

We can now isolate in an Alert without any cases
![image](https://user-images.githubusercontent.com/56395104/221695149-bf865a82-748a-4d12-91be-deb96a20b61b.png)

Isolate still works when there are cases present
![image](https://user-images.githubusercontent.com/56395104/221695198-492bcf17-6742-48f8-ab00-772d47bc0b93.png)


<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->