### PR TITLE
[Security solution] Fix alert grouping beta label

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/grouping/groups_selector/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/grouping/groups_selector/index.tsx
@@ -16,8 +16,6 @@ import { CustomFieldPanel } from './custom_field_panel';
 import * as i18n from '../translations';
 import { StyledContextMenu, StyledEuiButtonEmpty } from '../styles';
 
-const none = i18n.NONE;
-
 interface GroupSelectorProps {
   fields: FieldSpec[];
   groupSelected: string;
@@ -50,14 +48,19 @@ const GroupsSelectorComponent = ({
               {i18n.SELECT_FIELD.toUpperCase()}
             </EuiFlexItem>
             <EuiFlexItem grow={false} component="span">
-              <EuiBetaBadge label={i18n.BETA} size="s" tooltipContent={i18n.BETA_TOOL_TIP} />
+              <EuiBetaBadge
+                label={i18n.BETA}
+                size="s"
+                tooltipContent={i18n.BETA_TOOL_TIP}
+                tooltipPosition="left"
+              />
             </EuiFlexItem>
           </EuiFlexGroup>
         ),
         items: [
           {
             'data-test-subj': 'panel-none',
-            name: none,
+            name: i18n.NONE,
             icon: groupSelected === 'none' ? 'check' : 'empty',
             onClick: () => onGroupChange('none'),
           },
@@ -110,12 +113,16 @@ const GroupsSelectorComponent = ({
         iconType="arrowDown"
         onClick={onButtonClick}
         title={
-          groupSelected !== 'none' && selectedOption.length > 0 ? selectedOption[0].label : none
+          groupSelected !== 'none' && selectedOption.length > 0
+            ? selectedOption[0].label
+            : i18n.NONE
         }
         size="xs"
       >
         {`${title}: ${
-          groupSelected !== 'none' && selectedOption.length > 0 ? selectedOption[0].label : none
+          groupSelected !== 'none' && selectedOption.length > 0
+            ? selectedOption[0].label
+            : i18n.NONE
         }`}
       </StyledEuiButtonEmpty>
     ),

--- a/x-pack/plugins/security_solution/public/common/components/grouping/groups_selector/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/grouping/groups_selector/index.tsx
@@ -9,17 +9,14 @@ import type {
   EuiContextMenuPanelDescriptor,
   EuiContextMenuPanelItemDescriptor,
 } from '@elastic/eui';
-import { EuiFlexGroup, EuiFlexItem, EuiBetaBadge, EuiPopover } from '@elastic/eui';
-import { i18n } from '@kbn/i18n';
+import { EuiBetaBadge, EuiFlexGroup, EuiFlexItem, EuiPopover } from '@elastic/eui';
 import React, { useCallback, useMemo, useState } from 'react';
 import type { FieldSpec } from '@kbn/data-views-plugin/common';
 import { CustomFieldPanel } from './custom_field_panel';
-import { GROUP_BY, TECHNICAL_PREVIEW } from '../translations';
+import * as i18n from '../translations';
 import { StyledContextMenu, StyledEuiButtonEmpty } from '../styles';
 
-const none = i18n.translate('xpack.securitySolution.groupsSelector.noneGroupByOptionName', {
-  defaultMessage: 'None',
-});
+const none = i18n.NONE;
 
 interface GroupSelectorProps {
   fields: FieldSpec[];
@@ -34,13 +31,29 @@ const GroupsSelectorComponent = ({
   groupSelected = 'none',
   onGroupChange,
   options,
-  title = '',
+  title = i18n.GROUP_BY,
 }: GroupSelectorProps) => {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+
   const panels: EuiContextMenuPanelDescriptor[] = useMemo(
     () => [
       {
         id: 'firstPanel',
+        title: (
+          <EuiFlexGroup
+            component="span"
+            justifyContent="spaceBetween"
+            gutterSize="none"
+            style={{ lineHeight: 1 }}
+          >
+            <EuiFlexItem grow={false} component="p" style={{ lineHeight: 1.5 }}>
+              {i18n.SELECT_FIELD.toUpperCase()}
+            </EuiFlexItem>
+            <EuiFlexItem grow={false} component="span">
+              <EuiBetaBadge label={i18n.BETA} size="s" tooltipContent={i18n.BETA_TOOL_TIP} />
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        ),
         items: [
           {
             'data-test-subj': 'panel-none',
@@ -56,9 +69,7 @@ const GroupsSelectorComponent = ({
           })),
           {
             'data-test-subj': `panel-custom`,
-            name: i18n.translate('xpack.securitySolution.groupsSelector.customGroupByOptionName', {
-              defaultMessage: 'Custom field',
-            }),
+            name: i18n.CUSTOM_FIELD,
             icon: 'empty',
             panel: 'customPanel',
           },
@@ -66,9 +77,7 @@ const GroupsSelectorComponent = ({
       },
       {
         id: 'customPanel',
-        title: i18n.translate('xpack.securitySolution.groupsSelector.customGroupByPanelTitle', {
-          defaultMessage: 'Group By Custom Field',
-        }),
+        title: i18n.GROUP_BY_CUSTOM_FIELD,
         width: 685,
         content: (
           <CustomFieldPanel
@@ -105,7 +114,7 @@ const GroupsSelectorComponent = ({
         }
         size="xs"
       >
-        {`${title ?? GROUP_BY}: ${
+        {`${title}: ${
           groupSelected !== 'none' && selectedOption.length > 0 ? selectedOption[0].label : none
         }`}
       </StyledEuiButtonEmpty>
@@ -114,25 +123,18 @@ const GroupsSelectorComponent = ({
   );
 
   return (
-    <EuiFlexGroup gutterSize="xs">
-      <EuiFlexItem>
-        <EuiPopover
-          button={button}
-          closePopover={closePopover}
-          isOpen={isPopoverOpen}
-          panelPaddingSize="none"
-        >
-          <StyledContextMenu
-            data-test-subj="groupByContextMenu"
-            initialPanelId="firstPanel"
-            panels={panels}
-          />
-        </EuiPopover>
-      </EuiFlexItem>
-      <EuiFlexItem>
-        <EuiBetaBadge label={TECHNICAL_PREVIEW} size="s" style={{ marginTop: 2 }} />
-      </EuiFlexItem>
-    </EuiFlexGroup>
+    <EuiPopover
+      button={button}
+      closePopover={closePopover}
+      isOpen={isPopoverOpen}
+      panelPaddingSize="none"
+    >
+      <StyledContextMenu
+        data-test-subj="groupByContextMenu"
+        initialPanelId="firstPanel"
+        panels={panels}
+      />
+    </EuiPopover>
   );
 };
 

--- a/x-pack/plugins/security_solution/public/common/components/grouping/translations.ts
+++ b/x-pack/plugins/security_solution/public/common/components/grouping/translations.ts
@@ -20,13 +20,40 @@ export const TAKE_ACTION = i18n.translate(
   }
 );
 
-export const TECHNICAL_PREVIEW = i18n.translate(
-  'xpack.securitySolution.grouping.technicalPreviewLabel',
+export const BETA = i18n.translate('xpack.securitySolution.grouping.betaLabel', {
+  defaultMessage: 'Beta',
+});
+
+export const BETA_TOOL_TIP = i18n.translate('xpack.securitySolution.grouping.betaToolTip', {
+  defaultMessage:
+    'Grouping may show only a subset of alerts while in beta. To see all alerts, use the list view by selecting "None"',
+});
+
+export const GROUP_BY = i18n.translate('xpack.securitySolution.selector.grouping.label', {
+  defaultMessage: 'Group alerts by',
+});
+
+export const GROUP_BY_CUSTOM_FIELD = i18n.translate(
+  'xpack.securitySolution.groupsSelector.customGroupByPanelTitle',
   {
-    defaultMessage: 'Technical Preview',
+    defaultMessage: 'Group By Custom Field',
   }
 );
 
-export const GROUP_BY = i18n.translate('xpack.securitySolution.selector.grouping.label', {
-  defaultMessage: 'Group by field',
+export const SELECT_FIELD = i18n.translate(
+  'xpack.securitySolution.groupsSelector.groupByPanelTitle',
+  {
+    defaultMessage: 'Select Field',
+  }
+);
+
+export const NONE = i18n.translate('xpack.securitySolution.groupsSelector.noneGroupByOptionName', {
+  defaultMessage: 'None',
 });
+
+export const CUSTOM_FIELD = i18n.translate(
+  'xpack.securitySolution.groupsSelector.customGroupByOptionName',
+  {
+    defaultMessage: 'Custom field',
+  }
+);

--- a/x-pack/plugins/security_solution/public/common/containers/grouping/hooks/use_get_group_selector.tsx
+++ b/x-pack/plugins/security_solution/public/common/containers/grouping/hooks/use_get_group_selector.tsx
@@ -8,6 +8,7 @@
 import type { FieldSpec } from '@kbn/data-views-plugin/common';
 import React, { useCallback, useEffect, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { GROUP_BY } from '../../../components/grouping/translations';
 import type { TableId } from '../../../../../common/types';
 import { getDefaultGroupingOptions } from '../../../../detections/components/alerts_table/grouping_settings';
 import type { State } from '../../../store';
@@ -101,7 +102,7 @@ export const useGetGroupingSelector = ({
         }}
         fields={fields}
         options={options}
-        title={'Group Alerts Selector'}
+        title={GROUP_BY}
       />
     ),
     [


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/security-team/issues/6129

Updates from the technical preview badge on the popover button to a label within the context menu.

## Before 
`TECHNICAL PREVIEW` badge is present
<img width="1193" alt="before2" src="https://user-images.githubusercontent.com/6935300/221736633-2d4fac10-d7dd-41dc-a789-4b121920dbe2.png">

## After
Removed `TECHNICAL PREVIEW` badge. Added title to context menu with `BETA` badge, including tooltip on hover
<img width="1214" alt="after2" src="https://user-images.githubusercontent.com/6935300/221736647-3b598a20-5c68-4418-a211-ec2456dca778.png">

### Tooltip
<img width="1174" alt="Screenshot 2023-02-27 at 8 25 23 PM" src="https://user-images.githubusercontent.com/6935300/221737616-2beb0128-bdd5-4af1-94e0-9ce3767343f1.png">


<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->