### PR TITLE
[8.7] [Security solution] Fix alert grouping take action items

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/detection_engine.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/detection_engine.tsx
@@ -448,6 +448,7 @@ const DetectionEnginePageComponent: React.FC<DetectionEngineComponentProps> = ({
               <EuiSpacer size="l" />
             </Display>
             <AlertsTable
+              filterGroup={filterGroup}
               tableId={TableId.alertsOnAlertsPage}
               loading={isAlertTableLoading}
               hasIndexWrite={hasIndexWrite ?? false}


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/150850

In order to hide a pointless action (Open Alert on already open alerts), we are doing a check for `if (currentStatus !== FILTER_OPEN)` before we push the action to the Take Actions menu. However, from the detection engine page we were not passing `filterGroup`, which becomes the value `currentStatus`. Passing the variable fixes the problem.

This was already fixed in main but not 8.7, so this is an 8.7 only PR
