### PR TITLE
[maps] fix layers are not displayed in offline environment and map.includeElasticMapsService not set to false

### DIFF
--- a/x-pack/plugins/maps/public/connected_components/mb_map/mb_map.tsx
+++ b/x-pack/plugins/maps/public/connected_components/mb_map/mb_map.tsx
@@ -155,50 +155,51 @@ export class MbMap extends Component<Props, State> {
 
   async _createMbMapInstance(initialView: MapCenterAndZoom | null): Promise<MapboxMap> {
     this._reportUsage();
-    return new Promise(async (resolve) => {
-      const mbStyle = {
-        version: 8 as 8,
-        sources: {},
-        layers: [],
-        glyphs: await getGlyphUrl(),
-      };
-
-      const options: MapOptions = {
-        attributionControl: false,
-        container: this._containerRef!,
-        style: mbStyle,
-        preserveDrawingBuffer: getPreserveDrawingBuffer(),
-        maxZoom: this.props.settings.maxZoom,
-        minZoom: this.props.settings.minZoom,
-      };
-      if (initialView) {
-        options.zoom = initialView.zoom;
-        options.center = {
-          lng: initialView.lon,
-          lat: initialView.lat,
+    return new Promise(async (resolve, reject) => {
+      try {
+        const mbStyle = {
+          version: 8 as 8,
+          sources: {},
+          layers: [],
+          glyphs: await getGlyphUrl(),
         };
-      } else {
-        options.bounds = [-170, -60, 170, 75];
-      }
-      const mbMap = new maplibregl.Map(options);
-      mbMap.dragRotate.disable();
-      mbMap.touchZoomRotate.disableRotation();
-
-      let emptyImage: HTMLImageElement;
-      mbMap.on('styleimagemissing', (e: unknown) => {
-        if (emptyImage) {
-          // @ts-expect-error
-          mbMap.addImage(e.id, emptyImage);
+        const options: MapOptions = {
+          attributionControl: false,
+          container: this._containerRef!,
+          style: mbStyle,
+          preserveDrawingBuffer: getPreserveDrawingBuffer(),
+          maxZoom: this.props.settings.maxZoom,
+          minZoom: this.props.settings.minZoom,
+        };
+        if (initialView) {
+          options.zoom = initialView.zoom;
+          options.center = {
+            lng: initialView.lon,
+            lat: initialView.lat,
+          };
+        } else {
+          options.bounds = [-170, -60, 170, 75];
         }
-      });
-      mbMap.on('load', () => {
-        emptyImage = new Image();
-
-        emptyImage.src =
-          'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQYV2NgAAIAAAUAAarVyFEAAAAASUVORK5CYII=';
-        emptyImage.crossOrigin = 'anonymous';
-        resolve(mbMap);
-      });
+        const mbMap = new maplibregl.Map(options);
+        mbMap.dragRotate.disable();
+        mbMap.touchZoomRotate.disableRotation();
+        let emptyImage: HTMLImageElement;
+        mbMap.on('styleimagemissing', (e: unknown) => {
+          if (emptyImage) {
+            // @ts-expect-error
+            mbMap.addImage(e.id, emptyImage);
+          }
+        });
+        mbMap.on('load', () => {
+          emptyImage = new Image();
+          emptyImage.src =
+            'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQYV2NgAAIAAAUAAarVyFEAAAAASUVORK5CYII=';
+          emptyImage.crossOrigin = 'anonymous';
+          resolve(mbMap);
+        });
+      } catch (error) {
+        reject(error);
+      }
     });
   }
 

--- a/x-pack/plugins/maps/public/connected_components/mb_map/mb_map.tsx
+++ b/x-pack/plugins/maps/public/connected_components/mb_map/mb_map.tsx
@@ -155,12 +155,12 @@ export class MbMap extends Component<Props, State> {
 
   async _createMbMapInstance(initialView: MapCenterAndZoom | null): Promise<MapboxMap> {
     this._reportUsage();
-    return new Promise((resolve) => {
+    return new Promise(async (resolve) => {
       const mbStyle = {
         version: 8 as 8,
         sources: {},
         layers: [],
-        glyphs: getGlyphUrl(),
+        glyphs: await getGlyphUrl(),
       };
 
       const options: MapOptions = {

--- a/x-pack/plugins/maps/public/connected_components/mb_map/mb_map.tsx
+++ b/x-pack/plugins/maps/public/connected_components/mb_map/mb_map.tsx
@@ -155,51 +155,51 @@ export class MbMap extends Component<Props, State> {
 
   async _createMbMapInstance(initialView: MapCenterAndZoom | null): Promise<MapboxMap> {
     this._reportUsage();
-    return new Promise(async (resolve, reject) => {
-      try {
-        const mbStyle = {
-          version: 8 as 8,
-          sources: {},
-          layers: [],
-          glyphs: await getGlyphUrl(),
+    const glyphsUrlTemplate = await getGlyphUrl();
+    return new Promise((resolve) => {
+      const mbStyle = {
+        version: 8 as 8,
+        sources: {},
+        layers: [],
+        glyphs: glyphsUrlTemplate,
+      };
+
+      const options: MapOptions = {
+        attributionControl: false,
+        container: this._containerRef!,
+        style: mbStyle,
+        preserveDrawingBuffer: getPreserveDrawingBuffer(),
+        maxZoom: this.props.settings.maxZoom,
+        minZoom: this.props.settings.minZoom,
+      };
+      if (initialView) {
+        options.zoom = initialView.zoom;
+        options.center = {
+          lng: initialView.lon,
+          lat: initialView.lat,
         };
-        const options: MapOptions = {
-          attributionControl: false,
-          container: this._containerRef!,
-          style: mbStyle,
-          preserveDrawingBuffer: getPreserveDrawingBuffer(),
-          maxZoom: this.props.settings.maxZoom,
-          minZoom: this.props.settings.minZoom,
-        };
-        if (initialView) {
-          options.zoom = initialView.zoom;
-          options.center = {
-            lng: initialView.lon,
-            lat: initialView.lat,
-          };
-        } else {
-          options.bounds = [-170, -60, 170, 75];
-        }
-        const mbMap = new maplibregl.Map(options);
-        mbMap.dragRotate.disable();
-        mbMap.touchZoomRotate.disableRotation();
-        let emptyImage: HTMLImageElement;
-        mbMap.on('styleimagemissing', (e: unknown) => {
-          if (emptyImage) {
-            // @ts-expect-error
-            mbMap.addImage(e.id, emptyImage);
-          }
-        });
-        mbMap.on('load', () => {
-          emptyImage = new Image();
-          emptyImage.src =
-            'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQYV2NgAAIAAAUAAarVyFEAAAAASUVORK5CYII=';
-          emptyImage.crossOrigin = 'anonymous';
-          resolve(mbMap);
-        });
-      } catch (error) {
-        reject(error);
+      } else {
+        options.bounds = [-170, -60, 170, 75];
       }
+      const mbMap = new maplibregl.Map(options);
+      mbMap.dragRotate.disable();
+      mbMap.touchZoomRotate.disableRotation();
+
+      let emptyImage: HTMLImageElement;
+      mbMap.on('styleimagemissing', (e: unknown) => {
+        if (emptyImage) {
+          // @ts-expect-error
+          mbMap.addImage(e.id, emptyImage);
+        }
+      });
+      mbMap.on('load', () => {
+        emptyImage = new Image();
+
+        emptyImage.src =
+          'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQYV2NgAAIAAAUAAarVyFEAAAAASUVORK5CYII=';
+        emptyImage.crossOrigin = 'anonymous';
+        resolve(mbMap);
+      });
     });
   }
 

--- a/x-pack/plugins/maps/public/util.test.js
+++ b/x-pack/plugins/maps/public/util.test.js
@@ -5,60 +5,84 @@
  * 2.0.
  */
 
-import { getGlyphUrl, makePublicExecutionContext } from './util';
-
-const MOCK_EMS_SETTINGS = {
-  isEMSEnabled: () => true,
-};
+import { getGlyphUrl, clearCanAccessEmsFontsPromise, makePublicExecutionContext } from './util';
 
 describe('getGlyphUrl', () => {
   describe('EMS enabled', () => {
-    beforeAll(() => {
+    beforeEach(() => {
       require('./kibana_services').getHttp = () => ({
         basePath: {
-          prepend: (url) => url, // No need to actually prepend a dev basepath for test
+          prepend: (path) => `abc${path}`,
         },
       });
+      clearCanAccessEmsFontsPromise();
     });
 
-    describe('EMS proxy disabled', () => {
+    describe('offline', () => {
       beforeAll(() => {
         require('./kibana_services').getEMSSettings = () => {
           return {
             getEMSFontLibraryUrl() {
-              return 'foobar';
+              return 'https://tiles.maps.elastic.co/fonts/{fontstack}/{range}.pbf';
             },
             isEMSEnabled() {
               return true;
             },
           };
         };
+        require('node-fetch').default = () => {
+          throw new Error('Simulated offline environment with no EMS access');
+        };
       });
 
-      test('should return EMS fonts URL', async () => {
-        expect(getGlyphUrl()).toBe('foobar');
+      test('should return kibana fonts template URL', async () => {
+        expect(await getGlyphUrl()).toBe('abc/api/maps/fonts/{fontstack}/{range}');
+      });
+    });
+
+    describe('online', () => {
+      beforeAll(() => {
+        require('./kibana_services').getEMSSettings = () => {
+          return {
+            getEMSFontLibraryUrl() {
+              return 'https://tiles.maps.elastic.co/fonts/{fontstack}/{range}.pbf';
+            },
+            isEMSEnabled() {
+              return true;
+            },
+          };
+        };
+        require('node-fetch').default = () => {
+          return Promise.resolve({ status: 200 });
+        };
+      });
+
+      test('should return EMS font template URL', async () => {
+        expect(await getGlyphUrl()).toBe(
+          'https://tiles.maps.elastic.co/fonts/{fontstack}/{range}.pbf'
+        );
       });
     });
   });
 
   describe('EMS disabled', () => {
     beforeAll(() => {
-      const mockHttp = {
-        basePath: {
-          prepend: (path) => `abc${path}`,
-        },
+      require('./kibana_services').getHttp = () => {
+        return {
+          basePath: {
+            prepend: (path) => `abc${path}`,
+          },
+        };
       };
-      require('./kibana_services').getHttp = () => mockHttp;
       require('./kibana_services').getEMSSettings = () => {
         return {
-          ...MOCK_EMS_SETTINGS,
           isEMSEnabled: () => false,
         };
       };
     });
 
-    test('should return kibana fonts URL', async () => {
-      expect(getGlyphUrl()).toBe('abc/api/maps/fonts/{fontstack}/{range}');
+    test('should return kibana fonts template URL', async () => {
+      expect(await getGlyphUrl()).toBe('abc/api/maps/fonts/{fontstack}/{range}');
     });
   });
 });

--- a/x-pack/plugins/maps/public/util.test.js
+++ b/x-pack/plugins/maps/public/util.test.js
@@ -5,7 +5,11 @@
  * 2.0.
  */
 
-import { getGlyphUrl, clearCanAccessEmsFontsPromise, makePublicExecutionContext } from './util';
+import {
+  getGlyphUrl,
+  makePublicExecutionContext,
+  testOnlyClearCanAccessEmsFontsPromise,
+} from './util';
 
 describe('getGlyphUrl', () => {
   describe('EMS enabled', () => {
@@ -15,7 +19,7 @@ describe('getGlyphUrl', () => {
           prepend: (path) => `abc${path}`,
         },
       });
-      clearCanAccessEmsFontsPromise();
+      testOnlyClearCanAccessEmsFontsPromise();
     });
 
     describe('offline', () => {
@@ -57,7 +61,7 @@ describe('getGlyphUrl', () => {
         };
       });
 
-      test('should return EMS font template URL', async () => {
+      test('should return EMS fonts template URL', async () => {
         expect(await getGlyphUrl()).toBe(
           'https://tiles.maps.elastic.co/fonts/{fontstack}/{range}.pbf'
         );

--- a/x-pack/plugins/maps/public/util.ts
+++ b/x-pack/plugins/maps/public/util.ts
@@ -96,8 +96,8 @@ async function canAccessEmsFonts(): Promise<boolean> {
   }
   return canAccessEmsFontsPromise;
 }
-// test only function to reset singlton for different test cases.
-export function clearCanAccessEmsFontsPromise() {
+// test only function to reset singleton for different test cases.
+export function testOnlyClearCanAccessEmsFontsPromise() {
   canAccessEmsFontsPromise = null;
 }
 

--- a/x-pack/plugins/maps/public/util.ts
+++ b/x-pack/plugins/maps/public/util.ts
@@ -64,33 +64,30 @@ async function getEMSClient(): Promise<EMSClient> {
 let canAccessEmsFontsPromise: Promise<boolean> | null = null;
 async function canAccessEmsFonts(): Promise<boolean> {
   if (!canAccessEmsFontsPromise) {
-    canAccessEmsFontsPromise = new Promise(async (resolve, reject) => {
+    canAccessEmsFontsPromise = new Promise(async (resolve) => {
       try {
         const emsSettings = getEMSSettings();
         if (!emsSettings!.isEMSEnabled()) {
           resolve(false);
         }
         const emsFontUrlTemplate = emsSettings!.getEMSFontLibraryUrl();
-        try {
-          const emsFontUrl = emsFontUrlTemplate
-            .replace('{fontstack}', 'Open Sans')
-            .replace('{range}', '0-255');
-          const resp = await fetch(emsFontUrl, {
-            method: 'HEAD',
-          });
-          if (resp.status >= 400) {
-            throw new Error(`status: ${resp.status}`);
-          }
-          resolve(true);
-        } catch (error) {
-          // eslint-disable-next-line no-console
-          console.warn(
-            `Unable to access fonts from Elastic Maps Service (EMS). Set kibana.yml 'map.includeElasticMapsService: false' to avoid unnecessary EMS requests.`
-          );
-          resolve(false);
+
+        const emsFontUrl = emsFontUrlTemplate
+          .replace('{fontstack}', 'Open Sans')
+          .replace('{range}', '0-255');
+        const resp = await fetch(emsFontUrl, {
+          method: 'HEAD',
+        });
+        if (resp.status >= 400) {
+          throw new Error(`status: ${resp.status}`);
         }
+        resolve(true);
       } catch (error) {
-        reject(error);
+        // eslint-disable-next-line no-console
+        console.warn(
+          `Unable to access fonts from Elastic Maps Service (EMS). Set kibana.yml 'map.includeElasticMapsService: false' to avoid unnecessary EMS requests.`
+        );
+        resolve(false);
       }
     });
   }

--- a/x-pack/plugins/maps/public/util.ts
+++ b/x-pack/plugins/maps/public/util.ts
@@ -64,29 +64,41 @@ async function getEMSClient(): Promise<EMSClient> {
 let canAccessEmsFontsPromise: Promise<boolean> | null = null;
 async function canAccessEmsFonts(): Promise<boolean> {
   if (!canAccessEmsFontsPromise) {
-    canAccessEmsFontsPromise = new Promise(async (resolve) => {
-      const emsSettings = getEMSSettings();
-      if (!emsSettings!.isEMSEnabled()) {
-        resolve(false);
-      }
-
-      const emsFontUrlTemplate = emsSettings!.getEMSFontLibraryUrl();
+    canAccessEmsFontsPromise = new Promise(async (resolve, reject) => {
       try {
-        const emsFontUrl = emsFontUrlTemplate.replace('{fontstack}', 'Open Sans').replace('{range}', '0-255');
-        const resp = await fetch(emsFontUrl, {
-          method: 'HEAD',
-        });
-        if (resp.status >= 400) {
-          throw new Error(`status: ${resp.status}`);
+        const emsSettings = getEMSSettings();
+        if (!emsSettings!.isEMSEnabled()) {
+          resolve(false);
         }
-        resolve(true);
+        const emsFontUrlTemplate = emsSettings!.getEMSFontLibraryUrl();
+        try {
+          const emsFontUrl = emsFontUrlTemplate
+            .replace('{fontstack}', 'Open Sans')
+            .replace('{range}', '0-255');
+          const resp = await fetch(emsFontUrl, {
+            method: 'HEAD',
+          });
+          if (resp.status >= 400) {
+            throw new Error(`status: ${resp.status}`);
+          }
+          resolve(true);
+        } catch (error) {
+          // eslint-disable-next-line no-console
+          console.warn(
+            `Unable to access fonts from Elastic Maps Service (EMS). Set kibana.yml 'map.includeElasticMapsService: false' to avoid unnecessary EMS requests.`
+          );
+          resolve(false);
+        }
       } catch (error) {
-        console.warn(`Unable to access fonts from Elastic Maps Service (EMS). Set kibana.yml 'map.includeElasticMapsService: false' to avoid unnecessary EMS requests.`);
-        resolve(false);
+        reject(error);
       }
     });
   }
   return canAccessEmsFontsPromise;
+}
+// test only function to reset singlton for different test cases.
+export function clearCanAccessEmsFontsPromise() {
+  canAccessEmsFontsPromise = null;
 }
 
 export async function getGlyphUrl(): Promise<string> {


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/152389

PR adds check to ensure client has access to EMS before using EMS fonts. If the client does not have access to EMS fonts then a warning is logged and map falls back to open sans fonts served from Kibana server.