### PR TITLE
[Security Solution][Exceptions] - Fix bulk rule duplicate, exception modal rule count

### DIFF
--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_tables.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_tables.tsx
@@ -231,6 +231,7 @@ export const RulesTables = React.memo<RulesTableProps>(({ selectedTab }) => {
 
   const shouldShowLinearProgress = (isFetched && isRefetching) || isUpgradingSecurityPackages;
   const shouldShowLoadingOverlay = (!isFetched && isRefetching) || isPreflightInProgress;
+  const numberOfSelectedRules = isAllSelected ? pagination.total : selectedRuleIds?.length ?? 1;
 
   return (
     <>
@@ -275,7 +276,7 @@ export const RulesTables = React.memo<RulesTableProps>(({ selectedTab }) => {
         <BulkActionDuplicateExceptionsConfirmation
           onCancel={cancelRuleDuplication}
           onConfirm={confirmRuleDuplication}
-          rulesCount={selectedRuleIds?.length ? selectedRuleIds?.length : 1}
+          rulesCount={numberOfSelectedRules}
         />
       )}
       {isBulkEditFlyoutVisible && bulkEditActionType !== undefined && (


### PR DESCRIPTION
## Summary

When user selects to bulk duplicate, a modal pops up asking them how they want to proceed with any rule exceptions. The rule count in this modal is wrong when all rules are selected. Updated so that now the count in the modal matches the actual selected count.

<img width="1330" alt="Screenshot 2023-02-28 at 1 23 25 PM" src="https://user-images.githubusercontent.com/10927944/222003713-42de18e5-9e05-478b-a5ff-8e373d6dc89c.png">
<img width="1249" alt="Screenshot 2023-02-28 at 1 23 37 PM" src="https://user-images.githubusercontent.com/10927944/222003718-eadb5415-8152-49d6-982a-cd769bce6b85.png">


### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->