### PR TITLE
[http] Adds route config option access flag to indicate if an API is public or internal

### DIFF
--- a/packages/core/http/core-http-router-server-internal/src/request.ts
+++ b/packages/core/http/core-http-router-server-internal/src/request.ts
@@ -201,6 +201,7 @@ export class CoreKibanaRequest<
       xsrfRequired:
         ((request.route?.settings as RouteOptions)?.app as KibanaRouteOptions)?.xsrfRequired ??
         true, // some places in LP call KibanaRequest.from(request) manually. remove fallback to true before v8
+      access: this.getAccess(request),
       tags: request.route?.settings?.tags || [],
       timeout: {
         payload: payloadTimeout,
@@ -221,6 +222,13 @@ export class CoreKibanaRequest<
       method,
       options,
     };
+  }
+  /** infer route access from path if not declared */
+  private getAccess(request: RawRequest): 'internal' | 'public' {
+    return (
+      ((request.route?.settings as RouteOptions)?.app as KibanaRouteOptions)?.access ??
+      (request.path.includes('internal') ? 'internal' : 'public')
+    );
   }
 
   private getAuthRequired(request: RawRequest): boolean | 'optional' {

--- a/packages/core/http/core-http-router-server-internal/src/request.ts
+++ b/packages/core/http/core-http-router-server-internal/src/request.ts
@@ -227,7 +227,7 @@ export class CoreKibanaRequest<
   private getAccess(request: RawRequest): 'internal' | 'public' {
     return (
       ((request.route?.settings as RouteOptions)?.app as KibanaRouteOptions)?.access ??
-      (request.path.includes('internal') ? 'internal' : 'public')
+      (request.path.startsWith('/internal') ? 'internal' : 'public')
     );
   }
 

--- a/packages/core/http/core-http-router-server-internal/src/route.ts
+++ b/packages/core/http/core-http-router-server-internal/src/route.ts
@@ -6,8 +6,12 @@
  * Side Public License, v 1.
  */
 
-import type { RouteMethod, SafeRouteMethod } from '@kbn/core-http-server';
+import type { RouteConfigOptions, RouteMethod, SafeRouteMethod } from '@kbn/core-http-server';
 
 export function isSafeMethod(method: RouteMethod): method is SafeRouteMethod {
   return method === 'get' || method === 'options';
+}
+
+export function isPublicRoute(options: RouteConfigOptions<RouteMethod>) {
+  return options.access === 'public';
 }

--- a/packages/core/http/core-http-router-server-internal/src/route.ts
+++ b/packages/core/http/core-http-router-server-internal/src/route.ts
@@ -6,12 +6,8 @@
  * Side Public License, v 1.
  */
 
-import type { RouteConfigOptions, RouteMethod, SafeRouteMethod } from '@kbn/core-http-server';
+import type { RouteMethod, SafeRouteMethod } from '@kbn/core-http-server';
 
 export function isSafeMethod(method: RouteMethod): method is SafeRouteMethod {
   return method === 'get' || method === 'options';
-}
-
-export function isPublicRoute(options: RouteConfigOptions<RouteMethod>) {
-  return options.access === 'public';
 }

--- a/packages/core/http/core-http-router-server-mocks/src/router.mock.ts
+++ b/packages/core/http/core-http-router-server-mocks/src/router.mock.ts
@@ -71,7 +71,7 @@ function createKibanaRequestMock<P = any, Q = any, B = any>({
   routeTags,
   routeAuthRequired,
   validation = {},
-  kibanaRouteOptions = { xsrfRequired: true },
+  kibanaRouteOptions = { xsrfRequired: true, access: 'public' },
   kibanaRequestState = {
     requestId: '123',
     requestUuid: '123e4567-e89b-12d3-a456-426614174000',

--- a/packages/core/http/core-http-server-internal/src/http_server.test.ts
+++ b/packages/core/http/core-http-server-internal/src/http_server.test.ts
@@ -849,6 +849,10 @@ test('infers access flag from path if not defined', async () => {
   router.get({ path: '/random/internal/foo', validate: false }, (context, req, res) =>
     res.ok({ body: { access: req.route.options.access } })
   );
+
+  router.get({ path: '/api/foo/internal/my-foo', validate: false }, (context, req, res) =>
+    res.ok({ body: { access: req.route.options.access } })
+  );
   registerRouter(router);
 
   await server.start();
@@ -857,6 +861,9 @@ test('infers access flag from path if not defined', async () => {
   await supertest(innerServer.listener).get('/random/foo').expect(200, { access: 'public' });
   await supertest(innerServer.listener)
     .get('/random/internal/foo')
+    .expect(200, { access: 'public' });
+  await supertest(innerServer.listener)
+    .get('/api/foo/internal/my-foo')
     .expect(200, { access: 'public' });
 });
 

--- a/packages/core/http/core-http-server-internal/src/http_server.test.ts
+++ b/packages/core/http/core-http-server-internal/src/http_server.test.ts
@@ -817,6 +817,49 @@ test('allows attaching metadata to attach meta-data tag strings to a route', asy
   await supertest(innerServer.listener).get('/without-tags').expect(200, { tags: [] });
 });
 
+test('allows declaring route access to flag a route as public or internal', async () => {
+  const access = 'internal';
+  const { registerRouter, server: innerServer } = await server.setup(config);
+
+  const router = new Router('', logger, enhanceWithContext);
+  router.get({ path: '/with-access', validate: false, options: { access } }, (context, req, res) =>
+    res.ok({ body: { access: req.route.options.access } })
+  );
+  router.get({ path: '/without-access', validate: false }, (context, req, res) =>
+    res.ok({ body: { access: req.route.options.access } })
+  );
+  registerRouter(router);
+
+  await server.start();
+  await supertest(innerServer.listener).get('/with-access').expect(200, { access });
+
+  await supertest(innerServer.listener).get('/without-access').expect(200, { access: 'public' });
+});
+
+test('infers access flag from path if not defined', async () => {
+  const { registerRouter, server: innerServer } = await server.setup(config);
+
+  const router = new Router('', logger, enhanceWithContext);
+  router.get({ path: '/internal/foo', validate: false }, (context, req, res) =>
+    res.ok({ body: { access: req.route.options.access } })
+  );
+  router.get({ path: '/random/foo', validate: false }, (context, req, res) =>
+    res.ok({ body: { access: req.route.options.access } })
+  );
+  router.get({ path: '/random/internal/foo', validate: false }, (context, req, res) =>
+    res.ok({ body: { access: req.route.options.access } })
+  );
+  registerRouter(router);
+
+  await server.start();
+  await supertest(innerServer.listener).get('/internal/foo').expect(200, { access: 'internal' });
+
+  await supertest(innerServer.listener).get('/random/foo').expect(200, { access: 'public' });
+  await supertest(innerServer.listener)
+    .get('/random/internal/foo')
+    .expect(200, { access: 'public' });
+});
+
 test('exposes route details of incoming request to a route handler', async () => {
   const { registerRouter, server: innerServer } = await server.setup(config);
 
@@ -833,6 +876,7 @@ test('exposes route details of incoming request to a route handler', async () =>
       options: {
         authRequired: true,
         xsrfRequired: false,
+        access: 'public',
         tags: [],
         timeout: {},
       },
@@ -1010,6 +1054,7 @@ test('exposes route details of incoming request to a route handler (POST + paylo
       options: {
         authRequired: true,
         xsrfRequired: true,
+        access: 'public',
         tags: [],
         timeout: {
           payload: 10000,

--- a/packages/core/http/core-http-server-internal/src/http_server.ts
+++ b/packages/core/http/core-http-server-internal/src/http_server.ts
@@ -526,7 +526,6 @@ export class HttpServer {
       xsrfRequired: route.options.xsrfRequired ?? !isSafeMethod(route.method),
       access: route.options.access ?? (route.path.startsWith('/internal') ? 'internal' : 'public'),
     };
-    this.log.debug(`kibanaRouteOptions [${kibanaRouteOptions.access}] for path [${route.path}]`);
 
     this.server!.route({
       handler: route.handler,

--- a/packages/core/http/core-http-server-internal/src/http_server.ts
+++ b/packages/core/http/core-http-server-internal/src/http_server.ts
@@ -524,7 +524,9 @@ export class HttpServer {
 
     const kibanaRouteOptions: KibanaRouteOptions = {
       xsrfRequired: route.options.xsrfRequired ?? !isSafeMethod(route.method),
+      access: route.options.access ?? (route.path.startsWith('/internal') ? 'internal' : 'public'),
     };
+    this.log.debug(`kibanaRouteOptions [${kibanaRouteOptions.access}] for path [${route.path}]`);
 
     this.server!.route({
       handler: route.handler,

--- a/packages/core/http/core-http-server-internal/src/lifecycle_handlers.test.ts
+++ b/packages/core/http/core-http-server-internal/src/lifecycle_handlers.test.ts
@@ -167,6 +167,7 @@ describe('xsrf post-auth handler', () => {
         path: '/some-path',
         kibanaRouteOptions: {
           xsrfRequired: false,
+          access: 'public',
         },
       });
 

--- a/packages/core/http/core-http-server-internal/src/lifecycle_handlers.ts
+++ b/packages/core/http/core-http-server-internal/src/lifecycle_handlers.ts
@@ -60,6 +60,7 @@ export const createVersionCheckPostAuthHandler = (kibanaVersion: string): OnPost
   };
 };
 
+// TODO: implement header required for accessing internal routes. See https://github.com/elastic/kibana/issues/151940
 export const createCustomHeadersPreResponseHandler = (config: HttpConfig): OnPreResponseHandler => {
   const {
     name: serverName,

--- a/packages/core/http/core-http-server/src/router/request.ts
+++ b/packages/core/http/core-http-server/src/router/request.ts
@@ -19,6 +19,7 @@ import type { Headers } from './headers';
  */
 export interface KibanaRouteOptions extends RouteOptionsApp {
   xsrfRequired: boolean;
+  access: 'internal' | 'public';
 }
 
 /**

--- a/packages/core/http/core-http-server/src/router/route.ts
+++ b/packages/core/http/core-http-server/src/router/route.ts
@@ -121,6 +121,18 @@ export interface RouteConfigOptions<Method extends RouteMethod> {
   xsrfRequired?: Method extends 'get' ? never : boolean;
 
   /**
+   * Defines access permission for a route
+   * - public. The route is public, declared stable and intended for external access.
+   *           In the future, may require an incomming request to contain a specified header.
+   * - internal. The route is internal and intended for internal access only.
+   *
+   * If not declared, infers access from route path:
+   * - access =`internal` for '/internal' route path prefix
+   * - access = `public` for '/api' route path prefix
+   */
+  access?: 'public' | 'internal';
+
+  /**
    * Additional metadata tag strings to attach to the route.
    */
   tags?: readonly string[];

--- a/packages/core/http/core-http-server/src/router/route.ts
+++ b/packages/core/http/core-http-server/src/router/route.ts
@@ -121,14 +121,14 @@ export interface RouteConfigOptions<Method extends RouteMethod> {
   xsrfRequired?: Method extends 'get' ? never : boolean;
 
   /**
-   * Defines access permission for a route
+   * Defines intended request origin of the route:
    * - public. The route is public, declared stable and intended for external access.
    *           In the future, may require an incomming request to contain a specified header.
    * - internal. The route is internal and intended for internal access only.
    *
    * If not declared, infers access from route path:
    * - access =`internal` for '/internal' route path prefix
-   * - access = `public` for '/api' route path prefix
+   * - access = `public` for everything else
    */
   access?: 'public' | 'internal';
 

--- a/packages/core/versioning/core-version-http-server/src/example.ts
+++ b/packages/core/versioning/core-version-http-server/src/example.ts
@@ -22,7 +22,7 @@ const versionedRouter = vtk.createVersionedRouter({ router });
 const versionedRoute = versionedRouter
   .post({
     path: '/api/my-app/foo/{id?}',
-    options: { timeout: { payload: 60000 } },
+    options: { timeout: { payload: 60000 }, access: 'public' },
   })
   .addVersion(
     {

--- a/packages/core/versioning/core-version-http-server/src/version_http_toolkit.ts
+++ b/packages/core/versioning/core-version-http-server/src/version_http_toolkit.ts
@@ -100,17 +100,13 @@ export interface VersionHTTPToolkit {
   ): VersionedRouter<Ctx>;
 }
 
-type WithRequiredProperty<Type, Key extends keyof Type> = Type & {
-  [Property in Key]-?: Type[Property];
-};
-
 /**
  * Versioned route access flag, required
  * - '/api/foo' is 'public'
  * - '/internal/my-foo'  is 'internal'
  * Required
  */
-type VersionedRouteConfigOptions = WithRequiredProperty<RouteConfigOptions<RouteMethod>, 'access'>;
+type VersionedRouteConfigOptions = Required<Pick<RouteConfigOptions<RouteMethod>, 'access'>>;
 /**
  * Configuration for a versioned route
  * @experimental

--- a/packages/core/versioning/core-version-http-server/src/version_http_toolkit.ts
+++ b/packages/core/versioning/core-version-http-server/src/version_http_toolkit.ts
@@ -13,6 +13,7 @@ import type {
   RequestHandler,
   RouteValidatorFullConfig,
   RequestHandlerContextBase,
+  RouteConfigOptions,
 } from '@kbn/core-http-server';
 
 type RqCtx = RequestHandlerContextBase;
@@ -45,7 +46,7 @@ export interface CreateVersionedRouterArgs<Ctx extends RqCtx = RqCtx> {
  * const versionedRoute = versionedRouter
  *   .post({
  *     path: '/api/my-app/foo/{id?}',
- *     options: { timeout: { payload: 60000 } },
+ *     options: { timeout: { payload: 60000 }, access: 'public' },
  *   })
  *   .addVersion(
  *     {
@@ -99,14 +100,25 @@ export interface VersionHTTPToolkit {
   ): VersionedRouter<Ctx>;
 }
 
+type WithRequiredProperty<Type, Key extends keyof Type> = Type & {
+  [Property in Key]-?: Type[Property];
+};
+
+/**
+ * Versioned route access flag, required
+ * - '/api/foo' is 'public'
+ * - '/internal/my-foo'  is 'internal'
+ * Required
+ */
+type VersionedRouteConfigOptions = WithRequiredProperty<RouteConfigOptions<RouteMethod>, 'access'>;
 /**
  * Configuration for a versioned route
  * @experimental
  */
 export type VersionedRouteConfig<Method extends RouteMethod> = Omit<
   RouteConfig<unknown, unknown, unknown, Method>,
-  'validate'
->;
+  'validate' | 'options'
+> & { options: VersionedRouteConfigOptions };
 
 /**
  * Create an {@link VersionedRoute | versioned route}.

--- a/packages/core/versioning/core-version-http-server/src/version_http_toolkit.ts
+++ b/packages/core/versioning/core-version-http-server/src/version_http_toolkit.ts
@@ -101,12 +101,19 @@ export interface VersionHTTPToolkit {
 }
 
 /**
+ * Converts an input property from optional to required. Needed for making RouteConfigOptions['access'] required.
+ */
+type WithRequiredProperty<Type, Key extends keyof Type> = Type & {
+  [Property in Key]-?: Type[Property];
+};
+
+/**
  * Versioned route access flag, required
  * - '/api/foo' is 'public'
  * - '/internal/my-foo'  is 'internal'
  * Required
  */
-type VersionedRouteConfigOptions = Required<Pick<RouteConfigOptions<RouteMethod>, 'access'>>;
+type VersionedRouteConfigOptions = WithRequiredProperty<RouteConfigOptions<RouteMethod>, 'access'>;
 /**
  * Configuration for a versioned route
  * @experimental


### PR DESCRIPTION
## Summary

Fix https://github.com/elastic/kibana/issues/152269
Fix https://github.com/elastic/kibana/issues/152276

Part of https://github.com/elastic/kibana/issues/151940

The current naming convention used to indicate if an API is intended for internal or public use has proven to be insufficient. This limits what we can change in internal APIs, since we risk breaking external integrations. As such, we want to formalize the distinction, both to clarify an API's intended use and reduce the number of public APIs we have to maintain for a long time.

This PR adds an optional `access` option to Core's `RouteConfigOptions` that allows consumers to mark their API's intended consumption.
ATM, the option is only a flag, but we intend to develop the formalization further at some later stage.

If `access` is not declared, core's HTTP service infers it from a route path:
`/internal/my-foo` is taken to be `access: 'internal'`, whereas any other path string is interpreted as 'public'.

This PR also makes the `access` parameter required for `Versioned` routers.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
Note: the new config option is optional in the core implementation specifically to avoid breaking changes.
