### PR TITLE
[ML] Fix regression to skip considering future data on use full data button in ML plugin.

### DIFF
--- a/x-pack/packages/ml/date_picker/index.ts
+++ b/x-pack/packages/ml/date_picker/index.ts
@@ -23,6 +23,7 @@ export {
 export {
   getTimeFilterRange,
   type TimeRange,
+  type SetFullTimeRangeApiPath,
 } from './src/services/full_time_range_selector_service';
 export { type GetTimeFieldRangeResponse } from './src/services/types';
 export { mlTimefilterRefresh$, type Refresh } from './src/services/timefilter_refresh_service';

--- a/x-pack/packages/ml/date_picker/src/components/full_time_range_selector.tsx
+++ b/x-pack/packages/ml/date_picker/src/components/full_time_range_selector.tsx
@@ -26,7 +26,10 @@ import type { DataView } from '@kbn/data-plugin/common';
 import type { TimefilterContract } from '@kbn/data-plugin/public';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { useDatePickerContext } from '../hooks/use_date_picker_context';
-import { setFullTimeRange } from '../services/full_time_range_selector_service';
+import {
+  setFullTimeRange,
+  type SetFullTimeRangeApiPath,
+} from '../services/full_time_range_selector_service';
 import type { GetTimeFieldRangeResponse } from '../services/types';
 import { FROZEN_TIER_PREFERENCE, type FrozenTierPreference } from '../storage';
 
@@ -68,7 +71,7 @@ export interface FullTimeRangeSelectorProps {
    * Optional API path.
    * @param value - The time field range response.
    */
-  apiPath?: string;
+  apiPath?: SetFullTimeRangeApiPath;
 }
 
 /**

--- a/x-pack/packages/ml/date_picker/src/components/full_time_range_selector.tsx
+++ b/x-pack/packages/ml/date_picker/src/components/full_time_range_selector.tsx
@@ -64,6 +64,11 @@ export interface FullTimeRangeSelectorProps {
    * @param value - The time field range response.
    */
   callback?: (value: GetTimeFieldRangeResponse) => void;
+  /**
+   * Optional API path.
+   * @param value - The time field range response.
+   */
+  apiPath?: string;
 }
 
 /**
@@ -83,6 +88,7 @@ export const FullTimeRangeSelector: FC<FullTimeRangeSelectorProps> = (props) => 
     query,
     disabled,
     callback,
+    apiPath,
   } = props;
   const {
     http,
@@ -98,7 +104,8 @@ export const FullTimeRangeSelector: FC<FullTimeRangeSelectorProps> = (props) => 
         toasts,
         http,
         query,
-        frozenDataPreference === FROZEN_TIER_PREFERENCE.EXCLUDE
+        frozenDataPreference === FROZEN_TIER_PREFERENCE.EXCLUDE,
+        apiPath
       );
       if (typeof callback === 'function') {
         callback(fullTimeRange);
@@ -113,7 +120,7 @@ export const FullTimeRangeSelector: FC<FullTimeRangeSelectorProps> = (props) => 
         )
       );
     }
-  }, [callback, dataView, frozenDataPreference, http, query, timefilter, toasts]);
+  }, [callback, dataView, frozenDataPreference, http, query, timefilter, toasts, apiPath]);
 
   const [isPopoverOpen, setPopover] = useState(false);
 

--- a/x-pack/packages/ml/date_picker/src/services/full_time_range_selector_service.ts
+++ b/x-pack/packages/ml/date_picker/src/services/full_time_range_selector_service.ts
@@ -17,6 +17,9 @@ import { addExcludeFrozenToQuery } from '@kbn/ml-query-utils';
 import { getTimeFieldRange } from './time_field_range';
 import type { GetTimeFieldRangeResponse } from './types';
 
+/**
+ * Allowed API paths to be passed to `setFullTimeRange`.
+ */
 export type SetFullTimeRangeApiPath =
   | '/internal/file_upload/time_field_range'
   | '/api/ml/fields_service/time_field_range';

--- a/x-pack/packages/ml/date_picker/src/services/full_time_range_selector_service.ts
+++ b/x-pack/packages/ml/date_picker/src/services/full_time_range_selector_service.ts
@@ -17,6 +17,10 @@ import { addExcludeFrozenToQuery } from '@kbn/ml-query-utils';
 import { getTimeFieldRange } from './time_field_range';
 import type { GetTimeFieldRangeResponse } from './types';
 
+export type SetFullTimeRangeApiPath =
+  | '/internal/file_upload/time_field_range'
+  | '/api/ml/fields_service/time_field_range';
+
 /**
  * Determines the full available time range of the given Data View and updates
  * the timefilter accordingly.
@@ -27,6 +31,7 @@ import type { GetTimeFieldRangeResponse } from './types';
  * @param http - HttpStart
  * @param query - optional query
  * @param excludeFrozenData - optional boolean flag
+ * @param path - optional SetFullTimeRangeApiPath
  * @returns {GetTimeFieldRangeResponse}
  */
 export async function setFullTimeRange(
@@ -36,7 +41,7 @@ export async function setFullTimeRange(
   http: HttpStart,
   query?: QueryDslQueryContainer,
   excludeFrozenData?: boolean,
-  path: string = '/internal/file_upload/time_field_range'
+  path: SetFullTimeRangeApiPath = '/internal/file_upload/time_field_range'
 ): Promise<GetTimeFieldRangeResponse> {
   try {
     const runtimeMappings = dataView.getRuntimeMappings();

--- a/x-pack/packages/ml/date_picker/src/services/time_field_range.ts
+++ b/x-pack/packages/ml/date_picker/src/services/time_field_range.ts
@@ -36,6 +36,10 @@ interface GetTimeFieldRangeOptions {
    * HTTP client
    */
   http: HttpStart;
+  /**
+   * API path ('/internal/file_upload/time_field_range')
+   */
+  path: string;
 }
 
 /**
@@ -44,10 +48,10 @@ interface GetTimeFieldRangeOptions {
  * @returns GetTimeFieldRangeResponse
  */
 export async function getTimeFieldRange(options: GetTimeFieldRangeOptions) {
-  const { http, ...body } = options;
+  const { http, path, ...body } = options;
 
   return await http.fetch<GetTimeFieldRangeResponse>({
-    path: `/internal/file_upload/time_field_range`,
+    path,
     method: 'POST',
     body: JSON.stringify(body),
   });

--- a/x-pack/plugins/ml/public/application/jobs/new_job/pages/components/time_range_step/time_range.tsx
+++ b/x-pack/plugins/ml/public/application/jobs/new_job/pages/components/time_range_step/time_range.tsx
@@ -135,6 +135,7 @@ export const TimeRangeStep: FC<StepProps> = ({ setCurrentStep, isCurrentStep }) 
                 disabled={false}
                 callback={fullTimeRangeCallback}
                 timefilter={timefilter}
+                apiPath="/api/ml/fields_service/time_field_range"
               />
             </EuiFlexItem>
             <EuiFlexItem />


### PR DESCRIPTION
## Summary

Fixes #152335.
Follow up to #148063.

Fixes a regression where the "Use full data" button in the ML plugin would no longer avoid considering future data.

Before (the "to" date goes until April):

<img width="1266" alt="image" src="https://user-images.githubusercontent.com/230104/222118234-792cc1b5-738e-43ef-ad59-a4dca532c034.png">

After (note the "to" date is now March 1st):

<img width="1264" alt="image" src="https://user-images.githubusercontent.com/230104/222117619-a2b3d33e-5006-44cf-b9c3-6d9009ea28d3.png">

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->