### PR TITLE
[Security Solution] Make timeline confirm prompt space aware

### DIFF
--- a/x-pack/plugins/security_solution/public/common/hooks/timeline/use_timeline_save_prompt.ts
+++ b/x-pack/plugins/security_solution/public/common/hooks/timeline/use_timeline_save_prompt.ts
@@ -30,7 +30,7 @@ export const useTimelineSavePrompt = (
   onAppLeave: (handler: AppLeaveHandler) => void
 ) => {
   const dispatch = useDispatch();
-  const { overlays, application } = useKibana().services;
+  const { overlays, application, http } = useKibana().services;
   const getIsTimelineVisible = useShowTimelineForGivenPath();
   const history = useHistory();
 
@@ -66,10 +66,12 @@ export const useTimelineSavePrompt = (
 
         if (confirmRes) {
           unblock();
-
-          application.navigateToUrl(location.pathname + location.hash + location.search, {
-            state: location.state,
-          });
+          application.navigateToUrl(
+            http.basePath.get() + location.pathname + location.hash + location.search,
+            {
+              state: location.state,
+            }
+          );
         } else {
           showSaveTimelineModal();
         }
@@ -92,6 +94,7 @@ export const useTimelineSavePrompt = (
     };
   }, [
     history,
+    http.basePath,
     application,
     overlays,
     showSaveTimelineModal,


### PR DESCRIPTION
## Summary

The timeline save prompt's use of application.navigateToUrl was not taking space into account, this pr updates it so that it does.

![timeline-block-space-aware](https://user-images.githubusercontent.com/56408403/222162486-b936ccd8-af62-46da-a4b2-a6c0825a9344.gif)







<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->