### PR TITLE
Upgrade `undici` dependency (`5.14.0` → `5.20.0`).

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -27762,9 +27762,9 @@ unc-path-regex@^0.1.2:
   integrity sha1-5z3T17DXxe2G+6xrCufYxqadUPo=
 
 undici@^5.11.0, undici@^5.5.1:
-  version "5.14.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-5.14.0.tgz#1169d0cdee06a4ffdd30810f6228d57998884d00"
-  integrity sha512-yJlHYw6yXPPsuOH0x2Ib1Km61vu4hLiRRQoafs+WUgX1vO64vgnxiCEN9dpIrhZyHFsai3F0AEj4P9zy19enEQ==
+  version "5.20.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-5.20.0.tgz#6327462f5ce1d3646bcdac99da7317f455bcc263"
+  integrity sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==
   dependencies:
     busboy "^1.6.0"
 


### PR DESCRIPTION
## Summary

Upgrade `undici` dependency (`5.14.0` → `5.20.0`).

Change log: https://github.com/nodejs/undici/releases

There are no breaking or notable changes in the release.

<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->