### PR TITLE
[SLO] Alternative split to remote indices

### DIFF
--- a/x-pack/plugins/observability/server/services/slo/transform_generators/common.test.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/common.test.ts
@@ -13,7 +13,9 @@ describe('common', () => {
       ['foo-*', 'foo-*'],
       ['foo-*,bar-*', ['foo-*', 'bar-*']],
       ['remote:foo-*', 'remote:foo-*'],
-      ['remote:foo*,bar-*', ['remote:foo*', 'remote:bar-*']],
+      ['remote:foo*,bar-*', ['remote:foo*', 'bar-*']],
+      ['remote:foo*,remote:bar-*', ['remote:foo*', 'remote:bar-*']],
+      ['remote:foo*,bar-*,remote:baz-*', ['remote:foo*', 'bar-*', 'remote:baz-*']],
     ])("parses the index '%s' correctly", (index, expected) => {
       expect(parseIndex(index)).toEqual(expected);
     });

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/common.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/common.ts
@@ -17,15 +17,9 @@ export function getElastichsearchQueryOrThrow(kuery: string) {
 }
 
 export function parseIndex(index: string): string | string[] {
-  if (index.indexOf(',') > -1) {
-    if (index.indexOf(':') > -1) {
-      const indexParts = index.split(':'); // "remote_name:foo-*,bar*"
-      const remoteName = indexParts[0];
-      return indexParts[1].split(',').map((idx) => `${remoteName}:${idx}`); // [ "remote_name:foo-*", "remote_name:bar-*"]
-    }
-
-    return index.split(',');
+  if (index.indexOf(',') === -1) {
+    return index;
   }
 
-  return index;
+  return index.split(',');
 }


### PR DESCRIPTION
## Summary

This updates the utility to process a string of one or more indices. It assumed when one part of the string passed contained `remote:`, all remaining indices would also have to contain `remote`, but this isn't necessary.  
