### PR TITLE
Generate a different hash for summary actions

### DIFF
--- a/x-pack/plugins/alerting/server/task_runner/rule_action_helper.test.ts
+++ b/x-pack/plugins/alerting/server/task_runner/rule_action_helper.test.ts
@@ -38,8 +38,7 @@ const mockAction: RuleAction = {
 
 const mockSummaryAction: RuleAction = {
   id: '1',
-  // @ts-ignore
-  group: null,
+  group: 'default',
   actionTypeId: 'slack',
   params: {},
   frequency: {

--- a/x-pack/plugins/alerting/server/task_runner/rule_action_helper.ts
+++ b/x-pack/plugins/alerting/server/task_runner/rule_action_helper.ts
@@ -69,7 +69,7 @@ export const isSummaryActionThrottled = ({
 };
 
 export const generateActionHash = (action: RuleAction) => {
-  return `${action.actionTypeId}:${action.group || 'summary'}:${
+  return `${action.actionTypeId}:${action.frequency?.summary ? 'summary' : action.group}:${
     action.frequency?.throttle || 'no-throttling'
   }`;
 };
@@ -82,7 +82,9 @@ export const getSummaryActionsFromTaskState = ({
   summaryActions?: ThrottledActions;
 }) => {
   return Object.entries(summaryActions).reduce((newObj, [key, val]) => {
-    const actionExists = actions.some((action) => generateActionHash(action) === key);
+    const actionExists = actions.some(
+      (action) => action.frequency?.summary && generateActionHash(action) === key
+    );
     if (actionExists) {
       return { ...newObj, [key]: val };
     } else {

--- a/x-pack/plugins/alerting/server/task_runner/task_runner.test.ts
+++ b/x-pack/plugins/alerting/server/task_runner/task_runner.test.ts
@@ -1486,7 +1486,7 @@ describe('Task Runner', () => {
         generateEnqueueFunctionInput({ isBulk, id: '1', foo: true })
       );
       expect(result.state.summaryActions).toEqual({
-        'slack:default:1h': { date: new Date(DATE_1970) },
+        'slack:summary:1h': { date: new Date(DATE_1970) },
       });
     }
   );


### PR DESCRIPTION
Fixes: #152500

This PR changes generateHash function to get a different hash for summary actions. 
So summary and non-summary actions wouldn't be mixed up.

<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->