### PR TITLE
[Fleet] Add support for select type in integrations

### DIFF
--- a/x-pack/plugins/fleet/common/services/validate_package_policy.test.ts
+++ b/x-pack/plugins/fleet/common/services/validate_package_policy.test.ts
@@ -991,7 +991,10 @@ describe('Fleet - validatePackagePolicyConfig', () => {
         {
           name: 'myvariable',
           type: 'select',
-          options: [{ value: 'a', text: 'A' }, { value: 'b', text: 'B' }],
+          options: [
+            { value: 'a', text: 'A' },
+            { value: 'b', text: 'B' },
+          ],
         },
         'myvariable',
         safeLoad

--- a/x-pack/plugins/fleet/common/services/validate_package_policy.test.ts
+++ b/x-pack/plugins/fleet/common/services/validate_package_policy.test.ts
@@ -947,42 +947,49 @@ describe('Fleet - validatePackagePolicyConfig', () => {
   });
 
   describe('Select', () => {
-    it('should return an error message if options are missing', () => {
+    it('should return an error message if the value is not an option value', () => {
       const res = validatePackagePolicyConfig(
         {
           type: 'select',
-          value: undefined,
+          value: 'c',
         },
         {
           name: 'myvariable',
           type: 'select',
+          options: [
+            { value: 'a', text: 'A' },
+            { value: 'b', text: 'B' },
+          ],
         },
         'myvariable',
         safeLoad
       );
 
-      expect(res).toEqual(['Options must be provided for select type']);
+      expect(res).toEqual(['Invalid value for select type']);
     });
 
-    it('should return an error message if options are empty', () => {
+    it('should accept a select with a valid value', () => {
       const res = validatePackagePolicyConfig(
         {
           type: 'select',
-          value: undefined,
+          value: 'b',
         },
         {
           name: 'myvariable',
           type: 'select',
-          options: [],
+          options: [
+            { value: 'a', text: 'A' },
+            { value: 'b', text: 'B' },
+          ],
         },
         'myvariable',
         safeLoad
       );
 
-      expect(res).toEqual(['Options array must contain at least one entry']);
+      expect(res).toBeNull();
     });
 
-    it('should accept a select with valid options', () => {
+    it('should accept a select with undefined value', () => {
       const res = validatePackagePolicyConfig(
         {
           type: 'select',

--- a/x-pack/plugins/fleet/common/services/validate_package_policy.test.ts
+++ b/x-pack/plugins/fleet/common/services/validate_package_policy.test.ts
@@ -945,4 +945,59 @@ describe('Fleet - validatePackagePolicyConfig', () => {
       expect(res).toBeNull();
     });
   });
+
+  describe('Select', () => {
+    it('should return an error message if options are missing', () => {
+      const res = validatePackagePolicyConfig(
+        {
+          type: 'select',
+          value: undefined,
+        },
+        {
+          name: 'myvariable',
+          type: 'select',
+        },
+        'myvariable',
+        safeLoad
+      );
+
+      expect(res).toEqual(['Options must be provided for select type']);
+    });
+
+    it('should return an error message if options are empty', () => {
+      const res = validatePackagePolicyConfig(
+        {
+          type: 'select',
+          value: undefined,
+        },
+        {
+          name: 'myvariable',
+          type: 'select',
+          options: [],
+        },
+        'myvariable',
+        safeLoad
+      );
+
+      expect(res).toEqual(['Options array must contain at least one entry']);
+    });
+
+    it('should accept a select with valid options', () => {
+      const res = validatePackagePolicyConfig(
+        {
+          type: 'select',
+          value: undefined,
+        },
+        {
+          name: 'myvariable',
+          type: 'select',
+          options: [{ value: 'a', text: 'A' }, { value: 'b', text: 'B' }],
+        },
+        'myvariable',
+        safeLoad
+      );
+
+      expect(res).toBeNull();
+    });
+  });
 });

--- a/x-pack/plugins/fleet/common/services/validate_package_policy.ts
+++ b/x-pack/plugins/fleet/common/services/validate_package_policy.ts
@@ -337,21 +337,13 @@ export const validatePackagePolicyConfig = (
     }
   }
 
-  if (varDef.type === 'select') {
-    if (!varDef.options) {
+  if (varDef.type === 'select' && parsedValue) {
+    if (!varDef.options?.map(o => o.value).includes(parsedValue)) {
       errors.push(
-        i18n.translate('xpack.fleet.packagePolicyValidation.missingSelectOptionsErrorMessage', {
-          defaultMessage: 'Options must be provided for select type',
+        i18n.translate('xpack.fleet.packagePolicyValidation.invalidSelectValueErrorMessage', {
+          defaultMessage: 'Invalid value for select type',
         })
       );
-    } else {
-      if (varDef.options.length === 0) {
-        errors.push(
-          i18n.translate('xpack.fleet.packagePolicyValidation.emptySelectOptionsErrorMessage', {
-            defaultMessage: 'Options array must contain at least one entry',
-          })
-        );
-      }
     }
   }
 

--- a/x-pack/plugins/fleet/common/services/validate_package_policy.ts
+++ b/x-pack/plugins/fleet/common/services/validate_package_policy.ts
@@ -337,6 +337,24 @@ export const validatePackagePolicyConfig = (
     }
   }
 
+  if (varDef.type === 'select') {
+    if (!varDef.options) {
+      errors.push(
+        i18n.translate('xpack.fleet.packagePolicyValidation.missingSelectOptionsErrorMessage', {
+          defaultMessage: 'Options must be provided for select type'
+        })
+      )
+    } else {
+      if (varDef.options.length === 0) {
+        errors.push(
+          i18n.translate('xpack.fleet.packagePolicyValidation.emptySelectOptionsErrorMessage', {
+            defaultMessage: 'Options array must contain at least one entry'
+          })
+        )
+      }
+    }
+  }
+
   return errors.length ? errors : null;
 };
 

--- a/x-pack/plugins/fleet/common/services/validate_package_policy.ts
+++ b/x-pack/plugins/fleet/common/services/validate_package_policy.ts
@@ -338,7 +338,7 @@ export const validatePackagePolicyConfig = (
   }
 
   if (varDef.type === 'select' && parsedValue) {
-    if (!varDef.options?.map(o => o.value).includes(parsedValue)) {
+    if (!varDef.options?.map((o) => o.value).includes(parsedValue)) {
       errors.push(
         i18n.translate('xpack.fleet.packagePolicyValidation.invalidSelectValueErrorMessage', {
           defaultMessage: 'Invalid value for select type',

--- a/x-pack/plugins/fleet/common/services/validate_package_policy.ts
+++ b/x-pack/plugins/fleet/common/services/validate_package_policy.ts
@@ -341,16 +341,16 @@ export const validatePackagePolicyConfig = (
     if (!varDef.options) {
       errors.push(
         i18n.translate('xpack.fleet.packagePolicyValidation.missingSelectOptionsErrorMessage', {
-          defaultMessage: 'Options must be provided for select type'
+          defaultMessage: 'Options must be provided for select type',
         })
-      )
+      );
     } else {
       if (varDef.options.length === 0) {
         errors.push(
           i18n.translate('xpack.fleet.packagePolicyValidation.emptySelectOptionsErrorMessage', {
-            defaultMessage: 'Options array must contain at least one entry'
+            defaultMessage: 'Options array must contain at least one entry',
           })
-        )
+        );
       }
     }
   }

--- a/x-pack/plugins/fleet/common/types/models/epm.ts
+++ b/x-pack/plugins/fleet/common/types/models/epm.ts
@@ -407,7 +407,7 @@ export interface RegistryVarsEntry {
   [RegistryVarsEntryKeys.required]?: boolean;
   [RegistryVarsEntryKeys.show_user]?: boolean;
   [RegistryVarsEntryKeys.multi]?: boolean;
-  [RegistryVarsEntryKeys.options]: Array<{ value: string; text: string }>;
+  [RegistryVarsEntryKeys.options]?: Array<{ value: string; text: string }>;
   [RegistryVarsEntryKeys.default]?: string | string[] | boolean;
   [RegistryVarsEntryKeys.os]?: {
     [key: string]: {

--- a/x-pack/plugins/fleet/common/types/models/epm.ts
+++ b/x-pack/plugins/fleet/common/types/models/epm.ts
@@ -378,6 +378,7 @@ export type RegistryVarType =
   | 'integer'
   | 'bool'
   | 'password'
+  | 'select'
   | 'text'
   | 'yaml'
   | 'string'

--- a/x-pack/plugins/fleet/common/types/models/epm.ts
+++ b/x-pack/plugins/fleet/common/types/models/epm.ts
@@ -391,6 +391,7 @@ export enum RegistryVarsEntryKeys {
   required = 'required',
   show_user = 'show_user',
   multi = 'multi',
+  options = 'options',
   default = 'default',
   os = 'os',
 }
@@ -406,6 +407,7 @@ export interface RegistryVarsEntry {
   [RegistryVarsEntryKeys.required]?: boolean;
   [RegistryVarsEntryKeys.show_user]?: boolean;
   [RegistryVarsEntryKeys.multi]?: boolean;
+  [RegistryVarsEntryKeys.options]: Array<{ value: string; text: string }>;
   [RegistryVarsEntryKeys.default]?: string | string[] | boolean;
   [RegistryVarsEntryKeys.os]?: {
     [key: string]: {

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_var_field.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_var_field.tsx
@@ -159,11 +159,7 @@ export const PackagePolicyInputVarField: React.FunctionComponent<{
           );
         case 'select':
           return (
-            <EuiSelect
-              options={options}
-              value={value}
-              onChange={(e) => onChange(e.target.value)}
-            />
+            <EuiSelect options={options} value={value} onChange={(e) => onChange(e.target.value)} />
           );
         default:
           return (

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_var_field.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_var_field.tsx
@@ -17,6 +17,7 @@ import {
   EuiFieldPassword,
   EuiCodeBlock,
   EuiTextArea,
+  EuiSelect,
 } from '@elastic/eui';
 import styled from 'styled-components';
 
@@ -37,6 +38,7 @@ export const PackagePolicyInputVarField: React.FunctionComponent<{
   varDef: RegistryVarsEntry;
   value: any;
   onChange: (newValue: any) => void;
+  options?: { value: string; text: string }[];
   errors?: string[] | null;
   forceShowErrors?: boolean;
   frozen?: boolean;
@@ -49,6 +51,7 @@ export const PackagePolicyInputVarField: React.FunctionComponent<{
     varDef,
     value,
     onChange,
+    options,
     errors: varErrors,
     forceShowErrors,
     frozen,
@@ -152,6 +155,14 @@ export const PackagePolicyInputVarField: React.FunctionComponent<{
               onChange={(e) => onChange(e.target.value)}
               onBlur={() => setIsDirty(true)}
               disabled={frozen}
+            />
+          );
+        case 'select':
+          return (
+            <EuiSelect
+              options={options}
+              value={value}
+              onChange={(e) => onChange(e.target.value)}
             />
           );
         default:

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_var_field.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_var_field.tsx
@@ -38,7 +38,6 @@ export const PackagePolicyInputVarField: React.FunctionComponent<{
   varDef: RegistryVarsEntry;
   value: any;
   onChange: (newValue: any) => void;
-  options?: Array<{ value: string; text: string }>;
   errors?: string[] | null;
   forceShowErrors?: boolean;
   frozen?: boolean;
@@ -51,7 +50,6 @@ export const PackagePolicyInputVarField: React.FunctionComponent<{
     varDef,
     value,
     onChange,
-    options,
     errors: varErrors,
     forceShowErrors,
     frozen,
@@ -61,7 +59,7 @@ export const PackagePolicyInputVarField: React.FunctionComponent<{
     isEditPage = false,
   }) => {
     const [isDirty, setIsDirty] = useState<boolean>(false);
-    const { multi, required, type, title, name, description } = varDef;
+    const { multi, required, type, title, name, description, options } = varDef;
     const isInvalid = (isDirty || forceShowErrors) && !!varErrors;
     const errors = isInvalid ? varErrors : null;
     const fieldLabel = title || name;
@@ -159,7 +157,11 @@ export const PackagePolicyInputVarField: React.FunctionComponent<{
           );
         case 'select':
           return (
-            <EuiSelect options={options} value={value} onChange={(e) => onChange(e.target.value)} />
+            <EuiSelect
+              options={options}
+              value={value}
+              onChange={(e) => onChange(e.target.value)}
+            />
           );
         default:
           return (
@@ -179,7 +181,6 @@ export const PackagePolicyInputVarField: React.FunctionComponent<{
       type,
       value,
       onChange,
-      options,
       frozen,
       packageName,
       datastreams,

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_var_field.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_var_field.tsx
@@ -38,7 +38,7 @@ export const PackagePolicyInputVarField: React.FunctionComponent<{
   varDef: RegistryVarsEntry;
   value: any;
   onChange: (newValue: any) => void;
-  options?: { value: string; text: string }[];
+  options?: Array<{ value: string; text: string }>;
   errors?: string[] | null;
   forceShowErrors?: boolean;
   frozen?: boolean;
@@ -183,6 +183,7 @@ export const PackagePolicyInputVarField: React.FunctionComponent<{
       type,
       value,
       onChange,
+      options,
       frozen,
       packageName,
       datastreams,

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_var_field.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_var_field.tsx
@@ -187,6 +187,7 @@ export const PackagePolicyInputVarField: React.FunctionComponent<{
       isEditPage,
       isInvalid,
       fieldLabel,
+      options,
     ]);
 
     // Boolean cannot be optional by default set to false

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_var_field.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_var_field.tsx
@@ -157,11 +157,7 @@ export const PackagePolicyInputVarField: React.FunctionComponent<{
           );
         case 'select':
           return (
-            <EuiSelect
-              options={options}
-              value={value}
-              onChange={(e) => onChange(e.target.value)}
-            />
+            <EuiSelect options={options} value={value} onChange={(e) => onChange(e.target.value)} />
           );
         default:
           return (


### PR DESCRIPTION
## Summary

This PR adds support for the new `select` var type in integrations.

Context and discussion in related issue: https://github.com/elastic/package-spec/issues/453
Related package-spec PR: https://github.com/elastic/package-spec/pull/486

### Screenshots

#### Before
Current `Scope` advanced option in the Elasticsearch metrics settings (free text field):
<img width="777" alt="Screenshot 2023-03-08 at 09 37 30" src="https://user-images.githubusercontent.com/23701614/223664474-a5cc5c2b-43c3-451f-9678-30e8c661bfcf.png">

#### After
Same option with a select instead:
<img width="777" alt="Screenshot 2023-03-08 at 09 36 25" src="https://user-images.githubusercontent.com/23701614/223664552-37c56bff-d6c9-4035-af4c-3a27e355beed.png">
<img width="777" alt="Screenshot 2023-03-08 at 09 36 31" src="https://user-images.githubusercontent.com/23701614/223664581-9e92abfa-6202-433e-b4de-2740fc7c96bc.png">

### Checklist

- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
