### PR TITLE
[Enterprise Search] Allow custom pipelines to be deleted

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/index/create_custom_pipeline_api_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/index/create_custom_pipeline_api_logic.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { IngestPipeline } from '@elastic/elasticsearch/lib/api/types';
 import { i18n } from '@kbn/i18n';
 
 import { createApiLogic } from '../../../shared/api_logic/create_api_logic';
@@ -14,9 +15,7 @@ export interface CreateCustomPipelineApiLogicArgs {
   indexName: string;
 }
 
-export interface CreateCustomPipelineApiLogicResponse {
-  created: string[];
-}
+export type CreateCustomPipelineApiLogicResponse = Record<string, IngestPipeline | undefined>;
 
 export const createCustomPipeline = async ({
   indexName,

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/pipelines/revert_connector_pipeline_api_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/pipelines/revert_connector_pipeline_api_logic.test.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { mockHttpValues } from '../../../__mocks__/kea_logic';
+
+import { revertConnectorPipeline } from './revert_connector_pipeline_api_logic';
+
+describe('RevertConnectorPipelineApiLogic', () => {
+  it('should call delete pipeline endpoint', () => {
+    const { http } = mockHttpValues;
+    revertConnectorPipeline({ indexName: 'indexName' });
+    expect(http.delete).toHaveBeenCalledWith(
+      '/internal/enterprise_search/indices/indexName/pipeline'
+    );
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/pipelines/revert_connector_pipeline_api_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/pipelines/revert_connector_pipeline_api_logic.test.ts
@@ -14,7 +14,7 @@ describe('RevertConnectorPipelineApiLogic', () => {
     const { http } = mockHttpValues;
     revertConnectorPipeline({ indexName: 'indexName' });
     expect(http.delete).toHaveBeenCalledWith(
-      '/internal/enterprise_search/indices/indexName/pipeline'
+      '/internal/enterprise_search/indices/indexName/pipelines'
     );
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/pipelines/revert_connector_pipeline_api_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/pipelines/revert_connector_pipeline_api_logic.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { Actions, createApiLogic } from '../../../shared/api_logic/create_api_logic';
+import { HttpLogic } from '../../../shared/http';
+
+export interface RevertConnectorPipelineArgs {
+  indexName: string;
+}
+
+export const revertConnectorPipeline = async ({ indexName }: RevertConnectorPipelineArgs) => {
+  const route = `/internal/enterprise_search/indices/${indexName}/pipelines`;
+
+  return await HttpLogic.values.http.delete(route);
+};
+
+export const RevertConnectorPipelineApilogic = createApiLogic(
+  ['revert_connector_pipeline_api'],
+  revertConnectorPipeline
+);
+
+export type RevertConnectorPipelineActions = Actions<RevertConnectorPipelineArgs, {}>;

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ingest_pipelines/customize_pipeline_item.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ingest_pipelines/customize_pipeline_item.tsx
@@ -9,20 +9,32 @@ import React from 'react';
 
 import { useActions, useValues } from 'kea';
 
-import { EuiButtonEmpty, EuiFlexGroup, EuiSpacer, EuiText } from '@elastic/eui';
+import { EuiButtonEmpty, EuiConfirmModal, EuiFlexGroup, EuiSpacer, EuiText } from '@elastic/eui';
+
 import { i18n } from '@kbn/i18n';
+
+import { Status } from '../../../../../../../common/types/api';
+
+import { CANCEL_BUTTON_LABEL } from '../../../../../shared/constants';
 
 import { KibanaLogic } from '../../../../../shared/kibana';
 import { LicensingLogic } from '../../../../../shared/licensing';
 import { CreateCustomPipelineApiLogic } from '../../../../api/index/create_custom_pipeline_api_logic';
 
+import { RevertConnectorPipelineApilogic } from '../../../../api/pipelines/revert_connector_pipeline_api_logic';
 import { IndexViewLogic } from '../../index_view_logic';
+import { PipelinesLogic } from '../pipelines_logic';
 
 export const CustomizeIngestPipelineItem: React.FC = () => {
   const { indexName, ingestionMethod } = useValues(IndexViewLogic);
   const { isCloud } = useValues(KibanaLogic);
   const { hasPlatinumLicense } = useValues(LicensingLogic);
   const { makeRequest: createCustomPipeline } = useActions(CreateCustomPipelineApiLogic);
+  const { status: createStatus } = useValues(CreateCustomPipelineApiLogic);
+  const { isDeleteModalOpen, hasIndexIngestionPipeline } = useValues(PipelinesLogic);
+  const { closeDeleteModal, openDeleteModal } = useActions(PipelinesLogic);
+  const { makeRequest: revertPipeline } = useActions(RevertConnectorPipelineApilogic);
+  const { status: revertStatus } = useValues(RevertConnectorPipelineApilogic);
   const isGated = !isCloud && !hasPlatinumLicense;
 
   return (
@@ -49,17 +61,61 @@ export const CustomizeIngestPipelineItem: React.FC = () => {
         </EuiText>
       )}
       <EuiFlexGroup justifyContent="flexEnd">
-        <EuiButtonEmpty
-          data-telemetry-id={`entSearchContent-${ingestionMethod}-pipelines-ingestPipelines-copyAndCustomize`}
-          disabled={isGated}
-          iconType={isGated ? 'lock' : undefined}
-          onClick={() => createCustomPipeline({ indexName })}
-        >
-          {i18n.translate(
-            'xpack.enterpriseSearch.content.index.pipelines.ingestFlyout.copyButtonLabel',
-            { defaultMessage: 'Copy and customize' }
-          )}
-        </EuiButtonEmpty>
+        {isDeleteModalOpen && (
+          <EuiConfirmModal
+            title={i18n.translate(
+              'xpack.enterpriseSearch.content.index.pipelines.deleteModal.title',
+              {
+                defaultMessage: 'Delete custom pipeline',
+              }
+            )}
+            isLoading={revertStatus === Status.LOADING}
+            onCancel={closeDeleteModal}
+            onConfirm={() => revertPipeline({ indexName })}
+            cancelButtonText={CANCEL_BUTTON_LABEL}
+            confirmButtonText={i18n.translate(
+              'xpack.enterpriseSearch.content.index.pipelines.deleteModal.confirmButton',
+              {
+                defaultMessage: 'Delete pipeline',
+              }
+            )}
+            buttonColor="danger"
+          >
+            <p>
+              {i18n.translate(
+                'xpack.enterpriseSearch.content.index.pipelines.deleteModal.description',
+                {
+                  defaultMessage:
+                    'This will delete any custom pipelines associated with this index, including machine learning inference pipelines. The index will revert to using the default ingest pipeline.',
+                }
+              )}
+            </p>
+          </EuiConfirmModal>
+        )}
+        {hasIndexIngestionPipeline ? (
+          <EuiButtonEmpty
+            data-telemetry-id={`entSearchContent-${ingestionMethod}-pipelines-ingestPipelines-revertPipeline`}
+            onClick={() => openDeleteModal()}
+          >
+            {i18n.translate(
+              'xpack.enterpriseSearch.content.index.pipelines.ingestFlyout.revertPipelineLabel',
+              { defaultMessage: 'Delete custom pipeline' }
+            )}
+          </EuiButtonEmpty>
+        ) : (
+          <EuiButtonEmpty
+            data-telemetry-id={`entSearchContent-${ingestionMethod}-pipelines-ingestPipelines-copyAndCustomize`}
+            disabled={isGated}
+            isLoading={createStatus === Status.LOADING}
+            iconType={isGated ? 'lock' : undefined}
+            onClick={() => createCustomPipeline({ indexName })}
+          >
+            {i18n.translate(
+              'xpack.enterpriseSearch.content.index.pipelines.ingestFlyout.copyButtonLabel',
+              { defaultMessage: 'Copy and customize' }
+            )}
+          </EuiButtonEmpty>
+        )}
       </EuiFlexGroup>
       <EuiSpacer size="m" />
     </>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ingest_pipelines/ingest_pipelines_card.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ingest_pipelines/ingest_pipelines_card.test.tsx
@@ -12,8 +12,6 @@ import React from 'react';
 
 import { shallow } from 'enzyme';
 
-import { IngestPipeline } from '@elastic/elasticsearch/lib/api/types';
-
 import { DEFAULT_PIPELINE_NAME } from '../../../../../../../common/constants';
 
 import { CustomPipelineItem } from './custom_pipeline_item';
@@ -51,29 +49,5 @@ describe('IngestPipelinesCard', () => {
     expect(wrapper.find(DefaultPipelineItem)).toHaveLength(1);
     expect(wrapper.find(CustomizeIngestPipelineItem)).toHaveLength(1);
     expect(wrapper.find(CustomPipelineItem)).toHaveLength(0);
-  });
-  it('does not render customize cta with index ingest pipeline', () => {
-    const pipelineName = crawlerIndex.name;
-    const pipelines: Record<string, IngestPipeline | undefined> = {
-      [pipelineName]: {},
-      [`${pipelineName}@custom`]: {
-        processors: [],
-      },
-    };
-    setMockValues({
-      ...DEFAULT_VALUES,
-      data: pipelines,
-      hasIndexIngestionPipeline: true,
-      pipelineName,
-      pipelineState: {
-        ...DEFAULT_VALUES.pipelineState,
-        name: pipelineName,
-      },
-    });
-
-    const wrapper = shallow(<IngestPipelinesCard />);
-    expect(wrapper.find(CustomizeIngestPipelineItem)).toHaveLength(0);
-    expect(wrapper.find(DefaultPipelineItem)).toHaveLength(1);
-    expect(wrapper.find(CustomPipelineItem)).toHaveLength(1);
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ingest_pipelines/ingest_pipelines_card.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ingest_pipelines/ingest_pipelines_card.tsx
@@ -24,14 +24,8 @@ import { IngestPipelineFlyout } from './ingest_pipeline_flyout';
 export const IngestPipelinesCard: React.FC = () => {
   const { indexName, ingestionMethod } = useValues(IndexViewLogic);
 
-  const {
-    canSetPipeline,
-    hasIndexIngestionPipeline,
-    index,
-    pipelineName,
-    pipelineState,
-    showPipelineSettings,
-  } = useValues(PipelinesLogic);
+  const { canSetPipeline, index, pipelineName, pipelineState, showPipelineSettings } =
+    useValues(PipelinesLogic);
   const { closePipelineSettings, openPipelineSettings, setPipelineState, savePipeline } =
     useActions(PipelinesLogic);
   const { makeRequest: fetchCustomPipeline } = useActions(FetchCustomPipelineApiLogic);
@@ -45,7 +39,7 @@ export const IngestPipelinesCard: React.FC = () => {
 
   return (
     <>
-      {!hasIndexIngestionPipeline && <CustomizeIngestPipelineItem />}
+      <CustomizeIngestPipelineItem />
       <EuiFlexGroup direction="column" gutterSize="s">
         {showPipelineSettings && (
           <IngestPipelineFlyout

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/pipelines.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/pipelines.tsx
@@ -10,6 +10,8 @@ import React from 'react';
 import { useActions, useValues } from 'kea';
 
 import {
+  EuiButton,
+  EuiCallOut,
   EuiFlexGroup,
   EuiFlexItem,
   EuiLink,
@@ -23,7 +25,10 @@ import { i18n } from '@kbn/i18n';
 
 import { DataPanel } from '../../../../shared/data_panel/data_panel';
 import { docLinks } from '../../../../shared/doc_links';
+import { RevertConnectorPipelineApilogic } from '../../../api/pipelines/revert_connector_pipeline_api_logic';
 import { isApiIndex } from '../../../utils/indices';
+
+import { IndexNameLogic } from '../index_name_logic';
 
 import { InferenceErrors } from './inference_errors';
 import { InferenceHistory } from './inference_history';
@@ -35,10 +40,17 @@ import { PipelinesJSONConfigurations } from './pipelines_json_configurations';
 import { PipelinesLogic } from './pipelines_logic';
 
 export const SearchIndexPipelines: React.FC = () => {
-  const { showAddMlInferencePipelineModal, hasIndexIngestionPipeline, index, pipelineName } =
-    useValues(PipelinesLogic);
+  const {
+    showMissingPipelineCallout,
+    showAddMlInferencePipelineModal,
+    hasIndexIngestionPipeline,
+    index,
+    pipelineName,
+  } = useValues(PipelinesLogic);
   const { closeAddMlInferencePipelineModal, openAddMlInferencePipelineModal } =
     useActions(PipelinesLogic);
+  const { indexName } = useValues(IndexNameLogic);
+  const { makeRequest: revertPipeline } = useActions(RevertConnectorPipelineApilogic);
   const apiIndex = isApiIndex(index);
 
   const pipelinesTabs: EuiTabbedContentTab[] = [
@@ -66,6 +78,36 @@ export const SearchIndexPipelines: React.FC = () => {
 
   return (
     <>
+      {showMissingPipelineCallout && (
+        <EuiCallOut
+          color="danger"
+          iconType="error"
+          title={i18n.translate(
+            'xpack.enterpriseSearch.content.indices.pipelines.missingPipeline.title',
+            {
+              defaultMessage: 'Custom pipeline missing',
+            }
+          )}
+        >
+          <p>
+            {i18n.translate(
+              'xpack.enterpriseSearch.content.indices.pipelines.missingPipeline.description',
+              {
+                defaultMessage:
+                  'The custom pipeline for this index has been deleted. This may affect connector data ingestion. Its configuration will need to be reverted to the default pipeline settings.',
+              }
+            )}
+          </p>
+          <EuiButton color="danger" fill onClick={() => revertPipeline({ indexName })}>
+            {i18n.translate(
+              'xpack.enterpriseSearch.content.indices.pipelines.missingPipeline.buttonLabel',
+              {
+                defaultMessage: 'Revert pipeline to default',
+              }
+            )}
+          </EuiButton>
+        </EuiCallOut>
+      )}
       <EuiSpacer />
       <EuiFlexGroup direction="row" wrap>
         <EuiFlexItem grow={5}>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/pipelines_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/pipelines_logic.test.ts
@@ -35,10 +35,12 @@ const DEFAULT_VALUES = {
   hasIndexIngestionPipeline: false,
   index: undefined,
   indexName: '',
+  isDeleteModalOpen: false,
   mlInferencePipelineProcessors: undefined,
   pipelineName: DEFAULT_PIPELINE_VALUES.name,
   pipelineState: DEFAULT_PIPELINE_VALUES,
   showAddMlInferencePipelineModal: false,
+  showMissingPipelineCallout: false,
   showPipelineSettings: false,
 };
 
@@ -145,16 +147,16 @@ describe('PipelinesLogic', () => {
       });
     });
     describe('createCustomPipelineSuccess', () => {
-      it('should call flashSuccessToast', () => {
+      it('should call flashSuccessToast and update pipelines', () => {
         PipelinesLogic.actions.setPipelineState = jest.fn();
         PipelinesLogic.actions.savePipeline = jest.fn();
         PipelinesLogic.actions.fetchCustomPipeline = jest.fn();
         PipelinesLogic.actions.fetchIndexApiSuccess(connectorIndex);
-        PipelinesLogic.actions.createCustomPipelineSuccess({ created: ['a', 'b'] });
+        PipelinesLogic.actions.createCustomPipelineSuccess({ [connectorIndex.name]: {} });
         expect(flashSuccessToast).toHaveBeenCalledWith('Custom pipeline created');
         expect(PipelinesLogic.actions.setPipelineState).toHaveBeenCalledWith({
           ...PipelinesLogic.values.pipelineState,
-          name: 'a',
+          name: connectorIndex.name,
         });
         expect(PipelinesLogic.actions.savePipeline).toHaveBeenCalled();
         expect(PipelinesLogic.actions.fetchCustomPipeline).toHaveBeenCalled();

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/pipelines_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/pipelines_logic.ts
@@ -429,10 +429,12 @@ export const PipelinesLogic = kea<MakeLogicType<PipelinesValues, PipelinesAction
         customPipelineData: Record<string, IngestPipeline | undefined> | undefined,
         index: ElasticsearchIndexWithIngestion
       ) =>
-        hasCustomPipeline &&
-        customPipelineData &&
-        !customPipelineData[pipelineName] &&
-        isConnectorIndex(index),
+        Boolean(
+          hasCustomPipeline &&
+            customPipelineData &&
+            !customPipelineData[pipelineName] &&
+            isConnectorIndex(index)
+        ),
     ],
   }),
 });

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/pipelines_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/pipelines_logic.ts
@@ -66,6 +66,10 @@ import {
 } from '../../../api/pipelines/detach_ml_inference_pipeline';
 
 import { FetchMlInferencePipelineProcessorsApiLogic } from '../../../api/pipelines/fetch_ml_inference_pipeline_processors';
+import {
+  RevertConnectorPipelineActions,
+  RevertConnectorPipelineApilogic,
+} from '../../../api/pipelines/revert_connector_pipeline_api_logic';
 import { isApiIndex, isConnectorIndex, isCrawlerIndex } from '../../../utils/indices';
 
 type PipelinesActions = Pick<
@@ -77,6 +81,7 @@ type PipelinesActions = Pick<
     AttachMlInferencePipelineResponse
   >['apiSuccess'];
   closeAddMlInferencePipelineModal: () => void;
+  closeDeleteModal: () => void;
   closePipelineSettings: () => void;
   createCustomPipeline: Actions<
     CreateCustomPipelineApiLogicArgs,
@@ -132,7 +137,9 @@ type PipelinesActions = Pick<
   fetchMlInferenceProcessors: typeof FetchMlInferencePipelineProcessorsApiLogic.actions.makeRequest;
   fetchMlInferenceProcessorsApiError: (error: HttpError) => HttpError;
   openAddMlInferencePipelineModal: () => void;
+  openDeleteModal: () => void;
   openPipelineSettings: () => void;
+  revertPipelineSuccess: RevertConnectorPipelineActions['apiSuccess'];
   savePipeline: () => void;
   setPipelineState(pipeline: IngestPipelineParams): {
     pipeline: IngestPipelineParams;
@@ -148,18 +155,22 @@ interface PipelinesValues {
   hasIndexIngestionPipeline: boolean;
   index: CachedFetchIndexApiLogicValues['fetchIndexApiData'];
   indexName: string;
+  isDeleteModalOpen: boolean;
   mlInferencePipelineProcessors: InferencePipeline[];
   pipelineName: string;
   pipelineState: IngestPipelineParams;
   showAddMlInferencePipelineModal: boolean;
+  showMissingPipelineCallout: boolean;
   showPipelineSettings: boolean;
 }
 
 export const PipelinesLogic = kea<MakeLogicType<PipelinesValues, PipelinesActions>>({
   actions: {
     closeAddMlInferencePipelineModal: true,
+    closeDeleteModal: true,
     closePipelineSettings: true,
     openAddMlInferencePipelineModal: true,
+    openDeleteModal: true,
     openPipelineSettings: true,
     savePipeline: true,
     setPipelineState: (pipeline: IngestPipelineParams) => ({ pipeline }),
@@ -201,6 +212,8 @@ export const PipelinesLogic = kea<MakeLogicType<PipelinesValues, PipelinesAction
         'apiSuccess as detachMlPipelineSuccess',
         'makeRequest as detachMlPipeline',
       ],
+      RevertConnectorPipelineApilogic,
+      ['apiSuccess as revertPipelineSuccess'],
     ],
     values: [
       FetchCustomPipelineApiLogic,
@@ -247,8 +260,9 @@ export const PipelinesLogic = kea<MakeLogicType<PipelinesValues, PipelinesAction
           ? values.index.connector?.pipeline ?? values.defaultPipelineValues
           : values.defaultPipelineValues
       ),
-    createCustomPipelineSuccess: ({ created }) => {
-      actions.setPipelineState({ ...values.pipelineState, name: created[0] });
+    createCustomPipelineSuccess: (created) => {
+      actions.fetchCustomPipelineSuccess(created);
+      actions.setPipelineState({ ...values.pipelineState, name: values.indexName });
       actions.savePipeline();
       actions.fetchCustomPipeline({ indexName: values.index.name });
     },
@@ -313,6 +327,19 @@ export const PipelinesLogic = kea<MakeLogicType<PipelinesValues, PipelinesAction
           : values.defaultPipelineValues;
       actions.setPipelineState(pipeline ?? values.defaultPipelineValues);
     },
+    revertPipelineSuccess: () => {
+      if (isConnectorIndex(values.index) || isCrawlerIndex(values.index)) {
+        if (values.index.connector) {
+          // had to split up these if checks rather than nest them or typescript wouldn't recognize connector as defined
+          actions.fetchIndexApiSuccess({
+            ...values.index,
+            connector: { ...values.index.connector, pipeline: values.defaultPipelineValues },
+          });
+          actions.fetchCustomPipelineSuccess({});
+        }
+      }
+      actions.fetchCustomPipeline({ indexName: values.indexName });
+    },
     savePipeline: () => {
       if (isConnectorIndex(values.index) || isCrawlerIndex(values.index)) {
         if (values.index.connector) {
@@ -326,6 +353,14 @@ export const PipelinesLogic = kea<MakeLogicType<PipelinesValues, PipelinesAction
   }),
   path: ['enterprise_search', 'content', 'pipelines'],
   reducers: () => ({
+    isDeleteModalOpen: [
+      false,
+      {
+        closeDeleteModal: () => false,
+        openDeleteModal: () => true,
+        revertPipelineSuccess: () => false,
+      },
+    ],
     pipelineState: [
       DEFAULT_PIPELINE_VALUES,
       {
@@ -380,6 +415,24 @@ export const PipelinesLogic = kea<MakeLogicType<PipelinesValues, PipelinesAction
       () => [selectors.pipelineState, selectors.customPipelineData, selectors.indexName],
       (pipelineState, customPipelineData, indexName) =>
         customPipelineData && customPipelineData[indexName] ? indexName : pipelineState.name,
+    ],
+    showMissingPipelineCallout: [
+      () => [
+        selectors.hasIndexIngestionPipeline,
+        selectors.pipelineName,
+        selectors.customPipelineData,
+        selectors.index,
+      ],
+      (
+        hasCustomPipeline: boolean,
+        pipelineName: string,
+        customPipelineData: Record<string, IngestPipeline | undefined> | undefined,
+        index: ElasticsearchIndexWithIngestion
+      ) =>
+        hasCustomPipeline &&
+        customPipelineData &&
+        !customPipelineData[pipelineName] &&
+        isConnectorIndex(index),
     ],
   }),
 });

--- a/x-pack/plugins/enterprise_search/server/lib/pipelines/create_pipeline_definitions.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/pipelines/create_pipeline_definitions.test.ts
@@ -8,8 +8,6 @@ import { merge } from 'lodash';
 
 import { ElasticsearchClient } from '@kbn/core/server';
 
-import { getInferencePipelineNameFromIndexName } from '../../utils/ml_inference_pipeline_utils';
-
 import { createIndexPipelineDefinitions } from './create_pipeline_definitions';
 import { formatMlPipelineBody } from './create_pipeline_definitions';
 
@@ -22,10 +20,6 @@ describe('createIndexPipelineDefinitions util function', () => {
     },
   };
 
-  const expectedResult = {
-    created: [indexName, `${indexName}@custom`, getInferencePipelineNameFromIndexName(indexName)],
-  };
-
   beforeEach(() => {
     jest.clearAllMocks();
   });
@@ -34,7 +28,7 @@ describe('createIndexPipelineDefinitions util function', () => {
     mockClient.ingest.putPipeline.mockImplementation(() => Promise.resolve({ acknowledged: true }));
     await expect(
       createIndexPipelineDefinitions(indexName, mockClient as unknown as ElasticsearchClient)
-    ).resolves.toEqual(expectedResult);
+    ).resolves;
     expect(mockClient.ingest.putPipeline).toHaveBeenCalledTimes(3);
   });
 });

--- a/x-pack/plugins/enterprise_search/server/lib/pipelines/create_pipeline_definitions.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/pipelines/create_pipeline_definitions.test.ts
@@ -26,9 +26,7 @@ describe('createIndexPipelineDefinitions util function', () => {
 
   it('should create the pipelines', async () => {
     mockClient.ingest.putPipeline.mockImplementation(() => Promise.resolve({ acknowledged: true }));
-    await expect(
-      createIndexPipelineDefinitions(indexName, mockClient as unknown as ElasticsearchClient)
-    ).resolves;
+    await createIndexPipelineDefinitions(indexName, mockClient as unknown as ElasticsearchClient);
     expect(mockClient.ingest.putPipeline).toHaveBeenCalledTimes(3);
   });
 });

--- a/x-pack/plugins/enterprise_search/server/lib/pipelines/delete_pipelines.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/pipelines/delete_pipelines.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { IScopedClusterClient } from '@kbn/core/server';
+
+import { getInferencePipelineNameFromIndexName } from '../../utils/ml_inference_pipeline_utils';
+
+export const deleteIndexPipelines = async (
+  client: IScopedClusterClient,
+  indexName: string
+): Promise<{ deleted: string[] }> => {
+  const deleted: string[] = [];
+  const promises = [
+    client.asCurrentUser.ingest
+      .deletePipeline({ id: indexName })
+      .then(() => deleted.push(indexName)),
+    client.asCurrentUser.ingest
+      .deletePipeline({
+        id: getInferencePipelineNameFromIndexName(indexName),
+      })
+      .then(() => deleted.push(getInferencePipelineNameFromIndexName(indexName))),
+    client.asCurrentUser.ingest
+      .deletePipeline({ id: `${indexName}@custom` })
+      .then(() => deleted.push(`${indexName}@custom`)),
+  ];
+  await Promise.allSettled(promises);
+  return {
+    deleted,
+  };
+};

--- a/x-pack/plugins/enterprise_search/server/lib/pipelines/revert_custom_pipeline.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/pipelines/revert_custom_pipeline.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { IScopedClusterClient } from '@kbn/core/server';
+
+import { CONNECTORS_INDEX } from '../..';
+
+import { fetchConnectorByIndexName } from '../connectors/fetch_connectors';
+
+import { deleteIndexPipelines } from './delete_pipelines';
+
+import { getDefaultPipeline } from './get_default_pipeline';
+
+export const revertCustomPipeline = async (client: IScopedClusterClient, indexName: string) => {
+  const connector = await fetchConnectorByIndexName(client, indexName);
+  if (connector) {
+    const pipeline = await getDefaultPipeline(client);
+    await client.asCurrentUser.update({
+      doc: { pipeline },
+      id: connector?.id,
+      index: CONNECTORS_INDEX,
+    });
+  }
+  return await deleteIndexPipelines(client, indexName);
+};


### PR DESCRIPTION
## Summary

This allows users to revert their custom ingestion pipeline to the default pipeline settings, and prompts them to do so if their custom pipeline is still configured but has been deleted.

https://user-images.githubusercontent.com/94373878/222418282-6b7367a3-a8c8-4c87-9482-c1aa47feb2f5.mov

https://user-images.githubusercontent.com/94373878/222418308-3cd7f2a9-c1cd-4527-86d7-a4de0f2accfc.mov




<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->