### PR TITLE
Expose authorization header parser

### DIFF
--- a/x-pack/plugins/security/server/index.ts
+++ b/x-pack/plugins/security/server/index.ts
@@ -29,6 +29,7 @@ export type {
   ValidateAPIKeyParams,
   AuthenticationServiceStart,
 } from './authentication';
+export { HTTPAuthorizationHeader } from './authentication';
 export type { CheckPrivilegesPayload, CasesSupportedOperations } from './authorization';
 export type AuthorizationServiceSetup = SecurityPluginStart['authz'];
 export type { AuditLogger, AuditEvent, AuditHttp, AuditKibana, AuditRequest } from './audit';


### PR DESCRIPTION
Resolves #152116

## Summary

Exposes HTTPAuthorizationHeader interface to allow extracting credentials from request headers. 

## Example

```ts
import { HTTPAuthorizationHeader } from '@kbn/security-plugin/server';

HTTPAuthorizationHeader.parseFromRequest(request);
```

Returns the following object:

```
HTTPAuthorizationHeader {
  scheme: 'ApiKey',
  credentials: 'ZmhPUm5JWUItbEhKWktnU2VjWlY6TF9CSDB1c3JSd1NsZkNzZ3kzMnNpdw=='
}
```