### PR TITLE
[fleet] Add feature flag for Agent Tamper Protection

### DIFF
--- a/x-pack/plugins/fleet/common/experimental_features.ts
+++ b/x-pack/plugins/fleet/common/experimental_features.ts
@@ -22,6 +22,7 @@ export const allowedExperimentalValues = Object.freeze({
   agentFqdnMode: true,
   showExperimentalShipperOptions: false,
   fleetServerStandalone: false,
+  agentTamperProtectionEnabled: false,
 });
 
 type ExperimentalConfigKeys = Array<keyof ExperimentalFeatures>;


### PR DESCRIPTION
## Summary

Adds a new feature flag called `agentTamperProtectionEnabled` to Fleet.
