### PR TITLE
[ML] Functional tests - fix report names in API configs

### DIFF
--- a/x-pack/test/api_integration/apis/ml/config.ts
+++ b/x-pack/test/api_integration/apis/ml/config.ts
@@ -14,7 +14,7 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
     ...baseIntegrationTestsConfig.getAll(),
     testFiles: [require.resolve('.')],
     junit: {
-      reportName: 'Chrome X-Pack UI Functional Tests - ml',
+      reportName: 'X-Pack API Integration Tests - ml',
     },
   };
 }

--- a/x-pack/test/api_integration/apis/transform/config.ts
+++ b/x-pack/test/api_integration/apis/transform/config.ts
@@ -14,7 +14,7 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
     ...baseIntegrationTestsConfig.getAll(),
     testFiles: [require.resolve('.')],
     junit: {
-      reportName: 'Chrome X-Pack UI Functional Tests - transform',
+      reportName: 'X-Pack API Integration Tests - transform',
     },
   };
 }


### PR DESCRIPTION
## Summary

This PR fixes the API integration test suite report names for ML and Transform tests.

Follow-up on #151729, where the suite names have been introduced with a copy/paste mistake.


<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->