### PR TITLE
[Fleet] add support for message signing without encryption key

### DIFF
--- a/x-pack/plugins/fleet/server/services/security/message_signing_service.test.ts
+++ b/x-pack/plugins/fleet/server/services/security/message_signing_service.test.ts
@@ -10,6 +10,7 @@ import { createVerify } from 'crypto';
 import type { KibanaRequest } from '@kbn/core-http-server';
 import type { SavedObjectsClientContract } from '@kbn/core/server';
 import type { EncryptedSavedObjectsClient } from '@kbn/encrypted-saved-objects-plugin/server';
+import { encryptedSavedObjectsMock } from '@kbn/encrypted-saved-objects-plugin/server/mocks';
 
 import { MESSAGE_SIGNING_KEYS_SAVED_OBJECT_TYPE } from '../../constants';
 import { createAppContextStartContractMock } from '../../mocks';
@@ -24,17 +25,6 @@ describe('MessageSigningService', () => {
   let soClientMock: jest.Mocked<SavedObjectsClientContract>;
   let esoClientMock: jest.Mocked<EncryptedSavedObjectsClient>;
   let messageSigningService: MessageSigningServiceInterface;
-  const keyPairObj = {
-    id: 'id1',
-    type: MESSAGE_SIGNING_KEYS_SAVED_OBJECT_TYPE,
-    attributes: {
-      private_key:
-        'MIHsMFcGCSqGSIb3DQEFDTBKMCkGCSqGSIb3DQEFDDAcBAgtNcDFoj07+QICCAAwDAYIKoZIhvcNAgkFADAdBglghkgBZQMEASoEELajFPDz2bpD2qfPCRHphAgEgZCq0eUxTOEGrefdeNgHR2VVxXjWRZG+cGn+e8LW4auBCwwMiZsAZPKKvzLdlLi5sQhH+qWPM7Z9/OLbF/0ZKvyDM2/+4/9+5Iwna7vueTZtcdSIuGIFRjqUZbgNLejPSPcBMM9SP1V6I8TjDguGAQ3Nj95t7g7cbl0x48nQZ9bNDJyvy4ytHl+ubzdanLlFkLc=',
-      public_key:
-        'MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE6E5aKP8dAa+TlBuSKrrgl9UtkzHjn6YUQO+72vi3khGfUQIpD9qq9MsjsWz6Bvm6tnSOyyPXv+Koh80lNCKw5A==',
-      passphrase: 'eb35af2291344a51c9a8bb81e653281c38892d564db617a2cb0bc660f0ae96f2',
-    },
-  };
 
   function mockCreatePointInTimeFinderAsInternalUser(savedObjects: unknown[] = []) {
     esoClientMock.createPointInTimeFinderDecryptedAsInternalUser = jest.fn().mockResolvedValue({
@@ -45,8 +35,11 @@ describe('MessageSigningService', () => {
     });
   }
 
-  beforeEach(() => {
+  function setupMocks(canEncrypt = true) {
     const mockContext = createAppContextStartContractMock();
+    mockContext.encryptedSavedObjectsSetup = encryptedSavedObjectsMock.createSetup({
+      canEncrypt,
+    });
     appContextService.start(mockContext);
     esoClientMock =
       mockContext.encryptedSavedObjectsStart!.getClient() as jest.Mocked<EncryptedSavedObjectsClient>;
@@ -55,48 +48,115 @@ describe('MessageSigningService', () => {
       .getScopedClient({} as unknown as KibanaRequest) as jest.Mocked<SavedObjectsClientContract>;
 
     messageSigningService = new MessageSigningService(esoClientMock);
-  });
+  }
 
-  afterEach(() => {
-    jest.resetAllMocks();
-  });
+  describe('with encryption key configured', () => {
+    const keyPairObj = {
+      id: 'id1',
+      type: MESSAGE_SIGNING_KEYS_SAVED_OBJECT_TYPE,
+      attributes: {
+        private_key:
+          'MIHsMFcGCSqGSIb3DQEFDTBKMCkGCSqGSIb3DQEFDDAcBAgtNcDFoj07+QICCAAwDAYIKoZIhvcNAgkFADAdBglghkgBZQMEASoEELajFPDz2bpD2qfPCRHphAgEgZCq0eUxTOEGrefdeNgHR2VVxXjWRZG+cGn+e8LW4auBCwwMiZsAZPKKvzLdlLi5sQhH+qWPM7Z9/OLbF/0ZKvyDM2/+4/9+5Iwna7vueTZtcdSIuGIFRjqUZbgNLejPSPcBMM9SP1V6I8TjDguGAQ3Nj95t7g7cbl0x48nQZ9bNDJyvy4ytHl+ubzdanLlFkLc=',
+        public_key:
+          'MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE6E5aKP8dAa+TlBuSKrrgl9UtkzHjn6YUQO+72vi3khGfUQIpD9qq9MsjsWz6Bvm6tnSOyyPXv+Koh80lNCKw5A==',
+        passphrase: 'eb35af2291344a51c9a8bb81e653281c38892d564db617a2cb0bc660f0ae96f2',
+      },
+    };
 
-  it('can correctly generate key pair if none exist', async () => {
-    mockCreatePointInTimeFinderAsInternalUser();
+    beforeEach(() => {
+      setupMocks();
+    });
 
-    await messageSigningService.generateKeyPair();
-    expect(soClientMock.create).toBeCalledWith(MESSAGE_SIGNING_KEYS_SAVED_OBJECT_TYPE, {
-      private_key: expect.any(String),
-      public_key: expect.any(String),
-      passphrase: expect.any(String),
+    afterEach(() => {
+      jest.resetAllMocks();
+    });
+
+    it('can correctly generate key pair if none exist', async () => {
+      mockCreatePointInTimeFinderAsInternalUser();
+
+      await messageSigningService.generateKeyPair();
+      expect(soClientMock.create).toBeCalledWith(MESSAGE_SIGNING_KEYS_SAVED_OBJECT_TYPE, {
+        private_key: expect.any(String),
+        public_key: expect.any(String),
+        passphrase: expect.any(String),
+      });
+    });
+
+    it('does not generate key pair if one exists', async () => {
+      mockCreatePointInTimeFinderAsInternalUser([keyPairObj]);
+
+      await messageSigningService.generateKeyPair();
+      expect(soClientMock.create).not.toBeCalled();
+    });
+
+    it('can correctly sign messages', async () => {
+      mockCreatePointInTimeFinderAsInternalUser([keyPairObj]);
+
+      const message = Buffer.from(JSON.stringify({ message: 'foobar' }), 'utf8');
+      const { data, signature } = await messageSigningService.sign(message);
+
+      const verifier = createVerify('SHA256');
+      verifier.update(data);
+      verifier.end();
+
+      const serializedPublicKey = await messageSigningService.getPublicKey();
+      const publicKey = Buffer.from(serializedPublicKey, 'base64');
+      const isVerified = verifier.verify(
+        { key: publicKey, format: 'der', type: 'spki' },
+        signature,
+        'base64'
+      );
+      expect(isVerified).toBe(true);
+      expect(data).toBe(message);
     });
   });
 
-  it('does not generate key pair if one exists', async () => {
-    mockCreatePointInTimeFinderAsInternalUser([keyPairObj]);
+  describe('with NO encryption key configured', () => {
+    const keyPairObj = {
+      id: 'id1',
+      type: MESSAGE_SIGNING_KEYS_SAVED_OBJECT_TYPE,
+      attributes: {
+        private_key:
+          'MIHsMFcGCSqGSIb3DQEFDTBKMCkGCSqGSIb3DQEFDDAcBAgtNcDFoj07+QICCAAwDAYIKoZIhvcNAgkFADAdBglghkgBZQMEASoEELajFPDz2bpD2qfPCRHphAgEgZCq0eUxTOEGrefdeNgHR2VVxXjWRZG+cGn+e8LW4auBCwwMiZsAZPKKvzLdlLi5sQhH+qWPM7Z9/OLbF/0ZKvyDM2/+4/9+5Iwna7vueTZtcdSIuGIFRjqUZbgNLejPSPcBMM9SP1V6I8TjDguGAQ3Nj95t7g7cbl0x48nQZ9bNDJyvy4ytHl+ubzdanLlFkLc=',
+        public_key:
+          'MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE6E5aKP8dAa+TlBuSKrrgl9UtkzHjn6YUQO+72vi3khGfUQIpD9qq9MsjsWz6Bvm6tnSOyyPXv+Koh80lNCKw5A==',
+        passphrase_plain: 'eb35af2291344a51c9a8bb81e653281c38892d564db617a2cb0bc660f0ae96f2',
+      },
+    };
 
-    await messageSigningService.generateKeyPair();
-    expect(soClientMock.create).not.toBeCalled();
-  });
+    beforeEach(() => {
+      setupMocks(false);
+    });
 
-  it('can correctly sign messages', async () => {
-    mockCreatePointInTimeFinderAsInternalUser([keyPairObj]);
+    afterEach(() => {
+      jest.resetAllMocks();
+    });
 
-    const message = Buffer.from(JSON.stringify({ message: 'foobar' }), 'utf8');
-    const { data, signature } = await messageSigningService.sign(message);
+    it('can correctly generate key pair if none exist', async () => {
+      mockCreatePointInTimeFinderAsInternalUser();
 
-    const verifier = createVerify('SHA256');
-    verifier.update(data);
-    verifier.end();
+      await messageSigningService.generateKeyPair();
+      expect(soClientMock.create).toBeCalledWith(MESSAGE_SIGNING_KEYS_SAVED_OBJECT_TYPE, {
+        private_key: expect.any(String),
+        public_key: expect.any(String),
+        passphrase_plain: expect.any(String),
+      });
+    });
 
-    const serializedPublicKey = await messageSigningService.getPublicKey();
-    const publicKey = Buffer.from(serializedPublicKey, 'base64');
-    const isVerified = verifier.verify(
-      { key: publicKey, format: 'der', type: 'spki' },
-      signature,
-      'base64'
-    );
-    expect(isVerified).toBe(true);
-    expect(data).toBe(message);
+    it('encrypts passphrase when encryption key is newly configured', async () => {
+      setupMocks();
+      mockCreatePointInTimeFinderAsInternalUser([keyPairObj]);
+
+      await messageSigningService.generateKeyPair();
+      expect(soClientMock.create).not.toBeCalled();
+      expect(soClientMock.update).toBeCalledWith(
+        MESSAGE_SIGNING_KEYS_SAVED_OBJECT_TYPE,
+        keyPairObj.id,
+        {
+          passphrase: expect.any(String),
+          passphrase_plain: '',
+        }
+      );
+    });
   });
 });

--- a/x-pack/plugins/fleet/server/services/setup.ts
+++ b/x-pack/plugins/fleet/server/services/setup.ts
@@ -165,12 +165,13 @@ async function createSetupSideEffects(
   logger.debug('Upgrade Fleet package install versions');
   await upgradePackageInstallVersion({ soClient, esClient, logger });
 
-  if (appContextService.getMessageSigningService()?.isEncryptionAvailable) {
-    logger.debug('Generating key pair for message signing');
-    await appContextService.getMessageSigningService()?.generateKeyPair();
-  } else {
-    logger.info('No encryption key set, skipping key pair generation for message signing');
+  logger.debug('Generating key pair for message signing');
+  if (!appContextService.getMessageSigningService()?.isEncryptionAvailable) {
+    logger.warn(
+      'xpack.encryptedSavedObjects.encryptionKey is not configured, private key passphrase is being stored in plain text'
+    );
   }
+  await appContextService.getMessageSigningService()?.generateKeyPair();
 
   logger.debug('Upgrade Agent policy schema version');
   await upgradeAgentPolicySchemaVersion(soClient);


### PR DESCRIPTION
## Summary

adds support for using `MessageSigningService` even if encryption key is not configured:
* generates key pair for message signing even if encryption key is not configured
* private key passphrase is stored in plain text if no encryption key is configured
* passphrase will be automatically encrypted if encryption key is added after key pair is generated
* logs a warning if encryption key is not configured
* additional unit tests

implements: https://github.com/elastic/security-team/issues/6052


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
