### PR TITLE
[8.7] [Fleet] Disable FQDN selector by default (#152592)

### DIFF
--- a/x-pack/plugins/fleet/common/experimental_features.ts
+++ b/x-pack/plugins/fleet/common/experimental_features.ts
@@ -19,7 +19,7 @@ export const allowedExperimentalValues = Object.freeze({
   experimentalDataStreamSettings: false,
   displayAgentMetrics: true,
   showIntegrationsSubcategories: false,
-  agentFqdnMode: true,
+  agentFqdnMode: false,
 });
 
 type ExperimentalConfigKeys = Array<keyof ExperimentalFeatures>;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.7`:
 - [[Fleet] Disable FQDN selector by default (#152592)](https://github.com/elastic/kibana/pull/152592)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Mark Hopkin","email":"mark.hopkin@elastic.co"},"sourceCommit":{"committedDate":"2023-03-02T17:28:11Z","message":"[Fleet] Disable FQDN selector by default (#152592)\n\n## Summary\r\n\r\nHide the FQDN selector unless experimental feature is enabled. This\r\nselector was added as part of\r\nhttps://github.com/elastic/kibana/issues/149059\r\n\r\n### Before:\r\n<img width=\"1073\" alt=\"Screenshot 2023-03-02 at 16 15 39\"\r\nsrc=\"https://user-images.githubusercontent.com/3315046/222487164-75024608-b0f1-419d-bbb0-299bad55cae1.png\">\r\n\r\n### After:\r\n<img width=\"1112\" alt=\"Screenshot 2023-03-02 at 16 14 52\"\r\nsrc=\"https://user-images.githubusercontent.com/3315046/222487206-c58f76eb-6977-4d3a-908d-3b72b0f901fa.png\">\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"de482cbc9ebce0f6d424e90b3e98cffd9979e707","branchLabelMapping":{"^v8.8.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Fleet","v8.7.0","v8.8.0"],"number":152592,"url":"https://github.com/elastic/kibana/pull/152592","mergeCommit":{"message":"[Fleet] Disable FQDN selector by default (#152592)\n\n## Summary\r\n\r\nHide the FQDN selector unless experimental feature is enabled. This\r\nselector was added as part of\r\nhttps://github.com/elastic/kibana/issues/149059\r\n\r\n### Before:\r\n<img width=\"1073\" alt=\"Screenshot 2023-03-02 at 16 15 39\"\r\nsrc=\"https://user-images.githubusercontent.com/3315046/222487164-75024608-b0f1-419d-bbb0-299bad55cae1.png\">\r\n\r\n### After:\r\n<img width=\"1112\" alt=\"Screenshot 2023-03-02 at 16 14 52\"\r\nsrc=\"https://user-images.githubusercontent.com/3315046/222487206-c58f76eb-6977-4d3a-908d-3b72b0f901fa.png\">\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"de482cbc9ebce0f6d424e90b3e98cffd9979e707"}},"sourceBranch":"main","suggestedTargetBranches":["8.7"],"targetPullRequestStates":[{"branch":"8.7","label":"v8.7.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.8.0","labelRegex":"^v8.8.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/152592","number":152592,"mergeCommit":{"message":"[Fleet] Disable FQDN selector by default (#152592)\n\n## Summary\r\n\r\nHide the FQDN selector unless experimental feature is enabled. This\r\nselector was added as part of\r\nhttps://github.com/elastic/kibana/issues/149059\r\n\r\n### Before:\r\n<img width=\"1073\" alt=\"Screenshot 2023-03-02 at 16 15 39\"\r\nsrc=\"https://user-images.githubusercontent.com/3315046/222487164-75024608-b0f1-419d-bbb0-299bad55cae1.png\">\r\n\r\n### After:\r\n<img width=\"1112\" alt=\"Screenshot 2023-03-02 at 16 14 52\"\r\nsrc=\"https://user-images.githubusercontent.com/3315046/222487206-c58f76eb-6977-4d3a-908d-3b72b0f901fa.png\">\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"de482cbc9ebce0f6d424e90b3e98cffd9979e707"}}]}] BACKPORT-->