### PR TITLE
[SavedObjectsFinder] Replace the component in Visualizations plugin

### DIFF
--- a/src/plugins/saved_objects_management/mocks/index.ts
+++ b/src/plugins/saved_objects_management/mocks/index.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+export { savedObjectsManagementPluginMock } from './mocks';

--- a/src/plugins/saved_objects_management/mocks/index.ts
+++ b/src/plugins/saved_objects_management/mocks/index.ts
@@ -1,9 +1,0 @@
-/*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0 and the Server Side Public License, v 1; you may not use this file except
- * in compliance with, at your election, the Elastic License 2.0 or the Server
- * Side Public License, v 1.
- */
-
-export { savedObjectsManagementPluginMock } from './mocks';

--- a/src/plugins/saved_objects_management/mocks/mocks.ts
+++ b/src/plugins/saved_objects_management/mocks/mocks.ts
@@ -8,7 +8,7 @@
 
 import { actionServiceMock } from './services/action_service.mock';
 import { columnServiceMock } from './services/column_service.mock';
-import { SavedObjectsManagementPluginSetup, SavedObjectsManagementPluginStart } from './plugin';
+import { SavedObjectsManagementPluginSetup, SavedObjectsManagementPluginStart } from '../public';
 
 const createSetupContractMock = (): jest.Mocked<SavedObjectsManagementPluginSetup> => {
   const mock = {

--- a/src/plugins/saved_objects_management/mocks/services/action_service.mock.ts
+++ b/src/plugins/saved_objects_management/mocks/services/action_service.mock.ts
@@ -11,7 +11,7 @@ import {
   SavedObjectsManagementActionService,
   SavedObjectsManagementActionServiceSetup,
   SavedObjectsManagementActionServiceStart,
-} from './action_service';
+} from '../../public/services';
 
 const createSetupMock = (): jest.Mocked<SavedObjectsManagementActionServiceSetup> => {
   const mock = {

--- a/src/plugins/saved_objects_management/mocks/services/column_service.mock.ts
+++ b/src/plugins/saved_objects_management/mocks/services/column_service.mock.ts
@@ -11,7 +11,7 @@ import {
   SavedObjectsManagementColumnService,
   SavedObjectsManagementColumnServiceSetup,
   SavedObjectsManagementColumnServiceStart,
-} from './column_service';
+} from '../../public/services';
 
 const createSetupMock = (): jest.Mocked<SavedObjectsManagementColumnServiceSetup> => {
   const mock = {

--- a/src/plugins/saved_objects_management/public/mocks.ts
+++ b/src/plugins/saved_objects_management/public/mocks.ts
@@ -8,7 +8,7 @@
 
 import { actionServiceMock } from './services/action_service.mock';
 import { columnServiceMock } from './services/column_service.mock';
-import { SavedObjectsManagementPluginSetup, SavedObjectsManagementPluginStart } from '../public';
+import { SavedObjectsManagementPluginSetup, SavedObjectsManagementPluginStart } from './plugin';
 
 const createSetupContractMock = (): jest.Mocked<SavedObjectsManagementPluginSetup> => {
   const mock = {

--- a/src/plugins/saved_objects_management/public/services/action_service.mock.ts
+++ b/src/plugins/saved_objects_management/public/services/action_service.mock.ts
@@ -11,7 +11,7 @@ import {
   SavedObjectsManagementActionService,
   SavedObjectsManagementActionServiceSetup,
   SavedObjectsManagementActionServiceStart,
-} from '.';
+} from './action_service';
 
 const createSetupMock = (): jest.Mocked<SavedObjectsManagementActionServiceSetup> => {
   const mock = {

--- a/src/plugins/saved_objects_management/public/services/action_service.mock.ts
+++ b/src/plugins/saved_objects_management/public/services/action_service.mock.ts
@@ -11,7 +11,7 @@ import {
   SavedObjectsManagementActionService,
   SavedObjectsManagementActionServiceSetup,
   SavedObjectsManagementActionServiceStart,
-} from '../../public/services';
+} from '.';
 
 const createSetupMock = (): jest.Mocked<SavedObjectsManagementActionServiceSetup> => {
   const mock = {

--- a/src/plugins/saved_objects_management/public/services/column_service.mock.ts
+++ b/src/plugins/saved_objects_management/public/services/column_service.mock.ts
@@ -11,7 +11,7 @@ import {
   SavedObjectsManagementColumnService,
   SavedObjectsManagementColumnServiceSetup,
   SavedObjectsManagementColumnServiceStart,
-} from '../../public/services';
+} from '.';
 
 const createSetupMock = (): jest.Mocked<SavedObjectsManagementColumnServiceSetup> => {
   const mock = {

--- a/src/plugins/saved_objects_management/public/services/column_service.mock.ts
+++ b/src/plugins/saved_objects_management/public/services/column_service.mock.ts
@@ -11,7 +11,7 @@ import {
   SavedObjectsManagementColumnService,
   SavedObjectsManagementColumnServiceSetup,
   SavedObjectsManagementColumnServiceStart,
-} from '.';
+} from './column_service';
 
 const createSetupMock = (): jest.Mocked<SavedObjectsManagementColumnServiceSetup> => {
   const mock = {

--- a/src/plugins/saved_objects_management/tsconfig.json
+++ b/src/plugins/saved_objects_management/tsconfig.json
@@ -7,7 +7,6 @@
     "common/**/*",
     "public/**/*",
     "server/**/*",
-    "mocks/**/*",
   ],
   "kbn_references": [
     "@kbn/core",

--- a/src/plugins/saved_objects_management/tsconfig.json
+++ b/src/plugins/saved_objects_management/tsconfig.json
@@ -7,6 +7,7 @@
     "common/**/*",
     "public/**/*",
     "server/**/*",
+    "mocks/**/*",
   ],
   "kbn_references": [
     "@kbn/core",

--- a/src/plugins/visualizations/kibana.jsonc
+++ b/src/plugins/visualizations/kibana.jsonc
@@ -23,7 +23,9 @@
       "dataViews",
       "dataViewEditor",
       "unifiedSearch",
-      "usageCollection"
+      "usageCollection",
+      "savedObjectsFinder",
+      "savedObjectsManagement",
     ],
     "optionalPlugins": [
       "home",

--- a/src/plugins/visualizations/public/mocks.ts
+++ b/src/plugins/visualizations/public/mocks.ts
@@ -24,6 +24,7 @@ import { savedObjectTaggingOssPluginMock } from '@kbn/saved-objects-tagging-oss-
 import { screenshotModePluginMock } from '@kbn/screenshot-mode-plugin/public/mocks';
 import { fieldFormatsServiceMock } from '@kbn/field-formats-plugin/public/mocks';
 import { unifiedSearchPluginMock } from '@kbn/unified-search-plugin/public/mocks';
+import { savedObjectsManagementPluginMock } from '@kbn/saved-objects-management-plugin/public/mocks';
 import { VisualizationsPlugin } from './plugin';
 import { Schemas } from './vis_types';
 import { Schema, VisualizationsSetup, VisualizationsStart } from '.';
@@ -80,6 +81,7 @@ const createInstance = async () => {
       usageCollection: {
         reportUiCounter: jest.fn(),
       },
+      savedObjectsManagement: savedObjectsManagementPluginMock.createStartContract(),
     });
 
   return {

--- a/src/plugins/visualizations/public/plugin.ts
+++ b/src/plugins/visualizations/public/plugin.ts
@@ -57,6 +57,7 @@ import type { ScreenshotModePluginStart } from '@kbn/screenshot-mode-plugin/publ
 import type { HomePublicPluginSetup } from '@kbn/home-plugin/public';
 import type { SpacesPluginStart } from '@kbn/spaces-plugin/public';
 import type { DataViewEditorStart } from '@kbn/data-view-editor-plugin/public';
+import { SavedObjectsManagementPluginStart } from '@kbn/saved-objects-management-plugin/public';
 import type { TypesSetup, TypesStart } from './vis_types';
 import type { VisualizeServices } from './visualize_app/types';
 import {
@@ -98,6 +99,7 @@ import {
   setFieldFormats,
   setSavedObjectTagging,
   setUsageCollection,
+  setSavedObjectsManagement,
 } from './services';
 import { VisualizeConstants } from '../common/constants';
 import { EditInLensAction } from './actions/edit_in_lens_action';
@@ -147,6 +149,7 @@ export interface VisualizationsStartDeps {
   fieldFormats: FieldFormatsStart;
   unifiedSearch: UnifiedSearchPublicPluginStart;
   usageCollection: UsageCollectionStart;
+  savedObjectsManagement: SavedObjectsManagementPluginStart;
 }
 
 /**
@@ -379,6 +382,7 @@ export class VisualizationsPlugin
       savedObjectsTaggingOss,
       fieldFormats,
       usageCollection,
+      savedObjectsManagement,
     }: VisualizationsStartDeps
   ): VisualizationsStart {
     const types = this.types.start();
@@ -399,6 +403,7 @@ export class VisualizationsPlugin
     setChrome(core.chrome);
     setFieldFormats(fieldFormats);
     setUsageCollection(usageCollection);
+    setSavedObjectsManagement(savedObjectsManagement);
 
     if (spaces) {
       setSpaces(spaces);

--- a/src/plugins/visualizations/public/services.ts
+++ b/src/plugins/visualizations/public/services.ts
@@ -27,6 +27,7 @@ import type { EmbeddableStart } from '@kbn/embeddable-plugin/public';
 import type { SpacesPluginStart } from '@kbn/spaces-plugin/public';
 import type { SavedObjectTaggingOssPluginStart } from '@kbn/saved-objects-tagging-oss-plugin/public';
 import type { UsageCollectionStart } from '@kbn/usage-collection-plugin/public';
+import { SavedObjectsManagementPluginStart } from '@kbn/saved-objects-management-plugin/public';
 import type { TypesStart } from './vis_types';
 
 export const [getUISettings, setUISettings] = createGetterSetter<IUiSettingsClient>('UISettings');
@@ -76,3 +77,6 @@ export const [getSavedObjectTagging, setSavedObjectTagging] =
 
 export const [getUsageCollection, setUsageCollection] =
   createGetterSetter<UsageCollectionStart>('UsageCollection');
+
+export const [getSavedObjectsManagement, setSavedObjectsManagement] =
+  createGetterSetter<SavedObjectsManagementPluginStart>('SavedObjectsManagement');

--- a/src/plugins/visualizations/public/wizard/new_vis_modal.test.tsx
+++ b/src/plugins/visualizations/public/wizard/new_vis_modal.test.tsx
@@ -13,7 +13,7 @@ import NewVisModal from './new_vis_modal';
 import { ApplicationStart, DocLinksStart } from '@kbn/core/public';
 import { embeddablePluginMock } from '@kbn/embeddable-plugin/public/mocks';
 import { httpServiceMock } from '@kbn/core-http-browser-mocks';
-import { savedObjectsManagementPluginMock } from '@kbn/saved-objects-management-plugin/mocks';
+import { savedObjectsManagementPluginMock } from '@kbn/saved-objects-management-plugin/public/mocks';
 
 describe('NewVisModal', () => {
   const defaultVisTypeParams = {

--- a/src/plugins/visualizations/public/wizard/new_vis_modal.test.tsx
+++ b/src/plugins/visualizations/public/wizard/new_vis_modal.test.tsx
@@ -13,6 +13,7 @@ import NewVisModal from './new_vis_modal';
 import { ApplicationStart, DocLinksStart } from '@kbn/core/public';
 import { embeddablePluginMock } from '@kbn/embeddable-plugin/public/mocks';
 import { httpServiceMock } from '@kbn/core-http-browser-mocks';
+import { savedObjectsManagementPluginMock } from '@kbn/saved-objects-management-plugin/mocks';
 
 describe('NewVisModal', () => {
   const defaultVisTypeParams = {
@@ -77,6 +78,7 @@ describe('NewVisModal', () => {
     },
   };
   const http = httpServiceMock.createStartContract({ basePath: '' });
+  const savedObjectsManagement = savedObjectsManagementPluginMock.createStartContract();
 
   beforeAll(() => {
     Object.defineProperty(window, 'location', {
@@ -101,6 +103,7 @@ describe('NewVisModal', () => {
         application={{} as ApplicationStart}
         docLinks={docLinks as DocLinksStart}
         http={http}
+        savedObjectsManagement={savedObjectsManagement}
       />
     );
     expect(wrapper.find('[data-test-subj="visGroup-aggbased"]').exists()).toBe(true);
@@ -118,6 +121,7 @@ describe('NewVisModal', () => {
         application={{} as ApplicationStart}
         docLinks={docLinks as DocLinksStart}
         http={http}
+        savedObjectsManagement={savedObjectsManagement}
       />
     );
     expect(wrapper.find('[data-test-subj="visGroup-tools"]').exists()).toBe(true);
@@ -134,6 +138,7 @@ describe('NewVisModal', () => {
         application={{} as ApplicationStart}
         docLinks={docLinks as DocLinksStart}
         http={http}
+        savedObjectsManagement={savedObjectsManagement}
       />
     );
     expect(wrapper.find('[data-test-subj="visType-vis2"]').exists()).toBe(true);
@@ -151,6 +156,7 @@ describe('NewVisModal', () => {
           application={{} as ApplicationStart}
           docLinks={docLinks as DocLinksStart}
           http={http}
+          savedObjectsManagement={savedObjectsManagement}
         />
       );
       const visCard = wrapper.find('[data-test-subj="visType-vis"]').last();
@@ -170,6 +176,7 @@ describe('NewVisModal', () => {
           application={{} as ApplicationStart}
           docLinks={docLinks as DocLinksStart}
           http={http}
+          savedObjectsManagement={savedObjectsManagement}
         />
       );
       const visCard = wrapper.find('[data-test-subj="visType-vis"]').last();
@@ -196,6 +203,7 @@ describe('NewVisModal', () => {
           docLinks={docLinks as DocLinksStart}
           stateTransfer={stateTransfer}
           http={http}
+          savedObjectsManagement={savedObjectsManagement}
         />
       );
       const visCard = wrapper.find('[data-test-subj="visType-visWithAliasUrl"]').last();
@@ -221,6 +229,7 @@ describe('NewVisModal', () => {
           application={{ navigateToApp } as unknown as ApplicationStart}
           docLinks={docLinks as DocLinksStart}
           http={http}
+          savedObjectsManagement={savedObjectsManagement}
         />
       );
       const visCard = wrapper.find('[data-test-subj="visType-visWithAliasUrl"]').last();
@@ -242,6 +251,7 @@ describe('NewVisModal', () => {
           application={{} as ApplicationStart}
           docLinks={docLinks as DocLinksStart}
           http={http}
+          savedObjectsManagement={savedObjectsManagement}
         />
       );
       const aggBasedGroupCard = wrapper

--- a/src/plugins/visualizations/public/wizard/new_vis_modal.tsx
+++ b/src/plugins/visualizations/public/wizard/new_vis_modal.tsx
@@ -14,6 +14,7 @@ import { i18n } from '@kbn/i18n';
 import { METRIC_TYPE, UiCounterMetricType } from '@kbn/analytics';
 import { ApplicationStart, IUiSettingsClient, DocLinksStart, HttpStart } from '@kbn/core/public';
 import { EmbeddableStateTransfer } from '@kbn/embeddable-plugin/public';
+import { SavedObjectsManagementPluginStart } from '@kbn/saved-objects-management-plugin/public';
 import { SearchSelection } from './search_selection';
 import { GroupSelection } from './group_selection';
 import { AggBasedSelection } from './agg_based_selection';
@@ -36,6 +37,7 @@ interface TypeSelectionProps {
   originatingApp?: string;
   showAggsSelection?: boolean;
   selectedVisType?: BaseVisType;
+  savedObjectsManagement: SavedObjectsManagementPluginStart;
 }
 
 interface TypeSelectionState {
@@ -93,6 +95,7 @@ class NewVisModal extends React.Component<TypeSelectionProps, TypeSelectionState
             visType={this.state.visType}
             uiSettings={this.props.uiSettings}
             http={this.props.http}
+            savedObjectsManagement={this.props.savedObjectsManagement}
             goBack={() => this.setState({ showSearchVisModal: false })}
           />
         </EuiModal>

--- a/src/plugins/visualizations/public/wizard/search_selection/search_selection.tsx
+++ b/src/plugins/visualizations/public/wizard/search_selection/search_selection.tsx
@@ -12,7 +12,8 @@ import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { IUiSettingsClient, HttpStart } from '@kbn/core/public';
 
-import { SavedObjectFinderUi } from '@kbn/saved-objects-plugin/public';
+import { SavedObjectsManagementPluginStart } from '@kbn/saved-objects-management-plugin/public';
+import { SavedObjectFinder } from '@kbn/saved-objects-finder-plugin/public';
 import type { BaseVisType } from '../../vis_types';
 import { DialogNavigation } from '../dialog_navigation';
 import { showSavedObject } from './show_saved_object';
@@ -22,12 +23,12 @@ interface SearchSelectionProps {
   visType: BaseVisType;
   uiSettings: IUiSettingsClient;
   http: HttpStart;
+  savedObjectsManagement: SavedObjectsManagementPluginStart;
   goBack: () => void;
 }
 
 export class SearchSelection extends React.Component<SearchSelectionProps> {
   private fixedPageSize: number = 8;
-
   public render() {
     return (
       <React.Fragment>
@@ -47,7 +48,7 @@ export class SearchSelection extends React.Component<SearchSelectionProps> {
         </EuiModalHeader>
         <EuiModalBody>
           <DialogNavigation goBack={this.props.goBack} />
-          <SavedObjectFinderUi
+          <SavedObjectFinder
             key="searchSavedObjectFinder"
             onChoose={this.props.onSearchSelected}
             showFilter
@@ -84,8 +85,11 @@ export class SearchSelection extends React.Component<SearchSelectionProps> {
               },
             ]}
             fixedPageSize={this.fixedPageSize}
-            uiSettings={this.props.uiSettings}
-            http={this.props.http}
+            services={{
+              uiSettings: this.props.uiSettings,
+              http: this.props.http,
+              savedObjectsManagement: this.props.savedObjectsManagement,
+            }}
           />
         </EuiModalBody>
       </React.Fragment>

--- a/src/plugins/visualizations/public/wizard/search_selection/show_saved_object.ts
+++ b/src/plugins/visualizations/public/wizard/search_selection/show_saved_object.ts
@@ -6,15 +6,14 @@
  * Side Public License, v 1.
  */
 
-import type { SimpleSavedObject, SavedObjectAttributes } from '@kbn/core/public';
-import type { FinderAttributes } from '@kbn/saved-objects-plugin/public';
+import type { SavedObjectCommon, FinderAttributes } from '@kbn/saved-objects-finder-plugin/common';
 
-export interface SavedSearchesAttributes extends SavedObjectAttributes {
+export interface SavedSearchesAttributes extends SavedObjectCommon {
   isTextBasedQuery: boolean;
   usesAdHocDataView?: boolean;
 }
 
-export const showSavedObject = (savedObject: SimpleSavedObject<FinderAttributes>) => {
-  const so = savedObject as unknown as SimpleSavedObject<SavedSearchesAttributes>;
+export const showSavedObject = (savedObject: SavedObjectCommon<FinderAttributes>) => {
+  const so = savedObject as unknown as SavedObjectCommon<SavedSearchesAttributes>;
   return !so.attributes.isTextBasedQuery && !so.attributes.usesAdHocDataView;
 };

--- a/src/plugins/visualizations/public/wizard/show_new_vis.tsx
+++ b/src/plugins/visualizations/public/wizard/show_new_vis.tsx
@@ -19,6 +19,7 @@ import {
   getEmbeddable,
   getDocLinks,
   getTheme,
+  getSavedObjectsManagement,
 } from '../services';
 import type { BaseVisType } from '../vis_types';
 
@@ -81,6 +82,7 @@ export function showNewVisModal({
             addBasePath={getHttp().basePath.prepend}
             uiSettings={getUISettings()}
             http={getHttp()}
+            savedObjectsManagement={getSavedObjectsManagement()}
             application={getApplication()}
             docLinks={getDocLinks()}
             showAggsSelection={showAggsSelection}

--- a/src/plugins/visualizations/tsconfig.json
+++ b/src/plugins/visualizations/tsconfig.json
@@ -52,6 +52,8 @@
     "@kbn/usage-collection-plugin",
     "@kbn/core-http-browser-mocks",
     "@kbn/shared-ux-router",
+    "@kbn/saved-objects-management-plugin",
+    "@kbn/saved-objects-finder-plugin",
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
## Summary

This PR replaces the SavedObjectsFinder component from saved_objects plugin with the one in saved_objects_finder plugin. This is a part of making the component BWCA compliant [effort](https://github.com/elastic/kibana/issues/150604).


### Checklist

Delete any items that are not applicable to this PR.

~- [] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)~
~- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [X] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
~- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))~
~- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))~
~- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
~- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))~
~- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)~


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
