### PR TITLE
[Fleet] Configure Fleet for serverless

### DIFF
--- a/config/serverless.yml
+++ b/config/serverless.yml
@@ -1,0 +1,1 @@
+xpack.fleet.enableExperimental: ['fleetServerStandalone']


### PR DESCRIPTION
## Summary

In serverless Fleet Server will not run as an Elastic Agent, in the UI we should not display warnings if the "Fleet Server Agent" is not healthy. 

That PR add the config to bypass that check