### PR TITLE
[APM] Show logs for all environments

### DIFF
--- a/x-pack/plugins/apm/public/components/app/service_logs/index.test.ts
+++ b/x-pack/plugins/apm/public/components/app/service_logs/index.test.ts
@@ -4,6 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+import { ENVIRONMENT_ALL } from '../../../../common/environment_filter_values';
 import { getInfrastructureKQLFilter } from '.';
 
 describe('service logs', () => {
@@ -25,6 +26,20 @@ describe('service logs', () => {
       ).toEqual(
         '(service.name: "opbeans-node" and service.environment: "production") or (service.name: "opbeans-node" and not service.environment: *)'
       );
+    });
+
+    it('does not filter by environment all', () => {
+      expect(
+        getInfrastructureKQLFilter({
+          data: {
+            containerIds: [],
+            hostNames: [],
+            podNames: [],
+          },
+          serviceName,
+          environment: ENVIRONMENT_ALL.value,
+        })
+      ).toEqual('service.name: "opbeans-node"');
     });
 
     it('filter by container id as fallback', () => {


### PR DESCRIPTION
This fixes a bug where no logs would be shown if the user selected `Environment: All` (which is the default selection)

Follow-up to https://github.com/elastic/kibana/pull/150065

<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->