### PR TITLE
[Security Solution][Alerts] Update mapping conflicts warning message

### DIFF
--- a/packages/kbn-securitysolution-autocomplete/src/translations/index.ts
+++ b/packages/kbn-securitysolution-autocomplete/src/translations/index.ts
@@ -53,7 +53,8 @@ export const FIELD_CONFLICT_INDICES_WARNING_TITLE = i18n.translate(
 export const FIELD_CONFLICT_INDICES_WARNING_DESCRIPTION = i18n.translate(
   'autocomplete.conflictIndicesWarning.description',
   {
-    defaultMessage: 'This field is defined as several types across different indices.',
+    defaultMessage:
+      'This field is defined as different types across the following indices or is unmapped. This can cause unexpected query results.',
   }
 );
 

--- a/x-pack/plugins/lists/public/exceptions/components/builder/entry_renderer.test.tsx
+++ b/x-pack/plugins/lists/public/exceptions/components/builder/entry_renderer.test.tsx
@@ -186,7 +186,7 @@ describe('BuilderEntryItem', () => {
     );
 
     expect(wrapper.find('.euiFormHelpText.euiFormRow__text').text()).toMatch(
-      /This field is defined as several types across different indices./
+      /This field is defined as different types across the following indices or is unmapped. This can cause unexpected query results./
     );
   });
 

--- a/x-pack/plugins/lists/public/exceptions/components/builder/translations.ts
+++ b/x-pack/plugins/lists/public/exceptions/components/builder/translations.ts
@@ -87,7 +87,8 @@ export const CUSTOM_COMBOBOX_OPTION_TEXT = i18n.translate(
 export const FIELD_CONFLICT_INDICES_WARNING_DESCRIPTION = i18n.translate(
   'xpack.lists.exceptions.field.mappingConflict.description',
   {
-    defaultMessage: 'This field is defined as several types across different indices.',
+    defaultMessage:
+      'This field is defined as different types across the following indices or is unmapped. This can cause unexpected query results.',
   }
 );
 


### PR DESCRIPTION
## Summary

These changes update warning message that we show to user to indicate index mapping conflicts while selecting a field to build a Rule Exception.

New tooltip message:

<img width="829" alt="Screenshot 2023-03-06 at 16 18 51" src="https://user-images.githubusercontent.com/2700761/223154197-ee4ed680-5cc1-4b48-82d8-e225aa24519b.png">

[Main ticket](https://github.com/elastic/kibana/issues/146845)
Addition to [this PR](https://github.com/elastic/kibana/pull/149149)


cc @nastasha-solomon 

<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->