### PR TITLE
[Content management] BWC - versioned content

### DIFF
--- a/examples/content_management_examples/public/examples/todos/stories/todo.stories.tsx
+++ b/examples/content_management_examples/public/examples/todos/stories/todo.stories.tsx
@@ -7,7 +7,11 @@
  */
 
 import * as React from 'react';
-import { ContentClientProvider, ContentClient } from '@kbn/content-management-plugin/public';
+import {
+  ContentClientProvider,
+  ContentClient,
+  ContentTypeRegistry,
+} from '@kbn/content-management-plugin/public';
 
 import { Todos } from '../todos';
 import { TodosClient } from './todos_client';
@@ -19,6 +23,10 @@ export default {
 };
 
 const todosClient = new TodosClient();
+
+const contentTypeRegistry = new ContentTypeRegistry();
+contentTypeRegistry.register({ id: 'todos', version: { latest: 'v1' } });
+
 const contentClient = new ContentClient((contentType: string) => {
   switch (contentType) {
     case 'todos':
@@ -27,7 +35,7 @@ const contentClient = new ContentClient((contentType: string) => {
     default:
       throw new Error(`Unknown content type: ${contentType}`);
   }
-});
+}, contentTypeRegistry);
 
 export const SimpleTodoApp = () => (
   <ContentClientProvider contentClient={contentClient}>

--- a/examples/content_management_examples/public/examples/todos/stories/todo.stories.tsx
+++ b/examples/content_management_examples/public/examples/todos/stories/todo.stories.tsx
@@ -7,11 +7,8 @@
  */
 
 import * as React from 'react';
-import {
-  ContentClientProvider,
-  ContentClient,
-  ContentTypeRegistry,
-} from '@kbn/content-management-plugin/public';
+import { ContentClientProvider, ContentClient } from '@kbn/content-management-plugin/public';
+import { ContentTypeRegistry } from '@kbn/content-management-plugin/public/registry';
 
 import { Todos } from '../todos';
 import { TodosClient } from './todos_client';

--- a/examples/content_management_examples/public/plugin.ts
+++ b/examples/content_management_examples/public/plugin.ts
@@ -31,10 +31,17 @@ export class ContentManagementExamplesPlugin
       },
     });
 
+    contentManagement.registry.register({
+      id: 'todos',
+      version: {
+        latest: 'v1',
+      },
+    });
+
     return {};
   }
 
-  public start(core: CoreStart) {
+  public start(core: CoreStart, deps: StartDeps) {
     return {};
   }
 

--- a/examples/content_management_examples/server/examples/todos/todos.ts
+++ b/examples/content_management_examples/server/examples/todos/todos.ts
@@ -73,6 +73,9 @@ export const registerTodoContentType = ({
       },
     },
     storage: new TodosStorage(),
+    version: {
+      latest: 'v1',
+    },
   });
 };
 

--- a/examples/content_management_examples/server/examples/todos/todos.ts
+++ b/examples/content_management_examples/server/examples/todos/todos.ts
@@ -13,20 +13,13 @@ import {
 } from '@kbn/content-management-plugin/server';
 import { v4 } from 'uuid';
 import {
-  createInSchema,
-  searchInSchema,
   Todo,
   TODO_CONTENT_ID,
-  updateInSchema,
   TodoSearchOut,
   TodoCreateOut,
   TodoUpdateOut,
   TodoDeleteOut,
   TodoGetOut,
-  createOutSchema,
-  getOutSchema,
-  updateOutSchema,
-  searchOutSchema,
   TodoUpdateIn,
   TodoSearchIn,
   TodoCreateIn,
@@ -39,39 +32,6 @@ export const registerTodoContentType = ({
 }) => {
   contentManagement.register({
     id: TODO_CONTENT_ID,
-    schemas: {
-      content: {
-        create: {
-          in: {
-            data: createInSchema,
-          },
-          out: {
-            result: createOutSchema,
-          },
-        },
-        update: {
-          in: {
-            data: updateInSchema,
-          },
-          out: {
-            result: updateOutSchema,
-          },
-        },
-        search: {
-          in: {
-            query: searchInSchema,
-          },
-          out: {
-            result: searchOutSchema,
-          },
-        },
-        get: {
-          out: {
-            result: getOutSchema,
-          },
-        },
-      },
-    },
     storage: new TodosStorage(),
     version: {
       latest: 'v1',

--- a/src/plugins/content_management/common/index.ts
+++ b/src/plugins/content_management/common/index.ts
@@ -19,11 +19,4 @@ export type {
   SearchIn,
 } from './rpc';
 
-export { procedureNames } from './rpc/constants';
-
-export { validateVersion } from './utils';
-
-// intentionally not exporting schemas to not include @kbn/schema in the public bundle
-// export { schemas as rpcSchemas } from './rpc';
-
 export type { Version } from './types';

--- a/src/plugins/content_management/common/index.ts
+++ b/src/plugins/content_management/common/index.ts
@@ -21,5 +21,9 @@ export type {
 
 export { procedureNames } from './rpc/constants';
 
+export { validateVersion } from './utils';
+
 // intentionally not exporting schemas to not include @kbn/schema in the public bundle
 // export { schemas as rpcSchemas } from './rpc';
+
+export type { Version } from './types';

--- a/src/plugins/content_management/common/rpc/bulk_get.ts
+++ b/src/plugins/content_management/common/rpc/bulk_get.ts
@@ -7,6 +7,7 @@
  */
 import { schema } from '@kbn/config-schema';
 import type { Version } from '../types';
+import { versionSchema } from './constants';
 
 import type { ProcedureSchemas } from './types';
 
@@ -14,6 +15,7 @@ export const bulkGetSchemas: ProcedureSchemas = {
   in: schema.object(
     {
       contentTypeId: schema.string(),
+      version: versionSchema,
       ids: schema.arrayOf(schema.string({ minLength: 1 }), { minSize: 1 }),
       options: schema.maybe(schema.object({}, { unknowns: 'allow' })),
     },

--- a/src/plugins/content_management/common/rpc/bulk_get.ts
+++ b/src/plugins/content_management/common/rpc/bulk_get.ts
@@ -6,6 +6,7 @@
  * Side Public License, v 1.
  */
 import { schema } from '@kbn/config-schema';
+import type { Version } from '../types';
 
 import type { ProcedureSchemas } from './types';
 
@@ -27,5 +28,6 @@ export const bulkGetSchemas: ProcedureSchemas = {
 export interface BulkGetIn<T extends string = string, Options extends object = object> {
   contentTypeId: T;
   ids: string[];
+  version?: Version;
   options?: Options;
 }

--- a/src/plugins/content_management/common/rpc/constants.ts
+++ b/src/plugins/content_management/common/rpc/constants.ts
@@ -5,7 +5,20 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
+import { schema } from '@kbn/config-schema';
+
+import { validateVersion } from '../utils';
 
 export const procedureNames = ['get', 'bulkGet', 'create', 'update', 'delete', 'search'] as const;
 
 export type ProcedureName = typeof procedureNames[number];
+
+export const versionSchema = schema.string({
+  validate: (value) => {
+    try {
+      validateVersion(value);
+    } catch (e) {
+      return 'must follow the pattern [v${number}]';
+    }
+  },
+});

--- a/src/plugins/content_management/common/rpc/create.ts
+++ b/src/plugins/content_management/common/rpc/create.ts
@@ -6,6 +6,7 @@
  * Side Public License, v 1.
  */
 import { schema } from '@kbn/config-schema';
+import type { Version } from '../types';
 
 import type { ProcedureSchemas } from './types';
 
@@ -29,5 +30,6 @@ export interface CreateIn<
 > {
   contentTypeId: T;
   data: Data;
+  version?: Version;
   options?: Options;
 }

--- a/src/plugins/content_management/common/rpc/create.ts
+++ b/src/plugins/content_management/common/rpc/create.ts
@@ -7,6 +7,7 @@
  */
 import { schema } from '@kbn/config-schema';
 import type { Version } from '../types';
+import { versionSchema } from './constants';
 
 import type { ProcedureSchemas } from './types';
 
@@ -14,6 +15,7 @@ export const createSchemas: ProcedureSchemas = {
   in: schema.object(
     {
       contentTypeId: schema.string(),
+      version: versionSchema,
       // --> "data" to create a content will be defined by each content type
       data: schema.recordOf(schema.string(), schema.any()),
       options: schema.maybe(schema.object({}, { unknowns: 'allow' })),

--- a/src/plugins/content_management/common/rpc/delete.ts
+++ b/src/plugins/content_management/common/rpc/delete.ts
@@ -6,6 +6,7 @@
  * Side Public License, v 1.
  */
 import { schema } from '@kbn/config-schema';
+import type { Version } from '../types';
 
 import type { ProcedureSchemas } from './types';
 
@@ -24,5 +25,6 @@ export const deleteSchemas: ProcedureSchemas = {
 export interface DeleteIn<T extends string = string, Options extends object = object> {
   contentTypeId: T;
   id: string;
+  version?: Version;
   options?: Options;
 }

--- a/src/plugins/content_management/common/rpc/delete.ts
+++ b/src/plugins/content_management/common/rpc/delete.ts
@@ -7,6 +7,7 @@
  */
 import { schema } from '@kbn/config-schema';
 import type { Version } from '../types';
+import { versionSchema } from './constants';
 
 import type { ProcedureSchemas } from './types';
 
@@ -15,6 +16,7 @@ export const deleteSchemas: ProcedureSchemas = {
     {
       contentTypeId: schema.string(),
       id: schema.string({ minLength: 1 }),
+      version: versionSchema,
       options: schema.maybe(schema.object({}, { unknowns: 'allow' })),
     },
     { unknowns: 'forbid' }

--- a/src/plugins/content_management/common/rpc/get.ts
+++ b/src/plugins/content_management/common/rpc/get.ts
@@ -7,6 +7,7 @@
  */
 import { schema } from '@kbn/config-schema';
 import type { Version } from '../types';
+import { versionSchema } from './constants';
 
 import type { ProcedureSchemas } from './types';
 
@@ -15,6 +16,7 @@ export const getSchemas: ProcedureSchemas = {
     {
       contentTypeId: schema.string(),
       id: schema.string({ minLength: 1 }),
+      version: versionSchema,
       options: schema.maybe(schema.object({}, { unknowns: 'allow' })),
     },
     { unknowns: 'forbid' }

--- a/src/plugins/content_management/common/rpc/get.ts
+++ b/src/plugins/content_management/common/rpc/get.ts
@@ -6,6 +6,7 @@
  * Side Public License, v 1.
  */
 import { schema } from '@kbn/config-schema';
+import type { Version } from '../types';
 
 import type { ProcedureSchemas } from './types';
 
@@ -25,5 +26,6 @@ export const getSchemas: ProcedureSchemas = {
 export interface GetIn<T extends string = string, Options extends object = object> {
   id: string;
   contentTypeId: T;
+  version?: Version;
   options?: Options;
 }

--- a/src/plugins/content_management/common/rpc/search.ts
+++ b/src/plugins/content_management/common/rpc/search.ts
@@ -7,6 +7,7 @@
  */
 import { schema } from '@kbn/config-schema';
 import type { Version } from '../types';
+import { versionSchema } from './constants';
 
 import type { ProcedureSchemas } from './types';
 
@@ -14,6 +15,7 @@ export const searchSchemas: ProcedureSchemas = {
   in: schema.object(
     {
       contentTypeId: schema.string(),
+      version: versionSchema,
       // --> "query" that can be executed will be defined by each content type
       query: schema.recordOf(schema.string(), schema.any()),
       options: schema.maybe(schema.object({}, { unknowns: 'allow' })),

--- a/src/plugins/content_management/common/rpc/search.ts
+++ b/src/plugins/content_management/common/rpc/search.ts
@@ -6,6 +6,7 @@
  * Side Public License, v 1.
  */
 import { schema } from '@kbn/config-schema';
+import type { Version } from '../types';
 
 import type { ProcedureSchemas } from './types';
 
@@ -32,5 +33,6 @@ export interface SearchIn<
 > {
   contentTypeId: T;
   query: Query;
+  version?: Version;
   options?: Options;
 }

--- a/src/plugins/content_management/common/rpc/update.ts
+++ b/src/plugins/content_management/common/rpc/update.ts
@@ -6,6 +6,7 @@
  * Side Public License, v 1.
  */
 import { schema } from '@kbn/config-schema';
+import type { Version } from '../types';
 
 import type { ProcedureSchemas } from './types';
 
@@ -31,5 +32,6 @@ export interface UpdateIn<
   contentTypeId: T;
   id: string;
   data: Data;
+  version?: Version;
   options?: Options;
 }

--- a/src/plugins/content_management/common/rpc/update.ts
+++ b/src/plugins/content_management/common/rpc/update.ts
@@ -7,6 +7,7 @@
  */
 import { schema } from '@kbn/config-schema';
 import type { Version } from '../types';
+import { versionSchema } from './constants';
 
 import type { ProcedureSchemas } from './types';
 
@@ -15,6 +16,7 @@ export const updateSchemas: ProcedureSchemas = {
     {
       contentTypeId: schema.string(),
       id: schema.string({ minLength: 1 }),
+      version: versionSchema,
       // --> "data" to update a content will be defined by each content type
       data: schema.recordOf(schema.string(), schema.any()),
       options: schema.maybe(schema.object({}, { unknowns: 'allow' })),

--- a/src/plugins/content_management/common/types.ts
+++ b/src/plugins/content_management/common/types.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+export type Version = `v${number}`;

--- a/src/plugins/content_management/common/utils.test.ts
+++ b/src/plugins/content_management/common/utils.test.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { validateVersion } from './utils';
+
+describe('utils', () => {
+  describe('validateVersion', () => {
+    const isValid = (version: unknown): boolean => {
+      try {
+        validateVersion(version);
+        return true;
+      } catch (e) {
+        return false;
+      }
+    };
+
+    [
+      {
+        version: 'v1',
+        expected: true,
+      },
+      {
+        version: 'v689584563',
+        expected: true,
+      },
+      {
+        version: 'v0', // Invalid: must be >= 1
+        expected: false,
+      },
+      {
+        version: 'av0',
+        expected: false,
+      },
+      {
+        version: '1',
+        expected: false,
+      },
+      {
+        version: 'vv1',
+        expected: false,
+      },
+    ].forEach(({ version, expected }) => {
+      test(`should validate [${version}] version`, () => {
+        expect(isValid(version)).toBe(expected);
+      });
+    });
+
+    test('should return the version number', () => {
+      expect(validateVersion('v7')).toBe(7);
+    });
+  });
+});

--- a/src/plugins/content_management/common/utils.ts
+++ b/src/plugins/content_management/common/utils.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/** Utility to validate that a content version follows the pattern `v${number}` */
+export const validateVersion = (version: unknown): number => {
+  if (typeof version !== 'string') {
+    throw new Error(`Invalid version [${version}]. Must follow the pattern [v$\{number\}]`);
+  }
+
+  if (/^v\d+$/.test(version) === false) {
+    throw new Error(`Invalid version [${version}]. Must follow the pattern [v$\{number\}]`);
+  }
+
+  const versionNumber = parseInt(version.substring(1), 10);
+
+  if (versionNumber < 1) {
+    throw new Error(`Version must be >= 1`);
+  }
+
+  return versionNumber;
+};

--- a/src/plugins/content_management/public/content_client/content_client.test.ts
+++ b/src/plugins/content_management/public/content_client/content_client.test.ts
@@ -11,11 +11,17 @@ import { takeWhile, toArray } from 'rxjs/operators';
 import { createCrudClientMock } from '../crud_client/crud_client.mock';
 import { ContentClient } from './content_client';
 import type { GetIn, CreateIn, UpdateIn, DeleteIn, SearchIn } from '../../common';
+import { ContentTypeRegistry } from '../registry';
 
 const setup = () => {
   const crudClient = createCrudClientMock();
-  const contentClient = new ContentClient(() => crudClient);
-  return { crudClient, contentClient };
+  const contentTypeRegistry = new ContentTypeRegistry();
+  contentTypeRegistry.register({
+    id: 'testType',
+    version: { latest: 'v3' },
+  });
+  const contentClient = new ContentClient(() => crudClient, contentTypeRegistry);
+  return { crudClient, contentClient, contentTypeRegistry };
 };
 
 describe('#get', () => {
@@ -25,7 +31,27 @@ describe('#get', () => {
     const output = { test: 'test' };
     crudClient.get.mockResolvedValueOnce(output);
     expect(await contentClient.get(input)).toEqual(output);
+    expect(crudClient.get).toBeCalledWith({ ...input, version: 'v3' }); // latest version added
+  });
+
+  it('does not add the latest version if one is passed', async () => {
+    const { crudClient, contentClient } = setup();
+    const input: GetIn = { id: 'test', contentTypeId: 'testType', version: 'v1' };
+    await contentClient.get(input);
     expect(crudClient.get).toBeCalledWith(input);
+  });
+
+  it('throws if version is not valid', async () => {
+    const { contentClient } = setup();
+    let input = { id: 'test', contentTypeId: 'testType', version: 'vv' }; // Invalid format
+    await expect(async () => {
+      contentClient.get(input as any);
+    }).rejects.toThrowError('Invalid version [vv]. Must follow the pattern [v${number}]');
+
+    input = { id: 'test', contentTypeId: 'testType', version: 'v4' }; // Latest version is v3
+    await expect(async () => {
+      contentClient.get(input as any);
+    }).rejects.toThrowError('Invalid version [v4]. Latest version is [v3]');
   });
 
   it('calls rpcClient.get$ with input and returns output', async () => {
@@ -58,6 +84,13 @@ describe('#create', () => {
     crudClient.create.mockResolvedValueOnce(output);
 
     expect(await contentClient.create(input)).toEqual(output);
+    expect(crudClient.create).toBeCalledWith({ ...input, version: 'v3' }); // latest version added
+  });
+
+  it('does not add the latest version if one is passed', async () => {
+    const { crudClient, contentClient } = setup();
+    const input: CreateIn = { contentTypeId: 'testType', data: { foo: 'bar' }, version: 'v1' };
+    await contentClient.create(input);
     expect(crudClient.create).toBeCalledWith(input);
   });
 });
@@ -65,11 +98,28 @@ describe('#create', () => {
 describe('#update', () => {
   it('calls rpcClient.update with input and returns output', async () => {
     const { crudClient, contentClient } = setup();
-    const input: UpdateIn = { contentTypeId: 'testType', id: 'test', data: { foo: 'bar' } };
+    const input: UpdateIn = {
+      contentTypeId: 'testType',
+      id: 'test',
+      data: { foo: 'bar' },
+    };
     const output = { test: 'test' };
     crudClient.update.mockResolvedValueOnce(output);
 
     expect(await contentClient.update(input)).toEqual(output);
+    expect(crudClient.update).toBeCalledWith({ ...input, version: 'v3' }); // latest version added
+  });
+
+  it('does not add the latest version if one is passed', async () => {
+    const { crudClient, contentClient } = setup();
+
+    const input: UpdateIn = {
+      contentTypeId: 'testType',
+      id: 'test',
+      data: { foo: 'bar' },
+      version: 'v1',
+    };
+    await contentClient.update(input);
     expect(crudClient.update).toBeCalledWith(input);
   });
 });
@@ -82,6 +132,13 @@ describe('#delete', () => {
     crudClient.delete.mockResolvedValueOnce(output);
 
     expect(await contentClient.delete(input)).toEqual(output);
+    expect(crudClient.delete).toBeCalledWith({ ...input, version: 'v3' }); // latest version added
+  });
+
+  it('does not add the latest version if one is passed', async () => {
+    const { crudClient, contentClient } = setup();
+    const input: DeleteIn = { contentTypeId: 'testType', id: 'test', version: 'v1' };
+    await contentClient.delete(input);
     expect(crudClient.delete).toBeCalledWith(input);
   });
 });
@@ -93,6 +150,13 @@ describe('#search', () => {
     const output = { hits: [{ id: 'test' }] };
     crudClient.search.mockResolvedValueOnce(output);
     expect(await contentClient.search(input)).toEqual(output);
+    expect(crudClient.search).toBeCalledWith({ ...input, version: 'v3' }); // latest version added
+  });
+
+  it('does not add the latest version if one is passed', async () => {
+    const { crudClient, contentClient } = setup();
+    const input: SearchIn = { contentTypeId: 'testType', query: {}, version: 'v1' };
+    await contentClient.search(input);
     expect(crudClient.search).toBeCalledWith(input);
   });
 

--- a/src/plugins/content_management/public/content_client/content_client.tsx
+++ b/src/plugins/content_management/public/content_client/content_client.tsx
@@ -9,7 +9,9 @@
 import { QueryClient } from '@tanstack/react-query';
 import { createQueryObservable } from './query_observable';
 import type { CrudClient } from '../crud_client';
-import type { CreateIn, GetIn, UpdateIn, DeleteIn, SearchIn } from '../../common';
+import type { CreateIn, GetIn, UpdateIn, DeleteIn, SearchIn, Version } from '../../common';
+import { validateVersion } from '../../common';
+import { ContentTypeRegistry } from '../registry';
 
 export const queryKeyBuilder = {
   all: (type: string) => [type] as const,
@@ -19,6 +21,32 @@ export const queryKeyBuilder = {
   search: (type: string, query: unknown) => {
     return [...queryKeyBuilder.all(type), 'search', query] as const;
   },
+};
+
+const addVersion = <I extends { contentTypeId: string; version?: Version }>(
+  input: I,
+  contentTypeRegistry: ContentTypeRegistry
+): I & { version: Version } => {
+  const contentType = contentTypeRegistry.get(input.contentTypeId);
+
+  if (!contentType) {
+    throw new Error(`Unknown content type [${input.contentTypeId}]`);
+  }
+
+  const version = input.version ?? contentType.version.latest;
+
+  const versionNumber = validateVersion(version);
+
+  if (versionNumber > parseInt(contentType.version.latest.substring(1), 10)) {
+    throw new Error(
+      `Invalid version [${version}]. Latest version is [${contentType.version.latest}]`
+    );
+  }
+
+  return {
+    ...input,
+    version,
+  };
 };
 
 const createQueryOptionBuilder = ({
@@ -46,7 +74,10 @@ export class ContentClient {
   readonly queryClient: QueryClient;
   readonly queryOptionBuilder: ReturnType<typeof createQueryOptionBuilder>;
 
-  constructor(private readonly crudClientProvider: (contentType: string) => CrudClient) {
+  constructor(
+    private readonly crudClientProvider: (contentType: string) => CrudClient,
+    private readonly contentTypeRegistry: ContentTypeRegistry
+  ) {
     this.queryClient = new QueryClient();
     this.queryOptionBuilder = createQueryOptionBuilder({
       crudClientProvider: this.crudClientProvider,
@@ -54,30 +85,46 @@ export class ContentClient {
   }
 
   get<I extends GetIn = GetIn, O = unknown>(input: I): Promise<O> {
-    return this.queryClient.fetchQuery(this.queryOptionBuilder.get(input));
+    return this.queryClient.fetchQuery(
+      this.queryOptionBuilder.get(addVersion(input, this.contentTypeRegistry))
+    );
   }
 
   get$<I extends GetIn = GetIn, O = unknown>(input: I) {
-    return createQueryObservable(this.queryClient, this.queryOptionBuilder.get<I, O>(input));
+    return createQueryObservable(
+      this.queryClient,
+      this.queryOptionBuilder.get<I, O>(addVersion(input, this.contentTypeRegistry))
+    );
   }
 
   create<I extends CreateIn, O = unknown>(input: I): Promise<O> {
-    return this.crudClientProvider(input.contentTypeId).create(input) as Promise<O>;
+    return this.crudClientProvider(input.contentTypeId).create(
+      addVersion(input, this.contentTypeRegistry)
+    ) as Promise<O>;
   }
 
   update<I extends UpdateIn, O = unknown>(input: I): Promise<O> {
-    return this.crudClientProvider(input.contentTypeId).update(input) as Promise<O>;
+    return this.crudClientProvider(input.contentTypeId).update(
+      addVersion(input, this.contentTypeRegistry)
+    ) as Promise<O>;
   }
 
   delete<I extends DeleteIn, O = unknown>(input: I): Promise<O> {
-    return this.crudClientProvider(input.contentTypeId).delete(input) as Promise<O>;
+    return this.crudClientProvider(input.contentTypeId).delete(
+      addVersion(input, this.contentTypeRegistry)
+    ) as Promise<O>;
   }
 
   search<I extends SearchIn, O = unknown>(input: I): Promise<O> {
-    return this.crudClientProvider(input.contentTypeId).search(input) as Promise<O>;
+    return this.crudClientProvider(input.contentTypeId).search(
+      addVersion(input, this.contentTypeRegistry)
+    ) as Promise<O>;
   }
 
   search$<I extends SearchIn, O = unknown>(input: I) {
-    return createQueryObservable(this.queryClient, this.queryOptionBuilder.search<I, O>(input));
+    return createQueryObservable(
+      this.queryClient,
+      this.queryOptionBuilder.search<I, O>(addVersion(input, this.contentTypeRegistry))
+    );
   }
 }

--- a/src/plugins/content_management/public/content_client/content_client.tsx
+++ b/src/plugins/content_management/public/content_client/content_client.tsx
@@ -10,8 +10,8 @@ import { QueryClient } from '@tanstack/react-query';
 import { createQueryObservable } from './query_observable';
 import type { CrudClient } from '../crud_client';
 import type { CreateIn, GetIn, UpdateIn, DeleteIn, SearchIn, Version } from '../../common';
-import { validateVersion } from '../../common';
-import { ContentTypeRegistry } from '../registry';
+import { validateVersion } from '../../common/utils';
+import type { ContentTypeRegistry } from '../registry';
 
 export const queryKeyBuilder = {
   all: (type: string) => [type] as const,

--- a/src/plugins/content_management/public/content_client/content_client_mutation_hooks.test.tsx
+++ b/src/plugins/content_management/public/content_client/content_client_mutation_hooks.test.tsx
@@ -17,10 +17,16 @@ import {
   useDeleteContentMutation,
 } from './content_client_mutation_hooks';
 import type { CreateIn, UpdateIn, DeleteIn } from '../../common';
+import { ContentTypeRegistry } from '../registry';
 
 const setup = () => {
   const crudClient = createCrudClientMock();
-  const contentClient = new ContentClient(() => crudClient);
+  const contentTypeRegistry = new ContentTypeRegistry();
+  contentTypeRegistry.register({
+    id: 'testType',
+    version: { latest: 'v3' },
+  });
+  const contentClient = new ContentClient(() => crudClient, contentTypeRegistry);
 
   const Wrapper: React.FC = ({ children }) => (
     <ContentClientProvider contentClient={contentClient}>{children}</ContentClientProvider>
@@ -36,7 +42,7 @@ const setup = () => {
 describe('useCreateContentMutation', () => {
   test('should call rpcClient.create with input and resolve with output', async () => {
     const { Wrapper, crudClient } = setup();
-    const input: CreateIn = { contentTypeId: 'testType', data: { foo: 'bar' } };
+    const input: CreateIn = { contentTypeId: 'testType', data: { foo: 'bar' }, version: 'v2' };
     const output = { test: 'test' };
     crudClient.create.mockResolvedValueOnce(output);
     const { result, waitFor } = renderHook(() => useCreateContentMutation(), { wrapper: Wrapper });
@@ -51,7 +57,12 @@ describe('useCreateContentMutation', () => {
 describe('useUpdateContentMutation', () => {
   test('should call rpcClient.update with input and resolve with output', async () => {
     const { Wrapper, crudClient } = setup();
-    const input: UpdateIn = { contentTypeId: 'testType', id: 'test', data: { foo: 'bar' } };
+    const input: UpdateIn = {
+      contentTypeId: 'testType',
+      id: 'test',
+      data: { foo: 'bar' },
+      version: 'v2',
+    };
     const output = { test: 'test' };
     crudClient.update.mockResolvedValueOnce(output);
     const { result, waitFor } = renderHook(() => useUpdateContentMutation(), { wrapper: Wrapper });
@@ -66,7 +77,7 @@ describe('useUpdateContentMutation', () => {
 describe('useDeleteContentMutation', () => {
   test('should call rpcClient.delete with input and resolve with output', async () => {
     const { Wrapper, crudClient } = setup();
-    const input: DeleteIn = { contentTypeId: 'testType', id: 'test' };
+    const input: DeleteIn = { contentTypeId: 'testType', id: 'test', version: 'v2' };
     const output = { test: 'test' };
     crudClient.delete.mockResolvedValueOnce(output);
     const { result, waitFor } = renderHook(() => useDeleteContentMutation(), { wrapper: Wrapper });

--- a/src/plugins/content_management/public/content_client/content_client_query_hooks.test.tsx
+++ b/src/plugins/content_management/public/content_client/content_client_query_hooks.test.tsx
@@ -18,6 +18,10 @@ import { ContentTypeRegistry } from '../registry';
 const setup = () => {
   const crudClient = createCrudClientMock();
   const contentTypeRegistry = new ContentTypeRegistry();
+  contentTypeRegistry.register({
+    id: 'testType',
+    version: { latest: 'v2' },
+  });
   const contentClient = new ContentClient(() => crudClient, contentTypeRegistry);
 
   const Wrapper: React.FC = ({ children }) => (

--- a/src/plugins/content_management/public/content_client/content_client_query_hooks.test.tsx
+++ b/src/plugins/content_management/public/content_client/content_client_query_hooks.test.tsx
@@ -13,10 +13,12 @@ import { ContentClient } from './content_client';
 import { createCrudClientMock } from '../crud_client/crud_client.mock';
 import { useGetContentQuery, useSearchContentQuery } from './content_client_query_hooks';
 import type { GetIn, SearchIn } from '../../common';
+import { ContentTypeRegistry } from '../registry';
 
 const setup = () => {
   const crudClient = createCrudClientMock();
-  const contentClient = new ContentClient(() => crudClient);
+  const contentTypeRegistry = new ContentTypeRegistry();
+  const contentClient = new ContentClient(() => crudClient, contentTypeRegistry);
 
   const Wrapper: React.FC = ({ children }) => (
     <ContentClientProvider contentClient={contentClient}>{children}</ContentClientProvider>
@@ -32,7 +34,7 @@ const setup = () => {
 describe('useGetContentQuery', () => {
   test('should call rpcClient.get with input and resolve with output', async () => {
     const { crudClient, Wrapper } = setup();
-    const input: GetIn = { id: 'test', contentTypeId: 'testType' };
+    const input: GetIn = { id: 'test', contentTypeId: 'testType', version: 'v2' };
     const output = { test: 'test' };
     crudClient.get.mockResolvedValueOnce(output);
     const { result, waitFor } = renderHook(() => useGetContentQuery(input), { wrapper: Wrapper });
@@ -44,7 +46,7 @@ describe('useGetContentQuery', () => {
 describe('useSearchContentQuery', () => {
   test('should call rpcClient.search with input and resolve with output', async () => {
     const { crudClient, Wrapper } = setup();
-    const input: SearchIn = { contentTypeId: 'testType', query: {} };
+    const input: SearchIn = { contentTypeId: 'testType', query: {}, version: 'v2' };
     const output = { hits: [{ id: 'test' }] };
     crudClient.search.mockResolvedValueOnce(output);
     const { result, waitFor } = renderHook(() => useSearchContentQuery(input), {

--- a/src/plugins/content_management/public/index.ts
+++ b/src/plugins/content_management/public/index.ts
@@ -20,6 +20,8 @@ export {
   type QueryOptions,
 } from './content_client';
 
+export { ContentTypeRegistry } from './registry';
+
 export function plugin() {
   return new ContentManagementPlugin();
 }

--- a/src/plugins/content_management/public/index.ts
+++ b/src/plugins/content_management/public/index.ts
@@ -20,8 +20,6 @@ export {
   type QueryOptions,
 } from './content_client';
 
-export { ContentTypeRegistry } from './registry';
-
 export function plugin() {
   return new ContentManagementPlugin();
 }

--- a/src/plugins/content_management/public/plugin.ts
+++ b/src/plugins/content_management/public/plugin.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import type { CoreSetup, CoreStart, Plugin } from '@kbn/core/public';
+import type { CoreStart, Plugin } from '@kbn/core/public';
 import {
   ContentManagementPublicStart,
   ContentManagementPublicSetup,
@@ -26,17 +26,16 @@ export class ContentManagementPlugin
       StartDependencies
     >
 {
-  public setup(core: CoreSetup, deps: SetupDependencies) {
-    return {
-      registry: {} as ContentTypeRegistry,
-    };
+  public setup() {
+    return {};
   }
 
   public start(core: CoreStart, deps: StartDependencies) {
     const rpcClient = new RpcClient(core.http);
     const contentTypeRegistry = new ContentTypeRegistry();
     const contentClient = new ContentClient(
-      (contentType) => contentTypeRegistry.get(contentType)?.crud ?? rpcClient
+      (contentType) => contentTypeRegistry.get(contentType)?.crud ?? rpcClient,
+      contentTypeRegistry
     );
     return { client: contentClient, registry: contentTypeRegistry };
   }

--- a/src/plugins/content_management/public/plugin.ts
+++ b/src/plugins/content_management/public/plugin.ts
@@ -26,17 +26,33 @@ export class ContentManagementPlugin
       StartDependencies
     >
 {
+  private contentTypeRegistry: ContentTypeRegistry;
+
+  constructor() {
+    this.contentTypeRegistry = new ContentTypeRegistry();
+  }
+
   public setup() {
-    return {};
+    return {
+      registry: {
+        register: this.contentTypeRegistry.register.bind(this.contentTypeRegistry),
+      },
+    };
   }
 
   public start(core: CoreStart, deps: StartDependencies) {
     const rpcClient = new RpcClient(core.http);
-    const contentTypeRegistry = new ContentTypeRegistry();
+
     const contentClient = new ContentClient(
-      (contentType) => contentTypeRegistry.get(contentType)?.crud ?? rpcClient,
-      contentTypeRegistry
+      (contentType) => this.contentTypeRegistry.get(contentType)?.crud ?? rpcClient,
+      this.contentTypeRegistry
     );
-    return { client: contentClient, registry: contentTypeRegistry };
+    return {
+      client: contentClient,
+      registry: {
+        get: this.contentTypeRegistry.get.bind(this.contentTypeRegistry),
+        getAll: this.contentTypeRegistry.getAll.bind(this.contentTypeRegistry),
+      },
+    };
   }
 }

--- a/src/plugins/content_management/public/registry/content_type.test.ts
+++ b/src/plugins/content_management/public/registry/content_type.test.ts
@@ -10,7 +10,7 @@ import { ContentType } from './content_type';
 import type { ContentTypeDefinition } from './content_type_definition';
 
 test('create a content type with just an id', () => {
-  const type = new ContentType({ id: 'test' });
+  const type = new ContentType({ id: 'test', version: { latest: 'v1' } });
 
   expect(type.id).toBe('test');
   expect(type.name).toBe('test');
@@ -24,6 +24,7 @@ test('create a content type with all the full definition', () => {
     name: 'Test',
     icon: 'test',
     description: 'Test description',
+    version: { latest: 'v1' },
   };
   const type = new ContentType(definition);
 

--- a/src/plugins/content_management/public/registry/content_type.ts
+++ b/src/plugins/content_management/public/registry/content_type.ts
@@ -31,4 +31,8 @@ export class ContentType {
   public get crud(): CrudClient | undefined {
     return this.definition.crud;
   }
+
+  public get version(): ContentTypeDefinition['version'] {
+    return this.definition.version;
+  }
 }

--- a/src/plugins/content_management/public/registry/content_type_definition.ts
+++ b/src/plugins/content_management/public/registry/content_type_definition.ts
@@ -6,6 +6,7 @@
  * Side Public License, v 1.
  */
 
+import type { Version } from '../../common';
 import type { CrudClient } from '../crud_client';
 
 /**
@@ -39,4 +40,9 @@ export interface ContentTypeDefinition {
    * If not provided the default CRUD client is used assuming that this type has a server-side content registry
    */
   crud?: CrudClient;
+
+  version: {
+    /** The latest version for this content */
+    latest: Version;
+  };
 }

--- a/src/plugins/content_management/public/registry/registry.test.ts
+++ b/src/plugins/content_management/public/registry/registry.test.ts
@@ -14,28 +14,63 @@ beforeEach(() => {
   registry = new ContentTypeRegistry();
 });
 
+const versionInfo = {
+  latest: 'v2',
+} as const;
+
 test('registering a content type', () => {
   const type = registry.register({
     id: 'test',
     name: 'Test',
     icon: 'test',
     description: 'Test description',
+    version: versionInfo,
   });
 
   expect(type.id).toBe('test');
   expect(type.name).toBe('Test');
   expect(type.icon).toBe('test');
   expect(type.description).toBe('Test description');
+  expect(type.version).toEqual(versionInfo);
 });
 
 test('registering already registered content type throws', () => {
   registry.register({
     id: 'test',
+    version: versionInfo,
   });
 
-  expect(() => registry.register({ id: 'test' })).toThrowErrorMatchingInlineSnapshot(
-    `"Content type with id \\"test\\" already registered."`
-  );
+  expect(() =>
+    registry.register({ id: 'test', version: versionInfo })
+  ).toThrowErrorMatchingInlineSnapshot(`"Content type with id \\"test\\" already registered."`);
+});
+
+test('registering without version throws', () => {
+  expect(() => {
+    registry.register({
+      id: 'test',
+    } as any);
+  }).toThrowError('Invalid version [undefined]. Must follow the pattern [v${number}]');
+});
+
+test('registering invalid version throws', () => {
+  expect(() => {
+    registry.register({
+      id: 'test',
+      version: {
+        latest: 'bad',
+      },
+    } as any);
+  }).toThrowError('Invalid version [bad]. Must follow the pattern [v${number}]');
+
+  expect(() => {
+    registry.register({
+      id: 'test',
+      version: {
+        latest: 'v0',
+      },
+    });
+  }).toThrowError('Version must be >= 1');
 });
 
 test('getting non registered content returns undefined', () => {
@@ -45,6 +80,7 @@ test('getting non registered content returns undefined', () => {
 test('get', () => {
   const type = registry.register({
     id: 'test',
+    version: versionInfo,
   });
 
   expect(registry.get('test')).toEqual(type);
@@ -53,9 +89,11 @@ test('get', () => {
 test('getAll', () => {
   registry.register({
     id: 'test1',
+    version: versionInfo,
   });
   registry.register({
     id: 'test2',
+    version: versionInfo,
   });
 
   expect(registry.getAll()).toHaveLength(2);

--- a/src/plugins/content_management/public/registry/registry.ts
+++ b/src/plugins/content_management/public/registry/registry.ts
@@ -8,6 +8,7 @@
 
 import type { ContentTypeDefinition } from './content_type_definition';
 import { ContentType } from './content_type';
+import { validateVersion } from '../../common';
 
 export class ContentTypeRegistry {
   private readonly types: Map<string, ContentType> = new Map();
@@ -16,6 +17,9 @@ export class ContentTypeRegistry {
     if (this.types.has(definition.id)) {
       throw new Error(`Content type with id "${definition.id}" already registered.`);
     }
+
+    validateVersion(definition.version?.latest);
+
     const type = new ContentType(definition);
     this.types.set(type.id, type);
 

--- a/src/plugins/content_management/public/registry/registry.ts
+++ b/src/plugins/content_management/public/registry/registry.ts
@@ -8,7 +8,7 @@
 
 import type { ContentTypeDefinition } from './content_type_definition';
 import { ContentType } from './content_type';
-import { validateVersion } from '../../common';
+import { validateVersion } from '../../common/utils';
 
 export class ContentTypeRegistry {
   private readonly types: Map<string, ContentType> = new Map();

--- a/src/plugins/content_management/public/rpc_client/rpc_client.test.ts
+++ b/src/plugins/content_management/public/rpc_client/rpc_client.test.ts
@@ -6,7 +6,8 @@
  * Side Public License, v 1.
  */
 
-import { API_ENDPOINT, procedureNames } from '../../common';
+import { API_ENDPOINT } from '../../common';
+import { procedureNames } from '../../common/rpc';
 
 import { RpcClient } from './rpc_client';
 

--- a/src/plugins/content_management/public/types.ts
+++ b/src/plugins/content_management/public/types.ts
@@ -15,8 +15,9 @@ export interface SetupDependencies {}
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface StartDependencies {}
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface ContentManagementPublicSetup {}
+export interface ContentManagementPublicSetup {
+  registry: Pick<ContentTypeRegistry, 'register'>;
+}
 
 export interface ContentManagementPublicStart {
   client: ContentClient;

--- a/src/plugins/content_management/public/types.ts
+++ b/src/plugins/content_management/public/types.ts
@@ -15,9 +15,8 @@ export interface SetupDependencies {}
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface StartDependencies {}
 
-export interface ContentManagementPublicSetup {
-  registry: Pick<ContentTypeRegistry, 'register'>;
-}
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface ContentManagementPublicSetup {}
 
 export interface ContentManagementPublicStart {
   client: ContentClient;

--- a/src/plugins/content_management/server/core/core.test.ts
+++ b/src/plugins/content_management/server/core/core.test.ts
@@ -5,8 +5,6 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
-import { schema } from '@kbn/config-schema';
-
 import { loggingSystemMock } from '@kbn/core/server/mocks';
 import { Core } from './core';
 import { createMemoryStorage, FooContent } from './mocks';
@@ -37,11 +35,14 @@ import { ContentTypeDefinition, StorageContext } from './types';
 const logger = loggingSystemMock.createLogger();
 
 const FOO_CONTENT_ID = 'foo';
-const fooSchema = schema.object({ title: schema.string() });
 
 const setup = ({ registerFooType = false }: { registerFooType?: boolean } = {}) => {
   const ctx: StorageContext = {
     requestHandlerContext: {} as any,
+    version: {
+      latest: 'v1',
+      request: 'v1',
+    },
   };
 
   const core = new Core({ logger });
@@ -49,13 +50,6 @@ const setup = ({ registerFooType = false }: { registerFooType?: boolean } = {}) 
   const contentDefinition: ContentTypeDefinition = {
     id: FOO_CONTENT_ID,
     storage: createMemoryStorage(),
-    schemas: {
-      content: {
-        create: { in: { data: fooSchema } },
-        update: { in: { data: fooSchema } },
-        search: { in: { query: schema.any() } },
-      },
-    },
     version: {
       latest: 'v2',
     },

--- a/src/plugins/content_management/server/core/core.test.ts
+++ b/src/plugins/content_management/server/core/core.test.ts
@@ -56,6 +56,9 @@ const setup = ({ registerFooType = false }: { registerFooType?: boolean } = {}) 
         search: { in: { query: schema.any() } },
       },
     },
+    version: {
+      latest: 'v2',
+    },
   };
   const cleanUp = () => {
     coreSetup.api.eventBus.stop();
@@ -108,6 +111,27 @@ describe('Content Core', () => {
           // the content into our "contentRegistry" instance
           expect(contentRegistry.isContentRegistered(FOO_CONTENT_ID)).toBe(true);
           expect(contentRegistry.getDefinition(FOO_CONTENT_ID)).toBe(contentDefinition);
+
+          cleanUp();
+        });
+
+        test('should throw if latest version passed is not valid', () => {
+          const { coreSetup, cleanUp, contentDefinition } = setup();
+
+          const {
+            contentRegistry,
+            api: { register },
+          } = coreSetup;
+
+          expect(contentRegistry.isContentRegistered(FOO_CONTENT_ID)).toBe(false);
+
+          expect(() => {
+            register({ ...contentDefinition, version: undefined } as any);
+          }).toThrowError('Invalid version [undefined]. Must follow the pattern [v${number}]');
+
+          expect(() => {
+            register({ ...contentDefinition, version: { latest: 'v0' } });
+          }).toThrowError('Version must be >= 1');
 
           cleanUp();
         });

--- a/src/plugins/content_management/server/core/index.ts
+++ b/src/plugins/content_management/server/core/index.ts
@@ -12,7 +12,7 @@ export type { CoreApi } from './core';
 
 export type { ContentType } from './content_type';
 
-export type { ContentStorage, ContentTypeDefinition, StorageContext, RpcSchemas } from './types';
+export type { ContentStorage, ContentTypeDefinition, StorageContext } from './types';
 
 export type { ContentRegistry } from './registry';
 

--- a/src/plugins/content_management/server/core/registry.ts
+++ b/src/plugins/content_management/server/core/registry.ts
@@ -6,6 +6,7 @@
  * Side Public License, v 1.
  */
 
+import { validateVersion } from '../../common';
 import { ContentType } from './content_type';
 import { EventBus } from './event_bus';
 import type { ContentStorage, ContentTypeDefinition } from './types';
@@ -25,6 +26,8 @@ export class ContentRegistry {
     if (this.types.has(definition.id)) {
       throw new Error(`Content [${definition.id}] is already registered`);
     }
+
+    validateVersion(definition.version?.latest);
 
     const contentType = new ContentType(definition, this.eventBus);
 

--- a/src/plugins/content_management/server/core/registry.ts
+++ b/src/plugins/content_management/server/core/registry.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { validateVersion } from '../../common';
+import { validateVersion } from '../../common/utils';
 import { ContentType } from './content_type';
 import { EventBus } from './event_bus';
 import type { ContentStorage, ContentTypeDefinition } from './types';

--- a/src/plugins/content_management/server/core/types.ts
+++ b/src/plugins/content_management/server/core/types.ts
@@ -6,7 +6,6 @@
  * Side Public License, v 1.
  */
 
-import type { Type } from '@kbn/config-schema';
 import type { RequestHandlerContext } from '@kbn/core-http-request-handler-context-server';
 
 import type { Version } from '../../common';
@@ -40,70 +39,11 @@ export interface ContentStorage {
   search(ctx: StorageContext, query: object, options: unknown): Promise<any>;
 }
 
-export interface RpcSchemas {
-  get?: {
-    in?: {
-      options?: Type<any>;
-    };
-    out?: {
-      result: Type<any>;
-    };
-  };
-  bulkGet?: {
-    in?: {
-      options?: Type<any>;
-    };
-    out?: {
-      result: Type<any>;
-    };
-  };
-  create: {
-    in: {
-      data: Type<any>;
-      options?: Type<any>;
-    };
-    out?: {
-      result: Type<any>;
-    };
-  };
-  update: {
-    in: {
-      data: Type<any>;
-      options?: Type<any>;
-    };
-    out?: {
-      result: Type<any>;
-    };
-  };
-  delete?: {
-    in?: {
-      options?: Type<any>;
-    };
-    out?: {
-      result: Type<any>;
-    };
-  };
-  search: {
-    in: {
-      query: Type<any>;
-      options?: Type<any>;
-    };
-    out?: {
-      result: Type<any>;
-    };
-  };
-}
-
-export type ContentSchemas = RpcSchemas;
-
 export interface ContentTypeDefinition<S extends ContentStorage = ContentStorage> {
   /** Unique id for the content type */
   id: string;
   /** The storage layer for the content. It must implment the ContentStorage interface. */
   storage: S;
-  schemas: {
-    content: ContentSchemas;
-  };
   version: {
     latest: Version;
   };

--- a/src/plugins/content_management/server/core/types.ts
+++ b/src/plugins/content_management/server/core/types.ts
@@ -14,6 +14,10 @@ import type { Version } from '../../common';
 /** Context that is sent to all storage instance methods */
 export interface StorageContext {
   requestHandlerContext: RequestHandlerContext;
+  version: {
+    request: Version;
+    latest: Version;
+  };
 }
 
 export interface ContentStorage {

--- a/src/plugins/content_management/server/core/types.ts
+++ b/src/plugins/content_management/server/core/types.ts
@@ -9,6 +9,8 @@
 import type { Type } from '@kbn/config-schema';
 import type { RequestHandlerContext } from '@kbn/core-http-request-handler-context-server';
 
+import type { Version } from '../../common';
+
 /** Context that is sent to all storage instance methods */
 export interface StorageContext {
   requestHandlerContext: RequestHandlerContext;
@@ -97,5 +99,8 @@ export interface ContentTypeDefinition<S extends ContentStorage = ContentStorage
   storage: S;
   schemas: {
     content: ContentSchemas;
+  };
+  version: {
+    latest: Version;
   };
 }

--- a/src/plugins/content_management/server/plugin.test.ts
+++ b/src/plugins/content_management/server/plugin.test.ts
@@ -9,7 +9,8 @@
 import { loggingSystemMock, coreMock } from '@kbn/core/server/mocks';
 import { ContentManagementPlugin } from './plugin';
 import { IRouter } from '@kbn/core/server';
-import { ProcedureName, procedureNames } from '../common';
+import type { ProcedureName } from '../common';
+import { procedureNames } from '../common/rpc';
 
 jest.mock('./core', () => ({
   ...jest.requireActual('./core'),

--- a/src/plugins/content_management/server/plugin.ts
+++ b/src/plugins/content_management/server/plugin.ts
@@ -21,7 +21,7 @@ import {
   ContentManagementServerStart,
   SetupDependencies,
 } from './types';
-import { procedureNames } from '../common';
+import { procedureNames } from '../common/rpc';
 
 type CreateRouterFn = CoreSetup['http']['createRouter'];
 

--- a/src/plugins/content_management/server/rpc/procedures/bulk_get.test.ts
+++ b/src/plugins/content_management/server/rpc/procedures/bulk_get.test.ts
@@ -201,6 +201,17 @@ describe('RPC -> bulkGet()', () => {
           new Error('Content [unknown] is not registered.')
         );
       });
+
+      test('should throw if the request version is higher than the registered version', () => {
+        const { ctx } = setup();
+        expect(() =>
+          fn(ctx, {
+            contentTypeId: FOO_CONTENT_ID,
+            ids: ['123', '456'],
+            version: 'v7',
+          })
+        ).rejects.toEqual(new Error('Invalid version. Latest version is [v2].'));
+      });
     });
   });
 });

--- a/src/plugins/content_management/server/rpc/procedures/bulk_get.test.ts
+++ b/src/plugins/content_management/server/rpc/procedures/bulk_get.test.ts
@@ -157,6 +157,9 @@ describe('RPC -> bulkGet()', () => {
         schemas: {
           content: contentSchemas,
         },
+        version: {
+          latest: 'v2',
+        },
       });
 
       const requestHandlerContext = 'mockedRequestHandlerContext';

--- a/src/plugins/content_management/server/rpc/procedures/bulk_get.test.ts
+++ b/src/plugins/content_management/server/rpc/procedures/bulk_get.test.ts
@@ -186,7 +186,11 @@ describe('RPC -> bulkGet()', () => {
       const expected = ['Item1', 'Item2'];
       storage.bulkGet.mockResolvedValueOnce(expected);
 
-      const result = await fn(ctx, { contentTypeId: FOO_CONTENT_ID, ids: ['123', '456'] });
+      const result = await fn(ctx, {
+        contentTypeId: FOO_CONTENT_ID,
+        version: 'v1',
+        ids: ['123', '456'],
+      });
 
       expect(result).toEqual({
         contentTypeId: FOO_CONTENT_ID,
@@ -194,7 +198,13 @@ describe('RPC -> bulkGet()', () => {
       });
 
       expect(storage.bulkGet).toHaveBeenCalledWith(
-        { requestHandlerContext: ctx.requestHandlerContext },
+        {
+          requestHandlerContext: ctx.requestHandlerContext,
+          version: {
+            request: 'v1',
+            latest: 'v2', // from the registry
+          },
+        },
         ['123', '456'],
         undefined
       );

--- a/src/plugins/content_management/server/rpc/procedures/bulk_get.ts
+++ b/src/plugins/content_management/server/rpc/procedures/bulk_get.ts
@@ -12,18 +12,20 @@ import type { StorageContext, ContentCrud } from '../../core';
 import type { ProcedureDefinition } from '../rpc_service';
 import type { Context } from '../types';
 import { BulkGetResponse } from '../../core/crud';
+import { validateRequestVersion } from './utils';
 
 export const bulkGet: ProcedureDefinition<Context, BulkGetIn<string>, BulkGetResponse> = {
   schemas: rpcSchemas.bulkGet,
-  fn: async (ctx, { contentTypeId, version, ids, options }) => {
+  fn: async (ctx, { contentTypeId, version: _version, ids, options }) => {
     const contentDefinition = ctx.contentRegistry.getDefinition(contentTypeId);
+    const version = validateRequestVersion(_version, contentDefinition.version.latest);
 
     // Execute CRUD
     const crudInstance: ContentCrud = ctx.contentRegistry.getCrud(contentTypeId);
     const storageContext: StorageContext = {
       requestHandlerContext: ctx.requestHandlerContext,
       version: {
-        request: version!,
+        request: version,
         latest: contentDefinition.version.latest,
       },
     };

--- a/src/plugins/content_management/server/rpc/procedures/bulk_get.ts
+++ b/src/plugins/content_management/server/rpc/procedures/bulk_get.ts
@@ -11,27 +11,12 @@ import type { BulkGetIn } from '../../../common';
 import type { StorageContext, ContentCrud } from '../../core';
 import type { ProcedureDefinition } from '../rpc_service';
 import type { Context } from '../types';
-import { validate } from '../../utils';
 import { BulkGetResponse } from '../../core/crud';
 
 export const bulkGet: ProcedureDefinition<Context, BulkGetIn<string>, BulkGetResponse> = {
   schemas: rpcSchemas.bulkGet,
   fn: async (ctx, { contentTypeId, version, ids, options }) => {
     const contentDefinition = ctx.contentRegistry.getDefinition(contentTypeId);
-    const { bulkGet: schemas } = contentDefinition.schemas.content;
-
-    // Validate the possible options
-    if (options) {
-      if (!schemas?.in?.options) {
-        // TODO: Improve error handling
-        throw new Error('Schema missing for rpc procedure [bulkGet.in.options].');
-      }
-      const error = validate(options, schemas.in.options);
-      if (error) {
-        // TODO: Improve error handling
-        throw error;
-      }
-    }
 
     // Execute CRUD
     const crudInstance: ContentCrud = ctx.contentRegistry.getCrud(contentTypeId);
@@ -43,16 +28,6 @@ export const bulkGet: ProcedureDefinition<Context, BulkGetIn<string>, BulkGetRes
       },
     };
     const result = await crudInstance.bulkGet(storageContext, ids, options);
-
-    // Validate result
-    const resultSchema = schemas?.out?.result;
-    if (resultSchema) {
-      const error = validate(result.items, resultSchema);
-      if (error) {
-        // TODO: Improve error handling
-        throw error;
-      }
-    }
 
     return result;
   },

--- a/src/plugins/content_management/server/rpc/procedures/bulk_get.ts
+++ b/src/plugins/content_management/server/rpc/procedures/bulk_get.ts
@@ -16,7 +16,7 @@ import { BulkGetResponse } from '../../core/crud';
 
 export const bulkGet: ProcedureDefinition<Context, BulkGetIn<string>, BulkGetResponse> = {
   schemas: rpcSchemas.bulkGet,
-  fn: async (ctx, { contentTypeId, ids, options }) => {
+  fn: async (ctx, { contentTypeId, version, ids, options }) => {
     const contentDefinition = ctx.contentRegistry.getDefinition(contentTypeId);
     const { bulkGet: schemas } = contentDefinition.schemas.content;
 
@@ -37,6 +37,10 @@ export const bulkGet: ProcedureDefinition<Context, BulkGetIn<string>, BulkGetRes
     const crudInstance: ContentCrud = ctx.contentRegistry.getCrud(contentTypeId);
     const storageContext: StorageContext = {
       requestHandlerContext: ctx.requestHandlerContext,
+      version: {
+        request: version!,
+        latest: contentDefinition.version.latest,
+      },
     };
     const result = await crudInstance.bulkGet(storageContext, ids, options);
 

--- a/src/plugins/content_management/server/rpc/procedures/create.test.ts
+++ b/src/plugins/content_management/server/rpc/procedures/create.test.ts
@@ -173,6 +173,17 @@ describe('RPC -> create()', () => {
           fn(ctx, { contentTypeId: 'unknown', data: { title: 'Hello' } })
         ).rejects.toEqual(new Error('Content [unknown] is not registered.'));
       });
+
+      test('should throw if the request version is higher than the registered version', () => {
+        const { ctx } = setup();
+        expect(() =>
+          fn(ctx, {
+            contentTypeId: FOO_CONTENT_ID,
+            data: { title: 'Hello' },
+            version: 'v7',
+          })
+        ).rejects.toEqual(new Error('Invalid version. Latest version is [v2].'));
+      });
     });
   });
 });

--- a/src/plugins/content_management/server/rpc/procedures/create.test.ts
+++ b/src/plugins/content_management/server/rpc/procedures/create.test.ts
@@ -132,6 +132,9 @@ describe('RPC -> create()', () => {
         schemas: {
           content: contentSchemas,
         },
+        version: {
+          latest: 'v2',
+        },
       });
 
       const requestHandlerContext = 'mockedRequestHandlerContext';

--- a/src/plugins/content_management/server/rpc/procedures/create.test.ts
+++ b/src/plugins/content_management/server/rpc/procedures/create.test.ts
@@ -158,7 +158,11 @@ describe('RPC -> create()', () => {
       const expected = 'CreateResult';
       storage.create.mockResolvedValueOnce(expected);
 
-      const result = await fn(ctx, { contentTypeId: FOO_CONTENT_ID, data: { title: 'Hello' } });
+      const result = await fn(ctx, {
+        contentTypeId: FOO_CONTENT_ID,
+        version: 'v1',
+        data: { title: 'Hello' },
+      });
 
       expect(result).toEqual({
         contentTypeId: FOO_CONTENT_ID,
@@ -166,7 +170,13 @@ describe('RPC -> create()', () => {
       });
 
       expect(storage.create).toHaveBeenCalledWith(
-        { requestHandlerContext: ctx.requestHandlerContext },
+        {
+          requestHandlerContext: ctx.requestHandlerContext,
+          version: {
+            request: 'v1',
+            latest: 'v2', // from the registry
+          },
+        },
         { title: 'Hello' },
         undefined
       );

--- a/src/plugins/content_management/server/rpc/procedures/create.ts
+++ b/src/plugins/content_management/server/rpc/procedures/create.ts
@@ -11,18 +11,20 @@ import type { CreateIn } from '../../../common';
 import type { StorageContext, ContentCrud } from '../../core';
 import type { ProcedureDefinition } from '../rpc_service';
 import type { Context } from '../types';
+import { validateRequestVersion } from './utils';
 
 export const create: ProcedureDefinition<Context, CreateIn<string>> = {
   schemas: rpcSchemas.create,
-  fn: async (ctx, { contentTypeId, version, data, options }) => {
+  fn: async (ctx, { contentTypeId, version: _version, data, options }) => {
     const contentDefinition = ctx.contentRegistry.getDefinition(contentTypeId);
+    const version = validateRequestVersion(_version, contentDefinition.version.latest);
 
     // Execute CRUD
     const crudInstance: ContentCrud = ctx.contentRegistry.getCrud(contentTypeId);
     const storageContext: StorageContext = {
       requestHandlerContext: ctx.requestHandlerContext,
       version: {
-        request: version!,
+        request: version,
         latest: contentDefinition.version.latest,
       },
     };

--- a/src/plugins/content_management/server/rpc/procedures/create.ts
+++ b/src/plugins/content_management/server/rpc/procedures/create.ts
@@ -11,38 +11,11 @@ import type { CreateIn } from '../../../common';
 import type { StorageContext, ContentCrud } from '../../core';
 import type { ProcedureDefinition } from '../rpc_service';
 import type { Context } from '../types';
-import { validate } from '../../utils';
 
 export const create: ProcedureDefinition<Context, CreateIn<string>> = {
   schemas: rpcSchemas.create,
   fn: async (ctx, { contentTypeId, version, data, options }) => {
     const contentDefinition = ctx.contentRegistry.getDefinition(contentTypeId);
-    const { create: schemas } = contentDefinition.schemas.content;
-
-    // Validate data to be stored
-    if (schemas?.in?.data) {
-      const error = validate(data, schemas.in.data);
-      if (error) {
-        // TODO: Improve error handling
-        throw error;
-      }
-    } else {
-      // TODO: Improve error handling
-      throw new Error('Schema missing for rpc procedure [create.in.data].');
-    }
-
-    // Validate the possible options
-    if (options) {
-      if (!schemas.in?.options) {
-        // TODO: Improve error handling
-        throw new Error('Schema missing for rpc procedure [create.in.options].');
-      }
-      const error = validate(options, schemas.in.options);
-      if (error) {
-        // TODO: Improve error handling
-        throw error;
-      }
-    }
 
     // Execute CRUD
     const crudInstance: ContentCrud = ctx.contentRegistry.getCrud(contentTypeId);
@@ -54,16 +27,6 @@ export const create: ProcedureDefinition<Context, CreateIn<string>> = {
       },
     };
     const result = await crudInstance.create(storageContext, data, options);
-
-    // Validate result
-    const resultSchema = schemas.out?.result;
-    if (resultSchema) {
-      const error = validate(result.result, resultSchema);
-      if (error) {
-        // TODO: Improve error handling
-        throw error;
-      }
-    }
 
     return result;
   },

--- a/src/plugins/content_management/server/rpc/procedures/delete.test.ts
+++ b/src/plugins/content_management/server/rpc/procedures/delete.test.ts
@@ -121,6 +121,9 @@ describe('RPC -> delete()', () => {
         schemas: {
           content: contentSchemas,
         },
+        version: {
+          latest: 'v2',
+        },
       });
 
       const requestHandlerContext = 'mockedRequestHandlerContext';

--- a/src/plugins/content_management/server/rpc/procedures/delete.test.ts
+++ b/src/plugins/content_management/server/rpc/procedures/delete.test.ts
@@ -148,7 +148,7 @@ describe('RPC -> delete()', () => {
       const expected = 'DeleteResult';
       storage.delete.mockResolvedValueOnce(expected);
 
-      const result = await fn(ctx, { contentTypeId: FOO_CONTENT_ID, id: '1234' });
+      const result = await fn(ctx, { contentTypeId: FOO_CONTENT_ID, version: 'v1', id: '1234' });
 
       expect(result).toEqual({
         contentTypeId: FOO_CONTENT_ID,
@@ -156,7 +156,13 @@ describe('RPC -> delete()', () => {
       });
 
       expect(storage.delete).toHaveBeenCalledWith(
-        { requestHandlerContext: ctx.requestHandlerContext },
+        {
+          requestHandlerContext: ctx.requestHandlerContext,
+          version: {
+            request: 'v1',
+            latest: 'v2', // from the registry
+          },
+        },
         '1234',
         undefined
       );

--- a/src/plugins/content_management/server/rpc/procedures/delete.test.ts
+++ b/src/plugins/content_management/server/rpc/procedures/delete.test.ts
@@ -166,6 +166,17 @@ describe('RPC -> delete()', () => {
           new Error('Content [unknown] is not registered.')
         );
       });
+
+      test('should throw if the request version is higher than the registered version', () => {
+        const { ctx } = setup();
+        expect(() =>
+          fn(ctx, {
+            contentTypeId: FOO_CONTENT_ID,
+            id: '1234',
+            version: 'v7',
+          })
+        ).rejects.toEqual(new Error('Invalid version. Latest version is [v2].'));
+      });
     });
   });
 });

--- a/src/plugins/content_management/server/rpc/procedures/delete.ts
+++ b/src/plugins/content_management/server/rpc/procedures/delete.ts
@@ -14,7 +14,7 @@ import { validate } from '../../utils';
 
 export const deleteProc: ProcedureDefinition<Context, DeleteIn<string>> = {
   schemas: rpcSchemas.delete,
-  fn: async (ctx, { contentTypeId, id, options }) => {
+  fn: async (ctx, { contentTypeId, id, version, options }) => {
     const contentDefinition = ctx.contentRegistry.getDefinition(contentTypeId);
     const { delete: schemas } = contentDefinition.schemas.content;
 
@@ -34,6 +34,10 @@ export const deleteProc: ProcedureDefinition<Context, DeleteIn<string>> = {
     const crudInstance: ContentCrud = ctx.contentRegistry.getCrud(contentTypeId);
     const storageContext: StorageContext = {
       requestHandlerContext: ctx.requestHandlerContext,
+      version: {
+        request: version!,
+        latest: contentDefinition.version.latest,
+      },
     };
     const result = await crudInstance.delete(storageContext, id, options);
 

--- a/src/plugins/content_management/server/rpc/procedures/delete.ts
+++ b/src/plugins/content_management/server/rpc/procedures/delete.ts
@@ -10,18 +10,20 @@ import type { DeleteIn } from '../../../common';
 import type { StorageContext, ContentCrud } from '../../core';
 import type { ProcedureDefinition } from '../rpc_service';
 import type { Context } from '../types';
+import { validateRequestVersion } from './utils';
 
 export const deleteProc: ProcedureDefinition<Context, DeleteIn<string>> = {
   schemas: rpcSchemas.delete,
-  fn: async (ctx, { contentTypeId, id, version, options }) => {
+  fn: async (ctx, { contentTypeId, id, version: _version, options }) => {
     const contentDefinition = ctx.contentRegistry.getDefinition(contentTypeId);
+    const version = validateRequestVersion(_version, contentDefinition.version.latest);
 
     // Execute CRUD
     const crudInstance: ContentCrud = ctx.contentRegistry.getCrud(contentTypeId);
     const storageContext: StorageContext = {
       requestHandlerContext: ctx.requestHandlerContext,
       version: {
-        request: version!,
+        request: version,
         latest: contentDefinition.version.latest,
       },
     };

--- a/src/plugins/content_management/server/rpc/procedures/delete.ts
+++ b/src/plugins/content_management/server/rpc/procedures/delete.ts
@@ -10,25 +10,11 @@ import type { DeleteIn } from '../../../common';
 import type { StorageContext, ContentCrud } from '../../core';
 import type { ProcedureDefinition } from '../rpc_service';
 import type { Context } from '../types';
-import { validate } from '../../utils';
 
 export const deleteProc: ProcedureDefinition<Context, DeleteIn<string>> = {
   schemas: rpcSchemas.delete,
   fn: async (ctx, { contentTypeId, id, version, options }) => {
     const contentDefinition = ctx.contentRegistry.getDefinition(contentTypeId);
-    const { delete: schemas } = contentDefinition.schemas.content;
-
-    if (options) {
-      // Validate the options provided
-      if (!schemas?.in?.options) {
-        throw new Error(`Schema missing for rpc procedure [delete.in.options].`);
-      }
-      const error = validate(options, schemas.in.options);
-      if (error) {
-        // TODO: Improve error handling
-        throw error;
-      }
-    }
 
     // Execute CRUD
     const crudInstance: ContentCrud = ctx.contentRegistry.getCrud(contentTypeId);
@@ -40,16 +26,6 @@ export const deleteProc: ProcedureDefinition<Context, DeleteIn<string>> = {
       },
     };
     const result = await crudInstance.delete(storageContext, id, options);
-
-    // Validate result
-    const resultSchema = schemas?.out?.result;
-    if (resultSchema) {
-      const error = validate(result.result, resultSchema);
-      if (error) {
-        // TODO: Improve error handling
-        throw error;
-      }
-    }
 
     return result;
   },

--- a/src/plugins/content_management/server/rpc/procedures/get.test.ts
+++ b/src/plugins/content_management/server/rpc/procedures/get.test.ts
@@ -166,6 +166,17 @@ describe('RPC -> get()', () => {
           new Error('Content [unknown] is not registered.')
         );
       });
+
+      test('should throw if the request version is higher than the registered version', () => {
+        const { ctx } = setup();
+        expect(() =>
+          fn(ctx, {
+            contentTypeId: FOO_CONTENT_ID,
+            id: '1234',
+            version: 'v7',
+          })
+        ).rejects.toEqual(new Error('Invalid version. Latest version is [v2].'));
+      });
     });
   });
 });

--- a/src/plugins/content_management/server/rpc/procedures/get.test.ts
+++ b/src/plugins/content_management/server/rpc/procedures/get.test.ts
@@ -7,6 +7,8 @@
  */
 
 import { schema } from '@kbn/config-schema';
+import { omit } from 'lodash';
+
 import { validate } from '../../utils';
 import { ContentRegistry } from '../../core/registry';
 import { createMockedStorage } from '../../core/mocks';
@@ -31,24 +33,30 @@ const FOO_CONTENT_ID = 'foo';
 
 describe('RPC -> get()', () => {
   describe('Input/Output validation', () => {
-    /**
-     * These tests are for the procedure call itself. Every RPC needs to declare in/out schema
-     * We will test _specific_ validation schema inside the procedure in separate tests.
-     */
+    const validInput = { contentTypeId: 'foo', id: '123', version: 'v1' };
+
     test('should validate that a contentTypeId and an id is passed', () => {
       [
-        { input: { contentTypeId: 'foo', id: '123' } },
+        { input: validInput },
         {
-          input: { id: '777' }, // contentTypeId missing
+          input: omit(validInput, 'contentTypeId'),
           expectedError: '[contentTypeId]: expected value of type [string] but got [undefined]',
         },
         {
-          input: { contentTypeId: 'foo', id: '123', unknown: 'foo' },
+          input: { ...validInput, unknown: 'foo' },
           expectedError: '[unknown]: definition for this key is missing',
         },
         {
-          input: { contentTypeId: 'foo', id: '' }, // id must have min 1 char
+          input: { ...validInput, id: '' }, // id must have min 1 char
           expectedError: '[id]: value has length [0] but it must have a minimum length of [1].',
+        },
+        {
+          input: omit(validInput, 'version'),
+          expectedError: '[version]: expected value of type [string] but got [undefined]',
+        },
+        {
+          input: { ...validInput, version: '1' }, // invalid version format
+          expectedError: '[version]: must follow the pattern [v${number}]',
         },
       ].forEach(({ input, expectedError }) => {
         const error = validate(input, inputSchema);
@@ -70,6 +78,7 @@ describe('RPC -> get()', () => {
         {
           contentTypeId: 'foo',
           id: '123',
+          version: 'v1',
           options: { any: 'object' },
         },
         inputSchema
@@ -81,6 +90,7 @@ describe('RPC -> get()', () => {
         {
           contentTypeId: 'foo',
           id: '123',
+          version: 'v1',
           options: 123, // Not an object
         },
         inputSchema

--- a/src/plugins/content_management/server/rpc/procedures/get.test.ts
+++ b/src/plugins/content_management/server/rpc/procedures/get.test.ts
@@ -148,7 +148,7 @@ describe('RPC -> get()', () => {
       const expected = 'GetResult';
       storage.get.mockResolvedValueOnce(expected);
 
-      const result = await fn(ctx, { contentTypeId: FOO_CONTENT_ID, id: '1234' });
+      const result = await fn(ctx, { contentTypeId: FOO_CONTENT_ID, id: '1234', version: 'v1' });
 
       expect(result).toEqual({
         contentTypeId: FOO_CONTENT_ID,
@@ -156,7 +156,13 @@ describe('RPC -> get()', () => {
       });
 
       expect(storage.get).toHaveBeenCalledWith(
-        { requestHandlerContext: ctx.requestHandlerContext },
+        {
+          requestHandlerContext: ctx.requestHandlerContext,
+          version: {
+            request: 'v1',
+            latest: 'v2', // from the registry
+          },
+        },
         '1234',
         undefined
       );

--- a/src/plugins/content_management/server/rpc/procedures/get.test.ts
+++ b/src/plugins/content_management/server/rpc/procedures/get.test.ts
@@ -6,13 +6,11 @@
  * Side Public License, v 1.
  */
 
-import { schema } from '@kbn/config-schema';
 import { omit } from 'lodash';
 
 import { validate } from '../../utils';
 import { ContentRegistry } from '../../core/registry';
 import { createMockedStorage } from '../../core/mocks';
-import type { RpcSchemas } from '../../core';
 import { EventBus } from '../../core/event_bus';
 import { get } from './get';
 
@@ -118,19 +116,12 @@ describe('RPC -> get()', () => {
   });
 
   describe('procedure', () => {
-    const createSchemas = (): RpcSchemas => {
-      return {} as any;
-    };
-
-    const setup = ({ contentSchemas = createSchemas() } = {}) => {
+    const setup = () => {
       const contentRegistry = new ContentRegistry(new EventBus());
       const storage = createMockedStorage();
       contentRegistry.register({
         id: FOO_CONTENT_ID,
         storage,
-        schemas: {
-          content: contentSchemas,
-        },
         version: {
           latest: 'v2',
         },
@@ -173,45 +164,6 @@ describe('RPC -> get()', () => {
         const { ctx } = setup();
         expect(() => fn(ctx, { contentTypeId: 'unknown', id: '1234' })).rejects.toEqual(
           new Error('Content [unknown] is not registered.')
-        );
-      });
-
-      test('should enforce a schema for options if options are passed', () => {
-        const { ctx } = setup();
-        expect(() =>
-          fn(ctx, { contentTypeId: FOO_CONTENT_ID, id: '1234', options: { foo: 'bar' } })
-        ).rejects.toEqual(new Error('Schema missing for rpc procedure [get.in.options].'));
-      });
-
-      test('should validate the options', () => {
-        const { ctx } = setup({
-          contentSchemas: {
-            get: {
-              in: {
-                options: schema.object({ validOption: schema.maybe(schema.boolean()) }),
-              },
-            },
-          } as any,
-        });
-        expect(() =>
-          fn(ctx, { contentTypeId: FOO_CONTENT_ID, id: '1234', options: { foo: 'bar' } })
-        ).rejects.toEqual(new Error('[foo]: definition for this key is missing'));
-      });
-
-      test('should validate the result if schema is provided', () => {
-        const { ctx, storage } = setup({
-          contentSchemas: {
-            get: {
-              out: { result: schema.object({ validField: schema.maybe(schema.boolean()) }) },
-            },
-          } as any,
-        });
-
-        const invalidResult = { wrongField: 'bad' };
-        storage.get.mockResolvedValueOnce(invalidResult);
-
-        expect(() => fn(ctx, { contentTypeId: FOO_CONTENT_ID, id: '1234' })).rejects.toEqual(
-          new Error('[wrongField]: definition for this key is missing')
         );
       });
     });

--- a/src/plugins/content_management/server/rpc/procedures/get.test.ts
+++ b/src/plugins/content_management/server/rpc/procedures/get.test.ts
@@ -121,6 +121,9 @@ describe('RPC -> get()', () => {
         schemas: {
           content: contentSchemas,
         },
+        version: {
+          latest: 'v2',
+        },
       });
 
       const requestHandlerContext = 'mockedRequestHandlerContext';

--- a/src/plugins/content_management/server/rpc/procedures/get.ts
+++ b/src/plugins/content_management/server/rpc/procedures/get.ts
@@ -9,7 +9,6 @@
 import { rpcSchemas } from '../../../common/schemas';
 import type { GetIn } from '../../../common';
 import type { ContentCrud, StorageContext } from '../../core';
-import { validate } from '../../utils';
 import type { ProcedureDefinition } from '../rpc_service';
 import type { Context } from '../types';
 
@@ -17,19 +16,6 @@ export const get: ProcedureDefinition<Context, GetIn<string>> = {
   schemas: rpcSchemas.get,
   fn: async (ctx, { contentTypeId, id, version, options }) => {
     const contentDefinition = ctx.contentRegistry.getDefinition(contentTypeId);
-    const { get: schemas } = contentDefinition.schemas.content;
-
-    if (options) {
-      // Validate the options provided
-      if (!schemas?.in?.options) {
-        throw new Error(`Schema missing for rpc procedure [get.in.options].`);
-      }
-      const error = validate(options, schemas.in.options);
-      if (error) {
-        // TODO: Improve error handling
-        throw error;
-      }
-    }
 
     // Execute CRUD
     const crudInstance: ContentCrud = ctx.contentRegistry.getCrud(contentTypeId);
@@ -41,16 +27,6 @@ export const get: ProcedureDefinition<Context, GetIn<string>> = {
       },
     };
     const result = await crudInstance.get(storageContext, id, options);
-
-    // Validate result
-    const resultSchema = schemas?.out?.result;
-    if (resultSchema) {
-      const error = validate(result.item, resultSchema);
-      if (error) {
-        // TODO: Improve error handling
-        throw error;
-      }
-    }
 
     return result;
   },

--- a/src/plugins/content_management/server/rpc/procedures/get.ts
+++ b/src/plugins/content_management/server/rpc/procedures/get.ts
@@ -11,18 +11,20 @@ import type { GetIn } from '../../../common';
 import type { ContentCrud, StorageContext } from '../../core';
 import type { ProcedureDefinition } from '../rpc_service';
 import type { Context } from '../types';
+import { validateRequestVersion } from './utils';
 
 export const get: ProcedureDefinition<Context, GetIn<string>> = {
   schemas: rpcSchemas.get,
-  fn: async (ctx, { contentTypeId, id, version, options }) => {
+  fn: async (ctx, { contentTypeId, id, version: _version, options }) => {
     const contentDefinition = ctx.contentRegistry.getDefinition(contentTypeId);
+    const version = validateRequestVersion(_version, contentDefinition.version.latest);
 
     // Execute CRUD
     const crudInstance: ContentCrud = ctx.contentRegistry.getCrud(contentTypeId);
     const storageContext: StorageContext = {
       requestHandlerContext: ctx.requestHandlerContext,
       version: {
-        request: version!,
+        request: version,
         latest: contentDefinition.version.latest,
       },
     };

--- a/src/plugins/content_management/server/rpc/procedures/search.test.ts
+++ b/src/plugins/content_management/server/rpc/procedures/search.test.ts
@@ -174,7 +174,11 @@ describe('RPC -> search()', () => {
       const expected = 'SearchResult';
       storage.search.mockResolvedValueOnce(expected);
 
-      const result = await fn(ctx, { contentTypeId: FOO_CONTENT_ID, query: { title: 'Hello' } });
+      const result = await fn(ctx, {
+        contentTypeId: FOO_CONTENT_ID,
+        version: 'v1', // version in request
+        query: { title: 'Hello' },
+      });
 
       expect(result).toEqual({
         contentTypeId: FOO_CONTENT_ID,
@@ -182,7 +186,13 @@ describe('RPC -> search()', () => {
       });
 
       expect(storage.search).toHaveBeenCalledWith(
-        { requestHandlerContext: ctx.requestHandlerContext },
+        {
+          requestHandlerContext: ctx.requestHandlerContext,
+          version: {
+            request: 'v1',
+            latest: 'v2', // from the registry
+          },
+        },
         { title: 'Hello' },
         undefined
       );

--- a/src/plugins/content_management/server/rpc/procedures/search.test.ts
+++ b/src/plugins/content_management/server/rpc/procedures/search.test.ts
@@ -148,6 +148,9 @@ describe('RPC -> search()', () => {
         schemas: {
           content: contentSchemas,
         },
+        version: {
+          latest: 'v2',
+        },
       });
 
       const requestHandlerContext = 'mockedRequestHandlerContext';

--- a/src/plugins/content_management/server/rpc/procedures/search.test.ts
+++ b/src/plugins/content_management/server/rpc/procedures/search.test.ts
@@ -189,6 +189,17 @@ describe('RPC -> search()', () => {
           fn(ctx, { contentTypeId: 'unknown', query: { title: 'Hello' } })
         ).rejects.toEqual(new Error('Content [unknown] is not registered.'));
       });
+
+      test('should throw if the request version is higher than the registered version', () => {
+        const { ctx } = setup();
+        expect(() =>
+          fn(ctx, {
+            contentTypeId: FOO_CONTENT_ID,
+            query: { title: 'Hello' },
+            version: 'v7',
+          })
+        ).rejects.toEqual(new Error('Invalid version. Latest version is [v2].'));
+      });
     });
   });
 });

--- a/src/plugins/content_management/server/rpc/procedures/search.ts
+++ b/src/plugins/content_management/server/rpc/procedures/search.ts
@@ -11,38 +11,11 @@ import type { SearchIn } from '../../../common';
 import type { StorageContext, ContentCrud } from '../../core';
 import type { ProcedureDefinition } from '../rpc_service';
 import type { Context } from '../types';
-import { validate } from '../../utils';
 
 export const search: ProcedureDefinition<Context, SearchIn<string>> = {
   schemas: rpcSchemas.search,
   fn: async (ctx, { contentTypeId, version, query, options }) => {
     const contentDefinition = ctx.contentRegistry.getDefinition(contentTypeId);
-    const { search: schemas } = contentDefinition.schemas.content;
-
-    // Validate query to execute
-    if (schemas?.in?.query) {
-      const error = validate(query, schemas.in.query);
-      if (error) {
-        // TODO: Improve error handling
-        throw error;
-      }
-    } else {
-      // TODO: Improve error handling
-      throw new Error('Schema missing for rpc procedure [search.in.query].');
-    }
-
-    // Validate the possible options
-    if (options) {
-      if (!schemas.in?.options) {
-        // TODO: Improve error handling
-        throw new Error('Schema missing for rpc procedure [search.in.options].');
-      }
-      const error = validate(options, schemas.in.options);
-      if (error) {
-        // TODO: Improve error handling
-        throw error;
-      }
-    }
 
     // Execute CRUD
     const crudInstance: ContentCrud = ctx.contentRegistry.getCrud(contentTypeId);
@@ -54,16 +27,6 @@ export const search: ProcedureDefinition<Context, SearchIn<string>> = {
       },
     };
     const result = await crudInstance.search(storageContext, query, options);
-
-    // Validate result
-    const resultSchema = schemas.out?.result;
-    if (resultSchema) {
-      const error = validate(result.result, resultSchema);
-      if (error) {
-        // TODO: Improve error handling
-        throw error;
-      }
-    }
 
     return result;
   },

--- a/src/plugins/content_management/server/rpc/procedures/search.ts
+++ b/src/plugins/content_management/server/rpc/procedures/search.ts
@@ -11,18 +11,20 @@ import type { SearchIn } from '../../../common';
 import type { StorageContext, ContentCrud } from '../../core';
 import type { ProcedureDefinition } from '../rpc_service';
 import type { Context } from '../types';
+import { validateRequestVersion } from './utils';
 
 export const search: ProcedureDefinition<Context, SearchIn<string>> = {
   schemas: rpcSchemas.search,
-  fn: async (ctx, { contentTypeId, version, query, options }) => {
+  fn: async (ctx, { contentTypeId, version: _version, query, options }) => {
     const contentDefinition = ctx.contentRegistry.getDefinition(contentTypeId);
+    const version = validateRequestVersion(_version, contentDefinition.version.latest);
 
     // Execute CRUD
     const crudInstance: ContentCrud = ctx.contentRegistry.getCrud(contentTypeId);
     const storageContext: StorageContext = {
       requestHandlerContext: ctx.requestHandlerContext,
       version: {
-        request: version!,
+        request: version,
         latest: contentDefinition.version.latest,
       },
     };

--- a/src/plugins/content_management/server/rpc/procedures/search.ts
+++ b/src/plugins/content_management/server/rpc/procedures/search.ts
@@ -15,7 +15,7 @@ import { validate } from '../../utils';
 
 export const search: ProcedureDefinition<Context, SearchIn<string>> = {
   schemas: rpcSchemas.search,
-  fn: async (ctx, { contentTypeId, query, options }) => {
+  fn: async (ctx, { contentTypeId, version, query, options }) => {
     const contentDefinition = ctx.contentRegistry.getDefinition(contentTypeId);
     const { search: schemas } = contentDefinition.schemas.content;
 
@@ -48,6 +48,10 @@ export const search: ProcedureDefinition<Context, SearchIn<string>> = {
     const crudInstance: ContentCrud = ctx.contentRegistry.getCrud(contentTypeId);
     const storageContext: StorageContext = {
       requestHandlerContext: ctx.requestHandlerContext,
+      version: {
+        request: version!,
+        latest: contentDefinition.version.latest,
+      },
     };
     const result = await crudInstance.search(storageContext, query, options);
 

--- a/src/plugins/content_management/server/rpc/procedures/update.test.ts
+++ b/src/plugins/content_management/server/rpc/procedures/update.test.ts
@@ -6,13 +6,11 @@
  * Side Public License, v 1.
  */
 
-import { schema } from '@kbn/config-schema';
 import { omit } from 'lodash';
 
 import { validate } from '../../utils';
 import { ContentRegistry } from '../../core/registry';
 import { createMockedStorage } from '../../core/mocks';
-import type { RpcSchemas } from '../../core';
 import { EventBus } from '../../core/event_bus';
 import { update } from './update';
 
@@ -30,7 +28,6 @@ if (!outputSchema) {
 }
 
 const FOO_CONTENT_ID = 'foo';
-const fooDataSchema = schema.object({ title: schema.string() }, { unknowns: 'forbid' });
 
 describe('RPC -> update()', () => {
   describe('Input/Output validation', () => {
@@ -130,17 +127,7 @@ describe('RPC -> update()', () => {
   });
 
   describe('procedure', () => {
-    const createSchemas = (): RpcSchemas => {
-      return {
-        update: {
-          in: {
-            data: fooDataSchema,
-          },
-        },
-      } as any;
-    };
-
-    const setup = ({ contentSchemas = createSchemas() } = {}) => {
+    const setup = () => {
       const contentRegistry = new ContentRegistry(new EventBus());
       const storage = createMockedStorage();
       contentRegistry.register({

--- a/src/plugins/content_management/server/rpc/procedures/update.test.ts
+++ b/src/plugins/content_management/server/rpc/procedures/update.test.ts
@@ -169,6 +169,7 @@ describe('RPC -> update()', () => {
       const result = await fn(ctx, {
         contentTypeId: FOO_CONTENT_ID,
         id: '123',
+        version: 'v1',
         data: { title: 'Hello' },
       });
 
@@ -178,7 +179,13 @@ describe('RPC -> update()', () => {
       });
 
       expect(storage.update).toHaveBeenCalledWith(
-        { requestHandlerContext: ctx.requestHandlerContext },
+        {
+          requestHandlerContext: ctx.requestHandlerContext,
+          version: {
+            request: 'v1',
+            latest: 'v2', // from the registry
+          },
+        },
         '123',
         { title: 'Hello' },
         undefined

--- a/src/plugins/content_management/server/rpc/procedures/update.test.ts
+++ b/src/plugins/content_management/server/rpc/procedures/update.test.ts
@@ -196,6 +196,18 @@ describe('RPC -> update()', () => {
           fn(ctx, { contentTypeId: 'unknown', id: '123', data: { title: 'Hello' } })
         ).rejects.toEqual(new Error('Content [unknown] is not registered.'));
       });
+
+      test('should throw if the request version is higher than the registered version', () => {
+        const { ctx } = setup();
+        expect(() =>
+          fn(ctx, {
+            contentTypeId: FOO_CONTENT_ID,
+            id: '123',
+            data: { title: 'Hello' },
+            version: 'v7',
+          })
+        ).rejects.toEqual(new Error('Invalid version. Latest version is [v2].'));
+      });
     });
   });
 });

--- a/src/plugins/content_management/server/rpc/procedures/update.test.ts
+++ b/src/plugins/content_management/server/rpc/procedures/update.test.ts
@@ -146,9 +146,6 @@ describe('RPC -> update()', () => {
       contentRegistry.register({
         id: FOO_CONTENT_ID,
         storage,
-        schemas: {
-          content: contentSchemas,
-        },
         version: {
           latest: 'v2',
         },
@@ -198,84 +195,6 @@ describe('RPC -> update()', () => {
         expect(() =>
           fn(ctx, { contentTypeId: 'unknown', id: '123', data: { title: 'Hello' } })
         ).rejects.toEqual(new Error('Content [unknown] is not registered.'));
-      });
-
-      test('should enforce a schema for the data', () => {
-        const { ctx } = setup({ contentSchemas: {} as any });
-        expect(() =>
-          fn(ctx, { contentTypeId: FOO_CONTENT_ID, id: '123', data: {} })
-        ).rejects.toEqual(new Error('Schema missing for rpc procedure [update.in.data].'));
-      });
-
-      test('should validate the data sent in input - missing field', () => {
-        const { ctx } = setup();
-        expect(() =>
-          fn(ctx, { contentTypeId: FOO_CONTENT_ID, id: '123', data: {} })
-        ).rejects.toEqual(
-          new Error('[title]: expected value of type [string] but got [undefined]')
-        );
-      });
-
-      test('should validate the data sent in input - unknown field', () => {
-        const { ctx } = setup();
-        expect(() =>
-          fn(ctx, {
-            contentTypeId: FOO_CONTENT_ID,
-            id: '123',
-            data: { title: 'Hello', unknownField: 'Hello' },
-          })
-        ).rejects.toEqual(new Error('[unknownField]: definition for this key is missing'));
-      });
-
-      test('should enforce a schema for options if options are passed', () => {
-        const { ctx } = setup();
-        expect(() =>
-          fn(ctx, {
-            contentTypeId: FOO_CONTENT_ID,
-            id: '123',
-            data: { title: 'Hello' },
-            options: { foo: 'bar' },
-          })
-        ).rejects.toEqual(new Error('Schema missing for rpc procedure [update.in.options].'));
-      });
-
-      test('should validate the options', () => {
-        const { ctx } = setup({
-          contentSchemas: {
-            update: {
-              in: {
-                data: fooDataSchema,
-                options: schema.object({ validOption: schema.maybe(schema.boolean()) }),
-              },
-            },
-          } as any,
-        });
-        expect(() =>
-          fn(ctx, {
-            contentTypeId: FOO_CONTENT_ID,
-            id: '123',
-            data: { title: 'Hello' },
-            options: { foo: 'bar' },
-          })
-        ).rejects.toEqual(new Error('[foo]: definition for this key is missing'));
-      });
-
-      test('should validate the result if schema is provided', () => {
-        const { ctx, storage } = setup({
-          contentSchemas: {
-            update: {
-              in: { data: fooDataSchema },
-              out: { result: schema.object({ validField: schema.maybe(schema.boolean()) }) },
-            },
-          } as any,
-        });
-
-        const invalidResult = { wrongField: 'bad' };
-        storage.update.mockResolvedValueOnce(invalidResult);
-
-        expect(() =>
-          fn(ctx, { contentTypeId: FOO_CONTENT_ID, id: '123', data: { title: 'Hello' } })
-        ).rejects.toEqual(new Error('[wrongField]: definition for this key is missing'));
       });
     });
   });

--- a/src/plugins/content_management/server/rpc/procedures/update.test.ts
+++ b/src/plugins/content_management/server/rpc/procedures/update.test.ts
@@ -140,6 +140,9 @@ describe('RPC -> update()', () => {
         schemas: {
           content: contentSchemas,
         },
+        version: {
+          latest: 'v2',
+        },
       });
 
       const requestHandlerContext = 'mockedRequestHandlerContext';

--- a/src/plugins/content_management/server/rpc/procedures/update.ts
+++ b/src/plugins/content_management/server/rpc/procedures/update.ts
@@ -14,7 +14,7 @@ import { validate } from '../../utils';
 
 export const update: ProcedureDefinition<Context, UpdateIn<string>> = {
   schemas: rpcSchemas.update,
-  fn: async (ctx, { contentTypeId, id, data, options }) => {
+  fn: async (ctx, { contentTypeId, id, version, data, options }) => {
     const contentDefinition = ctx.contentRegistry.getDefinition(contentTypeId);
     const { update: schemas } = contentDefinition.schemas.content;
 
@@ -47,6 +47,10 @@ export const update: ProcedureDefinition<Context, UpdateIn<string>> = {
     const crudInstance: ContentCrud = ctx.contentRegistry.getCrud(contentTypeId);
     const storageContext: StorageContext = {
       requestHandlerContext: ctx.requestHandlerContext,
+      version: {
+        request: version!,
+        latest: contentDefinition.version.latest,
+      },
     };
     const result = await crudInstance.update(storageContext, id, data, options);
 

--- a/src/plugins/content_management/server/rpc/procedures/update.ts
+++ b/src/plugins/content_management/server/rpc/procedures/update.ts
@@ -10,38 +10,11 @@ import type { UpdateIn } from '../../../common';
 import type { StorageContext, ContentCrud } from '../../core';
 import type { ProcedureDefinition } from '../rpc_service';
 import type { Context } from '../types';
-import { validate } from '../../utils';
 
 export const update: ProcedureDefinition<Context, UpdateIn<string>> = {
   schemas: rpcSchemas.update,
   fn: async (ctx, { contentTypeId, id, version, data, options }) => {
     const contentDefinition = ctx.contentRegistry.getDefinition(contentTypeId);
-    const { update: schemas } = contentDefinition.schemas.content;
-
-    // Validate data to be stored
-    if (schemas?.in?.data) {
-      const error = validate(data, schemas.in.data);
-      if (error) {
-        // TODO: Improve error handling
-        throw error;
-      }
-    } else {
-      // TODO: Improve error handling
-      throw new Error('Schema missing for rpc procedure [update.in.data].');
-    }
-
-    // Validate the possible options
-    if (options) {
-      if (!schemas.in?.options) {
-        // TODO: Improve error handling
-        throw new Error('Schema missing for rpc procedure [update.in.options].');
-      }
-      const error = validate(options, schemas.in.options);
-      if (error) {
-        // TODO: Improve error handling
-        throw error;
-      }
-    }
 
     // Execute CRUD
     const crudInstance: ContentCrud = ctx.contentRegistry.getCrud(contentTypeId);
@@ -53,16 +26,6 @@ export const update: ProcedureDefinition<Context, UpdateIn<string>> = {
       },
     };
     const result = await crudInstance.update(storageContext, id, data, options);
-
-    // Validate result
-    const resultSchema = schemas.out?.result;
-    if (resultSchema) {
-      const error = validate(result.result, resultSchema);
-      if (error) {
-        // TODO: Improve error handling
-        throw error;
-      }
-    }
 
     return result;
   },

--- a/src/plugins/content_management/server/rpc/procedures/update.ts
+++ b/src/plugins/content_management/server/rpc/procedures/update.ts
@@ -10,18 +10,20 @@ import type { UpdateIn } from '../../../common';
 import type { StorageContext, ContentCrud } from '../../core';
 import type { ProcedureDefinition } from '../rpc_service';
 import type { Context } from '../types';
+import { validateRequestVersion } from './utils';
 
 export const update: ProcedureDefinition<Context, UpdateIn<string>> = {
   schemas: rpcSchemas.update,
-  fn: async (ctx, { contentTypeId, id, version, data, options }) => {
+  fn: async (ctx, { contentTypeId, id, version: _version, data, options }) => {
     const contentDefinition = ctx.contentRegistry.getDefinition(contentTypeId);
+    const version = validateRequestVersion(_version, contentDefinition.version.latest);
 
     // Execute CRUD
     const crudInstance: ContentCrud = ctx.contentRegistry.getCrud(contentTypeId);
     const storageContext: StorageContext = {
       requestHandlerContext: ctx.requestHandlerContext,
       version: {
-        request: version!,
+        request: version,
         latest: contentDefinition.version.latest,
       },
     };

--- a/src/plugins/content_management/server/rpc/procedures/utils.ts
+++ b/src/plugins/content_management/server/rpc/procedures/utils.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { validateVersion } from '../../../common';
+import type { Version } from '../../../common';
+
+export const validateRequestVersion = (
+  requestVersion: Version | undefined,
+  latestVersion: Version
+): Version => {
+  if (requestVersion === undefined) {
+    // this should never happen as we have schema in place at the route level
+    throw new Error('Request version missing');
+  }
+
+  const requestVersionNumber = validateVersion(requestVersion);
+  const latestVersionNumber = parseInt(latestVersion.substring(1), 10);
+
+  if (requestVersionNumber > latestVersionNumber) {
+    throw new Error(`Invalid version. Latest version is [${latestVersion}].`);
+  }
+
+  return requestVersion;
+};

--- a/src/plugins/content_management/server/rpc/procedures/utils.ts
+++ b/src/plugins/content_management/server/rpc/procedures/utils.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { validateVersion } from '../../../common';
+import { validateVersion } from '../../../common/utils';
 import type { Version } from '../../../common';
 
 export const validateRequestVersion = (


### PR DESCRIPTION
This PR adds BWC support in Content Management.

## Notes on implementation

* every method of the storage instance receives the request version + the latest version in the `context` object

<img width="599" alt="Screenshot 2023-03-09 at 14 24 19" src="https://user-images.githubusercontent.com/2854616/224054262-a0308e00-94fa-47f6-ad4e-942a09c175ee.png">


* It is now required to **both** register the content in the browser and on the server. This ensure that all content is versioned and no "guess" logic is in place for non versioned RPC requests
* The CM public client automatically attach the `latestVersion` information in each RPC Request `payload`. Unless a specific `version` is asked by the consumer (e.g. if for some reason the client needs a `v1` while the server is on `v2`)
* Ideally every content will use the same constant (exported from the `common` folder) to register their latest version. If they don't and by mistake they register a higher version on the client than on the browser the request will throw an error before hitting the storage layer. 
* The schema validation for the different objects that can be passed to the storage methods (`data`, `query` and `options`) has been removed. Same for the `result` schema which is not validated before sending it back to the client. It is now the responsibility of each content provider to validate the incoming data (objects) and response result. In a future PR we will provide tooling to make this validation easier.

## Test in Kibana

* start kibana with the examples `yarn start --run-examples`
* go to the content management examples and start using yhe "Todos" app
* Inspect the request: every call to the rpc crud + searc should include the latest content version

<img width="785" alt="Screenshot 2023-03-09 at 14 11 55" src="https://user-images.githubusercontent.com/2854616/224054557-164be495-c27f-4d05-b206-b53d0c07474c.png">
<img width="812" alt="Screenshot 2023-03-09 at 14 12 18" src="https://user-images.githubusercontent.com/2854616/224054559-039e3d66-d86b-416c-b816-7835d9feb50a.png">
