### PR TITLE
feat(slo): use UI settings date format

### DIFF
--- a/x-pack/plugins/observability/public/pages/slo_details/components/overview.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_details/components/overview.tsx
@@ -11,9 +11,9 @@ import { SLOWithSummaryResponse } from '@kbn/slo-schema';
 import { assertNever } from '@kbn/std';
 import moment from 'moment';
 import React from 'react';
-import { DEFAULT_DATE_FORMAT } from '../constants';
-import { toHighPrecisionPercentage } from '../helpers/number';
 
+import { useKibana } from '../../../utils/kibana_react';
+import { toHighPrecisionPercentage } from '../helpers/number';
 import { OverviewItem } from './overview_item';
 
 export interface Props {
@@ -21,7 +21,10 @@ export interface Props {
 }
 
 export function Overview({ slo }: Props) {
+  const { uiSettings } = useKibana().services;
+  const dateFormat = uiSettings.get('dateFormat');
   const hasNoData = slo.summary.status === 'NO_DATA';
+
   return (
     <EuiPanel paddingSize="none" color="transparent">
       <EuiFlexGroup direction="column" gutterSize="l">
@@ -81,13 +84,13 @@ export function Overview({ slo }: Props) {
             title={i18n.translate('xpack.observability.slo.sloDetails.overview.createdAtTitle', {
               defaultMessage: 'Created at',
             })}
-            subtitle={moment(slo.createdAt).format(DEFAULT_DATE_FORMAT)}
+            subtitle={moment(slo.createdAt).format(dateFormat)}
           />
           <OverviewItem
             title={i18n.translate('xpack.observability.slo.sloDetails.overview.updatedAtTitle', {
               defaultMessage: 'Last update at',
             })}
-            subtitle={moment(slo.updatedAt).format(DEFAULT_DATE_FORMAT)}
+            subtitle={moment(slo.updatedAt).format(dateFormat)}
           />
           <OverviewItem
             title={i18n.translate('xpack.observability.slo.sloDetails.overview.tagsTitle', {

--- a/x-pack/plugins/observability/public/pages/slo_details/components/wide_chart.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_details/components/wide_chart.tsx
@@ -22,7 +22,6 @@ import moment from 'moment';
 import { ChartData } from '../../../typings';
 import { useKibana } from '../../../utils/kibana_react';
 import { toHighPrecisionPercentage } from '../helpers/number';
-import { DEFAULT_DATE_FORMAT } from '../constants';
 
 type ChartType = 'area' | 'line';
 type State = 'success' | 'error';
@@ -36,10 +35,11 @@ export interface Props {
 }
 
 export function WideChart({ chart, data, id, isLoading, state }: Props) {
-  const charts = useKibana().services.charts;
+  const { charts, uiSettings } = useKibana().services;
   const theme = charts.theme.useChartsTheme();
   const baseTheme = charts.theme.useChartsBaseTheme();
   const { euiTheme } = useEuiTheme();
+  const dateFormat = uiSettings.get('dateFormat');
 
   const color = state === 'error' ? euiTheme.colors.danger : euiTheme.colors.success;
   const ChartComponent = chart === 'area' ? AreaSeries : LineSeries;
@@ -61,7 +61,7 @@ export function WideChart({ chart, data, id, isLoading, state }: Props) {
         id="bottom"
         position={Position.Bottom}
         showOverlappingTicks
-        tickFormat={(d) => moment(d).format(DEFAULT_DATE_FORMAT)}
+        tickFormat={(d) => moment(d).format(dateFormat)}
       />
       <Axis
         id="left"

--- a/x-pack/plugins/observability/public/pages/slo_details/components/wide_chart.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_details/components/wide_chart.tsx
@@ -17,8 +17,8 @@ import {
 } from '@elastic/charts';
 import React from 'react';
 import { EuiIcon, EuiLoadingChart, useEuiTheme } from '@elastic/eui';
-
 import moment from 'moment';
+
 import { ChartData } from '../../../typings';
 import { useKibana } from '../../../utils/kibana_react';
 import { toHighPrecisionPercentage } from '../helpers/number';

--- a/x-pack/plugins/observability/public/pages/slo_details/constants.ts
+++ b/x-pack/plugins/observability/public/pages/slo_details/constants.ts
@@ -1,8 +1,0 @@
-/*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0; you may not use this file except in compliance with the Elastic License
- * 2.0.
- */
-
-export const DEFAULT_DATE_FORMAT = 'MMM D, YYYY @ HH:mm:ss.SSS';

--- a/x-pack/plugins/observability/public/pages/slo_details/index.test.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_details/index.test.tsx
@@ -55,6 +55,12 @@ const mockKibana = () => {
           prepend: mockBasePathPrepend,
         },
       },
+      uiSettings: {
+        get: (settings: string) => {
+          if (settings === 'dateFormat') return 'YYYY-MM-DD';
+          return '';
+        },
+      },
     },
   });
 };


### PR DESCRIPTION
## Summary

This PR uses the user defined date format from the UI settings instead of the hard coded format.

## Testing

Checks your SLO charts are displayed with the correct date format. Alternatively, you can check storybook as well.