### PR TITLE
[Cases] Refactoring file kinds

### DIFF
--- a/x-pack/plugins/cases/common/constants/files.ts
+++ b/x-pack/plugins/cases/common/constants/files.ts
@@ -7,9 +7,10 @@
 
 import type { HttpApiTagOperation, Owner } from './types';
 
-export const MAX_FILES_PER_CASE = 100;
 export const MAX_FILE_SIZE = 100 * 1024 * 1024; // 100 MiB
 
 export const constructFilesHttpOperationTag = (owner: Owner, operation: HttpApiTagOperation) => {
   return `${owner}FilesCases${operation}`;
 };
+
+export const constructFileKindIdByOwner = (owner: Owner) => `${owner}FilesCases`;

--- a/x-pack/plugins/cases/public/files/index.ts
+++ b/x-pack/plugins/cases/public/files/index.ts
@@ -8,13 +8,13 @@
 import type { FilesSetup } from '@kbn/files-plugin/public';
 import type { FileKindBrowser } from '@kbn/shared-ux-file-types';
 import { ALLOWED_MIME_TYPES } from '../../common/constants/mime_types';
-import { MAX_FILE_SIZE } from '../../common/constants';
+import { constructFileKindIdByOwner, MAX_FILE_SIZE } from '../../common/constants';
 import type { Owner } from '../../common/constants/types';
 import { APP_ID, OBSERVABILITY_OWNER, SECURITY_SOLUTION_OWNER } from '../../common';
 
 const buildFileKind = (owner: Owner): FileKindBrowser => {
   return {
-    id: owner,
+    id: constructFileKindIdByOwner(owner),
     allowedMimeTypes: ALLOWED_MIME_TYPES,
     maxSizeBytes: MAX_FILE_SIZE,
   };

--- a/x-pack/plugins/cases/server/common/limiter_checker/limiters/files.ts
+++ b/x-pack/plugins/cases/server/common/limiter_checker/limiters/files.ts
@@ -8,9 +8,10 @@
 import { buildFilter } from '../../../client/utils';
 import { CommentType, FILE_ATTACHMENT_TYPE } from '../../../../common/api';
 import type { CommentRequest } from '../../../../common/api';
-import { CASE_COMMENT_SAVED_OBJECT, MAX_FILES_PER_CASE } from '../../../../common/constants';
+import { CASE_COMMENT_SAVED_OBJECT } from '../../../../common/constants';
 import { isFileAttachmentRequest } from '../../utils';
 import { BaseLimiter } from '../base_limiter';
+import { MAX_FILES_PER_CASE } from '../../../files';
 
 export class FileLimiter extends BaseLimiter {
   constructor() {

--- a/x-pack/plugins/cases/server/files/index.ts
+++ b/x-pack/plugins/cases/server/files/index.ts
@@ -9,6 +9,7 @@ import type { FileJSON, FileKind } from '@kbn/files-plugin/common';
 import type { FilesSetup } from '@kbn/files-plugin/server';
 import {
   APP_ID,
+  constructFileKindIdByOwner,
   constructFilesHttpOperationTag,
   MAX_FILE_SIZE,
   OBSERVABILITY_OWNER,
@@ -20,7 +21,7 @@ import { ALLOWED_MIME_TYPES, IMAGE_MIME_TYPES } from '../../common/constants/mim
 
 const buildFileKind = (owner: Owner): FileKind => {
   return {
-    id: owner,
+    id: constructFileKindIdByOwner(owner),
     http: fileKindHttpTags(owner),
     maxSizeBytes,
     allowedMimeTypes: ALLOWED_MIME_TYPES,
@@ -69,3 +70,5 @@ export const registerCaseFileKinds = (filesSetupPlugin: FilesSetup) => {
     filesSetupPlugin.registerFileKind(fileKind);
   }
 };
+
+export const MAX_FILES_PER_CASE = 100;


### PR DESCRIPTION
This PR refactors the file kinds to be scoped to cases. Original the file kinds were `cases`, `observability`, and `securitySolution`. Now they will be `casesFilesCases`, `observabilityFilesCases`, `securitySolutionFilesCases` to avoid clashing with file kinds that the solutions would want to register in the future.