### PR TITLE
[Dashboard] [Maps] Fix logic of maps loading state

### DIFF
--- a/x-pack/plugins/maps/public/actions/map_actions.ts
+++ b/x-pack/plugins/maps/public/actions/map_actions.ts
@@ -164,10 +164,6 @@ export function mapReady() {
     dispatch: ThunkDispatch<MapStoreState, void, AnyAction>,
     getState: () => MapStoreState
   ) => {
-    dispatch({
-      type: MAP_READY,
-    });
-
     const waitingForMapReadyLayerList = getWaitingForMapReadyLayerListRaw(getState());
     dispatch({
       type: CLEAR_WAITING_FOR_MAP_READY_LAYER_LIST,
@@ -183,6 +179,10 @@ export function mapReady() {
         dispatch(addLayer(layerDescriptor));
       });
     }
+
+    dispatch({
+      type: MAP_READY,
+    });
   };
 }
 

--- a/x-pack/plugins/maps/public/actions/map_actions.ts
+++ b/x-pack/plugins/maps/public/actions/map_actions.ts
@@ -164,6 +164,10 @@ export function mapReady() {
     dispatch: ThunkDispatch<MapStoreState, void, AnyAction>,
     getState: () => MapStoreState
   ) => {
+    dispatch({
+      type: MAP_READY,
+    });
+
     const waitingForMapReadyLayerList = getWaitingForMapReadyLayerListRaw(getState());
     dispatch({
       type: CLEAR_WAITING_FOR_MAP_READY_LAYER_LIST,
@@ -179,10 +183,6 @@ export function mapReady() {
         dispatch(addLayer(layerDescriptor));
       });
     }
-
-    dispatch({
-      type: MAP_READY,
-    });
   };
 }
 

--- a/x-pack/plugins/maps/public/embeddable/map_embeddable.tsx
+++ b/x-pack/plugins/maps/public/embeddable/map_embeddable.tsx
@@ -61,6 +61,7 @@ import {
   getMapZoom,
   getHiddenLayerIds,
   getQueryableUniqueIndexPatternIds,
+  getWaitingForMapReadyLayerListRaw,
 } from '../selectors/map_selectors';
 import {
   APP_ID,
@@ -750,9 +751,10 @@ export class MapEmbeddable
     }
 
     if (areLayersLoaded(this._savedMap.getStore().getState())) {
-      const layers = getLayerList(this._savedMap.getStore().getState());
+      const mapState = this._savedMap.getStore().getState();
+      const layers = getLayerList(mapState);
       const isLoading =
-        layers.length !== 0 &&
+        getWaitingForMapReadyLayerListRaw(mapState).length > 0 ||
         layers.some((layer) => {
           return layer.isLayerLoading();
         });

--- a/x-pack/plugins/maps/public/embeddable/map_embeddable.tsx
+++ b/x-pack/plugins/maps/public/embeddable/map_embeddable.tsx
@@ -752,7 +752,7 @@ export class MapEmbeddable
     if (areLayersLoaded(this._savedMap.getStore().getState())) {
       const layers = getLayerList(this._savedMap.getStore().getState());
       const isLoading =
-        layers.length === 0 ||
+        layers.length !== 0 &&
         layers.some((layer) => {
           return layer.isLayerLoading();
         });

--- a/x-pack/plugins/maps/public/embeddable/map_embeddable.tsx
+++ b/x-pack/plugins/maps/public/embeddable/map_embeddable.tsx
@@ -61,7 +61,6 @@ import {
   getMapZoom,
   getHiddenLayerIds,
   getQueryableUniqueIndexPatternIds,
-  getWaitingForMapReadyLayerListRaw,
 } from '../selectors/map_selectors';
 import {
   APP_ID,
@@ -754,7 +753,7 @@ export class MapEmbeddable
       const mapState = this._savedMap.getStore().getState();
       const layers = getLayerList(mapState);
       const isLoading =
-        getWaitingForMapReadyLayerListRaw(mapState).length > 0 ||
+        !getMapReady(mapState) ||
         layers.some((layer) => {
           return layer.isLayerLoading();
         });

--- a/x-pack/test/functional/apps/dashboard/group2/dashboard_maps_by_value.ts
+++ b/x-pack/test/functional/apps/dashboard/group2/dashboard_maps_by_value.ts
@@ -26,6 +26,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const kibanaServer = getService('kibanaServer');
 
   const LAYER_NAME = 'World Countries';
+  let mapCounter = 0;
 
   async function createAndAddMapByValue() {
     log.debug(`createAndAddMapByValue`);
@@ -53,12 +54,9 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     if (saveToLibrary) {
       await testSubjects.click('importFileButton');
       await testSubjects.click('mapSaveButton');
-      await PageObjects.timeToVisualize.saveFromModal(
-        `my map ${Math.floor(Math.random() * 1000)}`,
-        {
-          redirectToOrigin: saveToDashboard,
-        }
-      );
+      await PageObjects.timeToVisualize.saveFromModal(`my map ${mapCounter++}`, {
+        redirectToOrigin: saveToDashboard,
+      });
 
       if (!saveToDashboard) {
         await appsMenu.clickLink('Dashboard');
@@ -76,8 +74,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     await PageObjects.dashboard.clickNewDashboard();
   }
 
-  // Failing: See https://github.com/elastic/kibana/issues/152476
-  describe.only('dashboard maps by value', function () {
+  describe('dashboard maps by value', function () {
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
       await kibanaServer.importExport.load(

--- a/x-pack/test/functional/apps/dashboard/group2/dashboard_maps_by_value.ts
+++ b/x-pack/test/functional/apps/dashboard/group2/dashboard_maps_by_value.ts
@@ -74,7 +74,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     await PageObjects.dashboard.clickNewDashboard();
   }
 
-  describe('dashboard maps by value', function () {
+  describe.only('dashboard maps by value', function () {
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
       await kibanaServer.importExport.load(

--- a/x-pack/test/functional/apps/dashboard/group2/dashboard_maps_by_value.ts
+++ b/x-pack/test/functional/apps/dashboard/group2/dashboard_maps_by_value.ts
@@ -74,7 +74,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     await PageObjects.dashboard.clickNewDashboard();
   }
 
-  describe.only('dashboard maps by value', function () {
+  describe('dashboard maps by value', function () {
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
       await kibanaServer.importExport.load(

--- a/x-pack/test/functional/apps/dashboard/group2/dashboard_maps_by_value.ts
+++ b/x-pack/test/functional/apps/dashboard/group2/dashboard_maps_by_value.ts
@@ -26,7 +26,6 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const kibanaServer = getService('kibanaServer');
 
   const LAYER_NAME = 'World Countries';
-  let mapCounter = 0;
 
   async function createAndAddMapByValue() {
     log.debug(`createAndAddMapByValue`);
@@ -54,11 +53,12 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     if (saveToLibrary) {
       await testSubjects.click('importFileButton');
       await testSubjects.click('mapSaveButton');
-      await PageObjects.timeToVisualize.ensureSaveModalIsOpen;
-
-      await PageObjects.timeToVisualize.saveFromModal(`my map ${mapCounter++}`, {
-        redirectToOrigin: saveToDashboard,
-      });
+      await PageObjects.timeToVisualize.saveFromModal(
+        `my map ${Math.floor(Math.random() * 1000)}`,
+        {
+          redirectToOrigin: saveToDashboard,
+        }
+      );
 
       if (!saveToDashboard) {
         await appsMenu.clickLink('Dashboard');
@@ -77,7 +77,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   }
 
   // Failing: See https://github.com/elastic/kibana/issues/152476
-  describe.skip('dashboard maps by value', function () {
+  describe.only('dashboard maps by value', function () {
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
       await kibanaServer.importExport.load(


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/152476

## Summary
The above test was failing because the map embeddable stayed in a loading state when there were zero layers due to a logic error. To summarize Nathan's explanation:

> Maps stores layers in `waitingForMapReadyLayerList` until MapLibre map is initialized.

> Once it is initialized, layers are moved from `waitingForMapReadyLayerList` to `layerList` in Redux ... [since] layers throw errors if they don't have certain state that is not available until MapLibre map is ready.

> This logic (`layers.length === 0`) was incorrectly added to account for this movement from `waitingForMapReadyLayerList` to `layerList`. But, yes, it does not work if your map has no layers

This PR fixes this by changing the logic as follows:
- If `waitingForMapReadyLayerList` has at least one layer, then MapLibre is still being initialized - so, keep the map embeddable in a loading state
- If `waitingForMapReadyLayerList` has no layers (i.e. all layers have been moved to `layerList`) but at least one of the layers in `layerList` is still loading, then the map embeddable should be in a loading state
- If neither of the above is true, then the map embeddable is done loading!

### Flaky Test Runner

<a href="https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/1988"><img src="https://user-images.githubusercontent.com/8698078/223270610-7417b7be-057d-466d-9790-03ebdaa1d407.png"/></a>

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
