### PR TITLE
[lens][maps] log warning when unable to fetch EMS boundaries for lens region map

### DIFF
--- a/docs/maps/connect-to-ems.asciidoc
+++ b/docs/maps/connect-to-ems.asciidoc
@@ -32,7 +32,7 @@ If you cannot connect to Elastic Maps Service from the {kib} server or browser c
 
 {hosted-ems} is a self-managed version of Elastic Maps Service offered as a Docker image that provides both the EMS basemaps and EMS boundaries. The image is bundled with basemaps up to zoom level 8. After connecting it to your {es} cluster for license validation, you have the option to download and configure a more detailed basemaps database.
 
-IMPORTANT: {hosted-ems} does not serve raster tiles, needed by Vega, coordinate, and region map visualizations.
+IMPORTANT: {hosted-ems} does not serve raster tiles needed by <<vega-with-a-map, vega maps>>.
 
 You can use +docker pull+ to download the {hosted-ems} image from the Elastic Docker registry.
 

--- a/docs/maps/connect-to-ems.asciidoc
+++ b/docs/maps/connect-to-ems.asciidoc
@@ -32,8 +32,6 @@ If you cannot connect to Elastic Maps Service from the {kib} server or browser c
 
 {hosted-ems} is a self-managed version of Elastic Maps Service offered as a Docker image that provides both the EMS basemaps and EMS boundaries. The image is bundled with basemaps up to zoom level 8. After connecting it to your {es} cluster for license validation, you have the option to download and configure a more detailed basemaps database.
 
-IMPORTANT: {hosted-ems} does not serve raster tiles needed by <<vega-with-a-map, vega maps>>.
-
 You can use +docker pull+ to download the {hosted-ems} image from the Elastic Docker registry.
 
 ifeval::["{release-state}"=="unreleased"]

--- a/packages/kbn-doc-links/src/get_doc_links.ts
+++ b/packages/kbn-doc-links/src/get_doc_links.ts
@@ -501,6 +501,7 @@ export const getDocLinks = ({ kibanaBranch }: GetDocLinkOptions): DocLinks => {
       healthMonitoring: `${KIBANA_DOCS}task-manager-health-monitoring.html`,
     },
     maps: {
+      connectToEms: `${KIBANA_DOCS}maps-connect-to-ems.html`,
       guide: `${KIBANA_DOCS}maps.html`,
       importGeospatialPrivileges: `${KIBANA_DOCS}import-geospatial-data.html#import-geospatial-privileges`,
       gdalTutorial: `${ELASTIC_WEBSITE_URL}blog/how-to-ingest-geospatial-data-into-elasticsearch-with-gdal`,

--- a/packages/kbn-doc-links/src/types.ts
+++ b/packages/kbn-doc-links/src/types.ts
@@ -383,6 +383,7 @@ export interface DocLinks {
     healthMonitoring: string;
   }>;
   readonly maps: Readonly<{
+    connectToEms: string;
     guide: string;
     importGeospatialPrivileges: string;
     gdalTutorial: string;

--- a/x-pack/plugins/maps/public/lens/choropleth_chart/setup.ts
+++ b/x-pack/plugins/maps/public/lens/choropleth_chart/setup.ts
@@ -36,7 +36,7 @@ export function setupLensChoroplethChart(
     } catch (error) {
       // eslint-disable-next-line no-console
       console.warn(
-        `Lens region map is unable to access boundaries from Elastic Maps Service (EMS). Set kibana.yml 'map.includeElasticMapsService: false' to avoid unnecessary EMS requests. For more details please visit ${coreStart.docLinks.links.maps.connectToEms}`
+        `Lens region map visualization is unable to access administrative boundaries from Elastic Maps Service (EMS). Set kibana.yml 'map.includeElasticMapsService: false' to avoid unnecessary EMS requests. For more details please visit ${coreStart.docLinks.links.maps.connectToEms}`
       );
     }
 

--- a/x-pack/plugins/maps/public/lens/choropleth_chart/setup.ts
+++ b/x-pack/plugins/maps/public/lens/choropleth_chart/setup.ts
@@ -36,7 +36,7 @@ export function setupLensChoroplethChart(
     } catch (error) {
       // eslint-disable-next-line no-console
       console.warn(
-        `Lens region map visualization is unable to access administrative boundaries from Elastic Maps Service (EMS). Set kibana.yml 'map.includeElasticMapsService: false' to avoid unnecessary EMS requests. For more details please visit ${coreStart.docLinks.links.maps.connectToEms}`
+        `Lens region map setup is unable to access administrative boundaries from Elastic Maps Service (EMS). Set kibana.yml 'map.includeElasticMapsService: false' to avoid unnecessary EMS requests. For more details please visit ${coreStart.docLinks.links.maps.connectToEms}`
       );
     }
 

--- a/x-pack/plugins/maps/public/lens/choropleth_chart/setup.ts
+++ b/x-pack/plugins/maps/public/lens/choropleth_chart/setup.ts
@@ -36,7 +36,7 @@ export function setupLensChoroplethChart(
     } catch (error) {
       // eslint-disable-next-line no-console
       console.warn(
-        `Lens region map setup is unable to access administrative boundaries from Elastic Maps Service (EMS). Set kibana.yml 'map.includeElasticMapsService: false' to avoid unnecessary EMS requests. For more details please visit ${coreStart.docLinks.links.maps.connectToEms}`
+        `Lens region map setup is unable to access administrative boundaries from Elastic Maps Service (EMS). To avoid unnecessary EMS requests, set 'map.includeElasticMapsService: false' in 'kibana.yml'. For more details please visit ${coreStart.docLinks.links.maps.connectToEms}`
       );
     }
 

--- a/x-pack/plugins/maps/public/lens/choropleth_chart/setup.ts
+++ b/x-pack/plugins/maps/public/lens/choropleth_chart/setup.ts
@@ -34,7 +34,10 @@ export function setupLensChoroplethChart(
     try {
       emsFileLayers = await getEmsFileLayers();
     } catch (error) {
-      // ignore error, lack of EMS file layers will be surfaced in dimension editor
+      // eslint-disable-next-line no-console
+      console.warn(
+        `Lens region map is unable to access boundaries from Elastic Maps Service (EMS). Set kibana.yml 'map.includeElasticMapsService: false' to avoid unnecessary EMS requests. For more details please visit ${coreStart.docLinks.links.maps.connectToEms}`
+      );
     }
 
     return getVisualization({

--- a/x-pack/plugins/maps/public/util.test.js
+++ b/x-pack/plugins/maps/public/util.test.js
@@ -16,11 +16,11 @@ jest.mock('./kibana_services', () => ({
     return {
       links: {
         maps: {
-          connectToEms: 'https://www.elastic.co/guide/en/kibana/current/maps-connect-to-ems.html'
-        }
-      }
+          connectToEms: 'https://www.elastic.co/guide/en/kibana/current/maps-connect-to-ems.html',
+        },
+      },
     };
-  }
+  },
 }));
 
 describe('getGlyphUrl', () => {

--- a/x-pack/plugins/maps/public/util.test.js
+++ b/x-pack/plugins/maps/public/util.test.js
@@ -11,6 +11,18 @@ import {
   testOnlyClearCanAccessEmsFontsPromise,
 } from './util';
 
+jest.mock('./kibana_services', () => ({
+  getDocLinks: () => {
+    return {
+      links: {
+        maps: {
+          connectToEms: 'https://www.elastic.co/guide/en/kibana/current/maps-connect-to-ems.html'
+        }
+      }
+    };
+  }
+}));
+
 describe('getGlyphUrl', () => {
   describe('EMS enabled', () => {
     beforeEach(() => {

--- a/x-pack/plugins/maps/public/util.ts
+++ b/x-pack/plugins/maps/public/util.ts
@@ -86,7 +86,7 @@ async function canAccessEmsFonts(): Promise<boolean> {
       } catch (error) {
         // eslint-disable-next-line no-console
         console.warn(
-          `Unable to access fonts from Elastic Maps Service (EMS). Set kibana.yml 'map.includeElasticMapsService: false' to avoid unnecessary EMS requests. For more details please visit: ${getDocLinks().links.maps.connectToEms}`
+          `Unable to access fonts from Elastic Maps Service (EMS). To avoid unnecessary EMS requests, set 'map.includeElasticMapsService: false' in 'kibana.yml'. For more details please visit: ${getDocLinks().links.maps.connectToEms}`
         );
         resolve(false);
       }

--- a/x-pack/plugins/maps/public/util.ts
+++ b/x-pack/plugins/maps/public/util.ts
@@ -86,7 +86,9 @@ async function canAccessEmsFonts(): Promise<boolean> {
       } catch (error) {
         // eslint-disable-next-line no-console
         console.warn(
-          `Unable to access fonts from Elastic Maps Service (EMS). To avoid unnecessary EMS requests, set 'map.includeElasticMapsService: false' in 'kibana.yml'. For more details please visit: ${getDocLinks().links.maps.connectToEms}`
+          `Unable to access fonts from Elastic Maps Service (EMS). To avoid unnecessary EMS requests, set 'map.includeElasticMapsService: false' in 'kibana.yml'. For more details please visit: ${
+            getDocLinks().links.maps.connectToEms
+          }`
         );
         resolve(false);
       }

--- a/x-pack/plugins/maps/public/util.ts
+++ b/x-pack/plugins/maps/public/util.ts
@@ -10,6 +10,7 @@ import { EMSClient, FileLayer, TMSService } from '@elastic/ems-client';
 import type { KibanaExecutionContext } from '@kbn/core/public';
 import { FONTS_API_PATH } from '../common/constants';
 import {
+  getDocLinks,
   getHttp,
   getTilemap,
   getEMSSettings,
@@ -85,7 +86,7 @@ async function canAccessEmsFonts(): Promise<boolean> {
       } catch (error) {
         // eslint-disable-next-line no-console
         console.warn(
-          `Unable to access fonts from Elastic Maps Service (EMS). Set kibana.yml 'map.includeElasticMapsService: false' to avoid unnecessary EMS requests.`
+          `Unable to access fonts from Elastic Maps Service (EMS). Set kibana.yml 'map.includeElasticMapsService: false' to avoid unnecessary EMS requests. For more details please visit: ${getDocLinks().links.maps.connectToEms}`
         );
         resolve(false);
       }


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/152495

<img width="500" alt="Screen Shot 2023-03-06 at 12 46 41 PM" src="https://user-images.githubusercontent.com/373691/223216940-0b41a775-cbf4-424d-ab89-6c1a3b8a4c14.png">


Running Kibana in an offline environment without setting `map.includeElasticMapsService: false` is an anti-pattern and leads to lens and maps visualizations delaying initialization while waiting for EMS connection. This PR ensures there is proper console notification. Better messaging should point users to the correct resolution of setting `map.includeElasticMapsService: false`.

The PR does not resolve the timeout issue. Not going to resolve the timeout issue since running in an offline environment without setting `map.includeElasticMapsService: false` is not supported.