### PR TITLE
[Cases] Adding comments indicating which fields are not indexed

### DIFF
--- a/x-pack/plugins/cases/server/saved_object_types/comments.ts
+++ b/x-pack/plugins/cases/server/saved_object_types/comments.ts
@@ -10,6 +10,11 @@ import { CASE_COMMENT_SAVED_OBJECT } from '../../common/constants';
 import type { CreateCommentsMigrationsDeps } from './migrations';
 import { createCommentsMigrations } from './migrations';
 
+/**
+ * The comments in the mapping indicate the additional properties that are stored in Elasticsearch but are not indexed.
+ * Remove these comments when https://github.com/elastic/kibana/issues/152756 is resolved.
+ */
+
 export const createCaseCommentSavedObjectType = ({
   migrationDeps,
 }: {
@@ -33,22 +38,68 @@ export const createCaseCommentSavedObjectType = ({
       },
       actions: {
         properties: {
+          /*
+          targets: {
+            properties: {
+              hostname: { type: 'keyword' },
+              endpointId: { type: 'keyword' },
+            }
+          }
+           */
           type: { type: 'keyword' },
         },
       },
       alertId: {
         type: 'keyword',
       },
+      /*
+      index: {
+        type: 'keyword',
+      }
+       */
       created_at: {
         type: 'date',
       },
       created_by: {
         properties: {
+          /*
+          full_name: {
+            type: 'keyword',
+          }
+          email: {
+            type: 'keyword',
+          }
+          profile_uid: {
+            type: 'keyword',
+          }
+           */
           username: {
             type: 'keyword',
           },
         },
       },
+      /*
+      externalReferenceId: {
+        type: 'keyword',
+      },
+      externalReferenceStorage: {
+        dynamic: false,
+        properties: {
+          // externalReferenceStorage.type
+          type: {
+            type: 'keyword',
+          },
+        },
+      },
+      externalReferenceMetadata: {
+        dynamic: false,
+        properties: {},
+      },
+      persistableStateAttachmentState: {
+        dynamic: false,
+        properties: {},
+      },
+       */
       externalReferenceAttachmentTypeId: {
         type: 'keyword',
       },
@@ -58,9 +109,55 @@ export const createCaseCommentSavedObjectType = ({
       pushed_at: {
         type: 'date',
       },
+      /*
+      pushed_by: {
+        properties: {
+          username: {
+            type: 'keyword',
+          },
+          full_name: {
+            type: 'keyword',
+          },
+          email: {
+            type: 'keyword',
+          },
+          profile_uid: {
+            type: 'keyword',
+          },
+        },
+      },
+      rule: {
+        properties: {
+          id: {
+            type: 'keyword',
+          },
+          name: {
+            type: 'keyword',
+          },
+        },
+      },
+      */
       updated_at: {
         type: 'date',
       },
+      /*
+      updated_by: {
+        properties: {
+          username: {
+            type: 'keyword',
+          },
+          full_name: {
+            type: 'keyword',
+          },
+          email: {
+            type: 'keyword',
+          },
+          profile_uid: {
+            type: 'keyword',
+          },
+        },
+      },
+      */
     },
   },
   migrations: () => createCommentsMigrations(migrationDeps),

--- a/x-pack/plugins/cases/server/saved_object_types/configure.ts
+++ b/x-pack/plugins/cases/server/saved_object_types/configure.ts
@@ -9,6 +9,11 @@ import type { SavedObjectsType } from '@kbn/core/server';
 import { CASE_CONFIGURE_SAVED_OBJECT } from '../../common/constants';
 import { configureMigrations } from './migrations';
 
+/**
+ * The comments in the mapping indicate the additional properties that are stored in Elasticsearch but are not indexed.
+ * Remove these comments when https://github.com/elastic/kibana/issues/152756 is resolved.
+ */
+
 export const caseConfigureSavedObjectType: SavedObjectsType = {
   name: CASE_CONFIGURE_SAVED_OBJECT,
   hidden: true,
@@ -20,12 +25,71 @@ export const caseConfigureSavedObjectType: SavedObjectsType = {
       created_at: {
         type: 'date',
       },
+      /*
+      created_by: {
+        properties: {
+          email: {
+            type: 'keyword',
+          },
+          username: {
+            type: 'keyword',
+          },
+          full_name: {
+            type: 'keyword',
+          },
+          profile_uid: {
+            type: 'keyword',
+          },
+        },
+      },
+      connector: {
+        properties: {
+          name: {
+            type: 'text',
+          },
+          type: {
+            type: 'keyword',
+          },
+          fields: {
+            properties: {
+              key: {
+                type: 'text',
+              },
+              value: {
+                type: 'text',
+              },
+            },
+          },
+        },
+      },
+      */
       closure_type: {
         type: 'keyword',
       },
       owner: {
         type: 'keyword',
       },
+      /*
+      updated_at: {
+        type: 'date',
+      },
+      updated_by: {
+        properties: {
+          email: {
+            type: 'keyword',
+          },
+          username: {
+            type: 'keyword',
+          },
+          full_name: {
+            type: 'keyword',
+          },
+          profile_uid: {
+            type: 'keyword',
+          },
+        },
+      },
+      */
     },
   },
   migrations: configureMigrations,

--- a/x-pack/plugins/cases/server/saved_object_types/connector_mappings.ts
+++ b/x-pack/plugins/cases/server/saved_object_types/connector_mappings.ts
@@ -9,6 +9,11 @@ import type { SavedObjectsType } from '@kbn/core/server';
 import { CASE_CONNECTOR_MAPPINGS_SAVED_OBJECT } from '../../common/constants';
 import { connectorMappingsMigrations } from './migrations';
 
+/**
+ * The comments in the mapping indicate the additional properties that are stored in Elasticsearch but are not indexed.
+ * Remove these comments when https://github.com/elastic/kibana/issues/152756 is resolved.
+ */
+
 export const caseConnectorMappingsSavedObjectType: SavedObjectsType = {
   name: CASE_CONNECTOR_MAPPINGS_SAVED_OBJECT,
   hidden: true,
@@ -17,6 +22,21 @@ export const caseConnectorMappingsSavedObjectType: SavedObjectsType = {
   mappings: {
     dynamic: false,
     properties: {
+      /*
+      mappings: {
+        properties: {
+          source: {
+            type: 'keyword',
+          },
+          target: {
+            type: 'keyword',
+          },
+          action_type: {
+            type: 'keyword',
+          },
+        },
+      },
+      */
       owner: {
         type: 'keyword',
       },

--- a/x-pack/plugins/cases/server/saved_object_types/user_actions.ts
+++ b/x-pack/plugins/cases/server/saved_object_types/user_actions.ts
@@ -10,6 +10,11 @@ import { CASE_USER_ACTION_SAVED_OBJECT } from '../../common/constants';
 import type { UserActionsMigrationsDeps } from './migrations/user_actions';
 import { createUserActionsMigrations } from './migrations/user_actions';
 
+/**
+ * The comments in the mapping indicate the additional properties that are stored in Elasticsearch but are not indexed.
+ * Remove these comments when https://github.com/elastic/kibana/issues/152756 is resolved.
+ */
+
 export const createCaseUserActionSavedObjectType = (
   migrationDeps: UserActionsMigrationsDeps
 ): SavedObjectsType => ({
@@ -28,6 +33,17 @@ export const createCaseUserActionSavedObjectType = (
       },
       created_by: {
         properties: {
+          /*
+          email: {
+            type: 'keyword',
+          },
+          full_name: {
+            type: 'keyword',
+          },
+          profile_uid: {
+            type: 'keyword',
+          },
+          */
           username: {
             type: 'keyword',
           },


### PR DESCRIPTION
This PR adds comments to the various mapping files that had fields removed as part of removing fields that should not be indexed.

This PR removed the fields from being mapped: https://github.com/elastic/kibana/pull/151511

This serves to indicate which fields are stored in elasticsearch even though they are not mapped. Once we have resolved this issue: https://github.com/elastic/kibana/issues/152756 we can remove these comments.