### PR TITLE
Renames EUI icon usages of "crossInACircleFilled" to "error" and "alert" to "warning"

### DIFF
--- a/examples/files_example/public/components/app.tsx
+++ b/examples/files_example/public/components/app.tsx
@@ -87,7 +87,7 @@ export const FilesExampleApp = ({ files, notifications }: FilesExampleAppDeps) =
         ) : status === 'AWAITING_UPLOAD' ? (
           <EuiIcon type="clock" aria-label={status} />
         ) : (
-          <EuiIcon color="danger" type="alert" arial-label={status} />
+          <EuiIcon color="danger" type="warning" arial-label={status} />
         ),
     },
     {

--- a/examples/files_example/public/components/confirm_button.tsx
+++ b/examples/files_example/public/components/confirm_button.tsx
@@ -30,7 +30,7 @@ export const ConfirmButtonIcon: FunctionComponent<Props> = ({
         disabled={disabled}
         aria-label={confirmationText}
         color="warning"
-        iconType="alert"
+        iconType="warning"
         onClick={onConfirm}
       />
     </EuiToolTip>

--- a/examples/response_stream/public/containers/app/pages/page_simple_string_stream/index.tsx
+++ b/examples/response_stream/public/containers/app/pages/page_simple_string_stream/index.tsx
@@ -83,7 +83,7 @@ export const PageSimpleStringStream: FC = () => {
         <p>{data}</p>
       </EuiText>
       {errors.length > 0 && (
-        <EuiCallOut title="Sorry, there was an error" color="danger" iconType="alert">
+        <EuiCallOut title="Sorry, there was an error" color="danger" iconType="warning">
           {errors.length === 1 ? (
             <p>{errors[0]}</p>
           ) : (

--- a/examples/routing_example/public/get_message_example.tsx
+++ b/examples/routing_example/public/get_message_example.tsx
@@ -70,7 +70,7 @@ export function GetMessageRouteExample({ getMessageById }: Props) {
         </EuiFormRow>
 
         {error !== undefined ? (
-          <EuiCallOut color="danger" iconType="alert">
+          <EuiCallOut color="danger" iconType="warning">
             {error.message}
           </EuiCallOut>
         ) : null}

--- a/examples/routing_example/public/post_message_example.tsx
+++ b/examples/routing_example/public/post_message_example.tsx
@@ -82,7 +82,7 @@ export function PostMessageRouteExample({ postMessage, addSuccessToast }: Props)
         </EuiFormRow>
 
         {error !== undefined ? (
-          <EuiCallOut color="danger" iconType="alert">
+          <EuiCallOut color="danger" iconType="warning">
             {error.message}
           </EuiCallOut>
         ) : null}

--- a/examples/routing_example/public/random_number_between_example.tsx
+++ b/examples/routing_example/public/random_number_between_example.tsx
@@ -71,7 +71,7 @@ export function RandomNumberBetweenRouteExample({ fetchRandomNumberBetween }: Pr
         </EuiFormRow>
 
         {error !== undefined ? (
-          <EuiCallOut color="danger" iconType="alert">
+          <EuiCallOut color="danger" iconType="warning">
             {error.message}
           </EuiCallOut>
         ) : null}

--- a/examples/routing_example/public/random_number_example.tsx
+++ b/examples/routing_example/public/random_number_example.tsx
@@ -52,7 +52,7 @@ export function RandomNumberRouteExample({ fetchRandomNumber }: Props) {
         </EuiButton>
 
         {error !== undefined ? (
-          <EuiCallOut color="danger" iconType="alert">
+          <EuiCallOut color="danger" iconType="warning">
             {error}
           </EuiCallOut>
         ) : null}

--- a/examples/search_examples/public/search/app.tsx
+++ b/examples/search_examples/public/search/app.tsx
@@ -784,7 +784,7 @@ export const SearchExamplesApp = ({
                 <EuiButtonEmpty
                   size="xs"
                   onClick={() => data.search.session.start()}
-                  iconType="alert"
+                  iconType="warning"
                   data-test-subj="searchExamplesStartSession"
                 >
                   <FormattedMessage
@@ -795,7 +795,7 @@ export const SearchExamplesApp = ({
                 <EuiButtonEmpty
                   size="xs"
                   onClick={() => data.search.session.clear()}
-                  iconType="alert"
+                  iconType="warning"
                   data-test-subj="searchExamplesClearSession"
                 >
                   <FormattedMessage

--- a/packages/content-management/table_list/src/table_list_view.tsx
+++ b/packages/content-management/table_list/src/table_list_view.tsx
@@ -724,7 +724,7 @@ function TableListViewComp<T extends UserContentCommonSchema>({
             />
           }
           color="danger"
-          iconType="alert"
+          iconType="warning"
         >
           <p>
             <FormattedMessage

--- a/packages/core/application/core-application-browser-internal/src/ui/app_not_found_screen.tsx
+++ b/packages/core/application/core-application-browser-internal/src/ui/app_not_found_screen.tsx
@@ -20,7 +20,7 @@ export const AppNotFound = () => (
     <EuiPageBody>
       <EuiPageContent verticalPosition="center" horizontalPosition="center">
         <EuiEmptyPrompt
-          iconType="alert"
+          iconType="warning"
           iconColor="danger"
           title={
             <h2>

--- a/packages/core/apps/core-apps-browser-internal/src/errors/error_application.tsx
+++ b/packages/core/apps/core-apps-browser-internal/src/errors/error_application.tsx
@@ -40,7 +40,7 @@ const ErrorPage: React.FC<Props> = ({ title, children }) => {
       <EuiPageBody>
         <EuiPageContent verticalPosition="center" horizontalPosition="center">
           <EuiEmptyPrompt
-            iconType="alert"
+            iconType="warning"
             iconColor="danger"
             title={<h2>{title}</h2>}
             body={children}

--- a/packages/core/fatal-errors/core-fatal-errors-browser-internal/src/fatal_errors_screen.tsx
+++ b/packages/core/fatal-errors/core-fatal-errors-browser-internal/src/fatal_errors_screen.tsx
@@ -79,7 +79,7 @@ export class FatalErrorsScreen extends React.Component<Props, State> {
         <EuiPageBody>
           <EuiPageContent verticalPosition="center" horizontalPosition="center">
             <EuiEmptyPrompt
-              iconType="alert"
+              iconType="warning"
               iconColor="danger"
               title={
                 <h2>
@@ -119,7 +119,7 @@ export class FatalErrorsScreen extends React.Component<Props, State> {
               ]}
             />
             {this.state.errors.map((error, i) => (
-              <EuiCallOut key={i} title={error.message} color="danger" iconType="alert">
+              <EuiCallOut key={i} title={error.message} color="danger" iconType="warning">
                 <EuiCodeBlock language="bash" className="eui-textBreakAll">
                   {`Version: ${this.props.kibanaVersion}` +
                     '\n' +

--- a/packages/kbn-securitysolution-autocomplete/src/field/use_field.tsx
+++ b/packages/kbn-securitysolution-autocomplete/src/field/use_field.tsx
@@ -231,7 +231,7 @@ export const useField = ({
             {label}
             <EuiIcon
               tabIndex={0}
-              type="alert"
+              type="warning"
               title={i18n.FIELD_CONFLICT_INDICES_WARNING_TITLE}
               size="s"
               css={{ marginLeft: `${sPaddingSize}` }}

--- a/packages/shared-ux/file/file_picker/impl/src/components/error_content.tsx
+++ b/packages/shared-ux/file/file_picker/impl/src/components/error_content.tsx
@@ -23,7 +23,7 @@ export const ErrorContent: FunctionComponent<Props> = ({ error }) => {
   return (
     <EuiEmptyPrompt
       data-test-subj="errorPrompt"
-      iconType="alert"
+      iconType="warning"
       iconColor="danger"
       titleSize="xs"
       title={<h3>{i18nTexts.loadingFilesErrorTitle}</h3>}

--- a/src/plugins/advanced_settings/public/management_app/advanced_settings.tsx
+++ b/src/plugins/advanced_settings/public/management_app/advanced_settings.tsx
@@ -61,7 +61,7 @@ export class AdvancedSettings extends Component<AdvancedSettingsProps> {
     return (
       <div>
         <EuiSpacer size="xl" />
-        <EuiCallOut title={this.props.callOutTitle} iconType="alert">
+        <EuiCallOut title={this.props.callOutTitle} iconType="warning">
           <p>{this.props.callOutSubtitle}</p>
         </EuiCallOut>
         <EuiSpacer size="xl" />

--- a/src/plugins/chart_expressions/expression_tagcloud/public/components/tagcloud_component.tsx
+++ b/src/plugins/chart_expressions/expression_tagcloud/public/components/tagcloud_component.tsx
@@ -218,7 +218,7 @@ export const TagCloudChart = ({
           {warning && (
             <div className="tgcChart__warning">
               <EuiIconTip
-                type="alert"
+                type="warning"
                 color="warning"
                 content={
                   <FormattedMessage
@@ -232,7 +232,7 @@ export const TagCloudChart = ({
           {tagCloudData.length > MAX_TAG_COUNT && (
             <div className="tgcChart__warning">
               <EuiIconTip
-                type="alert"
+                type="warning"
                 color="warning"
                 content={
                   <FormattedMessage

--- a/src/plugins/charts/public/static/components/warnings.tsx
+++ b/src/plugins/charts/public/static/components/warnings.tsx
@@ -58,7 +58,7 @@ export function Warnings({
                 }
               `}
               iconSize="s"
-              iconType="alert"
+              iconType="warning"
               minWidth={0}
               onClick={onWarningButtonClick}
               size="s"
@@ -69,7 +69,7 @@ export function Warnings({
           ) : (
             <EuiButtonEmpty
               color="warning"
-              iconType="alert"
+              iconType="warning"
               onClick={onWarningButtonClick}
               size="xs"
               data-test-subj={dataTestSubj}

--- a/src/plugins/console/public/application/components/something_went_wrong_callout.tsx
+++ b/src/plugins/console/public/application/components/something_went_wrong_callout.tsx
@@ -24,7 +24,7 @@ export const SomethingWentWrongCallout: FunctionComponent<Props> = ({ error, onB
 
   return (
     <EuiCallOut
-      iconType="alert"
+      iconType="warning"
       color="danger"
       title={i18n.translate('console.loadingError.title', {
         defaultMessage: 'Cannot load Console',

--- a/src/plugins/controls/public/options_list/components/options_list_popover_title.tsx
+++ b/src/plugins/controls/public/options_list/components/options_list_popover_title.tsx
@@ -34,7 +34,7 @@ export const OptionsListPopoverTitle = () => {
           <EuiFlexItem data-test-subj="optionsList-allow-expensive-queries-warning" grow={false}>
             <EuiIconTip
               aria-label="Warning"
-              type="alert"
+              type="warning"
               color="warning"
               content={OptionsListStrings.popover.getAllowExpensiveQueriesWarning()}
             />

--- a/src/plugins/data/public/search/session/sessions_mgmt/components/status.tsx
+++ b/src/plugins/data/public/search/session/sessions_mgmt/components/status.tsx
@@ -104,7 +104,7 @@ const getStatusAttributes = ({
 
     case SearchSessionStatus.CANCELLED:
       return {
-        icon: <EuiIcon color="#9AA" type="crossInACircleFilled" />,
+        icon: <EuiIcon color="#9AA" type="error" />,
         label: <TableText>{getStatusText(session.status)}</TableText>,
         toolTipContent: i18n.translate('data.mgmt.searchSessions.status.message.cancelled', {
           defaultMessage: 'Cancelled by user',
@@ -114,7 +114,7 @@ const getStatusAttributes = ({
     case SearchSessionStatus.ERROR:
       return {
         textColor: 'danger',
-        icon: <EuiIcon color="danger" type="crossInACircleFilled" />,
+        icon: <EuiIcon color="danger" type="error" />,
         label: <TableText>{getStatusText(session.status)}</TableText>,
         toolTipContent:
           session.errors && session.errors.length > 0

--- a/src/plugins/data/public/search/session/sessions_mgmt/lib/get_columns.tsx
+++ b/src/plugins/data/public/search/session/sessions_mgmt/lib/get_columns.tsx
@@ -107,7 +107,7 @@ export const getColumns = (
           <>
             {' '}
             <EuiIconTip
-              type="alert"
+              type="warning"
               content={
                 <FormattedMessage
                   id="data.mgmt.searchSessions.table.notRestorableWarning"
@@ -127,7 +127,7 @@ export const getColumns = (
             <>
               {' '}
               <EuiIconTip
-                type="alert"
+                type="warning"
                 iconProps={{ 'data-test-subj': 'versionIncompatibleWarningTestSubj' }}
                 content={
                   <FormattedMessage

--- a/src/plugins/data/public/shard_failure_modal/shard_failure_modal.tsx
+++ b/src/plugins/data/public/shard_failure_modal/shard_failure_modal.tsx
@@ -41,7 +41,7 @@ export function ShardFailureModal({ request, response, title, onClose }: Props) 
   ) {
     // this should never ever happen, but just in case
     return (
-      <EuiCallOut title="Sorry, there was an error" color="danger" iconType="alert">
+      <EuiCallOut title="Sorry, there was an error" color="danger" iconType="warning">
         The ShardFailureModal component received invalid properties
       </EuiCallOut>
     );

--- a/src/plugins/data_view_field_editor/public/components/confirm_modals/delete_field_modal.tsx
+++ b/src/plugins/data_view_field_editor/public/components/confirm_modals/delete_field_modal.tsx
@@ -99,7 +99,7 @@ export function DeleteFieldModal({ fieldsToDelete, closeModal, confirmDelete }: 
       confirmButtonText={confirmButtonText}
       confirmButtonDisabled={confirmContent?.toUpperCase() !== 'REMOVE'}
     >
-      <EuiCallOut color="warning" title={i18nTexts.warningRemovingFields} iconType="alert" size="s">
+      <EuiCallOut color="warning" title={i18nTexts.warningRemovingFields} iconType="warning" size="s">
         {isMultiple && (
           <>
             <p>{warningMultipleFields}</p>

--- a/src/plugins/data_view_field_editor/public/components/confirm_modals/delete_field_modal.tsx
+++ b/src/plugins/data_view_field_editor/public/components/confirm_modals/delete_field_modal.tsx
@@ -99,7 +99,12 @@ export function DeleteFieldModal({ fieldsToDelete, closeModal, confirmDelete }: 
       confirmButtonText={confirmButtonText}
       confirmButtonDisabled={confirmContent?.toUpperCase() !== 'REMOVE'}
     >
-      <EuiCallOut color="warning" title={i18nTexts.warningRemovingFields} iconType="warning" size="s">
+      <EuiCallOut
+        color="warning"
+        title={i18nTexts.warningRemovingFields}
+        iconType="warning"
+        size="s"
+      >
         {isMultiple && (
           <>
             <p>{warningMultipleFields}</p>

--- a/src/plugins/data_view_field_editor/public/components/confirm_modals/save_field_type_or_name_changed_modal.tsx
+++ b/src/plugins/data_view_field_editor/public/components/confirm_modals/save_field_type_or_name_changed_modal.tsx
@@ -70,7 +70,7 @@ export const SaveFieldTypeOrNameChangedModal: React.FC<Props> = ({
       <EuiCallOut
         color="warning"
         title={i18nTexts.warningChangingFields}
-        iconType="alert"
+        iconType="warning"
         size="s"
       />
       <EuiSpacer />

--- a/src/plugins/data_view_field_editor/public/components/field_editor/field_editor.tsx
+++ b/src/plugins/data_view_field_editor/public/components/field_editor/field_editor.tsx
@@ -276,7 +276,7 @@ const FieldEditorComponent = ({ field, onChange, onFormModifiedChange }: Props) 
           <EuiCallOut
             color="warning"
             title={changeWarning}
-            iconType="alert"
+            iconType="warning"
             size="s"
             data-test-subj="changeWarning"
           />

--- a/src/plugins/data_view_field_editor/public/components/preview/field_list/field_list_item.tsx
+++ b/src/plugins/data_view_field_editor/public/components/preview/field_list/field_list_item.tsx
@@ -83,7 +83,7 @@ export const PreviewListItem: React.FC<Props> = ({
     if (hasScriptError) {
       return (
         <div>
-          <EuiBadge iconType="alert" color="danger" data-test-subj="scriptErrorBadge">
+          <EuiBadge iconType="warning" color="danger" data-test-subj="scriptErrorBadge">
             {i18n.translate('indexPatternFieldEditor.fieldPreview.scriptErrorBadgeLabel', {
               defaultMessage: 'Script error',
             })}

--- a/src/plugins/data_view_field_editor/public/components/preview/field_preview.tsx
+++ b/src/plugins/data_view_field_editor/public/components/preview/field_preview.tsx
@@ -98,7 +98,7 @@ export const FieldPreview = () => {
                 }
               )}
               color="warning"
-              iconType="alert"
+              iconType="warning"
               role="alert"
               data-test-subj="previewNotAvailableCallout"
             >

--- a/src/plugins/data_view_field_editor/public/components/preview/field_preview_error.tsx
+++ b/src/plugins/data_view_field_editor/public/components/preview/field_preview_error.tsx
@@ -26,7 +26,7 @@ export const FieldPreviewError = () => {
         defaultMessage: 'Error fetching document',
       })}
       color="danger"
-      iconType="alert"
+      iconType="warning"
       role="alert"
       data-test-subj="fetchDocError"
     >

--- a/src/plugins/data_view_management/public/components/edit_index_pattern/edit_index_pattern.tsx
+++ b/src/plugins/data_view_management/public/components/edit_index_pattern/edit_index_pattern.tsx
@@ -249,7 +249,7 @@ export const EditIndexPattern = withRouter(
           {conflictedFields.length > 0 && (
             <>
               <EuiSpacer />
-              <EuiCallOut title={mappingConflictHeader} color="warning" iconType="alert">
+              <EuiCallOut title={mappingConflictHeader} color="warning" iconType="warning">
                 <p>{mappingConflictLabel}</p>
               </EuiCallOut>
             </>

--- a/src/plugins/data_view_management/public/components/edit_index_pattern/indexed_fields_table/components/table/table.tsx
+++ b/src/plugins/data_view_management/public/components/edit_index_pattern/indexed_fields_table/components/table/table.tsx
@@ -357,7 +357,7 @@ const getConflictBtn = (
     <span>
       <EuiBadge
         color="warning"
-        iconType="alert"
+        iconType="warning"
         onClick={onClick}
         iconOnClick={onClick}
         iconOnClickAriaLabel={conflictDetailIconAria}

--- a/src/plugins/data_view_management/public/components/edit_index_pattern/scripted_fields_table/components/header/header.tsx
+++ b/src/plugins/data_view_management/public/components/edit_index_pattern/scripted_fields_table/components/header/header.tsx
@@ -35,7 +35,7 @@ export const Header = withRouter(({ indexPatternId, history }: HeaderProps) => {
               defaultMessage="Scripted fields can be used in visualizations and displayed in documents. However, they cannot be searched."
             />
             <br />
-            <EuiIcon type="alert" color="warning" style={{ marginRight: '4px' }} />
+            <EuiIcon type="warning" color="warning" style={{ marginRight: '4px' }} />
             <FormattedMessage
               id="indexPatternManagement.editIndexPattern.deprecation"
               defaultMessage="Scripted fields are deprecated. Use {runtimeDocs} instead."

--- a/src/plugins/data_view_management/public/components/field_editor/components/scripting_call_outs/disabled_call_out.tsx
+++ b/src/plugins/data_view_management/public/components/field_editor/components/scripting_call_outs/disabled_call_out.tsx
@@ -24,7 +24,7 @@ export const ScriptingDisabledCallOut = ({ isVisible = false }) => {
           />
         }
         color="danger"
-        iconType="alert"
+        iconType="warning"
       >
         <p>
           <FormattedMessage

--- a/src/plugins/data_view_management/public/components/field_editor/components/scripting_call_outs/warning_call_out.tsx
+++ b/src/plugins/data_view_management/public/components/field_editor/components/scripting_call_outs/warning_call_out.tsx
@@ -54,7 +54,7 @@ export const ScriptingWarningCallOut = ({ isVisible = false }: ScriptingWarningC
       <EuiSpacer size="m" />
       <EuiCallOut
         color="warning"
-        iconType="alert"
+        iconType="warning"
         title={
           <FormattedMessage
             id="indexPatternManagement.scriptedFieldsDeprecatedTitle"

--- a/src/plugins/data_view_management/public/components/field_editor/field_editor.tsx
+++ b/src/plugins/data_view_management/public/components/field_editor/field_editor.tsx
@@ -280,7 +280,7 @@ export class FieldEditor extends PureComponent<FieldEdiorProps, FieldEditorState
         helpText={
           this.isDuplicateName() ? (
             <span>
-              <EuiIcon type="alert" color="warning" size="s" />
+              <EuiIcon type="warning" color="warning" size="s" />
               &nbsp;
               <FormattedMessage
                 id="indexPatternManagement.mappingConflictLabel.mappingConflictDetail"
@@ -342,7 +342,7 @@ export class FieldEditor extends PureComponent<FieldEdiorProps, FieldEditorState
         helpText={
           isDeprecatedLang ? (
             <span>
-              <EuiIcon type="alert" color="warning" size="s" />
+              <EuiIcon type="warning" color="warning" size="s" />
               &nbsp;
               <strong>
                 <FormattedMessage
@@ -471,7 +471,7 @@ export class FieldEditor extends PureComponent<FieldEdiorProps, FieldEditorState
         <EuiSpacer size="m" />
         <EuiCallOut
           color="warning"
-          iconType="alert"
+          iconType="warning"
           title={
             <FormattedMessage
               id="indexPatternManagement.fieldTypeConflict"

--- a/src/plugins/data_view_management/public/components/index_pattern_table/delete_modal_msg.tsx
+++ b/src/plugins/data_view_management/public/components/index_pattern_table/delete_modal_msg.tsx
@@ -55,7 +55,7 @@ export const deleteModalMsg = (views: RemoveDataViewProps[], hasSpaces: boolean)
     <div>
       <EuiCallOut
         color="warning"
-        iconType="alert"
+        iconType="warning"
         title="Data views are deleted from every space they are shared in."
       />
       <EuiSpacer size="m" />

--- a/src/plugins/discover/public/application/context/components/context_error_message/context_error_message.tsx
+++ b/src/plugins/discover/public/application/context/components/context_error_message/context_error_message.tsx
@@ -35,7 +35,7 @@ export function ContextErrorMessage({ status }: ContextErrorMessageProps) {
         />
       }
       color="danger"
-      iconType="alert"
+      iconType="warning"
       data-test-subj="contextErrorMessageTitle"
     >
       <EuiText data-test-subj="contextErrorMessageBody">

--- a/src/plugins/discover/public/application/context/context_app_route.tsx
+++ b/src/plugins/discover/public/application/context/context_app_route.tsx
@@ -54,7 +54,7 @@ export function ContextAppRoute() {
   if (error) {
     return (
       <EuiEmptyPrompt
-        iconType="alert"
+        iconType="warning"
         iconColor="danger"
         title={
           <FormattedMessage

--- a/src/plugins/discover/public/application/doc/components/doc.tsx
+++ b/src/plugins/discover/public/application/doc/components/doc.tsx
@@ -83,7 +83,7 @@ export function Doc(props: DocProps) {
           <EuiCallOut
             color="danger"
             data-test-subj={`doc-msg-notFoundDataView`}
-            iconType="alert"
+            iconType="warning"
             title={
               <FormattedMessage
                 id="discover.doc.failedToLocateDataView"
@@ -97,7 +97,7 @@ export function Doc(props: DocProps) {
           <EuiCallOut
             color="danger"
             data-test-subj={`doc-msg-notFound`}
-            iconType="alert"
+            iconType="warning"
             title={
               <FormattedMessage
                 id="discover.doc.failedToLocateDocumentDescription"
@@ -116,7 +116,7 @@ export function Doc(props: DocProps) {
           <EuiCallOut
             color="danger"
             data-test-subj={`doc-msg-error`}
-            iconType="alert"
+            iconType="warning"
             title={
               <FormattedMessage
                 id="discover.doc.failedToExecuteQueryDescription"

--- a/src/plugins/discover/public/application/doc/single_doc_route.tsx
+++ b/src/plugins/discover/public/application/doc/single_doc_route.tsx
@@ -55,7 +55,7 @@ export const SingleDocRoute = () => {
   if (error) {
     return (
       <EuiEmptyPrompt
-        iconType="alert"
+        iconType="warning"
         iconColor="danger"
         title={
           <FormattedMessage

--- a/src/plugins/discover/public/application/main/components/no_results/no_results.tsx
+++ b/src/plugins/discover/public/application/main/components/no_results/no_results.tsx
@@ -54,7 +54,7 @@ export function DiscoverNoResults({
           />
         }
         color="danger"
-        iconType="alert"
+        iconType="warning"
         data-test-subj="discoverNoResultsError"
       >
         <EuiButton

--- a/src/plugins/discover/public/application/main/components/sidebar/discover_field.tsx
+++ b/src/plugins/discover/public/application/main/components/sidebar/discover_field.tsx
@@ -49,7 +49,7 @@ const FieldInfoIcon: React.FC = memo(() => (
   >
     <EuiIcon
       tabIndex={0}
-      type="alert"
+      type="warning"
       title={i18n.translate('discover.field.mappingConflict.title', {
         defaultMessage: 'Mapping Conflict',
       })}

--- a/src/plugins/discover/public/components/common/error_alert.tsx
+++ b/src/plugins/discover/public/components/common/error_alert.tsx
@@ -22,7 +22,7 @@ export const DiscoverError = ({ error }: { error: Error }) => {
   return (
     <EuiEmptyPrompt
       paddingSize="l"
-      iconType="alert"
+      iconType="warning"
       iconColor="danger"
       title={
         <h2>

--- a/src/plugins/discover/public/components/doc_table/components/table_header/score_sort_warning.tsx
+++ b/src/plugins/discover/public/components/doc_table/components/table_header/score_sort_warning.tsx
@@ -15,5 +15,5 @@ export function DocViewTableScoreSortWarning() {
     defaultMessage: 'In order to retrieve values for _score, you must sort by it.',
   });
 
-  return <EuiIconTip content={tooltipContent} color="warning" size="s" type="alert" />;
+  return <EuiIconTip content={tooltipContent} color="warning" size="s" type="warning" />;
 }

--- a/src/plugins/discover/public/services/doc_views/components/doc_viewer_source/source.tsx
+++ b/src/plugins/discover/public/services/doc_views/components/doc_viewer_source/source.tsx
@@ -115,7 +115,7 @@ export const DocViewerSource = ({
     </div>
   );
   const errorState = (
-    <EuiEmptyPrompt iconType="alert" title={errorMessageTitle} body={errorMessage} />
+    <EuiEmptyPrompt iconType="warning" title={errorMessageTitle} body={errorMessage} />
   );
 
   if (reqState === ElasticRequestState.Error || reqState === ElasticRequestState.NotFound) {

--- a/src/plugins/discover/public/services/doc_views/components/doc_viewer_table/table_cell_value.tsx
+++ b/src/plugins/discover/public/services/doc_views/components/doc_viewer_table/table_cell_value.tsx
@@ -65,7 +65,7 @@ const IgnoreWarning: React.FC<IgnoreWarningProps> = React.memo(({ rawValue, reas
         `}
       >
         <EuiFlexItem grow={false}>
-          <EuiIcon type="alert" color="warning" />
+          <EuiIcon type="warning" color="warning" />
         </EuiFlexItem>
         <EuiFlexItem>
           <EuiTextColor color="warning">

--- a/src/plugins/embeddable/public/lib/panel/embeddable_panel_error.tsx
+++ b/src/plugins/embeddable/public/lib/panel/embeddable_panel_error.tsx
@@ -72,7 +72,7 @@ export function EmbeddablePanelError({
         </EuiText>
       }
       data-test-subj="embeddableStackError"
-      iconType="alert"
+      iconType="warning"
       iconColor="danger"
       layout="vertical"
       actions={

--- a/src/plugins/es_ui_shared/__packages_do_not_import__/authorization/components/page_error.tsx
+++ b/src/plugins/es_ui_shared/__packages_do_not_import__/authorization/components/page_error.tsx
@@ -65,7 +65,7 @@ export const PageError: React.FunctionComponent<Props> = ({
             </>
           )
         }
-        iconType="alert"
+        iconType="warning"
         actions={actions}
         {...rest}
       />

--- a/src/plugins/es_ui_shared/__packages_do_not_import__/authorization/components/section_error.tsx
+++ b/src/plugins/es_ui_shared/__packages_do_not_import__/authorization/components/section_error.tsx
@@ -29,7 +29,7 @@ export const SectionError: React.FunctionComponent<Props> = ({
   } = error;
 
   return (
-    <EuiCallOut title={title} color="danger" iconType="alert" {...rest}>
+    <EuiCallOut title={title} color="danger" iconType="warning" {...rest}>
       {cause ? message || errorString : <p>{message || errorString}</p>}
       {cause && (
         <Fragment>

--- a/src/plugins/expression_error/public/components/error_component.tsx
+++ b/src/plugins/expression_error/public/components/error_component.tsx
@@ -52,7 +52,7 @@ function ErrorComponent({ onLoaded, parentNode, error }: ErrorComponentProps) {
               height: buttonSize,
               width: buttonSize,
             }}
-            type="alert"
+            type="warning"
           />
         }
         isOpen={isPopoverOpen}

--- a/src/plugins/guided_onboarding/public/components/guide_panel.tsx
+++ b/src/plugins/guided_onboarding/public/components/guide_panel.tsx
@@ -68,7 +68,7 @@ const getProgress = (state?: GuideState): number => {
 const errorSection = (
   <EuiEmptyPrompt
     data-test-subj="guideErrorSection"
-    iconType="alert"
+    iconType="warning"
     color="danger"
     title={
       <h2>

--- a/src/plugins/home/public/application/components/guided_onboarding/getting_started.tsx
+++ b/src/plugins/home/public/application/components/guided_onboarding/getting_started.tsx
@@ -146,7 +146,7 @@ export const GettingStarted = () => {
   if (isError) {
     return (
       <KibanaPageTemplate.EmptyPrompt
-        iconType="alert"
+        iconType="warning"
         color="danger"
         title={
           <h2>

--- a/src/plugins/input_control_vis/public/components/vis/form_row.tsx
+++ b/src/plugins/input_control_vis/public/components/vis/form_row.tsx
@@ -32,7 +32,7 @@ export function FormRow(props: FormRowProps) {
   const label = props.warningMsg ? (
     <>
       <EuiToolTip position="top" content={props.warningMsg}>
-        <EuiIcon type="alert" />
+        <EuiIcon type="warning" />
       </EuiToolTip>
       {props.label}
     </>

--- a/src/plugins/interactive_setup/public/cluster_configuration_form.tsx
+++ b/src/plugins/interactive_setup/public/cluster_configuration_form.tsx
@@ -222,7 +222,7 @@ export const ClusterConfigurationForm: FunctionComponent<ClusterConfigurationFor
         <>
           <EuiCallOut
             color="warning"
-            iconType="alert"
+            iconType="warning"
             title={i18n.translate(
               'interactiveSetup.clusterConfigurationForm.insecureClusterTitle',
               {

--- a/src/plugins/saved_objects_management/public/management_section/object_view/components/not_found_errors.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/object_view/components/not_found_errors.tsx
@@ -61,7 +61,7 @@ export const NotFoundErrors = ({ type, docLinks }: NotFoundErrors) => {
           defaultMessage="There is a problem with this saved object"
         />
       }
-      iconType="alert"
+      iconType="warning"
       color="danger"
     >
       <div>{getMessage()}</div>

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/delete_confirm_modal.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/delete_confirm_modal.tsx
@@ -94,7 +94,7 @@ export const DeleteConfirmModal: FC<DeleteConfirmModalProps> = ({
                   defaultMessage="Some objects cannot be deleted"
                 />
               }
-              iconType="alert"
+              iconType="warning"
               color="warning"
             >
               <p>
@@ -119,7 +119,7 @@ export const DeleteConfirmModal: FC<DeleteConfirmModalProps> = ({
                   values={{ sharedObjectsCount }}
                 />
               }
-              iconType="alert"
+              iconType="warning"
               color="warning"
             >
               <p>

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/import_summary.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/import_summary.tsx
@@ -232,7 +232,7 @@ const ImportWarning: FC<{ warning: SavedObjectsImportWarning; basePath: IBasePat
     <EuiCallOut
       color="warning"
       size="s"
-      iconType="alert"
+      iconType="warning"
       data-test-subj="importSavedObjectsWarning"
       title={warning.message}
     >

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/relationships.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/relationships.tsx
@@ -194,7 +194,7 @@ export class Relationships extends Component<RelationshipsProps, RelationshipsSt
       <>
         <EuiCallOut
           color="warning"
-          iconType="alert"
+          iconType="warning"
           title={i18n.translate(
             'savedObjectsManagement.objectsTable.relationships.invalidRelationShip',
             {

--- a/src/plugins/ui_actions_enhanced/public/drilldowns/drilldown_manager/components/drilldown_form/drilldown_form.tsx
+++ b/src/plugins/ui_actions_enhanced/public/drilldowns/drilldown_manager/components/drilldown_form/drilldown_form.tsx
@@ -53,7 +53,7 @@ export const DrilldownForm: React.FC<FormDrilldownWizardProps> = ({
   if (!!triggers && !triggers.items.length) {
     // Below callout is not translated, because this message is only for developers.
     return (
-      <EuiCallOut title="Sorry, there was an error" color="danger" iconType="alert">
+      <EuiCallOut title="Sorry, there was an error" color="danger" iconType="warning">
         <p>
           No triggers provided in <EuiCode>triggers</EuiCode> prop.
         </p>

--- a/src/plugins/ui_actions_enhanced/public/drilldowns/drilldown_manager/components/drilldown_table/drilldown_table.tsx
+++ b/src/plugins/ui_actions_enhanced/public/drilldowns/drilldown_manager/components/drilldown_table/drilldown_table.tsx
@@ -75,7 +75,7 @@ export const DrilldownTable: React.FC<DrilldownTableProps> = ({
           {drilldown.error && (
             <EuiToolTip id={`drilldownError-${drilldown.id}`} content={drilldown.error}>
               <EuiIcon
-                type="alert"
+                type="warning"
                 color="danger"
                 title={drilldown.error}
                 aria-label={drilldown.error}

--- a/src/plugins/unified_field_list/public/components/field_list_grouped/fields_accordion.tsx
+++ b/src/plugins/unified_field_list/public/components/field_list_grouped/fields_accordion.tsx
@@ -100,7 +100,7 @@ function InnerFieldsAccordion<T extends FieldListItem = DataViewField>({
           aria-label={i18n.translate('unifiedFieldList.fieldsAccordion.existenceErrorAriaLabel', {
             defaultMessage: 'Existence fetch failed',
           })}
-          type="alert"
+          type="warning"
           color="warning"
           content={i18n.translate('unifiedFieldList.fieldsAccordion.existenceErrorLabel', {
             defaultMessage: "Field information can't be loaded",

--- a/src/plugins/unified_histogram/public/chart/hooks/use_time_range.test.tsx
+++ b/src/plugins/unified_histogram/public/chart/hooks/use_time_range.test.tsx
@@ -164,7 +164,7 @@ describe('useTimeRange', () => {
             color="warning"
             content="This interval creates buckets that are too large to show in the selected time range, so it has been scaled to 1 minute."
             title="Warning"
-            type="alert"
+            type="warning"
           />
         </EuiFlexItem>
       </EuiFlexGroup>
@@ -230,7 +230,7 @@ describe('useTimeRange', () => {
             color="warning"
             content="This interval creates too many buckets to show in the selected time range, so it has been scaled to 1 minute."
             title="Warning"
-            type="alert"
+            type="warning"
           />
         </EuiFlexItem>
       </EuiFlexGroup>

--- a/src/plugins/unified_histogram/public/chart/hooks/use_time_range.tsx
+++ b/src/plugins/unified_histogram/public/chart/hooks/use_time_range.tsx
@@ -114,7 +114,7 @@ export const useTimeRange = ({
       >
         <EuiFlexItem grow={false}>{timeRangeDisplay}</EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiIconTip type="alert" color="warning" title={toolTipTitle} content={toolTipContent} />
+          <EuiIconTip type="warning" color="warning" title={toolTipTitle} content={toolTipContent} />
         </EuiFlexItem>
       </EuiFlexGroup>
     );

--- a/src/plugins/unified_histogram/public/chart/hooks/use_time_range.tsx
+++ b/src/plugins/unified_histogram/public/chart/hooks/use_time_range.tsx
@@ -114,7 +114,12 @@ export const useTimeRange = ({
       >
         <EuiFlexItem grow={false}>{timeRangeDisplay}</EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiIconTip type="warning" color="warning" title={toolTipTitle} content={toolTipContent} />
+          <EuiIconTip
+            type="warning"
+            color="warning"
+            title={toolTipTitle}
+            content={toolTipContent}
+          />
         </EuiFlexItem>
       </EuiFlexGroup>
     );

--- a/src/plugins/unified_search/public/dataview_picker/change_dataview.tsx
+++ b/src/plugins/unified_search/public/dataview_picker/change_dataview.tsx
@@ -249,7 +249,7 @@ export function ChangeDataView({
                       )}
                     >
                       <EuiIcon
-                        type="alert"
+                        type="warning"
                         color="warning"
                         data-test-subj="textBasedLang-warning"
                       />

--- a/src/plugins/unified_search/public/query_string_input/text_based_languages_editor/editor_footer.tsx
+++ b/src/plugins/unified_search/public/query_string_input/text_based_languages_editor/editor_footer.tsx
@@ -127,11 +127,7 @@ export const EditorFooter = memo(function EditorFooter({
                                 <EuiFlexItem grow={false}>
                                   <EuiFlexGroup gutterSize="s" alignItems="center">
                                     <EuiFlexItem grow={false}>
-                                      <EuiIcon
-                                        type="error"
-                                        color="danger"
-                                        size="s"
-                                      />
+                                      <EuiIcon type="error" color="danger" size="s" />
                                     </EuiFlexItem>
                                     <EuiFlexItem style={{ whiteSpace: 'nowrap' }}>
                                       {i18n.translate(

--- a/src/plugins/unified_search/public/query_string_input/text_based_languages_editor/editor_footer.tsx
+++ b/src/plugins/unified_search/public/query_string_input/text_based_languages_editor/editor_footer.tsx
@@ -68,7 +68,7 @@ export const EditorFooter = memo(function EditorFooter({
             <EuiFlexItem grow={false}>
               <EuiFlexGroup gutterSize="xs" responsive={false} alignItems="center">
                 <EuiFlexItem grow={false}>
-                  <EuiIcon type="crossInACircleFilled" color="danger" size="s" />
+                  <EuiIcon type="error" color="danger" size="s" />
                 </EuiFlexItem>
                 <EuiFlexItem grow={false}>
                   <EuiPopover
@@ -128,7 +128,7 @@ export const EditorFooter = memo(function EditorFooter({
                                   <EuiFlexGroup gutterSize="s" alignItems="center">
                                     <EuiFlexItem grow={false}>
                                       <EuiIcon
-                                        type="crossInACircleFilled"
+                                        type="error"
                                         color="danger"
                                         size="s"
                                       />

--- a/src/plugins/unified_search/public/query_string_input/text_based_languages_editor/index.tsx
+++ b/src/plugins/unified_search/public/query_string_input/text_based_languages_editor/index.tsx
@@ -500,7 +500,7 @@ export const TextBasedLanguagesEditor = memo(function TextBasedLanguagesEditor({
                       <EuiBadge
                         color={euiTheme.colors.danger}
                         css={styles.errorsBadge}
-                        iconType="crossInACircleFilled"
+                        iconType="error"
                         iconSide="left"
                         data-test-subj="unifiedTextLangEditor-inline-errors-badge"
                       >

--- a/src/plugins/vis_default_editor/public/components/sidebar/controls.tsx
+++ b/src/plugins/vis_default_editor/public/components/sidebar/controls.tsx
@@ -83,7 +83,7 @@ function DefaultEditorControls({
                   defaultMessage: 'Errors in the highlighted fields need to be resolved.',
                 })}
               >
-                <EuiButton color="danger" iconType="alert" size="s" disabled>
+                <EuiButton color="danger" iconType="warning" size="s" disabled>
                   <FormattedMessage
                     id="visDefaultEditor.sidebar.updateChartButtonLabel"
                     defaultMessage="Update"

--- a/src/plugins/vis_types/timeseries/public/application/components/error.js
+++ b/src/plugins/vis_types/timeseries/public/application/components/error.js
@@ -47,7 +47,7 @@ export function ErrorComponent(props) {
   return (
     <div className="visError">
       <EuiText size="xs" color="subdued">
-        <EuiIcon type="alert" size="m" color="danger" aria-hidden="true" />
+        <EuiIcon type="warning" size="m" color="danger" aria-hidden="true" />
 
         <EuiSpacer size="s" />
 

--- a/src/plugins/vis_types/vega/public/vega_inspector/vega_data_inspector.tsx
+++ b/src/plugins/vis_types/vega/public/vega_inspector/vega_data_inspector.tsx
@@ -49,7 +49,7 @@ const VegaDataInspector = ({ adapters }: VegaDataInspectorProps) => {
           defaultMessage: `Vega didn't render successfully`,
         })}
         color="danger"
-        iconType="alert"
+        iconType="warning"
       >
         <p>{error}</p>
       </EuiCallOut>

--- a/src/plugins/visualizations/public/components/visualization_error.tsx
+++ b/src/plugins/visualizations/public/components/visualization_error.tsx
@@ -18,7 +18,7 @@ export class VisualizationError extends React.Component<VisualizationErrorProps>
   public render() {
     return (
       <EuiEmptyPrompt
-        iconType="alert"
+        iconType="warning"
         iconColor="danger"
         data-test-subj="visualization-error"
         body={

--- a/src/plugins/visualizations/public/components/visualization_missed_saved_object_error.tsx
+++ b/src/plugins/visualizations/public/components/visualization_missed_saved_object_error.tsx
@@ -34,7 +34,7 @@ export const VisualizationMissedSavedObjectError = ({
 
   return (
     <EuiEmptyPrompt
-      iconType="alert"
+      iconType="warning"
       iconColor="danger"
       data-test-subj="visualization-missed-data-view-error"
       actions={

--- a/src/plugins/visualizations/public/visualize_app/components/viz_chart_warning.tsx
+++ b/src/plugins/visualizations/public/visualize_app/components/viz_chart_warning.tsx
@@ -166,7 +166,7 @@ export const VizChartWarning: FC<Props> = ({ chartType, chartConfigToken, mode }
           mode={mode}
         />
       }
-      iconType="alert"
+      iconType="warning"
       color="warning"
       size="s"
     />

--- a/src/plugins/visualizations/public/visualize_app/utils/get_table_columns.tsx
+++ b/src/plugins/visualizations/public/visualize_app/utils/get_table_columns.tsx
@@ -82,7 +82,7 @@ export const getCustomColumn = () => {
           {getBadge(record)}
         </span>
       ) : (
-        <EuiBadge iconType="alert" color="warning">
+        <EuiBadge iconType="warning" color="warning">
           {record.error}
         </EuiBadge>
       ),

--- a/x-pack/examples/alerting_example/public/alert_types/astros.tsx
+++ b/x-pack/examples/alerting_example/public/alert_types/astros.tsx
@@ -139,7 +139,7 @@ export const PeopleinSpaceExpression: React.FunctionComponent<PeopleinSpaceParam
   return (
     <Fragment>
       {errorsCallout.length ? (
-        <EuiCallOut title="Sorry, there was an error" color="danger" iconType="alert">
+        <EuiCallOut title="Sorry, there was an error" color="danger" iconType="warning">
           {errorsCallout}
         </EuiCallOut>
       ) : (

--- a/x-pack/examples/alerting_example/public/components/documentation.tsx
+++ b/x-pack/examples/alerting_example/public/components/documentation.tsx
@@ -50,7 +50,7 @@ export const DocumentationPage = (
             registration of example the RuleTypes, while the `public` handles creation of, and
             navigation for, these rule types.
           </p>
-          <EuiCallOut title="Transport Layer Security" iconType="alert" color="warning">
+          <EuiCallOut title="Transport Layer Security" iconType="warning" color="warning">
             If you see a message about needing to enable the Transport Layer Security, start ES with{' '}
             <code>yarn es snapshot --ssl --license trial</code> and Kibana with{' '}
             <code>yarn start --run-examples --ssl</code>. If you running chrome on a mac, you may

--- a/x-pack/examples/embedded_lens_example/public/mount.tsx
+++ b/x-pack/examples/embedded_lens_example/public/mount.tsx
@@ -31,7 +31,7 @@ export const mount =
           <EuiCallOut
             title="Please define a default index pattern to use this demo"
             color="danger"
-            iconType="alert"
+            iconType="warning"
           >
             <p>This demo only works if your default index pattern is set and time based</p>
           </EuiCallOut>

--- a/x-pack/examples/screenshotting_example/public/app/app.tsx
+++ b/x-pack/examples/screenshotting_example/public/app/app.tsx
@@ -88,7 +88,7 @@ export function App() {
                 <EuiCallOut
                   title="Sorry, there was an error"
                   color="danger"
-                  iconType="alert"
+                  iconType="warning"
                   data-test-subj="error"
                 >
                   <p>{response.errors.join('\n')}</p>

--- a/x-pack/examples/testing_embedded_lens/public/app.tsx
+++ b/x-pack/examples/testing_embedded_lens/public/app.tsx
@@ -697,7 +697,7 @@ export const App = (props: {
                       </EuiButton>
                     </EuiFlexItem>
                     {hasParsingErrorDebounced && currentSO.current !== currentValid && (
-                      <EuiCallOut title="Error" color="danger" iconType="alert">
+                      <EuiCallOut title="Error" color="danger" iconType="warning">
                         <p>Check the spec</p>
                       </EuiCallOut>
                     )}

--- a/x-pack/examples/testing_embedded_lens/public/mount.tsx
+++ b/x-pack/examples/testing_embedded_lens/public/mount.tsx
@@ -40,7 +40,7 @@ export const mount =
           <EuiCallOut
             title="Please define a default index pattern to use this demo"
             color="danger"
-            iconType="alert"
+            iconType="warning"
           >
             <p>This demo only works if your default index pattern is set and time based</p>
           </EuiCallOut>

--- a/x-pack/packages/ml/aiops_components/src/progress_controls/progress_controls.tsx
+++ b/x-pack/packages/ml/aiops_components/src/progress_controls/progress_controls.tsx
@@ -91,7 +91,7 @@ export function ProgressControls({
                   <EuiFlexItem>
                     <EuiIconTip
                       aria-label="Warning"
-                      type="alert"
+                      type="warning"
                       color="warning"
                       content={i18n.translate('xpack.aiops.rerunAnalysisTooltipContent', {
                         defaultMessage:

--- a/x-pack/plugins/aiops/public/components/change_point_detection/change_point_detection_page.tsx
+++ b/x-pack/plugins/aiops/public/components/change_point_detection/change_point_detection_page.tsx
@@ -100,7 +100,7 @@ export const ChangePointDetectionPage: FC = () => {
           values: { dataViewTitle: dataView.getName() },
         })}
         color="danger"
-        iconType="alert"
+        iconType="warning"
       >
         <p>
           {i18n.translate('xpack.aiops.index.dataViewWithoutMetricNotificationDescription', {
@@ -162,7 +162,7 @@ export const ChangePointDetectionPage: FC = () => {
               defaultMessage: 'Analysis has been limited',
             })}
             color="warning"
-            iconType="alert"
+            iconType="warning"
           >
             <p>
               {i18n.translate('xpack.aiops.changePointDetection.cardinalityWarningMessage', {
@@ -247,7 +247,7 @@ export const ChangePointDetectionPage: FC = () => {
                         <EuiIcon
                           tabIndex={0}
                           color={'warning'}
-                          type="alert"
+                          type="warning"
                           title={i18n.translate(
                             'xpack.aiops.changePointDetection.notResultsWarning',
                             {

--- a/x-pack/plugins/aiops/public/components/change_point_detection/change_point_detetion_root.tsx
+++ b/x-pack/plugins/aiops/public/components/change_point_detection/change_point_detetion_root.tsx
@@ -57,7 +57,7 @@ export const ChangePointDetectionAppState: FC<ChangePointDetectionAppStateProps>
           values: { dataViewTitle: dataView.getName() },
         })}
         color="danger"
-        iconType="alert"
+        iconType="warning"
       >
         <p>
           {i18n.translate('xpack.aiops.index.changePointTimeSeriesNotificationDescription', {

--- a/x-pack/plugins/aiops/public/components/explain_log_rate_spikes/explain_log_rate_spikes_analysis.tsx
+++ b/x-pack/plugins/aiops/public/components/explain_log_rate_spikes/explain_log_rate_spikes_analysis.tsx
@@ -208,7 +208,7 @@ export const ExplainLogRateSpikesAnalysis: FC<ExplainLogRateSpikesAnalysisProps>
               values: { errorCount: errors.length },
             })}
             color="warning"
-            iconType="alert"
+            iconType="warning"
             size="s"
           >
             <EuiText size="s">

--- a/x-pack/plugins/aiops/public/components/explain_log_rate_spikes/explain_log_rate_spikes_app_state.tsx
+++ b/x-pack/plugins/aiops/public/components/explain_log_rate_spikes/explain_log_rate_spikes_app_state.tsx
@@ -85,7 +85,7 @@ export const ExplainLogRateSpikesAppState: FC<ExplainLogRateSpikesAppStateProps>
           values: { dataViewTitle: dataView.getName() },
         })}
         color="danger"
-        iconType="alert"
+        iconType="warning"
       >
         <p>
           {i18n.translate('xpack.aiops.index.dataViewNotBasedOnTimeSeriesNotificationDescription', {

--- a/x-pack/plugins/apm/public/components/alerting/ui_components/alert_details_app_section/latency_alerts_history_chart.tsx
+++ b/x-pack/plugins/apm/public/components/alerting/ui_components/alert_details_app_section/latency_alerts_history_chart.tsx
@@ -214,7 +214,9 @@ export function LatencyAlertsHistoryChart({
                 opacity: 1,
               },
             }}
-            marker={<EuiIcon type="warning" color={CHART_ANNOTATION_RED_COLOR} />}
+            marker={
+              <EuiIcon type="warning" color={CHART_ANNOTATION_RED_COLOR} />
+            }
             markerBody={(annotationData) => (
               <>
                 <EuiBadge color={CHART_ANNOTATION_RED_COLOR}>

--- a/x-pack/plugins/apm/public/components/alerting/ui_components/alert_details_app_section/latency_alerts_history_chart.tsx
+++ b/x-pack/plugins/apm/public/components/alerting/ui_components/alert_details_app_section/latency_alerts_history_chart.tsx
@@ -214,7 +214,7 @@ export function LatencyAlertsHistoryChart({
                 opacity: 1,
               },
             }}
-            marker={<EuiIcon type="alert" color={CHART_ANNOTATION_RED_COLOR} />}
+            marker={<EuiIcon type="warning" color={CHART_ANNOTATION_RED_COLOR} />}
             markerBody={(annotationData) => (
               <>
                 <EuiBadge color={CHART_ANNOTATION_RED_COLOR}>

--- a/x-pack/plugins/apm/public/components/alerting/ui_components/alert_details_app_section/latency_chart_components/alert_annotation.tsx
+++ b/x-pack/plugins/apm/public/components/alerting/ui_components/alert_details_app_section/latency_chart_components/alert_annotation.tsx
@@ -40,7 +40,7 @@ export function AlertAnnotation({ alertStarted }: { alertStarted: number }) {
           opacity: 1,
         },
       }}
-      marker={<EuiIcon type="alert" color={CHART_ANNOTATION_RED_COLOR} />}
+      marker={<EuiIcon type="warning" color={CHART_ANNOTATION_RED_COLOR} />}
       markerPosition={Position.Top}
     />
   );

--- a/x-pack/plugins/apm/public/components/alerting/ui_components/apm_rule_params_container/index.tsx
+++ b/x-pack/plugins/apm/public/components/alerting/ui_components/apm_rule_params_container/index.tsx
@@ -99,7 +99,7 @@ function MinimumWindowSizeWarning({
         minimumWindowSize.value
       } ${getTimeUnitLabel(minimumWindowSize.unit)}`}
       color="warning"
-      iconType="alert"
+      iconType="warning"
     >
       <p>{description}</p>
     </EuiCallOut>

--- a/x-pack/plugins/apm/public/components/app/infra_overview/infra_tabs/failure_prompt.tsx
+++ b/x-pack/plugins/apm/public/components/app/infra_overview/infra_tabs/failure_prompt.tsx
@@ -22,7 +22,7 @@ export function FailurePrompt() {
     >
       <EuiEmptyPrompt
         color="danger"
-        iconType="alert"
+        iconType="warning"
         layout="vertical"
         title={
           <h2>

--- a/x-pack/plugins/apm/public/components/app/service_groups/service_groups_list/service_group_card.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_groups/service_groups_list/service_group_card.tsx
@@ -91,7 +91,7 @@ export function ServiceGroupsCard({
                 )}
               >
                 <EuiBadge
-                  iconType="alert"
+                  iconType="warning"
                   color="danger"
                   href={activeAlertsHref}
                   {...({

--- a/x-pack/plugins/apm/public/components/app/service_inventory/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_inventory/index.tsx
@@ -286,7 +286,7 @@ export function ServiceInventory() {
           }
         )}
         color="warning"
-        iconType="alert"
+        iconType="warning"
       >
         <EuiText size="s">
           <FormattedMessage

--- a/x-pack/plugins/apm/public/components/app/service_inventory/service_list/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_inventory/service_list/index.tsx
@@ -101,7 +101,7 @@ export function getServiceColumns({
                   )}
                 >
                   <EuiBadge
-                    iconType="alert"
+                    iconType="warning"
                     color="danger"
                     href={link('/services/{serviceName}/alerts', {
                       path: { serviceName },

--- a/x-pack/plugins/apm/public/components/app/service_map/timeout_prompt.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_map/timeout_prompt.tsx
@@ -17,7 +17,7 @@ export function TimeoutPrompt({
 }) {
   return (
     <EuiEmptyPrompt
-      iconType="alert"
+      iconType="warning"
       iconColor="subdued"
       title={
         <h2>

--- a/x-pack/plugins/apm/public/components/app/settings/agent_configurations/agent_configuration_create_edit/service_page/service_page.tsx
+++ b/x-pack/plugins/apm/public/components/app/settings/agent_configurations/agent_configuration_create_edit/service_page/service_page.tsx
@@ -142,7 +142,7 @@ export function ServicePage({ newConfig, setNewConfig, onClickNext }: Props) {
       {isAllOptionSelected && (
         <EuiCallOut
           color="warning"
-          iconType="alert"
+          iconType="warning"
           title={i18n.translate(
             'xpack.apm.settings.agentConfiguration.all.option.calloutTitle',
             {

--- a/x-pack/plugins/apm/public/components/app/settings/agent_configurations/agent_configuration_create_edit/settings_page/settings_page.tsx
+++ b/x-pack/plugins/apm/public/components/app/settings/agent_configurations/agent_configuration_create_edit/settings_page/settings_page.tsx
@@ -105,7 +105,7 @@ export function SettingsPage({
           { defaultMessage: 'Sorry, there was an error' }
         )}
         color="danger"
-        iconType="alert"
+        iconType="warning"
       >
         <p>
           {i18n.translate(

--- a/x-pack/plugins/apm/public/components/app/settings/agent_configurations/list/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/settings/agent_configurations/list/index.tsx
@@ -97,7 +97,7 @@ export function AgentConfigurationList({
 
   const failurePrompt = (
     <EuiEmptyPrompt
-      iconType="alert"
+      iconType="warning"
       body={
         <>
           <p>

--- a/x-pack/plugins/apm/public/components/app/settings/agent_keys/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/settings/agent_keys/index.tsx
@@ -193,7 +193,7 @@ function AgentKeysContent({
     if (requestFailed) {
       return (
         <EuiEmptyPrompt
-          iconType="alert"
+          iconType="warning"
           title={
             <h2>
               {i18n.translate(

--- a/x-pack/plugins/apm/public/components/app/settings/agent_keys/prompts/api_keys_not_enabled.tsx
+++ b/x-pack/plugins/apm/public/components/app/settings/agent_keys/prompts/api_keys_not_enabled.tsx
@@ -27,7 +27,7 @@ export function ApiKeysNotEnabled() {
           )}
         </h2>
       }
-      iconType="alert"
+      iconType="warning"
       body={
         <p>
           <FormattedMessage

--- a/x-pack/plugins/apm/public/components/app/settings/anomaly_detection/add_environments.tsx
+++ b/x-pack/plugins/apm/public/components/app/settings/anomaly_detection/add_environments.tsx
@@ -69,7 +69,7 @@ export function AddEnvironments({
   if (!canCreateJob) {
     return (
       <EuiEmptyPrompt
-        iconType="alert"
+        iconType="warning"
         body={<>{ML_ERRORS.MISSING_WRITE_PRIVILEGES}</>}
       />
     );

--- a/x-pack/plugins/apm/public/components/app/settings/anomaly_detection/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/settings/anomaly_detection/index.tsx
@@ -49,7 +49,7 @@ export function AnomalyDetection() {
     return (
       <EuiPanel>
         <EuiEmptyPrompt
-          iconType="alert"
+          iconType="warning"
           body={<>{ML_ERRORS.MISSING_READ_PRIVILEGES}</>}
         />
       </EuiPanel>

--- a/x-pack/plugins/apm/public/components/app/settings/custom_link/create_edit_custom_link_flyout/link_preview.tsx
+++ b/x-pack/plugins/apm/public/components/app/settings/custom_link/create_edit_custom_link_flyout/link_preview.tsx
@@ -130,7 +130,7 @@ export function LinkPreview({ label, url, filters }: LinkPreviewProps) {
             {error && (
               <EuiToolTip position="top" content={error}>
                 <EuiIcon
-                  type="alert"
+                  type="warning"
                   color="warning"
                   data-test-subj="preview-warning"
                 />

--- a/x-pack/plugins/apm/public/components/app/settings/schema/migrated/upgrade_available_card.tsx
+++ b/x-pack/plugins/apm/public/components/app/settings/schema/migrated/upgrade_available_card.tsx
@@ -22,7 +22,7 @@ export function UpgradeAvailableCard({
 
   return (
     <EuiCard
-      icon={<EuiIcon size="xxl" type="alert" color="warning" />}
+      icon={<EuiIcon size="xxl" type="warning" color="warning" />}
       title={i18n.translate(
         'xpack.apm.settings.schema.upgradeAvailable.title',
         {

--- a/x-pack/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/index.tsx
@@ -115,7 +115,7 @@ export function Waterfall({
         <EuiCallOut
           color="warning"
           size="s"
-          iconType="alert"
+          iconType="warning"
           title={i18n.translate('xpack.apm.waterfall.exceedsMax', {
             defaultMessage:
               'The number of items in this trace is {traceItemCount} which is higher than the current limit of {maxTraceItems}. Please increase the limit to see the full trace',

--- a/x-pack/plugins/apm/public/components/shared/charts/transaction_charts/ml_header.tsx
+++ b/x-pack/plugins/apm/public/components/shared/charts/transaction_charts/ml_header.tsx
@@ -49,7 +49,7 @@ export function MLHeader({ hasValidMlLicense, mlJobId }: Props) {
   const icon = hasKuery ? (
     <EuiIconTip
       aria-label="Warning"
-      type="alert"
+      type="warning"
       color="warning"
       content={i18n.translate(
         'xpack.apm.metrics.transactionChart.machineLearningTooltip.withKuery',

--- a/x-pack/plugins/apm/public/components/shared/links/apm/service_link/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/links/apm/service_link/index.tsx
@@ -67,7 +67,7 @@ export function ServiceLink({
               defaultMessage:
                 'Number of services instrumented has reached the current capacity of the APM server',
             })}
-            iconType="alert"
+            iconType="warning"
           >
             <EuiText style={{ width: `${unit * 28}px` }} size="s">
               <ServiceMaxGroupsMessage

--- a/x-pack/plugins/apm/public/components/shared/links/apm/transaction_detail_link/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/links/apm/transaction_detail_link/index.tsx
@@ -98,7 +98,7 @@ export function TransactionDetailLink({
           ariaLabel={i18n.translate('xpack.apm.transactionDetail.tooltip', {
             defaultMessage: 'Max transaction groups reached tooltip',
           })}
-          iconType="alert"
+          iconType="warning"
         >
           <EuiText style={{ width: `${unit * 28}px` }} size="s">
             <FormattedMessage

--- a/x-pack/plugins/apm/public/components/shared/transactions_table/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/transactions_table/index.tsx
@@ -318,7 +318,7 @@ export function TransactionsTable({
               }
             )}
             color="warning"
-            iconType="alert"
+            iconType="warning"
           >
             <p>
               <FormattedMessage

--- a/x-pack/plugins/apm/public/context/license/invalid_license_notification.tsx
+++ b/x-pack/plugins/apm/public/context/license/invalid_license_notification.tsx
@@ -17,7 +17,7 @@ export function InvalidLicenseNotification() {
 
   return (
     <EuiEmptyPrompt
-      iconType="alert"
+      iconType="warning"
       iconColor="warning"
       title={
         <h1>

--- a/x-pack/plugins/canvas/canvas_plugin_src/uis/datasources/esdocs.js
+++ b/x-pack/plugins/canvas/canvas_plugin_src/uis/datasources/esdocs.js
@@ -155,7 +155,7 @@ const EsdocsDatasource = ({ args, updateArgs, defaultIndex }) => {
 
       <EuiSpacer size="m" />
 
-      <EuiCallOut size="s" title={strings.getWarningTitle()} iconType="alert" color="warning">
+      <EuiCallOut size="s" title={strings.getWarningTitle()} iconType="warning" color="warning">
         <p>{strings.getWarning()}</p>
       </EuiCallOut>
     </div>

--- a/x-pack/plugins/canvas/public/components/color_dot/__stories__/color_dot.stories.tsx
+++ b/x-pack/plugins/canvas/public/components/color_dot/__stories__/color_dot.stories.tsx
@@ -43,7 +43,7 @@ storiesOf('components/Color/ColorDot', module)
         <EuiIcon type="minusInCircle" color="#fff" />
       </ColorDot>
       <ColorDot key="3" value="rgba(100, 150, 250, .5)">
-        <EuiIcon type="alert" color="#fff" />
+        <EuiIcon type="warning" color="#fff" />
       </ColorDot>
       <ColorDot key="4" value="#000">
         <EuiIcon type="check" color="#fff" />

--- a/x-pack/plugins/canvas/public/components/var_config/edit_var.tsx
+++ b/x-pack/plugins/canvas/public/components/var_config/edit_var.tsx
@@ -156,7 +156,7 @@ export const EditVar: FC<Props> = ({ variables, selectedVar, onCancel, onSave })
             <EuiCallOut
               title={strings.getEditWarning()}
               color="warning"
-              iconType="alert"
+              iconType="warning"
               size="s"
             />
             <EuiSpacer size="m" />

--- a/x-pack/plugins/canvas/public/components/workpad_header/share_menu/flyout/flyout.component.tsx
+++ b/x-pack/plugins/canvas/public/components/workpad_header/share_menu/flyout/flyout.component.tsx
@@ -179,7 +179,7 @@ export const ShareWebsiteFlyout: FC<Props> = ({
       <EuiSpacer size="xs" key="spacer" />,
     ];
     warningText = [
-      <EuiCallOut title={warning} color="warning" size="s" iconType="alert" key="callout" />,
+      <EuiCallOut title={warning} color="warning" size="s" iconType="warning" key="callout" />,
       <EuiSpacer key="spacer" />,
     ];
   }

--- a/x-pack/plugins/cases/public/components/configure_cases/connectors_dropdown.test.tsx
+++ b/x-pack/plugins/cases/public/components/configure_cases/connectors_dropdown.test.tsx
@@ -195,7 +195,7 @@ describe('ConnectorsDropdown', () => {
                 color="warning"
                 content="This connector is deprecated. Update it, or create a new one."
                 size="m"
-                type="alert"
+                type="warning"
               />
             </EuiFlexItem>
           </EuiFlexGroup>,

--- a/x-pack/plugins/cases/public/components/configure_cases/connectors_dropdown.tsx
+++ b/x-pack/plugins/cases/public/components/configure_cases/connectors_dropdown.tsx
@@ -96,7 +96,7 @@ const ConnectorsDropdownComponent: React.FC<Props> = ({
                     <StyledEuiIconTip
                       aria-label={i18n.DEPRECATED_TOOLTIP_CONTENT}
                       size={ICON_SIZE}
-                      type="alert"
+                      type="warning"
                       color="warning"
                       content={i18n.DEPRECATED_TOOLTIP_CONTENT}
                     />

--- a/x-pack/plugins/cases/public/components/connectors/deprecated_callout.tsx
+++ b/x-pack/plugins/cases/public/components/connectors/deprecated_callout.tsx
@@ -32,7 +32,7 @@ const DeprecatedCalloutComponent: React.FC<Props> = ({ type = 'warning' }) => (
   <EuiCallOut
     title={DEPRECATED_CONNECTOR_WARNING_TITLE}
     color={type}
-    iconType="alert"
+    iconType="warning"
     data-test-subj="deprecated-connector-warning-callout"
   >
     {DEPRECATED_CONNECTOR_WARNING_DESC}

--- a/x-pack/plugins/cases/public/components/connectors/swimlane/case_fields.tsx
+++ b/x-pack/plugins/cases/public/components/connectors/swimlane/case_fields.tsx
@@ -35,7 +35,7 @@ const SwimlaneComponent: React.FunctionComponent<ConnectorFieldsProps<SwimlaneFi
         <EuiCallOut
           title={i18n.EMPTY_MAPPING_WARNING_TITLE}
           color="danger"
-          iconType="alert"
+          iconType="warning"
           data-test-subj="mapping-warning-callout"
         >
           {i18n.EMPTY_MAPPING_WARNING_DESC}

--- a/x-pack/plugins/cases/public/components/link_icon/index.test.tsx
+++ b/x-pack/plugins/cases/public/components/link_icon/index.test.tsx
@@ -14,7 +14,7 @@ import { LinkIcon } from '.';
 describe('LinkIcon', () => {
   test('it renders', () => {
     const wrapper = shallow(
-      <LinkIcon href="#" iconSide="right" iconSize="xxl" iconType="alert">
+      <LinkIcon href="#" iconSide="right" iconSize="xxl" iconType="warning">
         {'Test link'}
       </LinkIcon>
     );
@@ -25,7 +25,7 @@ describe('LinkIcon', () => {
   test('it renders an action button when onClick is provided', () => {
     const wrapper = mount(
       <TestProviders>
-        <LinkIcon iconType="alert" onClick={() => alert('Test alert')}>
+        <LinkIcon iconType="warning" onClick={() => alert('Test alert')}>
           {'Test link'}
         </LinkIcon>
       </TestProviders>
@@ -37,7 +37,7 @@ describe('LinkIcon', () => {
   test('it renders an action link when href is provided', () => {
     const wrapper = mount(
       <TestProviders>
-        <LinkIcon href="#" iconType="alert">
+        <LinkIcon href="#" iconType="warning">
           {'Test link'}
         </LinkIcon>
       </TestProviders>
@@ -49,7 +49,7 @@ describe('LinkIcon', () => {
   test('it renders an icon', () => {
     const wrapper = mount(
       <TestProviders>
-        <LinkIcon iconType="alert">{'Test link'}</LinkIcon>
+        <LinkIcon iconType="warning">{'Test link'}</LinkIcon>
       </TestProviders>
     );
 
@@ -59,7 +59,7 @@ describe('LinkIcon', () => {
   test('it positions the icon to the right when iconSide is right', () => {
     const wrapper = mount(
       <TestProviders>
-        <LinkIcon iconSide="right" iconType="alert">
+        <LinkIcon iconSide="right" iconType="warning">
           {'Test link'}
         </LinkIcon>
       </TestProviders>
@@ -71,7 +71,7 @@ describe('LinkIcon', () => {
   test('it positions the icon to the left when iconSide is left (or not provided)', () => {
     const wrapper = mount(
       <TestProviders>
-        <LinkIcon iconSide="left" iconType="alert">
+        <LinkIcon iconSide="left" iconType="warning">
           {'Test link'}
         </LinkIcon>
       </TestProviders>
@@ -86,7 +86,7 @@ describe('LinkIcon', () => {
   test('it renders a label', () => {
     const wrapper = mount(
       <TestProviders>
-        <LinkIcon iconType="alert">{'Test link'}</LinkIcon>
+        <LinkIcon iconType="warning">{'Test link'}</LinkIcon>
       </TestProviders>
     );
 

--- a/x-pack/plugins/cases/public/components/user_actions/comment/registered_attachments.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/comment/registered_attachments.tsx
@@ -97,7 +97,7 @@ export const createRegisteredAttachmentUserActionBuilder = <
           'data-test-subj': `comment-${comment.type}-not-found`,
           timestamp: <UserActionTimestamp createdAt={userAction.createdAt} />,
           children: (
-            <EuiCallOut title={ATTACHMENT_NOT_REGISTERED_ERROR} color="danger" iconType="alert" />
+            <EuiCallOut title={ATTACHMENT_NOT_REGISTERED_ERROR} color="danger" iconType="warning" />
           ),
         },
       ];

--- a/x-pack/plugins/cloud_defend/public/components/cloud_defend_page/index.tsx
+++ b/x-pack/plugins/cloud_defend/public/components/cloud_defend_page/index.tsx
@@ -172,7 +172,7 @@ const defaultErrorRenderer = (error: unknown) => (
   <FullSizeCenteredPage>
     <EuiEmptyPrompt
       color="danger"
-      iconType="alert"
+      iconType="warning"
       data-test-subj={ERROR_STATE_TEST_SUBJECT}
       title={
         <h2>

--- a/x-pack/plugins/cloud_defend/public/components/subscription_not_allowed/index.tsx
+++ b/x-pack/plugins/cloud_defend/public/components/subscription_not_allowed/index.tsx
@@ -15,7 +15,7 @@ export const SubscriptionNotAllowed = () => {
   return (
     <EuiPageSection color="danger" alignment="center">
       <EuiEmptyPrompt
-        iconType="alert"
+        iconType="warning"
         title={
           <h2>
             <FormattedMessage

--- a/x-pack/plugins/cloud_security_posture/public/components/cloud_posture_page.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/cloud_posture_page.tsx
@@ -181,7 +181,7 @@ const defaultErrorRenderer = (error: unknown) => (
   <FullSizeCenteredPage>
     <EuiEmptyPrompt
       color="danger"
-      iconType="alert"
+      iconType="warning"
       data-test-subj={ERROR_STATE_TEST_SUBJECT}
       title={
         <h2>

--- a/x-pack/plugins/cloud_security_posture/public/components/subscription_not_allowed.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/subscription_not_allowed.tsx
@@ -15,7 +15,7 @@ export const SubscriptionNotAllowed = () => {
   return (
     <EuiPageSection color="danger" alignment="center">
       <EuiEmptyPrompt
-        iconType="alert"
+        iconType="warning"
         title={
           <h2>
             <FormattedMessage

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/layout/error_callout.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/layout/error_callout.tsx
@@ -32,7 +32,7 @@ export const ErrorCallout = ({ error }: { error: Error }) => {
               defaultMessage: 'We encountered an error retrieving search results',
             })}
             color="danger"
-            iconType="alert"
+            iconType="warning"
           >
             <EuiSpacer />
             <EuiButton size="s" color="danger" onClick={() => search.showError(error)}>

--- a/x-pack/plugins/cross_cluster_replication/public/app/components/section_error.js
+++ b/x-pack/plugins/cross_cluster_replication/public/app/components/section_error.js
@@ -14,7 +14,7 @@ export function SectionError(props) {
   const { error: errorString, attributes, message } = data;
 
   return (
-    <EuiCallOut title={title} color="danger" iconType="alert" {...rest}>
+    <EuiCallOut title={title} color="danger" iconType="warning" {...rest}>
       <div>{message || errorString}</div>
       {attributes?.error?.root_cause && (
         <Fragment>

--- a/x-pack/plugins/cross_cluster_replication/public/app/sections/auto_follow_pattern_edit/auto_follow_pattern_edit.js
+++ b/x-pack/plugins/cross_cluster_replication/public/app/sections/auto_follow_pattern_edit/auto_follow_pattern_edit.js
@@ -100,7 +100,7 @@ export class AutoFollowPatternEdit extends PureComponent {
     return (
       <EuiPageContent verticalPosition="center" horizontalPosition="center" color="danger">
         <EuiEmptyPrompt
-          iconType="alert"
+          iconType="warning"
           title={
             <h2>
               <FormattedMessage

--- a/x-pack/plugins/cross_cluster_replication/public/app/sections/follower_index_edit/follower_index_edit.js
+++ b/x-pack/plugins/cross_cluster_replication/public/app/sections/follower_index_edit/follower_index_edit.js
@@ -133,7 +133,7 @@ export class FollowerIndexEdit extends PureComponent {
     return (
       <EuiPageContent verticalPosition="center" horizontalPosition="center" color="danger">
         <EuiEmptyPrompt
-          iconType="alert"
+          iconType="warning"
           title={
             <h2>
               <FormattedMessage

--- a/x-pack/plugins/cross_cluster_replication/public/app/sections/home/auto_follow_pattern_list/components/detail_panel/detail_panel.js
+++ b/x-pack/plugins/cross_cluster_replication/public/app/sections/home/auto_follow_pattern_list/components/detail_panel/detail_panel.js
@@ -211,7 +211,7 @@ export class DetailPanel extends Component {
       <EuiFlyoutBody>
         <EuiFlexGroup justifyContent="flexStart" alignItems="center" gutterSize="s">
           <EuiFlexItem grow={false}>
-            <EuiIcon size="m" type="alert" color="danger" />
+            <EuiIcon size="m" type="warning" color="danger" />
           </EuiFlexItem>
 
           <EuiFlexItem grow={false}>
@@ -238,7 +238,7 @@ export class DetailPanel extends Component {
       <section data-test-subj="errors">
         <EuiFlexGroup justifyContent="flexStart" alignItems="center" gutterSize="s">
           <EuiFlexItem grow={false}>
-            <EuiIcon type="alert" color="danger" />
+            <EuiIcon type="warning" color="danger" />
           </EuiFlexItem>
 
           <EuiFlexItem grow={false}>

--- a/x-pack/plugins/cross_cluster_replication/public/app/sections/home/follower_indices_list/components/detail_panel/detail_panel.js
+++ b/x-pack/plugins/cross_cluster_replication/public/app/sections/home/follower_indices_list/components/detail_panel/detail_panel.js
@@ -423,7 +423,7 @@ export class DetailPanel extends Component {
         <EuiFlyoutBody>
           <EuiFlexGroup justifyContent="flexStart" alignItems="center" gutterSize="s">
             <EuiFlexItem grow={false}>
-              <EuiIcon size="m" type="alert" color="danger" />
+              <EuiIcon size="m" type="warning" color="danger" />
             </EuiFlexItem>
 
             <EuiFlexItem grow={false}>

--- a/x-pack/plugins/data_visualizer/public/application/common/components/not_in_docs_content/not_in_docs_context.tsx
+++ b/x-pack/plugins/data_visualizer/public/application/common/components/not_in_docs_content/not_in_docs_context.tsx
@@ -13,7 +13,7 @@ import { FormattedMessage } from '@kbn/i18n-react';
 export const NotInDocsContent: FC = () => (
   <Fragment>
     <EuiText textAlign="center">
-      <EuiIcon type="alert" />
+      <EuiIcon type="warning" />
     </EuiText>
     <EuiText textAlign="center" size={'xs'}>
       <FormattedMessage

--- a/x-pack/plugins/data_visualizer/public/application/common/components/stats_table/components/field_data_expanded_row/text_content.tsx
+++ b/x-pack/plugins/data_visualizer/public/application/common/components/stats_table/components/field_data_expanded_row/text_content.tsx
@@ -39,7 +39,7 @@ export const TextContent: FC<FieldDataRowProps> = ({ config }) => {
                   defaultMessage: 'No examples were obtained for this field',
                 }
               )}
-              iconType="alert"
+              iconType="warning"
             >
               <FormattedMessage
                 id="xpack.dataVisualizer.dataGrid.fieldText.fieldNotPresentDescription"

--- a/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/embeddables/grid_embeddable/grid_embeddable.tsx
+++ b/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/embeddables/grid_embeddable/grid_embeddable.tsx
@@ -175,7 +175,7 @@ export const IndexDataVisualizerViewWrapper = (props: {
   } else {
     return (
       <EuiEmptyPrompt
-        iconType="alert"
+        iconType="warning"
         iconColor="danger"
         title={
           <h2>

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/add_domain_form_errors.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/add_domain_form_errors.tsx
@@ -21,7 +21,7 @@ export const AddDomainFormErrors: React.FC = () => {
     return (
       <EuiCallOut
         color="danger"
-        iconType="alert"
+        iconType="warning"
         title={i18n.translate(
           'xpack.enterpriseSearch.appSearch.crawler.addDomainForm.errorsTitle',
           {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/validation_state_icon.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/validation_state_icon.tsx
@@ -18,7 +18,7 @@ export const ValidationStateIcon: React.FC<{ state: CrawlerDomainValidationStepS
     case 'valid':
       return <EuiIcon color="success" type="check" />;
     case 'warning':
-      return <EuiIcon color="warning" type="alert" />;
+      return <EuiIcon color="warning" type="warning" />;
     case 'invalid':
       return <EuiIcon color="danger" type="cross" />;
     default:

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_flyout/form_components/key_update_warning.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_flyout/form_components/key_update_warning.tsx
@@ -18,7 +18,7 @@ export const FormKeyUpdateWarning: React.FC = () => (
         defaultMessage: 'Proceed with caution!',
       })}
       color="warning"
-      iconType="alert"
+      iconType="warning"
     >
       <p>
         {i18n.translate('xpack.enterpriseSearch.appSearch.credentials.updateWarning', {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/components/suggestions_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/components/suggestions_table.tsx
@@ -44,7 +44,7 @@ const columns: Array<EuiBasicTableColumn<CurationSuggestion>> = [
         {query}
         {curation.override_manual_curation && (
           <>
-            <EuiBadge iconType="alert" color="warning" className="suggestionsTableBadge">
+            <EuiBadge iconType="warning" color="warning" className="suggestionsTableBadge">
               {i18n.translate(
                 'xpack.enterpriseSearch.appSearch.engine.curations.suggestionsTable.overridesLabel',
                 { defaultMessage: 'Overrides' }

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curation_suggestion/curation_action_bar.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curation_suggestion/curation_action_bar.tsx
@@ -39,7 +39,7 @@ export const CurationActionBar: React.FC = () => {
                   <EuiButton
                     size="s"
                     color="danger"
-                    iconType="crossInACircleFilled"
+                    iconType="cross"
                     data-test-subj="rejectButton"
                     onClick={rejectSuggestion}
                   >

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/creation_response_components/errors.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/creation_response_components/errors.tsx
@@ -20,14 +20,14 @@ export const Errors: React.FC = () => {
   return (
     <>
       {errors.length > 0 && (
-        <EuiCallOut color="danger" iconType="alert" title={DOCUMENT_CREATION_ERRORS.TITLE}>
+        <EuiCallOut color="danger" iconType="warning" title={DOCUMENT_CREATION_ERRORS.TITLE}>
           {errors.map((message, index) => (
             <p key={index}>{message}</p>
           ))}
         </EuiCallOut>
       )}
       {warnings.length > 0 && (
-        <EuiCallOut color="warning" iconType="alert" title={DOCUMENT_CREATION_WARNINGS.TITLE}>
+        <EuiCallOut color="warning" iconType="warning" title={DOCUMENT_CREATION_WARNINGS.TITLE}>
           {warnings.map((message, index) => (
             <p key={index}>{message}</p>
           ))}

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/creation_response_components/summary.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/creation_response_components/summary.tsx
@@ -60,7 +60,7 @@ export const FlyoutBody: React.FC = () => {
   const { summary } = useValues(DocumentCreationLogic);
   const hasInvalidDocuments = summary.invalidDocuments.total > 0;
   const invalidDocumentsBanner = (
-    <EuiCallOut color="danger" iconType="alert" title={DOCUMENT_CREATION_ERRORS.TITLE} />
+    <EuiCallOut color="danger" iconType="warning" title={DOCUMENT_CREATION_ERRORS.TITLE} />
   );
 
   return (

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_nav.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_nav.tsx
@@ -157,7 +157,7 @@ export const useEngineNav = () => {
         <>
           {hasSchemaErrors && (
             <EuiIcon
-              type="alert"
+              type="warning"
               color="danger"
               className="appSearchNavIcon"
               title={i18n.translate('xpack.enterpriseSearch.appSearch.engine.schema.errors', {
@@ -180,7 +180,7 @@ export const useEngineNav = () => {
           )}
           {hasSchemaConflicts && (
             <EuiIcon
-              type="alert"
+              type="warning"
               color="warning"
               className="appSearchNavIcon"
               title={i18n.translate('xpack.enterpriseSearch.appSearch.engine.schema.conflicts', {
@@ -191,7 +191,7 @@ export const useEngineNav = () => {
           )}
           {hasIncompleteFields && (
             <EuiIcon
-              type="alert"
+              type="warning"
               color="warning"
               className="appSearchNavIcon"
               title={i18n.translate(
@@ -242,7 +242,7 @@ export const useEngineNav = () => {
         <>
           {invalidBoosts && (
             <EuiIcon
-              type="alert"
+              type="warning"
               color="warning"
               className="appSearchNavIcon"
               title={i18n.translate(
@@ -254,7 +254,7 @@ export const useEngineNav = () => {
           )}
           {unsearchedUnconfirmedFields && (
             <EuiIcon
-              type="alert"
+              type="warning"
               color="warning"
               className="appSearchNavIcon"
               title={i18n.translate(

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/log_retention/components/log_retention_callout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/log_retention/components/log_retention_callout.tsx
@@ -56,7 +56,7 @@ export const LogRetentionCallout: React.FC<Props> = ({ type }) => {
   return hasLogRetentionDisabled ? (
     <>
       <EuiCallOut
-        iconType="alert"
+        iconType="warning"
         color="primary"
         title={
           logRetentionSettings?.disabledAt ? (

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/relevance_tuning_callouts.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/relevance_tuning_callouts.tsx
@@ -30,7 +30,7 @@ export const RelevanceTuningCallouts: React.FC = () => {
   const invalidBoostsCallout = () => (
     <EuiCallOut
       color="warning"
-      iconType="alert"
+      iconType="warning"
       title={i18n.translate(
         'xpack.enterpriseSearch.appSearch.engine.relevanceTuning.invalidBoostsBannerLabel',
         {
@@ -52,7 +52,7 @@ export const RelevanceTuningCallouts: React.FC = () => {
   const unsearchedUnconfirmedFieldsCallout = () => (
     <EuiCallOut
       color="warning"
-      iconType="alert"
+      iconType="warning"
       title={i18n.translate(
         'xpack.enterpriseSearch.appSearch.engine.relevanceTuning.uncofirmedFieldsBannerLabel',
         {
@@ -83,7 +83,7 @@ export const RelevanceTuningCallouts: React.FC = () => {
   const schemaFieldsWithConflictsCallout = () => (
     <EuiCallOut
       color="warning"
-      iconType="alert"
+      iconType="warning"
       title={i18n.translate(
         'xpack.enterpriseSearch.appSearch.engine.relevanceTuning.schemaConflictsBannerLabel',
         {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/components/schema_callouts.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/components/schema_callouts.tsx
@@ -142,7 +142,7 @@ export const MissingSubfieldsCallout: React.FC = () => {
 
   return (
     <EuiCallOut
-      iconType="alert"
+      iconType="warning"
       color="warning"
       title={i18n.translate(
         'xpack.enterpriseSearch.appSearch.engine.schema.incompleteFields.title',

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/views/meta_engine_schema.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/views/meta_engine_schema.tsx
@@ -46,7 +46,7 @@ export const MetaEngineSchema: React.FC = () => {
       {hasConflicts && (
         <>
           <EuiCallOut
-            iconType="alert"
+            iconType="warning"
             color="warning"
             title={i18n.translate(
               'xpack.enterpriseSearch.appSearch.engine.schema.metaEngine.conflictsCalloutTitle',

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_indices.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_indices.tsx
@@ -218,7 +218,7 @@ export const EngineIndices: React.FC = () => {
           <>
             <EuiCallOut
               color="warning"
-              iconType="alert"
+              iconType="warning"
               title={i18n.translate(
                 'xpack.enterpriseSearch.content.engine.indices.unknownIndicesCallout.title',
                 { defaultMessage: 'Some of your indices are unavailable.' }

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_overview.tsx
@@ -59,7 +59,7 @@ export const EngineOverview: React.FC = () => {
               >
                 <EuiFlexGroup alignItems="center">
                   {hasUnknownIndices ? (
-                    <EuiIcon size="xxl" type="alert" color={colors.warning} />
+                    <EuiIcon size="xxl" type="warning" color={colors.warning} />
                   ) : (
                     <EuiIcon size="xxl" type="visTable" color={colors.mediumShade} />
                   )}

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/method_connector/method_connector.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/method_connector/method_connector.tsx
@@ -79,7 +79,7 @@ export const MethodConnector: React.FC<{ isNative: boolean }> = ({ isNative }) =
               }
             )}
             color="warning"
-            iconType="alert"
+            iconType="warning"
           >
             {i18n.translate(
               'xpack.enterpriseSearch.content.nativeConnector.memoryCallout.content',

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_scheduling.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_scheduling.tsx
@@ -128,7 +128,7 @@ export const ConnectorSchedulingComponent: React.FC = () => {
           {ingestionStatus === IngestionStatus.ERROR ? (
             <EuiCallOut
               color="warning"
-              iconType="alert"
+              iconType="warning"
               title={i18n.translate(
                 'xpack.enterpriseSearch.content.indices.connectorScheduling.error.title',
                 { defaultMessage: 'Review your connector configuration for reported errors.' }

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/custom_connector_configuration_config.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/custom_connector_configuration_config.tsx
@@ -67,7 +67,7 @@ export const ConnectorConfigurationConfig: React.FC = () => {
         />
         <EuiSpacer />
         <EuiCallOut
-          iconType="alert"
+          iconType="warning"
           color="warning"
           title={i18n.translate(
             'xpack.enterpriseSearch.content.indices.configurationConnector.config.warning.title',

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/crawler_domain_detail/authentication_panel/authentication_panel_actions.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/crawler_domain_detail/authentication_panel/authentication_panel_actions.tsx
@@ -49,7 +49,7 @@ export const AuthenticationPanelActions: React.FC = () => {
       <EuiFlexItem>
         <EuiButtonEmpty
           data-telemetry-id="entSearchContent-crawler-domainDetail-authentication-cancel"
-          iconType="crossInACircleFilled"
+          iconType="cross"
           size="s"
           color="danger"
           onClick={() => disableEditing()}

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/domain_management/add_domain/add_domain_form_errors.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/domain_management/add_domain/add_domain_form_errors.tsx
@@ -21,7 +21,7 @@ export const AddDomainFormErrors: React.FC = () => {
     return (
       <EuiCallOut
         color="danger"
-        iconType="alert"
+        iconType="warning"
         title={i18n.translate('xpack.enterpriseSearch.crawler.addDomainForm.errorsTitle', {
           defaultMessage: 'Something went wrong. Please address the errors and try again.',
         })}

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/domain_management/add_domain/validation_state_icon.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/domain_management/add_domain/validation_state_icon.tsx
@@ -18,7 +18,7 @@ export const ValidationStateIcon: React.FC<{ state: CrawlerDomainValidationStepS
     case 'valid':
       return <EuiIcon color="success" type="check" />;
     case 'warning':
-      return <EuiIcon color="warning" type="alert" />;
+      return <EuiIcon color="warning" type="warning" />;
     case 'invalid':
       return <EuiIcon color="danger" type="cross" />;
     default:

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/no_connector_record.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/no_connector_record.tsx
@@ -36,7 +36,7 @@ export const NoConnectorRecord: React.FC = () => {
       <DeleteIndexModal />
 
       <EuiPageTemplate.EmptyPrompt
-        iconType="alert"
+        iconType="warning"
         color="danger"
         title={
           <h2>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/overview.tsx
@@ -35,7 +35,7 @@ export const SearchIndexOverview: React.FC = () => {
       {isConnectorIndex(indexData) && error && (
         <>
           <EuiCallOut
-            iconType="alert"
+            iconType="warning"
             color="danger"
             title={i18n.translate(
               'xpack.enterpriseSearch.content.searchIndex.connectorErrorCallOut.title',

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/add_inference_pipeline_flyout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/add_inference_pipeline_flyout.tsx
@@ -116,7 +116,7 @@ export const AddInferencePipelineContent = ({ onClose }: AddInferencePipelineFly
                 { defaultMessage: 'Error creating pipeline' }
               )}
               color="danger"
-              iconType="alert"
+              iconType="warning"
             >
               {createErrors.map((message, i) => (
                 <p key={`createError.${i}`}>{message}</p>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/pipeline_select_option.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/pipeline_select_option.tsx
@@ -25,7 +25,7 @@ export const PipelineSelectOption: React.FC<PipelineSelectOptionProps> = ({ pipe
         <EuiFlexItem>
           <EuiFlexGroup>
             <EuiFlexItem grow={false}>
-              <EuiIcon type="alert" color="warning" />
+              <EuiIcon type="warning" color="warning" />
             </EuiFlexItem>
             <EuiFlexItem>
               <EuiTextColor color="default">

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_indices/delete_index_modal.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_indices/delete_index_modal.tsx
@@ -91,7 +91,7 @@ export const DeleteIndexModal: React.FC = () => {
         <>
           <EuiCallOut
             color="warning"
-            iconType="alert"
+            iconType="warning"
             title={i18n.translate(
               'xpack.enterpriseSearch.content.searchIndices.deleteModal.syncsWarning.title',
               {

--- a/x-pack/plugins/enterprise_search/public/applications/shared/error_state/error_state_prompt.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/error_state/error_state_prompt.tsx
@@ -44,7 +44,7 @@ export const ErrorStatePrompt: React.FC = () => {
 
   return (
     <EuiEmptyPrompt
-      iconType="alert"
+      iconType="warning"
       iconColor="danger"
       title={
         <h2>

--- a/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/deactivated_user_callout.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/deactivated_user_callout.test.tsx
@@ -22,7 +22,7 @@ describe('DeactivatedUserCallout', () => {
         >
           <EuiIcon
             color="warning"
-            type="alert"
+            type="warning"
           />
            
           <strong>
@@ -53,7 +53,7 @@ describe('DeactivatedUserCallout', () => {
         >
           <EuiIcon
             color="warning"
-            type="alert"
+            type="warning"
           />
            
           <strong>

--- a/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/deactivated_user_callout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/deactivated_user_callout.tsx
@@ -19,7 +19,7 @@ export const DeactivatedUserCallout: React.FC<Props> = ({ isNew }) => (
   <>
     {!isNew && <EuiSpacer />}
     <EuiText size="s">
-      <EuiIcon type="alert" color="warning" /> <strong>{DEACTIVATED_USER_CALLOUT_LABEL}</strong>
+      <EuiIcon type="warning" color="warning" /> <strong>{DEACTIVATED_USER_CALLOUT_LABEL}</strong>
     </EuiText>
     <EuiSpacer size="xs" />
     <EuiText size="s">{DEACTIVATED_USER_CALLOUT_DESCRIPTION}</EuiText>

--- a/x-pack/plugins/enterprise_search/public/applications/shared/schema/errors_callout/index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/schema/errors_callout/index.tsx
@@ -20,7 +20,7 @@ interface Props {
 export const SchemaErrorsCallout: React.FC<Props> = ({ viewErrorsPath }) => (
   <EuiCallOut
     color="danger"
-    iconType="alert"
+    iconType="warning"
     title={SCHEMA_ERRORS_TITLE}
     data-test-subj="schemaErrorsCallout"
   >

--- a/x-pack/plugins/enterprise_search/public/applications/shared/tables/inline_editable_table/action_column.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/tables/inline_editable_table/action_column.tsx
@@ -76,7 +76,7 @@ export const ActionColumn = <Item extends ItemWithAnID>({
           <EuiButtonEmpty
             data-test-subj="cancelButton"
             color="danger"
-            iconType="crossInACircleFilled"
+            iconType="cross"
             onClick={doneEditing}
             disabled={isLoading}
           >

--- a/x-pack/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/body_row.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/body_row.tsx
@@ -66,7 +66,7 @@ export const BodyRow = <Item extends object>({
         <EuiFlexGroup direction="column">
           {errors.map((errorMessage, errorMessageIndex) => (
             <EuiFlexItem key={errorMessageIndex}>
-              <EuiCallOut iconType="alert" size="s" color="danger" title={errorMessage} />
+              <EuiCallOut iconType="warning" size="s" color="danger" title={errorMessage} />
             </EuiFlexItem>
           ))}
         </EuiFlexGroup>

--- a/x-pack/plugins/enterprise_search/public/applications/shared/version_mismatch/version_mismatch_error.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/version_mismatch/version_mismatch_error.tsx
@@ -21,7 +21,7 @@ export const VersionMismatchError: React.FC<Props> = ({
 }) => {
   return (
     <EuiEmptyPrompt
-      iconType="alert"
+      iconType="warning"
       iconColor="danger"
       title={
         <h2>

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_external_connector/external_connector_form_fields.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_external_connector/external_connector_form_fields.tsx
@@ -33,7 +33,7 @@ export const ExternalConnectorFormFields: React.FC = () => {
         <>
           <EuiCallOut
             color="danger"
-            iconType="alert"
+            iconType="warning"
             title={i18n.translate(
               'xpack.enterpriseSearch.workplaceSearch.contentSource.addSource.externalConnectorConfig.insecureTitle',
               {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_layout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_layout.tsx
@@ -47,7 +47,7 @@ export const SourceLayout: React.FC<PageTemplateProps> = ({
 
   const callout = (
     <>
-      <EuiCallOut title={SOURCE_DISABLED_CALLOUT_TITLE} color="warning" iconType="alert">
+      <EuiCallOut title={SOURCE_DISABLED_CALLOUT_TITLE} color="warning" iconType="warning">
         <p>{SOURCE_DISABLED_CALLOUT_DESCRIPTION}</p>
         <EuiButton color="warning" href={docLinks.licenseManagement}>
           {SOURCE_DISABLED_CALLOUT_BUTTON}

--- a/x-pack/plugins/file_upload/public/components/import_complete_view.tsx
+++ b/x-pack/plugins/file_upload/public/components/import_complete_view.tsx
@@ -105,7 +105,7 @@ export class ImportCompleteView extends Component<Props, {}> {
             defaultMessage: 'Unable to upload file',
           })}
           color="danger"
-          iconType="alert"
+          iconType="warning"
           data-test-subj={STATUS_CALLOUT_DATA_TEST_SUBJ}
         >
           <p>
@@ -149,7 +149,7 @@ export class ImportCompleteView extends Component<Props, {}> {
             defaultMessage: 'Unable to upload file',
           })}
           color="danger"
-          iconType="alert"
+          iconType="warning"
           data-test-subj={STATUS_CALLOUT_DATA_TEST_SUBJ}
         >
           <p>{errorMsg}</p>

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_yaml_flyout.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_yaml_flyout.tsx
@@ -49,7 +49,7 @@ export const AgentPolicyYamlFlyout = memo<{ policyId: string; onClose: () => voi
           />
         }
         color="danger"
-        iconType="alert"
+        iconType="warning"
       >
         {error.message}
       </EuiCallOut>

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/dataset_combo.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/dataset_combo.tsx
@@ -99,7 +99,7 @@ export const DatasetComboBox: React.FC<{
         <>
           <EuiSpacer size="xs" />
           <EuiText size="xs" color="warning">
-            <EuiIcon type="alert" />
+            <EuiIcon type="warning" />
             &nbsp;
             <FormattedMessage
               id="xpack.fleet.datasetCombo.warning"

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/details_page/components/package_policies/package_policies_table.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/details_page/components/package_policies/package_policies_table.tsx
@@ -190,7 +190,7 @@ export const PackagePoliciesTable: React.FunctionComponent<Props> = ({
                         { defaultMessage: 'Upgrade Available' }
                       )}
                     >
-                      <EuiIcon type="alert" color="warning" />
+                      <EuiIcon type="warning" color="warning" />
                     </EuiToolTip>
                   </EuiFlexItem>
                   <EuiFlexItem grow={false}>

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/components/upgrade.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/components/upgrade.tsx
@@ -96,7 +96,7 @@ export const UpgradeStatusCallout: React.FunctionComponent<{
             defaultMessage: 'Review field conflicts',
           })}
           color="warning"
-          iconType="alert"
+          iconType="warning"
         >
           <FormattedMessage
             id="xpack.fleet.upgradePackagePolicy.statusCallout.errorContent"

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_details/agent_details_integrations.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_details/agent_details_integrations.tsx
@@ -234,7 +234,7 @@ export const AgentDetailsIntegration: React.FunctionComponent<{
               </EuiFlexItem>
               {showNeedsAttentionBadge && (
                 <EuiFlexItem grow={false}>
-                  <EuiBadge color={theme.euiTheme.colors.danger} iconType="alert" iconSide="left">
+                  <EuiBadge color={theme.euiTheme.colors.danger} iconType="warning" iconSide="left">
                     <FormattedMessage
                       id="xpack.fleet.agentDetailsIntegrations.needsAttention.label"
                       defaultMessage="Needs attention"

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_details/agent_details_overview.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_details/agent_details_overview.tsx
@@ -181,7 +181,7 @@ export const AgentDetailsOverviewSection: React.FunctionComponent<{
                             defaultMessage: 'Upgrade available',
                           })}
                         >
-                          <EuiIcon type="alert" color="warning" />
+                          <EuiIcon type="warning" color="warning" />
                         </EuiToolTip>
                       </EuiFlexItem>
                     ) : null}

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_diagnostics/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_diagnostics/index.tsx
@@ -134,7 +134,7 @@ export const AgentDiagnosticsTab: React.FunctionComponent<AgentDiagnosticsProps>
     }
   }, [prevDiagnosticsEntries, diagnosticsEntries, notifications.toasts]);
 
-  const errorIcon = <MarginedIcon type="alert" color="red" />;
+  const errorIcon = <MarginedIcon type="warning" color="red" />;
   const getErrorMessage = (error?: string) => (error ? `Error: ${error}` : '');
 
   const columns: Array<EuiTableFieldDataColumnType<AgentDiagnostics>> = [
@@ -238,7 +238,7 @@ export const AgentDiagnosticsTab: React.FunctionComponent<AgentDiagnosticsProps>
     <EuiFlexGroup direction="column" gutterSize="l">
       <EuiFlexItem>
         <EuiCallOut
-          iconType="alert"
+          iconType="warning"
           color="warning"
           title={
             <FormattedMessage

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agent_activity_flyout.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agent_activity_flyout.tsx
@@ -386,7 +386,7 @@ const ActivityItem: React.FunctionComponent<{ action: ActionStatus }> = ({ actio
     ROLLOUT_PASSED: {
       icon:
         action.nbAgentsFailed > 0 ? (
-          <EuiIcon size="m" type="alert" color="red" />
+          <EuiIcon size="m" type="warning" color="red" />
         ) : (
           <EuiIcon size="m" type="checkInCircleFilled" color="green" />
         ),
@@ -422,13 +422,13 @@ const ActivityItem: React.FunctionComponent<{ action: ActionStatus }> = ({ actio
         ),
     },
     FAILED: {
-      icon: <EuiIcon size="m" type="alert" color="red" />,
+      icon: <EuiIcon size="m" type="warning" color="red" />,
       title: completeTitle,
       titleColor: 'red',
       description: failedDescription,
     },
     CANCELLED: {
-      icon: <EuiIcon size="m" type="alert" color="grey" />,
+      icon: <EuiIcon size="m" type="warning" color="grey" />,
       titleColor: 'grey',
       title: (
         <EuiText>
@@ -454,7 +454,7 @@ const ActivityItem: React.FunctionComponent<{ action: ActionStatus }> = ({ actio
       ),
     },
     EXPIRED: {
-      icon: <EuiIcon size="m" type="alert" color="grey" />,
+      icon: <EuiIcon size="m" type="warning" color="grey" />,
       titleColor: 'grey',
       title: (
         <EuiText>

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agent_list_table.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agent_list_table.tsx
@@ -145,7 +145,7 @@ export const AgentListTable: React.FC<Props> = (props: Props) => {
             {showWarning && (
               <EuiFlexItem grow={false}>
                 <EuiText color="subdued" size="xs" className="eui-textNoWrap">
-                  <EuiIcon size="m" type="alert" color="warning" />
+                  <EuiIcon size="m" type="warning" color="warning" />
                   &nbsp;
                   <FormattedMessage
                     id="xpack.fleet.agentList.outOfDateLabel"
@@ -243,7 +243,7 @@ export const AgentListTable: React.FC<Props> = (props: Props) => {
           {isAgentSelectable(agent) && isAgentUpgradeable(agent, kibanaVersion) ? (
             <EuiFlexItem grow={false}>
               <EuiText color="subdued" size="xs" className="eui-textNoWrap">
-                <EuiIcon size="m" type="alert" color="warning" />
+                <EuiIcon size="m" type="warning" color="warning" />
                 &nbsp;
                 <FormattedMessage
                   id="xpack.fleet.agentList.agentUpgradeLabel"

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/search_and_filter_bar.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/search_and_filter_bar.tsx
@@ -244,7 +244,7 @@ export const SearchAndFilterBar: React.FunctionComponent<{
                       >
                         <EuiFlexGroup alignItems="center" justifyContent="center" gutterSize="s">
                           <EuiFlexItem grow={false}>
-                            <EuiIcon type="crossInACircleFilled" color="danger" size="s" />
+                            <EuiIcon type="error" color="danger" size="s" />
                           </EuiFlexItem>
                           <EuiFlexItem grow={false}>Clear all</EuiFlexItem>
                         </EuiFlexGroup>

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_requirements_page/es_requirements_page.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_requirements_page/es_requirements_page.tsx
@@ -35,7 +35,7 @@ export const RequirementItem: React.FunctionComponent<{ isMissing: boolean }> = 
       <EuiFlexItem grow={false}>
         <EuiText>
           {isMissing ? (
-            <EuiIcon type="crossInACircleFilled" color="danger" />
+            <EuiIcon type="error" color="danger" />
           ) : (
             <EuiIcon type="checkInCircleFilled" color="success" />
           )}
@@ -62,7 +62,7 @@ export const MissingESRequirementsPage: React.FunctionComponent<{
               defaultMessage: 'Missing security requirements',
             })}
             color="warning"
-            iconType="alert"
+            iconType="warning"
           >
             <FormattedMessage
               id="xpack.fleet.setupPage.missingRequirementsCalloutDescription"

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/agent_unenroll_modal/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/agent_unenroll_modal/index.tsx
@@ -133,7 +133,7 @@ export const AgentUnenrollAgentModal: React.FunctionComponent<Props> = ({
                 defaultMessage: 'This agent is running Fleet Server',
               })}
               color="warning"
-              iconType="alert"
+              iconType="warning"
             >
               <p>
                 <FormattedMessage

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/fleet_server_callouts/fleet_server_cloud_unhealthy_callout.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/fleet_server_callouts/fleet_server_cloud_unhealthy_callout.tsx
@@ -21,7 +21,7 @@ export const FleetServerCloudUnhealthyCallout: React.FunctionComponent<
   const { docLinks } = useStartServices();
   return (
     <EuiCallOut
-      iconType="alert"
+      iconType="warning"
       color="warning"
       title={
         <FormattedMessage

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/fleet_server_callouts/fleet_server_on_prem_required_callout.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/fleet_server_callouts/fleet_server_on_prem_required_callout.tsx
@@ -15,7 +15,7 @@ export const FleetServerOnPremRequiredCallout = () => {
   const { docLinks } = useStartServices();
   return (
     <EuiCallOut
-      iconType="alert"
+      iconType="warning"
       title={
         <FormattedMessage
           id="xpack.fleet.fleetServerOnPremRequiredCallout.calloutTitle"

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/fleet_server_callouts/fleet_server_on_prem_unhealthy_callout.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/fleet_server_callouts/fleet_server_on_prem_unhealthy_callout.tsx
@@ -20,7 +20,7 @@ export const FleetServerOnPremUnhealthyCallout: React.FunctionComponent<
   const { docLinks } = useStartServices();
   return (
     <EuiCallOut
-      iconType="alert"
+      iconType="warning"
       color="warning"
       title={
         <FormattedMessage

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/debug/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/debug/index.tsx
@@ -115,7 +115,7 @@ export const DebugPage: React.FunctionComponent<{
               iconType="wrench"
             />
             <EuiSpacer size="m" />
-            <EuiCallOut color="danger" iconType="alert" title="Danger zone">
+            <EuiCallOut color="danger" iconType="warning" title="Danger zone">
               <EuiText grow={false}>
                 <FormattedMessage
                   id="xpack.fleet.debug.dangerZone.description"
@@ -144,7 +144,7 @@ export const DebugPage: React.FunctionComponent<{
             {!isInitialized && setupError?.message && (
               <>
                 <EuiSpacer size="s" />
-                <EuiCallOut color="danger" iconType="alert" title="Setup error">
+                <EuiCallOut color="danger" iconType="warning" title="Setup error">
                   <EuiText grow={false}>
                     <FormattedMessage
                       id="xpack.fleet.debug.initializationError.description"

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/encryption_key_required_callout.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/encryption_key_required_callout.tsx
@@ -15,7 +15,7 @@ export const EncryptionKeyRequiredCallout: React.FunctionComponent = () => {
   const { docLinks } = useStartServices();
   return (
     <EuiCallOut
-      iconType="alert"
+      iconType="warning"
       color="warning"
       title={
         <FormattedMessage

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/fleet_server_hosts_flyout/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/fleet_server_hosts_flyout/index.tsx
@@ -80,7 +80,7 @@ export const FleetServerHostsFlyout: React.FunctionComponent<FleetServerHostsFly
         <EuiCallOut
           size="m"
           color="warning"
-          iconType="alert"
+          iconType="warning"
           title={
             <FormattedMessage
               id="xpack.fleet.settings.fleetServerHostsFlyout.warningCalloutTitle"

--- a/x-pack/plugins/fleet/public/applications/integrations/components/confirm_open_unverified_modal.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/components/confirm_open_unverified_modal.tsx
@@ -53,7 +53,7 @@ export const ConfirmOpenUnverifiedModal: React.FC<{
           },
         })}
         color="warning"
-        iconType="alert"
+        iconType="warning"
         children={
           <FormattedMessage
             id="xpack.fleet.ConfirmOpenUnverifiedModal.calloutBody"

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/components/icons.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/components/icons.tsx
@@ -16,7 +16,7 @@ export const UpdateIcon = ({ size = 'm' }: { size?: EuiIconProps['size'] }) => (
       defaultMessage: 'Update available',
     })}
     size={size}
-    type="alert"
+    type="warning"
     color="warning"
     content={i18n.translate('xpack.fleet.epm.updateAvailableTooltip', {
       defaultMessage: 'Update available',

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/components/update_icon.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/components/update_icon.tsx
@@ -16,7 +16,7 @@ export const UpdateIcon = ({ size = 'm' }: { size?: EuiIconProps['size'] }) => (
       defaultMessage: 'Update available',
     })}
     size={size}
-    type="alert"
+    type="warning"
     color="warning"
     content={i18n.translate('xpack.fleet.epm.updateAvailableTooltip', {
       defaultMessage: 'Update available',

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/overview/overview.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/overview/overview.tsx
@@ -49,7 +49,7 @@ const UnverifiedCallout: React.FC = () => {
         title={i18n.translate('xpack.fleet.epm.verificationWarningCalloutTitle', {
           defaultMessage: 'Integration not verified',
         })}
-        iconType="alert"
+        iconType="warning"
         color="warning"
       >
         <p>

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/policies/package_policies.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/policies/package_policies.tsx
@@ -71,7 +71,7 @@ const IntegrationDetailsLink = memo<{
 
 const AgentPolicyNotFound = () => (
   <EuiText color="subdued" size="xs" className="eui-textNoWrap">
-    <EuiIcon size="m" type="alert" color="warning" />
+    <EuiIcon size="m" type="warning" color="warning" />
     &nbsp;
     <FormattedMessage
       id="xpack.fleet.epm.packageDetails.integrationList.agentPolicyDeletedWarning"

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/settings/settings.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/settings/settings.tsx
@@ -73,7 +73,7 @@ const UpdatesAvailableMsg = ({
 }) => (
   <EuiCallOut
     color="warning"
-    iconType="alert"
+    iconType="warning"
     title={i18n.translate('xpack.fleet.integrations.settings.versionInfo.updatesAvailable', {
       defaultMessage: 'New version available',
     })}

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/settings/update_button.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/settings/update_button.tsx
@@ -239,7 +239,7 @@ export const UpdateButton: React.FunctionComponent<UpdateButtonProps> = ({
           <>
             <EuiCallOut
               color="warning"
-              iconType="alert"
+              iconType="warning"
               title={i18n.translate(
                 'xpack.fleet.integrations.settings.confirmUpdateModal.conflictCallOut.title',
                 { defaultMessage: 'Some integration policies have conflicts' }

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/home/installed_packages.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/home/installed_packages.tsx
@@ -77,7 +77,7 @@ const UpdatesAvailableCallout: React.FC<{ count: number }> = ({ count }) => (
         count,
       },
     })}
-    iconType="alert"
+    iconType="warning"
     color="warning"
   >
     <p>
@@ -97,7 +97,7 @@ const VerificationWarningCallout: React.FC = () => {
       title={i18n.translate('xpack.fleet.epmList.verificationWarningCalloutTitle', {
         defaultMessage: 'Integrations not verified',
       })}
-      iconType="alert"
+      iconType="warning"
       color="warning"
     >
       <p>

--- a/x-pack/plugins/fleet/public/components/agent_policy_package_badges.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_policy_package_badges.tsx
@@ -106,7 +106,7 @@ export const AgentPolicyPackageBadges: React.FunctionComponent<Props> = ({
           <EuiCallOut
             size="s"
             color="warning"
-            iconType="alert"
+            iconType="warning"
             title={i18n.translate(
               'xpack.fleet.agentReassignPolicy.packageBadgeFleetServerWarning',
               {

--- a/x-pack/plugins/fleet/public/components/confirm_force_install_modal.tsx
+++ b/x-pack/plugins/fleet/public/components/confirm_force_install_modal.tsx
@@ -62,7 +62,7 @@ export const ConfirmForceInstallModal: React.FC<{
       <EuiCallOut
         title={title}
         color="warning"
-        iconType="alert"
+        iconType="warning"
         children={
           <FormattedMessage
             id="xpack.fleet.ConfirmForceInstallModal.calloutBody"

--- a/x-pack/plugins/fleet/public/components/error.tsx
+++ b/x-pack/plugins/fleet/public/components/error.tsx
@@ -13,7 +13,7 @@ export const Error: React.FunctionComponent<{
   error: Error | string;
 }> = ({ title, error }) => {
   return (
-    <EuiCallOut title={title} color="danger" iconType="alert">
+    <EuiCallOut title={title} color="danger" iconType="warning">
       <p>{typeof error === 'string' ? error : error.message}</p>
     </EuiCallOut>
   );

--- a/x-pack/plugins/fleet/public/components/platform_selector.tsx
+++ b/x-pack/plugins/fleet/public/components/platform_selector.tsx
@@ -79,7 +79,7 @@ export const PlatformSelector: React.FunctionComponent<Props> = ({
           'We recommend using the installers (TAR/ZIP) over system packages (RPM/DEB) because they provide the ability to upgrade your agent with Fleet.',
       })}
       color="warning"
-      iconType="alert"
+      iconType="warning"
     />
   );
 
@@ -90,7 +90,7 @@ export const PlatformSelector: React.FunctionComponent<Props> = ({
           'We recommend adding the Kubernetes integration to your agent policy in order to get useful metrics and logs from your Kubernetes clusters.',
       })}
       color="warning"
-      iconType="alert"
+      iconType="warning"
     />
   );
 

--- a/x-pack/plugins/grokdebugger/public/components/inactive_license.js
+++ b/x-pack/plugins/grokdebugger/public/components/inactive_license.js
@@ -50,7 +50,7 @@ export const InactiveLicenseSlate = () => {
                 defaultMessage: 'License error',
               })}
               color="danger"
-              iconType="alert"
+              iconType="warning"
               style={{ padding: '16px' }}
             >
               <EuiText size="s">

--- a/x-pack/plugins/index_lifecycle_management/public/application/sections/edit_policy/components/edit_warning.tsx
+++ b/x-pack/plugins/index_lifecycle_management/public/application/sections/edit_policy/components/edit_warning.tsx
@@ -89,7 +89,7 @@ export const EditWarning: FunctionComponent = () => {
                 />
               }
               color="danger"
-              iconType="alert"
+              iconType="warning"
               data-test-subj="editManagedPolicyCallOut"
             >
               <p>

--- a/x-pack/plugins/index_lifecycle_management/public/application/sections/edit_policy/components/phases/hot_phase/components/max_index_size_field.tsx
+++ b/x-pack/plugins/index_lifecycle_management/public/application/sections/edit_policy/components/phases/hot_phase/components/max_index_size_field.tsx
@@ -42,7 +42,7 @@ export const MaxIndexSizeField: FunctionComponent = () => {
               min: 1,
               prepend: (
                 <EuiIconTip
-                  type="alert"
+                  type="warning"
                   aria-label={i18nTexts.deprecationMessage}
                   content={i18nTexts.deprecationMessage}
                 />

--- a/x-pack/plugins/index_lifecycle_management/public/application/sections/edit_policy/components/phases/phase/phase_title.tsx
+++ b/x-pack/plugins/index_lifecycle_management/public/application/sections/edit_policy/components/phases/phase/phase_title.tsx
@@ -96,7 +96,7 @@ export const PhaseTitle: FunctionComponent<Props> = ({ phase }) => {
           {hasErrors && (
             <EuiFlexItem grow={false} data-test-subj={`phaseErrorIndicator-${phase}`}>
               <EuiIconTip
-                type="alert"
+                type="warning"
                 color="danger"
                 content={
                   <FormattedMessage

--- a/x-pack/plugins/index_lifecycle_management/public/application/sections/edit_policy/components/policy_json_flyout.tsx
+++ b/x-pack/plugins/index_lifecycle_management/public/application/sections/edit_policy/components/policy_json_flyout.tsx
@@ -89,7 +89,7 @@ export const PolicyJsonFlyout: React.FunctionComponent<Props> = ({ policyName, c
       content = (
         <EuiCallOut
           data-test-subj="policyRequestInvalidAlert"
-          iconType="alert"
+          iconType="warning"
           color="danger"
           title={i18n.translate(
             'xpack.indexLifecycleMgmt.policyJsonFlyout.validationErrorCallout.title',

--- a/x-pack/plugins/index_lifecycle_management/public/application/sections/policy_list/components/confirm_delete.tsx
+++ b/x-pack/plugins/index_lifecycle_management/public/application/sections/policy_list/components/confirm_delete.tsx
@@ -93,7 +93,7 @@ export class ConfirmDelete extends Component<Props> {
               />
             }
             color="danger"
-            iconType="alert"
+            iconType="warning"
             data-test-subj="deleteManagedPolicyCallOut"
           >
             <p>

--- a/x-pack/plugins/index_management/public/application/components/component_templates/component_template_details/component_template_details.tsx
+++ b/x-pack/plugins/index_management/public/application/components/component_templates/component_template_details/component_template_details.tsx
@@ -84,7 +84,7 @@ export const ComponentTemplateDetailsFlyoutContent: React.FunctionComponent<Prop
           />
         }
         color="danger"
-        iconType="alert"
+        iconType="warning"
         data-test-subj="sectionError"
       >
         <p>{error.message}</p>

--- a/x-pack/plugins/index_management/public/application/components/component_templates/component_template_wizard/component_template_edit/mappings_datastreams_rollover_modal.tsx
+++ b/x-pack/plugins/index_management/public/application/components/component_templates/component_template_wizard/component_template_edit/mappings_datastreams_rollover_modal.tsx
@@ -82,7 +82,7 @@ export const MappingsDatastreamRolloverModal: React.FunctionComponent<Props> = (
               />
             }
             color="danger"
-            iconType="alert"
+            iconType="warning"
             data-test-subj="applyMappingsRolloverError"
           >
             <div>{error.message}</div>

--- a/x-pack/plugins/index_management/public/application/components/component_templates/component_template_wizard/component_template_form/component_template_form.tsx
+++ b/x-pack/plugins/index_management/public/application/components/component_templates/component_template_wizard/component_template_form/component_template_form.tsx
@@ -133,7 +133,7 @@ export const ComponentTemplateForm = ({
           />
         }
         color="danger"
-        iconType="alert"
+        iconType="warning"
         data-test-subj="saveComponentTemplateError"
       >
         <div>{saveError.message || saveError.statusText}</div>

--- a/x-pack/plugins/index_management/public/application/components/index_templates/legacy_index_template_deprecation.tsx
+++ b/x-pack/plugins/index_management/public/application/components/index_templates/legacy_index_template_deprecation.tsx
@@ -29,7 +29,7 @@ export const LegacyIndexTemplatesDeprecation: React.FunctionComponent<Props> = (
           'Legacy index templates are deprecated in favor of composable index templates',
       })}
       color="warning"
-      iconType="alert"
+      iconType="warning"
       data-test-subj="legacyIndexTemplateDeprecationWarning"
     >
       {showCta && history && (

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/components/configuration_form/source_field_section/source_field_section.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/components/configuration_form/source_field_section/source_field_section.tsx
@@ -21,7 +21,7 @@ export const SourceFieldSection = () => {
       title={i18n.translate('xpack.idxMgmt.mappingsEditor.disabledSourceFieldCallOutTitle', {
         defaultMessage: 'Use caution when disabling the _source field',
       })}
-      iconType="alert"
+      iconType="warning"
       color="warning"
     >
       <p>

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/field_parameters/fielddata_parameter.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/field_parameters/fielddata_parameter.tsx
@@ -114,7 +114,7 @@ export const FieldDataParameter = ({ field, defaultToggleValue }: Props) => {
             <>
               <EuiCallOut
                 color="warning"
-                iconType="alert"
+                iconType="warning"
                 size="s"
                 title={
                   <FormattedMessage

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/field_parameters/relations_parameter.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/field_parameters/relations_parameter.tsx
@@ -94,7 +94,7 @@ export const RelationsParameter = () => {
   const renderWarning = () => (
     <EuiCallOut
       color="warning"
-      iconType="alert"
+      iconType="warning"
       size="s"
       title={
         <FormattedMessage

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/field_types/text_type.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/field_types/text_type.tsx
@@ -211,7 +211,7 @@ export const TextType = React.memo(({ field, kibanaVersion }: Props) => {
                           defaultMessage: 'Positions not enabled.',
                         })}
                         color="danger"
-                        iconType="alert"
+                        iconType="warning"
                       >
                         <p>
                           {i18n.translate('xpack.idxMgmt.mappingsEditor.positionsErrorMessage', {

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/components/load_mappings/load_mappings_provider.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/components/load_mappings/load_mappings_provider.tsx
@@ -249,7 +249,11 @@ export const LoadMappingsProvider = ({ onJson, esNodesPlugins, children }: Props
             </div>
           ) : (
             <>
-              <EuiCallOut title={i18nTexts.validationErrors.title} iconType="warning" color="warning">
+              <EuiCallOut
+                title={i18nTexts.validationErrors.title}
+                iconType="warning"
+                color="warning"
+              >
                 <EuiText>
                   <p>{i18nTexts.validationErrors.description}</p>
                 </EuiText>

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/components/load_mappings/load_mappings_provider.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/components/load_mappings/load_mappings_provider.tsx
@@ -249,7 +249,7 @@ export const LoadMappingsProvider = ({ onJson, esNodesPlugins, children }: Props
             </div>
           ) : (
             <>
-              <EuiCallOut title={i18nTexts.validationErrors.title} iconType="alert" color="warning">
+              <EuiCallOut title={i18nTexts.validationErrors.title} iconType="warning" color="warning">
                 <EuiText>
                   <p>{i18nTexts.validationErrors.description}</p>
                 </EuiText>

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/components/multiple_mappings_warning.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/components/multiple_mappings_warning.tsx
@@ -17,7 +17,7 @@ export const MultipleMappingsWarning = () => (
     title={i18n.translate('xpack.idxMgmt.mappingsEditor.mappingTypesDetectedCallOutTitle', {
       defaultMessage: 'Mapping types detected',
     })}
-    iconType="alert"
+    iconType="warning"
     color="warning"
     data-test-subj="mappingTypesDetectedCallout"
   >

--- a/x-pack/plugins/index_management/public/application/components/section_error.tsx
+++ b/x-pack/plugins/index_management/public/application/components/section_error.tsx
@@ -33,7 +33,7 @@ export const SectionError: React.FunctionComponent<Props> = ({ title, error, ...
   const cause = causeAttributes ?? causeRoot;
 
   return (
-    <EuiCallOut title={title} color="danger" iconType="alert" {...rest}>
+    <EuiCallOut title={title} color="danger" iconType="warning" {...rest}>
       <div>{message || statusText}</div>
       {cause && (
         <Fragment>

--- a/x-pack/plugins/index_management/public/application/components/template_delete_modal.tsx
+++ b/x-pack/plugins/index_management/public/application/components/template_delete_modal.tsx
@@ -124,7 +124,7 @@ export const TemplateDeleteModal = ({
               {name.startsWith('.') ? (
                 <Fragment>
                   {' '}
-                  <EuiBadge iconType="alert" color="hollow">
+                  <EuiBadge iconType="warning" color="hollow">
                     <FormattedMessage
                       id="xpack.idxMgmt.deleteTemplatesModal.systemTemplateLabel"
                       defaultMessage="System template"
@@ -144,7 +144,7 @@ export const TemplateDeleteModal = ({
               />
             }
             color="danger"
-            iconType="alert"
+            iconType="warning"
             data-test-subj="deleteSystemTemplateCallOut"
           >
             <p>

--- a/x-pack/plugins/index_management/public/application/sections/home/data_stream_list/delete_data_stream_confirmation_modal/delete_data_stream_confirmation_modal.tsx
+++ b/x-pack/plugins/index_management/public/application/sections/home/data_stream_list/delete_data_stream_confirmation_modal/delete_data_stream_confirmation_modal.tsx
@@ -123,7 +123,7 @@ export const DeleteDataStreamConfirmationModal: React.FunctionComponent<Props> =
             />
           }
           color="danger"
-          iconType="alert"
+          iconType="warning"
         >
           <p>
             <FormattedMessage

--- a/x-pack/plugins/index_management/public/application/sections/home/index_list/detail_panel/edit_settings_json/edit_settings_json.js
+++ b/x-pack/plugins/index_management/public/application/sections/home/index_list/detail_panel/edit_settings_json/edit_settings_json.js
@@ -103,7 +103,7 @@ export class EditSettingsJson extends React.PureComponent {
             defaultMessage: 'There was an error while trying to save your settings',
           })}
           color="danger"
-          iconType="alert"
+          iconType="warning"
           data-test-subj="updateIndexSettingsErrorCallout"
         >
           <p>{error}</p>

--- a/x-pack/plugins/index_management/public/application/sections/home/index_list/index_actions_context_menu/index_actions_context_menu.js
+++ b/x-pack/plugins/index_management/public/application/sections/home/index_list/index_actions_context_menu/index_actions_context_menu.js
@@ -433,7 +433,7 @@ export class IndexActionsContextMenu extends Component {
               {isSystemIndexByName[indexName] ? (
                 <Fragment>
                   {' '}
-                  <EuiBadge iconType="alert" color="hollow">
+                  <EuiBadge iconType="warning" color="hollow">
                     <FormattedMessage
                       id="xpack.idxMgmt.indexActionsMenu.deleteIndex.systemIndexLabel"
                       defaultMessage="System index"
@@ -455,7 +455,7 @@ export class IndexActionsContextMenu extends Component {
             }
           )}
           color="danger"
-          iconType="alert"
+          iconType="warning"
         >
           <p>
             <FormattedMessage
@@ -561,7 +561,7 @@ export class IndexActionsContextMenu extends Component {
               {isSystemIndexByName[indexName] ? (
                 <Fragment>
                   {' '}
-                  <EuiBadge iconType="alert" color="hollow">
+                  <EuiBadge iconType="warning" color="hollow">
                     <FormattedMessage
                       id="xpack.idxMgmt.indexActionsMenu.closeIndex.systemIndexLabel"
                       defaultMessage="System index"
@@ -583,7 +583,7 @@ export class IndexActionsContextMenu extends Component {
             }
           )}
           color="danger"
-          iconType="alert"
+          iconType="warning"
         >
           <p>
             <FormattedMessage

--- a/x-pack/plugins/index_management/public/application/sections/template_edit/template_edit.tsx
+++ b/x-pack/plugins/index_management/public/application/sections/template_edit/template_edit.tsx
@@ -136,7 +136,7 @@ export const TemplateEdit: React.FunctionComponent<RouteComponentProps<MatchPara
               />
             }
             color="danger"
-            iconType="alert"
+            iconType="warning"
             data-test-subj="systemTemplateEditCallout"
           >
             <FormattedMessage

--- a/x-pack/plugins/infra/public/alerting/log_threshold/components/expression_editor/editor.tsx
+++ b/x-pack/plugins/infra/public/alerting/log_threshold/components/expression_editor/editor.tsx
@@ -139,7 +139,7 @@ export const SourceStatusWrapper: React.FC = ({ children }) => {
             defaultMessage: 'Sorry, there was a problem loading field information',
           })}
           color="danger"
-          iconType="alert"
+          iconType="warning"
         >
           <EuiButton onClick={load} iconType="refresh">
             {i18n.translate('xpack.infra.logs.alertFlyout.sourceStatusErrorTryAgain', {

--- a/x-pack/plugins/infra/public/components/data_search_error_callout.tsx
+++ b/x-pack/plugins/infra/public/components/data_search_error_callout.tsx
@@ -23,7 +23,7 @@ export const DataSearchErrorCallout: React.FC<{
   const calloutColor = errors.some((error) => error.type !== 'aborted') ? 'danger' : 'warning';
 
   return (
-    <EuiCallOut color={calloutColor} iconType="alert" title={title}>
+    <EuiCallOut color={calloutColor} iconType="warning" title={title}>
       {errors?.map((error, errorIndex) => (
         <DataSearchErrorMessage key={errorIndex} error={error} />
       ))}

--- a/x-pack/plugins/infra/public/components/infrastructure_node_metrics_tables/shared/components/error_content.tsx
+++ b/x-pack/plugins/infra/public/components/infrastructure_node_metrics_tables/shared/components/error_content.tsx
@@ -17,7 +17,7 @@ export const MetricsTableErrorContent = ({ error }: { error: Error }) => (
     }
     color="danger"
     data-test-subj="metricsTableErrorContent"
-    iconType="alert"
+    iconType="warning"
     title={<h2>{error.message}</h2>}
     titleSize="s"
   />

--- a/x-pack/plugins/infra/public/components/logging/log_analysis_job_status/recreate_job_callout.tsx
+++ b/x-pack/plugins/infra/public/components/logging/log_analysis_job_status/recreate_job_callout.tsx
@@ -14,7 +14,7 @@ export const RecreateJobCallout: React.FC<{
   onRecreateMlJob: () => void;
   title?: React.ReactNode;
 }> = ({ children, hasSetupCapabilities, onRecreateMlJob, title }) => (
-  <EuiCallOut color="warning" iconType="alert" title={title}>
+  <EuiCallOut color="warning" iconType="warning" title={title}>
     {children}
     <RecreateJobButton
       color="warning"

--- a/x-pack/plugins/infra/public/components/logging/log_analysis_setup/initial_configuration_step/index_setup_dataset_filter.tsx
+++ b/x-pack/plugins/infra/public/components/logging/log_analysis_setup/initial_configuration_step/index_setup_dataset_filter.tsx
@@ -108,5 +108,5 @@ const DatasetWarningMarker: React.FC<{ warnings: QualityWarning[] }> = ({ warnin
       : []
   );
 
-  return <EuiIconTip content={warningDescriptions} type="alert" color="warning" />;
+  return <EuiIconTip content={warningDescriptions} type="warning" color="warning" />;
 };

--- a/x-pack/plugins/infra/public/components/logging/log_analysis_setup/initial_configuration_step/index_setup_row.tsx
+++ b/x-pack/plugins/infra/public/components/logging/log_analysis_setup/initial_configuration_step/index_setup_row.tsx
@@ -78,7 +78,7 @@ export const IndexSetupRow: React.FC<{
                     defaultMessage="While analyzing the log messages from these indices we've detected some problems which might indicate a reduced quality of the results. Consider excluding these indices or problematic datasets from the analysis."
                   />
                 }
-                type="alert"
+                type="warning"
                 color="warning"
               />
             ) : null}

--- a/x-pack/plugins/infra/public/components/logging/log_analysis_setup/initial_configuration_step/initial_configuration_step.tsx
+++ b/x-pack/plugins/infra/public/components/logging/log_analysis_setup/initial_configuration_step/initial_configuration_step.tsx
@@ -111,7 +111,7 @@ const ValidationErrors: React.FC<{ errors: ValidationUIError[] }> = ({ errors })
 
   return (
     <>
-      <EuiCallOut color="danger" iconType="alert" title={errorCalloutTitle}>
+      <EuiCallOut color="danger" iconType="warning" title={errorCalloutTitle}>
         <ul>
           {errors.map((error, i) => (
             <li key={i}>{formatValidationError(error)}</li>

--- a/x-pack/plugins/infra/public/components/logging/log_analysis_setup/process_step/process_step.tsx
+++ b/x-pack/plugins/infra/public/components/logging/log_analysis_setup/process_step/process_step.tsx
@@ -76,7 +76,7 @@ export const ProcessStep: React.FunctionComponent<ProcessStepProps> = ({
           />
           <EuiSpacer />
           {setupStatus.reasons.map((errorMessage, i) => (
-            <EuiCallOut key={i} color="danger" iconType="alert" title={errorCalloutTitle}>
+            <EuiCallOut key={i} color="danger" iconType="warning" title={errorCalloutTitle}>
               <EuiCode transparentBackground>{errorMessage}</EuiCode>
             </EuiCallOut>
           ))}

--- a/x-pack/plugins/infra/public/observability_logs/xstate_helpers/src/invalid_state_callout.tsx
+++ b/x-pack/plugins/infra/public/observability_logs/xstate_helpers/src/invalid_state_callout.tsx
@@ -15,7 +15,7 @@ import type { State } from 'xstate';
 export const InvalidStateCallout: React.FC<{ state: State<any, any, any, any, any> }> = ({
   state,
 }) => (
-  <EuiCallOut title={invalidStateCalloutTitle} color="danger" iconType="alert">
+  <EuiCallOut title={invalidStateCalloutTitle} color="danger" iconType="warning">
     <FormattedMessage
       id="xpack.infra.logs.common.invalidStateMessage"
       defaultMessage="Unable to handle state {stateValue}."

--- a/x-pack/plugins/infra/public/pages/logs/settings/source_configuration_form_errors.tsx
+++ b/x-pack/plugins/infra/public/pages/logs/settings/source_configuration_form_errors.tsx
@@ -14,7 +14,7 @@ import { FormValidationError } from './validation_errors';
 export const LogSourceConfigurationFormErrors: React.FC<{ errors: FormValidationError[] }> = ({
   errors,
 }) => (
-  <EuiCallOut color="danger" iconType="alert" title={logSourceConfigurationFormErrorsCalloutTitle}>
+  <EuiCallOut color="danger" iconType="warning" title={logSourceConfigurationFormErrorsCalloutTitle}>
     <ul>
       {errors.map((error, errorIndex) => (
         <li key={errorIndex}>

--- a/x-pack/plugins/infra/public/pages/logs/settings/source_configuration_form_errors.tsx
+++ b/x-pack/plugins/infra/public/pages/logs/settings/source_configuration_form_errors.tsx
@@ -14,7 +14,11 @@ import { FormValidationError } from './validation_errors';
 export const LogSourceConfigurationFormErrors: React.FC<{ errors: FormValidationError[] }> = ({
   errors,
 }) => (
-  <EuiCallOut color="danger" iconType="warning" title={logSourceConfigurationFormErrorsCalloutTitle}>
+  <EuiCallOut
+    color="danger"
+    iconType="warning"
+    title={logSourceConfigurationFormErrorsCalloutTitle}
+  >
     <ul>
       {errors.map((error, errorIndex) => (
         <li key={errorIndex}>

--- a/x-pack/plugins/infra/public/pages/logs/shared/page_log_view_error.tsx
+++ b/x-pack/plugins/infra/public/pages/logs/shared/page_log_view_error.tsx
@@ -28,7 +28,7 @@ export const LogViewErrorPage: React.FC<{
   return (
     <LogsPageTemplate isEmptyState={true}>
       <EuiEmptyPrompt
-        iconType="alert"
+        iconType="warning"
         iconColor="danger"
         title={
           <h2>
@@ -153,7 +153,7 @@ const LogSourceErrorMessage: React.FC<{ error: Error }> = ({ error }) => {
 };
 
 const LogSourceErrorCallout: React.FC<{ title: React.ReactNode }> = ({ title, children }) => (
-  <EuiCallOut className="eui-textLeft" color="danger" iconType="alert" title={title}>
+  <EuiCallOut className="eui-textLeft" color="danger" iconType="warning" title={title}>
     <p>{children}</p>
   </EuiCallOut>
 );

--- a/x-pack/plugins/infra/public/pages/metrics/hosts/components/tabs/alerts_tab_badge.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/hosts/components/tabs/alerts_tab_badge.tsx
@@ -31,7 +31,7 @@ export const AlertsTabBadge = () => {
             'The active alert count was not retrieved correctly, try reloading the page.',
         })}
       >
-        <EuiIcon color="warning" type="alert" />
+        <EuiIcon color="warning" type="warning" />
       </EuiToolTip>
     );
   }

--- a/x-pack/plugins/infra/public/pages/metrics/hosts/components/tabs/metrics/metric_chart.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/hosts/components/tabs/metrics/metric_chart.tsx
@@ -91,7 +91,7 @@ export const MetricChart = ({ title, type, breakdownSize }: MetricChartProps) =>
           direction="column"
         >
           <EuiFlexItem grow={false}>
-            <EuiIcon type="alert" />
+            <EuiIcon type="warning" />
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiText size="s" textAlign="center">

--- a/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/node_details/tabs/processes/index.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/node_details/tabs/processes/index.tsx
@@ -135,7 +135,7 @@ const TabComponent = ({ currentTime, node, nodeType }: TabProps) => {
           />
         ) : (
           <EuiEmptyPrompt
-            iconType="alert"
+            iconType="warning"
             title={
               <h4>
                 {i18n.translate('xpack.infra.metrics.nodeDetails.processListError', {

--- a/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/node_details/tabs/processes/process_row_charts.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/node_details/tabs/processes/process_row_charts.tsx
@@ -40,14 +40,14 @@ export const ProcessRowCharts = ({ command }: Props) => {
   const isLoading = loading || !response;
 
   const cpuChart = error ? (
-    <EuiEmptyPrompt iconType="alert" title={<EuiText>{failedToLoadChart}</EuiText>} />
+    <EuiEmptyPrompt iconType="warning" title={<EuiText>{failedToLoadChart}</EuiText>} />
   ) : isLoading ? (
     <EuiLoadingChart />
   ) : (
     <ProcessChart timeseries={response!.cpu} color={Color.color2} label={cpuMetricLabel} />
   );
   const memoryChart = error ? (
-    <EuiEmptyPrompt iconType="alert" title={<EuiText>{failedToLoadChart}</EuiText>} />
+    <EuiEmptyPrompt iconType="warning" title={<EuiText>{failedToLoadChart}</EuiText>} />
   ) : isLoading ? (
     <EuiLoadingChart />
   ) : (

--- a/x-pack/plugins/ingest_pipelines/public/application/components/pipeline_editor/components/load_from_json/modal_provider.tsx
+++ b/x-pack/plugins/ingest_pipelines/public/application/components/pipeline_editor/components/load_from_json/modal_provider.tsx
@@ -117,7 +117,7 @@ export const ModalProvider: FunctionComponent<Props> = ({ onDone, children }) =>
                   data-test-subj="errorCallOut"
                   title={i18nTexts.error.title}
                   color="danger"
-                  iconType="alert"
+                  iconType="warning"
                 >
                   {i18nTexts.error.body}
                 </EuiCallOut>

--- a/x-pack/plugins/ingest_pipelines/public/application/components/pipeline_editor/components/processor_form/processor_output/processor_output.tsx
+++ b/x-pack/plugins/ingest_pipelines/public/application/components/pipeline_editor/components/processor_form/processor_output/processor_output.tsx
@@ -94,7 +94,7 @@ export const ProcessorOutput: FunctionComponent<Props> = ({
   }
 
   if (!processorOutput) {
-    return <EuiCallOut title={i18nTexts.noOutputCalloutTitle} color="danger" iconType="alert" />;
+    return <EuiCallOut title={i18nTexts.noOutputCalloutTitle} color="danger" iconType="warning" />;
   }
 
   const {

--- a/x-pack/plugins/ingest_pipelines/public/application/components/pipeline_editor/components/test_pipeline/test_pipeline_flyout.tsx
+++ b/x-pack/plugins/ingest_pipelines/public/application/components/pipeline_editor/components/test_pipeline/test_pipeline_flyout.tsx
@@ -125,7 +125,7 @@ export const TestPipelineFlyout: React.FunctionComponent<Props> = ({
                 />
               }
               color="danger"
-              iconType="alert"
+              iconType="warning"
               data-test-subj="pipelineExecutionError"
             >
               <p>{testingError.message}</p>

--- a/x-pack/plugins/ingest_pipelines/public/application/components/pipeline_editor/components/test_pipeline/test_pipeline_tabs/tab_documents/add_document_form.tsx
+++ b/x-pack/plugins/ingest_pipelines/public/application/components/pipeline_editor/components/test_pipeline/test_pipeline_tabs/tab_documents/add_document_form.tsx
@@ -148,7 +148,7 @@ export const AddDocumentForm: FunctionComponent<Props> = ({ onAddDocuments }) =>
           <EuiCallOut
             title={i18nTexts.addDocumentErrorMessage}
             color="danger"
-            iconType="alert"
+            iconType="warning"
             data-test-subj="addDocumentError"
             size="s"
           >

--- a/x-pack/plugins/ingest_pipelines/public/application/components/pipeline_form/pipeline_form_error/pipeline_form_error.tsx
+++ b/x-pack/plugins/ingest_pipelines/public/application/components/pipeline_form/pipeline_form_error/pipeline_form_error.tsx
@@ -46,7 +46,7 @@ export const PipelineFormError: React.FunctionComponent<Props> = ({ error }) => 
       <EuiCallOut
         title={i18nTexts.title}
         color="danger"
-        iconType="alert"
+        iconType="warning"
         data-test-subj="savePipelineError"
       >
         {results.length > 1 ? (

--- a/x-pack/plugins/ingest_pipelines/public/application/sections/pipelines_create_from_csv/error_display.tsx
+++ b/x-pack/plugins/ingest_pipelines/public/application/sections/pipelines_create_from_csv/error_display.tsx
@@ -15,7 +15,7 @@ interface Props {
 
 export const Error: FC<Props> = ({ error }) => {
   return (
-    <EuiCallOut title={error.title} color="danger" iconType="alert" data-test-subj="errorCallout">
+    <EuiCallOut title={error.title} color="danger" iconType="warning" data-test-subj="errorCallout">
       <p>
         <FormattedMessage
           id="xpack.ingestPipelines.createFromCsv.errorMessage"

--- a/x-pack/plugins/ingest_pipelines/public/application/sections/pipelines_edit/pipelines_edit.tsx
+++ b/x-pack/plugins/ingest_pipelines/public/application/sections/pipelines_edit/pipelines_edit.tsx
@@ -32,7 +32,7 @@ interface MatchParams {
 const ManagedPipelineCallout = () => (
   <EuiCallOut
     color="danger"
-    iconType="alert"
+    iconType="warning"
     data-test-subj="managedPipelineCallout"
     title={
       <FormattedMessage
@@ -115,7 +115,7 @@ export const PipelinesEdit: React.FunctionComponent<RouteComponentProps<MatchPar
         data-test-subj="fetchPipelineError"
       >
         <EuiEmptyPrompt
-          iconType="alert"
+          iconType="warning"
           title={
             <h2>
               <FormattedMessage

--- a/x-pack/plugins/ingest_pipelines/public/application/sections/pipelines_list/main.tsx
+++ b/x-pack/plugins/ingest_pipelines/public/application/sections/pipelines_list/main.tsx
@@ -83,7 +83,7 @@ export const PipelinesList: React.FunctionComponent<RouteComponentProps> = ({
     return (
       <EuiPageContent verticalPosition="center" horizontalPosition="center" color="danger">
         <EuiEmptyPrompt
-          iconType="alert"
+          iconType="warning"
           title={
             <h2 data-test-subj="pipelineLoadError">
               <FormattedMessage

--- a/x-pack/plugins/ingest_pipelines/public/application/sections/pipelines_list/not_found_flyout.tsx
+++ b/x-pack/plugins/ingest_pipelines/public/application/sections/pipelines_list/not_found_flyout.tsx
@@ -35,7 +35,7 @@ export const PipelineNotFoundFlyout: FunctionComponent<Props> = ({ onClose, pipe
             />
           }
           color="danger"
-          iconType="alert"
+          iconType="warning"
         />
       </EuiFlyoutBody>
     </EuiFlyout>

--- a/x-pack/plugins/lens/public/datasources/form_based/datapanel.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/datapanel.tsx
@@ -127,7 +127,7 @@ export function FormBasedDataPanel({
                 defaultMessage: 'No data views',
               })}
               color="warning"
-              iconType="alert"
+              iconType="warning"
             >
               <p>
                 <FormattedMessage

--- a/x-pack/plugins/lens/public/datasources/form_based/dimension_panel/dimensions_editor_helpers.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/dimension_panel/dimensions_editor_helpers.tsx
@@ -71,7 +71,7 @@ export const CalloutWarning = ({
           title={i18n.translate('xpack.lens.indexPattern.staticValueWarning', {
             defaultMessage: 'Static value currently applied',
           })}
-          iconType="alert"
+          iconType="warning"
           color="warning"
         >
           <p>
@@ -91,7 +91,7 @@ export const CalloutWarning = ({
         title={i18n.translate('xpack.lens.indexPattern.formulaWarning', {
           defaultMessage: 'Formula currently applied',
         })}
-        iconType="alert"
+        iconType="warning"
         color="warning"
       >
         {temporaryStateType !== 'quickFunctions' ? (

--- a/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/formula/editor/formula_editor.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/formula/editor/formula_editor.tsx
@@ -883,7 +883,7 @@ export function FormulaEditor({
                         <EuiButtonEmpty
                           color={errorCount ? 'danger' : 'warning'}
                           className="lnsFormula__editorError"
-                          iconType="alert"
+                          iconType="warning"
                           size="xs"
                           flush="right"
                           onClick={() => {

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/suggestion_panel.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/suggestion_panel.tsx
@@ -118,7 +118,7 @@ const PreviewRenderer = ({
       <EuiIconTip
         size="xl"
         color="danger"
-        type="alert"
+        type="warning"
         aria-label={i18n.translate('xpack.lens.editorFrame.previewErrorLabel', {
           defaultMessage: 'Preview rendering failed',
         })}

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/chart_switch.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/chart_switch.tsx
@@ -368,7 +368,7 @@ export const ChartSwitch = memo(function ChartSwitch(props: Props) {
                                 aria-label={i18n.translate('xpack.lens.chartSwitch.dataLossLabel', {
                                   defaultMessage: 'Warning',
                                 })}
-                                type="alert"
+                                type="warning"
                                 color="warning"
                                 content={i18n.translate(
                                   'xpack.lens.chartSwitch.dataLossDescription',

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.tsx
@@ -711,7 +711,7 @@ export const VisualizationWrapper = ({
               </>
             }
             iconColor="danger"
-            iconType="alert"
+            iconType="warning"
           />
         </EuiFlexItem>
       </EuiFlexGroup>
@@ -780,7 +780,7 @@ export const VisualizationWrapper = ({
                     </>
                   }
                   iconColor="danger"
-                  iconType="alert"
+                  iconType="warning"
                 />
               </EuiFlexItem>
             </EuiFlexGroup>

--- a/x-pack/plugins/lens/public/embeddable/embeddable.tsx
+++ b/x-pack/plugins/lens/public/embeddable/embeddable.tsx
@@ -204,7 +204,7 @@ function VisualizationErrorPanel({ errors, canEdit }: { errors: UserMessage[]; c
   return (
     <div className="lnsEmbeddedError">
       <EuiEmptyPrompt
-        iconType="alert"
+        iconType="warning"
         iconColor="danger"
         data-test-subj="embeddable-lens-failure"
         body={

--- a/x-pack/plugins/license_management/public/application/app.js
+++ b/x-pack/plugins/license_management/public/application/app.js
@@ -54,7 +54,7 @@ export const App = ({
     return (
       <EuiPageContent verticalPosition="center" horizontalPosition="center" color="danger">
         <EuiEmptyPrompt
-          iconType="alert"
+          iconType="warning"
           title={
             <h1>
               <FormattedMessage

--- a/x-pack/plugins/license_management/public/application/sections/license_dashboard/license_page_header/license_page_header.js
+++ b/x-pack/plugins/license_management/public/application/sections/license_dashboard/license_page_header/license_page_header.js
@@ -89,7 +89,7 @@ export const LicensePageHeader = () => {
         <ExpiredLicensePageHeader
           license={license}
           bottomBorder
-          iconType="alert"
+          iconType="warning"
           iconProps={{ color: 'danger' }}
         />
       ) : (

--- a/x-pack/plugins/lists/public/exceptions/components/builder/entry_renderer.tsx
+++ b/x-pack/plugins/lists/public/exceptions/components/builder/entry_renderer.tsx
@@ -224,7 +224,7 @@ export const BuilderEntryItem: React.FC<EntryItemProps> = ({
               id={'1'}
               buttonContent={
                 <>
-                  <EuiIcon tabIndex={0} type="alert" size="s" css={warningIconCss} />
+                  <EuiIcon tabIndex={0} type="warning" size="s" css={warningIconCss} />
                   {i18n.FIELD_CONFLICT_INDICES_WARNING_DESCRIPTION}
                 </>
               }

--- a/x-pack/plugins/maps/public/classes/layers/vector_layer/geojson_vector_layer/geojson_vector_layer.tsx
+++ b/x-pack/plugins/maps/public/classes/layers/vector_layer/geojson_vector_layer/geojson_vector_layer.tsx
@@ -93,7 +93,7 @@ export class GeoJsonVectorLayer extends AbstractVectorLayer {
       this.getSource().getSourceStatus(sourceDataRequest);
     return {
       icon: isDeprecated ? (
-        <EuiIcon type="alert" color="danger" />
+        <EuiIcon type="warning" color="danger" />
       ) : (
         this.getCurrentStyle().getIcon(isTocIcon && areResultsTrimmed)
       ),

--- a/x-pack/plugins/maps/public/classes/layers/wizards/new_vector_layer_wizard/wizard.tsx
+++ b/x-pack/plugins/maps/public/classes/layers/wizards/new_vector_layer_wizard/wizard.tsx
@@ -157,7 +157,7 @@ export class NewVectorLayerEditor extends Component<RenderWizardArguments, State
               defaultMessage: 'Missing index privileges',
             })}
             color="danger"
-            iconType="alert"
+            iconType="warning"
           >
             <p>{this.state.createIndexError}</p>
           </EuiCallOut>
@@ -169,7 +169,7 @@ export class NewVectorLayerEditor extends Component<RenderWizardArguments, State
             defaultMessage: 'Unable to create index',
           })}
           color="danger"
-          iconType="alert"
+          iconType="warning"
         >
           <p>{this.state.createIndexError}</p>
         </EuiCallOut>

--- a/x-pack/plugins/maps/public/connected_components/mb_map/tooltip_control/features_tooltip/feature_properties.tsx
+++ b/x-pack/plugins/maps/public/connected_components/mb_map/tooltip_control/features_tooltip/feature_properties.tsx
@@ -296,7 +296,7 @@ export class FeatureProperties extends Component<Props, State> {
             defaultMessage: 'Unable to load tooltip content',
           })}
           color="danger"
-          iconType="alert"
+          iconType="warning"
           size="s"
         >
           <p>{this.state.loadPropertiesErrorMsg}</p>

--- a/x-pack/plugins/maps/public/connected_components/right_side_controls/layer_control/layer_toc/toc_entry/toc_entry_button/toc_entry_button.tsx
+++ b/x-pack/plugins/maps/public/connected_components/right_side_controls/layer_control/layer_toc/toc_entry/toc_entry_button/toc_entry_button.tsx
@@ -78,7 +78,7 @@ export class TOCEntryButton extends Component<Props, State> {
               defaultMessage: 'Load warning',
             })}
             size="m"
-            type="alert"
+            type="warning"
             color="warning"
           />
         ),

--- a/x-pack/plugins/maps/public/embeddable/map_embeddable.tsx
+++ b/x-pack/plugins/maps/public/embeddable/map_embeddable.tsx
@@ -488,7 +488,7 @@ export class MapEmbeddable
       sharingSavedObjectProps && spaces && sharingSavedObjectProps?.outcome === 'conflict' ? (
         <div className="mapEmbeddedError">
           <EuiEmptyPrompt
-            iconType="alert"
+            iconType="warning"
             iconColor="danger"
             data-test-subj="embeddable-maps-failure"
             body={spaces.ui.components.getEmbeddableLegacyUrlConflict({

--- a/x-pack/plugins/ml/public/alerting/preview_alert_condition.tsx
+++ b/x-pack/plugins/ml/public/alerting/preview_alert_condition.tsx
@@ -219,7 +219,7 @@ export const PreviewAlertCondition: FC<PreviewAlertConditionProps> = ({
               />
             }
             color="danger"
-            iconType="alert"
+            iconType="warning"
           >
             <p>{previewError.message}</p>
           </EuiCallOut>

--- a/x-pack/plugins/ml/public/application/access_denied/page.tsx
+++ b/x-pack/plugins/ml/public/application/access_denied/page.tsx
@@ -31,7 +31,7 @@ export const Page = () => {
         <EuiFlexItem grow={false}>
           <EuiPageContent verticalPosition="center" horizontalPosition="center" color="danger">
             <EuiEmptyPrompt
-              iconType="alert"
+              iconType="warning"
               title={
                 <h2>
                   <FormattedMessage

--- a/x-pack/plugins/ml/public/application/components/anomalies_table/anomaly_details.tsx
+++ b/x-pack/plugins/ml/public/application/components/anomalies_table/anomaly_details.tsx
@@ -261,7 +261,7 @@ const Details: FC<{
         )}
         {isInterimResult === true && (
           <>
-            <EuiIcon type="alert" />
+            <EuiIcon type="warning" />
             <span className="interim-result">
               <FormattedMessage
                 id="xpack.ml.anomaliesTable.anomalyDetails.interimResultLabel"

--- a/x-pack/plugins/ml/public/application/components/model_snapshots/revert_model_snapshot_flyout/revert_model_snapshot_flyout.tsx
+++ b/x-pack/plugins/ml/public/application/components/model_snapshots/revert_model_snapshot_flyout/revert_model_snapshot_flyout.tsx
@@ -250,7 +250,7 @@ export const RevertModelSnapshotFlyout: FC<Props> = ({
               }
             )}
             color="warning"
-            iconType="alert"
+            iconType="warning"
           >
             <FormattedMessage
               id="xpack.ml.newJob.wizard.revertModelSnapshotFlyout.warningCallout.contents"

--- a/x-pack/plugins/ml/public/application/components/node_available_warning/warning.tsx
+++ b/x-pack/plugins/ml/public/application/components/node_available_warning/warning.tsx
@@ -33,7 +33,7 @@ export const Warning: FC<Props> = ({ size, isCloud, isCloudTrial, deploymentId }
           />
         }
         color="warning"
-        iconType="alert"
+        iconType="warning"
       >
         <div>
           <FormattedMessage

--- a/x-pack/plugins/ml/public/application/components/saved_objects_warning/saved_objects_warning.tsx
+++ b/x-pack/plugins/ml/public/application/components/saved_objects_warning/saved_objects_warning.tsx
@@ -93,7 +93,7 @@ export const SavedObjectsWarning: FC<Props> = ({
           />
         }
         color="warning"
-        iconType="alert"
+        iconType="warning"
         data-test-subj="mlJobSyncRequiredWarning"
       >
         <>

--- a/x-pack/plugins/ml/public/application/components/upgrade/upgrade_warning.tsx
+++ b/x-pack/plugins/ml/public/application/components/upgrade/upgrade_warning.tsx
@@ -24,7 +24,7 @@ export const UpgradeWarning: FC = () => {
             />
           }
           color="warning"
-          iconType="alert"
+          iconType="warning"
         >
           <p>
             <FormattedMessage

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/components/validation_step/validation_step_details.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/components/validation_step/validation_step_details.tsx
@@ -60,7 +60,7 @@ export const ValidationStepDetails: FC<{
               <EuiText size="s">{validationSummary.warning}</EuiText>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiIcon type="alert" />
+              <EuiIcon type="warning" />
             </EuiFlexItem>
           </EuiFlexGroup>
         </>

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/components/feature_importance/decision_path_regression.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/components/feature_importance/decision_path_regression.tsx
@@ -69,7 +69,7 @@ export const RegressionDecisionPath: FC<RegressionDecisionPathProps> = ({
             />
           }
           color="warning"
-          iconType="alert"
+          iconType="warning"
         />
       )}
       <DecisionPathChart

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/page.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/page.tsx
@@ -104,7 +104,7 @@ export const Page: FC<{
     return (
       <>
         <EuiEmptyPrompt
-          iconType="alert"
+          iconType="warning"
           title={
             <h2>
               <FormattedMessage

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_management/components/analytics_list/analytics_list.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_management/components/analytics_list/analytics_list.tsx
@@ -220,7 +220,7 @@ export const DataFrameAnalyticsList: FC<Props> = ({
           defaultMessage: 'An error occurred getting the data frame analytics list.',
         })}
         color="danger"
-        iconType="alert"
+        iconType="warning"
       >
         <pre>{JSON.stringify(errorMessage)}</pre>
       </EuiCallOut>

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_management/components/analytics_list/expanded_row.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_management/components/analytics_list/expanded_row.tsx
@@ -53,7 +53,7 @@ interface LoadedStatProps {
 const LoadedStat: FC<LoadedStatProps> = ({ isLoading, evalData, resultProperty }) => {
   return (
     <Fragment>
-      {isLoading === false && evalData.error !== null && <EuiIcon type="alert" size="s" />}
+      {isLoading === false && evalData.error !== null && <EuiIcon type="warning" size="s" />}
       {isLoading === true && <EuiLoadingSpinner size="s" />}
       {isLoading === false && evalData.error === null && evalData[resultProperty]}
     </Fragment>

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/job_map/page.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/job_map/page.tsx
@@ -79,7 +79,7 @@ export const Page: FC = () => {
     return (
       <>
         <EuiEmptyPrompt
-          iconType="alert"
+          iconType="warning"
           title={
             <h2>
               <FormattedMessage

--- a/x-pack/plugins/ml/public/application/explorer/components/explorer_no_jobs_selected/explorer_no_jobs_selected.tsx
+++ b/x-pack/plugins/ml/public/application/explorer/components/explorer_no_jobs_selected/explorer_no_jobs_selected.tsx
@@ -15,7 +15,7 @@ import { EuiEmptyPrompt } from '@elastic/eui';
 export const ExplorerNoJobsSelected: FC = () => {
   return (
     <EuiEmptyPrompt
-      iconType="alert"
+      iconType="warning"
       title={
         <h2>
           <FormattedMessage

--- a/x-pack/plugins/ml/public/application/explorer/explorer.tsx
+++ b/x-pack/plugins/ml/public/application/explorer/explorer.tsx
@@ -498,7 +498,7 @@ export const Explorer: FC<ExplorerUIProps> = ({
                 defaultMessage: 'An error occurred loading annotations:',
               })}
               color="danger"
-              iconType="alert"
+              iconType="warning"
             >
               <p>{annotationsError}</p>
             </EuiCallOut>

--- a/x-pack/plugins/ml/public/application/explorer/explorer_charts/explorer_charts_container.js
+++ b/x-pack/plugins/ml/public/application/explorer/explorer_charts/explorer_charts_container.js
@@ -262,7 +262,7 @@ function ExplorerChartContainer({
                 content={tooManyBucketsCalloutMsg ?? textTooManyBuckets}
                 position="top"
                 size="s"
-                type="alert"
+                type="warning"
                 color="warning"
               />
             )}

--- a/x-pack/plugins/ml/public/application/jobs/jobs_list/components/job_details/datafeed_preview_tab.js
+++ b/x-pack/plugins/ml/public/application/jobs/jobs_list/components/job_details/datafeed_preview_tab.js
@@ -40,7 +40,7 @@ export class DatafeedPreviewPane extends Component {
             />
           }
           color="warning"
-          iconType="alert"
+          iconType="warning"
         >
           <p>
             <FormattedMessage

--- a/x-pack/plugins/ml/public/application/jobs/new_job/pages/components/pick_fields_step/components/advanced_view/detector_list.tsx
+++ b/x-pack/plugins/ml/public/application/jobs/new_job/pages/components/pick_fields_step/components/advanced_view/detector_list.tsx
@@ -162,7 +162,7 @@ const NoDetectorsWarning: FC<{ show: boolean }> = ({ show }) => {
         title={i18n.translate('xpack.ml.newJob.wizard.pickFieldsStep.noDetectorsCallout.title', {
           defaultMessage: 'No detectors',
         })}
-        iconType="alert"
+        iconType="warning"
         data-test-subj="mlAdvancedNoDetectorsMessage"
       >
         <FormattedMessage

--- a/x-pack/plugins/ml/public/application/jobs/new_job/pages/job_type/page.tsx
+++ b/x-pack/plugins/ml/public/application/jobs/new_job/pages/job_type/page.tsx
@@ -252,7 +252,7 @@ export const Page: FC = () => {
 
       {isTimeBasedIndex === false && (
         <>
-          <EuiCallOut title={indexWarningTitle} color="warning" iconType="alert">
+          <EuiCallOut title={indexWarningTitle} color="warning" iconType="warning">
             <FormattedMessage
               id="xpack.ml.newJob.wizard.jobType.howToRunAnomalyDetectionDescription"
               defaultMessage="Anomaly detection can only be run over indices which are time based."

--- a/x-pack/plugins/ml/public/application/jobs/new_job/recognize/components/create_result_callout.tsx
+++ b/x-pack/plugins/ml/public/application/jobs/new_job/recognize/components/create_result_callout.tsx
@@ -45,7 +45,7 @@ export const CreateResultCallout: FC<CreateResultCalloutProps> = memo(
               />
             }
             color="danger"
-            iconType="alert"
+            iconType="warning"
           />
         )}
         {saveState === SAVE_STATE.PARTIAL_FAILURE && (
@@ -57,7 +57,7 @@ export const CreateResultCallout: FC<CreateResultCalloutProps> = memo(
               />
             }
             color="warning"
-            iconType="alert"
+            iconType="warning"
           />
         )}
         <EuiSpacer size="l" />

--- a/x-pack/plugins/ml/public/application/jobs/new_job/recognize/page.tsx
+++ b/x-pack/plugins/ml/public/application/jobs/new_job/recognize/page.tsx
@@ -307,7 +307,7 @@ export const Page: FC<PageProps> = ({ moduleId, existingGroupIds }) => {
               />
             }
             color="warning"
-            iconType="alert"
+            iconType="warning"
           >
             <EuiText size="s">
               <FormattedMessage

--- a/x-pack/plugins/ml/public/application/management/jobs_list/components/access_denied_page.tsx
+++ b/x-pack/plugins/ml/public/application/management/jobs_list/components/access_denied_page.tsx
@@ -20,7 +20,7 @@ export const AccessDeniedPage = () => (
       data-test-subj="mlPageAccessDenied"
     >
       <EuiEmptyPrompt
-        iconType="alert"
+        iconType="warning"
         title={
           <h2>
             <FormattedMessage

--- a/x-pack/plugins/ml/public/application/management/jobs_list/components/insufficient_license_page.tsx
+++ b/x-pack/plugins/ml/public/application/management/jobs_list/components/insufficient_license_page.tsx
@@ -25,7 +25,7 @@ export const InsufficientLicensePage: FC<Props> = ({ basePath }) => (
       data-test-subj="mlPageInsufficientLicense"
     >
       <EuiEmptyPrompt
-        iconType="alert"
+        iconType="warning"
         title={
           <h2>
             <FormattedMessage

--- a/x-pack/plugins/ml/public/application/memory_usage/memory_tree_map/tree_map.tsx
+++ b/x-pack/plugins/ml/public/application/memory_usage/memory_tree_map/tree_map.tsx
@@ -183,7 +183,7 @@ export const JobMemoryTreeMap: FC<Props> = ({ node, type, height }) => {
         ) : (
           <EuiEmptyPrompt
             titleSize="xs"
-            iconType="alert"
+            iconType="warning"
             data-test-subj="mlEmptyMemoryUsageTreeMap"
             title={
               <h2>

--- a/x-pack/plugins/ml/public/application/notifications/components/notifications_list.tsx
+++ b/x-pack/plugins/ml/public/application/notifications/components/notifications_list.tsx
@@ -374,7 +374,7 @@ export const NotificationsList: FC = () => {
               />
             }
             color="danger"
-            iconType="alert"
+            iconType="warning"
           >
             <p>{queryError}</p>
           </EuiCallOut>

--- a/x-pack/plugins/ml/public/application/overview/components/analytics_panel/analytics_panel.tsx
+++ b/x-pack/plugins/ml/public/application/overview/components/analytics_panel/analytics_panel.tsx
@@ -65,7 +65,7 @@ export const AnalyticsPanel: FC<Props> = ({ setLazyJobCount }) => {
         defaultMessage: 'An error occurred getting the data frame analytics list.',
       })}
       color="danger"
-      iconType="alert"
+      iconType="warning"
     >
       <pre>
         {errorMessage && errorMessage.message !== undefined

--- a/x-pack/plugins/ml/public/application/overview/components/anomaly_detection_panel/anomaly_detection_panel.tsx
+++ b/x-pack/plugins/ml/public/application/overview/components/anomaly_detection_panel/anomaly_detection_panel.tsx
@@ -136,7 +136,7 @@ export const AnomalyDetectionPanel: FC<Props> = ({
           defaultMessage: 'An error occurred getting the anomaly detection jobs list.',
         })}
         color="danger"
-        iconType="alert"
+        iconType="warning"
       >
         <pre>{errorMessage}</pre>
       </EuiCallOut>

--- a/x-pack/plugins/ml/public/application/timeseriesexplorer/components/timeseriesexplorer_chart_data_error/timeseriesexplorer_chart_data_error.tsx
+++ b/x-pack/plugins/ml/public/application/timeseriesexplorer/components/timeseriesexplorer_chart_data_error/timeseriesexplorer_chart_data_error.tsx
@@ -9,5 +9,5 @@ import { EuiEmptyPrompt } from '@elastic/eui';
 import React from 'react';
 
 export const TimeseriesexplorerChartDataError = ({ errorMsg }: { errorMsg: string }) => {
-  return <EuiEmptyPrompt iconType="alert" title={<h2>{errorMsg}</h2>} />;
+  return <EuiEmptyPrompt iconType="warning" title={<h2>{errorMsg}</h2>} />;
 };

--- a/x-pack/plugins/ml/public/application/timeseriesexplorer/components/timeseriesexplorer_no_jobs_found/timeseriesexplorer_no_jobs_found.tsx
+++ b/x-pack/plugins/ml/public/application/timeseriesexplorer/components/timeseriesexplorer_no_jobs_found/timeseriesexplorer_no_jobs_found.tsx
@@ -27,7 +27,7 @@ export const TimeseriesexplorerNoJobsFound = () => {
   return (
     <EuiEmptyPrompt
       data-test-subj="mlNoSingleMetricJobsFound"
-      iconType="alert"
+      iconType="warning"
       title={
         <h2>
           <FormattedMessage

--- a/x-pack/plugins/ml/public/application/timeseriesexplorer/timeseriesexplorer.js
+++ b/x-pack/plugins/ml/public/application/timeseriesexplorer/timeseriesexplorer.js
@@ -1238,7 +1238,7 @@ export class TimeSeriesExplorer extends React.Component {
                         }
                       )}
                       color="danger"
-                      iconType="alert"
+                      iconType="warning"
                     >
                       <p>{focusAnnotationError}</p>
                     </EuiCallOut>

--- a/x-pack/plugins/ml/public/embeddables/anomaly_charts/embeddable_anomaly_charts_container.tsx
+++ b/x-pack/plugins/ml/public/embeddables/anomaly_charts/embeddable_anomaly_charts_container.tsx
@@ -151,7 +151,7 @@ export const EmbeddableAnomalyChartsContainer: FC<EmbeddableAnomalyChartsContain
           />
         }
         color="danger"
-        iconType="alert"
+        iconType="warning"
         style={{ width: '100%' }}
       >
         <p>{error.message}</p>

--- a/x-pack/plugins/ml/public/embeddables/anomaly_swimlane/embeddable_swim_lane_container.tsx
+++ b/x-pack/plugins/ml/public/embeddables/anomaly_swimlane/embeddable_swim_lane_container.tsx
@@ -117,7 +117,7 @@ export const EmbeddableSwimLaneContainer: FC<ExplorerSwimlaneContainerProps> = (
           />
         }
         color="danger"
-        iconType="alert"
+        iconType="warning"
         css={{ width: '100%' }}
       >
         <p>{error.message}</p>

--- a/x-pack/plugins/ml/public/embeddables/job_creation/lens/lens_vis_layer_selection_flyout/layer/incompatible_layer.tsx
+++ b/x-pack/plugins/ml/public/embeddables/job_creation/lens/lens_vis_layer_selection_flyout/layer/incompatible_layer.tsx
@@ -23,7 +23,7 @@ export const IncompatibleLayer: FC<Props> = ({ layer }) => {
     <EuiFlexGroup gutterSize="s" color="subdued" data-test-subj="mlLensLayerIncompatible">
       <EuiFlexItem grow={false}>
         <EuiText size="s">
-          <EuiIcon type="crossInACircleFilled" color="subdued" />
+          <EuiIcon type="error" color="subdued" />
         </EuiText>
       </EuiFlexItem>
       <EuiFlexItem>

--- a/x-pack/plugins/ml/public/embeddables/job_creation/map/map_vis_layer_selection_flyout/layer/incompatible_layer.tsx
+++ b/x-pack/plugins/ml/public/embeddables/job_creation/map/map_vis_layer_selection_flyout/layer/incompatible_layer.tsx
@@ -18,7 +18,7 @@ export const IncompatibleLayer: FC<Props> = ({ noDataView }) => {
     <EuiFlexGroup gutterSize="s" color="subdued" data-test-subj="mlMapLayerIncompatible">
       <EuiFlexItem grow={false}>
         <EuiText size="s">
-          <EuiIcon type="crossInACircleFilled" color="subdued" />
+          <EuiIcon type="error" color="subdued" />
         </EuiText>
       </EuiFlexItem>
       <EuiFlexItem>

--- a/x-pack/plugins/monitoring/public/alerts/callout.tsx
+++ b/x-pack/plugins/monitoring/public/alerts/callout.tsx
@@ -49,7 +49,7 @@ export const AlertsCallout: React.FC<Props> = (props: Props) => {
       <div>
         <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
           <EuiFlexItem grow={false}>
-            <EuiIcon type="alert" size="m" color="danger" />
+            <EuiIcon type="warning" size="m" color="danger" />
           </EuiFlexItem>
 
           <EuiFlexItem>

--- a/x-pack/plugins/monitoring/public/application/pages/access_denied/index.tsx
+++ b/x-pack/plugins/monitoring/public/application/pages/access_denied/index.tsx
@@ -46,7 +46,12 @@ export const AccessDeniedPage: React.FC<ComponentProps> = () => {
   }
   return (
     <EuiPanel paddingSize="m">
-      <EuiCallOut title={title} color="danger" iconType="warning" data-test-subj="accessDeniedTitle">
+      <EuiCallOut
+        title={title}
+        color="danger"
+        iconType="warning"
+        data-test-subj="accessDeniedTitle"
+      >
         <p>
           <FormattedMessage
             id="xpack.monitoring.accessDenied.notAuthorizedDescription"

--- a/x-pack/plugins/monitoring/public/application/pages/access_denied/index.tsx
+++ b/x-pack/plugins/monitoring/public/application/pages/access_denied/index.tsx
@@ -46,7 +46,7 @@ export const AccessDeniedPage: React.FC<ComponentProps> = () => {
   }
   return (
     <EuiPanel paddingSize="m">
-      <EuiCallOut title={title} color="danger" iconType="alert" data-test-subj="accessDeniedTitle">
+      <EuiCallOut title={title} color="danger" iconType="warning" data-test-subj="accessDeniedTitle">
         <p>
           <FormattedMessage
             id="xpack.monitoring.accessDenied.notAuthorizedDescription"

--- a/x-pack/plugins/monitoring/public/application/pages/elasticsearch/ingest_pipeline_modal.tsx
+++ b/x-pack/plugins/monitoring/public/application/pages/elasticsearch/ingest_pipeline_modal.tsx
@@ -141,7 +141,7 @@ export const IngestPipelineModal = ({
               />
             }
             color="danger"
-            iconType="alert"
+            iconType="warning"
           />
           <EuiSpacer />
         </>

--- a/x-pack/plugins/monitoring/public/components/cluster/overview/kibana_panel.js
+++ b/x-pack/plugins/monitoring/public/components/cluster/overview/kibana_panel.js
@@ -256,7 +256,7 @@ function statusIndicator(status, someStatusIsStale, instancesHref, staleStatusTh
     <>
       <div style={{ marginBottom: '8px' }}>
         <EuiToolTip position="top" content={staleMessage}>
-          <EuiBadge iconType="alert" color="warning" data-test-subj="status">
+          <EuiBadge iconType="warning" color="warning" data-test-subj="status">
             {i18n.translate('xpack.monitoring.cluster.overview.kibanaPanel.staleStatusLabel', {
               defaultMessage: 'Stale',
             })}

--- a/x-pack/plugins/monitoring/public/components/kibana/cluster_status/index.tsx
+++ b/x-pack/plugins/monitoring/public/components/kibana/cluster_status/index.tsx
@@ -129,7 +129,7 @@ function OverviewPageStatusIndicator({ staleMessage }: IndicatorProps) {
     <>
       <div style={{ marginBottom: '8px' }}>
         <EuiToolTip position="top" content={staleMessage}>
-          <EuiBadge iconType="alert" color="warning">
+          <EuiBadge iconType="warning" color="warning">
             {i18n.translate(
               'xpack.monitoring.kibana.clusterStatus.overview.staleStatusInstancesLabel',
               {
@@ -167,7 +167,7 @@ function OverviewPageStatusIndicator({ staleMessage }: IndicatorProps) {
 function InstancesPageStatusIndicator({ staleMessage }: IndicatorProps) {
   const title = (
     <EuiToolTip position="top" content={staleMessage}>
-      <EuiBadge iconType="alert" color="warning">
+      <EuiBadge iconType="warning" color="warning">
         {i18n.translate(
           'xpack.monitoring.kibana.clusterStatus.instances.staleStatusInstancesLabel',
           {

--- a/x-pack/plugins/monitoring/public/components/kibana/detail_status/index.js
+++ b/x-pack/plugins/monitoring/public/components/kibana/detail_status/index.js
@@ -125,7 +125,7 @@ function prepareStaleMessage(status, lastSeenTimestamp, staleStatusThresholdSeco
       {capitalize(status)}
       <span style={{ marginLeft: '8px' }}>
         <EuiToolTip position="top" content={staleMessage}>
-          <EuiBadge iconType="alert" color="warning">
+          <EuiBadge iconType="warning" color="warning">
             {i18n.translate('xpack.monitoring.kibana.detailStatus.staleStatusLabel', {
               defaultMessage: 'Stale',
             })}

--- a/x-pack/plugins/monitoring/public/components/kibana/instances/instances.tsx
+++ b/x-pack/plugins/monitoring/public/components/kibana/instances/instances.tsx
@@ -146,7 +146,7 @@ const getColumns = (
                   aria-label={staleMessage}
                   content={staleMessage}
                   size="l"
-                  type="alert"
+                  type="warning"
                   color="warning"
                 />
               </>

--- a/x-pack/plugins/monitoring/public/components/license/index.tsx
+++ b/x-pack/plugins/monitoring/public/components/license/index.tsx
@@ -72,7 +72,7 @@ class LicenseStatus extends React.PureComponent<LicenseStatusProps> {
     let title;
     let message;
     if (isExpired) {
-      icon = <EuiIcon color="danger" type="alert" />;
+      icon = <EuiIcon color="danger" type="warning" />;
       message = (
         <Fragment>
           <FormattedMessage

--- a/x-pack/plugins/observability/public/pages/alert_details/components/alert_details.tsx
+++ b/x-pack/plugins/observability/public/pages/alert_details/components/alert_details.tsx
@@ -78,7 +78,7 @@ export function AlertDetails() {
     return (
       <EuiPanel data-test-subj="alertDetailsError">
         <EuiEmptyPrompt
-          iconType="alert"
+          iconType="warning"
           color="danger"
           title={
             <h2>

--- a/x-pack/plugins/observability/public/pages/rule_details/index.tsx
+++ b/x-pack/plugins/observability/public/pages/rule_details/index.tsx
@@ -302,7 +302,7 @@ export function RuleDetailsPage() {
     return (
       <EuiPanel>
         <EuiEmptyPrompt
-          iconType="alert"
+          iconType="warning"
           color="danger"
           title={
             <h2>

--- a/x-pack/plugins/observability/public/pages/slos/components/badges/slo_badges.tsx
+++ b/x-pack/plugins/observability/public/pages/slos/components/badges/slo_badges.tsx
@@ -48,7 +48,7 @@ export function SloBadges({ slo, activeAlerts }: Props) {
       {!!activeAlerts && (
         <EuiFlexItem grow={false}>
           <EuiBadge
-            iconType="alert"
+            iconType="warning"
             color="danger"
             onClick={handleClick}
             onClickAriaLabel={i18n.translate(

--- a/x-pack/plugins/observability/public/pages/slos/components/slo_list_empty.tsx
+++ b/x-pack/plugins/observability/public/pages/slos/components/slo_list_empty.tsx
@@ -16,7 +16,7 @@ export function SloListEmpty() {
         defaultMessage: 'No results',
       })}
       color="warning"
-      iconType="alert"
+      iconType="warning"
     >
       {i18n.translate('xpack.observability.slo.list.emptyMessage', {
         defaultMessage: 'There are no results for your criteria.',

--- a/x-pack/plugins/observability/public/pages/slos/components/slo_list_error.tsx
+++ b/x-pack/plugins/observability/public/pages/slos/components/slo_list_error.tsx
@@ -12,7 +12,7 @@ import { i18n } from '@kbn/i18n';
 export function SloListError() {
   return (
     <EuiEmptyPrompt
-      iconType="alert"
+      iconType="warning"
       color="danger"
       title={
         <h2>

--- a/x-pack/plugins/osquery/public/results/results_table.tsx
+++ b/x-pack/plugins/osquery/public/results/results_table.tsx
@@ -406,7 +406,7 @@ const ResultsTableComponent: React.FC<ResultsTableComponentProps> = ({
           />
         }
         color="danger"
-        iconType="alert"
+        iconType="warning"
       >
         <p>
           <FormattedMessage

--- a/x-pack/plugins/painless_lab/public/application/components/output_pane/output_pane.tsx
+++ b/x-pack/plugins/painless_lab/public/application/components/output_pane/output_pane.tsx
@@ -32,7 +32,7 @@ export const OutputPane: FunctionComponent<Props> = ({ isLoading, response }) =>
         {isLoading ? (
           <EuiLoadingSpinner size="m" />
         ) : response && response.error ? (
-          <EuiIcon type="alert" color="danger" />
+          <EuiIcon type="warning" color="danger" />
         ) : (
           <EuiIcon type="check" color="success" />
         )}

--- a/x-pack/plugins/profiling/public/components/async_component.tsx
+++ b/x-pack/plugins/profiling/public/components/async_component.tsx
@@ -40,7 +40,7 @@ export function AsyncComponent({
         {error && status === AsyncStatus.Settled ? (
           <EuiFlexGroup direction="row" gutterSize="xs" alignItems="center">
             <EuiFlexItem>
-              <EuiIcon type="alert" color="warning" />
+              <EuiIcon type="warning" color="warning" />
             </EuiFlexItem>
             <EuiFlexItem>
               <EuiText style={{ whiteSpace: 'nowrap' }}>

--- a/x-pack/plugins/remote_clusters/public/application/sections/remote_cluster_edit/remote_cluster_edit.js
+++ b/x-pack/plugins/remote_clusters/public/application/sections/remote_cluster_edit/remote_cluster_edit.js
@@ -110,7 +110,7 @@ export class RemoteClusterEdit extends Component {
       return (
         <EuiPageContent verticalPosition="center" horizontalPosition="center" color="danger">
           <EuiEmptyPrompt
-            iconType="alert"
+            iconType="warning"
             title={
               <h2>
                 <FormattedMessage

--- a/x-pack/plugins/remote_clusters/public/application/sections/remote_cluster_list/detail_panel/detail_panel.js
+++ b/x-pack/plugins/remote_clusters/public/application/sections/remote_cluster_list/detail_panel/detail_panel.js
@@ -83,7 +83,7 @@ export class DetailPanel extends Component {
         data-test-subj="remoteClusterDetailClusterNotFound"
       >
         <EuiFlexItem grow={false}>
-          <EuiIcon size="m" type="alert" color="danger" />
+          <EuiIcon size="m" type="warning" color="danger" />
         </EuiFlexItem>
 
         <EuiFlexItem grow={false}>

--- a/x-pack/plugins/remote_clusters/public/application/sections/remote_cluster_list/remote_cluster_list.js
+++ b/x-pack/plugins/remote_clusters/public/application/sections/remote_cluster_list/remote_cluster_list.js
@@ -92,7 +92,7 @@ export class RemoteClusterList extends Component {
     return (
       <EuiPageContent verticalPosition="center" horizontalPosition="center" color="danger">
         <EuiEmptyPrompt
-          iconType="alert"
+          iconType="warning"
           title={
             <h2>
               <FormattedMessage
@@ -122,7 +122,7 @@ export class RemoteClusterList extends Component {
     return (
       <EuiPageContent verticalPosition="center" horizontalPosition="center" color="danger">
         <EuiEmptyPrompt
-          iconType="alert"
+          iconType="warning"
           title={
             <h2>
               <FormattedMessage

--- a/x-pack/plugins/remote_clusters/public/application/sections/remote_cluster_list/remote_cluster_table/remote_cluster_table.js
+++ b/x-pack/plugins/remote_clusters/public/application/sections/remote_cluster_list/remote_cluster_table/remote_cluster_table.js
@@ -172,7 +172,7 @@ export class RemoteClusterTable extends Component {
                   data-test-subj="remoteClustersTableListDeprecatedSetttingsTooltip"
                 >
                   <EuiIconTip
-                    type="alert"
+                    type="warning"
                     color="warning"
                     content={
                       <FormattedMessage

--- a/x-pack/plugins/reporting/public/management/components/report_diagnostic.tsx
+++ b/x-pack/plugins/reporting/public/management/components/report_diagnostic.tsx
@@ -178,7 +178,7 @@ export const ReportDiagnostic = ({ apiClient }: Props) => {
         <Fragment>
           {help.length ? (
             <Fragment>
-              <EuiCallOut color="danger" iconType="alert">
+              <EuiCallOut color="danger" iconType="warning">
                 <p>
                   <EuiMarkdownFormat>{help.join('\n')}</EuiMarkdownFormat>
                 </p>

--- a/x-pack/plugins/reporting/public/management/components/report_status_indicator.tsx
+++ b/x-pack/plugins/reporting/public/management/components/report_status_indicator.tsx
@@ -62,7 +62,7 @@ export const ReportStatusIndicator: FC<Props> = ({ job }) => {
   switch (job.status) {
     case JOB_STATUSES.COMPLETED:
       if (hasIssues) {
-        icon = <EuiIcon type="alert" color="warning" />;
+        icon = <EuiIcon type="warning" color="warning" />;
         statusText = i18nTexts.completedWithWarnings;
         break;
       }
@@ -70,7 +70,7 @@ export const ReportStatusIndicator: FC<Props> = ({ job }) => {
       statusText = i18nTexts.completed;
       break;
     case JOB_STATUSES.WARNINGS:
-      icon = <EuiIcon type="alert" color="warning" />;
+      icon = <EuiIcon type="warning" color="warning" />;
       statusText = i18nTexts.completedWithWarnings;
       break;
     case JOB_STATUSES.PENDING:
@@ -82,7 +82,7 @@ export const ReportStatusIndicator: FC<Props> = ({ job }) => {
       statusText = i18nTexts.processing({ attempt: job.attempts, of: job.max_attempts });
       break;
     case JOB_STATUSES.FAILED:
-      icon = <EuiIcon type="crossInACircleFilled" color="danger" />;
+      icon = <EuiIcon type="error" color="danger" />;
       statusText = i18nTexts.failed;
       break;
     default:

--- a/x-pack/plugins/reporting/public/notifier/general_error.tsx
+++ b/x-pack/plugins/reporting/public/notifier/general_error.tsx
@@ -18,7 +18,7 @@ export const getGeneralErrorToast = (
 ): ToastInput => ({
   text: toMountPoint(
     <>
-      <EuiCallOut title={errorText} color="danger" iconType="alert">
+      <EuiCallOut title={errorText} color="danger" iconType="warning">
         {err.toString()}
       </EuiCallOut>
 

--- a/x-pack/plugins/reporting/public/share_context_menu/reporting_panel_content/components/error_unsaved_work_panel.tsx
+++ b/x-pack/plugins/reporting/public/share_context_menu/reporting_panel_content/components/error_unsaved_work_panel.tsx
@@ -18,7 +18,7 @@ const i18nTexts = {
 
 export const ErrorUnsavedWorkPanel: FunctionComponent = () => {
   return (
-    <EuiCallOut size="s" title={i18nTexts.title} iconType="alert" color="danger">
+    <EuiCallOut size="s" title={i18nTexts.title} iconType="warning" color="danger">
       <EuiText size="s">
         <p>
           <FormattedMessage

--- a/x-pack/plugins/reporting/public/share_context_menu/reporting_panel_content/components/error_url_too_long_panel.tsx
+++ b/x-pack/plugins/reporting/public/share_context_menu/reporting_panel_content/components/error_url_too_long_panel.tsx
@@ -22,7 +22,7 @@ const i18nTexts = {
 };
 
 export const ErrorUrlTooLongPanel: FunctionComponent<Props> = ({ isUnsaved }) => (
-  <EuiCallOut title={i18nTexts.title} size="s" iconType="alert" color="danger">
+  <EuiCallOut title={i18nTexts.title} size="s" iconType="warning" color="danger">
     <EuiText size="s">
       <p>
         {isUnsaved ? (

--- a/x-pack/plugins/rollup/public/crud_app/sections/job_list/detail_panel/detail_panel.js
+++ b/x-pack/plugins/rollup/public/crud_app/sections/job_list/detail_panel/detail_panel.js
@@ -210,7 +210,7 @@ export class DetailPanel extends Component {
         <EuiFlyoutBody data-test-subj="rollupJobDetailJobNotFound">
           <EuiFlexGroup justifyContent="flexStart" alignItems="center" gutterSize="s">
             <EuiFlexItem grow={false}>
-              <EuiIcon size="m" type="alert" color="danger" />
+              <EuiIcon size="m" type="warning" color="danger" />
             </EuiFlexItem>
 
             <EuiFlexItem grow={false}>

--- a/x-pack/plugins/rollup/public/crud_app/sections/job_list/job_list.js
+++ b/x-pack/plugins/rollup/public/crud_app/sections/job_list/job_list.js
@@ -90,7 +90,7 @@ export class JobListUi extends Component {
       <EuiPageContent verticalPosition="center" horizontalPosition="center" color="danger">
         <EuiEmptyPrompt
           data-test-subj="jobListNoPermission"
-          iconType="alert"
+          iconType="warning"
           title={<h1>{title}</h1>}
           body={
             <p>
@@ -118,7 +118,7 @@ export class JobListUi extends Component {
       <EuiPageContent verticalPosition="center" horizontalPosition="center" color="danger">
         <EuiEmptyPrompt
           data-test-subj="jobListError"
-          iconType="alert"
+          iconType="warning"
           title={<h1>{title}</h1>}
           body={
             <p>

--- a/x-pack/plugins/searchprofiler/public/application/components/license_warning_notice/license_warning_notice.tsx
+++ b/x-pack/plugins/searchprofiler/public/application/components/license_warning_notice/license_warning_notice.tsx
@@ -38,7 +38,7 @@ export const LicenseWarningNotice = () => {
           defaultMessage: 'License error',
         })}
         color="danger"
-        iconType="alert"
+        iconType="warning"
         style={{ padding: '16px' }}
       >
         <EuiText size="s">

--- a/x-pack/plugins/security/public/account_management/account_management_page.tsx
+++ b/x-pack/plugins/security/public/account_management/account_management_page.tsx
@@ -35,7 +35,7 @@ export const AccountManagementPage: FunctionComponent = () => {
 
   const error = currentUser.error || profileLoadError;
   if (error) {
-    return <EuiEmptyPrompt iconType="alert" title={<h2>{error.message}</h2>} />;
+    return <EuiEmptyPrompt iconType="warning" title={<h2>{error.message}</h2>} />;
   }
 
   if (!currentUser.value || (canUserHaveProfile(currentUser.value) && !userProfile.value)) {

--- a/x-pack/plugins/security/public/management/api_keys/api_keys_grid/api_keys_empty_prompt.tsx
+++ b/x-pack/plugins/security/public/management/api_keys/api_keys_grid/api_keys_empty_prompt.tsx
@@ -31,7 +31,7 @@ export const ApiKeysEmptyPrompt: FunctionComponent<ApiKeysEmptyPromptProps> = ({
     if (doesErrorIndicateAPIKeysAreDisabled(error)) {
       return (
         <KibanaPageTemplate.EmptyPrompt
-          iconType="alert"
+          iconType="warning"
           body={
             <>
               <p>
@@ -76,7 +76,7 @@ export const ApiKeysEmptyPrompt: FunctionComponent<ApiKeysEmptyPromptProps> = ({
 
     return (
       <KibanaPageTemplate.EmptyPrompt
-        iconType="alert"
+        iconType="warning"
         body={
           <p>
             <FormattedMessage
@@ -120,7 +120,7 @@ export const ApiKeysEmptyPrompt: FunctionComponent<ApiKeysEmptyPromptProps> = ({
   if (readOnly) {
     return (
       <KibanaPageTemplate.EmptyPrompt
-        iconType="crossInACircleFilled"
+        iconType="error"
         title={
           <h1>
             <FormattedMessage

--- a/x-pack/plugins/security/public/management/api_keys/api_keys_grid/not_enabled/not_enabled.tsx
+++ b/x-pack/plugins/security/public/management/api_keys/api_keys_grid/not_enabled/not_enabled.tsx
@@ -25,7 +25,7 @@ export const NotEnabled: React.FunctionComponent = () => {
         </h2>
       }
       color="danger"
-      iconType="alert"
+      iconType="warning"
       body={
         <p>
           <FormattedMessage

--- a/x-pack/plugins/security/public/management/role_mappings/components/no_compatible_realms/no_compatible_realms.tsx
+++ b/x-pack/plugins/security/public/management/role_mappings/components/no_compatible_realms/no_compatible_realms.tsx
@@ -22,7 +22,7 @@ export const NoCompatibleRealms: React.FunctionComponent = () => {
         />
       }
       color="warning"
-      iconType="alert"
+      iconType="warning"
     >
       <FormattedMessage
         id="xpack.security.management.roleMappings.noCompatibleRealmsErrorDescription"

--- a/x-pack/plugins/security/public/management/role_mappings/edit_role_mapping/role_selector/add_role_template_button.test.tsx
+++ b/x-pack/plugins/security/public/management/role_mappings/edit_role_mapping/role_selector/add_role_template_button.test.tsx
@@ -24,7 +24,7 @@ describe('AddRoleTemplateButton', () => {
     expect(wrapper).toMatchInlineSnapshot(`
       <EuiCallOut
         color="danger"
-        iconType="alert"
+        iconType="warning"
         title={
           <FormattedMessage
             defaultMessage="Role templates unavailable"

--- a/x-pack/plugins/security/public/management/role_mappings/edit_role_mapping/role_selector/add_role_template_button.tsx
+++ b/x-pack/plugins/security/public/management/role_mappings/edit_role_mapping/role_selector/add_role_template_button.tsx
@@ -20,7 +20,7 @@ export const AddRoleTemplateButton = (props: Props) => {
   if (!props.canUseStoredScripts && !props.canUseInlineScripts) {
     return (
       <EuiCallOut
-        iconType="alert"
+        iconType="warning"
         color="danger"
         title={
           <FormattedMessage

--- a/x-pack/plugins/security/public/management/role_mappings/edit_role_mapping/rule_editor_panel/visual_rule_editor.tsx
+++ b/x-pack/plugins/security/public/management/role_mappings/edit_role_mapping/rule_editor_panel/visual_rule_editor.tsx
@@ -91,7 +91,7 @@ export class VisualRuleEditor extends Component<Props, {}> {
     return (
       <Fragment>
         <EuiCallOut
-          iconType="alert"
+          iconType="warning"
           title={
             <FormattedMessage
               id="xpack.security.management.editRoleMapping.visualRuleEditor.switchToJSONEditorTitle"

--- a/x-pack/plugins/security/public/management/role_mappings/role_mappings_grid/role_mappings_grid_page.tsx
+++ b/x-pack/plugins/security/public/management/role_mappings/role_mappings_grid/role_mappings_grid_page.tsx
@@ -127,7 +127,7 @@ export class RoleMappingsGridPage extends Component<Props, State> {
               />
             }
             color="danger"
-            iconType="alert"
+            iconType="warning"
           >
             {statusCode}: {errorTitle} - {message}
           </EuiCallOut>

--- a/x-pack/plugins/security/public/management/role_table_display/role_table_display.tsx
+++ b/x-pack/plugins/security/public/management/role_table_display/role_table_display.tsx
@@ -31,7 +31,7 @@ export const RoleTableDisplay = ({ role, navigateToApp }: Props) => {
         data-test-subj="roleDeprecationTooltip"
       >
         <div>
-          {role.name} <EuiIcon type="alert" color="warning" size="s" className={'eui-alignTop'} />
+          {role.name} <EuiIcon type="warning" color="warning" size="s" className={'eui-alignTop'} />
         </div>
       </EuiToolTip>
     );

--- a/x-pack/plugins/security/public/management/roles/edit_role/edit_role_page.tsx
+++ b/x-pack/plugins/security/public/management/roles/edit_role/edit_role_page.tsx
@@ -648,7 +648,7 @@ export const EditRolePage: FunctionComponent<Props> = ({
             <EuiCallOut
               title={getExtendedRoleDeprecationNotice(role)}
               color="warning"
-              iconType="alert"
+              iconType="warning"
             />
           </Fragment>
         )}

--- a/x-pack/plugins/security/public/management/roles/edit_role/privileges/kibana/simple_privilege_section/unsupported_space_privileges_warning.tsx
+++ b/x-pack/plugins/security/public/management/roles/edit_role/privileges/kibana/simple_privilege_section/unsupported_space_privileges_warning.tsx
@@ -12,7 +12,7 @@ import { FormattedMessage } from '@kbn/i18n-react';
 
 export class UnsupportedSpacePrivilegesWarning extends Component<{}, {}> {
   public render() {
-    return <EuiCallOut iconType="alert" color="warning" title={this.getMessage()} />;
+    return <EuiCallOut iconType="warning" color="warning" title={this.getMessage()} />;
   }
 
   private getMessage = () => {

--- a/x-pack/plugins/security/public/management/roles/edit_role/privileges/kibana/space_aware_privilege_section/privilege_space_form.tsx
+++ b/x-pack/plugins/security/public/management/roles/edit_role/privileges/kibana/space_aware_privilege_section/privilege_space_form.tsx
@@ -120,7 +120,7 @@ export class PrivilegeSpaceForm extends Component<Props, State> {
             <Fragment>
               <EuiCallOut
                 color="warning"
-                iconType="alert"
+                iconType="warning"
                 data-test-subj="spaceFormGlobalPermissionsSupersedeWarning"
                 title={
                   <FormattedMessage
@@ -271,7 +271,7 @@ export class PrivilegeSpaceForm extends Component<Props, State> {
             <EuiSpacer size="l" />
             <EuiCallOut
               color="warning"
-              iconType="alert"
+              iconType="warning"
               data-test-subj="globalPrivilegeWarning"
               title={
                 <FormattedMessage

--- a/x-pack/plugins/security/public/management/roles/edit_role/privileges/kibana/space_aware_privilege_section/privilege_space_table.tsx
+++ b/x-pack/plugins/security/public/management/roles/edit_role/privileges/kibana/space_aware_privilege_section/privilege_space_table.tsx
@@ -185,7 +185,7 @@ export class PrivilegeSpaceTable extends Component<Props, State> {
             icon = (
               <span data-test-subj="spaceTablePrivilegeSupersededWarning">
                 <EuiIconTip
-                  type="alert"
+                  type="warning"
                   size="s"
                   content={
                     <FormattedMessage

--- a/x-pack/plugins/security/public/management/roles/edit_role/privileges/kibana/space_aware_privilege_section/space_aware_privilege_section.tsx
+++ b/x-pack/plugins/security/public/management/roles/edit_role/privileges/kibana/space_aware_privilege_section/space_aware_privilege_section.tsx
@@ -87,7 +87,7 @@ export class SpaceAwarePrivilegeSection extends Component<Props, State> {
               defaultMessage="Insufficient Privileges"
             />
           }
-          iconType="alert"
+          iconType="warning"
           color="danger"
           data-test-subj="userCannotManageSpacesCallout"
         >

--- a/x-pack/plugins/security/public/management/roles/edit_role/privileges/kibana/transform_error_section/transform_error_section.tsx
+++ b/x-pack/plugins/security/public/management/roles/edit_role/privileges/kibana/transform_error_section/transform_error_section.tsx
@@ -15,7 +15,7 @@ export class TransformErrorSection extends PureComponent<{}, {}> {
     return (
       <EuiEmptyPrompt
         color="danger"
-        iconType="alert"
+        iconType="warning"
         title={
           <h2>
             <FormattedMessage

--- a/x-pack/plugins/security/public/management/users/edit_user/change_password_modal.tsx
+++ b/x-pack/plugins/security/public/management/users/edit_user/change_password_modal.tsx
@@ -180,7 +180,7 @@ export const ChangePasswordModal: FunctionComponent<ChangePasswordModalProps> = 
                     { defaultMessage: 'Kibana will lose connection to Elasticsearch' }
                   )}
                   color="danger"
-                  iconType="alert"
+                  iconType="warning"
                   style={{ maxWidth: euiThemeVars.euiFormMaxWidth }}
                 >
                   <p>

--- a/x-pack/plugins/security/public/management/users/edit_user/edit_user_page.tsx
+++ b/x-pack/plugins/security/public/management/users/edit_user/edit_user_page.tsx
@@ -111,7 +111,7 @@ export const EditUserPage: FunctionComponent<EditUserPageProps> = ({ username })
                 defaultMessage="This user is deprecated."
               />
             }
-            iconType="alert"
+            iconType="warning"
             color="warning"
           >
             {user.metadata?._deprecated_reason?.replace(/\[(.+)\]/, "'$1'")}

--- a/x-pack/plugins/security/server/prompt_page.tsx
+++ b/x-pack/plugins/security/server/prompt_page.tsx
@@ -65,7 +65,7 @@ export function PromptPage({
           <EuiPageBody>
             <EuiPageContent verticalPosition="center" horizontalPosition="center">
               <EuiEmptyPrompt
-                iconType="alert"
+                iconType="warning"
                 iconColor="danger"
                 title={<h2>{title}</h2>}
                 body={body}

--- a/x-pack/plugins/security_solution/public/common/components/event_details/insights/insight_accordion.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/insights/insight_accordion.tsx
@@ -51,7 +51,7 @@ export const InsightAccordion = React.memo<Props>(
             id={accordionId}
             buttonContent={
               <span>
-                <EuiIcon type="alert" color="danger" style={{ marginRight: '6px' }} />
+                <EuiIcon type="warning" color="danger" style={{ marginRight: '6px' }} />
                 {text}
               </span>
             }

--- a/x-pack/plugins/security_solution/public/common/components/first_last_seen/first_last_seen.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/first_last_seen/first_last_seen.tsx
@@ -48,7 +48,7 @@ export const FirstLastSeen = React.memo<FirstLastSeenProps>(
           aria-label={`firstLastSeenError-${type}`}
           id={`firstLastSeenError-${field}-${type}`}
         >
-          <EuiIcon aria-describedby={`firstLastSeenError-${field}-${type}`} type="alert" />
+          <EuiIcon aria-describedby={`firstLastSeenError-${field}-${type}`} type="warning" />
         </EuiToolTip>
       );
     }

--- a/x-pack/plugins/security_solution/public/common/components/import_data_modal/action_connectors_warning/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/import_data_modal/action_connectors_warning/index.tsx
@@ -30,7 +30,7 @@ const ActionConnectorWarningsComponent: FC<ActionConnectorWarningsComponentProps
       data-test-subj="actionConnectorsWarningsCallOut"
       size="m"
       heading="h2"
-      iconType="alert"
+      iconType="warning"
       title={
         <span data-test-subj="actionConnectorsWarningsCallOutTitle">
           {i18n.ACTION_CONNECTORS_WARNING_TITLE(importedActionConnectorsCount)}

--- a/x-pack/plugins/security_solution/public/common/components/last_event_time/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/last_event_time/index.tsx
@@ -43,7 +43,7 @@ export const LastEventTime = memo<LastEventTimeProps>(
           aria-label="last_event_time_error"
           id={`last_event_time_error-${indexKey}`}
         >
-          <EuiIcon aria-describedby={`last_event_time_error-${indexKey}`} type="alert" />
+          <EuiIcon aria-describedby={`last_event_time_error-${indexKey}`} type="warning" />
         </EuiToolTip>
       );
     }

--- a/x-pack/plugins/security_solution/public/common/components/link_icon/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/link_icon/index.test.tsx
@@ -14,7 +14,7 @@ import { LinkIcon } from '.';
 describe('LinkIcon', () => {
   test('it renders', () => {
     const wrapper = shallow(
-      <LinkIcon href="#" iconSide="right" iconSize="xxl" iconType="alert" dataTestSubj="link">
+      <LinkIcon href="#" iconSide="right" iconSize="xxl" iconType="warning" dataTestSubj="link">
         {'Test link'}
       </LinkIcon>
     );
@@ -25,7 +25,7 @@ describe('LinkIcon', () => {
   test('it renders an action button when onClick is provided', () => {
     const wrapper = mount(
       <TestProviders>
-        <LinkIcon iconType="alert" dataTestSubj="link" onClick={() => alert('Test alert')}>
+        <LinkIcon iconType="warning" dataTestSubj="link" onClick={() => alert('Test alert')}>
           {'Test link'}
         </LinkIcon>
       </TestProviders>
@@ -37,7 +37,7 @@ describe('LinkIcon', () => {
   test('it renders an action link when href is provided', () => {
     const wrapper = mount(
       <TestProviders>
-        <LinkIcon href="#" iconType="alert" dataTestSubj="link">
+        <LinkIcon href="#" iconType="warning" dataTestSubj="link">
           {'Test link'}
         </LinkIcon>
       </TestProviders>
@@ -49,7 +49,7 @@ describe('LinkIcon', () => {
   test('it renders an icon', () => {
     const wrapper = mount(
       <TestProviders>
-        <LinkIcon dataTestSubj="link" iconType="alert">
+        <LinkIcon dataTestSubj="link" iconType="warning">
           {'Test link'}
         </LinkIcon>
       </TestProviders>
@@ -61,7 +61,7 @@ describe('LinkIcon', () => {
   test('it positions the icon to the right when iconSide is right', () => {
     const wrapper = mount(
       <TestProviders>
-        <LinkIcon dataTestSubj="link" iconSide="right" iconType="alert">
+        <LinkIcon dataTestSubj="link" iconSide="right" iconType="warning">
           {'Test link'}
         </LinkIcon>
       </TestProviders>
@@ -73,7 +73,7 @@ describe('LinkIcon', () => {
   test('it positions the icon to the left when iconSide is left (or not provided)', () => {
     const wrapper = mount(
       <TestProviders>
-        <LinkIcon dataTestSubj="link" iconSide="left" iconType="alert">
+        <LinkIcon dataTestSubj="link" iconSide="left" iconType="warning">
           {'Test link'}
         </LinkIcon>
       </TestProviders>
@@ -88,7 +88,7 @@ describe('LinkIcon', () => {
   test('it renders a label', () => {
     const wrapper = mount(
       <TestProviders>
-        <LinkIcon dataTestSubj="link" iconType="alert">
+        <LinkIcon dataTestSubj="link" iconType="warning">
           {'Test link'}
         </LinkIcon>
       </TestProviders>

--- a/x-pack/plugins/security_solution/public/common/components/ml_popover/jobs_table/jobs_table.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/ml_popover/jobs_table/jobs_table.tsx
@@ -122,7 +122,7 @@ const getJobsTableColumns = (
           onJobStateChange={onJobStateChange}
         />
       ) : (
-        <EuiIcon aria-label="Warning" size="s" type="alert" color="warning" />
+        <EuiIcon aria-label="Warning" size="s" type="warning" color="warning" />
       ),
     align: CENTER_ALIGNMENT,
     width: '80px',

--- a/x-pack/plugins/security_solution/public/common/components/ml_popover/ml_popover.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/ml_popover/ml_popover.tsx
@@ -153,7 +153,7 @@ export const MlPopover = React.memo(() => {
               <EuiCallOut
                 title={i18n.MODULE_NOT_COMPATIBLE_TITLE(incompatibleJobCount)}
                 color="warning"
-                iconType="alert"
+                iconType="warning"
                 size="s"
               >
                 <p>

--- a/x-pack/plugins/security_solution/public/common/components/sourcerer/temporary.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/sourcerer/temporary.tsx
@@ -111,7 +111,7 @@ export const TemporarySourcererComp = React.memo<Props>(
         <EuiCallOut
           color="warning"
           data-test-subj="sourcerer-deprecated-callout"
-          iconType="alert"
+          iconType="warning"
           size="s"
           title={translations[isModified].title[timelineType]}
         />

--- a/x-pack/plugins/security_solution/public/common/components/toasters/modal_all_errors.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/toasters/modal_all_errors.tsx
@@ -47,7 +47,7 @@ const ModalAllErrorsComponent: React.FC<FullErrorProps> = ({ isShowing, toast, t
       </EuiModalHeader>
 
       <EuiModalBody>
-        <EuiCallOut title={toast.title} color="danger" size="s" iconType="alert" />
+        <EuiCallOut title={toast.title} color="danger" size="s" iconType="warning" />
         <EuiSpacer size="s" />
         {Array.isArray(toast.errors) && // FunFact: This can be a non-array in some rare cases
           toast.errors.map((error, index) => (

--- a/x-pack/plugins/security_solution/public/common/components/utility_bar/utility_bar_action.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/utility_bar/utility_bar_action.test.tsx
@@ -15,7 +15,7 @@ describe('UtilityBarAction', () => {
   test('it renders', () => {
     const wrapper = shallow(
       <TestProviders>
-        <UtilityBarAction dataTestSubj="alert" iconType="alert">
+        <UtilityBarAction dataTestSubj="alert" iconType="warning">
           {'Test action'}
         </UtilityBarAction>
       </TestProviders>
@@ -29,7 +29,7 @@ describe('UtilityBarAction', () => {
       <TestProviders>
         <UtilityBarAction
           dataTestSubj="alert"
-          iconType="alert"
+          iconType="warning"
           popoverContent={() => <p>{'Test popover'}</p>}
         >
           {'Test action'}

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/pages/rule_editing/index.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/pages/rule_editing/index.tsx
@@ -496,7 +496,7 @@ const EditRulePageComponent: FC = () => {
                         </EuiButton>
                       </HeaderPage>
                       {invalidSteps.length > 0 && (
-                        <EuiCallOut title={i18n.SORRY_ERRORS} color="danger" iconType="alert">
+                        <EuiCallOut title={i18n.SORRY_ERRORS} color="danger" iconType="warning">
                           <FormattedMessage
                             id="xpack.securitySolution.detectionEngine.rule.editRule.errorMsgDescription"
                             defaultMessage="You have an invalid input in {countError, plural, one {this tab} other {these tabs}}: {tabHasError}"

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_exceptions/components/add_exception_flyout/index.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_exceptions/components/add_exception_flyout/index.tsx
@@ -481,7 +481,7 @@ export const AddExceptionFlyout = memo(function AddExceptionFlyout({
         <FlyoutBodySection className="builder-section">
           {errorSubmitting != null && (
             <>
-              <EuiCallOut title={i18n.SUBMIT_ERROR_TITLE} color="danger" iconType="alert">
+              <EuiCallOut title={i18n.SUBMIT_ERROR_TITLE} color="danger" iconType="warning">
                 <EuiText>{i18n.SUBMIT_ERROR_DISMISS_MESSAGE}</EuiText>
                 <EuiSpacer size="s" />
                 <EuiButton color="danger" onClick={handleDismissError}>

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_exceptions/components/error_callout/index.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_exceptions/components/error_callout/index.tsx
@@ -114,7 +114,7 @@ const ErrorCalloutComponent = ({
       data-test-subj="errorCalloutContainer"
       title={`${i18n.ERROR}: ${errorTitle}`}
       color="danger"
-      iconType="alert"
+      iconType="warning"
     >
       <EuiText size="s">
         <p data-test-subj="errorCalloutMessage">{errorMessage}</p>

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_response_actions/response_actions_form.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_response_actions/response_actions_form.tsx
@@ -97,7 +97,7 @@ export const ResponseActionsForm = ({
               data-test-subj="response-actions-error"
               title={FORM_ERRORS_TITLE}
               color="danger"
-              iconType="alert"
+              iconType="warning"
             >
               <ReactMarkdown>{uiFieldErrors}</ReactMarkdown>
             </EuiCallOut>

--- a/x-pack/plugins/security_solution/public/detections/components/callouts/no_api_integration_callout/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/callouts/no_api_integration_callout/index.tsx
@@ -16,7 +16,7 @@ const NoApiIntegrationKeyCallOutComponent = () => {
 
   return showCallOut ? (
     <>
-      <EuiCallOut title={i18n.NO_API_INTEGRATION_KEY_CALLOUT_TITLE} color="danger" iconType="alert">
+      <EuiCallOut title={i18n.NO_API_INTEGRATION_KEY_CALLOUT_TITLE} color="danger" iconType="warning">
         <p>{i18n.NO_API_INTEGRATION_KEY_CALLOUT_MSG}</p>
         <EuiButton color="danger" onClick={handleCallOut}>
           {i18n.DISMISS_CALLOUT}

--- a/x-pack/plugins/security_solution/public/detections/components/callouts/no_api_integration_callout/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/callouts/no_api_integration_callout/index.tsx
@@ -16,7 +16,11 @@ const NoApiIntegrationKeyCallOutComponent = () => {
 
   return showCallOut ? (
     <>
-      <EuiCallOut title={i18n.NO_API_INTEGRATION_KEY_CALLOUT_TITLE} color="danger" iconType="warning">
+      <EuiCallOut
+        title={i18n.NO_API_INTEGRATION_KEY_CALLOUT_TITLE}
+        color="danger"
+        iconType="warning"
+      >
         <p>{i18n.NO_API_INTEGRATION_KEY_CALLOUT_MSG}</p>
         <EuiButton color="danger" onClick={handleCallOut}>
           {i18n.DISMISS_CALLOUT}

--- a/x-pack/plugins/security_solution/public/detections/components/rules/eql_query_bar/errors_popover.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/eql_query_bar/errors_popover.tsx
@@ -33,7 +33,7 @@ export const ErrorsPopover: FC<ErrorsPopoverProps> = ({ ariaLabel, errors }) => 
       button={
         <EuiButtonEmpty
           data-test-subj="eql-validation-errors-popover-button"
-          iconType="crossInACircleFilled"
+          iconType="error"
           size="s"
           color="danger"
           aria-label={ariaLabel}

--- a/x-pack/plugins/security_solution/public/detections/components/rules/rule_actions_field/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/rule_actions_field/index.tsx
@@ -171,7 +171,7 @@ export const RuleActionsField: React.FC<Props> = ({ field, messageVariables }) =
       {fieldErrors ? (
         <>
           <FieldErrorsContainer>
-            <EuiCallOut title={FORM_ERRORS_TITLE} color="danger" iconType="alert">
+            <EuiCallOut title={FORM_ERRORS_TITLE} color="danger" iconType="warning">
               <ReactMarkdown>{fieldErrors}</ReactMarkdown>
             </EuiCallOut>
           </FieldErrorsContainer>

--- a/x-pack/plugins/security_solution/public/detections/components/rules/rule_execution_status/rule_status_failed_callout.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/rule_execution_status/rule_status_failed_callout.tsx
@@ -37,7 +37,7 @@ const RuleStatusFailedCallOutComponent: React.FC<RuleStatusFailedCallOutProps> =
         </>
       }
       color={color}
-      iconType="alert"
+      iconType="warning"
       data-test-subj="ruleStatusFailedCallOut"
     >
       {message.split('\n').map((line) => (

--- a/x-pack/plugins/security_solution/public/detections/components/rules/rule_preview/preview_logs.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/rule_preview/preview_logs.tsx
@@ -28,7 +28,7 @@ interface LogAccordionProps {
 }
 
 const CustomWarning: React.FC<{ message: string }> = ({ message }) => (
-  <EuiCallOut color={'warning'} iconType="alert" data-test-subj={'preview-abort'}>
+  <EuiCallOut color={'warning'} iconType="warning" data-test-subj={'preview-abort'}>
     <EuiText>
       <p>{message}</p>
     </EuiText>
@@ -125,7 +125,7 @@ export const CalloutGroup: React.FC<{
         <Fragment key={i}>
           <EuiCallOut
             color={isError ? 'danger' : 'warning'}
-            iconType="alert"
+            iconType="warning"
             data-test-subj={isError ? 'preview-error' : 'preview-warning'}
             title={`${startedAt ? `[${startedAt}] ` : ''}[${duration}ms]`}
           >

--- a/x-pack/plugins/security_solution/public/detections/pages/alert_details/components/error_page.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/alert_details/components/error_page.tsx
@@ -14,7 +14,7 @@ export const AlertDetailsErrorPage = memo(({ eventId }: { eventId: string }) => 
     <EuiEmptyPrompt
       color="danger"
       data-test-subj="alert-details-page-error"
-      iconType="alert"
+      iconType="warning"
       title={<h2>{ERROR_PAGE_TITLE}</h2>}
       body={
         <div>

--- a/x-pack/plugins/security_solution/public/detections/pages/alert_details/tabs/summary/cases_panel/related_case.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/alert_details/tabs/summary/cases_panel/related_case.tsx
@@ -91,7 +91,7 @@ export const RelatedCasesList = ({
                 </EuiFlexItem>
                 <EuiFlexItem>
                   <EuiFlexGroup dir="row">
-                    <StyledIcon type="alert" />
+                    <StyledIcon type="warning" />
                     <span>{totals.alerts}</span>
                   </EuiFlexGroup>
                 </EuiFlexItem>

--- a/x-pack/plugins/security_solution/public/explore/hosts/components/kpi_hosts/risky_hosts/index.tsx
+++ b/x-pack/plugins/security_solution/public/explore/hosts/components/kpi_hosts/risky_hosts/index.tsx
@@ -108,7 +108,7 @@ const RiskyHostsComponent: React.FC<{
           <EuiFlexItem>
             <EuiFlexGroup alignItems="center" gutterSize="m" responsive={false}>
               <EuiFlexItem grow={false}>
-                <EuiIcon type="alert" color={euiLightVars.euiColorDarkestShade} size="l" />
+                <EuiIcon type="warning" color={euiLightVars.euiColorDarkestShade} size="l" />
               </EuiFlexItem>
               <EuiFlexItem>
                 <StatusTitle className="eui-textTruncate" data-test-subj="riskyHostsTotal">

--- a/x-pack/plugins/security_solution/public/management/components/artifact_list_page/components/artifact_delete_modal.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/artifact_list_page/components/artifact_delete_modal.tsx
@@ -116,7 +116,7 @@ export const ArtifactDeleteModal = memo<DeleteArtifactModalProps>(
               data-test-subj={getTestId('impactCallout')}
               title={labels.deleteModalImpactTitle}
               color="danger"
-              iconType="alert"
+              iconType="warning"
             >
               <p data-test-subj={getTestId('impactCalloutInfo')}>
                 {labels.deleteModalImpactInfo(item)}

--- a/x-pack/plugins/security_solution/public/management/components/endpoint_policy_link.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/endpoint_policy_link.tsx
@@ -42,7 +42,7 @@ export const EndpointPolicyLink = memo<
         {children}
         {
           <EuiText color="subdued" size="xs" className="eui-textNoWrap">
-            <EuiIcon size="m" type="alert" color="warning" />
+            <EuiIcon size="m" type="warning" color="warning" />
             &nbsp;
             <FormattedMessage
               id="xpack.securitySolution.endpoint.policyNotFound"

--- a/x-pack/plugins/security_solution/public/management/components/endpoint_responder/lib/get_command_about_info.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/endpoint_responder/lib/get_command_about_info.tsx
@@ -18,7 +18,7 @@ const UNSUPPORTED_COMMAND_INFO = i18n.translate(
 );
 
 const DisabledTooltip = React.memo(() => {
-  return <EuiIconTip content={UNSUPPORTED_COMMAND_INFO} type="alert" color="danger" />;
+  return <EuiIconTip content={UNSUPPORTED_COMMAND_INFO} type="warning" color="danger" />;
 });
 DisabledTooltip.displayName = 'DisabledTooltip';
 

--- a/x-pack/plugins/security_solution/public/management/components/no_permissons/no_permissions.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/no_permissons/no_permissions.tsx
@@ -13,7 +13,7 @@ export const NoPermissions = memo(() => {
   return (
     <>
       <EuiEmptyPrompt
-        iconType="alert"
+        iconType="warning"
         iconColor="danger"
         titleSize="l"
         data-test-subj="noIngestPermissions"

--- a/x-pack/plugins/security_solution/public/management/components/package_action_item/package_action_item_error.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/package_action_item/package_action_item_error.tsx
@@ -31,7 +31,7 @@ export const PackageActionItemError = memo(({ actionFormatter }: PackageActionIt
     <StyledEuiCallout
       title={actionFormatter.title}
       color="danger"
-      iconType="alert"
+      iconType="warning"
       data-test-subj="packageItemErrorCallOut"
     >
       <StyledEuiText size="s" data-test-subj="packageItemErrorCallOutMessage">

--- a/x-pack/plugins/security_solution/public/management/components/policy_response/policy_response_action_item.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/policy_response/policy_response_action_item.tsx
@@ -32,7 +32,7 @@ export const PolicyResponseActionItem = memo(
       <StyledEuiCallout
         title={policyResponseActionFormatter.errorTitle}
         color="danger"
-        iconType="alert"
+        iconType="warning"
         data-test-subj="endpointPolicyResponseErrorCallOut"
       >
         <StyledEuiText size="s" data-test-subj="endpointPolicyResponseMessage">

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/components/out_of_date.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/components/out_of_date.tsx
@@ -18,7 +18,7 @@ export const OutOfDate = React.memo<{ style?: React.CSSProperties }>(({ style, .
       style={style}
       {...otherProps}
     >
-      <EuiIcon className={'eui-alignTop'} size="m" type="alert" color="warning" />
+      <EuiIcon className={'eui-alignTop'} size="m" type="warning" color="warning" />
       <FormattedMessage id="xpack.securitySolution.outOfDateLabel" defaultMessage="Out-of-date" />
     </EuiText>
   );

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/ingest_manager_integration/endpoint_policy_edit_extension/endpoint_policy_edit_extension.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/ingest_manager_integration/endpoint_policy_edit_extension/endpoint_policy_edit_extension.tsx
@@ -122,7 +122,7 @@ const WrappedPolicyDetailsForm = memo<{
                 defaultMessage="Failed to load endpoint policy settings"
               />
             }
-            iconType="alert"
+            iconType="warning"
             color="warning"
             data-test-subj="endpiontPolicySettingsLoadingError"
           >

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/policy_advanced.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/policy_advanced.tsx
@@ -98,7 +98,7 @@ const warningMessage = i18n.translate(
 export const AdvancedPolicyForms = React.memo(({ isPlatinumPlus }: { isPlatinumPlus: boolean }) => {
   return (
     <>
-      <EuiCallOut title={calloutTitle} color="warning" iconType="alert">
+      <EuiCallOut title={calloutTitle} color="warning" iconType="warning">
         <p>{warningMessage}</p>
       </EuiCallOut>
       <EuiSpacer />

--- a/x-pack/plugins/security_solution/public/overview/components/entity_analytics/anomalies/columns.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/entity_analytics/anomalies/columns.tsx
@@ -82,7 +82,7 @@ export const useAnomaliesColumns = (
           } else if (job.isCompatible) {
             return <EnableJob job={job} isLoading={loading} onJobStateChange={onJobStateChange} />;
           } else {
-            return <EuiIcon aria-label="Warning" size="s" type="alert" color="warning" />;
+            return <EuiIcon aria-label="Warning" size="s" type="warning" color="warning" />;
           }
         },
       },

--- a/x-pack/plugins/security_solution/public/overview/components/entity_analytics/anomalies/index.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/entity_analytics/anomalies/index.tsx
@@ -171,7 +171,7 @@ export const EntityAnalyticsAnomalies = () => {
                 title={i18n.MODULE_NOT_COMPATIBLE_TITLE(incompatibleJobCount)}
                 data-test-subj="incompatible_jobs_warnings"
                 color="warning"
-                iconType="alert"
+                iconType="warning"
                 size="s"
               >
                 <p>

--- a/x-pack/plugins/security_solution/public/resolver/view/panels/node_events_of_type.tsx
+++ b/x-pack/plugins/security_solution/public/resolver/view/panels/node_events_of_type.tsx
@@ -65,7 +65,7 @@ export const NodeEventsInCategory = memo(function ({
                 }
               )}
               color="danger"
-              iconType="alert"
+              iconType="warning"
               data-test-subj="resolver:nodeEventsInCategory:error"
             >
               <p>

--- a/x-pack/plugins/security_solution/public/timelines/components/edit_data_provider/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/edit_data_provider/index.tsx
@@ -272,7 +272,7 @@ export const StatefulEditDataProvider = React.memo<Props>(
               <>
                 <EuiCallOut
                   color="warning"
-                  iconType="alert"
+                  iconType="warning"
                   size="s"
                   title={i18n.UNAVAILABLE_OPERATOR(updatedOperator[0].label)}
                 />

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/header/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/header/index.tsx
@@ -37,7 +37,7 @@ const TimelineHeaderComponent: React.FC<Props> = ({
         data-test-subj="timelineCallOutUnauthorized"
         title={i18n.CALL_OUT_UNAUTHORIZED_MSG}
         color="warning"
-        iconType="alert"
+        iconType="warning"
         size="s"
       />
     )}
@@ -46,7 +46,7 @@ const TimelineHeaderComponent: React.FC<Props> = ({
         data-test-subj="timelineImmutableCallOut"
         title={i18n.CALL_OUT_IMMUTABLE}
         color="primary"
-        iconType="alert"
+        iconType="warning"
         size="s"
       />
     )}

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/header/title_and_description.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/header/title_and_description.tsx
@@ -201,7 +201,7 @@ export const TimelineTitleAndDescription = React.memo<TimelineTitleAndDescriptio
               <EuiCallOut
                 title={calloutMessage}
                 color="danger"
-                iconType="alert"
+                iconType="warning"
                 data-test-subj="save-timeline-callout"
               />
               <EuiSpacer size="m" />

--- a/x-pack/plugins/session_view/public/components/detail_panel_alert_group_item/index.tsx
+++ b/x-pack/plugins/session_view/public/components/detail_panel_alert_group_item/index.tsx
@@ -51,7 +51,7 @@ export const DetailPanelAlertGroupItem = ({
           size="s"
         >
           <p css={styles.alertTitle}>
-            <EuiIcon color="danger" type="alert" css={styles.alertIcon} />
+            <EuiIcon color="danger" type="warning" css={styles.alertIcon} />
             {dataOrDash(rule?.name)}
           </p>
         </EuiText>

--- a/x-pack/plugins/session_view/public/components/session_view/index.tsx
+++ b/x-pack/plugins/session_view/public/components/session_view/index.tsx
@@ -344,7 +344,7 @@ export const SessionView = ({
               <EuiResizablePanel initialSize={100} minSize="60%" paddingSize="none">
                 {hasError && (
                   <EuiEmptyPrompt
-                    iconType="alert"
+                    iconType="warning"
                     color="danger"
                     title={
                       <h2>

--- a/x-pack/plugins/snapshot_restore/public/application/components/policy_form/steps/step_logistics.tsx
+++ b/x-pack/plugins/snapshot_restore/public/application/components/policy_form/steps/step_logistics.tsx
@@ -515,7 +515,7 @@ export const PolicyStepLogistics: React.FunctionComponent<StepProps> = ({
               />
             }
             color="danger"
-            iconType="alert"
+            iconType="warning"
           >
             <FormattedMessage
               id="xpack.snapshotRestore.policyForm.stepLogistics.selectRepository.policyRepositoryNotFoundDescription"

--- a/x-pack/plugins/snapshot_restore/public/application/components/policy_form/steps/step_settings/fields/include_feature_states_field/include_feature_states_field.tsx
+++ b/x-pack/plugins/snapshot_restore/public/application/components/policy_form/steps/step_settings/fields/include_feature_states_field/include_feature_states_field.tsx
@@ -109,7 +109,7 @@ export const IncludeFeatureStatesField: FunctionComponent<Props> = ({ policy, on
           ) : (
             <EuiCallOut
               color="warning"
-              iconType="alert"
+              iconType="warning"
               title={
                 <FormattedMessage
                   id="xpack.snapshotRestore.errorLoadingFeatureStatesLabel"

--- a/x-pack/plugins/snapshot_restore/public/application/components/restore_snapshot_form/steps/step_logistics/data_streams_global_state_call_out.tsx
+++ b/x-pack/plugins/snapshot_restore/public/application/components/restore_snapshot_form/steps/step_logistics/data_streams_global_state_call_out.tsx
@@ -48,7 +48,7 @@ export const DataStreamsGlobalStateCallOut: FunctionComponent<Props> = ({ dataSt
     <EuiCallOut
       data-test-subj="dataStreamWarningCallOut"
       title={i18nTexts.callout.title(dataStreamsCount)}
-      iconType="alert"
+      iconType="warning"
       color="warning"
     >
       {i18nTexts.callout.body(docLinks.links.snapshotRestore.createSnapshot)}

--- a/x-pack/plugins/snapshot_restore/public/application/components/retention_update_modal_provider.tsx
+++ b/x-pack/plugins/snapshot_restore/public/application/components/retention_update_modal_provider.tsx
@@ -156,7 +156,7 @@ export const RetentionSettingsUpdateModalProvider: React.FunctionComponent<Props
                   />
                 }
                 color="danger"
-                iconType="alert"
+                iconType="warning"
               >
                 {saveError.data && saveError.data.message ? <p>{saveError.data.message}</p> : null}
               </EuiCallOut>

--- a/x-pack/plugins/snapshot_restore/public/application/sections/home/policy_list/policy_list.tsx
+++ b/x-pack/plugins/snapshot_restore/public/application/sections/home/policy_list/policy_list.tsx
@@ -183,7 +183,7 @@ export const PolicyList: React.FunctionComponent<RouteComponentProps<MatchParams
                 />
               }
               color="warning"
-              iconType="alert"
+              iconType="warning"
             >
               <FormattedMessage
                 id="xpack.snapshotRestore.policyScheduleWarningDescription"

--- a/x-pack/plugins/snapshot_restore/public/application/sections/home/policy_list/policy_retention_schedule/policy_retention_schedule.tsx
+++ b/x-pack/plugins/snapshot_restore/public/application/sections/home/policy_list/policy_retention_schedule/policy_retention_schedule.tsx
@@ -144,7 +144,7 @@ export const PolicyRetentionSchedule: React.FunctionComponent<Props> = ({
           />
         }
         color="warning"
-        iconType="alert"
+        iconType="warning"
       >
         <p>
           <FormattedMessage
@@ -255,7 +255,7 @@ export const PolicyRetentionSchedule: React.FunctionComponent<Props> = ({
             />
           }
           color="danger"
-          iconType="alert"
+          iconType="warning"
         >
           {error.data && error.data.message ? <p>{error.data.message}</p> : null}
           <EuiButton iconType="refresh" color="danger" onClick={onRetentionScheduleUpdated}>

--- a/x-pack/plugins/snapshot_restore/public/application/sections/home/policy_list/policy_table/policy_table.tsx
+++ b/x-pack/plugins/snapshot_restore/public/application/sections/home/policy_list/policy_table/policy_table.tsx
@@ -127,7 +127,7 @@ export const PolicyTable: React.FunctionComponent<Props> = ({
                     }
                   )}
                 >
-                  <EuiIcon type="alert" color="danger" />
+                  <EuiIcon type="warning" color="danger" />
                 </EuiToolTip>
               </EuiFlexItem>
               <EuiFlexItem grow={1}>

--- a/x-pack/plugins/snapshot_restore/public/application/sections/home/snapshot_list/components/snapshot_search_bar.tsx
+++ b/x-pack/plugins/snapshot_restore/public/application/sections/home/snapshot_list/components/snapshot_search_bar.tsx
@@ -159,7 +159,7 @@ export const SnapshotSearchBar: React.FunctionComponent<Props> = ({
         <>
           <EuiCallOut
             data-test-subj="snapshotListSearchError"
-            iconType="alert"
+            iconType="warning"
             color="danger"
             title={
               <FormattedMessage

--- a/x-pack/plugins/snapshot_restore/public/application/sections/home/snapshot_list/snapshot_details/tabs/snapshot_state.tsx
+++ b/x-pack/plugins/snapshot_restore/public/application/sections/home/snapshot_list/snapshot_details/tabs/snapshot_state.tsx
@@ -39,7 +39,7 @@ export const SnapshotState: React.FC<Props> = ({ state }) => {
       }),
     },
     [SNAPSHOT_STATE.PARTIAL]: {
-      icon: <EuiIcon color="warning" type="alert" />,
+      icon: <EuiIcon color="warning" type="warning" />,
       label: i18n.translate('xpack.snapshotRestore.snapshotState.partialLabel', {
         defaultMessage: 'Partial failure',
       }),
@@ -48,7 +48,7 @@ export const SnapshotState: React.FC<Props> = ({ state }) => {
       }),
     },
     [SNAPSHOT_STATE.INCOMPATIBLE]: {
-      icon: <EuiIcon color="warning" type="alert" />,
+      icon: <EuiIcon color="warning" type="warning" />,
       label: i18n.translate('xpack.snapshotRestore.snapshotState.incompatibleLabel', {
         defaultMessage: 'Incompatible version',
       }),

--- a/x-pack/plugins/snapshot_restore/public/application/sections/home/snapshot_list/snapshot_list.tsx
+++ b/x-pack/plugins/snapshot_restore/public/application/sections/home/snapshot_list/snapshot_list.tsx
@@ -162,7 +162,7 @@ export const SnapshotList: React.FunctionComponent<RouteComponentProps<MatchPara
             />
           }
           color="warning"
-          iconType="alert"
+          iconType="warning"
           data-test-subj="repositoryErrorsWarning"
         >
           <FormattedMessage

--- a/x-pack/plugins/spaces/public/legacy_urls/components/embeddable_legacy_url_conflict_internal.tsx
+++ b/x-pack/plugins/spaces/public/legacy_urls/components/embeddable_legacy_url_conflict_internal.tsx
@@ -73,7 +73,7 @@ export const EmbeddableLegacyUrlConflictInternal = (
               />
             }
             color="danger"
-            iconType="alert"
+            iconType="warning"
           >
             <EuiCodeBlock fontSize="s" language="json" isCopyable={true} paddingSize="none">
               {aliasJsonString}

--- a/x-pack/plugins/spaces/public/management/components/confirm_delete_modal/confirm_delete_modal.tsx
+++ b/x-pack/plugins/spaces/public/management/components/confirm_delete_modal/confirm_delete_modal.tsx
@@ -89,7 +89,7 @@ export const ConfirmDeleteModal: FunctionComponent<Props> = ({
         <>
           <EuiCallOut
             color="warning"
-            iconType="alert"
+            iconType="warning"
             title={i18n.translate('xpack.spaces.management.confirmDeleteModal.currentSpaceTitle', {
               defaultMessage: 'You are currently in this space.',
             })}

--- a/x-pack/plugins/spaces/public/share_saved_objects_to_space/components/selectable_spaces_control.tsx
+++ b/x-pack/plugins/spaces/public/share_saved_objects_to_space/components/selectable_spaces_control.tsx
@@ -92,7 +92,7 @@ const APPEND_FEATURE_IS_DISABLED = (
       defaultMessage: 'This feature is disabled in this space.',
     })}
     position="left"
-    type="alert"
+    type="warning"
     color="warning"
   />
 );

--- a/x-pack/plugins/spaces/public/share_saved_objects_to_space/components/share_to_space_flyout_internal.test.tsx
+++ b/x-pack/plugins/spaces/public/share_saved_objects_to_space/components/share_to_space_flyout_internal.test.tsx
@@ -523,7 +523,7 @@ describe('ShareToSpaceFlyout', () => {
               color="warning"
               content="This feature is disabled in this space."
               position="left"
-              type="alert"
+              type="warning"
             />
           </React.Fragment>
         `);
@@ -560,7 +560,7 @@ describe('ShareToSpaceFlyout', () => {
           color="warning"
           content="This feature is disabled in this space."
           position="left"
-          type="alert"
+          type="warning"
         />
       `);
       expect(option.checked).toEqual('on');

--- a/x-pack/plugins/stack_alerts/public/rule_types/es_query/expression/search_source_expression.tsx
+++ b/x-pack/plugins/stack_alerts/public/rule_types/es_query/expression/search_source_expression.tsx
@@ -112,7 +112,7 @@ export const SearchSourceExpression = ({
   if (paramsError) {
     return (
       <>
-        <EuiCallOut color="danger" iconType="alert">
+        <EuiCallOut color="danger" iconType="warning">
           <p>{paramsError.message}</p>
         </EuiCallOut>
         <EuiSpacer size="s" />

--- a/x-pack/plugins/stack_alerts/public/rule_types/threshold/visualization.tsx
+++ b/x-pack/plugins/stack_alerts/public/rule_types/threshold/visualization.tsx
@@ -225,7 +225,7 @@ export const ThresholdVisualization: React.FunctionComponent<Props> = ({
             />
           }
           color="danger"
-          iconType="alert"
+          iconType="warning"
         >
           {errorMessage}
         </EuiCallOut>

--- a/x-pack/plugins/stack_connectors/public/connector_types/lib/servicenow/application_required_callout.tsx
+++ b/x-pack/plugins/stack_connectors/public/connector_types/lib/servicenow/application_required_callout.tsx
@@ -35,7 +35,7 @@ const ApplicationRequiredCalloutComponent: React.FC<Props> = ({ appId, message }
       <EuiSpacer size="s" />
       <EuiCallOut
         size="m"
-        iconType="alert"
+        iconType="warning"
         data-test-subj="snApplicationCallout"
         color="danger"
         title={i18n.translate(

--- a/x-pack/plugins/stack_connectors/public/connector_types/lib/servicenow/deprecated_callout.tsx
+++ b/x-pack/plugins/stack_connectors/public/connector_types/lib/servicenow/deprecated_callout.tsx
@@ -28,7 +28,7 @@ const DeprecatedCalloutComponent: React.FC<Props> = ({ onMigrate }) => {
     <>
       <EuiCallOut
         size="m"
-        iconType="alert"
+        iconType="warning"
         data-test-subj="snDeprecatedCallout"
         color="warning"
         title={i18n.translate(

--- a/x-pack/plugins/stack_connectors/public/connector_types/lib/servicenow/installation_callout.tsx
+++ b/x-pack/plugins/stack_connectors/public/connector_types/lib/servicenow/installation_callout.tsx
@@ -21,7 +21,7 @@ const InstallationCalloutComponent: React.FC<Props> = ({ appId }) => {
       <EuiSpacer size="s" />
       <EuiCallOut
         size="m"
-        iconType="alert"
+        iconType="warning"
         color="warning"
         data-test-subj="snInstallationCallout"
         title={i18n.INSTALLATION_CALLOUT_TITLE}

--- a/x-pack/plugins/stack_connectors/public/connector_types/lib/servicenow/selection_row.tsx
+++ b/x-pack/plugins/stack_connectors/public/connector_types/lib/servicenow/selection_row.tsx
@@ -22,7 +22,7 @@ export function ServiceNowSelectableRowIcon({
   return (
     <EuiIconTip
       aria-label={deprecatedTooltipTitle}
-      type="alert"
+      type="warning"
       color="warning"
       content={connectorDeprecatedMessage}
       data-test-subj={`deprecated-connector-icon-${actionConnector.id}`}

--- a/x-pack/plugins/stack_connectors/public/connector_types/lib/servicenow/update_connector.tsx
+++ b/x-pack/plugins/stack_connectors/public/connector_types/lib/servicenow/update_connector.tsx
@@ -128,7 +128,7 @@ const UpdateConnectorComponent: React.FC<Props> = ({
             <EuiCallOut
               size="m"
               color="danger"
-              iconType="alert"
+              iconType="warning"
               data-test-subj="snUpdateInstallationCallout"
               title={warningMessage}
             />

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/common/components/stderr_logs.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/common/components/stderr_logs.tsx
@@ -114,7 +114,7 @@ export const StdErrorLogs = ({
             </EuiFlexItem>
           </EuiFlexGroup>
           {summaryMessage && (
-            <EuiCallOut title={ERROR_SUMMARY_LABEL} color="danger" iconType="alert">
+            <EuiCallOut title={ERROR_SUMMARY_LABEL} color="danger" iconType="warning">
               <p>{summaryMessage}</p>
             </EuiCallOut>
           )}

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/common/links/error_details_link.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/common/links/error_details_link.tsx
@@ -41,7 +41,7 @@ export const ErrorDetailsButton = ({
   const link = useErrorDetailsLink({ configId, stateId, locationId: selectedLocation?.id });
 
   return (
-    <EuiButtonEmpty flush="left" iconType="alert" color="danger" href={link}>
+    <EuiButtonEmpty flush="left" iconType="warning" color="danger" href={link}>
       {label ?? VIEW_DETAILS}
     </EuiButtonEmpty>
   );

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/locations_loading_error.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/locations_loading_error.tsx
@@ -12,7 +12,7 @@ import { EuiEmptyPrompt } from '@elastic/eui';
 export const LocationsLoadingError = () => {
   return (
     <EuiEmptyPrompt
-      iconType="alert"
+      iconType="warning"
       color="danger"
       title={
         <h3>

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/monitor_edit_page.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/monitor_edit_page.tsx
@@ -51,7 +51,7 @@ export const MonitorEditPage: React.FC = () => {
   if (error) {
     return (
       <EuiEmptyPrompt
-        iconType="alert"
+        iconType="warning"
         color="danger"
         title={
           <h3>

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_status/monitor_status_legend.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_status/monitor_status_legend.tsx
@@ -45,7 +45,7 @@ export const MonitorStatusLegend = ({ brushable }: { brushable: boolean }) => {
       {/*
         // Hiding error for now until @elastic/chart's Heatmap chart supports annotations
         // `getErrorVizColor` can be imported from './monitor_status_data'
-        <LegendItem color={getErrorVizColor(euiTheme)} label={labels.ERROR_LABEL} iconType="alert" />
+        <LegendItem color={getErrorVizColor(euiTheme)} label={labels.ERROR_LABEL} iconType="warning" />
       */}
 
       {brushable ? (

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/last_test_run.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/last_test_run.tsx
@@ -97,7 +97,7 @@ export const LastTestRunComponent = ({
           title={latestPing?.error.message}
           size="s"
           color="danger"
-          iconType="alert"
+          iconType="warning"
         >
           {isErrorDetails ? (
             <></>

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/route_config.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/route_config.tsx
@@ -143,7 +143,7 @@ const getMonitorSummaryHeader = (
         label: i18n.translate('xpack.synthetics.monitorErrorsTab.title', {
           defaultMessage: 'Errors',
         }),
-        prepend: <EuiIcon type="alert" color="danger" />,
+        prepend: <EuiIcon type="warning" color="danger" />,
         isSelected: selectedTab === 'errors',
         href: `${syntheticsPath}${MONITOR_ERRORS_ROUTE.replace(':monitorId', monitorId)}${search}`,
         'data-test-subj': 'syntheticsMonitorErrorsTab',

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/management/loader/loader.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/management/loader/loader.tsx
@@ -32,7 +32,7 @@ export const Loader = ({
         <>
           <EuiSpacer size="xxl" />
           <EuiEmptyPrompt
-            iconType="alert"
+            iconType="warning"
             color="danger"
             title={<h2>{errorTitle}</h2>}
             body={<p>{errorBody}</p>}

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/management/monitor_errors/monitor_async_error.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/management/monitor_errors/monitor_async_error.tsx
@@ -28,7 +28,7 @@ export const MonitorAsyncError = () => {
           />
         }
         color="warning"
-        iconType="alert"
+        iconType="warning"
       >
         <p>
           <FormattedMessage

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/metric_item_icon.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/metric_item_icon.tsx
@@ -117,7 +117,12 @@ export const MetricItemIcon = ({
                 }
               }}
             >
-              <EuiButtonIcon iconType="warning" color="danger" size="m" aria-label={ERROR_DETAILS} />
+              <EuiButtonIcon
+                iconType="warning"
+                color="danger"
+                size="m"
+                aria-label={ERROR_DETAILS}
+              />
             </StyledIcon>
           }
           isOpen={configIdByLocation === isPopoverOpen}

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/metric_item_icon.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/metric_item_icon.tsx
@@ -117,7 +117,7 @@ export const MetricItemIcon = ({
                 }
               }}
             >
-              <EuiButtonIcon iconType="alert" color="danger" size="m" aria-label={ERROR_DETAILS} />
+              <EuiButtonIcon iconType="warning" color="danger" size="m" aria-label={ERROR_DETAILS} />
             </StyledIcon>
           }
           isOpen={configIdByLocation === isPopoverOpen}
@@ -136,7 +136,7 @@ export const MetricItemIcon = ({
             </EuiFlexGroup>
           </EuiPopoverTitle>
           <div style={{ width: '300px' }}>
-            <EuiCallOut title={ping?.error?.message} color="danger" iconType="alert" />
+            <EuiCallOut title={ping?.error?.message} color="danger" iconType="warning" />
           </div>
           <EuiPopoverFooter>
             <EuiButton fullWidth size="s" href={errorLink}>

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/step_details_page/error_callout.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/step_details_page/error_callout.tsx
@@ -21,7 +21,7 @@ export const ErrorCallOut = ({ step }: { step?: JourneyStep }) => {
 
   return (
     <>
-      <EuiCallOut title={error} color="danger" iconType="alert" />
+      <EuiCallOut title={error} color="danger" iconType="warning" />
       <EuiSpacer />
     </>
   );

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/test_now_mode/browser/browser_test_results.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/test_now_mode/browser/browser_test_results.tsx
@@ -92,7 +92,7 @@ export const BrowserTestRunResult = ({ expectPings, onDone, testRunId }: Props) 
                 title={ERROR_RUNNING_TEST}
                 size="s"
                 color="danger"
-                iconType="alert"
+                iconType="warning"
               >
                 <EuiText color="danger">{summaryDoc?.error?.message ?? FAILED_TO_RUN}</EuiText>
               </EuiCallOut>

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/test_now_mode/test_now_mode.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/test_now_mode/test_now_mode.tsx
@@ -46,7 +46,7 @@ export function TestNowMode({
   return (
     <EuiPanel color="subdued" hasBorder={true}>
       {(hasBlockingError && !isPushing && (
-        <EuiCallOut title={blockingErrorMessage} color="danger" iconType="alert" />
+        <EuiCallOut title={blockingErrorMessage} color="danger" iconType="warning" />
       )) ||
         null}
 

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/test_run_details/components/test_run_error_info.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/test_run_details/components/test_run_error_info.tsx
@@ -34,7 +34,7 @@ export const TestRunErrorInfo = ({
           data-test-subj="monitorTestRunErrorCallout"
           title={ERROR_RUNNING_TEST}
           color="danger"
-          iconType="alert"
+          iconType="warning"
         >
           <EuiText color="danger">{errorMessage ?? FAILED_TO_RUN}</EuiText>
         </EuiCallOut>

--- a/x-pack/plugins/synthetics/public/legacy_uptime/components/fleet_package/browser/throttling_fields.tsx
+++ b/x-pack/plugins/synthetics/public/legacy_uptime/components/fleet_package/browser/throttling_fields.tsx
@@ -44,7 +44,7 @@ export const ThrottlingDisabledCallout = () => {
         />
       }
       color="warning"
-      iconType="alert"
+      iconType="warning"
     >
       <FormattedMessage
         id="xpack.synthetics.createPackagePolicy.stepConfigure.browserAdvancedSettings.throttling.automatic_node_cap.message"
@@ -64,7 +64,7 @@ export const ThrottlingExceededCallout = () => {
         />
       }
       color="warning"
-      iconType="alert"
+      iconType="warning"
     >
       <FormattedMessage
         id="xpack.synthetics.createPackagePolicy.stepConfigure.browserAdvancedSettings.throttling.exceeded_throttling.message"

--- a/x-pack/plugins/synthetics/public/legacy_uptime/components/monitor_management/loader/loader.tsx
+++ b/x-pack/plugins/synthetics/public/legacy_uptime/components/monitor_management/loader/loader.tsx
@@ -32,7 +32,7 @@ export const Loader = ({
         <>
           <EuiSpacer size="xxl" />
           <EuiEmptyPrompt
-            iconType="alert"
+            iconType="warning"
             color="danger"
             title={<h2>{errorTitle}</h2>}
             body={<p>{errorBody}</p>}

--- a/x-pack/plugins/synthetics/public/legacy_uptime/components/monitor_management/monitor_list/inline_error.tsx
+++ b/x-pack/plugins/synthetics/public/legacy_uptime/components/monitor_management/monitor_list/inline_error.tsx
@@ -29,7 +29,7 @@ export const InlineError = ({ errorSummary }: { errorSummary: Ping }) => {
         <EuiToolTip content={errorMessage}>
           <EuiButtonIcon
             aria-label={errorMessage}
-            iconType="alert"
+            iconType="warning"
             onClick={() => setIsOpen(true)}
             color="danger"
           />

--- a/x-pack/plugins/synthetics/public/legacy_uptime/components/monitor_management/monitor_list/monitor_async_error.tsx
+++ b/x-pack/plugins/synthetics/public/legacy_uptime/components/monitor_management/monitor_list/monitor_async_error.tsx
@@ -27,7 +27,7 @@ export const MonitorAsyncError = () => {
           />
         }
         color="warning"
-        iconType="alert"
+        iconType="warning"
       >
         <p>
           <FormattedMessage

--- a/x-pack/plugins/synthetics/public/legacy_uptime/components/monitor_management/test_now_mode/test_now_mode.tsx
+++ b/x-pack/plugins/synthetics/public/legacy_uptime/components/monitor_management/test_now_mode/test_now_mode.tsx
@@ -93,7 +93,7 @@ export function TestNowMode({
       )}
 
       {(hasBlockingError && !isPushing && (
-        <EuiCallOut title={blockingErrorMessage} color="danger" iconType="alert" />
+        <EuiCallOut title={blockingErrorMessage} color="danger" iconType="warning" />
       )) ||
         null}
 

--- a/x-pack/plugins/synthetics/public/legacy_uptime/components/overview/alerts/monitor_status_alert/old_alert_call_out.tsx
+++ b/x-pack/plugins/synthetics/public/legacy_uptime/components/overview/alerts/monitor_status_alert/old_alert_call_out.tsx
@@ -27,7 +27,7 @@ export const OldAlertCallOut: React.FC<Props> = ({ isOldAlert }) => {
             defaultMessage="You may be editing an older alert, some fields may not auto-populate."
           />
         }
-        iconType="alert"
+        iconType="warning"
       />
     </>
   );

--- a/x-pack/plugins/synthetics/public/legacy_uptime/components/overview/alerts/monitor_status_alert/old_alert_callout.test.tsx
+++ b/x-pack/plugins/synthetics/public/legacy_uptime/components/overview/alerts/monitor_status_alert/old_alert_callout.test.tsx
@@ -21,7 +21,7 @@ describe('OldAlertCallOut', () => {
           size="m"
         />
         <EuiCallOut
-          iconType="alert"
+          iconType="warning"
           size="s"
           title={
             <FormattedMessage

--- a/x-pack/plugins/synthetics/public/legacy_uptime/components/synthetics/check_steps/stderr_logs.tsx
+++ b/x-pack/plugins/synthetics/public/legacy_uptime/components/synthetics/check_steps/stderr_logs.tsx
@@ -117,7 +117,7 @@ export const StdErrorLogs = ({
               </EuiLink>
             </EuiFlexItem>
           </EuiFlexGroup>
-          <EuiCallOut title={ERROR_SUMMARY_LABEL} color="danger" iconType="alert">
+          <EuiCallOut title={ERROR_SUMMARY_LABEL} color="danger" iconType="warning">
             <p>{summaryMessage}</p>
           </EuiCallOut>
         </>

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/flyout/empty_prompt/empty_prompt.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/flyout/empty_prompt/empty_prompt.tsx
@@ -13,7 +13,7 @@ export const EMPTY_PROMPT_TEST_ID = 'indicatorEmptyPrompt';
 
 export const IndicatorEmptyPrompt: VFC = () => (
   <EuiEmptyPrompt
-    iconType="alert"
+    iconType="warning"
     color="danger"
     title={
       <h2>

--- a/x-pack/plugins/transform/public/app/components/section_error.tsx
+++ b/x-pack/plugins/transform/public/app/components/section_error.tsx
@@ -25,7 +25,7 @@ export const SectionError: React.FunctionComponent<Props> = ({
   return (
     <EuiPageContent verticalPosition="center" horizontalPosition="center" color="danger">
       <EuiEmptyPrompt
-        iconType="alert"
+        iconType="warning"
         title={<h2>{title}</h2>}
         body={
           <p>

--- a/x-pack/plugins/transform/public/app/sections/clone_transform/clone_transform_section.tsx
+++ b/x-pack/plugins/transform/public/app/sections/clone_transform/clone_transform_section.tsx
@@ -140,7 +140,7 @@ export const CloneTransformSection: FC<Props> = ({ match, location }) => {
                 defaultMessage: 'An error occurred getting the transform configuration.',
               })}
               color="danger"
-              iconType="alert"
+              iconType="warning"
             >
               <pre>{JSON.stringify(errorMessage)}</pre>
             </EuiCallOut>

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/filter_agg/components/editor_form.tsx
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/filter_agg/components/editor_form.tsx
@@ -41,7 +41,7 @@ export const FilterEditorForm: FilterAggConfigEditor['aggTypeConfig']['FilterAgg
       {isValid === false ? (
         <>
           <EuiSpacer size="m" />
-          <EuiCallOut color="danger" iconType="alert" size="s">
+          <EuiCallOut color="danger" iconType="warning" size="s">
             <FormattedMessage
               id="xpack.transform.agg.filterEditorForm.jsonInvalidErrorMessage"
               defaultMessage="JSON is invalid."

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/latest_function_form.tsx
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/latest_function_form.tsx
@@ -97,7 +97,7 @@ export const LatestFunctionForm: FC<LatestFunctionFormProps> = ({
             />
           )}
           {latestFunctionService.sortFieldOptions.length === 0 && (
-            <EuiCallOut color="danger" iconType="alert" size="m">
+            <EuiCallOut color="danger" iconType="warning" size="m">
               <p>
                 <FormattedMessage
                   id="xpack.transform.stepDefineForm.sortFieldOptionsEmptyError"

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/step_details/step_details_form.tsx
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/step_details/step_details_form.tsx
@@ -524,7 +524,7 @@ export const StepDetailsForm: FC<StepDetailsFormProps> = React.memo(
           {stepDefineState.transformFunction === TRANSFORM_FUNCTION.LATEST ? (
             <>
               <EuiSpacer size={'m'} />
-              <EuiCallOut color="warning" iconType="alert" size="m">
+              <EuiCallOut color="warning" iconType="warning" size="m">
                 <p>
                   <FormattedMessage
                     id="xpack.transform.stepDetailsForm.destinationIndexWarning"

--- a/x-pack/plugins/transform/public/app/sections/create_transform/create_transform_section.tsx
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/create_transform_section.tsx
@@ -71,7 +71,7 @@ export const CreateTransformSection: FC<Props> = ({ match }) => {
       <EuiPageContentBody data-test-subj="transformPageCreateTransform">
         {searchItemsError !== undefined && (
           <>
-            <EuiCallOut title={searchItemsError} color="danger" iconType="alert" />
+            <EuiCallOut title={searchItemsError} color="danger" iconType="warning" />
             <EuiSpacer size="l" />
           </>
         )}

--- a/x-pack/plugins/transform/public/app/sections/transform_management/components/edit_transform_flyout/edit_transform_flyout.tsx
+++ b/x-pack/plugins/transform/public/app/sections/transform_management/components/edit_transform_flyout/edit_transform_flyout.tsx
@@ -123,7 +123,7 @@ export const EditTransformFlyout: FC<EditTransformFlyoutProps> = ({
                 }
               )}
               color="danger"
-              iconType="alert"
+              iconType="warning"
             >
               <p>{errorMessage}</p>
             </EuiCallOut>

--- a/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/transforms_stats_bar.tsx
+++ b/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/transforms_stats_bar.tsx
@@ -130,7 +130,7 @@ export const TransformStatsBar: FC<TransformStatsBarProps> = ({
               />
             }
             color="warning"
-            iconType="alert"
+            iconType="warning"
           >
             <p>
               <FormattedMessage

--- a/x-pack/plugins/transform/public/app/sections/transform_management/transform_management_section.tsx
+++ b/x-pack/plugins/transform/public/app/sections/transform_management/transform_management_section.tsx
@@ -143,7 +143,7 @@ export const TransformManagement: FC = () => {
                     color="danger"
                   >
                     <EuiEmptyPrompt
-                      iconType="alert"
+                      iconType="warning"
                       title={
                         <h2>
                           <FormattedMessage

--- a/x-pack/plugins/triggers_actions_ui/public/application/components/delete_modal_confirmation.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/components/delete_modal_confirmation.tsx
@@ -97,7 +97,7 @@ export const DeleteModalConfirmation = ({
     >
       <p>{getConfirmDeletionModalText(numIdsToDelete, singleTitle, multipleTitle)}</p>
       {showWarningText && (
-        <EuiCallOut title={<>{warningText}</>} color="warning" iconType="alert" />
+        <EuiCallOut title={<>{warningText}</>} color="warning" iconType="warning" />
       )}
     </EuiConfirmModal>
   );

--- a/x-pack/plugins/triggers_actions_ui/public/application/components/json_editor_with_message_variables.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/components/json_editor_with_message_variables.tsx
@@ -140,7 +140,7 @@ export const JsonEditorWithMessageVariables: React.FunctionComponent<Props> = ({
     return (
       <>
         <EuiSpacer size="s" />
-        <EuiCallOut size="s" color="danger" iconType="alert" title={NO_EDITOR_ERROR_TITLE}>
+        <EuiCallOut size="s" color="danger" iconType="warning" title={NO_EDITOR_ERROR_TITLE}>
           <p>{NO_EDITOR_ERROR_MESSAGE}</p>
         </EuiCallOut>
         <EuiSpacer size="s" />

--- a/x-pack/plugins/triggers_actions_ui/public/application/components/rules_delete_modal_confirmation.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/components/rules_delete_modal_confirmation.tsx
@@ -34,6 +34,6 @@ export const RulesDeleteModalConfirmation = ({
     confirmButtonText={confirmButtonText}
   >
     <p>{confirmModalText}</p>
-    {showWarningText && <EuiCallOut title={<>{warningText}</>} color="warning" iconType="alert" />}
+    {showWarningText && <EuiCallOut title={<>{warningText}</>} color="warning" iconType="warning" />}
   </EuiConfirmModal>
 );

--- a/x-pack/plugins/triggers_actions_ui/public/application/components/rules_delete_modal_confirmation.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/components/rules_delete_modal_confirmation.tsx
@@ -34,6 +34,8 @@ export const RulesDeleteModalConfirmation = ({
     confirmButtonText={confirmButtonText}
   >
     <p>{confirmModalText}</p>
-    {showWarningText && <EuiCallOut title={<>{warningText}</>} color="warning" iconType="warning" />}
+    {showWarningText && (
+      <EuiCallOut title={<>{warningText}</>} color="warning" iconType="warning" />
+    )}
   </EuiConfirmModal>
 );

--- a/x-pack/plugins/triggers_actions_ui/public/application/components/rules_setting/rules_settings_modal.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/components/rules_setting/rules_settings_modal.tsx
@@ -66,7 +66,7 @@ export const RulesSettingsErrorPrompt = memo(() => {
     <EuiEmptyPrompt
       data-test-subj="rulesSettingsErrorPrompt"
       color="danger"
-      iconType="alert"
+      iconType="warning"
       title={
         <h4>
           <FormattedMessage

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/action_type_form.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/action_type_form.tsx
@@ -497,7 +497,11 @@ export const ActionTypeForm = ({
                       )}
                       {warning && !isOpen && (
                         <EuiFlexItem grow={false}>
-                          <EuiBadge data-test-subj="warning-badge" iconType="warning" color="warning">
+                          <EuiBadge
+                            data-test-subj="warning-badge"
+                            iconType="warning"
+                            color="warning"
+                          >
                             {i18n.translate(
                               'xpack.triggersActionsUI.sections.actionTypeForm.actionWarningsTitle',
                               {

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/action_type_form.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/action_type_form.tsx
@@ -447,7 +447,7 @@ export const ActionTypeForm = ({
                   >
                     <EuiIcon
                       data-test-subj="action-group-error-icon"
-                      type="alert"
+                      type="warning"
                       color="danger"
                       size="m"
                     />
@@ -497,7 +497,7 @@ export const ActionTypeForm = ({
                       )}
                       {warning && !isOpen && (
                         <EuiFlexItem grow={false}>
-                          <EuiBadge data-test-subj="warning-badge" iconType="alert" color="warning">
+                          <EuiBadge data-test-subj="warning-badge" iconType="warning" color="warning">
                             {i18n.translate(
                               'xpack.triggersActionsUI.sections.actionTypeForm.actionWarningsTitle',
                               {
@@ -511,7 +511,7 @@ export const ActionTypeForm = ({
                         {checkEnabledResult.isEnabled === false && (
                           <>
                             <EuiIconTip
-                              type="alert"
+                              type="warning"
                               color="danger"
                               content={i18n.translate(
                                 'xpack.triggersActionsUI.sections.actionTypeForm.actionDisabledTitle',

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/connector_add_inline.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/connector_add_inline.tsx
@@ -168,7 +168,7 @@ export const AddConnectorInline = ({
             {!isEmptyActionId && (
               <EuiFlexItem grow={false}>
                 <EuiIconTip
-                  type="alert"
+                  type="warning"
                   size="m"
                   color="danger"
                   data-test-subj={`alertActionAccordionErrorTooltip`}

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/test_connector_form.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/test_connector_form.tsx
@@ -118,7 +118,7 @@ export const TestConnectorForm = ({
         <>
           {executeEnabled ? null : (
             <>
-              <EuiCallOut iconType="alert" color="warning">
+              <EuiCallOut iconType="warning" color="warning">
                 <p>
                   <FormattedMessage
                     defaultMessage="Save your changes before testing the connector."
@@ -247,7 +247,7 @@ const FailedExecussion = ({
       )}
       data-test-subj="executionFailureResult"
       color="danger"
-      iconType="alert"
+      iconType="warning"
     >
       <EuiDescriptionList textStyle="reverse" listItems={items} />
     </EuiCallOut>

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/actions_connectors_list/components/actions_connectors_list.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/actions_connectors_list/components/actions_connectors_list.tsx
@@ -69,7 +69,7 @@ const ConnectorIconTipWithSpacing = withTheme(({ theme }: { theme: EuiTheme }) =
           })}
           aria-label="Warning"
           size="m"
-          type="alert"
+          type="warning"
           color="warning"
           content={connectorDeprecatedMessage}
           position="right"
@@ -243,7 +243,7 @@ const ActionsConnectorsList: React.FunctionComponent = () => {
             {item.isMissingSecrets ? (
               <EuiIconTip
                 iconProps={{ 'data-test-subj': `missingSecrets_${item.id}` }}
-                type="alert"
+                type="warning"
                 color="warning"
                 content={i18n.translate(
                   'xpack.triggersActionsUI.sections.actionsConnectorsList.connectorsListTable.columns.actions.missingSecretsDescription',

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alert_summary_widget/components/active_alert_counts.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alert_summary_widget/components/active_alert_counts.tsx
@@ -27,7 +27,7 @@ export const ActiveAlertCounts = ({ activeAlertCount }: Props) => {
           {!!activeAlertCount && (
             <>
               &nbsp;
-              <EuiIcon type="alert" ascent={10} />
+              <EuiIcon type="warning" ascent={10} />
             </>
           )}
         </h3>

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alert_summary_widget/components/alert_summary_widget_error.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alert_summary_widget/components/alert_summary_widget_error.tsx
@@ -13,7 +13,7 @@ export const AlertSummaryWidgetError = () => {
   return (
     <EuiEmptyPrompt
       data-test-subj="alertSummaryWidgetError"
-      iconType="alert"
+      iconType="warning"
       color="danger"
       title={
         <h5>

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/rule_details/components/rule_details.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/rule_details/components/rule_details.tsx
@@ -418,7 +418,7 @@ export const RuleDetails: React.FunctionComponent<RuleDetailsProps> = ({
             <EuiFlexItem>
               <EuiCallOut color="danger" data-test-subj="ruleErrorBanner" size="s" iconType="rule">
                 <p>
-                  <EuiIcon color="danger" type="alert" />
+                  <EuiIcon color="danger" type="warning" />
                   &nbsp;
                   <b>{getRuleStatusErrorReasonText()}</b>&#44;&nbsp;
                   {rule.executionStatus.error?.message}
@@ -445,10 +445,10 @@ export const RuleDetails: React.FunctionComponent<RuleDetailsProps> = ({
                 color="warning"
                 data-test-subj="ruleWarningBanner"
                 size="s"
-                iconType="alert"
+                iconType="warning"
               >
                 <p>
-                  <EuiIcon color="warning" type="alert" />
+                  <EuiIcon color="warning" type="warning" />
                   &nbsp;
                   {getRuleStatusWarningReasonText()}
                   &nbsp;
@@ -468,7 +468,7 @@ export const RuleDetails: React.FunctionComponent<RuleDetailsProps> = ({
                 size="s"
               >
                 <p>
-                  <EuiIcon color="warning" type="alert" />
+                  <EuiIcon color="warning" type="warning" />
                   &nbsp;
                   <FormattedMessage
                     id="xpack.triggersActionsUI.sections.ruleDetails.actionWithBrokenConnectorWarningBannerTitle"

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/rule_details/components/rule_event_log_list_table.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/rule_details/components/rule_event_log_list_table.tsx
@@ -498,7 +498,7 @@ export const RuleEventLogListTable = <T extends RuleEventLogListOptions>(
             const actionErrors = runLog?.num_errored_actions as number;
             if (actionErrors) {
               return (
-                <Component onClick={() => onFlyoutOpen(runLog)} iconType="alert">
+                <Component onClick={() => onFlyoutOpen(runLog)} iconType="warning">
                   <FormattedMessage
                     id="xpack.triggersActionsUI.sections.ruleDetails.eventLogColumn.viewActionErrors"
                     defaultMessage="View action errors"

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/rule_details/components/rule_execution_summary_and_chart.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/rule_details/components/rule_execution_summary_and_chart.tsx
@@ -163,7 +163,7 @@ export const RuleExecutionSummaryAndChart = (props: RuleExecutionSummaryAndChart
                     <EuiIconTip
                       data-test-subj="ruleDurationWarning"
                       anchorClassName="ruleDurationWarningIcon"
-                      type="alert"
+                      type="warning"
                       color="warning"
                       content={i18n.translate(
                         'xpack.triggersActionsUI.sections.ruleDetails.alertsList.ruleTypeExcessDurationMessage',

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/rule_form/rule_edit.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/rule_form/rule_edit.tsx
@@ -272,7 +272,7 @@ export const RuleEdit = ({
                     {config.isUsingSecurity && (
                       <EuiFlexItem grow={false}>
                         <EuiIconTip
-                          type="alert"
+                          type="warning"
                           position="top"
                           data-test-subj="changeInPrivilegesTip"
                           content={i18n.translate(

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/rules_list/components/rules_list_error_banner.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/rules_list/components/rules_list_error_banner.tsx
@@ -37,7 +37,7 @@ export const RulesListErrorBanner = (props: RulesListErrorBannerProps) => {
     <>
       <EuiCallOut color="danger" size="s" data-test-subj="rulesErrorBanner">
         <p>
-          <EuiIcon color="danger" type="alert" />
+          <EuiIcon color="danger" type="warning" />
           &nbsp;
           <FormattedMessage
             id="xpack.triggersActionsUI.sections.rulesList.attentionBannerTitle"

--- a/x-pack/plugins/upgrade_assistant/public/application/components/es_deprecation_logs/fix_deprecation_logs/deprecations_count_checkpoint/deprecations_count_checkpoint.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/es_deprecation_logs/fix_deprecation_logs/deprecations_count_checkpoint/deprecations_count_checkpoint.tsx
@@ -103,7 +103,7 @@ export const DeprecationsCountCheckpoint: FunctionComponent<Props> = ({
       <EuiCallOut
         title={i18nTexts.loadingError}
         color="danger"
-        iconType="alert"
+        iconType="warning"
         data-test-subj="errorCallout"
       >
         <p>

--- a/x-pack/plugins/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/cluster_settings/flyout.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/cluster_settings/flyout.tsx
@@ -121,7 +121,7 @@ export const RemoveClusterSettingsFlyout = ({
             <EuiCallOut
               title={i18nTexts.errorTitle}
               color="danger"
-              iconType="alert"
+              iconType="warning"
               data-test-subj="deleteClusterSettingsError"
             >
               {statusDetails!.message}

--- a/x-pack/plugins/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/cluster_settings/resolution_table_cell.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/cluster_settings/resolution_table_cell.tsx
@@ -102,7 +102,7 @@ export const ClusterSettingsResolutionCell: React.FunctionComponent<Props> = ({ 
         data-test-subj="clusterSettingsResolutionStatusCell"
       >
         <EuiFlexItem grow={false}>
-          <EuiIcon type="alert" color="danger" />
+          <EuiIcon type="warning" color="danger" />
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiText size="s">{i18nTexts.deleteFailedText}</EuiText>

--- a/x-pack/plugins/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/index_settings/flyout.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/index_settings/flyout.tsx
@@ -134,7 +134,7 @@ export const RemoveIndexSettingsFlyout = ({
             <EuiCallOut
               title={i18nTexts.errorTitle}
               color="danger"
-              iconType="alert"
+              iconType="warning"
               data-test-subj="deleteSettingsError"
             >
               {statusDetails!.message}

--- a/x-pack/plugins/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/index_settings/resolution_table_cell.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/index_settings/resolution_table_cell.tsx
@@ -102,7 +102,7 @@ export const IndexSettingsResolutionCell: React.FunctionComponent<Props> = ({ st
         data-test-subj="indexSettingsResolutionStatusCell"
       >
         <EuiFlexItem grow={false}>
-          <EuiIcon type="alert" color="danger" />
+          <EuiIcon type="warning" color="danger" />
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiText size="s">{i18nTexts.deleteFailedText}</EuiText>

--- a/x-pack/plugins/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/ml_snapshots/flyout.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/ml_snapshots/flyout.tsx
@@ -203,7 +203,7 @@ export const FixSnapshotsFlyout = ({
                   : i18nTexts.upgradeSnapshotErrorTitle
               }
               color="danger"
-              iconType="alert"
+              iconType="warning"
               data-test-subj="resolveSnapshotError"
             >
               {snapshotState.error.message}
@@ -217,7 +217,7 @@ export const FixSnapshotsFlyout = ({
             <EuiCallOut
               title={i18nTexts.upgradeModeEnabledErrorTitle}
               color="warning"
-              iconType="alert"
+              iconType="warning"
               data-test-subj="mlUpgradeModeEnabledError"
             >
               <p>

--- a/x-pack/plugins/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/ml_snapshots/resolution_table_cell.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/ml_snapshots/resolution_table_cell.tsx
@@ -112,7 +112,7 @@ export const MlSnapshotsResolutionCell: React.FunctionComponent = () => {
     return (
       <EuiFlexGroup gutterSize="s" alignItems="center" data-test-subj="mlActionResolutionCell">
         <EuiFlexItem grow={false}>
-          <EuiIcon type="alert" color="danger" />
+          <EuiIcon type="warning" color="danger" />
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiText size="s">

--- a/x-pack/plugins/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/reindex/flyout/checklist_step.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/reindex/flyout/checklist_step.tsx
@@ -106,7 +106,7 @@ export const ChecklistFlyoutStep: React.FunctionComponent<{
                 />
               }
               color="danger"
-              iconType="alert"
+              iconType="warning"
             />
           </Fragment>
         )}
@@ -115,7 +115,7 @@ export const ChecklistFlyoutStep: React.FunctionComponent<{
           <>
             <EuiCallOut
               color="warning"
-              iconType="alert"
+              iconType="warning"
               data-test-subj="lowDiskSpaceCallout"
               title={
                 <FormattedMessage
@@ -156,7 +156,7 @@ export const ChecklistFlyoutStep: React.FunctionComponent<{
           <>
             <EuiCallOut
               color="danger"
-              iconType="alert"
+              iconType="warning"
               data-test-subj={hasFetchFailed ? 'fetchFailedCallout' : 'reindexingFailedCallout'}
               title={
                 hasFetchFailed ? (

--- a/x-pack/plugins/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/reindex/flyout/warnings_step.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/reindex/flyout/warnings_step.tsx
@@ -104,7 +104,7 @@ export const WarningsFlyoutStep: React.FunctionComponent<WarningsConfirmationFly
                 />
               }
               color="warning"
-              iconType="alert"
+              iconType="warning"
             >
               <p>
                 <FormattedMessage

--- a/x-pack/plugins/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/reindex/resolution_table_cell.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/reindex/resolution_table_cell.tsx
@@ -127,7 +127,7 @@ export const ReindexResolutionCell: React.FunctionComponent = () => {
       return (
         <EuiFlexGroup gutterSize="s" alignItems="center">
           <EuiFlexItem grow={false}>
-            <EuiIcon type="alert" color="danger" />
+            <EuiIcon type="warning" color="danger" />
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiText size="s">{i18nTexts.reindexFailedText}</EuiText>
@@ -138,7 +138,7 @@ export const ReindexResolutionCell: React.FunctionComponent = () => {
       return (
         <EuiFlexGroup gutterSize="s" alignItems="center">
           <EuiFlexItem grow={false}>
-            <EuiIcon type="alert" color="danger" />
+            <EuiIcon type="warning" color="danger" />
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiText size="s">{i18nTexts.reindexFetchFailedText}</EuiText>
@@ -149,7 +149,7 @@ export const ReindexResolutionCell: React.FunctionComponent = () => {
       return (
         <EuiFlexGroup gutterSize="s" alignItems="center">
           <EuiFlexItem grow={false}>
-            <EuiIcon type="alert" color="danger" />
+            <EuiIcon type="warning" color="danger" />
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiText size="s">{i18nTexts.reindexPausedText}</EuiText>

--- a/x-pack/plugins/upgrade_assistant/public/application/components/es_deprecations/es_deprecations_table.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/es_deprecations/es_deprecations_table.tsx
@@ -272,7 +272,7 @@ export const EsDeprecationsTable: React.FunctionComponent<Props> = ({
           <EuiSpacer size="l" />
 
           <EuiCallOut
-            iconType="alert"
+            iconType="warning"
             color="danger"
             title={`Invalid search: ${searchError.message}`}
           />

--- a/x-pack/plugins/upgrade_assistant/public/application/components/kibana_deprecations/deprecation_details_flyout.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/kibana_deprecations/deprecation_details_flyout.tsx
@@ -145,7 +145,7 @@ export const DeprecationDetailsFlyout = ({
             <EuiCallOut
               title={i18nTexts.quickResolveErrorTitle}
               color="danger"
-              iconType="alert"
+              iconType="warning"
               data-test-subj="quickResolveError"
             >
               {deprecationResolutionState.resolveDeprecationError}

--- a/x-pack/plugins/upgrade_assistant/public/application/components/kibana_deprecations/kibana_deprecations.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/kibana_deprecations/kibana_deprecations.tsx
@@ -272,7 +272,7 @@ export const KibanaDeprecations = withRouter(({ history }: RouteComponentProps) 
           <EuiCallOut
             title={i18nTexts.kibanaDeprecationErrorTitle}
             color="warning"
-            iconType="alert"
+            iconType="warning"
             data-test-subj="kibanaDeprecationErrors"
           >
             <p>{i18nTexts.getKibanaDeprecationErrorDescription(kibanaDeprecationErrors)}</p>

--- a/x-pack/plugins/upgrade_assistant/public/application/components/kibana_deprecations/resolution_table_cell.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/kibana_deprecations/resolution_table_cell.tsx
@@ -95,7 +95,7 @@ export const ResolutionTableCell: React.FunctionComponent<Props> = ({
           return (
             <EuiFlexGroup gutterSize="s" alignItems="center" data-test-subj="resolutionStatusCell">
               <EuiFlexItem grow={false}>
-                <EuiIcon type="alert" color="danger" />
+                <EuiIcon type="warning" color="danger" />
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
                 <EuiText size="s">{i18nTexts.automationFailedCellLabel}</EuiText>

--- a/x-pack/plugins/upgrade_assistant/public/application/components/overview/backup_step/cloud_backup.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/overview/backup_step/cloud_backup.tsx
@@ -78,7 +78,7 @@ export const CloudBackup: React.FunctionComponent<Props> = ({
           defaultMessage: 'An error occurred while retrieving the latest snapshot status',
         })}
         color="danger"
-        iconType="alert"
+        iconType="warning"
         data-test-subj="cloudBackupErrorCallout"
       >
         <p>
@@ -128,7 +128,7 @@ export const CloudBackup: React.FunctionComponent<Props> = ({
   ) : (
     <EuiFlexGroup alignItems="center" gutterSize="s" data-test-subj="dataNotBackedUpStatus">
       <EuiFlexItem grow={false}>
-        <EuiIcon type="alert" color="danger" />
+        <EuiIcon type="warning" color="danger" />
       </EuiFlexItem>
 
       <EuiFlexItem>

--- a/x-pack/plugins/upgrade_assistant/public/application/components/overview/fix_issues_step/components/loading_issues_error.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/overview/fix_issues_step/components/loading_issues_error.tsx
@@ -12,7 +12,7 @@ export const LoadingIssuesError: FunctionComponent = ({ children }) => (
   <EuiText color="subdued" data-test-subj="loadingIssuesError">
     <EuiFlexGroup gutterSize="s" alignItems="center">
       <EuiFlexItem grow={false}>
-        <EuiIcon type="alert" color="danger" />
+        <EuiIcon type="warning" color="danger" />
       </EuiFlexItem>
 
       <EuiFlexItem grow={false}>{children}</EuiFlexItem>

--- a/x-pack/plugins/upgrade_assistant/public/application/components/overview/logs_step/logs_step.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/overview/logs_step/logs_step.tsx
@@ -160,7 +160,7 @@ const LogsStep = ({
       <EuiCallOut
         title={i18nTexts.loadingError}
         color="danger"
-        iconType="alert"
+        iconType="warning"
         data-test-subj="deprecationLogsErrorCallout"
       >
         <p>

--- a/x-pack/plugins/upgrade_assistant/public/application/components/overview/migrate_system_indices/flyout.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/overview/migrate_system_indices/flyout.tsx
@@ -127,7 +127,7 @@ const renderMigrationStatus = (status: MIGRATION_STATUS) => {
     return (
       <EuiFlexGroup alignItems="center" gutterSize="s">
         <EuiFlexItem grow={false}>
-          <EuiIcon type="alert" color="danger" />
+          <EuiIcon type="warning" color="danger" />
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiText color="danger" size="s" data-test-subj="featureError">

--- a/x-pack/plugins/upgrade_assistant/public/application/components/overview/migrate_system_indices/migrate_system_indices.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/overview/migrate_system_indices/migrate_system_indices.tsx
@@ -138,7 +138,7 @@ const MigrateSystemIndicesStep: FunctionComponent<Props> = ({ setIsComplete }) =
       <EuiCallOut
         title={i18nTexts.loadingError}
         color="danger"
-        iconType="alert"
+        iconType="warning"
         data-test-subj="systemIndicesStatusErrorCallout"
       >
         <p>
@@ -181,7 +181,7 @@ const MigrateSystemIndicesStep: FunctionComponent<Props> = ({ setIsComplete }) =
           <EuiCallOut
             size="s"
             color="danger"
-            iconType="alert"
+            iconType="warning"
             title={`${startMigrationStatus.error!.statusCode} - ${
               startMigrationStatus.error!.message
             }`}
@@ -196,7 +196,7 @@ const MigrateSystemIndicesStep: FunctionComponent<Props> = ({ setIsComplete }) =
           <EuiCallOut
             size="s"
             color="danger"
-            iconType="alert"
+            iconType="warning"
             title={i18nTexts.migrationFailedTitle}
             data-test-subj="migrationFailedCallout"
           >

--- a/x-pack/plugins/upgrade_assistant/public/application/components/overview/upgrade_step/upgrade_step.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/overview/upgrade_step/upgrade_step.tsx
@@ -68,7 +68,7 @@ const UpgradeStep = () => {
             defaultMessage: 'An error occurred while retrieving the upgrade status',
           })}
           color="danger"
-          iconType="alert"
+          iconType="warning"
           data-test-subj="upgradeStatusErrorCallout"
         >
           <p>

--- a/x-pack/plugins/upgrade_assistant/public/application/components/shared/deprecations_page_loading_error.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/shared/deprecations_page_loading_error.tsx
@@ -27,7 +27,7 @@ export const DeprecationsPageLoadingError: FunctionComponent<Props> = ({
     data-test-subj="deprecationsPageLoadingError"
   >
     <EuiEmptyPrompt
-      iconType="alert"
+      iconType="warning"
       title={
         <h2>
           {i18n.translate('xpack.upgradeAssistant.deprecationsPageLoadingError.title', {

--- a/x-pack/plugins/watcher/public/application/app.tsx
+++ b/x-pack/plugins/watcher/public/application/app.tsx
@@ -63,7 +63,7 @@ export const App = (deps: AppDeps) => {
     return (
       <EuiPageContent verticalPosition="center" horizontalPosition="center" color="danger">
         <EuiEmptyPrompt
-          iconType="alert"
+          iconType="warning"
           title={
             <h1>
               <FormattedMessage

--- a/x-pack/plugins/watcher/public/application/components/page_error/page_error_forbidden.tsx
+++ b/x-pack/plugins/watcher/public/application/components/page_error/page_error_forbidden.tsx
@@ -13,7 +13,7 @@ import { FormattedMessage } from '@kbn/i18n-react';
 export function PageErrorForbidden() {
   return (
     <EuiEmptyPrompt
-      iconType="alert"
+      iconType="warning"
       title={
         <h1>
           <FormattedMessage

--- a/x-pack/plugins/watcher/public/application/components/page_error/page_error_not_exist.tsx
+++ b/x-pack/plugins/watcher/public/application/components/page_error/page_error_not_exist.tsx
@@ -13,7 +13,7 @@ import { FormattedMessage } from '@kbn/i18n-react';
 export function PageErrorNotExist({ id }: { id?: string }) {
   return (
     <EuiEmptyPrompt
-      iconType="alert"
+      iconType="warning"
       title={
         <h1>
           <FormattedMessage

--- a/x-pack/plugins/watcher/public/application/components/section_error.tsx
+++ b/x-pack/plugins/watcher/public/application/components/section_error.tsx
@@ -39,7 +39,7 @@ export const SectionError: React.FunctionComponent<Props> = ({ title, error, ...
   const { error: errorString, cause, message } = data;
 
   return (
-    <EuiCallOut title={title} color="danger" iconType="alert" {...rest}>
+    <EuiCallOut title={title} color="danger" iconType="warning" {...rest}>
       <div data-test-subj="sectionErrorMessage">{message || errorString}</div>
       {cause && (
         <Fragment>


### PR DESCRIPTION
## Summary

EUI 76 replaces the icons `crossInACircleFIlled` and `alert` with `error` and `warning` respectively. This PR updates all references to those icon names in Kibana. 


### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
