### PR TITLE
Capability resolver: minor optimizations

### DIFF
--- a/packages/core/capabilities/core-capabilities-server-internal/src/merge_capabilities.ts
+++ b/packages/core/capabilities/core-capabilities-server-internal/src/merge_capabilities.ts
@@ -10,7 +10,7 @@ import { mergeWith } from 'lodash';
 import type { Capabilities } from '@kbn/core-capabilities-common';
 
 export const mergeCapabilities = (...sources: Array<Partial<Capabilities>>): Capabilities =>
-  mergeWith({}, ...sources, (a: any, b: any) => {
+  mergeWith({}, ...sources, (a: unknown, b: unknown) => {
     if (
       (typeof a === 'boolean' && typeof b === 'object') ||
       (typeof a === 'object' && typeof b === 'boolean')

--- a/packages/core/capabilities/core-capabilities-server-internal/src/resolve_capabilities.test.ts
+++ b/packages/core/capabilities/core-capabilities-server-internal/src/resolve_capabilities.test.ts
@@ -150,49 +150,4 @@ describe('resolveCapabilities', () => {
       },
     });
   });
-
-  it('does not allow re-enabling', async () => {
-    const caps = {
-      ...defaultCaps,
-      catalogue: {
-        A: false,
-        B: false,
-      },
-    };
-    const switcher = (req: KibanaRequest, capabilities: Capabilities) => ({
-      catalogue: {
-        A: true,
-      },
-    });
-    const result = await resolveCapabilities(caps, [switcher], request, [], false);
-    expect(result.catalogue).toEqual({
-      A: false,
-      B: false,
-    });
-  });
-
-  it('does not allow re-enabling from another switcher', async () => {
-    const caps = {
-      ...defaultCaps,
-      catalogue: {
-        A: true,
-        B: true,
-      },
-    };
-    const switcherA = (req: KibanaRequest, capabilities: Capabilities) => ({
-      catalogue: {
-        A: false,
-      },
-    });
-    const switcherB = (req: KibanaRequest, capabilities: Capabilities) => ({
-      catalogue: {
-        A: true,
-      },
-    });
-    const result = await resolveCapabilities(caps, [switcherA, switcherB], request, [], false);
-    expect(result.catalogue).toEqual({
-      A: false,
-      B: true,
-    });
-  });
 });

--- a/packages/core/capabilities/core-capabilities-server-internal/src/resolve_capabilities.test.ts
+++ b/packages/core/capabilities/core-capabilities-server-internal/src/resolve_capabilities.test.ts
@@ -150,4 +150,49 @@ describe('resolveCapabilities', () => {
       },
     });
   });
+
+  it('does not allow re-enabling', async () => {
+    const caps = {
+      ...defaultCaps,
+      catalogue: {
+        A: false,
+        B: false,
+      },
+    };
+    const switcher = (req: KibanaRequest, capabilities: Capabilities) => ({
+      catalogue: {
+        A: true,
+      },
+    });
+    const result = await resolveCapabilities(caps, [switcher], request, [], false);
+    expect(result.catalogue).toEqual({
+      A: false,
+      B: false,
+    });
+  });
+
+  it('does not allow re-enabling from another switcher', async () => {
+    const caps = {
+      ...defaultCaps,
+      catalogue: {
+        A: true,
+        B: true,
+      },
+    };
+    const switcherA = (req: KibanaRequest, capabilities: Capabilities) => ({
+      catalogue: {
+        A: false,
+      },
+    });
+    const switcherB = (req: KibanaRequest, capabilities: Capabilities) => ({
+      catalogue: {
+        A: true,
+      },
+    });
+    const result = await resolveCapabilities(caps, [switcherA, switcherB], request, [], false);
+    expect(result.catalogue).toEqual({
+      A: false,
+      B: true,
+    });
+  });
 });

--- a/packages/core/capabilities/core-capabilities-server-internal/src/resolve_capabilities.ts
+++ b/packages/core/capabilities/core-capabilities-server-internal/src/resolve_capabilities.ts
@@ -57,6 +57,13 @@ export const resolveCapabilities = async (
     ),
   });
 
+  return switchers.reduce(async (caps, switcher) => {
+    const resolvedCaps = await caps;
+    const changes = await switcher(request, resolvedCaps, useDefaultCapabilities);
+    return recursiveApplyChanges(resolvedCaps, changes);
+  }, Promise.resolve(mergedCaps));
+
+  /*
   const switcherChanges = await Promise.all(
     switchers.map((switcher) => {
       return switcher(request, mergedCaps, useDefaultCapabilities);
@@ -66,6 +73,7 @@ export const resolveCapabilities = async (
   return switcherChanges.reduce<Capabilities>((caps, changes) => {
     return recursiveApplyChanges(caps, changes);
   }, mergedCaps);
+  */
 };
 
 function recursiveApplyChanges<
@@ -84,11 +92,8 @@ function recursiveApplyChanges<
       }
       return [key, typeof orig === typeof changed ? changed : orig];
     })
-    .reduce(
-      (acc, [key, value]) => ({
-        ...acc,
-        [key as string]: value,
-      }),
-      {} as TDestination
-    );
+    .reduce((acc, [key, value]) => {
+      acc[key as keyof TDestination] = value;
+      return acc;
+    }, {} as TDestination);
 }

--- a/packages/core/capabilities/core-capabilities-server-internal/src/resolve_capabilities.ts
+++ b/packages/core/capabilities/core-capabilities-server-internal/src/resolve_capabilities.ts
@@ -57,13 +57,6 @@ export const resolveCapabilities = async (
     ),
   });
 
-  return switchers.reduce(async (caps, switcher) => {
-    const resolvedCaps = await caps;
-    const changes = await switcher(request, resolvedCaps, useDefaultCapabilities);
-    return recursiveApplyChanges(resolvedCaps, changes);
-  }, Promise.resolve(mergedCaps));
-
-  /*
   const switcherChanges = await Promise.all(
     switchers.map((switcher) => {
       return switcher(request, mergedCaps, useDefaultCapabilities);
@@ -73,7 +66,6 @@ export const resolveCapabilities = async (
   return switcherChanges.reduce<Capabilities>((caps, changes) => {
     return recursiveApplyChanges(caps, changes);
   }, mergedCaps);
-  */
 };
 
 function recursiveApplyChanges<
@@ -87,10 +79,15 @@ function recursiveApplyChanges<
       if (changed == null) {
         return [key, orig];
       }
-      if (typeof orig === 'object' && typeof changed === 'object') {
-        return [key, recursiveApplyChanges(orig, changed)];
+      if (typeof orig === typeof changed) {
+        if (typeof orig === 'object') {
+          return [key, recursiveApplyChanges(orig, changed)];
+        }
+        if (typeof orig === 'boolean') {
+          return [key, orig && changed];
+        }
       }
-      return [key, typeof orig === typeof changed ? changed : orig];
+      return [key, orig];
     })
     .reduce((acc, [key, value]) => {
       acc[key as keyof TDestination] = value;

--- a/packages/core/capabilities/core-capabilities-server/src/contracts.ts
+++ b/packages/core/capabilities/core-capabilities-server/src/contracts.ts
@@ -53,8 +53,8 @@ export interface CapabilitiesSetup {
    * Register a {@link CapabilitiesSwitcher} to be used to change the default state
    * of the {@link Capabilities} entries when resolving them.
    *
-   * A capabilities switcher can only change the state of existing capabilities.
-   * Capabilities added or removed when invoking the switcher will be ignored.
+   * A capabilities switcher can only change the state of existing capabilities from `true` to `false`.
+   * Capabilities added, removed, or set to `true` when invoking the switcher will be ignored.
    *
    * @example
    * How to restrict some capabilities

--- a/packages/core/capabilities/core-capabilities-server/src/contracts.ts
+++ b/packages/core/capabilities/core-capabilities-server/src/contracts.ts
@@ -53,8 +53,8 @@ export interface CapabilitiesSetup {
    * Register a {@link CapabilitiesSwitcher} to be used to change the default state
    * of the {@link Capabilities} entries when resolving them.
    *
-   * A capabilities switcher can only change the state of existing capabilities from `true` to `false`.
-   * Capabilities added, removed, or set to `true` when invoking the switcher will be ignored.
+   * A capabilities switcher can only change the state of existing capabilities.
+   * Capabilities added or removed when invoking the switcher will be ignored.
    *
    * @example
    * How to restrict some capabilities

--- a/x-pack/plugins/file_upload/server/capabilities.test.ts
+++ b/x-pack/plugins/file_upload/server/capabilities.test.ts
@@ -44,16 +44,9 @@ describe('setupCapabilities', () => {
 
     const request = httpServerMock.createKibanaRequest();
 
-    await expect(switcher(request, capabilities, false)).resolves.toMatchInlineSnapshot(`
-            Object {
-              "catalogue": Object {},
-              "fileUpload": Object {
-                "show": true,
-              },
-              "management": Object {},
-              "navLinks": Object {},
-            }
-          `);
+    await expect(switcher(request, capabilities, false)).resolves.toMatchInlineSnapshot(
+      `Object {}`
+    );
   });
 
   it('registers a capabilities switcher that returns unaltered capabilities when default capabilities are requested', async () => {
@@ -81,16 +74,7 @@ describe('setupCapabilities', () => {
 
     const request = httpServerMock.createKibanaRequest();
 
-    await expect(switcher(request, capabilities, true)).resolves.toMatchInlineSnapshot(`
-            Object {
-              "catalogue": Object {},
-              "fileUpload": Object {
-                "show": true,
-              },
-              "management": Object {},
-              "navLinks": Object {},
-            }
-          `);
+    await expect(switcher(request, capabilities, true)).resolves.toMatchInlineSnapshot(`Object {}`);
 
     expect(security.authz.mode.useRbacForRequest).not.toHaveBeenCalled();
     expect(security.authz.checkPrivilegesDynamicallyWithRequest).not.toHaveBeenCalled();
@@ -166,16 +150,9 @@ describe('setupCapabilities', () => {
 
     const request = httpServerMock.createKibanaRequest();
 
-    await expect(switcher(request, capabilities, false)).resolves.toMatchInlineSnapshot(`
-            Object {
-              "catalogue": Object {},
-              "fileUpload": Object {
-                "show": true,
-              },
-              "management": Object {},
-              "navLinks": Object {},
-            }
-          `);
+    await expect(switcher(request, capabilities, false)).resolves.toMatchInlineSnapshot(
+      `Object {}`
+    );
 
     expect(security.authz.mode.useRbacForRequest).toHaveBeenCalledTimes(1);
     expect(security.authz.mode.useRbacForRequest).toHaveBeenCalledWith(request);
@@ -249,16 +226,9 @@ describe('setupCapabilities', () => {
 
     const request = httpServerMock.createKibanaRequest();
 
-    await expect(switcher(request, capabilities, false)).resolves.toMatchInlineSnapshot(`
-            Object {
-              "catalogue": Object {},
-              "fileUpload": Object {
-                "show": true,
-              },
-              "management": Object {},
-              "navLinks": Object {},
-            }
-          `);
+    await expect(switcher(request, capabilities, false)).resolves.toMatchInlineSnapshot(
+      `Object {}`
+    );
 
     expect(security.authz.mode.useRbacForRequest).toHaveBeenCalledTimes(1);
     expect(security.authz.mode.useRbacForRequest).toHaveBeenCalledWith(request);

--- a/x-pack/plugins/file_upload/server/capabilities.ts
+++ b/x-pack/plugins/file_upload/server/capabilities.ts
@@ -22,7 +22,7 @@ export const setupCapabilities = (
 
   core.capabilities.registerSwitcher(async (request, capabilities, useDefaultCapabilities) => {
     if (useDefaultCapabilities) {
-      return capabilities;
+      return {};
     }
     const [, { security }] = await core.getStartServices();
 
@@ -42,6 +42,6 @@ export const setupCapabilities = (
       };
     }
 
-    return capabilities;
+    return {};
   });
 };

--- a/x-pack/plugins/ml/server/lib/capabilities/capabilities_switcher.ts
+++ b/x-pack/plugins/ml/server/lib/capabilities/capabilities_switcher.ts
@@ -23,9 +23,8 @@ export const setupCapabilitiesSwitcher = (
 function getSwitcher(license$: Observable<ILicense>, logger: Logger): CapabilitiesSwitcher {
   return async (request, capabilities) => {
     const isAnonymousRequest = !request.route.options.authRequired;
-
     if (isAnonymousRequest) {
-      return capabilities;
+      return {};
     }
 
     try {
@@ -34,11 +33,11 @@ function getSwitcher(license$: Observable<ILicense>, logger: Logger): Capabiliti
 
       // full license, leave capabilities as they were
       if (mlEnabled && isFullLicense(license)) {
-        return capabilities;
+        return {};
       }
 
-      const mlCaps = capabilities.ml as MlCapabilities;
-      const originalCapabilities = cloneDeep(mlCaps);
+      const originalCapabilities = capabilities.ml as MlCapabilities;
+      const mlCaps = cloneDeep(originalCapabilities);
 
       // not full licence, switch off all capabilities
       Object.keys(mlCaps).forEach((k) => {
@@ -50,10 +49,10 @@ function getSwitcher(license$: Observable<ILicense>, logger: Logger): Capabiliti
         basicLicenseMlCapabilities.forEach((c) => (mlCaps[c] = originalCapabilities[c]));
       }
 
-      return capabilities;
+      return { ml: mlCaps };
     } catch (e) {
       logger.debug(`Error updating capabilities for ML based on licensing: ${e}`);
-      return capabilities;
+      return {};
     }
   };
 }

--- a/x-pack/plugins/security/server/authorization/authorization_service.tsx
+++ b/x-pack/plugins/security/server/authorization/authorization_service.tsx
@@ -156,7 +156,7 @@ export class AuthorizationService {
         // If we have a license which doesn't enable security, or we're a legacy user we shouldn't
         // disable any ui capabilities
         if (!mode.useRbacForRequest(request)) {
-          return uiCapabilities;
+          return {};
         }
 
         const disableUICapabilities = disableUICapabilitiesFactory(

--- a/x-pack/plugins/spaces/server/capabilities/capabilities_switcher.test.ts
+++ b/x-pack/plugins/spaces/server/capabilities/capabilities_switcher.test.ts
@@ -173,7 +173,7 @@ describe('capabilitiesSwitcher', () => {
 
     const result = await switcher(request, capabilities, false);
 
-    expect(result).toEqual(buildCapabilities());
+    expect(result).toEqual({});
     expect(spacesService.getActiveSpace).not.toHaveBeenCalled();
   });
 
@@ -191,7 +191,7 @@ describe('capabilitiesSwitcher', () => {
 
     const result = await switcher(request, capabilities, true);
 
-    expect(result).toEqual(buildCapabilities());
+    expect(result).toEqual({});
     expect(spacesService.getActiveSpace).not.toHaveBeenCalled();
   });
 

--- a/x-pack/plugins/spaces/server/capabilities/capabilities_switcher.ts
+++ b/x-pack/plugins/spaces/server/capabilities/capabilities_switcher.ts
@@ -24,7 +24,7 @@ export function setupCapabilitiesSwitcher(
     const shouldNotToggleCapabilities = isAuthRequiredOrOptional || useDefaultCapabilities;
 
     if (shouldNotToggleCapabilities) {
-      return capabilities;
+      return {};
     }
 
     try {


### PR DESCRIPTION
## Summary

Related to https://github.com/elastic/kibana/issues/146881

I tried to fix the issue, but couldn't so I kept the tiny optimizations I made on the way:
- optimize reduce blocks to re-use the memo instead of spreading into a new object
- update most of the existing resolver to only return the list of changes rather than the whole capability objects (which was how it was supposed to work) - minor perf improvement when merging the result of the resolvers