### PR TITLE
[Profiling] Fine-tune mappings

### DIFF
--- a/x-pack/plugins/profiling/server/lib/setup/steps/component_template_profiling_stackframes.json
+++ b/x-pack/plugins/profiling/server/lib/setup/steps/component_template_profiling_stackframes.json
@@ -30,7 +30,9 @@
       },
       "Stackframe.function.name": {
         "type": "keyword",
-        "index": false
+        "index": false,
+        "doc_values": false,
+        "store": false
       },
       "Stackframe.function.offset": {
         "type": "integer",

--- a/x-pack/plugins/profiling/server/lib/setup/steps/component_template_profiling_stacktraces.json
+++ b/x-pack/plugins/profiling/server/lib/setup/steps/component_template_profiling_stacktraces.json
@@ -2,7 +2,12 @@
   "settings": {
     "index": {
       "number_of_shards": 16,
-      "refresh_interval": "10s"
+      "refresh_interval": "10s",
+      "sort": {
+        "field": [
+          "Stacktrace.frame.ids"
+        ]
+      }
     }
   },
   "mappings": {


### PR DESCRIPTION
With this commit we avoid storing doc values for
`stackframe.function.name` to save disk space as doc values are not needed due to our access pattern. We also sort stack traces by stack frame ids to improve disk layout.

<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->