### PR TITLE
[Security solutions] Fix execution context page

### DIFF
--- a/x-pack/plugins/security_solution/public/app/home/index.tsx
+++ b/x-pack/plugins/security_solution/public/app/home/index.tsx
@@ -26,6 +26,7 @@ import { TourContextProvider } from '../../common/components/guided_onboarding_t
 import { useUrlState } from '../../common/hooks/use_url_state';
 import { useUpdateBrowserTitle } from '../../common/hooks/use_update_browser_title';
 import { useUpgradeSecurityPackages } from '../../detection_engine/rule_management/logic/use_upgrade_security_packages';
+import { useUpdateExecutionContext } from '../../common/hooks/use_update_execution_context';
 
 interface HomePageProps {
   children: React.ReactNode;
@@ -37,6 +38,7 @@ const HomePageComponent: React.FC<HomePageProps> = ({ children, setHeaderActionM
   useInitSourcerer(getScopeFromPath(pathname));
   useUrlState();
   useUpdateBrowserTitle();
+  useUpdateExecutionContext();
 
   const { browserFields } = useSourcererDataView(getScopeFromPath(pathname));
   // side effect: this will attempt to upgrade the endpoint package if it is not up to date

--- a/x-pack/plugins/security_solution/public/common/hooks/use_update_execution_context.ts
+++ b/x-pack/plugins/security_solution/public/common/hooks/use_update_execution_context.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+import { useKibana } from '../lib/kibana';
+
+export const useUpdateExecutionContext = () => {
+  const { pathname } = useLocation();
+  const { executionContext } = useKibana().services;
+
+  useEffect(() => {
+    // setImmediate is required to ensure that EBT telemetry for the previous page is shipped before the new page is updated
+    setImmediate(() => {
+      executionContext.set({ page: pathname });
+    });
+  }, [pathname, executionContext]);
+};


### PR DESCRIPTION
## Summary

Event Based Telemetry sends context data for each event, for that it uses Kibana `ExecutionContext`. Before this PR events sent from Security Solutions had `context.page` value undefined. 



### How to test it
1. Open the browser console and filter for EBT
2. Navigate between pages 
3. Check if the click event has the right `context.page` value.
