### PR TITLE
[Kibana migrator test kit] Flush logger after running migrations

### DIFF
--- a/src/core/server/integration_tests/saved_objects/migrations/group2/cleanup.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/group2/cleanup.test.ts
@@ -42,10 +42,9 @@ describe('migration v2', () => {
   });
 
   it('clean ups if migration fails', async () => {
-    const { migrator, client } = await setupNextMinor();
-    migrator.prepareMigrations();
+    const { runMigrations, client } = await setupNextMinor();
 
-    await expect(migrator.runMigrations()).rejects.toThrowErrorMatchingInlineSnapshot(`
+    await expect(runMigrations()).rejects.toThrowErrorMatchingInlineSnapshot(`
       "Unable to complete saved object migrations for the [${defaultKibanaIndex}] index: Migrations failed. Reason: 1 corrupt saved object documents were found: corrupt:2baf4de0-a6d4-11ed-ba5a-39196fc76e60
 
       To allow migrations to proceed, please delete or fix these documents.
@@ -135,13 +134,12 @@ const setupBaseline = async () => {
     },
   ];
 
-  const { migrator: baselineMigrator, client } = await getKibanaMigratorTestKit({
+  const { runMigrations, client } = await getKibanaMigratorTestKit({
     types: typesCurrent,
     logFilePath,
   });
 
-  baselineMigrator.prepareMigrations();
-  await baselineMigrator.runMigrations();
+  await runMigrations();
 
   // inject corrupt saved objects directly using esClient
   await Promise.all(
@@ -175,7 +173,7 @@ const setupNextMinor = async () => {
     },
   ];
 
-  const { migrator, client } = await getKibanaMigratorTestKit({
+  return await getKibanaMigratorTestKit({
     types: typesNextMinor,
     kibanaVersion: nextMinor,
     logFilePath,
@@ -203,6 +201,4 @@ const setupNextMinor = async () => {
       },
     },
   });
-
-  return { migrator, client };
 };

--- a/src/core/server/integration_tests/saved_objects/migrations/group3/skip_reindex.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/group3/skip_reindex.test.ts
@@ -22,8 +22,7 @@ import {
 } from '../kibana_migrator_test_kit';
 import { delay } from '../test_utils';
 
-// FLAKY: https://github.com/elastic/kibana/issues/152448
-describe.skip('when migrating to a new version', () => {
+describe('when migrating to a new version', () => {
   let esServer: TestElasticsearchUtils['es'];
   let esClient: ElasticsearchClient;
   let migrator: IKibanaMigrator;

--- a/src/core/server/integration_tests/saved_objects/migrations/kibana_migrator_test_kit.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/kibana_migrator_test_kit.ts
@@ -43,7 +43,6 @@ import type { ISavedObjectsRepository } from '@kbn/core-saved-objects-api-server
 import { getDocLinks, getDocLinksMeta } from '@kbn/doc-links';
 import type { DocLinksServiceStart } from '@kbn/core-doc-links-server';
 import { baselineDocuments, baselineTypes } from './kibana_migrator_test_kit.fixtures';
-import { delay } from './test_utils';
 
 export const defaultLogFilePath = Path.join(__dirname, 'kibana_migrator_test_kit.log');
 

--- a/src/core/server/integration_tests/saved_objects/migrations/kibana_migrator_test_kit.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/kibana_migrator_test_kit.ts
@@ -386,7 +386,6 @@ export const getIncompatibleMappingsMigrator = async ({
 };
 
 export const readLog = async (logFilePath: string = defaultLogFilePath): Promise<string> => {
-  await delay(0.1); // give the logger enough time to write to the file
   return await fs.readFile(logFilePath, 'utf-8');
 };
 

--- a/src/core/server/integration_tests/saved_objects/migrations/kibana_migrator_test_kit.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/kibana_migrator_test_kit.ts
@@ -150,7 +150,9 @@ export const getKibanaMigratorTestKit = async ({
 
   const runMigrations = async (rerun?: boolean) => {
     migrator.prepareMigrations();
-    return await migrator.runMigrations({ rerun });
+    const migrationResults = await migrator.runMigrations({ rerun });
+    await loggingSystem.stop();
+    return migrationResults;
   };
 
   const savedObjectsRepository = SavedObjectsRepository.createRepository(
@@ -283,13 +285,12 @@ const registerTypes = (
 };
 
 export const createBaseline = async () => {
-  const { client, migrator, savedObjectsRepository } = await getKibanaMigratorTestKit({
+  const { client, runMigrations, savedObjectsRepository } = await getKibanaMigratorTestKit({
     kibanaIndex: defaultKibanaIndex,
     types: baselineTypes,
   });
 
-  migrator.prepareMigrations();
-  await migrator.runMigrations();
+  await runMigrations();
 
   await savedObjectsRepository.bulkCreate(baselineDocuments, {
     refresh: 'wait_for',


### PR DESCRIPTION
This PR addresses flakiness of:

- https://github.com/elastic/kibana/issues/152472
- https://github.com/elastic/kibana/issues/152448

These tests fail because we have a race condition. We are checking certain conditions in the log files, and sometimes we do it before the logs are actually written.

With the Kibana migrator test kit, we can actually flush + wait for all the logging appenders. This way, we are sure that the logs are complete when we inspect them in the tests.

<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->