### PR TITLE
[Infrastructure UI] Add abort controller to Snapshot API call

### DIFF
--- a/x-pack/plugins/infra/public/hooks/use_http_request.tsx
+++ b/x-pack/plugins/infra/public/hooks/use_http_request.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useCallback, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { i18n } from '@kbn/i18n';
 import { HttpHandler } from '@kbn/core/public';
 import { ToastInput } from '@kbn/core/public';
@@ -74,6 +74,14 @@ export function useHTTPRequest<Response>(
     },
     [toast]
   );
+
+  useEffect(() => {
+    return () => {
+      if (abortable) {
+        abortController.current.abort();
+      }
+    };
+  }, [abortable]);
 
   const [request, makeRequest] = useTrackedPromise<any, Response>(
     {

--- a/x-pack/plugins/infra/public/hooks/use_http_request.tsx
+++ b/x-pack/plugins/infra/public/hooks/use_http_request.tsx
@@ -5,11 +5,12 @@
  * 2.0.
  */
 
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 import { i18n } from '@kbn/i18n';
 import { HttpHandler } from '@kbn/core/public';
 import { ToastInput } from '@kbn/core/public';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
+import { AbortError } from '@kbn/kibana-utils-plugin/common';
 import { useTrackedPromise, CanceledPromiseError } from '../utils/use_tracked_promise';
 import { InfraHttpError } from '../types';
 
@@ -19,18 +20,20 @@ export function useHTTPRequest<Response>(
   body?: string | null,
   decode: (response: any) => Response = (response) => response,
   fetch?: HttpHandler,
-  toastDanger?: (input: ToastInput) => void
+  toastDanger?: (input: ToastInput) => void,
+  abortable = false
 ) {
   const kibana = useKibana();
   const fetchService = fetch ? fetch : kibana.services.http?.fetch;
   const toast = toastDanger ? toastDanger : kibana.notifications.toasts.danger;
   const [response, setResponse] = useState<Response | null>(null);
   const [error, setError] = useState<InfraHttpError | null>(null);
+  const abortController = useRef(new AbortController());
 
   const onError = useCallback(
     (e: unknown) => {
       const err = e as InfraHttpError;
-      if (e && e instanceof CanceledPromiseError) {
+      if (e && (e instanceof CanceledPromiseError || (e as Error).name === AbortError.name)) {
         return;
       }
       setError(err);
@@ -79,7 +82,15 @@ export function useHTTPRequest<Response>(
         if (!fetchService) {
           throw new Error('HTTP service is unavailable');
         }
+
+        if (abortable) {
+          abortController.current.abort();
+        }
+
+        abortController.current = new AbortController();
+
         return fetchService(pathname, {
+          signal: abortController.current.signal,
           method,
           body,
         });

--- a/x-pack/plugins/infra/public/pages/metrics/hosts/components/hosts_table.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/hosts/components/hosts_table.tsx
@@ -18,10 +18,10 @@ import { useUnifiedSearchContext } from '../hooks/use_unified_search';
 
 export const HostsTable = () => {
   const { hostNodes, loading } = useHostsViewContext();
-  const { onSubmit, unifiedSearchDateRange } = useUnifiedSearchContext();
+  const { onSubmit, searchCriteria } = useUnifiedSearchContext();
   const [properties, setProperties] = useTableProperties();
 
-  const { columns, items } = useHostsTable(hostNodes, { time: unifiedSearchDateRange });
+  const { columns, items } = useHostsTable(hostNodes, { time: searchCriteria.dateRange });
 
   const noData = items.length === 0;
 
@@ -67,7 +67,7 @@ export const HostsTable = () => {
         refetchText={i18n.translate('xpack.infra.waffle.checkNewDataButtonLabel', {
           defaultMessage: 'Check for new data',
         })}
-        onRefetch={() => onSubmit()}
+        onRefetch={() => onSubmit({ ...searchCriteria })}
         testString="noMetricsDataPrompt"
       />
     );

--- a/x-pack/plugins/infra/public/pages/metrics/hosts/components/hosts_table.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/hosts/components/hosts_table.tsx
@@ -67,7 +67,7 @@ export const HostsTable = () => {
         refetchText={i18n.translate('xpack.infra.waffle.checkNewDataButtonLabel', {
           defaultMessage: 'Check for new data',
         })}
-        onRefetch={() => onSubmit({ ...searchCriteria })}
+        onRefetch={() => onSubmit()}
         testString="noMetricsDataPrompt"
       />
     );

--- a/x-pack/plugins/infra/public/pages/metrics/hosts/components/kpi_charts/tile.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/hosts/components/kpi_charts/tile.tsx
@@ -17,13 +17,16 @@ interface Props extends Omit<ChartBaseProps, 'type'> {
 export const Tile = ({ type, ...props }: Props) => {
   const { baseRequest } = useHostsViewContext();
 
-  const { nodes, loading } = useSnapshot({
-    ...baseRequest,
-    metrics: [{ type }],
-    groupBy: null,
-    includeTimeseries: true,
-    dropPartialBuckets: false,
-  });
+  const { nodes, loading } = useSnapshot(
+    {
+      ...baseRequest,
+      metrics: [{ type }],
+      groupBy: null,
+      includeTimeseries: true,
+      dropPartialBuckets: false,
+    },
+    { abortable: true }
+  );
 
   return <KPIChart id={`$metric-${type}`} type={type} nodes={nodes} loading={loading} {...props} />;
 };

--- a/x-pack/plugins/infra/public/pages/metrics/hosts/components/tabs/alerts/alerts_tab_content.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/hosts/components/tabs/alerts/alerts_tab_content.tsx
@@ -36,7 +36,7 @@ export const AlertsTabContent = () => {
 
   const { alertStatus, setAlertStatus, alertsEsQueryByStatus } = useAlertsQuery();
 
-  const { unifiedSearchDateRange } = useUnifiedSearchContext();
+  const { searchCriteria } = useUnifiedSearchContext();
 
   const { application, cases, triggersActionsUi } = services;
 
@@ -58,7 +58,7 @@ export const AlertsTabContent = () => {
         <EuiFlexItem>
           <MemoAlertSummaryWidget
             alertsQuery={alertsEsQueryByStatus}
-            dateRange={unifiedSearchDateRange}
+            dateRange={searchCriteria.dateRange}
           />
         </EuiFlexItem>
         {alertsEsQueryByStatus && (

--- a/x-pack/plugins/infra/public/pages/metrics/hosts/components/tabs/metrics/metric_chart.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/hosts/components/tabs/metrics/metric_chart.tsx
@@ -30,13 +30,7 @@ export interface MetricChartProps {
 const MIN_HEIGHT = 300;
 
 export const MetricChart = ({ title, type, breakdownSize }: MetricChartProps) => {
-  const {
-    unifiedSearchDateRange,
-    unifiedSearchQuery,
-    unifiedSearchFilters,
-    controlPanelFilters,
-    onSubmit,
-  } = useUnifiedSearchContext();
+  const { searchCriteria, onSubmit } = useUnifiedSearchContext();
   const { metricsDataView } = useMetricsDataViewContext();
   const { baseRequest } = useHostsViewContext();
   const {
@@ -54,12 +48,12 @@ export const MetricChart = ({ title, type, breakdownSize }: MetricChartProps) =>
   });
 
   const injectedLensAttributes = injectData({
-    filters: [...unifiedSearchFilters, ...controlPanelFilters],
-    query: unifiedSearchQuery,
+    filters: [...searchCriteria.filters, ...searchCriteria.panelFilters],
+    query: searchCriteria.query,
     title,
   });
 
-  const extraActionOptions = getExtraActions(injectedLensAttributes, unifiedSearchDateRange);
+  const extraActionOptions = getExtraActions(injectedLensAttributes, searchCriteria.dateRange);
   const extraAction: Action[] = [extraActionOptions.openInLens];
 
   const handleBrushEnd = ({ range }: BrushTriggerEvent['data']) => {
@@ -109,9 +103,9 @@ export const MetricChart = ({ title, type, breakdownSize }: MetricChartProps) =>
             style={{ height: MIN_HEIGHT }}
             attributes={injectedLensAttributes}
             viewMode={ViewMode.VIEW}
-            timeRange={unifiedSearchDateRange}
-            query={unifiedSearchQuery}
-            filters={unifiedSearchFilters}
+            timeRange={searchCriteria.dateRange}
+            query={searchCriteria.query}
+            filters={searchCriteria.filters}
             extraActions={extraAction}
             lastReloadRequestTime={baseRequest.requestTs}
             executionContext={{

--- a/x-pack/plugins/infra/public/pages/metrics/hosts/components/unified_search_bar.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/hosts/components/unified_search_bar.tsx
@@ -25,15 +25,7 @@ export const UnifiedSearchBar = ({ dataView }: Props) => {
   const {
     services: { unifiedSearch, application },
   } = useKibana<InfraClientStartDeps>();
-  const {
-    unifiedSearchDateRange,
-    unifiedSearchQuery,
-    unifiedSearchFilters,
-    controlPanelFilters,
-    onSubmit,
-    saveQuery,
-    clearSavedQuery,
-  } = useUnifiedSearchContext();
+  const { searchCriteria, onSubmit, saveQuery, clearSavedQuery } = useUnifiedSearchContext();
 
   const { SearchBar } = unifiedSearch.ui;
 
@@ -43,7 +35,7 @@ export const UnifiedSearchBar = ({ dataView }: Props) => {
 
   const onPanelFiltersChange = (panelFilters: Filter[]) => {
     // <ControlsContent /> triggers this event 2 times during its loading lifecycle
-    if (!deepEqual(controlPanelFilters, panelFilters)) {
+    if (!deepEqual(searchCriteria.panelFilters, panelFilters)) {
       onQueryChange({ panelFilters });
     }
   };
@@ -74,9 +66,9 @@ export const UnifiedSearchBar = ({ dataView }: Props) => {
           defaultMessage: 'Search hosts (E.g. cloud.provider:gcp AND system.load.1 > 0.5)',
         })}
         indexPatterns={[dataView]}
-        query={unifiedSearchQuery}
-        dateRangeFrom={unifiedSearchDateRange.from}
-        dateRangeTo={unifiedSearchDateRange.to}
+        query={searchCriteria.query}
+        dateRangeFrom={searchCriteria.dateRange.from}
+        dateRangeTo={searchCriteria.dateRange.to}
         onQuerySubmit={onQuerySubmit}
         onSaved={onQuerySave}
         onSavedQueryUpdated={onQuerySave}
@@ -86,11 +78,9 @@ export const UnifiedSearchBar = ({ dataView }: Props) => {
         displayStyle="inPage"
       />
       <ControlsContent
-        timeRange={unifiedSearchDateRange}
+        timeRange={searchCriteria.dateRange}
         dataView={dataView}
-        query={unifiedSearchQuery}
-        filters={unifiedSearchFilters}
-        onFilterChange={onPanelFiltersChange}
+        onFiltersChanged={onPanelFiltersChange}
       />
     </EuiFlexGrid>
   );

--- a/x-pack/plugins/infra/public/pages/metrics/hosts/components/unified_search_bar.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/hosts/components/unified_search_bar.tsx
@@ -7,7 +7,13 @@
 
 import React from 'react';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
-import type { Filter, Query, TimeRange } from '@kbn/es-query';
+import {
+  compareFilters,
+  COMPARE_ALL_OPTIONS,
+  type Filter,
+  type Query,
+  type TimeRange,
+} from '@kbn/es-query';
 import type { DataView } from '@kbn/data-views-plugin/public';
 import type { SavedQuery } from '@kbn/data-plugin/public';
 import { i18n } from '@kbn/i18n';
@@ -33,7 +39,9 @@ export const UnifiedSearchBar = ({ dataView }: Props) => {
   };
 
   const onPanelFiltersChange = (panelFilters: Filter[]) => {
-    onQueryChange({ panelFilters });
+    if (!compareFilters(searchCriteria.panelFilters, panelFilters, COMPARE_ALL_OPTIONS)) {
+      onQueryChange({ panelFilters });
+    }
   };
 
   const onClearSavedQuery = () => {

--- a/x-pack/plugins/infra/public/pages/metrics/hosts/components/unified_search_bar.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/hosts/components/unified_search_bar.tsx
@@ -12,7 +12,6 @@ import type { DataView } from '@kbn/data-views-plugin/public';
 import type { SavedQuery } from '@kbn/data-plugin/public';
 import { i18n } from '@kbn/i18n';
 import { EuiFlexGrid } from '@elastic/eui';
-import deepEqual from 'fast-deep-equal';
 import type { InfraClientStartDeps } from '../../../../types';
 import { useUnifiedSearchContext } from '../hooks/use_unified_search';
 import { ControlsContent } from './controls_content';
@@ -34,10 +33,7 @@ export const UnifiedSearchBar = ({ dataView }: Props) => {
   };
 
   const onPanelFiltersChange = (panelFilters: Filter[]) => {
-    // <ControlsContent /> triggers this event 2 times during its loading lifecycle
-    if (!deepEqual(searchCriteria.panelFilters, panelFilters)) {
-      onQueryChange({ panelFilters });
-    }
+    onQueryChange({ panelFilters });
   };
 
   const onClearSavedQuery = () => {
@@ -80,7 +76,9 @@ export const UnifiedSearchBar = ({ dataView }: Props) => {
       <ControlsContent
         timeRange={searchCriteria.dateRange}
         dataView={dataView}
-        onFiltersChanged={onPanelFiltersChange}
+        query={searchCriteria.query}
+        filters={searchCriteria.filters}
+        onFiltersChange={onPanelFiltersChange}
       />
     </EuiFlexGrid>
   );

--- a/x-pack/plugins/infra/public/pages/metrics/hosts/hooks/use_alerts_query.ts
+++ b/x-pack/plugins/infra/public/pages/metrics/hosts/hooks/use_alerts_query.ts
@@ -23,14 +23,14 @@ export interface AlertsEsQuery {
 export const useAlertsQueryImpl = () => {
   const { hostNodes } = useHostsViewContext();
 
-  const { unifiedSearchDateRange } = useUnifiedSearchContext();
+  const { searchCriteria } = useUnifiedSearchContext();
 
   const [alertStatus, setAlertStatus] = useState<AlertStatus>('all');
 
   const getAlertsEsQuery = useCallback(
     (status?: AlertStatus) =>
-      createAlertsEsQuery({ dateRange: unifiedSearchDateRange, hostNodes, status }),
-    [hostNodes, unifiedSearchDateRange]
+      createAlertsEsQuery({ dateRange: searchCriteria.dateRange, hostNodes, status }),
+    [hostNodes, searchCriteria.dateRange]
   );
 
   // Regenerate the query when status change even if is not used.

--- a/x-pack/plugins/infra/public/pages/metrics/hosts/hooks/use_control_panels_url_state.ts
+++ b/x-pack/plugins/infra/public/pages/metrics/hosts/hooks/use_control_panels_url_state.ts
@@ -129,6 +129,7 @@ const PanelRT = rt.type({
       dataViewId: rt.string,
       fieldName: rt.string,
       title: rt.union([rt.string, rt.undefined]),
+      selectedOptions: rt.array(rt.string),
     }),
   ]),
 });

--- a/x-pack/plugins/infra/public/pages/metrics/hosts/hooks/use_hosts_view.ts
+++ b/x-pack/plugins/infra/public/pages/metrics/hosts/hooks/use_hosts_view.ts
@@ -51,7 +51,13 @@ export const useHostsView = () => {
     loading,
     error,
     nodes: hostNodes,
-  } = useSnapshot({ ...baseRequest, metrics: HOST_TABLE_METRICS });
+  } = useSnapshot(
+    {
+      ...baseRequest,
+      metrics: HOST_TABLE_METRICS,
+    },
+    { abortable: true }
+  );
 
   return {
     baseRequest,

--- a/x-pack/plugins/infra/public/pages/metrics/hosts/hooks/use_unified_search.ts
+++ b/x-pack/plugins/infra/public/pages/metrics/hosts/hooks/use_unified_search.ts
@@ -157,13 +157,10 @@ export const useUnifiedSearch = () => {
   return {
     buildQuery,
     clearSavedQuery,
-    controlPanelFilters: state.panelFilters,
     onSubmit: debounceOnSubmit,
     saveQuery,
     getDateRangeAsTimestamp,
-    unifiedSearchQuery: state.query,
-    unifiedSearchDateRange: state.dateRange,
-    unifiedSearchFilters: state.filters,
+    searchCriteria: { ...state },
   };
 };
 

--- a/x-pack/plugins/infra/public/pages/metrics/inventory_view/hooks/use_snaphot.ts
+++ b/x-pack/plugins/infra/public/pages/metrics/inventory_view/hooks/use_snaphot.ts
@@ -26,18 +26,26 @@ export interface UseSnapshotRequest
   timerange?: InfraTimerangeInput;
   requestTs?: number;
 }
-export function useSnapshot({
-  timerange,
-  currentTime,
-  accountId = '',
-  region = '',
-  groupBy = null,
-  sendRequestImmediately = true,
-  includeTimeseries = true,
-  dropPartialBuckets = true,
-  requestTs,
-  ...args
-}: UseSnapshotRequest) {
+
+export interface UseSnapshotRequestOptions {
+  abortable?: boolean;
+}
+
+export function useSnapshot(
+  {
+    timerange,
+    currentTime,
+    accountId = '',
+    region = '',
+    groupBy = null,
+    sendRequestImmediately = true,
+    includeTimeseries = true,
+    dropPartialBuckets = true,
+    requestTs,
+    ...args
+  }: UseSnapshotRequest,
+  options?: UseSnapshotRequestOptions
+) {
   const decodeResponse = (response: any) => {
     return pipe(
       SnapshotNodeResponseRT.decode(response),
@@ -64,7 +72,10 @@ export function useSnapshot({
     '/api/metrics/snapshot',
     'POST',
     JSON.stringify(payload),
-    decodeResponse
+    decodeResponse,
+    undefined,
+    undefined,
+    options?.abortable
   );
 
   useEffect(() => {

--- a/x-pack/plugins/infra/public/utils/use_tracked_promise.ts
+++ b/x-pack/plugins/infra/public/utils/use_tracked_promise.ts
@@ -201,9 +201,9 @@ export const useTrackedPromise = <Arguments extends any[], Result>(
               if (shouldTriggerOrThrow()) {
                 if (onReject) {
                   onReject(value);
+                } else {
+                  throw value;
                 }
-
-                throw value;
               }
             }
           ),


### PR DESCRIPTION
## Summary

Closes [152896](https://github.com/elastic/kibana/issues/152896)

This PR adds AbortController to Snapshot API within the Hosts View context, to cancel pending requests before making new ones.

https://user-images.githubusercontent.com/2767137/223687356-b78e3759-382f-4bc2-9fb3-79e3cc22acee.mov

https://user-images.githubusercontent.com/2767137/223694389-e5473956-a290-447c-9561-b5d1b2f1ad1c.mov


<br />

**Current behaviour**

https://user-images.githubusercontent.com/2767137/223694452-ec9db680-cf49-4a27-bda9-db0fbadaef23.mov

It's not part of this PR solving the problem of possible sequential requests caused by updates in the filter controls. It works like this, because the filters show contextual options, so it needs the unified search filters in order to fetch its content.


### How to test it
- Rage click on the unified search submit button
- Rage click on the filter control options
- Navigate to a different page while the Hosts View is still waiting for the Snapshot API response

<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->