### PR TITLE
Remove ingestion method column from engine indices overview

### DIFF
--- a/x-pack/plugins/enterprise_search/common/types/engines.ts
+++ b/x-pack/plugins/enterprise_search/common/types/engines.ts
@@ -35,7 +35,6 @@ export interface EnterpriseSearchEngineIndex {
   count: number;
   health: HealthStatus | 'unknown';
   name: string;
-  source: 'api' | 'connector' | 'crawler';
 }
 
 export interface EnterpriseSearchEngineFieldCapabilities {

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_indices.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_indices.tsx
@@ -33,8 +33,6 @@ import { EuiLinkTo } from '../../../shared/react_router_helpers';
 import { TelemetryLogic } from '../../../shared/telemetry/telemetry_logic';
 
 import { SEARCH_INDEX_PATH, EngineViewTabs } from '../../routes';
-import { IngestionMethod } from '../../types';
-import { ingestionMethodToText } from '../../utils/indices';
 
 import { EnterpriseSearchEnginesPageTemplate } from '../layout/engines_page_template';
 
@@ -132,20 +130,6 @@ export const EngineIndices: React.FC = () => {
             )
           : count,
       sortable: true,
-      truncateText: true,
-      width: '15%',
-    },
-    {
-      field: 'source',
-      name: i18n.translate(
-        'xpack.enterpriseSearch.content.engine.indices.ingestionMethod.columnTitle',
-        {
-          defaultMessage: 'Ingestion method',
-        }
-      ),
-      render: (source: IngestionMethod) => (
-        <EuiText size="s">{ingestionMethodToText(source)}</EuiText>
-      ),
       truncateText: true,
       width: '15%',
     },

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_indices_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_indices_logic.test.ts
@@ -26,13 +26,11 @@ const mockEngineData: EnterpriseSearchEngineDetails = {
       count: 10,
       health: 'green',
       name: 'search-001',
-      source: 'api',
     },
     {
       count: 1000,
       health: 'yellow',
       name: 'search-002',
-      source: 'crawler',
     },
   ],
   name: DEFAULT_VALUES.engineName,

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_overview_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_overview_logic.test.ts
@@ -76,13 +76,11 @@ describe('EngineOverviewLogic', () => {
             count: 10,
             health: 'green',
             name: 'index-001',
-            source: 'api',
           },
           {
             count: 10,
             health: 'green',
             name: 'index-002',
-            source: 'api',
           },
         ];
         const engineData = {
@@ -101,11 +99,11 @@ describe('EngineOverviewLogic', () => {
       it('returns the number of indices', () => {
         const noIndices: EnterpriseSearchEngineIndex[] = [];
         const oneIndex = [
-          { count: 23, health: 'unknown', name: 'index-001', source: 'api' },
+          { count: 23, health: 'unknown', name: 'index-001' },
         ] as EnterpriseSearchEngineIndex[];
         const twoIndices = [
-          { count: 23, health: 'unknown', name: 'index-001', source: 'api' },
-          { count: 92, health: 'unknown', name: 'index-002', source: 'api' },
+          { count: 23, health: 'unknown', name: 'index-001' },
+          { count: 92, health: 'unknown', name: 'index-002' },
         ] as EnterpriseSearchEngineIndex[];
 
         expect(selectIndicesCount(noIndices)).toBe(0);
@@ -130,19 +128,16 @@ describe('EngineOverviewLogic', () => {
             count: 12,
             health: 'unknown',
             name: 'index-001',
-            source: 'api',
           },
           {
             count: 34,
             health: 'unknown',
             name: 'index-002',
-            source: 'crawler',
           },
           {
             count: 56,
             health: 'unknown',
             name: 'index-003',
-            source: 'api',
           },
         ] as EnterpriseSearchEngineIndex[];
         it('returns true', () => {
@@ -156,19 +151,16 @@ describe('EngineOverviewLogic', () => {
             count: 12,
             health: 'unknown',
             name: 'index-001',
-            source: 'api',
           },
           {
             count: 34,
             health: 'yellow',
             name: 'index-002',
-            source: 'crawler',
           },
           {
             count: 56,
             health: 'green',
             name: 'index-003',
-            source: 'api',
           },
         ] as EnterpriseSearchEngineIndex[];
         it('returns true', () => {
@@ -182,19 +174,16 @@ describe('EngineOverviewLogic', () => {
             count: 12,
             health: 'unknown',
             name: 'index-001',
-            source: 'api',
           },
           {
             count: 34,
             health: 'yellow',
             name: 'index-002',
-            source: 'crawler',
           },
           {
             count: 56,
             health: 'unknown',
             name: 'index-003',
-            source: 'api',
           },
         ] as EnterpriseSearchEngineIndex[];
         it('returns true', () => {
@@ -208,19 +197,16 @@ describe('EngineOverviewLogic', () => {
             count: 12,
             health: 'green',
             name: 'index-001',
-            source: 'api',
           },
           {
             count: 34,
             health: 'yellow',
             name: 'index-002',
-            source: 'crawler',
           },
           {
             count: 56,
             health: 'green',
             name: 'index-003',
-            source: 'api',
           },
         ] as EnterpriseSearchEngineIndex[];
         it('returns false', () => {
@@ -245,7 +231,6 @@ describe('EngineOverviewLogic', () => {
               count: 23,
               health: 'green',
               name: 'index-001',
-              source: 'crawler',
             },
           ] as EnterpriseSearchEngineIndex[])
         ).toBe(23);
@@ -258,13 +243,11 @@ describe('EngineOverviewLogic', () => {
               count: 23,
               health: 'green',
               name: 'index-001',
-              source: 'crawler',
             },
             {
               count: 45,
               health: 'green',
               name: 'index-002',
-              source: 'crawler',
             },
           ] as EnterpriseSearchEngineIndex[])
         ).toBe(68);
@@ -277,19 +260,16 @@ describe('EngineOverviewLogic', () => {
               count: 23,
               health: 'green',
               name: 'index-001',
-              source: 'crawler',
             },
             {
               count: null,
               health: 'unknown',
               name: 'index-002',
-              source: 'crawler',
             },
             {
               count: 45,
               health: 'green',
               name: 'index-002',
-              source: 'crawler',
             },
           ] as EnterpriseSearchEngineIndex[])
         ).toBe(68);

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engines/engines_list_flyout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engines/engines_list_flyout.tsx
@@ -33,8 +33,6 @@ import { healthColorsMap } from '../../../shared/constants/health_colors';
 import { generateEncodedPath } from '../../../shared/encode_path_params';
 import { EuiLinkTo } from '../../../shared/react_router_helpers';
 import { SEARCH_INDEX_PATH } from '../../routes';
-import { IngestionMethod } from '../../types';
-import { ingestionMethodToText } from '../../utils/indices';
 
 import { EngineError } from '../engine/engine_error';
 
@@ -104,20 +102,6 @@ export const EngineListIndicesFlyout: React.FC = () => {
         }
       ),
       sortable: true,
-      truncateText: true,
-      width: '15%',
-    },
-    {
-      field: 'source',
-      name: i18n.translate(
-        'xpack.enterpriseSearch.content.enginesList.indicesFlyout.table.ingestionMethod.columnTitle',
-        {
-          defaultMessage: 'Ingestion method',
-        }
-      ),
-      render: (source: IngestionMethod) => (
-        <EuiText size="s">{ingestionMethodToText(source)}</EuiText>
-      ),
       truncateText: true,
       width: '15%',
     },

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engines/engines_list_flyout_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engines/engines_list_flyout_logic.test.ts
@@ -30,13 +30,11 @@ const mockEngineData: EnterpriseSearchEngineDetails = {
       count: 10,
       health: 'green',
       name: 'search-001',
-      source: 'api',
     },
     {
       count: 1000,
       health: 'yellow',
       name: 'search-002',
-      source: 'crawler',
     },
   ],
   name: 'my-test-engine',


### PR DESCRIPTION
We have decided not to show the source (API, crawler, connector) for the indices included in an engine.
