### PR TITLE
[8.7] [embeddable] centralize should fetch embeddable observable logic (#151799)

### DIFF
--- a/src/plugins/dashboard/public/dashboard_container/embeddable/integrations/diff_state/dashboard_diffing_functions.ts
+++ b/src/plugins/dashboard/public/dashboard_container/embeddable/integrations/diff_state/dashboard_diffing_functions.ts
@@ -15,6 +15,7 @@ import {
   isFilterPinned,
   onlyDisabledFiltersChanged,
 } from '@kbn/es-query';
+import { shouldRefreshFilterCompareOptions } from '@kbn/embeddable-plugin/public';
 
 import { DashboardContainer } from '../../dashboard_container';
 import { DashboardContainerByValueInput } from '../../../../../common';
@@ -115,12 +116,6 @@ export const unsavedChangesDiffingFunctions: DashboardDiffFunctions = {
     persistableControlGroupInputIsEqual(currentValue, lastValue),
 
   viewMode: () => false, // When compared view mode is always considered unequal so that it gets backed up.
-};
-
-const shouldRefreshFilterCompareOptions = {
-  ...COMPARE_ALL_OPTIONS,
-  // do not compare $state to avoid refreshing when filter is pinned/unpinned (which does not impact results)
-  state: false,
 };
 
 export const shouldRefreshDiffingFunctions: DashboardDiffFunctions = {

--- a/src/plugins/embeddable/public/index.ts
+++ b/src/plugins/embeddable/public/index.ts
@@ -87,6 +87,8 @@ export {
   EmbeddableRenderer,
   useEmbeddableFactory,
   isFilterableEmbeddable,
+  shouldFetch$,
+  shouldRefreshFilterCompareOptions,
 } from './lib';
 
 export { AttributeService, ATTRIBUTE_SERVICE_KEY } from './lib/attribute_service';

--- a/src/plugins/embeddable/public/lib/filterable_embeddable/index.ts
+++ b/src/plugins/embeddable/public/lib/filterable_embeddable/index.ts
@@ -8,3 +8,4 @@
 
 export type { FilterableEmbeddable } from './types';
 export { isFilterableEmbeddable } from './types';
+export { shouldFetch$, shouldRefreshFilterCompareOptions } from './should_fetch';

--- a/src/plugins/embeddable/public/lib/filterable_embeddable/should_fetch.tsx
+++ b/src/plugins/embeddable/public/lib/filterable_embeddable/should_fetch.tsx
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import fastIsEqual from 'fast-deep-equal';
+import { Observable } from 'rxjs';
+import { map, distinctUntilChanged, skip, startWith } from 'rxjs/operators';
+import { COMPARE_ALL_OPTIONS, onlyDisabledFiltersChanged } from '@kbn/es-query';
+import type { FilterableEmbeddableInput } from './types';
+
+export const shouldRefreshFilterCompareOptions = {
+  ...COMPARE_ALL_OPTIONS,
+  // do not compare $state to avoid refreshing when filter is pinned/unpinned (which does not impact results)
+  state: false,
+};
+
+export function shouldFetch$<
+  TFilterableEmbeddableInput extends FilterableEmbeddableInput = FilterableEmbeddableInput
+>(
+  updated$: Observable<unknown>,
+  getInput: () => TFilterableEmbeddableInput
+): Observable<TFilterableEmbeddableInput> {
+  return updated$.pipe(map(() => getInput())).pipe(
+    // wrapping distinctUntilChanged with startWith and skip to prime distinctUntilChanged with an initial input value.
+    startWith(getInput()),
+    distinctUntilChanged((a: TFilterableEmbeddableInput, b: TFilterableEmbeddableInput) => {
+      if (
+        !fastIsEqual(
+          [a.searchSessionId, a.query, a.timeRange, a.timeslice],
+          [b.searchSessionId, b.query, b.timeRange, b.timeslice]
+        )
+      ) {
+        return false;
+      }
+
+      return onlyDisabledFiltersChanged(a.filters, b.filters, shouldRefreshFilterCompareOptions);
+    }),
+    skip(1)
+  );
+}

--- a/src/plugins/embeddable/public/lib/filterable_embeddable/types.ts
+++ b/src/plugins/embeddable/public/lib/filterable_embeddable/types.ts
@@ -6,7 +6,15 @@
  * Side Public License, v 1.
  */
 
-import { type AggregateQuery, type Filter, type Query } from '@kbn/es-query';
+import type { AggregateQuery, Filter, Query, TimeRange } from '@kbn/es-query';
+import { EmbeddableInput } from '../embeddables';
+
+export type FilterableEmbeddableInput = EmbeddableInput & {
+  filters?: Filter[];
+  query?: Query;
+  timeRange?: TimeRange;
+  timeslice?: [number, number];
+};
 
 /**
  * All embeddables that implement this interface should support being filtered

--- a/x-pack/plugins/lens/public/embeddable/embeddable.tsx
+++ b/x-pack/plugins/lens/public/embeddable/embeddable.tsx
@@ -55,6 +55,7 @@ import {
   cellValueTrigger,
   CELL_VALUE_TRIGGER,
   type CellValueContext,
+  shouldFetch$,
 } from '@kbn/embeddable-plugin/public';
 import type { Action, UiActionsStart } from '@kbn/ui-actions-plugin/public';
 import type { DataViewsContract, DataView } from '@kbn/data-views-plugin/public';
@@ -432,20 +433,11 @@ export class Embeddable
 
     // Update search context and reload on changes related to search
     this.inputReloadSubscriptions.push(
-      this.getUpdated$()
-        .pipe(map(() => this.getInput()))
-        .pipe(
-          distinctUntilChanged((a, b) =>
-            fastIsEqual(
-              [a.filters, a.query, a.timeRange, a.searchSessionId],
-              [b.filters, b.query, b.timeRange, b.searchSessionId]
-            )
-          ),
-          skip(1)
-        )
-        .subscribe(async (input) => {
+      shouldFetch$<LensEmbeddableInput>(this.getUpdated$(), () => this.getInput()).subscribe(
+        (input) => {
           this.onContainerStateChanged(input);
-        })
+        }
+      )
     );
   }
 

--- a/x-pack/plugins/maps/public/embeddable/map_embeddable.test.tsx
+++ b/x-pack/plugins/maps/public/embeddable/map_embeddable.test.tsx
@@ -1,0 +1,290 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { v4 as uuidv4 } from 'uuid';
+import { getControlledBy, MapEmbeddable } from './map_embeddable';
+import { buildExistsFilter, disableFilter, pinFilter, toggleFilterNegated } from '@kbn/es-query';
+import type { DataViewFieldBase, DataViewBase } from '@kbn/es-query';
+import { MapEmbeddableConfig, MapEmbeddableInput } from './types';
+import { MapSavedObjectAttributes } from '../../common/map_saved_object_type';
+
+jest.mock('../kibana_services', () => {
+  return {
+    getHttp() {
+      return {
+        basePath: {
+          prepend: (url: string) => url,
+        },
+      };
+    },
+    getMapsCapabilities() {
+      return { save: true };
+    },
+    getSearchService() {
+      return {
+        session: {
+          getSearchOptions() {
+            return undefined;
+          },
+        },
+      };
+    },
+    getShowMapsInspectorAdapter() {
+      return false;
+    },
+    getTimeFilter() {
+      return {
+        getTime() {
+          return { from: 'now-7d', to: 'now' };
+        },
+      };
+    },
+  };
+});
+
+jest.mock('../connected_components/map_container', () => {
+  return {
+    MapContainer: () => {
+      return <div>mockLayerTOC</div>;
+    },
+  };
+});
+
+jest.mock('../routes/map_page', () => {
+  class MockSavedMap {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    private _store = require('../reducers/store').createMapStore();
+    private _attributes: MapSavedObjectAttributes = {
+      title: 'myMap',
+    };
+
+    whenReady = async function () {};
+
+    getStore() {
+      return this._store;
+    }
+    getAttributes() {
+      return this._attributes;
+    }
+    getAutoFitToBounds() {
+      return true;
+    }
+    getSharingSavedObjectProps() {
+      return null;
+    }
+  }
+  return { SavedMap: MockSavedMap };
+});
+
+function untilInitialized(mapEmbeddable: MapEmbeddable): Promise<void> {
+  return new Promise((resolve) => {
+    // @ts-expect-error setInitializationFinished is protected but we are overriding it to know when embeddable is initialized
+    mapEmbeddable.setInitializationFinished = () => {
+      resolve();
+    };
+  });
+}
+
+function onNextTick(): Promise<void> {
+  // wait one tick to give observables time to fire
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe('shouldFetch$', () => {
+  test('should not fetch when search context does not change', async () => {
+    const mapEmbeddable = new MapEmbeddable(
+      {} as unknown as MapEmbeddableConfig,
+      {
+        id: 'map1',
+      } as unknown as MapEmbeddableInput
+    );
+    await untilInitialized(mapEmbeddable);
+
+    const fetchSpy = jest.spyOn(mapEmbeddable, '_dispatchSetQuery');
+
+    mapEmbeddable.updateInput({
+      title: 'updated map title',
+    });
+
+    await onNextTick();
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  describe('on filters change', () => {
+    test('should fetch on filter change', async () => {
+      const existsFilter = buildExistsFilter(
+        {
+          name: 'myFieldName',
+        } as DataViewFieldBase,
+        {
+          id: 'myDataViewId',
+        } as DataViewBase
+      );
+      const mapEmbeddable = new MapEmbeddable(
+        {} as unknown as MapEmbeddableConfig,
+        {
+          id: 'map1',
+          filters: [existsFilter],
+        } as unknown as MapEmbeddableInput
+      );
+      await untilInitialized(mapEmbeddable);
+
+      const fetchSpy = jest.spyOn(mapEmbeddable, '_dispatchSetQuery');
+
+      mapEmbeddable.updateInput({
+        filters: [toggleFilterNegated(existsFilter)],
+      });
+
+      await onNextTick();
+
+      expect(fetchSpy).toHaveBeenCalled();
+    });
+
+    test('should not fetch on disabled filter change', async () => {
+      const disabledFilter = disableFilter(
+        buildExistsFilter(
+          {
+            name: 'myFieldName',
+          } as DataViewFieldBase,
+          {
+            id: 'myDataViewId',
+          } as DataViewBase
+        )
+      );
+      const mapEmbeddable = new MapEmbeddable(
+        {} as unknown as MapEmbeddableConfig,
+        {
+          id: 'map1',
+          filters: [disabledFilter],
+        } as unknown as MapEmbeddableInput
+      );
+      await untilInitialized(mapEmbeddable);
+
+      const fetchSpy = jest.spyOn(mapEmbeddable, '_dispatchSetQuery');
+
+      mapEmbeddable.updateInput({
+        filters: [toggleFilterNegated(disabledFilter)],
+      });
+
+      await onNextTick();
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    test('should not fetch when unpinned filter is pinned', async () => {
+      const unpinnedFilter = buildExistsFilter(
+        {
+          name: 'myFieldName',
+        } as DataViewFieldBase,
+        {
+          id: 'myDataViewId',
+        } as DataViewBase
+      );
+      const mapEmbeddable = new MapEmbeddable(
+        {} as unknown as MapEmbeddableConfig,
+        {
+          id: 'map1',
+          filters: [unpinnedFilter],
+        } as unknown as MapEmbeddableInput
+      );
+      await untilInitialized(mapEmbeddable);
+
+      const fetchSpy = jest.spyOn(mapEmbeddable, '_dispatchSetQuery');
+
+      mapEmbeddable.updateInput({
+        filters: [pinFilter(unpinnedFilter)],
+      });
+
+      await onNextTick();
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    test('should not fetch on filter controlled by map embeddable change', async () => {
+      const embeddableId = 'map1';
+      const filter = buildExistsFilter(
+        {
+          name: 'myFieldName',
+        } as DataViewFieldBase,
+        {
+          id: 'myDataViewId',
+        } as DataViewBase
+      );
+      const controlledByFilter = {
+        ...filter,
+        meta: {
+          ...filter.meta,
+          controlledBy: getControlledBy(embeddableId),
+        },
+      };
+      const mapEmbeddable = new MapEmbeddable(
+        {} as unknown as MapEmbeddableConfig,
+        {
+          id: embeddableId,
+          filters: [controlledByFilter],
+        } as unknown as MapEmbeddableInput
+      );
+      await untilInitialized(mapEmbeddable);
+
+      const fetchSpy = jest.spyOn(mapEmbeddable, '_dispatchSetQuery');
+
+      mapEmbeddable.updateInput({
+        filters: [toggleFilterNegated(controlledByFilter)],
+      });
+
+      await onNextTick();
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('on searchSessionId change', () => {
+    test('should fetch when filterByMapExtent is false', async () => {
+      const mapEmbeddable = new MapEmbeddable(
+        {} as unknown as MapEmbeddableConfig,
+        {
+          id: 'map1',
+          filterByMapExtent: false,
+        } as unknown as MapEmbeddableInput
+      );
+      await untilInitialized(mapEmbeddable);
+
+      const fetchSpy = jest.spyOn(mapEmbeddable, '_dispatchSetQuery');
+
+      mapEmbeddable.updateInput({
+        searchSessionId: uuidv4(),
+      });
+
+      await onNextTick();
+
+      expect(fetchSpy).toHaveBeenCalled();
+    });
+
+    test('should not fetch when filterByMapExtent is true', async () => {
+      const mapEmbeddable = new MapEmbeddable(
+        {} as unknown as MapEmbeddableConfig,
+        {
+          id: 'map1',
+          filterByMapExtent: true,
+        } as unknown as MapEmbeddableInput
+      );
+      await untilInitialized(mapEmbeddable);
+
+      const fetchSpy = jest.spyOn(mapEmbeddable, '_dispatchSetQuery');
+
+      mapEmbeddable.updateInput({
+        searchSessionId: uuidv4(),
+      });
+
+      await onNextTick();
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/x-pack/plugins/maps/public/embeddable/types.ts
+++ b/x-pack/plugins/maps/public/embeddable/types.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import type { Filter } from '@kbn/es-query';
 import type { DataView } from '@kbn/data-plugin/common';
 import {
   Embeddable,
@@ -13,7 +12,7 @@ import {
   EmbeddableOutput,
   SavedObjectEmbeddableInput,
 } from '@kbn/embeddable-plugin/public';
-import type { Query, TimeRange } from '@kbn/es-query';
+import type { Filter, Query, TimeRange } from '@kbn/es-query';
 import { MapCenterAndZoom, MapExtent, MapSettings } from '../../common/descriptor_types';
 import { MapSavedObjectAttributes } from '../../common/map_saved_object_type';
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.7`:
 - [[embeddable] centralize should fetch embeddable observable logic (#151799)](https://github.com/elastic/kibana/pull/151799)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Nathan Reese","email":"reese.nathan@elastic.co"},"sourceCommit":{"committedDate":"2023-03-01T01:47:48Z","message":"[embeddable] centralize should fetch embeddable observable logic (#151799)\n\nFixes https://github.com/elastic/kibana/issues/151223 and\r\nhttps://github.com/elastic/kibana/issues/151128\r\n\r\nPR does the following\r\n1) creates `shouldFetch# Backport

This will backport the following commits from `main` to `8.7`:
 - [[embeddable] centralize should fetch embeddable observable logic (#151799)](https://github.com/elastic/kibana/pull/151799)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT  method that centralizes logic for checking\r\nwhen an embeddable should fetch.\r\n2) updates Lens and Maps embeddable to use `shouldFetch# Backport

This will backport the following commits from `main` to `8.7`:
 - [[embeddable] centralize should fetch embeddable observable logic (#151799)](https://github.com/elastic/kibana/pull/151799)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT \r\n3) Adds unit tests for Maps embeddable to capture behavior of unique\r\nedge cases\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"afb251c624552024076ae75890de9c7d5f4458f0","branchLabelMapping":{"^v8.8.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Visualizations","Feature:Embedding","Team:Presentation","release_note:skip","backport:skip","Feature:Maps","v8.8.0"],"number":151799,"url":"https://github.com/elastic/kibana/pull/151799","mergeCommit":{"message":"[embeddable] centralize should fetch embeddable observable logic (#151799)\n\nFixes https://github.com/elastic/kibana/issues/151223 and\r\nhttps://github.com/elastic/kibana/issues/151128\r\n\r\nPR does the following\r\n1) creates `shouldFetch# Backport

This will backport the following commits from `main` to `8.7`:
 - [[embeddable] centralize should fetch embeddable observable logic (#151799)](https://github.com/elastic/kibana/pull/151799)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT  method that centralizes logic for checking\r\nwhen an embeddable should fetch.\r\n2) updates Lens and Maps embeddable to use `shouldFetch# Backport

This will backport the following commits from `main` to `8.7`:
 - [[embeddable] centralize should fetch embeddable observable logic (#151799)](https://github.com/elastic/kibana/pull/151799)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT \r\n3) Adds unit tests for Maps embeddable to capture behavior of unique\r\nedge cases\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"afb251c624552024076ae75890de9c7d5f4458f0"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.8.0","labelRegex":"^v8.8.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/151799","number":151799,"mergeCommit":{"message":"[embeddable] centralize should fetch embeddable observable logic (#151799)\n\nFixes https://github.com/elastic/kibana/issues/151223 and\r\nhttps://github.com/elastic/kibana/issues/151128\r\n\r\nPR does the following\r\n1) creates `shouldFetch# Backport

This will backport the following commits from `main` to `8.7`:
 - [[embeddable] centralize should fetch embeddable observable logic (#151799)](https://github.com/elastic/kibana/pull/151799)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT  method that centralizes logic for checking\r\nwhen an embeddable should fetch.\r\n2) updates Lens and Maps embeddable to use `shouldFetch# Backport

This will backport the following commits from `main` to `8.7`:
 - [[embeddable] centralize should fetch embeddable observable logic (#151799)](https://github.com/elastic/kibana/pull/151799)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT \r\n3) Adds unit tests for Maps embeddable to capture behavior of unique\r\nedge cases\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"afb251c624552024076ae75890de9c7d5f4458f0"}}]}] BACKPORT-->