### PR TITLE
[Dashboard] [Controls] Fix flaky runtime field test

### DIFF
--- a/test/functional/apps/dashboard_elements/controls/options_list/options_list_dashboard_interaction.ts
+++ b/test/functional/apps/dashboard_elements/controls/options_list/options_list_dashboard_interaction.ts
@@ -294,18 +294,11 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await common.navigateToApp('settings');
         await settings.clickKibanaIndexPatterns();
         await settings.clickIndexPatternByName('animals-*');
-
-        const startingCount = parseInt(await settings.getFieldsTabCount(), 10);
         await settings.addRuntimeField(
           FIELD_NAME,
           'keyword',
           `emit(doc['sound.keyword'].value.substring(0, 1).toUpperCase())`
         );
-        await header.waitUntilLoadingHasFinished();
-        await retry.try(async function () {
-          expect(parseInt(await settings.getFieldsTabCount(), 10)).to.be(startingCount + 1);
-        });
-
         await returnToDashboard();
         await dashboardControls.deleteAllControls();
       });

--- a/test/functional/apps/dashboard_elements/controls/options_list/options_list_dashboard_interaction.ts
+++ b/test/functional/apps/dashboard_elements/controls/options_list/options_list_dashboard_interaction.ts
@@ -294,15 +294,17 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await common.navigateToApp('settings');
         await settings.clickKibanaIndexPatterns();
         await settings.clickIndexPatternByName('animals-*');
+
+        const startingCount = parseInt(await settings.getFieldsTabCount(), 10);
         await settings.addRuntimeField(
           FIELD_NAME,
           'keyword',
           `emit(doc['sound.keyword'].value.substring(0, 1).toUpperCase())`
         );
-        await retry.waitFor('field editor flyout to close', async () => {
-          return !(await testSubjects.exists('fieldEditor'));
-        });
         await header.waitUntilLoadingHasFinished();
+        await retry.try(async function () {
+          expect(parseInt(await settings.getFieldsTabCount(), 10)).to.be(startingCount + 1);
+        });
 
         await returnToDashboard();
         await dashboardControls.deleteAllControls();

--- a/test/functional/apps/dashboard_elements/controls/options_list/options_list_dashboard_interaction.ts
+++ b/test/functional/apps/dashboard_elements/controls/options_list/options_list_dashboard_interaction.ts
@@ -299,6 +299,9 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
           'keyword',
           `emit(doc['sound.keyword'].value.substring(0, 1).toUpperCase())`
         );
+        await retry.waitFor('field editor flyout to close', async () => {
+          return !(await testSubjects.exists('fieldEditor'));
+        });
         await header.waitUntilLoadingHasFinished();
 
         await returnToDashboard();

--- a/test/functional/page_objects/settings_page.ts
+++ b/test/functional/page_objects/settings_page.ts
@@ -713,6 +713,7 @@ export class SettingsPageObject extends FtrService {
   }
 
   async addRuntimeField(name: string, type: string, script: string, doSaveField = true) {
+    const startingCount = parseInt(await this.getFieldsTabCount(), 10);
     await this.clickAddField();
     await this.setFieldName(name);
     await this.setFieldType(type);
@@ -722,6 +723,9 @@ export class SettingsPageObject extends FtrService {
 
     if (doSaveField) {
       await this.clickSaveField();
+      await this.retry.try(async () => {
+        expect(parseInt(await this.getFieldsTabCount(), 10)).to.be(startingCount + 1);
+      });
     }
   }
 
@@ -791,6 +795,7 @@ export class SettingsPageObject extends FtrService {
   async clickSaveField() {
     this.log.debug('click Save');
     await this.testSubjects.click('fieldSaveButton');
+    await this.header.waitUntilLoadingHasFinished();
   }
 
   async setFieldName(name: string) {


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/152827

## Summary

This PR potentially fixes the above flaky test or, at the very least, it will create a more informative failure screenshot if it continues to be flaky.

The test is failing because, for one reason or another, the scripted field is not created. I've added a check to ensure that the field is created **before** navigating back to Dashboard so that, if something is going wrong in the creation process, we should have a better understanding of why this has failed (for example, any error toasts). It's possible, however, that we simply weren't waiting long enough for the field to actually be added before navigating away - if this is the case, then my changes **should** also fix this.

### Flaky Test Runner
<a href="https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/1994"><img src="https://user-images.githubusercontent.com/8698078/223538599-126a24a1-5319-4c8e-bb7f-11dfec5b3ed6.png"/></a>

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
