### PR TITLE
[Enterprise Search] Engines Search Preview bugs

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/convert_results.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/convert_results.test.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { convertResults, flattenObject } from './convert_results';
+
+describe('flattenObject', () => {
+  it('flattens an object', () => {
+    const obj = {
+      a: {
+        b: {
+          c: 'd',
+        },
+      },
+    };
+
+    expect(flattenObject(obj)).toEqual({
+      'a.b.c': 'd',
+    });
+  });
+
+  it('handles null values', () => {
+    const obj = {
+      a: {
+        b: null,
+        c: 'd',
+      },
+    };
+
+    expect(flattenObject(obj)).toEqual({
+      'a.b': null,
+      'a.c': 'd',
+    });
+  });
+});
+
+describe('convertResults', () => {
+  it('flattens objects and returns arrays of field/value pairs', () => {
+    const result = {
+      a: {
+        _meta: { id: 1337 },
+        b: {
+          c: 'd',
+        },
+      },
+      e: false,
+    };
+
+    expect(convertResults(result)).toEqual([
+      {
+        field: 'a._meta.id',
+        value: '1337',
+      },
+      {
+        field: 'a.b.c',
+        value: '"d"',
+      },
+      {
+        field: 'e',
+        value: 'false',
+      },
+    ]);
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/convert_results.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/convert_results.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+type FlatRecord<T extends string | number | symbol, U> = Record<T, Exclude<U, object>>;
+
+export const flattenObject = (
+  obj: Record<string, unknown>,
+  prefix = ''
+): FlatRecord<string, unknown> => {
+  return Object.keys(obj).reduce((acc: FlatRecord<string, unknown>, key: string) => {
+    const dot = prefix.length ? prefix + '.' : '';
+    const val = obj[key];
+    if (val !== null && typeof val === 'object') {
+      Object.assign(acc, flattenObject(val as Record<string, unknown>, dot + key));
+    } else {
+      acc[dot + key] = val;
+    }
+    return acc;
+  }, {});
+};
+
+export interface ConvertedResult {
+  field: string;
+  value: string;
+}
+
+export const convertResults = (result: Record<string, unknown>): ConvertedResult[] => {
+  const flattenedResult = flattenObject(result);
+  const unsortedFields = Object.entries(flattenedResult).map(
+    ([field, value]: [string, unknown]) => ({
+      field,
+      value: JSON.stringify(value),
+    })
+  );
+  const sortedFields = unsortedFields.sort((a, b) => a.field.localeCompare(b.field));
+  return sortedFields;
+};

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/engine_search_preview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/engine_search_preview.tsx
@@ -102,7 +102,7 @@ export const EngineSearchPreview: React.FC = () => {
         search_fields: searchableFields,
       },
     };
-  }, [http, engineName, setLastAPICall]);
+  }, [http, engineName, setLastAPICall, resultFields, searchableFields]);
 
   if (!engineData) return null;
 

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/engine_search_preview_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/engine_search_preview_logic.ts
@@ -100,7 +100,8 @@ export const EngineSearchPreviewLogic = kea<
                 aggregatable && !isMeta
             )
           )
-          .map(([field]) => field);
+          .map(([field]) => field)
+          .sort();
       },
     ],
   }),


### PR DESCRIPTION
## Summary

- flattens search preview results so we don't try to render out objects (would crash react)
- adds `searchableFields` and `resultsFields` to the `useMemo` dependencies
    - without this sometimes the search config would be created before these values were loaded and searching would not work because `searchableFields` would be empty

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

