### PR TITLE
[Security Solution] fix flaky test timeline url state

### DIFF
--- a/x-pack/plugins/security_solution/cypress/e2e/urls/state.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/urls/state.cy.ts
@@ -287,9 +287,8 @@ describe('url state', () => {
 
     cy.intercept('PATCH', '/api/timeline').as('timeline');
 
-    addNameToTimeline(getTimeline().title);
-
     cy.wait('@timeline').then(({ response }) => {
+      addNameToTimeline(getTimeline().title);
       closeTimeline();
       cy.wrap(response?.statusCode).should('eql', 200);
       const timelineId = response?.body.data.persistTimeline.timeline.savedObjectId;


### PR DESCRIPTION
## Summary

A CI build failed for a Cypress test

![Screenshot 2023-03-07 at 2 28 42 PM](https://user-images.githubusercontent.com/17276605/223544958-dabc5a6d-4c8e-4a72-8ae4-0f235b536fc3.png)

I was able to reproduce the flakiness in the latest `main` branch: the issue is related to a re-render happening when the PATH `/api/timeline` calls finishes, stopping the `type` action in the save timeline modal's `title` input

![Screenshot 2023-03-07 at 2 28 22 PM](https://user-images.githubusercontent.com/17276605/223545274-b80517cd-5dd7-4ed0-b756-d58990eb5271.png)

After the fix, I ran that test multiple times and we have 100% success.

![Screenshot 2023-03-07 at 2 25 24 PM](https://user-images.githubusercontent.com/17276605/223545457-216e40d9-b66f-4270-ad24-7f99b58d8b57.png)