### PR TITLE
[timelion] Fix glob path on windows

### DIFF
--- a/src/plugins/vis_types/timelion/server/lib/load_functions.js
+++ b/src/plugins/vis_types/timelion/server/lib/load_functions.js
@@ -9,6 +9,7 @@
 import _ from 'lodash';
 import globby from 'globby';
 import path from 'path';
+import normalizePath from 'normalize-path';
 import processFunctionDefinition from './process_function_definition';
 
 export default function (directory) {
@@ -19,7 +20,7 @@ export default function (directory) {
   // Get a list of all files and use the filename as the object key
   const files = _.map(
     globby
-      .sync(path.resolve(__dirname, '../' + directory + '/*.js'))
+      .sync(normalizePath(path.resolve(__dirname, '../' + directory + '/*.js')))
       .filter((filename) => !filename.includes('.test')),
     function (file) {
       const name = file.substring(file.lastIndexOf('/') + 1, file.lastIndexOf('.'));
@@ -29,7 +30,7 @@ export default function (directory) {
 
   // Get a list of all directories with an index.js, use the directory name as the key in the object
   const directories = _.chain(
-    globby.sync(path.resolve(__dirname, '../' + directory + '/*/index.js'))
+    globby.sync(normalizePath(path.resolve(__dirname, '../' + directory + '/*/index.js')))
   )
     .map(function (file) {
       const parts = file.split('/');


### PR DESCRIPTION
Fixes a bug introduced in #138571.  Paths need to be normalized before being passed to our current version of globby.

Closes #150396

<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->