### PR TITLE
[ML] AIOps: Fix use full data button when time range returns null.

### DIFF
--- a/x-pack/packages/ml/date_picker/src/components/full_time_range_selector.tsx
+++ b/x-pack/packages/ml/date_picker/src/components/full_time_range_selector.tsx
@@ -110,7 +110,7 @@ export const FullTimeRangeSelector: FC<FullTimeRangeSelectorProps> = (props) => 
         frozenDataPreference === FROZEN_TIER_PREFERENCE.EXCLUDE,
         apiPath
       );
-      if (typeof callback === 'function') {
+      if (typeof callback === 'function' && fullTimeRange !== undefined) {
         callback(fullTimeRange);
       }
     } catch (e) {

--- a/x-pack/packages/ml/date_picker/src/services/full_time_range_selector_service.test.ts
+++ b/x-pack/packages/ml/date_picker/src/services/full_time_range_selector_service.test.ts
@@ -1,0 +1,106 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import moment from 'moment';
+
+import type { TimefilterContract } from '@kbn/data-plugin/public';
+import type { DataView } from '@kbn/data-views-plugin/public';
+import type { ToastsStart, HttpStart } from '@kbn/core/public';
+
+import { setFullTimeRange } from './full_time_range_selector_service';
+
+jest.mock('./time_field_range');
+
+import { getTimeFieldRange } from './time_field_range';
+
+const mockParamsFactory = () => ({
+  timefilter: { setTime: jest.fn() } as unknown as TimefilterContract,
+  dataView: { getIndexPattern: jest.fn(), getRuntimeMappings: jest.fn() } as unknown as DataView,
+  toasts: { addWarning: jest.fn(), addDanger: jest.fn() } as unknown as ToastsStart,
+});
+
+describe('setFullTimeRange', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns the full time range based off the file upload endpoint format', async () => {
+    // prepare
+    const { timefilter, dataView, toasts } = mockParamsFactory();
+    (getTimeFieldRange as jest.MockedFunction<any>).mockImplementationOnce(async () => ({
+      success: true,
+      start: { epoch: 1234, string: moment(1234).toISOString() },
+      end: { epoch: 2345, string: moment(2345).toISOString() },
+    }));
+
+    // act
+    const fullTimeRange = await setFullTimeRange(timefilter, dataView, toasts, {} as HttpStart);
+
+    // assert
+    expect(getTimeFieldRange).toHaveBeenCalledTimes(1);
+    expect(fullTimeRange).toStrictEqual({
+      success: true,
+      start: { epoch: 1234, string: '1970-01-01T00:00:01.234Z' },
+      end: { epoch: 2345, string: '1970-01-01T00:00:02.345Z' },
+    });
+  });
+
+  it('returns the full time range based off the ml endpoint format', async () => {
+    // prepare
+    const { timefilter, dataView, toasts } = mockParamsFactory();
+    (getTimeFieldRange as jest.MockedFunction<any>).mockImplementationOnce(async () => ({
+      success: true,
+      start: 1234,
+      end: 2345,
+    }));
+
+    // act
+    const fullTimeRange = await setFullTimeRange(timefilter, dataView, toasts, {} as HttpStart);
+
+    // assert
+    expect(getTimeFieldRange).toHaveBeenCalledTimes(1);
+    expect(fullTimeRange).toStrictEqual({
+      success: true,
+      start: { epoch: 1234, string: '1970-01-01T00:00:01.234Z' },
+      end: { epoch: 2345, string: '1970-01-01T00:00:02.345Z' },
+    });
+  });
+
+  it('returns undefined based off the file upload endpoint format', async () => {
+    // prepare
+    const { timefilter, dataView, toasts } = mockParamsFactory();
+    (getTimeFieldRange as jest.MockedFunction<any>).mockImplementationOnce(async () => ({
+      success: true,
+      start: { epoch: null, string: moment(null).toISOString() },
+      end: { epoch: null, string: moment(null).toISOString() },
+    }));
+
+    // act
+    const fullTimeRange = await setFullTimeRange(timefilter, dataView, toasts, {} as HttpStart);
+
+    // assert
+    expect(getTimeFieldRange).toHaveBeenCalledTimes(1);
+    expect(fullTimeRange).toStrictEqual(undefined);
+  });
+
+  it('returns undefined based off the ml endpoint format', async () => {
+    // prepare
+    const { timefilter, dataView, toasts } = mockParamsFactory();
+    (getTimeFieldRange as jest.MockedFunction<any>).mockImplementationOnce(async () => ({
+      success: true,
+      start: null,
+      end: null,
+    }));
+
+    // act
+    const fullTimeRange = await setFullTimeRange(timefilter, dataView, toasts, {} as HttpStart);
+
+    // assert
+    expect(getTimeFieldRange).toHaveBeenCalledTimes(1);
+    expect(fullTimeRange).toStrictEqual(undefined);
+  });
+});

--- a/x-pack/packages/ml/date_picker/src/services/full_time_range_selector_service.ts
+++ b/x-pack/packages/ml/date_picker/src/services/full_time_range_selector_service.ts
@@ -45,7 +45,7 @@ export async function setFullTimeRange(
   query?: QueryDslQueryContainer,
   excludeFrozenData?: boolean,
   path: SetFullTimeRangeApiPath = '/internal/file_upload/time_field_range'
-): Promise<GetTimeFieldRangeResponse> {
+): Promise<GetTimeFieldRangeResponse | undefined> {
   try {
     const runtimeMappings = dataView.getRuntimeMappings();
     const resp = await getTimeFieldRange({
@@ -62,6 +62,7 @@ export async function setFullTimeRange(
         from: moment(resp.start.epoch).toISOString(),
         to: moment(resp.end.epoch).toISOString(),
       });
+      return resp;
     } else if (typeof resp.start === 'number' && typeof resp.end === 'number') {
       timefilter.setTime({
         from: moment(resp.start).toISOString(),
@@ -79,9 +80,7 @@ export async function setFullTimeRange(
         }),
       });
     }
-
-    return resp;
-  } catch (resp) {
+  } catch (error) {
     toasts.addDanger(
       i18n.translate(
         'xpack.ml.datePicker.fullTimeRangeSelector.errorSettingTimeRangeNotification',
@@ -90,7 +89,6 @@ export async function setFullTimeRange(
         }
       )
     );
-    return resp;
   }
 }
 


### PR DESCRIPTION
## Summary

In certain cases the endpoint to get the full date range may return `{ start: null, end: null }`, for example when querying against a frozen-only index but with the option enabled to exclude the frozen tier. In AIOps we added a callback to push that information to the URL's global state but that would corrupt then the global state with the page crashing.

This PR fixes it with an update to `setFullTimeRange`. The function will now only return the time range if it's fully populated. After that, the `FullTimeRangeSelector` component will only call the callback if it receives such a time range and will skip the callback if `setFullTimeRange` returned `undefined`.

Jest unit tests for `setFullTimeRange` and `FullTimeRangeSelector` have been updated/created to cover both cases with populated time ranges and without.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->