### PR TITLE
[Security Solution] Fix exporting all rules

### DIFF
--- a/x-pack/plugins/security_solution/cypress/e2e/detection_rules/import_rules.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_rules/import_rules.cy.ts
@@ -5,10 +5,9 @@
  * 2.0.
  */
 
-import { RULES_MANAGEMENT_TABLE, TOASTER } from '../../screens/alerts_detection_rules';
+import { TOASTER } from '../../screens/alerts_detection_rules';
 import {
-  expectNumberOfRules,
-  expectToContainRule,
+  expectManagementTableRules,
   importRules,
   importRulesWithOverwriteAll,
 } from '../../tasks/alerts_detection_rules';
@@ -16,6 +15,7 @@ import { cleanKibana, deleteAlertsAndRules, reload } from '../../tasks/common';
 import { login, visitWithoutDateRange } from '../../tasks/login';
 
 import { DETECTIONS_RULE_MANAGEMENT_URL } from '../../urls/navigation';
+const RULES_TO_IMPORT_FILENAME = 'cypress/fixtures/7_16_rules.ndjson';
 
 describe('Import rules', () => {
   before(() => {
@@ -29,10 +29,7 @@ describe('Import rules', () => {
   });
 
   it('Imports a custom rule with exceptions', function () {
-    const expectedNumberOfRules = 1;
-    const expectedImportedRuleName = 'Test Custom Rule';
-
-    importRules('7_16_rules.ndjson');
+    importRules(RULES_TO_IMPORT_FILENAME);
 
     cy.wait('@import').then(({ response }) => {
       cy.wrap(response?.statusCode).should('eql', 200);
@@ -41,20 +38,19 @@ describe('Import rules', () => {
         'Successfully imported 1 ruleSuccessfully imported 1 exception.'
       );
 
-      expectNumberOfRules(RULES_MANAGEMENT_TABLE, expectedNumberOfRules);
-      expectToContainRule(RULES_MANAGEMENT_TABLE, expectedImportedRuleName);
+      expectManagementTableRules(['Test Custom Rule']);
     });
   });
 
   it('Shows error toaster when trying to import rule and exception list that already exist', function () {
-    importRules('7_16_rules.ndjson');
+    importRules(RULES_TO_IMPORT_FILENAME);
 
     cy.wait('@import').then(({ response }) => {
       cy.wrap(response?.statusCode).should('eql', 200);
     });
 
     reload();
-    importRules('7_16_rules.ndjson');
+    importRules(RULES_TO_IMPORT_FILENAME);
 
     cy.wait('@import').then(({ response }) => {
       cy.wrap(response?.statusCode).should('eql', 200);
@@ -63,14 +59,14 @@ describe('Import rules', () => {
   });
 
   it('Does not show error toaster when trying to import rule and exception list that already exist when overwrite is true', function () {
-    importRules('7_16_rules.ndjson');
+    importRules(RULES_TO_IMPORT_FILENAME);
 
     cy.wait('@import').then(({ response }) => {
       cy.wrap(response?.statusCode).should('eql', 200);
     });
 
     reload();
-    importRulesWithOverwriteAll('7_16_rules.ndjson');
+    importRulesWithOverwriteAll(RULES_TO_IMPORT_FILENAME);
 
     cy.wait('@import').then(({ response }) => {
       cy.wrap(response?.statusCode).should('eql', 200);

--- a/x-pack/plugins/security_solution/cypress/e2e/detection_rules/persistent_rules_table_state.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_rules/persistent_rules_table_state.cy.ts
@@ -17,8 +17,6 @@ import {
 } from '../../urls/navigation';
 import { getNewRule } from '../../objects/rule';
 import {
-  expectNumberOfRules,
-  expectToContainRule,
   filterByCustomRules,
   filterBySearchTerm,
   filterByTags,
@@ -35,8 +33,8 @@ import {
   filterByDisabledRules,
   expectFilterByPrebuiltRules,
   expectFilterByEnabledRules,
+  expectManagementTableRules,
 } from '../../tasks/alerts_detection_rules';
-import { RULES_MANAGEMENT_TABLE } from '../../screens/alerts_detection_rules';
 import { createRule } from '../../tasks/api_calls/rules';
 import {
   expectRowsPerPage,
@@ -106,14 +104,6 @@ function expectDefaultRulesTableState(): void {
   expectTableSorting('Enabled', 'desc');
   expectRowsPerPage(20);
   expectTablePage(1);
-}
-
-function expectManagementTableRules(ruleNames: string[]): void {
-  expectNumberOfRules(RULES_MANAGEMENT_TABLE, ruleNames.length);
-
-  for (const ruleName of ruleNames) {
-    expectToContainRule(RULES_MANAGEMENT_TABLE, ruleName);
-  }
 }
 
 describe('Persistent rules table state', () => {

--- a/x-pack/plugins/security_solution/cypress/screens/alerts_detection_rules.ts
+++ b/x-pack/plugins/security_solution/cypress/screens/alerts_detection_rules.ts
@@ -71,6 +71,8 @@ export const RULE_CHECKBOX = '.euiTableRow .euiCheckbox__input';
 
 export const RULE_NAME = '[data-test-subj="ruleName"]';
 
+export const RULE_LAST_RUN = '[data-test-subj="ruleLastRun"]';
+
 export const RULE_SWITCH = '[data-test-subj="ruleSwitch"]';
 
 export const RULE_SWITCH_LOADER = '[data-test-subj="ruleSwitchLoader"]';
@@ -142,6 +144,8 @@ export const RULES_SELECTED_TAG = '.euiSelectableListItem[data-test-selected="tr
 export const SELECTED_RULES_NUMBER_LABEL = '[data-test-subj="selectedRules"]';
 
 export const REFRESH_SETTINGS_POPOVER = '[data-test-subj="refreshSettings-popover"]';
+
+export const REFRESH_RULES_TABLE_BUTTON = '[data-test-subj="refreshRulesAction-linkIcon"]';
 
 export const REFRESH_SETTINGS_SWITCH = '[data-test-subj="refreshSettingsSwitch"]';
 

--- a/x-pack/plugins/security_solution/cypress/tasks/alerts_detection_rules.ts
+++ b/x-pack/plugins/security_solution/cypress/tasks/alerts_detection_rules.ts
@@ -60,6 +60,8 @@ import {
   RULES_MONITORING_TAB,
   ENABLED_RULES_BTN,
   DISABLED_RULES_BTN,
+  REFRESH_RULES_TABLE_BUTTON,
+  RULE_LAST_RUN,
 } from '../screens/alerts_detection_rules';
 import type { RULES_MONITORING_TABLE } from '../screens/alerts_detection_rules';
 import { EUI_CHECKBOX } from '../screens/common/controls';
@@ -162,8 +164,10 @@ export const disableSelectedRules = () => {
   cy.get(DISABLE_RULE_BULK_BTN).click();
 };
 
-export const exportFirstRule = () => {
-  cy.get(COLLAPSED_ACTION_BTN).first().click({ force: true });
+export const exportRule = (name: string) => {
+  cy.log(`Export rule "${name}"`);
+
+  cy.contains(RULE_NAME, name).parents(RULES_ROW).find(COLLAPSED_ACTION_BTN).click();
   cy.get(EXPORT_ACTION_BTN).click();
   cy.get(EXPORT_ACTION_BTN).should('not.exist');
 };
@@ -181,6 +185,19 @@ export const filterByTags = (tags: string[]) => {
   for (const tag of tags) {
     cy.get(RULES_TAGS_FILTER_POPOVER).contains(tag).click();
   }
+};
+
+export const waitForRuleExecution = (name: string) => {
+  cy.log(`Wait for rule "${name}" to be executed`);
+  cy.waitUntil(() => {
+    cy.get(REFRESH_RULES_TABLE_BUTTON).click();
+
+    return cy
+      .contains(RULE_NAME, name)
+      .parents(RULES_ROW)
+      .find(RULE_LAST_RUN)
+      .then(($el) => $el.text().endsWith('ago'));
+  });
 };
 
 export const filterByElasticRules = () => {
@@ -358,7 +375,7 @@ export const checkAutoRefresh = (ms: number, condition: string) => {
 export const importRules = (rulesFile: string) => {
   cy.get(RULE_IMPORT_MODAL).click();
   cy.get(INPUT_FILE).should('exist');
-  cy.get(INPUT_FILE).trigger('click', { force: true }).attachFile(rulesFile).trigger('change');
+  cy.get(INPUT_FILE).trigger('click', { force: true }).selectFile(rulesFile).trigger('change');
   cy.get(RULE_IMPORT_MODAL_BUTTON).last().click({ force: true });
   cy.get(INPUT_FILE).should('not.exist');
 };
@@ -455,6 +472,14 @@ const selectOverwriteRulesImport = () => {
     .should('be.checked');
 };
 
+export const expectManagementTableRules = (ruleNames: string[]): void => {
+  expectNumberOfRules(RULES_MANAGEMENT_TABLE, ruleNames.length);
+
+  for (const ruleName of ruleNames) {
+    expectToContainRule(RULES_MANAGEMENT_TABLE, ruleName);
+  }
+};
+
 const selectOverwriteExceptionsRulesImport = () => {
   cy.get(RULE_IMPORT_OVERWRITE_EXCEPTIONS_CHECKBOX)
     .pipe(($el) => $el.trigger('click'))
@@ -468,7 +493,7 @@ const selectOverwriteConnectorsRulesImport = () => {
 export const importRulesWithOverwriteAll = (rulesFile: string) => {
   cy.get(RULE_IMPORT_MODAL).click();
   cy.get(INPUT_FILE).should('exist');
-  cy.get(INPUT_FILE).trigger('click', { force: true }).attachFile(rulesFile).trigger('change');
+  cy.get(INPUT_FILE).trigger('click', { force: true }).selectFile(rulesFile).trigger('change');
   selectOverwriteRulesImport();
   selectOverwriteExceptionsRulesImport();
   selectOverwriteConnectorsRulesImport();

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/use_columns.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/use_columns.tsx
@@ -278,15 +278,19 @@ export const useRulesColumns = ({
         field: 'execution_summary.last_execution.date',
         name: i18n.COLUMN_LAST_COMPLETE_RUN,
         render: (value: RuleExecutionSummary['last_execution']['date'] | undefined) => {
-          return value == null ? (
-            getEmptyTagValue()
-          ) : (
-            <FormattedRelativePreferenceDate
-              tooltipFieldName={i18n.COLUMN_LAST_COMPLETE_RUN}
-              relativeThresholdInHrs={DEFAULT_RELATIVE_DATE_THRESHOLD}
-              value={value}
-              tooltipAnchorClassName="eui-textTruncate"
-            />
+          return (
+            <EuiFlexGroup data-test-subj="ruleLastRun">
+              {value == null ? (
+                getEmptyTagValue()
+              ) : (
+                <FormattedRelativePreferenceDate
+                  tooltipFieldName={i18n.COLUMN_LAST_COMPLETE_RUN}
+                  relativeThresholdInHrs={DEFAULT_RELATIVE_DATE_THRESHOLD}
+                  value={value}
+                  tooltipAnchorClassName="eui-textTruncate"
+                />
+              )}
+            </EuiFlexGroup>
           );
         },
         sortable: true,
@@ -438,15 +442,19 @@ export const useMonitoringColumns = ({
         field: 'execution_summary.last_execution.date',
         name: i18n.COLUMN_LAST_COMPLETE_RUN,
         render: (value: RuleExecutionSummary['last_execution']['date'] | undefined) => {
-          return value == null ? (
-            getEmptyTagValue()
-          ) : (
-            <FormattedRelativePreferenceDate
-              tooltipFieldName={i18n.COLUMN_LAST_COMPLETE_RUN}
-              relativeThresholdInHrs={DEFAULT_RELATIVE_DATE_THRESHOLD}
-              value={value}
-              tooltipAnchorClassName="eui-textTruncate"
-            />
+          return (
+            <EuiFlexGroup data-test-subj="ruleLastRun">
+              {value == null ? (
+                getEmptyTagValue()
+              ) : (
+                <FormattedRelativePreferenceDate
+                  tooltipFieldName={i18n.COLUMN_LAST_COMPLETE_RUN}
+                  relativeThresholdInHrs={DEFAULT_RELATIVE_DATE_THRESHOLD}
+                  value={value}
+                  tooltipAnchorClassName="eui-textTruncate"
+                />
+              )}
+            </EuiFlexGroup>
           );
         },
         sortable: true,

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/logic/export/get_export_all.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/logic/export/get_export_all.ts
@@ -12,7 +12,7 @@ import type { ExceptionListClient } from '@kbn/lists-plugin/server';
 import type { RulesClient, RuleExecutorServices } from '@kbn/alerting-plugin/server';
 import { getNonPackagedRules } from '../search/get_existing_prepackaged_rules';
 import { getExportDetailsNdjson } from './get_export_details_ndjson';
-import { transformAlertsToRules } from '../../utils/utils';
+import { transformAlertsToRules, transformRuleToExportableFormat } from '../../utils/utils';
 import { getRuleExceptionsForExport } from './get_export_rule_exceptions';
 import { getRuleActionConnectorsForExport } from './get_export_rule_action_connectors';
 
@@ -42,6 +42,7 @@ export const getExportAll = async (
     logger,
   });
   const rules = transformAlertsToRules(ruleAlertTypes, legacyActions);
+  const exportRules = rules.map((r) => transformRuleToExportableFormat(r));
 
   // Gather exceptions
   const exceptions = rules.flatMap((rule) => rule.exceptions_list ?? []);
@@ -55,7 +56,7 @@ export const getExportAll = async (
     request
   );
 
-  const rulesNdjson = transformDataToNdjson(rules);
+  const rulesNdjson = transformDataToNdjson(exportRules);
   const exportDetails = getExportDetailsNdjson(rules, [], exceptionDetails, actionConnectorDetails);
 
   return { rulesNdjson, exportDetails, exceptionLists, actionConnectors };

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/logic/export/get_export_by_object_ids.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/logic/export/get_export_by_object_ids.ts
@@ -17,6 +17,7 @@ import { getExportDetailsNdjson } from './get_export_details_ndjson';
 
 import { isAlertType } from '../../../rule_schema';
 import { findRules } from '../search/find_rules';
+import { transformRuleToExportableFormat } from '../../utils/utils';
 import { getRuleExceptionsForExport } from './get_export_rule_exceptions';
 import { getRuleActionConnectorsForExport } from './get_export_rule_action_connectors';
 
@@ -133,14 +134,11 @@ export const getRulesFromObjects = async (
       isAlertType(matchingRule) &&
       matchingRule.params.immutable !== true
     ) {
-      const rule = internalRuleToAPIResponse(matchingRule, legacyActions[matchingRule.id]);
-
-      // Fields containing runtime information shouldn't be exported. It causes import failures.
-      delete rule.execution_summary;
-
       return {
         statusCode: 200,
-        rule,
+        rule: transformRuleToExportableFormat(
+          internalRuleToAPIResponse(matchingRule, legacyActions[matchingRule.id])
+        ),
       };
     } else {
       return {

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/utils/utils.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/utils/utils.ts
@@ -98,6 +98,23 @@ export const transformAlertsToRules = (
   return rules.map((rule) => internalRuleToAPIResponse(rule, legacyRuleActions[rule.id]));
 };
 
+/**
+ * Transforms a rule object to exportable format. Exportable format shouldn't contain runtime fields like
+ * `execution_summary`
+ */
+export const transformRuleToExportableFormat = (
+  rule: RuleResponse
+): Omit<RuleResponse, 'execution_summary'> => {
+  const exportedRule = {
+    ...rule,
+  };
+
+  // Fields containing runtime information shouldn't be exported. It causes import failures.
+  delete exportedRule.execution_summary;
+
+  return exportedRule;
+};
+
 export const transformFindAlerts = (
   ruleFindResults: FindResult<RuleParams>,
   legacyRuleActions: Record<string, LegacyRulesActionsSavedObject | undefined>

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/group1/export_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/group1/export_rules.ts
@@ -26,7 +26,6 @@ import {
 // eslint-disable-next-line import/no-default-export
 export default ({ getService }: FtrProviderContext): void => {
   const supertest = getService('supertest');
-  const es = getService('es');
   const log = getService('log');
 
   describe('export_rules', () => {

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/group1/export_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/group1/export_rules.ts
@@ -20,7 +20,6 @@ import {
   getSimpleRuleOutput,
   getWebHookAction,
   removeServerGeneratedProperties,
-  waitForEventLogExecuteComplete,
   waitForRuleSuccessOrStatus,
 } from '../../utils';
 
@@ -68,7 +67,7 @@ export default ({ getService }: FtrProviderContext): void => {
         // ES Search API may return outdated data
         // it causes a reliable delay so exported rule's SO contains runtime fields returned via ES Search API
         // and will be removed after addressing this issue
-        await waitForEventLogExecuteComplete(es, log, rule.id);
+        await new Promise((r) => setTimeout(r, 1000));
 
         const { body } = await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_export`)
@@ -107,8 +106,7 @@ export default ({ getService }: FtrProviderContext): void => {
         // ES Search API may return outdated data
         // it causes a reliable delay so exported rule's SO contains runtime fields returned via ES Search API
         // and will be removed after addressing this issue
-        await waitForEventLogExecuteComplete(es, log, rule1.id);
-        await waitForEventLogExecuteComplete(es, log, rule2.id);
+        await new Promise((r) => setTimeout(r, 1000));
 
         const { body } = await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_export`)

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/group1/export_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/group1/export_rules.ts
@@ -608,7 +608,7 @@ function expectToMatchRuleSchema(obj: unknown): void {
     author: expect.arrayContaining([]),
     false_positives: expect.arrayContaining([]),
     from: expect.any(String),
-    max_signals: 100,
+    max_signals: expect.any(Number),
     risk_score_mapping: expect.arrayContaining([]),
     severity_mapping: expect.arrayContaining([]),
     threat: expect.arrayContaining([]),


### PR DESCRIPTION
**Relates to:** https://github.com/elastic/security-team/issues/5339, https://github.com/elastic/kibana/pull/150097, https://github.com/elastic/kibana/pull/150553

## Summary

This PR fixes all rules exporting functionality which started exporting unintentionally runtime fields like `execution_summary`. This way it lead to inability to import just exported rules if as minimum one of them executed just once.

On top of this the PR contains functional and Cypress tests to cover the fix.

## TODO

- [x] get rid of an 1 second wait time after `await waitForRuleSuccessOrStatus()` in functional tests (done in https://github.com/elastic/kibana/pull/153410)
- [ ] allow `getNewRule()` to rewrite its defaults

### Checklist

- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->