### PR TITLE
[Profiling] Adding tabs back

### DIFF
--- a/x-pack/plugins/profiling/public/components/profiling_app_page_template/index.tsx
+++ b/x-pack/plugins/profiling/public/components/profiling_app_page_template/index.tsx
@@ -82,6 +82,7 @@ export function ProfilingAppPageTemplate({
             </EuiFlexItem>
           </EuiFlexGroup>
         ),
+        tabs,
       }}
       restrictWidth={restrictWidth}
       pageSectionProps={{


### PR DESCRIPTION
The tabs were accidentally removed on this PR https://github.com/elastic/kibana/commit/c184ebf83ac3e0dce102931fa69e61e91b26e3b6#diff-2ec64b4bf09370503d267466862b40dce88c2a7b8d69a40d99c879103bcf72d4R56

Adding it back.
<img width="475" alt="Screenshot 2023-03-08 at 10 00 25 AM" src="https://user-images.githubusercontent.com/55978943/223748524-1a50e748-81b9-4c5b-b859-4a4966fe1f4f.png">
<img width="656" alt="Screenshot 2023-03-08 at 10 00 30 AM" src="https://user-images.githubusercontent.com/55978943/223748528-f46a686f-18d0-4847-840e-f1be7dd50c38.png">


One more reason why we must add e2e test ASAP. 
cc: @sboomsma 