### PR TITLE
[Enterprise Search]: Engines - parse field capabilities

### DIFF
--- a/x-pack/plugins/enterprise_search/common/types/engines.ts
+++ b/x-pack/plugins/enterprise_search/common/types/engines.ts
@@ -55,7 +55,7 @@ export interface SchemaFieldIndex {
 }
 
 export interface SchemaField {
-  fields?: SchemaField[];
+  fields: SchemaField[];
   indices: SchemaFieldIndex[];
   name: string;
   type: string;

--- a/x-pack/plugins/enterprise_search/common/types/engines.ts
+++ b/x-pack/plugins/enterprise_search/common/types/engines.ts
@@ -40,10 +40,24 @@ export interface EnterpriseSearchEngineIndex {
 export interface EnterpriseSearchEngineFieldCapabilities {
   created: string;
   field_capabilities: FieldCapsResponse;
+  fields?: SchemaField[];
   name: string;
   updated: string;
 }
 export interface EnterpriseSearchSchemaField {
   field_name: string;
   field_type: string[];
+}
+
+export interface SchemaFieldIndex {
+  name: string;
+  type: string;
+}
+
+// TODO: This should replace EnterpriseSearchSchemaField once parseFieldsCapabilities is ready
+export interface SchemaField {
+  fields?: SchemaField[];
+  indices: SchemaFieldIndex[];
+  name: string;
+  type: string;
 }

--- a/x-pack/plugins/enterprise_search/common/types/engines.ts
+++ b/x-pack/plugins/enterprise_search/common/types/engines.ts
@@ -13,7 +13,7 @@ export interface EnterpriseSearchEnginesResponse {
     size: number;
     total: number;
   };
-  params: { q?: string; from: number; size: number };
+  params: { from: number; q?: string; size: number };
   results: EnterpriseSearchEngine[];
 }
 
@@ -54,7 +54,6 @@ export interface SchemaFieldIndex {
   type: string;
 }
 
-// TODO: This should replace EnterpriseSearchSchemaField once parseFieldsCapabilities is ready
 export interface SchemaField {
   fields?: SchemaField[];
   indices: SchemaFieldIndex[];

--- a/x-pack/plugins/enterprise_search/server/lib/engines/field_capabilities.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/engines/field_capabilities.test.ts
@@ -8,9 +8,9 @@
 import { FieldCapsResponse } from '@elastic/elasticsearch/lib/api/types';
 import { IScopedClusterClient } from '@kbn/core-elasticsearch-server';
 
-import { EnterpriseSearchEngineDetails } from '../../../common/types/engines';
+import { EnterpriseSearchEngineDetails, SchemaField } from '../../../common/types/engines';
 
-import { fetchEngineFieldCapabilities } from './field_capabilities';
+import { fetchEngineFieldCapabilities, parseFieldsCapabilities } from './field_capabilities';
 
 describe('engines field_capabilities', () => {
   const mockClient = {
@@ -29,24 +29,940 @@ describe('engines field_capabilities', () => {
     jest.clearAllMocks();
   });
 
-  it('gets engine alias field capabilities', async () => {
-    const fieldCapsResponse = {} as FieldCapsResponse;
+  describe('fetchEngineFieldCapabilities', () => {
+    it('gets engine alias field capabilities', async () => {
+      const fieldCapsResponse: FieldCapsResponse = {
+        fields: {
+          body: {
+            text: {
+              aggregatable: false,
+              metadata_field: false,
+              searchable: true,
+              type: 'text',
+            },
+          },
+        },
+        indices: ['index-001'],
+      };
 
-    mockClient.asCurrentUser.fieldCaps.mockResolvedValueOnce(fieldCapsResponse);
-    await expect(
-      fetchEngineFieldCapabilities(mockClient as unknown as IScopedClusterClient, mockEngine)
-    ).resolves.toEqual({
-      created: mockEngine.created,
-      field_capabilities: fieldCapsResponse,
-      name: mockEngine.name,
-      updated: mockEngine.updated,
+      mockClient.asCurrentUser.fieldCaps.mockResolvedValueOnce(fieldCapsResponse);
+      await expect(
+        fetchEngineFieldCapabilities(mockClient as unknown as IScopedClusterClient, mockEngine)
+      ).resolves.toEqual({
+        created: mockEngine.created,
+        field_capabilities: fieldCapsResponse,
+        fields: [
+          {
+            indices: [
+              {
+                name: 'index-001',
+                type: 'text',
+              },
+            ],
+            name: 'body',
+            type: 'text',
+          },
+        ],
+        name: mockEngine.name,
+        updated: mockEngine.updated,
+      });
+
+      expect(mockClient.asCurrentUser.fieldCaps).toHaveBeenCalledTimes(1);
+      expect(mockClient.asCurrentUser.fieldCaps).toHaveBeenCalledWith({
+        fields: '*',
+        include_unmapped: true,
+        index: 'search-engine-unit-test-engine',
+      });
     });
+  });
 
-    expect(mockClient.asCurrentUser.fieldCaps).toHaveBeenCalledTimes(1);
-    expect(mockClient.asCurrentUser.fieldCaps).toHaveBeenCalledWith({
-      fields: '*',
-      include_unmapped: true,
-      index: 'search-engine-unit-test-engine',
+  describe('parseFieldsCapabilities', () => {
+    it('parse field capabilities to a list of fields', () => {
+      const fieldCapabilities: FieldCapsResponse = {
+        fields: {
+          body: {
+            text: {
+              aggregatable: false,
+              metadata_field: false,
+              searchable: true,
+              type: 'text',
+            },
+          },
+          views: {
+            number: {
+              aggregatable: false,
+              metadata_field: false,
+              searchable: false,
+              type: 'number',
+            },
+          },
+        },
+        indices: ['index-001'],
+      };
+      const expectedFields: SchemaField[] = [
+        {
+          indices: [
+            {
+              name: 'index-001',
+              type: 'text',
+            },
+          ],
+          name: 'body',
+          type: 'text',
+        },
+        {
+          indices: [
+            {
+              name: 'index-001',
+              type: 'number',
+            },
+          ],
+          name: 'views',
+          type: 'number',
+        },
+      ];
+      expect(parseFieldsCapabilities(fieldCapabilities)).toEqual(expectedFields);
+    });
+    it('handles multi-fields', () => {
+      const fieldCapabilities: FieldCapsResponse = {
+        fields: {
+          body: {
+            text: {
+              aggregatable: false,
+              metadata_field: false,
+              searchable: true,
+              type: 'text',
+            },
+          },
+          'body.keyword': {
+            keyword: {
+              aggregatable: true,
+              metadata_field: false,
+              searchable: true,
+              type: 'keyword',
+            },
+          },
+        },
+        indices: ['index-001'],
+      };
+      const expectedFields: SchemaField[] = [
+        {
+          fields: [
+            {
+              indices: [
+                {
+                  name: 'index-001',
+                  type: 'keyword',
+                },
+              ],
+              name: 'keyword',
+              type: 'keyword',
+            },
+          ],
+          indices: [
+            {
+              name: 'index-001',
+              type: 'text',
+            },
+          ],
+          name: 'body',
+          type: 'text',
+        },
+      ];
+      expect(parseFieldsCapabilities(fieldCapabilities)).toEqual(expectedFields);
+    });
+    it('handles object fields', () => {
+      const fieldCapabilities: FieldCapsResponse = {
+        fields: {
+          name: {
+            object: {
+              aggregatable: false,
+              metadata_field: false,
+              searchable: false,
+              type: 'object',
+            },
+          },
+          'name.first': {
+            text: {
+              aggregatable: false,
+              metadata_field: false,
+              searchable: true,
+              type: 'text',
+            },
+          },
+          'name.last': {
+            text: {
+              aggregatable: false,
+              metadata_field: false,
+              searchable: true,
+              type: 'text',
+            },
+          },
+        },
+        indices: ['index-001'],
+      };
+      const expectedFields: SchemaField[] = [
+        {
+          fields: [
+            {
+              indices: [
+                {
+                  name: 'index-001',
+                  type: 'text',
+                },
+              ],
+              name: 'first',
+              type: 'text',
+            },
+            {
+              indices: [
+                {
+                  name: 'index-001',
+                  type: 'text',
+                },
+              ],
+              name: 'last',
+              type: 'text',
+            },
+          ],
+          indices: [
+            {
+              name: 'index-001',
+              type: 'object',
+            },
+          ],
+          name: 'name',
+          type: 'object',
+        },
+      ];
+      expect(parseFieldsCapabilities(fieldCapabilities)).toEqual(expectedFields);
+    });
+    it('handles nested fields', () => {
+      const fieldCapabilities: FieldCapsResponse = {
+        fields: {
+          name: {
+            nested: {
+              aggregatable: false,
+              metadata_field: false,
+              searchable: false,
+              type: 'nested',
+            },
+          },
+          'name.first': {
+            text: {
+              aggregatable: false,
+              metadata_field: false,
+              searchable: true,
+              type: 'text',
+            },
+          },
+          'name.last': {
+            text: {
+              aggregatable: false,
+              metadata_field: false,
+              searchable: true,
+              type: 'text',
+            },
+          },
+        },
+        indices: ['index-001'],
+      };
+      const expectedFields: SchemaField[] = [
+        {
+          fields: [
+            {
+              indices: [
+                {
+                  name: 'index-001',
+                  type: 'text',
+                },
+              ],
+              name: 'first',
+              type: 'text',
+            },
+            {
+              indices: [
+                {
+                  name: 'index-001',
+                  type: 'text',
+                },
+              ],
+              name: 'last',
+              type: 'text',
+            },
+          ],
+          indices: [
+            {
+              name: 'index-001',
+              type: 'nested',
+            },
+          ],
+          name: 'name',
+          type: 'nested',
+        },
+      ];
+      expect(parseFieldsCapabilities(fieldCapabilities)).toEqual(expectedFields);
+    });
+    it('handles unmapped fields', () => {
+      const fieldCapabilities: FieldCapsResponse = {
+        fields: {
+          body: {
+            text: {
+              aggregatable: false,
+              indices: ['index-001'],
+              metadata_field: false,
+              searchable: true,
+              type: 'text',
+            },
+            unmapped: {
+              aggregatable: false,
+              indices: ['index-002'],
+              metadata_field: false,
+              searchable: true,
+              type: 'unmapped',
+            },
+          },
+        },
+        indices: ['index-001', 'index-002'],
+      };
+      const expectedFields: SchemaField[] = [
+        {
+          indices: [
+            {
+              name: 'index-001',
+              type: 'text',
+            },
+            {
+              name: 'index-002',
+              type: 'unmapped',
+            },
+          ],
+          name: 'body',
+          type: 'text',
+        },
+      ];
+      expect(parseFieldsCapabilities(fieldCapabilities)).toEqual(expectedFields);
+    });
+    it('handles conflicts in top-level fields', () => {
+      const fieldCapabilities: FieldCapsResponse = {
+        fields: {
+          name: {
+            object: {
+              aggregatable: false,
+              indices: ['index-002'],
+              metadata_field: false,
+              searchable: false,
+              type: 'object',
+            },
+            text: {
+              aggregatable: false,
+              indices: ['index-001'],
+              metadata_field: false,
+              searchable: true,
+              type: 'text',
+            },
+          },
+          'name.first': {
+            text: {
+              aggregatable: false,
+              indices: ['index-002'],
+              metadata_field: false,
+              searchable: true,
+              type: 'text',
+            },
+            unmapped: {
+              aggregatable: false,
+              indices: ['index-001'],
+              metadata_field: false,
+              searchable: true,
+              type: 'unmapped',
+            },
+          },
+          'name.last': {
+            text: {
+              aggregatable: false,
+              indices: ['index-002'],
+              metadata_field: false,
+              searchable: true,
+              type: 'text',
+            },
+            unmapped: {
+              aggregatable: false,
+              indices: ['index-001'],
+              metadata_field: false,
+              searchable: true,
+              type: 'unmapped',
+            },
+          },
+        },
+        indices: ['index-001', 'index-002'],
+      };
+      const expectedFields: SchemaField[] = [
+        {
+          fields: [
+            {
+              indices: [
+                {
+                  name: 'index-002',
+                  type: 'text',
+                },
+                {
+                  name: 'index-001',
+                  type: 'unmapped',
+                },
+              ],
+              name: 'first',
+              type: 'text',
+            },
+            {
+              indices: [
+                {
+                  name: 'index-002',
+                  type: 'text',
+                },
+                {
+                  name: 'index-001',
+                  type: 'unmapped',
+                },
+              ],
+              name: 'last',
+              type: 'text',
+            },
+          ],
+          indices: [
+            {
+              name: 'index-002',
+              type: 'object',
+            },
+            {
+              name: 'index-001',
+              type: 'text',
+            },
+          ],
+          name: 'name',
+          type: 'conflict',
+        },
+      ];
+      expect(parseFieldsCapabilities(fieldCapabilities)).toEqual(expectedFields);
+    });
+    it('handles conflicts  & unmapped fields together', () => {
+      const fieldCapabilities: FieldCapsResponse = {
+        fields: {
+          body: {
+            text: {
+              aggregatable: false,
+              indices: ['index-003'],
+              metadata_field: false,
+              searchable: true,
+              type: 'text',
+            },
+            unmapped: {
+              aggregatable: false,
+              indices: ['index-001', 'index-002'],
+              metadata_field: false,
+              searchable: true,
+              type: 'unmapped',
+            },
+          },
+          name: {
+            object: {
+              aggregatable: false,
+              indices: ['index-002'],
+              metadata_field: false,
+              searchable: false,
+              type: 'object',
+            },
+            text: {
+              aggregatable: false,
+              indices: ['index-001'],
+              metadata_field: false,
+              searchable: true,
+              type: 'text',
+            },
+            unmapped: {
+              aggregatable: false,
+              indices: ['index-003'],
+              metadata_field: false,
+              searchable: true,
+              type: 'unmapped',
+            },
+          },
+          'name.first': {
+            text: {
+              aggregatable: false,
+              indices: ['index-002'],
+              metadata_field: false,
+              searchable: true,
+              type: 'text',
+            },
+            unmapped: {
+              aggregatable: false,
+              indices: ['index-001', 'index-003'],
+              metadata_field: false,
+              searchable: true,
+              type: 'unmapped',
+            },
+          },
+          'name.last': {
+            text: {
+              aggregatable: false,
+              indices: ['index-002'],
+              metadata_field: false,
+              searchable: true,
+              type: 'text',
+            },
+            unmapped: {
+              aggregatable: false,
+              indices: ['index-001', 'index-003'],
+              metadata_field: false,
+              searchable: true,
+              type: 'unmapped',
+            },
+          },
+        },
+        indices: ['index-001', 'index-002', 'index-003'],
+      };
+      const expectedFields: SchemaField[] = [
+        {
+          indices: [
+            {
+              name: 'index-003',
+              type: 'text',
+            },
+            {
+              name: 'index-001',
+              type: 'unmapped',
+            },
+            {
+              name: 'index-002',
+              type: 'unmapped',
+            },
+          ],
+          name: 'body',
+          type: 'text',
+        },
+        {
+          fields: [
+            {
+              indices: [
+                {
+                  name: 'index-002',
+                  type: 'text',
+                },
+                {
+                  name: 'index-001',
+                  type: 'unmapped',
+                },
+                {
+                  name: 'index-003',
+                  type: 'unmapped',
+                },
+              ],
+              name: 'first',
+              type: 'text',
+            },
+            {
+              indices: [
+                {
+                  name: 'index-002',
+                  type: 'text',
+                },
+                {
+                  name: 'index-001',
+                  type: 'unmapped',
+                },
+                {
+                  name: 'index-003',
+                  type: 'unmapped',
+                },
+              ],
+              name: 'last',
+              type: 'text',
+            },
+          ],
+          indices: [
+            {
+              name: 'index-002',
+              type: 'object',
+            },
+            {
+              name: 'index-001',
+              type: 'text',
+            },
+            {
+              name: 'index-003',
+              type: 'unmapped',
+            },
+          ],
+          name: 'name',
+          type: 'conflict',
+        },
+      ];
+      expect(parseFieldsCapabilities(fieldCapabilities)).toEqual(expectedFields);
+    });
+    it('handles unmapped sub-fields in object fields', () => {
+      const fieldCapabilities: FieldCapsResponse = {
+        fields: {
+          name: {
+            object: {
+              aggregatable: false,
+              metadata_field: false,
+              searchable: false,
+              type: 'object',
+            },
+          },
+          'name.first': {
+            text: {
+              aggregatable: false,
+              metadata_field: false,
+              searchable: true,
+              type: 'text',
+            },
+          },
+          'name.last': {
+            text: {
+              aggregatable: false,
+              indices: ['index-001'],
+              metadata_field: false,
+              searchable: true,
+              type: 'text',
+            },
+            unmapped: {
+              aggregatable: false,
+              indices: ['index-002'],
+              metadata_field: false,
+              searchable: true,
+              type: 'unmapped',
+            },
+          },
+        },
+        indices: ['index-001', 'index-002'],
+      };
+      const expectedFields: SchemaField[] = [
+        {
+          fields: [
+            {
+              indices: [
+                {
+                  name: 'index-001',
+                  type: 'text',
+                },
+                {
+                  name: 'index-002',
+                  type: 'text',
+                },
+              ],
+              name: 'first',
+              type: 'text',
+            },
+            {
+              indices: [
+                {
+                  name: 'index-001',
+                  type: 'text',
+                },
+                {
+                  name: 'index-002',
+                  type: 'unmapped',
+                },
+              ],
+              name: 'last',
+              type: 'text',
+            },
+          ],
+          indices: [
+            {
+              name: 'index-001',
+              type: 'object',
+            },
+            {
+              name: 'index-002',
+              type: 'object',
+            },
+          ],
+          name: 'name',
+          type: 'object',
+        },
+      ];
+      expect(parseFieldsCapabilities(fieldCapabilities)).toEqual(expectedFields);
+    });
+    it('handles unmapped sub-fields in  nested fields', () => {
+      const fieldCapabilities: FieldCapsResponse = {
+        fields: {
+          name: {
+            nested: {
+              aggregatable: false,
+              metadata_field: false,
+              searchable: false,
+              type: 'nested',
+            },
+          },
+          'name.first': {
+            text: {
+              aggregatable: false,
+              metadata_field: false,
+              searchable: true,
+              type: 'text',
+            },
+          },
+          'name.last': {
+            text: {
+              aggregatable: false,
+              indices: ['index-001'],
+              metadata_field: false,
+              searchable: true,
+              type: 'text',
+            },
+            unmapped: {
+              aggregatable: false,
+              indices: ['index-002'],
+              metadata_field: false,
+              searchable: true,
+              type: 'unmapped',
+            },
+          },
+        },
+        indices: ['index-001', 'index-002'],
+      };
+      const expectedFields: SchemaField[] = [
+        {
+          fields: [
+            {
+              indices: [
+                {
+                  name: 'index-001',
+                  type: 'text',
+                },
+                {
+                  name: 'index-002',
+                  type: 'text',
+                },
+              ],
+              name: 'first',
+              type: 'text',
+            },
+            {
+              indices: [
+                {
+                  name: 'index-001',
+                  type: 'text',
+                },
+                {
+                  name: 'index-002',
+                  type: 'unmapped',
+                },
+              ],
+              name: 'last',
+              type: 'text',
+            },
+          ],
+          indices: [
+            {
+              name: 'index-001',
+              type: 'nested',
+            },
+            {
+              name: 'index-002',
+              type: 'nested',
+            },
+          ],
+          name: 'name',
+          type: 'nested',
+        },
+      ];
+      expect(parseFieldsCapabilities(fieldCapabilities)).toEqual(expectedFields);
+    });
+    it('handles unmapped multi fields', () => {
+      const fieldCapabilities: FieldCapsResponse = {
+        fields: {
+          body: {
+            text: {
+              aggregatable: false,
+              metadata_field: false,
+              searchable: true,
+              type: 'text',
+            },
+          },
+          'body.keyword': {
+            keyword: {
+              aggregatable: true,
+              indices: ['index-001'],
+              metadata_field: false,
+              searchable: true,
+              type: 'keyword',
+            },
+            unmapped: {
+              aggregatable: false,
+              indices: ['index-002'],
+              metadata_field: false,
+              searchable: true,
+              type: 'unmapped',
+            },
+          },
+        },
+        indices: ['index-001', 'index-002'],
+      };
+      const expectedFields: SchemaField[] = [
+        {
+          fields: [
+            {
+              indices: [
+                {
+                  name: 'index-001',
+                  type: 'keyword',
+                },
+                {
+                  name: 'index-002',
+                  type: 'unmapped',
+                },
+              ],
+              name: 'keyword',
+              type: 'keyword',
+            },
+          ],
+          indices: [
+            {
+              name: 'index-001',
+              type: 'text',
+            },
+            {
+              name: 'index-002',
+              type: 'text',
+            },
+          ],
+          name: 'body',
+          type: 'text',
+        },
+      ];
+      expect(parseFieldsCapabilities(fieldCapabilities)).toEqual(expectedFields);
+    });
+    it('handles conflicts in object fields', () => {
+      const fieldCapabilities: FieldCapsResponse = {
+        fields: {
+          order: {
+            object: {
+              aggregatable: false,
+              metadata_field: false,
+              searchable: false,
+              type: 'object',
+            },
+          },
+          'order.id': {
+            number: {
+              aggregatable: false,
+              indices: ['index-002'],
+              metadata_field: false,
+              searchable: false,
+              type: 'number',
+            },
+            text: {
+              aggregatable: false,
+              indices: ['index-001'],
+              metadata_field: false,
+              searchable: true,
+              type: 'text',
+            },
+          },
+        },
+        indices: ['index-001', 'index-002'],
+      };
+      const expectedFields: SchemaField[] = [
+        {
+          fields: [
+            {
+              indices: [
+                {
+                  name: 'index-002',
+                  type: 'number',
+                },
+                {
+                  name: 'index-001',
+                  type: 'text',
+                },
+              ],
+              name: 'id',
+              type: 'conflict',
+            },
+          ],
+          indices: [
+            {
+              name: 'index-001',
+              type: 'object',
+            },
+            {
+              name: 'index-002',
+              type: 'object',
+            },
+          ],
+          name: 'order',
+          type: 'object', // Should this be 'conflict' too?
+        },
+      ];
+      expect(parseFieldsCapabilities(fieldCapabilities)).toEqual(expectedFields);
+    });
+    it('handles conflicts in nested fields', () => {
+      const fieldCapabilities: FieldCapsResponse = {
+        fields: {
+          order: {
+            nested: {
+              aggregatable: false,
+              metadata_field: false,
+              searchable: false,
+              type: 'nested',
+            },
+          },
+          'order.id': {
+            number: {
+              aggregatable: false,
+              indices: ['index-002'],
+              metadata_field: false,
+              searchable: false,
+              type: 'number',
+            },
+            text: {
+              aggregatable: false,
+              indices: ['index-001'],
+              metadata_field: false,
+              searchable: true,
+              type: 'text',
+            },
+          },
+        },
+        indices: ['index-001', 'index-002'],
+      };
+      const expectedFields: SchemaField[] = [
+        {
+          fields: [
+            {
+              indices: [
+                {
+                  name: 'index-002',
+                  type: 'number',
+                },
+                {
+                  name: 'index-001',
+                  type: 'text',
+                },
+              ],
+              name: 'id',
+              type: 'conflict',
+            },
+          ],
+          indices: [
+            {
+              name: 'index-001',
+              type: 'nested',
+            },
+            {
+              name: 'index-002',
+              type: 'nested',
+            },
+          ],
+          name: 'order',
+          type: 'nested', // Should this be 'conflict' too?
+        },
+      ];
+      expect(parseFieldsCapabilities(fieldCapabilities)).toEqual(expectedFields);
     });
   });
 });

--- a/x-pack/plugins/enterprise_search/server/lib/engines/field_capabilities.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/engines/field_capabilities.test.ts
@@ -53,6 +53,7 @@ describe('engines field_capabilities', () => {
         field_capabilities: fieldCapsResponse,
         fields: [
           {
+            fields: [],
             indices: [
               {
                 name: 'index-001',
@@ -101,6 +102,7 @@ describe('engines field_capabilities', () => {
       };
       const expectedFields: SchemaField[] = [
         {
+          fields: [],
           indices: [
             {
               name: 'index-001',
@@ -111,6 +113,7 @@ describe('engines field_capabilities', () => {
           type: 'text',
         },
         {
+          fields: [],
           indices: [
             {
               name: 'index-001',
@@ -149,6 +152,7 @@ describe('engines field_capabilities', () => {
         {
           fields: [
             {
+              fields: [],
               indices: [
                 {
                   name: 'index-001',
@@ -205,6 +209,7 @@ describe('engines field_capabilities', () => {
         {
           fields: [
             {
+              fields: [],
               indices: [
                 {
                   name: 'index-001',
@@ -215,6 +220,7 @@ describe('engines field_capabilities', () => {
               type: 'text',
             },
             {
+              fields: [],
               indices: [
                 {
                   name: 'index-001',
@@ -271,6 +277,7 @@ describe('engines field_capabilities', () => {
         {
           fields: [
             {
+              fields: [],
               indices: [
                 {
                   name: 'index-001',
@@ -281,6 +288,7 @@ describe('engines field_capabilities', () => {
               type: 'text',
             },
             {
+              fields: [],
               indices: [
                 {
                   name: 'index-001',
@@ -327,6 +335,7 @@ describe('engines field_capabilities', () => {
       };
       const expectedFields: SchemaField[] = [
         {
+          fields: [],
           indices: [
             {
               name: 'index-001',
@@ -401,6 +410,7 @@ describe('engines field_capabilities', () => {
         {
           fields: [
             {
+              fields: [],
               indices: [
                 {
                   name: 'index-002',
@@ -415,6 +425,7 @@ describe('engines field_capabilities', () => {
               type: 'text',
             },
             {
+              fields: [],
               indices: [
                 {
                   name: 'index-002',
@@ -437,6 +448,126 @@ describe('engines field_capabilities', () => {
             {
               name: 'index-001',
               type: 'text',
+            },
+          ],
+          name: 'name',
+          type: 'conflict',
+        },
+      ];
+      expect(parseFieldsCapabilities(fieldCapabilities)).toEqual(expectedFields);
+    });
+    it('handles conflicts of more than two indices', () => {
+      const fieldCapabilities: FieldCapsResponse = {
+        fields: {
+          name: {
+            keyword: {
+              aggregatable: false,
+              indices: ['index-003'],
+              metadata_field: false,
+              searchable: true,
+              type: 'keyword',
+            },
+            object: {
+              aggregatable: false,
+              indices: ['index-002'],
+              metadata_field: false,
+              searchable: false,
+              type: 'object',
+            },
+            text: {
+              aggregatable: false,
+              indices: ['index-001'],
+              metadata_field: false,
+              searchable: true,
+              type: 'text',
+            },
+          },
+          'name.first': {
+            text: {
+              aggregatable: false,
+              indices: ['index-002', 'index-003'],
+              metadata_field: false,
+              searchable: true,
+              type: 'text',
+            },
+            unmapped: {
+              aggregatable: false,
+              indices: ['index-001'],
+              metadata_field: false,
+              searchable: true,
+              type: 'unmapped',
+            },
+          },
+          'name.last': {
+            text: {
+              aggregatable: false,
+              indices: ['index-002'],
+              metadata_field: false,
+              searchable: true,
+              type: 'text',
+            },
+            unmapped: {
+              aggregatable: false,
+              indices: ['index-001'],
+              metadata_field: false,
+              searchable: true,
+              type: 'unmapped',
+            },
+          },
+        },
+        indices: ['index-001', 'index-002', 'index-003'],
+      };
+
+      const expectedFields: SchemaField[] = [
+        {
+          fields: [
+            {
+              fields: [],
+              indices: [
+                {
+                  name: 'index-002',
+                  type: 'text',
+                },
+                {
+                  name: 'index-003',
+                  type: 'text',
+                },
+                {
+                  name: 'index-001',
+                  type: 'unmapped',
+                },
+              ],
+              name: 'first',
+              type: 'text',
+            },
+            {
+              fields: [],
+              indices: [
+                {
+                  name: 'index-002',
+                  type: 'text',
+                },
+                {
+                  name: 'index-001',
+                  type: 'unmapped',
+                },
+              ],
+              name: 'last',
+              type: 'text',
+            },
+          ],
+          indices: [
+            {
+              name: 'index-002',
+              type: 'object',
+            },
+            {
+              name: 'index-001',
+              type: 'text',
+            },
+            {
+              name: 'index-003',
+              type: 'keyword',
             },
           ],
           name: 'name',
@@ -524,6 +655,7 @@ describe('engines field_capabilities', () => {
       };
       const expectedFields: SchemaField[] = [
         {
+          fields: [],
           indices: [
             {
               name: 'index-003',
@@ -544,6 +676,7 @@ describe('engines field_capabilities', () => {
         {
           fields: [
             {
+              fields: [],
               indices: [
                 {
                   name: 'index-002',
@@ -562,6 +695,7 @@ describe('engines field_capabilities', () => {
               type: 'text',
             },
             {
+              fields: [],
               indices: [
                 {
                   name: 'index-002',
@@ -642,6 +776,7 @@ describe('engines field_capabilities', () => {
         {
           fields: [
             {
+              fields: [],
               indices: [
                 {
                   name: 'index-001',
@@ -656,6 +791,7 @@ describe('engines field_capabilities', () => {
               type: 'text',
             },
             {
+              fields: [],
               indices: [
                 {
                   name: 'index-001',
@@ -728,6 +864,7 @@ describe('engines field_capabilities', () => {
         {
           fields: [
             {
+              fields: [],
               indices: [
                 {
                   name: 'index-001',
@@ -742,6 +879,7 @@ describe('engines field_capabilities', () => {
               type: 'text',
             },
             {
+              fields: [],
               indices: [
                 {
                   name: 'index-001',
@@ -806,6 +944,7 @@ describe('engines field_capabilities', () => {
         {
           fields: [
             {
+              fields: [],
               indices: [
                 {
                   name: 'index-001',
@@ -870,6 +1009,7 @@ describe('engines field_capabilities', () => {
         {
           fields: [
             {
+              fields: [],
               indices: [
                 {
                   name: 'index-002',
@@ -934,6 +1074,7 @@ describe('engines field_capabilities', () => {
         {
           fields: [
             {
+              fields: [],
               indices: [
                 {
                   name: 'index-002',

--- a/x-pack/plugins/enterprise_search/server/lib/engines/field_capabilities.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/engines/field_capabilities.test.ts
@@ -558,16 +558,16 @@ describe('engines field_capabilities', () => {
           ],
           indices: [
             {
+              name: 'index-003',
+              type: 'keyword',
+            },
+            {
               name: 'index-002',
               type: 'object',
             },
             {
               name: 'index-001',
               type: 'text',
-            },
-            {
-              name: 'index-003',
-              type: 'keyword',
             },
           ],
           name: 'name',

--- a/x-pack/plugins/enterprise_search/server/lib/engines/field_capabilities.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/engines/field_capabilities.ts
@@ -5,11 +5,14 @@
  * 2.0.
  */
 
+import { FieldCapsResponse, FieldCapsFieldCapability } from '@elastic/elasticsearch/lib/api/types';
 import { IScopedClusterClient } from '@kbn/core-elasticsearch-server';
 
 import {
   EnterpriseSearchEngineDetails,
   EnterpriseSearchEngineFieldCapabilities,
+  SchemaField,
+  SchemaFieldIndex,
 } from '../../../common/types/engines';
 
 export const fetchEngineFieldCapabilities = async (
@@ -22,9 +25,11 @@ export const fetchEngineFieldCapabilities = async (
     include_unmapped: true,
     index: getEngineIndexAliasName(name),
   });
+  const fields = parseFieldsCapabilities(fieldCapabilities);
   return {
     created,
     field_capabilities: fieldCapabilities,
+    fields,
     name,
     updated,
   };
@@ -32,3 +37,122 @@ export const fetchEngineFieldCapabilities = async (
 
 // Note: This will likely need to be modified when engines move to es module
 const getEngineIndexAliasName = (engineName: string): string => `search-engine-${engineName}`;
+
+export const parseFieldsCapabilities = (fieldCaps: FieldCapsResponse): SchemaField[] => {
+  const { fields } = fieldCaps;
+  return Object.entries<Record<string, FieldCapsFieldCapability>>(fields)
+    .filter(([fieldName]) => isTopLevelField(fieldName))
+    .map(([fieldName, fieldValue]) => ({
+      ...parseFieldCapability(
+        fieldValue,
+        fieldCaps.indices,
+        getSubFieldCapabilities(fieldName, fields)
+      ),
+      name: fieldName,
+    }));
+};
+
+export const isTopLevelField = (fieldName: string): boolean => {
+  if (fieldName.startsWith('_')) return false;
+  if (fieldName.includes('.')) return false;
+  return true;
+};
+
+export const parseFieldCapability = (
+  value: Record<string, FieldCapsFieldCapability>,
+  indices: string | string[],
+  subFields: SubField[]
+): { fields?: SchemaField[]; indices: SchemaFieldIndex[]; type: string } => {
+  const typeKeys = Object.keys(value);
+  if (typeKeys.length === 0) {
+    return {
+      indices: indicesWithMatchingType('unknown', indices),
+      type: 'unknown',
+    };
+  }
+  let fields: SchemaField[] | undefined;
+  if (subFields.length > 0) {
+    fields = subFields
+      .filter(({ path }) => path.length === 1)
+      .map((subfield) => {
+        return {
+          ...parseFieldCapability(
+            subfield.capability,
+            indices,
+            getSubFields(subfield.path[0], subFields)
+          ),
+          name: subfield.path[0],
+        };
+      });
+  }
+  if (typeKeys.length === 1) {
+    return {
+      fields,
+      indices: indicesWithMatchingType(value[typeKeys[0]].type, indices),
+      type: value[typeKeys[0]].type,
+    };
+  }
+  let type: string;
+  if ('unmapped' in value && typeKeys.length === 2) {
+    type = typeKeys.filter((v) => v !== 'unmapped')[0];
+  } else {
+    type = 'conflict';
+  }
+  const fieldIndices: SchemaFieldIndex[] = [];
+  for (const fieldCapability of Object.values<FieldCapsFieldCapability>(value)) {
+    if (fieldCapability.indices) {
+      fieldIndices.push(...indicesWithMatchingType(fieldCapability.type, fieldCapability.indices));
+    }
+  }
+  return {
+    fields,
+    indices: fieldIndices,
+    type,
+  };
+};
+
+const indicesWithMatchingType = (type: string, indices: string | string[]): SchemaFieldIndex[] => {
+  if (typeof indices === 'string') {
+    return [
+      {
+        name: indices,
+        type,
+      },
+    ];
+  }
+  return indices.map((name) => ({ name, type }));
+};
+
+interface SubField {
+  capability: Record<string, FieldCapsFieldCapability>;
+  path: string[];
+}
+const getSubFieldCapabilities = (
+  name: string,
+  fields: Record<string, Record<string, FieldCapsFieldCapability>>
+): SubField[] => {
+  const result = Object.entries<Record<string, FieldCapsFieldCapability>>(fields)
+    .filter(([fieldName]) => fieldName.startsWith(`${name}.`))
+    .map(([fieldName, capability]) => {
+      const path = fieldName.split('.');
+      path.shift();
+      return {
+        capability,
+        path,
+      };
+    });
+  return result;
+};
+
+const getSubFields = (name: string, fields: SubField[]) => {
+  return fields
+    .filter((field) => field.path[0] === name && field.path.length > 1)
+    .map((field) => {
+      const path = [...field.path];
+      path.shift();
+      return {
+        ...field,
+        path,
+      };
+    });
+};

--- a/x-pack/plugins/enterprise_search/server/lib/engines/field_capabilities.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/engines/field_capabilities.ts
@@ -97,12 +97,14 @@ export const parseFieldCapability = (
   } else {
     type = 'conflict';
   }
-  const fieldIndices: SchemaFieldIndex[] = [];
-  for (const fieldCapability of Object.values<FieldCapsFieldCapability>(value)) {
-    if (fieldCapability.indices) {
-      fieldIndices.push(...indicesWithMatchingType(fieldCapability.type, fieldCapability.indices));
+  const fieldIndices: SchemaFieldIndex[] = Object.values<FieldCapsFieldCapability>(value).flatMap(
+    (fieldCapability) => {
+      if (fieldCapability.indices) {
+        return indicesWithMatchingType(fieldCapability.type, fieldCapability.indices);
+      }
+      return [];
     }
-  }
+  );
   return {
     fields,
     indices: fieldIndices,

--- a/x-pack/plugins/enterprise_search/server/lib/engines/field_capabilities.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/engines/field_capabilities.ts
@@ -69,21 +69,22 @@ export const parseFieldCapability = (
       type: 'unknown',
     };
   }
-  let fields: SchemaField[] | undefined;
-  if (subFields.length > 0) {
-    fields = subFields
-      .filter(({ path }) => path.length === 1)
-      .map((subfield) => {
-        return {
-          ...parseFieldCapability(
-            subfield.capability,
-            indices,
-            getSubFields(subfield.path[0], subFields)
-          ),
-          name: subfield.path[0],
-        };
-      });
-  }
+  const fields: SchemaField[] | undefined =
+    subFields.length > 0
+      ? subFields
+          .filter(({ path }) => path.length === 1)
+          .map((subfield) => {
+            return {
+              ...parseFieldCapability(
+                subfield.capability,
+                indices,
+                getSubFields(subfield.path[0], subFields)
+              ),
+              name: subfield.path[0],
+            };
+          })
+      : undefined;
+
   if (typeKeys.length === 1) {
     return {
       fields,

--- a/x-pack/plugins/enterprise_search/server/lib/engines/field_capabilities.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/engines/field_capabilities.ts
@@ -53,7 +53,6 @@ export const parseFieldsCapabilities = (fieldCaps: FieldCapsResponse): SchemaFie
 };
 
 export const isTopLevelField = (fieldName: string): boolean => {
-  if (fieldName.startsWith('_')) return false;
   if (fieldName.includes('.')) return false;
   return true;
 };

--- a/x-pack/plugins/enterprise_search/server/lib/engines/field_capabilities.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/engines/field_capabilities.ts
@@ -12,7 +12,6 @@ import {
   EnterpriseSearchEngineDetails,
   EnterpriseSearchEngineFieldCapabilities,
   SchemaField,
-  SchemaFieldIndex,
 } from '../../../common/types/engines';
 
 export const fetchEngineFieldCapabilities = async (
@@ -35,126 +34,60 @@ export const fetchEngineFieldCapabilities = async (
   };
 };
 
+const ensureIndices = (indices: string | string[] | undefined): string[] => {
+  if (!indices) return [];
+  return Array.isArray(indices) ? indices : [indices];
+};
+
+export const parseFieldsCapabilities = (
+  fieldCapsResponse: FieldCapsResponse,
+  prefix: string = ''
+): SchemaField[] => {
+  const { fields, indices: indexOrIndices } = fieldCapsResponse;
+  const inThisPass: Array<[string, Record<string, FieldCapsFieldCapability>]> = Object.entries(
+    fields
+  )
+    .filter(([key]) => key.startsWith(prefix))
+    .map(([key, value]) => [key.replace(prefix, ''), value]);
+
+  const atThisLevel = inThisPass.filter(([key]) => !key.includes('.'));
+
+  return atThisLevel.map(([name, value]) => {
+    const type = calculateType(Object.keys(value));
+    let indices = Object.values(value).flatMap((fieldCaps) => {
+      return ensureIndices(fieldCaps.indices).map((index) => ({
+        name: index,
+        type: fieldCaps.type,
+      }));
+    });
+
+    indices =
+      indices.length === 0
+        ? ensureIndices(indexOrIndices).map((index) => ({ name: index, type }))
+        : indices;
+
+    const subFields = parseFieldsCapabilities(fieldCapsResponse, `${prefix}${name}.`);
+    return {
+      fields: subFields,
+      indices,
+      name,
+      type,
+    };
+  });
+};
+
+const calculateType = (types: string[]): string => {
+  // If there is only one type, return it
+  if (types.length === 1) return types[0];
+
+  // Unmapped types are ignored for the purposes of determining the type
+  // If all of the mapped types are the same, return that type
+  const mapped = types.filter((t) => t !== 'unmapped');
+  if (new Set(mapped).size === 1) return mapped[0];
+
+  // Otherwise there is a conflict
+  return 'conflict';
+};
+
 // Note: This will likely need to be modified when engines move to es module
 const getEngineIndexAliasName = (engineName: string): string => `search-engine-${engineName}`;
-
-export const parseFieldsCapabilities = (fieldCaps: FieldCapsResponse): SchemaField[] => {
-  const { fields } = fieldCaps;
-  return Object.entries<Record<string, FieldCapsFieldCapability>>(fields)
-    .filter(([fieldName]) => isTopLevelField(fieldName))
-    .map(([fieldName, fieldValue]) => ({
-      ...parseFieldCapability(
-        fieldValue,
-        fieldCaps.indices,
-        getSubFieldCapabilities(fieldName, fields)
-      ),
-      name: fieldName,
-    }));
-};
-
-export const isTopLevelField = (fieldName: string): boolean => {
-  if (fieldName.includes('.')) return false;
-  return true;
-};
-
-export const parseFieldCapability = (
-  value: Record<string, FieldCapsFieldCapability>,
-  indices: string | string[],
-  subFields: SubField[]
-): { fields?: SchemaField[]; indices: SchemaFieldIndex[]; type: string } => {
-  const typeKeys = Object.keys(value);
-  if (typeKeys.length === 0) {
-    return {
-      indices: indicesWithMatchingType('unknown', indices),
-      type: 'unknown',
-    };
-  }
-  const fields: SchemaField[] | undefined =
-    subFields.length > 0
-      ? subFields
-          .filter(({ path }) => path.length === 1)
-          .map((subfield) => {
-            return {
-              ...parseFieldCapability(
-                subfield.capability,
-                indices,
-                getSubFields(subfield.path[0], subFields)
-              ),
-              name: subfield.path[0],
-            };
-          })
-      : undefined;
-
-  if (typeKeys.length === 1) {
-    return {
-      fields,
-      indices: indicesWithMatchingType(value[typeKeys[0]].type, indices),
-      type: value[typeKeys[0]].type,
-    };
-  }
-  let type: string;
-  if ('unmapped' in value && typeKeys.length === 2) {
-    type = typeKeys.filter((v) => v !== 'unmapped')[0];
-  } else {
-    type = 'conflict';
-  }
-  const fieldIndices: SchemaFieldIndex[] = Object.values<FieldCapsFieldCapability>(value).flatMap(
-    (fieldCapability) => {
-      if (fieldCapability.indices) {
-        return indicesWithMatchingType(fieldCapability.type, fieldCapability.indices);
-      }
-      return [];
-    }
-  );
-  return {
-    fields,
-    indices: fieldIndices,
-    type,
-  };
-};
-
-const indicesWithMatchingType = (type: string, indices: string | string[]): SchemaFieldIndex[] => {
-  if (typeof indices === 'string') {
-    return [
-      {
-        name: indices,
-        type,
-      },
-    ];
-  }
-  return indices.map((name) => ({ name, type }));
-};
-
-interface SubField {
-  capability: Record<string, FieldCapsFieldCapability>;
-  path: string[];
-}
-const getSubFieldCapabilities = (
-  name: string,
-  fields: Record<string, Record<string, FieldCapsFieldCapability>>
-): SubField[] => {
-  const result = Object.entries<Record<string, FieldCapsFieldCapability>>(fields)
-    .filter(([fieldName]) => fieldName.startsWith(`${name}.`))
-    .map(([fieldName, capability]) => {
-      const path = fieldName.split('.');
-      path.shift();
-      return {
-        capability,
-        path,
-      };
-    });
-  return result;
-};
-
-const getSubFields = (name: string, fields: SubField[]) => {
-  return fields
-    .filter((field) => field.path[0] === name && field.path.length > 1)
-    .map((field) => {
-      const path = [...field.path];
-      path.shift();
-      return {
-        ...field,
-        path,
-      };
-    });
-};


### PR DESCRIPTION
## Summary

Original: #152248

### TODO

- ~~[ ] Decide if more is needed for multi-fields~~
  - They currently show up in the `fields` list just like object & nested sub-fields but they need to be rendered slightly differently. So not sure if we need to add something to the object to differentiate they are multi-fields. Which would require writing something that can determine that difference, which could just be `type !== 'object' && type !== 'nested'` but I'm not :100: on that.
    - i think we can make these changes if needed when implementing the UI
- [x] Confirm if we want to include metadata fields, currently filtering them out of the list

these tasks will be completed in a separate PR/issue
- ~~[ ] Use `fields` in the UI instead of `field_capabilities`~~
- ~~[ ] remove `field_capabilities` from API response~~

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
