### PR TITLE
[Security Solution] skipping failing glyout_validation Cypress test

### DIFF
--- a/x-pack/plugins/security_solution/cypress/e2e/exceptions/add_edit_flyout/flyout_validation.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/exceptions/add_edit_flyout/flyout_validation.cy.ts
@@ -316,7 +316,7 @@ describe('Exceptions flyout', { testIsolation: false }, () => {
     cy.get(CONFIRM_BTN).should('be.enabled');
   });
 
-  it('Warns users about mapping conflicts on problematic field selection', async () => {
+  it.skip('Warns users about mapping conflicts on problematic field selection', async () => {
     // open add exception modal
     openExceptionFlyoutFromEmptyViewerPrompt();
 


### PR DESCRIPTION
## Summary

This test is consistently failing on `main` when ran locally. It **_could_** be related to this [PR](https://github.com/elastic/kibana/pull/151366) merged recently...

I've sent more than an hour trying to understand what's happening without success. It's blocking multiple PRs to be merged 
 :(
