### PR TITLE
[dashboard] fix Failing test: Chrome X-Pack UI Functional Tests.x-pack/test/functional/apps/dashboard/group2/sync_colors·ts

### DIFF
--- a/test/functional/services/dashboard/add_panel.ts
+++ b/test/functional/services/dashboard/add_panel.ts
@@ -15,6 +15,7 @@ export class DashboardAddPanelService extends FtrService {
   private readonly common = this.ctx.getPageObject('common');
   private readonly header = this.ctx.getPageObject('header');
   private readonly savedObjectsFinder = this.ctx.getService('savedObjectsFinder');
+  private readonly browser = this.ctx.getService('browser');
 
   async clickOpenAddPanel() {
     this.log.debug('DashboardAddPanel.clickOpenAddPanel');
@@ -26,6 +27,8 @@ export class DashboardAddPanelService extends FtrService {
   async clickCreateNewLink() {
     this.log.debug('DashboardAddPanel.clickAddNewPanelButton');
     await this.retry.try(async () => {
+      // prevent query bar auto suggest from blocking button
+      await this.browser.pressKeys(this.browser.keys.ESCAPE);
       await this.testSubjects.click('dashboardAddNewPanelButton');
       await this.testSubjects.waitForDeleted('dashboardAddNewPanelButton');
       await this.header.waitUntilLoadingHasFinished();


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/148557

flaky test runner https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2000

Image from failed test shows query autosuggest menu is blocking "create visualize" button. PR fixes issue be pressing escape to close autosuggest menu if its open.

![image](https://user-images.githubusercontent.com/373691/223846637-3e595803-e39d-4392-a84c-69a455f70a42.png)
