### PR TITLE
[Enterprise Search] Support pages without ent-search

### DIFF
--- a/test/plugin_functional/test_suites/core_plugins/rendering.ts
+++ b/test/plugin_functional/test_suites/core_plugins/rendering.ts
@@ -103,6 +103,7 @@ export default function ({ getService }: PluginFunctionalProviderContext) {
         'data.search.sessions.management.refreshTimeout (duration)',
         'data.search.sessions.maxUpdateRetries (number)',
         'data.search.sessions.notTouchedTimeout (duration)',
+        'enterpriseSearch.canDeployEntSearch (boolean)',
         'enterpriseSearch.host (string)',
         'home.disableWelcomeScreen (boolean)',
         'map.emsFileApiUrl (string)',

--- a/x-pack/plugins/enterprise_search/common/__mocks__/initial_app_data.ts
+++ b/x-pack/plugins/enterprise_search/common/__mocks__/initial_app_data.ts
@@ -29,10 +29,13 @@ export const DEFAULT_INITIAL_APP_DATA = {
   },
   access: {
     hasAppSearchAccess: true,
-    hasNativeConnectorsAccess: true,
     hasSearchEnginesAccess: false,
-    hasWebCrawlerAccess: true,
     hasWorkplaceSearchAccess: true,
+  },
+  features: {
+    hasNativeConnectors: true,
+    hasSearchApplications: false,
+    hasWebCrawler: true,
   },
   appSearch: {
     accountId: 'some-id-string',

--- a/x-pack/plugins/enterprise_search/common/__mocks__/initial_app_data.ts
+++ b/x-pack/plugins/enterprise_search/common/__mocks__/initial_app_data.ts
@@ -29,7 +29,9 @@ export const DEFAULT_INITIAL_APP_DATA = {
   },
   access: {
     hasAppSearchAccess: true,
+    hasNativeConnectorsAccess: true,
     hasSearchEnginesAccess: false,
+    hasWebCrawlerAccess: true,
     hasWorkplaceSearchAccess: true,
   },
   appSearch: {

--- a/x-pack/plugins/enterprise_search/common/__mocks__/initial_app_data.ts
+++ b/x-pack/plugins/enterprise_search/common/__mocks__/initial_app_data.ts
@@ -33,6 +33,8 @@ export const DEFAULT_INITIAL_APP_DATA = {
     hasWorkplaceSearchAccess: true,
   },
   features: {
+    hasConnectors: true,
+    hasDefaultIngestPipeline: true,
     hasNativeConnectors: true,
     hasSearchApplications: false,
     hasWebCrawler: true,

--- a/x-pack/plugins/enterprise_search/common/constants.ts
+++ b/x-pack/plugins/enterprise_search/common/constants.ts
@@ -164,6 +164,7 @@ export enum INGESTION_METHOD_IDS {
 }
 
 export const DEFAULT_PRODUCT_FEATURES: ProductFeatures = {
+  hasConnectors: true,
   hasDefaultIngestPipeline: true,
   hasNativeConnectors: true,
   hasSearchApplications: false,

--- a/x-pack/plugins/enterprise_search/common/constants.ts
+++ b/x-pack/plugins/enterprise_search/common/constants.ts
@@ -164,6 +164,7 @@ export enum INGESTION_METHOD_IDS {
 }
 
 export const DEFAULT_PRODUCT_FEATURES: ProductFeatures = {
+  hasDefaultIngestPipeline: true,
   hasNativeConnectors: true,
   hasSearchApplications: false,
   hasWebCrawler: true,

--- a/x-pack/plugins/enterprise_search/common/constants.ts
+++ b/x-pack/plugins/enterprise_search/common/constants.ts
@@ -7,6 +7,7 @@
 
 import { i18n } from '@kbn/i18n';
 
+import { ProductFeatures } from './types';
 import { IngestPipelineParams } from './types/connectors';
 
 export const ENTERPRISE_SEARCH_OVERVIEW_PLUGIN = {
@@ -161,3 +162,9 @@ export enum INGESTION_METHOD_IDS {
   crawler = 'crawler',
   native_connector = 'native_connector',
 }
+
+export const DEFAULT_PRODUCT_FEATURES: ProductFeatures = {
+  hasNativeConnectors: true,
+  hasSearchApplications: false,
+  hasWebCrawler: true,
+};

--- a/x-pack/plugins/enterprise_search/common/types/index.ts
+++ b/x-pack/plugins/enterprise_search/common/types/index.ts
@@ -19,6 +19,7 @@ export interface InitialAppData {
   appSearch?: AppSearchAccount;
   configuredLimits?: ConfiguredLimits;
   enterpriseSearchVersion?: string;
+  features?: ProductFeatures;
   kibanaVersion?: string;
   readOnlyMode?: boolean;
   searchOAuth?: SearchOAuth;
@@ -32,10 +33,14 @@ export interface ConfiguredLimits {
 
 export interface ProductAccess {
   hasAppSearchAccess: boolean;
-  hasNativeConnectorsAccess: boolean;
   hasSearchEnginesAccess: boolean;
-  hasWebCrawlerAccess: boolean;
   hasWorkplaceSearchAccess: boolean;
+}
+
+export interface ProductFeatures {
+  hasNativeConnectors: boolean;
+  hasSearchApplications: boolean;
+  hasWebCrawler: boolean;
 }
 
 export interface SearchOAuth {

--- a/x-pack/plugins/enterprise_search/common/types/index.ts
+++ b/x-pack/plugins/enterprise_search/common/types/index.ts
@@ -32,7 +32,9 @@ export interface ConfiguredLimits {
 
 export interface ProductAccess {
   hasAppSearchAccess: boolean;
+  hasNativeConnectorsAccess: boolean;
   hasSearchEnginesAccess: boolean;
+  hasWebCrawlerAccess: boolean;
   hasWorkplaceSearchAccess: boolean;
 }
 
@@ -50,6 +52,11 @@ export interface MetaPage {
 
 export interface Meta {
   page: MetaPage;
+}
+
+export interface ClientConfigType {
+  canDeployEntSearch: boolean;
+  host?: string;
 }
 
 export type { ElasticsearchIndexWithPrivileges } from './indices';

--- a/x-pack/plugins/enterprise_search/common/types/index.ts
+++ b/x-pack/plugins/enterprise_search/common/types/index.ts
@@ -38,6 +38,7 @@ export interface ProductAccess {
 }
 
 export interface ProductFeatures {
+  hasConnectors: boolean;
   hasDefaultIngestPipeline: boolean;
   hasNativeConnectors: boolean;
   hasSearchApplications: boolean;

--- a/x-pack/plugins/enterprise_search/common/types/index.ts
+++ b/x-pack/plugins/enterprise_search/common/types/index.ts
@@ -38,6 +38,7 @@ export interface ProductAccess {
 }
 
 export interface ProductFeatures {
+  hasDefaultIngestPipeline: boolean;
   hasNativeConnectors: boolean;
   hasSearchApplications: boolean;
   hasWebCrawler: boolean;

--- a/x-pack/plugins/enterprise_search/public/applications/__mocks__/kea_logic/kibana_logic.mock.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/__mocks__/kea_logic/kibana_logic.mock.ts
@@ -34,10 +34,13 @@ export const mockKibanaValues = {
   navigateToUrl: jest.fn(),
   productAccess: {
     hasAppSearchAccess: true,
-    hasNativeConnectorsAccess: true,
     hasSearchEnginesAccess: false,
-    hasWebCrawlerAccess: true,
     hasWorkplaceSearchAccess: true,
+  },
+  productFeatures: {
+    hasNativeConnectors: true,
+    hasSearchApplications: false,
+    hasWebCrawler: true,
   },
   uiSettings: uiSettingsServiceMock.createStartContract(),
   security: securityMock.createStart(),

--- a/x-pack/plugins/enterprise_search/public/applications/__mocks__/kea_logic/kibana_logic.mock.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/__mocks__/kea_logic/kibana_logic.mock.ts
@@ -34,7 +34,9 @@ export const mockKibanaValues = {
   navigateToUrl: jest.fn(),
   productAccess: {
     hasAppSearchAccess: true,
+    hasNativeConnectorsAccess: true,
     hasSearchEnginesAccess: false,
+    hasWebCrawlerAccess: true,
     hasWorkplaceSearchAccess: true,
   },
   uiSettings: uiSettingsServiceMock.createStartContract(),

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/new_index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/new_index.tsx
@@ -24,7 +24,7 @@ import { i18n } from '@kbn/i18n';
 
 import { INGESTION_METHOD_IDS } from '../../../../../common/constants';
 
-import { ProductAccess } from '../../../../../common/types';
+import { ProductFeatures } from '../../../../../common/types';
 import { BETA_LABEL } from '../../../shared/constants/labels';
 import { KibanaLogic } from '../../../shared/kibana/kibana_logic';
 import { parseQueryParams } from '../../../shared/query_params';
@@ -122,12 +122,12 @@ const METHOD_BUTTON_GROUP_OPTIONS: Record<INGESTION_METHOD_IDS, ButtonGroupOptio
   },
 };
 
-const getAvailableMethodOptions = (productAccess: ProductAccess): ButtonGroupOption[] => {
+const getAvailableMethodOptions = (productFeatures: ProductFeatures): ButtonGroupOption[] => {
   return [
-    ...(productAccess.hasWebCrawlerAccess
+    ...(productFeatures.hasWebCrawler
       ? [METHOD_BUTTON_GROUP_OPTIONS[INGESTION_METHOD_IDS.crawler]]
       : []),
-    ...(productAccess.hasNativeConnectorsAccess
+    ...(productFeatures.hasNativeConnectors
       ? [METHOD_BUTTON_GROUP_OPTIONS[INGESTION_METHOD_IDS.native_connector]]
       : []),
     METHOD_BUTTON_GROUP_OPTIONS[INGESTION_METHOD_IDS.api],
@@ -137,9 +137,9 @@ const getAvailableMethodOptions = (productAccess: ProductAccess): ButtonGroupOpt
 
 export const NewIndex: React.FC = () => {
   const { search } = useLocation();
-  const { capabilities, productAccess } = useValues(KibanaLogic);
+  const { capabilities, productFeatures } = useValues(KibanaLogic);
   const { method: methodParam } = parseQueryParams(search);
-  const availableIngestionMethodOptions = getAvailableMethodOptions(productAccess);
+  const availableIngestionMethodOptions = getAvailableMethodOptions(productFeatures);
 
   const initialSelectedMethod =
     availableIngestionMethodOptions.find((option) => option.id === methodParam) ??

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/new_index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/new_index.tsx
@@ -131,7 +131,9 @@ const getAvailableMethodOptions = (productFeatures: ProductFeatures): ButtonGrou
       ? [METHOD_BUTTON_GROUP_OPTIONS[INGESTION_METHOD_IDS.native_connector]]
       : []),
     METHOD_BUTTON_GROUP_OPTIONS[INGESTION_METHOD_IDS.api],
-    METHOD_BUTTON_GROUP_OPTIONS[INGESTION_METHOD_IDS.connector],
+    ...(productFeatures.hasConnectors
+      ? [METHOD_BUTTON_GROUP_OPTIONS[INGESTION_METHOD_IDS.connector]]
+      : []),
   ];
 };
 

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/new_index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/new_index.tsx
@@ -9,6 +9,8 @@ import React, { useState } from 'react';
 
 import { useLocation } from 'react-router-dom';
 
+import { useValues } from 'kea';
+
 import {
   EuiBadge,
   EuiFlexGroup,
@@ -22,7 +24,9 @@ import { i18n } from '@kbn/i18n';
 
 import { INGESTION_METHOD_IDS } from '../../../../../common/constants';
 
+import { ProductAccess } from '../../../../../common/types';
 import { BETA_LABEL } from '../../../shared/constants/labels';
+import { KibanaLogic } from '../../../shared/kibana/kibana_logic';
 import { parseQueryParams } from '../../../shared/query_params';
 import { EuiLinkTo } from '../../../shared/react_router_helpers';
 
@@ -41,8 +45,8 @@ const betaBadge = (
   </EuiBadge>
 );
 
-const METHOD_BUTTON_GROUP_OPTIONS: ButtonGroupOption[] = [
-  {
+const METHOD_BUTTON_GROUP_OPTIONS: Record<INGESTION_METHOD_IDS, ButtonGroupOption> = {
+  [INGESTION_METHOD_IDS.crawler]: {
     description: i18n.translate(
       'xpack.enterpriseSearch.content.newIndex.buttonGroup.crawler.description',
       {
@@ -58,7 +62,7 @@ const METHOD_BUTTON_GROUP_OPTIONS: ButtonGroupOption[] = [
       defaultMessage: 'Use the web crawler',
     }),
   },
-  {
+  [INGESTION_METHOD_IDS.native_connector]: {
     badge: betaBadge,
     description: i18n.translate(
       'xpack.enterpriseSearch.content.newIndex.buttonGroup.nativeConnector.description',
@@ -82,7 +86,7 @@ const METHOD_BUTTON_GROUP_OPTIONS: ButtonGroupOption[] = [
       }
     ),
   },
-  {
+  [INGESTION_METHOD_IDS.api]: {
     description: i18n.translate(
       'xpack.enterpriseSearch.content.newIndex.buttonGroup.api.description',
       {
@@ -98,7 +102,7 @@ const METHOD_BUTTON_GROUP_OPTIONS: ButtonGroupOption[] = [
       defaultMessage: 'Use the API',
     }),
   },
-  {
+  [INGESTION_METHOD_IDS.connector]: {
     badge: betaBadge,
     description: i18n.translate(
       'xpack.enterpriseSearch.content.newIndex.buttonGroup.connector.description',
@@ -116,15 +120,30 @@ const METHOD_BUTTON_GROUP_OPTIONS: ButtonGroupOption[] = [
       defaultMessage: 'Build a connector',
     }),
   },
-];
+};
+
+const getAvailableMethodOptions = (productAccess: ProductAccess): ButtonGroupOption[] => {
+  return [
+    ...(productAccess.hasWebCrawlerAccess
+      ? [METHOD_BUTTON_GROUP_OPTIONS[INGESTION_METHOD_IDS.crawler]]
+      : []),
+    ...(productAccess.hasNativeConnectorsAccess
+      ? [METHOD_BUTTON_GROUP_OPTIONS[INGESTION_METHOD_IDS.native_connector]]
+      : []),
+    METHOD_BUTTON_GROUP_OPTIONS[INGESTION_METHOD_IDS.api],
+    METHOD_BUTTON_GROUP_OPTIONS[INGESTION_METHOD_IDS.connector],
+  ];
+};
 
 export const NewIndex: React.FC = () => {
   const { search } = useLocation();
+  const { capabilities, productAccess } = useValues(KibanaLogic);
   const { method: methodParam } = parseQueryParams(search);
+  const availableIngestionMethodOptions = getAvailableMethodOptions(productAccess);
 
   const initialSelectedMethod =
-    METHOD_BUTTON_GROUP_OPTIONS.find((option) => option.id === methodParam) ??
-    METHOD_BUTTON_GROUP_OPTIONS[0];
+    availableIngestionMethodOptions.find((option) => option.id === methodParam) ??
+    availableIngestionMethodOptions[0];
 
   const [selectedMethod, setSelectedMethod] = useState<ButtonGroupOption>(initialSelectedMethod);
 
@@ -168,16 +187,20 @@ export const NewIndex: React.FC = () => {
             </EuiText>
             <EuiSpacer size="m" />
             <ButtonGroup
-              options={METHOD_BUTTON_GROUP_OPTIONS}
+              options={availableIngestionMethodOptions}
               selected={selectedMethod}
               onChange={setSelectedMethod}
             />
-            <EuiSpacer size="xxl" />
-            <EuiLinkTo to="/app/integrations" shouldNotCreateHref>
-              {i18n.translate('xpack.enterpriseSearch.content.newIndex.viewIntegrationsLink', {
-                defaultMessage: 'View additional integrations',
-              })}
-            </EuiLinkTo>
+            {capabilities.navLinks.integrations && (
+              <>
+                <EuiSpacer size="xxl" />
+                <EuiLinkTo to="/app/integrations" shouldNotCreateHref>
+                  {i18n.translate('xpack.enterpriseSearch.content.newIndex.viewIntegrationsLink', {
+                    defaultMessage: 'View additional integrations',
+                  })}
+                </EuiLinkTo>
+              </>
+            )}
           </EuiPanel>
         </EuiFlexItem>
         <EuiFlexItem>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/new_search_index_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/new_search_index_logic.test.ts
@@ -16,6 +16,9 @@ import { flashIndexCreatedToast } from './new_index_created_toast';
 import { NewSearchIndexLogic, NewSearchIndexValues } from './new_search_index_logic';
 
 jest.mock('./new_index_created_toast', () => ({ flashIndexCreatedToast: jest.fn() }));
+jest.mock('../../../shared/kibana/kibana_logic', () => ({
+  KibanaLogic: { values: { productAccess: { hasAppSearchAccess: true } } },
+}));
 
 const DEFAULT_VALUES: NewSearchIndexValues = {
   data: undefined as any,
@@ -35,14 +38,12 @@ describe('NewSearchIndexLogic', () => {
   });
 
   it('has expected default values', () => {
-    mount();
     expect(NewSearchIndexLogic.values).toEqual(DEFAULT_VALUES);
   });
 
   describe('actions', () => {
     describe('setLanguageSelectValue', () => {
       it('sets language to the provided value', () => {
-        mount();
         NewSearchIndexLogic.actions.setLanguageSelectValue('en');
         expect(NewSearchIndexLogic.values).toEqual({
           ...DEFAULT_VALUES,

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/new_search_index_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/new_search_index_logic.ts
@@ -8,6 +8,7 @@
 import { kea, MakeLogicType } from 'kea';
 
 import { Actions } from '../../../shared/api_logic/create_api_logic';
+import { KibanaLogic } from '../../../shared/kibana/kibana_logic';
 import {
   AddConnectorApiLogic,
   AddConnectorApiLogicArgs,
@@ -84,12 +85,15 @@ export const NewSearchIndexLogic = kea<MakeLogicType<NewSearchIndexValues, NewSe
   },
   listeners: ({ actions, values }) => ({
     apiIndexCreated: () => {
+      if (!KibanaLogic.values.productAccess.hasAppSearchAccess) return;
       flashIndexCreatedToast();
     },
     connectorIndexCreated: () => {
+      if (!KibanaLogic.values.productAccess.hasAppSearchAccess) return;
       flashIndexCreatedToast();
     },
     crawlerIndexCreated: () => {
+      if (!KibanaLogic.values.productAccess.hasAppSearchAccess) return;
       flashIndexCreatedToast();
     },
     setRawName: async (_, breakpoint) => {

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/components/header_actions/header_actions.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/components/header_actions/header_actions.test.tsx
@@ -17,12 +17,13 @@ import { SyncsContextMenu } from './syncs_context_menu';
 
 describe('Header Actions', () => {
   it('renders api index', () => {
-    expect(getHeaderActions(apiIndex)).toEqual([
+    expect(getHeaderActions(apiIndex, true)).toEqual([
       <SearchEnginesPopover indexName="api" ingestionMethod="api" isHiddenIndex={false} />,
     ]);
+    expect(getHeaderActions(apiIndex, false)).toEqual([]);
   });
   it('renders connector index', () => {
-    expect(getHeaderActions(connectorIndex)).toEqual([
+    expect(getHeaderActions(connectorIndex, true)).toEqual([
       <SyncsContextMenu />,
       <SearchEnginesPopover
         indexName="connector"
@@ -30,11 +31,13 @@ describe('Header Actions', () => {
         isHiddenIndex={false}
       />,
     ]);
+    expect(getHeaderActions(connectorIndex, false)).toEqual([<SyncsContextMenu />]);
   });
   it('renders crawler index', () => {
-    expect(getHeaderActions(crawlerIndex)).toEqual([
+    expect(getHeaderActions(crawlerIndex, true)).toEqual([
       <CrawlerStatusIndicator />,
       <SearchEnginesPopover indexName="crawler" ingestionMethod="crawler" isHiddenIndex={false} />,
     ]);
+    expect(getHeaderActions(crawlerIndex, false)).toEqual([<CrawlerStatusIndicator />]);
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/components/header_actions/header_actions.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/components/header_actions/header_actions.tsx
@@ -16,14 +16,14 @@ import { SyncsContextMenu } from './syncs_context_menu';
 
 // Used to populate rightSideItems of an EuiPageTemplate, which is rendered right-to-left
 export const getHeaderActions = (
-  indexData?: ElasticsearchIndexWithIngestion,
-  hasAppSearchAccess?: boolean
+  indexData: ElasticsearchIndexWithIngestion | undefined,
+  hasAppSearchAccess: boolean
 ) => {
   const ingestionMethod = getIngestionMethod(indexData);
   return [
     ...(isCrawlerIndex(indexData) && indexData.connector ? [<CrawlerStatusIndicator />] : []),
     ...(isConnectorIndex(indexData) ? [<SyncsContextMenu />] : []),
-    ...(hasAppSearchAccess || hasAppSearchAccess === undefined
+    ...(hasAppSearchAccess
       ? [
           <SearchEnginesPopover
             indexName={indexData?.name}

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/components/header_actions/header_actions.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/components/header_actions/header_actions.tsx
@@ -15,15 +15,22 @@ import { SearchEnginesPopover } from './search_engines_popover';
 import { SyncsContextMenu } from './syncs_context_menu';
 
 // Used to populate rightSideItems of an EuiPageTemplate, which is rendered right-to-left
-export const getHeaderActions = (indexData?: ElasticsearchIndexWithIngestion) => {
+export const getHeaderActions = (
+  indexData?: ElasticsearchIndexWithIngestion,
+  hasAppSearchAccess?: boolean
+) => {
   const ingestionMethod = getIngestionMethod(indexData);
   return [
     ...(isCrawlerIndex(indexData) && indexData.connector ? [<CrawlerStatusIndicator />] : []),
     ...(isConnectorIndex(indexData) ? [<SyncsContextMenu />] : []),
-    <SearchEnginesPopover
-      indexName={indexData?.name}
-      ingestionMethod={ingestionMethod}
-      isHiddenIndex={indexData?.hidden}
-    />,
+    ...(hasAppSearchAccess || hasAppSearchAccess === undefined
+      ? [
+          <SearchEnginesPopover
+            indexName={indexData?.name}
+            ingestionMethod={ingestionMethod}
+            isHiddenIndex={indexData?.hidden}
+          />,
+        ]
+      : []),
   ];
 };

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/components/manage_api_keys_popover/popover.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/components/manage_api_keys_popover/popover.tsx
@@ -46,6 +46,7 @@ export const ManageKeysPopover: React.FC = () => {
         size="s"
         items={[
           <EuiContextMenuItem
+            key="viewApiKeys"
             data-telemetry-id={`entSearchContent-${ingestionMethod}-overview-generateApiKeys-viewApiKeys`}
             icon="eye"
             onClick={() =>
@@ -64,6 +65,7 @@ export const ManageKeysPopover: React.FC = () => {
             </EuiText>
           </EuiContextMenuItem>,
           <EuiContextMenuItem
+            key="createNewApiKey"
             data-telemetry-id={`entSearchContent-${ingestionMethod}-overview-generateApiKeys-createNewApiKey`}
             icon="plusInCircle"
             onClick={openGenerateModal}

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/search_index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/search_index.tsx
@@ -78,6 +78,7 @@ export const SearchIndex: React.FC = () => {
   const {
     guidedOnboarding,
     productAccess: { hasAppSearchAccess },
+    productFeatures: { hasDefaultIngestPipeline },
   } = useValues(KibanaLogic);
   const isAppGuideActive = useObservable(
     guidedOnboarding.guidedOnboardingApi!.isGuideStepActive$('appSearch', 'add_data')
@@ -202,7 +203,7 @@ export const SearchIndex: React.FC = () => {
     ...ALL_INDICES_TABS,
     ...(isConnectorIndex(index) ? CONNECTOR_TABS : []),
     ...(isCrawlerIndex(index) ? CRAWLER_TABS : []),
-    PIPELINES_TAB,
+    ...(hasDefaultIngestPipeline ? [PIPELINES_TAB] : []),
   ];
 
   const selectedTab = tabs.find((tab) => tab.id === tabId);

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/search_index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/search_index.tsx
@@ -75,7 +75,10 @@ export const SearchIndex: React.FC = () => {
    * This needs to be checked for any of the 3 registered search guideIds
    * Putting it here guarantees that if a user is viewing an index with data, it'll be marked as complete
    */
-  const { guidedOnboarding } = useValues(KibanaLogic);
+  const {
+    guidedOnboarding,
+    productAccess: { hasAppSearchAccess },
+  } = useValues(KibanaLogic);
   const isAppGuideActive = useObservable(
     guidedOnboarding.guidedOnboardingApi!.isGuideStepActive$('appSearch', 'add_data')
   );
@@ -222,7 +225,7 @@ export const SearchIndex: React.FC = () => {
       isLoading={isInitialLoading}
       pageHeader={{
         pageTitle: indexName,
-        rightSideItems: getHeaderActions(index),
+        rightSideItems: getHeaderActions(index, hasAppSearchAccess),
       }}
     >
       {isCrawlerIndex(index) && !index.connector ? (

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/settings/settings_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/settings/settings_logic.ts
@@ -14,6 +14,7 @@ import { Status } from '../../../../../common/types/api';
 
 import { IngestPipelineParams } from '../../../../../common/types/connectors';
 import { Actions } from '../../../shared/api_logic/create_api_logic';
+import { KibanaLogic } from '../../../shared/kibana';
 
 import {
   FetchDefaultPipelineApiLogic,
@@ -70,6 +71,7 @@ export const SettingsLogic = kea<MakeLogicType<PipelinesValues, PipelinesActions
   },
   events: ({ actions }) => ({
     afterMount: () => {
+      if (KibanaLogic.values.productFeatures.hasDefaultIngestPipeline === false) return;
       actions.fetchDefaultPipeline(undefined);
     },
   }),

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/index.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/index.test.tsx
@@ -45,7 +45,7 @@ describe('EnterpriseSearchContent', () => {
   });
 
   it('renders EnterpriseSearchContentUnconfigured when config.host is not set', () => {
-    setMockValues({ config: { host: '' } });
+    setMockValues({ config: { canDeployEntSearch: true, host: '' } });
     const wrapper = shallow(<EnterpriseSearchContent />);
 
     expect(wrapper.find(EnterpriseSearchContentUnconfigured)).toHaveLength(1);
@@ -60,7 +60,17 @@ describe('EnterpriseSearchContent', () => {
   });
 
   it('renders EnterpriseSearchContentConfigured when config.host is set & available', () => {
-    setMockValues({ errorConnectingMessage: '', config: { host: 'some.url' } });
+    setMockValues({
+      config: { canDeployEntSearch: true, host: 'some.url' },
+      errorConnectingMessage: '',
+    });
+    const wrapper = shallow(<EnterpriseSearchContent />);
+
+    expect(wrapper.find(EnterpriseSearchContentConfigured)).toHaveLength(1);
+  });
+
+  it('renders EnterpriseSearchContentConfigured when config.host is not set & Ent Search cannot be deployed', () => {
+    setMockValues({ errorConnectingMessage: '', config: { canDeployEntSearch: false, host: '' } });
     const wrapper = shallow(<EnterpriseSearchContent />);
 
     expect(wrapper.find(EnterpriseSearchContentConfigured)).toHaveLength(1);

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/index.tsx
@@ -39,7 +39,7 @@ export const EnterpriseSearchContent: React.FC<InitialAppData> = (props) => {
   const incompatibleVersions = isVersionMismatch(enterpriseSearchVersion, kibanaVersion);
 
   const showView = () => {
-    if (!config.host) {
+    if (!config.host && config.canDeployEntSearch) {
       return <EnterpriseSearchContentUnconfigured />;
     } else if (incompatibleVersions) {
       return (

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_overview/components/product_selector/product_selector.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_overview/components/product_selector/product_selector.test.tsx
@@ -28,7 +28,7 @@ const props = {
 
 describe('ProductSelector', () => {
   it('renders the overview page, product cards, & setup guide CTAs with no host set', () => {
-    setMockValues({ config: { host: '' } });
+    setMockValues({ config: { canDeployEntSearch: true, host: '' } });
     const wrapper = shallow(<ProductSelector {...props} />);
 
     expect(wrapper.find(ProductCard)).toHaveLength(3);
@@ -36,14 +36,14 @@ describe('ProductSelector', () => {
   });
 
   it('renders the trial callout', () => {
-    setMockValues({ config: { host: 'localhost' } });
+    setMockValues({ config: { canDeployEntSearch: true, host: 'localhost' } });
     const wrapper = shallow(<ProductSelector {...props} />);
 
     expect(wrapper.find(TrialCallout)).toHaveLength(1);
   });
 
   it('passes correct URL when Workplace Search user is not an admin', () => {
-    setMockValues({ config: { host: '' } });
+    setMockValues({ config: { canDeployEntSearch: true, host: '' } });
     const wrapper = shallow(<ProductSelector {...props} isWorkplaceSearchAdmin={false} />);
 
     expect(wrapper.find(ProductCard).last().prop('url')).toEqual(
@@ -53,7 +53,7 @@ describe('ProductSelector', () => {
 
   describe('access checks when host is set', () => {
     beforeEach(() => {
-      setMockValues({ config: { host: 'localhost' } });
+      setMockValues({ config: { canDeployEntSearch: true, host: 'localhost' } });
     });
 
     it('does not render the App Search card if the user does not have access to AS', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_overview/components/product_selector/product_selector.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_overview/components/product_selector/product_selector.tsx
@@ -56,12 +56,14 @@ export const ProductSelector: React.FC<ProductSelectorProps> = ({
   const { config } = useValues(KibanaLogic);
 
   // If Enterprise Search hasn't been set up yet, show all products. Otherwise, only show products the user has access to
-  const shouldShowAppSearchCard = !config.host || hasAppSearchAccess;
-  const shouldShowWorkplaceSearchCard = !config.host || hasWorkplaceSearchAccess;
+  const shouldShowAppSearchCard = (!config.host && config.canDeployEntSearch) || hasAppSearchAccess;
+  const shouldShowWorkplaceSearchCard =
+    (!config.host && config.canDeployEntSearch) || hasWorkplaceSearchAccess;
 
   // If Enterprise Search has been set up and the user does not have access to either product, show a message saying they
   // need to contact an administrator to get access to one of the products.
-  const shouldShowEnterpriseSearchCards = shouldShowAppSearchCard || shouldShowWorkplaceSearchCard;
+  const shouldShowEnterpriseSearchCards =
+    shouldShowAppSearchCard || shouldShowWorkplaceSearchCard || !config.canDeployEntSearch;
 
   const WORKPLACE_SEARCH_URL = isWorkplaceSearchAdmin
     ? WORKPLACE_SEARCH_PLUGIN.URL
@@ -297,8 +299,12 @@ export const ProductSelector: React.FC<ProductSelectorProps> = ({
             />
           </EuiFlexItem>
         )}
+        {!config.host && config.canDeployEntSearch && (
+          <EuiFlexItem>
+            <SetupGuideCta />
+          </EuiFlexItem>
+        )}
       </EuiFlexGroup>
-      {!config.host && <SetupGuideCta />}
     </>
   );
 

--- a/x-pack/plugins/enterprise_search/public/applications/index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/index.tsx
@@ -18,8 +18,8 @@ import { I18nProvider } from '@kbn/i18n-react';
 
 import { KibanaContextProvider, KibanaThemeProvider } from '@kbn/kibana-react-plugin/public';
 
-import { InitialAppData, ProductAccess } from '../../common/types';
-import { PluginsStart, ClientConfigType, ClientData } from '../plugin';
+import { ClientConfigType, InitialAppData, ProductAccess } from '../../common/types';
+import { PluginsStart, ClientData } from '../plugin';
 
 import { externalUrl } from './shared/enterprise_search_url';
 import { mountFlashMessagesLogic, Toasts } from './shared/flash_messages';
@@ -45,7 +45,9 @@ export const renderApp = (
 
   const noProductAccess: ProductAccess = {
     hasAppSearchAccess: false,
+    hasNativeConnectorsAccess: false,
     hasSearchEnginesAccess: false,
+    hasWebCrawlerAccess: false,
     hasWorkplaceSearchAccess: false,
   };
   const productAccess = data.access || noProductAccess;

--- a/x-pack/plugins/enterprise_search/public/applications/index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/index.tsx
@@ -18,6 +18,7 @@ import { I18nProvider } from '@kbn/i18n-react';
 
 import { KibanaContextProvider, KibanaThemeProvider } from '@kbn/kibana-react-plugin/public';
 
+import { DEFAULT_PRODUCT_FEATURES } from '../../common/constants';
 import { ClientConfigType, InitialAppData, ProductAccess } from '../../common/types';
 import { PluginsStart, ClientData } from '../plugin';
 
@@ -45,12 +46,11 @@ export const renderApp = (
 
   const noProductAccess: ProductAccess = {
     hasAppSearchAccess: false,
-    hasNativeConnectorsAccess: false,
     hasSearchEnginesAccess: false,
-    hasWebCrawlerAccess: false,
     hasWorkplaceSearchAccess: false,
   };
   const productAccess = data.access || noProductAccess;
+  const productFeatures = data.features ?? { ...DEFAULT_PRODUCT_FEATURES };
 
   const EmptyContext: FC = ({ children }) => <>{children}</>;
   const CloudContext = plugins.cloud?.CloudContextProvider || EmptyContext;
@@ -63,6 +63,7 @@ export const renderApp = (
     capabilities: core.application.capabilities,
     config,
     productAccess,
+    productFeatures,
     charts: plugins.charts,
     cloud: plugins.cloud,
     uiSettings: core.uiSettings,

--- a/x-pack/plugins/enterprise_search/public/applications/shared/kibana/kibana_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/kibana/kibana_logic.test.ts
@@ -19,7 +19,7 @@ describe('KibanaLogic', () => {
 
   describe('mounts', () => {
     it('sets values from props', () => {
-      mountKibanaLogic(mockKibanaValues);
+      mountKibanaLogic(mockKibanaValues as any);
 
       expect(KibanaLogic.values).toEqual({
         ...mockKibanaValues,
@@ -41,7 +41,7 @@ describe('KibanaLogic', () => {
   });
 
   describe('navigateToUrl()', () => {
-    beforeEach(() => mountKibanaLogic(mockKibanaValues));
+    beforeEach(() => mountKibanaLogic(mockKibanaValues as any));
 
     it('runs paths through createHref before calling navigateToUrl', () => {
       KibanaLogic.values.navigateToUrl('/test');

--- a/x-pack/plugins/enterprise_search/public/applications/shared/kibana/kibana_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/kibana/kibana_logic.ts
@@ -21,7 +21,7 @@ import {
 import { GuidedOnboardingPluginStart } from '@kbn/guided-onboarding-plugin/public';
 import { SecurityPluginStart } from '@kbn/security-plugin/public';
 
-import { ProductAccess } from '../../../../common/types';
+import { ClientConfigType, ProductAccess } from '../../../../common/types';
 
 import { HttpLogic } from '../http';
 import { createHref, CreateHrefOptions } from '../react_router_helpers';
@@ -31,7 +31,7 @@ type RequiredFieldsOnly<T> = {
 };
 interface KibanaLogicProps {
   application: ApplicationStart;
-  config: { host?: string };
+  config: ClientConfigType;
   productAccess: ProductAccess;
   // Kibana core
   capabilities: Capabilities;

--- a/x-pack/plugins/enterprise_search/public/applications/shared/kibana/kibana_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/kibana/kibana_logic.ts
@@ -21,7 +21,7 @@ import {
 import { GuidedOnboardingPluginStart } from '@kbn/guided-onboarding-plugin/public';
 import { SecurityPluginStart } from '@kbn/security-plugin/public';
 
-import { ClientConfigType, ProductAccess } from '../../../../common/types';
+import { ClientConfigType, ProductAccess, ProductFeatures } from '../../../../common/types';
 
 import { HttpLogic } from '../http';
 import { createHref, CreateHrefOptions } from '../react_router_helpers';
@@ -33,6 +33,7 @@ interface KibanaLogicProps {
   application: ApplicationStart;
   config: ClientConfigType;
   productAccess: ProductAccess;
+  productFeatures: ProductFeatures;
   // Kibana core
   capabilities: Capabilities;
   history: ScopedHistory;
@@ -74,6 +75,7 @@ export const KibanaLogic = kea<MakeLogicType<KibanaValues>>({
       {},
     ],
     productAccess: [props.productAccess, {}],
+    productFeatures: [props.productFeatures, {}],
     renderHeaderActions: [props.renderHeaderActions, {}],
     security: [props.security, {}],
     setBreadcrumbs: [props.setBreadcrumbs, {}],

--- a/x-pack/plugins/enterprise_search/public/applications/shared/layout/nav.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/layout/nav.test.tsx
@@ -17,6 +17,14 @@ import { ProductAccess } from '../../../../common/types';
 
 import { useEnterpriseSearchNav, useEnterpriseSearchEngineNav } from './nav';
 
+const DEFAULT_PRODUCT_ACCESS: ProductAccess = {
+  hasAppSearchAccess: true,
+  hasNativeConnectorsAccess: true,
+  hasSearchEnginesAccess: false,
+  hasWebCrawlerAccess: true,
+  hasWorkplaceSearchAccess: true,
+};
+
 describe('useEnterpriseSearchContentNav', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -24,11 +32,7 @@ describe('useEnterpriseSearchContentNav', () => {
   });
 
   it('returns an array of top-level Enterprise Search nav items', () => {
-    const fullProductAccess: ProductAccess = {
-      hasAppSearchAccess: true,
-      hasSearchEnginesAccess: false,
-      hasWorkplaceSearchAccess: true,
-    };
+    const fullProductAccess: ProductAccess = DEFAULT_PRODUCT_ACCESS;
     setMockValues({ productAccess: fullProductAccess });
 
     expect(useEnterpriseSearchNav()).toEqual([
@@ -96,8 +100,8 @@ describe('useEnterpriseSearchContentNav', () => {
 
   it('excludes legacy products when the user has no access to them', () => {
     const noProductAccess: ProductAccess = {
+      ...DEFAULT_PRODUCT_ACCESS,
       hasAppSearchAccess: false,
-      hasSearchEnginesAccess: false,
       hasWorkplaceSearchAccess: false,
     };
 
@@ -105,7 +109,7 @@ describe('useEnterpriseSearchContentNav', () => {
     mockKibanaValues.uiSettings.get.mockReturnValue(false);
 
     const esNav = useEnterpriseSearchNav();
-    const searchNav = esNav.find((item) => item.id === 'search');
+    const searchNav = esNav?.find((item) => item.id === 'search');
     expect(searchNav).not.toBeUndefined();
     expect(searchNav).toEqual({
       id: 'search',
@@ -127,15 +131,15 @@ describe('useEnterpriseSearchContentNav', () => {
 
   it('excludes App Search when the user has no access to it', () => {
     const workplaceSearchProductAccess: ProductAccess = {
+      ...DEFAULT_PRODUCT_ACCESS,
       hasAppSearchAccess: false,
-      hasSearchEnginesAccess: false,
       hasWorkplaceSearchAccess: true,
     };
 
     setMockValues({ productAccess: workplaceSearchProductAccess });
 
     const esNav = useEnterpriseSearchNav();
-    const searchNav = esNav.find((item) => item.id === 'search');
+    const searchNav = esNav?.find((item) => item.id === 'search');
     expect(searchNav).not.toBeUndefined();
     expect(searchNav).toEqual({
       id: 'search',
@@ -162,15 +166,14 @@ describe('useEnterpriseSearchContentNav', () => {
 
   it('excludes Workplace Search when the user has no access to it', () => {
     const appSearchProductAccess: ProductAccess = {
-      hasAppSearchAccess: true,
-      hasSearchEnginesAccess: false,
+      ...DEFAULT_PRODUCT_ACCESS,
       hasWorkplaceSearchAccess: false,
     };
 
     setMockValues({ productAccess: appSearchProductAccess });
 
     const esNav = useEnterpriseSearchNav();
-    const searchNav = esNav.find((item) => item.id === 'search');
+    const searchNav = esNav?.find((item) => item.id === 'search');
     expect(searchNav).not.toBeUndefined();
     expect(searchNav).toEqual({
       id: 'search',
@@ -196,15 +199,11 @@ describe('useEnterpriseSearchContentNav', () => {
   });
 
   it('excludes engines when feature flag is off', () => {
-    const fullProductAccess: ProductAccess = {
-      hasAppSearchAccess: true,
-      hasSearchEnginesAccess: false,
-      hasWorkplaceSearchAccess: true,
-    };
+    const fullProductAccess: ProductAccess = DEFAULT_PRODUCT_ACCESS;
     setMockValues({ productAccess: fullProductAccess });
 
     const esNav = useEnterpriseSearchNav();
-    expect(esNav.find((item) => item.id === 'enginesSearch')).toBeUndefined();
+    expect(esNav?.find((item) => item.id === 'enginesSearch')).toBeUndefined();
   });
 });
 
@@ -215,9 +214,8 @@ describe('useEnterpriseSearchContentNav Engines feature flag', () => {
 
   it('returns an array of top-level Enterprise Search nav items', () => {
     const fullProductAccess: ProductAccess = {
-      hasAppSearchAccess: true,
+      ...DEFAULT_PRODUCT_ACCESS,
       hasSearchEnginesAccess: true,
-      hasWorkplaceSearchAccess: true,
     };
     setMockValues({ productAccess: fullProductAccess });
 
@@ -297,6 +295,7 @@ describe('useEnterpriseSearchContentNav Engines feature flag', () => {
 
   it('excludes standalone experiences when the user has no access to them', () => {
     const fullProductAccess: ProductAccess = {
+      ...DEFAULT_PRODUCT_ACCESS,
       hasAppSearchAccess: false,
       hasSearchEnginesAccess: true,
       hasWorkplaceSearchAccess: false,
@@ -304,18 +303,18 @@ describe('useEnterpriseSearchContentNav Engines feature flag', () => {
     setMockValues({ productAccess: fullProductAccess });
 
     const esNav = useEnterpriseSearchNav();
-    expect(esNav.find((item) => item.id === 'standaloneExperiences')).toBeUndefined();
+    expect(esNav?.find((item) => item.id === 'standaloneExperiences')).toBeUndefined();
   });
   it('excludes App Search when the user has no access to it', () => {
     const fullProductAccess: ProductAccess = {
+      ...DEFAULT_PRODUCT_ACCESS,
       hasAppSearchAccess: false,
       hasSearchEnginesAccess: true,
-      hasWorkplaceSearchAccess: true,
     };
     setMockValues({ productAccess: fullProductAccess });
 
     const esNav = useEnterpriseSearchNav();
-    const standAloneNav = esNav.find((item) => item.id === 'standaloneExperiences');
+    const standAloneNav = esNav?.find((item) => item.id === 'standaloneExperiences');
     expect(standAloneNav).not.toBeUndefined();
     expect(standAloneNav).toEqual({
       id: 'standaloneExperiences',
@@ -331,6 +330,7 @@ describe('useEnterpriseSearchContentNav Engines feature flag', () => {
   });
   it('excludes Workplace Search when the user has no access to it', () => {
     const fullProductAccess: ProductAccess = {
+      ...DEFAULT_PRODUCT_ACCESS,
       hasAppSearchAccess: true,
       hasSearchEnginesAccess: true,
       hasWorkplaceSearchAccess: false,
@@ -338,7 +338,7 @@ describe('useEnterpriseSearchContentNav Engines feature flag', () => {
     setMockValues({ productAccess: fullProductAccess });
 
     const esNav = useEnterpriseSearchNav();
-    const standAloneNav = esNav.find((item) => item.id === 'standaloneExperiences');
+    const standAloneNav = esNav?.find((item) => item.id === 'standaloneExperiences');
     expect(standAloneNav).not.toBeUndefined();
     expect(standAloneNav).toEqual({
       id: 'standaloneExperiences',
@@ -359,9 +359,8 @@ describe('useEnterpriseSearchEngineNav', () => {
     jest.clearAllMocks();
     mockKibanaValues.uiSettings.get.mockReturnValue(true);
     const fullProductAccess: ProductAccess = {
-      hasAppSearchAccess: true,
+      ...DEFAULT_PRODUCT_ACCESS,
       hasSearchEnginesAccess: true,
-      hasWorkplaceSearchAccess: true,
     };
     setMockValues({ productAccess: fullProductAccess });
   });
@@ -444,14 +443,14 @@ describe('useEnterpriseSearchEngineNav', () => {
   it('returns selected engine sub nav items', () => {
     const engineName = 'my-test-engine';
     const navItems = useEnterpriseSearchEngineNav(engineName);
-    expect(navItems.map((ni) => ni.name)).toEqual([
+    expect(navItems?.map((ni) => ni.name)).toEqual([
       'Overview',
       'Content',
       'Search',
       'Behavioral Analytics',
       'Standalone Experiences',
     ]);
-    const searchItem = navItems.find((ni) => ni.id === 'enginesSearch');
+    const searchItem = navItems?.find((ni) => ni.id === 'enginesSearch');
     expect(searchItem).not.toBeUndefined();
     expect(searchItem!.items).not.toBeUndefined();
     // @ts-ignore
@@ -501,14 +500,14 @@ describe('useEnterpriseSearchEngineNav', () => {
   it('returns selected engine without tabs when isEmpty', () => {
     const engineName = 'my-test-engine';
     const navItems = useEnterpriseSearchEngineNav(engineName, true);
-    expect(navItems.map((ni) => ni.name)).toEqual([
+    expect(navItems?.map((ni) => ni.name)).toEqual([
       'Overview',
       'Content',
       'Search',
       'Behavioral Analytics',
       'Standalone Experiences',
     ]);
-    const searchItem = navItems.find((ni) => ni.id === 'enginesSearch');
+    const searchItem = navItems?.find((ni) => ni.id === 'enginesSearch');
     expect(searchItem).not.toBeUndefined();
     expect(searchItem!.items).not.toBeUndefined();
     // @ts-ignore

--- a/x-pack/plugins/enterprise_search/public/applications/shared/layout/nav.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/layout/nav.test.tsx
@@ -19,9 +19,7 @@ import { useEnterpriseSearchNav, useEnterpriseSearchEngineNav } from './nav';
 
 const DEFAULT_PRODUCT_ACCESS: ProductAccess = {
   hasAppSearchAccess: true,
-  hasNativeConnectorsAccess: true,
   hasSearchEnginesAccess: false,
-  hasWebCrawlerAccess: true,
   hasWorkplaceSearchAccess: true,
 };
 

--- a/x-pack/plugins/enterprise_search/public/applications/shared/layout/nav.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/layout/nav.test.tsx
@@ -13,6 +13,7 @@ import { setMockValues, mockKibanaValues } from '../../__mocks__/kea_logic';
 
 import { EuiSideNavItemType } from '@elastic/eui';
 
+import { DEFAULT_PRODUCT_FEATURES } from '../../../../common/constants';
 import { ProductAccess } from '../../../../common/types';
 
 import { useEnterpriseSearchNav, useEnterpriseSearchEngineNav } from './nav';
@@ -31,7 +32,7 @@ describe('useEnterpriseSearchContentNav', () => {
 
   it('returns an array of top-level Enterprise Search nav items', () => {
     const fullProductAccess: ProductAccess = DEFAULT_PRODUCT_ACCESS;
-    setMockValues({ productAccess: fullProductAccess });
+    setMockValues({ productAccess: fullProductAccess, productFeatures: DEFAULT_PRODUCT_FEATURES });
 
     expect(useEnterpriseSearchNav()).toEqual([
       {
@@ -103,7 +104,7 @@ describe('useEnterpriseSearchContentNav', () => {
       hasWorkplaceSearchAccess: false,
     };
 
-    setMockValues({ productAccess: noProductAccess });
+    setMockValues({ productAccess: noProductAccess, productFeatures: DEFAULT_PRODUCT_FEATURES });
     mockKibanaValues.uiSettings.get.mockReturnValue(false);
 
     const esNav = useEnterpriseSearchNav();
@@ -134,7 +135,10 @@ describe('useEnterpriseSearchContentNav', () => {
       hasWorkplaceSearchAccess: true,
     };
 
-    setMockValues({ productAccess: workplaceSearchProductAccess });
+    setMockValues({
+      productAccess: workplaceSearchProductAccess,
+      productFeatures: DEFAULT_PRODUCT_FEATURES,
+    });
 
     const esNav = useEnterpriseSearchNav();
     const searchNav = esNav?.find((item) => item.id === 'search');
@@ -168,7 +172,10 @@ describe('useEnterpriseSearchContentNav', () => {
       hasWorkplaceSearchAccess: false,
     };
 
-    setMockValues({ productAccess: appSearchProductAccess });
+    setMockValues({
+      productAccess: appSearchProductAccess,
+      productFeatures: DEFAULT_PRODUCT_FEATURES,
+    });
 
     const esNav = useEnterpriseSearchNav();
     const searchNav = esNav?.find((item) => item.id === 'search');
@@ -198,7 +205,7 @@ describe('useEnterpriseSearchContentNav', () => {
 
   it('excludes engines when feature flag is off', () => {
     const fullProductAccess: ProductAccess = DEFAULT_PRODUCT_ACCESS;
-    setMockValues({ productAccess: fullProductAccess });
+    setMockValues({ productAccess: fullProductAccess, productFeatures: DEFAULT_PRODUCT_FEATURES });
 
     const esNav = useEnterpriseSearchNav();
     expect(esNav?.find((item) => item.id === 'enginesSearch')).toBeUndefined();
@@ -215,7 +222,7 @@ describe('useEnterpriseSearchContentNav Engines feature flag', () => {
       ...DEFAULT_PRODUCT_ACCESS,
       hasSearchEnginesAccess: true,
     };
-    setMockValues({ productAccess: fullProductAccess });
+    setMockValues({ productAccess: fullProductAccess, productFeatures: DEFAULT_PRODUCT_FEATURES });
 
     expect(useEnterpriseSearchNav()).toEqual([
       {
@@ -298,7 +305,7 @@ describe('useEnterpriseSearchContentNav Engines feature flag', () => {
       hasSearchEnginesAccess: true,
       hasWorkplaceSearchAccess: false,
     };
-    setMockValues({ productAccess: fullProductAccess });
+    setMockValues({ productAccess: fullProductAccess, productFeatures: DEFAULT_PRODUCT_FEATURES });
 
     const esNav = useEnterpriseSearchNav();
     expect(esNav?.find((item) => item.id === 'standaloneExperiences')).toBeUndefined();
@@ -309,7 +316,7 @@ describe('useEnterpriseSearchContentNav Engines feature flag', () => {
       hasAppSearchAccess: false,
       hasSearchEnginesAccess: true,
     };
-    setMockValues({ productAccess: fullProductAccess });
+    setMockValues({ productAccess: fullProductAccess, productFeatures: DEFAULT_PRODUCT_FEATURES });
 
     const esNav = useEnterpriseSearchNav();
     const standAloneNav = esNav?.find((item) => item.id === 'standaloneExperiences');
@@ -333,7 +340,7 @@ describe('useEnterpriseSearchContentNav Engines feature flag', () => {
       hasSearchEnginesAccess: true,
       hasWorkplaceSearchAccess: false,
     };
-    setMockValues({ productAccess: fullProductAccess });
+    setMockValues({ productAccess: fullProductAccess, productFeatures: DEFAULT_PRODUCT_FEATURES });
 
     const esNav = useEnterpriseSearchNav();
     const standAloneNav = esNav?.find((item) => item.id === 'standaloneExperiences');
@@ -360,7 +367,7 @@ describe('useEnterpriseSearchEngineNav', () => {
       ...DEFAULT_PRODUCT_ACCESS,
       hasSearchEnginesAccess: true,
     };
-    setMockValues({ productAccess: fullProductAccess });
+    setMockValues({ productAccess: fullProductAccess, productFeatures: DEFAULT_PRODUCT_FEATURES });
   });
 
   it('returns an array of top-level Enterprise Search nav items', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/shared/layout/nav.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/layout/nav.tsx
@@ -30,7 +30,7 @@ import { KibanaLogic } from '../kibana';
 import { generateNavLink } from './nav_link_helpers';
 
 export const useEnterpriseSearchNav = () => {
-  const { productAccess } = useValues(KibanaLogic);
+  const { productAccess, productFeatures } = useValues(KibanaLogic);
 
   const enginesSectionEnabled = productAccess.hasSearchEnginesAccess;
 
@@ -59,17 +59,21 @@ export const useEnterpriseSearchNav = () => {
             to: ENTERPRISE_SEARCH_CONTENT_PLUGIN.URL + SEARCH_INDICES_PATH,
           }),
         },
-        {
-          id: 'settings',
-          name: i18n.translate('xpack.enterpriseSearch.nav.contentSettingsTitle', {
-            defaultMessage: 'Settings',
-          }),
-          ...generateNavLink({
-            shouldNotCreateHref: true,
-            shouldShowActiveForSubroutes: true,
-            to: ENTERPRISE_SEARCH_CONTENT_PLUGIN.URL + SETTINGS_PATH,
-          }),
-        },
+        ...(productFeatures.hasDefaultIngestPipeline
+          ? [
+              {
+                id: 'settings',
+                name: i18n.translate('xpack.enterpriseSearch.nav.contentSettingsTitle', {
+                  defaultMessage: 'Settings',
+                }),
+                ...generateNavLink({
+                  shouldNotCreateHref: true,
+                  shouldShowActiveForSubroutes: true,
+                  to: ENTERPRISE_SEARCH_CONTENT_PLUGIN.URL + SETTINGS_PATH,
+                }),
+              },
+            ]
+          : []),
       ],
       name: i18n.translate('xpack.enterpriseSearch.nav.contentTitle', {
         defaultMessage: 'Content',

--- a/x-pack/plugins/enterprise_search/public/plugin.ts
+++ b/x-pack/plugins/enterprise_search/public/plugin.ts
@@ -322,7 +322,7 @@ export class EnterpriseSearchPlugin implements Plugin {
   }
 
   private async getInitialData(http: HttpSetup) {
-    if (!this.config.host) return; // No API to call
+    if (!this.config.host && this.config.canDeployEntSearch) return; // No API to call
     if (this.hasInitialized) return; // We've already made an initial call
 
     try {

--- a/x-pack/plugins/enterprise_search/public/plugin.ts
+++ b/x-pack/plugins/enterprise_search/public/plugin.ts
@@ -32,13 +32,9 @@ import {
   WORKPLACE_SEARCH_PLUGIN,
   SEARCH_EXPERIENCES_PLUGIN,
 } from '../common/constants';
-import { InitialAppData } from '../common/types';
+import { ClientConfigType, InitialAppData } from '../common/types';
 
 import { docLinks } from './applications/shared/doc_links';
-
-export interface ClientConfigType {
-  host?: string;
-}
 
 export interface ClientData extends InitialAppData {
   publicUrl?: string;

--- a/x-pack/plugins/enterprise_search/server/index.ts
+++ b/x-pack/plugins/enterprise_search/server/index.ts
@@ -17,7 +17,10 @@ export const plugin = (initializerContext: PluginInitializerContext) => {
 export const configSchema = schema.object({
   accessCheckTimeout: schema.number({ defaultValue: 5000 }),
   accessCheckTimeoutWarning: schema.number({ defaultValue: 300 }),
+  canDeployEntSearch: schema.boolean({ defaultValue: true }),
   customHeaders: schema.maybe(schema.object({}, { unknowns: 'allow' })),
+  hasNativeConnectors: schema.boolean({ defaultValue: true }),
+  hasWebCrawler: schema.boolean({ defaultValue: true }),
   host: schema.maybe(schema.string()),
   ssl: schema.object({
     certificateAuthorities: schema.maybe(
@@ -34,6 +37,7 @@ export type ConfigType = TypeOf<typeof configSchema>;
 
 export const config: PluginConfigDescriptor<ConfigType> = {
   exposeToBrowser: {
+    canDeployEntSearch: true,
     host: true,
   },
   schema: configSchema,

--- a/x-pack/plugins/enterprise_search/server/index.ts
+++ b/x-pack/plugins/enterprise_search/server/index.ts
@@ -19,9 +19,10 @@ export const configSchema = schema.object({
   accessCheckTimeoutWarning: schema.number({ defaultValue: 300 }),
   canDeployEntSearch: schema.boolean({ defaultValue: true }),
   customHeaders: schema.maybe(schema.object({}, { unknowns: 'allow' })),
+  hasConnectors: schema.boolean({ defaultValue: true }),
+  hasDefaultIngestPipeline: schema.boolean({ defaultValue: true }),
   hasNativeConnectors: schema.boolean({ defaultValue: true }),
   hasWebCrawler: schema.boolean({ defaultValue: true }),
-  hasDefaultIngestPipeline: schema.boolean({ defaultValue: true }),
   host: schema.maybe(schema.string()),
   ssl: schema.object({
     certificateAuthorities: schema.maybe(

--- a/x-pack/plugins/enterprise_search/server/index.ts
+++ b/x-pack/plugins/enterprise_search/server/index.ts
@@ -21,6 +21,7 @@ export const configSchema = schema.object({
   customHeaders: schema.maybe(schema.object({}, { unknowns: 'allow' })),
   hasNativeConnectors: schema.boolean({ defaultValue: true }),
   hasWebCrawler: schema.boolean({ defaultValue: true }),
+  hasDefaultIngestPipeline: schema.boolean({ defaultValue: true }),
   host: schema.maybe(schema.string()),
   ssl: schema.object({
     certificateAuthorities: schema.maybe(

--- a/x-pack/plugins/enterprise_search/server/lib/check_access.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/check_access.test.ts
@@ -47,7 +47,10 @@ describe('checkAccess', () => {
   const mockSpaces = spacesMock.createStart();
   const mockDependencies = {
     request: { auth: { isAuthenticated: true } },
-    config: { host: 'http://localhost:3002' },
+    config: {
+      canDeployEntSearch: true,
+      host: 'http://localhost:3002',
+    },
     security: mockSecurity,
     spaces: mockSpaces,
   } as any;
@@ -59,7 +62,9 @@ describe('checkAccess', () => {
       };
       expect(await checkAccess({ ...mockDependencies, security })).toEqual({
         hasAppSearchAccess: false,
+        hasNativeConnectorsAccess: false,
         hasSearchEnginesAccess: false,
+        hasWebCrawlerAccess: false,
         hasWorkplaceSearchAccess: false,
       });
     });
@@ -72,7 +77,9 @@ describe('checkAccess', () => {
       };
       expect(await checkAccess({ ...mockDependencies, request })).toEqual({
         hasAppSearchAccess: false,
+        hasNativeConnectorsAccess: false,
         hasSearchEnginesAccess: false,
+        hasWebCrawlerAccess: false,
         hasWorkplaceSearchAccess: false,
       });
     });
@@ -83,7 +90,9 @@ describe('checkAccess', () => {
       mockSpaces.spacesService.getActiveSpace.mockResolvedValueOnce(disabledSpace);
       expect(await checkAccess({ ...mockDependencies })).toEqual({
         hasAppSearchAccess: false,
+        hasNativeConnectorsAccess: false,
         hasSearchEnginesAccess: false,
+        hasWebCrawlerAccess: false,
         hasWorkplaceSearchAccess: false,
       });
     });
@@ -97,7 +106,9 @@ describe('checkAccess', () => {
         );
         expect(await checkAccess({ ...mockDependencies })).toEqual({
           hasAppSearchAccess: false,
+          hasNativeConnectorsAccess: false,
           hasSearchEnginesAccess: false,
+          hasWebCrawlerAccess: false,
           hasWorkplaceSearchAccess: false,
         });
       });
@@ -138,7 +149,9 @@ describe('checkAccess', () => {
         };
         expect(await checkAccess({ ...mockDependencies, security })).toEqual({
           hasAppSearchAccess: true,
+          hasNativeConnectorsAccess: true,
           hasSearchEnginesAccess: false,
+          hasWebCrawlerAccess: true,
           hasWorkplaceSearchAccess: true,
         });
       });
@@ -154,7 +167,9 @@ describe('checkAccess', () => {
         };
         expect(await checkAccess({ ...mockDependencies, security })).toEqual({
           hasAppSearchAccess: false,
+          hasNativeConnectorsAccess: false,
           hasSearchEnginesAccess: false,
+          hasWebCrawlerAccess: false,
           hasWorkplaceSearchAccess: false,
         });
       });
@@ -176,7 +191,9 @@ describe('checkAccess', () => {
           const config = { host: undefined };
           expect(await checkAccess({ ...mockDependencies, config })).toEqual({
             hasAppSearchAccess: false,
+            hasNativeConnectorsAccess: false,
             hasSearchEnginesAccess: false,
+            hasWebCrawlerAccess: false,
             hasWorkplaceSearchAccess: false,
           });
         });
@@ -202,7 +219,9 @@ describe('checkAccess', () => {
           (callEnterpriseSearchConfigAPI as jest.Mock).mockImplementationOnce(() => ({}));
           expect(await checkAccess(mockDependencies)).toEqual({
             hasAppSearchAccess: false,
+            hasNativeConnectorsAccess: false,
             hasSearchEnginesAccess: false,
+            hasWebCrawlerAccess: false,
             hasWorkplaceSearchAccess: false,
           });
         });
@@ -214,7 +233,9 @@ describe('checkAccess', () => {
           }));
           expect(await checkAccess(mockDependencies)).toEqual({
             hasAppSearchAccess: false,
+            hasNativeConnectorsAccess: false,
             hasSearchEnginesAccess: false,
+            hasWebCrawlerAccess: false,
             hasWorkplaceSearchAccess: false,
           });
         });

--- a/x-pack/plugins/enterprise_search/server/lib/check_access.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/check_access.test.ts
@@ -62,9 +62,7 @@ describe('checkAccess', () => {
       };
       expect(await checkAccess({ ...mockDependencies, security })).toEqual({
         hasAppSearchAccess: false,
-        hasNativeConnectorsAccess: false,
         hasSearchEnginesAccess: false,
-        hasWebCrawlerAccess: false,
         hasWorkplaceSearchAccess: false,
       });
     });
@@ -77,9 +75,7 @@ describe('checkAccess', () => {
       };
       expect(await checkAccess({ ...mockDependencies, request })).toEqual({
         hasAppSearchAccess: false,
-        hasNativeConnectorsAccess: false,
         hasSearchEnginesAccess: false,
-        hasWebCrawlerAccess: false,
         hasWorkplaceSearchAccess: false,
       });
     });
@@ -90,9 +86,7 @@ describe('checkAccess', () => {
       mockSpaces.spacesService.getActiveSpace.mockResolvedValueOnce(disabledSpace);
       expect(await checkAccess({ ...mockDependencies })).toEqual({
         hasAppSearchAccess: false,
-        hasNativeConnectorsAccess: false,
         hasSearchEnginesAccess: false,
-        hasWebCrawlerAccess: false,
         hasWorkplaceSearchAccess: false,
       });
     });
@@ -106,9 +100,7 @@ describe('checkAccess', () => {
         );
         expect(await checkAccess({ ...mockDependencies })).toEqual({
           hasAppSearchAccess: false,
-          hasNativeConnectorsAccess: false,
           hasSearchEnginesAccess: false,
-          hasWebCrawlerAccess: false,
           hasWorkplaceSearchAccess: false,
         });
       });
@@ -149,9 +141,7 @@ describe('checkAccess', () => {
         };
         expect(await checkAccess({ ...mockDependencies, security })).toEqual({
           hasAppSearchAccess: true,
-          hasNativeConnectorsAccess: true,
           hasSearchEnginesAccess: false,
-          hasWebCrawlerAccess: true,
           hasWorkplaceSearchAccess: true,
         });
       });
@@ -167,9 +157,7 @@ describe('checkAccess', () => {
         };
         expect(await checkAccess({ ...mockDependencies, security })).toEqual({
           hasAppSearchAccess: false,
-          hasNativeConnectorsAccess: false,
           hasSearchEnginesAccess: false,
-          hasWebCrawlerAccess: false,
           hasWorkplaceSearchAccess: false,
         });
       });
@@ -191,9 +179,7 @@ describe('checkAccess', () => {
           const config = { host: undefined };
           expect(await checkAccess({ ...mockDependencies, config })).toEqual({
             hasAppSearchAccess: false,
-            hasNativeConnectorsAccess: false,
             hasSearchEnginesAccess: false,
-            hasWebCrawlerAccess: false,
             hasWorkplaceSearchAccess: false,
           });
         });
@@ -219,9 +205,7 @@ describe('checkAccess', () => {
           (callEnterpriseSearchConfigAPI as jest.Mock).mockImplementationOnce(() => ({}));
           expect(await checkAccess(mockDependencies)).toEqual({
             hasAppSearchAccess: false,
-            hasNativeConnectorsAccess: false,
             hasSearchEnginesAccess: false,
-            hasWebCrawlerAccess: false,
             hasWorkplaceSearchAccess: false,
           });
         });
@@ -233,9 +217,7 @@ describe('checkAccess', () => {
           }));
           expect(await checkAccess(mockDependencies)).toEqual({
             hasAppSearchAccess: false,
-            hasNativeConnectorsAccess: false,
             hasSearchEnginesAccess: false,
-            hasWebCrawlerAccess: false,
             hasWorkplaceSearchAccess: false,
           });
         });

--- a/x-pack/plugins/enterprise_search/server/lib/check_access.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/check_access.ts
@@ -25,16 +25,12 @@ interface CheckAccess {
 
 const ALLOW_ALL_PLUGINS: ProductAccess = {
   hasAppSearchAccess: true,
-  hasNativeConnectorsAccess: true,
   hasSearchEnginesAccess: false, // still false unless Feature Flag explicitly enabled on backend
-  hasWebCrawlerAccess: true,
   hasWorkplaceSearchAccess: true,
 };
 const DENY_ALL_PLUGINS: ProductAccess = {
   hasAppSearchAccess: false,
-  hasNativeConnectorsAccess: false,
   hasSearchEnginesAccess: false,
-  hasWebCrawlerAccess: false,
   hasWorkplaceSearchAccess: false,
 };
 

--- a/x-pack/plugins/enterprise_search/server/lib/check_access.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/check_access.ts
@@ -25,12 +25,16 @@ interface CheckAccess {
 
 const ALLOW_ALL_PLUGINS: ProductAccess = {
   hasAppSearchAccess: true,
+  hasNativeConnectorsAccess: true,
   hasSearchEnginesAccess: false, // still false unless Feature Flag explicitly enabled on backend
+  hasWebCrawlerAccess: true,
   hasWorkplaceSearchAccess: true,
 };
 const DENY_ALL_PLUGINS: ProductAccess = {
   hasAppSearchAccess: false,
+  hasNativeConnectorsAccess: false,
   hasSearchEnginesAccess: false,
+  hasWebCrawlerAccess: false,
   hasWorkplaceSearchAccess: false,
 };
 

--- a/x-pack/plugins/enterprise_search/server/lib/enterprise_search_config_api.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/enterprise_search_config_api.test.ts
@@ -205,10 +205,29 @@ describe('callEnterpriseSearchConfigAPI', () => {
     });
   });
 
-  it('returns early if config.host is not set', async () => {
-    const config = { host: '' };
+  it('returns access & features if config.host is not set', async () => {
+    const config = {
+      hasDefaultIngestPipeline: false,
+      hasNativeConnectors: false,
+      hasSearchApplications: false,
+      hasWebCrawler: false,
+      host: '',
+    };
 
-    expect(await callEnterpriseSearchConfigAPI({ ...mockDependencies, config })).toEqual({});
+    expect(await callEnterpriseSearchConfigAPI({ ...mockDependencies, config })).toEqual({
+      access: {
+        hasAppSearchAccess: false,
+        hasSearchEnginesAccess: false,
+        hasWorkplaceSearchAccess: false,
+      },
+      features: {
+        hasDefaultIngestPipeline: false,
+        hasNativeConnectors: false,
+        hasSearchApplications: false,
+        hasWebCrawler: false,
+      },
+      kibanaVersion: '1.0.0',
+    });
     expect(fetch).not.toHaveBeenCalled();
   });
 

--- a/x-pack/plugins/enterprise_search/server/lib/enterprise_search_config_api.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/enterprise_search_config_api.test.ts
@@ -207,6 +207,7 @@ describe('callEnterpriseSearchConfigAPI', () => {
 
   it('returns access & features if config.host is not set', async () => {
     const config = {
+      hasConnectors: false,
       hasDefaultIngestPipeline: false,
       hasNativeConnectors: false,
       hasSearchApplications: false,
@@ -221,6 +222,7 @@ describe('callEnterpriseSearchConfigAPI', () => {
         hasWorkplaceSearchAccess: false,
       },
       features: {
+        hasConnectors: false,
         hasDefaultIngestPipeline: false,
         hasNativeConnectors: false,
         hasSearchApplications: false,

--- a/x-pack/plugins/enterprise_search/server/lib/enterprise_search_config_api.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/enterprise_search_config_api.test.ts
@@ -29,6 +29,8 @@ describe('callEnterpriseSearchConfigAPI', () => {
     host: 'http://localhost:3002',
     accessCheckTimeout: 200,
     accessCheckTimeoutWarning: 100,
+    hasNativeConnectors: true,
+    hasWebCrawler: true,
   };
   const mockRequest = {
     headers: { authorization: '==someAuth' },
@@ -127,6 +129,11 @@ describe('callEnterpriseSearchConfigAPI', () => {
         hasSearchEnginesAccess: true,
         hasWorkplaceSearchAccess: false,
       },
+      features: {
+        hasNativeConnectors: true,
+        hasSearchApplications: true,
+        hasWebCrawler: true,
+      },
       publicUrl: 'http://some.vanity.url',
     });
   });
@@ -140,6 +147,11 @@ describe('callEnterpriseSearchConfigAPI', () => {
         hasAppSearchAccess: false,
         hasSearchEnginesAccess: false,
         hasWorkplaceSearchAccess: false,
+      },
+      features: {
+        hasNativeConnectors: true,
+        hasSearchApplications: false,
+        hasWebCrawler: true,
       },
       publicUrl: undefined,
       readOnlyMode: false,

--- a/x-pack/plugins/enterprise_search/server/lib/enterprise_search_config_api.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/enterprise_search_config_api.ts
@@ -43,7 +43,21 @@ export const callEnterpriseSearchConfigAPI = async ({
   log,
   request,
 }: Params): Promise<Return | ResponseError> => {
-  if (!config.host) return {};
+  if (!config.host)
+    // Return Access and Features for when running without `ent-search`
+    return {
+      access: {
+        hasAppSearchAccess: false,
+        hasSearchEnginesAccess: false, // TODO: update to read ES feature flag, or just refactor out
+        hasWorkplaceSearchAccess: false,
+      },
+      features: {
+        hasNativeConnectors: config.hasNativeConnectors,
+        hasSearchApplications: false, // TODO: update to read ES feature flag, or just refactor out
+        hasWebCrawler: config.hasWebCrawler,
+      },
+      kibanaVersion: kibanaPackageJson.version,
+    };
 
   const TIMEOUT_WARNING = `Enterprise Search access check took over ${config.accessCheckTimeoutWarning}ms. Please ensure your Enterprise Search server is responding normally and not adversely impacting Kibana load speeds.`;
   const TIMEOUT_MESSAGE = `Exceeded ${config.accessCheckTimeout}ms timeout while checking ${config.host}. Please consider increasing your enterpriseSearch.accessCheckTimeout value so that users aren't prevented from accessing Enterprise Search plugins due to slow responses.`;

--- a/x-pack/plugins/enterprise_search/server/lib/enterprise_search_config_api.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/enterprise_search_config_api.ts
@@ -52,6 +52,7 @@ export const callEnterpriseSearchConfigAPI = async ({
         hasWorkplaceSearchAccess: false,
       },
       features: {
+        hasDefaultIngestPipeline: config.hasDefaultIngestPipeline,
         hasNativeConnectors: config.hasNativeConnectors,
         hasSearchApplications: false, // TODO: update to read ES feature flag, or just refactor out
         hasWebCrawler: config.hasWebCrawler,
@@ -105,6 +106,7 @@ export const callEnterpriseSearchConfigAPI = async ({
         hasWorkplaceSearchAccess: !!data?.current_user?.access?.workplace_search,
       },
       features: {
+        hasDefaultIngestPipeline: config.hasDefaultIngestPipeline,
         hasNativeConnectors: config.hasNativeConnectors,
         hasSearchApplications: !!data?.current_user?.access?.search_engines,
         hasWebCrawler: config.hasWebCrawler,

--- a/x-pack/plugins/enterprise_search/server/lib/enterprise_search_config_api.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/enterprise_search_config_api.ts
@@ -87,10 +87,13 @@ export const callEnterpriseSearchConfigAPI = async ({
       kibanaVersion: kibanaPackageJson.version,
       access: {
         hasAppSearchAccess: !!data?.current_user?.access?.app_search,
-        hasNativeConnectorsAccess: config.hasNativeConnectors,
         hasSearchEnginesAccess: !!data?.current_user?.access?.search_engines,
-        hasWebCrawlerAccess: config.hasWebCrawler,
         hasWorkplaceSearchAccess: !!data?.current_user?.access?.workplace_search,
+      },
+      features: {
+        hasNativeConnectors: config.hasNativeConnectors,
+        hasSearchApplications: !!data?.current_user?.access?.search_engines,
+        hasWebCrawler: config.hasWebCrawler,
       },
       publicUrl: stripTrailingSlash(data?.settings?.external_url),
       readOnlyMode: !!data?.settings?.read_only_mode,

--- a/x-pack/plugins/enterprise_search/server/lib/enterprise_search_config_api.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/enterprise_search_config_api.ts
@@ -87,7 +87,9 @@ export const callEnterpriseSearchConfigAPI = async ({
       kibanaVersion: kibanaPackageJson.version,
       access: {
         hasAppSearchAccess: !!data?.current_user?.access?.app_search,
+        hasNativeConnectorsAccess: config.hasNativeConnectors,
         hasSearchEnginesAccess: !!data?.current_user?.access?.search_engines,
+        hasWebCrawlerAccess: config.hasWebCrawler,
         hasWorkplaceSearchAccess: !!data?.current_user?.access?.workplace_search,
       },
       publicUrl: stripTrailingSlash(data?.settings?.external_url),

--- a/x-pack/plugins/enterprise_search/server/lib/enterprise_search_config_api.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/enterprise_search_config_api.ts
@@ -52,6 +52,7 @@ export const callEnterpriseSearchConfigAPI = async ({
         hasWorkplaceSearchAccess: false,
       },
       features: {
+        hasConnectors: config.hasConnectors,
         hasDefaultIngestPipeline: config.hasDefaultIngestPipeline,
         hasNativeConnectors: config.hasNativeConnectors,
         hasSearchApplications: false, // TODO: update to read ES feature flag, or just refactor out
@@ -106,6 +107,7 @@ export const callEnterpriseSearchConfigAPI = async ({
         hasWorkplaceSearchAccess: !!data?.current_user?.access?.workplace_search,
       },
       features: {
+        hasConnectors: config.hasConnectors,
         hasDefaultIngestPipeline: config.hasDefaultIngestPipeline,
         hasNativeConnectors: config.hasNativeConnectors,
         hasSearchApplications: !!data?.current_user?.access?.search_engines,

--- a/x-pack/plugins/enterprise_search/server/plugin.ts
+++ b/x-pack/plugins/enterprise_search/server/plugin.ts
@@ -131,8 +131,7 @@ export class EnterpriseSearchPlugin implements Plugin {
       ENTERPRISE_SEARCH_CONTENT_PLUGIN.ID,
       ELASTICSEARCH_PLUGIN.ID,
       ANALYTICS_PLUGIN.ID,
-      APP_SEARCH_PLUGIN.ID,
-      WORKPLACE_SEARCH_PLUGIN.ID,
+      ...(config.canDeployEntSearch ? [APP_SEARCH_PLUGIN.ID, WORKPLACE_SEARCH_PLUGIN.ID] : []),
       SEARCH_EXPERIENCES_PLUGIN.ID,
     ];
 
@@ -205,12 +204,12 @@ export class EnterpriseSearchPlugin implements Plugin {
     const dependencies = { router, config, log, enterpriseSearchRequestHandler, ml };
 
     registerConfigDataRoute(dependencies);
-    registerAppSearchRoutes(dependencies);
+    if (config.canDeployEntSearch) registerAppSearchRoutes(dependencies);
     registerEnterpriseSearchRoutes(dependencies);
-    registerWorkplaceSearchRoutes(dependencies);
+    if (config.canDeployEntSearch) registerWorkplaceSearchRoutes(dependencies);
     // Enterprise Search Routes
-    registerConnectorRoutes(dependencies);
-    registerCrawlerRoutes(dependencies);
+    if (config.hasNativeConnectors) registerConnectorRoutes(dependencies);
+    if (config.hasWebCrawler) registerCrawlerRoutes(dependencies);
     registerStatsRoutes(dependencies);
 
     // Analytics Routes (stand-alone product)
@@ -226,8 +225,10 @@ export class EnterpriseSearchPlugin implements Plugin {
      * Bootstrap the routes, saved objects, and collector for telemetry
      */
     savedObjects.registerType(enterpriseSearchTelemetryType);
-    savedObjects.registerType(appSearchTelemetryType);
-    savedObjects.registerType(workplaceSearchTelemetryType);
+    if (config.canDeployEntSearch) {
+      savedObjects.registerType(appSearchTelemetryType);
+      savedObjects.registerType(workplaceSearchTelemetryType);
+    }
     let savedObjectsStarted: SavedObjectsServiceStart;
 
     getStartServices().then(([coreStart]) => {
@@ -235,8 +236,10 @@ export class EnterpriseSearchPlugin implements Plugin {
 
       if (usageCollection) {
         registerESTelemetryUsageCollector(usageCollection, savedObjectsStarted, this.logger);
-        registerASTelemetryUsageCollector(usageCollection, savedObjectsStarted, this.logger);
-        registerWSTelemetryUsageCollector(usageCollection, savedObjectsStarted, this.logger);
+        if (config.canDeployEntSearch) {
+          registerASTelemetryUsageCollector(usageCollection, savedObjectsStarted, this.logger);
+          registerWSTelemetryUsageCollector(usageCollection, savedObjectsStarted, this.logger);
+        }
       }
     });
     registerTelemetryRoute({ ...dependencies, getSavedObjectsService: () => savedObjectsStarted });
@@ -272,9 +275,15 @@ export class EnterpriseSearchPlugin implements Plugin {
     /**
      * Register a config for the search guide
      */
-    guidedOnboarding.registerGuideConfig(appSearchGuideId, appSearchGuideConfig);
-    guidedOnboarding.registerGuideConfig(websiteSearchGuideId, websiteSearchGuideConfig);
-    guidedOnboarding.registerGuideConfig(databaseSearchGuideId, databaseSearchGuideConfig);
+    if (config.canDeployEntSearch) {
+      guidedOnboarding.registerGuideConfig(appSearchGuideId, appSearchGuideConfig);
+    }
+    if (config.hasWebCrawler) {
+      guidedOnboarding.registerGuideConfig(websiteSearchGuideId, websiteSearchGuideConfig);
+    }
+    if (config.hasNativeConnectors) {
+      guidedOnboarding.registerGuideConfig(databaseSearchGuideId, databaseSearchGuideConfig);
+    }
   }
 
   public start() {}

--- a/x-pack/plugins/enterprise_search/server/plugin.ts
+++ b/x-pack/plugins/enterprise_search/server/plugin.ts
@@ -172,7 +172,8 @@ export class EnterpriseSearchPlugin implements Plugin {
       const dependencies = { config, security, spaces, request, log, ml };
 
       const { hasAppSearchAccess, hasWorkplaceSearchAccess } = await checkAccess(dependencies);
-      const showEnterpriseSearch = hasAppSearchAccess || hasWorkplaceSearchAccess;
+      const showEnterpriseSearch =
+        hasAppSearchAccess || hasWorkplaceSearchAccess || !config.canDeployEntSearch;
 
       return {
         navLinks: {
@@ -180,8 +181,8 @@ export class EnterpriseSearchPlugin implements Plugin {
           enterpriseSearchContent: showEnterpriseSearch,
           enterpriseSearchAnalytics: showEnterpriseSearch,
           elasticsearch: showEnterpriseSearch,
-          appSearch: hasAppSearchAccess,
-          workplaceSearch: hasWorkplaceSearchAccess,
+          appSearch: hasAppSearchAccess && config.canDeployEntSearch,
+          workplaceSearch: hasWorkplaceSearchAccess && config.canDeployEntSearch,
           searchExperiences: showEnterpriseSearch,
         },
         catalogue: {
@@ -189,8 +190,8 @@ export class EnterpriseSearchPlugin implements Plugin {
           enterpriseSearchContent: showEnterpriseSearch,
           enterpriseSearchAnalytics: showEnterpriseSearch,
           elasticsearch: showEnterpriseSearch,
-          appSearch: hasAppSearchAccess,
-          workplaceSearch: hasWorkplaceSearchAccess,
+          appSearch: hasAppSearchAccess && config.canDeployEntSearch,
+          workplaceSearch: hasWorkplaceSearchAccess && config.canDeployEntSearch,
           searchExperiences: showEnterpriseSearch,
         },
       };


### PR DESCRIPTION
## Summary

Introduces new config properties related to running `enterprise_search` plugin without the `ent-search` service running. All three default to `true` and retain the current behavior when they are set to `true`.

`canDeployEntSearch` - Setting to false will result in not showing the Setup Guide for content pages when `config.host` is not set. Essentially ungating indices, engines etc. pages.
`hasConnectors` - setting to `false` will result in hiding the connector ingestion method when creating a new index.
`hasDefaultIngestPipeline` - setting to `false` will result in hiding the index Pipelines and Content Settings page, until we can migrate management of default ingest pipeline to the ES module
`hasNativeConnectors` - setting to `false` will result in hiding the native connector ingestion method when creating a new index.
`hasWebCrawler` - setting to `false` will result in hiding the web crawler ingestion method when creating a new index.

`hasNativeConnectors` & `hasWebCrawler` are intended to be temporary and can be removed once we are sure the connectors service and web crawler will be available in serverless.