### PR TITLE
[ci] Make container image tag update trigger async

### DIFF
--- a/.buildkite/scripts/steps/artifacts/docker_image.sh
+++ b/.buildkite/scripts/steps/artifacts/docker_image.sh
@@ -82,6 +82,7 @@ if [[ "$BUILDKITE_BRANCH" == "$KIBANA_BASE_BRANCH" ]]; then
   cat << EOF | buildkite-agent pipeline upload
 steps:
   - trigger: k8s-gitops-update-image-tag
+    async: true
     label: ":argo: Update image tag for Kibana"
     branches: main
     build:


### PR DESCRIPTION
Making this pipeline async will prevent duplicate notifications on failure.  This pipeline has some flakiness and doesn't need to be routed with our usual alerts.
