### PR TITLE
Only log deprecation warnings for calls to Saved Objects routes from non-kibana request

### DIFF
--- a/packages/core/saved-objects/core-saved-objects-server-internal/src/routes/bulk_create.ts
+++ b/packages/core/saved-objects/core-saved-objects-server-internal/src/routes/bulk_create.ts
@@ -11,7 +11,11 @@ import { SavedObjectConfig } from '@kbn/core-saved-objects-base-server-internal'
 import type { InternalCoreUsageDataSetup } from '@kbn/core-usage-data-base-server-internal';
 import type { Logger } from '@kbn/logging';
 import type { InternalSavedObjectRouter } from '../internal_types';
-import { catchAndReturnBoomErrors, throwIfAnyTypeNotVisibleByAPI } from './utils';
+import {
+  catchAndReturnBoomErrors,
+  logWarnOnExternalRequest,
+  throwIfAnyTypeNotVisibleByAPI,
+} from './utils';
 
 interface RouteDependencies {
   config: SavedObjectConfig;
@@ -54,9 +58,12 @@ export const registerBulkCreateRoute = (
       },
     },
     catchAndReturnBoomErrors(async (context, req, res) => {
-      logger.warn(
-        "The bulk create saved object API '/api/saved_objects/_bulk_create' is deprecated."
-      );
+      logWarnOnExternalRequest({
+        method: 'post',
+        path: '/api/saved_objects/_bulk_create',
+        req,
+        logger,
+      });
       const { overwrite } = req.query;
 
       const usageStatsClient = coreUsageData.getClient();

--- a/packages/core/saved-objects/core-saved-objects-server-internal/src/routes/bulk_delete.ts
+++ b/packages/core/saved-objects/core-saved-objects-server-internal/src/routes/bulk_delete.ts
@@ -11,7 +11,11 @@ import { SavedObjectConfig } from '@kbn/core-saved-objects-base-server-internal'
 import type { InternalCoreUsageDataSetup } from '@kbn/core-usage-data-base-server-internal';
 import type { Logger } from '@kbn/logging';
 import type { InternalSavedObjectRouter } from '../internal_types';
-import { catchAndReturnBoomErrors, throwIfAnyTypeNotVisibleByAPI } from './utils';
+import {
+  catchAndReturnBoomErrors,
+  logWarnOnExternalRequest,
+  throwIfAnyTypeNotVisibleByAPI,
+} from './utils';
 
 interface RouteDependencies {
   config: SavedObjectConfig;
@@ -40,9 +44,12 @@ export const registerBulkDeleteRoute = (
       },
     },
     catchAndReturnBoomErrors(async (context, req, res) => {
-      logger.warn(
-        "The bulk update saved object API '/api/saved_objects/_bulk_update' is deprecated."
-      );
+      logWarnOnExternalRequest({
+        method: 'post',
+        path: '/api/saved_objects/_bulk_delete',
+        req,
+        logger,
+      });
       const { force } = req.query;
       const usageStatsClient = coreUsageData.getClient();
       usageStatsClient.incrementSavedObjectsBulkDelete({ request: req }).catch(() => {});

--- a/packages/core/saved-objects/core-saved-objects-server-internal/src/routes/bulk_get.ts
+++ b/packages/core/saved-objects/core-saved-objects-server-internal/src/routes/bulk_get.ts
@@ -11,7 +11,11 @@ import { SavedObjectConfig } from '@kbn/core-saved-objects-base-server-internal'
 import type { InternalCoreUsageDataSetup } from '@kbn/core-usage-data-base-server-internal';
 import type { Logger } from '@kbn/logging';
 import type { InternalSavedObjectRouter } from '../internal_types';
-import { catchAndReturnBoomErrors, throwIfAnyTypeNotVisibleByAPI } from './utils';
+import {
+  catchAndReturnBoomErrors,
+  logWarnOnExternalRequest,
+  throwIfAnyTypeNotVisibleByAPI,
+} from './utils';
 
 interface RouteDependencies {
   config: SavedObjectConfig;
@@ -39,7 +43,12 @@ export const registerBulkGetRoute = (
       },
     },
     catchAndReturnBoomErrors(async (context, req, res) => {
-      logger.warn("The bulk get saved object API '/api/saved_objects/_bulk_get' is deprecated.");
+      logWarnOnExternalRequest({
+        method: 'post',
+        path: '/api/saved_objects/_bulk_get',
+        req,
+        logger,
+      });
       const usageStatsClient = coreUsageData.getClient();
       usageStatsClient.incrementSavedObjectsBulkGet({ request: req }).catch(() => {});
 

--- a/packages/core/saved-objects/core-saved-objects-server-internal/src/routes/bulk_resolve.ts
+++ b/packages/core/saved-objects/core-saved-objects-server-internal/src/routes/bulk_resolve.ts
@@ -11,7 +11,11 @@ import { SavedObjectConfig } from '@kbn/core-saved-objects-base-server-internal'
 import type { InternalCoreUsageDataSetup } from '@kbn/core-usage-data-base-server-internal';
 import type { Logger } from '@kbn/logging';
 import type { InternalSavedObjectRouter } from '../internal_types';
-import { catchAndReturnBoomErrors, throwIfAnyTypeNotVisibleByAPI } from './utils';
+import {
+  catchAndReturnBoomErrors,
+  logWarnOnExternalRequest,
+  throwIfAnyTypeNotVisibleByAPI,
+} from './utils';
 
 interface RouteDependencies {
   config: SavedObjectConfig;
@@ -37,9 +41,12 @@ export const registerBulkResolveRoute = (
       },
     },
     catchAndReturnBoomErrors(async (context, req, res) => {
-      logger.warn(
-        "The bulk resolve saved object API '/api/saved_objects/_bulk_resolve' is deprecated."
-      );
+      logWarnOnExternalRequest({
+        method: 'post',
+        path: '/api/saved_objects/_bulk_resolve',
+        req,
+        logger,
+      });
       const usageStatsClient = coreUsageData.getClient();
       usageStatsClient.incrementSavedObjectsBulkResolve({ request: req }).catch(() => {});
 

--- a/packages/core/saved-objects/core-saved-objects-server-internal/src/routes/bulk_update.ts
+++ b/packages/core/saved-objects/core-saved-objects-server-internal/src/routes/bulk_update.ts
@@ -11,7 +11,11 @@ import { SavedObjectConfig } from '@kbn/core-saved-objects-base-server-internal'
 import type { InternalCoreUsageDataSetup } from '@kbn/core-usage-data-base-server-internal';
 import type { Logger } from '@kbn/logging';
 import type { InternalSavedObjectRouter } from '../internal_types';
-import { catchAndReturnBoomErrors, throwIfAnyTypeNotVisibleByAPI } from './utils';
+import {
+  catchAndReturnBoomErrors,
+  logWarnOnExternalRequest,
+  throwIfAnyTypeNotVisibleByAPI,
+} from './utils';
 
 interface RouteDependencies {
   config: SavedObjectConfig;
@@ -49,9 +53,12 @@ export const registerBulkUpdateRoute = (
       },
     },
     catchAndReturnBoomErrors(async (context, req, res) => {
-      logger.warn(
-        "The bulk update saved object API '/api/saved_objects/_bulk_update' is deprecated."
-      );
+      logWarnOnExternalRequest({
+        method: 'put',
+        path: '/api/saved_objects/_bulk_update',
+        req,
+        logger,
+      });
       const usageStatsClient = coreUsageData.getClient();
       usageStatsClient.incrementSavedObjectsBulkUpdate({ request: req }).catch(() => {});
 

--- a/packages/core/saved-objects/core-saved-objects-server-internal/src/routes/create.ts
+++ b/packages/core/saved-objects/core-saved-objects-server-internal/src/routes/create.ts
@@ -11,7 +11,11 @@ import { SavedObjectConfig } from '@kbn/core-saved-objects-base-server-internal'
 import type { InternalCoreUsageDataSetup } from '@kbn/core-usage-data-base-server-internal';
 import type { Logger } from '@kbn/logging';
 import type { InternalSavedObjectRouter } from '../internal_types';
-import { catchAndReturnBoomErrors, throwIfTypeNotVisibleByAPI } from './utils';
+import {
+  catchAndReturnBoomErrors,
+  logWarnOnExternalRequest,
+  throwIfTypeNotVisibleByAPI,
+} from './utils';
 
 interface RouteDependencies {
   config: SavedObjectConfig;
@@ -53,7 +57,12 @@ export const registerCreateRoute = (
       },
     },
     catchAndReturnBoomErrors(async (context, req, res) => {
-      logger.warn("The create saved object API '/api/saved_objects/{type}/{id}' is deprecated.");
+      logWarnOnExternalRequest({
+        method: 'post',
+        path: '/api/saved_objects/{type}/{id?}',
+        req,
+        logger,
+      });
       const { type, id } = req.params;
       const { overwrite } = req.query;
       const { attributes, migrationVersion, coreMigrationVersion, references, initialNamespaces } =

--- a/packages/core/saved-objects/core-saved-objects-server-internal/src/routes/delete.ts
+++ b/packages/core/saved-objects/core-saved-objects-server-internal/src/routes/delete.ts
@@ -11,7 +11,11 @@ import { SavedObjectConfig } from '@kbn/core-saved-objects-base-server-internal'
 import type { InternalCoreUsageDataSetup } from '@kbn/core-usage-data-base-server-internal';
 import type { Logger } from '@kbn/logging';
 import type { InternalSavedObjectRouter } from '../internal_types';
-import { catchAndReturnBoomErrors, throwIfTypeNotVisibleByAPI } from './utils';
+import {
+  catchAndReturnBoomErrors,
+  logWarnOnExternalRequest,
+  throwIfTypeNotVisibleByAPI,
+} from './utils';
 
 interface RouteDependencies {
   config: SavedObjectConfig;
@@ -38,7 +42,12 @@ export const registerDeleteRoute = (
       },
     },
     catchAndReturnBoomErrors(async (context, req, res) => {
-      logger.warn("The delete saved object API '/api/saved_objects/{type}/{id}' is deprecated.");
+      logWarnOnExternalRequest({
+        method: 'delete',
+        path: '/api/saved_objects/{type}/{id}',
+        req,
+        logger,
+      });
       const { type, id } = req.params;
       const { force } = req.query;
       const { getClient, typeRegistry } = (await context.core).savedObjects;

--- a/packages/core/saved-objects/core-saved-objects-server-internal/src/routes/find.ts
+++ b/packages/core/saved-objects/core-saved-objects-server-internal/src/routes/find.ts
@@ -12,7 +12,7 @@ import type { InternalCoreUsageDataSetup } from '@kbn/core-usage-data-base-serve
 import type { Logger } from '@kbn/logging';
 import type { InternalSavedObjectRouter } from '../internal_types';
 import { catchAndReturnBoomErrors, throwOnHttpHiddenTypes } from './utils';
-
+import { logWarnOnExternalRequest } from './utils';
 interface RouteDependencies {
   config: SavedObjectConfig;
   coreUsageData: InternalCoreUsageDataSetup;
@@ -63,7 +63,12 @@ export const registerFindRoute = (
       },
     },
     catchAndReturnBoomErrors(async (context, req, res) => {
-      logger.warn("The find saved object API '/api/saved_objects/_find' is deprecated.");
+      logWarnOnExternalRequest({
+        method: 'get',
+        path: '/api/saved_objects/_find',
+        req,
+        logger,
+      });
       const query = req.query;
 
       const namespaces =

--- a/packages/core/saved-objects/core-saved-objects-server-internal/src/routes/get.ts
+++ b/packages/core/saved-objects/core-saved-objects-server-internal/src/routes/get.ts
@@ -11,7 +11,11 @@ import { SavedObjectConfig } from '@kbn/core-saved-objects-base-server-internal'
 import type { InternalCoreUsageDataSetup } from '@kbn/core-usage-data-base-server-internal';
 import type { Logger } from '@kbn/logging';
 import type { InternalSavedObjectRouter } from '../internal_types';
-import { catchAndReturnBoomErrors, throwIfTypeNotVisibleByAPI } from './utils';
+import {
+  catchAndReturnBoomErrors,
+  logWarnOnExternalRequest,
+  throwIfTypeNotVisibleByAPI,
+} from './utils';
 
 interface RouteDependencies {
   config: SavedObjectConfig;
@@ -35,7 +39,12 @@ export const registerGetRoute = (
       },
     },
     catchAndReturnBoomErrors(async (context, req, res) => {
-      logger.warn("The get saved object API '/api/saved_objects/{type}/{id}' is deprecated.");
+      logWarnOnExternalRequest({
+        method: 'get',
+        path: '/api/saved_objects/{type}/{id}',
+        req,
+        logger,
+      });
       const { type, id } = req.params;
 
       const usageStatsClient = coreUsageData.getClient();

--- a/packages/core/saved-objects/core-saved-objects-server-internal/src/routes/index.ts
+++ b/packages/core/saved-objects/core-saved-objects-server-internal/src/routes/index.ts
@@ -52,7 +52,6 @@ export function registerRoutes({
 }) {
   const router =
     http.createRouter<InternalSavedObjectsRequestHandlerContext>('/api/saved_objects/');
-
   registerGetRoute(router, { config, coreUsageData, logger });
   registerResolveRoute(router, { config, coreUsageData, logger });
   registerCreateRoute(router, { config, coreUsageData, logger });

--- a/packages/core/saved-objects/core-saved-objects-server-internal/src/routes/resolve.ts
+++ b/packages/core/saved-objects/core-saved-objects-server-internal/src/routes/resolve.ts
@@ -11,7 +11,7 @@ import { SavedObjectConfig } from '@kbn/core-saved-objects-base-server-internal'
 import type { InternalCoreUsageDataSetup } from '@kbn/core-usage-data-base-server-internal';
 import type { Logger } from '@kbn/logging';
 import type { InternalSavedObjectRouter } from '../internal_types';
-import { throwIfTypeNotVisibleByAPI } from './utils';
+import { throwIfTypeNotVisibleByAPI, logWarnOnExternalRequest } from './utils';
 
 interface RouteDependencies {
   config: SavedObjectConfig;
@@ -35,9 +35,12 @@ export const registerResolveRoute = (
       },
     },
     router.handleLegacyErrors(async (context, req, res) => {
-      logger.warn(
-        "The resolve saved object API '/api/saved_objects/resolve/{type}/{id}' is deprecated."
-      );
+      logWarnOnExternalRequest({
+        method: 'get',
+        path: '/api/saved_objects/resolve/{type}/{id}',
+        req,
+        logger,
+      });
       const { type, id } = req.params;
       const { savedObjects } = await context.core;
 

--- a/packages/core/saved-objects/core-saved-objects-server-internal/src/routes/update.ts
+++ b/packages/core/saved-objects/core-saved-objects-server-internal/src/routes/update.ts
@@ -12,7 +12,11 @@ import type { Logger } from '@kbn/logging';
 import { SavedObjectConfig } from '@kbn/core-saved-objects-base-server-internal';
 import type { InternalCoreUsageDataSetup } from '@kbn/core-usage-data-base-server-internal';
 import type { InternalSavedObjectRouter } from '../internal_types';
-import { catchAndReturnBoomErrors, throwIfTypeNotVisibleByAPI } from './utils';
+import {
+  catchAndReturnBoomErrors,
+  logWarnOnExternalRequest,
+  throwIfTypeNotVisibleByAPI,
+} from './utils';
 
 interface RouteDependencies {
   config: SavedObjectConfig;
@@ -50,7 +54,12 @@ export const registerUpdateRoute = (
       },
     },
     catchAndReturnBoomErrors(async (context, req, res) => {
-      logger.warn("The update saved object API '/api/saved_objects/{type}/{id}' is deprecated.");
+      logWarnOnExternalRequest({
+        method: 'get',
+        path: '/api/saved_objects/{type}/{id}',
+        req,
+        logger,
+      });
       const { type, id } = req.params;
       const { attributes, version, references, upsert } = req.body;
       const options: SavedObjectsUpdateOptions = { version, references, upsert };

--- a/packages/core/saved-objects/core-saved-objects-server-internal/src/routes/utils.ts
+++ b/packages/core/saved-objects/core-saved-objects-server-internal/src/routes/utils.ts
@@ -16,13 +16,14 @@ import {
   createConcatStream,
 } from '@kbn/utils';
 import Boom from '@hapi/boom';
-import type { RequestHandlerWrapper } from '@kbn/core-http-server';
+import type { KibanaRequest, RequestHandlerWrapper } from '@kbn/core-http-server';
 import {
   SavedObject,
   ISavedObjectTypeRegistry,
   SavedObjectsExportResultDetails,
   SavedObjectsErrorHelpers,
 } from '@kbn/core-saved-objects-server';
+import { Logger } from '@kbn/logging';
 
 export async function createSavedObjectsStreamFromNdJson(ndJsonStream: Readable) {
   const savedObjects = await createPromiseFromStreams([
@@ -151,4 +152,28 @@ export interface BulkGetItem {
   id: string;
   fields?: string[];
   namespaces?: string[];
+}
+
+export function getIsKibanaRequest({ headers }: KibanaRequest) {
+  // The presence of these two request headers gives us a good indication that this is a first-party request from the Kibana client.
+  // We can't be 100% certain, but this is a reasonable attempt.
+  return headers && headers['kbn-version'] && headers.referer;
+}
+
+export interface LogWarnOnExternalRequest {
+  method: string;
+  path: string;
+  req: KibanaRequest;
+  logger: Logger;
+}
+/**
+ * Only log a warning when the request is internal
+ * Allows us to silence the logs for development
+ *  @internal
+ */
+export function logWarnOnExternalRequest(params: LogWarnOnExternalRequest) {
+  const { method, path, req, logger } = params;
+  if (!getIsKibanaRequest(req)) {
+    logger.warn(`The ${method} saved object API ${path} is deprecated.`);
+  }
 }

--- a/packages/core/saved-objects/core-saved-objects-server-internal/src/routes/utils.ts
+++ b/packages/core/saved-objects/core-saved-objects-server-internal/src/routes/utils.ts
@@ -154,7 +154,7 @@ export interface BulkGetItem {
   namespaces?: string[];
 }
 
-export function getIsKibanaRequest({ headers }: KibanaRequest) {
+export function isKibanaRequest({ headers }: KibanaRequest) {
   // The presence of these two request headers gives us a good indication that this is a first-party request from the Kibana client.
   // We can't be 100% certain, but this is a reasonable attempt.
   return headers && headers['kbn-version'] && headers.referer;
@@ -173,7 +173,7 @@ export interface LogWarnOnExternalRequest {
  */
 export function logWarnOnExternalRequest(params: LogWarnOnExternalRequest) {
   const { method, path, req, logger } = params;
-  if (!getIsKibanaRequest(req)) {
+  if (!isKibanaRequest(req)) {
     logger.warn(`The ${method} saved object API ${path} is deprecated.`);
   }
 }

--- a/packages/core/saved-objects/core-saved-objects-server-internal/tsconfig.json
+++ b/packages/core/saved-objects/core-saved-objects-server-internal/tsconfig.json
@@ -45,6 +45,7 @@
     "@kbn/core-elasticsearch-server-mocks",
     "@kbn/utils",
     "@kbn/core-http-router-server-internal",
+    "@kbn/logging-mocks",
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
follow up to https://github.com/elastic/kibana/pull/150775

The logs are generated every time a deprecated route is called and we have extensive use of these routes throughout Kibana.

Since customers can't do anything about the Kibana UI using the saved objects client, logging these warnings so many times may lead to turning off logging completely.

This PR improves that, only logging when a request is external to Kibana.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### Risk Matrix

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| 3rd party plugin developers may miss the warning and fail to migrate off of the API's before they're removed, causing their plugin to break. | Low | Low | 3rd party developers should rely on typescript to catch the deprecations and take action appropriately. |


<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->