### PR TITLE
[Cloud Security][CSPM] Fix for incorrect link from Dashboard when account don't have name

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/dashboard_sections/benchmarks_section.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/dashboard_sections/benchmarks_section.tsx
@@ -39,7 +39,7 @@ const CLUSTER_DEFAULT_SORT_ORDER = 'asc';
 export const getClusterIdQuery = (cluster: Cluster): NavFilter => {
   if (cluster.meta.benchmark.posture_type === CSPM_POLICY_TEMPLATE) {
     // TODO: remove assertion after typing CspFinding as discriminating union
-    return { 'cloud.account.name': cluster.meta.cloud!.account.name };
+    return { 'cloud.account.id': cluster.meta.cloud!.account.id };
   }
   return { cluster_id: cluster.meta.assetIdentifierId };
 };


### PR DESCRIPTION
## Summary

This is a fix for the issue where user gets a wrong query format / incorrect link when clicking on the Cluster name on the dashboard. 

Fix : 
- CSPM now always uses cloud.account.id instead of either cloud.account.id or cloud.account.name (depending if they have a name or not) 





<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->