### PR TITLE
[Global settings] Restrict access to users with admin privileges

### DIFF
--- a/src/plugins/advanced_settings/public/management_app/mount_management_section.tsx
+++ b/src/plugins/advanced_settings/public/management_app/mount_management_section.tsx
@@ -68,8 +68,7 @@ export async function mountManagementSection(
   const canSaveGlobalSettings = globalSettings.save as boolean;
   const canShowGlobalSettings = globalSettings.show as boolean;
   const trackUiMetric = usageCollection?.reportUiCounter.bind(usageCollection, 'advanced_settings');
-
-  if (!canSaveAdvancedSettings || !canSaveGlobalSettings) {
+  if (!canSaveAdvancedSettings || (!canSaveGlobalSettings && canShowGlobalSettings)) {
     chrome.setBadge(readOnlyBadge);
   }
 

--- a/src/plugins/advanced_settings/public/management_app/mount_management_section.tsx
+++ b/src/plugins/advanced_settings/public/management_app/mount_management_section.tsx
@@ -63,10 +63,13 @@ export async function mountManagementSection(
   params.setBreadcrumbs(crumb);
   const [{ settings, notifications, docLinks, application, chrome }] = await getStartServices();
 
-  const canSave = application.capabilities.advancedSettings.save as boolean;
+  const { advancedSettings, globalSettings } = application.capabilities;
+  const canSaveAdvancedSettings = advancedSettings.save as boolean;
+  const canSaveGlobalSettings = globalSettings.save as boolean;
+  const canShowGlobalSettings = globalSettings.show as boolean;
   const trackUiMetric = usageCollection?.reportUiCounter.bind(usageCollection, 'advanced_settings');
 
-  if (!canSave) {
+  if (!canSaveAdvancedSettings || !canSaveGlobalSettings) {
     chrome.setBadge(readOnlyBadge);
   }
 
@@ -82,7 +85,8 @@ export async function mountManagementSection(
             <Route path="/">
               <Settings
                 history={params.history}
-                enableSaving={canSave}
+                enableSaving={{ namespace: canSaveAdvancedSettings, global: canSaveGlobalSettings }}
+                enableShowing={{ namespace: true, global: canShowGlobalSettings }}
                 toasts={notifications.toasts}
                 docLinks={docLinks.links}
                 settingsService={settings}

--- a/src/plugins/advanced_settings/public/management_app/settings.test.tsx
+++ b/src/plugins/advanced_settings/public/management_app/settings.test.tsx
@@ -23,6 +23,7 @@ import {
 } from '@kbn/core/public/mocks';
 import { ComponentRegistry } from '../component_registry';
 import { Search } from './components/search';
+import { EuiTab } from '@elastic/eui';
 
 jest.mock('./components/field', () => ({
   Field: () => {
@@ -251,7 +252,8 @@ describe('Settings', () => {
     const component = mountWithI18nProvider(
       <Settings
         history={mockHistory}
-        enableSaving={true}
+        enableSaving={{ global: true, namespace: true }}
+        enableShowing={{ global: true, namespace: true }}
         toasts={notificationServiceMock.createStartContract().toasts}
         docLinks={docLinksServiceMock.createStartContract().links}
         settingsService={mockConfig().core.settings}
@@ -269,7 +271,7 @@ describe('Settings', () => {
     ).toHaveLength(1);
   });
 
-  it('should should not render a custom setting', async () => {
+  it('should not render a custom setting', async () => {
     // The manual mock for the uiSettings client returns false for isConfig, override that
     const uiSettings = mockConfig().core.settings.client;
     uiSettings.isCustom = (key) => true;
@@ -279,7 +281,8 @@ describe('Settings', () => {
     const component = mountWithI18nProvider(
       <Settings
         history={mockHistory}
-        enableSaving={true}
+        enableSaving={{ global: true, namespace: true }}
+        enableShowing={{ global: true, namespace: true }}
         toasts={notificationServiceMock.createStartContract().toasts}
         docLinks={docLinksServiceMock.createStartContract().links}
         settingsService={mockConfig().core.settings}
@@ -304,7 +307,8 @@ describe('Settings', () => {
     const component = mountWithI18nProvider(
       <Settings
         history={mockHistory}
-        enableSaving={false}
+        enableSaving={{ global: true, namespace: false }}
+        enableShowing={{ global: true, namespace: true }}
         toasts={notificationServiceMock.createStartContract().toasts}
         docLinks={docLinksServiceMock.createStartContract().links}
         settingsService={mockConfig().core.settings}
@@ -332,7 +336,8 @@ describe('Settings', () => {
     const component = mountWithI18nProvider(
       <Settings
         history={mockHistory}
-        enableSaving={false}
+        enableSaving={{ global: false, namespace: false }}
+        enableShowing={{ global: true, namespace: true }}
         toasts={toasts}
         docLinks={docLinksServiceMock.createStartContract().links}
         settingsService={mockConfig().core.settings}
@@ -343,5 +348,27 @@ describe('Settings', () => {
 
     expect(toasts.addWarning).toHaveBeenCalledTimes(1);
     expect(component.find(Search).prop('query').text).toEqual('');
+  });
+
+  it('does not render global settings if show is set to false', async () => {
+    const badQuery = 'category:(accessibility))';
+    mockQuery(badQuery);
+    const { toasts } = notificationServiceMock.createStartContract();
+
+    const component = mountWithI18nProvider(
+      <Settings
+        history={mockHistory}
+        enableSaving={{ global: false, namespace: false }}
+        enableShowing={{ global: false, namespace: true }}
+        toasts={toasts}
+        docLinks={docLinksServiceMock.createStartContract().links}
+        settingsService={mockConfig().core.settings}
+        componentRegistry={new ComponentRegistry().start}
+        theme={themeServiceMock.createStartContract().theme$}
+      />
+    );
+
+    expect(component.find(EuiTab).length).toEqual(1);
+    expect(component.find(EuiTab).at(0).text()).toEqual('Space Settings');
   });
 });

--- a/src/plugins/advanced_settings/public/management_app/settings.tsx
+++ b/src/plugins/advanced_settings/public/management_app/settings.tsx
@@ -45,7 +45,8 @@ export type GroupedSettings = Record<string, FieldSetting[]>;
 
 interface Props {
   history: ScopedHistory;
-  enableSaving: boolean;
+  enableSaving: Record<UiSettingsScope, boolean>;
+  enableShowing: Record<UiSettingsScope, boolean>;
   settingsService: SettingsStart;
   docLinks: DocLinksStart['links'];
   toasts: ToastsStart;
@@ -58,7 +59,8 @@ const SPACE_SETTINGS_ID = 'space-settings';
 const GLOBAL_SETTINGS_ID = 'global-settings';
 
 export const Settings = (props: Props) => {
-  const { componentRegistry, history, settingsService, ...rest } = props;
+  const { componentRegistry, history, settingsService, enableSaving, enableShowing, ...rest } =
+    props;
   const uiSettings = settingsService.client;
   const globalUiSettings = settingsService.globalClient;
 
@@ -210,6 +212,7 @@ export const Settings = (props: Props) => {
         callOutSubtitle={callOutSubtitle(scope)}
         settingsService={settingsService}
         uiSettingsClient={getClientForScope(scope)}
+        enableSaving={enableSaving[scope]}
         {...rest}
       />
     );
@@ -227,7 +230,9 @@ export const Settings = (props: Props) => {
         ) : null,
       content: renderAdvancedSettings('namespace'),
     },
-    {
+  ];
+  if (enableShowing.global) {
+    tabs.push({
       id: GLOBAL_SETTINGS_ID,
       name: i18nTexts.globalTabTitle,
       append:
@@ -238,8 +243,8 @@ export const Settings = (props: Props) => {
           </EuiNotificationBadge>
         ) : null,
       content: renderAdvancedSettings('global'),
-    },
-  ];
+    });
+  }
 
   const [selectedTabId, setSelectedTabId] = useState(SPACE_SETTINGS_ID);
 

--- a/x-pack/test/functional/apps/advanced_settings/feature_controls/advanced_settings_security.ts
+++ b/x-pack/test/functional/apps/advanced_settings/feature_controls/advanced_settings_security.ts
@@ -27,6 +27,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
             {
               feature: {
                 advancedSettings: ['all'],
+                globalSettings: ['all'],
               },
               spaces: ['*'],
             },

--- a/x-pack/test/functional/apps/advanced_settings/feature_controls/advanced_settings_security.ts
+++ b/x-pack/test/functional/apps/advanced_settings/feature_controls/advanced_settings_security.ts
@@ -88,6 +88,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
             {
               feature: {
                 advancedSettings: ['read'],
+                globalSettings: ['show'],
               },
               spaces: ['*'],
             },


### PR DESCRIPTION
## Summary

This PR restricts access to global settings when required capabilities are not in place. The capabilities are:
`globalSettings.show` and `globalSettings.save`.

## Testing

### Global All

1. Create a user with the "kibana_admin" role
2. Log in as that user
3. Go to Advanced Settings

Should be able to see and save global settings.

### Global Readonly

1. Create a role "kibana_readonly" with Kibana global readonly privileges
2. Create a user with the "kibana_readonly" role
3. Log in as that user
4. Go to Advanced Settings

Should be able to see, but not save global settings.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
