### PR TITLE
[Control Group]: Option to toggle floating actions

### DIFF
--- a/examples/controls_example/public/edit_example.tsx
+++ b/examples/controls_example/public/edit_example.tsx
@@ -10,6 +10,8 @@ import React, { useState } from 'react';
 import {
   EuiButton,
   EuiButtonEmpty,
+  EuiComboBox,
+  EuiComboBoxOptionOption,
   EuiFlexGroup,
   EuiFlexItem,
   EuiLoadingContent,
@@ -19,16 +21,44 @@ import {
   EuiTitle,
 } from '@elastic/eui';
 import { ViewMode } from '@kbn/embeddable-plugin/public';
-import { LazyControlGroupRenderer, ControlGroupContainer } from '@kbn/controls-plugin/public';
+import {
+  LazyControlGroupRenderer,
+  ControlGroupContainer,
+  ControlGroupInput,
+} from '@kbn/controls-plugin/public';
 import { withSuspense } from '@kbn/presentation-util-plugin/public';
+import styled from '@emotion/react';
 
 const ControlGroupRenderer = withSuspense(LazyControlGroupRenderer);
 
 const INPUT_KEY = 'kbnControls:saveExample:input';
 
+const disabledActionOptions = [
+  {
+    label: 'edit',
+  },
+  {
+    label: 'remove',
+  },
+  {
+    label: 'all',
+  },
+  {
+    label: 'none',
+  },
+];
+
+// @ts-expect-error update types
+const CustomCombobox = styled(EuiComboBox)`
+  .euiFormControlLayout__prepend {
+    width: 127px;
+  }
+`;
+
 export const EditExample = () => {
   const [isSaving, setIsSaving] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
+  const [selectedOptions, setSelected] = useState([disabledActionOptions[3]]);
   const [controlGroup, setControlGroup] = useState<ControlGroupContainer>();
 
   async function onSave() {
@@ -61,6 +91,22 @@ export const EditExample = () => {
     setIsLoading(false);
     return input;
   }
+
+  const disableControl = (option?: 'edit' | 'remove' | 'all') => {
+    controlGroup?.updateInput({
+      disabledFloatingActions: option,
+    });
+  };
+
+  const onOptionsListChange = (selectedNewOpts: EuiComboBoxOptionOption[]) => {
+    setSelected(selectedNewOpts);
+
+    const newLabel = selectedNewOpts[0].label;
+    const newOption =
+      newLabel === 'none' ? undefined : (newLabel as ControlGroupInput['disabledFloatingActions']);
+
+    disableControl(newOption);
+  };
 
   return (
     <>
@@ -95,6 +141,17 @@ export const EditExample = () => {
             >
               Save
             </EuiButton>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <CustomCombobox
+              prepend={'Disabled Actions'}
+              aria-label="Accessible screen reader label"
+              placeholder="Select a single option"
+              singleSelection={{ asPlainText: true }}
+              options={disabledActionOptions}
+              selectedOptions={selectedOptions}
+              onChange={onOptionsListChange}
+            />
           </EuiFlexItem>
         </EuiFlexGroup>
         {isLoading ? (

--- a/src/plugins/controls/common/control_group/types.ts
+++ b/src/plugins/controls/common/control_group/types.ts
@@ -31,6 +31,7 @@ export interface ControlGroupInput extends EmbeddableInput, ControlInput {
   defaultControlGrow?: boolean;
   controlStyle: ControlStyle;
   panels: ControlsPanels;
+  disabledFloatingActions?: 'edit' | 'remove' | 'all';
 }
 
 /**

--- a/src/plugins/controls/public/control_group/component/control_frame_component.tsx
+++ b/src/plugins/controls/public/control_group/component/control_frame_component.tsx
@@ -75,6 +75,7 @@ export interface ControlFrameProps {
   enableActions?: boolean;
   embeddableId: string;
   embeddableType: string;
+  disabledFloatingActions?: 'edit' | 'remove' | 'all';
 }
 
 export const ControlFrame = ({
@@ -82,6 +83,7 @@ export const ControlFrame = ({
   enableActions,
   embeddableId,
   embeddableType,
+  disabledFloatingActions,
 }: ControlFrameProps) => {
   const embeddableRoot: React.RefObject<HTMLDivElement> = useMemo(() => React.createRef(), []);
   const [fatalError, setFatalError] = useState<Error>();
@@ -128,31 +130,35 @@ export const ControlFrame = ({
 
   const floatingActions = (
     <>
-      {!fatalError && embeddableType !== TIME_SLIDER_CONTROL && (
-        <EuiToolTip content={ControlGroupStrings.floatingActions.getEditButtonTitle()}>
-          <EditControlButton embeddableId={embeddableId} />
+      {!fatalError &&
+        embeddableType !== TIME_SLIDER_CONTROL &&
+        (!disabledFloatingActions || !['all', 'edit'].includes(disabledFloatingActions)) && (
+          <EuiToolTip content={ControlGroupStrings.floatingActions.getEditButtonTitle()}>
+            <EditControlButton embeddableId={embeddableId} />
+          </EuiToolTip>
+        )}
+      {(!disabledFloatingActions || !['all', 'remove'].includes(disabledFloatingActions)) && (
+        <EuiToolTip content={ControlGroupStrings.floatingActions.getRemoveButtonTitle()}>
+          <EuiButtonIcon
+            data-test-subj={`control-action-${embeddableId}-delete`}
+            aria-label={ControlGroupStrings.floatingActions.getRemoveButtonTitle()}
+            onClick={() =>
+              openConfirm(ControlGroupStrings.management.deleteControls.getSubtitle(), {
+                confirmButtonText: ControlGroupStrings.management.deleteControls.getConfirm(),
+                cancelButtonText: ControlGroupStrings.management.deleteControls.getCancel(),
+                title: ControlGroupStrings.management.deleteControls.getDeleteTitle(),
+                buttonColor: 'danger',
+              }).then((confirmed) => {
+                if (confirmed) {
+                  controlGroup.removeEmbeddable(embeddableId);
+                }
+              })
+            }
+            iconType="cross"
+            color="danger"
+          />
         </EuiToolTip>
       )}
-      <EuiToolTip content={ControlGroupStrings.floatingActions.getRemoveButtonTitle()}>
-        <EuiButtonIcon
-          data-test-subj={`control-action-${embeddableId}-delete`}
-          aria-label={ControlGroupStrings.floatingActions.getRemoveButtonTitle()}
-          onClick={() =>
-            openConfirm(ControlGroupStrings.management.deleteControls.getSubtitle(), {
-              confirmButtonText: ControlGroupStrings.management.deleteControls.getConfirm(),
-              cancelButtonText: ControlGroupStrings.management.deleteControls.getCancel(),
-              title: ControlGroupStrings.management.deleteControls.getDeleteTitle(),
-              buttonColor: 'danger',
-            }).then((confirmed) => {
-              if (confirmed) {
-                controlGroup.removeEmbeddable(embeddableId);
-              }
-            })
-          }
-          iconType="cross"
-          color="danger"
-        />
-      </EuiToolTip>
     </>
   );
 

--- a/src/plugins/controls/public/control_group/component/control_group_component.tsx
+++ b/src/plugins/controls/public/control_group/component/control_group_component.tsx
@@ -50,6 +50,7 @@ export const ControlGroup = () => {
   const viewMode = select((state) => state.explicitInput.viewMode);
   const controlStyle = select((state) => state.explicitInput.controlStyle);
   const showAddButton = select((state) => state.componentState.showAddButton);
+  const disabledFloatingActions = select((state) => state.explicitInput.disabledFloatingActions);
 
   const isEditable = viewMode === ViewMode.EDIT;
 
@@ -142,6 +143,7 @@ export const ControlGroup = () => {
                         panels[controlId] && (
                           <SortableControl
                             isEditable={isEditable}
+                            disabledFloatingActions={disabledFloatingActions}
                             dragInfo={{ index, draggingIndex }}
                             embeddableId={controlId}
                             embeddableType={panels[controlId].type}

--- a/src/plugins/controls/public/control_group/component/control_group_sortable_item.tsx
+++ b/src/plugins/controls/public/control_group/component/control_group_sortable_item.tsx
@@ -66,7 +66,15 @@ const SortableControlInner = forwardRef<
   SortableControlProps & { style: HTMLAttributes<HTMLButtonElement>['style'] }
 >(
   (
-    { embeddableId, embeddableType, dragInfo, style, isEditable, ...dragHandleProps },
+    {
+      embeddableId,
+      embeddableType,
+      dragInfo,
+      style,
+      isEditable,
+      disabledFloatingActions,
+      ...dragHandleProps
+    },
     dragHandleRef
   ) => {
     const { isOver, isDragging, draggingIndex, index } = dragInfo;
@@ -110,6 +118,7 @@ const SortableControlInner = forwardRef<
           embeddableId={embeddableId}
           embeddableType={embeddableType}
           customPrepend={isEditable ? dragHandle : undefined}
+          disabledFloatingActions={disabledFloatingActions}
         />
       </EuiFlexItem>
     );


### PR DESCRIPTION
## Summary

This PR adds the option to toggle floating actions.

## Motivation

In security solution, we have a need to disable `floating actions` selectively in some cases. For example, user can delete the controls but we want to enforce at least one control on the screen. Hence, we want to allow users to edit the control but not delete it.

https://user-images.githubusercontent.com/7485038/224053021-28565f2d-37c5-4a09-a18c-d421452e6a4f.mov
