### PR TITLE
Add 'Explore in APM' button to SLO Detail

### DIFF
--- a/x-pack/plugins/observability/public/pages/slo_details/helpers/convert_sli_apm_params_to_apm_app_deeplink_url.test.ts
+++ b/x-pack/plugins/observability/public/pages/slo_details/helpers/convert_sli_apm_params_to_apm_app_deeplink_url.test.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { convertSliApmParamsToApmAppDeeplinkUrl } from './convert_sli_apm_params_to_apm_app_deeplink_url';
+
+const SLI_APM_PARAMS = {
+  duration: '30-d',
+  environment: 'fooEnvironment',
+  filter: 'agent.name : "beats" ',
+  service: 'barService',
+  transactionName: 'bazName',
+  transactionType: 'blarfType',
+};
+
+describe('convertSliApmParamsToApmAppDeeplinkUrl', () => {
+  it('should return a correct APM deeplink when all params have a value', () => {
+    const url = convertSliApmParamsToApmAppDeeplinkUrl(SLI_APM_PARAMS);
+
+    expect(url).toBe(
+      '/app/apm/services/barService/overview?comparisonEnabled=true&environment=fooEnvironment&transactionType=blarfType&kuery=transaction.name%20%3A%20%22bazName%22%20and%20agent.name%20%3A%20%22beats%22%20&rangeFrom=now-30-d&rangeTo=now'
+    );
+  });
+
+  it('should return a correct APM deeplink when empty duration is passed', () => {
+    const url = convertSliApmParamsToApmAppDeeplinkUrl({
+      ...SLI_APM_PARAMS,
+      duration: '',
+    });
+
+    expect(url).toBe(
+      '/app/apm/services/barService/overview?comparisonEnabled=true&environment=fooEnvironment&transactionType=blarfType&kuery=transaction.name%20%3A%20%22bazName%22%20and%20agent.name%20%3A%20%22beats%22%20'
+    );
+  });
+
+  it('should return a correct APM deeplink when empty environment is passed', () => {
+    const url = convertSliApmParamsToApmAppDeeplinkUrl({
+      ...SLI_APM_PARAMS,
+      environment: '',
+    });
+
+    expect(url).toBe(
+      '/app/apm/services/barService/overview?comparisonEnabled=true&transactionType=blarfType&kuery=transaction.name%20%3A%20%22bazName%22%20and%20agent.name%20%3A%20%22beats%22%20&rangeFrom=now-30-d&rangeTo=now'
+    );
+  });
+
+  it('should return a correct APM deeplink when empty filter is passed', () => {
+    const url = convertSliApmParamsToApmAppDeeplinkUrl({
+      ...SLI_APM_PARAMS,
+      filter: '',
+    });
+
+    expect(url).toBe(
+      '/app/apm/services/barService/overview?comparisonEnabled=true&environment=fooEnvironment&transactionType=blarfType&kuery=transaction.name%20%3A%20%22bazName%22%20&rangeFrom=now-30-d&rangeTo=now'
+    );
+  });
+
+  it('should return an empty string if an empty service is passed', () => {
+    const url = convertSliApmParamsToApmAppDeeplinkUrl({
+      ...SLI_APM_PARAMS,
+      service: '',
+    });
+
+    expect(url).toBe('');
+  });
+
+  it('should return a correct APM deeplink when empty transactionName is passed', () => {
+    const url = convertSliApmParamsToApmAppDeeplinkUrl({
+      ...SLI_APM_PARAMS,
+      transactionName: '',
+    });
+
+    expect(url).toBe(
+      '/app/apm/services/barService/overview?comparisonEnabled=true&environment=fooEnvironment&transactionType=blarfType&kuery=%20and%20agent.name%20%3A%20%22beats%22%20&rangeFrom=now-30-d&rangeTo=now'
+    );
+  });
+
+  it('should return a correct APM deeplink when empty transactionType is passed', () => {
+    const url = convertSliApmParamsToApmAppDeeplinkUrl({
+      ...SLI_APM_PARAMS,
+      transactionType: '',
+    });
+
+    expect(url).toBe(
+      '/app/apm/services/barService/overview?comparisonEnabled=true&environment=fooEnvironment&kuery=transaction.name%20%3A%20%22bazName%22%20and%20agent.name%20%3A%20%22beats%22%20&rangeFrom=now-30-d&rangeTo=now'
+    );
+  });
+});

--- a/x-pack/plugins/observability/public/pages/slo_details/helpers/convert_sli_apm_params_to_apm_app_deeplink_url.ts
+++ b/x-pack/plugins/observability/public/pages/slo_details/helpers/convert_sli_apm_params_to_apm_app_deeplink_url.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+interface Props {
+  duration: string;
+  environment: string;
+  filter: string | undefined;
+  service: string;
+  transactionName: string;
+  transactionType: string;
+}
+
+export function convertSliApmParamsToApmAppDeeplinkUrl({
+  duration,
+  environment,
+  filter,
+  service,
+  transactionName,
+  transactionType,
+}: Props) {
+  if (!service) {
+    return '';
+  }
+
+  const environmentPartial = environment
+    ? `&environment=${environment === '*' ? 'ENVIRONMENT_ALL' : environment}`
+    : '';
+
+  const transactionTypePartial = transactionType
+    ? `&transactionType=${transactionType === '*' ? '' : transactionType}`
+    : '';
+
+  const dateRangePartial = duration ? `&rangeFrom=now-${duration}&rangeTo=now` : '';
+
+  const filterPartial =
+    filter || transactionName
+      ? `&kuery=${encodeURIComponent(
+          `${
+            transactionName && transactionName !== '*'
+              ? `transaction.name : "${transactionName}"`
+              : ''
+          } ${filter ? `and ${filter}` : ''}`
+        )}`
+      : '';
+
+  return `/app/apm/services/${service}/overview?comparisonEnabled=true${environmentPartial}${transactionTypePartial}${filterPartial}${dateRangePartial}`;
+}

--- a/x-pack/plugins/observability/public/pages/slo_details/slo_details.test.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_details/slo_details.test.tsx
@@ -20,6 +20,7 @@ import { useFetchHistoricalSummary } from '../../hooks/slo/use_fetch_historical_
 import { useCapabilities } from '../../hooks/slo/use_capabilities';
 import { historicalSummaryData } from '../../data/slo/historical_summary_data';
 import { chartPluginMock } from '@kbn/charts-plugin/public/mocks';
+import { buildApmAvailabilityIndicator } from '../../data/slo/indicator';
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
@@ -120,6 +121,32 @@ describe('SLO Details Page', () => {
       render(<SloDetailsPage />);
 
       expect(screen.queryByTestId('sloDetailsPage')).toBeTruthy();
+    });
+
+    describe('when an APM SLO is loaded', () => {
+      it('should render a Explore in APM button', async () => {
+        const slo = buildSlo({ indicator: buildApmAvailabilityIndicator() });
+        useParamsMock.mockReturnValue(slo.id);
+        useFetchSloDetailsMock.mockReturnValue({ isLoading: false, slo });
+        useLicenseMock.mockReturnValue({ hasAtLeast: () => true });
+
+        render(<SloDetailsPage />);
+
+        expect(screen.queryByTestId('sloDetailsExploreInApmButton')).toBeTruthy();
+      });
+    });
+
+    describe('when an Custom KQL SLO is loaded', () => {
+      it('should not render a Explore in APM button', async () => {
+        const slo = buildSlo();
+        useParamsMock.mockReturnValue(slo.id);
+        useFetchSloDetailsMock.mockReturnValue({ isLoading: false, slo });
+        useLicenseMock.mockReturnValue({ hasAtLeast: () => true });
+
+        render(<SloDetailsPage />);
+
+        expect(screen.queryByTestId('sloDetailsExploreInApmButton')).toBeFalsy();
+      });
     });
   });
 });

--- a/x-pack/plugins/observability/public/pages/slo_details/slo_details.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_details/slo_details.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
 import { EuiBreadcrumbProps } from '@elastic/eui/src/components/breadcrumbs/breadcrumb';
-import { EuiLoadingSpinner } from '@elastic/eui';
+import { EuiButtonEmpty, EuiLoadingSpinner } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import type { IBasePath } from '@kbn/core-http-browser';
 import type { SLOWithSummaryResponse } from '@kbn/slo-schema';
@@ -21,10 +21,11 @@ import { useLicense } from '../../hooks/use_license';
 import PageNotFound from '../404';
 import { SloDetails } from './components/slo_details';
 import { HeaderTitle } from './components/header_title';
+import { HeaderControl } from './components/header_control';
+import { convertSliApmParamsToApmAppDeeplinkUrl } from './helpers/convert_sli_apm_params_to_apm_app_deeplink_url';
 import { paths } from '../../config';
 import type { SloDetailsPathParams } from './types';
 import type { ObservabilityAppServices } from '../../application/types';
-import { HeaderControl } from './components/header_control';
 
 export function SloDetailsPage() {
   const {
@@ -48,11 +49,50 @@ export function SloDetailsPage() {
     navigateToUrl(basePath.prepend(paths.observability.slos));
   }
 
+  const handleNavigateToApm = () => {
+    if (
+      slo?.indicator.type === 'sli.apm.transactionDuration' ||
+      slo?.indicator.type === 'sli.apm.transactionErrorRate'
+    ) {
+      const {
+        indicator: {
+          params: { environment, filter, service, transactionName, transactionType },
+        },
+        timeWindow: { duration },
+      } = slo;
+
+      const url = convertSliApmParamsToApmAppDeeplinkUrl({
+        duration,
+        environment,
+        filter,
+        service,
+        transactionName,
+        transactionType,
+      });
+
+      navigateToUrl(basePath.prepend(url));
+    }
+  };
+
   return (
     <ObservabilityPageTemplate
       pageHeader={{
         pageTitle: <HeaderTitle isLoading={isLoading} slo={slo} />,
-        rightSideItems: [<HeaderControl isLoading={isLoading} slo={slo} />],
+        rightSideItems: [
+          <HeaderControl isLoading={isLoading} slo={slo} />,
+          slo?.indicator.type.includes('apm') ? (
+            <EuiButtonEmpty
+              data-test-subj="sloDetailsExploreInApmButton"
+              disabled={isLoading}
+              iconType="popout"
+              onClick={handleNavigateToApm}
+            >
+              {i18n.translate('xpack.observability.slos.sloDetails.exploreInApm', {
+                defaultMessage: 'Explore in APM',
+              })}
+            </EuiButtonEmpty>
+          ) : null,
+        ],
         bottomBorder: false,
       }}
       data-test-subj="sloDetailsPage"


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/154756

## 📝 Summary

This adds a "Explore in APM" button in the SLO Detail page. Upon clicking it the user will be navigated to the APM app, with all relevant filters (service name, environment, transaction name, transaction type, filter, date range) applied.


https://user-images.githubusercontent.com/535564/224090872-286d6fd3-d98f-42b5-8566-23874746272e.mov

## ✅ Acceptance criteria
- It should have a button on the SLO Detail page when the SLO is of an APM type, labelled "See in APM"
- Upon clicking it, the app should navigate to the APM app, to the Services page, with all the same properties selected as the SLO had
- It should reflect the properties in the APM url so it's easy for a user to bookmark this destination
