### PR TITLE
[Profiling] Add indices for private symbols to the 1-click setup

### DIFF
--- a/x-pack/plugins/profiling/server/lib/setup/steps/get_create_indices_step.ts
+++ b/x-pack/plugins/profiling/server/lib/setup/steps/get_create_indices_step.ts
@@ -9,9 +9,11 @@ import { MappingSourceField } from '@elastic/elasticsearch/lib/api/types';
 import { ProfilingSetupStep, ProfilingSetupStepFactoryOptions } from '../types';
 import { catchResourceAlreadyExistsException } from './catch_resource_already_exists_exception';
 
+const RETURNPADS_PRIVATE_INDEX = 'profiling-returnpads-private';
 const SQ_EXECUTABLES_INDEX = 'profiling-sq-executables';
-const LEAFFRAMES_INDEX = 'profiling-sq-leafframes';
+const SQ_LEAFFRAMES_INDEX = 'profiling-sq-leafframes';
 const SYMBOLS_INDEX = 'profiling-symbols';
+const SYMBOLS_PRIVATE_INDEX = 'profiling-symbols-private';
 const ILM_LOCK_INDEX = '.profiling-ilm-lock';
 
 const getKeyValueIndices = () => {
@@ -37,7 +39,14 @@ export function getCreateIndicesStep({
   return {
     name: 'create_indices',
     hasCompleted: async () => {
-      const nonKvIndices = [SQ_EXECUTABLES_INDEX, LEAFFRAMES_INDEX, SYMBOLS_INDEX, ILM_LOCK_INDEX];
+      const nonKvIndices = [
+        RETURNPADS_PRIVATE_INDEX,
+        SQ_EXECUTABLES_INDEX,
+        SQ_LEAFFRAMES_INDEX,
+        SYMBOLS_INDEX,
+        SYMBOLS_PRIVATE_INDEX,
+        ILM_LOCK_INDEX,
+      ];
 
       const results = await Promise.all([
         esClient.cat
@@ -107,6 +116,7 @@ export function getCreateIndicesStep({
             })
             .catch(catchResourceAlreadyExistsException);
         }),
+        // TODO: read the settings and mappings from the .json files
         esClient.indices
           .create({
             index: SQ_EXECUTABLES_INDEX,
@@ -146,7 +156,7 @@ export function getCreateIndicesStep({
           .catch(catchResourceAlreadyExistsException),
         esClient.indices
           .create({
-            index: LEAFFRAMES_INDEX,
+            index: SQ_LEAFFRAMES_INDEX,
             settings: {
               index: {
                 refresh_interval: '10s',
@@ -287,6 +297,173 @@ export function getCreateIndicesStep({
                   // PC ranges [begin, end)
                   type: 'ip_range',
                   index: true,
+                  doc_values: false,
+                  store: false,
+                },
+              },
+            },
+          })
+          .catch(catchResourceAlreadyExistsException),
+        esClient.indices
+          .create({
+            index: SYMBOLS_PRIVATE_INDEX,
+            settings: {
+              index: {
+                number_of_shards: '16',
+                refresh_interval: '10s',
+              },
+            },
+            mappings: {
+              _source: {
+                enabled: true,
+              } as MappingSourceField,
+              properties: {
+                'ecs.version': {
+                  type: 'keyword',
+                  index: true,
+                  doc_values: false,
+                  store: false,
+                },
+                'Symbol.function.name': {
+                  // name of the function
+                  type: 'keyword',
+                  index: false,
+                  doc_values: false,
+                  store: false,
+                },
+                'Symbol.file.name': {
+                  // file path
+                  type: 'keyword',
+                  index: false,
+                  doc_values: false,
+                  store: false,
+                },
+                'Symbol.call.file.name': {
+                  // (for inlined functions) file path where inline function was called
+                  type: 'keyword',
+                  index: false,
+                  doc_values: false,
+                  store: false,
+                },
+                'Symbol.call.line': {
+                  // (for inlined functions) line where inline function was called
+                  type: 'integer',
+                  index: false,
+                  doc_values: false,
+                  store: false,
+                },
+                'Symbol.function.line': {
+                  // function start line (only available from DWARF). Currently unused.
+                  type: 'integer',
+                  index: false,
+                  doc_values: false,
+                  store: false,
+                },
+                'Symbol.depth': {
+                  // inline depth
+                  type: 'integer',
+                  index: false,
+                  doc_values: false,
+                  store: false,
+                },
+                // pairs of (32bit PC offset, 32bit line number) followed by 64bit PC range base at the end.
+                // To find line number for a given PC: find lowest offset such as offsetBase+PC >= offset, then read corresponding line number.
+                // offsetBase could seemingly be available from exec_pc_range (it's the first value of the pair), but it's not the case.
+                // Ranges are stored as points, which cannot be retrieve when disabling _source.
+                // See https://www.elastic.co/guide/en/elasticsearch/reference/current/point.html .
+                'Symbol.linetable.base': {
+                  // Linetable: base for offsets (64bit PC range base)
+                  type: 'unsigned_long',
+                  index: false,
+                  doc_values: false,
+                  store: false,
+                },
+                'Symbol.linetable.length': {
+                  // Linetable: length of range (PC range is [base, base+length))
+                  type: 'unsigned_long',
+                  index: false,
+                  doc_values: false,
+                  store: false,
+                },
+                'Symbol.linetable.offsets': {
+                  // Linetable: concatenated offsets (each value is ULEB128encoded)
+                  type: 'keyword',
+                  index: false,
+                  doc_values: false,
+                  store: false,
+                },
+                'Symbol.linetable.lines': {
+                  // Linetable: concatenated lines (each value is ULEB128 encoded)
+                  type: 'keyword',
+                  index: false,
+                  doc_values: false,
+                  store: false,
+                },
+                'Symbol.file.id': {
+                  // fileID. used for deletion and Symbol.exec.pcrange collision handling on symbolization
+                  type: 'keyword',
+                  index: true,
+                  doc_values: false,
+                  store: false,
+                },
+                'Symbol.exec.pcrange': {
+                  // PC ranges [begin, end)
+                  type: 'ip_range',
+                  index: true,
+                  doc_values: false,
+                  store: false,
+                },
+              },
+            },
+          })
+          .catch(catchResourceAlreadyExistsException),
+        esClient.indices
+          .create({
+            index: RETURNPADS_PRIVATE_INDEX,
+            settings: {
+              index: {
+                refresh_interval: '10s',
+              },
+            },
+            mappings: {
+              _source: {
+                enabled: true,
+              } as MappingSourceField,
+              properties: {
+                'ecs.version': {
+                  type: 'keyword',
+                  index: true,
+                  doc_values: false,
+                  store: false,
+                },
+                'Symbfile.created': {
+                  // name of the function
+                  type: 'date',
+                  index: false,
+                  doc_values: true,
+                  store: false,
+                },
+                'Symbfile.file.id': {
+                  // file path
+                  type: 'keyword',
+                  index: true,
+                  doc_values: false,
+                  store: false,
+                },
+                'Symbfile.part': {
+                  type: 'short',
+                  index: false,
+                  doc_values: false,
+                  store: false,
+                },
+                'Symbfile.parts': {
+                  type: 'short',
+                  index: false,
+                  doc_values: false,
+                  store: false,
+                },
+                'Symbfile.data': {
+                  type: 'binary',
                   doc_values: false,
                   store: false,
                 },


### PR DESCRIPTION
Add setup/creation of indices `profiling-symbols-private` and `profiling-returnpads-private`.

This PR also adds the mappings/settings for the missing indices as `component_template_*.json` files (with comments removed). I followed the pattern that has been there (e.g. `component_template_profiling_symbols.json` already existed).

Todo for a follow-up PR:
- for the non-ILMed indices, load the mappings/settings from the .json files instead of using hard-coded javascript
- better rename the non-ILMed json files to something different than `component_template_*`