### PR TITLE
[ci] Add `depends_on: build` to unsupported ftrs step

### DIFF
--- a/.buildkite/pipelines/on_merge.yml
+++ b/.buildkite/pipelines/on_merge.yml
@@ -81,6 +81,8 @@ steps:
   - command: '.buildkite/scripts/steps/functional/on_merge_unsupported_ftrs.sh'
     label: Trigger unsupported ftr tests
     timeout_in_minutes: 10
+    depends_on:
+      - build
     agents:
       queue: 'kibana-default'
 


### PR DESCRIPTION
This should let us reuse the build from the on merge pipeline.