### PR TITLE
[scalability testing] get the correct Gatling report

### DIFF
--- a/x-pack/test/scalability/runner.ts
+++ b/x-pack/test/scalability/runner.ts
@@ -29,10 +29,10 @@ async function sendReportMetricsToTelemetry(
     .readdirSync(reportRootPath)
     // Gatling report folder has unique postfix, e.g. 'api.telemetry.cluster_stats.no_cache-20230309224753010'
     .filter(doesMatchWithoutSuffix);
-function doesMatchWithoutSuffix (filePath: string): Boolean {
-  const suffix: RegExp = /-\d+$/;
-  return filePath.replace(suffix, '') === fileName;    
-}
+  function doesMatchWithoutSuffix(filePath: string): boolean {
+    const suffix: RegExp = /-\d+$/;
+    return filePath.replace(suffix, '') === fileName;
+  }
   const lastReportPath = journeyReportDir.pop();
   if (!lastReportPath) {
     throw new Error(`No report found with '${fileName}' filename`);

--- a/x-pack/test/scalability/runner.ts
+++ b/x-pack/test/scalability/runner.ts
@@ -28,7 +28,11 @@ async function sendReportMetricsToTelemetry(
   const journeyReportDir = fs
     .readdirSync(reportRootPath)
     // Gatling report folder has unique postfix, e.g. 'api.telemetry.cluster_stats.no_cache-20230309224753010'
-    .filter((f) => f.replace(/-\d+$/, '') === fileName);
+    .filter(doesMatchWithoutSuffix);
+function doesMatchWithoutSuffix (filePath: string): Boolean {
+  const suffix: RegExp = /-\d+$/;
+  return filePath.replace(suffix, '') === fileName;    
+}
   const lastReportPath = journeyReportDir.pop();
   if (!lastReportPath) {
     throw new Error(`No report found with '${fileName}' filename`);

--- a/x-pack/test/scalability/runner.ts
+++ b/x-pack/test/scalability/runner.ts
@@ -25,9 +25,14 @@ async function sendReportMetricsToTelemetry(
 ) {
   const reportRootPath = path.resolve(gatlingProjectRootPath, 'target', 'gatling');
   const fileName = path.basename(scalabilityJsonPath, path.extname(scalabilityJsonPath));
-  const journeyReportDir = fs.readdirSync(reportRootPath).filter((f) => f.startsWith(fileName));
+  const journeyReportDir = fs
+    .readdirSync(reportRootPath)
+    // Gatling report folder has unique postfix, e.g. 'api.telemetry.cluster_stats.no_cache-20230309224753010'
+    .filter((f) => f.replace(/-\d+$/, '') === fileName);
   const lastReportPath = journeyReportDir.pop();
-  if (lastReportPath) {
+  if (!lastReportPath) {
+    throw new Error(`No report found with '${fileName}' filename`);
+  } else {
     const journeyHtmlReportPath = path.resolve(reportRootPath, lastReportPath, 'index.html');
 
     const journey: ScalabilityJourney = JSON.parse(fs.readFileSync(scalabilityJsonPath, 'utf8'));


### PR DESCRIPTION
## Summary

Adjusting the logic to pick the correct Gatling report after run:

It turns out `startWith` was picking the wrong report since 2 api journey names match the pattern:


`api.telemetry.cluster_stats.no_cache.json`
`api.telemetry.cluster_stats.no_cache.1600_dataviews.json`

This PR fixes the issue, so that we report to Telemetry stats for the correct journey.

Testing here https://buildkite.com/elastic/kibana-apis-capacity-testing/builds/450


<!--ONMERGE {"backportTargets":["8.6","8.7"]} ONMERGE-->