### PR TITLE
[Infrastructure UI] Upgrade assistand: Extend deprecation errors rules for 8.x

### DIFF
--- a/x-pack/plugins/infra/server/deprecations.ts
+++ b/x-pack/plugins/infra/server/deprecations.ts
@@ -198,7 +198,7 @@ export const getInfraDeprecationsFactory =
       const { name, fields } = configuration;
       for (const [key, defaultValue] of Object.entries(DEFAULT_VALUES)) {
         const configuredValue = Reflect.get(fields, key);
-        if (configuredValue !== defaultValue) {
+        if (configuredValue !== undefined && configuredValue !== defaultValue) {
           const affectedConfigNames = deprecatedFieldsToSourceConfigMap.get(key) ?? [];
           affectedConfigNames.push(name);
           deprecatedFieldsToSourceConfigMap.set(key, affectedConfigNames);


### PR DESCRIPTION
Closes #152954

## Summary

This PR fixes the issue with deprecation errors in the Upgrade assistance for versions newer than 8.x

### Testing

1. First check that they are no error - go to Kibana > Stack Management > Upgrade assistant and there shouldn't be any critical errors:  
![image](https://user-images.githubusercontent.com/14139027/224307316-70b800c6-ec8e-442e-8b93-5b53886b13e8.png)

2.  Go to Kibana > Infrastructure > Settings and change the default value from `metrics-*,metricbeat-*` to anything else - even `metricbeat-*,metrics-*` (swapping the order) will work. Apply the changes.  <img width="1725" alt="image" src="https://user-images.githubusercontent.com/14139027/224307871-bd710809-c1da-4403-8b48-1e0f9ad8298b.png">

3. Go to Kibana > Stack Management > Upgrade assistant and there shouldn't be any critical errors.


<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->