### PR TITLE
Update user button should not be active till user makes changes on user page

### DIFF
--- a/x-pack/plugins/security/public/management/users/edit_user/user_form.tsx
+++ b/x-pack/plugins/security/public/management/users/edit_user/user_form.tsx
@@ -18,7 +18,7 @@ import {
   EuiSpacer,
   EuiTextColor,
 } from '@elastic/eui';
-import { throttle } from 'lodash';
+import { isEqual, throttle } from 'lodash';
 import type { FunctionComponent } from 'react';
 import React, { useCallback, useEffect } from 'react';
 import useAsyncFn from 'react-use/lib/useAsyncFn';
@@ -217,6 +217,7 @@ export const UserForm: FunctionComponent<UserFormProps> = ({
     getRoles();
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
+  const isFormUnchanged = isEqual(form.values, defaultValues);
   const availableRoles = rolesState.value ?? [];
   const selectedRoleNames = form.values.roles ?? [];
   const deprecatedRoles = selectedRoleNames.reduce<Role[]>((roles, name) => {
@@ -434,7 +435,7 @@ export const UserForm: FunctionComponent<UserFormProps> = ({
         </EuiFormRow>
 
         <EuiSpacer size="xxl" />
-        {disabled || isReservedUser ? (
+        {disabled || isReservedUser || isFormUnchanged ? (
           <EuiFlexGroup responsive={false}>
             <EuiFlexItem grow={false}>
               <EuiButton iconType="arrowLeft" onClick={onCancel}>


### PR DESCRIPTION
Update user button should not be active till user makes changes on user page

Resolves https://github.com/elastic/kibana/issues/152800

### Loom video
https://user-images.githubusercontent.com/57623705/223767303-652819c6-3a2d-42f9-aad4-9c7392548d75.mov

---
This code was written and reviewed by GitStart Community. Growing future engineers, one PR at a time.
