### PR TITLE
[Infrastructure UI] Fix: Table and KPIs not reloading when filters are removed

### DIFF
--- a/x-pack/plugins/infra/public/pages/metrics/hosts/hooks/use_unified_search.ts
+++ b/x-pack/plugins/infra/public/pages/metrics/hosts/hooks/use_unified_search.ts
@@ -146,12 +146,12 @@ export const useUnifiedSearch = () => {
   }, [getDateRangeAsTimestamp, state, telemetry]);
 
   const getAllFilters = useCallback(
-    () => [...filterManagerService.getFilters(), ...state.panelFilters],
-    [filterManagerService, state.panelFilters]
+    () => [...state.filters, ...state.panelFilters],
+    [state.filters, state.panelFilters]
   );
   const buildQuery = useCallback(() => {
-    return buildEsQuery(metricsDataView, queryStringService.getQuery(), getAllFilters());
-  }, [metricsDataView, queryStringService, getAllFilters]);
+    return buildEsQuery(metricsDataView, state.query, getAllFilters());
+  }, [metricsDataView, state.query, getAllFilters]);
 
   return {
     buildQuery,


### PR DESCRIPTION
## Summary

Fixes: https://github.com/elastic/kibana/issues/153099

This PR fixes a problem introduced by https://github.com/elastic/kibana/pull/152579. After the PR was merged, the table and KPIs were no longer reloading when removing filters and switching between saved queries

https://user-images.githubusercontent.com/2767137/224320114-57a8c202-e0b5-4a8b-ad83-ec4be796ecfa.mov

https://user-images.githubusercontent.com/2767137/224320125-3359da1c-24e5-4a7f-8f68-c1c686140612.mov

### How to tests
- Add and remove a filter
- Save a search
- Load a saved search

<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->