### PR TITLE
[Security Solution] Make Alert Page filters heirarchical

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/detection_engine.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/detection_engine.tsx
@@ -341,7 +341,7 @@ const DetectionEnginePageComponent: React.FC<DetectionEngineComponentProps> = ({
             to,
             mode: 'absolute',
           }}
-          chainingSystem="NONE"
+          chainingSystem={'HIERARCHICAL'}
           onInit={setDetectionPageFilterHandler}
         />
       ),


### PR DESCRIPTION
## Summary

This Option was missed in last PR https://github.com/elastic/kibana/pull/152450 for Alert Page Filters Customization.

Just reverted this small option to make page filters working as desired.