### PR TITLE
feat(slo): global and slo specific diagnosis

### DIFF
--- a/packages/kbn-slo-schema/src/rest_specs/slo.ts
+++ b/packages/kbn-slo-schema/src/rest_specs/slo.ts
@@ -118,6 +118,10 @@ const findSLOResponseSchema = t.type({
 const fetchHistoricalSummaryParamsSchema = t.type({ body: t.type({ sloIds: t.array(t.string) }) });
 const fetchHistoricalSummaryResponseSchema = t.record(t.string, t.array(historicalSummarySchema));
 
+const getSLODiagnosisParamsSchema = t.type({
+  path: t.type({ id: t.string }),
+});
+
 type SLOResponse = t.OutputOf<typeof sloResponseSchema>;
 type SLOWithSummaryResponse = t.OutputOf<typeof sloWithSummaryResponseSchema>;
 
@@ -147,6 +151,7 @@ export {
   deleteSLOParamsSchema,
   findSLOParamsSchema,
   findSLOResponseSchema,
+  getSLODiagnosisParamsSchema,
   getSLOParamsSchema,
   getSLOResponseSchema,
   fetchHistoricalSummaryParamsSchema,

--- a/x-pack/plugins/observability/server/services/slo/get_diagnosis.ts
+++ b/x-pack/plugins/observability/server/services/slo/get_diagnosis.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
+import { SavedObjectsClientContract } from '@kbn/core-saved-objects-api-server';
+import { LicensingApiRequestHandlerContext } from '@kbn/licensing-plugin/server';
+
+import {
+  getSLOTransformId,
+  SLO_COMPONENT_TEMPLATE_MAPPINGS_NAME,
+  SLO_COMPONENT_TEMPLATE_SETTINGS_NAME,
+  SLO_INDEX_TEMPLATE_NAME,
+  SLO_INGEST_PIPELINE_NAME,
+} from '../../assets/constants';
+import { StoredSLO } from '../../domain/models';
+import { SO_SLO_TYPE } from '../../saved_objects';
+
+const OK = 'OK';
+const NOT_OK = 'NOT_OK';
+
+export async function getGlobalDiagnosis(
+  esClient: ElasticsearchClient,
+  licensing: LicensingApiRequestHandlerContext
+) {
+  const licenseInfo = licensing.license.toJSON();
+  const userPrivileges = await esClient.security.getUserPrivileges();
+  const sloResources = await getSloResourcesDiagnosis(esClient);
+
+  return {
+    licenseAndFeatures: licenseInfo,
+    userPrivileges,
+    sloResources,
+  };
+}
+
+export async function getSloDiagnosis(
+  sloId: string,
+  services: { esClient: ElasticsearchClient; soClient: SavedObjectsClientContract }
+) {
+  const { esClient, soClient } = services;
+
+  const sloResources = await getSloResourcesDiagnosis(esClient);
+
+  let sloSavedObject;
+  try {
+    sloSavedObject = await soClient.get<StoredSLO>(SO_SLO_TYPE, sloId);
+  } catch (err) {
+    // noop
+  }
+
+  const sloTransformStats = await esClient.transform.getTransformStats({
+    transform_id: getSLOTransformId(sloId, sloSavedObject?.attributes.revision ?? 1),
+  });
+
+  let dataSample;
+  if (sloSavedObject?.attributes.indicator.params.index) {
+    const slo = sloSavedObject.attributes;
+    dataSample = await esClient.search({
+      index: slo.indicator.params.index,
+      sort: { [slo.settings.timestampField]: 'desc' },
+      size: 5,
+    });
+  }
+
+  return {
+    sloResources,
+    sloSavedObject: sloSavedObject ?? NOT_OK,
+    sloTransformStats,
+    dataSample: dataSample ?? NOT_OK,
+  };
+}
+
+async function getSloResourcesDiagnosis(esClient: ElasticsearchClient) {
+  const indexTemplateExists = await esClient.indices.existsIndexTemplate({
+    name: SLO_INDEX_TEMPLATE_NAME,
+  });
+
+  const mappingsTemplateExists = await esClient.cluster.existsComponentTemplate({
+    name: SLO_COMPONENT_TEMPLATE_MAPPINGS_NAME,
+  });
+
+  const settingsTemplateExists = await esClient.cluster.existsComponentTemplate({
+    name: SLO_COMPONENT_TEMPLATE_SETTINGS_NAME,
+  });
+
+  let ingestPipelineExists = true;
+  try {
+    await esClient.ingest.getPipeline({ id: SLO_INGEST_PIPELINE_NAME });
+  } catch (err) {
+    ingestPipelineExists = false;
+  }
+
+  return {
+    [SLO_INDEX_TEMPLATE_NAME]: indexTemplateExists ? OK : NOT_OK,
+    [SLO_COMPONENT_TEMPLATE_MAPPINGS_NAME]: mappingsTemplateExists ? OK : NOT_OK,
+    [SLO_COMPONENT_TEMPLATE_SETTINGS_NAME]: settingsTemplateExists ? OK : NOT_OK,
+    [SLO_INGEST_PIPELINE_NAME]: ingestPipelineExists ? OK : NOT_OK,
+  };
+}

--- a/x-pack/plugins/observability/tsconfig.json
+++ b/x-pack/plugins/observability/tsconfig.json
@@ -73,6 +73,7 @@
     "@kbn/alerts-as-data-utils",
     "@kbn/core-application-browser",
     "@kbn/files-plugin",
+    "@kbn/core-elasticsearch-server",
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/152503

This PR introduces two new internal routes:
- GET /internal/observability/slos/_diagnosis
- GET /internal/observability/slos/{id}/_diagnosis

The first one performs a global diagnosis, while the second one focuses on the specific slo.

### Testing

Different scenarios:
1. Without any SLO created, the global diagnosis returns "NOT_OK" for the slo resources
2. With at least one SLO created, the global diagnosis returns "OK" for the slo resources
3. With an SLO, the slo diagnosis returns the transform stats as well as some sample from the index

```bash
curl --request GET \
  --url http://localhost:5601/kibana/internal/observability/slos/_diagnosis \
  --header 'Authorization: Basic ZWxhc3RpYzpjaGFuZ2VtZQ==' \
  --header 'kbn-xsrf: oui'
```

```bash
curl --request GET \
  --url http://localhost:5601/kibana/internal/observability/slos/{SLO_ID}/_diagnosis \
  --header 'Authorization: Basic ZWxhc3RpYzpjaGFuZ2VtZQ==' \
  --header 'kbn-xsrf: oui'
```

<details>
<summary>Example from slo diagnosis</summary>

```json
{
	"sloResources": {
		"slo-observability.sli": "OK",
		"slo-observability.sli-mappings": "OK",
		"slo-observability.sli-settings": "OK",
		"slo-observability.sli.monthly": "OK"
	},
	"sloSavedObject": {
		"id": "8bc13800-bf53-11ed-87f2-1f84267e6d31",
		"type": "slo",
		"namespaces": [
			"default"
		],
		"updated_at": "2023-03-10T14:55:06.626Z",
		"created_at": "2023-03-10T14:55:06.626Z",
		"version": "WzE5MSwxXQ==",
		"attributes": {
			"name": "latency critical",
			"description": "",
			"indicator": {
				"type": "sli.kql.custom",
				"params": {
					"index": "service-logs-latency",
					"filter": "dataset :\"healthy_then_failing\" and host : \"6b6cae72-768f-446f-a1d2-18d54f067e18\"",
					"good": "latency <= 100",
					"total": ""
				}
			},
			"timeWindow": {
				"duration": "30d",
				"isRolling": true
			},
			"budgetingMethod": "occurrences",
			"objective": {
				"target": 0.98
			},
			"id": "8bc13800-bf53-11ed-87f2-1f84267e6d31",
			"settings": {
				"timestampField": "@timestamp",
				"syncDelay": "1m",
				"frequency": "1m"
			},
			"revision": 1,
			"enabled": true,
			"createdAt": "2023-03-10T14:55:06.624Z",
			"updatedAt": "2023-03-10T14:55:06.624Z"
		},
		"references": [],
		"coreMigrationVersion": "8.0.0"
	},
	"sloTransformStats": {
		"count": 1,
		"transforms": [
			{
				"id": "slo-8bc13800-bf53-11ed-87f2-1f84267e6d31-1",
				"state": "started",
				"node": {
					"id": "MZa-zyzzQEGp7jPFm7czTw",
					"name": "Kevins-MacBook-Pro.local",
					"ephemeral_id": "AKX0b7A2TP67x0Yik8P07w",
					"transport_address": "127.0.0.1:9300",
					"attributes": {}
				},
				"stats": {
					"pages_processed": 664,
					"documents_processed": 520125,
					"documents_indexed": 43345,
					"documents_deleted": 0,
					"trigger_count": 145,
					"index_time_in_ms": 3397,
					"index_total": 231,
					"index_failures": 0,
					"search_time_in_ms": 7033,
					"search_total": 664,
					"search_failures": 0,
					"processing_time_in_ms": 88,
					"processing_total": 664,
					"delete_time_in_ms": 0,
					"exponential_avg_checkpoint_duration_ms": 63.995819400309756,
					"exponential_avg_documents_indexed": 1.0000000121859232,
					"exponential_avg_documents_processed": 11.93250807489107
				},
				"checkpointing": {
					"last": {
						"checkpoint": 145,
						"timestamp_millis": 1678468780920,
						"time_upper_bound_millis": 1678468680000
					},
					"operations_behind": 12,
					"changes_last_detected_at": 1678468780745,
					"last_search_time": 1678468780745
				},
				"health": {
					"status": "green"
				}
			}
		]
	},
	"dataSample": {
		"took": 0,
		"timed_out": false,
		"_shards": {
			"total": 1,
			"successful": 1,
			"skipped": 0,
			"failed": 0
		},
		"hits": {
			"total": {
				"value": 10000,
				"relation": "gte"
			},
			"max_score": null,
			"hits": [
				{
					"_index": "service-logs-latency",
					"_id": "E7qJzIYB-ECiHgMAUMrq",
					"_score": null,
					"_source": {
						"@timestamp": "2023-03-10T17:19:56.000Z",
						"dataset": "95percent_good",
						"host": "52e34a82-4e33-4154-bca8-fa6e76248078",
						"latency": 74
					},
					"sort": [
						1678468796000
					]
				},
				{
					"_index": "service-logs-latency",
					"_id": "FLqJzIYB-ECiHgMAUMr7",
					"_score": null,
					"_source": {
						"@timestamp": "2023-03-10T17:19:56.000Z",
						"dataset": "healthy_then_failing",
						"host": "6b6cae72-768f-446f-a1d2-18d54f067e18",
						"latency": 549
					},
					"sort": [
						1678468796000
					]
				},
				{
					"_index": "service-logs-latency",
					"_id": "FbqJzIYB-ECiHgMAUcoA",
					"_score": null,
					"_source": {
						"@timestamp": "2023-03-10T17:19:56.000Z",
						"dataset": "full_outage_every_day",
						"host": "cb247dc4-e4a0-4ac7-8838-240ed6bcb801",
						"latency": 4
					},
					"sort": [
						1678468796000
					]
				},
				{
					"_index": "service-logs-latency",
					"_id": "ELqJzIYB-ECiHgMAPcpQ",
					"_score": null,
					"_source": {
						"@timestamp": "2023-03-10T17:19:51.000Z",
						"dataset": "95percent_good",
						"host": "52e34a82-4e33-4154-bca8-fa6e76248078",
						"latency": 42
					},
					"sort": [
						1678468791000
					]
				},
				{
					"_index": "service-logs-latency",
					"_id": "EbqJzIYB-ECiHgMAPcpZ",
					"_score": null,
					"_source": {
						"@timestamp": "2023-03-10T17:19:51.000Z",
						"dataset": "healthy_then_failing",
						"host": "6b6cae72-768f-446f-a1d2-18d54f067e18",
						"latency": 579
					},
					"sort": [
						1678468791000
					]
				}
			]
		}
	}
}
```
</details>