### PR TITLE
Make pipeline creation endpoint accept a full pipeline definition

### DIFF
--- a/x-pack/plugins/enterprise_search/common/types/error_codes.ts
+++ b/x-pack/plugins/enterprise_search/common/types/error_codes.ts
@@ -13,6 +13,7 @@ export enum ErrorCode {
   DOCUMENT_NOT_FOUND = 'document_not_found',
   INDEX_ALREADY_EXISTS = 'index_already_exists',
   INDEX_NOT_FOUND = 'index_not_found',
+  PARAMETER_CONFLICT = 'parameter_conflict',
   PIPELINE_ALREADY_EXISTS = 'pipeline_already_exists',
   PIPELINE_IS_IN_USE = 'pipeline_is_in_use',
   PIPELINE_NOT_FOUND = 'pipeline_not_found',

--- a/x-pack/plugins/enterprise_search/server/lib/indices/pipelines/ml_inference/pipeline_processors/create_ml_inference_pipeline.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/indices/pipelines/ml_inference/pipeline_processors/create_ml_inference_pipeline.test.ts
@@ -161,6 +161,7 @@ describe('createMlInferencePipeline lib function', () => {
 
     const actualResult = createMlInferencePipeline(
       pipelineName,
+      undefined,
       modelId,
       sourceField,
       destinationField,

--- a/x-pack/plugins/enterprise_search/server/lib/indices/pipelines/ml_inference/pipeline_processors/create_ml_inference_pipeline.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/indices/pipelines/ml_inference/pipeline_processors/create_ml_inference_pipeline.test.ts
@@ -58,6 +58,7 @@ describe('createMlInferencePipeline lib function', () => {
 
     const actualResult = await createMlInferencePipeline(
       pipelineName,
+      undefined,
       modelId,
       sourceField,
       destinationField,
@@ -72,6 +73,7 @@ describe('createMlInferencePipeline lib function', () => {
   it('should convert spaces to underscores in the pipeline name', async () => {
     await createMlInferencePipeline(
       'my pipeline with spaces  ',
+      undefined,
       modelId,
       sourceField,
       destinationField,
@@ -92,6 +94,7 @@ describe('createMlInferencePipeline lib function', () => {
 
     await createMlInferencePipeline(
       pipelineName,
+      undefined,
       modelId,
       sourceField,
       undefined, // Omitted destination field
@@ -119,6 +122,7 @@ describe('createMlInferencePipeline lib function', () => {
 
     await createMlInferencePipeline(
       pipelineName,
+      undefined,
       modelId,
       sourceField,
       destinationField,

--- a/x-pack/plugins/enterprise_search/server/routes/enterprise_search/indices.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/enterprise_search/indices.ts
@@ -18,10 +18,7 @@ import { DEFAULT_PIPELINE_NAME } from '../../../common/constants';
 import { ErrorCode } from '../../../common/types/error_codes';
 import { AlwaysShowPattern } from '../../../common/types/indices';
 
-import type {
-  CreateMlInferencePipelineResponse,
-  AttachMlInferencePipelineResponse,
-} from '../../../common/types/pipelines';
+import type { AttachMlInferencePipelineResponse } from '../../../common/types/pipelines';
 
 import { deleteConnectorById } from '../../lib/connectors/delete_connector';
 
@@ -454,10 +451,9 @@ export function registerIndexRoutes({
         });
       }
 
-      let createPipelineResult: CreateMlInferencePipelineResponse | undefined;
       try {
         // Create the sub-pipeline for inference
-        createPipelineResult = await createAndReferenceMlInferencePipeline(
+        const createPipelineResult = await createAndReferenceMlInferencePipeline(
           indexName,
           pipelineName,
           pipelineDefinition,
@@ -467,6 +463,12 @@ export function registerIndexRoutes({
           inferenceConfig,
           client.asCurrentUser
         );
+        return response.ok({
+          body: {
+            created: createPipelineResult?.id,
+          },
+          headers: { 'content-type': 'application/json' },
+        });
       } catch (error) {
         // Handle scenario where pipeline already exists
         if ((error as Error).message === ErrorCode.PIPELINE_ALREADY_EXISTS) {
@@ -484,13 +486,6 @@ export function registerIndexRoutes({
 
         throw error;
       }
-
-      return response.ok({
-        body: {
-          created: createPipelineResult?.id,
-        },
-        headers: { 'content-type': 'application/json' },
-      });
     })
   );
 

--- a/x-pack/plugins/enterprise_search/server/routes/enterprise_search/indices.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/enterprise_search/indices.ts
@@ -402,10 +402,9 @@ export function registerIndexRoutes({
           ),
           model_id: schema.maybe(schema.string()),
           pipeline_definition: schema.maybe(
-            // TODO: make this more explicit?
             schema.object({
               description: schema.maybe(schema.string()),
-              processors: schema.arrayOf(schema.maybe(schema.any())),
+              processors: schema.arrayOf(schema.any()),
             })
           ),
           pipeline_name: schema.string(),

--- a/x-pack/plugins/enterprise_search/server/routes/enterprise_search/indices.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/enterprise_search/indices.ts
@@ -400,9 +400,16 @@ export function registerIndexRoutes({
               ),
             })
           ),
-          model_id: schema.string(),
+          model_id: schema.maybe(schema.string()),
+          pipeline_definition: schema.maybe(
+            // TODO: make this more explicit?
+            schema.object({
+              description: schema.maybe(schema.string()),
+              processors: schema.arrayOf(schema.maybe(schema.any())),
+            })
+          ),
           pipeline_name: schema.string(),
-          source_field: schema.string(),
+          source_field: schema.maybe(schema.string()),
         }),
       },
     },
@@ -413,10 +420,40 @@ export function registerIndexRoutes({
       const {
         model_id: modelId,
         pipeline_name: pipelineName,
+        pipeline_definition: pipelineDefinition,
         source_field: sourceField,
         destination_field: destinationField,
         inference_config: inferenceConfig,
       } = request.body;
+
+      // additional validations
+      if (pipelineDefinition && (sourceField || destinationField || modelId)) {
+        return createError({
+          errorCode: ErrorCode.PARAMETER_CONFLICT,
+          message: i18n.translate(
+            'xpack.enterpriseSearch.server.routes.createMlInferencePipeline.ParameterConflictError',
+            {
+              defaultMessage:
+                'pipeline_definition should only be provided if source_field and destination_field and model_id are not provided',
+            }
+          ),
+          response,
+          statusCode: 400,
+        });
+      } else if (!(pipelineDefinition || (sourceField && modelId))) {
+        return createError({
+          errorCode: ErrorCode.PARAMETER_CONFLICT,
+          message: i18n.translate(
+            'xpack.enterpriseSearch.server.routes.createMlInferencePipeline.ParameterMissingError',
+            {
+              defaultMessage:
+                'either pipeline_definition or source_field AND model_id must be provided',
+            }
+          ),
+          response,
+          statusCode: 400,
+        });
+      }
 
       let createPipelineResult: CreateMlInferencePipelineResponse | undefined;
       try {
@@ -424,6 +461,7 @@ export function registerIndexRoutes({
         createPipelineResult = await createAndReferenceMlInferencePipeline(
           indexName,
           pipelineName,
+          pipelineDefinition,
           modelId,
           sourceField,
           destinationField,


### PR DESCRIPTION
## Summary

Updates ML Inference Pipeline creation for Enterprise Search to accept either a full pipeline definition OR several distinct parameters (modelId, sourceField, destinationField). This will make it easier to create more complex pipelines without having to continue to grow this API, and will also enable future end-user editing of the pipeline JSON.


### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
