### PR TITLE
Add last_sync_scheduled_at to connector index

### DIFF
--- a/x-pack/plugins/enterprise_search/server/index_management/setup_indices.test.ts
+++ b/x-pack/plugins/enterprise_search/server/index_management/setup_indices.test.ts
@@ -130,6 +130,7 @@ describe('Setup Indices', () => {
       last_indexed_document_count: { type: 'long' },
       last_seen: { type: 'date' },
       last_sync_error: { type: 'keyword' },
+      last_sync_scheduled_at: { type: 'date' },
       last_sync_status: { type: 'keyword' },
       last_synced: { type: 'date' },
       name: { type: 'keyword' },

--- a/x-pack/plugins/enterprise_search/server/index_management/setup_indices.ts
+++ b/x-pack/plugins/enterprise_search/server/index_management/setup_indices.ts
@@ -119,6 +119,7 @@ const connectorMappingsProperties: Record<string, MappingProperty> = {
   last_indexed_document_count: { type: 'long' },
   last_seen: { type: 'date' },
   last_sync_error: { type: 'keyword' },
+  last_sync_scheduled_at: { type: 'date' },
   last_sync_status: { type: 'keyword' },
   last_synced: { type: 'date' },
   name: { type: 'keyword' },


### PR DESCRIPTION
# Part of https://github.com/elastic/enterprise-search-team/issues/4156

## Summary

This PR adds a new field `last_sync_scheduled_at` to index `.elastic-connectors`.


### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
