### PR TITLE
Upgrade transitive `webpack` dependency (`5.74.0` → `5.76.1`).

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -29152,9 +29152,9 @@ webpack@4, webpack@^4.41.5:
     webpack-sources "^1.4.1"
 
 "webpack@>=4.43.0 <6.0.0":
-  version "5.74.0"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.74.0.tgz#02a5dac19a17e0bb47093f2be67c695102a55980"
-  integrity sha512-A2InDwnhhGN4LYctJj6M1JEaGL7Luj6LOmyBHjcI8529cm5p6VXiTIW2sn6ffvEAKmveLzvu4jrihwXtPojlAA==
+  version "5.76.1"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.76.1.tgz#7773de017e988bccb0f13c7d75ec245f377d295c"
+  integrity sha512-4+YIK4Abzv8172/SGqObnUjaIHjLEuUasz9EwQj/9xmPPkYJy2Mh03Q/lJfSD3YLzbxy5FeTq5Uw0323Oh6SJQ==
   dependencies:
     "@types/eslint-scope" "^3.7.3"
     "@types/estree" "^0.0.51"


### PR DESCRIPTION
## Summary

Upgrade transitive `webpack` dependency (`5.74.0` → `5.76.1`).

Change log: https://github.com/webpack/webpack/releases

Since the upgraded version is a transitive dependency, there are no any notable changes we should care about.

<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->