### PR TITLE
[Fleet] Fix EPR and custom integration categories merge

### DIFF
--- a/src/plugins/custom_integrations/common/index.ts
+++ b/src/plugins/custom_integrations/common/index.ts
@@ -12,43 +12,45 @@ export const PLUGIN_NAME = 'customIntegrations';
  * A map of category names and their corresponding titles.
  */
 // TODO: consider i18n
-export const INTEGRATION_CATEGORY_DISPLAY = {
-  aws: 'AWS',
-  azure: 'Azure',
-  cloud: 'Cloud',
-  config_management: 'Config management',
-  containers: 'Containers',
-  crm: 'CRM',
-  custom: 'Custom',
-  datastore: 'Datastore',
-  elastic_stack: 'Elastic Stack',
-  google_cloud: 'Google Cloud',
-  infrastructure: 'Infrastructure',
-  kubernetes: 'Kubernetes',
-  languages: 'Languages',
-  message_queue: 'Message queue',
-  microsoft_365: 'Microsoft 365',
-  monitoring: 'Monitoring',
-  network: 'Network',
-  notification: 'Notification',
-  os_system: 'OS & System',
-  productivity: 'Productivity',
-  security: 'Security',
-  sample_data: 'Sample data',
-  support: 'Support',
-  threat_intel: 'Threat intelligence',
-  ticketing: 'Ticketing',
-  version_control: 'Version control',
-  web: 'Web',
+export const INTEGRATION_CATEGORY_DISPLAY: {
+  [key: string]: { title: string; parent_id?: string };
+} = {
+  aws: { title: 'AWS', parent_id: undefined },
+  azure: { title: 'Azure', parent_id: undefined },
+  cloud: { title: 'Cloud', parent_id: undefined },
+  config_management: { title: 'Config management', parent_id: undefined },
+  containers: { title: 'Containers', parent_id: undefined },
+  crm: { title: 'CRM', parent_id: undefined },
+  custom: { title: 'Custom', parent_id: undefined },
+  datastore: { title: 'Datastore', parent_id: undefined },
+  elastic_stack: { title: 'Elastic Stack', parent_id: undefined },
+  google_cloud: { title: 'Google Cloud', parent_id: undefined },
+  infrastructure: { title: 'Infrastructure', parent_id: undefined },
+  kubernetes: { title: 'Kubernetes', parent_id: undefined },
+  languages: { title: 'Languages', parent_id: undefined },
+  message_queue: { title: 'Message queue', parent_id: undefined },
+  microsoft_365: { title: 'Microsoft 365', parent_id: undefined },
+  monitoring: { title: 'Monitoring', parent_id: undefined },
+  network: { title: 'Network', parent_id: undefined },
+  notification: { title: 'Notification', parent_id: undefined },
+  os_system: { title: 'OS & System', parent_id: undefined },
+  productivity: { title: 'Productivity', parent_id: undefined },
+  security: { title: 'Security', parent_id: undefined },
+  sample_data: { title: 'Sample data', parent_id: undefined },
+  support: { title: 'Support', parent_id: undefined },
+  threat_intel: { title: 'Threat intelligence', parent_id: undefined },
+  ticketing: { title: 'Ticketing', parent_id: undefined },
+  version_control: { title: 'Version control', parent_id: undefined },
+  web: { title: 'Web', parent_id: undefined },
 
   // Kibana added
-  communications: 'Communications',
-  enterprise_search: 'Enterprise search',
-  file_storage: 'File storage',
-  language_client: 'Language client',
-  upload_file: 'Upload a file',
-  website_search: 'Website search',
-  geo: 'Geo',
+  communications: { title: 'Communications', parent_id: undefined },
+  enterprise_search: { title: 'Enterprise search', parent_id: undefined },
+  file_storage: { title: 'File storage', parent_id: undefined },
+  language_client: { title: 'Language client', parent_id: undefined },
+  upload_file: { title: 'Upload a file', parent_id: undefined },
+  website_search: { title: 'Website search', parent_id: undefined },
+  geo: { title: 'Geo', parent_id: undefined },
 };
 
 // featured integrations will be brought to the top of the search results for
@@ -61,7 +63,7 @@ export const FEATURED_INTEGRATIONS_BY_CATEGORY = {
 /**
  * A category applicable to an Integration.
  */
-export type IntegrationCategory = keyof typeof INTEGRATION_CATEGORY_DISPLAY;
+export type IntegrationCategory = string;
 
 /**
  * The list of all available categories.

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/home/hooks/use_available_packages.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/home/hooks/use_available_packages.tsx
@@ -6,7 +6,7 @@
  */
 import React, { useState, useMemo } from 'react';
 
-import { uniq, xorBy } from 'lodash';
+import { uniq } from 'lodash';
 
 import type { CustomIntegration } from '@kbn/custom-integrations-plugin/common';
 
@@ -21,7 +21,7 @@ import { useMergeEprPackagesWithReplacements } from '../../../../../hooks/use_me
 import { mapToCard } from '..';
 import type { PackageList, PackageListItem } from '../../../../../types';
 
-import { doesPackageHaveIntegrations } from '../../../../../services';
+import { doesPackageHaveIntegrations, ExperimentalFeaturesService } from '../../../../../services';
 
 import {
   isInputOnlyPolicyTemplate,
@@ -108,6 +108,7 @@ export const useAvailablePackages = () => {
   const [prereleaseIntegrationsEnabled, setPrereleaseIntegrationsEnabled] = React.useState<
     boolean | undefined
   >(undefined);
+  const { showIntegrationsSubcategories } = ExperimentalFeaturesService.get();
 
   const {
     initialSelectedCategory,
@@ -188,20 +189,11 @@ export const useAvailablePackages = () => {
   } = useGetCategoriesQuery({ prerelease: prereleaseIntegrationsEnabled });
 
   const eprCategories = useMemo(() => eprCategoriesRes?.items || [], [eprCategoriesRes]);
-  // Subcategories
-  const subCategories = useMemo(() => {
-    return eprCategories?.filter((item) => item.parent_id !== undefined);
-  }, [eprCategories]);
 
   const allCategories: CategoryFacet[] = useMemo(() => {
     const eprAndCustomCategories: CategoryFacet[] = isLoadingCategories
       ? []
-      : mergeCategoriesAndCount(
-          eprCategories
-            ? (eprCategories as Array<{ id: string; title: string; count: number }>)
-            : [],
-          cards
-        );
+      : mergeCategoriesAndCount(eprCategories ? eprCategories : [], cards);
     return [
       {
         ...ALL_CATEGORY,
@@ -212,11 +204,17 @@ export const useAvailablePackages = () => {
   }, [cards, eprCategories, isLoadingCategories]);
 
   // Filter out subcategories
-  const mainCategories = xorBy(allCategories, subCategories, 'id');
+  const mainCategories = useMemo(() => {
+    return showIntegrationsSubcategories
+      ? allCategories.filter((category) => category.parent_id === undefined)
+      : allCategories;
+  }, [allCategories, showIntegrationsSubcategories]);
 
   const availableSubCategories = useMemo(() => {
-    return subCategories?.filter((c) => c.parent_id === selectedCategory);
-  }, [selectedCategory, subCategories]);
+    return showIntegrationsSubcategories
+      ? allCategories?.filter((c) => c.parent_id === selectedCategory)
+      : [];
+  }, [allCategories, selectedCategory, showIntegrationsSubcategories]);
 
   return {
     initialSelectedCategory,


### PR DESCRIPTION
## Summary

While testing https://github.com/elastic/integrations/pull/5123 and https://github.com/elastic/kibana/pull/153216, I discovered two problems with the list of categories on the Browse integration page:

1. The categories list doesn't respect `showIntegrationsSubcategories` feature flag. When it is turned off, it will still only display top-level parent categories. This PR fixes that so that when `showIntegrationsSubcategories` is turned off, _all_ categories will be listed on the left sidebar. When it is turned on, only the top-level categories will be listed.
2. The merging of the categories list from EPR (i.e. `<EPR_HOST>/categories`) with the categories hard-coded in Kibana for custom integration cards is flawed: there can be a situation where a category or subcategory is not returned by EPR, due to no EPR-hosted integrations having it, but it is registered by a custom card. In this case, the category is missing from the list. This PR fixes the merging logic.

<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->