### PR TITLE
[Cloud Security] Fixed text for cloud dashboard benchmark section

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/dashboard_sections/benchmarks_section.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/dashboard_sections/benchmarks_section.tsx
@@ -195,7 +195,13 @@ export const BenchmarksSection = ({
               }
               viewAllButtonTitle={i18n.translate(
                 'xpack.csp.dashboard.risksTable.clusterCardViewAllButtonTitle',
-                { defaultMessage: 'View all failed findings for this cluster' }
+                {
+                  defaultMessage: 'View all failed findings for this {postureAsset}',
+                  values: {
+                    postureAsset:
+                      dashboardType === CSPM_POLICY_TEMPLATE ? 'cloud account' : 'cluster',
+                  },
+                }
               )}
               onViewAllClick={() => navToFailedFindingsByCluster(cluster)}
             />

--- a/x-pack/plugins/translations/translations/fr-FR.json
+++ b/x-pack/plugins/translations/translations/fr-FR.json
@@ -10036,7 +10036,6 @@
     "xpack.csp.dashboard.benchmarkSection.manageRulesButton": "Gérer les règles",
     "xpack.csp.dashboard.cspPageTemplate.pageTitle": "Niveau du cloud",
     "xpack.csp.dashboard.risksTable.cisSectionColumnLabel": "Section CIS",
-    "xpack.csp.dashboard.risksTable.clusterCardViewAllButtonTitle": "Afficher tous les échecs des résultats pour ce cluster",
     "xpack.csp.dashboard.risksTable.complianceColumnLabel": "Conformité",
     "xpack.csp.dashboard.risksTable.viewAllButtonTitle": "Afficher tous les échecs des résultats",
     "xpack.csp.dashboard.summarySection.complianceByCisSectionPanelTitle": "Conformité par section CIS",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -10040,7 +10040,6 @@
     "xpack.csp.dashboard.benchmarkSection.manageRulesButton": "管理规则",
     "xpack.csp.dashboard.cspPageTemplate.pageTitle": "云态势",
     "xpack.csp.dashboard.risksTable.cisSectionColumnLabel": "CIS 部分",
-    "xpack.csp.dashboard.risksTable.clusterCardViewAllButtonTitle": "查看此集群的所有失败结果",
     "xpack.csp.dashboard.risksTable.complianceColumnLabel": "合规性",
     "xpack.csp.dashboard.risksTable.viewAllButtonTitle": "查看所有失败的结果",
     "xpack.csp.dashboard.summarySection.complianceByCisSectionPanelTitle": "合规性（按 CIS 部分）",


### PR DESCRIPTION
Resolves #152940

## Summary

cis table show all button will now display `cloud account` or `cluster` depending on dashboard context

<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->