### PR TITLE
[8.7] Fix selected text not showing correct entity (#152045)

### DIFF
--- a/x-pack/plugins/security_solution/common/types/data_table/index.ts
+++ b/x-pack/plugins/security_solution/common/types/data_table/index.ts
@@ -35,6 +35,26 @@ export enum TableId {
   kubernetesPageSessions = 'kubernetes-page-sessions',
 }
 
+export enum TableEntityType {
+  alert = 'alert',
+  event = 'event',
+  session = 'session',
+}
+
+export const tableEntity: Record<TableId, TableEntityType> = {
+  [TableId.alertsOnAlertsPage]: TableEntityType.alert,
+  [TableId.alertsOnCasePage]: TableEntityType.alert,
+  [TableId.alertsOnRuleDetailsPage]: TableEntityType.alert,
+  [TableId.hostsPageEvents]: TableEntityType.event,
+  [TableId.networkPageEvents]: TableEntityType.event,
+  [TableId.usersPageEvents]: TableEntityType.event,
+  [TableId.test]: TableEntityType.event,
+  [TableId.alternateTest]: TableEntityType.event,
+  [TableId.rulePreview]: TableEntityType.event,
+  [TableId.hostsPageSessions]: TableEntityType.session,
+  [TableId.kubernetesPageSessions]: TableEntityType.session,
+} as const;
+
 const TableIdLiteralRt = runtimeTypes.union([
   runtimeTypes.literal(TableId.usersPageEvents),
   runtimeTypes.literal(TableId.hostsPageEvents),

--- a/x-pack/plugins/security_solution/common/types/data_table/index.ts
+++ b/x-pack/plugins/security_solution/common/types/data_table/index.ts
@@ -43,7 +43,6 @@ export enum TableEntityType {
 
 export const tableEntity: Record<TableId, TableEntityType> = {
   [TableId.alertsOnAlertsPage]: TableEntityType.alert,
-  [TableId.alertsOnCasePage]: TableEntityType.alert,
   [TableId.alertsOnRuleDetailsPage]: TableEntityType.alert,
   [TableId.hostsPageEvents]: TableEntityType.event,
   [TableId.networkPageEvents]: TableEntityType.event,

--- a/x-pack/plugins/security_solution/public/common/components/events_viewer/use_alert_bulk_actions.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/events_viewer/use_alert_bulk_actions.tsx
@@ -8,13 +8,14 @@
 import { EuiLoadingSpinner } from '@elastic/eui';
 import React, { lazy, Suspense, useMemo } from 'react';
 import type { TimelineItem } from '../../../../common/search_strategy';
+import type { TableId } from '../../../../common/types';
 import type { AlertWorkflowStatus } from '../../types';
 import type { BulkActionsProp } from '../toolbar/bulk_actions/types';
 
 const StatefulAlertBulkActions = lazy(() => import('../toolbar/bulk_actions/alert_bulk_actions'));
 
 interface OwnProps {
-  tableId: string;
+  tableId: TableId;
   data: TimelineItem[];
   totalItems: number;
   indexNames: string[];
@@ -25,6 +26,7 @@ interface OwnProps {
   bulkActions?: BulkActionsProp;
   selectedCount?: number;
 }
+
 export const useAlertBulkActions = ({
   tableId,
   data,

--- a/x-pack/plugins/security_solution/public/common/components/toolbar/bulk_actions/alert_bulk_actions.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/toolbar/bulk_actions/alert_bulk_actions.tsx
@@ -5,14 +5,20 @@
  * 2.0.
  */
 
-import React, { useCallback, useEffect, useState } from 'react';
+import numeral from '@elastic/numeral';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+
 import type { ConnectedProps } from 'react-redux';
 import { connect, useDispatch } from 'react-redux';
+import { useUiSetting$ } from '@kbn/kibana-react-plugin/public';
+import { DEFAULT_NUMBER_FORMAT } from '../../../../../common/constants';
 import type {
   CustomBulkActionProp,
   SetEventsDeleted,
   SetEventsLoading,
+  TableId,
 } from '../../../../../common/types';
+import { tableEntity } from '../../../../../common/types';
 import { BulkActions } from '.';
 import { useBulkActionItems } from './use_bulk_action_items';
 import { dataTableActions, dataTableSelectors } from '../../../store/data_table';
@@ -23,9 +29,10 @@ import type { OnUpdateAlertStatusError, OnUpdateAlertStatusSuccess } from './typ
 import type { inputsModel } from '../../../store';
 import { inputsSelectors } from '../../../store';
 import { useDeepEqualSelector } from '../../../hooks/use_selector';
+import * as i18n from './translations';
 
 interface OwnProps {
-  id: string;
+  id: TableId;
   totalItems: number;
   filterStatus?: AlertWorkflowStatus;
   query?: string;
@@ -66,6 +73,41 @@ export const AlertBulkActionsComponent = React.memo<StatefulAlertBulkActionsProp
     const refetchQuery = useCallback(() => {
       globalQueries.forEach((q) => q.refetch && (q.refetch as inputsModel.Refetch)());
     }, [globalQueries]);
+
+    const [defaultNumberFormat] = useUiSetting$<string>(DEFAULT_NUMBER_FORMAT);
+    const selectedCount = useMemo(() => Object.keys(selectedEventIds).length, [selectedEventIds]);
+
+    const formattedTotalCount = useMemo(
+      () => numeral(totalItems).format(defaultNumberFormat),
+      [defaultNumberFormat, totalItems]
+    );
+    const formattedSelectedCount = useMemo(
+      () => numeral(selectedCount).format(defaultNumberFormat),
+      [defaultNumberFormat, selectedCount]
+    );
+
+    const selectText = useMemo(
+      () =>
+        showClearSelection
+          ? i18n.SELECTED_ENTITIES(tableEntity[id], formattedTotalCount, totalItems)
+          : i18n.SELECTED_ENTITIES(tableEntity[id], formattedSelectedCount, selectedCount),
+      [
+        id,
+        showClearSelection,
+        formattedTotalCount,
+        formattedSelectedCount,
+        totalItems,
+        selectedCount,
+      ]
+    );
+
+    const selectClearAllText = useMemo(
+      () =>
+        showClearSelection
+          ? i18n.CLEAR_SELECTION
+          : i18n.SELECT_ALL_ENTITIES(tableEntity[id], formattedTotalCount, totalItems),
+      [id, showClearSelection, formattedTotalCount, totalItems]
+    );
 
     // Catches state change isSelectAllChecked->false (page checkbox) upon user selection change to reset toolbar select all
     useEffect(() => {
@@ -148,9 +190,9 @@ export const AlertBulkActionsComponent = React.memo<StatefulAlertBulkActionsProp
 
     return (
       <BulkActions
+        selectText={selectText}
+        selectClearAllText={selectClearAllText}
         data-test-subj="bulk-actions"
-        selectedCount={Object.keys(selectedEventIds).length}
-        totalItems={totalItems}
         showClearSelection={showClearSelection}
         onSelectAll={onSelectAll}
         onClearSelection={onClearSelection}

--- a/x-pack/plugins/security_solution/public/common/components/toolbar/bulk_actions/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/toolbar/bulk_actions/index.tsx
@@ -6,16 +6,12 @@
  */
 
 import { EuiPopover, EuiButtonEmpty, EuiContextMenuPanel } from '@elastic/eui';
-import numeral from '@elastic/numeral';
-import React, { useState, useCallback, useMemo } from 'react';
+import React, { useState, useCallback } from 'react';
 import styled from 'styled-components';
-import { useUiSetting$ } from '@kbn/kibana-react-plugin/public';
-import { DEFAULT_NUMBER_FORMAT } from '../../../../../common/constants';
-import * as i18n from './translations';
 
 interface OwnProps {
-  totalItems: number;
-  selectedCount: number;
+  selectText: string;
+  selectClearAllText: string;
   showClearSelection: boolean;
   onSelectAll: () => void;
   onClearSelection: () => void;
@@ -33,24 +29,14 @@ BulkActionsContainer.displayName = 'BulkActionsContainer';
  * Stateless component integrating the bulk actions menu and the select all button
  */
 const BulkActionsComponent: React.FC<OwnProps> = ({
-  selectedCount,
-  totalItems,
+  selectText,
+  selectClearAllText,
   showClearSelection,
   onSelectAll,
   onClearSelection,
   bulkActionItems,
 }) => {
   const [isActionsPopoverOpen, setIsActionsPopoverOpen] = useState(false);
-  const [defaultNumberFormat] = useUiSetting$<string>(DEFAULT_NUMBER_FORMAT);
-
-  const formattedTotalCount = useMemo(
-    () => numeral(totalItems).format(defaultNumberFormat),
-    [defaultNumberFormat, totalItems]
-  );
-  const formattedSelectedEventsCount = useMemo(
-    () => numeral(selectedCount).format(defaultNumberFormat),
-    [defaultNumberFormat, selectedCount]
-  );
 
   const toggleIsActionOpen = useCallback(() => {
     setIsActionsPopoverOpen((currentIsOpen) => !currentIsOpen);
@@ -74,28 +60,6 @@ const BulkActionsComponent: React.FC<OwnProps> = ({
     }
   }, [onClearSelection, onSelectAll, showClearSelection]);
 
-  const selectedAlertsText = useMemo(
-    () =>
-      showClearSelection
-        ? i18n.SELECTED_ALERTS(formattedTotalCount, totalItems)
-        : i18n.SELECTED_ALERTS(formattedSelectedEventsCount, selectedCount),
-    [
-      showClearSelection,
-      formattedTotalCount,
-      formattedSelectedEventsCount,
-      totalItems,
-      selectedCount,
-    ]
-  );
-
-  const selectClearAllAlertsText = useMemo(
-    () =>
-      showClearSelection
-        ? i18n.CLEAR_SELECTION
-        : i18n.SELECT_ALL_ALERTS(formattedTotalCount, totalItems),
-    [showClearSelection, formattedTotalCount, totalItems]
-  );
-
   return (
     <BulkActionsContainer
       onClick={closeIfPopoverIsOpen}
@@ -115,7 +79,7 @@ const BulkActionsComponent: React.FC<OwnProps> = ({
             color="primary"
             onClick={toggleIsActionOpen}
           >
-            {selectedAlertsText}
+            {selectText}
           </EuiButtonEmpty>
         }
         closePopover={closeActionPopover}
@@ -130,7 +94,7 @@ const BulkActionsComponent: React.FC<OwnProps> = ({
         iconType={showClearSelection ? 'cross' : 'pagesSelect'}
         onClick={toggleSelectAll}
       >
-        {selectClearAllAlertsText}
+        {selectClearAllText}
       </EuiButtonEmpty>
     </BulkActionsContainer>
   );

--- a/x-pack/plugins/security_solution/public/common/components/toolbar/bulk_actions/translations.ts
+++ b/x-pack/plugins/security_solution/public/common/components/toolbar/bulk_actions/translations.ts
@@ -7,18 +7,49 @@
 
 import { i18n } from '@kbn/i18n';
 
-export const SELECTED_ALERTS = (selectedAlertsFormatted: string, selectedAlerts: number) =>
-  i18n.translate('xpack.securitySolution.toolbar.bulkActions.selectedAlertsTitle', {
-    values: { selectedAlertsFormatted, selectedAlerts },
-    defaultMessage:
-      'Selected {selectedAlertsFormatted} {selectedAlerts, plural, =1 {alert} other {alerts}}',
+import { TableEntityType } from '../../../../../common/types';
+
+const ENTITY_TYPE_PLURAL = (entityType: TableEntityType, count: number) => {
+  switch (entityType) {
+    case TableEntityType.alert: {
+      return i18n.translate('xpack.securitySolution.toolbar.bulkActions.entityAlerts', {
+        values: { count },
+        defaultMessage: '{count, plural, =1 {alert} other {alerts}}',
+      });
+    }
+    case TableEntityType.event: {
+      return i18n.translate('xpack.securitySolution.toolbar.bulkActions.entityEvents', {
+        values: { count },
+        defaultMessage: '{count, plural, =1 {event} other {events}}',
+      });
+    }
+    case TableEntityType.session: {
+      return i18n.translate('xpack.securitySolution.toolbar.bulkActions.entitySessions', {
+        values: { count },
+        defaultMessage: '{count, plural, =1 {session} other {sessions}}',
+      });
+    }
+  }
+};
+
+export const SELECT_ALL_ENTITIES = (
+  entityType: TableEntityType,
+  totalFormatted: string,
+  total: number
+) =>
+  i18n.translate('xpack.securitySolution.toolbar.bulkActions.selectAllEntitiesTitle', {
+    values: { entityPlural: ENTITY_TYPE_PLURAL(entityType, total), totalFormatted, total },
+    defaultMessage: 'Select {total, plural, =1 {} other {all}} {totalFormatted} {entityPlural}',
   });
 
-export const SELECT_ALL_ALERTS = (totalAlertsFormatted: string, totalAlerts: number) =>
-  i18n.translate('xpack.securitySolution.toolbar.bulkActions.selectAllAlertsTitle', {
-    values: { totalAlertsFormatted, totalAlerts },
-    defaultMessage:
-      'Select all {totalAlertsFormatted} {totalAlerts, plural, =1 {alert} other {alerts}}',
+export const SELECTED_ENTITIES = (
+  entityType: TableEntityType,
+  totalFormatted: string,
+  total: number
+) =>
+  i18n.translate('xpack.securitySolution.toolbar.bulkActions.selectedEntitiesTitle', {
+    values: { entityPlural: ENTITY_TYPE_PLURAL(entityType, total), totalFormatted },
+    defaultMessage: 'Selected {totalFormatted} {entityPlural}',
   });
 
 export const CLEAR_SELECTION = i18n.translate(


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.7`:
 - [Fix selected text not showing correct entity (#152045)](https://github.com/elastic/kibana/pull/152045)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Kristof C","email":"kpac.ja@gmail.com"},"sourceCommit":{"committedDate":"2023-03-06T17:44:34Z","message":"Fix selected text not showing correct entity (#152045)\n\nAs it relates to #151263\r\n\r\n## Summary\r\nUpdate the text where entity counts (see image) are shown to be the\r\ncorrect entity instead of defaulting to 'alerts'\r\n\r\nDepending on the type of table (event, alert, or session):\r\n\r\n\r\nThe text will now read \r\n```\r\nSelected x [alert | event | session](s)\r\n```\r\n\r\nand \r\n```\r\nSelect (all) x [alert | event | session](s)\r\n```\r\nwhere `x` is  number & 'all' & 's'  is conditional upon plurality. \r\n\r\n| Before  |   After |\r\n:-------------------------:|:-------------------------:\r\n<img width=\"678\" alt=\"image\"\r\nsrc=\"https://user-images.githubusercontent.com/28942857/221037551-e119211c-fc7a-4d29-93cd-58a6fb3cce82.png\">\r\n| <img width=\"525\" alt=\"image\"\r\nsrc=\"https://user-images.githubusercontent.com/28942857/221038780-4c52713a-4713-4099-95e7-430341fe22f0.png\">\r\n\r\n\r\n`selectText` & `selectClearText` are shifted from `BulkActions` to\r\n`AlertBulkActionsComponent` Where they can be computed using the\r\n`tableId` then passed to `BulkActions`.\r\n\r\nOne note, as per conversation with Explore team and @paulewing when a\r\nuser selects `show only external alerts` the entity type is still\r\nevents.\r\n\r\n### Checklist\r\n\r\n- [x ] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case\r\n### For maintainers\r\n\r\n---------\r\n\r\nCo-authored-by: Kristof-Pierre Cummings <kristofpierre.cummings@elastic.co>","sha":"7fdf0129cca588c303178f1324fcb6e4f0c9ac59","branchLabelMapping":{"^v8.8.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Threat Hunting","Team: SecuritySolution","Team:Threat Hunting:Explore","backport:prev-minor","v8.7.0","v8.8.0"],"number":152045,"url":"https://github.com/elastic/kibana/pull/152045","mergeCommit":{"message":"Fix selected text not showing correct entity (#152045)\n\nAs it relates to #151263\r\n\r\n## Summary\r\nUpdate the text where entity counts (see image) are shown to be the\r\ncorrect entity instead of defaulting to 'alerts'\r\n\r\nDepending on the type of table (event, alert, or session):\r\n\r\n\r\nThe text will now read \r\n```\r\nSelected x [alert | event | session](s)\r\n```\r\n\r\nand \r\n```\r\nSelect (all) x [alert | event | session](s)\r\n```\r\nwhere `x` is  number & 'all' & 's'  is conditional upon plurality. \r\n\r\n| Before  |   After |\r\n:-------------------------:|:-------------------------:\r\n<img width=\"678\" alt=\"image\"\r\nsrc=\"https://user-images.githubusercontent.com/28942857/221037551-e119211c-fc7a-4d29-93cd-58a6fb3cce82.png\">\r\n| <img width=\"525\" alt=\"image\"\r\nsrc=\"https://user-images.githubusercontent.com/28942857/221038780-4c52713a-4713-4099-95e7-430341fe22f0.png\">\r\n\r\n\r\n`selectText` & `selectClearText` are shifted from `BulkActions` to\r\n`AlertBulkActionsComponent` Where they can be computed using the\r\n`tableId` then passed to `BulkActions`.\r\n\r\nOne note, as per conversation with Explore team and @paulewing when a\r\nuser selects `show only external alerts` the entity type is still\r\nevents.\r\n\r\n### Checklist\r\n\r\n- [x ] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case\r\n### For maintainers\r\n\r\n---------\r\n\r\nCo-authored-by: Kristof-Pierre Cummings <kristofpierre.cummings@elastic.co>","sha":"7fdf0129cca588c303178f1324fcb6e4f0c9ac59"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"8.7","label":"v8.7.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/152753","number":152753,"state":"OPEN"},{"branch":"main","label":"v8.8.0","labelRegex":"^v8.8.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/152045","number":152045,"mergeCommit":{"message":"Fix selected text not showing correct entity (#152045)\n\nAs it relates to #151263\r\n\r\n## Summary\r\nUpdate the text where entity counts (see image) are shown to be the\r\ncorrect entity instead of defaulting to 'alerts'\r\n\r\nDepending on the type of table (event, alert, or session):\r\n\r\n\r\nThe text will now read \r\n```\r\nSelected x [alert | event | session](s)\r\n```\r\n\r\nand \r\n```\r\nSelect (all) x [alert | event | session](s)\r\n```\r\nwhere `x` is  number & 'all' & 's'  is conditional upon plurality. \r\n\r\n| Before  |   After |\r\n:-------------------------:|:-------------------------:\r\n<img width=\"678\" alt=\"image\"\r\nsrc=\"https://user-images.githubusercontent.com/28942857/221037551-e119211c-fc7a-4d29-93cd-58a6fb3cce82.png\">\r\n| <img width=\"525\" alt=\"image\"\r\nsrc=\"https://user-images.githubusercontent.com/28942857/221038780-4c52713a-4713-4099-95e7-430341fe22f0.png\">\r\n\r\n\r\n`selectText` & `selectClearText` are shifted from `BulkActions` to\r\n`AlertBulkActionsComponent` Where they can be computed using the\r\n`tableId` then passed to `BulkActions`.\r\n\r\nOne note, as per conversation with Explore team and @paulewing when a\r\nuser selects `show only external alerts` the entity type is still\r\nevents.\r\n\r\n### Checklist\r\n\r\n- [x ] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case\r\n### For maintainers\r\n\r\n---------\r\n\r\nCo-authored-by: Kristof-Pierre Cummings <kristofpierre.cummings@elastic.co>","sha":"7fdf0129cca588c303178f1324fcb6e4f0c9ac59"}}]}] BACKPORT-->