### PR TITLE
[Cloud Security] fixed onboarding link directs to cspm integration

### DIFF
--- a/packages/kbn-guided-onboarding/src/components/landing_page/__snapshots__/guide_cards.test.tsx.snap
+++ b/packages/kbn-guided-onboarding/src/components/landing_page/__snapshots__/guide_cards.test.tsx.snap
@@ -253,7 +253,7 @@ exports[`guide cards snapshots should render all cards 1`] = `
         Object {
           "navigateTo": Object {
             "appId": "integrations",
-            "path": "/detail/cloud_security_posture/overview",
+            "path": "/detail/cloud_security_posture/overview?integration=cspm",
           },
           "order": 9,
           "solution": "security",

--- a/packages/kbn-guided-onboarding/src/components/landing_page/guide_cards.constants.tsx
+++ b/packages/kbn-guided-onboarding/src/components/landing_page/guide_cards.constants.tsx
@@ -169,7 +169,7 @@ export const guideCards: GuideCardConstants[] = [
     ),
     navigateTo: {
       appId: 'integrations',
-      path: '/detail/cloud_security_posture/overview',
+      path: '/detail/cloud_security_posture/overview?integration=cspm',
     },
     telemetryId: 'onboarding--security--cloud',
     order: 9,


### PR DESCRIPTION
## Summary

Updates onboarding link of CSPM to direct to `CSPM` integration instead of Cloud Security which includes kspm.
The button text is: `Secure my cloud assets with {lineBreak} cloud security posture management (CSPM)`. Therefore it makes more sense to open the CSPM integration directly.
