### PR TITLE
[8.7] [Cloud Security][CSPM] Fix for incorrect link from Dashboard when account don't have name (#152981)

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/dashboard_sections/benchmarks_section.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/dashboard_sections/benchmarks_section.tsx
@@ -38,7 +38,8 @@ const CLUSTER_DEFAULT_SORT_ORDER = 'asc';
 
 export const getClusterIdQuery = (cluster: Cluster) => {
   if (cluster.meta.benchmark.posture_type === CSPM_POLICY_TEMPLATE) {
-    return { 'cloud.account.name': cluster.meta.cloud?.account.name };
+    // TODO: remove assertion after typing CspFinding as discriminating union
+    return { 'cloud.account.id': cluster.meta.cloud!.account.id };
   }
   if (cluster.meta.benchmark.posture_type === 'kspm') {
     return { cluster_id: cluster.meta.assetIdentifierId };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.7`:
 - [[Cloud Security][CSPM] Fix for incorrect link from Dashboard when account don't have name (#152981)](https://github.com/elastic/kibana/pull/152981)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Rickyanto Ang","email":"rickyangwyn@gmail.com"},"sourceCommit":{"committedDate":"2023-03-09T16:05:44Z","message":"[Cloud Security][CSPM] Fix for incorrect link from Dashboard when account don't have name (#152981)\n\n## Summary\r\n\r\nThis is a fix for the issue where user gets a wrong query format /\r\nincorrect link when clicking on the Cluster name on the dashboard.\r\n\r\nFix : \r\n- CSPM now always uses cloud.account.id instead of either\r\ncloud.account.id or cloud.account.name (depending if they have a name or\r\nnot)","sha":"3da0d44d727b847ae6803a437c8eb7a98474c835","branchLabelMapping":{"^v8.8.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","auto-backport","Team:Cloud Security","v8.7.0","v8.8.0"],"number":152981,"url":"https://github.com/elastic/kibana/pull/152981","mergeCommit":{"message":"[Cloud Security][CSPM] Fix for incorrect link from Dashboard when account don't have name (#152981)\n\n## Summary\r\n\r\nThis is a fix for the issue where user gets a wrong query format /\r\nincorrect link when clicking on the Cluster name on the dashboard.\r\n\r\nFix : \r\n- CSPM now always uses cloud.account.id instead of either\r\ncloud.account.id or cloud.account.name (depending if they have a name or\r\nnot)","sha":"3da0d44d727b847ae6803a437c8eb7a98474c835"}},"sourceBranch":"main","suggestedTargetBranches":["8.7"],"targetPullRequestStates":[{"branch":"8.7","label":"v8.7.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.8.0","labelRegex":"^v8.8.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/152981","number":152981,"mergeCommit":{"message":"[Cloud Security][CSPM] Fix for incorrect link from Dashboard when account don't have name (#152981)\n\n## Summary\r\n\r\nThis is a fix for the issue where user gets a wrong query format /\r\nincorrect link when clicking on the Cluster name on the dashboard.\r\n\r\nFix : \r\n- CSPM now always uses cloud.account.id instead of either\r\ncloud.account.id or cloud.account.name (depending if they have a name or\r\nnot)","sha":"3da0d44d727b847ae6803a437c8eb7a98474c835"}}]}] BACKPORT-->