### PR TITLE
[8.7] [Cloud Security] Support the use case when all streams are disabled by default (#153234)

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/components/fleet_extensions/policy_template_form.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/fleet_extensions/policy_template_form.tsx
@@ -8,16 +8,25 @@ import React, { memo, useCallback, useEffect } from 'react';
 import { EuiFieldText, EuiFormRow, EuiSpacer, EuiTitle } from '@elastic/eui';
 import type { NewPackagePolicy } from '@kbn/fleet-plugin/public';
 import { FormattedMessage } from '@kbn/i18n-react';
-import type { PackagePolicyReplaceDefineStepExtensionComponentProps } from '@kbn/fleet-plugin/public/types';
+import type {
+  NewPackagePolicyInput,
+  PackagePolicyReplaceDefineStepExtensionComponentProps,
+} from '@kbn/fleet-plugin/public/types';
 import { useParams } from 'react-router-dom';
 import type { PostureInput, PosturePolicyTemplate } from '../../../common/types';
-import { CLOUDBEAT_AWS, CLOUDBEAT_VANILLA } from '../../../common/constants';
+import {
+  CLOUDBEAT_AWS,
+  CLOUDBEAT_VANILLA,
+  CLOUDBEAT_VULN_MGMT_AWS,
+  CSPM_POLICY_TEMPLATE,
+  SUPPORTED_POLICY_TEMPLATES,
+} from '../../../common/constants';
 import {
   getPosturePolicy,
-  getEnabledPostureInput,
   getPostureInputHiddenVars,
   POSTURE_NAMESPACE,
   NewPackagePolicyPostureInput,
+  isPostureInput,
 } from './utils';
 import {
   PolicyTemplateInfo,
@@ -25,6 +34,7 @@ import {
   PolicyTemplateSelector,
   PolicyTemplateVarsForm,
 } from './policy_template_selectors';
+import { assert } from '../../../common/utils/helpers';
 
 const DEFAULT_INPUT_TYPE = {
   kspm: CLOUDBEAT_VANILLA,
@@ -67,8 +77,11 @@ const IntegrationSettings = ({ onChange, fields }: IntegrationInfoFieldsProps) =
 
 export const CspPolicyTemplateForm = memo<PackagePolicyReplaceDefineStepExtensionComponentProps>(
   ({ newPolicy, onChange, validationResults, isEditPage }) => {
-    const { integration } = useParams<{ integration: PosturePolicyTemplate }>();
-    const input = getEnabledPostureInput(newPolicy);
+    const integrationParam = useParams<{ integration: CloudSecurityPolicyTemplate }>().integration;
+    const integration = SUPPORTED_POLICY_TEMPLATES.includes(integrationParam)
+      ? integrationParam
+      : undefined;
+    const input = getSelectedOption(newPolicy.inputs, integration);
 
     const updatePolicy = useCallback(
       (updatedPolicy: NewPackagePolicy) => onChange({ isValid: true, updatedPolicy }),
@@ -185,4 +198,22 @@ const useEnsureDefaultNamespace = ({
     const policy = { ...getPosturePolicy(newPolicy, input.type), namespace: POSTURE_NAMESPACE };
     updatePolicy(policy);
   }, [newPolicy, input, updatePolicy]);
+};
+
+const getSelectedOption = (
+  options: NewPackagePolicyInput[],
+  policyTemplate: string = CSPM_POLICY_TEMPLATE
+) => {
+  // Looks for the enabled deployment (aka input). By default, all inputs are disabled.
+  // Initial state when all inputs are disabled is to choose the first available of the relevant policyTemplate
+  // Default selected policy template is CSPM
+  const selectedOption =
+    options.find((i) => i.enabled) ||
+    options.find((i) => i.policy_template === policyTemplate) ||
+    options[0];
+
+  assert(selectedOption, 'Failed to determine selected option'); // We can't provide a default input without knowing the policy template
+  assert(isPostureInput(selectedOption), 'Unknown option: ' + selectedOption.type);
+
+  return selectedOption;
 };

--- a/x-pack/plugins/cloud_security_posture/public/components/fleet_extensions/utils.ts
+++ b/x-pack/plugins/cloud_security_posture/public/components/fleet_extensions/utils.ts
@@ -18,21 +18,22 @@ import {
   CLOUDBEAT_AZURE,
   SUPPORTED_POLICY_TEMPLATES,
   SUPPORTED_CLOUDBEAT_INPUTS,
+  CSPM_POLICY_TEMPLATE,
+  KSPM_POLICY_TEMPLATE,
 } from '../../../common/constants';
 import { DEFAULT_AWS_VARS_GROUP } from './aws_credentials_form';
 import type { PostureInput, PosturePolicyTemplate } from '../../../common/types';
-import { assert } from '../../../common/utils/helpers';
 import { cloudPostureIntegrations } from '../../common/constants';
 
 // Posture policies only support the default namespace
 export const POSTURE_NAMESPACE = 'default';
 
 type PosturePolicyInput =
-  | { type: typeof CLOUDBEAT_AZURE; policy_template: 'cspm' }
-  | { type: typeof CLOUDBEAT_GCP; policy_template: 'cspm' }
-  | { type: typeof CLOUDBEAT_AWS; policy_template: 'cspm' }
-  | { type: typeof CLOUDBEAT_VANILLA; policy_template: 'kspm' }
-  | { type: typeof CLOUDBEAT_EKS; policy_template: 'kspm' };
+  | { type: typeof CLOUDBEAT_AZURE; policy_template: typeof CSPM_POLICY_TEMPLATE }
+  | { type: typeof CLOUDBEAT_GCP; policy_template: typeof CSPM_POLICY_TEMPLATE }
+  | { type: typeof CLOUDBEAT_AWS; policy_template: typeof CSPM_POLICY_TEMPLATE }
+  | { type: typeof CLOUDBEAT_VANILLA; policy_template: typeof KSPM_POLICY_TEMPLATE }
+  | { type: typeof CLOUDBEAT_EKS; policy_template: typeof KSPM_POLICY_TEMPLATE };
 
 // Extend NewPackagePolicyInput with known string literals for input type and policy template
 export type NewPackagePolicyPostureInput = NewPackagePolicyInput & PosturePolicyInput;
@@ -110,13 +111,3 @@ export const getPolicyTemplateInputOptions = (policyTemplate: PosturePolicyTempl
     icon: o.icon,
     disabled: o.disabled,
   }));
-
-export const getEnabledPostureInput = (policy: NewPackagePolicy) => {
-  // Take first enabled input
-  const input = policy.inputs.find((i) => i.enabled);
-
-  assert(input, 'Missing enabled input'); // We can't provide a default input without knowing the policy template
-  assert(isPostureInput(input), 'Invalid enabled input');
-
-  return input;
-};


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.7`:
 - [[Cloud Security] Support the use case when all streams are disabled by default (#153234)](https://github.com/elastic/kibana/pull/153234)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Kfir Peled","email":"61654899+kfirpeled@users.noreply.github.com"},"sourceCommit":{"committedDate":"2023-03-20T10:09:39Z","message":"[Cloud Security] Support the use case when all streams are disabled by default (#153234)","sha":"7a0b6ba524d1c808c34b50ea578d0da08897fd45","branchLabelMapping":{"^v8.8.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Cloud Security","v8.7.0","v8.8.0"],"number":153234,"url":"https://github.com/elastic/kibana/pull/153234","mergeCommit":{"message":"[Cloud Security] Support the use case when all streams are disabled by default (#153234)","sha":"7a0b6ba524d1c808c34b50ea578d0da08897fd45"}},"sourceBranch":"main","suggestedTargetBranches":["8.7"],"targetPullRequestStates":[{"branch":"8.7","label":"v8.7.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.8.0","labelRegex":"^v8.8.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/153234","number":153234,"mergeCommit":{"message":"[Cloud Security] Support the use case when all streams are disabled by default (#153234)","sha":"7a0b6ba524d1c808c34b50ea578d0da08897fd45"}}]}] BACKPORT-->