### PR TITLE
fix overflow bucket issue for service inventory page

### DIFF
--- a/x-pack/plugins/apm/server/routes/services/get_services/get_service_transaction_stats.ts
+++ b/x-pack/plugins/apm/server/routes/services/get_services/get_service_transaction_stats.ts
@@ -28,6 +28,7 @@ import {
   getOutcomeAggregation,
 } from '../../../lib/helpers/transaction_error_rate';
 import { serviceGroupQuery } from '../../../lib/service_group_query';
+import { maybe } from '../../../../common/utils/maybe';
 
 interface AggregationParams {
   environment: string;
@@ -48,12 +49,12 @@ interface AggregationParams {
 export interface ServiceTransactionStatsResponse {
   serviceStats: Array<{
     serviceName: string;
-    transactionType: string;
+    transactionType?: string;
     environments: string[];
-    agentName: AgentName;
-    latency: number | null;
-    transactionErrorRate: number;
-    throughput: number;
+    agentName?: AgentName;
+    latency?: number | null;
+    transactionErrorRate?: number;
+    throughput?: number;
   }>;
   serviceOverflowCount: number;
 }
@@ -153,29 +154,33 @@ export async function getServiceTransactionStats({
   return {
     serviceStats:
       response.aggregations?.sample.services.buckets.map((bucket) => {
-        const topTransactionTypeBucket =
+        const topTransactionTypeBucket = maybe(
           bucket.transactionType.buckets.find(({ key }) =>
             isDefaultTransactionType(key as string)
-          ) ?? bucket.transactionType.buckets[0];
+          ) ?? bucket.transactionType.buckets[0]
+        );
 
         return {
           serviceName: bucket.key as string,
-          transactionType: topTransactionTypeBucket.key as string,
-          environments: topTransactionTypeBucket.environments.buckets.map(
-            (environmentBucket) => environmentBucket.key as string
-          ),
-          agentName: topTransactionTypeBucket.sample.top[0].metrics[
+          transactionType: topTransactionTypeBucket?.key as string | undefined,
+          environments:
+            topTransactionTypeBucket?.environments.buckets.map(
+              (environmentBucket) => environmentBucket.key as string
+            ) ?? [],
+          agentName: topTransactionTypeBucket?.sample.top[0].metrics[
             AGENT_NAME
-          ] as AgentName,
-          latency: topTransactionTypeBucket.avg_duration.value,
-          transactionErrorRate: calculateFailedTransactionRate(
-            topTransactionTypeBucket
-          ),
-          throughput: calculateThroughputWithRange({
-            start,
-            end,
-            value: topTransactionTypeBucket.doc_count,
-          }),
+          ] as AgentName | undefined,
+          latency: topTransactionTypeBucket?.avg_duration.value,
+          transactionErrorRate: topTransactionTypeBucket
+            ? calculateFailedTransactionRate(topTransactionTypeBucket)
+            : undefined,
+          throughput: topTransactionTypeBucket
+            ? calculateThroughputWithRange({
+                start,
+                end,
+                value: topTransactionTypeBucket?.doc_count,
+              })
+            : undefined,
         };
       }) ?? [],
     serviceOverflowCount:

--- a/x-pack/plugins/apm/server/routes/services/get_services_detailed_statistics/get_service_transaction_detailed_statistics.ts
+++ b/x-pack/plugins/apm/server/routes/services/get_services_detailed_statistics/get_service_transaction_detailed_statistics.ts
@@ -25,12 +25,13 @@ import {
   getOutcomeAggregation,
 } from '../../../lib/helpers/transaction_error_rate';
 import { withApmSpan } from '../../../utils/with_apm_span';
+import { maybe } from '../../../../common/utils/maybe';
 
 interface ServiceTransactionDetailedStat {
   serviceName: string;
   latency: Array<{ x: number; y: number | null }>;
-  transactionErrorRate: Array<{ x: number; y: number }>;
-  throughput: Array<{ x: number; y: number }>;
+  transactionErrorRate?: Array<{ x: number; y: number }>;
+  throughput?: Array<{ x: number; y: number }>;
 }
 
 export async function getServiceTransactionDetailedStats({
@@ -140,26 +141,25 @@ export async function getServiceTransactionDetailedStats({
 
   return keyBy(
     response.aggregations?.sample.services.buckets.map((bucket) => {
-      const topTransactionTypeBucket =
+      const topTransactionTypeBucket = maybe(
         bucket.transactionType.buckets.find(({ key }) =>
           isDefaultTransactionType(key as string)
-        ) ?? bucket.transactionType.buckets[0];
+        ) ?? bucket.transactionType.buckets[0]
+      );
 
       return {
         serviceName: bucket.key as string,
-        latency: topTransactionTypeBucket.timeseries.buckets.map(
-          (dateBucket) => ({
+        latency:
+          topTransactionTypeBucket?.timeseries.buckets.map((dateBucket) => ({
             x: dateBucket.key + offsetInMs,
             y: dateBucket.avg_duration.value,
-          })
-        ),
-        transactionErrorRate: topTransactionTypeBucket.timeseries.buckets.map(
-          (dateBucket) => ({
+          })) ?? [],
+        transactionErrorRate:
+          topTransactionTypeBucket?.timeseries.buckets.map((dateBucket) => ({
             x: dateBucket.key + offsetInMs,
             y: calculateFailedTransactionRate(dateBucket),
-          })
-        ),
-        throughput: topTransactionTypeBucket.timeseries.buckets.map(
+          })) ?? undefined,
+        throughput: topTransactionTypeBucket?.timeseries.buckets.map(
           (dateBucket) => ({
             x: dateBucket.key + offsetInMs,
             y: calculateThroughputWithInterval({

--- a/x-pack/test/apm_api_integration/tests/services/archive_services_detailed_statistics.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/services/archive_services_detailed_statistics.spec.ts
@@ -106,24 +106,24 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         const statistics = servicesDetailedStatistics.currentPeriod[serviceNames[0]];
 
         expect(statistics.latency.length).to.be.greaterThan(0);
-        expect(statistics.throughput.length).to.be.greaterThan(0);
-        expect(statistics.transactionErrorRate.length).to.be.greaterThan(0);
+        expect(statistics.throughput?.length).to.be.greaterThan(0);
+        expect(statistics.transactionErrorRate?.length).to.be.greaterThan(0);
 
         // latency
         const nonNullLantencyDataPoints = statistics.latency.filter(({ y }) => isFiniteNumber(y));
         expect(nonNullLantencyDataPoints.length).to.be.greaterThan(0);
 
         // throughput
-        const nonNullThroughputDataPoints = statistics.throughput.filter(({ y }) =>
+        const nonNullThroughputDataPoints = statistics.throughput?.filter(({ y }) =>
           isFiniteNumber(y)
         );
-        expect(nonNullThroughputDataPoints.length).to.be.greaterThan(0);
+        expect(nonNullThroughputDataPoints?.length).to.be.greaterThan(0);
 
-        // transaction erro rate
-        const nonNullTransactionErrorRateDataPoints = statistics.transactionErrorRate.filter(
+        // transaction error rate
+        const nonNullTransactionErrorRateDataPoints = statistics.transactionErrorRate?.filter(
           ({ y }) => isFiniteNumber(y)
         );
-        expect(nonNullTransactionErrorRateDataPoints.length).to.be.greaterThan(0);
+        expect(nonNullTransactionErrorRateDataPoints?.length).to.be.greaterThan(0);
       });
 
       it('returns empty when empty service names is passed', async () => {
@@ -253,8 +253,8 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         const previousPeriodStatistics = servicesDetailedStatistics.previousPeriod[serviceNames[0]];
 
         expect(currentPeriodStatistics.latency.length).to.be.greaterThan(0);
-        expect(currentPeriodStatistics.throughput.length).to.be.greaterThan(0);
-        expect(currentPeriodStatistics.transactionErrorRate.length).to.be.greaterThan(0);
+        expect(currentPeriodStatistics.throughput?.length).to.be.greaterThan(0);
+        expect(currentPeriodStatistics.transactionErrorRate?.length).to.be.greaterThan(0);
 
         // latency
         const nonNullCurrentPeriodLantencyDataPoints = currentPeriodStatistics.latency.filter(
@@ -263,19 +263,19 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         expect(nonNullCurrentPeriodLantencyDataPoints.length).to.be.greaterThan(0);
 
         // throughput
-        const nonNullCurrentPeriodThroughputDataPoints = currentPeriodStatistics.throughput.filter(
+        const nonNullCurrentPeriodThroughputDataPoints = currentPeriodStatistics.throughput?.filter(
           ({ y }) => isFiniteNumber(y)
         );
-        expect(nonNullCurrentPeriodThroughputDataPoints.length).to.be.greaterThan(0);
+        expect(nonNullCurrentPeriodThroughputDataPoints?.length).to.be.greaterThan(0);
 
-        // transaction erro rate
+        // transaction error rate
         const nonNullCurrentPeriodTransactionErrorRateDataPoints =
-          currentPeriodStatistics.transactionErrorRate.filter(({ y }) => isFiniteNumber(y));
-        expect(nonNullCurrentPeriodTransactionErrorRateDataPoints.length).to.be.greaterThan(0);
+          currentPeriodStatistics.transactionErrorRate?.filter(({ y }) => isFiniteNumber(y));
+        expect(nonNullCurrentPeriodTransactionErrorRateDataPoints?.length).to.be.greaterThan(0);
 
         expect(previousPeriodStatistics.latency.length).to.be.greaterThan(0);
-        expect(previousPeriodStatistics.throughput.length).to.be.greaterThan(0);
-        expect(previousPeriodStatistics.transactionErrorRate.length).to.be.greaterThan(0);
+        expect(previousPeriodStatistics.throughput?.length).to.be.greaterThan(0);
+        expect(previousPeriodStatistics.transactionErrorRate?.length).to.be.greaterThan(0);
 
         // latency
         const nonNullPreviousPeriodLantencyDataPoints = previousPeriodStatistics.latency.filter(
@@ -285,13 +285,13 @@ export default function ApiTest({ getService }: FtrProviderContext) {
 
         // throughput
         const nonNullPreviousPeriodThroughputDataPoints =
-          previousPeriodStatistics.throughput.filter(({ y }) => isFiniteNumber(y));
-        expect(nonNullPreviousPeriodThroughputDataPoints.length).to.be.greaterThan(0);
+          previousPeriodStatistics.throughput?.filter(({ y }) => isFiniteNumber(y));
+        expect(nonNullPreviousPeriodThroughputDataPoints?.length).to.be.greaterThan(0);
 
-        // transaction erro rate
+        // transaction error rate
         const nonNullPreviousPeriodTransactionErrorRateDataPoints =
-          previousPeriodStatistics.transactionErrorRate.filter(({ y }) => isFiniteNumber(y));
-        expect(nonNullPreviousPeriodTransactionErrorRateDataPoints.length).to.be.greaterThan(0);
+          previousPeriodStatistics.transactionErrorRate?.filter(({ y }) => isFiniteNumber(y));
+        expect(nonNullPreviousPeriodTransactionErrorRateDataPoints?.length).to.be.greaterThan(0);
       });
     }
   );


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/153289
## Summary

When overflow bucket is generated, there is not transaction type present for the `_other` bucket which causes  a 500 on the Service Inventory Page.

<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->