### PR TITLE
[Docs] Fix curl examples in update data view api docs

### DIFF
--- a/docs/api/data-views/update.asciidoc
+++ b/docs/api/data-views/update.asciidoc
@@ -62,7 +62,7 @@ Update a title of the `<my-view>` data view:
 
 [source,sh]
 --------------------------------------------------
-$ curl -X POST api/data_views/data-view/my-view
+$ curl -X POST api/data_views/data_view/my-view
 {
   "data_view": {
     "title": "some-other-view-*"
@@ -75,7 +75,7 @@ Customize the update behavior:
 
 [source,sh]
 --------------------------------------------------
-$ curl -X POST api/data_views/data-view/my-view
+$ curl -X POST api/data_views/data_view/my-view
 {
   "refresh_fields": true,
   "data_view": {
@@ -90,7 +90,7 @@ All update fields are optional, but you can specify the following fields:
 
 [source,sh]
 --------------------------------------------------
-$ curl -X POST api/data_views/data-view/my-view
+$ curl -X POST api/data_views/data_view/my-view
 {
   "data_view": {
     "title": "...",


### PR DESCRIPTION
## Summary

Fixes typos in the curl examples in the Update data views API docs.

[Reported by a community user](https://discuss.elastic.co/t/kibana-data-view-update-api-request-doesnt-work/327435/5).


<!--ONMERGE {"backportTargets":["7.17","8.0","8.1","8.2","8.3","8.4","8.5","8.6","8.7"]} ONMERGE-->