### PR TITLE
[8.7] fix overflow bucket issue for service inventory page (#153290)

### DIFF
--- a/x-pack/plugins/apm/server/routes/services/get_services/get_service_transaction_stats.ts
+++ b/x-pack/plugins/apm/server/routes/services/get_services/get_service_transaction_stats.ts
@@ -28,6 +28,7 @@ import {
   getOutcomeAggregation,
 } from '../../../lib/helpers/transaction_error_rate';
 import { serviceGroupQuery } from '../../../lib/service_group_query';
+import { maybe } from '../../../../common/utils/maybe';
 
 interface AggregationParams {
   environment: string;
@@ -140,29 +141,33 @@ export async function getServiceTransactionStats({
   return {
     serviceStats:
       response.aggregations?.sample.services.buckets.map((bucket) => {
-        const topTransactionTypeBucket =
+        const topTransactionTypeBucket = maybe(
           bucket.transactionType.buckets.find(({ key }) =>
             isDefaultTransactionType(key as string)
-          ) ?? bucket.transactionType.buckets[0];
+          ) ?? bucket.transactionType.buckets[0]
+        );
 
         return {
           serviceName: bucket.key as string,
-          transactionType: topTransactionTypeBucket.key as string,
-          environments: topTransactionTypeBucket.environments.buckets.map(
-            (environmentBucket) => environmentBucket.key as string
-          ),
-          agentName: topTransactionTypeBucket.sample.top[0].metrics[
+          transactionType: topTransactionTypeBucket?.key as string | undefined,
+          environments:
+            topTransactionTypeBucket?.environments.buckets.map(
+              (environmentBucket) => environmentBucket.key as string
+            ) ?? [],
+          agentName: topTransactionTypeBucket?.sample.top[0].metrics[
             AGENT_NAME
-          ] as AgentName,
-          latency: topTransactionTypeBucket.avg_duration.value,
-          transactionErrorRate: calculateFailedTransactionRate(
-            topTransactionTypeBucket
-          ),
-          throughput: calculateThroughputWithRange({
-            start,
-            end,
-            value: topTransactionTypeBucket.doc_count,
-          }),
+          ] as AgentName | undefined,
+          latency: topTransactionTypeBucket?.avg_duration.value,
+          transactionErrorRate: topTransactionTypeBucket
+            ? calculateFailedTransactionRate(topTransactionTypeBucket)
+            : undefined,
+          throughput: topTransactionTypeBucket
+            ? calculateThroughputWithRange({
+                start,
+                end,
+                value: topTransactionTypeBucket?.doc_count,
+              })
+            : undefined,
         };
       }) ?? [],
     serviceOverflowCount:

--- a/x-pack/plugins/apm/server/routes/services/route.ts
+++ b/x-pack/plugins/apm/server/routes/services/route.ts
@@ -76,17 +76,17 @@ const servicesRoute = createApmServerRoute({
     items: import('./../../../common/utils/join_by_key/index').JoinedReturnType<
       | {
           serviceName: string;
-          transactionType: string;
+          transactionType?: string;
           environments: string[];
-          agentName: import('./../../../typings/es_schemas/ui/fields/agent').AgentName;
-          latency: number | null;
-          transactionErrorRate: number;
-          throughput: number;
+          agentName?: import('./../../../typings/es_schemas/ui/fields/agent').AgentName;
+          latency?: number | null;
+          transactionErrorRate?: number;
+          throughput?: number;
         }
       | {
           serviceName: string;
           environments: string[];
-          agentName: import('./../../../typings/es_schemas/ui/fields/agent').AgentName;
+          agentName?: import('./../../../typings/es_schemas/ui/fields/agent').AgentName;
         }
       | {
           serviceName: string;
@@ -98,16 +98,16 @@ const servicesRoute = createApmServerRoute({
         },
       {
         serviceName: string;
-        transactionType: string;
+        transactionType?: string;
         environments: string[];
-        agentName: import('./../../../typings/es_schemas/ui/fields/agent').AgentName;
-        latency: number | null;
-        transactionErrorRate: number;
-        throughput: number;
+        agentName?: import('./../../../typings/es_schemas/ui/fields/agent').AgentName;
+        latency?: number | null;
+        transactionErrorRate?: number;
+        throughput?: number;
       } & {
         serviceName: string;
         environments: string[];
-        agentName: import('./../../../typings/es_schemas/ui/fields/agent').AgentName;
+        agentName?: import('./../../../typings/es_schemas/ui/fields/agent').AgentName;
       } & {
         serviceName: string;
         healthStatus: import('./../../../common/service_health_status').ServiceHealthStatus;
@@ -192,30 +192,30 @@ const servicesDetailedStatisticsRoute = createApmServerRoute({
   ): Promise<{
     currentPeriod: import('./../../../../../../node_modules/@types/lodash/ts3.1/index').Dictionary<{
       serviceName: string;
-      latency: Array<{
+      latency?: Array<{
         x: number;
         y: number | null;
       }>;
-      transactionErrorRate: Array<{
+      transactionErrorRate?: Array<{
         x: number;
         y: number;
       }>;
-      throughput: Array<{
+      throughput?: Array<{
         x: number;
         y: number;
       }>;
     }>;
     previousPeriod: import('./../../../../../../node_modules/@types/lodash/ts3.1/index').Dictionary<{
       serviceName: string;
-      latency: Array<{
+      latency?: Array<{
         x: number;
         y: number | null;
       }>;
-      transactionErrorRate: Array<{
+      transactionErrorRate?: Array<{
         x: number;
         y: number;
       }>;
-      throughput: Array<{
+      throughput?: Array<{
         x: number;
         y: number;
       }>;

--- a/x-pack/plugins/apm/server/routes/services/route.ts
+++ b/x-pack/plugins/apm/server/routes/services/route.ts
@@ -192,7 +192,7 @@ const servicesDetailedStatisticsRoute = createApmServerRoute({
   ): Promise<{
     currentPeriod: import('./../../../../../../node_modules/@types/lodash/ts3.1/index').Dictionary<{
       serviceName: string;
-      latency?: Array<{
+      latency: Array<{
         x: number;
         y: number | null;
       }>;
@@ -207,7 +207,7 @@ const servicesDetailedStatisticsRoute = createApmServerRoute({
     }>;
     previousPeriod: import('./../../../../../../node_modules/@types/lodash/ts3.1/index').Dictionary<{
       serviceName: string;
-      latency?: Array<{
+      latency: Array<{
         x: number;
         y: number | null;
       }>;

--- a/x-pack/test/apm_api_integration/tests/services/archive_services_detailed_statistics.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/services/archive_services_detailed_statistics.spec.ts
@@ -106,24 +106,24 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         const statistics = servicesDetailedStatistics.currentPeriod[serviceNames[0]];
 
         expect(statistics.latency.length).to.be.greaterThan(0);
-        expect(statistics.throughput.length).to.be.greaterThan(0);
-        expect(statistics.transactionErrorRate.length).to.be.greaterThan(0);
+        expect(statistics.throughput?.length).to.be.greaterThan(0);
+        expect(statistics.transactionErrorRate?.length).to.be.greaterThan(0);
 
         // latency
         const nonNullLantencyDataPoints = statistics.latency.filter(({ y }) => isFiniteNumber(y));
         expect(nonNullLantencyDataPoints.length).to.be.greaterThan(0);
 
         // throughput
-        const nonNullThroughputDataPoints = statistics.throughput.filter(({ y }) =>
+        const nonNullThroughputDataPoints = statistics.throughput?.filter(({ y }) =>
           isFiniteNumber(y)
         );
-        expect(nonNullThroughputDataPoints.length).to.be.greaterThan(0);
+        expect(nonNullThroughputDataPoints?.length).to.be.greaterThan(0);
 
-        // transaction erro rate
-        const nonNullTransactionErrorRateDataPoints = statistics.transactionErrorRate.filter(
+        // transaction error rate
+        const nonNullTransactionErrorRateDataPoints = statistics.transactionErrorRate?.filter(
           ({ y }) => isFiniteNumber(y)
         );
-        expect(nonNullTransactionErrorRateDataPoints.length).to.be.greaterThan(0);
+        expect(nonNullTransactionErrorRateDataPoints?.length).to.be.greaterThan(0);
       });
 
       it('returns empty when empty service names is passed', async () => {
@@ -253,8 +253,8 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         const previousPeriodStatistics = servicesDetailedStatistics.previousPeriod[serviceNames[0]];
 
         expect(currentPeriodStatistics.latency.length).to.be.greaterThan(0);
-        expect(currentPeriodStatistics.throughput.length).to.be.greaterThan(0);
-        expect(currentPeriodStatistics.transactionErrorRate.length).to.be.greaterThan(0);
+        expect(currentPeriodStatistics.throughput?.length).to.be.greaterThan(0);
+        expect(currentPeriodStatistics.transactionErrorRate?.length).to.be.greaterThan(0);
 
         // latency
         const nonNullCurrentPeriodLantencyDataPoints = currentPeriodStatistics.latency.filter(
@@ -263,19 +263,19 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         expect(nonNullCurrentPeriodLantencyDataPoints.length).to.be.greaterThan(0);
 
         // throughput
-        const nonNullCurrentPeriodThroughputDataPoints = currentPeriodStatistics.throughput.filter(
+        const nonNullCurrentPeriodThroughputDataPoints = currentPeriodStatistics.throughput?.filter(
           ({ y }) => isFiniteNumber(y)
         );
-        expect(nonNullCurrentPeriodThroughputDataPoints.length).to.be.greaterThan(0);
+        expect(nonNullCurrentPeriodThroughputDataPoints?.length).to.be.greaterThan(0);
 
-        // transaction erro rate
+        // transaction error rate
         const nonNullCurrentPeriodTransactionErrorRateDataPoints =
-          currentPeriodStatistics.transactionErrorRate.filter(({ y }) => isFiniteNumber(y));
-        expect(nonNullCurrentPeriodTransactionErrorRateDataPoints.length).to.be.greaterThan(0);
+          currentPeriodStatistics.transactionErrorRate?.filter(({ y }) => isFiniteNumber(y));
+        expect(nonNullCurrentPeriodTransactionErrorRateDataPoints?.length).to.be.greaterThan(0);
 
         expect(previousPeriodStatistics.latency.length).to.be.greaterThan(0);
-        expect(previousPeriodStatistics.throughput.length).to.be.greaterThan(0);
-        expect(previousPeriodStatistics.transactionErrorRate.length).to.be.greaterThan(0);
+        expect(previousPeriodStatistics.throughput?.length).to.be.greaterThan(0);
+        expect(previousPeriodStatistics.transactionErrorRate?.length).to.be.greaterThan(0);
 
         // latency
         const nonNullPreviousPeriodLantencyDataPoints = previousPeriodStatistics.latency.filter(
@@ -285,13 +285,13 @@ export default function ApiTest({ getService }: FtrProviderContext) {
 
         // throughput
         const nonNullPreviousPeriodThroughputDataPoints =
-          previousPeriodStatistics.throughput.filter(({ y }) => isFiniteNumber(y));
-        expect(nonNullPreviousPeriodThroughputDataPoints.length).to.be.greaterThan(0);
+          previousPeriodStatistics.throughput?.filter(({ y }) => isFiniteNumber(y));
+        expect(nonNullPreviousPeriodThroughputDataPoints?.length).to.be.greaterThan(0);
 
-        // transaction erro rate
+        // transaction error rate
         const nonNullPreviousPeriodTransactionErrorRateDataPoints =
-          previousPeriodStatistics.transactionErrorRate.filter(({ y }) => isFiniteNumber(y));
-        expect(nonNullPreviousPeriodTransactionErrorRateDataPoints.length).to.be.greaterThan(0);
+          previousPeriodStatistics.transactionErrorRate?.filter(({ y }) => isFiniteNumber(y));
+        expect(nonNullPreviousPeriodTransactionErrorRateDataPoints?.length).to.be.greaterThan(0);
       });
     }
   );


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.7`:
 - [fix overflow bucket issue for service inventory page (#153290)](https://github.com/elastic/kibana/pull/153290)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Achyut Jhunjhunwala","email":"achyut.jhunjhunwala@elastic.co"},"sourceCommit":{"committedDate":"2023-03-20T13:50:04Z","message":"fix overflow bucket issue for service inventory page (#153290)\n\nFixes https://github.com/elastic/kibana/issues/153289\r\n## Summary\r\n\r\nWhen overflow bucket is generated, there is not transaction type present\r\nfor the `_other` bucket which causes a 500 on the Service Inventory\r\nPage.","sha":"4d8dac6c8e9f6fa1572d001306922801a6d73ea7","branchLabelMapping":{"^v8.8.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:APM","release_note:skip","v8.7.0","v8.8.0"],"number":153290,"url":"https://github.com/elastic/kibana/pull/153290","mergeCommit":{"message":"fix overflow bucket issue for service inventory page (#153290)\n\nFixes https://github.com/elastic/kibana/issues/153289\r\n## Summary\r\n\r\nWhen overflow bucket is generated, there is not transaction type present\r\nfor the `_other` bucket which causes a 500 on the Service Inventory\r\nPage.","sha":"4d8dac6c8e9f6fa1572d001306922801a6d73ea7"}},"sourceBranch":"main","suggestedTargetBranches":["8.7"],"targetPullRequestStates":[{"branch":"8.7","label":"v8.7.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.8.0","labelRegex":"^v8.8.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/153290","number":153290,"mergeCommit":{"message":"fix overflow bucket issue for service inventory page (#153290)\n\nFixes https://github.com/elastic/kibana/issues/153289\r\n## Summary\r\n\r\nWhen overflow bucket is generated, there is not transaction type present\r\nfor the `_other` bucket which causes a 500 on the Service Inventory\r\nPage.","sha":"4d8dac6c8e9f6fa1572d001306922801a6d73ea7"}}]}] BACKPORT-->