### PR TITLE
[Security Solution] Fix security-solution storybook package codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -531,7 +531,7 @@ x-pack/plugins/security @elastic/kibana-security
 x-pack/test/cases_api_integration/common/plugins/security_solution @elastic/response-ops
 x-pack/plugins/security_solution @elastic/security-solution
 packages/security-solution/side_nav @elastic/security-threat-hunting-explore
-packages/security-solution/storybook/config @elastic/appex-sharedux
+packages/security-solution/storybook @elastic/security-threat-hunting-explore
 x-pack/test/security_functional/plugins/test_endpoints @elastic/kibana-security
 packages/kbn-securitysolution-autocomplete @elastic/security-solution-platform
 packages/kbn-securitysolution-ecs @elastic/security-threat-hunting-explore

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -531,7 +531,7 @@ x-pack/plugins/security @elastic/kibana-security
 x-pack/test/cases_api_integration/common/plugins/security_solution @elastic/response-ops
 x-pack/plugins/security_solution @elastic/security-solution
 packages/security-solution/side_nav @elastic/security-threat-hunting-explore
-packages/security-solution/storybook @elastic/security-threat-hunting-explore
+packages/security-solution/storybook/config @elastic/security-threat-hunting-explore
 x-pack/test/security_functional/plugins/test_endpoints @elastic/kibana-security
 packages/kbn-securitysolution-autocomplete @elastic/security-solution-platform
 packages/kbn-securitysolution-ecs @elastic/security-threat-hunting-explore

--- a/packages/security-solution/storybook/config/kibana.jsonc
+++ b/packages/security-solution/storybook/config/kibana.jsonc
@@ -1,5 +1,5 @@
 {
   "type": "shared-common",
   "id": "@kbn/security-solution-storybook-config",
-  "owner": "@elastic/appex-sharedux"
+  "owner": "@elastic/security-threat-hunting-explore"
 }


### PR DESCRIPTION
## Summary

The owner of the security-solution/storybook package was incorrectly set to `appex-sharedux` (sorry, copy/pasta 🍝  mistake)

Changed to `security-threat-hunting-explore`


