### PR TITLE
[Fleet] fix upgrade modal when agents selection is query and there is one version

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/agent_upgrade_modal/index.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/agent_upgrade_modal/index.test.tsx
@@ -7,6 +7,8 @@
 
 import React from 'react';
 
+import { waitFor } from '@testing-library/react';
+
 import { createFleetTestRendererMock } from '../../../../../../mock';
 
 import { AgentUpgradeAgentModal } from '.';
@@ -23,6 +25,17 @@ jest.mock('@elastic/eui', () => {
   return {
     ...jest.requireActual('@elastic/eui'),
     EuiConfirmModal: ({ children }: any) => <>{children}</>,
+  };
+});
+
+jest.mock('../../../../hooks', () => {
+  return {
+    ...jest.requireActual('../../../../hooks'),
+    sendGetAgentsAvailableVersions: jest.fn().mockResolvedValue({
+      data: {
+        items: ['8.7.0'],
+      },
+    }),
   };
 });
 
@@ -74,5 +87,17 @@ describe('AgentUpgradeAgentModal', () => {
 
     expect(el).not.toBeNull();
     expect(el?.textContent).toBe('1 hour');
+  });
+
+  it('should enable the version combo if agents is a query', async () => {
+    const { utils } = renderAgentUpgradeAgentModal({
+      agents: '*',
+      agentCount: 30,
+    });
+
+    const el = utils.getByTestId('agentUpgradeModal.VersionCombobox');
+    await waitFor(() => {
+      expect(el.classList.contains('euiComboBox-isDisabled')).toBe(false);
+    });
   });
 });

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/agent_upgrade_modal/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/agent_upgrade_modal/index.tsx
@@ -98,6 +98,10 @@ export const AgentUpgradeAgentModal: React.FunctionComponent<AgentUpgradeAgentMo
 
   const minVersion = useMemo(() => {
     if (!Array.isArray(agents)) {
+      // when agent is a query, don't set minVersion, so the versions are available to select
+      if (typeof agents === 'string') {
+        return undefined;
+      }
       return getMinVersion(availableVersions);
     }
     const versions = (agents as Agent[]).map(


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/152986

Added a fix when the upgrade modal version select was disabled when agents selection is a query (more than 20 agents) and there is one available version (+ optionally the current kibana version).

To verify:
- Enroll more than 20 agents with horde
- Select all agents and click Upgrade action
- Expect to see version select enabled

If `/available_versions` API returns more than one versions, add a mock return value [here](https://github.com/elastic/kibana/blob/94c281c46d05e70076da21463af204b90ea4b0d1/x-pack/plugins/fleet/server/routes/agent/handlers.ts#L392) locally to test with 1 version. E.g. `return response.ok({body: {"items":["8.8.0"]}})`

<img width="1056" alt="image" src="https://user-images.githubusercontent.com/90178898/226392649-6edcf7f3-8e31-4902-87d0-cb1053196a27.png">


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->