### PR TITLE
chore(slo): Make APM indicator's index required

### DIFF
--- a/packages/kbn-slo-schema/src/schema/indicators.ts
+++ b/packages/kbn-slo-schema/src/schema/indicators.ts
@@ -19,9 +19,9 @@ const apmTransactionDurationIndicatorSchema = t.type({
       transactionType: allOrAnyString,
       transactionName: allOrAnyString,
       threshold: t.number,
+      index: t.string,
     }),
     t.partial({
-      index: t.string,
       filter: t.string,
     }),
   ]),
@@ -36,12 +36,12 @@ const apmTransactionErrorRateIndicatorSchema = t.type({
       service: allOrAnyString,
       transactionType: allOrAnyString,
       transactionName: allOrAnyString,
+      index: t.string,
     }),
     t.partial({
       goodStatusCodes: t.array(
         t.union([t.literal('2xx'), t.literal('3xx'), t.literal('4xx'), t.literal('5xx')])
       ),
-      index: t.string,
       filter: t.string,
     }),
   ]),

--- a/x-pack/plugins/observability/dev_docs/slo.md
+++ b/x-pack/plugins/observability/dev_docs/slo.md
@@ -70,7 +70,8 @@ curl --request POST \
 			"service": "o11y-app",
 			"transactionType": "request",
 			"transactionName": "GET /api",
-			"goodStatusCodes": ["2xx", "3xx", "4xx"]
+			"goodStatusCodes": ["2xx", "3xx", "4xx"],
+			"index": "metrics-apm*"
 		}
 	},
 	"timeWindow": {
@@ -105,7 +106,8 @@ curl --request POST \
 			"service": "o11y-app",
 			"transactionType": "request",
 			"transactionName": "GET /api",
-			"goodStatusCodes": ["2xx", "3xx", "4xx"]
+			"goodStatusCodes": ["2xx", "3xx", "4xx"],
+			"index": "metrics-apm*"
 		}
 	},
 	"timeWindow": {
@@ -142,7 +144,8 @@ curl --request POST \
 			"service": "o11y-app",
 			"transactionType": "request",
 			"transactionName": "GET /api",
-			"goodStatusCodes": ["2xx", "3xx", "4xx"]
+			"goodStatusCodes": ["2xx", "3xx", "4xx"],
+			"index": "metrics-apm*"
 		}
 	},
 	"timeWindow": {
@@ -181,7 +184,8 @@ curl --request POST \
 			"service": "o11y-app",
 			"transactionType": "request",
 			"transactionName": "GET /api",
-			"threshold": 500000
+			"threshold": 500,
+			"index": "metrics-apm*"
 		}
 	},
 	"timeWindow": {
@@ -216,7 +220,8 @@ curl --request POST \
 			"service": "o11y-app",
 			"transactionType": "request",
 			"transactionName": "GET /api",
-			"threshold": 500000
+			"threshold": 500,
+			"index": "metrics-apm*"
 		}
 	},
 	"timeWindow": {
@@ -253,7 +258,8 @@ curl --request POST \
 			"service": "o11y-app",
 			"transactionType": "request",
 			"transactionName": "GET /api",
-			"threshold": 500000
+			"threshold": 500,
+			"index": "metrics-apm*"
 		}
 	},
 	"timeWindow": {

--- a/x-pack/plugins/observability/docs/openapi/slo/bundled.yaml
+++ b/x-pack/plugins/observability/docs/openapi/slo/bundled.yaml
@@ -145,7 +145,7 @@ paths:
         - $ref: '#/components/parameters/slo_id'
       responses:
         '200':
-          description: Succesful request
+          description: Successful request
           content:
             application/json:
               schema:
@@ -181,7 +181,7 @@ paths:
               $ref: '#/components/schemas/update_slo_request'
       responses:
         '200':
-          description: Succesful request
+          description: Successful request
           content:
             application/json:
               schema:
@@ -211,7 +211,7 @@ paths:
         - $ref: '#/components/parameters/slo_id'
       responses:
         '204':
-          description: Succesful request
+          description: Successful request
         '400':
           description: Bad request
           content:
@@ -238,7 +238,7 @@ paths:
         - $ref: '#/components/parameters/slo_id'
       responses:
         '204':
-          description: Succesful request
+          description: Successful request
         '400':
           description: Bad request
           content:
@@ -265,7 +265,7 @@ paths:
         - $ref: '#/components/parameters/slo_id'
       responses:
         '200':
-          description: Succesful request
+          description: Successful request
         '400':
           description: Bad request
           content:
@@ -400,6 +400,7 @@ components:
             - environment
             - transactionType
             - transactionName
+            - index
           properties:
             service:
               description: The APM service name
@@ -455,6 +456,7 @@ components:
             - environment
             - transactionType
             - transactionName
+            - index
           properties:
             service:
               description: The APM service name

--- a/x-pack/plugins/observability/docs/openapi/slo/components/schemas/indicator_properties_apm_availability.yaml
+++ b/x-pack/plugins/observability/docs/openapi/slo/components/schemas/indicator_properties_apm_availability.yaml
@@ -14,6 +14,7 @@ properties:
       - environment
       - transactionType
       - transactionName
+      - index
     properties:
       service:
         description: The APM service name

--- a/x-pack/plugins/observability/docs/openapi/slo/components/schemas/indicator_properties_apm_latency.yaml
+++ b/x-pack/plugins/observability/docs/openapi/slo/components/schemas/indicator_properties_apm_latency.yaml
@@ -14,6 +14,7 @@ properties:
       - environment
       - transactionType
       - transactionName
+      - index
     properties:
       service:
         description: The APM service name

--- a/x-pack/plugins/observability/public/data/slo/indicator.ts
+++ b/x-pack/plugins/observability/public/data/slo/indicator.ts
@@ -18,6 +18,7 @@ export const buildApmAvailabilityIndicator = (
       transactionType: 'request',
       transactionName: 'GET /flaky',
       goodStatusCodes: ['2xx', '3xx', '4xx'],
+      index: 'metrics-apm*',
       ...params,
     },
   };
@@ -33,7 +34,8 @@ export const buildApmLatencyIndicator = (
       service: 'o11y-app',
       transactionType: 'request',
       transactionName: 'GET /slow',
-      threshold: 5000000,
+      threshold: 500,
+      index: 'metrics-apm*',
       ...params,
     },
   };

--- a/x-pack/plugins/observability/server/services/slo/find_slo.test.ts
+++ b/x-pack/plugins/observability/server/services/slo/find_slo.test.ts
@@ -54,6 +54,7 @@ describe('FindSLO', () => {
                 transactionName: 'irrelevant',
                 transactionType: 'irrelevant',
                 threshold: 500,
+                index: 'metrics-apm*',
               },
               type: 'sli.apm.transactionDuration',
             },

--- a/x-pack/plugins/observability/server/services/slo/fixtures/slo.ts
+++ b/x-pack/plugins/observability/server/services/slo/fixtures/slo.ts
@@ -35,6 +35,7 @@ export const createAPMTransactionErrorRateIndicator = (
     transactionName: 'irrelevant',
     transactionType: 'irrelevant',
     goodStatusCodes: ['2xx', '3xx', '4xx'],
+    index: 'metrics-apm*',
     ...params,
   },
 });
@@ -49,6 +50,7 @@ export const createAPMTransactionDurationIndicator = (
     transactionName: 'irrelevant',
     transactionType: 'irrelevant',
     threshold: 500,
+    index: 'metrics-apm*',
     ...params,
   },
 });

--- a/x-pack/plugins/observability/server/services/slo/get_slo.test.ts
+++ b/x-pack/plugins/observability/server/services/slo/get_slo.test.ts
@@ -54,6 +54,7 @@ describe('GetSLO', () => {
             transactionName: 'irrelevant',
             transactionType: 'irrelevant',
             goodStatusCodes: ['2xx', '3xx', '4xx'],
+            index: 'metrics-apm*',
           },
           type: 'sli.apm.transactionErrorRate',
         },

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/apm_transaction_duration.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/apm_transaction_duration.ts
@@ -20,7 +20,6 @@ import {
 import { getSLOTransformTemplate } from '../../../assets/transform_templates/slo_transform_template';
 import { SLO, APMTransactionDurationIndicator } from '../../../domain/models';
 import { getElastichsearchQueryOrThrow, TransformGenerator } from '.';
-import { DEFAULT_APM_INDEX } from './constants';
 import { Query } from './types';
 import { parseIndex } from './common';
 
@@ -92,7 +91,7 @@ export class ApmTransactionDurationTransformGenerator extends TransformGenerator
     }
 
     return {
-      index: parseIndex(indicator.params.index ?? DEFAULT_APM_INDEX),
+      index: parseIndex(indicator.params.index),
       runtime_mappings: this.buildCommonRuntimeMappings(slo),
       query: {
         bool: {

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/apm_transaction_error_rate.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/apm_transaction_error_rate.ts
@@ -21,7 +21,6 @@ import {
   getSLOTransformId,
 } from '../../../assets/constants';
 import { APMTransactionErrorRateIndicator, SLO } from '../../../domain/models';
-import { DEFAULT_APM_INDEX } from './constants';
 import { Query } from './types';
 import { parseIndex } from './common';
 
@@ -97,7 +96,7 @@ export class ApmTransactionErrorRateTransformGenerator extends TransformGenerato
     }
 
     return {
-      index: parseIndex(indicator.params.index ?? DEFAULT_APM_INDEX),
+      index: parseIndex(indicator.params.index),
       runtime_mappings: this.buildCommonRuntimeMappings(slo),
       query: {
         bool: {

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/constants.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/constants.ts
@@ -1,8 +1,0 @@
-/*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0; you may not use this file except in compliance with the Elastic License
- * 2.0.
- */
-
-export const DEFAULT_APM_INDEX = 'metrics-apm*';


### PR DESCRIPTION
## Summary

This PR introduces a breaking change by making the APM indicator's index required when creating an SLO. Reasoning behind it is that the apm metrics index can be different from cluster to cluster, and we are already always providing the value from the UI, so it makes sense to require it from the API standpoint.

## 🥼 Manual testing

You can make an API call with and without the `indicator.params.index` field:

```
curl --request POST \
  --url http://localhost:5601/kibana/api/observability/slos \
  --header 'Authorization: Basic ZWxhc3RpYzpjaGFuZ2VtZQ==' \
  --header 'Content-Type: application/json' \
  --header 'kbn-xsrf: oui' \
  --data '{
	"name": "My SLO Service Latency",
	"description": "My SLO Desc",
	"indicator": {
		"type": "sli.apm.transactionDuration",
		"params": {
			"environment": "development",
			"service": "o11y-app",
			"transactionType": "request",
			"transactionName": "GET /slow",
			"threshold": 5000,
			"filter": "",
			"index": "metrics-apm*"
		}
	},
	"timeWindow": {
		"duration": "7d",
		"isRolling": true
	},
	"budgetingMethod": "timeslices",
	"objective": {
		"target": 0.95,
		"timesliceTarget": 0.80,
		"timesliceWindow": "1m"
	}
}'
```