### PR TITLE
[Security Solution + Files + Fleet] Add option to Files client to handle index alias and fix Endpoint/Fleet usage to set new option to true

### DIFF
--- a/src/plugins/files/server/blob_storage_service/adapters/es/content_stream/content_stream.test.ts
+++ b/src/plugins/files/server/blob_storage_service/adapters/es/content_stream/content_stream.test.ts
@@ -37,7 +37,9 @@ describe('ContentStream', () => {
   beforeEach(() => {
     client = elasticsearchServiceMock.createClusterClient().asInternalUser;
     logger = loggingSystemMock.createLogger();
-    client.get.mockResponse(toReadable(set({}, '_source.data', Buffer.from('some content'))));
+    client.get.mockResponse(
+      toReadable(set({ found: true }, '_source.data', Buffer.from('some content')))
+    );
   });
 
   describe('read', () => {
@@ -81,7 +83,7 @@ describe('ContentStream', () => {
 
     it('should decode base64 encoded content', async () => {
       client.get.mockResponseOnce(
-        toReadable(set({}, '_source.data', Buffer.from('encoded content')))
+        toReadable(set({ found: true }, '_source.data', Buffer.from('encoded content')))
       );
       const data = await new Promise((resolve) => stream.once('data', resolve));
 
@@ -90,9 +92,9 @@ describe('ContentStream', () => {
 
     it('should compound content from multiple chunks', async () => {
       const [one, two, three] = ['12', '34', '56'].map(Buffer.from);
-      client.get.mockResponseOnce(toReadable(set({}, '_source.data', one)));
-      client.get.mockResponseOnce(toReadable(set({}, '_source.data', two)));
-      client.get.mockResponseOnce(toReadable(set({}, '_source.data', three)));
+      client.get.mockResponseOnce(toReadable(set({ found: true }, '_source.data', one)));
+      client.get.mockResponseOnce(toReadable(set({ found: true }, '_source.data', two)));
+      client.get.mockResponseOnce(toReadable(set({ found: true }, '_source.data', three)));
 
       stream = getContentStream({
         params: { size: 6 },
@@ -118,9 +120,9 @@ describe('ContentStream', () => {
 
     it('should stop reading on empty chunk', async () => {
       const [one, two, three] = ['12', '34', ''].map(Buffer.from);
-      client.get.mockResponseOnce(toReadable(set({}, '_source.data', one)));
-      client.get.mockResponseOnce(toReadable(set({}, '_source.data', two)));
-      client.get.mockResponseOnce(toReadable(set({}, '_source.data', three)));
+      client.get.mockResponseOnce(toReadable(set({ found: true }, '_source.data', one)));
+      client.get.mockResponseOnce(toReadable(set({ found: true }, '_source.data', two)));
+      client.get.mockResponseOnce(toReadable(set({ found: true }, '_source.data', three)));
       stream = getContentStream({ params: { size: 12 } });
       let data = '';
       for await (const chunk of stream) {
@@ -133,9 +135,9 @@ describe('ContentStream', () => {
 
     it('should read while chunks are present when there is no size', async () => {
       const [one, two] = ['12', '34'].map(Buffer.from);
-      client.get.mockResponseOnce(toReadable(set({}, '_source.data', one)));
-      client.get.mockResponseOnce(toReadable(set({}, '_source.data', two)));
-      client.get.mockResponseOnce(toReadable({}));
+      client.get.mockResponseOnce(toReadable(set({ found: true }, '_source.data', one)));
+      client.get.mockResponseOnce(toReadable(set({ found: true }, '_source.data', two)));
+      client.get.mockResponseOnce(toReadable({ found: true }));
       stream = getContentStream({ params: { size: undefined } });
       let data = '';
       for await (const chunk of stream) {
@@ -148,10 +150,10 @@ describe('ContentStream', () => {
 
     it('should decode every chunk separately', async () => {
       const [one, two, three, four] = ['12', '34', '56', ''].map(Buffer.from);
-      client.get.mockResponseOnce(toReadable(set({}, '_source.data', one)));
-      client.get.mockResponseOnce(toReadable(set({}, '_source.data', two)));
-      client.get.mockResponseOnce(toReadable(set({}, '_source.data', three)));
-      client.get.mockResponseOnce(toReadable(set({}, '_source.data', four)));
+      client.get.mockResponseOnce(toReadable(set({ found: true }, '_source.data', one)));
+      client.get.mockResponseOnce(toReadable(set({ found: true }, '_source.data', two)));
+      client.get.mockResponseOnce(toReadable(set({ found: true }, '_source.data', three)));
+      client.get.mockResponseOnce(toReadable(set({ found: true }, '_source.data', four)));
       stream = getContentStream({ params: { size: 12 } });
       let data = '';
       for await (const chunk of stream) {

--- a/src/plugins/files/server/blob_storage_service/adapters/es/content_stream/content_stream.ts
+++ b/src/plugins/files/server/blob_storage_service/adapters/es/content_stream/content_stream.ts
@@ -143,7 +143,7 @@ export class ContentStream extends Duplex {
         ? (cborx.decode(buffer) as GetResponse<FileChunkDocument>)
         : undefined;
 
-      // Because `asStream` was used in retrieving the document, errors will also not be processes
+      // Because `asStream` was used in retrieving the document, errors are also not be processed
       // and thus are returned "as is", so we check to see if an ES error occurred while attempting
       // to retrieve the chunk.
       if (decodedChunkDoc && ('error' in decodedChunkDoc || !decodedChunkDoc.found)) {

--- a/src/plugins/files/server/blob_storage_service/adapters/es/content_stream/content_stream.ts
+++ b/src/plugins/files/server/blob_storage_service/adapters/es/content_stream/content_stream.ts
@@ -63,7 +63,8 @@ export class ContentStream extends Duplex {
     private id: undefined | string,
     private readonly index: string,
     private readonly logger: Logger,
-    parameters: ContentStreamParameters = {}
+    parameters: ContentStreamParameters = {},
+    private readonly indexIsAlias: boolean = false
   ) {
     super();
     this.parameters = defaults(parameters, {
@@ -86,19 +87,45 @@ export class ContentStream extends Duplex {
     return this.maxChunkSize;
   }
 
+  private async getChunkRealIndex(id: string): Promise<string> {
+    const chunkDocMeta = await this.client.search({
+      index: this.index,
+      body: {
+        size: 1,
+        query: {
+          term: {
+            _id: id,
+          },
+        },
+        _source: false, // suppress the document content
+      },
+    });
+
+    const docIndex = chunkDocMeta.hits.hits[0]._index;
+
+    if (!docIndex) {
+      throw new Error(
+        `Unable to determine index for file chunk id [${id}] in index (alias) [${this.index}]`
+      );
+    }
+
+    return docIndex;
+  }
+
   private async readChunk(): Promise<[data: null | Buffer, last?: boolean]> {
     if (!this.id) {
       throw new Error('No document ID provided. Cannot read chunk.');
     }
     const id = this.getChunkId(this.chunksRead);
+    const chunkIndex = this.indexIsAlias ? await this.getChunkRealIndex(id) : this.index;
 
-    this.logger.debug(`Reading chunk #${this.chunksRead}.`);
+    this.logger.debug(`Reading chunk #${this.chunksRead} from index [${chunkIndex}]`);
 
     try {
       const stream = await this.client.get(
         {
           id,
-          index: this.index,
+          index: chunkIndex,
           _source_includes: ['data', 'last'],
         },
         {
@@ -119,9 +146,10 @@ export class ContentStream extends Duplex {
       // Because `asStream` was used in retrieving the document, errors will also not be processes
       // and thus are returned "as is", so we check to see if an ES error occurred while attempting
       // to retrieve the chunk.
-      if (decodedChunkDoc && 'error' in decodedChunkDoc) {
-        const err = new Error(`Failed to retrieve chunk id [${id}] from index [${this.index}]`);
-        this.logger.error(`${err.message}\n${inspect(decodedChunkDoc, { depth: 5 })}`);
+      if (decodedChunkDoc && ('error' in decodedChunkDoc || !decodedChunkDoc.found)) {
+        const err = new Error(`Failed to retrieve chunk id [${id}] from index [${chunkIndex}]`);
+        this.logger.error(err);
+        this.logger.error(inspect(decodedChunkDoc, { depth: 5 }));
         throw err;
       }
 
@@ -374,10 +402,19 @@ export interface ContentStreamArgs {
    */
   logger: Logger;
   parameters?: ContentStreamParameters;
+  /** indicates the index provided is an alias (changes how the content is retrieved internally) */
+  indexIsAlias?: boolean;
 }
 
-function getContentStream({ client, id, index, logger, parameters }: ContentStreamArgs) {
-  return new ContentStream(client, id, index, logger, parameters);
+function getContentStream({
+  client,
+  id,
+  index,
+  logger,
+  parameters,
+  indexIsAlias = false,
+}: ContentStreamArgs) {
+  return new ContentStream(client, id, index, logger, parameters, indexIsAlias);
 }
 
 export type WritableContentStream = Writable &

--- a/src/plugins/files/server/blob_storage_service/adapters/es/es.ts
+++ b/src/plugins/files/server/blob_storage_service/adapters/es/es.ts
@@ -57,7 +57,9 @@ export class ElasticsearchBlobStorageClient implements BlobStorageClient {
      * Override the default concurrent upload limit by passing in a different
      * semaphore
      */
-    private readonly uploadSemaphore = ElasticsearchBlobStorageClient.defaultSemaphore
+    private readonly uploadSemaphore = ElasticsearchBlobStorageClient.defaultSemaphore,
+    /** Indicates that the index provided is an alias (changes how content is retrieved internally) */
+    private readonly indexIsAlias: boolean = false
   ) {
     assert(this.uploadSemaphore, `No default semaphore provided and no semaphore was passed in.`);
   }
@@ -166,6 +168,7 @@ export class ElasticsearchBlobStorageClient implements BlobStorageClient {
       parameters: {
         size,
       },
+      indexIsAlias: this.indexIsAlias,
     });
   }
 

--- a/src/plugins/files/server/file_client/create_es_file_client.ts
+++ b/src/plugins/files/server/file_client/create_es_file_client.ts
@@ -31,8 +31,8 @@ export interface CreateEsFileClientArgs {
    */
   elasticsearchClient: ElasticsearchClient;
   /**
-   * Tread the indexes provided as Aliases. If set to true, ES `search()` will be used to
-   * retrieve the file info and content instead of `get()`. This is needed to ensurer the
+   * Treat the indices provided as Aliases. If set to true, ES `search()` will be used to
+   * retrieve the file info and content instead of `get()`. This is needed to ensure the
    * content can be retrieved in cases where an index may have rolled over (ES `get()`
    * needs a "real" index)
    */

--- a/src/plugins/files/server/file_client/create_es_file_client.ts
+++ b/src/plugins/files/server/file_client/create_es_file_client.ts
@@ -71,7 +71,14 @@ export function createEsFileClient(arg: CreateEsFileClientArgs): FileClient {
       maxSizeBytes,
     },
     new EsIndexFilesMetadataClient(metadataIndex, elasticsearchClient, logger, indexIsAlias),
-    new ElasticsearchBlobStorageClient(elasticsearchClient, blobStorageIndex, undefined, logger),
+    new ElasticsearchBlobStorageClient(
+      elasticsearchClient,
+      blobStorageIndex,
+      undefined,
+      logger,
+      undefined,
+      indexIsAlias
+    ),
     undefined,
     undefined,
     logger

--- a/src/plugins/files/server/file_client/create_es_file_client.ts
+++ b/src/plugins/files/server/file_client/create_es_file_client.ts
@@ -31,6 +31,13 @@ export interface CreateEsFileClientArgs {
    */
   elasticsearchClient: ElasticsearchClient;
   /**
+   * Tread the indexes provided as Aliases. If set to true, ES `search()` will be used to
+   * retrieve the file info and content instead of `get()`. This is needed to ensurer the
+   * content can be retrieved in cases where an index may have rolled over (ES `get()`
+   * needs a "real" index)
+   */
+  indexIsAlias?: boolean;
+  /**
    * The maximum file size to be written.
    */
   maxSizeBytes?: number;
@@ -49,14 +56,21 @@ export interface CreateEsFileClientArgs {
  * @param arg - See {@link CreateEsFileClientArgs}
  */
 export function createEsFileClient(arg: CreateEsFileClientArgs): FileClient {
-  const { blobStorageIndex, elasticsearchClient, logger, metadataIndex, maxSizeBytes } = arg;
+  const {
+    blobStorageIndex,
+    elasticsearchClient,
+    logger,
+    metadataIndex,
+    maxSizeBytes,
+    indexIsAlias,
+  } = arg;
   return new FileClientImpl(
     {
       id: NO_FILE_KIND,
       http: {},
       maxSizeBytes,
     },
-    new EsIndexFilesMetadataClient(metadataIndex, elasticsearchClient, logger),
+    new EsIndexFilesMetadataClient(metadataIndex, elasticsearchClient, logger, indexIsAlias),
     new ElasticsearchBlobStorageClient(elasticsearchClient, blobStorageIndex, undefined, logger),
     undefined,
     undefined,

--- a/x-pack/plugins/fleet/server/services/agents/uploads.ts
+++ b/x-pack/plugins/fleet/server/services/agents/uploads.ts
@@ -186,6 +186,7 @@ export async function getAgentUploadFile(
       metadataIndex: FILE_STORAGE_METADATA_AGENT_INDEX,
       elasticsearchClient: esClient,
       logger: appContextService.getLogger(),
+      indexIsAlias: true,
     });
 
     const file = await fileClient.get({

--- a/x-pack/plugins/security_solution/scripts/endpoint/agent_emulator/services/endpoint_response_actions.ts
+++ b/x-pack/plugins/security_solution/scripts/endpoint/agent_emulator/services/endpoint_response_actions.ts
@@ -248,27 +248,29 @@ export const sendEndpointActionResponse = async (
     // Index the file content (just one chunk)
     // call to `.index()` copied from File plugin here:
     // https://github.com/elastic/kibana/blob/main/src/plugins/files/server/blob_storage_service/adapters/es/content_stream/content_stream.ts#L195
-    await esClient.index(
-      {
-        index: FILE_STORAGE_DATA_INDEX,
-        id: `${fileMeta._id}.0`,
-        document: cborx.encode({
-          bid: fileMeta._id,
-          last: true,
-          data: Buffer.from(
-            'UEsDBAoACQAAAFZeRFWpAsDLHwAAABMAAAAMABwAYmFkX2ZpbGUudHh0VVQJAANTVjxjU1Y8Y3V4CwABBPUBAAAEFAAAAMOcoyEq/Q4VyG02U9O0LRbGlwP/y5SOCfRKqLz1rsBQSwcIqQLAyx8AAAATAAAAUEsBAh4DCgAJAAAAVl5EVakCwMsfAAAAEwAAAAwAGAAAAAAAAQAAAKSBAAAAAGJhZF9maWxlLnR4dFVUBQADU1Y8Y3V4CwABBPUBAAAEFAAAAFBLBQYAAAAAAQABAFIAAAB1AAAAAAA=',
-            'base64'
-          ),
-        }),
-        refresh: 'wait_for',
-      },
-      {
-        headers: {
-          'content-type': 'application/cbor',
-          accept: 'application/json',
+    await esClient
+      .index(
+        {
+          index: FILE_STORAGE_DATA_INDEX,
+          id: `${fileMeta._id}.0`,
+          document: cborx.encode({
+            bid: fileMeta._id,
+            last: true,
+            data: Buffer.from(
+              'UEsDBAoACQAAAFZeRFWpAsDLHwAAABMAAAAMABwAYmFkX2ZpbGUudHh0VVQJAANTVjxjU1Y8Y3V4CwABBPUBAAAEFAAAAMOcoyEq/Q4VyG02U9O0LRbGlwP/y5SOCfRKqLz1rsBQSwcIqQLAyx8AAAATAAAAUEsBAh4DCgAJAAAAVl5EVakCwMsfAAAAEwAAAAwAGAAAAAAAAQAAAKSBAAAAAGJhZF9maWxlLnR4dFVUBQADU1Y8Y3V4CwABBPUBAAAEFAAAAFBLBQYAAAAAAQABAFIAAAB1AAAAAAA=',
+              'base64'
+            ),
+          }),
+          refresh: 'wait_for',
         },
-      }
-    );
+        {
+          headers: {
+            'content-type': 'application/cbor',
+            accept: 'application/json',
+          },
+        }
+      )
+      .then(() => sleep(2000));
   }
 
   return endpointResponse;

--- a/x-pack/plugins/security_solution/server/endpoint/services/actions/action_files.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/services/actions/action_files.ts
@@ -26,6 +26,7 @@ const getFileClient = (esClient: ElasticsearchClient, logger: Logger): FileClien
     blobStorageIndex: FILE_STORAGE_DATA_INDEX,
     elasticsearchClient: esClient,
     logger,
+    indexIsAlias: true,
   });
 };
 

--- a/x-pack/plugins/security_solution/server/endpoint/services/actions/action_files.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/services/actions/action_files.ts
@@ -43,6 +43,10 @@ const getFileRetrievalError = (
     }
   }
 
+  if (error instanceof EndpointError) {
+    return error;
+  }
+
   return new EndpointError(`Failed to get file using id [${fileId}]: ${error.message}`, error);
 };
 

--- a/x-pack/plugins/security_solution/server/endpoint/services/actions/action_files.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/services/actions/action_files.ts
@@ -85,10 +85,19 @@ export const getFileInfo = async (
   fileId: string
 ): Promise<UploadedFileInfo> => {
   try {
-    const { _id: id, _source: fileDoc } = await esClient.get<FileUploadMetadata>({
+    const fileDocSearchResult = await esClient.search<FileUploadMetadata>({
       index: FILE_STORAGE_METADATA_INDEX,
-      id: fileId,
+      body: {
+        size: 1,
+        query: {
+          term: {
+            _id: fileId,
+          },
+        },
+      },
     });
+
+    const { _id: id, _source: fileDoc } = fileDocSearchResult.hits.hits[0] ?? {};
 
     if (!fileDoc) {
       throw new NotFoundError(`File with id [${fileId}] not found`);


### PR DESCRIPTION
## Summary

- Adds `indexIsAlias` to `Files` plugin client. Used when provided indexes are Aliases (changes how the documents are retrieved internally)
- Changes security solution (endpoint) file service to use `.search()` instead of `.get()` when retrieving a file metadata via `id`
- Changed Security Solution call to `createEsFileClient()` (`Files` plugin service) to set `indexIsAlias` to `true`
- Changed Fleet call to `createEsFileClient()` (`Files` plugin service) to set `indexIsAlias` to `true`


Addresses the following Issues that were raised for 8.7:

- Fixes #153322 
- FIxes #153334


_________

![olm-6234-fix-file-downloads](https://user-images.githubusercontent.com/56442535/226675846-eae1e611-8ad7-4114-95e5-a1daae834273.gif)




<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->