### PR TITLE
[Cloud Posture] add cvs score color utility function

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/common/utils/get_cvsscore_color.test.ts
+++ b/x-pack/plugins/cloud_security_posture/public/common/utils/get_cvsscore_color.test.ts
@@ -5,30 +5,31 @@
  * 2.0.
  */
 
+import { euiThemeVars } from '@kbn/ui-theme';
 import { getCvsScoreColor } from './get_cvsscore_color';
 
 describe('getCvsScoreColor', () => {
   it('returns correct color for low severity score', () => {
-    expect(getCvsScoreColor(1.5)).toBe('#54B399');
+    expect(getCvsScoreColor(1.5)).toBe(euiThemeVars.euiColorVis0);
   });
 
   it('returns correct color for medium severity score', () => {
-    expect(getCvsScoreColor(5.5)).toBe('#D6BF57');
+    expect(getCvsScoreColor(5.5)).toBe(euiThemeVars.euiColorVis7);
   });
 
   it('returns correct color for high severity score', () => {
-    expect(getCvsScoreColor(7.9)).toBe('#DA8B45');
+    expect(getCvsScoreColor(7.9)).toBe(euiThemeVars.euiColorVis9);
   });
 
   it('returns correct color for critical severity score', () => {
-    expect(getCvsScoreColor(10.0)).toBe('#BD271E');
+    expect(getCvsScoreColor(10.0)).toBe(euiThemeVars.euiColorDanger);
   });
 
   it('returns error message for invalid score', () => {
-    expect(getCvsScoreColor(-1)).toBe('Invalid score');
+    expect(getCvsScoreColor(-1)).toBe(undefined);
   });
 
   it('returns error message for invalid score when score is 0.0', () => {
-    expect(getCvsScoreColor(0.0)).toBe('Invalid score');
+    expect(getCvsScoreColor(0.0)).toBe(undefined);
   });
 });

--- a/x-pack/plugins/cloud_security_posture/public/common/utils/get_cvsscore_color.test.ts
+++ b/x-pack/plugins/cloud_security_posture/public/common/utils/get_cvsscore_color.test.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getCvsScoreColor } from './get_cvsscore_color';
+
+describe('getCvsScoreColor', () => {
+  it('returns correct color for low severity score', () => {
+    expect(getCvsScoreColor(1.5)).toBe('#54B399');
+  });
+
+  it('returns correct color for medium severity score', () => {
+    expect(getCvsScoreColor(5.5)).toBe('#D6BF57');
+  });
+
+  it('returns correct color for high severity score', () => {
+    expect(getCvsScoreColor(7.9)).toBe('#DA8B45');
+  });
+
+  it('returns correct color for critical severity score', () => {
+    expect(getCvsScoreColor(10.0)).toBe('#BD271E');
+  });
+
+  it('returns error message for invalid score', () => {
+    expect(getCvsScoreColor(-1)).toBe('Invalid score');
+  });
+
+  it('returns error message for invalid score when score is 0.0', () => {
+    expect(getCvsScoreColor(0.0)).toBe('Invalid score');
+  });
+});

--- a/x-pack/plugins/cloud_security_posture/public/common/utils/get_cvsscore_color.ts
+++ b/x-pack/plugins/cloud_security_posture/public/common/utils/get_cvsscore_color.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const getCvsScoreColor = (score: number): string => {
+  if (score >= 0.1 && score <= 3.9) {
+    return '#54B399'; // low severity
+  } else if (score >= 4.0 && score <= 6.9) {
+    return '#D6BF57'; // medium severity
+  } else if (score >= 7.0 && score <= 8.9) {
+    return '#DA8B45'; // high severity
+  } else if (score >= 9.0 && score <= 10.0) {
+    return '#BD271E'; // critical severity
+  } else {
+    return 'Invalid score'; // if the score is not within the valid range
+  }
+};

--- a/x-pack/plugins/cloud_security_posture/public/common/utils/get_cvsscore_color.ts
+++ b/x-pack/plugins/cloud_security_posture/public/common/utils/get_cvsscore_color.ts
@@ -5,16 +5,18 @@
  * 2.0.
  */
 
-export const getCvsScoreColor = (score: number): string => {
+import { euiThemeVars } from '@kbn/ui-theme';
+
+export const getCvsScoreColor = (score: number): string | undefined => {
   if (score >= 0.1 && score <= 3.9) {
-    return '#54B399'; // low severity
+    return euiThemeVars.euiColorVis0; // low severity
   } else if (score >= 4.0 && score <= 6.9) {
-    return '#D6BF57'; // medium severity
+    return euiThemeVars.euiColorVis7; // medium severity
   } else if (score >= 7.0 && score <= 8.9) {
-    return '#DA8B45'; // high severity
+    return euiThemeVars.euiColorVis9; // high severity
   } else if (score >= 9.0 && score <= 10.0) {
-    return '#BD271E'; // critical severity
+    return euiThemeVars.euiColorDanger; // critical severity
   } else {
-    return 'Invalid score'; // if the score is not within the valid range
+    return undefined; // if the score is not within the valid range
   }
 };


### PR DESCRIPTION
## Summary

This is a small pr to add utility function so we can get the CVS score color for various badges based on the range of Cvsscore from  [version 3.](https://nvd.nist.gov/vuln-metrics/cvss) 