### PR TITLE
[Reporting] Remove no longer relevant comment about frozen indices

### DIFF
--- a/x-pack/plugins/reporting/server/export_types/csv_searchsource/generate_csv/generate_csv.ts
+++ b/x-pack/plugins/reporting/server/export_types/csv_searchsource/generate_csv/generate_csv.ts
@@ -66,10 +66,6 @@ export class CsvGenerator {
           index: indexPatternTitle,
           keep_alive: duration,
           ignore_unavailable: true,
-          // TODO: currently this doesn't do anything as es has a bug that throttled indices are always included when using PIT api
-          // if es fixes the issue, everything should work as expected. Just needs to be tested and this comment removed
-          // if es decides to not fix, then we can close the issue and remove the `ignore_throttled` code from here
-          // https://github.com/elastic/kibana/issues/152884
           // @ts-expect-error ignore_throttled is not in the type definition, but it is accepted by es
           ignore_throttled: settings.includeFrozen ? false : undefined, // "true" will cause deprecation warnings logged in ES
         },


### PR DESCRIPTION
## Summary

close https://github.com/elastic/kibana/issues/152884 since https://github.com/elastic/elasticsearch/pull/94377 was fixed. I tested it, works good except one thing I noticed: 

@dnhatn, I noticed that deleting a PIT created for a frozen index without `include_throttled=false` will result in a 404 error: 

```
POST /test/_pit?keep_alive=1m // `test` index is frozen

// returns
{
  "id": "45XtAwAA"
}

DELETE /_pit
{
    "id" : "45XtAwAA"
}

// returns 404
{
  "succeeded": true,
  "num_freed": 0
}

```

@dnhatn, is this expected? Should we adjust the Kibana code not to consider this an error? 
