### PR TITLE
[Lens] Remove the flattened field type from the Lens SO

### DIFF
--- a/src/core/server/integration_tests/saved_objects/migrations/group2/check_registered_types.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/group2/check_registered_types.test.ts
@@ -110,7 +110,7 @@ describe('checking migration metadata changes on all registered SO types', () =>
         "inventory-view": "6d47ef0b38166ecbd1c2fc7394599a4500db1ae4",
         "kql-telemetry": "23ed96ff02cd69cbfaa22f313cae3a54c434db51",
         "legacy-url-alias": "9b8cca3fbb2da46fd12823d3cd38fdf1c9f24bc8",
-        "lens": "42793535312de4e3e3df16a69cb85f5df3b14f72",
+        "lens": "2f6a8231591e3d62a83506b19e165774d74588ea",
         "lens-ui-telemetry": "d6c4e330d170eefc6214dbf77a53de913fa3eebc",
         "map": "7902b2e2a550e0b73fd5aa6c4e2ba3a4e6558877",
         "metrics-explorer-view": "713dbf1ab5e067791d19170f715eb82cf07ebbcc",

--- a/x-pack/plugins/lens/server/saved_objects.ts
+++ b/x-pack/plugins/lens/server/saved_objects.ts
@@ -50,7 +50,8 @@ export function setupSavedObjects(
           type: 'keyword',
         },
         state: {
-          type: 'flattened',
+          dynamic: false,
+          properties: {},
         },
         expression: {
           index: false,

--- a/x-pack/plugins/lens/server/saved_objects.ts
+++ b/x-pack/plugins/lens/server/saved_objects.ts
@@ -53,11 +53,6 @@ export function setupSavedObjects(
           dynamic: false,
           properties: {},
         },
-        expression: {
-          index: false,
-          doc_values: false,
-          type: 'keyword',
-        },
       },
     },
   });


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/152582

This PR:

- removes the expression property from the mappings as it was removed in 7.10 https://github.com/elastic/kibana/blob/main/x-pack/plugins/lens/server/migrations/saved_object_migrations.ts#L309
- changes the mapping of the state property. With this change:
  - we are adding the state without the type with dynamic false. In this case, ES is not going to automatically add mappings to the sub fields
  - If we want to aggregate on one state property on the future we can do it by adding this on the mapping as:

```
state: {
          dynamic: false,
          properties: {
              fieldToAggregate: long
          },
        },
```
### How to test
Migrate Lens SOs from 7.17 and 8.7 or 8.6 to this branch.