### PR TITLE
[Discover] Migrate expandedDoc to internalStateContainer

### DIFF
--- a/src/plugins/discover/public/application/main/components/layout/__stories__/discover_layout.stories.tsx
+++ b/src/plugins/discover/public/application/main/components/layout/__stories__/discover_layout.stories.tsx
@@ -10,7 +10,7 @@ import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
 import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
 import { DiscoverMainProvider } from '../../../services/discover_state_provider';
-import { AppState } from '../../../services/discover_app_state_container';
+import { DiscoverAppState } from '../../../services/discover_app_state_container';
 import { getDataViewMock } from '../../../../../__mocks__/__storybook_mocks__/get_data_view_mock';
 import { withDiscoverServices } from '../../../../../__mocks__/__storybook_mocks__/with_discover_services';
 import { getDocumentsLayoutProps, getPlainRecordLayoutProps } from './get_layout_props';
@@ -23,7 +23,7 @@ setHeaderActionMenuMounter(() => void 0);
 const DiscoverLayoutStory = (layoutProps: DiscoverLayoutProps) => {
   const [state, setState] = useState({});
 
-  const update = (newState: Partial<AppState>) => {
+  const update = (newState: Partial<DiscoverAppState>) => {
     setState((prevState) => ({ ...prevState, ...newState }));
   };
 

--- a/src/plugins/discover/public/application/main/components/layout/discover_documents.test.tsx
+++ b/src/plugins/discover/public/application/main/components/layout/discover_documents.test.tsx
@@ -22,7 +22,7 @@ import { buildDataTableRecord } from '../../../../utils/build_data_record';
 import { EsHitRecord } from '../../../../types';
 import { DiscoverMainProvider } from '../../services/discover_state_provider';
 import { getDiscoverStateMock } from '../../../../__mocks__/discover_state.mock';
-import { AppState } from '../../services/discover_app_state_container';
+import { DiscoverAppState } from '../../services/discover_app_state_container';
 
 setHeaderActionMenuMounter(jest.fn());
 
@@ -84,7 +84,7 @@ describe('Discover documents layout', () => {
   test('should set rounded width to state on resize column', () => {
     const state = {
       grid: { columns: { timestamp: { width: 173 }, someField: { width: 197 } } },
-    } as AppState;
+    } as DiscoverAppState;
     const container = getDiscoverStateMock({});
     container.appState.update(state);
 

--- a/src/plugins/discover/public/application/main/components/layout/discover_documents.tsx
+++ b/src/plugins/discover/public/application/main/components/layout/discover_documents.tsx
@@ -16,6 +16,8 @@ import {
 import { FormattedMessage } from '@kbn/i18n-react';
 import { DataView } from '@kbn/data-views-plugin/public';
 import { SavedSearch, SortOrder } from '@kbn/saved-search-plugin/public';
+import { DataTableRecord } from '../../../../types';
+import { useInternalStateSelector } from '../../services/discover_internal_state_container';
 import { useAppStateSelector } from '../../services/discover_app_state_container';
 import { useDiscoverServices } from '../../../../hooks/use_discover_services';
 import { DocViewFilterFn } from '../../../../services/doc_views/doc_views_types';
@@ -36,7 +38,6 @@ import { DocTableInfinite } from '../../../../components/doc_table/doc_table_inf
 import { DocumentExplorerCallout } from '../document_explorer_callout';
 import { DocumentExplorerUpdateCallout } from '../document_explorer_callout/document_explorer_update_callout';
 import { DiscoverTourProvider } from '../../../../components/discover_tour';
-import { DataTableRecord } from '../../../../types';
 import { getRawRecordType } from '../../utils/get_raw_record_type';
 import { DiscoverGridFlyout } from '../../../../components/discover_grid/discover_grid_flyout';
 import { DocViewer } from '../../../../services/doc_views/components/doc_viewer';
@@ -60,20 +61,16 @@ export const onResize = (
 };
 
 function DiscoverDocumentsComponent({
-  expandedDoc,
   dataView,
   onAddFilter,
   savedSearch,
-  setExpandedDoc,
   stateContainer,
   onFieldEdited,
 }: {
-  expandedDoc?: DataTableRecord;
   dataView: DataView;
   navigateTo: (url: string) => void;
   onAddFilter?: DocViewFilterFn;
   savedSearch: SavedSearch;
-  setExpandedDoc: (doc?: DataTableRecord) => void;
   stateContainer: DiscoverStateContainer;
   onFieldEdited?: () => void;
 }) {
@@ -93,6 +90,14 @@ function DiscoverDocumentsComponent({
       ];
     }
   );
+  const setExpandedDoc = useCallback(
+    (doc: DataTableRecord | undefined) => {
+      stateContainer.internalState.transitions.setExpandedDoc(doc);
+    },
+    [stateContainer]
+  );
+
+  const expandedDoc = useInternalStateSelector((state) => state.expandedDoc);
 
   const useNewFieldsApi = useMemo(() => !uiSettings.get(SEARCH_FIELDS_FROM_SOURCE), [uiSettings]);
   const hideAnnouncements = useMemo(() => uiSettings.get(HIDE_ANNOUNCEMENTS), [uiSettings]);

--- a/src/plugins/discover/public/application/main/components/layout/discover_histogram_layout.test.tsx
+++ b/src/plugins/discover/public/application/main/components/layout/discover_histogram_layout.test.tsx
@@ -119,7 +119,6 @@ const mountComponent = async ({
     isPlainRecord,
     dataView: dataViewMock,
     navigateTo: jest.fn(),
-    setExpandedDoc: jest.fn(),
     savedSearch,
     stateContainer,
     onFieldEdited: jest.fn(),

--- a/src/plugins/discover/public/application/main/components/layout/discover_layout.tsx
+++ b/src/plugins/discover/public/application/main/components/layout/discover_layout.tsx
@@ -55,11 +55,9 @@ const TopNavMemoized = React.memo(DiscoverTopNav);
 
 export function DiscoverLayout({
   inspectorAdapters,
-  expandedDoc,
   navigateTo,
   onChangeDataView,
   onUpdateQuery,
-  setExpandedDoc,
   resetSavedSearch,
   savedSearch,
   searchSource,
@@ -121,8 +119,8 @@ export function DiscoverLayout({
   );
 
   const onOpenInspector = useInspector({
-    setExpandedDoc,
     inspector,
+    stateContainer,
     inspectorAdapters,
     savedSearch,
   });
@@ -240,8 +238,6 @@ export function DiscoverLayout({
           dataView={dataView}
           navigateTo={navigateTo}
           resetSavedSearch={resetSavedSearch}
-          expandedDoc={expandedDoc}
-          setExpandedDoc={setExpandedDoc}
           savedSearch={savedSearch}
           stateContainer={stateContainer}
           columns={currentColumns}
@@ -259,7 +255,6 @@ export function DiscoverLayout({
     data,
     dataState.error,
     dataView,
-    expandedDoc,
     inspectorAdapters,
     isPlainRecord,
     isTimeBased,
@@ -270,7 +265,6 @@ export function DiscoverLayout({
     resetSavedSearch,
     resultState,
     savedSearch,
-    setExpandedDoc,
     stateContainer,
     viewMode,
   ]);

--- a/src/plugins/discover/public/application/main/components/layout/discover_main_content.test.tsx
+++ b/src/plugins/discover/public/application/main/components/layout/discover_main_content.test.tsx
@@ -100,7 +100,6 @@ const mountComponent = ({
     isPlainRecord,
     dataView: dataViewMock,
     navigateTo: jest.fn(),
-    setExpandedDoc: jest.fn(),
     savedSearch,
     stateContainer,
     onFieldEdited: jest.fn(),

--- a/src/plugins/discover/public/application/main/components/layout/discover_main_content.tsx
+++ b/src/plugins/discover/public/application/main/components/layout/discover_main_content.tsx
@@ -13,7 +13,6 @@ import { DataView } from '@kbn/data-views-plugin/common';
 import { METRIC_TYPE } from '@kbn/analytics';
 import { VIEW_MODE } from '../../../../../common/constants';
 import { useDiscoverServices } from '../../../../hooks/use_discover_services';
-import { DataTableRecord } from '../../../../types';
 import { DocumentViewModeToggle } from '../../../../components/view_mode_toggle';
 import { DocViewFilterFn } from '../../../../services/doc_views/doc_views_types';
 import { DiscoverStateContainer } from '../../services/discover_state';
@@ -27,8 +26,6 @@ export interface DiscoverMainContentProps {
   isPlainRecord: boolean;
   navigateTo: (url: string) => void;
   stateContainer: DiscoverStateContainer;
-  expandedDoc?: DataTableRecord;
-  setExpandedDoc: (doc?: DataTableRecord) => void;
   viewMode: VIEW_MODE;
   onAddFilter: DocViewFilterFn | undefined;
   onFieldEdited: () => Promise<void>;
@@ -39,8 +36,6 @@ export const DiscoverMainContent = ({
   dataView,
   isPlainRecord,
   navigateTo,
-  expandedDoc,
-  setExpandedDoc,
   viewMode,
   onAddFilter,
   onFieldEdited,
@@ -80,12 +75,10 @@ export const DiscoverMainContent = ({
       )}
       {viewMode === VIEW_MODE.DOCUMENT_LEVEL ? (
         <DiscoverDocuments
-          expandedDoc={expandedDoc}
           dataView={dataView}
           navigateTo={navigateTo}
           onAddFilter={!isPlainRecord ? onAddFilter : undefined}
           savedSearch={savedSearch}
-          setExpandedDoc={setExpandedDoc}
           stateContainer={stateContainer}
           onFieldEdited={!isPlainRecord ? onFieldEdited : undefined}
         />

--- a/src/plugins/discover/public/application/main/components/layout/types.ts
+++ b/src/plugins/discover/public/application/main/components/layout/types.ts
@@ -10,7 +10,6 @@ import type { Query, TimeRange, AggregateQuery } from '@kbn/es-query';
 import type { DataView } from '@kbn/data-views-plugin/public';
 import type { ISearchSource } from '@kbn/data-plugin/public';
 import { SavedSearch } from '@kbn/saved-search-plugin/public';
-import { DataTableRecord } from '../../../../types';
 import { DiscoverStateContainer } from '../../services/discover_state';
 import type { InspectorAdapters } from '../../hooks/use_inspector';
 
@@ -23,8 +22,6 @@ export interface DiscoverLayoutProps {
     isUpdate?: boolean
   ) => void;
   resetSavedSearch: () => void;
-  expandedDoc?: DataTableRecord;
-  setExpandedDoc: (doc?: DataTableRecord) => void;
   savedSearch: SavedSearch;
   searchSource: ISearchSource;
   stateContainer: DiscoverStateContainer;

--- a/src/plugins/discover/public/application/main/discover_main_app.tsx
+++ b/src/plugins/discover/public/application/main/discover_main_app.tsx
@@ -5,7 +5,7 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
 import { SavedSearch } from '@kbn/saved-search-plugin/public';
 import { DataViewListItem } from '@kbn/data-views-plugin/public';
@@ -15,7 +15,6 @@ import { addHelpMenuToAppChrome } from '../../components/help_menu/help_menu_uti
 import { useDiscoverState } from './hooks/use_discover_state';
 import { useUrl } from './hooks/use_url';
 import { useDiscoverServices } from '../../hooks/use_discover_services';
-import { DataTableRecord } from '../../types';
 import { useSavedSearchAliasMatchRedirect } from '../../hooks/saved_search_alias_match_redirect';
 import { DiscoverMainProvider } from './services/discover_state_provider';
 
@@ -37,7 +36,6 @@ export function DiscoverMainApp(props: DiscoverMainProps) {
   const services = useDiscoverServices();
   const { chrome, docLinks, data, spaces, history } = services;
   const usedHistory = useHistory();
-  const [expandedDoc, setExpandedDoc] = useState<DataTableRecord | undefined>(undefined);
   const navigateTo = useCallback(
     (path: string) => {
       usedHistory.push(path);
@@ -62,7 +60,6 @@ export function DiscoverMainApp(props: DiscoverMainProps) {
     services,
     history: usedHistory,
     savedSearch,
-    setExpandedDoc,
   });
 
   /**
@@ -107,11 +104,9 @@ export function DiscoverMainApp(props: DiscoverMainProps) {
     <DiscoverMainProvider value={stateContainer}>
       <DiscoverLayoutMemoized
         inspectorAdapters={inspectorAdapters}
-        expandedDoc={expandedDoc}
         onChangeDataView={onChangeDataView}
         onUpdateQuery={onUpdateQuery}
         resetSavedSearch={resetCurrentSavedSearch}
-        setExpandedDoc={setExpandedDoc}
         navigateTo={navigateTo}
         savedSearch={savedSearch}
         searchSource={searchSource}

--- a/src/plugins/discover/public/application/main/hooks/use_discover_state.test.tsx
+++ b/src/plugins/discover/public/application/main/hooks/use_discover_state.test.tsx
@@ -29,7 +29,6 @@ describe('test useDiscoverState', () => {
           services: discoverServiceMock,
           history,
           savedSearch: savedSearchMock,
-          setExpandedDoc: jest.fn(),
         });
       },
       {

--- a/src/plugins/discover/public/application/main/hooks/use_discover_state.ts
+++ b/src/plugins/discover/public/application/main/hooks/use_discover_state.ts
@@ -19,7 +19,6 @@ import { useUrlTracking } from './use_url_tracking';
 import { getDiscoverStateContainer } from '../services/discover_state';
 import { getStateDefaults } from '../utils/get_state_defaults';
 import { DiscoverServices } from '../../../build_services';
-import { DataTableRecord } from '../../../types';
 import { restoreStateFromSavedSearch } from '../../../services/saved_searches/restore_from_saved_search';
 import { useAdHocDataViews } from './use_adhoc_data_views';
 
@@ -27,12 +26,10 @@ export function useDiscoverState({
   services,
   history,
   savedSearch,
-  setExpandedDoc,
 }: {
   services: DiscoverServices;
   savedSearch: SavedSearch;
   history: History;
-  setExpandedDoc: (doc?: DataTableRecord) => void;
 }) {
   const { data, filterManager, dataViews, toastNotifications, trackUiMetric } = services;
 
@@ -150,9 +147,9 @@ export function useDiscoverState({
   const onChangeDataView = useCallback(
     async (id: string) => {
       await changeDataView(id, { services, discoverState: stateContainer, setUrlTracking });
-      setExpandedDoc(undefined);
+      stateContainer.internalState.transitions.setExpandedDoc(undefined);
     },
-    [services, setExpandedDoc, setUrlTracking, stateContainer]
+    [services, setUrlTracking, stateContainer]
   );
 
   /**

--- a/src/plugins/discover/public/application/main/hooks/use_inspector.test.ts
+++ b/src/plugins/discover/public/application/main/hooks/use_inspector.test.ts
@@ -21,7 +21,7 @@ describe('test useInspector', () => {
     let adapters: Adapters | undefined;
     jest.spyOn(discoverServiceMock.inspector, 'open').mockImplementation((localAdapters) => {
       adapters = localAdapters;
-      return {} as OverlayRef;
+      return { close: jest.fn() } as unknown as OverlayRef;
     });
     const requests = new RequestAdapter();
     const lensRequests = new RequestAdapter();
@@ -32,7 +32,7 @@ describe('test useInspector', () => {
         inspectorAdapters: { requests, lensRequests },
         savedSearch: savedSearchMock,
         inspector: discoverServiceMock.inspector,
-        stateContainer: getDiscoverStateMock({ isTimeBased: true }),
+        stateContainer,
       });
     });
     await act(async () => {

--- a/src/plugins/discover/public/application/main/hooks/use_inspector.test.ts
+++ b/src/plugins/discover/public/application/main/hooks/use_inspector.test.ts
@@ -6,17 +6,18 @@
  * Side Public License, v 1.
  */
 
-import { renderHook } from '@testing-library/react-hooks';
+import { act, renderHook } from '@testing-library/react-hooks';
 import { discoverServiceMock } from '../../../__mocks__/services';
 import { savedSearchMock } from '../../../__mocks__/saved_search';
 import { useInspector } from './use_inspector';
 import { Adapters, RequestAdapter } from '@kbn/inspector-plugin/common';
 import { OverlayRef } from '@kbn/core/public';
 import { AggregateRequestAdapter } from '../utils/aggregate_request_adapter';
+import { getDiscoverStateMock } from '../../../__mocks__/discover_state.mock';
+import { DataTableRecord } from '../../../types';
 
 describe('test useInspector', () => {
   test('inspector open function is executed, expanded doc is closed', async () => {
-    const setExpandedDoc = jest.fn();
     let adapters: Adapters | undefined;
     jest.spyOn(discoverServiceMock.inspector, 'open').mockImplementation((localAdapters) => {
       adapters = localAdapters;
@@ -24,21 +25,25 @@ describe('test useInspector', () => {
     });
     const requests = new RequestAdapter();
     const lensRequests = new RequestAdapter();
+    const stateContainer = getDiscoverStateMock({ isTimeBased: true });
+    stateContainer.internalState.transitions.setExpandedDoc({} as unknown as DataTableRecord);
     const { result } = renderHook(() => {
       return useInspector({
         inspectorAdapters: { requests, lensRequests },
         savedSearch: savedSearchMock,
         inspector: discoverServiceMock.inspector,
-        setExpandedDoc,
+        stateContainer: getDiscoverStateMock({ isTimeBased: true }),
       });
     });
-    result.current();
-    expect(setExpandedDoc).toHaveBeenCalledWith(undefined);
+    await act(async () => {
+      result.current();
+    });
     expect(discoverServiceMock.inspector.open).toHaveBeenCalled();
     expect(adapters?.requests).toBeInstanceOf(AggregateRequestAdapter);
     expect(adapters?.requests?.getRequests()).toEqual([
       ...requests.getRequests(),
       ...lensRequests.getRequests(),
     ]);
+    expect(stateContainer.internalState.getState().expandedDoc).toBe(undefined);
   });
 });

--- a/src/plugins/discover/public/application/main/hooks/use_inspector.ts
+++ b/src/plugins/discover/public/application/main/hooks/use_inspector.ts
@@ -13,7 +13,7 @@ import {
   Start as InspectorPublicPluginStart,
 } from '@kbn/inspector-plugin/public';
 import { SavedSearch } from '@kbn/saved-search-plugin/public';
-import { DataTableRecord } from '../../../types';
+import { DiscoverStateContainer } from '../services/discover_state';
 import { AggregateRequestAdapter } from '../utils/aggregate_request_adapter';
 
 export interface InspectorAdapters {
@@ -22,21 +22,21 @@ export interface InspectorAdapters {
 }
 
 export function useInspector({
-  setExpandedDoc,
   inspector,
+  stateContainer,
   inspectorAdapters,
   savedSearch,
 }: {
   inspectorAdapters: InspectorAdapters;
   savedSearch: SavedSearch;
-  setExpandedDoc: (doc?: DataTableRecord) => void;
   inspector: InspectorPublicPluginStart;
+  stateContainer: DiscoverStateContainer;
 }) {
   const [inspectorSession, setInspectorSession] = useState<InspectorSession | undefined>(undefined);
 
   const onOpenInspector = useCallback(() => {
     // prevent overlapping
-    setExpandedDoc(undefined);
+    stateContainer.internalState.transitions.setExpandedDoc(undefined);
 
     const requestAdapters = inspectorAdapters.lensRequests
       ? [inspectorAdapters.requests, inspectorAdapters.lensRequests]
@@ -49,7 +49,7 @@ export function useInspector({
 
     setInspectorSession(session);
   }, [
-    setExpandedDoc,
+    stateContainer,
     inspectorAdapters.lensRequests,
     inspectorAdapters.requests,
     inspector,

--- a/src/plugins/discover/public/application/main/hooks/utils/build_state_subscribe.ts
+++ b/src/plugins/discover/public/application/main/hooks/utils/build_state_subscribe.ts
@@ -8,7 +8,7 @@
 import { SavedSearch } from '@kbn/saved-search-plugin/public';
 import { isEqual } from 'lodash';
 import { DiscoverStateContainer } from '../../services/discover_state';
-import { AppState, isEqualState } from '../../services/discover_app_state_container';
+import { DiscoverAppState, isEqualState } from '../../services/discover_app_state_container';
 import { addLog } from '../../../../utils/add_log';
 import { FetchStatus } from '../../../types';
 
@@ -27,9 +27,9 @@ export const buildStateSubscribe =
   }: {
     stateContainer: DiscoverStateContainer;
     savedSearch: SavedSearch;
-    setState: (state: AppState) => void;
+    setState: (state: DiscoverAppState) => void;
   }) =>
-  async (nextState: AppState) => {
+  async (nextState: DiscoverAppState) => {
     const prevState = stateContainer.appState.getPrevious();
     if (isEqualState(prevState, nextState)) {
       addLog('[appstate] subscribe update ignored due to no changes');

--- a/src/plugins/discover/public/application/main/services/discover_app_state_container.ts
+++ b/src/plugins/discover/public/application/main/services/discover_app_state_container.ts
@@ -32,11 +32,11 @@ import { handleSourceColumnState } from '../../../utils/state_helpers';
 import { DiscoverGridSettings } from '../../../components/discover_grid/types';
 
 export const APP_STATE_URL_KEY = '_a';
-export interface DiscoverAppStateContainer extends ReduxLikeStateContainer<AppState> {
+export interface DiscoverAppStateContainer extends ReduxLikeStateContainer<DiscoverAppState> {
   /**
    * Returns the previous state, used for diffing e.g. if fetching new data is necessary
    */
-  getPrevious: () => AppState;
+  getPrevious: () => DiscoverAppState;
   /**
    * Determines if the current state is different from the initial state
    */
@@ -51,7 +51,7 @@ export interface DiscoverAppStateContainer extends ReduxLikeStateContainer<AppSt
    * @param newState
    * @param merge if true, the given state is merged with the current state
    */
-  replaceUrlState: (newPartial: AppState, merge?: boolean) => void;
+  replaceUrlState: (newPartial: DiscoverAppState, merge?: boolean) => void;
   /**
    * Resets the state by the given saved search
    * @param savedSearch
@@ -70,10 +70,10 @@ export interface DiscoverAppStateContainer extends ReduxLikeStateContainer<AppSt
    * @param newPartial
    * @param replace
    */
-  update: (newPartial: AppState, replace?: boolean) => void;
+  update: (newPartial: DiscoverAppState, replace?: boolean) => void;
 }
 
-export interface AppState {
+export interface DiscoverAppState {
   /**
    * Columns displayed in the table
    */
@@ -133,7 +133,7 @@ export interface AppState {
 }
 
 export const { Provider: DiscoverAppStateProvider, useSelector: useAppStateSelector } =
-  createStateContainerReactHelpers<ReduxLikeStateContainer<AppState>>();
+  createStateContainerReactHelpers<ReduxLikeStateContainer<DiscoverAppState>>();
 
 /**
  * This is the app state container for Discover main, it's responsible for syncing state with the URL
@@ -150,13 +150,13 @@ export const getDiscoverAppStateContainer = ({
   savedSearch: SavedSearch;
   services: DiscoverServices;
 }): DiscoverAppStateContainer => {
-  let previousState: AppState = {};
+  let previousState: DiscoverAppState = {};
   let initialState = getInitialState(stateStorage, savedSearch, services);
-  const appStateContainer = createStateContainer<AppState>(initialState);
+  const appStateContainer = createStateContainer<DiscoverAppState>(initialState);
 
   const enhancedAppContainer = {
     ...appStateContainer,
-    set: (value: AppState | null) => {
+    set: (value: DiscoverAppState | null) => {
       if (value) {
         previousState = appStateContainer.getState();
         appStateContainer.set(value);
@@ -173,7 +173,7 @@ export const getDiscoverAppStateContainer = ({
     initialState = appStateContainer.getState();
   };
 
-  const replaceUrlState = async (newPartial: AppState = {}, merge = true) => {
+  const replaceUrlState = async (newPartial: DiscoverAppState = {}, merge = true) => {
     addLog('[appState] replaceUrlState', { newPartial, merge });
     const state = merge ? { ...appStateContainer.getState(), ...newPartial } : newPartial;
     await stateStorage.set(APP_STATE_URL_KEY, state, { replace: true });
@@ -247,7 +247,7 @@ export const getDiscoverAppStateContainer = ({
     appStateContainer.set(nextAppState);
   };
 
-  const update = (newPartial: AppState, replace = false) => {
+  const update = (newPartial: DiscoverAppState, replace = false) => {
     addLog('[appState] update', { newPartial, replace });
     if (replace) {
       return replaceUrlState(newPartial);
@@ -272,7 +272,7 @@ export const getDiscoverAppStateContainer = ({
   };
 };
 
-export interface AppStateUrl extends Omit<AppState, 'sort'> {
+export interface AppStateUrl extends Omit<DiscoverAppState, 'sort'> {
   /**
    * Necessary to take care of legacy links [fieldName,direction]
    */
@@ -304,7 +304,10 @@ function getInitialState(
  * Helper function to merge a given new state with the existing state and to set the given state
  * container
  */
-export function setState(stateContainer: ReduxLikeStateContainer<AppState>, newState: AppState) {
+export function setState(
+  stateContainer: ReduxLikeStateContainer<DiscoverAppState>,
+  newState: DiscoverAppState
+) {
   addLog('[appstate] setState', { newState });
   const oldState = stateContainer.getState();
   const mergedState = { ...oldState, ...newState };
@@ -329,7 +332,7 @@ export function isEqualFilters(filtersA?: Filter[] | Filter, filtersB?: Filter[]
  * Helper function to compare 2 different state, is needed since comparing filters
  * works differently
  */
-export function isEqualState(stateA: AppState, stateB: AppState) {
+export function isEqualState(stateA: DiscoverAppState, stateB: DiscoverAppState) {
   if (!stateA && !stateB) {
     return true;
   } else if (!stateA || !stateB) {

--- a/src/plugins/discover/public/application/main/services/discover_data_state_container.ts
+++ b/src/plugins/discover/public/application/main/services/discover_data_state_container.ts
@@ -14,7 +14,7 @@ import { AggregateQuery, Query } from '@kbn/es-query';
 import type { SearchResponse } from '@elastic/elasticsearch/lib/api/types';
 import { ReduxLikeStateContainer } from '@kbn/kibana-utils-plugin/common';
 import { getRawRecordType } from '../utils/get_raw_record_type';
-import { AppState } from './discover_app_state_container';
+import { DiscoverAppState } from './discover_app_state_container';
 import { DiscoverServices } from '../../../build_services';
 import { DiscoverSearchSessionManager } from './discover_search_session';
 import { SEARCH_FIELDS_FROM_SOURCE, SEARCH_ON_PAGE_LOAD_SETTING } from '../../../../common';
@@ -84,7 +84,7 @@ export interface DataAvailableFieldsMsg extends DataMsg {
   fields?: string[];
 }
 
-export interface DataStateContainer {
+export interface DiscoverDataStateContainer {
   /**
    * Implicitly starting fetching data from ES
    */
@@ -134,10 +134,10 @@ export function getDataStateContainer({
 }: {
   services: DiscoverServices;
   searchSessionManager: DiscoverSearchSessionManager;
-  getAppState: () => AppState;
+  getAppState: () => DiscoverAppState;
   getSavedSearch: () => SavedSearch;
-  appStateContainer: ReduxLikeStateContainer<AppState>;
-}): DataStateContainer {
+  appStateContainer: ReduxLikeStateContainer<DiscoverAppState>;
+}): DiscoverDataStateContainer {
   const { data, uiSettings, toastNotifications } = services;
   const { timefilter } = data.query.timefilter;
   const inspectorAdapters = { requests: new RequestAdapter() };

--- a/src/plugins/discover/public/application/main/services/discover_internal_state_container.ts
+++ b/src/plugins/discover/public/application/main/services/discover_internal_state_container.ts
@@ -12,11 +12,13 @@ import {
   ReduxLikeStateContainer,
 } from '@kbn/kibana-utils-plugin/common';
 import { DataView, DataViewListItem } from '@kbn/data-views-plugin/common';
+import { DataTableRecord } from '../../../types';
 
 export interface InternalState {
   dataView: DataView | undefined;
   savedDataViews: DataViewListItem[];
   adHocDataViews: DataView[];
+  expandedDoc: DataTableRecord | undefined;
 }
 
 interface InternalStateTransitions {
@@ -30,9 +32,12 @@ interface InternalStateTransitions {
   replaceAdHocDataViewWithId: (
     state: InternalState
   ) => (id: string, dataView: DataView) => InternalState;
+  setExpandedDoc: (
+    state: InternalState
+  ) => (dataView: DataTableRecord | undefined) => InternalState;
 }
 
-export type InternalStateContainer = ReduxLikeStateContainer<
+export type DiscoverInternalStateContainer = ReduxLikeStateContainer<
   InternalState,
   InternalStateTransitions
 >;
@@ -46,6 +51,7 @@ export function getInternalStateContainer() {
       dataView: undefined,
       adHocDataViews: [],
       savedDataViews: [],
+      expandedDoc: undefined,
     },
     {
       setDataView: (prevState: InternalState) => (nextDataView: DataView) => ({
@@ -87,6 +93,10 @@ export function getInternalStateContainer() {
             dataView.id === prevId ? newDataView : dataView
           ),
         }),
+      setExpandedDoc: (prevState: InternalState) => (expandedDoc: DataTableRecord | undefined) => ({
+        ...prevState,
+        expandedDoc,
+      }),
     },
     {},
     { freeze: (state) => state }

--- a/src/plugins/discover/public/application/main/services/discover_state.ts
+++ b/src/plugins/discover/public/application/main/services/discover_state.ts
@@ -33,8 +33,8 @@ import {
   GLOBAL_STATE_URL_KEY,
 } from './discover_app_state_container';
 import {
+  DiscoverInternalStateContainer,
   getInternalStateContainer,
-  InternalStateContainer,
 } from './discover_internal_state_container';
 import { DiscoverServices } from '../../../build_services';
 interface DiscoverStateContainerParams {
@@ -64,7 +64,7 @@ export interface DiscoverStateContainer {
   /**
    * Internal state that's used at several places in the UI
    */
-  internalState: InternalStateContainer;
+  internalState: DiscoverInternalStateContainer;
   /**
    * Service for handling search sessions
    */

--- a/src/plugins/discover/public/application/main/services/discover_state.ts
+++ b/src/plugins/discover/public/application/main/services/discover_state.ts
@@ -23,11 +23,11 @@ import {
 import { DataView } from '@kbn/data-views-plugin/public';
 import { SavedSearch } from '@kbn/saved-search-plugin/public';
 import { loadDataView, resolveDataView } from '../utils/resolve_data_view';
-import { DataStateContainer, getDataStateContainer } from './discover_data_state_container';
+import { DiscoverDataStateContainer, getDataStateContainer } from './discover_data_state_container';
 import { DiscoverSearchSessionManager } from './discover_search_session';
 import { DISCOVER_APP_LOCATOR, DiscoverAppLocatorParams } from '../../../../common';
 import {
-  AppState,
+  DiscoverAppState,
   DiscoverAppStateContainer,
   getDiscoverAppStateContainer,
   GLOBAL_STATE_URL_KEY,
@@ -72,7 +72,7 @@ export interface DiscoverStateContainer {
   /**
    * Data fetching related state
    **/
-  dataState: DataStateContainer;
+  dataState: DiscoverDataStateContainer;
   /**
    * functions executed by UI
    */
@@ -233,7 +233,7 @@ export function getDiscoverStateContainer({
 }
 
 export function createSearchSessionRestorationDataProvider(deps: {
-  appStateContainer: StateContainer<AppState>;
+  appStateContainer: StateContainer<DiscoverAppState>;
   data: DataPublicPluginStart;
   getSavedSearch: () => SavedSearch;
 }): SearchSessionInfoProvider {
@@ -272,7 +272,7 @@ function createUrlGeneratorState({
   getSavedSearchId,
   shouldRestoreSearchSession,
 }: {
-  appStateContainer: StateContainer<AppState>;
+  appStateContainer: StateContainer<DiscoverAppState>;
   data: DataPublicPluginStart;
   getSavedSearchId: () => string | undefined;
   shouldRestoreSearchSession: boolean;

--- a/src/plugins/discover/public/application/main/utils/cleanup_url_state.ts
+++ b/src/plugins/discover/public/application/main/utils/cleanup_url_state.ts
@@ -6,14 +6,14 @@
  * Side Public License, v 1.
  */
 import { isOfAggregateQueryType } from '@kbn/es-query';
-import { AppState, AppStateUrl } from '../services/discover_app_state_container';
+import { DiscoverAppState, AppStateUrl } from '../services/discover_app_state_container';
 import { migrateLegacyQuery } from '../../../utils/migrate_legacy_query';
 
 /**
  * Takes care of the given url state, migrates legacy props and cleans up empty props
  * @param appStateFromUrl
  */
-export function cleanupUrlState(appStateFromUrl: AppStateUrl): AppState {
+export function cleanupUrlState(appStateFromUrl: AppStateUrl): DiscoverAppState {
   if (
     appStateFromUrl &&
     appStateFromUrl.query &&
@@ -46,5 +46,5 @@ export function cleanupUrlState(appStateFromUrl: AppStateUrl): AppState {
     delete appStateFromUrl.rowsPerPage;
   }
 
-  return appStateFromUrl as AppState;
+  return appStateFromUrl as DiscoverAppState;
 }

--- a/src/plugins/discover/public/application/main/utils/fetch_all.test.ts
+++ b/src/plugins/discover/public/application/main/utils/fetch_all.test.ts
@@ -26,7 +26,7 @@ import { fetchDocuments } from './fetch_documents';
 import { fetchSql } from './fetch_sql';
 import { buildDataTableRecord } from '../../../utils/build_data_record';
 import { dataViewMock } from '../../../__mocks__/data_view';
-import { AppState } from '../services/discover_app_state_container';
+import { DiscoverAppState } from '../services/discover_app_state_container';
 
 jest.mock('./fetch_documents', () => ({
   fetchDocuments: jest.fn().mockResolvedValue([]),
@@ -70,7 +70,7 @@ describe('test fetchAll', () => {
         getState: () => {
           return { interval: 'auto' };
         },
-      } as ReduxLikeStateContainer<AppState>,
+      } as ReduxLikeStateContainer<DiscoverAppState>,
       abortController: new AbortController(),
       data: discoverServiceMock.data,
       inspectorAdapters: { requests: new RequestAdapter() },
@@ -258,7 +258,7 @@ describe('test fetchAll', () => {
         getState: () => {
           return { interval: 'auto', query };
         },
-      } as unknown as ReduxLikeStateContainer<AppState>,
+      } as unknown as ReduxLikeStateContainer<DiscoverAppState>,
       abortController: new AbortController(),
       data: discoverServiceMock.data,
       inspectorAdapters: { requests: new RequestAdapter() },

--- a/src/plugins/discover/public/application/main/utils/fetch_all.ts
+++ b/src/plugins/discover/public/application/main/utils/fetch_all.ts
@@ -10,7 +10,7 @@ import { Adapters } from '@kbn/inspector-plugin/common';
 import { ReduxLikeStateContainer } from '@kbn/kibana-utils-plugin/common';
 import type { SavedSearch, SortOrder } from '@kbn/saved-search-plugin/public';
 import { BehaviorSubject, filter, firstValueFrom, map, merge, scan } from 'rxjs';
-import { AppState } from '../services/discover_app_state_container';
+import { DiscoverAppState } from '../services/discover_app_state_container';
 import { getRawRecordType } from './get_raw_record_type';
 import {
   checkHitCount,
@@ -29,7 +29,7 @@ import { fetchSql } from './fetch_sql';
 
 export interface FetchDeps {
   abortController: AbortController;
-  appStateContainer: ReduxLikeStateContainer<AppState>;
+  appStateContainer: ReduxLikeStateContainer<DiscoverAppState>;
   data: DataPublicPluginStart;
   initialFetchStatus: FetchStatus;
   inspectorAdapters: Adapters;

--- a/src/plugins/discover/public/application/main/utils/get_state_defaults.ts
+++ b/src/plugins/discover/public/application/main/utils/get_state_defaults.ts
@@ -10,7 +10,7 @@ import { cloneDeep, isEqual } from 'lodash';
 import { IUiSettingsClient } from '@kbn/core/public';
 import { SavedSearch } from '@kbn/saved-search-plugin/public';
 import { getChartHidden } from '@kbn/unified-histogram-plugin/public';
-import { AppState } from '../services/discover_app_state_container';
+import { DiscoverAppState } from '../services/discover_app_state_container';
 import { DiscoverServices } from '../../../build_services';
 import { getDefaultSort, getSortArray } from '../../../utils/sorting';
 import {
@@ -49,7 +49,7 @@ export function getStateDefaults({
   const columns = getDefaultColumns(savedSearch, uiSettings);
   const chartHidden = getChartHidden(storage, 'discover');
 
-  const defaultState: AppState = {
+  const defaultState: DiscoverAppState = {
     query,
     sort: !sort.length
       ? getDefaultSort(
@@ -61,7 +61,7 @@ export function getStateDefaults({
     columns,
     index: dataView?.id,
     interval: 'auto',
-    filters: cloneDeep(searchSource.getOwnField('filter')) as AppState['filters'],
+    filters: cloneDeep(searchSource.getOwnField('filter')) as DiscoverAppState['filters'],
     hideChart: typeof chartHidden === 'boolean' ? chartHidden : undefined,
     viewMode: undefined,
     hideAggregatedPreview: undefined,

--- a/src/plugins/discover/public/application/main/utils/persist_saved_search.ts
+++ b/src/plugins/discover/public/application/main/utils/persist_saved_search.ts
@@ -9,7 +9,7 @@ import { isOfAggregateQueryType } from '@kbn/es-query';
 import { DataView } from '@kbn/data-views-plugin/public';
 import { SavedObjectSaveOpts } from '@kbn/saved-objects-plugin/public';
 import { SavedSearch, SortOrder, saveSavedSearch } from '@kbn/saved-search-plugin/public';
-import { AppState } from '../services/discover_app_state_container';
+import { DiscoverAppState } from '../services/discover_app_state_container';
 import { updateSearchSource } from './update_search_source';
 import { DiscoverServices } from '../../../build_services';
 /**
@@ -30,7 +30,7 @@ export async function persistSavedSearch(
     onSuccess: (id: string) => void;
     saveOptions: SavedObjectSaveOpts;
     services: DiscoverServices;
-    state: AppState;
+    state: DiscoverAppState;
   }
 ) {
   updateSearchSource(savedSearch.searchSource, true, {

--- a/src/plugins/discover/public/components/doc_table/actions/columns.test.ts
+++ b/src/plugins/discover/public/components/doc_table/actions/columns.test.ts
@@ -11,9 +11,12 @@ import { configMock } from '../../../__mocks__/config';
 import { dataViewMock } from '../../../__mocks__/data_view';
 import { dataViewsMock } from '../../../__mocks__/data_views';
 import { Capabilities } from '@kbn/core/types';
-import { AppState } from '../../../application/main/services/discover_app_state_container';
+import { DiscoverAppState } from '../../../application/main/services/discover_app_state_container';
 
-function getStateColumnAction(state: AppState, setAppState: (state: Partial<AppState>) => void) {
+function getStateColumnAction(
+  state: DiscoverAppState,
+  setAppState: (state: Partial<DiscoverAppState>) => void
+) {
   return getStateColumnActions({
     capabilities: {
       discover: {

--- a/src/plugins/discover/public/utils/get_sharing_data.ts
+++ b/src/plugins/discover/public/utils/get_sharing_data.ts
@@ -16,7 +16,7 @@ import type {
 import type { Filter } from '@kbn/es-query';
 import type { SavedSearch, SortOrder } from '@kbn/saved-search-plugin/public';
 import {
-  AppState,
+  DiscoverAppState,
   isEqualFilters,
 } from '../application/main/services/discover_app_state_container';
 import { getSortForSearchSource } from './sorting';
@@ -31,7 +31,7 @@ import {
  */
 export async function getSharingData(
   currentSearchSource: ISearchSource,
-  state: AppState | SavedSearch,
+  state: DiscoverAppState | SavedSearch,
   services: { uiSettings: IUiSettingsClient; data: DataPublicPluginStart }
 ) {
   const { uiSettings: config, data } = services;


### PR DESCRIPTION
## Summary

This PR migrates the stateful `expandedDoc` property (It determines which ES document should be displayed in the flyout showing he doc viewer, and needs to be closed when e.g. the inspector is displayed) to the `internalStateContainer`, one less `useState` based prop left that needs to be passed down the component tree.

Additionally `AppState` is renamed to `DiscoverAppState`,  `DataStateContainer` to `DiscoverDataStateContainer` and `InternalStateContainer` to `DiscoverInternalStateContainer` for better consistency of naming and easier autocompletion when developing


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
