### PR TITLE
[Synthetics] Fix data view loading for exp view on initial load

### DIFF
--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/embeddable/use_app_data_view.ts
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/embeddable/use_app_data_view.ts
@@ -5,10 +5,14 @@
  * 2.0.
  */
 
-import { useCallback, useEffect, useState } from 'react';
+import { useState } from 'react';
 import { DataView } from '@kbn/data-views-plugin/common';
 import { useLocalDataView } from './use_local_data_view';
-import type { ExploratoryEmbeddableProps, ObservabilityPublicPluginsStart } from '../../../..';
+import {
+  ExploratoryEmbeddableProps,
+  ObservabilityPublicPluginsStart,
+  useFetcher,
+} from '../../../..';
 import type { DataViewState } from '../hooks/use_app_data_view';
 import type { AppDataType } from '../types';
 import { ObservabilityDataViews } from '../../../../utils/observability_data_views/observability_data_views';
@@ -28,42 +32,24 @@ export const useAppDataView = ({
   dataTypesIndexPatterns: ExploratoryEmbeddableProps['dataTypesIndexPatterns'];
 }) => {
   const [dataViews, setDataViews] = useState<DataViewState>({} as DataViewState);
-  const [loading, setLoading] = useState(false);
-
   const { dataViewTitle } = useLocalDataView(seriesDataType, dataTypesIndexPatterns);
 
-  const loadIndexPattern = useCallback(
-    async ({ dataType }: { dataType: AppDataType }) => {
-      setLoading(true);
-      try {
-        if (dataViewTitle) {
-          if (dataViewCache[dataViewTitle]) {
-            setDataViews((prevState) => ({
-              ...(prevState ?? {}),
-              [dataType]: dataViewCache[dataViewTitle],
-            }));
-          } else {
-            const obsvIndexP = new ObservabilityDataViews(dataViewsService, true);
-            const indPattern = await obsvIndexP.getDataView(dataType, dataViewTitle);
-            dataViewCache[dataViewTitle] = indPattern!;
-            setDataViews((prevState) => ({ ...(prevState ?? {}), [dataType]: indPattern }));
-          }
-
-          setLoading(false);
-        }
-      } catch (e) {
-        setLoading(false);
+  const { loading } = useFetcher(async () => {
+    if (dataViewTitle && !dataViews[seriesDataType]) {
+      if (dataViewCache[dataViewTitle]) {
+        setDataViews((prevState) => ({
+          ...(prevState ?? {}),
+          [seriesDataType]: dataViewCache[dataViewTitle],
+        }));
+      } else {
+        const obsvIndexP = new ObservabilityDataViews(dataViewsService, true);
+        const indPattern = await obsvIndexP.getDataView(seriesDataType, dataViewTitle);
+        dataViewCache[dataViewTitle] = indPattern!;
+        setDataViews((prevState) => ({ ...(prevState ?? {}), [seriesDataType]: indPattern }));
       }
-    },
-    [dataViewCache, dataViewTitle, dataViewsService]
-  );
-
-  useEffect(() => {
-    if (seriesDataType && !loading && !dataViews[seriesDataType]) {
-      loadIndexPattern({ dataType: seriesDataType });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [dataViewTitle, seriesDataType, loadIndexPattern, JSON.stringify(series)]);
+  }, [dataViewTitle, seriesDataType, JSON.stringify(series)]);
 
   return { dataViews, loading };
 };


### PR DESCRIPTION
## Summary

Fix data view loading for exp view on initial load

### After
Delete local storage and load the details page, it should load all the content on page
<img width="1787" alt="image" src="https://user-images.githubusercontent.com/3505601/226653915-b8043bb4-eed9-4f36-87bd-38833c78589f.png">



### Before
Delete all local storage and load the monitor details page , page will remain in loading state, this only happens on first time. if you load the page again. it should be fine.
<img width="1782" alt="image" src="https://user-images.githubusercontent.com/3505601/226653561-371a1974-699a-40c1-8db9-d20663cff69b.png">


<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->