### PR TITLE
[Fleet] Generate time_serie_dimension for any fields with dimension:true

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/mappings.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/mappings.ts
@@ -58,7 +58,6 @@ export function keyword(field: Field): Properties {
     fieldProps.normalizer = field.normalizer;
   }
   if (field.dimension) {
-    fieldProps.time_series_dimension = field.dimension;
     delete fieldProps.ignore_above;
   }
 

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.test.ts
@@ -802,7 +802,7 @@ describe('EPM template', () => {
     expect(JSON.stringify(mappings)).toEqual(JSON.stringify(constantKeywordMapping));
   });
 
-  it('tests processing dimension field', () => {
+  it('tests processing dimension field on a keyword', () => {
     const literalYml = `
 - name: example.id
   type: keyword
@@ -822,7 +822,60 @@ describe('EPM template', () => {
     };
     const fields: Field[] = safeLoad(literalYml);
     const processedFields = processFields(fields);
-    const mappings = generateMappings(processedFields);
+    const mappings = generateMappings(processedFields, {
+      isIndexModeTimeSeries: true,
+    });
+    expect(mappings).toEqual(expectedMapping);
+  });
+
+  it('tests processing dimension field on an long', () => {
+    const literalYml = `
+- name: example.id
+  type: long
+  dimension: true
+  `;
+    const expectedMapping = {
+      properties: {
+        example: {
+          properties: {
+            id: {
+              time_series_dimension: true,
+              type: 'long',
+            },
+          },
+        },
+      },
+    };
+    const fields: Field[] = safeLoad(literalYml);
+    const processedFields = processFields(fields);
+    const mappings = generateMappings(processedFields, {
+      isIndexModeTimeSeries: true,
+    });
+    expect(mappings).toEqual(expectedMapping);
+  });
+
+  it('tests processing dimension field on an long without timeserie enabled', () => {
+    const literalYml = `
+- name: example.id
+  type: long
+  dimension: true
+  `;
+    const expectedMapping = {
+      properties: {
+        example: {
+          properties: {
+            id: {
+              type: 'long',
+            },
+          },
+        },
+      },
+    };
+    const fields: Field[] = safeLoad(literalYml);
+    const processedFields = processFields(fields);
+    const mappings = generateMappings(processedFields, {
+      isIndexModeTimeSeries: false,
+    });
     expect(mappings).toEqual(expectedMapping);
   });
 

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.ts
@@ -347,6 +347,9 @@ function _generateMappings(
         if (options?.isIndexModeTimeSeries && 'metric_type' in field) {
           fieldProps.time_series_metric = field.metric_type;
         }
+        if (options?.isIndexModeTimeSeries && field.dimension) {
+          fieldProps.time_series_dimension = field.dimension;
+        }
 
         props[field.name] = fieldProps;
         hasNonDynamicTemplateMappings = true;


### PR DESCRIPTION
## Summary

Resolve #153220 

Fleet code was only setting `time_series_dimension` for keyword field, that PR fix that by settings it for any fields with `dimension:true`

I choose to implement this as we implement `time_series_metric` and to only generate that mapping if TSDB is enabled for that template.

## Tests

That code is cover by unit test

<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->