### PR TITLE
Fix the `CaseViewPage` flaky test

### DIFF
--- a/x-pack/plugins/cases/public/components/case_view/case_view_page.test.tsx
+++ b/x-pack/plugins/cases/public/components/case_view/case_view_page.test.tsx
@@ -111,601 +111,607 @@ export const caseClosedProps: CaseViewPageProps = {
   caseData: basicCaseClosed,
 };
 
-describe('CaseViewPage', () => {
-  // eslint-disable-next-line prefer-object-spread
-  const originalGetComputedStyle = Object.assign({}, window.getComputedStyle);
+for (let index = 0; index < 50; index++) {
+  describe('CaseViewPage', () => {
+    // eslint-disable-next-line prefer-object-spread
+    const originalGetComputedStyle = Object.assign({}, window.getComputedStyle);
 
-  beforeAll(() => {
-    // The JSDOM implementation is too slow
-    // Especially for dropdowns that try to position themselves
-    // perf issue - https://github.com/jsdom/jsdom/issues/3234
-    Object.defineProperty(window, 'getComputedStyle', {
-      value: (el: HTMLElement) => {
-        /**
-         * This is based on the jsdom implementation of getComputedStyle
-         * https://github.com/jsdom/jsdom/blob/9dae17bf0ad09042cfccd82e6a9d06d3a615d9f4/lib/jsdom/browser/Window.js#L779-L820
-         *
-         * It is missing global style parsing and will only return styles applied directly to an element.
-         * Will not return styles that are global or from emotion
-         */
-        const declaration = new CSSStyleDeclaration();
-        const { style } = el;
+    beforeAll(() => {
+      // The JSDOM implementation is too slow
+      // Especially for dropdowns that try to position themselves
+      // perf issue - https://github.com/jsdom/jsdom/issues/3234
+      Object.defineProperty(window, 'getComputedStyle', {
+        value: (el: HTMLElement) => {
+          /**
+           * This is based on the jsdom implementation of getComputedStyle
+           * https://github.com/jsdom/jsdom/blob/9dae17bf0ad09042cfccd82e6a9d06d3a615d9f4/lib/jsdom/browser/Window.js#L779-L820
+           *
+           * It is missing global style parsing and will only return styles applied directly to an element.
+           * Will not return styles that are global or from emotion
+           */
+          const declaration = new CSSStyleDeclaration();
+          const { style } = el;
 
-        Array.prototype.forEach.call(style, (property: string) => {
-          declaration.setProperty(
-            property,
-            style.getPropertyValue(property),
-            style.getPropertyPriority(property)
-          );
-        });
+          Array.prototype.forEach.call(style, (property: string) => {
+            declaration.setProperty(
+              property,
+              style.getPropertyValue(property),
+              style.getPropertyPriority(property)
+            );
+          });
 
-        return declaration;
-      },
-      configurable: true,
-      writable: true,
-    });
-  });
-
-  afterAll(() => {
-    Object.defineProperty(window, 'getComputedStyle', originalGetComputedStyle);
-  });
-
-  const updateCaseProperty = defaultUpdateCaseState.updateCaseProperty;
-  const pushCaseToExternalService = jest.fn();
-  const data = caseProps.caseData;
-  let appMockRenderer: AppMockRenderer;
-  const caseConnectors = getCaseConnectorsMockResponse();
-  const caseUsers = getCaseUsersMockResponse();
-  const refetchFindCaseUserActions = jest.fn();
-
-  beforeEach(() => {
-    mockGetCase();
-    jest.clearAllMocks();
-    useUpdateCaseMock.mockReturnValue(defaultUpdateCaseState);
-    useGetCaseMetricsMock.mockReturnValue(defaultGetCaseMetrics);
-    useFindCaseUserActionsMock.mockReturnValue(defaultUseFindCaseUserActions);
-    usePostPushToServiceMock.mockReturnValue({ isLoading: false, pushCaseToExternalService });
-    useGetCaseConnectorsMock.mockReturnValue({
-      isLoading: false,
-      data: caseConnectors,
-    });
-    useGetConnectorsMock.mockReturnValue({ data: connectorsMock, isLoading: false });
-    useGetTagsMock.mockReturnValue({ data: [], isLoading: false });
-    const license = licensingMock.createLicense({
-      license: { type: 'platinum' },
-    });
-    useGetCaseUsersMock.mockReturnValue({ isLoading: false, data: caseUsers });
-
-    appMockRenderer = createAppMockRenderer({ license });
-  });
-
-  it('should render CaseViewPage', async () => {
-    const damagedRaccoonUser = userProfiles[0].user;
-    const caseDataWithDamagedRaccoon = {
-      ...caseData,
-      createdBy: {
-        profileUid: userProfiles[0].uid,
-        username: damagedRaccoonUser.username,
-        fullName: damagedRaccoonUser.full_name,
-        email: damagedRaccoonUser.email,
-      },
-    };
-
-    const license = licensingMock.createLicense({
-      license: { type: 'platinum' },
-    });
-
-    const props = { ...caseProps, caseData: caseDataWithDamagedRaccoon };
-    appMockRenderer = createAppMockRenderer({ features: { metrics: ['alerts.count'] }, license });
-    const result = appMockRenderer.render(<CaseViewPage {...props} />);
-
-    expect(result.getByTestId('header-page-title')).toHaveTextContent(data.title);
-    expect(result.getByTestId('case-view-status-dropdown')).toHaveTextContent('Open');
-    expect(result.getByTestId('case-view-metrics-panel')).toBeInTheDocument();
-    expect(
-      within(result.getByTestId('case-view-tag-list')).getByTestId('tag-coke')
-    ).toHaveTextContent(data.tags[0]);
-
-    expect(
-      within(result.getByTestId('case-view-tag-list')).getByTestId('tag-pepsi')
-    ).toHaveTextContent(data.tags[1]);
-
-    expect(result.getAllByText(data.createdBy.fullName!)[0]).toBeInTheDocument();
-
-    expect(
-      within(result.getByTestId('description-action')).getByTestId('user-action-markdown')
-    ).toHaveTextContent(data.description);
-
-    expect(result.getByTestId('case-view-status-action-button')).toHaveTextContent(
-      'Mark in progress'
-    );
-  });
-
-  it('should show closed indicators in header when case is closed', async () => {
-    useUpdateCaseMock.mockImplementation(() => ({
-      ...defaultUpdateCaseState,
-      caseData: basicCaseClosed,
-    }));
-
-    const result = appMockRenderer.render(<CaseViewPage {...caseClosedProps} />);
-
-    expect(result.getByTestId('case-view-status-dropdown')).toHaveTextContent('Closed');
-  });
-
-  it('should update status', async () => {
-    const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
-
-    const dropdown = result.getByTestId('case-view-status-dropdown');
-    userEvent.click(dropdown.querySelector('button')!, undefined, { skipPointerEventsCheck: true });
-    await waitForEuiPopoverOpen();
-    userEvent.click(result.getByTestId('case-view-status-dropdown-closed'), undefined, {
-      skipPointerEventsCheck: true,
-    });
-    const updateObject = updateCaseProperty.mock.calls[0][0];
-
-    await waitFor(() => {
-      expect(updateCaseProperty).toHaveBeenCalledTimes(1);
-      expect(updateObject.updateKey).toEqual('status');
-      expect(updateObject.updateValue).toEqual('closed');
-    });
-  });
-
-  it('should display EditableTitle isLoading', async () => {
-    useUpdateCaseMock.mockImplementation(() => ({
-      ...defaultUpdateCaseState,
-      isLoading: true,
-      updateKey: 'title',
-    }));
-    const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
-
-    await waitFor(() => {
-      expect(result.getByTestId('editable-title-loading')).toBeInTheDocument();
-      expect(result.queryByTestId('editable-title-edit-icon')).not.toBeInTheDocument();
-    });
-  });
-
-  it('should display tags isLoading', async () => {
-    useUpdateCaseMock.mockImplementation(() => ({
-      ...defaultUpdateCaseState,
-      isLoading: true,
-      updateKey: 'tags',
-    }));
-
-    const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
-
-    await waitFor(() => {
-      expect(
-        within(result.getByTestId('case-view-tag-list')).getByTestId('tag-list-loading')
-      ).toBeInTheDocument();
-    });
-
-    await waitFor(() => {
-      expect(result.queryByTestId('tag-list-edit')).not.toBeInTheDocument();
-    });
-  });
-
-  it('should update title', async () => {
-    const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
-    const newTitle = 'The new title';
-    userEvent.click(result.getByTestId('editable-title-edit-icon'), undefined, {
-      skipPointerEventsCheck: true,
-    });
-    userEvent.clear(result.getByTestId('editable-title-input-field'));
-    userEvent.paste(result.getByTestId('editable-title-input-field'), newTitle);
-    userEvent.click(result.getByTestId('editable-title-submit-btn'), undefined, {
-      skipPointerEventsCheck: true,
-    });
-
-    const updateObject = updateCaseProperty.mock.calls[0][0];
-    await waitFor(() => {
-      expect(updateObject.updateKey).toEqual('title');
-      expect(updateObject.updateValue).toEqual(newTitle);
-    });
-  });
-
-  it('should push updates on button click', async () => {
-    useGetCaseConnectorsMock.mockImplementation(() => ({
-      isLoading: false,
-      data: {
-        ...caseConnectors,
-        'resilient-2': {
-          ...caseConnectors['resilient-2'],
-          push: { ...caseConnectors['resilient-2'].push, needsToBePushed: true },
+          return declaration;
         },
-      },
-    }));
-
-    const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
-
-    expect(result.getByTestId('push-to-external-service')).toBeInTheDocument();
-
-    userEvent.click(result.getByTestId('push-to-external-service'), undefined, {
-      skipPointerEventsCheck: true,
-    });
-
-    await waitFor(() => {
-      expect(pushCaseToExternalService).toHaveBeenCalled();
-    });
-  });
-
-  it('should disable the push button when connector is invalid', async () => {
-    const result = appMockRenderer.render(
-      <CaseViewPage
-        {...{
-          ...caseProps,
-          caseData: { ...caseProps.caseData, connectorId: 'not-exist' },
-        }}
-      />
-    );
-    await waitFor(() => {
-      expect(result.getByTestId('push-to-external-service')).toBeDisabled();
-    });
-  });
-
-  it('should update connector', async () => {
-    const result = appMockRenderer.render(
-      <CaseViewPage
-        {...caseProps}
-        caseData={{
-          ...caseProps.caseData,
-          connector: {
-            id: 'servicenow-1',
-            name: 'SN 1',
-            type: ConnectorTypes.serviceNowITSM,
-            fields: null,
-          },
-        }}
-      />
-    );
-    userEvent.click(result.getByTestId('connector-edit').querySelector('button')!, undefined, {
-      skipPointerEventsCheck: true,
-    });
-    userEvent.click(result.getByTestId('dropdown-connectors'), undefined, {
-      skipPointerEventsCheck: true,
-    });
-    await waitForEuiPopoverOpen();
-    userEvent.click(result.getByTestId('dropdown-connector-resilient-2'), undefined, {
-      skipPointerEventsCheck: true,
-    });
-
-    await waitFor(() => {
-      expect(result.getByTestId('connector-fields-resilient')).toBeInTheDocument();
-    });
-
-    userEvent.click(result.getByTestId('edit-connectors-submit'), undefined, {
-      skipPointerEventsCheck: true,
-    });
-
-    await waitFor(() => {
-      expect(updateCaseProperty).toHaveBeenCalledTimes(1);
-      const updateObject = updateCaseProperty.mock.calls[0][0];
-      expect(updateObject.updateKey).toEqual('connector');
-      expect(updateObject.updateValue).toEqual({
-        id: 'resilient-2',
-        name: 'My Resilient connector',
-        type: ConnectorTypes.resilient,
-        fields: {
-          incidentTypes: null,
-          severityCode: null,
-        },
+        configurable: true,
+        writable: true,
       });
     });
-  });
 
-  it('should call onComponentInitialized on mount', async () => {
-    const onComponentInitialized = jest.fn();
-    appMockRenderer.render(
-      <CaseViewPage {...caseProps} onComponentInitialized={onComponentInitialized} />
-    );
-
-    await waitFor(() => {
-      expect(onComponentInitialized).toHaveBeenCalled();
-    });
-  });
-
-  it('should show loading content when loading user actions', async () => {
-    const useFetchAlertData = jest.fn().mockReturnValue([true]);
-    useFindCaseUserActionsMock.mockReturnValue({
-      data: undefined,
-      isError: false,
-      isLoading: true,
-      isFetching: true,
-      refetch: refetchFindCaseUserActions,
+    afterAll(() => {
+      Object.defineProperty(window, 'getComputedStyle', originalGetComputedStyle);
     });
 
-    const result = appMockRenderer.render(
-      <CaseViewPage {...caseProps} useFetchAlertData={useFetchAlertData} />
-    );
-    await waitFor(() => {
-      expect(result.getByTestId('case-view-loading-content')).toBeInTheDocument();
-      expect(result.queryByTestId('user-actions')).not.toBeInTheDocument();
+    const updateCaseProperty = defaultUpdateCaseState.updateCaseProperty;
+    const pushCaseToExternalService = jest.fn();
+    const data = caseProps.caseData;
+    let appMockRenderer: AppMockRenderer;
+    const caseConnectors = getCaseConnectorsMockResponse();
+    const caseUsers = getCaseUsersMockResponse();
+    const refetchFindCaseUserActions = jest.fn();
+
+    beforeEach(() => {
+      mockGetCase();
+      jest.clearAllMocks();
+      useUpdateCaseMock.mockReturnValue(defaultUpdateCaseState);
+      useGetCaseMetricsMock.mockReturnValue(defaultGetCaseMetrics);
+      useFindCaseUserActionsMock.mockReturnValue(defaultUseFindCaseUserActions);
+      usePostPushToServiceMock.mockReturnValue({ isLoading: false, pushCaseToExternalService });
+      useGetCaseConnectorsMock.mockReturnValue({
+        isLoading: false,
+        data: caseConnectors,
+      });
+      useGetConnectorsMock.mockReturnValue({ data: connectorsMock, isLoading: false });
+      useGetTagsMock.mockReturnValue({ data: [], isLoading: false });
+      const license = licensingMock.createLicense({
+        license: { type: 'platinum' },
+      });
+      useGetCaseUsersMock.mockReturnValue({ isLoading: false, data: caseUsers });
+
+      appMockRenderer = createAppMockRenderer({ license });
     });
-  });
 
-  it('should call show alert details with expected arguments', async () => {
-    const showAlertDetails = jest.fn();
-    const result = appMockRenderer.render(
-      <CaseViewPage {...caseProps} showAlertDetails={showAlertDetails} />
-    );
+    it('should render CaseViewPage', async () => {
+      const damagedRaccoonUser = userProfiles[0].user;
+      const caseDataWithDamagedRaccoon = {
+        ...caseData,
+        createdBy: {
+          profileUid: userProfiles[0].uid,
+          username: damagedRaccoonUser.username,
+          fullName: damagedRaccoonUser.full_name,
+          email: damagedRaccoonUser.email,
+        },
+      };
 
-    userEvent.click(result.getByTestId('comment-action-show-alert-alert-action-id'), undefined, {
-      skipPointerEventsCheck: true,
-    });
+      const license = licensingMock.createLicense({
+        license: { type: 'platinum' },
+      });
 
-    await waitFor(() => {
-      expect(showAlertDetails).toHaveBeenCalledWith('alert-id-1', 'alert-index-1');
-    });
-  });
+      const props = { ...caseProps, caseData: caseDataWithDamagedRaccoon };
+      appMockRenderer = createAppMockRenderer({ features: { metrics: ['alerts.count'] }, license });
+      const result = appMockRenderer.render(<CaseViewPage {...props} />);
 
-  it('should show the rule name', async () => {
-    const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
-
-    await waitFor(() => {
+      expect(result.getByTestId('header-page-title')).toHaveTextContent(data.title);
+      expect(result.getByTestId('case-view-status-dropdown')).toHaveTextContent('Open');
+      expect(result.getByTestId('case-view-metrics-panel')).toBeInTheDocument();
       expect(
-        result
-          .getByTestId('user-action-alert-comment-create-action-alert-action-id')
-          .querySelector('.euiCommentEvent__headerEvent')
-      ).toHaveTextContent('added an alert from Awesome rule');
-    });
-  });
+        within(result.getByTestId('case-view-tag-list')).getByTestId('tag-coke')
+      ).toHaveTextContent(data.tags[0]);
 
-  it('should update settings', async () => {
-    const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
-    userEvent.click(result.getByTestId('sync-alerts-switch'), undefined, {
-      skipPointerEventsCheck: true,
-    });
-    const updateObject = updateCaseProperty.mock.calls[0][0];
+      expect(
+        within(result.getByTestId('case-view-tag-list')).getByTestId('tag-pepsi')
+      ).toHaveTextContent(data.tags[1]);
 
-    await waitFor(() => {
-      expect(updateObject.updateKey).toEqual('settings');
-      expect(updateObject.updateValue).toEqual({ syncAlerts: false });
-    });
-  });
+      expect(result.getAllByText(data.createdBy.fullName!)[0]).toBeInTheDocument();
 
-  it('should show the correct connector name on the push button', async () => {
-    useGetConnectorsMock.mockImplementation(() => ({ data: connectorsMock, isLoading: false }));
+      expect(
+        within(result.getByTestId('description-action')).getByTestId('user-action-markdown')
+      ).toHaveTextContent(data.description);
 
-    const result = appMockRenderer.render(
-      <CaseViewPage {...{ ...caseProps, connector: { ...caseProps, name: 'old-name' } }} />
-    );
-
-    await waitFor(() => {
-      expect(result.getByTestId('push-to-external-service')).toHaveTextContent(
-        'My Resilient connector'
+      expect(result.getByTestId('case-view-status-action-button')).toHaveTextContent(
+        'Mark in progress'
       );
     });
-  });
 
-  describe('Callouts', () => {
-    it('it shows the danger callout when a connector has been deleted', async () => {
-      useGetConnectorsMock.mockImplementation(() => ({ data: [], isLoading: false }));
-      const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
+    it('should show closed indicators in header when case is closed', async () => {
+      useUpdateCaseMock.mockImplementation(() => ({
+        ...defaultUpdateCaseState,
+        caseData: basicCaseClosed,
+      }));
 
-      expect(result.container.querySelector('.euiCallOut--danger')).toBeInTheDocument();
+      const result = appMockRenderer.render(<CaseViewPage {...caseClosedProps} />);
+
+      expect(result.getByTestId('case-view-status-dropdown')).toHaveTextContent('Closed');
     });
 
-    it('it does NOT shows the danger callout when connectors are loading', async () => {
-      useGetConnectorsMock.mockImplementation(() => ({ data: [], isLoading: true }));
+    it('should update status', async () => {
       const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
 
-      expect(result.container.querySelector('.euiCallOut--danger')).not.toBeInTheDocument();
-    });
-  });
+      const dropdown = result.getByTestId('case-view-status-dropdown');
+      userEvent.click(dropdown.querySelector('button')!, undefined, {
+        skipPointerEventsCheck: true,
+      });
+      await waitForEuiPopoverOpen();
+      userEvent.click(result.getByTestId('case-view-status-dropdown-closed'), undefined, {
+        skipPointerEventsCheck: true,
+      });
+      const updateObject = updateCaseProperty.mock.calls[0][0];
 
-  describe('Tabs', () => {
-    jest.mock('@kbn/kibana-react-plugin/public', () => ({
-      useKibana: () => ({
-        services: {
-          application: {
-            capabilities: {
-              fakeCases: {
-                create_cases: true,
-                read_cases: true,
-                update_cases: true,
-                delete_cases: true,
-                push_cases: true,
+      await waitFor(() => {
+        expect(updateCaseProperty).toHaveBeenCalledTimes(1);
+        expect(updateObject.updateKey).toEqual('status');
+        expect(updateObject.updateValue).toEqual('closed');
+      });
+    });
+
+    it('should display EditableTitle isLoading', async () => {
+      useUpdateCaseMock.mockImplementation(() => ({
+        ...defaultUpdateCaseState,
+        isLoading: true,
+        updateKey: 'title',
+      }));
+      const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
+
+      await waitFor(() => {
+        expect(result.getByTestId('editable-title-loading')).toBeInTheDocument();
+        expect(result.queryByTestId('editable-title-edit-icon')).not.toBeInTheDocument();
+      });
+    });
+
+    it('should display tags isLoading', async () => {
+      useUpdateCaseMock.mockImplementation(() => ({
+        ...defaultUpdateCaseState,
+        isLoading: true,
+        updateKey: 'tags',
+      }));
+
+      const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
+
+      await waitFor(() => {
+        expect(
+          within(result.getByTestId('case-view-tag-list')).getByTestId('tag-list-loading')
+        ).toBeInTheDocument();
+      });
+
+      await waitFor(() => {
+        expect(result.queryByTestId('tag-list-edit')).not.toBeInTheDocument();
+      });
+    });
+
+    it('should update title', async () => {
+      const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
+      const newTitle = 'The new title';
+      userEvent.click(result.getByTestId('editable-title-edit-icon'), undefined, {
+        skipPointerEventsCheck: true,
+      });
+      userEvent.clear(result.getByTestId('editable-title-input-field'));
+      userEvent.paste(result.getByTestId('editable-title-input-field'), newTitle);
+      userEvent.click(result.getByTestId('editable-title-submit-btn'), undefined, {
+        skipPointerEventsCheck: true,
+      });
+
+      const updateObject = updateCaseProperty.mock.calls[0][0];
+      await waitFor(() => {
+        expect(updateObject.updateKey).toEqual('title');
+        expect(updateObject.updateValue).toEqual(newTitle);
+      });
+    });
+
+    it('should push updates on button click', async () => {
+      useGetCaseConnectorsMock.mockImplementation(() => ({
+        isLoading: false,
+        data: {
+          ...caseConnectors,
+          'resilient-2': {
+            ...caseConnectors['resilient-2'],
+            push: { ...caseConnectors['resilient-2'].push, needsToBePushed: true },
+          },
+        },
+      }));
+
+      const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
+
+      expect(result.getByTestId('push-to-external-service')).toBeInTheDocument();
+
+      userEvent.click(result.getByTestId('push-to-external-service'), undefined, {
+        skipPointerEventsCheck: true,
+      });
+
+      await waitFor(() => {
+        expect(pushCaseToExternalService).toHaveBeenCalled();
+      });
+    });
+
+    it('should disable the push button when connector is invalid', async () => {
+      const result = appMockRenderer.render(
+        <CaseViewPage
+          {...{
+            ...caseProps,
+            caseData: { ...caseProps.caseData, connectorId: 'not-exist' },
+          }}
+        />
+      );
+      await waitFor(() => {
+        expect(result.getByTestId('push-to-external-service')).toBeDisabled();
+      });
+    });
+
+    it('should update connector', async () => {
+      const result = appMockRenderer.render(
+        <CaseViewPage
+          {...caseProps}
+          caseData={{
+            ...caseProps.caseData,
+            connector: {
+              id: 'servicenow-1',
+              name: 'SN 1',
+              type: ConnectorTypes.serviceNowITSM,
+              fields: null,
+            },
+          }}
+        />
+      );
+      userEvent.click(result.getByTestId('connector-edit').querySelector('button')!, undefined, {
+        skipPointerEventsCheck: true,
+      });
+      userEvent.click(result.getByTestId('dropdown-connectors'), undefined, {
+        skipPointerEventsCheck: true,
+      });
+      await waitForEuiPopoverOpen();
+      userEvent.click(result.getByTestId('dropdown-connector-resilient-2'), undefined, {
+        skipPointerEventsCheck: true,
+      });
+
+      await waitFor(() => {
+        expect(result.getByTestId('connector-fields-resilient')).toBeInTheDocument();
+      });
+
+      userEvent.click(result.getByTestId('edit-connectors-submit'), undefined, {
+        skipPointerEventsCheck: true,
+      });
+
+      await waitFor(() => {
+        expect(updateCaseProperty).toHaveBeenCalledTimes(1);
+        const updateObject = updateCaseProperty.mock.calls[0][0];
+        expect(updateObject.updateKey).toEqual('connector');
+        expect(updateObject.updateValue).toEqual({
+          id: 'resilient-2',
+          name: 'My Resilient connector',
+          type: ConnectorTypes.resilient,
+          fields: {
+            incidentTypes: null,
+            severityCode: null,
+          },
+        });
+      });
+    });
+
+    it('should call onComponentInitialized on mount', async () => {
+      const onComponentInitialized = jest.fn();
+      appMockRenderer.render(
+        <CaseViewPage {...caseProps} onComponentInitialized={onComponentInitialized} />
+      );
+
+      await waitFor(() => {
+        expect(onComponentInitialized).toHaveBeenCalled();
+      });
+    });
+
+    it('should show loading content when loading user actions', async () => {
+      const useFetchAlertData = jest.fn().mockReturnValue([true]);
+      useFindCaseUserActionsMock.mockReturnValue({
+        data: undefined,
+        isError: false,
+        isLoading: true,
+        isFetching: true,
+        refetch: refetchFindCaseUserActions,
+      });
+
+      const result = appMockRenderer.render(
+        <CaseViewPage {...caseProps} useFetchAlertData={useFetchAlertData} />
+      );
+      await waitFor(() => {
+        expect(result.getByTestId('case-view-loading-content')).toBeInTheDocument();
+        expect(result.queryByTestId('user-actions')).not.toBeInTheDocument();
+      });
+    });
+
+    it('should call show alert details with expected arguments', async () => {
+      const showAlertDetails = jest.fn();
+      const result = appMockRenderer.render(
+        <CaseViewPage {...caseProps} showAlertDetails={showAlertDetails} />
+      );
+
+      userEvent.click(result.getByTestId('comment-action-show-alert-alert-action-id'), undefined, {
+        skipPointerEventsCheck: true,
+      });
+
+      await waitFor(() => {
+        expect(showAlertDetails).toHaveBeenCalledWith('alert-id-1', 'alert-index-1');
+      });
+    });
+
+    it('should show the rule name', async () => {
+      const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
+
+      await waitFor(() => {
+        expect(
+          result
+            .getByTestId('user-action-alert-comment-create-action-alert-action-id')
+            .querySelector('.euiCommentEvent__headerEvent')
+        ).toHaveTextContent('added an alert from Awesome rule');
+      });
+    });
+
+    it('should update settings', async () => {
+      const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
+      userEvent.click(result.getByTestId('sync-alerts-switch'), undefined, {
+        skipPointerEventsCheck: true,
+      });
+      const updateObject = updateCaseProperty.mock.calls[0][0];
+
+      await waitFor(() => {
+        expect(updateObject.updateKey).toEqual('settings');
+        expect(updateObject.updateValue).toEqual({ syncAlerts: false });
+      });
+    });
+
+    it('should show the correct connector name on the push button', async () => {
+      useGetConnectorsMock.mockImplementation(() => ({ data: connectorsMock, isLoading: false }));
+
+      const result = appMockRenderer.render(
+        <CaseViewPage {...{ ...caseProps, connector: { ...caseProps, name: 'old-name' } }} />
+      );
+
+      await waitFor(() => {
+        expect(result.getByTestId('push-to-external-service')).toHaveTextContent(
+          'My Resilient connector'
+        );
+      });
+    });
+
+    describe('Callouts', () => {
+      it('it shows the danger callout when a connector has been deleted', async () => {
+        useGetConnectorsMock.mockImplementation(() => ({ data: [], isLoading: false }));
+        const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
+
+        expect(result.container.querySelector('.euiCallOut--danger')).toBeInTheDocument();
+      });
+
+      it('it does NOT shows the danger callout when connectors are loading', async () => {
+        useGetConnectorsMock.mockImplementation(() => ({ data: [], isLoading: true }));
+        const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
+
+        expect(result.container.querySelector('.euiCallOut--danger')).not.toBeInTheDocument();
+      });
+    });
+
+    describe('Tabs', () => {
+      jest.mock('@kbn/kibana-react-plugin/public', () => ({
+        useKibana: () => ({
+          services: {
+            application: {
+              capabilities: {
+                fakeCases: {
+                  create_cases: true,
+                  read_cases: true,
+                  update_cases: true,
+                  delete_cases: true,
+                  push_cases: true,
+                },
+              },
+            },
+            cases: {
+              ui: {
+                getCasesContext: () => null,
+              },
+              helpers: {
+                getUICapabilities: () => ({
+                  all: true,
+                  read: true,
+                  create: true,
+                  update: true,
+                  delete: true,
+                  push: true,
+                }),
+              },
+            },
+            notifications: {
+              toasts: {
+                addDanger: () => {},
               },
             },
           },
-          cases: {
-            ui: {
-              getCasesContext: () => null,
-            },
-            helpers: {
-              getUICapabilities: () => ({
-                all: true,
-                read: true,
-                create: true,
-                update: true,
-                delete: true,
-                push: true,
-              }),
-            },
+        }),
+      }));
+
+      it('renders tabs correctly', async () => {
+        const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
+        await act(async () => {
+          expect(result.getByTestId('case-view-tab-title-alerts')).toBeTruthy();
+          expect(result.getByTestId('case-view-tab-title-activity')).toBeTruthy();
+        });
+      });
+
+      it('renders the activity tab by default', async () => {
+        const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
+        await act(async () => {
+          expect(result.getByTestId('case-view-tab-content-activity')).toBeTruthy();
+        });
+      });
+
+      it('renders the alerts tab when the query parameter tabId has alerts', async () => {
+        useUrlParamsMock.mockReturnValue({
+          urlParams: {
+            tabId: CASE_VIEW_PAGE_TABS.ALERTS,
           },
-          notifications: {
-            toasts: {
-              addDanger: () => {},
-            },
+        });
+        const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
+        await act(async () => {
+          expect(result.getByTestId('case-view-tab-content-alerts')).toBeTruthy();
+        });
+      });
+
+      it('renders the activity tab when the query parameter tabId has activity', async () => {
+        useUrlParamsMock.mockReturnValue({
+          urlParams: {
+            tabId: CASE_VIEW_PAGE_TABS.ACTIVITY,
           },
-        },
-      }),
-    }));
-
-    it('renders tabs correctly', async () => {
-      const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
-      await act(async () => {
-        expect(result.getByTestId('case-view-tab-title-alerts')).toBeTruthy();
-        expect(result.getByTestId('case-view-tab-title-activity')).toBeTruthy();
-      });
-    });
-
-    it('renders the activity tab by default', async () => {
-      const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
-      await act(async () => {
-        expect(result.getByTestId('case-view-tab-content-activity')).toBeTruthy();
-      });
-    });
-
-    it('renders the alerts tab when the query parameter tabId has alerts', async () => {
-      useUrlParamsMock.mockReturnValue({
-        urlParams: {
-          tabId: CASE_VIEW_PAGE_TABS.ALERTS,
-        },
-      });
-      const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
-      await act(async () => {
-        expect(result.getByTestId('case-view-tab-content-alerts')).toBeTruthy();
-      });
-    });
-
-    it('renders the activity tab when the query parameter tabId has activity', async () => {
-      useUrlParamsMock.mockReturnValue({
-        urlParams: {
-          tabId: CASE_VIEW_PAGE_TABS.ACTIVITY,
-        },
-      });
-      const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
-      await act(async () => {
-        expect(result.getByTestId('case-view-tab-content-activity')).toBeTruthy();
-      });
-    });
-
-    it('renders the activity tab when the query parameter tabId has an unknown value', async () => {
-      useUrlParamsMock.mockReturnValue({
-        urlParams: {
-          tabId: 'what-is-love',
-        },
-      });
-      const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
-      await act(async () => {
-        expect(result.getByTestId('case-view-tab-content-activity')).toBeTruthy();
-        expect(result.queryByTestId('case-view-tab-content-alerts')).toBeFalsy();
-      });
-    });
-
-    it('navigates to the activity tab when the activity tab is clicked', async () => {
-      const navigateToCaseViewMock = useCaseViewNavigationMock().navigateToCaseView;
-      const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
-      userEvent.click(result.getByTestId('case-view-tab-title-activity'), undefined, {
-        skipPointerEventsCheck: true,
-      });
-      await act(async () => {
-        expect(navigateToCaseViewMock).toHaveBeenCalledWith({
-          detailName: caseData.id,
-          tabId: CASE_VIEW_PAGE_TABS.ACTIVITY,
         });
-      });
-    });
-
-    it('navigates to the alerts tab when the alerts tab is clicked', async () => {
-      const navigateToCaseViewMock = useCaseViewNavigationMock().navigateToCaseView;
-      const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
-      userEvent.click(result.getByTestId('case-view-tab-title-alerts'), undefined, {
-        skipPointerEventsCheck: true,
-      });
-      await act(async () => {
-        expect(navigateToCaseViewMock).toHaveBeenCalledWith({
-          detailName: caseData.id,
-          tabId: CASE_VIEW_PAGE_TABS.ALERTS,
-        });
-      });
-    });
-
-    it('should display the alerts tab when the feature is enabled', async () => {
-      appMockRenderer = createAppMockRenderer({ features: { alerts: { enabled: true } } });
-      const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
-      await act(async () => {
-        expect(result.queryByTestId('case-view-tab-title-activity')).toBeTruthy();
-        expect(result.queryByTestId('case-view-tab-title-alerts')).toBeTruthy();
-      });
-    });
-
-    it('should not display the alerts tab when the feature is disabled', async () => {
-      appMockRenderer = createAppMockRenderer({ features: { alerts: { enabled: false } } });
-      const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
-      await act(async () => {
-        expect(result.queryByTestId('case-view-tab-title-activity')).toBeTruthy();
-        expect(result.queryByTestId('case-view-tab-title-alerts')).toBeFalsy();
-      });
-    });
-
-    it('should not show the experimental badge on the alerts table', async () => {
-      appMockRenderer = createAppMockRenderer({ features: { alerts: { isExperimental: false } } });
-      const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
-
-      await act(async () => {
-        expect(result.queryByTestId('case-view-alerts-table-experimental-badge')).toBeFalsy();
-      });
-    });
-
-    it('should show the experimental badge on the alerts table', async () => {
-      appMockRenderer = createAppMockRenderer({ features: { alerts: { isExperimental: true } } });
-      const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
-
-      await act(async () => {
-        expect(result.queryByTestId('case-view-alerts-table-experimental-badge')).toBeTruthy();
-      });
-    });
-
-    describe('description', () => {
-      it('renders the descriptions user correctly', async () => {
-        appMockRenderer.render(<CaseViewPage {...caseProps} />);
-
-        const description = within(screen.getByTestId('description-action'));
-
-        expect(await description.findByText('Leslie Knope')).toBeInTheDocument();
-      });
-
-      it('should display description isLoading', async () => {
-        useUpdateCaseMock.mockImplementation(() => ({
-          ...defaultUpdateCaseState,
-          isLoading: true,
-          updateKey: 'description',
-        }));
-
-        appMockRenderer.render(<CaseViewPage {...caseProps} />);
-
-        await waitFor(() => {
-          expect(screen.getByTestId('description-loading')).toBeInTheDocument();
-          expect(screen.queryByTestId('description-action')).not.toBeInTheDocument();
+        const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
+        await act(async () => {
+          expect(result.getByTestId('case-view-tab-content-activity')).toBeTruthy();
         });
       });
 
-      it.skip('it should persist the draft of new comment while description is updated', async () => {
-        const newComment = 'another cool comment';
+      it('renders the activity tab when the query parameter tabId has an unknown value', async () => {
+        useUrlParamsMock.mockReturnValue({
+          urlParams: {
+            tabId: 'what-is-love',
+          },
+        });
+        const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
+        await act(async () => {
+          expect(result.getByTestId('case-view-tab-content-activity')).toBeTruthy();
+          expect(result.queryByTestId('case-view-tab-content-alerts')).toBeFalsy();
+        });
+      });
 
-        appMockRenderer.render(<CaseViewPage {...caseProps} />);
-
-        userEvent.click(
-          await screen.findByTestId('user-actions-filter-activity-button-all'),
-          undefined,
-          { skipPointerEventsCheck: true }
-        );
-
-        userEvent.paste(await screen.findByTestId('euiMarkdownEditorTextArea'), newComment);
-
-        userEvent.click(await screen.findByTestId('editable-description-edit-icon'), undefined, {
+      it('navigates to the activity tab when the activity tab is clicked', async () => {
+        const navigateToCaseViewMock = useCaseViewNavigationMock().navigateToCaseView;
+        const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
+        userEvent.click(result.getByTestId('case-view-tab-title-activity'), undefined, {
           skipPointerEventsCheck: true,
         });
+        await act(async () => {
+          expect(navigateToCaseViewMock).toHaveBeenCalledWith({
+            detailName: caseData.id,
+            tabId: CASE_VIEW_PAGE_TABS.ACTIVITY,
+          });
+        });
+      });
 
-        userEvent.paste(screen.getAllByTestId('euiMarkdownEditorTextArea')[0], 'Edited!');
-
-        userEvent.click(screen.getByTestId('user-action-save-markdown'), undefined, {
+      it('navigates to the alerts tab when the alerts tab is clicked', async () => {
+        const navigateToCaseViewMock = useCaseViewNavigationMock().navigateToCaseView;
+        const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
+        userEvent.click(result.getByTestId('case-view-tab-title-alerts'), undefined, {
           skipPointerEventsCheck: true,
         });
-
-        expect(await screen.findByTestId('euiMarkdownEditorTextArea')).toHaveTextContent(
-          newComment
-        );
+        await act(async () => {
+          expect(navigateToCaseViewMock).toHaveBeenCalledWith({
+            detailName: caseData.id,
+            tabId: CASE_VIEW_PAGE_TABS.ALERTS,
+          });
+        });
       });
-    });
 
-    describe('breadcrumbs', () => {
-      it('should set the cases title', () => {
-        appMockRenderer.render(<CaseViewPage {...caseProps} />);
+      it('should display the alerts tab when the feature is enabled', async () => {
+        appMockRenderer = createAppMockRenderer({ features: { alerts: { enabled: true } } });
+        const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
+        await act(async () => {
+          expect(result.queryByTestId('case-view-tab-title-activity')).toBeTruthy();
+          expect(result.queryByTestId('case-view-tab-title-alerts')).toBeTruthy();
+        });
+      });
 
-        expect(mockSetTitle).toHaveBeenCalledWith([caseProps.caseData.title, 'Cases', 'Test']);
+      it('should not display the alerts tab when the feature is disabled', async () => {
+        appMockRenderer = createAppMockRenderer({ features: { alerts: { enabled: false } } });
+        const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
+        await act(async () => {
+          expect(result.queryByTestId('case-view-tab-title-activity')).toBeTruthy();
+          expect(result.queryByTestId('case-view-tab-title-alerts')).toBeFalsy();
+        });
+      });
+
+      it('should not show the experimental badge on the alerts table', async () => {
+        appMockRenderer = createAppMockRenderer({
+          features: { alerts: { isExperimental: false } },
+        });
+        const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
+
+        await act(async () => {
+          expect(result.queryByTestId('case-view-alerts-table-experimental-badge')).toBeFalsy();
+        });
+      });
+
+      it('should show the experimental badge on the alerts table', async () => {
+        appMockRenderer = createAppMockRenderer({ features: { alerts: { isExperimental: true } } });
+        const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
+
+        await act(async () => {
+          expect(result.queryByTestId('case-view-alerts-table-experimental-badge')).toBeTruthy();
+        });
+      });
+
+      describe('description', () => {
+        it('renders the descriptions user correctly', async () => {
+          appMockRenderer.render(<CaseViewPage {...caseProps} />);
+
+          const description = within(screen.getByTestId('description-action'));
+
+          expect(await description.findByText('Leslie Knope')).toBeInTheDocument();
+        });
+
+        it('should display description isLoading', async () => {
+          useUpdateCaseMock.mockImplementation(() => ({
+            ...defaultUpdateCaseState,
+            isLoading: true,
+            updateKey: 'description',
+          }));
+
+          appMockRenderer.render(<CaseViewPage {...caseProps} />);
+
+          await waitFor(() => {
+            expect(screen.getByTestId('description-loading')).toBeInTheDocument();
+            expect(screen.queryByTestId('description-action')).not.toBeInTheDocument();
+          });
+        });
+
+        it.skip('it should persist the draft of new comment while description is updated', async () => {
+          const newComment = 'another cool comment';
+
+          appMockRenderer.render(<CaseViewPage {...caseProps} />);
+
+          userEvent.click(
+            await screen.findByTestId('user-actions-filter-activity-button-all'),
+            undefined,
+            { skipPointerEventsCheck: true }
+          );
+
+          userEvent.paste(await screen.findByTestId('euiMarkdownEditorTextArea'), newComment);
+
+          userEvent.click(await screen.findByTestId('editable-description-edit-icon'), undefined, {
+            skipPointerEventsCheck: true,
+          });
+
+          userEvent.paste(screen.getAllByTestId('euiMarkdownEditorTextArea')[0], 'Edited!');
+
+          userEvent.click(screen.getByTestId('user-action-save-markdown'), undefined, {
+            skipPointerEventsCheck: true,
+          });
+
+          expect(await screen.findByTestId('euiMarkdownEditorTextArea')).toHaveTextContent(
+            newComment
+          );
+        });
+      });
+
+      describe('breadcrumbs', () => {
+        it('should set the cases title', () => {
+          appMockRenderer.render(<CaseViewPage {...caseProps} />);
+
+          expect(mockSetTitle).toHaveBeenCalledWith([caseProps.caseData.title, 'Cases', 'Test']);
+        });
       });
     });
   });
-});
+}

--- a/x-pack/plugins/cases/public/components/case_view/case_view_page.test.tsx
+++ b/x-pack/plugins/cases/public/components/case_view/case_view_page.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { act, waitFor, within, screen } from '@testing-library/react';
+import { waitFor, within, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { waitForEuiPopoverOpen } from '@elastic/eui/lib/test/rtl';
 import { ConnectorTypes } from '../../../common/api';
@@ -25,6 +25,9 @@ import { usePostPushToService } from '../../containers/use_post_push_to_service'
 import { useGetCaseConnectors } from '../../containers/use_get_case_connectors';
 import { useUpdateCase } from '../../containers/use_update_case';
 import { useGetCaseUsers } from '../../containers/use_get_case_users';
+import { useGetCurrentUserProfile } from '../../containers/user_profiles/use_get_current_user_profile';
+import { useGetCaseUserActionsStats } from '../../containers/use_get_case_user_actions_stats';
+import { useSuggestUserProfiles } from '../../containers/user_profiles/use_suggest_user_profiles';
 import { CaseViewPage } from './case_view_page';
 import {
   caseData,
@@ -53,12 +56,21 @@ jest.mock('../../containers/use_post_push_to_service');
 jest.mock('../../containers/use_get_case_connectors');
 jest.mock('../../containers/use_get_case_users');
 jest.mock('../../containers/user_profiles/use_bulk_get_user_profiles');
+jest.mock('../../containers/user_profiles/use_get_current_user_profile');
+jest.mock('../../containers/use_get_case_user_actions_stats');
+jest.mock('../../containers/user_profiles/use_suggest_user_profiles');
+
 jest.mock('../user_actions/timestamp', () => ({
   UserActionTimestamp: () => <></>,
 }));
 jest.mock('../../common/navigation/hooks');
 jest.mock('../../common/hooks');
 jest.mock('../connectors/resilient/api');
+
+const AlertsTableMock: React.FC = () => {
+  return <>{'alerts table'}</>;
+};
+
 jest.mock('../../common/lib/kibana', () => {
   const originalModule = jest.requireActual('../../common/lib/kibana');
   return {
@@ -68,6 +80,10 @@ jest.mock('../../common/lib/kibana', () => {
       return {
         services: {
           ...services,
+          triggersActionsUi: {
+            alertsTableConfigurationRegistry: {},
+            getAlertsStateTable: () => <AlertsTableMock />,
+          },
           chrome: { setBreadcrumbs: jest.fn(), docTitle: { change: mockSetTitle } },
         },
       };
@@ -86,6 +102,9 @@ const useGetCaseConnectorsMock = useGetCaseConnectors as jest.Mock;
 const useGetCaseMetricsMock = useGetCaseMetrics as jest.Mock;
 const useGetTagsMock = useGetTags as jest.Mock;
 const useGetCaseUsersMock = useGetCaseUsers as jest.Mock;
+const useGetCurrentUserProfileMock = useGetCurrentUserProfile as jest.Mock;
+const useGetCaseUserActionsStatsMock = useGetCaseUserActionsStats as jest.Mock;
+const useSuggestUserProfilesMock = useSuggestUserProfiles as jest.Mock;
 
 const mockGetCase = (props: Partial<UseGetCase> = {}) => {
   const data = {
@@ -101,7 +120,6 @@ const mockGetCase = (props: Partial<UseGetCase> = {}) => {
 
 export const caseProps: CaseViewPageProps = {
   ...caseViewProps,
-  caseId: caseData.id,
   caseData,
   fetchCase: jest.fn(),
 };
@@ -111,607 +129,533 @@ export const caseClosedProps: CaseViewPageProps = {
   caseData: basicCaseClosed,
 };
 
-for (let index = 0; index < 50; index++) {
-  describe('CaseViewPage', () => {
-    // eslint-disable-next-line prefer-object-spread
-    const originalGetComputedStyle = Object.assign({}, window.getComputedStyle);
+const userActionsStats = {
+  total: 21,
+  totalComments: 9,
+  totalOtherActions: 11,
+};
 
-    beforeAll(() => {
-      // The JSDOM implementation is too slow
-      // Especially for dropdowns that try to position themselves
-      // perf issue - https://github.com/jsdom/jsdom/issues/3234
-      Object.defineProperty(window, 'getComputedStyle', {
-        value: (el: HTMLElement) => {
-          /**
-           * This is based on the jsdom implementation of getComputedStyle
-           * https://github.com/jsdom/jsdom/blob/9dae17bf0ad09042cfccd82e6a9d06d3a615d9f4/lib/jsdom/browser/Window.js#L779-L820
-           *
-           * It is missing global style parsing and will only return styles applied directly to an element.
-           * Will not return styles that are global or from emotion
-           */
-          const declaration = new CSSStyleDeclaration();
-          const { style } = el;
+describe('CaseViewPage', () => {
+  const updateCaseProperty = defaultUpdateCaseState.updateCaseProperty;
+  const pushCaseToExternalService = jest.fn();
+  const data = caseProps.caseData;
+  let appMockRenderer: AppMockRenderer;
+  const caseConnectors = getCaseConnectorsMockResponse();
+  const caseUsers = getCaseUsersMockResponse();
+  const refetchFindCaseUserActions = jest.fn();
 
-          Array.prototype.forEach.call(style, (property: string) => {
-            declaration.setProperty(
-              property,
-              style.getPropertyValue(property),
-              style.getPropertyPriority(property)
-            );
-          });
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetCase();
+    useUpdateCaseMock.mockReturnValue(defaultUpdateCaseState);
+    useGetCaseMetricsMock.mockReturnValue(defaultGetCaseMetrics);
+    useFindCaseUserActionsMock.mockReturnValue(defaultUseFindCaseUserActions);
+    usePostPushToServiceMock.mockReturnValue({ isLoading: false, pushCaseToExternalService });
+    useGetCaseConnectorsMock.mockReturnValue({
+      isLoading: false,
+      data: caseConnectors,
+    });
+    useGetConnectorsMock.mockReturnValue({ data: connectorsMock, isLoading: false });
+    useGetTagsMock.mockReturnValue({ data: [], isLoading: false });
+    const license = licensingMock.createLicense({
+      license: { type: 'platinum' },
+    });
+    useGetCaseUsersMock.mockReturnValue({ isLoading: false, data: caseUsers });
+    useGetCurrentUserProfileMock.mockReturnValue({ isLoading: false, data: userProfiles[0] });
+    useGetCaseUserActionsStatsMock.mockReturnValue({ data: userActionsStats, isLoading: false });
+    useSuggestUserProfilesMock.mockReturnValue({ data: [], isLoading: false });
 
-          return declaration;
+    appMockRenderer = createAppMockRenderer({ license });
+  });
+
+  it('should render CaseViewPage', async () => {
+    const damagedRaccoonUser = userProfiles[0].user;
+    const caseDataWithDamagedRaccoon = {
+      ...caseData,
+      createdBy: {
+        profileUid: userProfiles[0].uid,
+        username: damagedRaccoonUser.username,
+        fullName: damagedRaccoonUser.full_name,
+        email: damagedRaccoonUser.email,
+      },
+    };
+
+    const license = licensingMock.createLicense({
+      license: { type: 'platinum' },
+    });
+
+    const props = { ...caseProps, caseData: caseDataWithDamagedRaccoon };
+    appMockRenderer = createAppMockRenderer({ features: { metrics: ['alerts.count'] }, license });
+    const result = appMockRenderer.render(<CaseViewPage {...props} />);
+
+    expect(result.getByTestId('header-page-title')).toHaveTextContent(data.title);
+    expect(result.getByTestId('case-view-status-dropdown')).toHaveTextContent('Open');
+    expect(result.getByTestId('case-view-metrics-panel')).toBeInTheDocument();
+    expect(
+      within(result.getByTestId('case-view-tag-list')).getByTestId('tag-coke')
+    ).toHaveTextContent(data.tags[0]);
+
+    expect(
+      within(result.getByTestId('case-view-tag-list')).getByTestId('tag-pepsi')
+    ).toHaveTextContent(data.tags[1]);
+
+    expect(result.getAllByText(data.createdBy.fullName!)[0]).toBeInTheDocument();
+
+    expect(
+      within(result.getByTestId('description-action')).getByTestId('user-action-markdown')
+    ).toHaveTextContent(data.description);
+
+    expect(result.getByTestId('case-view-status-action-button')).toHaveTextContent(
+      'Mark in progress'
+    );
+  });
+
+  it('should show closed indicators in header when case is closed', async () => {
+    useUpdateCaseMock.mockImplementation(() => ({
+      ...defaultUpdateCaseState,
+      caseData: basicCaseClosed,
+    }));
+
+    const result = appMockRenderer.render(<CaseViewPage {...caseClosedProps} />);
+
+    expect(result.getByTestId('case-view-status-dropdown')).toHaveTextContent('Closed');
+  });
+
+  it('should update status', async () => {
+    const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
+
+    const dropdown = result.getByTestId('case-view-status-dropdown');
+    userEvent.click(dropdown.querySelector('button')!, undefined, { skipPointerEventsCheck: true });
+    await waitForEuiPopoverOpen();
+    userEvent.click(result.getByTestId('case-view-status-dropdown-closed'), undefined, {
+      skipPointerEventsCheck: true,
+    });
+    const updateObject = updateCaseProperty.mock.calls[0][0];
+
+    await waitFor(() => {
+      expect(updateCaseProperty).toHaveBeenCalledTimes(1);
+      expect(updateObject.updateKey).toEqual('status');
+      expect(updateObject.updateValue).toEqual('closed');
+    });
+  });
+
+  it('should display EditableTitle isLoading', async () => {
+    useUpdateCaseMock.mockImplementation(() => ({
+      ...defaultUpdateCaseState,
+      isLoading: true,
+      updateKey: 'title',
+    }));
+    const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
+
+    await waitFor(() => {
+      expect(result.getByTestId('editable-title-loading')).toBeInTheDocument();
+      expect(result.queryByTestId('editable-title-edit-icon')).not.toBeInTheDocument();
+    });
+  });
+
+  it('should display tags isLoading', async () => {
+    useUpdateCaseMock.mockImplementation(() => ({
+      ...defaultUpdateCaseState,
+      isLoading: true,
+      updateKey: 'tags',
+    }));
+
+    const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
+
+    await waitFor(() => {
+      expect(
+        within(result.getByTestId('case-view-tag-list')).getByTestId('tag-list-loading')
+      ).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(result.queryByTestId('tag-list-edit')).not.toBeInTheDocument();
+    });
+  });
+
+  it('should update title', async () => {
+    const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
+    const newTitle = 'The new title';
+    userEvent.click(result.getByTestId('editable-title-edit-icon'), undefined, {
+      skipPointerEventsCheck: true,
+    });
+    userEvent.clear(result.getByTestId('editable-title-input-field'));
+    userEvent.paste(result.getByTestId('editable-title-input-field'), newTitle);
+    userEvent.click(result.getByTestId('editable-title-submit-btn'), undefined, {
+      skipPointerEventsCheck: true,
+    });
+
+    const updateObject = updateCaseProperty.mock.calls[0][0];
+    await waitFor(() => {
+      expect(updateObject.updateKey).toEqual('title');
+      expect(updateObject.updateValue).toEqual(newTitle);
+    });
+  });
+
+  it('should push updates on button click', async () => {
+    useGetCaseConnectorsMock.mockImplementation(() => ({
+      isLoading: false,
+      data: {
+        ...caseConnectors,
+        'resilient-2': {
+          ...caseConnectors['resilient-2'],
+          push: { ...caseConnectors['resilient-2'].push, needsToBePushed: true },
         },
-        configurable: true,
-        writable: true,
-      });
+      },
+    }));
+
+    const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
+
+    expect(result.getByTestId('push-to-external-service')).toBeInTheDocument();
+
+    userEvent.click(result.getByTestId('push-to-external-service'), undefined, {
+      skipPointerEventsCheck: true,
     });
 
-    afterAll(() => {
-      Object.defineProperty(window, 'getComputedStyle', originalGetComputedStyle);
+    await waitFor(() => {
+      expect(pushCaseToExternalService).toHaveBeenCalled();
     });
+  });
 
-    const updateCaseProperty = defaultUpdateCaseState.updateCaseProperty;
-    const pushCaseToExternalService = jest.fn();
-    const data = caseProps.caseData;
-    let appMockRenderer: AppMockRenderer;
-    const caseConnectors = getCaseConnectorsMockResponse();
-    const caseUsers = getCaseUsersMockResponse();
-    const refetchFindCaseUserActions = jest.fn();
-
-    beforeEach(() => {
-      mockGetCase();
-      jest.clearAllMocks();
-      useUpdateCaseMock.mockReturnValue(defaultUpdateCaseState);
-      useGetCaseMetricsMock.mockReturnValue(defaultGetCaseMetrics);
-      useFindCaseUserActionsMock.mockReturnValue(defaultUseFindCaseUserActions);
-      usePostPushToServiceMock.mockReturnValue({ isLoading: false, pushCaseToExternalService });
-      useGetCaseConnectorsMock.mockReturnValue({
-        isLoading: false,
-        data: caseConnectors,
-      });
-      useGetConnectorsMock.mockReturnValue({ data: connectorsMock, isLoading: false });
-      useGetTagsMock.mockReturnValue({ data: [], isLoading: false });
-      const license = licensingMock.createLicense({
-        license: { type: 'platinum' },
-      });
-      useGetCaseUsersMock.mockReturnValue({ isLoading: false, data: caseUsers });
-
-      appMockRenderer = createAppMockRenderer({ license });
+  it('should disable the push button when connector is invalid', async () => {
+    const result = appMockRenderer.render(
+      <CaseViewPage
+        {...{
+          ...caseProps,
+          caseData: { ...caseProps.caseData, connectorId: 'not-exist' },
+        }}
+      />
+    );
+    await waitFor(() => {
+      expect(result.getByTestId('push-to-external-service')).toBeDisabled();
     });
+  });
 
-    it('should render CaseViewPage', async () => {
-      const damagedRaccoonUser = userProfiles[0].user;
-      const caseDataWithDamagedRaccoon = {
-        ...caseData,
-        createdBy: {
-          profileUid: userProfiles[0].uid,
-          username: damagedRaccoonUser.username,
-          fullName: damagedRaccoonUser.full_name,
-          email: damagedRaccoonUser.email,
-        },
-      };
-
-      const license = licensingMock.createLicense({
-        license: { type: 'platinum' },
-      });
-
-      const props = { ...caseProps, caseData: caseDataWithDamagedRaccoon };
-      appMockRenderer = createAppMockRenderer({ features: { metrics: ['alerts.count'] }, license });
-      const result = appMockRenderer.render(<CaseViewPage {...props} />);
-
-      expect(result.getByTestId('header-page-title')).toHaveTextContent(data.title);
-      expect(result.getByTestId('case-view-status-dropdown')).toHaveTextContent('Open');
-      expect(result.getByTestId('case-view-metrics-panel')).toBeInTheDocument();
-      expect(
-        within(result.getByTestId('case-view-tag-list')).getByTestId('tag-coke')
-      ).toHaveTextContent(data.tags[0]);
-
-      expect(
-        within(result.getByTestId('case-view-tag-list')).getByTestId('tag-pepsi')
-      ).toHaveTextContent(data.tags[1]);
-
-      expect(result.getAllByText(data.createdBy.fullName!)[0]).toBeInTheDocument();
-
-      expect(
-        within(result.getByTestId('description-action')).getByTestId('user-action-markdown')
-      ).toHaveTextContent(data.description);
-
-      expect(result.getByTestId('case-view-status-action-button')).toHaveTextContent(
-        'Mark in progress'
-      );
-    });
-
-    it('should show closed indicators in header when case is closed', async () => {
-      useUpdateCaseMock.mockImplementation(() => ({
-        ...defaultUpdateCaseState,
-        caseData: basicCaseClosed,
-      }));
-
-      const result = appMockRenderer.render(<CaseViewPage {...caseClosedProps} />);
-
-      expect(result.getByTestId('case-view-status-dropdown')).toHaveTextContent('Closed');
-    });
-
-    it('should update status', async () => {
-      const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
-
-      const dropdown = result.getByTestId('case-view-status-dropdown');
-      userEvent.click(dropdown.querySelector('button')!, undefined, {
-        skipPointerEventsCheck: true,
-      });
-      await waitForEuiPopoverOpen();
-      userEvent.click(result.getByTestId('case-view-status-dropdown-closed'), undefined, {
-        skipPointerEventsCheck: true,
-      });
-      const updateObject = updateCaseProperty.mock.calls[0][0];
-
-      await waitFor(() => {
-        expect(updateCaseProperty).toHaveBeenCalledTimes(1);
-        expect(updateObject.updateKey).toEqual('status');
-        expect(updateObject.updateValue).toEqual('closed');
-      });
-    });
-
-    it('should display EditableTitle isLoading', async () => {
-      useUpdateCaseMock.mockImplementation(() => ({
-        ...defaultUpdateCaseState,
-        isLoading: true,
-        updateKey: 'title',
-      }));
-      const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
-
-      await waitFor(() => {
-        expect(result.getByTestId('editable-title-loading')).toBeInTheDocument();
-        expect(result.queryByTestId('editable-title-edit-icon')).not.toBeInTheDocument();
-      });
-    });
-
-    it('should display tags isLoading', async () => {
-      useUpdateCaseMock.mockImplementation(() => ({
-        ...defaultUpdateCaseState,
-        isLoading: true,
-        updateKey: 'tags',
-      }));
-
-      const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
-
-      await waitFor(() => {
-        expect(
-          within(result.getByTestId('case-view-tag-list')).getByTestId('tag-list-loading')
-        ).toBeInTheDocument();
-      });
-
-      await waitFor(() => {
-        expect(result.queryByTestId('tag-list-edit')).not.toBeInTheDocument();
-      });
-    });
-
-    it('should update title', async () => {
-      const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
-      const newTitle = 'The new title';
-      userEvent.click(result.getByTestId('editable-title-edit-icon'), undefined, {
-        skipPointerEventsCheck: true,
-      });
-      userEvent.clear(result.getByTestId('editable-title-input-field'));
-      userEvent.paste(result.getByTestId('editable-title-input-field'), newTitle);
-      userEvent.click(result.getByTestId('editable-title-submit-btn'), undefined, {
-        skipPointerEventsCheck: true,
-      });
-
-      const updateObject = updateCaseProperty.mock.calls[0][0];
-      await waitFor(() => {
-        expect(updateObject.updateKey).toEqual('title');
-        expect(updateObject.updateValue).toEqual(newTitle);
-      });
-    });
-
-    it('should push updates on button click', async () => {
-      useGetCaseConnectorsMock.mockImplementation(() => ({
-        isLoading: false,
-        data: {
-          ...caseConnectors,
-          'resilient-2': {
-            ...caseConnectors['resilient-2'],
-            push: { ...caseConnectors['resilient-2'].push, needsToBePushed: true },
+  it('should update connector', async () => {
+    const result = appMockRenderer.render(
+      <CaseViewPage
+        {...caseProps}
+        caseData={{
+          ...caseProps.caseData,
+          connector: {
+            id: 'servicenow-1',
+            name: 'SN 1',
+            type: ConnectorTypes.serviceNowITSM,
+            fields: null,
           },
-        },
-      }));
+        }}
+      />
+    );
+    userEvent.click(result.getByTestId('connector-edit').querySelector('button')!, undefined, {
+      skipPointerEventsCheck: true,
+    });
+    userEvent.click(result.getByTestId('dropdown-connectors'), undefined, {
+      skipPointerEventsCheck: true,
+    });
+    await waitForEuiPopoverOpen();
+    userEvent.click(result.getByTestId('dropdown-connector-resilient-2'), undefined, {
+      skipPointerEventsCheck: true,
+    });
 
+    await waitFor(() => {
+      expect(result.getByTestId('connector-fields-resilient')).toBeInTheDocument();
+    });
+
+    userEvent.click(result.getByTestId('edit-connectors-submit'), undefined, {
+      skipPointerEventsCheck: true,
+    });
+
+    await waitFor(() => {
+      expect(updateCaseProperty).toHaveBeenCalledTimes(1);
+      const updateObject = updateCaseProperty.mock.calls[0][0];
+      expect(updateObject.updateKey).toEqual('connector');
+      expect(updateObject.updateValue).toEqual({
+        id: 'resilient-2',
+        name: 'My Resilient connector',
+        type: ConnectorTypes.resilient,
+        fields: {
+          incidentTypes: null,
+          severityCode: null,
+        },
+      });
+    });
+  });
+
+  it('should call onComponentInitialized on mount', async () => {
+    const onComponentInitialized = jest.fn();
+    appMockRenderer.render(
+      <CaseViewPage {...caseProps} onComponentInitialized={onComponentInitialized} />
+    );
+
+    await waitFor(() => {
+      expect(onComponentInitialized).toHaveBeenCalled();
+    });
+  });
+
+  it('should show loading content when loading user actions', async () => {
+    const useFetchAlertData = jest.fn().mockReturnValue([true]);
+    useFindCaseUserActionsMock.mockReturnValue({
+      data: undefined,
+      isError: false,
+      isLoading: true,
+      isFetching: true,
+      refetch: refetchFindCaseUserActions,
+    });
+
+    const result = appMockRenderer.render(
+      <CaseViewPage {...caseProps} useFetchAlertData={useFetchAlertData} />
+    );
+    await waitFor(() => {
+      expect(result.getByTestId('case-view-loading-content')).toBeInTheDocument();
+      expect(result.queryByTestId('user-actions')).not.toBeInTheDocument();
+    });
+  });
+
+  it('should call show alert details with expected arguments', async () => {
+    const showAlertDetails = jest.fn();
+    const result = appMockRenderer.render(
+      <CaseViewPage {...caseProps} showAlertDetails={showAlertDetails} />
+    );
+
+    userEvent.click(result.getByTestId('comment-action-show-alert-alert-action-id'), undefined, {
+      skipPointerEventsCheck: true,
+    });
+
+    await waitFor(() => {
+      expect(showAlertDetails).toHaveBeenCalledWith('alert-id-1', 'alert-index-1');
+    });
+  });
+
+  it('should show the rule name', async () => {
+    const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
+
+    await waitFor(() => {
+      expect(
+        result
+          .getByTestId('user-action-alert-comment-create-action-alert-action-id')
+          .querySelector('.euiCommentEvent__headerEvent')
+      ).toHaveTextContent('added an alert from Awesome rule');
+    });
+  });
+
+  it('should update settings', async () => {
+    const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
+    userEvent.click(result.getByTestId('sync-alerts-switch'), undefined, {
+      skipPointerEventsCheck: true,
+    });
+    const updateObject = updateCaseProperty.mock.calls[0][0];
+
+    await waitFor(() => {
+      expect(updateObject.updateKey).toEqual('settings');
+      expect(updateObject.updateValue).toEqual({ syncAlerts: false });
+    });
+  });
+
+  it('should show the correct connector name on the push button', async () => {
+    useGetConnectorsMock.mockImplementation(() => ({ data: connectorsMock, isLoading: false }));
+
+    const result = appMockRenderer.render(
+      <CaseViewPage {...{ ...caseProps, connector: { ...caseProps, name: 'old-name' } }} />
+    );
+
+    await waitFor(() => {
+      expect(result.getByTestId('push-to-external-service')).toHaveTextContent(
+        'My Resilient connector'
+      );
+    });
+  });
+
+  describe('Callouts', () => {
+    it('it shows the danger callout when a connector has been deleted', async () => {
+      useGetConnectorsMock.mockImplementation(() => ({ data: [], isLoading: false }));
       const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
 
-      expect(result.getByTestId('push-to-external-service')).toBeInTheDocument();
-
-      userEvent.click(result.getByTestId('push-to-external-service'), undefined, {
-        skipPointerEventsCheck: true,
-      });
-
-      await waitFor(() => {
-        expect(pushCaseToExternalService).toHaveBeenCalled();
-      });
+      expect(result.container.querySelector('.euiCallOut--danger')).toBeInTheDocument();
     });
 
-    it('should disable the push button when connector is invalid', async () => {
-      const result = appMockRenderer.render(
-        <CaseViewPage
-          {...{
-            ...caseProps,
-            caseData: { ...caseProps.caseData, connectorId: 'not-exist' },
-          }}
-        />
-      );
-      await waitFor(() => {
-        expect(result.getByTestId('push-to-external-service')).toBeDisabled();
-      });
+    it('it does NOT shows the danger callout when connectors are loading', async () => {
+      useGetConnectorsMock.mockImplementation(() => ({ data: [], isLoading: true }));
+      const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
+
+      expect(result.container.querySelector('.euiCallOut--danger')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Tabs', () => {
+    it('renders tabs correctly', async () => {
+      appMockRenderer.render(<CaseViewPage {...caseProps} />);
+      expect(await screen.findByTestId('case-view-tab-title-alerts')).toBeInTheDocument();
+      expect(await screen.findByTestId('case-view-tab-title-activity')).toBeInTheDocument();
     });
 
-    it('should update connector', async () => {
-      const result = appMockRenderer.render(
-        <CaseViewPage
-          {...caseProps}
-          caseData={{
-            ...caseProps.caseData,
-            connector: {
-              id: 'servicenow-1',
-              name: 'SN 1',
-              type: ConnectorTypes.serviceNowITSM,
-              fields: null,
-            },
-          }}
-        />
-      );
-      userEvent.click(result.getByTestId('connector-edit').querySelector('button')!, undefined, {
-        skipPointerEventsCheck: true,
+    it('renders the activity tab by default', async () => {
+      appMockRenderer.render(<CaseViewPage {...caseProps} />);
+      expect(await screen.findByTestId('case-view-tab-content-activity')).toBeInTheDocument();
+    });
+
+    it('renders the alerts tab when the query parameter tabId has alerts', async () => {
+      useUrlParamsMock.mockReturnValue({
+        urlParams: {
+          tabId: CASE_VIEW_PAGE_TABS.ALERTS,
+        },
       });
-      userEvent.click(result.getByTestId('dropdown-connectors'), undefined, {
-        skipPointerEventsCheck: true,
+
+      appMockRenderer.render(<CaseViewPage {...caseProps} />);
+
+      expect(await screen.findByText('alerts table')).toBeInTheDocument();
+      expect(await screen.findByTestId('case-view-tab-content-alerts')).toBeInTheDocument();
+    });
+
+    it('renders the activity tab when the query parameter tabId has activity', async () => {
+      useUrlParamsMock.mockReturnValue({
+        urlParams: {
+          tabId: CASE_VIEW_PAGE_TABS.ACTIVITY,
+        },
       });
-      await waitForEuiPopoverOpen();
-      userEvent.click(result.getByTestId('dropdown-connector-resilient-2'), undefined, {
+
+      appMockRenderer.render(<CaseViewPage {...caseProps} />);
+      expect(await screen.findByTestId('case-view-tab-content-activity')).toBeInTheDocument();
+    });
+
+    it('renders the activity tab when the query parameter tabId has an unknown value', async () => {
+      useUrlParamsMock.mockReturnValue({
+        urlParams: {
+          tabId: 'what-is-love',
+        },
+      });
+
+      appMockRenderer.render(<CaseViewPage {...caseProps} />);
+      expect(await screen.findByTestId('case-view-tab-content-activity')).toBeInTheDocument();
+      expect(screen.queryByTestId('case-view-tab-content-alerts')).not.toBeInTheDocument();
+    });
+
+    it('navigates to the activity tab when the activity tab is clicked', async () => {
+      const navigateToCaseViewMock = useCaseViewNavigationMock().navigateToCaseView;
+      appMockRenderer.render(<CaseViewPage {...caseProps} />);
+
+      userEvent.click(await screen.findByTestId('case-view-tab-title-activity'), undefined, {
         skipPointerEventsCheck: true,
       });
 
-      await waitFor(() => {
-        expect(result.getByTestId('connector-fields-resilient')).toBeInTheDocument();
-      });
-
-      userEvent.click(result.getByTestId('edit-connectors-submit'), undefined, {
-        skipPointerEventsCheck: true,
-      });
-
-      await waitFor(() => {
-        expect(updateCaseProperty).toHaveBeenCalledTimes(1);
-        const updateObject = updateCaseProperty.mock.calls[0][0];
-        expect(updateObject.updateKey).toEqual('connector');
-        expect(updateObject.updateValue).toEqual({
-          id: 'resilient-2',
-          name: 'My Resilient connector',
-          type: ConnectorTypes.resilient,
-          fields: {
-            incidentTypes: null,
-            severityCode: null,
-          },
+      await waitFor(async () => {
+        expect(navigateToCaseViewMock).toHaveBeenCalledWith({
+          detailName: caseData.id,
+          tabId: CASE_VIEW_PAGE_TABS.ACTIVITY,
         });
       });
     });
 
-    it('should call onComponentInitialized on mount', async () => {
-      const onComponentInitialized = jest.fn();
-      appMockRenderer.render(
-        <CaseViewPage {...caseProps} onComponentInitialized={onComponentInitialized} />
-      );
+    it('navigates to the alerts tab when the alerts tab is clicked', async () => {
+      const navigateToCaseViewMock = useCaseViewNavigationMock().navigateToCaseView;
+      appMockRenderer.render(<CaseViewPage {...caseProps} />);
 
-      await waitFor(() => {
-        expect(onComponentInitialized).toHaveBeenCalled();
-      });
-    });
-
-    it('should show loading content when loading user actions', async () => {
-      const useFetchAlertData = jest.fn().mockReturnValue([true]);
-      useFindCaseUserActionsMock.mockReturnValue({
-        data: undefined,
-        isError: false,
-        isLoading: true,
-        isFetching: true,
-        refetch: refetchFindCaseUserActions,
-      });
-
-      const result = appMockRenderer.render(
-        <CaseViewPage {...caseProps} useFetchAlertData={useFetchAlertData} />
-      );
-      await waitFor(() => {
-        expect(result.getByTestId('case-view-loading-content')).toBeInTheDocument();
-        expect(result.queryByTestId('user-actions')).not.toBeInTheDocument();
-      });
-    });
-
-    it('should call show alert details with expected arguments', async () => {
-      const showAlertDetails = jest.fn();
-      const result = appMockRenderer.render(
-        <CaseViewPage {...caseProps} showAlertDetails={showAlertDetails} />
-      );
-
-      userEvent.click(result.getByTestId('comment-action-show-alert-alert-action-id'), undefined, {
+      userEvent.click(await screen.findByTestId('case-view-tab-title-alerts'), undefined, {
         skipPointerEventsCheck: true,
       });
 
-      await waitFor(() => {
-        expect(showAlertDetails).toHaveBeenCalledWith('alert-id-1', 'alert-index-1');
+      await waitFor(async () => {
+        expect(navigateToCaseViewMock).toHaveBeenCalledWith({
+          detailName: caseData.id,
+          tabId: CASE_VIEW_PAGE_TABS.ALERTS,
+        });
       });
     });
 
-    it('should show the rule name', async () => {
-      const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
+    it('should display the alerts tab when the feature is enabled', async () => {
+      appMockRenderer = createAppMockRenderer({ features: { alerts: { enabled: true } } });
+      appMockRenderer.render(<CaseViewPage {...caseProps} />);
 
-      await waitFor(() => {
-        expect(
-          result
-            .getByTestId('user-action-alert-comment-create-action-alert-action-id')
-            .querySelector('.euiCommentEvent__headerEvent')
-        ).toHaveTextContent('added an alert from Awesome rule');
-      });
+      expect(await screen.findByTestId('case-view-tab-title-activity')).toBeInTheDocument();
+      expect(await screen.findByTestId('case-view-tab-title-alerts')).toBeInTheDocument();
     });
 
-    it('should update settings', async () => {
-      const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
-      userEvent.click(result.getByTestId('sync-alerts-switch'), undefined, {
-        skipPointerEventsCheck: true,
-      });
-      const updateObject = updateCaseProperty.mock.calls[0][0];
+    it('should not display the alerts tab when the feature is disabled', async () => {
+      appMockRenderer = createAppMockRenderer({ features: { alerts: { enabled: false } } });
+      appMockRenderer.render(<CaseViewPage {...caseProps} />);
 
-      await waitFor(() => {
-        expect(updateObject.updateKey).toEqual('settings');
-        expect(updateObject.updateValue).toEqual({ syncAlerts: false });
-      });
+      expect(await screen.findByTestId('case-view-tab-title-activity')).toBeInTheDocument();
+      expect(screen.queryByTestId('case-view-tab-title-alerts')).not.toBeInTheDocument();
     });
 
-    it('should show the correct connector name on the push button', async () => {
-      useGetConnectorsMock.mockImplementation(() => ({ data: connectorsMock, isLoading: false }));
+    it('should not show the experimental badge on the alerts table', async () => {
+      appMockRenderer = createAppMockRenderer({ features: { alerts: { isExperimental: false } } });
+      appMockRenderer.render(<CaseViewPage {...caseProps} />);
 
-      const result = appMockRenderer.render(
-        <CaseViewPage {...{ ...caseProps, connector: { ...caseProps, name: 'old-name' } }} />
-      );
+      expect(
+        screen.queryByTestId('case-view-alerts-table-experimental-badge')
+      ).not.toBeInTheDocument();
+    });
 
-      await waitFor(() => {
-        expect(result.getByTestId('push-to-external-service')).toHaveTextContent(
-          'My Resilient connector'
+    it('should show the experimental badge on the alerts table', async () => {
+      appMockRenderer = createAppMockRenderer({ features: { alerts: { isExperimental: true } } });
+      appMockRenderer.render(<CaseViewPage {...caseProps} />);
+
+      expect(
+        await screen.findByTestId('case-view-alerts-table-experimental-badge')
+      ).toBeInTheDocument();
+    });
+
+    describe('description', () => {
+      it('renders the descriptions user correctly', async () => {
+        appMockRenderer.render(<CaseViewPage {...caseProps} />);
+
+        const description = within(await screen.findByTestId('description-action'));
+
+        expect(await description.findByText('Leslie Knope')).toBeInTheDocument();
+      });
+
+      it('should display description isLoading', async () => {
+        useUpdateCaseMock.mockImplementation(() => ({
+          ...defaultUpdateCaseState,
+          isLoading: true,
+          updateKey: 'description',
+        }));
+
+        appMockRenderer.render(<CaseViewPage {...caseProps} />);
+
+        await waitFor(() => {
+          expect(screen.getByTestId('description-loading')).toBeInTheDocument();
+          expect(screen.queryByTestId('description-action')).not.toBeInTheDocument();
+        });
+      });
+
+      it.skip('it should persist the draft of new comment while description is updated', async () => {
+        const newComment = 'another cool comment';
+
+        appMockRenderer.render(<CaseViewPage {...caseProps} />);
+
+        userEvent.click(
+          await screen.findByTestId('user-actions-filter-activity-button-all'),
+          undefined,
+          { skipPointerEventsCheck: true }
+        );
+
+        userEvent.paste(await screen.findByTestId('euiMarkdownEditorTextArea'), newComment);
+
+        userEvent.click(await screen.findByTestId('editable-description-edit-icon'), undefined, {
+          skipPointerEventsCheck: true,
+        });
+
+        userEvent.paste(screen.getAllByTestId('euiMarkdownEditorTextArea')[0], 'Edited!');
+
+        userEvent.click(screen.getByTestId('user-action-save-markdown'), undefined, {
+          skipPointerEventsCheck: true,
+        });
+
+        expect(await screen.findByTestId('euiMarkdownEditorTextArea')).toHaveTextContent(
+          newComment
         );
       });
     });
 
-    describe('Callouts', () => {
-      it('it shows the danger callout when a connector has been deleted', async () => {
-        useGetConnectorsMock.mockImplementation(() => ({ data: [], isLoading: false }));
-        const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
+    describe('breadcrumbs', () => {
+      it('should set the cases title', async () => {
+        appMockRenderer.render(<CaseViewPage {...caseProps} />);
 
-        expect(result.container.querySelector('.euiCallOut--danger')).toBeInTheDocument();
-      });
-
-      it('it does NOT shows the danger callout when connectors are loading', async () => {
-        useGetConnectorsMock.mockImplementation(() => ({ data: [], isLoading: true }));
-        const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
-
-        expect(result.container.querySelector('.euiCallOut--danger')).not.toBeInTheDocument();
-      });
-    });
-
-    describe('Tabs', () => {
-      jest.mock('@kbn/kibana-react-plugin/public', () => ({
-        useKibana: () => ({
-          services: {
-            application: {
-              capabilities: {
-                fakeCases: {
-                  create_cases: true,
-                  read_cases: true,
-                  update_cases: true,
-                  delete_cases: true,
-                  push_cases: true,
-                },
-              },
-            },
-            cases: {
-              ui: {
-                getCasesContext: () => null,
-              },
-              helpers: {
-                getUICapabilities: () => ({
-                  all: true,
-                  read: true,
-                  create: true,
-                  update: true,
-                  delete: true,
-                  push: true,
-                }),
-              },
-            },
-            notifications: {
-              toasts: {
-                addDanger: () => {},
-              },
-            },
-          },
-        }),
-      }));
-
-      it('renders tabs correctly', async () => {
-        const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
-        await act(async () => {
-          expect(result.getByTestId('case-view-tab-title-alerts')).toBeTruthy();
-          expect(result.getByTestId('case-view-tab-title-activity')).toBeTruthy();
-        });
-      });
-
-      it('renders the activity tab by default', async () => {
-        const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
-        await act(async () => {
-          expect(result.getByTestId('case-view-tab-content-activity')).toBeTruthy();
-        });
-      });
-
-      it('renders the alerts tab when the query parameter tabId has alerts', async () => {
-        useUrlParamsMock.mockReturnValue({
-          urlParams: {
-            tabId: CASE_VIEW_PAGE_TABS.ALERTS,
-          },
-        });
-        const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
-        await act(async () => {
-          expect(result.getByTestId('case-view-tab-content-alerts')).toBeTruthy();
-        });
-      });
-
-      it('renders the activity tab when the query parameter tabId has activity', async () => {
-        useUrlParamsMock.mockReturnValue({
-          urlParams: {
-            tabId: CASE_VIEW_PAGE_TABS.ACTIVITY,
-          },
-        });
-        const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
-        await act(async () => {
-          expect(result.getByTestId('case-view-tab-content-activity')).toBeTruthy();
-        });
-      });
-
-      it('renders the activity tab when the query parameter tabId has an unknown value', async () => {
-        useUrlParamsMock.mockReturnValue({
-          urlParams: {
-            tabId: 'what-is-love',
-          },
-        });
-        const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
-        await act(async () => {
-          expect(result.getByTestId('case-view-tab-content-activity')).toBeTruthy();
-          expect(result.queryByTestId('case-view-tab-content-alerts')).toBeFalsy();
-        });
-      });
-
-      it('navigates to the activity tab when the activity tab is clicked', async () => {
-        const navigateToCaseViewMock = useCaseViewNavigationMock().navigateToCaseView;
-        const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
-        userEvent.click(result.getByTestId('case-view-tab-title-activity'), undefined, {
-          skipPointerEventsCheck: true,
-        });
-        await act(async () => {
-          expect(navigateToCaseViewMock).toHaveBeenCalledWith({
-            detailName: caseData.id,
-            tabId: CASE_VIEW_PAGE_TABS.ACTIVITY,
-          });
-        });
-      });
-
-      it('navigates to the alerts tab when the alerts tab is clicked', async () => {
-        const navigateToCaseViewMock = useCaseViewNavigationMock().navigateToCaseView;
-        const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
-        userEvent.click(result.getByTestId('case-view-tab-title-alerts'), undefined, {
-          skipPointerEventsCheck: true,
-        });
-        await act(async () => {
-          expect(navigateToCaseViewMock).toHaveBeenCalledWith({
-            detailName: caseData.id,
-            tabId: CASE_VIEW_PAGE_TABS.ALERTS,
-          });
-        });
-      });
-
-      it('should display the alerts tab when the feature is enabled', async () => {
-        appMockRenderer = createAppMockRenderer({ features: { alerts: { enabled: true } } });
-        const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
-        await act(async () => {
-          expect(result.queryByTestId('case-view-tab-title-activity')).toBeTruthy();
-          expect(result.queryByTestId('case-view-tab-title-alerts')).toBeTruthy();
-        });
-      });
-
-      it('should not display the alerts tab when the feature is disabled', async () => {
-        appMockRenderer = createAppMockRenderer({ features: { alerts: { enabled: false } } });
-        const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
-        await act(async () => {
-          expect(result.queryByTestId('case-view-tab-title-activity')).toBeTruthy();
-          expect(result.queryByTestId('case-view-tab-title-alerts')).toBeFalsy();
-        });
-      });
-
-      it('should not show the experimental badge on the alerts table', async () => {
-        appMockRenderer = createAppMockRenderer({
-          features: { alerts: { isExperimental: false } },
-        });
-        const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
-
-        await act(async () => {
-          expect(result.queryByTestId('case-view-alerts-table-experimental-badge')).toBeFalsy();
-        });
-      });
-
-      it('should show the experimental badge on the alerts table', async () => {
-        appMockRenderer = createAppMockRenderer({ features: { alerts: { isExperimental: true } } });
-        const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
-
-        await act(async () => {
-          expect(result.queryByTestId('case-view-alerts-table-experimental-badge')).toBeTruthy();
-        });
-      });
-
-      describe('description', () => {
-        it('renders the descriptions user correctly', async () => {
-          appMockRenderer.render(<CaseViewPage {...caseProps} />);
-
-          const description = within(screen.getByTestId('description-action'));
-
-          expect(await description.findByText('Leslie Knope')).toBeInTheDocument();
-        });
-
-        it('should display description isLoading', async () => {
-          useUpdateCaseMock.mockImplementation(() => ({
-            ...defaultUpdateCaseState,
-            isLoading: true,
-            updateKey: 'description',
-          }));
-
-          appMockRenderer.render(<CaseViewPage {...caseProps} />);
-
-          await waitFor(() => {
-            expect(screen.getByTestId('description-loading')).toBeInTheDocument();
-            expect(screen.queryByTestId('description-action')).not.toBeInTheDocument();
-          });
-        });
-
-        it.skip('it should persist the draft of new comment while description is updated', async () => {
-          const newComment = 'another cool comment';
-
-          appMockRenderer.render(<CaseViewPage {...caseProps} />);
-
-          userEvent.click(
-            await screen.findByTestId('user-actions-filter-activity-button-all'),
-            undefined,
-            { skipPointerEventsCheck: true }
-          );
-
-          userEvent.paste(await screen.findByTestId('euiMarkdownEditorTextArea'), newComment);
-
-          userEvent.click(await screen.findByTestId('editable-description-edit-icon'), undefined, {
-            skipPointerEventsCheck: true,
-          });
-
-          userEvent.paste(screen.getAllByTestId('euiMarkdownEditorTextArea')[0], 'Edited!');
-
-          userEvent.click(screen.getByTestId('user-action-save-markdown'), undefined, {
-            skipPointerEventsCheck: true,
-          });
-
-          expect(await screen.findByTestId('euiMarkdownEditorTextArea')).toHaveTextContent(
-            newComment
-          );
-        });
-      });
-
-      describe('breadcrumbs', () => {
-        it('should set the cases title', () => {
-          appMockRenderer.render(<CaseViewPage {...caseProps} />);
-
+        await waitFor(() => {
           expect(mockSetTitle).toHaveBeenCalledWith([caseProps.caseData.title, 'Cases', 'Test']);
         });
       });
     });
   });
-}
+});

--- a/x-pack/plugins/cases/public/components/case_view/case_view_page.test.tsx
+++ b/x-pack/plugins/cases/public/components/case_view/case_view_page.test.tsx
@@ -135,511 +135,513 @@ const userActionsStats = {
   totalOtherActions: 11,
 };
 
-describe('CaseViewPage', () => {
-  const updateCaseProperty = defaultUpdateCaseState.updateCaseProperty;
-  const pushCaseToExternalService = jest.fn();
-  const data = caseProps.caseData;
-  let appMockRenderer: AppMockRenderer;
-  const caseConnectors = getCaseConnectorsMockResponse();
-  const caseUsers = getCaseUsersMockResponse();
-  const refetchFindCaseUserActions = jest.fn();
+for (let index = 0; index < 50; index++) {
+  describe('CaseViewPage', () => {
+    const updateCaseProperty = defaultUpdateCaseState.updateCaseProperty;
+    const pushCaseToExternalService = jest.fn();
+    const data = caseProps.caseData;
+    let appMockRenderer: AppMockRenderer;
+    const caseConnectors = getCaseConnectorsMockResponse();
+    const caseUsers = getCaseUsersMockResponse();
+    const refetchFindCaseUserActions = jest.fn();
 
-  beforeEach(() => {
-    jest.clearAllMocks();
-    mockGetCase();
-    useUpdateCaseMock.mockReturnValue(defaultUpdateCaseState);
-    useGetCaseMetricsMock.mockReturnValue(defaultGetCaseMetrics);
-    useFindCaseUserActionsMock.mockReturnValue(defaultUseFindCaseUserActions);
-    usePostPushToServiceMock.mockReturnValue({ isLoading: false, pushCaseToExternalService });
-    useGetCaseConnectorsMock.mockReturnValue({
-      isLoading: false,
-      data: caseConnectors,
-    });
-    useGetConnectorsMock.mockReturnValue({ data: connectorsMock, isLoading: false });
-    useGetTagsMock.mockReturnValue({ data: [], isLoading: false });
-    const license = licensingMock.createLicense({
-      license: { type: 'platinum' },
-    });
-    useGetCaseUsersMock.mockReturnValue({ isLoading: false, data: caseUsers });
-    useGetCurrentUserProfileMock.mockReturnValue({ isLoading: false, data: userProfiles[0] });
-    useGetCaseUserActionsStatsMock.mockReturnValue({ data: userActionsStats, isLoading: false });
-    useSuggestUserProfilesMock.mockReturnValue({ data: [], isLoading: false });
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockGetCase();
+      useUpdateCaseMock.mockReturnValue(defaultUpdateCaseState);
+      useGetCaseMetricsMock.mockReturnValue(defaultGetCaseMetrics);
+      useFindCaseUserActionsMock.mockReturnValue(defaultUseFindCaseUserActions);
+      usePostPushToServiceMock.mockReturnValue({ isLoading: false, pushCaseToExternalService });
+      useGetCaseConnectorsMock.mockReturnValue({
+        isLoading: false,
+        data: caseConnectors,
+      });
+      useGetConnectorsMock.mockReturnValue({ data: connectorsMock, isLoading: false });
+      useGetTagsMock.mockReturnValue({ data: [], isLoading: false });
+      const license = licensingMock.createLicense({
+        license: { type: 'platinum' },
+      });
+      useGetCaseUsersMock.mockReturnValue({ isLoading: false, data: caseUsers });
+      useGetCurrentUserProfileMock.mockReturnValue({ isLoading: false, data: userProfiles[0] });
+      useGetCaseUserActionsStatsMock.mockReturnValue({ data: userActionsStats, isLoading: false });
+      useSuggestUserProfilesMock.mockReturnValue({ data: [], isLoading: false });
 
-    appMockRenderer = createAppMockRenderer({ license });
-  });
-
-  it('should render CaseViewPage', async () => {
-    const damagedRaccoonUser = userProfiles[0].user;
-    const caseDataWithDamagedRaccoon = {
-      ...caseData,
-      createdBy: {
-        profileUid: userProfiles[0].uid,
-        username: damagedRaccoonUser.username,
-        fullName: damagedRaccoonUser.full_name,
-        email: damagedRaccoonUser.email,
-      },
-    };
-
-    const license = licensingMock.createLicense({
-      license: { type: 'platinum' },
+      appMockRenderer = createAppMockRenderer({ license });
     });
 
-    const props = { ...caseProps, caseData: caseDataWithDamagedRaccoon };
-    appMockRenderer = createAppMockRenderer({ features: { metrics: ['alerts.count'] }, license });
-    appMockRenderer.render(<CaseViewPage {...props} />);
-
-    expect(screen.getByTestId('header-page-title')).toHaveTextContent(data.title);
-    expect(screen.getByTestId('case-view-status-dropdown')).toHaveTextContent('Open');
-    expect(screen.getByTestId('case-view-metrics-panel')).toBeInTheDocument();
-    expect(
-      within(screen.getByTestId('case-view-tag-list')).getByTestId('tag-coke')
-    ).toHaveTextContent(data.tags[0]);
-
-    expect(
-      within(screen.getByTestId('case-view-tag-list')).getByTestId('tag-pepsi')
-    ).toHaveTextContent(data.tags[1]);
-
-    expect(screen.getAllByText(data.createdBy.fullName!)[0]).toBeInTheDocument();
-
-    expect(
-      within(screen.getByTestId('description-action')).getByTestId('user-action-markdown')
-    ).toHaveTextContent(data.description);
-
-    expect(screen.getByTestId('case-view-status-action-button')).toHaveTextContent(
-      'Mark in progress'
-    );
-  });
-
-  it('should show closed indicators in header when case is closed', async () => {
-    useUpdateCaseMock.mockImplementation(() => ({
-      ...defaultUpdateCaseState,
-      caseData: basicCaseClosed,
-    }));
-
-    appMockRenderer.render(<CaseViewPage {...caseClosedProps} />);
-
-    expect(screen.getByTestId('case-view-status-dropdown')).toHaveTextContent('Closed');
-  });
-
-  it('should update status', async () => {
-    appMockRenderer.render(<CaseViewPage {...caseProps} />);
-
-    const dropdown = screen.getByTestId('case-view-status-dropdown');
-    userEvent.click(dropdown.querySelector('button')!, undefined, {
-      skipPointerEventsCheck: true,
-    });
-    await waitForEuiPopoverOpen();
-    userEvent.click(screen.getByTestId('case-view-status-dropdown-closed'), undefined, {
-      skipPointerEventsCheck: true,
-    });
-    const updateObject = updateCaseProperty.mock.calls[0][0];
-
-    await waitFor(() => {
-      expect(updateCaseProperty).toHaveBeenCalledTimes(1);
-      expect(updateObject.updateKey).toEqual('status');
-      expect(updateObject.updateValue).toEqual('closed');
-    });
-  });
-
-  it('should display EditableTitle isLoading', async () => {
-    useUpdateCaseMock.mockImplementation(() => ({
-      ...defaultUpdateCaseState,
-      isLoading: true,
-      updateKey: 'title',
-    }));
-    appMockRenderer.render(<CaseViewPage {...caseProps} />);
-
-    expect(await screen.findByTestId('editable-title-loading')).toBeInTheDocument();
-    expect(screen.queryByTestId('editable-title-edit-icon')).not.toBeInTheDocument();
-  });
-
-  it('should display tags isLoading', async () => {
-    useUpdateCaseMock.mockImplementation(() => ({
-      ...defaultUpdateCaseState,
-      isLoading: true,
-      updateKey: 'tags',
-    }));
-
-    appMockRenderer.render(<CaseViewPage {...caseProps} />);
-
-    expect(
-      within(await screen.findByTestId('case-view-tag-list')).getByTestId('tag-list-loading')
-    ).toBeInTheDocument();
-
-    expect(screen.queryByTestId('tag-list-edit')).not.toBeInTheDocument();
-  });
-
-  it('should update title', async () => {
-    appMockRenderer.render(<CaseViewPage {...caseProps} />);
-    const newTitle = 'The new title';
-    userEvent.click(screen.getByTestId('editable-title-edit-icon'), undefined, {
-      skipPointerEventsCheck: true,
-    });
-    userEvent.clear(screen.getByTestId('editable-title-input-field'));
-    userEvent.paste(screen.getByTestId('editable-title-input-field'), newTitle);
-    userEvent.click(screen.getByTestId('editable-title-submit-btn'), undefined, {
-      skipPointerEventsCheck: true,
-    });
-
-    const updateObject = updateCaseProperty.mock.calls[0][0];
-    await waitFor(() => {
-      expect(updateObject.updateKey).toEqual('title');
-      expect(updateObject.updateValue).toEqual(newTitle);
-    });
-  });
-
-  it('should push updates on button click', async () => {
-    useGetCaseConnectorsMock.mockImplementation(() => ({
-      isLoading: false,
-      data: {
-        ...caseConnectors,
-        'resilient-2': {
-          ...caseConnectors['resilient-2'],
-          push: { ...caseConnectors['resilient-2'].push, needsToBePushed: true },
+    it('should render CaseViewPage', async () => {
+      const damagedRaccoonUser = userProfiles[0].user;
+      const caseDataWithDamagedRaccoon = {
+        ...caseData,
+        createdBy: {
+          profileUid: userProfiles[0].uid,
+          username: damagedRaccoonUser.username,
+          fullName: damagedRaccoonUser.full_name,
+          email: damagedRaccoonUser.email,
         },
-      },
-    }));
+      };
 
-    appMockRenderer.render(<CaseViewPage {...caseProps} />);
+      const license = licensingMock.createLicense({
+        license: { type: 'platinum' },
+      });
 
-    expect(screen.getByTestId('push-to-external-service')).toBeInTheDocument();
+      const props = { ...caseProps, caseData: caseDataWithDamagedRaccoon };
+      appMockRenderer = createAppMockRenderer({ features: { metrics: ['alerts.count'] }, license });
+      appMockRenderer.render(<CaseViewPage {...props} />);
 
-    userEvent.click(screen.getByTestId('push-to-external-service'), undefined, {
-      skipPointerEventsCheck: true,
+      expect(screen.getByTestId('header-page-title')).toHaveTextContent(data.title);
+      expect(screen.getByTestId('case-view-status-dropdown')).toHaveTextContent('Open');
+      expect(screen.getByTestId('case-view-metrics-panel')).toBeInTheDocument();
+      expect(
+        within(screen.getByTestId('case-view-tag-list')).getByTestId('tag-coke')
+      ).toHaveTextContent(data.tags[0]);
+
+      expect(
+        within(screen.getByTestId('case-view-tag-list')).getByTestId('tag-pepsi')
+      ).toHaveTextContent(data.tags[1]);
+
+      expect(screen.getAllByText(data.createdBy.fullName!)[0]).toBeInTheDocument();
+
+      expect(
+        within(screen.getByTestId('description-action')).getByTestId('user-action-markdown')
+      ).toHaveTextContent(data.description);
+
+      expect(screen.getByTestId('case-view-status-action-button')).toHaveTextContent(
+        'Mark in progress'
+      );
     });
 
-    await waitFor(() => {
-      expect(pushCaseToExternalService).toHaveBeenCalled();
-    });
-  });
+    it('should show closed indicators in header when case is closed', async () => {
+      useUpdateCaseMock.mockImplementation(() => ({
+        ...defaultUpdateCaseState,
+        caseData: basicCaseClosed,
+      }));
 
-  it('should disable the push button when connector is invalid', async () => {
-    appMockRenderer.render(
-      <CaseViewPage
-        {...{
-          ...caseProps,
-          caseData: { ...caseProps.caseData, connectorId: 'not-exist' },
-        }}
-      />
-    );
+      appMockRenderer.render(<CaseViewPage {...caseClosedProps} />);
 
-    expect(await screen.findByTestId('push-to-external-service')).toBeDisabled();
-  });
-
-  it('should update connector', async () => {
-    appMockRenderer.render(
-      <CaseViewPage
-        {...caseProps}
-        caseData={{
-          ...caseProps.caseData,
-          connector: {
-            id: 'servicenow-1',
-            name: 'SN 1',
-            type: ConnectorTypes.serviceNowITSM,
-            fields: null,
-          },
-        }}
-      />
-    );
-    userEvent.click(screen.getByTestId('connector-edit').querySelector('button')!, undefined, {
-      skipPointerEventsCheck: true,
-    });
-    userEvent.click(screen.getByTestId('dropdown-connectors'), undefined, {
-      skipPointerEventsCheck: true,
-    });
-    await waitForEuiPopoverOpen();
-    userEvent.click(screen.getByTestId('dropdown-connector-resilient-2'), undefined, {
-      skipPointerEventsCheck: true,
+      expect(screen.getByTestId('case-view-status-dropdown')).toHaveTextContent('Closed');
     });
 
-    expect(await screen.findByTestId('connector-fields-resilient')).toBeInTheDocument();
+    it('should update status', async () => {
+      appMockRenderer.render(<CaseViewPage {...caseProps} />);
 
-    userEvent.click(screen.getByTestId('edit-connectors-submit'), undefined, {
-      skipPointerEventsCheck: true,
-    });
-
-    await waitFor(() => {
-      expect(updateCaseProperty).toHaveBeenCalledTimes(1);
+      const dropdown = screen.getByTestId('case-view-status-dropdown');
+      userEvent.click(dropdown.querySelector('button')!, undefined, {
+        skipPointerEventsCheck: true,
+      });
+      await waitForEuiPopoverOpen();
+      userEvent.click(screen.getByTestId('case-view-status-dropdown-closed'), undefined, {
+        skipPointerEventsCheck: true,
+      });
       const updateObject = updateCaseProperty.mock.calls[0][0];
-      expect(updateObject.updateKey).toEqual('connector');
-      expect(updateObject.updateValue).toEqual({
-        id: 'resilient-2',
-        name: 'My Resilient connector',
-        type: ConnectorTypes.resilient,
-        fields: {
-          incidentTypes: null,
-          severityCode: null,
-        },
-      });
-    });
-  });
 
-  it('should call onComponentInitialized on mount', async () => {
-    const onComponentInitialized = jest.fn();
-    appMockRenderer.render(
-      <CaseViewPage {...caseProps} onComponentInitialized={onComponentInitialized} />
-    );
-
-    await waitFor(() => {
-      expect(onComponentInitialized).toHaveBeenCalled();
-    });
-  });
-
-  it('should show loading content when loading user actions', async () => {
-    const useFetchAlertData = jest.fn().mockReturnValue([true]);
-    useFindCaseUserActionsMock.mockReturnValue({
-      data: undefined,
-      isError: false,
-      isLoading: true,
-      isFetching: true,
-      refetch: refetchFindCaseUserActions,
-    });
-
-    appMockRenderer.render(<CaseViewPage {...caseProps} useFetchAlertData={useFetchAlertData} />);
-
-    expect(await screen.findByTestId('case-view-loading-content')).toBeInTheDocument();
-    expect(screen.queryByTestId('user-actions')).not.toBeInTheDocument();
-  });
-
-  it('should call show alert details with expected arguments', async () => {
-    const showAlertDetails = jest.fn();
-    appMockRenderer.render(<CaseViewPage {...caseProps} showAlertDetails={showAlertDetails} />);
-
-    userEvent.click(screen.getByTestId('comment-action-show-alert-alert-action-id'), undefined, {
-      skipPointerEventsCheck: true,
-    });
-
-    await waitFor(() => {
-      expect(showAlertDetails).toHaveBeenCalledWith('alert-id-1', 'alert-index-1');
-    });
-  });
-
-  it('should show the rule name', async () => {
-    appMockRenderer.render(<CaseViewPage {...caseProps} />);
-
-    expect(
-      (
-        await screen.findByTestId('user-action-alert-comment-create-action-alert-action-id')
-      ).querySelector('.euiCommentEvent__headerEvent')
-    ).toHaveTextContent('added an alert from Awesome rule');
-  });
-
-  it('should update settings', async () => {
-    appMockRenderer.render(<CaseViewPage {...caseProps} />);
-    userEvent.click(screen.getByTestId('sync-alerts-switch'), undefined, {
-      skipPointerEventsCheck: true,
-    });
-    const updateObject = updateCaseProperty.mock.calls[0][0];
-
-    await waitFor(() => {
-      expect(updateObject.updateKey).toEqual('settings');
-      expect(updateObject.updateValue).toEqual({ syncAlerts: false });
-    });
-  });
-
-  it('should show the correct connector name on the push button', async () => {
-    useGetConnectorsMock.mockImplementation(() => ({ data: connectorsMock, isLoading: false }));
-
-    appMockRenderer.render(
-      <CaseViewPage {...{ ...caseProps, connector: { ...caseProps, name: 'old-name' } }} />
-    );
-
-    expect(await screen.findByTestId('push-to-external-service')).toHaveTextContent(
-      'My Resilient connector'
-    );
-  });
-
-  describe('Callouts', () => {
-    it('it shows the danger callout when a connector has been deleted', async () => {
-      useGetConnectorsMock.mockImplementation(() => ({ data: [], isLoading: false }));
-      const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
-
-      expect(result.container.querySelector('.euiCallOut--danger')).toBeInTheDocument();
-    });
-
-    it('it does NOT shows the danger callout when connectors are loading', async () => {
-      useGetConnectorsMock.mockImplementation(() => ({ data: [], isLoading: true }));
-      const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
-
-      expect(result.container.querySelector('.euiCallOut--danger')).not.toBeInTheDocument();
-    });
-  });
-
-  describe('Tabs', () => {
-    it('renders tabs correctly', async () => {
-      appMockRenderer.render(<CaseViewPage {...caseProps} />);
-      expect(await screen.findByTestId('case-view-tab-title-alerts')).toBeInTheDocument();
-      expect(await screen.findByTestId('case-view-tab-title-activity')).toBeInTheDocument();
-    });
-
-    it('renders the activity tab by default', async () => {
-      appMockRenderer.render(<CaseViewPage {...caseProps} />);
-      expect(await screen.findByTestId('case-view-tab-content-activity')).toBeInTheDocument();
-    });
-
-    it('renders the alerts tab when the query parameter tabId has alerts', async () => {
-      useUrlParamsMock.mockReturnValue({
-        urlParams: {
-          tabId: CASE_VIEW_PAGE_TABS.ALERTS,
-        },
-      });
-
-      appMockRenderer.render(<CaseViewPage {...caseProps} />);
-
-      expect(await screen.findByText('alerts table')).toBeInTheDocument();
-      expect(await screen.findByTestId('case-view-tab-content-alerts')).toBeInTheDocument();
-    });
-
-    it('renders the activity tab when the query parameter tabId has activity', async () => {
-      useUrlParamsMock.mockReturnValue({
-        urlParams: {
-          tabId: CASE_VIEW_PAGE_TABS.ACTIVITY,
-        },
-      });
-
-      appMockRenderer.render(<CaseViewPage {...caseProps} />);
-      expect(await screen.findByTestId('case-view-tab-content-activity')).toBeInTheDocument();
-    });
-
-    it('renders the activity tab when the query parameter tabId has an unknown value', async () => {
-      useUrlParamsMock.mockReturnValue({
-        urlParams: {
-          tabId: 'what-is-love',
-        },
-      });
-
-      appMockRenderer.render(<CaseViewPage {...caseProps} />);
-      expect(await screen.findByTestId('case-view-tab-content-activity')).toBeInTheDocument();
-      expect(screen.queryByTestId('case-view-tab-content-alerts')).not.toBeInTheDocument();
-    });
-
-    it('navigates to the activity tab when the activity tab is clicked', async () => {
-      const navigateToCaseViewMock = useCaseViewNavigationMock().navigateToCaseView;
-      appMockRenderer.render(<CaseViewPage {...caseProps} />);
-
-      userEvent.click(await screen.findByTestId('case-view-tab-title-activity'), undefined, {
-        skipPointerEventsCheck: true,
-      });
-
-      await waitFor(async () => {
-        expect(navigateToCaseViewMock).toHaveBeenCalledWith({
-          detailName: caseData.id,
-          tabId: CASE_VIEW_PAGE_TABS.ACTIVITY,
-        });
+      await waitFor(() => {
+        expect(updateCaseProperty).toHaveBeenCalledTimes(1);
+        expect(updateObject.updateKey).toEqual('status');
+        expect(updateObject.updateValue).toEqual('closed');
       });
     });
 
-    it('navigates to the alerts tab when the alerts tab is clicked', async () => {
-      const navigateToCaseViewMock = useCaseViewNavigationMock().navigateToCaseView;
+    it('should display EditableTitle isLoading', async () => {
+      useUpdateCaseMock.mockImplementation(() => ({
+        ...defaultUpdateCaseState,
+        isLoading: true,
+        updateKey: 'title',
+      }));
       appMockRenderer.render(<CaseViewPage {...caseProps} />);
 
-      userEvent.click(await screen.findByTestId('case-view-tab-title-alerts'), undefined, {
-        skipPointerEventsCheck: true,
-      });
-
-      await waitFor(async () => {
-        expect(navigateToCaseViewMock).toHaveBeenCalledWith({
-          detailName: caseData.id,
-          tabId: CASE_VIEW_PAGE_TABS.ALERTS,
-        });
-      });
+      expect(await screen.findByTestId('editable-title-loading')).toBeInTheDocument();
+      expect(screen.queryByTestId('editable-title-edit-icon')).not.toBeInTheDocument();
     });
 
-    it('should display the alerts tab when the feature is enabled', async () => {
-      appMockRenderer = createAppMockRenderer({ features: { alerts: { enabled: true } } });
-      appMockRenderer.render(<CaseViewPage {...caseProps} />);
+    it('should display tags isLoading', async () => {
+      useUpdateCaseMock.mockImplementation(() => ({
+        ...defaultUpdateCaseState,
+        isLoading: true,
+        updateKey: 'tags',
+      }));
 
-      expect(await screen.findByTestId('case-view-tab-title-activity')).toBeInTheDocument();
-      expect(await screen.findByTestId('case-view-tab-title-alerts')).toBeInTheDocument();
-    });
-
-    it('should not display the alerts tab when the feature is disabled', async () => {
-      appMockRenderer = createAppMockRenderer({ features: { alerts: { enabled: false } } });
-      appMockRenderer.render(<CaseViewPage {...caseProps} />);
-
-      expect(await screen.findByTestId('case-view-tab-title-activity')).toBeInTheDocument();
-      expect(screen.queryByTestId('case-view-tab-title-alerts')).not.toBeInTheDocument();
-    });
-
-    it('should not show the experimental badge on the alerts table', async () => {
-      appMockRenderer = createAppMockRenderer({
-        features: { alerts: { isExperimental: false } },
-      });
       appMockRenderer.render(<CaseViewPage {...caseProps} />);
 
       expect(
-        screen.queryByTestId('case-view-alerts-table-experimental-badge')
-      ).not.toBeInTheDocument();
-    });
-
-    it('should show the experimental badge on the alerts table', async () => {
-      appMockRenderer = createAppMockRenderer({ features: { alerts: { isExperimental: true } } });
-      appMockRenderer.render(<CaseViewPage {...caseProps} />);
-
-      expect(
-        await screen.findByTestId('case-view-alerts-table-experimental-badge')
+        within(await screen.findByTestId('case-view-tag-list')).getByTestId('tag-list-loading')
       ).toBeInTheDocument();
+
+      expect(screen.queryByTestId('tag-list-edit')).not.toBeInTheDocument();
     });
 
-    describe('description', () => {
-      it('renders the descriptions user correctly', async () => {
-        appMockRenderer.render(<CaseViewPage {...caseProps} />);
-
-        const description = within(await screen.findByTestId('description-action'));
-
-        expect(await description.findByText('Leslie Knope')).toBeInTheDocument();
+    it('should update title', async () => {
+      appMockRenderer.render(<CaseViewPage {...caseProps} />);
+      const newTitle = 'The new title';
+      userEvent.click(screen.getByTestId('editable-title-edit-icon'), undefined, {
+        skipPointerEventsCheck: true,
+      });
+      userEvent.clear(screen.getByTestId('editable-title-input-field'));
+      userEvent.paste(screen.getByTestId('editable-title-input-field'), newTitle);
+      userEvent.click(screen.getByTestId('editable-title-submit-btn'), undefined, {
+        skipPointerEventsCheck: true,
       });
 
-      it('should display description isLoading', async () => {
-        useUpdateCaseMock.mockImplementation(() => ({
-          ...defaultUpdateCaseState,
-          isLoading: true,
-          updateKey: 'description',
-        }));
-
-        appMockRenderer.render(<CaseViewPage {...caseProps} />);
-
-        expect(await screen.findByTestId('description-loading')).toBeInTheDocument();
-        expect(screen.queryByTestId('description-action')).not.toBeInTheDocument();
-      });
-
-      it.skip('it should persist the draft of new comment while description is updated', async () => {
-        const newComment = 'another cool comment';
-
-        appMockRenderer.render(<CaseViewPage {...caseProps} />);
-
-        userEvent.click(
-          await screen.findByTestId('user-actions-filter-activity-button-all'),
-          undefined,
-          { skipPointerEventsCheck: true }
-        );
-
-        userEvent.paste(await screen.findByTestId('euiMarkdownEditorTextArea'), newComment);
-
-        userEvent.click(await screen.findByTestId('editable-description-edit-icon'), undefined, {
-          skipPointerEventsCheck: true,
-        });
-
-        userEvent.paste(screen.getAllByTestId('euiMarkdownEditorTextArea')[0], 'Edited!');
-
-        userEvent.click(screen.getByTestId('user-action-save-markdown'), undefined, {
-          skipPointerEventsCheck: true,
-        });
-
-        expect(await screen.findByTestId('euiMarkdownEditorTextArea')).toHaveTextContent(
-          newComment
-        );
+      const updateObject = updateCaseProperty.mock.calls[0][0];
+      await waitFor(() => {
+        expect(updateObject.updateKey).toEqual('title');
+        expect(updateObject.updateValue).toEqual(newTitle);
       });
     });
 
-    describe('breadcrumbs', () => {
-      it('should set the cases title', async () => {
+    it('should push updates on button click', async () => {
+      useGetCaseConnectorsMock.mockImplementation(() => ({
+        isLoading: false,
+        data: {
+          ...caseConnectors,
+          'resilient-2': {
+            ...caseConnectors['resilient-2'],
+            push: { ...caseConnectors['resilient-2'].push, needsToBePushed: true },
+          },
+        },
+      }));
+
+      appMockRenderer.render(<CaseViewPage {...caseProps} />);
+
+      expect(screen.getByTestId('push-to-external-service')).toBeInTheDocument();
+
+      userEvent.click(screen.getByTestId('push-to-external-service'), undefined, {
+        skipPointerEventsCheck: true,
+      });
+
+      await waitFor(() => {
+        expect(pushCaseToExternalService).toHaveBeenCalled();
+      });
+    });
+
+    it('should disable the push button when connector is invalid', async () => {
+      appMockRenderer.render(
+        <CaseViewPage
+          {...{
+            ...caseProps,
+            caseData: { ...caseProps.caseData, connectorId: 'not-exist' },
+          }}
+        />
+      );
+
+      expect(await screen.findByTestId('push-to-external-service')).toBeDisabled();
+    });
+
+    it('should update connector', async () => {
+      appMockRenderer.render(
+        <CaseViewPage
+          {...caseProps}
+          caseData={{
+            ...caseProps.caseData,
+            connector: {
+              id: 'servicenow-1',
+              name: 'SN 1',
+              type: ConnectorTypes.serviceNowITSM,
+              fields: null,
+            },
+          }}
+        />
+      );
+      userEvent.click(screen.getByTestId('connector-edit').querySelector('button')!, undefined, {
+        skipPointerEventsCheck: true,
+      });
+      userEvent.click(screen.getByTestId('dropdown-connectors'), undefined, {
+        skipPointerEventsCheck: true,
+      });
+      await waitForEuiPopoverOpen();
+      userEvent.click(screen.getByTestId('dropdown-connector-resilient-2'), undefined, {
+        skipPointerEventsCheck: true,
+      });
+
+      expect(await screen.findByTestId('connector-fields-resilient')).toBeInTheDocument();
+
+      userEvent.click(screen.getByTestId('edit-connectors-submit'), undefined, {
+        skipPointerEventsCheck: true,
+      });
+
+      await waitFor(() => {
+        expect(updateCaseProperty).toHaveBeenCalledTimes(1);
+        const updateObject = updateCaseProperty.mock.calls[0][0];
+        expect(updateObject.updateKey).toEqual('connector');
+        expect(updateObject.updateValue).toEqual({
+          id: 'resilient-2',
+          name: 'My Resilient connector',
+          type: ConnectorTypes.resilient,
+          fields: {
+            incidentTypes: null,
+            severityCode: null,
+          },
+        });
+      });
+    });
+
+    it('should call onComponentInitialized on mount', async () => {
+      const onComponentInitialized = jest.fn();
+      appMockRenderer.render(
+        <CaseViewPage {...caseProps} onComponentInitialized={onComponentInitialized} />
+      );
+
+      await waitFor(() => {
+        expect(onComponentInitialized).toHaveBeenCalled();
+      });
+    });
+
+    it('should show loading content when loading user actions', async () => {
+      const useFetchAlertData = jest.fn().mockReturnValue([true]);
+      useFindCaseUserActionsMock.mockReturnValue({
+        data: undefined,
+        isError: false,
+        isLoading: true,
+        isFetching: true,
+        refetch: refetchFindCaseUserActions,
+      });
+
+      appMockRenderer.render(<CaseViewPage {...caseProps} useFetchAlertData={useFetchAlertData} />);
+
+      expect(await screen.findByTestId('case-view-loading-content')).toBeInTheDocument();
+      expect(screen.queryByTestId('user-actions')).not.toBeInTheDocument();
+    });
+
+    it('should call show alert details with expected arguments', async () => {
+      const showAlertDetails = jest.fn();
+      appMockRenderer.render(<CaseViewPage {...caseProps} showAlertDetails={showAlertDetails} />);
+
+      userEvent.click(screen.getByTestId('comment-action-show-alert-alert-action-id'), undefined, {
+        skipPointerEventsCheck: true,
+      });
+
+      await waitFor(() => {
+        expect(showAlertDetails).toHaveBeenCalledWith('alert-id-1', 'alert-index-1');
+      });
+    });
+
+    it('should show the rule name', async () => {
+      appMockRenderer.render(<CaseViewPage {...caseProps} />);
+
+      expect(
+        (
+          await screen.findByTestId('user-action-alert-comment-create-action-alert-action-id')
+        ).querySelector('.euiCommentEvent__headerEvent')
+      ).toHaveTextContent('added an alert from Awesome rule');
+    });
+
+    it('should update settings', async () => {
+      appMockRenderer.render(<CaseViewPage {...caseProps} />);
+      userEvent.click(screen.getByTestId('sync-alerts-switch'), undefined, {
+        skipPointerEventsCheck: true,
+      });
+      const updateObject = updateCaseProperty.mock.calls[0][0];
+
+      await waitFor(() => {
+        expect(updateObject.updateKey).toEqual('settings');
+        expect(updateObject.updateValue).toEqual({ syncAlerts: false });
+      });
+    });
+
+    it('should show the correct connector name on the push button', async () => {
+      useGetConnectorsMock.mockImplementation(() => ({ data: connectorsMock, isLoading: false }));
+
+      appMockRenderer.render(
+        <CaseViewPage {...{ ...caseProps, connector: { ...caseProps, name: 'old-name' } }} />
+      );
+
+      expect(await screen.findByTestId('push-to-external-service')).toHaveTextContent(
+        'My Resilient connector'
+      );
+    });
+
+    describe('Callouts', () => {
+      it('it shows the danger callout when a connector has been deleted', async () => {
+        useGetConnectorsMock.mockImplementation(() => ({ data: [], isLoading: false }));
+        const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
+
+        expect(result.container.querySelector('.euiCallOut--danger')).toBeInTheDocument();
+      });
+
+      it('it does NOT shows the danger callout when connectors are loading', async () => {
+        useGetConnectorsMock.mockImplementation(() => ({ data: [], isLoading: true }));
+        const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
+
+        expect(result.container.querySelector('.euiCallOut--danger')).not.toBeInTheDocument();
+      });
+    });
+
+    describe('Tabs', () => {
+      it('renders tabs correctly', async () => {
+        appMockRenderer.render(<CaseViewPage {...caseProps} />);
+        expect(await screen.findByTestId('case-view-tab-title-alerts')).toBeInTheDocument();
+        expect(await screen.findByTestId('case-view-tab-title-activity')).toBeInTheDocument();
+      });
+
+      it('renders the activity tab by default', async () => {
+        appMockRenderer.render(<CaseViewPage {...caseProps} />);
+        expect(await screen.findByTestId('case-view-tab-content-activity')).toBeInTheDocument();
+      });
+
+      it('renders the alerts tab when the query parameter tabId has alerts', async () => {
+        useUrlParamsMock.mockReturnValue({
+          urlParams: {
+            tabId: CASE_VIEW_PAGE_TABS.ALERTS,
+          },
+        });
+
         appMockRenderer.render(<CaseViewPage {...caseProps} />);
 
-        await waitFor(() => {
-          expect(mockSetTitle).toHaveBeenCalledWith([caseProps.caseData.title, 'Cases', 'Test']);
+        expect(await screen.findByText('alerts table')).toBeInTheDocument();
+        expect(await screen.findByTestId('case-view-tab-content-alerts')).toBeInTheDocument();
+      });
+
+      it('renders the activity tab when the query parameter tabId has activity', async () => {
+        useUrlParamsMock.mockReturnValue({
+          urlParams: {
+            tabId: CASE_VIEW_PAGE_TABS.ACTIVITY,
+          },
+        });
+
+        appMockRenderer.render(<CaseViewPage {...caseProps} />);
+        expect(await screen.findByTestId('case-view-tab-content-activity')).toBeInTheDocument();
+      });
+
+      it('renders the activity tab when the query parameter tabId has an unknown value', async () => {
+        useUrlParamsMock.mockReturnValue({
+          urlParams: {
+            tabId: 'what-is-love',
+          },
+        });
+
+        appMockRenderer.render(<CaseViewPage {...caseProps} />);
+        expect(await screen.findByTestId('case-view-tab-content-activity')).toBeInTheDocument();
+        expect(screen.queryByTestId('case-view-tab-content-alerts')).not.toBeInTheDocument();
+      });
+
+      it('navigates to the activity tab when the activity tab is clicked', async () => {
+        const navigateToCaseViewMock = useCaseViewNavigationMock().navigateToCaseView;
+        appMockRenderer.render(<CaseViewPage {...caseProps} />);
+
+        userEvent.click(await screen.findByTestId('case-view-tab-title-activity'), undefined, {
+          skipPointerEventsCheck: true,
+        });
+
+        await waitFor(async () => {
+          expect(navigateToCaseViewMock).toHaveBeenCalledWith({
+            detailName: caseData.id,
+            tabId: CASE_VIEW_PAGE_TABS.ACTIVITY,
+          });
+        });
+      });
+
+      it('navigates to the alerts tab when the alerts tab is clicked', async () => {
+        const navigateToCaseViewMock = useCaseViewNavigationMock().navigateToCaseView;
+        appMockRenderer.render(<CaseViewPage {...caseProps} />);
+
+        userEvent.click(await screen.findByTestId('case-view-tab-title-alerts'), undefined, {
+          skipPointerEventsCheck: true,
+        });
+
+        await waitFor(async () => {
+          expect(navigateToCaseViewMock).toHaveBeenCalledWith({
+            detailName: caseData.id,
+            tabId: CASE_VIEW_PAGE_TABS.ALERTS,
+          });
+        });
+      });
+
+      it('should display the alerts tab when the feature is enabled', async () => {
+        appMockRenderer = createAppMockRenderer({ features: { alerts: { enabled: true } } });
+        appMockRenderer.render(<CaseViewPage {...caseProps} />);
+
+        expect(await screen.findByTestId('case-view-tab-title-activity')).toBeInTheDocument();
+        expect(await screen.findByTestId('case-view-tab-title-alerts')).toBeInTheDocument();
+      });
+
+      it('should not display the alerts tab when the feature is disabled', async () => {
+        appMockRenderer = createAppMockRenderer({ features: { alerts: { enabled: false } } });
+        appMockRenderer.render(<CaseViewPage {...caseProps} />);
+
+        expect(await screen.findByTestId('case-view-tab-title-activity')).toBeInTheDocument();
+        expect(screen.queryByTestId('case-view-tab-title-alerts')).not.toBeInTheDocument();
+      });
+
+      it('should not show the experimental badge on the alerts table', async () => {
+        appMockRenderer = createAppMockRenderer({
+          features: { alerts: { isExperimental: false } },
+        });
+        appMockRenderer.render(<CaseViewPage {...caseProps} />);
+
+        expect(
+          screen.queryByTestId('case-view-alerts-table-experimental-badge')
+        ).not.toBeInTheDocument();
+      });
+
+      it('should show the experimental badge on the alerts table', async () => {
+        appMockRenderer = createAppMockRenderer({ features: { alerts: { isExperimental: true } } });
+        appMockRenderer.render(<CaseViewPage {...caseProps} />);
+
+        expect(
+          await screen.findByTestId('case-view-alerts-table-experimental-badge')
+        ).toBeInTheDocument();
+      });
+
+      describe('description', () => {
+        it('renders the descriptions user correctly', async () => {
+          appMockRenderer.render(<CaseViewPage {...caseProps} />);
+
+          const description = within(await screen.findByTestId('description-action'));
+
+          expect(await description.findByText('Leslie Knope')).toBeInTheDocument();
+        });
+
+        it('should display description isLoading', async () => {
+          useUpdateCaseMock.mockImplementation(() => ({
+            ...defaultUpdateCaseState,
+            isLoading: true,
+            updateKey: 'description',
+          }));
+
+          appMockRenderer.render(<CaseViewPage {...caseProps} />);
+
+          expect(await screen.findByTestId('description-loading')).toBeInTheDocument();
+          expect(screen.queryByTestId('description-action')).not.toBeInTheDocument();
+        });
+
+        it.skip('it should persist the draft of new comment while description is updated', async () => {
+          const newComment = 'another cool comment';
+
+          appMockRenderer.render(<CaseViewPage {...caseProps} />);
+
+          userEvent.click(
+            await screen.findByTestId('user-actions-filter-activity-button-all'),
+            undefined,
+            { skipPointerEventsCheck: true }
+          );
+
+          userEvent.paste(await screen.findByTestId('euiMarkdownEditorTextArea'), newComment);
+
+          userEvent.click(await screen.findByTestId('editable-description-edit-icon'), undefined, {
+            skipPointerEventsCheck: true,
+          });
+
+          userEvent.paste(screen.getAllByTestId('euiMarkdownEditorTextArea')[0], 'Edited!');
+
+          userEvent.click(screen.getByTestId('user-action-save-markdown'), undefined, {
+            skipPointerEventsCheck: true,
+          });
+
+          expect(await screen.findByTestId('euiMarkdownEditorTextArea')).toHaveTextContent(
+            newComment
+          );
+        });
+      });
+
+      describe('breadcrumbs', () => {
+        it('should set the cases title', async () => {
+          appMockRenderer.render(<CaseViewPage {...caseProps} />);
+
+          await waitFor(() => {
+            expect(mockSetTitle).toHaveBeenCalledWith([caseProps.caseData.title, 'Cases', 'Test']);
+          });
         });
       });
     });
   });
-});
+}

--- a/x-pack/plugins/cases/public/components/case_view/case_view_page.test.tsx
+++ b/x-pack/plugins/cases/public/components/case_view/case_view_page.test.tsx
@@ -135,527 +135,533 @@ const userActionsStats = {
   totalOtherActions: 11,
 };
 
-describe('CaseViewPage', () => {
-  const updateCaseProperty = defaultUpdateCaseState.updateCaseProperty;
-  const pushCaseToExternalService = jest.fn();
-  const data = caseProps.caseData;
-  let appMockRenderer: AppMockRenderer;
-  const caseConnectors = getCaseConnectorsMockResponse();
-  const caseUsers = getCaseUsersMockResponse();
-  const refetchFindCaseUserActions = jest.fn();
+for (let index = 0; index < 50; index++) {
+  describe('CaseViewPage', () => {
+    const updateCaseProperty = defaultUpdateCaseState.updateCaseProperty;
+    const pushCaseToExternalService = jest.fn();
+    const data = caseProps.caseData;
+    let appMockRenderer: AppMockRenderer;
+    const caseConnectors = getCaseConnectorsMockResponse();
+    const caseUsers = getCaseUsersMockResponse();
+    const refetchFindCaseUserActions = jest.fn();
 
-  beforeEach(() => {
-    jest.clearAllMocks();
-    mockGetCase();
-    useUpdateCaseMock.mockReturnValue(defaultUpdateCaseState);
-    useGetCaseMetricsMock.mockReturnValue(defaultGetCaseMetrics);
-    useFindCaseUserActionsMock.mockReturnValue(defaultUseFindCaseUserActions);
-    usePostPushToServiceMock.mockReturnValue({ isLoading: false, pushCaseToExternalService });
-    useGetCaseConnectorsMock.mockReturnValue({
-      isLoading: false,
-      data: caseConnectors,
-    });
-    useGetConnectorsMock.mockReturnValue({ data: connectorsMock, isLoading: false });
-    useGetTagsMock.mockReturnValue({ data: [], isLoading: false });
-    const license = licensingMock.createLicense({
-      license: { type: 'platinum' },
-    });
-    useGetCaseUsersMock.mockReturnValue({ isLoading: false, data: caseUsers });
-    useGetCurrentUserProfileMock.mockReturnValue({ isLoading: false, data: userProfiles[0] });
-    useGetCaseUserActionsStatsMock.mockReturnValue({ data: userActionsStats, isLoading: false });
-    useSuggestUserProfilesMock.mockReturnValue({ data: [], isLoading: false });
-
-    appMockRenderer = createAppMockRenderer({ license });
-  });
-
-  it('should render CaseViewPage', async () => {
-    const damagedRaccoonUser = userProfiles[0].user;
-    const caseDataWithDamagedRaccoon = {
-      ...caseData,
-      createdBy: {
-        profileUid: userProfiles[0].uid,
-        username: damagedRaccoonUser.username,
-        fullName: damagedRaccoonUser.full_name,
-        email: damagedRaccoonUser.email,
-      },
-    };
-
-    const license = licensingMock.createLicense({
-      license: { type: 'platinum' },
-    });
-
-    const props = { ...caseProps, caseData: caseDataWithDamagedRaccoon };
-    appMockRenderer = createAppMockRenderer({ features: { metrics: ['alerts.count'] }, license });
-    const result = appMockRenderer.render(<CaseViewPage {...props} />);
-
-    expect(result.getByTestId('header-page-title')).toHaveTextContent(data.title);
-    expect(result.getByTestId('case-view-status-dropdown')).toHaveTextContent('Open');
-    expect(result.getByTestId('case-view-metrics-panel')).toBeInTheDocument();
-    expect(
-      within(result.getByTestId('case-view-tag-list')).getByTestId('tag-coke')
-    ).toHaveTextContent(data.tags[0]);
-
-    expect(
-      within(result.getByTestId('case-view-tag-list')).getByTestId('tag-pepsi')
-    ).toHaveTextContent(data.tags[1]);
-
-    expect(result.getAllByText(data.createdBy.fullName!)[0]).toBeInTheDocument();
-
-    expect(
-      within(result.getByTestId('description-action')).getByTestId('user-action-markdown')
-    ).toHaveTextContent(data.description);
-
-    expect(result.getByTestId('case-view-status-action-button')).toHaveTextContent(
-      'Mark in progress'
-    );
-  });
-
-  it('should show closed indicators in header when case is closed', async () => {
-    useUpdateCaseMock.mockImplementation(() => ({
-      ...defaultUpdateCaseState,
-      caseData: basicCaseClosed,
-    }));
-
-    const result = appMockRenderer.render(<CaseViewPage {...caseClosedProps} />);
-
-    expect(result.getByTestId('case-view-status-dropdown')).toHaveTextContent('Closed');
-  });
-
-  it('should update status', async () => {
-    const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
-
-    const dropdown = result.getByTestId('case-view-status-dropdown');
-    userEvent.click(dropdown.querySelector('button')!, undefined, { skipPointerEventsCheck: true });
-    await waitForEuiPopoverOpen();
-    userEvent.click(result.getByTestId('case-view-status-dropdown-closed'), undefined, {
-      skipPointerEventsCheck: true,
-    });
-    const updateObject = updateCaseProperty.mock.calls[0][0];
-
-    await waitFor(() => {
-      expect(updateCaseProperty).toHaveBeenCalledTimes(1);
-      expect(updateObject.updateKey).toEqual('status');
-      expect(updateObject.updateValue).toEqual('closed');
-    });
-  });
-
-  it('should display EditableTitle isLoading', async () => {
-    useUpdateCaseMock.mockImplementation(() => ({
-      ...defaultUpdateCaseState,
-      isLoading: true,
-      updateKey: 'title',
-    }));
-    const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
-
-    await waitFor(() => {
-      expect(result.getByTestId('editable-title-loading')).toBeInTheDocument();
-      expect(result.queryByTestId('editable-title-edit-icon')).not.toBeInTheDocument();
-    });
-  });
-
-  it('should display tags isLoading', async () => {
-    useUpdateCaseMock.mockImplementation(() => ({
-      ...defaultUpdateCaseState,
-      isLoading: true,
-      updateKey: 'tags',
-    }));
-
-    const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
-
-    await waitFor(() => {
-      expect(
-        within(result.getByTestId('case-view-tag-list')).getByTestId('tag-list-loading')
-      ).toBeInTheDocument();
-    });
-
-    await waitFor(() => {
-      expect(result.queryByTestId('tag-list-edit')).not.toBeInTheDocument();
-    });
-  });
-
-  it('should update title', async () => {
-    const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
-    const newTitle = 'The new title';
-    userEvent.click(result.getByTestId('editable-title-edit-icon'), undefined, {
-      skipPointerEventsCheck: true,
-    });
-    userEvent.clear(result.getByTestId('editable-title-input-field'));
-    userEvent.paste(result.getByTestId('editable-title-input-field'), newTitle);
-    userEvent.click(result.getByTestId('editable-title-submit-btn'), undefined, {
-      skipPointerEventsCheck: true,
-    });
-
-    const updateObject = updateCaseProperty.mock.calls[0][0];
-    await waitFor(() => {
-      expect(updateObject.updateKey).toEqual('title');
-      expect(updateObject.updateValue).toEqual(newTitle);
-    });
-  });
-
-  it('should push updates on button click', async () => {
-    useGetCaseConnectorsMock.mockImplementation(() => ({
-      isLoading: false,
-      data: {
-        ...caseConnectors,
-        'resilient-2': {
-          ...caseConnectors['resilient-2'],
-          push: { ...caseConnectors['resilient-2'].push, needsToBePushed: true },
-        },
-      },
-    }));
-
-    const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
-
-    expect(result.getByTestId('push-to-external-service')).toBeInTheDocument();
-
-    userEvent.click(result.getByTestId('push-to-external-service'), undefined, {
-      skipPointerEventsCheck: true,
-    });
-
-    await waitFor(() => {
-      expect(pushCaseToExternalService).toHaveBeenCalled();
-    });
-  });
-
-  it('should disable the push button when connector is invalid', async () => {
-    const result = appMockRenderer.render(
-      <CaseViewPage
-        {...{
-          ...caseProps,
-          caseData: { ...caseProps.caseData, connectorId: 'not-exist' },
-        }}
-      />
-    );
-    await waitFor(() => {
-      expect(result.getByTestId('push-to-external-service')).toBeDisabled();
-    });
-  });
-
-  it('should update connector', async () => {
-    const result = appMockRenderer.render(
-      <CaseViewPage
-        {...caseProps}
-        caseData={{
-          ...caseProps.caseData,
-          connector: {
-            id: 'servicenow-1',
-            name: 'SN 1',
-            type: ConnectorTypes.serviceNowITSM,
-            fields: null,
-          },
-        }}
-      />
-    );
-    userEvent.click(result.getByTestId('connector-edit').querySelector('button')!, undefined, {
-      skipPointerEventsCheck: true,
-    });
-    userEvent.click(result.getByTestId('dropdown-connectors'), undefined, {
-      skipPointerEventsCheck: true,
-    });
-    await waitForEuiPopoverOpen();
-    userEvent.click(result.getByTestId('dropdown-connector-resilient-2'), undefined, {
-      skipPointerEventsCheck: true,
-    });
-
-    await waitFor(() => {
-      expect(result.getByTestId('connector-fields-resilient')).toBeInTheDocument();
-    });
-
-    userEvent.click(result.getByTestId('edit-connectors-submit'), undefined, {
-      skipPointerEventsCheck: true,
-    });
-
-    await waitFor(() => {
-      expect(updateCaseProperty).toHaveBeenCalledTimes(1);
-      const updateObject = updateCaseProperty.mock.calls[0][0];
-      expect(updateObject.updateKey).toEqual('connector');
-      expect(updateObject.updateValue).toEqual({
-        id: 'resilient-2',
-        name: 'My Resilient connector',
-        type: ConnectorTypes.resilient,
-        fields: {
-          incidentTypes: null,
-          severityCode: null,
-        },
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockGetCase();
+      useUpdateCaseMock.mockReturnValue(defaultUpdateCaseState);
+      useGetCaseMetricsMock.mockReturnValue(defaultGetCaseMetrics);
+      useFindCaseUserActionsMock.mockReturnValue(defaultUseFindCaseUserActions);
+      usePostPushToServiceMock.mockReturnValue({ isLoading: false, pushCaseToExternalService });
+      useGetCaseConnectorsMock.mockReturnValue({
+        isLoading: false,
+        data: caseConnectors,
       });
-    });
-  });
+      useGetConnectorsMock.mockReturnValue({ data: connectorsMock, isLoading: false });
+      useGetTagsMock.mockReturnValue({ data: [], isLoading: false });
+      const license = licensingMock.createLicense({
+        license: { type: 'platinum' },
+      });
+      useGetCaseUsersMock.mockReturnValue({ isLoading: false, data: caseUsers });
+      useGetCurrentUserProfileMock.mockReturnValue({ isLoading: false, data: userProfiles[0] });
+      useGetCaseUserActionsStatsMock.mockReturnValue({ data: userActionsStats, isLoading: false });
+      useSuggestUserProfilesMock.mockReturnValue({ data: [], isLoading: false });
 
-  it('should call onComponentInitialized on mount', async () => {
-    const onComponentInitialized = jest.fn();
-    appMockRenderer.render(
-      <CaseViewPage {...caseProps} onComponentInitialized={onComponentInitialized} />
-    );
-
-    await waitFor(() => {
-      expect(onComponentInitialized).toHaveBeenCalled();
-    });
-  });
-
-  it('should show loading content when loading user actions', async () => {
-    const useFetchAlertData = jest.fn().mockReturnValue([true]);
-    useFindCaseUserActionsMock.mockReturnValue({
-      data: undefined,
-      isError: false,
-      isLoading: true,
-      isFetching: true,
-      refetch: refetchFindCaseUserActions,
+      appMockRenderer = createAppMockRenderer({ license });
     });
 
-    const result = appMockRenderer.render(
-      <CaseViewPage {...caseProps} useFetchAlertData={useFetchAlertData} />
-    );
-    await waitFor(() => {
-      expect(result.getByTestId('case-view-loading-content')).toBeInTheDocument();
-      expect(result.queryByTestId('user-actions')).not.toBeInTheDocument();
-    });
-  });
+    it('should render CaseViewPage', async () => {
+      const damagedRaccoonUser = userProfiles[0].user;
+      const caseDataWithDamagedRaccoon = {
+        ...caseData,
+        createdBy: {
+          profileUid: userProfiles[0].uid,
+          username: damagedRaccoonUser.username,
+          fullName: damagedRaccoonUser.full_name,
+          email: damagedRaccoonUser.email,
+        },
+      };
 
-  it('should call show alert details with expected arguments', async () => {
-    const showAlertDetails = jest.fn();
-    const result = appMockRenderer.render(
-      <CaseViewPage {...caseProps} showAlertDetails={showAlertDetails} />
-    );
+      const license = licensingMock.createLicense({
+        license: { type: 'platinum' },
+      });
 
-    userEvent.click(result.getByTestId('comment-action-show-alert-alert-action-id'), undefined, {
-      skipPointerEventsCheck: true,
-    });
+      const props = { ...caseProps, caseData: caseDataWithDamagedRaccoon };
+      appMockRenderer = createAppMockRenderer({ features: { metrics: ['alerts.count'] }, license });
+      const result = appMockRenderer.render(<CaseViewPage {...props} />);
 
-    await waitFor(() => {
-      expect(showAlertDetails).toHaveBeenCalledWith('alert-id-1', 'alert-index-1');
-    });
-  });
-
-  it('should show the rule name', async () => {
-    const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
-
-    await waitFor(() => {
+      expect(result.getByTestId('header-page-title')).toHaveTextContent(data.title);
+      expect(result.getByTestId('case-view-status-dropdown')).toHaveTextContent('Open');
+      expect(result.getByTestId('case-view-metrics-panel')).toBeInTheDocument();
       expect(
-        result
-          .getByTestId('user-action-alert-comment-create-action-alert-action-id')
-          .querySelector('.euiCommentEvent__headerEvent')
-      ).toHaveTextContent('added an alert from Awesome rule');
-    });
-  });
+        within(result.getByTestId('case-view-tag-list')).getByTestId('tag-coke')
+      ).toHaveTextContent(data.tags[0]);
 
-  it('should update settings', async () => {
-    const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
-    userEvent.click(result.getByTestId('sync-alerts-switch'), undefined, {
-      skipPointerEventsCheck: true,
-    });
-    const updateObject = updateCaseProperty.mock.calls[0][0];
+      expect(
+        within(result.getByTestId('case-view-tag-list')).getByTestId('tag-pepsi')
+      ).toHaveTextContent(data.tags[1]);
 
-    await waitFor(() => {
-      expect(updateObject.updateKey).toEqual('settings');
-      expect(updateObject.updateValue).toEqual({ syncAlerts: false });
-    });
-  });
+      expect(result.getAllByText(data.createdBy.fullName!)[0]).toBeInTheDocument();
 
-  it('should show the correct connector name on the push button', async () => {
-    useGetConnectorsMock.mockImplementation(() => ({ data: connectorsMock, isLoading: false }));
+      expect(
+        within(result.getByTestId('description-action')).getByTestId('user-action-markdown')
+      ).toHaveTextContent(data.description);
 
-    const result = appMockRenderer.render(
-      <CaseViewPage {...{ ...caseProps, connector: { ...caseProps, name: 'old-name' } }} />
-    );
-
-    await waitFor(() => {
-      expect(result.getByTestId('push-to-external-service')).toHaveTextContent(
-        'My Resilient connector'
+      expect(result.getByTestId('case-view-status-action-button')).toHaveTextContent(
+        'Mark in progress'
       );
     });
-  });
 
-  describe('Callouts', () => {
-    it('it shows the danger callout when a connector has been deleted', async () => {
-      useGetConnectorsMock.mockImplementation(() => ({ data: [], isLoading: false }));
+    it('should show closed indicators in header when case is closed', async () => {
+      useUpdateCaseMock.mockImplementation(() => ({
+        ...defaultUpdateCaseState,
+        caseData: basicCaseClosed,
+      }));
+
+      const result = appMockRenderer.render(<CaseViewPage {...caseClosedProps} />);
+
+      expect(result.getByTestId('case-view-status-dropdown')).toHaveTextContent('Closed');
+    });
+
+    it('should update status', async () => {
       const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
 
-      expect(result.container.querySelector('.euiCallOut--danger')).toBeInTheDocument();
+      const dropdown = result.getByTestId('case-view-status-dropdown');
+      userEvent.click(dropdown.querySelector('button')!, undefined, {
+        skipPointerEventsCheck: true,
+      });
+      await waitForEuiPopoverOpen();
+      userEvent.click(result.getByTestId('case-view-status-dropdown-closed'), undefined, {
+        skipPointerEventsCheck: true,
+      });
+      const updateObject = updateCaseProperty.mock.calls[0][0];
+
+      await waitFor(() => {
+        expect(updateCaseProperty).toHaveBeenCalledTimes(1);
+        expect(updateObject.updateKey).toEqual('status');
+        expect(updateObject.updateValue).toEqual('closed');
+      });
     });
 
-    it('it does NOT shows the danger callout when connectors are loading', async () => {
-      useGetConnectorsMock.mockImplementation(() => ({ data: [], isLoading: true }));
+    it('should display EditableTitle isLoading', async () => {
+      useUpdateCaseMock.mockImplementation(() => ({
+        ...defaultUpdateCaseState,
+        isLoading: true,
+        updateKey: 'title',
+      }));
       const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
 
-      expect(result.container.querySelector('.euiCallOut--danger')).not.toBeInTheDocument();
-    });
-  });
-
-  describe('Tabs', () => {
-    it('renders tabs correctly', async () => {
-      appMockRenderer.render(<CaseViewPage {...caseProps} />);
-      expect(await screen.findByTestId('case-view-tab-title-alerts')).toBeInTheDocument();
-      expect(await screen.findByTestId('case-view-tab-title-activity')).toBeInTheDocument();
+      await waitFor(() => {
+        expect(result.getByTestId('editable-title-loading')).toBeInTheDocument();
+        expect(result.queryByTestId('editable-title-edit-icon')).not.toBeInTheDocument();
+      });
     });
 
-    it('renders the activity tab by default', async () => {
-      appMockRenderer.render(<CaseViewPage {...caseProps} />);
-      expect(await screen.findByTestId('case-view-tab-content-activity')).toBeInTheDocument();
-    });
+    it('should display tags isLoading', async () => {
+      useUpdateCaseMock.mockImplementation(() => ({
+        ...defaultUpdateCaseState,
+        isLoading: true,
+        updateKey: 'tags',
+      }));
 
-    it('renders the alerts tab when the query parameter tabId has alerts', async () => {
-      useUrlParamsMock.mockReturnValue({
-        urlParams: {
-          tabId: CASE_VIEW_PAGE_TABS.ALERTS,
-        },
+      const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
+
+      await waitFor(() => {
+        expect(
+          within(result.getByTestId('case-view-tag-list')).getByTestId('tag-list-loading')
+        ).toBeInTheDocument();
       });
 
-      appMockRenderer.render(<CaseViewPage {...caseProps} />);
-
-      expect(await screen.findByText('alerts table')).toBeInTheDocument();
-      expect(await screen.findByTestId('case-view-tab-content-alerts')).toBeInTheDocument();
-    });
-
-    it('renders the activity tab when the query parameter tabId has activity', async () => {
-      useUrlParamsMock.mockReturnValue({
-        urlParams: {
-          tabId: CASE_VIEW_PAGE_TABS.ACTIVITY,
-        },
+      await waitFor(() => {
+        expect(result.queryByTestId('tag-list-edit')).not.toBeInTheDocument();
       });
-
-      appMockRenderer.render(<CaseViewPage {...caseProps} />);
-      expect(await screen.findByTestId('case-view-tab-content-activity')).toBeInTheDocument();
     });
 
-    it('renders the activity tab when the query parameter tabId has an unknown value', async () => {
-      useUrlParamsMock.mockReturnValue({
-        urlParams: {
-          tabId: 'what-is-love',
-        },
+    it('should update title', async () => {
+      const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
+      const newTitle = 'The new title';
+      userEvent.click(result.getByTestId('editable-title-edit-icon'), undefined, {
+        skipPointerEventsCheck: true,
       });
-
-      appMockRenderer.render(<CaseViewPage {...caseProps} />);
-      expect(await screen.findByTestId('case-view-tab-content-activity')).toBeInTheDocument();
-      expect(screen.queryByTestId('case-view-tab-content-alerts')).not.toBeInTheDocument();
-    });
-
-    it('navigates to the activity tab when the activity tab is clicked', async () => {
-      const navigateToCaseViewMock = useCaseViewNavigationMock().navigateToCaseView;
-      appMockRenderer.render(<CaseViewPage {...caseProps} />);
-
-      userEvent.click(await screen.findByTestId('case-view-tab-title-activity'), undefined, {
+      userEvent.clear(result.getByTestId('editable-title-input-field'));
+      userEvent.paste(result.getByTestId('editable-title-input-field'), newTitle);
+      userEvent.click(result.getByTestId('editable-title-submit-btn'), undefined, {
         skipPointerEventsCheck: true,
       });
 
-      await waitFor(async () => {
-        expect(navigateToCaseViewMock).toHaveBeenCalledWith({
-          detailName: caseData.id,
-          tabId: CASE_VIEW_PAGE_TABS.ACTIVITY,
-        });
+      const updateObject = updateCaseProperty.mock.calls[0][0];
+      await waitFor(() => {
+        expect(updateObject.updateKey).toEqual('title');
+        expect(updateObject.updateValue).toEqual(newTitle);
       });
     });
 
-    it('navigates to the alerts tab when the alerts tab is clicked', async () => {
-      const navigateToCaseViewMock = useCaseViewNavigationMock().navigateToCaseView;
-      appMockRenderer.render(<CaseViewPage {...caseProps} />);
+    it('should push updates on button click', async () => {
+      useGetCaseConnectorsMock.mockImplementation(() => ({
+        isLoading: false,
+        data: {
+          ...caseConnectors,
+          'resilient-2': {
+            ...caseConnectors['resilient-2'],
+            push: { ...caseConnectors['resilient-2'].push, needsToBePushed: true },
+          },
+        },
+      }));
 
-      userEvent.click(await screen.findByTestId('case-view-tab-title-alerts'), undefined, {
+      const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
+
+      expect(result.getByTestId('push-to-external-service')).toBeInTheDocument();
+
+      userEvent.click(result.getByTestId('push-to-external-service'), undefined, {
         skipPointerEventsCheck: true,
       });
 
-      await waitFor(async () => {
-        expect(navigateToCaseViewMock).toHaveBeenCalledWith({
-          detailName: caseData.id,
-          tabId: CASE_VIEW_PAGE_TABS.ALERTS,
+      await waitFor(() => {
+        expect(pushCaseToExternalService).toHaveBeenCalled();
+      });
+    });
+
+    it('should disable the push button when connector is invalid', async () => {
+      const result = appMockRenderer.render(
+        <CaseViewPage
+          {...{
+            ...caseProps,
+            caseData: { ...caseProps.caseData, connectorId: 'not-exist' },
+          }}
+        />
+      );
+      await waitFor(() => {
+        expect(result.getByTestId('push-to-external-service')).toBeDisabled();
+      });
+    });
+
+    it('should update connector', async () => {
+      const result = appMockRenderer.render(
+        <CaseViewPage
+          {...caseProps}
+          caseData={{
+            ...caseProps.caseData,
+            connector: {
+              id: 'servicenow-1',
+              name: 'SN 1',
+              type: ConnectorTypes.serviceNowITSM,
+              fields: null,
+            },
+          }}
+        />
+      );
+      userEvent.click(result.getByTestId('connector-edit').querySelector('button')!, undefined, {
+        skipPointerEventsCheck: true,
+      });
+      userEvent.click(result.getByTestId('dropdown-connectors'), undefined, {
+        skipPointerEventsCheck: true,
+      });
+      await waitForEuiPopoverOpen();
+      userEvent.click(result.getByTestId('dropdown-connector-resilient-2'), undefined, {
+        skipPointerEventsCheck: true,
+      });
+
+      await waitFor(() => {
+        expect(result.getByTestId('connector-fields-resilient')).toBeInTheDocument();
+      });
+
+      userEvent.click(result.getByTestId('edit-connectors-submit'), undefined, {
+        skipPointerEventsCheck: true,
+      });
+
+      await waitFor(() => {
+        expect(updateCaseProperty).toHaveBeenCalledTimes(1);
+        const updateObject = updateCaseProperty.mock.calls[0][0];
+        expect(updateObject.updateKey).toEqual('connector');
+        expect(updateObject.updateValue).toEqual({
+          id: 'resilient-2',
+          name: 'My Resilient connector',
+          type: ConnectorTypes.resilient,
+          fields: {
+            incidentTypes: null,
+            severityCode: null,
+          },
         });
       });
     });
 
-    it('should display the alerts tab when the feature is enabled', async () => {
-      appMockRenderer = createAppMockRenderer({ features: { alerts: { enabled: true } } });
-      appMockRenderer.render(<CaseViewPage {...caseProps} />);
+    it('should call onComponentInitialized on mount', async () => {
+      const onComponentInitialized = jest.fn();
+      appMockRenderer.render(
+        <CaseViewPage {...caseProps} onComponentInitialized={onComponentInitialized} />
+      );
 
-      expect(await screen.findByTestId('case-view-tab-title-activity')).toBeInTheDocument();
-      expect(await screen.findByTestId('case-view-tab-title-alerts')).toBeInTheDocument();
+      await waitFor(() => {
+        expect(onComponentInitialized).toHaveBeenCalled();
+      });
     });
 
-    it('should not display the alerts tab when the feature is disabled', async () => {
-      appMockRenderer = createAppMockRenderer({ features: { alerts: { enabled: false } } });
-      appMockRenderer.render(<CaseViewPage {...caseProps} />);
-
-      expect(await screen.findByTestId('case-view-tab-title-activity')).toBeInTheDocument();
-      expect(screen.queryByTestId('case-view-tab-title-alerts')).not.toBeInTheDocument();
-    });
-
-    it('should not show the experimental badge on the alerts table', async () => {
-      appMockRenderer = createAppMockRenderer({ features: { alerts: { isExperimental: false } } });
-      appMockRenderer.render(<CaseViewPage {...caseProps} />);
-
-      expect(
-        screen.queryByTestId('case-view-alerts-table-experimental-badge')
-      ).not.toBeInTheDocument();
-    });
-
-    it('should show the experimental badge on the alerts table', async () => {
-      appMockRenderer = createAppMockRenderer({ features: { alerts: { isExperimental: true } } });
-      appMockRenderer.render(<CaseViewPage {...caseProps} />);
-
-      expect(
-        await screen.findByTestId('case-view-alerts-table-experimental-badge')
-      ).toBeInTheDocument();
-    });
-
-    describe('description', () => {
-      it('renders the descriptions user correctly', async () => {
-        appMockRenderer.render(<CaseViewPage {...caseProps} />);
-
-        const description = within(await screen.findByTestId('description-action'));
-
-        expect(await description.findByText('Leslie Knope')).toBeInTheDocument();
+    it('should show loading content when loading user actions', async () => {
+      const useFetchAlertData = jest.fn().mockReturnValue([true]);
+      useFindCaseUserActionsMock.mockReturnValue({
+        data: undefined,
+        isError: false,
+        isLoading: true,
+        isFetching: true,
+        refetch: refetchFindCaseUserActions,
       });
 
-      it('should display description isLoading', async () => {
-        useUpdateCaseMock.mockImplementation(() => ({
-          ...defaultUpdateCaseState,
-          isLoading: true,
-          updateKey: 'description',
-        }));
+      const result = appMockRenderer.render(
+        <CaseViewPage {...caseProps} useFetchAlertData={useFetchAlertData} />
+      );
+      await waitFor(() => {
+        expect(result.getByTestId('case-view-loading-content')).toBeInTheDocument();
+        expect(result.queryByTestId('user-actions')).not.toBeInTheDocument();
+      });
+    });
 
-        appMockRenderer.render(<CaseViewPage {...caseProps} />);
+    it('should call show alert details with expected arguments', async () => {
+      const showAlertDetails = jest.fn();
+      const result = appMockRenderer.render(
+        <CaseViewPage {...caseProps} showAlertDetails={showAlertDetails} />
+      );
 
-        await waitFor(() => {
-          expect(screen.getByTestId('description-loading')).toBeInTheDocument();
-          expect(screen.queryByTestId('description-action')).not.toBeInTheDocument();
-        });
+      userEvent.click(result.getByTestId('comment-action-show-alert-alert-action-id'), undefined, {
+        skipPointerEventsCheck: true,
       });
 
-      it.skip('it should persist the draft of new comment while description is updated', async () => {
-        const newComment = 'another cool comment';
+      await waitFor(() => {
+        expect(showAlertDetails).toHaveBeenCalledWith('alert-id-1', 'alert-index-1');
+      });
+    });
 
-        appMockRenderer.render(<CaseViewPage {...caseProps} />);
+    it('should show the rule name', async () => {
+      const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
 
-        userEvent.click(
-          await screen.findByTestId('user-actions-filter-activity-button-all'),
-          undefined,
-          { skipPointerEventsCheck: true }
+      await waitFor(() => {
+        expect(
+          result
+            .getByTestId('user-action-alert-comment-create-action-alert-action-id')
+            .querySelector('.euiCommentEvent__headerEvent')
+        ).toHaveTextContent('added an alert from Awesome rule');
+      });
+    });
+
+    it('should update settings', async () => {
+      const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
+      userEvent.click(result.getByTestId('sync-alerts-switch'), undefined, {
+        skipPointerEventsCheck: true,
+      });
+      const updateObject = updateCaseProperty.mock.calls[0][0];
+
+      await waitFor(() => {
+        expect(updateObject.updateKey).toEqual('settings');
+        expect(updateObject.updateValue).toEqual({ syncAlerts: false });
+      });
+    });
+
+    it('should show the correct connector name on the push button', async () => {
+      useGetConnectorsMock.mockImplementation(() => ({ data: connectorsMock, isLoading: false }));
+
+      const result = appMockRenderer.render(
+        <CaseViewPage {...{ ...caseProps, connector: { ...caseProps, name: 'old-name' } }} />
+      );
+
+      await waitFor(() => {
+        expect(result.getByTestId('push-to-external-service')).toHaveTextContent(
+          'My Resilient connector'
         );
+      });
+    });
 
-        userEvent.paste(await screen.findByTestId('euiMarkdownEditorTextArea'), newComment);
+    describe('Callouts', () => {
+      it('it shows the danger callout when a connector has been deleted', async () => {
+        useGetConnectorsMock.mockImplementation(() => ({ data: [], isLoading: false }));
+        const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
 
-        userEvent.click(await screen.findByTestId('editable-description-edit-icon'), undefined, {
+        expect(result.container.querySelector('.euiCallOut--danger')).toBeInTheDocument();
+      });
+
+      it('it does NOT shows the danger callout when connectors are loading', async () => {
+        useGetConnectorsMock.mockImplementation(() => ({ data: [], isLoading: true }));
+        const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
+
+        expect(result.container.querySelector('.euiCallOut--danger')).not.toBeInTheDocument();
+      });
+    });
+
+    describe('Tabs', () => {
+      it('renders tabs correctly', async () => {
+        appMockRenderer.render(<CaseViewPage {...caseProps} />);
+        expect(await screen.findByTestId('case-view-tab-title-alerts')).toBeInTheDocument();
+        expect(await screen.findByTestId('case-view-tab-title-activity')).toBeInTheDocument();
+      });
+
+      it('renders the activity tab by default', async () => {
+        appMockRenderer.render(<CaseViewPage {...caseProps} />);
+        expect(await screen.findByTestId('case-view-tab-content-activity')).toBeInTheDocument();
+      });
+
+      it('renders the alerts tab when the query parameter tabId has alerts', async () => {
+        useUrlParamsMock.mockReturnValue({
+          urlParams: {
+            tabId: CASE_VIEW_PAGE_TABS.ALERTS,
+          },
+        });
+
+        appMockRenderer.render(<CaseViewPage {...caseProps} />);
+
+        expect(await screen.findByText('alerts table')).toBeInTheDocument();
+        expect(await screen.findByTestId('case-view-tab-content-alerts')).toBeInTheDocument();
+      });
+
+      it('renders the activity tab when the query parameter tabId has activity', async () => {
+        useUrlParamsMock.mockReturnValue({
+          urlParams: {
+            tabId: CASE_VIEW_PAGE_TABS.ACTIVITY,
+          },
+        });
+
+        appMockRenderer.render(<CaseViewPage {...caseProps} />);
+        expect(await screen.findByTestId('case-view-tab-content-activity')).toBeInTheDocument();
+      });
+
+      it('renders the activity tab when the query parameter tabId has an unknown value', async () => {
+        useUrlParamsMock.mockReturnValue({
+          urlParams: {
+            tabId: 'what-is-love',
+          },
+        });
+
+        appMockRenderer.render(<CaseViewPage {...caseProps} />);
+        expect(await screen.findByTestId('case-view-tab-content-activity')).toBeInTheDocument();
+        expect(screen.queryByTestId('case-view-tab-content-alerts')).not.toBeInTheDocument();
+      });
+
+      it('navigates to the activity tab when the activity tab is clicked', async () => {
+        const navigateToCaseViewMock = useCaseViewNavigationMock().navigateToCaseView;
+        appMockRenderer.render(<CaseViewPage {...caseProps} />);
+
+        userEvent.click(await screen.findByTestId('case-view-tab-title-activity'), undefined, {
           skipPointerEventsCheck: true,
         });
 
-        userEvent.paste(screen.getAllByTestId('euiMarkdownEditorTextArea')[0], 'Edited!');
+        await waitFor(async () => {
+          expect(navigateToCaseViewMock).toHaveBeenCalledWith({
+            detailName: caseData.id,
+            tabId: CASE_VIEW_PAGE_TABS.ACTIVITY,
+          });
+        });
+      });
 
-        userEvent.click(screen.getByTestId('user-action-save-markdown'), undefined, {
+      it('navigates to the alerts tab when the alerts tab is clicked', async () => {
+        const navigateToCaseViewMock = useCaseViewNavigationMock().navigateToCaseView;
+        appMockRenderer.render(<CaseViewPage {...caseProps} />);
+
+        userEvent.click(await screen.findByTestId('case-view-tab-title-alerts'), undefined, {
           skipPointerEventsCheck: true,
         });
 
-        expect(await screen.findByTestId('euiMarkdownEditorTextArea')).toHaveTextContent(
-          newComment
-        );
+        await waitFor(async () => {
+          expect(navigateToCaseViewMock).toHaveBeenCalledWith({
+            detailName: caseData.id,
+            tabId: CASE_VIEW_PAGE_TABS.ALERTS,
+          });
+        });
       });
-    });
 
-    describe('breadcrumbs', () => {
-      it('should set the cases title', async () => {
+      it('should display the alerts tab when the feature is enabled', async () => {
+        appMockRenderer = createAppMockRenderer({ features: { alerts: { enabled: true } } });
         appMockRenderer.render(<CaseViewPage {...caseProps} />);
 
-        await waitFor(() => {
-          expect(mockSetTitle).toHaveBeenCalledWith([caseProps.caseData.title, 'Cases', 'Test']);
+        expect(await screen.findByTestId('case-view-tab-title-activity')).toBeInTheDocument();
+        expect(await screen.findByTestId('case-view-tab-title-alerts')).toBeInTheDocument();
+      });
+
+      it('should not display the alerts tab when the feature is disabled', async () => {
+        appMockRenderer = createAppMockRenderer({ features: { alerts: { enabled: false } } });
+        appMockRenderer.render(<CaseViewPage {...caseProps} />);
+
+        expect(await screen.findByTestId('case-view-tab-title-activity')).toBeInTheDocument();
+        expect(screen.queryByTestId('case-view-tab-title-alerts')).not.toBeInTheDocument();
+      });
+
+      it('should not show the experimental badge on the alerts table', async () => {
+        appMockRenderer = createAppMockRenderer({
+          features: { alerts: { isExperimental: false } },
+        });
+        appMockRenderer.render(<CaseViewPage {...caseProps} />);
+
+        expect(
+          screen.queryByTestId('case-view-alerts-table-experimental-badge')
+        ).not.toBeInTheDocument();
+      });
+
+      it('should show the experimental badge on the alerts table', async () => {
+        appMockRenderer = createAppMockRenderer({ features: { alerts: { isExperimental: true } } });
+        appMockRenderer.render(<CaseViewPage {...caseProps} />);
+
+        expect(
+          await screen.findByTestId('case-view-alerts-table-experimental-badge')
+        ).toBeInTheDocument();
+      });
+
+      describe('description', () => {
+        it('renders the descriptions user correctly', async () => {
+          appMockRenderer.render(<CaseViewPage {...caseProps} />);
+
+          const description = within(await screen.findByTestId('description-action'));
+
+          expect(await description.findByText('Leslie Knope')).toBeInTheDocument();
+        });
+
+        it('should display description isLoading', async () => {
+          useUpdateCaseMock.mockImplementation(() => ({
+            ...defaultUpdateCaseState,
+            isLoading: true,
+            updateKey: 'description',
+          }));
+
+          appMockRenderer.render(<CaseViewPage {...caseProps} />);
+
+          await waitFor(() => {
+            expect(screen.getByTestId('description-loading')).toBeInTheDocument();
+            expect(screen.queryByTestId('description-action')).not.toBeInTheDocument();
+          });
+        });
+
+        it.skip('it should persist the draft of new comment while description is updated', async () => {
+          const newComment = 'another cool comment';
+
+          appMockRenderer.render(<CaseViewPage {...caseProps} />);
+
+          userEvent.click(
+            await screen.findByTestId('user-actions-filter-activity-button-all'),
+            undefined,
+            { skipPointerEventsCheck: true }
+          );
+
+          userEvent.paste(await screen.findByTestId('euiMarkdownEditorTextArea'), newComment);
+
+          userEvent.click(await screen.findByTestId('editable-description-edit-icon'), undefined, {
+            skipPointerEventsCheck: true,
+          });
+
+          userEvent.paste(screen.getAllByTestId('euiMarkdownEditorTextArea')[0], 'Edited!');
+
+          userEvent.click(screen.getByTestId('user-action-save-markdown'), undefined, {
+            skipPointerEventsCheck: true,
+          });
+
+          expect(await screen.findByTestId('euiMarkdownEditorTextArea')).toHaveTextContent(
+            newComment
+          );
+        });
+      });
+
+      describe('breadcrumbs', () => {
+        it('should set the cases title', async () => {
+          appMockRenderer.render(<CaseViewPage {...caseProps} />);
+
+          await waitFor(() => {
+            expect(mockSetTitle).toHaveBeenCalledWith([caseProps.caseData.title, 'Cases', 'Test']);
+          });
         });
       });
     });
   });
-});
+}

--- a/x-pack/plugins/cases/public/components/case_view/case_view_page.test.tsx
+++ b/x-pack/plugins/cases/public/components/case_view/case_view_page.test.tsx
@@ -273,12 +273,14 @@ for (let index = 0; index < 50; index++) {
     it('should update title', async () => {
       appMockRenderer.render(<CaseViewPage {...caseProps} />);
       const newTitle = 'The new title';
-      userEvent.click(screen.getByTestId('editable-title-edit-icon'), undefined, {
+
+      userEvent.click(await screen.findByTestId('editable-title-edit-icon'), undefined, {
         skipPointerEventsCheck: true,
       });
-      userEvent.clear(screen.getByTestId('editable-title-input-field'));
-      userEvent.paste(screen.getByTestId('editable-title-input-field'), newTitle);
-      userEvent.click(screen.getByTestId('editable-title-submit-btn'), undefined, {
+
+      userEvent.clear(await screen.findByTestId('editable-title-input-field'));
+      userEvent.paste(await screen.findByTestId('editable-title-input-field'), newTitle);
+      userEvent.click(await screen.findByTestId('editable-title-submit-btn'), undefined, {
         skipPointerEventsCheck: true,
       });
 
@@ -342,20 +344,28 @@ for (let index = 0; index < 50; index++) {
           }}
         />
       );
-      userEvent.click(screen.getByTestId('connector-edit').querySelector('button')!, undefined, {
+
+      userEvent.click(
+        (await screen.findByTestId('connector-edit')).querySelector('button')!,
+        undefined,
+        {
+          skipPointerEventsCheck: true,
+        }
+      );
+
+      userEvent.click(await screen.findByTestId('dropdown-connectors'), undefined, {
         skipPointerEventsCheck: true,
       });
-      userEvent.click(screen.getByTestId('dropdown-connectors'), undefined, {
-        skipPointerEventsCheck: true,
-      });
+
       await waitForEuiPopoverOpen();
-      userEvent.click(screen.getByTestId('dropdown-connector-resilient-2'), undefined, {
+
+      userEvent.click(await screen.findByTestId('dropdown-connector-resilient-2'), undefined, {
         skipPointerEventsCheck: true,
       });
 
       expect(await screen.findByTestId('connector-fields-resilient')).toBeInTheDocument();
 
-      userEvent.click(screen.getByTestId('edit-connectors-submit'), undefined, {
+      userEvent.click(await screen.findByTestId('edit-connectors-submit'), undefined, {
         skipPointerEventsCheck: true,
       });
 
@@ -406,9 +416,13 @@ for (let index = 0; index < 50; index++) {
       const showAlertDetails = jest.fn();
       appMockRenderer.render(<CaseViewPage {...caseProps} showAlertDetails={showAlertDetails} />);
 
-      userEvent.click(screen.getByTestId('comment-action-show-alert-alert-action-id'), undefined, {
-        skipPointerEventsCheck: true,
-      });
+      userEvent.click(
+        await screen.findByTestId('comment-action-show-alert-alert-action-id'),
+        undefined,
+        {
+          skipPointerEventsCheck: true,
+        }
+      );
 
       await waitFor(() => {
         expect(showAlertDetails).toHaveBeenCalledWith('alert-id-1', 'alert-index-1');
@@ -427,9 +441,11 @@ for (let index = 0; index < 50; index++) {
 
     it('should update settings', async () => {
       appMockRenderer.render(<CaseViewPage {...caseProps} />);
-      userEvent.click(screen.getByTestId('sync-alerts-switch'), undefined, {
+
+      userEvent.click(await screen.findByTestId('sync-alerts-switch'), undefined, {
         skipPointerEventsCheck: true,
       });
+
       const updateObject = updateCaseProperty.mock.calls[0][0];
 
       await waitFor(() => {
@@ -453,16 +469,24 @@ for (let index = 0; index < 50; index++) {
     describe('Callouts', () => {
       it('it shows the danger callout when a connector has been deleted', async () => {
         useGetConnectorsMock.mockImplementation(() => ({ data: [], isLoading: false }));
-        const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
+        appMockRenderer.render(<CaseViewPage {...caseProps} />);
 
-        expect(result.container.querySelector('.euiCallOut--danger')).toBeInTheDocument();
+        expect(
+          await screen.findByText(
+            /The connector used to send updates to the external service has been deleted/
+          )
+        ).toBeInTheDocument();
       });
 
       it('it does NOT shows the danger callout when connectors are loading', async () => {
         useGetConnectorsMock.mockImplementation(() => ({ data: [], isLoading: true }));
-        const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
+        appMockRenderer.render(<CaseViewPage {...caseProps} />);
 
-        expect(result.container.querySelector('.euiCallOut--danger')).not.toBeInTheDocument();
+        expect(
+          screen.queryByText(
+            /The connector used to send updates to the external service has been deleted/
+          )
+        ).not.toBeInTheDocument();
       });
     });
 

--- a/x-pack/plugins/cases/public/components/case_view/case_view_page.test.tsx
+++ b/x-pack/plugins/cases/public/components/case_view/case_view_page.test.tsx
@@ -135,533 +135,511 @@ const userActionsStats = {
   totalOtherActions: 11,
 };
 
-for (let index = 0; index < 50; index++) {
-  describe('CaseViewPage', () => {
-    const updateCaseProperty = defaultUpdateCaseState.updateCaseProperty;
-    const pushCaseToExternalService = jest.fn();
-    const data = caseProps.caseData;
-    let appMockRenderer: AppMockRenderer;
-    const caseConnectors = getCaseConnectorsMockResponse();
-    const caseUsers = getCaseUsersMockResponse();
-    const refetchFindCaseUserActions = jest.fn();
+describe('CaseViewPage', () => {
+  const updateCaseProperty = defaultUpdateCaseState.updateCaseProperty;
+  const pushCaseToExternalService = jest.fn();
+  const data = caseProps.caseData;
+  let appMockRenderer: AppMockRenderer;
+  const caseConnectors = getCaseConnectorsMockResponse();
+  const caseUsers = getCaseUsersMockResponse();
+  const refetchFindCaseUserActions = jest.fn();
 
-    beforeEach(() => {
-      jest.clearAllMocks();
-      mockGetCase();
-      useUpdateCaseMock.mockReturnValue(defaultUpdateCaseState);
-      useGetCaseMetricsMock.mockReturnValue(defaultGetCaseMetrics);
-      useFindCaseUserActionsMock.mockReturnValue(defaultUseFindCaseUserActions);
-      usePostPushToServiceMock.mockReturnValue({ isLoading: false, pushCaseToExternalService });
-      useGetCaseConnectorsMock.mockReturnValue({
-        isLoading: false,
-        data: caseConnectors,
-      });
-      useGetConnectorsMock.mockReturnValue({ data: connectorsMock, isLoading: false });
-      useGetTagsMock.mockReturnValue({ data: [], isLoading: false });
-      const license = licensingMock.createLicense({
-        license: { type: 'platinum' },
-      });
-      useGetCaseUsersMock.mockReturnValue({ isLoading: false, data: caseUsers });
-      useGetCurrentUserProfileMock.mockReturnValue({ isLoading: false, data: userProfiles[0] });
-      useGetCaseUserActionsStatsMock.mockReturnValue({ data: userActionsStats, isLoading: false });
-      useSuggestUserProfilesMock.mockReturnValue({ data: [], isLoading: false });
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetCase();
+    useUpdateCaseMock.mockReturnValue(defaultUpdateCaseState);
+    useGetCaseMetricsMock.mockReturnValue(defaultGetCaseMetrics);
+    useFindCaseUserActionsMock.mockReturnValue(defaultUseFindCaseUserActions);
+    usePostPushToServiceMock.mockReturnValue({ isLoading: false, pushCaseToExternalService });
+    useGetCaseConnectorsMock.mockReturnValue({
+      isLoading: false,
+      data: caseConnectors,
+    });
+    useGetConnectorsMock.mockReturnValue({ data: connectorsMock, isLoading: false });
+    useGetTagsMock.mockReturnValue({ data: [], isLoading: false });
+    const license = licensingMock.createLicense({
+      license: { type: 'platinum' },
+    });
+    useGetCaseUsersMock.mockReturnValue({ isLoading: false, data: caseUsers });
+    useGetCurrentUserProfileMock.mockReturnValue({ isLoading: false, data: userProfiles[0] });
+    useGetCaseUserActionsStatsMock.mockReturnValue({ data: userActionsStats, isLoading: false });
+    useSuggestUserProfilesMock.mockReturnValue({ data: [], isLoading: false });
 
-      appMockRenderer = createAppMockRenderer({ license });
+    appMockRenderer = createAppMockRenderer({ license });
+  });
+
+  it('should render CaseViewPage', async () => {
+    const damagedRaccoonUser = userProfiles[0].user;
+    const caseDataWithDamagedRaccoon = {
+      ...caseData,
+      createdBy: {
+        profileUid: userProfiles[0].uid,
+        username: damagedRaccoonUser.username,
+        fullName: damagedRaccoonUser.full_name,
+        email: damagedRaccoonUser.email,
+      },
+    };
+
+    const license = licensingMock.createLicense({
+      license: { type: 'platinum' },
     });
 
-    it('should render CaseViewPage', async () => {
-      const damagedRaccoonUser = userProfiles[0].user;
-      const caseDataWithDamagedRaccoon = {
-        ...caseData,
-        createdBy: {
-          profileUid: userProfiles[0].uid,
-          username: damagedRaccoonUser.username,
-          fullName: damagedRaccoonUser.full_name,
-          email: damagedRaccoonUser.email,
+    const props = { ...caseProps, caseData: caseDataWithDamagedRaccoon };
+    appMockRenderer = createAppMockRenderer({ features: { metrics: ['alerts.count'] }, license });
+    appMockRenderer.render(<CaseViewPage {...props} />);
+
+    expect(screen.getByTestId('header-page-title')).toHaveTextContent(data.title);
+    expect(screen.getByTestId('case-view-status-dropdown')).toHaveTextContent('Open');
+    expect(screen.getByTestId('case-view-metrics-panel')).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId('case-view-tag-list')).getByTestId('tag-coke')
+    ).toHaveTextContent(data.tags[0]);
+
+    expect(
+      within(screen.getByTestId('case-view-tag-list')).getByTestId('tag-pepsi')
+    ).toHaveTextContent(data.tags[1]);
+
+    expect(screen.getAllByText(data.createdBy.fullName!)[0]).toBeInTheDocument();
+
+    expect(
+      within(screen.getByTestId('description-action')).getByTestId('user-action-markdown')
+    ).toHaveTextContent(data.description);
+
+    expect(screen.getByTestId('case-view-status-action-button')).toHaveTextContent(
+      'Mark in progress'
+    );
+  });
+
+  it('should show closed indicators in header when case is closed', async () => {
+    useUpdateCaseMock.mockImplementation(() => ({
+      ...defaultUpdateCaseState,
+      caseData: basicCaseClosed,
+    }));
+
+    appMockRenderer.render(<CaseViewPage {...caseClosedProps} />);
+
+    expect(screen.getByTestId('case-view-status-dropdown')).toHaveTextContent('Closed');
+  });
+
+  it('should update status', async () => {
+    appMockRenderer.render(<CaseViewPage {...caseProps} />);
+
+    const dropdown = screen.getByTestId('case-view-status-dropdown');
+    userEvent.click(dropdown.querySelector('button')!, undefined, {
+      skipPointerEventsCheck: true,
+    });
+    await waitForEuiPopoverOpen();
+    userEvent.click(screen.getByTestId('case-view-status-dropdown-closed'), undefined, {
+      skipPointerEventsCheck: true,
+    });
+    const updateObject = updateCaseProperty.mock.calls[0][0];
+
+    await waitFor(() => {
+      expect(updateCaseProperty).toHaveBeenCalledTimes(1);
+      expect(updateObject.updateKey).toEqual('status');
+      expect(updateObject.updateValue).toEqual('closed');
+    });
+  });
+
+  it('should display EditableTitle isLoading', async () => {
+    useUpdateCaseMock.mockImplementation(() => ({
+      ...defaultUpdateCaseState,
+      isLoading: true,
+      updateKey: 'title',
+    }));
+    appMockRenderer.render(<CaseViewPage {...caseProps} />);
+
+    expect(await screen.findByTestId('editable-title-loading')).toBeInTheDocument();
+    expect(screen.queryByTestId('editable-title-edit-icon')).not.toBeInTheDocument();
+  });
+
+  it('should display tags isLoading', async () => {
+    useUpdateCaseMock.mockImplementation(() => ({
+      ...defaultUpdateCaseState,
+      isLoading: true,
+      updateKey: 'tags',
+    }));
+
+    appMockRenderer.render(<CaseViewPage {...caseProps} />);
+
+    expect(
+      within(await screen.findByTestId('case-view-tag-list')).getByTestId('tag-list-loading')
+    ).toBeInTheDocument();
+
+    expect(screen.queryByTestId('tag-list-edit')).not.toBeInTheDocument();
+  });
+
+  it('should update title', async () => {
+    appMockRenderer.render(<CaseViewPage {...caseProps} />);
+    const newTitle = 'The new title';
+    userEvent.click(screen.getByTestId('editable-title-edit-icon'), undefined, {
+      skipPointerEventsCheck: true,
+    });
+    userEvent.clear(screen.getByTestId('editable-title-input-field'));
+    userEvent.paste(screen.getByTestId('editable-title-input-field'), newTitle);
+    userEvent.click(screen.getByTestId('editable-title-submit-btn'), undefined, {
+      skipPointerEventsCheck: true,
+    });
+
+    const updateObject = updateCaseProperty.mock.calls[0][0];
+    await waitFor(() => {
+      expect(updateObject.updateKey).toEqual('title');
+      expect(updateObject.updateValue).toEqual(newTitle);
+    });
+  });
+
+  it('should push updates on button click', async () => {
+    useGetCaseConnectorsMock.mockImplementation(() => ({
+      isLoading: false,
+      data: {
+        ...caseConnectors,
+        'resilient-2': {
+          ...caseConnectors['resilient-2'],
+          push: { ...caseConnectors['resilient-2'].push, needsToBePushed: true },
         },
-      };
+      },
+    }));
 
-      const license = licensingMock.createLicense({
-        license: { type: 'platinum' },
-      });
+    appMockRenderer.render(<CaseViewPage {...caseProps} />);
 
-      const props = { ...caseProps, caseData: caseDataWithDamagedRaccoon };
-      appMockRenderer = createAppMockRenderer({ features: { metrics: ['alerts.count'] }, license });
-      const result = appMockRenderer.render(<CaseViewPage {...props} />);
+    expect(screen.getByTestId('push-to-external-service')).toBeInTheDocument();
 
-      expect(result.getByTestId('header-page-title')).toHaveTextContent(data.title);
-      expect(result.getByTestId('case-view-status-dropdown')).toHaveTextContent('Open');
-      expect(result.getByTestId('case-view-metrics-panel')).toBeInTheDocument();
-      expect(
-        within(result.getByTestId('case-view-tag-list')).getByTestId('tag-coke')
-      ).toHaveTextContent(data.tags[0]);
-
-      expect(
-        within(result.getByTestId('case-view-tag-list')).getByTestId('tag-pepsi')
-      ).toHaveTextContent(data.tags[1]);
-
-      expect(result.getAllByText(data.createdBy.fullName!)[0]).toBeInTheDocument();
-
-      expect(
-        within(result.getByTestId('description-action')).getByTestId('user-action-markdown')
-      ).toHaveTextContent(data.description);
-
-      expect(result.getByTestId('case-view-status-action-button')).toHaveTextContent(
-        'Mark in progress'
-      );
+    userEvent.click(screen.getByTestId('push-to-external-service'), undefined, {
+      skipPointerEventsCheck: true,
     });
 
-    it('should show closed indicators in header when case is closed', async () => {
-      useUpdateCaseMock.mockImplementation(() => ({
-        ...defaultUpdateCaseState,
-        caseData: basicCaseClosed,
-      }));
-
-      const result = appMockRenderer.render(<CaseViewPage {...caseClosedProps} />);
-
-      expect(result.getByTestId('case-view-status-dropdown')).toHaveTextContent('Closed');
+    await waitFor(() => {
+      expect(pushCaseToExternalService).toHaveBeenCalled();
     });
+  });
 
-    it('should update status', async () => {
-      const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
+  it('should disable the push button when connector is invalid', async () => {
+    appMockRenderer.render(
+      <CaseViewPage
+        {...{
+          ...caseProps,
+          caseData: { ...caseProps.caseData, connectorId: 'not-exist' },
+        }}
+      />
+    );
 
-      const dropdown = result.getByTestId('case-view-status-dropdown');
-      userEvent.click(dropdown.querySelector('button')!, undefined, {
-        skipPointerEventsCheck: true,
-      });
-      await waitForEuiPopoverOpen();
-      userEvent.click(result.getByTestId('case-view-status-dropdown-closed'), undefined, {
-        skipPointerEventsCheck: true,
-      });
-      const updateObject = updateCaseProperty.mock.calls[0][0];
+    expect(await screen.findByTestId('push-to-external-service')).toBeDisabled();
+  });
 
-      await waitFor(() => {
-        expect(updateCaseProperty).toHaveBeenCalledTimes(1);
-        expect(updateObject.updateKey).toEqual('status');
-        expect(updateObject.updateValue).toEqual('closed');
-      });
-    });
-
-    it('should display EditableTitle isLoading', async () => {
-      useUpdateCaseMock.mockImplementation(() => ({
-        ...defaultUpdateCaseState,
-        isLoading: true,
-        updateKey: 'title',
-      }));
-      const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
-
-      await waitFor(() => {
-        expect(result.getByTestId('editable-title-loading')).toBeInTheDocument();
-        expect(result.queryByTestId('editable-title-edit-icon')).not.toBeInTheDocument();
-      });
-    });
-
-    it('should display tags isLoading', async () => {
-      useUpdateCaseMock.mockImplementation(() => ({
-        ...defaultUpdateCaseState,
-        isLoading: true,
-        updateKey: 'tags',
-      }));
-
-      const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
-
-      await waitFor(() => {
-        expect(
-          within(result.getByTestId('case-view-tag-list')).getByTestId('tag-list-loading')
-        ).toBeInTheDocument();
-      });
-
-      await waitFor(() => {
-        expect(result.queryByTestId('tag-list-edit')).not.toBeInTheDocument();
-      });
-    });
-
-    it('should update title', async () => {
-      const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
-      const newTitle = 'The new title';
-      userEvent.click(result.getByTestId('editable-title-edit-icon'), undefined, {
-        skipPointerEventsCheck: true,
-      });
-      userEvent.clear(result.getByTestId('editable-title-input-field'));
-      userEvent.paste(result.getByTestId('editable-title-input-field'), newTitle);
-      userEvent.click(result.getByTestId('editable-title-submit-btn'), undefined, {
-        skipPointerEventsCheck: true,
-      });
-
-      const updateObject = updateCaseProperty.mock.calls[0][0];
-      await waitFor(() => {
-        expect(updateObject.updateKey).toEqual('title');
-        expect(updateObject.updateValue).toEqual(newTitle);
-      });
-    });
-
-    it('should push updates on button click', async () => {
-      useGetCaseConnectorsMock.mockImplementation(() => ({
-        isLoading: false,
-        data: {
-          ...caseConnectors,
-          'resilient-2': {
-            ...caseConnectors['resilient-2'],
-            push: { ...caseConnectors['resilient-2'].push, needsToBePushed: true },
+  it('should update connector', async () => {
+    appMockRenderer.render(
+      <CaseViewPage
+        {...caseProps}
+        caseData={{
+          ...caseProps.caseData,
+          connector: {
+            id: 'servicenow-1',
+            name: 'SN 1',
+            type: ConnectorTypes.serviceNowITSM,
+            fields: null,
           },
+        }}
+      />
+    );
+    userEvent.click(screen.getByTestId('connector-edit').querySelector('button')!, undefined, {
+      skipPointerEventsCheck: true,
+    });
+    userEvent.click(screen.getByTestId('dropdown-connectors'), undefined, {
+      skipPointerEventsCheck: true,
+    });
+    await waitForEuiPopoverOpen();
+    userEvent.click(screen.getByTestId('dropdown-connector-resilient-2'), undefined, {
+      skipPointerEventsCheck: true,
+    });
+
+    expect(await screen.findByTestId('connector-fields-resilient')).toBeInTheDocument();
+
+    userEvent.click(screen.getByTestId('edit-connectors-submit'), undefined, {
+      skipPointerEventsCheck: true,
+    });
+
+    await waitFor(() => {
+      expect(updateCaseProperty).toHaveBeenCalledTimes(1);
+      const updateObject = updateCaseProperty.mock.calls[0][0];
+      expect(updateObject.updateKey).toEqual('connector');
+      expect(updateObject.updateValue).toEqual({
+        id: 'resilient-2',
+        name: 'My Resilient connector',
+        type: ConnectorTypes.resilient,
+        fields: {
+          incidentTypes: null,
+          severityCode: null,
         },
-      }));
+      });
+    });
+  });
 
+  it('should call onComponentInitialized on mount', async () => {
+    const onComponentInitialized = jest.fn();
+    appMockRenderer.render(
+      <CaseViewPage {...caseProps} onComponentInitialized={onComponentInitialized} />
+    );
+
+    await waitFor(() => {
+      expect(onComponentInitialized).toHaveBeenCalled();
+    });
+  });
+
+  it('should show loading content when loading user actions', async () => {
+    const useFetchAlertData = jest.fn().mockReturnValue([true]);
+    useFindCaseUserActionsMock.mockReturnValue({
+      data: undefined,
+      isError: false,
+      isLoading: true,
+      isFetching: true,
+      refetch: refetchFindCaseUserActions,
+    });
+
+    appMockRenderer.render(<CaseViewPage {...caseProps} useFetchAlertData={useFetchAlertData} />);
+
+    expect(await screen.findByTestId('case-view-loading-content')).toBeInTheDocument();
+    expect(screen.queryByTestId('user-actions')).not.toBeInTheDocument();
+  });
+
+  it('should call show alert details with expected arguments', async () => {
+    const showAlertDetails = jest.fn();
+    appMockRenderer.render(<CaseViewPage {...caseProps} showAlertDetails={showAlertDetails} />);
+
+    userEvent.click(screen.getByTestId('comment-action-show-alert-alert-action-id'), undefined, {
+      skipPointerEventsCheck: true,
+    });
+
+    await waitFor(() => {
+      expect(showAlertDetails).toHaveBeenCalledWith('alert-id-1', 'alert-index-1');
+    });
+  });
+
+  it('should show the rule name', async () => {
+    appMockRenderer.render(<CaseViewPage {...caseProps} />);
+
+    expect(
+      (
+        await screen.findByTestId('user-action-alert-comment-create-action-alert-action-id')
+      ).querySelector('.euiCommentEvent__headerEvent')
+    ).toHaveTextContent('added an alert from Awesome rule');
+  });
+
+  it('should update settings', async () => {
+    appMockRenderer.render(<CaseViewPage {...caseProps} />);
+    userEvent.click(screen.getByTestId('sync-alerts-switch'), undefined, {
+      skipPointerEventsCheck: true,
+    });
+    const updateObject = updateCaseProperty.mock.calls[0][0];
+
+    await waitFor(() => {
+      expect(updateObject.updateKey).toEqual('settings');
+      expect(updateObject.updateValue).toEqual({ syncAlerts: false });
+    });
+  });
+
+  it('should show the correct connector name on the push button', async () => {
+    useGetConnectorsMock.mockImplementation(() => ({ data: connectorsMock, isLoading: false }));
+
+    appMockRenderer.render(
+      <CaseViewPage {...{ ...caseProps, connector: { ...caseProps, name: 'old-name' } }} />
+    );
+
+    expect(await screen.findByTestId('push-to-external-service')).toHaveTextContent(
+      'My Resilient connector'
+    );
+  });
+
+  describe('Callouts', () => {
+    it('it shows the danger callout when a connector has been deleted', async () => {
+      useGetConnectorsMock.mockImplementation(() => ({ data: [], isLoading: false }));
       const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
 
-      expect(result.getByTestId('push-to-external-service')).toBeInTheDocument();
-
-      userEvent.click(result.getByTestId('push-to-external-service'), undefined, {
-        skipPointerEventsCheck: true,
-      });
-
-      await waitFor(() => {
-        expect(pushCaseToExternalService).toHaveBeenCalled();
-      });
+      expect(result.container.querySelector('.euiCallOut--danger')).toBeInTheDocument();
     });
 
-    it('should disable the push button when connector is invalid', async () => {
-      const result = appMockRenderer.render(
-        <CaseViewPage
-          {...{
-            ...caseProps,
-            caseData: { ...caseProps.caseData, connectorId: 'not-exist' },
-          }}
-        />
-      );
-      await waitFor(() => {
-        expect(result.getByTestId('push-to-external-service')).toBeDisabled();
-      });
+    it('it does NOT shows the danger callout when connectors are loading', async () => {
+      useGetConnectorsMock.mockImplementation(() => ({ data: [], isLoading: true }));
+      const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
+
+      expect(result.container.querySelector('.euiCallOut--danger')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Tabs', () => {
+    it('renders tabs correctly', async () => {
+      appMockRenderer.render(<CaseViewPage {...caseProps} />);
+      expect(await screen.findByTestId('case-view-tab-title-alerts')).toBeInTheDocument();
+      expect(await screen.findByTestId('case-view-tab-title-activity')).toBeInTheDocument();
     });
 
-    it('should update connector', async () => {
-      const result = appMockRenderer.render(
-        <CaseViewPage
-          {...caseProps}
-          caseData={{
-            ...caseProps.caseData,
-            connector: {
-              id: 'servicenow-1',
-              name: 'SN 1',
-              type: ConnectorTypes.serviceNowITSM,
-              fields: null,
-            },
-          }}
-        />
-      );
-      userEvent.click(result.getByTestId('connector-edit').querySelector('button')!, undefined, {
-        skipPointerEventsCheck: true,
+    it('renders the activity tab by default', async () => {
+      appMockRenderer.render(<CaseViewPage {...caseProps} />);
+      expect(await screen.findByTestId('case-view-tab-content-activity')).toBeInTheDocument();
+    });
+
+    it('renders the alerts tab when the query parameter tabId has alerts', async () => {
+      useUrlParamsMock.mockReturnValue({
+        urlParams: {
+          tabId: CASE_VIEW_PAGE_TABS.ALERTS,
+        },
       });
-      userEvent.click(result.getByTestId('dropdown-connectors'), undefined, {
-        skipPointerEventsCheck: true,
+
+      appMockRenderer.render(<CaseViewPage {...caseProps} />);
+
+      expect(await screen.findByText('alerts table')).toBeInTheDocument();
+      expect(await screen.findByTestId('case-view-tab-content-alerts')).toBeInTheDocument();
+    });
+
+    it('renders the activity tab when the query parameter tabId has activity', async () => {
+      useUrlParamsMock.mockReturnValue({
+        urlParams: {
+          tabId: CASE_VIEW_PAGE_TABS.ACTIVITY,
+        },
       });
-      await waitForEuiPopoverOpen();
-      userEvent.click(result.getByTestId('dropdown-connector-resilient-2'), undefined, {
+
+      appMockRenderer.render(<CaseViewPage {...caseProps} />);
+      expect(await screen.findByTestId('case-view-tab-content-activity')).toBeInTheDocument();
+    });
+
+    it('renders the activity tab when the query parameter tabId has an unknown value', async () => {
+      useUrlParamsMock.mockReturnValue({
+        urlParams: {
+          tabId: 'what-is-love',
+        },
+      });
+
+      appMockRenderer.render(<CaseViewPage {...caseProps} />);
+      expect(await screen.findByTestId('case-view-tab-content-activity')).toBeInTheDocument();
+      expect(screen.queryByTestId('case-view-tab-content-alerts')).not.toBeInTheDocument();
+    });
+
+    it('navigates to the activity tab when the activity tab is clicked', async () => {
+      const navigateToCaseViewMock = useCaseViewNavigationMock().navigateToCaseView;
+      appMockRenderer.render(<CaseViewPage {...caseProps} />);
+
+      userEvent.click(await screen.findByTestId('case-view-tab-title-activity'), undefined, {
         skipPointerEventsCheck: true,
       });
 
-      await waitFor(() => {
-        expect(result.getByTestId('connector-fields-resilient')).toBeInTheDocument();
-      });
-
-      userEvent.click(result.getByTestId('edit-connectors-submit'), undefined, {
-        skipPointerEventsCheck: true,
-      });
-
-      await waitFor(() => {
-        expect(updateCaseProperty).toHaveBeenCalledTimes(1);
-        const updateObject = updateCaseProperty.mock.calls[0][0];
-        expect(updateObject.updateKey).toEqual('connector');
-        expect(updateObject.updateValue).toEqual({
-          id: 'resilient-2',
-          name: 'My Resilient connector',
-          type: ConnectorTypes.resilient,
-          fields: {
-            incidentTypes: null,
-            severityCode: null,
-          },
+      await waitFor(async () => {
+        expect(navigateToCaseViewMock).toHaveBeenCalledWith({
+          detailName: caseData.id,
+          tabId: CASE_VIEW_PAGE_TABS.ACTIVITY,
         });
       });
     });
 
-    it('should call onComponentInitialized on mount', async () => {
-      const onComponentInitialized = jest.fn();
-      appMockRenderer.render(
-        <CaseViewPage {...caseProps} onComponentInitialized={onComponentInitialized} />
-      );
+    it('navigates to the alerts tab when the alerts tab is clicked', async () => {
+      const navigateToCaseViewMock = useCaseViewNavigationMock().navigateToCaseView;
+      appMockRenderer.render(<CaseViewPage {...caseProps} />);
 
-      await waitFor(() => {
-        expect(onComponentInitialized).toHaveBeenCalled();
-      });
-    });
-
-    it('should show loading content when loading user actions', async () => {
-      const useFetchAlertData = jest.fn().mockReturnValue([true]);
-      useFindCaseUserActionsMock.mockReturnValue({
-        data: undefined,
-        isError: false,
-        isLoading: true,
-        isFetching: true,
-        refetch: refetchFindCaseUserActions,
-      });
-
-      const result = appMockRenderer.render(
-        <CaseViewPage {...caseProps} useFetchAlertData={useFetchAlertData} />
-      );
-      await waitFor(() => {
-        expect(result.getByTestId('case-view-loading-content')).toBeInTheDocument();
-        expect(result.queryByTestId('user-actions')).not.toBeInTheDocument();
-      });
-    });
-
-    it('should call show alert details with expected arguments', async () => {
-      const showAlertDetails = jest.fn();
-      const result = appMockRenderer.render(
-        <CaseViewPage {...caseProps} showAlertDetails={showAlertDetails} />
-      );
-
-      userEvent.click(result.getByTestId('comment-action-show-alert-alert-action-id'), undefined, {
+      userEvent.click(await screen.findByTestId('case-view-tab-title-alerts'), undefined, {
         skipPointerEventsCheck: true,
       });
 
-      await waitFor(() => {
-        expect(showAlertDetails).toHaveBeenCalledWith('alert-id-1', 'alert-index-1');
+      await waitFor(async () => {
+        expect(navigateToCaseViewMock).toHaveBeenCalledWith({
+          detailName: caseData.id,
+          tabId: CASE_VIEW_PAGE_TABS.ALERTS,
+        });
       });
     });
 
-    it('should show the rule name', async () => {
-      const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
+    it('should display the alerts tab when the feature is enabled', async () => {
+      appMockRenderer = createAppMockRenderer({ features: { alerts: { enabled: true } } });
+      appMockRenderer.render(<CaseViewPage {...caseProps} />);
 
-      await waitFor(() => {
-        expect(
-          result
-            .getByTestId('user-action-alert-comment-create-action-alert-action-id')
-            .querySelector('.euiCommentEvent__headerEvent')
-        ).toHaveTextContent('added an alert from Awesome rule');
-      });
+      expect(await screen.findByTestId('case-view-tab-title-activity')).toBeInTheDocument();
+      expect(await screen.findByTestId('case-view-tab-title-alerts')).toBeInTheDocument();
     });
 
-    it('should update settings', async () => {
-      const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
-      userEvent.click(result.getByTestId('sync-alerts-switch'), undefined, {
-        skipPointerEventsCheck: true,
-      });
-      const updateObject = updateCaseProperty.mock.calls[0][0];
+    it('should not display the alerts tab when the feature is disabled', async () => {
+      appMockRenderer = createAppMockRenderer({ features: { alerts: { enabled: false } } });
+      appMockRenderer.render(<CaseViewPage {...caseProps} />);
 
-      await waitFor(() => {
-        expect(updateObject.updateKey).toEqual('settings');
-        expect(updateObject.updateValue).toEqual({ syncAlerts: false });
-      });
+      expect(await screen.findByTestId('case-view-tab-title-activity')).toBeInTheDocument();
+      expect(screen.queryByTestId('case-view-tab-title-alerts')).not.toBeInTheDocument();
     });
 
-    it('should show the correct connector name on the push button', async () => {
-      useGetConnectorsMock.mockImplementation(() => ({ data: connectorsMock, isLoading: false }));
+    it('should not show the experimental badge on the alerts table', async () => {
+      appMockRenderer = createAppMockRenderer({
+        features: { alerts: { isExperimental: false } },
+      });
+      appMockRenderer.render(<CaseViewPage {...caseProps} />);
 
-      const result = appMockRenderer.render(
-        <CaseViewPage {...{ ...caseProps, connector: { ...caseProps, name: 'old-name' } }} />
-      );
+      expect(
+        screen.queryByTestId('case-view-alerts-table-experimental-badge')
+      ).not.toBeInTheDocument();
+    });
 
-      await waitFor(() => {
-        expect(result.getByTestId('push-to-external-service')).toHaveTextContent(
-          'My Resilient connector'
+    it('should show the experimental badge on the alerts table', async () => {
+      appMockRenderer = createAppMockRenderer({ features: { alerts: { isExperimental: true } } });
+      appMockRenderer.render(<CaseViewPage {...caseProps} />);
+
+      expect(
+        await screen.findByTestId('case-view-alerts-table-experimental-badge')
+      ).toBeInTheDocument();
+    });
+
+    describe('description', () => {
+      it('renders the descriptions user correctly', async () => {
+        appMockRenderer.render(<CaseViewPage {...caseProps} />);
+
+        const description = within(await screen.findByTestId('description-action'));
+
+        expect(await description.findByText('Leslie Knope')).toBeInTheDocument();
+      });
+
+      it('should display description isLoading', async () => {
+        useUpdateCaseMock.mockImplementation(() => ({
+          ...defaultUpdateCaseState,
+          isLoading: true,
+          updateKey: 'description',
+        }));
+
+        appMockRenderer.render(<CaseViewPage {...caseProps} />);
+
+        expect(await screen.findByTestId('description-loading')).toBeInTheDocument();
+        expect(screen.queryByTestId('description-action')).not.toBeInTheDocument();
+      });
+
+      it.skip('it should persist the draft of new comment while description is updated', async () => {
+        const newComment = 'another cool comment';
+
+        appMockRenderer.render(<CaseViewPage {...caseProps} />);
+
+        userEvent.click(
+          await screen.findByTestId('user-actions-filter-activity-button-all'),
+          undefined,
+          { skipPointerEventsCheck: true }
+        );
+
+        userEvent.paste(await screen.findByTestId('euiMarkdownEditorTextArea'), newComment);
+
+        userEvent.click(await screen.findByTestId('editable-description-edit-icon'), undefined, {
+          skipPointerEventsCheck: true,
+        });
+
+        userEvent.paste(screen.getAllByTestId('euiMarkdownEditorTextArea')[0], 'Edited!');
+
+        userEvent.click(screen.getByTestId('user-action-save-markdown'), undefined, {
+          skipPointerEventsCheck: true,
+        });
+
+        expect(await screen.findByTestId('euiMarkdownEditorTextArea')).toHaveTextContent(
+          newComment
         );
       });
     });
 
-    describe('Callouts', () => {
-      it('it shows the danger callout when a connector has been deleted', async () => {
-        useGetConnectorsMock.mockImplementation(() => ({ data: [], isLoading: false }));
-        const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
-
-        expect(result.container.querySelector('.euiCallOut--danger')).toBeInTheDocument();
-      });
-
-      it('it does NOT shows the danger callout when connectors are loading', async () => {
-        useGetConnectorsMock.mockImplementation(() => ({ data: [], isLoading: true }));
-        const result = appMockRenderer.render(<CaseViewPage {...caseProps} />);
-
-        expect(result.container.querySelector('.euiCallOut--danger')).not.toBeInTheDocument();
-      });
-    });
-
-    describe('Tabs', () => {
-      it('renders tabs correctly', async () => {
-        appMockRenderer.render(<CaseViewPage {...caseProps} />);
-        expect(await screen.findByTestId('case-view-tab-title-alerts')).toBeInTheDocument();
-        expect(await screen.findByTestId('case-view-tab-title-activity')).toBeInTheDocument();
-      });
-
-      it('renders the activity tab by default', async () => {
-        appMockRenderer.render(<CaseViewPage {...caseProps} />);
-        expect(await screen.findByTestId('case-view-tab-content-activity')).toBeInTheDocument();
-      });
-
-      it('renders the alerts tab when the query parameter tabId has alerts', async () => {
-        useUrlParamsMock.mockReturnValue({
-          urlParams: {
-            tabId: CASE_VIEW_PAGE_TABS.ALERTS,
-          },
-        });
-
+    describe('breadcrumbs', () => {
+      it('should set the cases title', async () => {
         appMockRenderer.render(<CaseViewPage {...caseProps} />);
 
-        expect(await screen.findByText('alerts table')).toBeInTheDocument();
-        expect(await screen.findByTestId('case-view-tab-content-alerts')).toBeInTheDocument();
-      });
-
-      it('renders the activity tab when the query parameter tabId has activity', async () => {
-        useUrlParamsMock.mockReturnValue({
-          urlParams: {
-            tabId: CASE_VIEW_PAGE_TABS.ACTIVITY,
-          },
-        });
-
-        appMockRenderer.render(<CaseViewPage {...caseProps} />);
-        expect(await screen.findByTestId('case-view-tab-content-activity')).toBeInTheDocument();
-      });
-
-      it('renders the activity tab when the query parameter tabId has an unknown value', async () => {
-        useUrlParamsMock.mockReturnValue({
-          urlParams: {
-            tabId: 'what-is-love',
-          },
-        });
-
-        appMockRenderer.render(<CaseViewPage {...caseProps} />);
-        expect(await screen.findByTestId('case-view-tab-content-activity')).toBeInTheDocument();
-        expect(screen.queryByTestId('case-view-tab-content-alerts')).not.toBeInTheDocument();
-      });
-
-      it('navigates to the activity tab when the activity tab is clicked', async () => {
-        const navigateToCaseViewMock = useCaseViewNavigationMock().navigateToCaseView;
-        appMockRenderer.render(<CaseViewPage {...caseProps} />);
-
-        userEvent.click(await screen.findByTestId('case-view-tab-title-activity'), undefined, {
-          skipPointerEventsCheck: true,
-        });
-
-        await waitFor(async () => {
-          expect(navigateToCaseViewMock).toHaveBeenCalledWith({
-            detailName: caseData.id,
-            tabId: CASE_VIEW_PAGE_TABS.ACTIVITY,
-          });
-        });
-      });
-
-      it('navigates to the alerts tab when the alerts tab is clicked', async () => {
-        const navigateToCaseViewMock = useCaseViewNavigationMock().navigateToCaseView;
-        appMockRenderer.render(<CaseViewPage {...caseProps} />);
-
-        userEvent.click(await screen.findByTestId('case-view-tab-title-alerts'), undefined, {
-          skipPointerEventsCheck: true,
-        });
-
-        await waitFor(async () => {
-          expect(navigateToCaseViewMock).toHaveBeenCalledWith({
-            detailName: caseData.id,
-            tabId: CASE_VIEW_PAGE_TABS.ALERTS,
-          });
-        });
-      });
-
-      it('should display the alerts tab when the feature is enabled', async () => {
-        appMockRenderer = createAppMockRenderer({ features: { alerts: { enabled: true } } });
-        appMockRenderer.render(<CaseViewPage {...caseProps} />);
-
-        expect(await screen.findByTestId('case-view-tab-title-activity')).toBeInTheDocument();
-        expect(await screen.findByTestId('case-view-tab-title-alerts')).toBeInTheDocument();
-      });
-
-      it('should not display the alerts tab when the feature is disabled', async () => {
-        appMockRenderer = createAppMockRenderer({ features: { alerts: { enabled: false } } });
-        appMockRenderer.render(<CaseViewPage {...caseProps} />);
-
-        expect(await screen.findByTestId('case-view-tab-title-activity')).toBeInTheDocument();
-        expect(screen.queryByTestId('case-view-tab-title-alerts')).not.toBeInTheDocument();
-      });
-
-      it('should not show the experimental badge on the alerts table', async () => {
-        appMockRenderer = createAppMockRenderer({
-          features: { alerts: { isExperimental: false } },
-        });
-        appMockRenderer.render(<CaseViewPage {...caseProps} />);
-
-        expect(
-          screen.queryByTestId('case-view-alerts-table-experimental-badge')
-        ).not.toBeInTheDocument();
-      });
-
-      it('should show the experimental badge on the alerts table', async () => {
-        appMockRenderer = createAppMockRenderer({ features: { alerts: { isExperimental: true } } });
-        appMockRenderer.render(<CaseViewPage {...caseProps} />);
-
-        expect(
-          await screen.findByTestId('case-view-alerts-table-experimental-badge')
-        ).toBeInTheDocument();
-      });
-
-      describe('description', () => {
-        it('renders the descriptions user correctly', async () => {
-          appMockRenderer.render(<CaseViewPage {...caseProps} />);
-
-          const description = within(await screen.findByTestId('description-action'));
-
-          expect(await description.findByText('Leslie Knope')).toBeInTheDocument();
-        });
-
-        it('should display description isLoading', async () => {
-          useUpdateCaseMock.mockImplementation(() => ({
-            ...defaultUpdateCaseState,
-            isLoading: true,
-            updateKey: 'description',
-          }));
-
-          appMockRenderer.render(<CaseViewPage {...caseProps} />);
-
-          await waitFor(() => {
-            expect(screen.getByTestId('description-loading')).toBeInTheDocument();
-            expect(screen.queryByTestId('description-action')).not.toBeInTheDocument();
-          });
-        });
-
-        it.skip('it should persist the draft of new comment while description is updated', async () => {
-          const newComment = 'another cool comment';
-
-          appMockRenderer.render(<CaseViewPage {...caseProps} />);
-
-          userEvent.click(
-            await screen.findByTestId('user-actions-filter-activity-button-all'),
-            undefined,
-            { skipPointerEventsCheck: true }
-          );
-
-          userEvent.paste(await screen.findByTestId('euiMarkdownEditorTextArea'), newComment);
-
-          userEvent.click(await screen.findByTestId('editable-description-edit-icon'), undefined, {
-            skipPointerEventsCheck: true,
-          });
-
-          userEvent.paste(screen.getAllByTestId('euiMarkdownEditorTextArea')[0], 'Edited!');
-
-          userEvent.click(screen.getByTestId('user-action-save-markdown'), undefined, {
-            skipPointerEventsCheck: true,
-          });
-
-          expect(await screen.findByTestId('euiMarkdownEditorTextArea')).toHaveTextContent(
-            newComment
-          );
-        });
-      });
-
-      describe('breadcrumbs', () => {
-        it('should set the cases title', async () => {
-          appMockRenderer.render(<CaseViewPage {...caseProps} />);
-
-          await waitFor(() => {
-            expect(mockSetTitle).toHaveBeenCalledWith([caseProps.caseData.title, 'Cases', 'Test']);
-          });
+        await waitFor(() => {
+          expect(mockSetTitle).toHaveBeenCalledWith([caseProps.caseData.title, 'Cases', 'Test']);
         });
       });
     });
   });
-}
+});

--- a/x-pack/plugins/cases/public/components/case_view/case_view_page.tsx
+++ b/x-pack/plugins/cases/public/components/case_view/case_view_page.tsx
@@ -26,7 +26,6 @@ import { useOnUpdateField } from './use_on_update_field';
 export const CaseViewPage = React.memo<CaseViewPageProps>(
   ({
     caseData,
-    caseId,
     onComponentInitialized,
     refreshRef,
     ruleDetailsNavigation,
@@ -83,15 +82,12 @@ export const CaseViewPage = React.memo<CaseViewPageProps>(
       [onUpdateField]
     );
 
-    // useEffect used for component's initialization
-    useEffect(() => {
-      if (init.current) {
-        init.current = false;
-        if (onComponentInitialized) {
-          onComponentInitialized();
-        }
+    if (init.current) {
+      init.current = false;
+      if (onComponentInitialized) {
+        onComponentInitialized();
       }
-    }, [onComponentInitialized]);
+    }
 
     return (
       <>

--- a/x-pack/plugins/cases/public/components/case_view/index.tsx
+++ b/x-pack/plugins/cases/public/components/case_view/index.tsx
@@ -86,7 +86,6 @@ export const CaseView = React.memo(
         {getLegacyUrlConflictCallout()}
         <CaseViewPage
           caseData={data.case}
-          caseId={caseId}
           fetchCase={refetch}
           onComponentInitialized={onComponentInitialized}
           actionsNavigation={actionsNavigation}

--- a/x-pack/plugins/cases/public/components/case_view/types.ts
+++ b/x-pack/plugins/cases/public/components/case_view/types.ts
@@ -28,7 +28,6 @@ export interface CaseViewProps extends CaseViewBaseProps {
 }
 
 export interface CaseViewPageProps extends CaseViewBaseProps {
-  caseId: string;
   fetchCase: () => void;
   caseData: Case;
 }


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
