### PR TITLE
[Controls] Fix auto-focus of search

### DIFF
--- a/src/plugins/controls/public/options_list/components/options_list_control.tsx
+++ b/src/plugins/controls/public/options_list/components/options_list_control.tsx
@@ -166,6 +166,7 @@ export const OptionsListControl = ({
         isOpen={isPopoverOpen}
         panelPaddingSize="none"
         anchorPosition="downCenter"
+        initialFocus={'[data-test-subj=optionsList-control-search-input]'}
         className="optionsList__popoverOverride"
         closePopover={() => dispatch(setPopoverOpen(false))}
         anchorClassName="optionsList__anchorOverride"

--- a/src/plugins/controls/public/options_list/components/options_list_popover_action_bar.tsx
+++ b/src/plugins/controls/public/options_list/components/options_list_popover_action_bar.tsx
@@ -64,7 +64,6 @@ export const OptionsListPopoverActionBar = ({
               value={searchString.value}
               data-test-subj="optionsList-control-search-input"
               placeholder={OptionsListStrings.popover.getSearchPlaceholder()}
-              autoFocus={true}
             />
           </EuiFlexItem>
           {!hideSort && (


### PR DESCRIPTION
## Summary

### Before

The team behind the Observability > Infrastructure > Hosts page was trying to contain the control group renderer in a sticky container; however, as part of this, they found a bug where opening the popover for an options list control would jump them back to the top of the page:

https://user-images.githubusercontent.com/8698078/226758604-ab6b43d5-b949-47fc-8b6c-ea6744ad3ade.mov

### After

I figured out that this was due to the `autoFocus` prop of the `EuiFieldSearch` component, which was added as a super quick UX improvement because it saves users a click (since it is very common for searching to be the first action that a user takes when opening an options list control). However, it is still possible to get this behaviour **without** the `autoFocus` prop by using the `initialFocus` prop of the `EuiPopover` component instead - by switching to this, the popover works as expected on the Hosts page:

https://user-images.githubusercontent.com/8698078/226758759-5731747b-b9cb-4c40-886f-77634e7f89d7.mov

<br>Note in the above video that the `EuiFieldSearch` component still receives focus as soon as the popover opens, which means we haven't lost this desired behaviour :+1:

### Checklist

- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
