### PR TITLE
[Lens] Remove header (empty) when no x axis

### DIFF
--- a/src/plugins/chart_expressions/expression_xy/public/components/xy_chart.test.tsx
+++ b/src/plugins/chart_expressions/expression_xy/public/components/xy_chart.test.tsx
@@ -1105,6 +1105,41 @@ describe('XYChart component', () => {
     expect(wrapper.find(Settings).at(0).prop('allowBrushingLastHistogramBin')).toEqual(true);
   });
 
+  test('should not render tooltip header if no x axis', () => {
+    const { args, data } = sampleArgs();
+    const component = shallow(
+      <XYChart
+        {...defaultProps}
+        args={{
+          ...args,
+          layers: [
+            {
+              layerId: 'first',
+              type: 'dataLayer',
+              layerType: LayerTypes.DATA,
+              seriesType: 'line',
+              isHorizontal: false,
+              isStacked: false,
+              isPercentage: false,
+              showLines: true,
+              xAccessor: undefined,
+              accessors: ['a', 'b'],
+              columnToLabel: '{"a": "Label A", "b": "Label B", "d": "Label D"}',
+              xScaleType: 'ordinal',
+              isHistogram: false,
+              palette: mockPaletteOutput,
+              table: data,
+            },
+          ],
+          detailedTooltip: false,
+        }}
+      />
+    );
+    const tooltip = component.find(Tooltip);
+    const headerFormatter = tooltip.prop('headerFormatter');
+    expect(headerFormatter).toBeUndefined();
+  });
+
   test('should not have tooltip actions for the detailed tooltip', () => {
     const { args, data } = sampleArgs();
 

--- a/src/plugins/chart_expressions/expression_xy/public/components/xy_chart.tsx
+++ b/src/plugins/chart_expressions/expression_xy/public/components/xy_chart.tsx
@@ -817,7 +817,7 @@ export function XYChart({
           <Tooltip<Record<string, string | number>, XYChartSeriesIdentifier>
             boundary={document.getElementById('app-fixed-viewport') ?? undefined}
             headerFormatter={
-              !args.detailedTooltip
+              !args.detailedTooltip && xAxisColumn
                 ? ({ value }) => (
                     <TooltipHeader
                       value={value}

--- a/src/plugins/chart_expressions/expression_xy/public/helpers/data_layers.tsx
+++ b/src/plugins/chart_expressions/expression_xy/public/helpers/data_layers.tsx
@@ -17,7 +17,6 @@ import {
   StackMode,
   XYChartSeriesIdentifier,
 } from '@elastic/charts';
-import { i18n } from '@kbn/i18n';
 import { IFieldFormat } from '@kbn/field-formats-plugin/common';
 import type { PersistedState } from '@kbn/visualizations-plugin/public';
 import { Datatable } from '@kbn/expressions-plugin/common';
@@ -453,9 +452,7 @@ export const getSeriesProps: GetSeriesPropsFn = ({
   );
 
   const emptyX: Record<string, string> = {
-    unifiedX: i18n.translate('expressionXY.xyChart.emptyXLabel', {
-      defaultMessage: '(empty)',
-    }),
+    unifiedX: '',
   };
 
   if (!xColumnId) {

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -3166,7 +3166,6 @@
     "expressionXY.reusable.function.xyVis.errors.valueLabelsForNotBarChartsError": "`valueLabels` 参数仅适用于条形图",
     "expressionXY.tooltipActions.emptyFilterSelection": "至少选择一个要筛选的序列",
     "expressionXY.xAxisConfigFn.help": "配置 xy 图表的 x 轴配置",
-    "expressionXY.xyChart.emptyXLabel": "（空）",
     "expressionXY.xyChart.iconSelect.alertIconLabel": "告警",
     "expressionXY.xyChart.iconSelect.asteriskIconLabel": "星号",
     "expressionXY.xyChart.iconSelect.bellIconLabel": "钟铃",


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/149042

Removes the (empty) tooltip header label that is being displayed when there is no x-axis

![1](https://user-images.githubusercontent.com/17003240/226839092-9a1c5c2a-dda6-47c5-817e-ed0d8888a03b.gif)


<img width="1287" alt="image" src="https://user-images.githubusercontent.com/17003240/226839775-a057d0cb-ff70-475b-bffc-e4fe6677ba08.png">
