### PR TITLE
[Synthetics] Fix test now for private location -  remaining cases

### DIFF
--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/run_test_manually.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/run_test_manually.tsx
@@ -19,6 +19,7 @@ import {
   manualTestMonitorAction,
   manualTestRunInProgressSelector,
 } from '../../state/manual_test_runs';
+import { useGetUrlParams } from '../../hooks/use_url_params';
 
 export const RunTestManually = () => {
   const dispatch = useDispatch();
@@ -27,13 +28,20 @@ export const RunTestManually = () => {
 
   const hasPublicLocation = monitor?.locations.some((loc) => loc.isServiceManaged);
 
+  const { locationId } = useGetUrlParams();
+
+  const isSelectedLocationPrivate = monitor?.locations.some(
+    (loc) => loc.isServiceManaged === false && loc.id === locationId
+  );
+
   const testInProgress = useSelector(manualTestRunInProgressSelector(monitor?.config_id));
 
-  const content = !hasPublicLocation
-    ? PRIVATE_AVAILABLE_LABEL
-    : testInProgress
-    ? TEST_SCHEDULED_LABEL
-    : TEST_NOW_ARIA_LABEL;
+  const content =
+    !hasPublicLocation || isSelectedLocationPrivate
+      ? PRIVATE_AVAILABLE_LABEL
+      : testInProgress
+      ? TEST_SCHEDULED_LABEL
+      : TEST_NOW_ARIA_LABEL;
 
   return (
     <EuiToolTip content={content} key={content}>
@@ -41,7 +49,7 @@ export const RunTestManually = () => {
         data-test-subj="syntheticsRunTestManuallyButton"
         color="success"
         iconType="beaker"
-        isDisabled={!hasPublicLocation}
+        isDisabled={!hasPublicLocation || isSelectedLocationPrivate}
         isLoading={!Boolean(monitor) || testInProgress}
         onClick={() => {
           if (monitor) {

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/actions_popover.test.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/actions_popover.test.tsx
@@ -45,6 +45,7 @@ describe('ActionsPopover', () => {
         isPopoverOpen={false}
         setIsPopoverOpen={jest.fn()}
         monitor={testMonitor}
+        locationId={testMonitor.location.id}
       />
     );
     expect(getByLabelText('Open actions menu'));
@@ -60,6 +61,7 @@ describe('ActionsPopover', () => {
         isPopoverOpen={isPopoverOpen}
         setIsPopoverOpen={setIsPopoverOpen}
         monitor={testMonitor}
+        locationId={testMonitor.location.id}
       />
     );
     const popoverButton = getByLabelText('Open actions menu');
@@ -79,6 +81,7 @@ describe('ActionsPopover', () => {
         isPopoverOpen={isPopoverOpen}
         setIsPopoverOpen={setIsPopoverOpen}
         monitor={testMonitor}
+        locationId={testMonitor.location.id}
       />
     );
     const popoverButton = getByLabelText('Open actions menu');
@@ -99,6 +102,7 @@ describe('ActionsPopover', () => {
         isPopoverOpen={true}
         setIsPopoverOpen={jest.fn()}
         monitor={testMonitor}
+        locationId={testMonitor.location.id}
       />
     );
     expect(getByRole('link')?.getAttribute('href')).toBe('/a/test/edit/url');
@@ -114,6 +118,7 @@ describe('ActionsPopover', () => {
         isPopoverOpen={true}
         setIsPopoverOpen={jest.fn()}
         monitor={testMonitor}
+        locationId={testMonitor.location.id}
       />
     );
     expect(getByRole('link')?.getAttribute('href')).toBe('/a/test/detail/url');
@@ -132,6 +137,7 @@ describe('ActionsPopover', () => {
         position="relative"
         setIsPopoverOpen={jest.fn()}
         monitor={testMonitor}
+        locationId={testMonitor.location.id}
       />
     );
     const enableButton = getByText('Disable monitor');
@@ -153,6 +159,7 @@ describe('ActionsPopover', () => {
         setIsPopoverOpen={jest.fn()}
         monitor={{ ...testMonitor, isEnabled: false }}
         position="relative"
+        locationId={testMonitor.location.id}
       />
     );
     const enableButton = getByText('Enable monitor');

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/actions_popover.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/actions_popover.tsx
@@ -76,7 +76,7 @@ interface Props {
   position: PopoverPosition;
   iconHasPanel?: boolean;
   iconSize?: 's' | 'xs';
-  locationId?: string;
+  locationId: string;
 }
 
 const CustomShadowPanel = styled(EuiPanel)<{ shadow: string }>`
@@ -112,7 +112,7 @@ export function ActionsPopover({
 }: Props) {
   const euiShadow = useEuiShadow('l');
   const dispatch = useDispatch();
-  const location = useLocationName({ locationId: monitor.location.id });
+  const location = useLocationName({ locationId });
   const locationName = location?.label || monitor.location.id;
 
   const isPrivateLocation = !Boolean(location?.isServiceManaged);

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/metric_item.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/metric_item.tsx
@@ -142,6 +142,7 @@ export const MetricItem = ({
             isPopoverOpen={isPopoverOpen}
             setIsPopoverOpen={setIsPopoverOpen}
             position="relative"
+            locationId={monitor.location.id}
           />
         )}
         {configIdByLocation && (


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/150924

When private location is selected in monitor details page

<img width="1780" alt="image" src="https://user-images.githubusercontent.com/3505601/226893532-a4a21939-5be0-4ddb-b3a1-ddecf19a5919.png">


from the flyout

<img width="1786" alt="image" src="https://user-images.githubusercontent.com/3505601/226893634-9eeefa01-4430-4a17-9c8c-da1c45cddf86.png">


<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->