### PR TITLE
action: GitHub command for new PRs created by the APM UI/Oblt teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -778,6 +778,7 @@ packages/kbn-yarn-lock-validator @elastic/kibana-operations
 
 # Observability robots
 /.github/workflows/deploy-my-kibana.yml @elastic/observablt-robots
+/.github/workflows/oblt-github-commands @elastic/observablt-robots
 
 # Infra Monitoring
 /x-pack/test/functional/apps/infra @elastic/infra-monitoring-ui

--- a/.github/workflows/oblt-github-commands.yml
+++ b/.github/workflows/oblt-github-commands.yml
@@ -1,0 +1,27 @@
+---
+##
+## This the automation to let Observability team members to know what are the
+## supported GitHub commands to interact with the Observability test environments.
+##
+## Owner: @elastic/observablt-robots
+##
+name: oblt-github-commands
+
+on:
+  issues:
+    types:
+      - opened
+
+permissions:
+  contents: read
+
+jobs:
+  oblt-kibana-github-commands:
+    if: ${{ github.event.issue.pull_request }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: elastic/apm-pipeline-library/.github/actions/oblt-kibana-github-commands@current
+        with:
+          vaultUrl: ${{ secrets.OBLT_VAULT_ADDR }}
+          vaultRoleId: ${{ secrets.OBLT_VAULT_ROLE_ID }}
+          vaultSecretId: ${{ secrets.OBLT_VAULT_SECRET_ID }}

--- a/.github/workflows/oblt-github-commands.yml
+++ b/.github/workflows/oblt-github-commands.yml
@@ -43,7 +43,7 @@ jobs:
           github-token: ${{ env.GITHUB_TOKEN }}
           script: |
             const body = `
-              ## :robot: GitHub comments
+              ### :robot: GitHub comments
 
               <details><summary>Expand to view the GitHub comments</summary>
               <p>

--- a/.github/workflows/oblt-github-commands.yml
+++ b/.github/workflows/oblt-github-commands.yml
@@ -8,7 +8,7 @@
 name: oblt-github-commands
 
 on:
-  issues:
+  pull_request_target:
     types:
       - opened
 
@@ -16,12 +16,48 @@ permissions:
   contents: read
 
 jobs:
-  oblt-kibana-github-commands:
-    if: ${{ github.event.issue.pull_request }}
+  comment-if-apm-ui:
     runs-on: ubuntu-latest
     steps:
-      - uses: elastic/apm-pipeline-library/.github/actions/oblt-kibana-github-commands@current
+      - uses: elastic/apm-pipeline-library/.github/actions/github-token@current
         with:
-          vaultUrl: ${{ secrets.OBLT_VAULT_ADDR }}
-          vaultRoleId: ${{ secrets.OBLT_VAULT_ROLE_ID }}
-          vaultSecretId: ${{ secrets.OBLT_VAULT_SECRET_ID }}
+          url: ${{ secrets.OBLT_VAULT_ADDR }}
+          roleId: ${{ secrets.OBLT_VAULT_ROLE_ID }}
+          secretId: ${{ secrets.OBLT_VAULT_SECRET_ID }}
+
+      - id: is_team_member
+        name: Check if user is member of the Elastic org and apm-ui team
+        run: |
+          if gh api -H "Accept: application/vnd.github+json" \
+            /orgs/elastic/teams/apm-ui/memberships/${{ github.actor }} ; then
+            echo "result=true" >> $GITHUB_OUTPUT
+          else
+            echo "result=false" >> $GITHUB_OUTPUT
+          fi
+        env:
+          GH_TOKEN: ${{ env.GITHUB_TOKEN }}
+
+      - if: ${{ steps.is_team_member.outputs.result == 'true' }}
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ env.GITHUB_TOKEN }}
+          script: |
+            const body = `
+              ## :robot: GitHub comments
+
+              <details><summary>Expand to view the GitHub comments</summary>
+              <p>
+
+              Just comment with:
+              - \`/oblt-deploy\` : Deploy a Kibana instance using the Observability test environments.
+              - \`run\` \`elasticsearch-ci/docs\` : Re-trigger the docs validation. (use unformatted text in the comment!)
+
+              </p>
+              </details>
+            `.replace(/  +/g, '')
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body
+            })

--- a/.github/workflows/oblt-github-commands.yml
+++ b/.github/workflows/oblt-github-commands.yml
@@ -16,7 +16,7 @@ permissions:
   contents: read
 
 jobs:
-  comment-if-apm-ui:
+  comment-if-oblt-member:
     runs-on: ubuntu-latest
     steps:
       - uses: elastic/apm-pipeline-library/.github/actions/github-token@current
@@ -26,10 +26,10 @@ jobs:
           secretId: ${{ secrets.OBLT_VAULT_SECRET_ID }}
 
       - id: is_team_member
-        name: Check if user is member of the Elastic org and apm-ui team
+        name: Check if user is member of the Elastic org and Observability team
         run: |
           if gh api -H "Accept: application/vnd.github+json" \
-            /orgs/elastic/teams/apm-ui/memberships/${{ github.actor }} ; then
+            /orgs/elastic/teams/observability/memberships/${{ github.actor }} ; then
             echo "result=true" >> $GITHUB_OUTPUT
           else
             echo "result=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

Make sure the `apm-ui`/`observability` teams are ware of the new features, such as https://github.com/elastic/kibana/pull/153106

For such, this new action will create a GitHub comment only when a PR is created by any member of `observability` team.

The comment will be something like:

<img width="1185" alt="image" src="https://user-images.githubusercontent.com/2871786/226889581-58d9962d-93f0-400e-9b82-3ba12f84c4fe.png">

cc @elastic/apm-ui @cachedout @kuisathaverat 