### PR TITLE
[Dashboard] Add better debugging to error embeddable checks

### DIFF
--- a/test/functional/services/dashboard/expectations.ts
+++ b/test/functional/services/dashboard/expectations.ts
@@ -32,9 +32,30 @@ export class DashboardExpectService extends FtrService {
   }
 
   async visualizationsArePresent(vizList: string[]) {
-    this.log.debug('Checking all visualisations are present on dashsboard');
+    this.log.debug('Checking all visualisations are present on the dashboard');
     const notLoaded = await this.dashboard.getNotLoadedVisualizations(vizList);
     expect(notLoaded).to.be.empty();
+  }
+
+  /**
+   * Asserts that there is no error embeddables on the dashboard
+   * @throws An error if an error embeddable is present
+   */
+  async noErrorEmbeddablesPresent() {
+    this.log.debug('Ensure that there are no error embeddables on the dashboard');
+    const errorEmbeddables = await this.testSubjects.findAll('embeddableError');
+    if (errorEmbeddables.length > 0) {
+      const errorTitles = await Promise.all(
+        errorEmbeddables.map(async (embeddable) => {
+          return (
+            (await (await embeddable.findByTestSubject('dashboardPanelTitle')).getVisibleText()) ??
+            'Empty title'
+          );
+        })
+      );
+      await errorEmbeddables[0].scrollIntoViewIfNecessary();
+      throw new Error(`Found error embeddable(s): ${errorTitles}`);
+    }
   }
 
   async selectedLegendColorCount(color: string, expectedCount: number) {

--- a/test/functional/services/dashboard/expectations.ts
+++ b/test/functional/services/dashboard/expectations.ts
@@ -16,7 +16,6 @@ export class DashboardExpectService extends FtrService {
   private readonly testSubjects = this.ctx.getService('testSubjects');
   private readonly find = this.ctx.getService('find');
   private readonly filterBar = this.ctx.getService('filterBar');
-  private readonly screenshotService = this.ctx.getService('screenshots');
 
   private readonly dashboard = this.ctx.getPageObject('dashboard');
   private readonly visChart = this.ctx.getPageObject('visChart');
@@ -49,7 +48,7 @@ export class DashboardExpectService extends FtrService {
     if (errorEmbeddables.length > 0) {
       const errorMessages = await Promise.all(
         errorEmbeddables.map(async (embeddable) => {
-          const panel = await embeddable.findByXpath('./..');
+          const panel = await embeddable.findByXpath('./..'); // get the parent of 'embeddableError'
           let panelTitle = 'Empty title';
           if (await this.testSubjects.descendantExists('dashboardPanelTitle', panel)) {
             panelTitle = await (
@@ -62,7 +61,7 @@ export class DashboardExpectService extends FtrService {
       );
 
       throw new Error(
-        `Found error embeddable(s): ${errorMessages.reduce((errorString, error, id) => {
+        `Found error embeddable(s): ${errorMessages.reduce((errorString, error) => {
           return errorString + '\n' + `\t- ${error}`;
         }, '')}`
       );

--- a/x-pack/test/search_sessions_integration/tests/apps/dashboard/async_search/async_search.ts
+++ b/x-pack/test/search_sessions_integration/tests/apps/dashboard/async_search/async_search.ts
@@ -16,6 +16,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const dashboardPanelActions = getService('dashboardPanelActions');
   const queryBar = getService('queryBar');
   const elasticChart = getService('elasticChart');
+  const dashboardExpect = getService('dashboardExpect');
+
   const xyChartSelector = 'xyVisChart';
 
   const enableNewChartLibraryDebug = async () => {
@@ -36,7 +38,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await PageObjects.common.navigateToApp('dashboard');
       await PageObjects.dashboard.loadSavedDashboard('Not Delayed');
       await PageObjects.header.waitUntilLoadingHasFinished();
-      await testSubjects.missingOrFail('embeddableError');
+      await dashboardExpect.noErrorEmbeddablesPresent();
       await enableNewChartLibraryDebug();
       const data = await PageObjects.visChart.getBarChartData(xyChartSelector, 'Sum of bytes');
       expect(data.length).to.be(5);
@@ -46,7 +48,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await PageObjects.common.navigateToApp('dashboard');
       await PageObjects.dashboard.loadSavedDashboard('Delayed 5s');
       await PageObjects.header.waitUntilLoadingHasFinished();
-      await testSubjects.missingOrFail('embeddableError');
+      await dashboardExpect.noErrorEmbeddablesPresent();
       await enableNewChartLibraryDebug();
       const data = await PageObjects.visChart.getBarChartData(xyChartSelector, 'Sum of bytes');
       expect(data.length).to.be(5);

--- a/x-pack/test/search_sessions_integration/tests/apps/dashboard/async_search/save_search_session.ts
+++ b/x-pack/test/search_sessions_integration/tests/apps/dashboard/async_search/save_search_session.ts
@@ -25,6 +25,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const queryBar = getService('queryBar');
   const elasticChart = getService('elasticChart');
   const toasts = getService('toasts');
+  const dashboardExpect = getService('dashboardExpect');
 
   const enableNewChartLibraryDebug = async () => {
     await elasticChart.setNewChartUiDebugFlag();
@@ -63,7 +64,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await queryBar.clickQuerySubmitButton();
       await PageObjects.header.waitUntilLoadingHasFinished();
       await searchSessions.expectState('completed');
-      await testSubjects.missingOrFail('embeddableError');
+      await dashboardExpect.noErrorEmbeddablesPresent();
       const session2 = await dashboardPanelActions.getSearchSessionIdByTitle(
         'Sum of Bytes by Extension'
       );
@@ -104,7 +105,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       // Check that session is restored
       await searchSessions.expectState('restored');
-      await testSubjects.missingOrFail('embeddableError');
+      await dashboardExpect.noErrorEmbeddablesPresent();
 
       // switching dashboard to edit mode (or any other non-fetch required) state change
       // should leave session state untouched

--- a/x-pack/test/search_sessions_integration/tests/apps/dashboard/async_search/save_search_session_relative_time.ts
+++ b/x-pack/test/search_sessions_integration/tests/apps/dashboard/async_search/save_search_session_relative_time.ts
@@ -6,6 +6,7 @@
  */
 
 import expect from '@kbn/expect';
+import { fail } from 'assert';
 import { FtrProviderContext } from '../../../../ftr_provider_context';
 
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
@@ -85,7 +86,14 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
   async function checkSampleDashboardLoaded(visualizationContainer?: string) {
     log.debug('Checking no error labels');
-    await testSubjects.missingOrFail('embeddableError');
+    if (await testSubjects.exists('embeddableError')) {
+      const error = await testSubjects.find('embeddableError');
+      await error.scrollIntoViewIfNecessary();
+      const title =
+        (await (await error.findByTestSubject('dashboardPanelTitle')).getVisibleText()) ??
+        'Empty title';
+      fail(`Found an error embeddable: ${title}`);
+    }
     log.debug('Checking charts rendered');
     await elasticChart.waitForRenderComplete(visualizationContainer ?? 'lnsVisualizationContainer');
     log.debug('Checking saved searches rendered');

--- a/x-pack/test/search_sessions_integration/tests/apps/dashboard/async_search/save_search_session_relative_time.ts
+++ b/x-pack/test/search_sessions_integration/tests/apps/dashboard/async_search/save_search_session_relative_time.ts
@@ -6,11 +6,9 @@
  */
 
 import expect from '@kbn/expect';
-import { fail } from 'assert';
 import { FtrProviderContext } from '../../../../ftr_provider_context';
 
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
-  const testSubjects = getService('testSubjects');
   const log = getService('log');
   const retry = getService('retry');
   const PageObjects = getPageObjects([
@@ -86,14 +84,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
   async function checkSampleDashboardLoaded(visualizationContainer?: string) {
     log.debug('Checking no error labels');
-    if (await testSubjects.exists('embeddableError')) {
-      const error = await testSubjects.find('embeddableError');
-      await error.scrollIntoViewIfNecessary();
-      const title =
-        (await (await error.findByTestSubject('dashboardPanelTitle')).getVisibleText()) ??
-        'Empty title';
-      fail(`Found an error embeddable: ${title}`);
-    }
+    await dashboardExpect.noErrorEmbeddablesPresent();
     log.debug('Checking charts rendered');
     await elasticChart.waitForRenderComplete(visualizationContainer ?? 'lnsVisualizationContainer');
     log.debug('Checking saved searches rendered');

--- a/x-pack/test/search_sessions_integration/tests/apps/dashboard/async_search/session_searches_integration.ts
+++ b/x-pack/test/search_sessions_integration/tests/apps/dashboard/async_search/session_searches_integration.ts
@@ -27,6 +27,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const listingTable = getService('listingTable');
   const testSubjects = getService('testSubjects');
   const elasticChart = getService('elasticChart');
+  const dashboardExpect = getService('dashboardExpect');
 
   describe('Session and searches integration', () => {
     before(async function () {
@@ -195,7 +196,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await searchSessionItem.view();
         expect(await toasts.getToastCount()).to.be(0); // there should be no warnings
         await searchSessions.expectState('restored', 20000);
-        await testSubjects.missingOrFail('embeddableError');
+        await dashboardExpect.noErrorEmbeddablesPresent();
 
         const data = await elasticChart.getChartDebugData();
         expect(data!.bars![0].bars.length).to.eql(4);

--- a/x-pack/test/search_sessions_integration/tests/apps/dashboard/async_search/sessions_in_space.ts
+++ b/x-pack/test/search_sessions_integration/tests/apps/dashboard/async_search/sessions_in_space.ts
@@ -9,7 +9,6 @@ import expect from '@kbn/expect';
 import { FtrProviderContext } from '../../../../ftr_provider_context';
 
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
-  const testSubjects = getService('testSubjects');
   const spacesService = getService('spaces');
   const security = getService('security');
   const PageObjects = getPageObjects([

--- a/x-pack/test/search_sessions_integration/tests/apps/dashboard/async_search/sessions_in_space.ts
+++ b/x-pack/test/search_sessions_integration/tests/apps/dashboard/async_search/sessions_in_space.ts
@@ -26,6 +26,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const searchSessions = getService('searchSessions');
   const kibanaServer = getService('kibanaServer');
   const toasts = getService('toasts');
+  const dashboardExpect = getService('dashboardExpect');
 
   describe('dashboard in space', () => {
     afterEach(async () => await clean());
@@ -67,7 +68,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
         // Check that session is restored
         await searchSessions.expectState('restored');
-        await testSubjects.missingOrFail('embeddableError');
+        await dashboardExpect.noErrorEmbeddablesPresent();
         expect(await toasts.getToastCount()).to.be(0); // no session restoration related warnings
       });
     });


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/97701

## Summary

This PR replaces all instances of `await testSubjects.missingOrFail('embeddableError');` with a call to the new `noErrorEmbeddablesPresent()` method from the `dashboardExpect` service.

This `noErrorEmbeddablesPresent()` method adds some extra debugging logic to the error embeddable check where, if at least one error embeddable is present, then both the panel title(s) and the relevant error message(s) will be printed as part of the error that is thrown.

With these changes, if the attached flaky test fails again, we should at least have some more information on **why** it failed.

### Flaky Test Runner

This was specifically only running the flaky `save_search_session_relative_time.ts` test suite:

<a href="https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2024"><img src="https://user-images.githubusercontent.com/8698078/227240095-a336b03b-6499-4d80-8b60-5e325d54a4ae.png"/></a>


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
