### PR TITLE
[Security Solution] Allow rewriting rule create props in Cypress tests

### DIFF
--- a/x-pack/plugins/security_solution/cypress/e2e/dashboards/enable_risk_score.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/dashboards/enable_risk_score.cy.ts
@@ -36,7 +36,7 @@ describe('Enable risk scores', () => {
   before(() => {
     cleanKibana();
     login();
-    createRule({ ...getNewRule(), rule_id: 'rule1' });
+    createRule(getNewRule({ rule_id: 'rule1' }));
   });
 
   beforeEach(() => {

--- a/x-pack/plugins/security_solution/cypress/e2e/dashboards/upgrade_risk_score.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/dashboards/upgrade_risk_score.cy.ts
@@ -39,7 +39,7 @@ describe('Upgrade risk scores', () => {
   before(() => {
     cleanKibana();
     login();
-    createRule({ ...getNewRule(), rule_id: 'rule1' });
+    createRule(getNewRule({ rule_id: 'rule1' }));
   });
 
   beforeEach(() => {
@@ -88,7 +88,7 @@ versions.forEach((version) =>
     before(() => {
       cleanKibana();
       login();
-      createRule({ ...getNewRule(), rule_id: 'rule1' });
+      createRule(getNewRule({ rule_id: 'rule1' }));
     });
 
     beforeEach(() => {

--- a/x-pack/plugins/security_solution/cypress/e2e/detection_alerts/alerts_charts.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_alerts/alerts_charts.cy.ts
@@ -30,7 +30,7 @@ describe('Histogram legend hover actions', { testIsolation: false }, () => {
   before(() => {
     cleanKibana();
     login();
-    createRule({ ...getNewRule(), rule_id: 'new custom rule' });
+    createRule(getNewRule({ rule_id: 'new custom rule' }));
     visit(ALERTS_URL);
     selectAlertsHistogram();
   });

--- a/x-pack/plugins/security_solution/cypress/e2e/detection_alerts/alerts_detection_callouts_index_outdated.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_alerts/alerts_detection_callouts_index_outdated.cy.ts
@@ -73,7 +73,7 @@ describe('Detections > Need Admin Callouts indicating an admin is needed to migr
 
       context('On Rule Details page', () => {
         beforeEach(() => {
-          createRule({ ...getNewRule(), rule_id: 'rule_testing' });
+          createRule(getNewRule({ rule_id: 'rule_testing' }));
           loadPageAsPlatformEngineerUser(DETECTIONS_RULE_MANAGEMENT_URL);
           waitForPageTitleToBeShown();
           goToRuleDetails();
@@ -123,7 +123,7 @@ describe('Detections > Need Admin Callouts indicating an admin is needed to migr
 
       context('On Rule Details page', () => {
         beforeEach(() => {
-          createRule({ ...getNewRule(), rule_id: 'rule_testing' });
+          createRule(getNewRule({ rule_id: 'rule_testing' }));
           loadPageAsPlatformEngineerUser(DETECTIONS_RULE_MANAGEMENT_URL);
           waitForPageTitleToBeShown();
           goToRuleDetails();
@@ -173,7 +173,7 @@ describe('Detections > Need Admin Callouts indicating an admin is needed to migr
 
       context('On Rule Details page', () => {
         beforeEach(() => {
-          createRule({ ...getNewRule(), rule_id: 'rule_testing' });
+          createRule(getNewRule({ rule_id: 'rule_testing' }));
           loadPageAsPlatformEngineerUser(DETECTIONS_RULE_MANAGEMENT_URL);
           waitForPageTitleToBeShown();
           goToRuleDetails();

--- a/x-pack/plugins/security_solution/cypress/e2e/detection_alerts/changing_alert_status.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_alerts/changing_alert_status.cy.ts
@@ -157,7 +157,7 @@ describe('Changing alert status', () => {
   context('Closing alerts', () => {
     beforeEach(() => {
       deleteAlertsAndRules();
-      createRule({ ...getNewRule(), rule_id: '1', max_signals: 100 });
+      createRule(getNewRule({ rule_id: '1', max_signals: 100 }));
       visit(ALERTS_URL);
       waitForAlertsToPopulate();
       selectCountTable();

--- a/x-pack/plugins/security_solution/cypress/e2e/detection_alerts/detection_page_filters.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_alerts/detection_page_filters.cy.ts
@@ -102,7 +102,7 @@ describe('Detections : Page Filters', { testIsolation: false }, () => {
   before(() => {
     cleanKibana();
     login();
-    createRule({ ...getNewRule(), rule_id: 'custom_rule_filters' });
+    createRule(getNewRule({ rule_id: 'custom_rule_filters' }));
     visit(ALERTS_URL);
     waitForAlerts();
     waitForPageFilters();

--- a/x-pack/plugins/security_solution/cypress/e2e/detection_alerts/enrichments.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_alerts/enrichments.cy.ts
@@ -45,7 +45,7 @@ describe('Enrichment', () => {
     beforeEach(() => {
       esArchiverLoad('risk_hosts');
       deleteAlertsAndRules();
-      createRule({ ...getNewRule(), rule_id: 'rule1' });
+      createRule(getNewRule({ rule_id: 'rule1' }));
       visit(ALERTS_URL);
       waitForAlertsToPopulate();
     });

--- a/x-pack/plugins/security_solution/cypress/e2e/detection_rules/all_rules_read_only.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_rules/all_rules_read_only.cy.ts
@@ -25,7 +25,7 @@ const MISSING_PRIVILEGES_CALLOUT = 'missing-user-privileges';
 describe('All rules - read only', () => {
   before(() => {
     cleanKibana();
-    createRule({ ...getNewRule(), rule_id: '1' });
+    createRule(getNewRule({ rule_id: '1' }));
     login(ROLES.reader);
   });
 

--- a/x-pack/plugins/security_solution/cypress/e2e/detection_rules/bulk_edit_rules.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_rules/bulk_edit_rules.cy.ts
@@ -125,17 +125,12 @@ describe('Detection rules, bulk edit', () => {
     resetRulesTableState();
     deleteAlertsAndRules();
     esArchiverResetKibana();
-    createRule({
-      ...getNewRule(),
-      name: RULE_NAME,
-      ...defaultRuleData,
-      rule_id: '1',
-    });
-    createRule({ ...getEqlRule(), ...defaultRuleData, rule_id: '2' });
-    createRule({ ...getMachineLearningRule(), tags: ['test-default-tag-1', 'test-default-tag-2'] });
-    createRule({ ...getNewThreatIndicatorRule(), ...defaultRuleData, rule_id: '4' });
-    createRule({ ...getNewThresholdRule(), ...defaultRuleData, rule_id: '5' });
-    createRule({ ...getNewTermsRule(), ...defaultRuleData, rule_id: '6' });
+    createRule(getNewRule({ name: RULE_NAME, ...defaultRuleData, rule_id: '1' }));
+    createRule(getEqlRule({ ...defaultRuleData, rule_id: '2' }));
+    createRule(getMachineLearningRule({ tags: ['test-default-tag-1', 'test-default-tag-2'] }));
+    createRule(getNewThreatIndicatorRule({ ...defaultRuleData, rule_id: '4' }));
+    createRule(getNewThresholdRule({ ...defaultRuleData, rule_id: '5' }));
+    createRule(getNewTermsRule({ ...defaultRuleData, rule_id: '6' }));
 
     visitWithoutDateRange(SECURITY_DETECTIONS_RULES_URL);
 

--- a/x-pack/plugins/security_solution/cypress/e2e/detection_rules/bulk_edit_rules_actions.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_rules/bulk_edit_rules_actions.cy.ts
@@ -85,21 +85,15 @@ describe('Detection rules, bulk edit of rule actions', () => {
         },
       ];
 
-      createRule({
-        ...getNewRule(),
-        name: ruleNameToAssert,
-        rule_id: '1',
-        max_signals: 500,
-        actions,
-      });
+      createRule(getNewRule({ name: ruleNameToAssert, rule_id: '1', max_signals: 500, actions }));
     });
 
-    createRule({ ...getEqlRule(), rule_id: '2' });
-    createRule({ ...getMachineLearningRule(), rule_id: '3' });
-    createRule({ ...getNewThreatIndicatorRule(), rule_id: '4' });
-    createRule({ ...getNewThresholdRule(), rule_id: '5' });
-    createRule({ ...getNewTermsRule(), rule_id: '6' });
-    createRule({ ...getNewRule(), saved_id: 'mocked', rule_id: '7' });
+    createRule(getEqlRule({ rule_id: '2' }));
+    createRule(getMachineLearningRule({ rule_id: '3' }));
+    createRule(getNewThreatIndicatorRule({ rule_id: '4' }));
+    createRule(getNewThresholdRule({ rule_id: '5' }));
+    createRule(getNewTermsRule({ rule_id: '6' }));
+    createRule(getNewRule({ saved_id: 'mocked', rule_id: '7' }));
 
     createSlackConnector();
   });

--- a/x-pack/plugins/security_solution/cypress/e2e/detection_rules/bulk_edit_rules_data_view.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_rules/bulk_edit_rules_data_view.cy.ts
@@ -62,33 +62,16 @@ describe('Bulk editing index patterns of rules with a data view only', () => {
 
     postDataView(DATA_VIEW_ID);
 
-    createRule({ ...getNewRule(), index: undefined, data_view_id: DATA_VIEW_ID, rule_id: '1' });
-    createRule({ ...getEqlRule(), index: undefined, data_view_id: DATA_VIEW_ID, rule_id: '2' });
-    createRule({
-      ...getNewThreatIndicatorRule(),
-      index: undefined,
-      data_view_id: DATA_VIEW_ID,
-      rule_id: '3',
-    });
-    createRule({
-      ...getNewThresholdRule(),
-      index: undefined,
-      data_view_id: DATA_VIEW_ID,
-      rule_id: '4',
-    });
-    createRule({
-      ...getNewTermsRule(),
-      index: undefined,
-      data_view_id: DATA_VIEW_ID,
-      rule_id: '5',
-    });
-    createRule({
-      ...getNewRule(),
-      index: undefined,
-      data_view_id: DATA_VIEW_ID,
-      saved_id: 'mocked',
-      rule_id: '6',
-    });
+    createRule(getNewRule({ index: undefined, data_view_id: DATA_VIEW_ID, rule_id: '1' }));
+    createRule(getEqlRule({ index: undefined, data_view_id: DATA_VIEW_ID, rule_id: '2' }));
+    createRule(
+      getNewThreatIndicatorRule({ index: undefined, data_view_id: DATA_VIEW_ID, rule_id: '3' })
+    );
+    createRule(getNewThresholdRule({ index: undefined, data_view_id: DATA_VIEW_ID, rule_id: '4' }));
+    createRule(getNewTermsRule({ index: undefined, data_view_id: DATA_VIEW_ID, rule_id: '5' }));
+    createRule(
+      getNewRule({ index: undefined, data_view_id: DATA_VIEW_ID, saved_id: 'mocked', rule_id: '6' })
+    );
 
     visitWithoutDateRange(SECURITY_DETECTIONS_RULES_URL);
 
@@ -205,12 +188,8 @@ describe('Bulk editing index patterns of rules with index patterns and rules wit
 
     postDataView(DATA_VIEW_ID);
 
-    createRule({ ...getNewRule(), index: undefined, data_view_id: DATA_VIEW_ID, rule_id: '1' });
-    createRule({
-      ...getNewRule(),
-      index: ['test-index-1-*'],
-      rule_id: '2',
-    });
+    createRule(getNewRule({ index: undefined, data_view_id: DATA_VIEW_ID, rule_id: '1' }));
+    createRule(getNewRule({ index: ['test-index-1-*'], rule_id: '2' }));
 
     visitWithoutDateRange(SECURITY_DETECTIONS_RULES_URL);
 

--- a/x-pack/plugins/security_solution/cypress/e2e/detection_rules/custom_query_rule.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_rules/custom_query_rule.cy.ts
@@ -234,9 +234,9 @@ describe('Custom query rules', () => {
     context('Deletion', () => {
       beforeEach(() => {
         deleteAlertsAndRules();
-        createRule({ ...getNewRule(), rule_id: 'rule1', enabled: true, max_signals: 500 });
-        createRule({ ...getNewOverrideRule(), rule_id: 'rule2', enabled: true, max_signals: 500 });
-        createRule({ ...getExistingRule(), rule_id: 'rule3', enabled: true });
+        createRule(getNewRule({ rule_id: 'rule1', enabled: true, max_signals: 500 }));
+        createRule(getNewOverrideRule({ rule_id: 'rule2', enabled: true, max_signals: 500 }));
+        createRule(getExistingRule({ rule_id: 'rule3', enabled: true }));
         visit(DETECTIONS_RULE_MANAGEMENT_URL);
       });
 
@@ -346,7 +346,7 @@ describe('Custom query rules', () => {
       before(() => {
         deleteAlertsAndRules();
         deleteConnectors();
-        createRule({ ...getExistingRule(), rule_id: 'rule1', enabled: true });
+        createRule(getExistingRule({ rule_id: 'rule1', enabled: true }));
       });
       beforeEach(() => {
         visit(DETECTIONS_RULE_MANAGEMENT_URL);

--- a/x-pack/plugins/security_solution/cypress/e2e/detection_rules/custom_saved_query_rule.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_rules/custom_saved_query_rule.cy.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { getNewRule } from '../../objects/rule';
+import { getNewRule, getSavedQueryRule } from '../../objects/rule';
 
 import {
   DEFINE_CONTINUE_BUTTON,
@@ -58,7 +58,7 @@ describe('Custom saved_query rules', () => {
     });
 
     it('Creates saved query rule', function () {
-      const rule = getNewRule();
+      const rule = getSavedQueryRule();
       createSavedQuery(savedQueryName, savedQueryQuery, savedQueryFilterKey);
       visit(RULE_CREATION);
 
@@ -101,12 +101,7 @@ describe('Custom saved_query rules', () => {
     context('Non existent saved query', () => {
       const FAILED_TO_LOAD_ERROR = 'Failed to load the saved query';
       beforeEach(() => {
-        createRule({
-          ...getNewRule(),
-          type: 'saved_query',
-          saved_id: 'non-existent',
-          query: undefined,
-        });
+        createRule(getSavedQueryRule({ saved_id: 'non-existent', query: undefined }));
         cy.visit(SECURITY_DETECTIONS_RULES_URL);
       });
       it('Shows error toast on details page when saved query can not be loaded', function () {
@@ -152,12 +147,7 @@ describe('Custom saved_query rules', () => {
         const expectedCustomTestQuery = 'random test query';
         createSavedQuery(savedQueryName, savedQueryQuery).then((response) => {
           cy.log(JSON.stringify(response.body, null, 2));
-          createRule({
-            ...getNewRule(),
-            type: 'saved_query',
-            saved_id: response.body.id,
-            query: undefined,
-          });
+          createRule(getSavedQueryRule({ saved_id: response.body.id, query: undefined }));
         });
 
         cy.visit(SECURITY_DETECTIONS_RULES_URL);
@@ -184,12 +174,7 @@ describe('Custom saved_query rules', () => {
 
       it('Allows to update saved_query rule with non-existent query by adding custom query', () => {
         const expectedCustomTestQuery = 'random test query';
-        createRule({
-          ...getNewRule(),
-          type: 'saved_query',
-          saved_id: 'non-existent',
-          query: undefined,
-        });
+        createRule(getSavedQueryRule({ saved_id: 'non-existent', query: undefined }));
 
         cy.visit(SECURITY_DETECTIONS_RULES_URL);
 
@@ -212,12 +197,7 @@ describe('Custom saved_query rules', () => {
 
       it('Allows to update saved_query rule with non-existent query by selecting another saved query', () => {
         createSavedQuery(savedQueryName, savedQueryQuery);
-        createRule({
-          ...getNewRule(),
-          type: 'saved_query',
-          saved_id: 'non-existent',
-          query: undefined,
-        });
+        createRule(getSavedQueryRule({ saved_id: 'non-existent', query: undefined }));
 
         cy.visit(SECURITY_DETECTIONS_RULES_URL);
 

--- a/x-pack/plugins/security_solution/cypress/e2e/detection_rules/export_rule.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_rules/export_rule.cy.ts
@@ -52,7 +52,7 @@ describe('Export rules', () => {
     // Rules get exported via _bulk_action endpoint
     cy.intercept('POST', '/api/detection_engine/rules/_bulk_action').as('bulk_action');
     visitWithoutDateRange(DETECTIONS_RULE_MANAGEMENT_URL);
-    createRule({ ...getNewRule(), name: 'Rule to export' }).as('ruleResponse');
+    createRule(getNewRule({ name: 'Rule to export' })).as('ruleResponse');
   });
 
   it('exports a custom rule', function () {
@@ -65,7 +65,7 @@ describe('Export rules', () => {
 
   it('creates an importable file from executed rule', () => {
     // Rule needs to be enabled to make sure it has been executed so rule's SO contains runtime fields like `execution_summary`
-    createRule({ ...getNewRule(), name: 'Enabled rule to export', enabled: true });
+    createRule(getNewRule({ name: 'Enabled rule to export', enabled: true }));
     waitForRuleExecution('Enabled rule to export');
 
     exportRule('Enabled rule to export');
@@ -128,19 +128,20 @@ describe('Export rules', () => {
       deleteExceptionList(exceptionList.list_id, exceptionList.namespace_type);
       // create rule with exceptions
       createExceptionList(exceptionList, exceptionList.list_id).then((response) =>
-        createRule({
-          ...getNewRule(),
-          name: 'rule with exceptions',
-          exceptions_list: [
-            {
-              id: response.body.id,
-              list_id: exceptionList.list_id,
-              type: exceptionList.type,
-              namespace_type: exceptionList.namespace_type,
-            },
-          ],
-          rule_id: '2',
-        })
+        createRule(
+          getNewRule({
+            name: 'rule with exceptions',
+            exceptions_list: [
+              {
+                id: response.body.id,
+                list_id: exceptionList.list_id,
+                type: exceptionList.type,
+                namespace_type: exceptionList.namespace_type,
+              },
+            ],
+            rule_id: '2',
+          })
+        )
       );
     });
 

--- a/x-pack/plugins/security_solution/cypress/e2e/detection_rules/indicator_match_rule.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_rules/indicator_match_rule.cy.ts
@@ -498,7 +498,7 @@ describe('indicator match', () => {
         const accessibilityText = `Press enter for options, or press space to begin dragging.`;
 
         loadPrepackagedTimelineTemplates();
-        createRule({ ...getNewThreatIndicatorRule(), rule_id: 'rule_testing', enabled: true });
+        createRule(getNewThreatIndicatorRule({ rule_id: 'rule_testing', enabled: true }));
         visit(DETECTIONS_RULE_MANAGEMENT_URL);
         goToRuleDetails();
         waitForAlertsToPopulate();
@@ -531,7 +531,7 @@ describe('indicator match', () => {
     describe('Duplicates the indicator rule', () => {
       beforeEach(() => {
         deleteAlertsAndRules();
-        createRule({ ...getNewThreatIndicatorRule(), rule_id: 'rule_testing', enabled: true });
+        createRule(getNewThreatIndicatorRule({ rule_id: 'rule_testing', enabled: true }));
         visitWithoutDateRange(DETECTIONS_RULE_MANAGEMENT_URL);
       });
 

--- a/x-pack/plugins/security_solution/cypress/e2e/detection_rules/links.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_rules/links.cy.ts
@@ -19,7 +19,7 @@ describe('Rules talbes links', () => {
   });
   beforeEach(() => {
     deleteAlertsAndRules();
-    createRule({ ...getNewRule(), rule_id: 'rule1' });
+    createRule(getNewRule({ rule_id: 'rule1' }));
     visitWithoutDateRange(DETECTIONS_RULE_MANAGEMENT_URL);
   });
 

--- a/x-pack/plugins/security_solution/cypress/e2e/detection_rules/persistent_rules_table_state.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_rules/persistent_rules_table_state.cy.ts
@@ -46,26 +46,18 @@ import {
 } from '../../tasks/table_pagination';
 
 function createTestRules(): void {
-  createRule({ ...getNewRule(), rule_id: '1', name: 'test 1', tags: ['tag-a'], enabled: false });
-  createRule({ ...getNewRule(), rule_id: '2', name: 'rule 1', tags: ['tag-b'], enabled: false });
-  createRule({ ...getNewRule(), rule_id: '3', name: 'rule 2', tags: ['tag-b'], enabled: false });
-  createRule({
-    ...getNewRule(),
-    rule_id: '4',
-    name: 'rule 3',
-    tags: ['tag-b', 'tag-c'],
-    enabled: false,
-  });
-  createRule({ ...getNewRule(), rule_id: '5', name: 'rule 4', tags: ['tag-b'], enabled: false });
-  createRule({
-    ...getNewRule(),
-    rule_id: '6',
-    name: 'rule 5',
-    tags: ['tag-b', 'tag-c'],
-    enabled: false,
-  });
-  createRule({ ...getNewRule(), rule_id: '7', name: 'rule 6', tags: ['tag-b'], enabled: false });
-  createRule({ ...getNewRule(), rule_id: '8', name: 'rule 7', tags: ['tag-b'], enabled: true });
+  createRule(getNewRule({ rule_id: '1', name: 'test 1', tags: ['tag-a'], enabled: false }));
+  createRule(getNewRule({ rule_id: '2', name: 'rule 1', tags: ['tag-b'], enabled: false }));
+  createRule(getNewRule({ rule_id: '3', name: 'rule 2', tags: ['tag-b'], enabled: false }));
+  createRule(
+    getNewRule({ rule_id: '4', name: 'rule 3', tags: ['tag-b', 'tag-c'], enabled: false })
+  );
+  createRule(getNewRule({ rule_id: '5', name: 'rule 4', tags: ['tag-b'], enabled: false }));
+  createRule(
+    getNewRule({ rule_id: '6', name: 'rule 5', tags: ['tag-b', 'tag-c'], enabled: false })
+  );
+  createRule(getNewRule({ rule_id: '7', name: 'rule 6', tags: ['tag-b'], enabled: false }));
+  createRule(getNewRule({ rule_id: '8', name: 'rule 7', tags: ['tag-b'], enabled: true }));
 }
 
 function visitRulesTableWithState(urlTableState: Record<string, unknown>): void {

--- a/x-pack/plugins/security_solution/cypress/e2e/detection_rules/rules_table_auto_refresh.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_rules/rules_table_auto_refresh.cy.ts
@@ -38,7 +38,7 @@ describe('Alerts detection rules table auto-refresh', () => {
     cleanKibana();
     login();
     for (let i = 1; i < 7; i += 1) {
-      createRule({ ...getNewRule(), name: `Test rule ${i}`, rule_id: `${i}` });
+      createRule(getNewRule({ name: `Test rule ${i}`, rule_id: `${i}` }));
     }
   });
 

--- a/x-pack/plugins/security_solution/cypress/e2e/detection_rules/sorting.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_rules/sorting.cy.ts
@@ -37,10 +37,10 @@ describe('Alerts detection rules', () => {
   before(() => {
     cleanKibana();
     login();
-    createRule({ ...getNewRule(), rule_id: '1' });
-    createRule({ ...getExistingRule(), rule_id: '2' });
-    createRule({ ...getNewOverrideRule(), rule_id: '3' });
-    createRule({ ...getNewThresholdRule(), rule_id: '4' });
+    createRule(getNewRule({ rule_id: '1' }));
+    createRule(getExistingRule({ rule_id: '2' }));
+    createRule(getNewOverrideRule({ rule_id: '3' }));
+    createRule(getNewThresholdRule({ rule_id: '4' }));
   });
 
   it('Sorts by enabled rules', () => {
@@ -62,8 +62,8 @@ describe('Alerts detection rules', () => {
   });
 
   it('Pagination updates page number and results', () => {
-    createRule({ ...getNewRule(), name: 'Test a rule', rule_id: '5' });
-    createRule({ ...getNewRule(), name: 'Not same as first rule', rule_id: '6' });
+    createRule(getNewRule({ name: 'Test a rule', rule_id: '5' }));
+    createRule(getNewRule({ name: 'Not same as first rule', rule_id: '6' }));
 
     visit(DETECTIONS_RULE_MANAGEMENT_URL);
     waitForRulesTableToBeLoaded();

--- a/x-pack/plugins/security_solution/cypress/e2e/exceptions/add_edit_flyout/flyout_validation.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/exceptions/add_edit_flyout/flyout_validation.cy.ts
@@ -78,19 +78,20 @@ describe('Exceptions flyout', { testIsolation: false }, () => {
     esArchiverLoad('conflicts_2');
     login();
     createExceptionList(getExceptionList(), getExceptionList().list_id).then((response) =>
-      createRule({
-        ...getNewRule(),
-        index: ['auditbeat-*', 'exceptions-*', 'conflicts-*'],
-        enabled: false,
-        exceptions_list: [
-          {
-            id: response.body.id,
-            list_id: getExceptionList().list_id,
-            type: getExceptionList().type,
-            namespace_type: getExceptionList().namespace_type,
-          },
-        ],
-      })
+      createRule(
+        getNewRule({
+          index: ['auditbeat-*', 'exceptions-*', 'conflicts-*'],
+          enabled: false,
+          exceptions_list: [
+            {
+              id: response.body.id,
+              list_id: getExceptionList().list_id,
+              type: getExceptionList().type,
+              namespace_type: getExceptionList().namespace_type,
+            },
+          ],
+        })
+      )
     );
   });
 

--- a/x-pack/plugins/security_solution/cypress/e2e/exceptions/alerts_table_flow/add_exception.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/exceptions/alerts_table_flow/add_exception.cy.ts
@@ -48,17 +48,18 @@ describe('Exceptions Table', () => {
 
     // Create exception list associated with a rule
     createExceptionList(getExceptionList2(), getExceptionList2().list_id).then((response) =>
-      createRule({
-        ...getNewRule(),
-        exceptions_list: [
-          {
-            id: response.body.id,
-            list_id: getExceptionList2().list_id,
-            type: getExceptionList2().type,
-            namespace_type: getExceptionList2().namespace_type,
-          },
-        ],
-      })
+      createRule(
+        getNewRule({
+          exceptions_list: [
+            {
+              id: response.body.id,
+              list_id: getExceptionList2().list_id,
+              type: getExceptionList2().type,
+              namespace_type: getExceptionList2().namespace_type,
+            },
+          ],
+        })
+      )
     );
 
     // Create exception list not used by any rules

--- a/x-pack/plugins/security_solution/cypress/e2e/exceptions/list_management_flow/list_details.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/exceptions/list_management_flow/list_details.cy.ts
@@ -41,17 +41,18 @@ describe('Exception list management page', () => {
 
     // Create exception list associated with a rule
     createExceptionList(getExceptionList1(), getExceptionList1().list_id).then((response) =>
-      createRule({
-        ...getNewRule(),
-        exceptions_list: [
-          {
-            id: response.body.id,
-            list_id: getExceptionList1().list_id,
-            type: getExceptionList1().type,
-            namespace_type: getExceptionList1().namespace_type,
-          },
-        ],
-      })
+      createRule(
+        getNewRule({
+          exceptions_list: [
+            {
+              id: response.body.id,
+              list_id: getExceptionList1().list_id,
+              type: getExceptionList1().type,
+              namespace_type: getExceptionList1().namespace_type,
+            },
+          ],
+        })
+      )
     );
   });
 

--- a/x-pack/plugins/security_solution/cypress/e2e/exceptions/rule_details_flow/add_edit_endpoint_exception.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/exceptions/rule_details_flow/add_edit_endpoint_exception.cy.ts
@@ -59,20 +59,21 @@ describe('Add endpoint exception from rule details', () => {
     deleteAlertsAndRules();
     // create rule with exception
     createEndpointExceptionList().then((response) => {
-      createRule({
-        ...getNewRule(),
-        query: 'event.code:*',
-        index: ['auditbeat*'],
-        exceptions_list: [
-          {
-            id: response.body.id,
-            list_id: response.body.list_id,
-            type: response.body.type,
-            namespace_type: response.body.namespace_type,
-          },
-        ],
-        rule_id: '2',
-      });
+      createRule(
+        getNewRule({
+          query: 'event.code:*',
+          index: ['auditbeat*'],
+          exceptions_list: [
+            {
+              id: response.body.id,
+              list_id: response.body.list_id,
+              type: response.body.type,
+              namespace_type: response.body.namespace_type,
+            },
+          ],
+          rule_id: '2',
+        })
+      );
     });
   });
 

--- a/x-pack/plugins/security_solution/cypress/e2e/exceptions/rule_details_flow/add_edit_exception.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/exceptions/rule_details_flow/add_edit_exception.cy.ts
@@ -86,20 +86,21 @@ describe('Add/edit exception from rule details', () => {
       deleteExceptionList(exceptionList.list_id, exceptionList.namespace_type);
       // create rule with exceptions
       createExceptionList(exceptionList, exceptionList.list_id).then((response) => {
-        createRule({
-          ...getNewRule(),
-          query: 'agent.name:*',
-          index: ['exceptions*'],
-          exceptions_list: [
-            {
-              id: response.body.id,
-              list_id: exceptionList.list_id,
-              type: exceptionList.type,
-              namespace_type: exceptionList.namespace_type,
-            },
-          ],
-          rule_id: '2',
-        });
+        createRule(
+          getNewRule({
+            query: 'agent.name:*',
+            index: ['exceptions*'],
+            exceptions_list: [
+              {
+                id: response.body.id,
+                list_id: exceptionList.list_id,
+                type: exceptionList.type,
+                namespace_type: exceptionList.namespace_type,
+              },
+            ],
+            rule_id: '2',
+          })
+        );
         createExceptionListItem(exceptionList.list_id, {
           list_id: exceptionList.list_id,
           item_id: 'simple_list_item',
@@ -249,13 +250,14 @@ describe('Add/edit exception from rule details', () => {
   describe('rule without existing exceptions', () => {
     beforeEach(() => {
       deleteAlertsAndRules();
-      createRule({
-        ...getNewRule(),
-        query: 'agent.name:*',
-        index: ['exceptions*'],
-        interval: '10s',
-        rule_id: 'rule_testing',
-      });
+      createRule(
+        getNewRule({
+          query: 'agent.name:*',
+          index: ['exceptions*'],
+          interval: '10s',
+          rule_id: 'rule_testing',
+        })
+      );
       visitWithoutDateRange(DETECTIONS_RULE_MANAGEMENT_URL);
       goToRuleDetails();
       goToExceptionsTab();

--- a/x-pack/plugins/security_solution/cypress/e2e/exceptions/rule_details_flow/add_edit_exception_data_view.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/exceptions/rule_details_flow/add_edit_exception_data_view.cy.ts
@@ -71,13 +71,14 @@ describe('Add exception using data views from rule details', () => {
 
   beforeEach(() => {
     deleteAlertsAndRules();
-    createRule({
-      ...getNewRule(),
-      query: 'agent.name:*',
-      data_view_id: 'exceptions-*',
-      interval: '10s',
-      rule_id: 'rule_testing',
-    });
+    createRule(
+      getNewRule({
+        query: 'agent.name:*',
+        data_view_id: 'exceptions-*',
+        interval: '10s',
+        rule_id: 'rule_testing',
+      })
+    );
     visitWithoutDateRange(DETECTIONS_RULE_MANAGEMENT_URL);
     goToRuleDetails();
     waitForAlertsToPopulate();

--- a/x-pack/plugins/security_solution/cypress/e2e/exceptions/rule_details_flow/read_only_view.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/exceptions/rule_details_flow/read_only_view.cy.ts
@@ -35,20 +35,21 @@ describe('Exceptions viewer read only', () => {
     esArchiverResetKibana();
     // create rule with exceptions
     createExceptionList(exceptionList, exceptionList.list_id).then((response) => {
-      createRule({
-        ...getNewRule(),
-        query: 'agent.name:*',
-        index: ['exceptions*'],
-        exceptions_list: [
-          {
-            id: response.body.id,
-            list_id: exceptionList.list_id,
-            type: exceptionList.type,
-            namespace_type: exceptionList.namespace_type,
-          },
-        ],
-        rule_id: '2',
-      });
+      createRule(
+        getNewRule({
+          query: 'agent.name:*',
+          index: ['exceptions*'],
+          exceptions_list: [
+            {
+              id: response.body.id,
+              list_id: exceptionList.list_id,
+              type: exceptionList.type,
+              namespace_type: exceptionList.namespace_type,
+            },
+          ],
+          rule_id: '2',
+        })
+      );
     });
 
     login(ROLES.reader);

--- a/x-pack/plugins/security_solution/cypress/e2e/exceptions/shared_exception_lists_management/manage_shared_exception_list.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/exceptions/shared_exception_lists_management/manage_shared_exception_list.cy.ts
@@ -48,17 +48,18 @@ describe('Manage shared exception list', () => {
 
     // Create exception list associated with a rule
     createExceptionList(getExceptionList2(), getExceptionList2().list_id).then((response) =>
-      createRule({
-        ...getNewRule(),
-        exceptions_list: [
-          {
-            id: response.body.id,
-            list_id: getExceptionList2().list_id,
-            type: getExceptionList2().type,
-            namespace_type: getExceptionList2().namespace_type,
-          },
-        ],
-      })
+      createRule(
+        getNewRule({
+          exceptions_list: [
+            {
+              id: response.body.id,
+              list_id: getExceptionList2().list_id,
+              type: getExceptionList2().type,
+              namespace_type: getExceptionList2().namespace_type,
+            },
+          ],
+        })
+      )
     );
 
     // Create exception list not used by any rules

--- a/x-pack/plugins/security_solution/cypress/e2e/guided_onboarding/tour.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/guided_onboarding/tour.cy.ts
@@ -32,7 +32,7 @@ describe('Guided onboarding tour', () => {
   before(() => {
     cleanKibana();
     login();
-    createRule({ ...getNewRule(), query: 'user.name:*' });
+    createRule(getNewRule({ query: 'user.name:*' }));
   });
   beforeEach(() => {
     startAlertsCasesTour();

--- a/x-pack/plugins/security_solution/cypress/e2e/users/user_details.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/users/user_details.cy.ts
@@ -28,7 +28,7 @@ describe('user details flyout', () => {
 
   it('shows user detail flyout from alert table', () => {
     visitWithoutDateRange(ALERTS_URL);
-    createRule({ ...getNewRule(), query: 'user.name:*' });
+    createRule(getNewRule({ query: 'user.name:*' }));
     refreshPage();
     waitForAlertsToPopulate();
 

--- a/x-pack/plugins/security_solution/cypress/objects/rule.ts
+++ b/x-pack/plugins/security_solution/cypress/objects/rule.ts
@@ -17,7 +17,7 @@ import type {
   ThreatMatchRuleCreateProps,
   ThresholdRuleCreateProps,
 } from '../../common/detection_engine/rule_schema';
-import { CreateRulePropsRewrites } from './types';
+import type { CreateRulePropsRewrites } from './types';
 
 const ccsRemoteName: string = Cypress.env('CCS_REMOTE_NAME');
 

--- a/x-pack/plugins/security_solution/cypress/objects/rule.ts
+++ b/x-pack/plugins/security_solution/cypress/objects/rule.ts
@@ -5,11 +5,7 @@
  * 2.0.
  */
 
-import type {
-  RuleActionThrottle,
-  SeverityMappingItem,
-  Threat,
-} from '@kbn/securitysolution-io-ts-alerting-types';
+import type { SeverityMappingItem, Threat } from '@kbn/securitysolution-io-ts-alerting-types';
 import { getMockThreatData } from '../../public/detections/mitre/mitre_tactics_techniques';
 import type {
   EqlRuleCreateProps,
@@ -17,17 +13,13 @@ import type {
   NewTermsRuleCreateProps,
   QueryRuleCreateProps,
   RuleResponse,
+  SavedQueryRuleCreateProps,
   ThreatMatchRuleCreateProps,
   ThresholdRuleCreateProps,
 } from '../../common/detection_engine/rule_schema';
-import type { Connectors } from './connector';
+import { CreateRulePropsRewrites } from './types';
 
 const ccsRemoteName: string = Cypress.env('CCS_REMOTE_NAME');
-
-export interface Actions {
-  throttle: RuleActionThrottle;
-  connectors: Connectors[];
-}
 
 export const getIndexPatterns = (): string[] => [
   'apm-*-transaction*',
@@ -123,7 +115,9 @@ const getSeverityOverride4 = (): SeverityMappingItem => ({
   severity: 'critical',
 });
 
-export const getDataViewRule = (): QueryRuleCreateProps => ({
+export const getDataViewRule = (
+  rewrites?: CreateRulePropsRewrites<QueryRuleCreateProps>
+): QueryRuleCreateProps => ({
   type: 'query',
   query: 'host.name: *',
   data_view_id: 'auditbeat-2022',
@@ -139,9 +133,12 @@ export const getDataViewRule = (): QueryRuleCreateProps => ({
   interval: '100m',
   from: 'now-50000h',
   max_signals: 100,
+  ...rewrites,
 });
 
-export const getNewRule = (): QueryRuleCreateProps => ({
+export const getNewRule = (
+  rewrites?: CreateRulePropsRewrites<QueryRuleCreateProps>
+): QueryRuleCreateProps => ({
   type: 'query',
   query: 'host.name: *',
   index: getIndexPatterns(),
@@ -157,9 +154,28 @@ export const getNewRule = (): QueryRuleCreateProps => ({
   interval: '100m',
   from: 'now-50000h',
   max_signals: 100,
+  ...rewrites,
 });
 
-export const getSimpleCustomQueryRule = (): QueryRuleCreateProps => ({
+export const getSavedQueryRule = (
+  rewrites?: CreateRulePropsRewrites<SavedQueryRuleCreateProps>
+): SavedQueryRuleCreateProps => ({
+  type: 'saved_query',
+  saved_id: 'some-id',
+  query: 'host.name: *',
+  index: getIndexPatterns(),
+  name: 'New Rule Test',
+  description: 'The new rule description.',
+  interval: '100m',
+  from: 'now-50000h',
+  severity: 'low',
+  risk_score: 21,
+  ...rewrites,
+});
+
+export const getSimpleCustomQueryRule = (
+  rewrites?: CreateRulePropsRewrites<QueryRuleCreateProps>
+): QueryRuleCreateProps => ({
   type: 'query',
   query: 'host.name: *',
   index: getIndexPatterns(),
@@ -169,9 +185,12 @@ export const getSimpleCustomQueryRule = (): QueryRuleCreateProps => ({
   from: 'now-50000h',
   severity: 'low',
   risk_score: 21,
+  ...rewrites,
 });
 
-export const getBuildingBlockRule = (): QueryRuleCreateProps => ({
+export const getBuildingBlockRule = (
+  rewrites?: CreateRulePropsRewrites<QueryRuleCreateProps>
+): QueryRuleCreateProps => ({
   type: 'query',
   query: 'host.name: *',
   index: getIndexPatterns(),
@@ -188,9 +207,12 @@ export const getBuildingBlockRule = (): QueryRuleCreateProps => ({
   from: 'now-50000h',
   max_signals: 100,
   building_block_type: 'default',
+  ...rewrites,
 });
 
-export const getUnmappedRule = (): QueryRuleCreateProps => ({
+export const getUnmappedRule = (
+  rewrites?: CreateRulePropsRewrites<QueryRuleCreateProps>
+): QueryRuleCreateProps => ({
   type: 'query',
   query: '*:*',
   index: ['unmapped*'],
@@ -206,9 +228,12 @@ export const getUnmappedRule = (): QueryRuleCreateProps => ({
   interval: '100m',
   from: 'now-50000h',
   max_signals: 100,
+  ...rewrites,
 });
 
-export const getUnmappedCCSRule = (): QueryRuleCreateProps => ({
+export const getUnmappedCCSRule = (
+  rewrites?: CreateRulePropsRewrites<QueryRuleCreateProps>
+): QueryRuleCreateProps => ({
   type: 'query',
   query: '*:*',
   index: [`${ccsRemoteName}:unmapped*`],
@@ -224,9 +249,12 @@ export const getUnmappedCCSRule = (): QueryRuleCreateProps => ({
   interval: '100m',
   from: 'now-50000h',
   max_signals: 100,
+  ...rewrites,
 });
 
-export const getExistingRule = (): QueryRuleCreateProps => ({
+export const getExistingRule = (
+  rewrites?: CreateRulePropsRewrites<QueryRuleCreateProps>
+): QueryRuleCreateProps => ({
   type: 'query',
   query: 'host.name: *',
   name: 'Rule 1',
@@ -244,9 +272,12 @@ export const getExistingRule = (): QueryRuleCreateProps => ({
   // Please do not change, or if you do, needs
   // to be any number other than default value
   max_signals: 500,
+  ...rewrites,
 });
 
-export const getNewOverrideRule = (): QueryRuleCreateProps => ({
+export const getNewOverrideRule = (
+  rewrites?: CreateRulePropsRewrites<QueryRuleCreateProps>
+): QueryRuleCreateProps => ({
   type: 'query',
   query: 'host.name: *',
   index: getIndexPatterns(),
@@ -273,9 +304,12 @@ export const getNewOverrideRule = (): QueryRuleCreateProps => ({
   interval: '100m',
   from: 'now-50000h',
   max_signals: 100,
+  ...rewrites,
 });
 
-export const getNewThresholdRule = (): ThresholdRuleCreateProps => ({
+export const getNewThresholdRule = (
+  rewrites?: CreateRulePropsRewrites<ThresholdRuleCreateProps>
+): ThresholdRuleCreateProps => ({
   type: 'threshold',
   query: 'host.name: *',
   index: getIndexPatterns(),
@@ -295,9 +329,12 @@ export const getNewThresholdRule = (): ThresholdRuleCreateProps => ({
   interval: '100m',
   from: 'now-50000h',
   max_signals: 100,
+  ...rewrites,
 });
 
-export const getNewTermsRule = (): NewTermsRuleCreateProps => ({
+export const getNewTermsRule = (
+  rewrites?: CreateRulePropsRewrites<NewTermsRuleCreateProps>
+): NewTermsRuleCreateProps => ({
   type: 'new_terms',
   query: 'host.name: *',
   index: getIndexPatterns(),
@@ -315,9 +352,12 @@ export const getNewTermsRule = (): NewTermsRuleCreateProps => ({
   interval: '100m',
   from: 'now-50000h',
   max_signals: 100,
+  ...rewrites,
 });
 
-export const getMachineLearningRule = (): MachineLearningRuleCreateProps => ({
+export const getMachineLearningRule = (
+  rewrites?: CreateRulePropsRewrites<MachineLearningRuleCreateProps>
+): MachineLearningRuleCreateProps => ({
   type: 'machine_learning',
   machine_learning_job_id: [
     'Unusual Linux Network Activity',
@@ -335,9 +375,12 @@ export const getMachineLearningRule = (): MachineLearningRuleCreateProps => ({
   note: '# test markdown',
   interval: '100m',
   from: 'now-50000h',
+  ...rewrites,
 });
 
-export const getEqlRule = (): EqlRuleCreateProps => ({
+export const getEqlRule = (
+  rewrites?: CreateRulePropsRewrites<EqlRuleCreateProps>
+): EqlRuleCreateProps => ({
   type: 'eql',
   language: 'eql',
   query: 'any where process.name == "zsh"',
@@ -354,9 +397,12 @@ export const getEqlRule = (): EqlRuleCreateProps => ({
   interval: '100m',
   from: 'now-50000h',
   max_signals: 100,
+  ...rewrites,
 });
 
-export const getCCSEqlRule = (): EqlRuleCreateProps => ({
+export const getCCSEqlRule = (
+  rewrites?: CreateRulePropsRewrites<EqlRuleCreateProps>
+): EqlRuleCreateProps => ({
   type: 'eql',
   language: 'eql',
   query: 'any where process.name == "run-parts"',
@@ -373,9 +419,12 @@ export const getCCSEqlRule = (): EqlRuleCreateProps => ({
   interval: '100m',
   from: 'now-50000h',
   max_signals: 100,
+  ...rewrites,
 });
 
-export const getEqlSequenceRule = (): EqlRuleCreateProps => ({
+export const getEqlSequenceRule = (
+  rewrites?: CreateRulePropsRewrites<EqlRuleCreateProps>
+): EqlRuleCreateProps => ({
   type: 'eql',
   language: 'eql',
   query:
@@ -395,9 +444,12 @@ export const getEqlSequenceRule = (): EqlRuleCreateProps => ({
   interval: '100m',
   from: 'now-50000h',
   max_signals: 100,
+  ...rewrites,
 });
 
-export const getNewThreatIndicatorRule = (): ThreatMatchRuleCreateProps => ({
+export const getNewThreatIndicatorRule = (
+  rewrites?: CreateRulePropsRewrites<ThreatMatchRuleCreateProps>
+): ThreatMatchRuleCreateProps => ({
   type: 'threat_match',
   name: 'Threat Indicator Rule Test',
   description: 'The threat indicator rule description.',
@@ -429,6 +481,7 @@ export const getNewThreatIndicatorRule = (): ThreatMatchRuleCreateProps => ({
   threat_indicator_path: 'threat.indicator',
   timeline_title: 'Generic Threat Match Timeline',
   timeline_id: '495ad7a7-316e-4544-8a0f-9c098daee76e',
+  ...rewrites,
 });
 
 export const indicatorRuleMatchingDoc = {
@@ -442,12 +495,12 @@ export const duplicatedRuleName = `${getNewThreatIndicatorRule().name} [Duplicat
 
 export const getSeveritiesOverride = (): string[] => ['Low', 'Medium', 'High', 'Critical'];
 
-export const getEditedRule = (): QueryRuleCreateProps => ({
-  ...getExistingRule(),
-  severity: 'medium',
-  description: 'Edited Rule description',
-  tags: [...(getExistingRule().tags || []), 'edited'],
-});
+export const getEditedRule = (): QueryRuleCreateProps =>
+  getExistingRule({
+    severity: 'medium',
+    description: 'Edited Rule description',
+    tags: [...(getExistingRule().tags || []), 'edited'],
+  });
 
 export const expectedExportedRule = (ruleResponse: Cypress.Response<RuleResponse>): string => {
   const {

--- a/x-pack/plugins/security_solution/cypress/objects/types.ts
+++ b/x-pack/plugins/security_solution/cypress/objects/types.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { RuleActionThrottle } from '@kbn/securitysolution-io-ts-alerting-types';
+
+import type { Connectors } from './connector';
+
+export type CreateRulePropsRewrites<CreateRuleProps> = Partial<Exclude<CreateRuleProps, 'type'>>;
+
+export interface Actions {
+  throttle: RuleActionThrottle;
+  connectors: Connectors[];
+}

--- a/x-pack/plugins/security_solution/cypress/tasks/create_new_rule.ts
+++ b/x-pack/plugins/security_solution/cypress/tasks/create_new_rule.ts
@@ -13,7 +13,7 @@ import type {
   ThreatSubtechnique,
   ThreatTechnique,
 } from '@kbn/securitysolution-io-ts-alerting-types';
-import type { Actions } from '../objects/rule';
+import type { Actions } from '../objects/types';
 // For some reason importing these functions from ../../public/detections/pages/detection_engine/rules/helpers
 // causes a "Webpack Compilation Error" in this file specifically, even though it imports fine in the test files
 // in ../e2e/*, so we have a copy of the implementations in the cypress helpers.

--- a/x-pack/plugins/security_solution/cypress/tasks/sourcerer.ts
+++ b/x-pack/plugins/security_solution/cypress/tasks/sourcerer.ts
@@ -154,7 +154,7 @@ const refreshUntilAlertsIndexExists = async () => {
 };
 
 export const waitForAlertsIndexToExist = () => {
-  createRule({ ...getNewRule(), rule_id: '1', max_signals: 100 });
+  createRule(getNewRule({ rule_id: '1', max_signals: 100 }));
   refreshUntilAlertsIndexExists();
 };
 


### PR DESCRIPTION
**Relates to:** https://github.com/elastic/kibana/pull/150553

## Summary

This PR is based on the review comments in https://github.com/elastic/kibana/pull/150553. It allows to rewrite rule create properties.

## Details

Rule create properties are returned by helper functions like `getNewRule()`, `getNewThresholdRule()` and so on. So instead of `createRule({ ...getNewRule(), index: undefined, data_view_id: DATA_VIEW_ID, rule_id: '1' })` it allows to use a concise and a much more readable structure `createRule(getNewRule({ index: undefined, data_view_id: DATA_VIEW_ID, rule_id: '1' ))`.

## Possible improvements

The PR doesn't implement deep / nested fields merge. High level fields completely rewrite default values. Deep merge would allow to extend defaults with the provided rewrites. For example, overriding nested properties become tiresome quickly, as shown in the following code snippet:

```ts
const rule = {
  ...getNewTermsRule(),
  rule_id: 'new_rule_id',
  runsEvery: {
    interval: '1',
    ...getNewTermsRule().runsEvery,
  },
};
```

If we implement deep merge, the readability could be greatly improved:

```ts
const rule = getNewTermsRule({
  rule_id: 'new_rule_id',
  runsEvery: {
    interval: '1',
  },
});
```

While it looks as a good idea we should take into consideration the fact that complete rewriting of default values can be a desired behavior. Engineers could tend to switch to `createRule({ ...getNewRule(), index: undefined, data_view_id: DATA_VIEW_ID, rule_id: '1' })` to overcome deep merge. So it should be analysed carefully before implementing it.


<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->