### PR TITLE
[Fleet] Remove text saying file uploads are deleted after 30 days

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_diagnostics/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_diagnostics/index.tsx
@@ -249,7 +249,7 @@ export const AgentDiagnosticsTab: React.FunctionComponent<AgentDiagnosticsProps>
         >
           <FormattedMessage
             id="xpack.fleet.requestDiagnostics.calloutText"
-            defaultMessage="Diagnostics files are stored in Elasticsearch, and as such can incur storage costs. Fleet will automatically remove old diagnostics files after 30 days."
+            defaultMessage="Diagnostics files are stored in Elasticsearch, and as such can incur storage costs."
           />
         </EuiCallOut>
       </EuiFlexItem>

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/agent_request_diagnostics_modal/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/agent_request_diagnostics_modal/index.tsx
@@ -119,7 +119,7 @@ export const AgentRequestDiagnosticsModal: React.FunctionComponent<Props> = ({
       <p>
         <FormattedMessage
           id="xpack.fleet.requestDiagnostics.description"
-          defaultMessage="Diagnostics files are stored in Elasticsearch, and as such can incur storage costs. Fleet will automatically remove old diagnostics files after 30 days."
+          defaultMessage="Diagnostics files are stored in Elasticsearch, and as such can incur storage costs."
         />
       </p>
     </EuiConfirmModal>


### PR DESCRIPTION
## Summary

We are having to remove the ILM policies that delete data after 30 days from 8.7.0 in https://github.com/elastic/elasticsearch/pull/94651,  so removing this text as well: "Fleet will automatically remove old diagnostics files after 30 days."

How they look now:
<img width="769" alt="Screenshot 2023-03-22 at 20 57 40" src="https://user-images.githubusercontent.com/3315046/227036926-29a12823-002f-483d-8ead-5bf759bdb7d4.png">
<img width="1247" alt="Screenshot 2023-03-22 at 20 57 33" src="https://user-images.githubusercontent.com/3315046/227036928-1dd4ae35-8d9d-4630-a769-33b943d19269.png">


<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->