### PR TITLE
[Security Solution] Invalidate updated rules instead of marking them instantly stale

### DIFF
--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/api/hooks/use_bulk_action_mutation.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/api/hooks/use_bulk_action_mutation.ts
@@ -57,10 +57,8 @@ export const useBulkActionMutation = (
           if (updatedRules) {
             // We have a list of updated rules, no need to invalidate all
             updateRulesCache(updatedRules);
-          } else {
-            // We failed to receive the list of update rules, invalidate all
-            invalidateFindRulesQuery();
           }
+          invalidateFindRulesQuery({ refetchType: 'none' });
           break;
         }
         case BulkActionType.delete:

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/api/hooks/use_fetch_rule_by_id_query.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/api/hooks/use_fetch_rule_by_id_query.ts
@@ -35,9 +35,6 @@ export const useFetchRuleByIdQuery = (id: string, options?: UseQueryOptions<Rule
     {
       ...DEFAULT_QUERY_OPTIONS,
       ...options,
-      // Mark this query as immediately stale helps to avoid problems related to filtering.
-      // e.g. enabled and disabled state filter require data update which happens at the backend side
-      staleTime: 0,
       enabled: !!id,
     }
   );

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/api/hooks/use_find_rules_query.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/api/hooks/use_find_rules_query.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { UseQueryOptions } from '@tanstack/react-query';
+import type { InvalidateQueryFilters, UseQueryOptions } from '@tanstack/react-query';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCallback } from 'react';
 import { DETECTION_ENGINE_RULES_URL_FIND } from '../../../../../common/constants';
@@ -54,9 +54,6 @@ export const useFindRulesQuery = (
     },
     {
       ...DEFAULT_QUERY_OPTIONS,
-      // Mark this query as immediately stale helps to avoid problems related to filtering.
-      // e.g. enabled and disabled state filter require data update which happens at the backend side
-      staleTime: 0,
       ...queryOptions,
     }
   );
@@ -72,15 +69,16 @@ export const useFindRulesQuery = (
 export const useInvalidateFindRulesQuery = () => {
   const queryClient = useQueryClient();
 
-  return useCallback(() => {
-    /**
-     * Invalidate all queries that start with FIND_RULES_QUERY_KEY. This
-     * includes the in-memory query cache and paged query cache.
-     */
-    queryClient.invalidateQueries(FIND_RULES_QUERY_KEY, {
-      refetchType: 'active',
-    });
-  }, [queryClient]);
+  return useCallback(
+    (filters: InvalidateQueryFilters = { refetchType: 'active' }) => {
+      /**
+       * Invalidate all queries that start with FIND_RULES_QUERY_KEY. This
+       * includes the in-memory query cache and paged query cache.
+       */
+      queryClient.invalidateQueries(FIND_RULES_QUERY_KEY, filters);
+    },
+    [queryClient]
+  );
 };
 
 /**


### PR DESCRIPTION
**Addresses:** https://github.com/elastic/kibana/issues/151151

## Summary

It's an improved fix of https://github.com/elastic/kibana/issues/151151. It helps to reduce the number of fetch data requests by reusing cache data when it's possible.

_Before:_

https://user-images.githubusercontent.com/3775283/227220801-1b87b455-8aef-4fe5-adbb-60e7ccabdfb9.mov


_After:_

https://user-images.githubusercontent.com/3775283/227220856-0a14a22c-8296-498c-ab5b-98e8f8a933e4.mov
