### PR TITLE
[AO] Fix time range filter in alerts table

### DIFF
--- a/x-pack/plugins/observability/public/utils/build_es_query/__snapshots__/build_es_query.test.ts.snap
+++ b/x-pack/plugins/observability/public/utils/build_es_query/__snapshots__/build_es_query.test.ts.snap
@@ -6,7 +6,7 @@ Object {
     "filter": Array [
       Object {
         "range": Object {
-          "@timestamp": Object {
+          "kibana.alert.time_range": Object {
             "format": "strict_date_optional_time",
             "gte": "2022-08-30T15:23:23.721Z",
             "lte": "2022-08-30T15:38:28.171Z",
@@ -39,7 +39,7 @@ Object {
       },
       Object {
         "range": Object {
-          "@timestamp": Object {
+          "kibana.alert.time_range": Object {
             "format": "strict_date_optional_time",
             "gte": "2022-08-30T15:23:23.721Z",
             "lte": "2022-08-30T15:38:28.171Z",
@@ -92,7 +92,7 @@ Object {
       },
       Object {
         "range": Object {
-          "@timestamp": Object {
+          "kibana.alert.time_range": Object {
             "format": "strict_date_optional_time",
             "gte": "2022-08-30T15:23:23.721Z",
             "lte": "2022-08-30T15:38:28.171Z",
@@ -131,7 +131,7 @@ Object {
       },
       Object {
         "range": Object {
-          "@timestamp": Object {
+          "kibana.alert.time_range": Object {
             "format": "strict_date_optional_time",
             "gte": "2022-08-30T15:23:23.721Z",
             "lte": "2022-08-30T15:38:28.171Z",
@@ -152,7 +152,7 @@ Object {
     "filter": Array [
       Object {
         "range": Object {
-          "@timestamp": Object {
+          "kibana.alert.time_range": Object {
             "format": "strict_date_optional_time",
             "gte": "2022-08-30T15:23:23.721Z",
             "lte": "2022-08-30T15:38:28.171Z",

--- a/x-pack/plugins/observability/public/utils/build_es_query/build_es_query.ts
+++ b/x-pack/plugins/observability/public/utils/build_es_query/build_es_query.ts
@@ -6,14 +6,14 @@
  */
 
 import { buildEsQuery as kbnBuildEsQuery, TimeRange, Query } from '@kbn/es-query';
-import { TIMESTAMP } from '@kbn/rule-data-utils';
+import { ALERT_TIME_RANGE } from '@kbn/rule-data-utils';
 import { getTime } from '@kbn/data-plugin/common';
 
 export function buildEsQuery(timeRange: TimeRange, kuery?: string, queries: Query[] = []) {
   const timeFilter =
     timeRange &&
     getTime(undefined, timeRange, {
-      fieldName: TIMESTAMP,
+      fieldName: ALERT_TIME_RANGE,
     });
   const filtersToUse = timeFilter ? [timeFilter] : [];
   const kueryFilter = kuery ? [{ query: kuery, language: 'kuery' }] : [];


### PR DESCRIPTION
## Summary

This PR fixes the time range filter by using the `ALERT_TIME_RANGE` instead of `TIMESTAMP`

![image](https://user-images.githubusercontent.com/12370520/227191827-1463009a-9549-45d7-9771-bf8a8d73b7c8.png)

