### PR TITLE
[Security Solution][Investigations] - skip flaky page fitlers test

### DIFF
--- a/x-pack/plugins/security_solution/cypress/e2e/detection_alerts/detection_page_filters.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_alerts/detection_page_filters.cy.ts
@@ -98,7 +98,7 @@ const assertFilterControlsWithFilterObject = (filterObject = DEFAULT_DETECTION_P
   });
 };
 
-describe('Detections : Page Filters', { testIsolation: false }, () => {
+describe.skip('Detections : Page Filters', { testIsolation: false }, () => {
   before(() => {
     cleanKibana();
     login();


### PR DESCRIPTION
## Summary

This test has been showing some flakiness on recent CI runs. To unblock other PR's while we resolve the issue we're going to skip the tests for now.
