### PR TITLE
[Console] Fix manual aggregation autocompletions

### DIFF
--- a/src/plugins/console/server/lib/spec_definitions/js/aggregations.ts
+++ b/src/plugins/console/server/lib/spec_definitions/js/aggregations.ts
@@ -164,7 +164,6 @@ const rules = {
     terms: {
       __template: {
         field: '',
-        size: 10,
       },
       field: '{field}',
       size: 10,
@@ -268,11 +267,11 @@ const rules = {
     date_histogram: {
       __template: {
         field: 'date',
-        interval: 'month',
+        fixed_interval: '1d',
       },
       field: '{field}',
-      interval: {
-        __one_of: ['year', 'quarter', 'week', 'day', 'hour', 'minute', 'second'],
+      fixed_interval: {
+        __one_of: ['1d', '1h', '1m', '1s', '1ms'],
       },
       min_doc_count: 0,
       extended_bounds: {
@@ -294,7 +293,6 @@ const rules = {
       keyed: { __one_of: [true, false] },
       pre_zone: '-01:00',
       post_zone: '-01:00',
-      pre_zone_adjust_large_interval: { __one_of: [true, false] },
       factor: 1000,
       pre_offset: '1d',
       post_offset: '1d',
@@ -302,7 +300,22 @@ const rules = {
       time_zone: '00:00',
       missing: '',
       calendar_interval: {
-        __one_of: ['year', 'quarter', 'week', 'day', 'hour', 'minute', 'second'],
+        __one_of: [
+          'year',
+          'quarter',
+          'month',
+          'week',
+          'day',
+          'hour',
+          'minute',
+          '1y',
+          '1q',
+          '1M',
+          '1w',
+          '1d',
+          '1h',
+          '1m',
+        ],
       },
     },
     geo_distance: {


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/153194
Fixes https://github.com/elastic/kibana/issues/153196

## Summary

This PR fixes the aggregation console autocompletions (which are written manually and not generated by the script) as follows:

The `Date histogram` aggregation (related to https://github.com/elastic/kibana/issues/153194) - [docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-datehistogram-aggregation.html):

- The `interval` field is already called 'fixed_interval'.
- The `fixed_interval` now supports the `'d', 'h', 'm', 's', 'ms'` units.
- The `calendar_interval` now supports the `'year', 'quarter', 'month', 'week', 'day', 'hour', 'minute', 'y', 'q', 'M', 'w', 'd', 'h', 'm',` units.
- The `pre_zone_adjust_large_interval` is not supported anymore.


https://user-images.githubusercontent.com/59341489/227272878-64e5b332-1866-44f8-9152-284a3117f8fe.mov



<br>

The `Composite` aggregation (related to https://github.com/elastic/kibana/issues/153196) - [docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-composite-aggregation.html):

- The `terms` value source doesn't support the `size` field so we should remove it from the template. This will also remove it from the template of the Terms aggregation, but since it is an optional field, running a Terms aggregation request with no `size` field will not cause any error.

https://user-images.githubusercontent.com/59341489/227272907-cc238bd6-85bf-4a66-a52e-1f57851dec2a.mov



