### PR TITLE
[Security Solution][Rule Preview] Fixes `<space-id>` index permission bug with Rule Preview

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_preview/api/preview_rules/route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_preview/api/preview_rules/route.ts
@@ -136,8 +136,8 @@ export const previewRulesRoute = async (
           .atSpace(spaceId, {
             elasticsearch: {
               index: {
-                [`${DEFAULT_PREVIEW_INDEX}`]: ['read'],
-                [`.internal${DEFAULT_PREVIEW_INDEX}-`]: ['read'],
+                [`${DEFAULT_PREVIEW_INDEX}-${spaceId}`]: ['read'],
+                [`.internal${DEFAULT_PREVIEW_INDEX}-${spaceId}-*`]: ['read'],
               },
               cluster: [],
             },


### PR DESCRIPTION
## Summary

Addresses a [problem found via the community discussion board](https://discuss.elastic.co/t/rule-preview-not-working/327737/2) where rule preview doesn't properly recognize permissions granted to it when using a kibana `space-id` which is correctly documented [here](https://www.elastic.co/guide/en/security/current/detections-permissions-section.html#enable-detections-ui) as something to include in the permissions.

To test:

- Create a role with the usual detection alerts index permissions in the `default` space, using `.preview.alerts-security.alerts-default` and/or `.internal.preview.alerts-security.alerts-default-*` instead of the normal preview indices.
- Attempt to use the rule preview feature within rule creation
- You are now able to use the rule preview without index permission error (this won't currently work in `main`/kibana dev)


### Checklist

Delete any items that are not applicable to this PR.

- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->