### PR TITLE
chore(slo): remove non searchable fields from slo mapping

### DIFF
--- a/src/core/server/integration_tests/saved_objects/migrations/group2/check_registered_types.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/group2/check_registered_types.test.ts
@@ -134,7 +134,7 @@ describe('checking migration metadata changes on all registered SO types', () =>
         "siem-ui-timeline": "e9d6b3a9fd7af6dc502293c21cbdb309409f3996",
         "siem-ui-timeline-note": "13c9d4c142f96624a93a623c6d7cba7e1ae9b5a6",
         "siem-ui-timeline-pinned-event": "96a43d59b9e2fc11f12255a0cb47ef0a3d83af4c",
-        "slo": "af2a119f3bceee5f12dc02d7eb4f54040bae4557",
+        "slo": "ee0e16abebba5779c37277bc3fe8da1fe1207b7a",
         "space": "7fc578a1f9f7708cb07479f03953d664ad9f1dae",
         "spaces-usage-stats": "084bd0f080f94fb5735d7f3cf12f13ec92f36bad",
         "synthetics-monitor": "96cc312bfa597022f83dfb3b5d1501e27a73e8d5",

--- a/x-pack/plugins/observability/server/saved_objects/slo.ts
+++ b/x-pack/plugins/observability/server/saved_objects/slo.ts
@@ -28,36 +28,9 @@ export const slo: SavedObjectsType = {
           params: { type: 'flattened' },
         },
       },
-      timeWindow: {
-        properties: {
-          duration: { type: 'keyword' },
-          isRolling: { type: 'boolean' },
-          calendar: {
-            properties: {
-              startTime: { type: 'date' },
-            },
-          },
-        },
-      },
       budgetingMethod: { type: 'keyword' },
-      objective: {
-        properties: {
-          target: { type: 'float' },
-          timesliceTarget: { type: 'float' },
-          timesliceWindow: { type: 'keyword' },
-        },
-      },
-      settings: {
-        properties: {
-          syncDelay: { type: 'keyword' },
-          frequency: { type: 'keyword' },
-        },
-      },
-      revision: { type: 'short' },
       enabled: { type: 'boolean' },
       tags: { type: 'keyword' },
-      createdAt: { type: 'date' },
-      updatedAt: { type: 'date' },
     },
   },
   management: {


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/153593

The SO mappings should list only searchable fields. This PR removes the fields not searchable from the mapping