### PR TITLE
[Fleet] unskip fleet epm get ftr tests

### DIFF
--- a/x-pack/test/fleet_api_integration/apis/epm/get.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/get.ts
@@ -38,8 +38,7 @@ export default function (providerContext: FtrProviderContext) {
     '../fixtures/direct_upload_packages/apache_0.1.4.zip'
   );
 
-  // Failing: See https://github.com/elastic/kibana/issues/149794
-  describe.skip('EPM - get', () => {
+  describe('EPM - get', () => {
     skipIfNoDockerRegistry(providerContext);
     setupFleetAndAgents(providerContext);
 
@@ -215,7 +214,7 @@ export default function (providerContext: FtrProviderContext) {
       const pkgVersion = '8.6.0';
       await installPackage(pkg, pkgVersion);
       const response = await supertestWithoutAuth
-        .get(`/api/fleet/epm/packages/${pkg}`)
+        .get(`/api/fleet/epm/packages/${pkg}/${pkgVersion}`)
         .auth(
           testUsers.endpoint_integr_read_only_fleet_none.username,
           testUsers.endpoint_integr_read_only_fleet_none.password


### PR DESCRIPTION
## Summary

unskip fleet epm get ftr tests. root cause was `transform.start` failing during package install. mitigated by https://github.com/elastic/kibana/pull/152119. long term fix: https://github.com/elastic/endpoint-package/pull/353.

Flaky test runner:
- https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2033 (x200 ✅ )
- https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2038 (x200 ✅ )

Issues:
- closes: https://github.com/elastic/kibana/issues/149794

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
