### PR TITLE
Merge tags in recovered infra alert documents

### DIFF
--- a/x-pack/plugins/rule_registry/server/utils/create_lifecycle_executor.test.ts
+++ b/x-pack/plugins/rule_registry/server/utils/create_lifecycle_executor.test.ts
@@ -24,6 +24,7 @@ import {
   EVENT_KIND,
   SPACE_IDS,
   ALERT_FLAPPING,
+  TAGS,
 } from '../../common/technical_rule_data_field_names';
 import { createRuleDataClientMock } from '../rule_data_client/rule_data_client.mock';
 import { createLifecycleExecutor } from './create_lifecycle_executor';
@@ -73,11 +74,11 @@ describe('createLifecycleExecutor', () => {
     )<{}, TestRuleState, never, never, never>(async ({ services, state }) => {
       services.alertWithLifecycle({
         id: 'TEST_ALERT_0',
-        fields: {},
+        fields: { [TAGS]: ['source-tag1', 'source-tag2'] },
       });
       services.alertWithLifecycle({
         id: 'TEST_ALERT_1',
-        fields: {},
+        fields: { [TAGS]: ['source-tag3', 'source-tag4'] },
       });
 
       return { state };
@@ -101,6 +102,7 @@ describe('createLifecycleExecutor', () => {
             [ALERT_STATUS]: ALERT_STATUS_ACTIVE,
             [EVENT_ACTION]: 'open',
             [EVENT_KIND]: 'signal',
+            [TAGS]: ['source-tag1', 'source-tag2', 'rule-tag1', 'rule-tag2'],
           }),
           { index: { _id: expect.any(String) } },
           expect.objectContaining({
@@ -108,6 +110,7 @@ describe('createLifecycleExecutor', () => {
             [ALERT_STATUS]: ALERT_STATUS_ACTIVE,
             [EVENT_ACTION]: 'open',
             [EVENT_KIND]: 'signal',
+            [TAGS]: ['source-tag3', 'source-tag4', 'rule-tag1', 'rule-tag2'],
           }),
         ],
       })
@@ -273,6 +276,7 @@ describe('createLifecycleExecutor', () => {
               [ALERT_STATUS]: ALERT_STATUS_ACTIVE,
               [SPACE_IDS]: ['fake-space-id'],
               labels: { LABEL_0_KEY: 'LABEL_0_VALUE' }, // this must show up in the written doc
+              [TAGS]: ['source-tag1', 'source-tag2'],
             },
           },
           {
@@ -289,6 +293,7 @@ describe('createLifecycleExecutor', () => {
               [ALERT_STATUS]: ALERT_STATUS_ACTIVE,
               [SPACE_IDS]: ['fake-space-id'],
               labels: { LABEL_0_KEY: 'LABEL_0_VALUE' }, // this must not show up in the written doc
+              [TAGS]: ['source-tag3', 'source-tag4'],
             },
           },
         ],
@@ -346,6 +351,7 @@ describe('createLifecycleExecutor', () => {
             [ALERT_INSTANCE_ID]: 'TEST_ALERT_0',
             [ALERT_STATUS]: ALERT_STATUS_RECOVERED,
             labels: { LABEL_0_KEY: 'LABEL_0_VALUE' },
+            [TAGS]: ['source-tag1', 'source-tag2', 'rule-tag1', 'rule-tag2'],
             [EVENT_ACTION]: 'close',
             [EVENT_KIND]: 'signal',
           }),
@@ -355,6 +361,7 @@ describe('createLifecycleExecutor', () => {
             [ALERT_STATUS]: ALERT_STATUS_ACTIVE,
             [EVENT_ACTION]: 'active',
             [EVENT_KIND]: 'signal',
+            [TAGS]: ['source-tag3', 'source-tag4', 'rule-tag1', 'rule-tag2'],
           }),
         ]),
       })

--- a/x-pack/plugins/rule_registry/server/utils/create_lifecycle_executor.ts
+++ b/x-pack/plugins/rule_registry/server/utils/create_lifecycle_executor.ts
@@ -308,7 +308,11 @@ export const createLifecycleExecutor =
           [EVENT_KIND]: 'signal',
           [EVENT_ACTION]: isNew ? 'open' : isActive ? 'active' : 'close',
           [TAGS]: Array.from(
-            new Set([...(currentAlertData?.tags ?? []), ...(options.rule.tags ?? [])])
+            new Set([
+              ...(currentAlertData?.tags ?? []),
+              ...(alertData?.fields[TAGS] ?? []),
+              ...(options.rule.tags ?? []),
+            ])
           ),
           [VERSION]: ruleDataClient.kibanaVersion,
           [ALERT_FLAPPING]: flapping,

--- a/x-pack/plugins/rule_registry/server/utils/rule_executor.test_helpers.ts
+++ b/x-pack/plugins/rule_registry/server/utils/rule_executor.test_helpers.ts
@@ -54,7 +54,7 @@ export const createDefaultAlertExecutorOptions = <
   rule: {
     id: alertId,
     updatedBy: null,
-    tags: [],
+    tags: ['rule-tag1', 'rule-tag2'],
     name: ruleName,
     createdBy: 'CREATED_BY',
     actions: [],


### PR DESCRIPTION
Part of https://github.com/elastic/actionable-observability/issues/20 

The `tags` field of 'recovered' alert document should contain tags coming from source as well as tags defined in the rule.

**Rules in Scope:**
- Inventory rule
- Metric threshold rule

### Manual Testing
1. Create Inventory rule and Metric threshold rule
2. Wait for alerts to trigger and then recover
3. Check the alert documents in AAD after recovery
4. Notice the `tags` array contains source tags and rule tags

### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios