### PR TITLE
[ML] Fix anomalies table drilldown time range for longer bucket spans

### DIFF
--- a/x-pack/plugins/ml/public/application/components/anomalies_table/links_menu.tsx
+++ b/x-pack/plugins/ml/public/application/components/anomalies_table/links_menu.tsx
@@ -227,16 +227,18 @@ export const LinksMenuUI = (props: LinksMenuProps) => {
         // Start from the previous hour.
         earliestMoment.subtract(1, 'h');
       }
-      let latestMoment = moment(record.timestamp).add(record.bucket_span, 's');
+
+      const latestMoment = moment(record.timestamp).add(record.bucket_span, 's');
       if (props.isAggregatedData === true) {
-        latestMoment = moment(record.timestamp).endOf(interval);
         if (interval === 'hour') {
           // Show to the end of the next hour.
-          latestMoment.add(1, 'h'); // e.g. 2016-02-08T18:59:59.999Z
+          latestMoment.add(1, 'h');
         }
+        latestMoment.subtract(1, 'ms').endOf(interval); // e.g. 2016-02-08T18:59:59.999Z
       }
+
       const from = timeFormatter(earliestMoment.unix() * 1000); // e.g. 2016-02-08T16:00:00.000Z
-      const to = timeFormatter(latestMoment.unix() * 1000);
+      const to = timeFormatter(latestMoment.unix() * 1000); // e.g. 2016-02-08T18:59:59.000Z
 
       let kqlQuery = '';
 
@@ -315,16 +317,16 @@ export const LinksMenuUI = (props: LinksMenuProps) => {
     }
 
     if (configuredUrlValue.includes('$latest$')) {
-      let latestMoment = moment(timestamp).add(record.bucket_span, 's');
+      const latestMoment = moment(timestamp).add(record.bucket_span, 's');
       if (timeRangeInterval !== null) {
         latestMoment.add(timeRangeInterval);
       } else {
         if (isAggregatedData === true) {
-          latestMoment = moment(timestamp).endOf(interval);
           if (interval === 'hour') {
             // Show to the end of the next hour.
             latestMoment.add(1, 'h'); // e.g. 2016-02-08T18:59:59.999Z
           }
+          latestMoment.subtract(1, 'ms').endOf(interval); // e.g. 2016-02-08T18:59:59.999Z
         }
       }
       record.latest = latestMoment.toISOString();


### PR DESCRIPTION
## Summary

Fixes the time range of the 'View in Discover' drilldown and for custom URLs from the anomalies table in the Anomaly Explorer and Single Metric Viewer for jobs with longer bucket spans.

Previously with a `1 hour` aggregation interval in the anomalies table, the target page would not display the full time range of the anomalous bucket if the bucket span was greater than 2 hours because the link was set to display a time range of:

```
Start: Anomaly timestamp minus 1 hour
End: Anomaly timestamp plus 1 hour plus an extra hour
```

And for a `1 day` aggregation interval, the target page would not display the full time range of the anomalous bucket if the bucket span was greater than 24 hours because the link was set to display a time range of:

```
Start: Start of day of the anomalous bucket
End: End of day of the start of the anomalous bucket
```

For these longer bucket spans, the target page will now display for 1 hour interval one hour either side of the full bucket, and for 1 day interval - start of the day for the start of the anomalous bucket to the end of the day of the end of the anomalous bucket.

### Example for job with 3h bucket span, interval of table set to 1 hour:

#### Before - time range of Discover does not show all of anomalous bucket, missing large spike around 05:30

![3h_drilldown_before](https://user-images.githubusercontent.com/7405507/227582488-1097f832-7186-4e34-a8f6-a13fc28df5b1.gif)

#### After - Discover shows full time range of anomalous bucket plus 1 hour either side

![3h_drilldown_fix](https://user-images.githubusercontent.com/7405507/227582525-bb68c772-33f0-4e1f-b3e5-eacc4a5460da.gif)


Fixes #142130