### PR TITLE
[Synthetics] HTTP monitors - adjust request body field to remove hardcoded readonly value

### DIFF
--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/fields/request_body_field.test.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/fields/request_body_field.test.tsx
@@ -8,6 +8,7 @@
 import 'jest-canvas-mock';
 
 import React, { useState, useCallback } from 'react';
+import userEvent from '@testing-library/user-event';
 import { fireEvent, waitFor } from '@testing-library/react';
 import { render } from '../../../utils/testing/rtl_helpers';
 import { RequestBodyField } from './request_body_field';
@@ -29,6 +30,7 @@ jest.mock('@kbn/kibana-react-plugin/public', () => {
         onChange={(e: any) => {
           props.onChange(e.jsonContent);
         }}
+        readOnly={props.readOnly}
       />
     ),
   };
@@ -37,7 +39,7 @@ jest.mock('@kbn/kibana-react-plugin/public', () => {
 describe('<RequestBodyField />', () => {
   const defaultMode = Mode.PLAINTEXT;
   const defaultValue = 'sample value';
-  const WrappedComponent = () => {
+  const WrappedComponent = ({ readOnly }: { readOnly?: boolean }) => {
     const [config, setConfig] = useState({
       type: defaultMode,
       value: defaultValue,
@@ -53,6 +55,7 @@ describe('<RequestBodyField />', () => {
           (code) => setConfig({ type: code.type as Mode, value: code.value }),
           [setConfig]
         )}
+        readOnly={readOnly}
       />
     );
   };
@@ -84,5 +87,77 @@ describe('<RequestBodyField />', () => {
       expect(getByText('Add form field')).toBeInTheDocument();
       expect(queryByLabelText('Text code editor')).not.toBeInTheDocument();
     });
+  });
+
+  it('handles updating input', async () => {
+    const { getByText, getByRole, getAllByRole, getByLabelText } = render(<WrappedComponent />);
+
+    expect(getByLabelText('Text code editor')).toBeInTheDocument();
+    userEvent.type(getByRole('textbox'), 'text');
+    expect(getByRole('textbox')).toHaveValue('text');
+
+    const xmlButton = getByText('XML').closest('button');
+    if (xmlButton) {
+      fireEvent.click(xmlButton);
+    }
+
+    expect(getByText('XML').closest('button')).toHaveAttribute('aria-selected', 'true');
+    userEvent.type(getByRole('textbox'), 'xml');
+    expect(getByRole('textbox')).toHaveValue('textxml');
+
+    const jsonButton = getByText('JSON').closest('button');
+    if (jsonButton) {
+      fireEvent.click(jsonButton);
+    }
+
+    expect(getByText('JSON').closest('button')).toHaveAttribute('aria-selected', 'true');
+    userEvent.type(getByRole('textbox'), 'json');
+    expect(getByRole('textbox')).toHaveValue('textxmljson');
+
+    const formButton = getByText('Form').closest('button');
+    if (formButton) {
+      fireEvent.click(formButton);
+    }
+
+    expect(getByText('Form').closest('button')).toHaveAttribute('aria-selected', 'true');
+    userEvent.click(getByText('Add form field'));
+    expect(getByText('Key')).toBeInTheDocument();
+    expect(getByText('Value')).toBeInTheDocument();
+    userEvent.type(getAllByRole('textbox')[0], 'formfield');
+    expect(getAllByRole('textbox')[0]).toHaveValue('formfield');
+  });
+
+  it('handles read only', async () => {
+    const { getByText, getByRole, getByLabelText } = render(<WrappedComponent readOnly={true} />);
+
+    expect(getByLabelText('Text code editor')).toBeInTheDocument();
+    userEvent.type(getByRole('textbox'), 'text');
+    expect(getByRole('textbox')).toHaveValue('');
+
+    const xmlButton = getByText('XML').closest('button');
+    if (xmlButton) {
+      fireEvent.click(xmlButton);
+    }
+
+    expect(getByText('XML').closest('button')).toHaveAttribute('aria-selected', 'true');
+    userEvent.type(getByRole('textbox'), 'xml');
+    expect(getByRole('textbox')).toHaveValue('');
+
+    const jsonButton = getByText('JSON').closest('button');
+    if (jsonButton) {
+      fireEvent.click(jsonButton);
+    }
+
+    expect(getByText('JSON').closest('button')).toHaveAttribute('aria-selected', 'true');
+    userEvent.type(getByRole('textbox'), 'json');
+    expect(getByRole('textbox')).toHaveValue('');
+
+    const formButton = getByText('Form').closest('button');
+    if (formButton) {
+      fireEvent.click(formButton);
+    }
+
+    expect(getByText('Form').closest('button')).toHaveAttribute('aria-selected', 'true');
+    expect(getByRole('button', { name: 'Add form field' })).toBeDisabled();
   });
 });

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/fields/request_body_field.test.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/fields/request_body_field.test.tsx
@@ -93,71 +93,74 @@ describe('<RequestBodyField />', () => {
     const { getByText, getByRole, getAllByRole, getByLabelText } = render(<WrappedComponent />);
 
     expect(getByLabelText('Text code editor')).toBeInTheDocument();
-    userEvent.type(getByRole('textbox'), 'text');
-    expect(getByRole('textbox')).toHaveValue('text');
+    const textbox = getByRole('textbox');
+    userEvent.type(textbox, 'text');
+    expect(textbox).toHaveValue('text');
 
     const xmlButton = getByText('XML').closest('button');
     if (xmlButton) {
       fireEvent.click(xmlButton);
     }
 
-    expect(getByText('XML').closest('button')).toHaveAttribute('aria-selected', 'true');
-    userEvent.type(getByRole('textbox'), 'xml');
-    expect(getByRole('textbox')).toHaveValue('textxml');
+    expect(xmlButton).toHaveAttribute('aria-selected', 'true');
+    userEvent.type(textbox, 'xml');
+    expect(textbox).toHaveValue('textxml');
 
     const jsonButton = getByText('JSON').closest('button');
     if (jsonButton) {
       fireEvent.click(jsonButton);
     }
 
-    expect(getByText('JSON').closest('button')).toHaveAttribute('aria-selected', 'true');
-    userEvent.type(getByRole('textbox'), 'json');
-    expect(getByRole('textbox')).toHaveValue('textxmljson');
+    expect(jsonButton).toHaveAttribute('aria-selected', 'true');
+    userEvent.type(textbox, 'json');
+    expect(textbox).toHaveValue('textxmljson');
 
     const formButton = getByText('Form').closest('button');
     if (formButton) {
       fireEvent.click(formButton);
     }
 
-    expect(getByText('Form').closest('button')).toHaveAttribute('aria-selected', 'true');
+    expect(formButton).toHaveAttribute('aria-selected', 'true');
     userEvent.click(getByText('Add form field'));
     expect(getByText('Key')).toBeInTheDocument();
     expect(getByText('Value')).toBeInTheDocument();
-    userEvent.type(getAllByRole('textbox')[0], 'formfield');
-    expect(getAllByRole('textbox')[0]).toHaveValue('formfield');
+    const keyValueTextBox = getAllByRole('textbox')[0];
+    userEvent.type(keyValueTextBox, 'formfield');
+    expect(keyValueTextBox).toHaveValue('formfield');
   });
 
   it('handles read only', async () => {
     const { getByText, getByRole, getByLabelText } = render(<WrappedComponent readOnly={true} />);
 
     expect(getByLabelText('Text code editor')).toBeInTheDocument();
-    userEvent.type(getByRole('textbox'), 'text');
-    expect(getByRole('textbox')).toHaveValue('');
+    const textbox = getByRole('textbox');
+    userEvent.type(textbox, 'text');
+    expect(textbox).toHaveValue('');
 
     const xmlButton = getByText('XML').closest('button');
     if (xmlButton) {
       fireEvent.click(xmlButton);
     }
 
-    expect(getByText('XML').closest('button')).toHaveAttribute('aria-selected', 'true');
-    userEvent.type(getByRole('textbox'), 'xml');
-    expect(getByRole('textbox')).toHaveValue('');
+    expect(xmlButton).toHaveAttribute('aria-selected', 'true');
+    userEvent.type(textbox, 'xml');
+    expect(textbox).toHaveValue('');
 
     const jsonButton = getByText('JSON').closest('button');
     if (jsonButton) {
       fireEvent.click(jsonButton);
     }
 
-    expect(getByText('JSON').closest('button')).toHaveAttribute('aria-selected', 'true');
-    userEvent.type(getByRole('textbox'), 'json');
-    expect(getByRole('textbox')).toHaveValue('');
+    expect(jsonButton).toHaveAttribute('aria-selected', 'true');
+    userEvent.type(textbox, 'json');
+    expect(textbox).toHaveValue('');
 
     const formButton = getByText('Form').closest('button');
     if (formButton) {
       fireEvent.click(formButton);
     }
 
-    expect(getByText('Form').closest('button')).toHaveAttribute('aria-selected', 'true');
+    expect(formButton).toHaveAttribute('aria-selected', 'true');
     expect(getByRole('button', { name: 'Add form field' })).toBeDisabled();
   });
 });

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/fields/request_body_field.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/fields/request_body_field.tsx
@@ -107,7 +107,7 @@ export const RequestBodyField = ({
             onBlur?.();
           }}
           value={values[ResponseBodyType.CODE]}
-          readOnly
+          readOnly={readOnly}
         />
       ),
     },
@@ -130,7 +130,7 @@ export const RequestBodyField = ({
             onBlur?.();
           }}
           value={values[ResponseBodyType.CODE]}
-          readOnly
+          readOnly={readOnly}
         />
       ),
     },
@@ -153,7 +153,7 @@ export const RequestBodyField = ({
             onBlur?.();
           }}
           value={values[ResponseBodyType.CODE]}
-          readOnly
+          readOnly={readOnly}
         />
       ),
     },
@@ -169,10 +169,11 @@ export const RequestBodyField = ({
               defaultMessage="Add form field"
             />
           }
+          data-test-subj={'syntheticsFormField'}
           defaultPairs={defaultFormPairs}
           onChange={onChangeFormFields}
           onBlur={() => onBlur?.()}
-          readOnly
+          readOnly={readOnly}
         />
       ),
     },


### PR DESCRIPTION
## Summary
Resolves https://github.com/elastic/kibana/issues/153698

Prevents hardcoded read-only value for the request body field when configuring HTTP monitors.

[Create-Monitor-Synthetics---Kibana (2).webm](https://user-images.githubusercontent.com/11356435/227623928-645c3369-8222-4247-b47d-feaf361056a9.webm)

### Testing

1. Click edit monitor
2. Attempt to create an HTTP monitor and add the request body field. Ensure each request body type (json, xml, text, form) can be edited
3. Save the monitor
4. Navigate to edit monitor
5. Ensure that the request body fields can still be interacted with

<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->