### PR TITLE
[Automated PR] Sync cloud_defend plugin policy schema with cloud-defend repo

### DIFF
--- a/x-pack/plugins/cloud_defend/public/components/control_yaml_view/hooks/policy_schema.json
+++ b/x-pack/plugins/cloud_defend/public/components/control_yaml_view/hooks/policy_schema.json
@@ -154,7 +154,8 @@
           "type": "array",
           "minItems": 1,
           "items": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^([a-zA-Z0-9\\.\\-]+\\/)?[a-zA-Z0-9\\.\\-]+:[a-zA-Z0-9\\.\\-\\_]*\\*?$"
           }
         },
         "orchestratorResourceName": {
@@ -326,7 +327,8 @@
           "type": "array",
           "minItems": 1,
           "items": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^([a-zA-Z0-9\\.\\-]+\\/)?[a-zA-Z0-9\\.\\-]+:[a-zA-Z0-9\\.\\-\\_]*\\*?$"
           }
         },
         "orchestratorResourceName": {
@@ -365,13 +367,6 @@
           }
         },
         "processName": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "type": "string"
-          }
-        },
-        "processUserName": {
           "type": "array",
           "minItems": 1,
           "items": {


### PR DESCRIPTION
Automated by https://buildkite.com/elastic/cloud-defend/builds/574

This automated PR adds a pattern to orchestratorResourceLabel for validation. The following has been tacked on as a result of that change:
- implement regex validation on string array condition values in UI
- unit tests