### PR TITLE
[Fleet] fix encryption key less message signing

### DIFF
--- a/x-pack/plugins/fleet/server/services/agent_policies/full_agent_policy.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policies/full_agent_policy.ts
@@ -186,7 +186,7 @@ export async function getFullAgentPolicy(
 
   // populate protection and signed properties
   const messageSigningService = appContextService.getMessageSigningService();
-  if (messageSigningService?.isEncryptionAvailable && fullAgentPolicy.agent) {
+  if (messageSigningService && fullAgentPolicy.agent) {
     const publicKey = await messageSigningService.getPublicKey();
 
     fullAgentPolicy.agent.protection = {


### PR DESCRIPTION
## Summary

Remove encryption key check when adding protection/signed properties to agent policy. We added support for no encryption key in message signing service in https://github.com/elastic/kibana/pull/152624, but I missed this.


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
