### PR TITLE
[8.7] [Cloud Security Posture] Update runtime fields

### DIFF
--- a/x-pack/plugins/cloud_security_posture/common/runtime_mappings/get_belongs_to_runtime_mapping.ts
+++ b/x-pack/plugins/cloud_security_posture/common/runtime_mappings/get_belongs_to_runtime_mapping.ts
@@ -12,40 +12,46 @@ import { MappingRuntimeFields } from '@elastic/elasticsearch/lib/api/types';
  * `account.cloud.name` or `cluster.id` based on the value of `rule.benchmark.posture_type`
  */
 export const getBelongsToRuntimeMapping = (): MappingRuntimeFields => ({
+  'rule.benchmark.posture_type': {
+    type: 'keyword',
+  },
+  'cloud.account.id': {
+    type: 'keyword',
+  },
+  'cloud.account.name': {
+    type: 'keyword',
+  },
   belongs_to: {
     type: 'keyword',
     script: {
       source: `
-        if (!doc.containsKey('rule.benchmark.posture_type'))
-          {
-            def belongs_to = doc["cluster_id"].value;
-            emit(belongs_to);
-            return
-          }
-        else
-        {
-          if(doc["rule.benchmark.posture_type"].size() > 0)
-            {
+      def belongs_to = "";
+
+      if (doc.containsKey('cluster_id') && doc["cluster_id"].size() > 0) {
+          belongs_to = doc["cluster_id"].value;
+      }
+
+      if (!doc.containsKey('rule.benchmark.posture_type')) {
+          emit(belongs_to);
+          return;
+      } else {
+          if (doc["rule.benchmark.posture_type"].size() > 0) {
               def policy_template_type = doc["rule.benchmark.posture_type"].value;
-              if (policy_template_type == "cspm")
-              {
-                def belongs_to = doc["cloud.account.name"].value;
-                emit(belongs_to);
-                return
+              if (policy_template_type == "cspm") {
+                if (doc.containsKey('cloud.account.name') && doc["cloud.account.name"].size() > 0 && doc["cloud.account.name"].value != '') {
+                      belongs_to = doc["cloud.account.name"].value;
+                  } else if (doc.containsKey('cloud.account.id') && doc["cloud.account.id"].size() > 0) {
+                      belongs_to = doc["cloud.account.id"].value;
+                  }
+              } else if (policy_template_type == "kspm") {
+                  if (doc.containsKey('cluster_id') && doc["cluster_id"].size() > 0) {
+                      belongs_to = doc["cluster_id"].value;
+                  }
               }
-
-              if (policy_template_type == "kspm")
-              {
-                def belongs_to = doc["cluster_id"].value;
-                emit(belongs_to);
-                return
-              }
-            }
-
-            def belongs_to = doc["cluster_id"].value;
-            emit(belongs_to);
-            return
-        }
+          }
+          emit(belongs_to);
+          return;
+      }
       `,
     },
   },

--- a/x-pack/plugins/cloud_security_posture/common/runtime_mappings/get_safe_posture_type_runtime_mapping.ts
+++ b/x-pack/plugins/cloud_security_posture/common/runtime_mappings/get_safe_posture_type_runtime_mapping.ts
@@ -12,6 +12,15 @@ import { MappingRuntimeFields } from '@elastic/elasticsearch/lib/api/types';
  * `kspm` or `cspm` based on the value of `rule.benchmark.posture_type`
  */
 export const getSafePostureTypeRuntimeMapping = (): MappingRuntimeFields => ({
+  'rule.benchmark.posture_type': {
+    type: 'keyword',
+  },
+  'cloud.account.id': {
+    type: 'keyword',
+  },
+  'cloud.account.name': {
+    type: 'keyword',
+  },
   safe_posture_type: {
     type: 'keyword',
     script: {

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings/use_latest_findings.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings/use_latest_findings.ts
@@ -60,6 +60,17 @@ export const getFindingsQuery = ({ query, sort }: UseFindingsOptions) => ({
   size: MAX_FINDINGS_TO_LOAD,
   aggs: getFindingsCountAggQuery(),
   ignore_unavailable: false,
+  runtime_mappings: {
+    'rule.benchmark.posture_type': {
+      type: 'keyword',
+    },
+    'cloud.account.id': {
+      type: 'keyword',
+    },
+    'cloud.account.name': {
+      type: 'keyword',
+    },
+  },
 });
 
 /**

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/findings_by_resource_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings_by_resource/findings_by_resource_table.tsx
@@ -166,7 +166,7 @@ const baseColumns: Array<EuiTableFieldDataColumnType<FindingsByResourcePage>> = 
         )}
         tooltipContent={i18n.translate(
           'xpack.csp.findings.findingsTable.findingsTableColumn.clusterIdColumnTooltipLabel',
-          { defaultMessage: 'Kubernetes Cluster ID or Cloud Account Name' }
+          { defaultMessage: 'Kubernetes Cluster ID or Cloud Account Name/ID' }
         )}
       />
     ),


### PR DESCRIPTION
## Summary

Updating CSP runtime fields to solve #153615 and #152974 and #151439

This fix aims for 8.7.0 only and introduces the necessary runtime fields to support backward compatibility with existing data from 8.6 to the updated UI in 8.7.

For 8.8 and beyond, we are going to update our plugin to correctly add mappings during the upgrade process, that is currently being tracked [here](https://github.com/elastic/kibana/issues/153718)