### PR TITLE
[Infrastructure UI] Fix wrong requests sent in the logs tab flyout

### DIFF
--- a/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/node_details/tabs/logs.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/node_details/tabs/logs.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useCallback, useMemo, useState } from 'react';
-import useThrottle from 'react-use/lib/useThrottle';
+import useDebounce from 'react-use/lib/useDebounce';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
 import { EuiFieldSearch } from '@elastic/eui';
@@ -22,24 +22,25 @@ import { getNodeLogsUrl } from '../../../../../link_to';
 
 const TabComponent = (props: TabProps) => {
   const [textQuery, setTextQuery] = useState('');
+  const [textQueryDebounced, setTextQueryDebounced] = useState('');
   const endTimestamp = props.currentTime;
   const startTimestamp = endTimestamp - 60 * 60 * 1000; // 60 minutes
   const { nodeType } = useWaffleOptionsContext();
   const { node } = props;
 
-  const throttledTextQuery = useThrottle(textQuery, textQueryThrottleInterval);
+  useDebounce(() => setTextQueryDebounced(textQuery), textQueryThrottleInterval, [textQuery]);
 
   const filter = useMemo(() => {
     const query = [
       `${findInventoryFields(nodeType).id}: "${node.id}"`,
-      ...(throttledTextQuery !== '' ? [throttledTextQuery] : []),
+      ...(textQueryDebounced !== '' ? [textQueryDebounced] : []),
     ].join(' and ');
 
     return {
       language: 'kuery',
       query,
     };
-  }, [nodeType, node.id, throttledTextQuery]);
+  }, [nodeType, node.id, textQueryDebounced]);
 
   const onQueryChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     setTextQuery(e.target.value);


### PR DESCRIPTION
closes  #152831 
## Summary

This PR replaces useThrottle with useDebounce in the logs tab to make sure that we are sending correct requests matching what is typed in the search field.

### Testing

1. Go to Inventory page
2. Click on any host to open the flyout
3. Go to logs tab and type `message:total` in the search bar
4. Quickly delete the last 2 characters and check the request sent you will notice it correctly has `message:tot` in the filters
