### PR TITLE
[8.7] Merge tags in recovered infra alert documents (#153677)

### DIFF
--- a/x-pack/plugins/rule_registry/server/utils/create_lifecycle_executor.test.ts
+++ b/x-pack/plugins/rule_registry/server/utils/create_lifecycle_executor.test.ts
@@ -24,6 +24,7 @@ import {
   EVENT_KIND,
   SPACE_IDS,
   ALERT_FLAPPING,
+  TAGS,
 } from '../../common/technical_rule_data_field_names';
 import { createRuleDataClientMock } from '../rule_data_client/rule_data_client.mock';
 import { createLifecycleExecutor } from './create_lifecycle_executor';
@@ -73,11 +74,11 @@ describe('createLifecycleExecutor', () => {
     )<{}, TestRuleState, never, never, never>(async ({ services, state }) => {
       services.alertWithLifecycle({
         id: 'TEST_ALERT_0',
-        fields: {},
+        fields: { [TAGS]: ['source-tag1', 'source-tag2'] },
       });
       services.alertWithLifecycle({
         id: 'TEST_ALERT_1',
-        fields: {},
+        fields: { [TAGS]: ['source-tag3', 'source-tag4'] },
       });
 
       return { state };
@@ -101,6 +102,7 @@ describe('createLifecycleExecutor', () => {
             [ALERT_STATUS]: ALERT_STATUS_ACTIVE,
             [EVENT_ACTION]: 'open',
             [EVENT_KIND]: 'signal',
+            [TAGS]: ['source-tag1', 'source-tag2', 'rule-tag1', 'rule-tag2'],
           }),
           { index: { _id: expect.any(String) } },
           expect.objectContaining({
@@ -108,6 +110,7 @@ describe('createLifecycleExecutor', () => {
             [ALERT_STATUS]: ALERT_STATUS_ACTIVE,
             [EVENT_ACTION]: 'open',
             [EVENT_KIND]: 'signal',
+            [TAGS]: ['source-tag3', 'source-tag4', 'rule-tag1', 'rule-tag2'],
           }),
         ],
       })
@@ -273,6 +276,7 @@ describe('createLifecycleExecutor', () => {
               [ALERT_STATUS]: ALERT_STATUS_ACTIVE,
               [SPACE_IDS]: ['fake-space-id'],
               labels: { LABEL_0_KEY: 'LABEL_0_VALUE' }, // this must show up in the written doc
+              [TAGS]: ['source-tag1', 'source-tag2'],
             },
           },
           {
@@ -289,6 +293,7 @@ describe('createLifecycleExecutor', () => {
               [ALERT_STATUS]: ALERT_STATUS_ACTIVE,
               [SPACE_IDS]: ['fake-space-id'],
               labels: { LABEL_0_KEY: 'LABEL_0_VALUE' }, // this must not show up in the written doc
+              [TAGS]: ['source-tag3', 'source-tag4'],
             },
           },
         ],
@@ -346,6 +351,7 @@ describe('createLifecycleExecutor', () => {
             [ALERT_INSTANCE_ID]: 'TEST_ALERT_0',
             [ALERT_STATUS]: ALERT_STATUS_RECOVERED,
             labels: { LABEL_0_KEY: 'LABEL_0_VALUE' },
+            [TAGS]: ['source-tag1', 'source-tag2', 'rule-tag1', 'rule-tag2'],
             [EVENT_ACTION]: 'close',
             [EVENT_KIND]: 'signal',
           }),
@@ -355,6 +361,7 @@ describe('createLifecycleExecutor', () => {
             [ALERT_STATUS]: ALERT_STATUS_ACTIVE,
             [EVENT_ACTION]: 'active',
             [EVENT_KIND]: 'signal',
+            [TAGS]: ['source-tag3', 'source-tag4', 'rule-tag1', 'rule-tag2'],
           }),
         ]),
       })

--- a/x-pack/plugins/rule_registry/server/utils/create_lifecycle_executor.ts
+++ b/x-pack/plugins/rule_registry/server/utils/create_lifecycle_executor.ts
@@ -308,7 +308,11 @@ export const createLifecycleExecutor =
           [EVENT_KIND]: 'signal',
           [EVENT_ACTION]: isNew ? 'open' : isActive ? 'active' : 'close',
           [TAGS]: Array.from(
-            new Set([...(currentAlertData?.tags ?? []), ...(options.rule.tags ?? [])])
+            new Set([
+              ...(currentAlertData?.tags ?? []),
+              ...(alertData?.fields[TAGS] ?? []),
+              ...(options.rule.tags ?? []),
+            ])
           ),
           [VERSION]: ruleDataClient.kibanaVersion,
           [ALERT_FLAPPING]: flapping,

--- a/x-pack/plugins/rule_registry/server/utils/rule_executor.test_helpers.ts
+++ b/x-pack/plugins/rule_registry/server/utils/rule_executor.test_helpers.ts
@@ -54,7 +54,7 @@ export const createDefaultAlertExecutorOptions = <
   rule: {
     id: alertId,
     updatedBy: null,
-    tags: [],
+    tags: ['rule-tag1', 'rule-tag2'],
     name: ruleName,
     createdBy: 'CREATED_BY',
     actions: [],


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.7`:
 - [Merge tags in recovered infra alert documents (#153677)](https://github.com/elastic/kibana/pull/153677)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Bena Kansara","email":"69037875+benakansara@users.noreply.github.com"},"sourceCommit":{"committedDate":"2023-03-27T13:32:10Z","message":"Merge tags in recovered infra alert documents (#153677)\n\nPart of https://github.com/elastic/kibana/issues/150110 \r\n\r\nThe `tags` field of 'recovered' alert document should contain tags\r\ncoming from source as well as tags defined in the rule.\r\n\r\n**Rules in Scope:**\r\n- Inventory rule\r\n- Metric threshold rule\r\n\r\n### Manual Testing\r\n1. Create Inventory rule and Metric threshold rule\r\n2. Wait for alerts to trigger and then recover\r\n3. Check the alert documents in AAD after recovery\r\n4. Notice the `tags` array contains source tags and rule tags\r\n\r\n### Checklist\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"b616950d0755753442c8e5dad91829b56e06059b","branchLabelMapping":{"^v8.8.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["backport","release_note:skip","Team: Actionable Observability","v8.8.0"],"number":153677,"url":"https://github.com/elastic/kibana/pull/153677","mergeCommit":{"message":"Merge tags in recovered infra alert documents (#153677)\n\nPart of https://github.com/elastic/kibana/issues/150110 \r\n\r\nThe `tags` field of 'recovered' alert document should contain tags\r\ncoming from source as well as tags defined in the rule.\r\n\r\n**Rules in Scope:**\r\n- Inventory rule\r\n- Metric threshold rule\r\n\r\n### Manual Testing\r\n1. Create Inventory rule and Metric threshold rule\r\n2. Wait for alerts to trigger and then recover\r\n3. Check the alert documents in AAD after recovery\r\n4. Notice the `tags` array contains source tags and rule tags\r\n\r\n### Checklist\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"b616950d0755753442c8e5dad91829b56e06059b"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.8.0","labelRegex":"^v8.8.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/153677","number":153677,"mergeCommit":{"message":"Merge tags in recovered infra alert documents (#153677)\n\nPart of https://github.com/elastic/kibana/issues/150110 \r\n\r\nThe `tags` field of 'recovered' alert document should contain tags\r\ncoming from source as well as tags defined in the rule.\r\n\r\n**Rules in Scope:**\r\n- Inventory rule\r\n- Metric threshold rule\r\n\r\n### Manual Testing\r\n1. Create Inventory rule and Metric threshold rule\r\n2. Wait for alerts to trigger and then recover\r\n3. Check the alert documents in AAD after recovery\r\n4. Notice the `tags` array contains source tags and rule tags\r\n\r\n### Checklist\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"b616950d0755753442c8e5dad91829b56e06059b"}}]}] BACKPORT-->