### PR TITLE
`features`: remove deprecated APIs

### DIFF
--- a/x-pack/plugins/features/server/mocks.ts
+++ b/x-pack/plugins/features/server/mocks.ts
@@ -13,8 +13,6 @@ import {
 
 const createSetup = (): jest.Mocked<PluginSetupContract> => {
   return {
-    getKibanaFeatures: jest.fn(),
-    getElasticsearchFeatures: jest.fn(),
     registerKibanaFeature: jest.fn(),
     registerElasticsearchFeature: jest.fn(),
     enableReportingUiCapabilities: jest.fn(),

--- a/x-pack/plugins/features/server/plugin.ts
+++ b/x-pack/plugins/features/server/plugin.ts
@@ -44,22 +44,6 @@ export interface PluginSetupContract {
   registerElasticsearchFeature(feature: ElasticsearchFeatureConfig): void;
 
   /**
-   * Calling this function during setup will crash Kibana.
-   * Use start contract instead.
-   * @deprecated
-   * @removeBy 8.8.0
-   */
-  getKibanaFeatures(): KibanaFeature[];
-
-  /**
-   * Calling this function during setup will crash Kibana.
-   * Use start contract instead.
-   * @deprecated
-   * @removeBy 8.8.0
-   */
-  getElasticsearchFeatures(): ElasticsearchFeature[];
-
-  /**
    * In the future, OSS features should register their own subfeature
    * privileges. This can be done when parts of Reporting are moved to
    * src/plugins. For now, this method exists for `reporting` to tell
@@ -113,10 +97,6 @@ export class FeaturesPlugin
     return deepFreeze({
       registerKibanaFeature: this.featureRegistry.registerKibanaFeature.bind(this.featureRegistry),
       registerElasticsearchFeature: this.featureRegistry.registerElasticsearchFeature.bind(
-        this.featureRegistry
-      ),
-      getKibanaFeatures: this.featureRegistry.getAllKibanaFeatures.bind(this.featureRegistry),
-      getElasticsearchFeatures: this.featureRegistry.getAllElasticsearchFeatures.bind(
         this.featureRegistry
       ),
       enableReportingUiCapabilities: this.enableReportingUiCapabilities.bind(this),

--- a/x-pack/plugins/spaces/server/lib/request_interceptors/on_post_auth_interceptor.test.ts
+++ b/x-pack/plugins/spaces/server/lib/request_interceptors/on_post_auth_interceptor.test.ts
@@ -69,7 +69,7 @@ describe.skip('onPostAuthInterceptor', () => {
 
     const loggingMock = loggingSystemMock.create().asLoggerFactory().get('xpack', 'spaces');
 
-    const featuresPlugin = featuresPluginMock.createSetup();
+    const featuresPlugin = featuresPluginMock.createStart();
     featuresPlugin.getKibanaFeatures.mockReturnValue([
       {
         id: 'feature-1',
@@ -152,7 +152,7 @@ describe.skip('onPostAuthInterceptor', () => {
     initSpacesOnPostAuthRequestInterceptor({
       http: http as unknown as CoreSetup['http'],
       log: loggingMock,
-      features: featuresPlugin,
+      getFeatureStartContract: () => featuresPlugin,
       getSpacesService: () => spacesServiceStart,
     });
 

--- a/x-pack/plugins/spaces/server/lib/request_interceptors/on_post_auth_interceptor.ts
+++ b/x-pack/plugins/spaces/server/lib/request_interceptors/on_post_auth_interceptor.ts
@@ -6,24 +6,24 @@
  */
 
 import type { CoreSetup, Logger } from '@kbn/core/server';
+import type { PluginStartContract as FeaturesStartContract } from '@kbn/features-plugin/server';
 
 import type { Space } from '../../../common';
 import { addSpaceIdToPath } from '../../../common';
 import { DEFAULT_SPACE_ID, ENTER_SPACE_PATH } from '../../../common/constants';
-import type { PluginsSetup } from '../../plugin';
 import type { SpacesServiceStart } from '../../spaces_service/spaces_service';
 import { wrapError } from '../errors';
 import { getSpaceSelectorUrl } from '../get_space_selector_url';
 
 export interface OnPostAuthInterceptorDeps {
   http: CoreSetup['http'];
-  features: PluginsSetup['features'];
+  getFeatureStartContract: () => FeaturesStartContract;
   getSpacesService: () => SpacesServiceStart;
   log: Logger;
 }
 
 export function initSpacesOnPostAuthRequestInterceptor({
-  features,
+  getFeatureStartContract,
   getSpacesService,
   log,
   http,
@@ -33,6 +33,7 @@ export function initSpacesOnPostAuthRequestInterceptor({
 
     const path = request.url.pathname;
 
+    const features = getFeatureStartContract();
     const spacesService = getSpacesService();
 
     const spaceId = spacesService.getSpaceId(request);

--- a/x-pack/plugins/spaces/server/lib/request_interceptors/on_post_auth_interceptor.ts
+++ b/x-pack/plugins/spaces/server/lib/request_interceptors/on_post_auth_interceptor.ts
@@ -6,18 +6,18 @@
  */
 
 import type { CoreSetup, Logger } from '@kbn/core/server';
-import type { PluginStartContract as FeaturesStartContract } from '@kbn/features-plugin/server';
 
 import type { Space } from '../../../common';
 import { addSpaceIdToPath } from '../../../common';
 import { DEFAULT_SPACE_ID, ENTER_SPACE_PATH } from '../../../common/constants';
+import type { PluginsStart } from '../../plugin';
 import type { SpacesServiceStart } from '../../spaces_service/spaces_service';
 import { wrapError } from '../errors';
 import { getSpaceSelectorUrl } from '../get_space_selector_url';
 
 export interface OnPostAuthInterceptorDeps {
   http: CoreSetup['http'];
-  getFeatureStartContract: () => FeaturesStartContract;
+  getFeatureStartContract: () => PluginsStart['features'];
   getSpacesService: () => SpacesServiceStart;
   log: Logger;
 }

--- a/x-pack/plugins/spaces/server/plugin.test.ts
+++ b/x-pack/plugins/spaces/server/plugin.test.ts
@@ -74,15 +74,16 @@ describe('Spaces plugin', () => {
     it('can start with all optional plugins disabled, exposing the expected contract', () => {
       const initializerContext = coreMock.createPluginInitializerContext({});
       const coreSetup = coreMock.createSetup() as CoreSetup<PluginsStart>;
-      const features = featuresPluginMock.createSetup();
+      const featuresSetup = featuresPluginMock.createSetup();
       const licensing = licensingMock.createSetup();
 
       const plugin = new SpacesPlugin(initializerContext);
-      plugin.setup(coreSetup, { features, licensing });
+      plugin.setup(coreSetup, { features: featuresSetup, licensing });
 
       const coreStart = coreMock.createStart();
+      const featuresStart = featuresPluginMock.createStart();
 
-      const spacesStart = plugin.start(coreStart);
+      const spacesStart = plugin.start(coreStart, { features: featuresStart });
       expect(spacesStart).toMatchInlineSnapshot(`
         Object {
           "spacesService": Object {

--- a/x-pack/plugins/spaces/server/usage_collection/spaces_usage_collector.test.ts
+++ b/x-pack/plugins/spaces/server/usage_collection/spaces_usage_collector.test.ts
@@ -12,7 +12,7 @@ import type { KibanaFeature } from '@kbn/features-plugin/server';
 import type { ILicense, LicensingPluginSetup } from '@kbn/licensing-plugin/server';
 import { createCollectorFetchContextMock } from '@kbn/usage-collection-plugin/server/mocks';
 
-import type { PluginsSetup } from '../plugin';
+import type { PluginsStart } from '../plugin';
 import type { UsageStats } from '../usage_stats';
 import { usageStatsClientMock } from '../usage_stats/usage_stats_client.mock';
 import { usageStatsServiceMock } from '../usage_stats/usage_stats_service.mock';
@@ -65,7 +65,7 @@ function setup({
 
   const featuresSetup = {
     getKibanaFeatures: jest.fn().mockReturnValue(features),
-  } as unknown as PluginsSetup['features'];
+  } as unknown as PluginsStart['features'];
 
   const usageStatsClient = usageStatsClientMock.create();
   usageStatsClient.getUsageStats.mockResolvedValue(MOCK_USAGE_STATS);
@@ -119,7 +119,7 @@ describe('error handling', () => {
     });
     const collector = getSpacesUsageCollector(usageCollection as any, {
       kibanaIndex,
-      features,
+      getFeatureStartContract: () => features,
       licensing,
       usageStatsServicePromise: Promise.resolve(usageStatsService),
     });
@@ -143,7 +143,7 @@ describe('with a basic license', () => {
   beforeAll(async () => {
     const collector = getSpacesUsageCollector(usageCollection as any, {
       kibanaIndex,
-      features,
+      getFeatureStartContract: () => features,
       licensing,
       usageStatsServicePromise: Promise.resolve(usageStatsService),
     });
@@ -202,7 +202,7 @@ describe('with no license', () => {
   beforeAll(async () => {
     const collector = getSpacesUsageCollector(usageCollection as any, {
       kibanaIndex,
-      features,
+      getFeatureStartContract: () => features,
       licensing,
       usageStatsServicePromise: Promise.resolve(usageStatsService),
     });
@@ -243,7 +243,7 @@ describe('with platinum license', () => {
   beforeAll(async () => {
     const collector = getSpacesUsageCollector(usageCollection as any, {
       kibanaIndex,
-      features,
+      getFeatureStartContract: () => features,
       licensing,
       usageStatsServicePromise: Promise.resolve(usageStatsService),
     });

--- a/x-pack/plugins/spaces/server/usage_collection/spaces_usage_collector.ts
+++ b/x-pack/plugins/spaces/server/usage_collection/spaces_usage_collector.ts
@@ -13,7 +13,7 @@ import type {
   UsageCollectionSetup,
 } from '@kbn/usage-collection-plugin/server';
 
-import type { PluginsSetup } from '../plugin';
+import type { PluginsSetup, PluginsStart } from '../plugin';
 import type { UsageStats, UsageStatsServiceSetup } from '../usage_stats';
 
 interface SpacesAggregationResponse {
@@ -38,7 +38,7 @@ interface SpacesAggregationResponse {
 async function getSpacesUsage(
   esClient: ElasticsearchClient,
   kibanaIndex: string,
-  features: PluginsSetup['features'],
+  features: PluginsStart['features'],
   spacesAvailable: boolean
 ) {
   if (!spacesAvailable) {
@@ -150,7 +150,7 @@ export interface UsageData extends UsageStats {
 
 interface CollectorDeps {
   kibanaIndex: string;
-  features: PluginsSetup['features'];
+  getFeatureStartContract: () => PluginsStart['features'];
   licensing: PluginsSetup['licensing'];
   usageStatsServicePromise: Promise<UsageStatsServiceSetup>;
 }
@@ -425,7 +425,8 @@ export function getSpacesUsageCollector(
       },
     },
     fetch: async ({ esClient }: CollectorFetchContext) => {
-      const { licensing, kibanaIndex, features, usageStatsServicePromise } = deps;
+      const { licensing, kibanaIndex, getFeatureStartContract, usageStatsServicePromise } = deps;
+      const features = getFeatureStartContract();
       const license = await firstValueFrom(licensing.license$);
       const available = license.isAvailable; // some form of spaces is available for all valid licenses
 


### PR DESCRIPTION
## Summary

Remove deprecated APIs that were flagged for removal for `8.8.0` from the `features` plugin's setup contract, and adapt remaining usages accordingly.