### PR TITLE
[Cases] Display total next to files tab in case detail view

### DIFF
--- a/x-pack/plugins/cases/public/components/case_view/case_view_tabs.test.tsx
+++ b/x-pack/plugins/cases/public/components/case_view/case_view_tabs.test.tsx
@@ -8,23 +8,28 @@
 import React from 'react';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+
 import type { AppMockRenderer } from '../../common/mock';
-import { createAppMockRenderer } from '../../common/mock';
-import '../../common/mock/match_media';
-import { useCaseViewNavigation } from '../../common/navigation/hooks';
 import type { UseGetCase } from '../../containers/use_get_case';
+import type { CaseViewTabsProps } from './case_view_tabs';
+
+import { CASE_VIEW_PAGE_TABS } from '../../../common/types';
+import '../../common/mock/match_media';
+import { createAppMockRenderer } from '../../common/mock';
+import { useCaseViewNavigation } from '../../common/navigation/hooks';
 import { useGetCase } from '../../containers/use_get_case';
 import { CaseViewTabs } from './case_view_tabs';
 import { caseData, defaultGetCase } from './mocks';
-import type { CaseViewTabsProps } from './case_view_tabs';
-import { CASE_VIEW_PAGE_TABS } from '../../../common/types';
+import { useGetCaseFileStats } from '../../containers/use_get_case_file_stats';
 
 jest.mock('../../containers/use_get_case');
 jest.mock('../../common/navigation/hooks');
 jest.mock('../../common/hooks');
+jest.mock('../../containers/use_get_case_file_stats');
 
 const useFetchCaseMock = useGetCase as jest.Mock;
 const useCaseViewNavigationMock = useCaseViewNavigation as jest.Mock;
+const useGetCaseFileStatsMock = useGetCaseFileStats as jest.Mock;
 
 const mockGetCase = (props: Partial<UseGetCase> = {}) => {
   const data = {
@@ -45,6 +50,9 @@ export const caseProps: CaseViewTabsProps = {
 
 describe('CaseViewTabs', () => {
   let appMockRenderer: AppMockRenderer;
+  const data = { total: 3 };
+
+  useGetCaseFileStatsMock.mockReturnValue({ data });
 
   beforeEach(() => {
     mockGetCase();
@@ -89,6 +97,14 @@ describe('CaseViewTabs', () => {
     expect(await screen.findByTestId('case-view-tab-title-files')).toHaveAttribute(
       'aria-selected',
       'true'
+    );
+  });
+
+  it('shows the files tab count correctly', async () => {
+    appMockRenderer.render(<CaseViewTabs {...caseProps} activeTab={CASE_VIEW_PAGE_TABS.FILES} />);
+
+    expect(await screen.findByTestId('case-view-files-stats-badge')).toHaveTextContent(
+      `${data.total}`
     );
   });
 

--- a/x-pack/plugins/cases/public/components/case_view/case_view_tabs.test.tsx
+++ b/x-pack/plugins/cases/public/components/case_view/case_view_tabs.test.tsx
@@ -103,35 +103,17 @@ describe('CaseViewTabs', () => {
   it('shows the files tab with the correct count and colour', async () => {
     appMockRenderer.render(<CaseViewTabs {...caseProps} activeTab={CASE_VIEW_PAGE_TABS.FILES} />);
 
-    expect(await screen.findByTestId('case-view-files-stats-badge')).toMatchInlineSnapshot(`
-    .c0 {
-      margin-left: 5px;
-    }
-
-    <span
-      class="euiNotificationBadge c0 emotion-euiNotificationBadge-s-accent"
-      data-test-subj="case-view-files-stats-badge"
-    >
-      3
-    </span>
-  `);
+    expect(
+      (await screen.findByTestId('case-view-files-stats-badge')).getAttribute('class')
+    ).toMatch(/accent/);
   });
 
   it('the files tab count has a different colour if the tab is not active', async () => {
     appMockRenderer.render(<CaseViewTabs {...caseProps} activeTab={CASE_VIEW_PAGE_TABS.ALERTS} />);
 
-    expect(await screen.findByTestId('case-view-files-stats-badge')).toMatchInlineSnapshot(`
-      .c0 {
-        margin-left: 5px;
-      }
-
-      <span
-        class="euiNotificationBadge c0 emotion-euiNotificationBadge-s-subdued"
-        data-test-subj="case-view-files-stats-badge"
-      >
-        3
-      </span>
-    `);
+    expect(
+      (await screen.findByTestId('case-view-files-stats-badge')).getAttribute('class')
+    ).not.toMatch(/accent/);
   });
 
   it('navigates to the activity tab when the activity tab is clicked', async () => {

--- a/x-pack/plugins/cases/public/components/case_view/case_view_tabs.test.tsx
+++ b/x-pack/plugins/cases/public/components/case_view/case_view_tabs.test.tsx
@@ -100,12 +100,38 @@ describe('CaseViewTabs', () => {
     );
   });
 
-  it('shows the files tab count correctly', async () => {
+  it('shows the files tab with the correct count and colour', async () => {
     appMockRenderer.render(<CaseViewTabs {...caseProps} activeTab={CASE_VIEW_PAGE_TABS.FILES} />);
 
-    expect(await screen.findByTestId('case-view-files-stats-badge')).toHaveTextContent(
-      `${data.total}`
-    );
+    expect(await screen.findByTestId('case-view-files-stats-badge')).toMatchInlineSnapshot(`
+    .c0 {
+      margin-left: 5px;
+    }
+
+    <span
+      class="euiNotificationBadge c0 emotion-euiNotificationBadge-s-accent"
+      data-test-subj="case-view-files-stats-badge"
+    >
+      3
+    </span>
+  `);
+  });
+
+  it('the files tab count has a different colour if the tab is not active', async () => {
+    appMockRenderer.render(<CaseViewTabs {...caseProps} activeTab={CASE_VIEW_PAGE_TABS.ALERTS} />);
+
+    expect(await screen.findByTestId('case-view-files-stats-badge')).toMatchInlineSnapshot(`
+      .c0 {
+        margin-left: 5px;
+      }
+
+      <span
+        class="euiNotificationBadge c0 emotion-euiNotificationBadge-s-subdued"
+        data-test-subj="case-view-files-stats-badge"
+      >
+        3
+      </span>
+    `);
   });
 
   it('navigates to the activity tab when the activity tab is clicked', async () => {

--- a/x-pack/plugins/cases/public/components/case_view/case_view_tabs.tsx
+++ b/x-pack/plugins/cases/public/components/case_view/case_view_tabs.tsx
@@ -20,6 +20,34 @@ const ExperimentalBadge = styled(EuiBetaBadge)`
   margin-left: 5px;
 `;
 
+const StyledNotificationBadge = styled(EuiNotificationBadge)`
+  margin-left: 5px;
+`;
+
+const FilesTab = ({
+  activeTab,
+  fileStatsData,
+  isLoading,
+}: {
+  activeTab: string;
+  fileStatsData: { total: number } | undefined;
+  isLoading: boolean;
+}) => (
+  <>
+    {FILES_TAB}
+    {!isLoading && fileStatsData && (
+      <StyledNotificationBadge
+        data-test-subj="case-view-files-stats-badge"
+        color={activeTab === CASE_VIEW_PAGE_TABS.FILES ? 'accent' : 'subdued'}
+      >
+        {fileStatsData.total > 0 ? fileStatsData.total : 0}
+      </StyledNotificationBadge>
+    )}
+  </>
+);
+
+FilesTab.displayName = 'FilesTab';
+
 export interface CaseViewTabsProps {
   caseData: Case;
   activeTab: CASE_VIEW_PAGE_TABS;
@@ -61,21 +89,11 @@ export const CaseViewTabs = React.memo<CaseViewTabsProps>(({ caseData, activeTab
       {
         id: CASE_VIEW_PAGE_TABS.FILES,
         name: (
-          <>
-            {FILES_TAB}
-            {!isLoading && fileStatsData && (
-              <>
-                {' '}
-                <EuiNotificationBadge data-test-subj="case-view-files-stats-badge">
-                  {fileStatsData.total}
-                </EuiNotificationBadge>
-              </>
-            )}
-          </>
+          <FilesTab isLoading={isLoading} fileStatsData={fileStatsData} activeTab={activeTab} />
         ),
       },
     ],
-    [features.alerts.enabled, features.alerts.isExperimental, fileStatsData, isLoading]
+    [activeTab, features.alerts.enabled, features.alerts.isExperimental, fileStatsData, isLoading]
   );
 
   const renderTabs = useCallback(() => {

--- a/x-pack/plugins/cases/public/components/case_view/case_view_tabs.tsx
+++ b/x-pack/plugins/cases/public/components/case_view/case_view_tabs.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EuiBetaBadge, EuiSpacer, EuiTab, EuiTabs } from '@elastic/eui';
+import { EuiBetaBadge, EuiNotificationBadge, EuiSpacer, EuiTab, EuiTabs } from '@elastic/eui';
 import React, { useCallback, useMemo } from 'react';
 import styled from 'styled-components';
 import { CASE_VIEW_PAGE_TABS } from '../../../common/types';
@@ -14,6 +14,7 @@ import { useCasesContext } from '../cases_context/use_cases_context';
 import { EXPERIMENTAL_DESC, EXPERIMENTAL_LABEL } from '../header_page/translations';
 import { ACTIVITY_TAB, ALERTS_TAB, FILES_TAB } from './translations';
 import type { Case } from '../../../common';
+import { useGetCaseFileStats } from '../../containers/use_get_case_file_stats';
 
 const ExperimentalBadge = styled(EuiBetaBadge)`
   margin-left: 5px;
@@ -27,6 +28,7 @@ export interface CaseViewTabsProps {
 export const CaseViewTabs = React.memo<CaseViewTabsProps>(({ caseData, activeTab }) => {
   const { features } = useCasesContext();
   const { navigateToCaseView } = useCaseViewNavigation();
+  const { data: fileStatsData, isLoading } = useGetCaseFileStats({ caseId: caseData.id });
 
   const tabs = useMemo(
     () => [
@@ -58,10 +60,22 @@ export const CaseViewTabs = React.memo<CaseViewTabsProps>(({ caseData, activeTab
         : []),
       {
         id: CASE_VIEW_PAGE_TABS.FILES,
-        name: FILES_TAB,
+        name: (
+          <>
+            {FILES_TAB}
+            {!isLoading && fileStatsData && (
+              <>
+                {' '}
+                <EuiNotificationBadge data-test-subj="case-view-files-stats-badge">
+                  {fileStatsData.total}
+                </EuiNotificationBadge>
+              </>
+            )}
+          </>
+        ),
       },
     ],
-    [features.alerts.enabled, features.alerts.isExperimental]
+    [features.alerts.enabled, features.alerts.isExperimental, fileStatsData, isLoading]
   );
 
   const renderTabs = useCallback(() => {

--- a/x-pack/plugins/cases/public/components/files/add_file.test.tsx
+++ b/x-pack/plugins/cases/public/components/files/add_file.test.tsx
@@ -108,9 +108,19 @@ describe('AddFile', () => {
     expect(await screen.findByTestId('cases-files-add')).toBeInTheDocument();
   });
 
-  it('add button disable if user has no creat permission', async () => {
+  it('AddFile is disabled if user has no create permission', async () => {
     appMockRender = createAppMockRenderer({
       permissions: buildCasesPermissions({ create: false }),
+    });
+
+    appMockRender.render(<AddFile caseId={'foobar'} />);
+
+    expect(await screen.findByTestId('cases-files-add')).toBeDisabled();
+  });
+
+  it('AddFile is if user has no update permission', async () => {
+    appMockRender = createAppMockRenderer({
+      permissions: buildCasesPermissions({ update: false }),
     });
 
     appMockRender.render(<AddFile caseId={'foobar'} />);

--- a/x-pack/plugins/cases/public/components/files/add_file.tsx
+++ b/x-pack/plugins/cases/public/components/files/add_file.tsx
@@ -122,7 +122,7 @@ const AddFileComponent: React.FC<AddFileProps> = ({ caseId }) => {
       <EuiButton
         data-test-subj="cases-files-add"
         iconType="plusInCircle"
-        isDisabled={isLoading || !permissions.create}
+        isDisabled={isLoading || !permissions.create || !permissions.update}
         isLoading={isLoading}
         onClick={showModal}
       >

--- a/x-pack/plugins/cases/public/components/files/utils.test.tsx
+++ b/x-pack/plugins/cases/public/components/files/utils.test.tsx
@@ -7,20 +7,15 @@
 
 import { isImage, parseMimeType } from './utils';
 
-import type { FileJSON } from '@kbn/shared-ux-file-types';
 import { imageMimeTypes, textMimeTypes } from '../../../common/constants/mime_types';
 
 describe('isImage', () => {
   it('should return true for allowed image mime types', () => {
-    isImage({ mimeType: imageMimeTypes[0] } as FileJSON);
-
     // @ts-ignore
     expect(imageMimeTypes.reduce((acc, curr) => acc && isImage({ mimeType: curr }))).toBeTruthy();
   });
 
   it('should return false for allowed non-image mime types', () => {
-    isImage({ mimeType: imageMimeTypes[0] } as FileJSON);
-
     // @ts-ignore
     expect(textMimeTypes.reduce((acc, curr) => acc && isImage({ mimeType: curr }))).toBeFalsy();
   });

--- a/x-pack/plugins/cases/public/containers/constants.ts
+++ b/x-pack/plugins/cases/public/containers/constants.ts
@@ -25,6 +25,7 @@ export const casesQueriesKeys = {
   case: (id: string) => [...casesQueriesKeys.caseView(), id] as const,
   caseFiles: (id: string, params: unknown) =>
     [...casesQueriesKeys.case(id), 'attachments', params] as const,
+  caseFileStats: (id: string) => [...casesQueriesKeys.case(id), 'stats'] as const,
   caseMetrics: (id: string, features: SingleCaseMetricsFeature[]) =>
     [...casesQueriesKeys.case(id), 'metrics', features] as const,
   caseConnectors: (id: string) => [...casesQueriesKeys.case(id), 'connectors'],

--- a/x-pack/plugins/cases/public/containers/constants.ts
+++ b/x-pack/plugins/cases/public/containers/constants.ts
@@ -24,8 +24,8 @@ export const casesQueriesKeys = {
   caseView: () => [...casesQueriesKeys.all, 'case'] as const,
   case: (id: string) => [...casesQueriesKeys.caseView(), id] as const,
   caseFiles: (id: string, params: unknown) =>
-    [...casesQueriesKeys.case(id), 'attachments', params] as const,
-  caseFileStats: (id: string) => [...casesQueriesKeys.case(id), 'stats'] as const,
+    [...casesQueriesKeys.case(id), 'files', params] as const,
+  caseFileStats: (id: string) => [...casesQueriesKeys.case(id), 'files', 'stats'] as const,
   caseMetrics: (id: string, features: SingleCaseMetricsFeature[]) =>
     [...casesQueriesKeys.case(id), 'metrics', features] as const,
   caseConnectors: (id: string) => [...casesQueriesKeys.case(id), 'connectors'],

--- a/x-pack/plugins/cases/public/containers/use_get_case_file_stats.test.tsx
+++ b/x-pack/plugins/cases/public/containers/use_get_case_file_stats.test.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook } from '@testing-library/react-hooks';
+
+import { basicCase } from './mock';
+
+import type { AppMockRenderer } from '../common/mock';
+import { mockedTestProvidersOwner, mockedFilesClient, createAppMockRenderer } from '../common/mock';
+import { useToasts } from '../common/lib/kibana';
+import { useGetCaseFileStats } from './use_get_case_file_stats';
+import { constructFileKindIdByOwner } from '../../common/constants/files';
+
+jest.mock('../common/lib/kibana');
+
+const hookParams = {
+  caseId: basicCase.id,
+};
+
+const expectedCallParams = {
+  kind: constructFileKindIdByOwner(mockedTestProvidersOwner[0]),
+  page: 1,
+  perPage: 1,
+  meta: hookParams,
+};
+
+describe('useGetCaseFileStats', () => {
+  let appMockRender: AppMockRenderer;
+
+  beforeEach(() => {
+    appMockRender = createAppMockRenderer();
+    jest.clearAllMocks();
+  });
+
+  it('calls filesClient.list with correct arguments', async () => {
+    const { waitForNextUpdate } = renderHook(() => useGetCaseFileStats(hookParams), {
+      wrapper: appMockRender.AppWrapper,
+    });
+    await waitForNextUpdate();
+
+    expect(mockedFilesClient.list).toHaveBeenCalledWith(expectedCallParams);
+  });
+
+  it('shows an error toast when filesClient.list throws', async () => {
+    const addError = jest.fn();
+    (useToasts as jest.Mock).mockReturnValue({ addError });
+
+    mockedFilesClient.list = jest.fn().mockImplementation(() => {
+      throw new Error('Something went wrong');
+    });
+
+    const { waitForNextUpdate } = renderHook(() => useGetCaseFileStats(hookParams), {
+      wrapper: appMockRender.AppWrapper,
+    });
+    await waitForNextUpdate();
+
+    expect(mockedFilesClient.list).toHaveBeenCalledWith(expectedCallParams);
+    expect(addError).toHaveBeenCalled();
+  });
+});

--- a/x-pack/plugins/cases/public/containers/use_get_case_file_stats.tsx
+++ b/x-pack/plugins/cases/public/containers/use_get_case_file_stats.tsx
@@ -7,6 +7,8 @@
 
 import type { UseQueryResult } from '@tanstack/react-query';
 
+import type { FileJSON } from '@kbn/shared-ux-file-types';
+
 import { useFilesContext } from '@kbn/shared-ux-file-context';
 import { useQuery } from '@tanstack/react-query';
 
@@ -18,6 +20,10 @@ import { useCasesToast } from '../common/use_cases_toast';
 import { useCasesContext } from '../components/cases_context/use_cases_context';
 import { casesQueriesKeys } from './constants';
 import * as i18n from './translations';
+
+const getTotalFromFileList = (data: { files: FileJSON[]; total: number }): { total: number } => ({
+  total: data.total,
+});
 
 export interface GetCaseFileStatsParams {
   caseId: string;
@@ -41,6 +47,7 @@ export const useGetCaseFileStats = ({
       });
     },
     {
+      select: getTotalFromFileList,
       keepPreviousData: true,
       onError: (error: ServerError) => {
         showErrorToast(error, { title: i18n.ERROR_TITLE });

--- a/x-pack/plugins/cases/public/containers/use_get_case_file_stats.tsx
+++ b/x-pack/plugins/cases/public/containers/use_get_case_file_stats.tsx
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { UseQueryResult } from '@tanstack/react-query';
+
+import { useFilesContext } from '@kbn/shared-ux-file-context';
+import { useQuery } from '@tanstack/react-query';
+
+import type { Owner } from '../../common/constants/types';
+import type { ServerError } from '../types';
+
+import { constructFileKindIdByOwner } from '../../common/constants';
+import { useCasesToast } from '../common/use_cases_toast';
+import { useCasesContext } from '../components/cases_context/use_cases_context';
+import { casesQueriesKeys } from './constants';
+import * as i18n from './translations';
+
+export interface GetCaseFileStatsParams {
+  caseId: string;
+}
+
+export const useGetCaseFileStats = ({
+  caseId,
+}: GetCaseFileStatsParams): UseQueryResult<{ total: number }> => {
+  const { owner } = useCasesContext();
+  const { showErrorToast } = useCasesToast();
+  const { client: filesClient } = useFilesContext();
+
+  return useQuery(
+    casesQueriesKeys.caseFileStats(caseId),
+    () => {
+      return filesClient.list({
+        kind: constructFileKindIdByOwner(owner[0] as Owner),
+        page: 1,
+        perPage: 1,
+        meta: { caseId },
+      });
+    },
+    {
+      keepPreviousData: true,
+      onError: (error: ServerError) => {
+        showErrorToast(error, { title: i18n.ERROR_TITLE });
+      },
+    }
+  );
+};


### PR DESCRIPTION
**Merging to a feature branch**

## Summary

In this PR we display the number of files attached to a case in the Files tab in the case detail view.

https://user-images.githubusercontent.com/1533137/228211345-58ff8c16-7201-4192-9e2e-f8c854b47da9.mov
