### PR TITLE
[Profiling] Functions improvements

### DIFF
--- a/x-pack/plugins/profiling/public/components/functions_view/index.tsx
+++ b/x-pack/plugins/profiling/public/components/functions_view/index.tsx
@@ -114,11 +114,11 @@ export function FunctionsView({ children }: { children: React.ReactElement }) {
     <ProfilingAppPageTemplate tabs={tabs} hideSearchBar={isDifferentialView}>
       <>
         <EuiFlexGroup direction="column">
-          {isDifferentialView ? (
+          {isDifferentialView && (
             <EuiFlexItem grow={false}>
               <PrimaryAndComparisonSearchBar />
             </EuiFlexItem>
-          ) : null}
+          )}
           <EuiFlexItem>
             <EuiFlexGroup direction="row" gutterSize="s">
               <EuiFlexItem>

--- a/x-pack/plugins/profiling/public/components/topn_functions/get_label.tsx
+++ b/x-pack/plugins/profiling/public/components/topn_functions/get_label.tsx
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { EuiIcon, EuiTextColor } from '@elastic/eui';
+import React from 'react';
+import { getColorLabel } from './utils';
+
+interface Props {
+  value: number;
+  append?: string;
+  prepend?: string;
+}
+
+export function GetLabel({ value, prepend, append }: Props) {
+  const { label, color, icon } = getColorLabel(value);
+  return (
+    <EuiTextColor color={color}>
+      {prepend}
+      {icon && <EuiIcon type={icon} size="s" color={color} />}
+      {label}
+      {append}
+    </EuiTextColor>
+  );
+}

--- a/x-pack/plugins/profiling/public/components/topn_functions/utils.test.ts
+++ b/x-pack/plugins/profiling/public/components/topn_functions/utils.test.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { getColorLabel } from './utils';
+
+describe('Top N functions: Utils', () => {
+  describe('getColorLabel', () => {
+    it('returns correct value when percentage is lower than 0', () => {
+      expect(getColorLabel(-10)).toEqual({
+        color: 'success',
+        label: '10.00%',
+        icon: 'sortDown',
+      });
+    });
+
+    it('returns correct value when percentage is 0', () => {
+      expect(getColorLabel(0)).toEqual({
+        color: 'danger',
+        label: '<0.01',
+        icon: undefined,
+      });
+    });
+
+    it('returns correct value when percentage is greater than  0', () => {
+      expect(getColorLabel(10)).toEqual({
+        color: 'danger',
+        label: '10.00%',
+        icon: 'sortUp',
+      });
+    });
+  });
+});

--- a/x-pack/plugins/profiling/public/components/topn_functions/utils.ts
+++ b/x-pack/plugins/profiling/public/components/topn_functions/utils.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+export function getColorLabel(percent: number) {
+  const color = percent < 0 ? 'success' : 'danger';
+  const icon = percent < 0 ? 'sortDown' : 'sortUp';
+  const isSmallPercent = Math.abs(percent) <= 0.01;
+  const label = isSmallPercent ? '<0.01' : Math.abs(percent).toFixed(2) + '%';
+
+  return { color, label, icon: isSmallPercent ? undefined : icon };
+}


### PR DESCRIPTION
Emphasis the `Total sample estimate` using the EuiStat component. 

Replace `-/+` signs by `up/down` arrows

<img width="2595" alt="Screenshot 2023-03-28 at 10 13 33 AM" src="https://user-images.githubusercontent.com/55978943/228269490-5f50c3bb-65ec-45cd-87af-17db0f1fe72e.png">
<img width="1450" alt="Screenshot 2023-03-28 at 10 21 12 AM" src="https://user-images.githubusercontent.com/55978943/228269494-af6e43ad-afbc-4939-80d6-0d6bce6c4a95.png">
