### PR TITLE
[Security Solution] fix flaky endpoint ftr tests

### DIFF
--- a/x-pack/plugins/security_solution/common/endpoint/data_loaders/setup_fleet_for_endpoint.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/data_loaders/setup_fleet_for_endpoint.ts
@@ -24,9 +24,7 @@ export interface SetupFleetForEndpointResponse {
  * Calls the fleet setup APIs and then installs the latest Endpoint package
  * @param kbnClient
  */
-export const setupFleetForEndpoint = async (
-  kbnClient: KbnClient
-): Promise<SetupFleetForEndpointResponse> => {
+export const setupFleetForEndpoint = async (kbnClient: KbnClient): Promise<void> => {
   // We try to use the kbnClient **private** logger, bug if unable to access it, then just use console
   // @ts-expect-error TS2341
   const log = kbnClient.log ? kbnClient.log : console;
@@ -66,18 +64,6 @@ export const setupFleetForEndpoint = async (
     log.error(error);
     throw error;
   }
-
-  // Install/upgrade the endpoint package
-  let endpointPackage: BulkInstallPackageInfo;
-
-  try {
-    endpointPackage = await installOrUpgradeEndpointFleetPackage(kbnClient);
-  } catch (error) {
-    log.error(error);
-    throw error;
-  }
-
-  return { endpointPackage };
 };
 
 /**

--- a/x-pack/plugins/security_solution/common/endpoint/index_data.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/index_data.ts
@@ -8,9 +8,7 @@
 import type { Client } from '@elastic/elasticsearch';
 import seedrandom from 'seedrandom';
 import type { KbnClient } from '@kbn/test';
-import type { AxiosResponse } from 'axios';
-import type { CreatePackagePolicyResponse, GetInfoResponse } from '@kbn/fleet-plugin/common';
-import { epmRouteService } from '@kbn/fleet-plugin/common';
+import type { CreatePackagePolicyResponse } from '@kbn/fleet-plugin/common';
 import type { TreeOptions } from './generate_data';
 import { EndpointDocGenerator } from './generate_data';
 import type {
@@ -25,6 +23,12 @@ import { enableFleetServerIfNecessary } from './data_loaders/index_fleet_server'
 import { indexAlerts } from './data_loaders/index_alerts';
 import { setupFleetForEndpoint } from './data_loaders/setup_fleet_for_endpoint';
 import { mergeAndAppendArrays } from './data_loaders/utils';
+import {
+  waitForMetadataTransformsReady,
+  stopMetadataTransforms,
+  startMetadataTransforms,
+} from './utils/transforms';
+import { getEndpointPackageInfo } from './utils/package';
 
 export type IndexedHostsAndAlertsResponse = IndexedHostsResponse;
 
@@ -58,7 +62,8 @@ export async function indexHostsAndAlerts(
   alertsPerHost: number,
   fleet: boolean,
   options: TreeOptions = {},
-  DocGenerator: typeof EndpointDocGenerator = EndpointDocGenerator
+  DocGenerator: typeof EndpointDocGenerator = EndpointDocGenerator,
+  startTransform = true
 ): Promise<IndexedHostsAndAlertsResponse> {
   const random = seedrandom(seed);
   const epmEndpointPackage = await getEndpointPackageInfo(kbnClient);
@@ -92,6 +97,9 @@ export async function indexHostsAndAlerts(
   // Keep a map of host applied policy ids (fake) to real ingest package configs (policy record)
   const realPolicies: Record<string, CreatePackagePolicyResponse['item']> = {};
 
+  await waitForMetadataTransformsReady(client);
+  await stopMetadataTransforms(client);
+
   for (let i = 0; i < numHosts; i++) {
     const generator = new DocGenerator(random);
     const indexedHosts = await indexEndpointHostDocs({
@@ -118,26 +126,15 @@ export async function indexHostsAndAlerts(
     });
   }
 
-  return response;
-}
-
-export const getEndpointPackageInfo = async (
-  kbnClient: KbnClient
-): Promise<GetInfoResponse['item']> => {
-  const path = epmRouteService.getInfoPath('endpoint');
-  const endpointPackage = (
-    (await kbnClient.request({
-      path,
-      method: 'GET',
-    })) as AxiosResponse<GetInfoResponse>
-  ).data.item;
-
-  if (!endpointPackage) {
-    throw new Error('EPM Endpoint package was not found!');
+  if (startTransform) {
+    await startMetadataTransforms(
+      client,
+      response.agents.map((agent) => agent.id)
+    );
   }
 
-  return endpointPackage;
-};
+  return response;
+}
 
 export type DeleteIndexedHostsAndAlertsResponse = DeleteIndexedEndpointHostsResponse;
 

--- a/x-pack/plugins/security_solution/common/endpoint/utils/package.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/utils/package.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { AxiosResponse } from 'axios';
+
+import type { KbnClient } from '@kbn/test';
+import type { GetInfoResponse } from '@kbn/fleet-plugin/common';
+import { epmRouteService } from '@kbn/fleet-plugin/common';
+
+export const getEndpointPackageInfo = async (
+  kbnClient: KbnClient
+): Promise<GetInfoResponse['item']> => {
+  const path = epmRouteService.getInfoPath('endpoint');
+  const endpointPackage = (
+    (await kbnClient.request({
+      path,
+      method: 'GET',
+    })) as AxiosResponse<GetInfoResponse>
+  ).data.item;
+
+  if (!endpointPackage) {
+    throw new Error('EPM Endpoint package was not found!');
+  }
+
+  return endpointPackage;
+};

--- a/x-pack/plugins/security_solution/common/endpoint/utils/transforms.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/utils/transforms.ts
@@ -1,0 +1,157 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Client } from '@elastic/elasticsearch';
+import type { TransformGetTransformStatsTransformStats } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+
+import {
+  metadataCurrentIndexPattern,
+  metadataTransformPrefix,
+  METADATA_TRANSFORMS_PATTERN,
+  METADATA_UNITED_TRANSFORM,
+} from '../constants';
+
+export async function waitForMetadataTransformsReady(esClient: Client): Promise<void> {
+  await waitFor(
+    () => areMetadataTransformsReady(esClient),
+    'failed while waiting for transform to start'
+  );
+}
+
+export async function stopMetadataTransforms(esClient: Client): Promise<void> {
+  const transformIds = await getMetadataTransformIds(esClient);
+
+  await Promise.all(
+    transformIds.map((transformId) =>
+      esClient.transform.stopTransform({
+        transform_id: transformId,
+        force: true,
+        wait_for_completion: true,
+        allow_no_match: true,
+      })
+    )
+  );
+}
+
+export async function startMetadataTransforms(
+  esClient: Client,
+  // agentIds to wait for
+  agentIds?: string[]
+): Promise<void> {
+  const transformIds = await getMetadataTransformIds(esClient);
+  const currentTransformId = transformIds.find((transformId) =>
+    transformId.startsWith(metadataTransformPrefix)
+  );
+  const unitedTransformId = transformIds.find((transformId) =>
+    transformId.startsWith(METADATA_UNITED_TRANSFORM)
+  );
+  if (!currentTransformId || !unitedTransformId) {
+    throw new Error('failed to start metadata transforms, transforms not found');
+  }
+
+  try {
+    await esClient.transform.startTransform({
+      transform_id: currentTransformId,
+    });
+  } catch (err) {
+    // ignore if transform already started
+    if (err.statusCode !== 409) {
+      throw err;
+    }
+  }
+
+  await waitForCurrentMetdataDocs(esClient, agentIds);
+
+  try {
+    await esClient.transform.startTransform({
+      transform_id: unitedTransformId,
+    });
+  } catch (err) {
+    // ignore if transform already started
+    if (err.statusCode !== 409) {
+      throw err;
+    }
+  }
+}
+
+async function getMetadataTransformStats(
+  esClient: Client
+): Promise<TransformGetTransformStatsTransformStats[]> {
+  return (
+    await esClient.transform.getTransformStats({
+      transform_id: METADATA_TRANSFORMS_PATTERN,
+      allow_no_match: true,
+    })
+  ).transforms;
+}
+
+async function getMetadataTransformIds(esClient: Client): Promise<string[]> {
+  return (await getMetadataTransformStats(esClient)).map((transform) => transform.id);
+}
+
+async function areMetadataTransformsReady(esClient: Client): Promise<boolean> {
+  const transforms = await getMetadataTransformStats(esClient);
+  return !transforms.some(
+    // TODO TransformGetTransformStatsTransformStats type needs to be updated to include health
+    (transform: TransformGetTransformStatsTransformStats & { health?: { status: string } }) =>
+      transform?.health?.status !== 'green'
+  );
+}
+
+async function waitForCurrentMetdataDocs(esClient: Client, agentIds?: string[]) {
+  const query = agentIds?.length
+    ? {
+        bool: {
+          filter: [
+            {
+              terms: {
+                'agent.id': agentIds,
+              },
+            },
+          ],
+        },
+      }
+    : {
+        size: 1,
+        query: {
+          match_all: {},
+        },
+      };
+  const size = agentIds?.length ? agentIds.length : 1;
+  await waitFor(
+    async () =>
+      (
+        await esClient.search({
+          index: metadataCurrentIndexPattern,
+          query,
+          size,
+          rest_total_hits_as_int: true,
+        })
+      ).hits.total === size,
+    'failed while waiting for current metadata docs to populate'
+  );
+}
+
+async function waitFor(
+  cb: () => Promise<boolean>,
+  errorMessage: string,
+  interval: number = 20000,
+  maxAttempts = 5
+): Promise<void> {
+  let attempts = 0;
+  let isReady = false;
+
+  while (!isReady) {
+    await new Promise((res) => setTimeout(() => res(''), interval));
+    isReady = await cb();
+    attempts++;
+
+    if (attempts > maxAttempts) {
+      throw new Error(errorMessage);
+    }
+  }
+}

--- a/x-pack/plugins/security_solution/public/management/cypress/tasks/index_endpoint_hosts.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/tasks/index_endpoint_hosts.ts
@@ -20,7 +20,7 @@ export const indexEndpointHosts = (
     count?: number;
   } = {}
 ): Cypress.Chainable<CyIndexEndpointHosts> => {
-  return cy.task('indexEndpointHosts', options).then((indexHosts) => {
+  return cy.task('indexEndpointHosts', options, { timeout: 120000 }).then((indexHosts) => {
     return {
       data: indexHosts,
       cleanup: () => {

--- a/x-pack/plugins/security_solution/scripts/endpoint/agent_emulator/services/endpoint_loader.ts
+++ b/x-pack/plugins/security_solution/scripts/endpoint/agent_emulator/services/endpoint_loader.ts
@@ -22,7 +22,7 @@ import { setupFleetForEndpoint } from '../../../../common/endpoint/data_loaders/
 import { enableFleetServerIfNecessary } from '../../../../common/endpoint/data_loaders/index_fleet_server';
 import { METADATA_DATASTREAM } from '../../../../common/endpoint/constants';
 import { EndpointMetadataGenerator } from '../../../../common/endpoint/data_generators/endpoint_metadata_generator';
-import { getEndpointPackageInfo } from '../../../../common/endpoint/index_data';
+import { getEndpointPackageInfo } from '../../../../common/endpoint/utils/package';
 import { ENDPOINT_ALERTS_INDEX, ENDPOINT_EVENTS_INDEX } from '../../common/constants';
 
 let WAS_FLEET_SETUP_DONE = false;

--- a/x-pack/plugins/security_solution/scripts/endpoint/common/random_policy_id_generator.ts
+++ b/x-pack/plugins/security_solution/scripts/endpoint/common/random_policy_id_generator.ts
@@ -15,6 +15,7 @@ import {
 import { indexFleetEndpointPolicy } from '../../../common/endpoint/data_loaders/index_fleet_endpoint_policy';
 import { setupFleetForEndpoint } from '../../../common/endpoint/data_loaders/setup_fleet_for_endpoint';
 import type { GetPolicyListResponse } from '../../../public/management/pages/policy/types';
+import { getEndpointPackageInfo } from '../../../common/endpoint/utils/package';
 
 const fetchEndpointPolicies = (
   kbnClient: KbnClient
@@ -35,7 +36,8 @@ export const randomPolicyIdGenerator: (
   log: ToolingLog
 ) => Promise<() => string> = async (kbn, log) => {
   log.info('Setting up fleet');
-  const fleetResponse = await setupFleetForEndpoint(kbn);
+  await setupFleetForEndpoint(kbn);
+  const endpointPackage = await getEndpointPackageInfo(kbn);
 
   log.info('Generarting test policies...');
   const randomN = (max: number): number => Math.floor(Math.random() * max);
@@ -50,7 +52,7 @@ export const randomPolicyIdGenerator: (
           await indexFleetEndpointPolicy(
             kbn,
             `Policy for exceptions assignment ${i + 1}`,
-            fleetResponse.endpointPackage.version
+            endpointPackage.version
           )
         ).integrationPolicies[0].id
       );

--- a/x-pack/plugins/security_solution/scripts/endpoint/endpoint_agent_runner/elastic_endpoint.ts
+++ b/x-pack/plugins/security_solution/scripts/endpoint/endpoint_agent_runner/elastic_endpoint.ts
@@ -15,7 +15,7 @@ import {
   type UpdatePackagePolicy,
 } from '@kbn/fleet-plugin/common';
 import chalk from 'chalk';
-import { getEndpointPackageInfo } from '../../../common/endpoint/index_data';
+import { getEndpointPackageInfo } from '../../../common/endpoint/utils/package';
 import { indexFleetEndpointPolicy } from '../../../common/endpoint/data_loaders/index_fleet_endpoint_policy';
 import {
   fetchAgentPolicyEnrollmentKey,

--- a/x-pack/plugins/security_solution/scripts/endpoint/endpoint_policies/index.ts
+++ b/x-pack/plugins/security_solution/scripts/endpoint/endpoint_policies/index.ts
@@ -11,6 +11,7 @@ import { KbnClient } from '@kbn/test';
 import { indexFleetEndpointPolicy } from '../../../common/endpoint/data_loaders/index_fleet_endpoint_policy';
 import { setupFleetForEndpoint } from '../../../common/endpoint/data_loaders/setup_fleet_for_endpoint';
 import { BaseDataGenerator } from '../../../common/endpoint/data_generators/base_data_generator';
+import { getEndpointPackageInfo } from '../../../common/endpoint/utils/package';
 
 class EndpointPolicyGenerator extends BaseDataGenerator {
   public policyName(preFix: string | number = '') {
@@ -30,7 +31,8 @@ export const cli = () => {
       log.info(`Creating ${count} endpoint policies...`);
 
       try {
-        const { endpointPackage } = await setupFleetForEndpoint(kbn);
+        await setupFleetForEndpoint(kbn);
+        const endpointPackage = await getEndpointPackageInfo(kbn);
 
         while (created < max) {
           created++;

--- a/x-pack/test/security_solution_endpoint/apps/endpoint/artifact_entries_list.ts
+++ b/x-pack/test/security_solution_endpoint/apps/endpoint/artifact_entries_list.ts
@@ -17,13 +17,11 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
   const testSubjects = getService('testSubjects');
   const browser = getService('browser');
   const endpointTestResources = getService('endpointTestResources');
-  const policyTestResources = getService('policyTestResources');
   const retry = getService('retry');
   const esClient = getService('es');
   const unzipPromisify = promisify(unzip);
 
-  // FLAKY: https://github.com/elastic/kibana/issues/153855
-  describe.skip('For each artifact list under management', function () {
+  describe('For each artifact list under management', function () {
     let indexedData: IndexedHostsAndAlertsResponse;
 
     const checkFleetArtifacts = async (
@@ -75,8 +73,6 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
     for (const testData of getArtifactsListTestsData()) {
       describe(`When on the ${testData.title} entries list`, function () {
         before(async () => {
-          const endpointPackage = await policyTestResources.getEndpointPackage();
-          await endpointTestResources.setMetadataTransformFrequency('1s', endpointPackage.version);
           indexedData = await endpointTestResources.loadEndpointData();
           await browser.refresh();
           await pageObjects.artifactEntriesList.navigateToList(testData.urlPath);

--- a/x-pack/test/security_solution_endpoint/apps/endpoint/endpoint_list.ts
+++ b/x-pack/test/security_solution_endpoint/apps/endpoint/endpoint_list.ts
@@ -81,8 +81,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
     return tableData;
   };
 
-  // FLAKY: https://github.com/elastic/kibana/issues/153855
-  describe.skip('endpoint list', function () {
+  describe('endpoint list', function () {
     const sleep = (ms = 100) => new Promise((resolve) => setTimeout(resolve, ms));
     let indexedData: IndexedHostsAndAlertsResponse;
     describe('when initially navigating to page', () => {

--- a/x-pack/test/security_solution_endpoint/apps/endpoint/endpoint_permissions.ts
+++ b/x-pack/test/security_solution_endpoint/apps/endpoint/endpoint_permissions.ts
@@ -18,16 +18,12 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
   const PageObjects = getPageObjects(['security', 'endpoint', 'detections', 'hosts']);
   const testSubjects = getService('testSubjects');
   const endpointTestResources = getService('endpointTestResources');
-  const policyTestResources = getService('policyTestResources');
 
-  // FLAKY: https://github.com/elastic/kibana/issues/153855
-  describe.skip('Endpoint permissions:', () => {
+  describe('Endpoint permissions:', () => {
     let indexedData: IndexedHostsAndAlertsResponse;
 
     before(async () => {
       // todo: way to force an endpoint to be created in isolated mode so we can check that state in the UI
-      const endpointPackage = await policyTestResources.getEndpointPackage();
-      await endpointTestResources.setMetadataTransformFrequency('1s', endpointPackage.version);
       indexedData = await endpointTestResources.loadEndpointData();
 
       // Force a logout so that we start from the login page

--- a/x-pack/test/security_solution_endpoint/apps/endpoint/endpoint_solution_integrations.ts
+++ b/x-pack/test/security_solution_endpoint/apps/endpoint/endpoint_solution_integrations.ts
@@ -24,8 +24,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
   const testSubjects = getService('testSubjects');
   const pageObjects = getPageObjects(['common', 'timeline']);
 
-  // FLAKY: https://github.com/elastic/kibana/issues/153855
-  describe.skip('App level Endpoint functionality', () => {
+  describe('App level Endpoint functionality', () => {
     let indexedData: IndexedHostsAndAlertsResponse;
     let indexedAlerts: IndexedEndpointRuleAlerts;
     let endpointAgentId: string;

--- a/x-pack/test/security_solution_endpoint/apps/endpoint/policy_details.ts
+++ b/x-pack/test/security_solution_endpoint/apps/endpoint/policy_details.ts
@@ -25,8 +25,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const policyTestResources = getService('policyTestResources');
   const endpointTestResources = getService('endpointTestResources');
 
-  // FLAKY: https://github.com/elastic/kibana/issues/153855
-  describe.skip('When on the Endpoint Policy Details Page', function () {
+  describe('When on the Endpoint Policy Details Page', function () {
     let indexedData: IndexedHostsAndAlertsResponse;
 
     before(async () => {

--- a/x-pack/test/security_solution_endpoint/apps/endpoint/policy_list.ts
+++ b/x-pack/test/security_solution_endpoint/apps/endpoint/policy_list.ts
@@ -26,8 +26,6 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
   describe('When on the Endpoint Policy List Page', () => {
     before(async () => {
-      const endpointPackage = await policyTestResources.getEndpointPackage();
-      await endpointTestResources.setMetadataTransformFrequency('1s', endpointPackage.version);
       await browser.refresh();
     });
 

--- a/x-pack/test/security_solution_endpoint/apps/endpoint/responder.ts
+++ b/x-pack/test/security_solution_endpoint/apps/endpoint/responder.ts
@@ -81,8 +81,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
     );
   };
 
-  // FLAKY: https://github.com/elastic/kibana/issues/153855
-  describe.skip('Response Actions Responder', function () {
+  describe('Response Actions Responder', function () {
     let indexedData: IndexedHostsAndAlertsResponse;
     let endpointAgentId: string;
 

--- a/x-pack/test/security_solution_endpoint/apps/endpoint/trusted_apps_list.ts
+++ b/x-pack/test/security_solution_endpoint/apps/endpoint/trusted_apps_list.ts
@@ -14,14 +14,10 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
   const testSubjects = getService('testSubjects');
   const browser = getService('browser');
   const endpointTestResources = getService('endpointTestResources');
-  const policyTestResources = getService('policyTestResources');
 
-  // FLAKY: https://github.com/elastic/kibana/issues/153855
-  describe.skip('When on the Trusted Apps list', function () {
+  describe('When on the Trusted Apps list', function () {
     let indexedData: IndexedHostsAndAlertsResponse;
     before(async () => {
-      const endpointPackage = await policyTestResources.getEndpointPackage();
-      await endpointTestResources.setMetadataTransformFrequency('1s', endpointPackage.version);
       indexedData = await endpointTestResources.loadEndpointData();
       await browser.refresh();
       await pageObjects.trustedApps.navigateToTrustedAppsList();

--- a/x-pack/test/security_solution_endpoint_api_int/apis/endpoint_authz.ts
+++ b/x-pack/test/security_solution_endpoint_api_int/apis/endpoint_authz.ts
@@ -38,8 +38,7 @@ export default function ({ getService }: FtrProviderContext) {
     body: Record<string, unknown> | undefined;
   }
 
-  // FLAKY: https://github.com/elastic/kibana/issues/153855
-  describe.skip('When attempting to call an endpoint api', () => {
+  describe('When attempting to call an endpoint api', () => {
     let indexedData: IndexedHostsAndAlertsResponse;
     let actionId = '';
     let agentId = '';
@@ -150,8 +149,8 @@ export default function ({ getService }: FtrProviderContext) {
       actionId = indexedData.actions[0].action_id;
     });
 
-    after(() => {
-      endpointTestResources.unloadEndpointData(indexedData);
+    after(async () => {
+      await endpointTestResources.unloadEndpointData(indexedData);
     });
 
     describe('with minimal_all', () => {

--- a/x-pack/test/security_solution_endpoint_api_int/apis/endpoint_response_actions/execute.ts
+++ b/x-pack/test/security_solution_endpoint_api_int/apis/endpoint_response_actions/execute.ts
@@ -15,8 +15,7 @@ export default function ({ getService }: FtrProviderContext) {
   const supertestWithoutAuth = getService('supertestWithoutAuth');
   const endpointTestResources = getService('endpointTestResources');
 
-  // FLAKY: https://github.com/elastic/kibana/issues/153855
-  describe.skip('Endpoint `execute` response action', () => {
+  describe('Endpoint `execute` response action', () => {
     let indexedData: IndexedHostsAndAlertsResponse;
     let agentId = '';
 
@@ -25,8 +24,8 @@ export default function ({ getService }: FtrProviderContext) {
       agentId = indexedData.hosts[0].agent.id;
     });
 
-    after(() => {
-      endpointTestResources.unloadEndpointData(indexedData);
+    after(async () => {
+      await endpointTestResources.unloadEndpointData(indexedData);
     });
 
     it('should not allow `execute` action without required privilege', async () => {

--- a/x-pack/test/security_solution_endpoint_api_int/apis/metadata.ts
+++ b/x-pack/test/security_solution_endpoint_api_int/apis/metadata.ts
@@ -37,12 +37,7 @@ export default function ({ getService }: FtrProviderContext) {
   const supertest = getService('supertest');
   const endpointTestResources = getService('endpointTestResources');
 
-  // FLAKY: https://github.com/elastic/kibana/issues/153855
-  describe.skip('test metadata apis', () => {
-    before(async () => {
-      await endpointTestResources.setMetadataTransformFrequency('1s');
-    });
-
+  describe('test metadata apis', () => {
     describe('list endpoints GET route', () => {
       const numberOfHostsInFixture = 2;
 


### PR DESCRIPTION
## Summary

Fix and unskip endpoint FTR tests.

* unskip endpoint FTR tests
* added some additional transform stop/wait/start logic into `indexHostsAndAlerts` to ensure data gets through properly
* removed the additional endpoint package install within `indexHostsAndAlerts` as:
	* fleet setup is already called in here and installs endpoint package
	* the additional install was creating a situation where the `unattended` transform wouldn't have its dest index installed properly
* removed `setMetadataTransformFrequency` and backing methods as the transforms are already at `1s`
* moved `getEndpointPackageInfo` into utils
* fixed instances of `endpointTestResources.unloadEndpointData` being called without await causing FTR to error out and stop

Flaky test runs:
- https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2057 (200x ✅ )
- https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2058 (200x ✅ )
- https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2061 (50x ✅ )


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
