### PR TITLE
Support ELSER model in inference pipeline config

### DIFF
--- a/x-pack/plugins/enterprise_search/common/ml_inference_pipeline/index.ts
+++ b/x-pack/plugins/enterprise_search/common/ml_inference_pipeline/index.ts
@@ -28,6 +28,7 @@ import {
 
 export const ELSER_TASK_TYPE = SUPPORTED_PYTORCH_TASKS.TEXT_EXPANSION;
 
+export const TEXT_EXPANSION_TYPE = SUPPORTED_PYTORCH_TASKS.TEXT_EXPANSION;
 export const TEXT_EXPANSION_FRIENDLY_TYPE = 'ELSER';
 
 export interface MlInferencePipelineParams {

--- a/x-pack/plugins/enterprise_search/common/ml_inference_pipeline/index.ts
+++ b/x-pack/plugins/enterprise_search/common/ml_inference_pipeline/index.ts
@@ -26,8 +26,6 @@ import {
   InferencePipelineInferenceConfig,
 } from '../types/pipelines';
 
-export const ELSER_TASK_TYPE = SUPPORTED_PYTORCH_TASKS.TEXT_EXPANSION;
-
 export const TEXT_EXPANSION_TYPE = SUPPORTED_PYTORCH_TASKS.TEXT_EXPANSION;
 export const TEXT_EXPANSION_FRIENDLY_TYPE = 'ELSER';
 

--- a/x-pack/plugins/enterprise_search/common/ml_inference_pipeline/index.ts
+++ b/x-pack/plugins/enterprise_search/common/ml_inference_pipeline/index.ts
@@ -28,6 +28,8 @@ import {
 
 export const ELSER_TASK_TYPE = SUPPORTED_PYTORCH_TASKS.TEXT_EXPANSION;
 
+export const TEXT_EXPANSION_FRIENDLY_TYPE = "ELSER";
+
 export interface MlInferencePipelineParams {
   description?: string;
   destinationField: string;

--- a/x-pack/plugins/enterprise_search/common/ml_inference_pipeline/index.ts
+++ b/x-pack/plugins/enterprise_search/common/ml_inference_pipeline/index.ts
@@ -28,7 +28,7 @@ import {
 
 export const ELSER_TASK_TYPE = SUPPORTED_PYTORCH_TASKS.TEXT_EXPANSION;
 
-export const TEXT_EXPANSION_FRIENDLY_TYPE = "ELSER";
+export const TEXT_EXPANSION_FRIENDLY_TYPE = 'ELSER';
 
 export interface MlInferencePipelineParams {
   description?: string;

--- a/x-pack/plugins/enterprise_search/common/ml_inference_pipeline/index.ts
+++ b/x-pack/plugins/enterprise_search/common/ml_inference_pipeline/index.ts
@@ -26,7 +26,7 @@ import {
   InferencePipelineInferenceConfig,
 } from '../types/pipelines';
 
-export const ELSER_TASK_TYPE = 'text_expansion';
+export const ELSER_TASK_TYPE = SUPPORTED_PYTORCH_TASKS.TEXT_EXPANSION;
 
 export interface MlInferencePipelineParams {
   description?: string;

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/ml_inference_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/ml_inference_logic.test.ts
@@ -366,6 +366,103 @@ describe('MlInferenceLogic', () => {
         expect(MLInferenceLogic.values.mlInferencePipeline).toEqual(existingPipeline);
       });
     });
+    describe('supportedMLModels', () => {
+      it('filters unsupported ML models', () => {
+        MLModelsApiLogic.actions.apiSuccess([
+          {
+            inference_config: {
+              ner: {},
+            },
+            input: {
+              field_names: ['text_field'],
+            },
+            model_id: 'ner-mocked-model',
+            model_type: 'pytorch',
+            tags: [],
+            version: '1',
+          },
+          {
+            inference_config: {
+              some_unsupported_task_type: {},
+            },
+            input: {
+              field_names: ['text_field'],
+            },
+            model_id: 'unsupported-mocked-model',
+            model_type: 'pytorch',
+            tags: [],
+            version: '1',
+          },
+        ]);
+
+        expect(MLInferenceLogic.values.supportedMLModels).toEqual([
+          expect.objectContaining({
+            inference_config: {
+              ner: {},
+            },
+          }),
+        ]);
+      });
+
+      it('promotes text_expansion ML models and sorts others by ID', () => {
+        MLModelsApiLogic.actions.apiSuccess([
+          {
+            inference_config: {
+              ner: {},
+            },
+            input: {
+              field_names: ['text_field'],
+            },
+            model_id: 'ner-mocked-model',
+            model_type: 'pytorch',
+            tags: [],
+            version: '1',
+          },
+          {
+            inference_config: {
+              text_expansion: {},
+            },
+            input: {
+              field_names: ['text_field'],
+            },
+            model_id: 'text-expansion-mocked-model',
+            model_type: 'pytorch',
+            tags: [],
+            version: '1',
+          },
+          {
+            inference_config: {
+              text_embedding: {},
+            },
+            input: {
+              field_names: ['text_field'],
+            },
+            model_id: 'text-embedding-mocked-model',
+            model_type: 'pytorch',
+            tags: [],
+            version: '1',
+          }
+        ]);
+      
+        expect(MLInferenceLogic.values.supportedMLModels).toEqual([
+          expect.objectContaining({
+            inference_config: {
+              text_expansion: {},
+            },
+          }),
+          expect.objectContaining({
+            inference_config: {
+              ner: {},
+            },
+          }),
+          expect.objectContaining({
+            inference_config: {
+              text_embedding: {},
+            },
+          }),
+        ]);
+      });
+    });
   });
 
   describe('listeners', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/ml_inference_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/ml_inference_logic.test.ts
@@ -441,9 +441,9 @@ describe('MlInferenceLogic', () => {
             model_type: 'pytorch',
             tags: [],
             version: '1',
-          }
+          },
         ]);
-      
+
         expect(MLInferenceLogic.values.supportedMLModels).toEqual([
           expect.objectContaining({
             inference_config: {

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/ml_inference_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/ml_inference_logic.ts
@@ -59,6 +59,7 @@ import { isConnectorIndex } from '../../../../utils/indices';
 import {
   getMLType,
   isSupportedMLModel,
+  sortModels,
   sortSourceFields,
 } from '../../../shared/ml_inference/utils';
 
@@ -408,9 +409,7 @@ export const MLInferenceLogic = kea<
       () => [selectors.mlModelsData],
       (mlModelsData: MLInferenceProcessorsValues['mlModelsData']) => {
         return (mlModelsData?.filter(isSupportedMLModel) ?? [])
-          .sort((m1, m2) => m1.inference_config.text_expansion ? -1 :
-              m2.inference_config.text_expansion ? 1 :
-              m1.model_id.localeCompare(m2.model_id));
+          .sort(sortModels);
       },
     ],
     existingInferencePipelines: [

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/ml_inference_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/ml_inference_logic.ts
@@ -14,7 +14,6 @@ import {
   generateMlInferencePipelineBody,
   getMlModelTypesForModelConfig,
   parseMlInferenceParametersFromPipeline,
-  SUPPORTED_PYTORCH_TASKS,
 } from '../../../../../../../common/ml_inference_pipeline';
 import { Status } from '../../../../../../../common/types/api';
 import { MlInferencePipeline } from '../../../../../../../common/types/pipelines';

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/ml_inference_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/ml_inference_logic.ts
@@ -14,6 +14,7 @@ import {
   generateMlInferencePipelineBody,
   getMlModelTypesForModelConfig,
   parseMlInferenceParametersFromPipeline,
+  SUPPORTED_PYTORCH_TASKS,
 } from '../../../../../../../common/ml_inference_pipeline';
 import { Status } from '../../../../../../../common/types/api';
 import { MlInferencePipeline } from '../../../../../../../common/types/pipelines';
@@ -407,7 +408,10 @@ export const MLInferenceLogic = kea<
     supportedMLModels: [
       () => [selectors.mlModelsData],
       (mlModelsData: MLInferenceProcessorsValues['mlModelsData']) => {
-        return mlModelsData?.filter(isSupportedMLModel) ?? [];
+        return (mlModelsData?.filter(isSupportedMLModel) ?? [])
+          .sort((m1, m2) => m1.inference_config.text_expansion ? -1 :
+              m2.inference_config.text_expansion ? 1 :
+              m1.model_id.localeCompare(m2.model_id));
       },
     ],
     existingInferencePipelines: [

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/ml_inference_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/ml_inference_logic.ts
@@ -408,8 +408,7 @@ export const MLInferenceLogic = kea<
     supportedMLModels: [
       () => [selectors.mlModelsData],
       (mlModelsData: MLInferenceProcessorsValues['mlModelsData']) => {
-        return (mlModelsData?.filter(isSupportedMLModel) ?? [])
-          .sort(sortModels);
+        return (mlModelsData?.filter(isSupportedMLModel) ?? []).sort(sortModels);
       },
     ],
     existingInferencePipelines: [

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/model_select_option.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/model_select_option.tsx
@@ -13,14 +13,9 @@ import {
   getMlModelTypesForModelConfig,
   parseModelStateFromStats,
   parseModelStateReasonFromStats,
-  TEXT_EXPANSION_FRIENDLY_TYPE,
 } from '../../../../../../../common/ml_inference_pipeline';
 import { TrainedModel } from '../../../../api/ml_models/ml_trained_models_logic';
-import {
-  getMLType,
-  getModelDisplayTitle,
-  isTextExpansionModel,
-} from '../../../shared/ml_inference/utils';
+import { getMLType, getModelDisplayTitle } from '../../../shared/ml_inference/utils';
 
 import { TrainedModelHealth } from '../ml_model_health';
 import { MLModelTypeBadge } from '../ml_model_type_badge';
@@ -30,7 +25,6 @@ export interface MlModelSelectOptionProps {
 }
 export const MlModelSelectOption: React.FC<MlModelSelectOptionProps> = ({ model }) => {
   const type = getMLType(getMlModelTypesForModelConfig(model));
-  const typeFriendlyName = isTextExpansionModel(model) ? TEXT_EXPANSION_FRIENDLY_TYPE : type;
   const title = getModelDisplayTitle(type);
   return (
     <EuiFlexGroup direction="column" gutterSize="xs">
@@ -55,9 +49,7 @@ export const MlModelSelectOption: React.FC<MlModelSelectOptionProps> = ({ model 
           <EuiFlexItem grow={false}>
             <EuiFlexGroup gutterSize="xs">
               <EuiFlexItem>
-                <span>
-                  <MLModelTypeBadge type={type} />
-                </span>
+                <MLModelTypeBadge type={type} />
               </EuiFlexItem>
             </EuiFlexGroup>
           </EuiFlexItem>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/model_select_option.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/model_select_option.tsx
@@ -16,7 +16,11 @@ import {
   TEXT_EXPANSION_FRIENDLY_TYPE,
 } from '../../../../../../../common/ml_inference_pipeline';
 import { TrainedModel } from '../../../../api/ml_models/ml_trained_models_logic';
-import { getMLType, getModelDisplayTitle, isTextExpansionModel } from '../../../shared/ml_inference/utils';
+import {
+  getMLType,
+  getModelDisplayTitle,
+  isTextExpansionModel,
+} from '../../../shared/ml_inference/utils';
 
 import { TrainedModelHealth } from '../ml_model_health';
 import { MLModelTypeBadge } from '../ml_model_type_badge';

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/model_select_option.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/model_select_option.tsx
@@ -13,9 +13,10 @@ import {
   getMlModelTypesForModelConfig,
   parseModelStateFromStats,
   parseModelStateReasonFromStats,
+  TEXT_EXPANSION_FRIENDLY_TYPE,
 } from '../../../../../../../common/ml_inference_pipeline';
 import { TrainedModel } from '../../../../api/ml_models/ml_trained_models_logic';
-import { getMLType, getModelDisplayTitle } from '../../../shared/ml_inference/utils';
+import { getMLType, getModelDisplayTitle, isTextExpansionModel } from '../../../shared/ml_inference/utils';
 
 import { TrainedModelHealth } from '../ml_model_health';
 import { MLModelTypeBadge } from '../ml_model_type_badge';
@@ -25,6 +26,7 @@ export interface MlModelSelectOptionProps {
 }
 export const MlModelSelectOption: React.FC<MlModelSelectOptionProps> = ({ model }) => {
   const type = getMLType(getMlModelTypesForModelConfig(model));
+  const typeFriendlyName = isTextExpansionModel(model) ? TEXT_EXPANSION_FRIENDLY_TYPE : type;
   const title = getModelDisplayTitle(type);
   return (
     <EuiFlexGroup direction="column" gutterSize="xs">

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_model_type_badge.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_model_type_badge.tsx
@@ -9,11 +9,14 @@ import React from 'react';
 
 import { EuiBadge } from '@elastic/eui';
 
-import { ELSER_TASK_TYPE } from '../../../../../../common/ml_inference_pipeline';
+import {
+  TEXT_EXPANSION_TYPE,
+  TEXT_EXPANSION_FRIENDLY_TYPE,
+} from '../../../../../../common/ml_inference_pipeline';
 
 export const MLModelTypeBadge: React.FC<{ type: string }> = ({ type }) => {
-  if (type === ELSER_TASK_TYPE) {
-    return <EuiBadge color="success">ELSER</EuiBadge>;
+  if (type === TEXT_EXPANSION_TYPE) {
+    return <EuiBadge color="success">{TEXT_EXPANSION_FRIENDLY_TYPE}</EuiBadge>;
   }
   return <EuiBadge color="hollow">{type}</EuiBadge>;
 };

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/shared/ml_inference/utils.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/shared/ml_inference/utils.ts
@@ -9,6 +9,7 @@ import { i18n } from '@kbn/i18n';
 import { TrainedModelConfigResponse } from '@kbn/ml-plugin/common/types/trained_models';
 
 import { TRAINED_MODEL_TYPE, SUPPORTED_PYTORCH_TASKS } from '@kbn/ml-trained-models-utils';
+import { TrainedModel } from '../../../api/ml_models/ml_trained_models_logic';
 
 export const NLP_CONFIG_KEYS: string[] = Object.values(SUPPORTED_PYTORCH_TASKS);
 export const RECOMMENDED_FIELDS = ['body', 'body_content', 'title'];
@@ -80,3 +81,5 @@ export const getMLType = (modelTypes: string[]): string => {
 };
 
 export const getModelDisplayTitle = (type: string): string | undefined => NLP_DISPLAY_TITLES[type];
+
+export const isTextExpansionModel = (model: TrainedModel) => model.inference_config.text_expansion;

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/shared/ml_inference/utils.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/shared/ml_inference/utils.ts
@@ -83,3 +83,11 @@ export const getMLType = (modelTypes: string[]): string => {
 export const getModelDisplayTitle = (type: string): string | undefined => NLP_DISPLAY_TITLES[type];
 
 export const isTextExpansionModel = (model: TrainedModel) => model.inference_config.text_expansion;
+
+/**
+ * Sort function for displaying a list of models. Promotes text_expansion models and sorts the rest by model ID.
+ */
+export const sortModels = (m1: TrainedModel, m2: TrainedModel) => 
+  isTextExpansionModel(m1) ? -1 :
+  isTextExpansionModel(m2) ? 1 :
+  m1.model_id.localeCompare(m2.model_id);

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/shared/ml_inference/utils.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/shared/ml_inference/utils.ts
@@ -38,6 +38,9 @@ export const NLP_DISPLAY_TITLES: Record<string, string | undefined> = {
   text_embedding: i18n.translate('xpack.enterpriseSearch.content.ml_inference.text_embedding', {
     defaultMessage: 'Dense Vector Text Embedding',
   }),
+  text_expansion: i18n.translate('xpack.enterpriseSearch.content.ml_inference.text_expansion', {
+    defaultMessage: 'ELSER Text Expansion',
+  }),
   zero_shot_classification: i18n.translate(
     'xpack.enterpriseSearch.content.ml_inference.zero_shot_classification',
     {

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/shared/ml_inference/utils.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/shared/ml_inference/utils.ts
@@ -9,6 +9,7 @@ import { i18n } from '@kbn/i18n';
 import { TrainedModelConfigResponse } from '@kbn/ml-plugin/common/types/trained_models';
 
 import { TRAINED_MODEL_TYPE, SUPPORTED_PYTORCH_TASKS } from '@kbn/ml-trained-models-utils';
+
 import { TrainedModel } from '../../../api/ml_models/ml_trained_models_logic';
 
 export const NLP_CONFIG_KEYS: string[] = Object.values(SUPPORTED_PYTORCH_TASKS);

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/shared/ml_inference/utils.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/shared/ml_inference/utils.ts
@@ -87,7 +87,9 @@ export const isTextExpansionModel = (model: TrainedModel) => model.inference_con
 /**
  * Sort function for displaying a list of models. Promotes text_expansion models and sorts the rest by model ID.
  */
-export const sortModels = (m1: TrainedModel, m2: TrainedModel) => 
-  isTextExpansionModel(m1) ? -1 :
-  isTextExpansionModel(m2) ? 1 :
-  m1.model_id.localeCompare(m2.model_id);
+export const sortModels = (m1: TrainedModel, m2: TrainedModel) =>
+  isTextExpansionModel(m1)
+    ? -1
+    : isTextExpansionModel(m2)
+    ? 1
+    : m1.model_id.localeCompare(m2.model_id);


### PR DESCRIPTION
## Summary

- Add support for ELSER (`model_type === "text_expansion"`) models in ML inference pipeline creation
- Promote ELSER on top and visually distinguish the badge with a friendly name

![Screenshot 2023-03-28 at 3 01 30 PM](https://user-images.githubusercontent.com/14224983/228340892-65c73b8f-a0d3-46c9-bde4-ca0adf0ee5e5.png)


### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

