### PR TITLE
[Security Solution] footer take action button

### DIFF
--- a/x-pack/plugins/security_solution/cypress/e2e/detection_alerts/expandable_flyout/alert_details_right_panel_footer.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_alerts/expandable_flyout/alert_details_right_panel_footer.cy.ts
@@ -1,0 +1,192 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  CASE_ACTION_WRAPPER,
+  CASE_ELLIPSE_BUTTON,
+  CASE_ELLIPSE_DELETE_CASE_CONFIRMATION_BUTTON,
+  CASE_ELLIPSE_DELETE_CASE_OPTION,
+  CREATE_CASE_BUTTON,
+  DOCUMENT_DETAILS_FLYOUT_FOOTER,
+  DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_ENDPOINT_EXCEPTION,
+  DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_MARK_AS_ACKNOWLEDGED,
+  DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_RULE_EXCEPTION,
+  DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_RULE_EXCEPTION_FLYOUT_CANCEL_BUTTON,
+  DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_RULE_EXCEPTION_FLYOUT_HEADER,
+  DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_TO_EXISTING_CASE,
+  DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_TO_NEW_CASE,
+  DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_TO_NEW_CASE_CREATE_BUTTON,
+  DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_TO_NEW_CASE_DESCRIPTION_INPUT,
+  DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_TO_NEW_CASE_NAME_INPUT,
+  DOCUMENT_DETAILS_FLYOUT_FOOTER_INVESTIGATE_IN_TIMELINE,
+  DOCUMENT_DETAILS_FLYOUT_FOOTER_INVESTIGATE_IN_TIMELINE_ENTRY,
+  DOCUMENT_DETAILS_FLYOUT_FOOTER_INVESTIGATE_IN_TIMELINE_SECTION,
+  DOCUMENT_DETAILS_FLYOUT_FOOTER_MARK_AS_CLOSED,
+  DOCUMENT_DETAILS_FLYOUT_FOOTER_RESPOND,
+  DOCUMENT_DETAILS_FLYOUT_FOOTER_TAKE_ACTION_BUTTON,
+  EXISTING_CASE_SELECT_BUTTON,
+  KIBANA_TOAST,
+  NEW_CASE_CREATE_BUTTON,
+  NEW_CASE_DESCRIPTION_INPUT,
+  NEW_CASE_NAME_INPUT,
+  VIEW_CASE_TOASTER_LINK,
+} from '../../../screens/document_expandable_flyout';
+import {
+  expandFirstAlertExpandableFlyout,
+  navigateToAlertsPage,
+  navigateToCasesPage,
+  openJsonTab,
+  openOverviewTab,
+  openTableTab,
+  openTakeActionButton,
+  openTakeActionButtonAndSelectItem,
+} from '../../../tasks/document_expandable_flyout';
+import { cleanKibana } from '../../../tasks/common';
+import { login, visit } from '../../../tasks/login';
+import { createRule } from '../../../tasks/api_calls/rules';
+import { getNewRule } from '../../../objects/rule';
+import { ALERTS_URL } from '../../../urls/navigation';
+import { waitForAlertsToPopulate } from '../../../tasks/create_new_rule';
+
+const createNewCaseFromCases = () => {
+  navigateToCasesPage();
+  cy.get(CREATE_CASE_BUTTON).should('be.visible').click();
+  cy.get(NEW_CASE_NAME_INPUT).should('be.visible').click().type('case');
+  cy.get(NEW_CASE_DESCRIPTION_INPUT).should('be.visible').click().type('case description');
+  cy.get(NEW_CASE_CREATE_BUTTON).should('be.visible').click();
+};
+
+const deleteCase = () => {
+  cy.get(CASE_ACTION_WRAPPER).find(CASE_ELLIPSE_BUTTON).should('be.visible').click();
+  cy.get(CASE_ELLIPSE_DELETE_CASE_OPTION).should('be.visible').click();
+  cy.get(CASE_ELLIPSE_DELETE_CASE_CONFIRMATION_BUTTON).should('be.visible').click();
+};
+
+// Skipping these for now as the feature is protected behind a feature flag set to false by default
+// To run the tests locally, add 'securityFlyoutEnabled' in the Cypress config.ts here https://github.com/elastic/kibana/blob/main/x-pack/test/security_solution_cypress/config.ts#L50
+describe.skip(
+  'Alert details expandable flyout right panel footer',
+  { testIsolation: false },
+  () => {
+    before(() => {
+      cleanKibana();
+      login();
+      createRule(getNewRule());
+      visit(ALERTS_URL);
+      waitForAlertsToPopulate();
+      expandFirstAlertExpandableFlyout();
+    });
+
+    it('should display footer take action button on all tabs', () => {
+      openOverviewTab();
+      cy.get(DOCUMENT_DETAILS_FLYOUT_FOOTER).scrollIntoView().should('be.visible');
+      cy.get(DOCUMENT_DETAILS_FLYOUT_FOOTER_TAKE_ACTION_BUTTON).should('be.visible');
+
+      openTableTab();
+      cy.get(DOCUMENT_DETAILS_FLYOUT_FOOTER).scrollIntoView().should('be.visible');
+      cy.get(DOCUMENT_DETAILS_FLYOUT_FOOTER_TAKE_ACTION_BUTTON).should('be.visible');
+
+      openJsonTab();
+      cy.get(DOCUMENT_DETAILS_FLYOUT_FOOTER).scrollIntoView().should('be.visible');
+      cy.get(DOCUMENT_DETAILS_FLYOUT_FOOTER_TAKE_ACTION_BUTTON).should('be.visible');
+
+      // reset state for next test
+      openOverviewTab();
+    });
+
+    // TODO this will change when add to existing case is improved
+    //  https://github.com/elastic/security-team/issues/6298
+    it('should add to existing case', () => {
+      createNewCaseFromCases();
+
+      navigateToAlertsPage();
+      waitForAlertsToPopulate();
+      expandFirstAlertExpandableFlyout();
+      openTakeActionButtonAndSelectItem(DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_TO_EXISTING_CASE);
+
+      cy.get(EXISTING_CASE_SELECT_BUTTON).should('be.visible').contains('Select').click();
+      cy.get(VIEW_CASE_TOASTER_LINK).click();
+      deleteCase();
+
+      // navigate back to alert page and reopen flyout for next test
+      navigateToAlertsPage();
+      waitForAlertsToPopulate();
+      expandFirstAlertExpandableFlyout();
+    });
+
+    // TODO this will change when add to new case is improved
+    //  https://github.com/elastic/security-team/issues/6298
+    it('should add to new case', () => {
+      openTakeActionButtonAndSelectItem(DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_TO_NEW_CASE);
+
+      cy.get(DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_TO_NEW_CASE_NAME_INPUT).type('case');
+      cy.get(DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_TO_NEW_CASE_DESCRIPTION_INPUT).type(
+        'case description'
+      );
+      cy.get(DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_TO_NEW_CASE_CREATE_BUTTON).click();
+
+      cy.get(VIEW_CASE_TOASTER_LINK).click();
+      deleteCase();
+
+      // navigate back to alert page and reopen flyout for next test
+      navigateToAlertsPage();
+      waitForAlertsToPopulate();
+      expandFirstAlertExpandableFlyout();
+    });
+
+    // TODO figure out how to properly test the result and recreate the alert for the next tests
+    it.skip('should mark as acknowledged', () => {
+      openTakeActionButtonAndSelectItem(DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_MARK_AS_ACKNOWLEDGED);
+      cy.get(KIBANA_TOAST)
+        // .should('be.visible')
+        .and('have.text', 'Successfully marked 1 alert as acknowledged.');
+    });
+
+    // TODO figure out how to properly test the result and recreate the alert for the next tests
+    it.skip('should mark as closed', () => {
+      openTakeActionButtonAndSelectItem(DOCUMENT_DETAILS_FLYOUT_FOOTER_MARK_AS_CLOSED);
+      cy.get(KIBANA_TOAST).should('be.visible').and('have.text', 'Successfully closed 1 alert.');
+    });
+
+    // TODO figure out why this option is disabled in Cypress but not running the app locally
+    //  https://github.com/elastic/security-team/issues/6300
+    it('should add endpoint exception', () => {
+      openTakeActionButton();
+      cy.get(DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_ENDPOINT_EXCEPTION).should('be.disabled');
+    });
+
+    // TODO this isn't fully testing the add rule exception yet
+    //  https://github.com/elastic/security-team/issues/6301
+    it('should add rule exception', () => {
+      openTakeActionButtonAndSelectItem(DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_RULE_EXCEPTION);
+      cy.get(DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_RULE_EXCEPTION_FLYOUT_HEADER).should('be.visible');
+      cy.get(DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_RULE_EXCEPTION_FLYOUT_CANCEL_BUTTON)
+        .should('be.visible')
+        .click();
+    });
+
+    // TODO figure out why isolate host isn't showing up in the dropdown
+    //  https://github.com/elastic/security-team/issues/6302
+    it.skip('should isolate host', () => {});
+
+    // TODO this will change when respond is improved
+    //  https://github.com/elastic/security-team/issues/6303
+    it('should respond', () => {
+      openTakeActionButton();
+      cy.get(DOCUMENT_DETAILS_FLYOUT_FOOTER_RESPOND).should('be.disabled');
+    });
+
+    it('should investigate in timeline', () => {
+      openTakeActionButtonAndSelectItem(DOCUMENT_DETAILS_FLYOUT_FOOTER_INVESTIGATE_IN_TIMELINE);
+      cy.get(DOCUMENT_DETAILS_FLYOUT_FOOTER_INVESTIGATE_IN_TIMELINE_SECTION)
+        .first()
+        .within(() =>
+          cy.get(DOCUMENT_DETAILS_FLYOUT_FOOTER_INVESTIGATE_IN_TIMELINE_ENTRY).should('be.visible')
+        );
+    });
+  }
+);

--- a/x-pack/plugins/security_solution/cypress/helpers/common.ts
+++ b/x-pack/plugins/security_solution/cypress/helpers/common.ts
@@ -13,6 +13,13 @@ export const getDataTestSubjectSelector = (dataTestSubjectValue: string) =>
   `[data-test-subj="${dataTestSubjectValue}"]`;
 
 /**
+ * Helper function to generate selector by data-test-subj that start width the value
+ * @param dataTestSubjectValue the partial value passed to the data-test-subj property of the DOM element
+ */
+export const getDataTestSubjectSelectorStartWith = (dataTestSubjectValue: string) =>
+  `[data-test-subj^="${dataTestSubjectValue}"]`;
+
+/**
  * Helper function to generate selector by class
  * @param className the value passed to class property of the DOM element
  */

--- a/x-pack/plugins/security_solution/cypress/helpers/common.ts
+++ b/x-pack/plugins/security_solution/cypress/helpers/common.ts
@@ -13,7 +13,7 @@ export const getDataTestSubjectSelector = (dataTestSubjectValue: string) =>
   `[data-test-subj="${dataTestSubjectValue}"]`;
 
 /**
- * Helper function to generate selector by data-test-subj that start width the value
+ * Helper function to generate selector by data-test-subj that start with the value
  * @param dataTestSubjectValue the partial value passed to the data-test-subj property of the DOM element
  */
 export const getDataTestSubjectSelectorStartWith = (dataTestSubjectValue: string) =>

--- a/x-pack/plugins/security_solution/cypress/screens/document_expandable_flyout.ts
+++ b/x-pack/plugins/security_solution/cypress/screens/document_expandable_flyout.ts
@@ -72,7 +72,19 @@ import {
   ENTITY_PANEL_CONTENT_TEST_ID,
   ENTITIES_VIEW_ALL_BUTTON_TEST_ID,
 } from '../../public/flyout/right/components/test_ids';
-import { getClassSelector, getDataTestSubjectSelector } from '../helpers/common';
+import {
+  getClassSelector,
+  getDataTestSubjectSelector,
+  getDataTestSubjectSelectorStartWith,
+} from '../helpers/common';
+
+/* Kibana */
+
+export const KIBANA_NAVBAR_ALERTS_PAGE = getDataTestSubjectSelector(
+  'solutionSideNavItemLink-alerts'
+);
+export const KIBANA_NAVBAR_CASES_PAGE = getDataTestSubjectSelector('solutionSideNavItemLink-cases');
+export const KIBANA_TOAST = getDataTestSubjectSelector('globalToastList');
 
 /* Right section */
 
@@ -151,6 +163,74 @@ export const DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_CORRELATIONS_BUTTON = getDataT
 export const DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_CORRELATIONS_CONTENT = getDataTestSubjectSelector(
   CORRELATIONS_DETAILS_TEST_ID
 );
+
+/* Footer */
+
+export const DOCUMENT_DETAILS_FLYOUT_FOOTER = getDataTestSubjectSelector(
+  'side-panel-flyout-footer'
+);
+export const DOCUMENT_DETAILS_FLYOUT_FOOTER_TAKE_ACTION_BUTTON = getDataTestSubjectSelector(
+  'take-action-dropdown-btn'
+);
+export const DOCUMENT_DETAILS_FLYOUT_FOOTER_TAKE_ACTION_BUTTON_DROPDOWN =
+  getDataTestSubjectSelector('takeActionPanelMenu');
+
+export const DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_TO_EXISTING_CASE = getDataTestSubjectSelector(
+  'add-to-existing-case-action'
+);
+export const CREATE_CASE_BUTTON = `[data-test-subj="createNewCaseBtn"]`;
+export const NEW_CASE_NAME_INPUT = `[data-test-subj="input"][aria-describedby="caseTitle"]`;
+
+export const NEW_CASE_DESCRIPTION_INPUT = getDataTestSubjectSelector('euiMarkdownEditorTextArea');
+
+export const NEW_CASE_CREATE_BUTTON = getDataTestSubjectSelector('create-case-submit');
+export const EXISTING_CASE_SELECT_BUTTON =
+  getDataTestSubjectSelectorStartWith('cases-table-row-select-');
+export const DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_TO_NEW_CASE =
+  getDataTestSubjectSelector('add-to-new-case-action');
+export const DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_TO_NEW_CASE_NAME_INPUT = NEW_CASE_NAME_INPUT;
+export const DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_TO_NEW_CASE_DESCRIPTION_INPUT =
+  NEW_CASE_DESCRIPTION_INPUT;
+
+export const DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_TO_NEW_CASE_CREATE_BUTTON = NEW_CASE_CREATE_BUTTON;
+
+export const VIEW_CASE_TOASTER_LINK = getDataTestSubjectSelector('toaster-content-case-view-link');
+export const CASE_ACTION_WRAPPER = getDataTestSubjectSelector('case-action-bar-wrapper');
+
+export const CASE_ELLIPSE_BUTTON = getDataTestSubjectSelector('property-actions-case-ellipses');
+
+export const CASE_ELLIPSE_DELETE_CASE_OPTION = getDataTestSubjectSelector(
+  'property-actions-case-trash'
+);
+
+export const CASE_ELLIPSE_DELETE_CASE_CONFIRMATION_BUTTON = getDataTestSubjectSelector(
+  'confirmModalConfirmButton'
+);
+
+export const DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_MARK_AS_ACKNOWLEDGED = getDataTestSubjectSelector(
+  'acknowledged-alert-status'
+);
+export const DOCUMENT_DETAILS_FLYOUT_FOOTER_MARK_AS_CLOSED =
+  getDataTestSubjectSelector('close-alert-status');
+export const DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_ENDPOINT_EXCEPTION = getDataTestSubjectSelector(
+  'add-endpoint-exception-menu-item'
+);
+export const DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_RULE_EXCEPTION =
+  getDataTestSubjectSelector('add-exception-menu-item');
+export const DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_RULE_EXCEPTION_FLYOUT_HEADER =
+  getDataTestSubjectSelector('exceptionFlyoutTitle');
+export const DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_RULE_EXCEPTION_FLYOUT_CANCEL_BUTTON =
+  getDataTestSubjectSelector('cancelExceptionAddButton');
+export const DOCUMENT_DETAILS_FLYOUT_FOOTER_RESPOND = getDataTestSubjectSelector(
+  'endpointResponseActions-action-item'
+);
+export const DOCUMENT_DETAILS_FLYOUT_FOOTER_INVESTIGATE_IN_TIMELINE = getDataTestSubjectSelector(
+  'investigate-in-timeline-action-item'
+);
+export const DOCUMENT_DETAILS_FLYOUT_FOOTER_INVESTIGATE_IN_TIMELINE_SECTION =
+  getDataTestSubjectSelector('timelineHeader');
+export const DOCUMENT_DETAILS_FLYOUT_FOOTER_INVESTIGATE_IN_TIMELINE_ENTRY =
+  getDataTestSubjectSelector('providerContainer');
 
 /* Overview tab */
 

--- a/x-pack/plugins/security_solution/cypress/tasks/document_expandable_flyout.ts
+++ b/x-pack/plugins/security_solution/cypress/tasks/document_expandable_flyout.ts
@@ -9,6 +9,8 @@ import {
   DOCUMENT_DETAILS_FLYOUT_BODY,
   DOCUMENT_DETAILS_FLYOUT_COLLAPSE_DETAILS_BUTTON,
   DOCUMENT_DETAILS_FLYOUT_EXPAND_DETAILS_BUTTON,
+  DOCUMENT_DETAILS_FLYOUT_FOOTER,
+  DOCUMENT_DETAILS_FLYOUT_FOOTER_TAKE_ACTION_BUTTON,
   DOCUMENT_DETAILS_FLYOUT_HISTORY_TAB,
   DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB,
   DOCUMENT_DETAILS_FLYOUT_INVESTIGATIONS_TAB,
@@ -31,9 +33,26 @@ import {
   DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_PREVALENCE_BUTTON,
   DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_CORRELATIONS_BUTTON,
   DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_THREAT_INTELLIGENCE_BUTTON,
+  DOCUMENT_DETAILS_FLYOUT_FOOTER_TAKE_ACTION_BUTTON_DROPDOWN,
+  KIBANA_NAVBAR_ALERTS_PAGE,
+  KIBANA_NAVBAR_CASES_PAGE,
 } from '../screens/document_expandable_flyout';
 import { EXPAND_ALERT_BTN } from '../screens/alerts';
 import { getClassSelector } from '../helpers/common';
+
+/**
+ * Navigates to the alerts page by clicking on the Kibana sidenav entry
+ */
+export const navigateToAlertsPage = () => {
+  cy.get(KIBANA_NAVBAR_ALERTS_PAGE).should('be.visible').click();
+};
+
+/**
+ * Navigates to the cases page by clicking on the Kibana sidenav entry
+ */
+export const navigateToCasesPage = () => {
+  cy.get(KIBANA_NAVBAR_CASES_PAGE).should('be.visible').click();
+};
 
 /**
  * Find the first alert row in the alerts table then click on the expand icon button to open the flyout
@@ -60,6 +79,34 @@ export const collapseDocumentDetailsExpandableFlyoutLeftSection = () =>
  */
 export const scrollWithinDocumentDetailsExpandableFlyoutRightSection = (x: number, y: number) =>
   cy.get(getClassSelector('euiFlyout')).last().scrollTo(x, y);
+
+/**
+ * Scroll down to the flyout footer's take action button, open its dropdown and click on the desired option
+ */
+export const openTakeActionButtonAndSelectItem = (option: string) => {
+  openTakeActionButton();
+  selectTakeActionItem(option);
+};
+
+/**
+ * Scroll down to the flyout footer's take action button and open its dropdown
+ */
+export const openTakeActionButton = () => {
+  cy.get(DOCUMENT_DETAILS_FLYOUT_FOOTER)
+    .scrollIntoView()
+    .within(() => {
+      cy.get(DOCUMENT_DETAILS_FLYOUT_FOOTER_TAKE_ACTION_BUTTON).should('be.visible').click();
+    });
+};
+
+/**
+ * Click on the item within the flyout's footer take action button dropdown
+ */
+export const selectTakeActionItem = (option: string) => {
+  cy.get(DOCUMENT_DETAILS_FLYOUT_FOOTER_TAKE_ACTION_BUTTON_DROPDOWN)
+    .should('be.visible')
+    .within(() => cy.get(option).should('be.visible').click());
+};
 
 /**
  * Open the Overview tab in the document details expandable flyout right section
@@ -101,13 +148,13 @@ export const toggleOverviewTabInsightsSection = () =>
  * Open the Table tab in the document details expandable flyout right section
  */
 export const openTableTab = () =>
-  cy.get(DOCUMENT_DETAILS_FLYOUT_TABLE_TAB).should('be.visible').click();
+  cy.get(DOCUMENT_DETAILS_FLYOUT_TABLE_TAB).scrollIntoView().should('be.visible').click();
 
 /**
  * Open the Json tab in the document details expandable flyout right section
  */
 export const openJsonTab = () =>
-  cy.get(DOCUMENT_DETAILS_FLYOUT_JSON_TAB).should('be.visible').click();
+  cy.get(DOCUMENT_DETAILS_FLYOUT_JSON_TAB).scrollIntoView().should('be.visible').click();
 
 /**
  * Open the Visualize tab in the document details expandable flyout left section

--- a/x-pack/plugins/security_solution/public/common/components/control_columns/row_action/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/control_columns/row_action/index.tsx
@@ -22,6 +22,7 @@ import type { TimelineItem, TimelineNonEcsData } from '../../../../../common/sea
 import type { ColumnHeaderOptions, OnRowSelected } from '../../../../../common/types/timeline';
 import { dataTableActions } from '../../../store/data_table';
 import { useIsExperimentalFeatureEnabled } from '../../../hooks/use_experimental_features';
+import { TableId } from '../../../../../common/types';
 
 type Props = EuiDataGridCellValueElementProps & {
   columnHeaders: ColumnHeaderOptions[];
@@ -103,6 +104,7 @@ const RowActionComponent = ({
           params: {
             id: eventId,
             indexName,
+            scopeId: TableId.alertsOnAlertsPage,
           },
         },
       });

--- a/x-pack/plugins/security_solution/public/common/components/control_columns/row_action/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/control_columns/row_action/index.tsx
@@ -22,7 +22,6 @@ import type { TimelineItem, TimelineNonEcsData } from '../../../../../common/sea
 import type { ColumnHeaderOptions, OnRowSelected } from '../../../../../common/types/timeline';
 import { dataTableActions } from '../../../store/data_table';
 import { useIsExperimentalFeatureEnabled } from '../../../hooks/use_experimental_features';
-import { TableId } from '../../../../../common/types';
 
 type Props = EuiDataGridCellValueElementProps & {
   columnHeaders: ColumnHeaderOptions[];
@@ -104,7 +103,7 @@ const RowActionComponent = ({
           params: {
             id: eventId,
             indexName,
-            scopeId: TableId.alertsOnAlertsPage,
+            scopeId: tableId,
           },
         },
       });

--- a/x-pack/plugins/security_solution/public/flyout/right/context.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/right/context.tsx
@@ -31,6 +31,10 @@ export interface RightPanelContext {
    */
   indexName: string;
   /**
+   * Maintain backwards compatibility // TODO remove when possible
+   */
+  scopeId: string;
+  /**
    * An object containing fields by type
    */
   browserFields: BrowserFields | null;
@@ -47,6 +51,10 @@ export interface RightPanelContext {
    */
   searchHit: SearchHit<object> | undefined;
   /**
+   *
+   */
+  refetchFlyoutData: () => Promise<void>;
+  /**
    * Retrieves searchHit values for the provided field
    */
   getFieldsData: (field: string) => unknown | unknown[];
@@ -61,7 +69,12 @@ export type RightPanelProviderProps = {
   children: React.ReactNode;
 } & Partial<RightPanelProps['params']>;
 
-export const RightPanelProvider = ({ id, indexName, children }: RightPanelProviderProps) => {
+export const RightPanelProvider = ({
+  id,
+  indexName,
+  scopeId,
+  children,
+}: RightPanelProviderProps) => {
   const currentSpaceId = useSpaceId();
   const eventIndex = indexName ? getAlertIndexAlias(indexName, currentSpaceId) ?? indexName : '';
   const [{ pageName }] = useRouteSpy();
@@ -70,7 +83,7 @@ export const RightPanelProvider = ({ id, indexName, children }: RightPanelProvid
       ? SourcererScopeName.detections
       : SourcererScopeName.default;
   const sourcererDataView = useSourcererDataView(sourcererScope);
-  const [loading, dataFormattedForFieldBrowser, searchHit, dataAsNestedObject] =
+  const [loading, dataFormattedForFieldBrowser, searchHit, dataAsNestedObject, refetchFlyoutData] =
     useTimelineEventsDetails({
       indexName: eventIndex,
       eventId: id ?? '',
@@ -81,24 +94,28 @@ export const RightPanelProvider = ({ id, indexName, children }: RightPanelProvid
 
   const contextValue = useMemo(
     () =>
-      id && indexName
+      id && indexName && scopeId
         ? {
             eventId: id,
             indexName,
+            scopeId,
             browserFields: sourcererDataView.browserFields,
             dataAsNestedObject: dataAsNestedObject as unknown as Ecs,
             dataFormattedForFieldBrowser,
             searchHit: searchHit as SearchHit<object>,
+            refetchFlyoutData,
             getFieldsData,
           }
         : undefined,
     [
       id,
       indexName,
+      scopeId,
       sourcererDataView.browserFields,
       dataAsNestedObject,
       dataFormattedForFieldBrowser,
       searchHit,
+      refetchFlyoutData,
       getFieldsData,
     ]
   );

--- a/x-pack/plugins/security_solution/public/flyout/right/footer.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/right/footer.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FC } from 'react';
+import React, { memo } from 'react';
+import { useExpandableFlyoutContext } from '@kbn/expandable-flyout';
+import { FlyoutFooter } from '../../timelines/components/side_panel/event_details/flyout';
+import { useRightPanelContext } from './context';
+import { useHostIsolationTools } from '../../timelines/components/side_panel/event_details/use_host_isolation_tools';
+
+/**
+ *
+ */
+export const PanelFooter: FC = memo(() => {
+  const { closeFlyout } = useExpandableFlyoutContext();
+  const {
+    eventId,
+    indexName,
+    dataFormattedForFieldBrowser,
+    dataAsNestedObject,
+    refetchFlyoutData,
+    scopeId,
+  } = useRightPanelContext();
+
+  const { isHostIsolationPanelOpen, showHostIsolationPanel } = useHostIsolationTools();
+
+  if (!dataFormattedForFieldBrowser || !dataAsNestedObject) {
+    return null;
+  }
+
+  return (
+    <FlyoutFooter
+      detailsData={dataFormattedForFieldBrowser}
+      detailsEcsData={dataAsNestedObject}
+      expandedEvent={{ eventId, indexName }}
+      handleOnEventClosed={closeFlyout}
+      isHostIsolationPanelOpen={isHostIsolationPanelOpen}
+      isReadOnly={false}
+      loadingEventDetails={false}
+      onAddIsolationStatusClick={showHostIsolationPanel}
+      scopeId={scopeId}
+      refetchFlyoutData={refetchFlyoutData}
+    />
+  );
+});
+
+PanelFooter.displayName = 'PanelFooter';

--- a/x-pack/plugins/security_solution/public/flyout/right/index.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/right/index.tsx
@@ -14,6 +14,7 @@ import { PanelHeader } from './header';
 import { PanelContent } from './content';
 import type { RightPanelTabsType } from './tabs';
 import { tabs } from './tabs';
+import { PanelFooter } from './footer';
 
 export type RightPanelPaths = 'overview' | 'table' | 'json';
 
@@ -26,6 +27,7 @@ export interface RightPanelProps extends FlyoutPanel {
   params?: {
     id: string;
     indexName: string;
+    scopeId: string;
   };
 }
 
@@ -34,7 +36,7 @@ export interface RightPanelProps extends FlyoutPanel {
  */
 export const RightPanel: FC<Partial<RightPanelProps>> = memo(({ path }) => {
   const { openRightPanel } = useExpandableFlyoutContext();
-  const { eventId, indexName } = useRightPanelContext();
+  const { eventId, indexName, scopeId } = useRightPanelContext();
 
   const selectedTabId = useMemo(() => {
     const defaultTab = tabs[0].id;
@@ -49,6 +51,7 @@ export const RightPanel: FC<Partial<RightPanelProps>> = memo(({ path }) => {
       params: {
         id: eventId,
         indexName,
+        scopeId,
       },
     });
   };
@@ -57,6 +60,7 @@ export const RightPanel: FC<Partial<RightPanelProps>> = memo(({ path }) => {
     <>
       <PanelHeader selectedTabId={selectedTabId} setSelectedTabId={setSelectedTabId} />
       <PanelContent selectedTabId={selectedTabId} />
+      <PanelFooter />
     </>
   );
 });


### PR DESCRIPTION
## Summary

This PR adds the Take Action button in the footer of the expandable flyout. The footer appears on each tab (Overview, table and Json) of the right section.
This is currently reusing the footer from the existing flyout ([here](https://github.com/elastic/kibana/blob/main/x-pack/plugins/security_solution/public/timelines/components/side_panel/event_details/flyout/footer.tsx)).

Future work will focus on individual items in the Take Action dropdown, and rework them to make them more integrated.

### How to test

- add `xpack.securitySolution.enableExperimental: ['securityFlyoutEnabled']` to the `kibana.json` file
- run `yarn es snapshot --license trial`,  `yarn test:generate` and `yarn start --no-base-path`
- go to the Alerts page, and click on the expand detail button on any row of the table
- navigate to the Overview tab

### Run tests and storybook
- `node scripts/storybook security_solution` to run Storybook
- `npm run test:jest --config ./x-pack/plugins/security_solution/public/flyout` to run the unit tests
- `yarn cypress:open-as-ci` but note that the integration/e2e tests have been written but are now skipped because the feature is protected behind a feature flag, disabled by default. To check them, add `'securityFlyoutEnabled'` [here](https://github.com/elastic/kibana/blob/main/x-pack/test/security_solution_cypress/config.ts#L50)

![Screenshot 2023-03-28 at 5 05 20 PM](https://user-images.githubusercontent.com/17276605/228377202-30cc7961-df2c-4cd8-a387-2e950b50c7c2.png)

https://user-images.githubusercontent.com/17276605/230224756-c256d4ce-47e4-4fd3-b79b-be223acf16e6.mov

https://github.com/elastic/security-team/issues/6118

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))