### PR TITLE
Update links to Exploratory View in APM app to use new Exploratory View app

### DIFF
--- a/x-pack/plugins/apm/kibana.jsonc
+++ b/x-pack/plugins/apm/kibana.jsonc
@@ -19,6 +19,7 @@
       "inspector",
       "licensing",
       "observability",
+      "exploratoryView",
       "ruleRegistry",
       "triggersActionsUi",
       "share",

--- a/x-pack/plugins/apm/public/components/routing/templates/apm_service_template/analyze_data_button.test.tsx
+++ b/x-pack/plugins/apm/public/components/routing/templates/apm_service_template/analyze_data_button.test.tsx
@@ -38,7 +38,7 @@ describe('AnalyzeDataButton', () => {
       render(<Example agentName="rum-js" />);
 
       expect((screen.getByRole('link') as HTMLAnchorElement).href).toEqual(
-        'http://localhost/app/observability/exploratory-view/#?reportType=kpi-over-time&sr=!((dt:ux,mt:transaction.duration.us,n:testServiceName-response-latency,op:average,rdf:(service.environment:!(testEnvironment),service.name:!(testServiceName)),time:(from:now-15m,to:now)))'
+        'http://localhost/app/exploratory-view/#?reportType=kpi-over-time&sr=!((dt:ux,mt:transaction.duration.us,n:testServiceName-response-latency,op:average,rdf:(service.environment:!(testEnvironment),service.name:!(testServiceName)),time:(from:now-15m,to:now)))'
       );
     });
   });
@@ -48,7 +48,7 @@ describe('AnalyzeDataButton', () => {
       render(<Example agentName="iOS/swift" />);
 
       expect((screen.getByRole('link') as HTMLAnchorElement).href).toEqual(
-        'http://localhost/app/observability/exploratory-view/#?reportType=kpi-over-time&sr=!((dt:mobile,mt:transaction.duration.us,n:testServiceName-response-latency,op:average,rdf:(service.environment:!(testEnvironment),service.name:!(testServiceName)),time:(from:now-15m,to:now)))'
+        'http://localhost/app/exploratory-view/#?reportType=kpi-over-time&sr=!((dt:mobile,mt:transaction.duration.us,n:testServiceName-response-latency,op:average,rdf:(service.environment:!(testEnvironment),service.name:!(testServiceName)),time:(from:now-15m,to:now)))'
       );
     });
   });
@@ -58,7 +58,7 @@ describe('AnalyzeDataButton', () => {
       render(<Example environment={ENVIRONMENT_NOT_DEFINED.value} />);
 
       expect((screen.getByRole('link') as HTMLAnchorElement).href).toEqual(
-        'http://localhost/app/observability/exploratory-view/#?reportType=kpi-over-time&sr=!((dt:mobile,mt:transaction.duration.us,n:testServiceName-response-latency,op:average,rdf:(service.environment:!(ENVIRONMENT_NOT_DEFINED),service.name:!(testServiceName)),time:(from:now-15m,to:now)))'
+        'http://localhost/app/exploratory-view/#?reportType=kpi-over-time&sr=!((dt:mobile,mt:transaction.duration.us,n:testServiceName-response-latency,op:average,rdf:(service.environment:!(ENVIRONMENT_NOT_DEFINED),service.name:!(testServiceName)),time:(from:now-15m,to:now)))'
       );
     });
   });
@@ -68,7 +68,7 @@ describe('AnalyzeDataButton', () => {
       render(<Example environment={ENVIRONMENT_ALL.value} />);
 
       expect((screen.getByRole('link') as HTMLAnchorElement).href).toEqual(
-        'http://localhost/app/observability/exploratory-view/#?reportType=kpi-over-time&sr=!((dt:mobile,mt:transaction.duration.us,n:testServiceName-response-latency,op:average,rdf:(service.environment:!(ALL_VALUES),service.name:!(testServiceName)),time:(from:now-15m,to:now)))'
+        'http://localhost/app/exploratory-view/#?reportType=kpi-over-time&sr=!((dt:mobile,mt:transaction.duration.us,n:testServiceName-response-latency,op:average,rdf:(service.environment:!(ALL_VALUES),service.name:!(testServiceName)),time:(from:now-15m,to:now)))'
       );
     });
   });

--- a/x-pack/plugins/apm/public/components/routing/templates/apm_service_template/analyze_data_button.tsx
+++ b/x-pack/plugins/apm/public/components/routing/templates/apm_service_template/analyze_data_button.tsx
@@ -9,8 +9,8 @@ import { EuiButtonEmpty, EuiToolTip } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
-import { createExploratoryViewUrl } from '@kbn/observability-plugin/public';
-import { ALL_VALUES_SELECTED } from '@kbn/observability-plugin/public';
+import { createExploratoryViewUrl } from '@kbn/exploratory-view-plugin/public';
+import { ALL_VALUES_SELECTED } from '@kbn/exploratory-view-plugin/public';
 import {
   isMobileAgentName,
   isRumAgentName,

--- a/x-pack/plugins/apm/public/plugin.ts
+++ b/x-pack/plugins/apm/public/plugin.ts
@@ -23,6 +23,7 @@ import type {
 } from '@kbn/data-plugin/public';
 import { LensPublicStart } from '@kbn/lens-plugin/public';
 import type { UnifiedSearchPublicPluginStart } from '@kbn/unified-search-plugin/public';
+import type { ExploratoryViewPublicSetup } from '@kbn/exploratory-view-plugin/public';
 import type { EmbeddableStart } from '@kbn/embeddable-plugin/public';
 import type { HomePublicPluginSetup } from '@kbn/home-plugin/public';
 import { Start as InspectorPluginStart } from '@kbn/inspector-plugin/public';
@@ -72,6 +73,7 @@ export type ApmPluginStart = void;
 export interface ApmPluginSetupDeps {
   alerting?: AlertingPluginPublicSetup;
   data: DataPublicPluginSetup;
+  exploratoryView: ExploratoryViewPublicSetup;
   unifiedSearch: UnifiedSearchPublicPluginStart;
   features: FeaturesPluginSetup;
   home?: HomePublicPluginSetup;
@@ -260,6 +262,18 @@ export class ApmPlugin implements Plugin<ApmPluginSetup, ApmPluginStart> {
     );
 
     plugins.observability.dashboard.register({
+      appName: 'apm',
+      hasData: async () => {
+        const dataHelper = await getApmDataHelper();
+        return await dataHelper.getHasData();
+      },
+      fetchData: async (params: FetchDataParams) => {
+        const dataHelper = await getApmDataHelper();
+        return await dataHelper.fetchObservabilityOverviewPageData(params);
+      },
+    });
+
+    plugins.exploratoryView.register({
       appName: 'apm',
       hasData: async () => {
         const dataHelper = await getApmDataHelper();

--- a/x-pack/plugins/apm/tsconfig.json
+++ b/x-pack/plugins/apm/tsconfig.json
@@ -81,6 +81,7 @@
     "@kbn/safer-lodash-set",
     "@kbn/shared-ux-router",
     "@kbn/alerts-as-data-utils",
+    "@kbn/exploratory-view-plugin",
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/153883

# 📝 Summary

Now that the Exploratory View app has been copied from the Observability app to its own separate app (https://github.com/elastic/kibana/issues/153830), we can update the links in consuming apps to the new URL. 

# ✅ Acceptance criteria
- [X] All links in APM that were going to `/app/observability/exploratory-view` should be updated to `/app/exploratory-view` 