### PR TITLE
[TSVB2Lens] Enable the metric bar when max is defined

### DIFF
--- a/src/plugins/vis_types/timeseries/public/convert_to_lens/lib/configurations/metric/index.test.ts
+++ b/src/plugins/vis_types/timeseries/public/convert_to_lens/lib/configurations/metric/index.test.ts
@@ -296,6 +296,7 @@ describe('getConfigurationForGauge', () => {
       palette: undefined,
       maxAccessor: maxColumnId,
       color: '#FFFFFF',
+      showBar: true,
     });
     expect(mockGetPalette).toBeCalledTimes(1);
   });
@@ -338,6 +339,7 @@ describe('getConfigurationForGauge', () => {
       metricAccessor: columnId1,
       palette,
       maxAccessor: maxColumnId,
+      showBar: true,
     });
     expect(mockGetPalette).toBeCalledTimes(1);
   });

--- a/src/plugins/vis_types/timeseries/public/convert_to_lens/lib/configurations/metric/index.ts
+++ b/src/plugins/vis_types/timeseries/public/convert_to_lens/lib/configurations/metric/index.ts
@@ -52,7 +52,7 @@ export const getConfigurationForGauge = (
   model: Panel,
   layer: Layer,
   bucket: Column | undefined,
-  gaugeMaxColumn: Column
+  gaugeMaxColumn?: Column
 ): MetricVisConfiguration | null => {
   const primarySeries = model.series[0];
   const primaryMetricWithCollapseFn = getMetricWithCollapseFn(primarySeries);
@@ -73,7 +73,8 @@ export const getConfigurationForGauge = (
     layerType: 'data',
     metricAccessor: primaryColumn?.columnId,
     breakdownByAccessor: bucket?.columnId,
-    maxAccessor: gaugeMaxColumn.columnId,
+    maxAccessor: gaugeMaxColumn?.columnId,
+    showBar: Boolean(gaugeMaxColumn),
     palette: gaugePalette,
     collapseFn: primaryMetricWithCollapseFn.collapseFn,
     ...(gaugePalette ? {} : { color: primaryColor }),


### PR DESCRIPTION
## Summary

Part of https://github.com/elastic/kibana/issues/151289

This PR addresses the first bullet. If  a max is set, it navigates to the new metric with the bar on.

![lens](https://user-images.githubusercontent.com/17003240/228484956-6c5c8d8d-f3da-42f1-8f6d-83884aaab979.gif)

Note: I am not addressing the second one because it needs discussion with the team

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
