### PR TITLE
[Fleet] Add placeholder to integration select field

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_var_field.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_var_field.tsx
@@ -156,8 +156,14 @@ export const PackagePolicyInputVarField: React.FunctionComponent<{
             />
           );
         case 'select':
+          const placeholderText = i18n.translate(
+            'xpack.fleet.packagePolicyField.selectPlaceholder',
+            {
+              defaultMessage: 'Select an option',
+            }
+          );
           const optionsWithPlaceholder = [
-            { value: '', text: 'Select an option', disabled: true },
+            { value: '', text: placeholderText, disabled: true },
             ...(options || []),
           ];
           return (

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_var_field.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_var_field.tsx
@@ -17,7 +17,7 @@ import {
   EuiFieldPassword,
   EuiCodeBlock,
   EuiTextArea,
-  EuiSelect,
+  EuiComboBox,
 } from '@elastic/eui';
 import styled from 'styled-components';
 
@@ -156,21 +156,23 @@ export const PackagePolicyInputVarField: React.FunctionComponent<{
             />
           );
         case 'select':
-          const placeholderText = i18n.translate(
-            'xpack.fleet.packagePolicyField.selectPlaceholder',
-            {
-              defaultMessage: 'Select an option',
-            }
-          );
-          const optionsWithPlaceholder = [
-            { value: '', text: placeholderText, disabled: true },
-            ...(options || []),
-          ];
+          const selectOptions = options?.map((option) => ({ value, label: option.text }));
+          const selectedOptions =
+            value === undefined ? [] : selectOptions?.filter((option) => option.value === value);
           return (
-            <EuiSelect
-              options={optionsWithPlaceholder}
-              value={value}
-              onChange={(e) => onChange(e.target.value)}
+            <EuiComboBox
+              placeholder={i18n.translate('xpack.fleet.packagePolicyField.selectPlaceholder', {
+                defaultMessage: 'Select an option',
+              })}
+              singleSelection={{ asPlainText: true }}
+              options={selectOptions}
+              selectedOptions={selectedOptions}
+              isClearable={true}
+              onChange={(newSelectedOptions: Array<{ label: string; value?: string }>) => {
+                const newValue =
+                  newSelectedOptions.length === 0 ? undefined : newSelectedOptions[0].value;
+                return onChange(newValue);
+              }}
               onBlur={() => setIsDirty(true)}
             />
           );

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_var_field.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_var_field.tsx
@@ -170,7 +170,6 @@ export const PackagePolicyInputVarField: React.FunctionComponent<{
             <EuiSelect
               options={optionsWithPlaceholder}
               value={value}
-              isInvalid={isInvalid}
               onChange={(e) => onChange(e.target.value)}
               onBlur={() => setIsDirty(true)}
             />

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_var_field.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_var_field.tsx
@@ -156,8 +156,18 @@ export const PackagePolicyInputVarField: React.FunctionComponent<{
             />
           );
         case 'select':
+          const optionsWithPlaceholder = [
+            { value: '', text: 'Select an option', disabled: true },
+            ...(options || []),
+          ];
           return (
-            <EuiSelect options={options} value={value} onChange={(e) => onChange(e.target.value)} />
+            <EuiSelect
+              options={optionsWithPlaceholder}
+              value={value}
+              isInvalid={isInvalid}
+              onChange={(e) => onChange(e.target.value)}
+              onBlur={() => setIsDirty(true)}
+            />
           );
         default:
           return (

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_var_field.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_var_field.tsx
@@ -156,7 +156,10 @@ export const PackagePolicyInputVarField: React.FunctionComponent<{
             />
           );
         case 'select':
-          const selectOptions = options?.map((option) => ({ value, label: option.text }));
+          const selectOptions = options?.map((option) => ({
+            value: option.value,
+            label: option.text,
+          }));
           const selectedOptions =
             value === undefined ? [] : selectOptions?.filter((option) => option.value === value);
           return (


### PR DESCRIPTION
## Summary

This PR is a followup fix to https://github.com/elastic/kibana/pull/152550.

As discovered in https://github.com/elastic/integrations/pull/5451#issuecomment-1487100507, there is currently an issue where the select is invalid upon first render because no default `value` exists, yet the first option appears to be selected.

The fix introduced in this PR replaces the EUISelect with a more flexible EUIComboBox component, with a placeholder with text `Select an option` when no value is selected. In addition, this new component allows the selection to be cleared, which can be useful for non required variables.

If the package specifies a default value, it should be selected by default. Otherwise, the placeholder will render. Note that the field will not be valid upon first render if the variable is required and no default value is provided.

<img width="1728" alt="Screenshot 2023-03-29 at 17 47 28" src="https://user-images.githubusercontent.com/23701614/228596370-d6b14c03-4a09-4f68-a137-95bb7ca7e78f.png">
<img width="1728" alt="Screenshot 2023-03-29 at 17 47 35" src="https://user-images.githubusercontent.com/23701614/228596387-dc99e4b2-5d9d-4218-baf1-010bf527b028.png">
<img width="1728" alt="Screenshot 2023-03-29 at 17 47 44" src="https://user-images.githubusercontent.com/23701614/228596415-9f1f73af-a9f5-4a88-a700-999213500c4e.png">

### Repro steps

1. Run package-registry with version 1.5.0 of Elasticsearch integration from https://github.com/elastic/integrations/pull/5451:
   1. In integrations repo, check out the branch in https://github.com/elastic/integrations/pull/5451
   2. In `packages/elasticsearch/changelog.yml`, change `version: 1.5.0-next` to `version: 1.5.0`
   3. In `packages/elasticsearch/manifest.yml`, change the version to 1.5.0
   4. In the shell, `cd packages/elasticsearch` if not there already and `elastic-package build -v`
   5. Run the package registry: `elastic-package stack up -v -d --services package-registry`
   6. Check that it is running correctly and that you can see version 1.5.0 of Elasticsearch at https://localhost:8080/search?package=elasticsearch
2. Run Kibana in dev on this branch:
   1. In your `kibana.dev.yml`, add `xpack.fleet.registryUrl: https://localhost:8080` if not there (⚠️ https, not http)
   2. Before running `yarn start`, run `export NODE_EXTRA_CA_CERTS=$HOME/.elastic-package/profiles/default/certs/kibana/ca-cert.pem` in the same shell. This is to set up the certificate needed to access EPR with https.
3. In Kibana, add the Elasticsearch integration (should be version 1.5.0). Check that the `Scope` setting is controlled by a select. Note: in the latest version, this integration now provides a default value, which should be set to `node`.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

