### PR TITLE
Redirect app/observability/exploratory-view to app/exploratory-view

### DIFF
--- a/x-pack/plugins/observability/public/routes/index.tsx
+++ b/x-pack/plugins/observability/public/routes/index.tsx
@@ -7,9 +7,9 @@
 
 import * as t from 'io-ts';
 import React from 'react';
-import { useHistory } from 'react-router-dom';
+import { useHistory, useLocation } from 'react-router-dom';
 import { DatePickerContextProvider } from '../context/date_picker_context';
-import { jsonRt } from './json_rt';
+import { useKibana } from '../utils/kibana_react';
 import { AlertsPage } from '../pages/alerts/alerts';
 import { AlertDetails } from '../pages/alert_details/alert_details';
 import { CasesPage } from '../pages/cases/cases';
@@ -19,7 +19,6 @@ import { RuleDetailsPage } from '../pages/rule_details';
 import { SlosPage } from '../pages/slos/slos';
 import { SloDetailsPage } from '../pages/slo_details/slo_details';
 import { SloEditPage } from '../pages/slo_edit/slo_edit';
-import { ObservabilityExploratoryView } from '../components/shared/exploratory_view/obsv_exploratory_view';
 import { casesPath } from '../../common';
 
 export type RouteParams<T extends keyof typeof routes> = DecodeParams<typeof routes[T]['params']>;
@@ -35,9 +34,20 @@ export interface Params {
 
 // Note: React Router DOM <Redirect> component was not working here
 // so I've recreated this simple version for this purpose.
-function SimpleRedirect({ to }: { to: string }) {
+function SimpleRedirect({ to, redirectToApp }: { to: string; redirectToApp?: string }) {
+  const {
+    http: { basePath },
+  } = useKibana().services;
   const history = useHistory();
-  history.replace(to);
+  const { search, hash } = useLocation();
+
+  if (redirectToApp) {
+    window.location.replace(
+      `${window.location.origin}${basePath.prepend(`/app/${redirectToApp}${to}${search}${hash}`)}`
+    );
+  } else if (to) {
+    history.replace(to);
+  }
   return null;
 }
 
@@ -83,18 +93,11 @@ export const routes = {
     },
     exact: true,
   },
-  '/exploratory-view/': {
+  '/exploratory-view': {
     handler: () => {
-      return <ObservabilityExploratoryView />;
+      return <SimpleRedirect to="/" redirectToApp="exploratory-view" />;
     },
-    params: {
-      query: t.partial({
-        rangeFrom: t.string,
-        rangeTo: t.string,
-        refreshPaused: jsonRt.pipe(t.boolean),
-        refreshInterval: jsonRt.pipe(t.number),
-      }),
-    },
+    params: {},
     exact: true,
   },
   '/alerts/rules': {


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/153940

# 📝 Summary

Now that the Exploratory View route inside the Observability app has been copied into its own separate application (https://github.com/elastic/kibana/issues/153830), we can redirect users from the Exploratory View component in the Obs app to Exploratory View application.

# ✅ Acceptance Criteria
- When navigating to `/app/observability/exploratory-view`, the Observability app should redirect to `/app/exploratory-view`.  Including search parameters!