### PR TITLE
feat(slo): Use dynamic fixed interval based on the slo time window duration

### DIFF
--- a/x-pack/plugins/observability/public/pages/slos/components/slo_sparkline.tsx
+++ b/x-pack/plugins/observability/public/pages/slos/components/slo_sparkline.tsx
@@ -9,6 +9,7 @@ import { AreaSeries, Chart, Fit, LineSeries, ScaleType, Settings } from '@elasti
 import React from 'react';
 import { EuiLoadingChart, useEuiTheme } from '@elastic/eui';
 import { EUI_SPARKLINE_THEME_PARTIAL } from '@elastic/eui/dist/eui_charts_theme';
+
 import { useKibana } from '../../../utils/kibana_react';
 
 interface Data {

--- a/x-pack/plugins/observability/server/services/slo/__snapshots__/historical_summary_client.test.ts.snap
+++ b/x-pack/plugins/observability/server/services/slo/__snapshots__/historical_summary_client.test.ts.snap
@@ -4,10 +4,10 @@ exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns th
 Object {
   "date": Any<ClockDate>,
   "errorBudget": Object {
-    "consumed": 0.004019,
+    "consumed": 0,
     "initial": 0.05,
     "isEstimated": true,
-    "remaining": 0.995981,
+    "remaining": 1,
   },
   "sliValue": 0.97,
   "status": "HEALTHY",
@@ -18,10 +18,10 @@ exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns th
 Object {
   "date": Any<ClockDate>,
   "errorBudget": Object {
-    "consumed": 0.023374,
+    "consumed": 0.003226,
     "initial": 0.05,
     "isEstimated": true,
-    "remaining": 0.976626,
+    "remaining": 0.996774,
   },
   "sliValue": 0.97,
   "status": "HEALTHY",
@@ -32,10 +32,10 @@ exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns th
 Object {
   "date": Any<ClockDate>,
   "errorBudget": Object {
-    "consumed": 0.042725,
+    "consumed": 0.006452,
     "initial": 0.05,
     "isEstimated": true,
-    "remaining": 0.957275,
+    "remaining": 0.993548,
   },
   "sliValue": 0.97,
   "status": "HEALTHY",
@@ -46,10 +46,10 @@ exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns th
 Object {
   "date": Any<ClockDate>,
   "errorBudget": Object {
-    "consumed": 0.06208,
+    "consumed": 0.009677,
     "initial": 0.05,
     "isEstimated": true,
-    "remaining": 0.93792,
+    "remaining": 0.990323,
   },
   "sliValue": 0.97,
   "status": "HEALTHY",
@@ -60,10 +60,10 @@ exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns th
 Object {
   "date": Any<ClockDate>,
   "errorBudget": Object {
-    "consumed": 0.081433,
+    "consumed": 0.012903,
     "initial": 0.05,
     "isEstimated": true,
-    "remaining": 0.918567,
+    "remaining": 0.987097,
   },
   "sliValue": 0.97,
   "status": "HEALTHY",
@@ -74,10 +74,10 @@ exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns th
 Object {
   "date": Any<ClockDate>,
   "errorBudget": Object {
-    "consumed": 0.100784,
+    "consumed": 0.016129,
     "initial": 0.05,
     "isEstimated": true,
-    "remaining": 0.899216,
+    "remaining": 0.983871,
   },
   "sliValue": 0.97,
   "status": "HEALTHY",
@@ -88,10 +88,10 @@ exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns th
 Object {
   "date": Any<ClockDate>,
   "errorBudget": Object {
-    "consumed": 0.120137,
+    "consumed": 0.019355,
     "initial": 0.05,
     "isEstimated": true,
-    "remaining": 0.879863,
+    "remaining": 0.980645,
   },
   "sliValue": 0.97,
   "status": "HEALTHY",
@@ -102,10 +102,10 @@ exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns th
 Object {
   "date": Any<ClockDate>,
   "errorBudget": Object {
-    "consumed": 0.139494,
+    "consumed": 0.022581,
     "initial": 0.05,
     "isEstimated": true,
-    "remaining": 0.860506,
+    "remaining": 0.977419,
   },
   "sliValue": 0.97,
   "status": "HEALTHY",
@@ -116,10 +116,10 @@ exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns th
 Object {
   "date": Any<ClockDate>,
   "errorBudget": Object {
-    "consumed": 0.15887,
+    "consumed": 0.025806,
     "initial": 0.05,
     "isEstimated": true,
-    "remaining": 0.84113,
+    "remaining": 0.974194,
   },
   "sliValue": 0.97,
   "status": "HEALTHY",
@@ -130,10 +130,10 @@ exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns th
 Object {
   "date": Any<ClockDate>,
   "errorBudget": Object {
-    "consumed": 0.1782,
+    "consumed": 0.029032,
     "initial": 0.05,
     "isEstimated": true,
-    "remaining": 0.8218,
+    "remaining": 0.970968,
   },
   "sliValue": 0.97,
   "status": "HEALTHY",
@@ -144,10 +144,10 @@ exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns th
 Object {
   "date": Any<ClockDate>,
   "errorBudget": Object {
-    "consumed": 0.197546,
+    "consumed": 0.032258,
     "initial": 0.05,
     "isEstimated": true,
-    "remaining": 0.802454,
+    "remaining": 0.967742,
   },
   "sliValue": 0.97,
   "status": "HEALTHY",
@@ -158,10 +158,10 @@ exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns th
 Object {
   "date": Any<ClockDate>,
   "errorBudget": Object {
-    "consumed": 0.216933,
+    "consumed": 0.035484,
     "initial": 0.05,
     "isEstimated": true,
-    "remaining": 0.783067,
+    "remaining": 0.964516,
   },
   "sliValue": 0.97,
   "status": "HEALTHY",
@@ -172,10 +172,10 @@ exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns th
 Object {
   "date": Any<ClockDate>,
   "errorBudget": Object {
-    "consumed": 0.236292,
+    "consumed": 0.03871,
     "initial": 0.05,
     "isEstimated": true,
-    "remaining": 0.763708,
+    "remaining": 0.96129,
   },
   "sliValue": 0.97,
   "status": "HEALTHY",
@@ -186,10 +186,10 @@ exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns th
 Object {
   "date": Any<ClockDate>,
   "errorBudget": Object {
-    "consumed": 0.25563,
+    "consumed": 0.041935,
     "initial": 0.05,
     "isEstimated": true,
-    "remaining": 0.74437,
+    "remaining": 0.958065,
   },
   "sliValue": 0.97,
   "status": "HEALTHY",
@@ -200,10 +200,10 @@ exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns th
 Object {
   "date": Any<ClockDate>,
   "errorBudget": Object {
-    "consumed": 0.274977,
+    "consumed": 0.04516,
     "initial": 0.05,
     "isEstimated": true,
-    "remaining": 0.725023,
+    "remaining": 0.95484,
   },
   "sliValue": 0.97,
   "status": "HEALTHY",
@@ -214,10 +214,10 @@ exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns th
 Object {
   "date": Any<ClockDate>,
   "errorBudget": Object {
-    "consumed": 0.294298,
+    "consumed": 0.048387,
     "initial": 0.05,
     "isEstimated": true,
-    "remaining": 0.705702,
+    "remaining": 0.951613,
   },
   "sliValue": 0.97,
   "status": "HEALTHY",
@@ -228,10 +228,10 @@ exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns th
 Object {
   "date": Any<ClockDate>,
   "errorBudget": Object {
-    "consumed": 0.313653,
+    "consumed": 0.051612,
     "initial": 0.05,
     "isEstimated": true,
-    "remaining": 0.686347,
+    "remaining": 0.948388,
   },
   "sliValue": 0.97,
   "status": "HEALTHY",
@@ -242,10 +242,1270 @@ exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns th
 Object {
   "date": Any<ClockDate>,
   "errorBudget": Object {
-    "consumed": 0.333025,
+    "consumed": 0.054839,
     "initial": 0.05,
     "isEstimated": true,
-    "remaining": 0.666975,
+    "remaining": 0.945161,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 19`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.058066,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.941934,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 20`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.06129,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.93871,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 21`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.064516,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.935484,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 22`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.067741,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.932259,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 23`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.070969,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.929031,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 24`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.074192,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.925808,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 25`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.077419,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.922581,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 26`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.080645,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.919355,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 27`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.083873,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.916127,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 28`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.087096,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.912904,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 29`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.090324,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.909676,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 30`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.09355,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.90645,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 31`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.096774,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.903226,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 32`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.1,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.9,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 33`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.103227,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.896773,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 34`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.10645,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.89355,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 35`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.109678,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.890322,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 36`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.112906,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.887094,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 37`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.116127,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.883873,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 38`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.119353,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.880647,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 39`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.122584,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.877416,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 40`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.125806,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.874194,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 41`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.129032,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.870968,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 42`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.132256,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.867744,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 43`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.135483,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.864517,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 44`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.138706,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.861294,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 45`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.141933,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.858067,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 46`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.145164,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.854836,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 47`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.14839,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.85161,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 48`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.151611,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.848389,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 49`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.154835,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.845165,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 50`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.158061,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.841939,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 51`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.16129,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.83871,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 52`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.164514,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.835486,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 53`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.167739,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.832261,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 54`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.170967,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.829033,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 55`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.174198,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.825802,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 56`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.177421,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.822579,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 57`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.180647,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.819353,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 58`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.183874,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.816126,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 59`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.187094,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.812906,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 60`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.190325,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.809675,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 61`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.193548,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.806452,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 62`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.196773,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.803227,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 63`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.2,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.8,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 64`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.203228,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.796772,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 65`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.206448,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.793552,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 66`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.209679,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.790321,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 67`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.212901,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.787099,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 68`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.216125,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.783875,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 69`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.219349,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.780651,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 70`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.222576,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.777424,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 71`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.225803,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.774197,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 72`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.229032,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.770968,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 73`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.232262,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.767738,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 74`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.235481,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.764519,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 75`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.238714,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.761286,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 76`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.241935,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.758065,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 77`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.245158,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.754842,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 78`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.248381,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.751619,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 79`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.251619,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.748381,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 80`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.254845,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.745155,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 81`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.258058,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.741942,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 82`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.261285,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.738715,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 83`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.264514,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.735486,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 84`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.267743,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.732257,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 85`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.270974,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.729026,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 86`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.274191,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.725809,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 87`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.277423,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.722577,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 88`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.280642,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.719358,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 89`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.283876,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.716124,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 90`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.287097,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.712903,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 91`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.290317,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.709683,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 92`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.293555,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.706445,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 93`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.296777,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.703223,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 94`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.3,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.7,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 95`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.303224,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.696776,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 96`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.306448,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.693552,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 97`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.309673,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.690327,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 98`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.312899,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.687101,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 99`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.316126,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.683874,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 100`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.319353,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.680647,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 101`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.322581,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.677419,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 102`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.325809,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.674191,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 103`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.329038,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.670962,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 104`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.332251,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.667749,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 105`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.335481,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.664519,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 106`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.338712,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.661288,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 107`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.341944,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.658056,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Occurrences SLOs returns the summary 108`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.345158,
+    "initial": 0.05,
+    "isEstimated": true,
+    "remaining": 0.654842,
   },
   "sliValue": 0.97,
   "status": "HEALTHY",
@@ -498,6 +1758,1266 @@ Object {
     "initial": 0.05,
     "isEstimated": false,
     "remaining": 0.975806,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 19`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.025538,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.974462,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 20`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.026882,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.973118,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 21`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.028226,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.971774,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 22`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.02957,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.97043,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 23`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.030914,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.969086,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 24`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.032258,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.967742,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 25`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.033602,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.966398,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 26`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.034946,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.965054,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 27`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.03629,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.96371,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 28`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.037634,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.962366,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 29`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.038978,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.961022,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 30`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.040323,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.959677,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 31`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.041667,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.958333,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 32`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.043011,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.956989,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 33`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.044355,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.955645,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 34`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.045699,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.954301,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 35`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.047043,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.952957,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 36`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.048387,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.951613,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 37`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.049731,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.950269,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 38`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.051075,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.948925,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 39`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.052419,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.947581,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 40`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.053763,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.946237,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 41`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.055108,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.944892,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 42`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.056452,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.943548,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 43`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.057796,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.942204,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 44`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.05914,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.94086,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 45`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.060484,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.939516,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 46`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.061828,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.938172,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 47`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.063172,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.936828,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 48`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.064516,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.935484,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 49`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.06586,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.93414,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 50`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.067204,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.932796,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 51`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.068548,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.931452,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 52`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.069892,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.930108,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 53`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.071237,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.928763,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 54`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.072581,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.927419,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 55`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.073925,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.926075,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 56`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.075269,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.924731,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 57`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.076613,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.923387,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 58`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.077957,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.922043,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 59`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.079301,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.920699,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 60`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.080645,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.919355,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 61`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.081989,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.918011,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 62`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.083333,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.916667,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 63`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.084677,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.915323,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 64`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.086022,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.913978,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 65`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.087366,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.912634,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 66`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.08871,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.91129,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 67`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.090054,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.909946,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 68`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.091398,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.908602,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 69`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.092742,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.907258,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 70`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.094086,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.905914,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 71`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.09543,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.90457,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 72`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.096774,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.903226,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 73`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.098118,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.901882,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 74`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.099462,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.900538,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 75`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.100806,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.899194,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 76`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.102151,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.897849,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 77`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.103495,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.896505,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 78`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.104839,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.895161,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 79`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.106183,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.893817,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 80`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.107527,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.892473,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 81`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.108871,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.891129,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 82`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.110215,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.889785,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 83`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.111559,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.888441,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 84`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.112903,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.887097,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 85`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.114247,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.885753,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 86`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.115591,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.884409,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 87`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.116935,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.883065,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 88`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.11828,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.88172,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 89`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.119624,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.880376,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 90`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.120968,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.879032,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 91`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.122312,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.877688,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 92`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.123656,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.876344,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 93`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.125,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.875,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 94`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.126344,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.873656,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 95`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.127688,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.872312,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 96`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.129032,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.870968,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 97`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.130376,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.869624,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 98`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.13172,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.86828,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 99`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.133065,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.866935,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 100`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.134409,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.865591,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 101`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.135753,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.864247,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 102`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.137097,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.862903,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 103`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.138441,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.861559,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 104`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.139785,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.860215,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 105`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.141129,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.858871,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 106`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.142473,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.857527,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 107`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.143817,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.856183,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Calendar Aligned and Timeslices SLOs returns the summary 108`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.145161,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.854839,
   },
   "sliValue": 0.97,
   "status": "HEALTHY",
@@ -924,6 +3444,2106 @@ Object {
 }
 `;
 
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 31`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 32`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 33`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 34`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 35`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 36`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 37`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 38`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 39`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 40`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 41`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 42`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 43`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 44`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 45`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 46`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 47`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 48`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 49`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 50`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 51`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 52`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 53`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 54`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 55`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 56`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 57`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 58`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 59`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 60`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 61`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 62`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 63`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 64`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 65`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 66`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 67`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 68`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 69`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 70`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 71`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 72`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 73`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 74`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 75`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 76`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 77`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 78`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 79`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 80`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 81`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 82`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 83`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 84`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 85`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 86`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 87`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 88`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 89`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 90`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 91`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 92`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 93`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 94`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 95`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 96`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 97`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 98`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 99`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 100`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 101`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 102`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 103`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 104`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 105`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 106`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 107`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 108`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 109`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 110`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 111`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 112`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 113`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 114`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 115`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 116`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 117`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 118`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 119`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 120`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 121`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 122`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 123`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 124`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 125`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 126`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 127`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 128`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 129`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 130`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 131`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 132`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 133`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 134`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 135`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 136`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 137`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 138`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 139`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 140`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 141`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 142`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 143`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 144`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 145`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 146`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 147`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 148`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 149`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 150`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 151`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 152`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 153`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 154`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 155`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 156`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 157`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 158`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 159`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 160`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 161`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 162`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 163`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 164`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 165`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 166`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 167`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 168`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 169`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 170`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 171`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 172`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 173`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 174`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 175`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 176`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 177`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 178`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 179`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Occurrences SLOs returns the summary 180`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
 exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 1`] = `
 Object {
   "date": Any<ClockDate>,
@@ -1331,6 +5951,2106 @@ Object {
 `;
 
 exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 30`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 31`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 32`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 33`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 34`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 35`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 36`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 37`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 38`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 39`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 40`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 41`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 42`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 43`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 44`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 45`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 46`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 47`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 48`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 49`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 50`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 51`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 52`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 53`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 54`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 55`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 56`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 57`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 58`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 59`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 60`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 61`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 62`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 63`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 64`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 65`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 66`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 67`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 68`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 69`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 70`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 71`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 72`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 73`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 74`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 75`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 76`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 77`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 78`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 79`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 80`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 81`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 82`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 83`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 84`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 85`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 86`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 87`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 88`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 89`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 90`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 91`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 92`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 93`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 94`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 95`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 96`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 97`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 98`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 99`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 100`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 101`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 102`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 103`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 104`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 105`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 106`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 107`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 108`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 109`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 110`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 111`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 112`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 113`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 114`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 115`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 116`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 117`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 118`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 119`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 120`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 121`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 122`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 123`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 124`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 125`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 126`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 127`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 128`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 129`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 130`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 131`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 132`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 133`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 134`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 135`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 136`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 137`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 138`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 139`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 140`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 141`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 142`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 143`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 144`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 145`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 146`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 147`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 148`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 149`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 150`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 151`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 152`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 153`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 154`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 155`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 156`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 157`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 158`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 159`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 160`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 161`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 162`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 163`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 164`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 165`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 166`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 167`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 168`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 169`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 170`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 171`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 172`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 173`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 174`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 175`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 176`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 177`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 178`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 179`] = `
+Object {
+  "date": Any<ClockDate>,
+  "errorBudget": Object {
+    "consumed": 0.6,
+    "initial": 0.05,
+    "isEstimated": false,
+    "remaining": 0.4,
+  },
+  "sliValue": 0.97,
+  "status": "HEALTHY",
+}
+`;
+
+exports[`FetchHistoricalSummary Rolling and Timeslices SLOs returns the summary 180`] = `
 Object {
   "date": Any<ClockDate>,
   "errorBudget": Object {

--- a/x-pack/plugins/observability/server/services/slo/historical_summary_client.test.ts
+++ b/x-pack/plugins/observability/server/services/slo/historical_summary_client.test.ts
@@ -9,7 +9,10 @@ import { ElasticsearchClientMock, elasticsearchServiceMock } from '@kbn/core/ser
 import moment from 'moment';
 import { oneMinute, oneMonth, thirtyDays } from './fixtures/duration';
 import { createSLO } from './fixtures/slo';
-import { DefaultHistoricalSummaryClient } from './historical_summary_client';
+import {
+  DefaultHistoricalSummaryClient,
+  getFixedIntervalAndBucketsPerDay,
+} from './historical_summary_client';
 
 const commonEsResponse = {
   took: 100,
@@ -30,8 +33,11 @@ const generateEsResponseForRollingSLO = (
   good: number = 97,
   total: number = 100
 ) => {
-  const numberOfBuckets = rollingDays * 2;
-  const day = moment.utc().subtract(numberOfBuckets, 'day').startOf('day');
+  const { fixedInterval, bucketsPerDay } = getFixedIntervalAndBucketsPerDay(rollingDays);
+  const numberOfBuckets = rollingDays * bucketsPerDay;
+  const doubleDuration = rollingDays * 2;
+  const startDay = moment.utc().subtract(doubleDuration, 'day').startOf('day');
+  const bucketSize = fixedInterval === '1d' ? 24 : Number(fixedInterval.slice(0, -1));
   return {
     ...commonEsResponse,
     responses: [
@@ -42,8 +48,14 @@ const generateEsResponseForRollingSLO = (
             buckets: Array(numberOfBuckets)
               .fill(0)
               .map((_, index) => ({
-                key_as_string: day.clone().add(index, 'day').toISOString(),
-                key: day.clone().add(index, 'day').format('x'),
+                key_as_string: startDay
+                  .clone()
+                  .add(index * bucketSize, 'hours')
+                  .toISOString(),
+                key: startDay
+                  .clone()
+                  .add(index * bucketSize, 'hours')
+                  .format('x'),
                 doc_count: 1440,
                 total: {
                   value: total,
@@ -65,8 +77,13 @@ const generateEsResponseForRollingSLO = (
   };
 };
 
-const generateEsResponseForCalendarAlignedSLO = (good: number = 97, total: number = 100) => {
-  const day = moment.utc().startOf('month');
+const generateEsResponseForMonthlyCalendarAlignedSLO = (good: number = 97, total: number = 100) => {
+  const { fixedInterval, bucketsPerDay } = getFixedIntervalAndBucketsPerDay(30);
+  const currentDayInMonth = 18;
+  const numberOfBuckets = currentDayInMonth * bucketsPerDay;
+  const bucketSize = Number(fixedInterval.slice(0, -1));
+  const startDay = moment.utc().startOf('month');
+
   return {
     ...commonEsResponse,
     responses: [
@@ -74,11 +91,17 @@ const generateEsResponseForCalendarAlignedSLO = (good: number = 97, total: numbe
         ...commonEsResponse,
         aggregations: {
           daily: {
-            buckets: Array(18)
+            buckets: Array(numberOfBuckets)
               .fill(0)
               .map((_, index) => ({
-                key_as_string: day.clone().add(index, 'day').toISOString(),
-                key: day.clone().add(index, 'day').format('x'),
+                key_as_string: startDay
+                  .clone()
+                  .add(index * bucketSize, 'hours')
+                  .toISOString(),
+                key: startDay
+                  .clone()
+                  .add(index * bucketSize, 'hours')
+                  .format('x'),
                 doc_count: 1440,
                 total: {
                   value: total,
@@ -126,7 +149,7 @@ describe('FetchHistoricalSummary', () => {
         expect(dailyResult).toMatchSnapshot({ date: expect.any(Date) })
       );
 
-      expect(results[slo.id]).toHaveLength(30);
+      expect(results[slo.id]).toHaveLength(180);
     });
   });
 
@@ -145,7 +168,7 @@ describe('FetchHistoricalSummary', () => {
       results[slo.id].forEach((dailyResult) =>
         expect(dailyResult).toMatchSnapshot({ date: expect.any(Date) })
       );
-      expect(results[slo.id]).toHaveLength(30);
+      expect(results[slo.id]).toHaveLength(180);
     });
   });
 
@@ -159,7 +182,7 @@ describe('FetchHistoricalSummary', () => {
         budgetingMethod: 'timeslices',
         objective: { target: 0.95, timesliceTarget: 0.9, timesliceWindow: oneMinute() },
       });
-      esClientMock.msearch.mockResolvedValueOnce(generateEsResponseForCalendarAlignedSLO());
+      esClientMock.msearch.mockResolvedValueOnce(generateEsResponseForMonthlyCalendarAlignedSLO());
       const client = new DefaultHistoricalSummaryClient(esClientMock);
 
       const results = await client.fetch([slo]);
@@ -168,7 +191,7 @@ describe('FetchHistoricalSummary', () => {
         expect(dailyResult).toMatchSnapshot({ date: expect.any(Date) })
       );
 
-      expect(results[slo.id]).toHaveLength(18);
+      expect(results[slo.id]).toHaveLength(108);
     });
   });
 
@@ -182,7 +205,7 @@ describe('FetchHistoricalSummary', () => {
         budgetingMethod: 'occurrences',
         objective: { target: 0.95 },
       });
-      esClientMock.msearch.mockResolvedValueOnce(generateEsResponseForCalendarAlignedSLO());
+      esClientMock.msearch.mockResolvedValueOnce(generateEsResponseForMonthlyCalendarAlignedSLO());
       const client = new DefaultHistoricalSummaryClient(esClientMock);
 
       const results = await client.fetch([slo]);
@@ -191,7 +214,7 @@ describe('FetchHistoricalSummary', () => {
         expect(dailyResult).toMatchSnapshot({ date: expect.any(Date) })
       );
 
-      expect(results[slo.id]).toHaveLength(18);
+      expect(results[slo.id]).toHaveLength(108);
     });
   });
 });

--- a/x-pack/plugins/observability/server/services/slo/historical_summary_client.ts
+++ b/x-pack/plugins/observability/server/services/slo/historical_summary_client.ts
@@ -130,8 +130,8 @@ function handleResultForCalendarAlignedAndOccurrences(
     const sliValue = computeSLI({ good, total });
 
     const durationCalendarPeriod = moment(dateRange.to).diff(dateRange.from, 'minutes');
-    const bucketDate = moment(bucket.key_as_string).endOf('day');
-    const durationSinceBeginning = bucketDate.isAfter(dateRange.to)
+    const bucketDate = moment(bucket.key_as_string);
+    const durationSinceBeginning = bucketDate.isSameOrAfter(dateRange.to)
       ? durationCalendarPeriod
       : moment(bucketDate).diff(dateRange.from, 'minutes');
 
@@ -183,8 +183,10 @@ function handleResultForRolling(slo: SLO, buckets: DailyAggBucket[]): Historical
     .duration(slo.timeWindow.duration.value, toMomentUnitOfTime(slo.timeWindow.duration.unit))
     .asDays();
 
+  const { bucketsPerDay } = getFixedIntervalAndBucketsPerDay(rollingWindowDurationInDays);
+
   return buckets
-    .slice(-rollingWindowDurationInDays)
+    .slice(-bucketsPerDay * rollingWindowDurationInDays)
     .map((bucket: DailyAggBucket): HistoricalSummary => {
       const good = bucket.cumulative_good?.value ?? 0;
       const total = bucket.cumulative_total?.value ?? 0;
@@ -204,6 +206,9 @@ function handleResultForRolling(slo: SLO, buckets: DailyAggBucket[]): Historical
 function generateSearchQuery(slo: SLO, dateRange: DateRange): MsearchMultisearchBody {
   const unit = toMomentUnitOfTime(slo.timeWindow.duration.unit);
   const timeWindowDurationInDays = moment.duration(slo.timeWindow.duration.value, unit).asDays();
+
+  const { fixedInterval, bucketsPerDay } =
+    getFixedIntervalAndBucketsPerDay(timeWindowDurationInDays);
 
   return {
     size: 0,
@@ -227,7 +232,7 @@ function generateSearchQuery(slo: SLO, dateRange: DateRange): MsearchMultisearch
       daily: {
         date_histogram: {
           field: '@timestamp',
-          fixed_interval: '1d',
+          fixed_interval: fixedInterval,
           extended_bounds: {
             min: dateRange.from.toISOString(),
             max: 'now/d',
@@ -261,7 +266,7 @@ function generateSearchQuery(slo: SLO, dateRange: DateRange): MsearchMultisearch
           cumulative_good: {
             moving_fn: {
               buckets_path: 'good',
-              window: timeWindowDurationInDays,
+              window: timeWindowDurationInDays * bucketsPerDay,
               shift: 1,
               script: 'MovingFunctions.sum(values)',
             },
@@ -269,7 +274,7 @@ function generateSearchQuery(slo: SLO, dateRange: DateRange): MsearchMultisearch
           cumulative_total: {
             moving_fn: {
               buckets_path: 'total',
-              window: timeWindowDurationInDays,
+              window: timeWindowDurationInDays * bucketsPerDay,
               shift: 1,
               script: 'MovingFunctions.sum(values)',
             },
@@ -299,4 +304,20 @@ function getDateRange(slo: SLO) {
   }
 
   assertNever(slo.timeWindow);
+}
+
+export function getFixedIntervalAndBucketsPerDay(durationInDays: number): {
+  fixedInterval: string;
+  bucketsPerDay: number;
+} {
+  if (durationInDays <= 7) {
+    return { fixedInterval: '1h', bucketsPerDay: 24 };
+  }
+  if (durationInDays <= 30) {
+    return { fixedInterval: '4h', bucketsPerDay: 6 };
+  }
+  if (durationInDays <= 90) {
+    return { fixedInterval: '12h', bucketsPerDay: 2 };
+  }
+  return { fixedInterval: '1d', bucketsPerDay: 1 };
 }


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/153949

This PR changes the fixed intervals used by the historical summary client and makes them dynamic based on the time window duration.


Time window duration | bucket size | number of buckets max
-- | -- | --
`<= 7 days` | 1h | 7 * 24 = 168
`> 7 days, <= 30 days` | 4h | 30 * 6 = 180
`> 30 days, <= 90 days` | 12h | 90 * 2 = 180
`> 90 days` | 1day | 365 * 1 = 365

## 🧪 Testing

Creating some SLO of different time window duration, using the [latency logs generator](https://github.com/kdelemme/slo#generate-latency-logs) and looking at the charts and responses from the historical summary API

## Screenshots


Screenshots |
-- |
![screencapture-localhost-5601-kibana-app-observability-slos-d5206830-ccd3-11ed-a42c-03bb27d378a8-2023-03-29-15_14_13](https://user-images.githubusercontent.com/1376800/228644087-0a2fbd7f-6f3e-45d2-8d5e-ad41fd0b8d35.png) |
![screencapture-localhost-5601-kibana-app-observability-slos-2655e590-ccd4-11ed-a42c-03bb27d378a8-2023-03-29-15_14_05](https://user-images.githubusercontent.com/1376800/228644094-3e313403-1daa-4176-a103-6ea21eaa00ac.png) |
![screencapture-localhost-5601-kibana-app-observability-slos-2023-03-29-15_13_52](https://user-images.githubusercontent.com/1376800/228644097-b3f0c9c4-0fdd-4e95-bbcb-94f14db5df25.png) |
