### PR TITLE
[ML] Fix data value passed to Single Metric viewer chart for anomaly where source data is missing

### DIFF
--- a/x-pack/plugins/ml/public/application/timeseriesexplorer/timeseriesexplorer_utils/timeseriesexplorer_utils.js
+++ b/x-pack/plugins/ml/public/application/timeseriesexplorer/timeseriesexplorer_utils/timeseriesexplorer_utils.js
@@ -166,11 +166,7 @@ export function processDataForFocusAnomalies(
         if (record.actual !== undefined) {
           // If cannot match chart point for anomaly time
           // substitute the value with the record's actual so it won't plot as null/0
-          if (chartPoint.value === null) {
-            chartPoint.value = record.actual;
-          }
-
-          if (record.function === ML_JOB_AGGREGATION.METRIC) {
+          if (chartPoint.value === null || record.function === ML_JOB_AGGREGATION.METRIC) {
             chartPoint.value = Array.isArray(record.actual) ? record.actual[0] : record.actual;
           }
 


### PR DESCRIPTION
## Summary

This PR corrects the type of value added to the Single Metric Viewer chart data for times where there is an anomaly but no corresponding source data, so that it is added as a single value rather than an array with one value. For a test case see https://github.com/elastic/kibana/issues/63098.

Before (last data point is an array):
<img width="1358" alt="image" src="https://user-images.githubusercontent.com/7405507/228911410-62ca8746-2892-4cef-bf83-c9cebdcfd25a.png">

After (last data point now a single value):
<img width="1328" alt="image" src="https://user-images.githubusercontent.com/7405507/228911723-65155718-9fac-4dbe-803e-f985b2c306a8.png">





