### PR TITLE
[Discover] [Saved Search] Cleanup saved search mappings

### DIFF
--- a/src/core/server/integration_tests/saved_objects/migrations/group2/check_registered_types.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/group2/check_registered_types.test.ts
@@ -125,7 +125,7 @@ describe('checking migration metadata changes on all registered SO types', () =>
         "query": "ec6000b775f06f81470df42d23f7a88cb31d64ba",
         "rules-settings": "9854495c3b54b16a6625fb250c35e5504da72266",
         "sample-data-telemetry": "c38daf1a49ed24f2a4fb091e6e1e833fccf19935",
-        "search": "4cc4abd3eb8a15348b30f5a487dbe57879be4886",
+        "search": "ed3a9b1681b57d69560909d51933fdf17576ea68",
         "search-session": "58a44d14ec991739166b2ec28d718001ab0f4b28",
         "search-telemetry": "ab67ef721f294f28d5e10febbd20653347720188",
         "security-rule": "1ff82dfb2298c3caf6888fc3ef15c6bf7a628877",

--- a/src/core/server/integration_tests/saved_objects/migrations/group2/check_registered_types.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/group2/check_registered_types.test.ts
@@ -125,7 +125,7 @@ describe('checking migration metadata changes on all registered SO types', () =>
         "query": "ec6000b775f06f81470df42d23f7a88cb31d64ba",
         "rules-settings": "9854495c3b54b16a6625fb250c35e5504da72266",
         "sample-data-telemetry": "c38daf1a49ed24f2a4fb091e6e1e833fccf19935",
-        "search": "01bc42d635e9ea0588741c4c7a2bbd3feb3ac5dc",
+        "search": "4cc4abd3eb8a15348b30f5a487dbe57879be4886",
         "search-session": "58a44d14ec991739166b2ec28d718001ab0f4b28",
         "search-telemetry": "ab67ef721f294f28d5e10febbd20653347720188",
         "security-rule": "1ff82dfb2298c3caf6888fc3ef15c6bf7a628877",

--- a/src/plugins/saved_search/common/types.ts
+++ b/src/plugins/saved_search/common/types.ts
@@ -37,7 +37,7 @@ export interface SavedSearchAttributes {
   rowHeight?: number;
 
   timeRestore?: boolean;
-  timeRange?: TimeRange;
+  timeRange?: Pick<TimeRange, 'from' | 'to'>;
   refreshInterval?: RefreshInterval;
 
   rowsPerPage?: number;

--- a/src/plugins/saved_search/public/services/saved_searches/saved_searches_utils.ts
+++ b/src/plugins/saved_search/public/services/saved_searches/saved_searches_utils.ts
@@ -6,6 +6,7 @@
  * Side Public License, v 1.
  */
 import { i18n } from '@kbn/i18n';
+import { pick } from 'lodash';
 import type { SavedSearchAttributes } from '../../../common';
 import { fromSavedSearchAttributes as fromSavedSearchAttributesCommon } from '../../../common';
 import type { SavedSearch } from './types';
@@ -54,7 +55,7 @@ export const toSavedSearchAttributes = (
   isTextBasedQuery: savedSearch.isTextBasedQuery ?? false,
   usesAdHocDataView: savedSearch.usesAdHocDataView,
   timeRestore: savedSearch.timeRestore ?? false,
-  timeRange: savedSearch.timeRange,
+  timeRange: savedSearch.timeRange ? pick(savedSearch.timeRange, ['from', 'to']) : undefined,
   refreshInterval: savedSearch.refreshInterval,
   rowsPerPage: savedSearch.rowsPerPage,
   breakdownField: savedSearch.breakdownField,

--- a/src/plugins/saved_search/server/saved_objects/search.ts
+++ b/src/plugins/saved_search/server/saved_objects/search.ts
@@ -39,29 +39,16 @@ export function getSavedSearchObjectType(
       properties: {
         title: { type: 'text' },
         description: { type: 'text' },
-        version: { type: 'integer' },
       },
     },
     schemas: {
       '8.8.0': schema.object({
+        // General
         title: schema.string(),
         description: schema.string({ defaultValue: '' }),
-        version: schema.maybe(schema.number()),
+
+        // Data grid
         columns: schema.arrayOf(schema.string(), { defaultValue: [] }),
-        viewMode: schema.maybe(
-          schema.oneOf([
-            schema.literal(VIEW_MODE.DOCUMENT_LEVEL),
-            schema.literal(VIEW_MODE.AGGREGATED_LEVEL),
-          ])
-        ),
-        hideChart: schema.boolean({ defaultValue: false }),
-        isTextBasedQuery: schema.boolean({ defaultValue: false }),
-        usesAdHocDataView: schema.maybe(schema.boolean()),
-        hideAggregatedPreview: schema.maybe(schema.boolean()),
-        hits: schema.maybe(schema.number()),
-        kibanaSavedObjectMeta: schema.object({
-          searchSourceJSON: schema.string(),
-        }),
         sort: schema.oneOf(
           [
             schema.arrayOf(schema.arrayOf(schema.string(), { minSize: 2, maxSize: 2 })),
@@ -83,6 +70,20 @@ export function getSavedSearchObjectType(
           { defaultValue: {} }
         ),
         rowHeight: schema.maybe(schema.number()),
+        rowsPerPage: schema.maybe(schema.number()),
+
+        // Chart
+        hideChart: schema.boolean({ defaultValue: false }),
+        breakdownField: schema.maybe(schema.string()),
+
+        // Search
+        kibanaSavedObjectMeta: schema.object({
+          searchSourceJSON: schema.string(),
+        }),
+        isTextBasedQuery: schema.boolean({ defaultValue: false }),
+        usesAdHocDataView: schema.maybe(schema.boolean()),
+
+        // Time
         timeRestore: schema.maybe(schema.boolean()),
         timeRange: schema.maybe(
           schema.object({
@@ -96,8 +97,19 @@ export function getSavedSearchObjectType(
             value: schema.number(),
           })
         ),
-        rowsPerPage: schema.maybe(schema.number()),
-        breakdownField: schema.maybe(schema.string()),
+
+        // Display
+        viewMode: schema.maybe(
+          schema.oneOf([
+            schema.literal(VIEW_MODE.DOCUMENT_LEVEL),
+            schema.literal(VIEW_MODE.AGGREGATED_LEVEL),
+          ])
+        ),
+        hideAggregatedPreview: schema.maybe(schema.boolean()),
+
+        // Legacy
+        hits: schema.maybe(schema.number()),
+        version: schema.maybe(schema.number()),
       }),
     },
     migrations: () => getAllMigrations(getSearchSourceMigrations()),

--- a/src/plugins/saved_search/server/saved_objects/search.ts
+++ b/src/plugins/saved_search/server/saved_objects/search.ts
@@ -88,9 +88,6 @@ export function getSavedSearchObjectType(
           schema.object({
             from: schema.string(),
             to: schema.string(),
-            mode: schema.maybe(
-              schema.oneOf([schema.literal('absolute'), schema.literal('relative')])
-            ),
           })
         ),
         refreshInterval: schema.maybe(

--- a/src/plugins/saved_search/server/saved_objects/search.ts
+++ b/src/plugins/saved_search/server/saved_objects/search.ts
@@ -37,15 +37,17 @@ export function getSavedSearchObjectType(
     mappings: {
       dynamic: false,
       properties: {
-        description: { type: 'text' },
         title: { type: 'text' },
+        description: { type: 'text' },
         version: { type: 'integer' },
       },
     },
     schemas: {
       '8.8.0': schema.object({
-        columns: schema.arrayOf(schema.string(), { defaultValue: [] }),
+        title: schema.string(),
         description: schema.string({ defaultValue: '' }),
+        version: schema.maybe(schema.number()),
+        columns: schema.arrayOf(schema.string(), { defaultValue: [] }),
         viewMode: schema.maybe(
           schema.oneOf([
             schema.literal(VIEW_MODE.DOCUMENT_LEVEL),
@@ -67,7 +69,6 @@ export function getSavedSearchObjectType(
           ],
           { defaultValue: [] }
         ),
-        title: schema.string({ defaultValue: '' }),
         grid: schema.object(
           {
             columns: schema.maybe(
@@ -81,7 +82,6 @@ export function getSavedSearchObjectType(
           },
           { defaultValue: {} }
         ),
-        version: schema.maybe(schema.number()),
         rowHeight: schema.maybe(schema.number()),
         timeRestore: schema.maybe(schema.boolean()),
         timeRange: schema.maybe(

--- a/src/plugins/saved_search/server/saved_objects/search.ts
+++ b/src/plugins/saved_search/server/saved_objects/search.ts
@@ -44,34 +44,39 @@ export function getSavedSearchObjectType(
     },
     schemas: {
       '8.8.0': schema.object({
-        columns: schema.arrayOf(schema.string()),
-        description: schema.string(),
+        columns: schema.arrayOf(schema.string(), { defaultValue: [] }),
+        description: schema.string({ defaultValue: '' }),
         viewMode: schema.maybe(
           schema.oneOf([
             schema.literal(VIEW_MODE.DOCUMENT_LEVEL),
             schema.literal(VIEW_MODE.AGGREGATED_LEVEL),
           ])
         ),
-        hideChart: schema.boolean(),
-        isTextBasedQuery: schema.boolean(),
+        hideChart: schema.boolean({ defaultValue: false }),
+        isTextBasedQuery: schema.boolean({ defaultValue: false }),
         usesAdHocDataView: schema.maybe(schema.boolean()),
         hideAggregatedPreview: schema.maybe(schema.boolean()),
         hits: schema.maybe(schema.number()),
         kibanaSavedObjectMeta: schema.object({
           searchSourceJSON: schema.string(),
         }),
-        sort: schema.arrayOf(schema.arrayOf(schema.string(), { minSize: 2, maxSize: 2 })),
-        title: schema.string(),
-        grid: schema.object({
-          columns: schema.maybe(
-            schema.recordOf(
-              schema.string(),
-              schema.object({
-                width: schema.maybe(schema.number()),
-              })
-            )
-          ),
+        sort: schema.arrayOf(schema.arrayOf(schema.string(), { minSize: 2, maxSize: 2 }), {
+          defaultValue: [],
         }),
+        title: schema.string({ defaultValue: '' }),
+        grid: schema.object(
+          {
+            columns: schema.maybe(
+              schema.recordOf(
+                schema.string(),
+                schema.object({
+                  width: schema.maybe(schema.number()),
+                })
+              )
+            ),
+          },
+          { defaultValue: {} }
+        ),
         version: schema.maybe(schema.number()),
         rowHeight: schema.maybe(schema.number()),
         timeRestore: schema.maybe(schema.boolean()),

--- a/src/plugins/saved_search/server/saved_objects/search.ts
+++ b/src/plugins/saved_search/server/saved_objects/search.ts
@@ -60,9 +60,13 @@ export function getSavedSearchObjectType(
         kibanaSavedObjectMeta: schema.object({
           searchSourceJSON: schema.string(),
         }),
-        sort: schema.arrayOf(schema.arrayOf(schema.string(), { minSize: 2, maxSize: 2 }), {
-          defaultValue: [],
-        }),
+        sort: schema.oneOf(
+          [
+            schema.arrayOf(schema.arrayOf(schema.string(), { minSize: 2, maxSize: 2 })),
+            schema.arrayOf(schema.string(), { minSize: 2, maxSize: 2 }),
+          ],
+          { defaultValue: [] }
+        ),
         title: schema.string({ defaultValue: '' }),
         grid: schema.object(
           {

--- a/src/plugins/saved_search/tsconfig.json
+++ b/src/plugins/saved_search/tsconfig.json
@@ -16,6 +16,7 @@
     "@kbn/spaces-plugin",
     "@kbn/saved-objects-tagging-oss-plugin",
     "@kbn/i18n",
+    "@kbn/config-schema",
   ],
   "exclude": [
     "target/**/*",

--- a/x-pack/test/api_integration/apis/security/index_fields.ts
+++ b/x-pack/test/api_integration/apis/security/index_fields.ts
@@ -33,7 +33,7 @@ export default function ({ getService }: FtrProviderContext) {
               'type',
               'visualization.title',
               'dashboard.title',
-              'search.columns',
+              'search.title',
               'space.name',
             ];
 


### PR DESCRIPTION
## Summary

This PR cleans up saved search mappings, removing all fields that aren't being searched or aggregated on.

Continuation of the work started in #153129.

### Checklist

- [ ] ~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)~
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [ ] ~[Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios~
- [ ] ~Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))~
- [ ] ~Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))~
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))~
- [ ] ~This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)~

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)