### PR TITLE
[Stack Functional Integration] Change screenshot compare resolution

### DIFF
--- a/x-pack/test/stack_functional_integration/apps/metricbeat/_metricbeat_dashboard.ts
+++ b/x-pack/test/stack_functional_integration/apps/metricbeat/_metricbeat_dashboard.ts
@@ -55,7 +55,7 @@ export default function ({
       await PageObjects.common.dismissBanner();
       await PageObjects.dashboard.waitForRenderComplete();
       await PageObjects.common.sleep(2000);
-      await browser.setScreenshotSize(1000, 1337);
+      await browser.setScreenshotSize(1000, 1937);
       await PageObjects.common.sleep(2000);
     });
 


### PR DESCRIPTION
## Summary
This changes the compare resolution for the Metricbeat dashboard visual compare tests in order to remove the vertical scroll bar influencing the results.  Various OSs used in testing have different scroll bar behaviors and widths. 




<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->