### PR TITLE
Logstash tooltip mentioned "legacy in-memory queue"

### DIFF
--- a/x-pack/plugins/logstash/common/constants/tooltips.ts
+++ b/x-pack/plugins/logstash/common/constants/tooltips.ts
@@ -38,7 +38,7 @@ export const TOOLTIPS = {
     'queue.type': i18n.translate('xpack.logstash.queueTypeTooltip', {
       defaultMessage:
         'The internal queuing model to use for event buffering. Specify memory for ' +
-        'legacy in-memory based queuing, or persisted for disk-based ACKed queueing\n\n' +
+        'in-memory based queuing, or persisted for disk-based ACKed queueing\n\n' +
         'Default value: memory',
     }),
 

--- a/x-pack/plugins/logstash/public/application/components/pipeline_editor/__snapshots__/pipeline_editor.test.js.snap
+++ b/x-pack/plugins/logstash/public/application/components/pipeline_editor/__snapshots__/pipeline_editor.test.js.snap
@@ -159,7 +159,7 @@ Default value: 50ms"
     <EuiFlexGroup>
       <FlexItemSetting
         formRowLabelText="Queue type"
-        formRowTooltipText="The internal queuing model to use for event buffering. Specify memory for legacy in-memory based queuing, or persisted for disk-based ACKed queueing
+        formRowTooltipText="The internal queuing model to use for event buffering. Specify memory for in-memory based queuing, or persisted for disk-based ACKed queueing
 
 Default value: memory"
       >
@@ -450,7 +450,7 @@ Default value: 50ms"
     <EuiFlexGroup>
       <FlexItemSetting
         formRowLabelText="Queue type"
-        formRowTooltipText="The internal queuing model to use for event buffering. Specify memory for legacy in-memory based queuing, or persisted for disk-based ACKed queueing
+        formRowTooltipText="The internal queuing model to use for event buffering. Specify memory for in-memory based queuing, or persisted for disk-based ACKed queueing
 
 Default value: memory"
       >
@@ -741,7 +741,7 @@ Default value: 50ms"
     <EuiFlexGroup>
       <FlexItemSetting
         formRowLabelText="Queue type"
-        formRowTooltipText="The internal queuing model to use for event buffering. Specify memory for legacy in-memory based queuing, or persisted for disk-based ACKed queueing
+        formRowTooltipText="The internal queuing model to use for event buffering. Specify memory for in-memory based queuing, or persisted for disk-based ACKed queueing
 
 Default value: memory"
       >
@@ -1003,7 +1003,7 @@ Default value: 50ms"
     <EuiFlexGroup>
       <FlexItemSetting
         formRowLabelText="Queue type"
-        formRowTooltipText="The internal queuing model to use for event buffering. Specify memory for legacy in-memory based queuing, or persisted for disk-based ACKed queueing
+        formRowTooltipText="The internal queuing model to use for event buffering. Specify memory for in-memory based queuing, or persisted for disk-based ACKed queueing
 
 Default value: memory"
       >
@@ -1305,7 +1305,7 @@ Default value: 50ms"
     <EuiFlexGroup>
       <FlexItemSetting
         formRowLabelText="Queue type"
-        formRowTooltipText="The internal queuing model to use for event buffering. Specify memory for legacy in-memory based queuing, or persisted for disk-based ACKed queueing
+        formRowTooltipText="The internal queuing model to use for event buffering. Specify memory for in-memory based queuing, or persisted for disk-based ACKed queueing
 
 Default value: memory"
       >
@@ -1567,7 +1567,7 @@ Default value: 50ms"
     <EuiFlexGroup>
       <FlexItemSetting
         formRowLabelText="Queue type"
-        formRowTooltipText="The internal queuing model to use for event buffering. Specify memory for legacy in-memory based queuing, or persisted for disk-based ACKed queueing
+        formRowTooltipText="The internal queuing model to use for event buffering. Specify memory for in-memory based queuing, or persisted for disk-based ACKed queueing
 
 Default value: memory"
       >


### PR DESCRIPTION
## Summary

I adapted the Logstash tooltip since the in-memory queue is not legacy.

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
