### PR TITLE
[Fleet] Disable TSBD setting switch when enabled

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/experimental_datastream_settings.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/experimental_datastream_settings.test.tsx
@@ -198,7 +198,7 @@ describe('ExperimentDatastreamSettings', () => {
       expect(mockSetNewExperimentalDataFeatures).not.toBeCalled();
     });
 
-    it('should be enabled and checked if registry data streams includes "elasticsearch.index_mode: time_series"', () => {
+    it('should be disabled and checked with a tooltip if registry data streams includes "elasticsearch.index_mode: time_series"', () => {
       const mockSetNewExperimentalDataFeatures = jest.fn();
       const res = createFleetTestRendererMock().render(
         <ExperimentDatastreamSettings
@@ -216,7 +216,7 @@ describe('ExperimentDatastreamSettings', () => {
         />
       );
 
-      const tsdbSwitch = res.getByTestId('packagePolicyEditor.tsdbExperimentalFeature.switch');
+      const tsdbSwitch = res.getByTestId('packagePolicyEditor.tsdbExperimentalFeature.switchTooltip');
 
       expect(tsdbSwitch).toBeDisabled();
       expect(tsdbSwitch).toBeChecked();

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/experimental_datastream_settings.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/experimental_datastream_settings.test.tsx
@@ -218,7 +218,7 @@ describe('ExperimentDatastreamSettings', () => {
 
       const tsdbSwitch = res.getByTestId('packagePolicyEditor.tsdbExperimentalFeature.switch');
 
-      expect(tsdbSwitch).toBeEnabled();
+      expect(tsdbSwitch).toBeDisabled();
       expect(tsdbSwitch).toBeChecked();
       expect(mockSetNewExperimentalDataFeatures).not.toBeCalled();
     });

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/experimental_datastream_settings.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/experimental_datastream_settings.test.tsx
@@ -216,7 +216,9 @@ describe('ExperimentDatastreamSettings', () => {
         />
       );
 
-      const tsdbSwitch = res.getByTestId('packagePolicyEditor.tsdbExperimentalFeature.switchTooltip');
+      const tsdbSwitch = res.getByTestId(
+        'packagePolicyEditor.tsdbExperimentalFeature.switchTooltip'
+      );
 
       expect(tsdbSwitch).toBeDisabled();
       expect(tsdbSwitch).toBeChecked();

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/experimental_datastream_settings.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/experimental_datastream_settings.tsx
@@ -187,6 +187,7 @@ export const ExperimentDatastreamSettings: React.FunctionComponent<Props> = ({
         <EuiFlexItem>
           <EuiSwitch
             checked={newExperimentalIndexingFeature.tsdb ?? false}
+            disabled={isTimeSeriesEnabledByDefault}
             data-test-subj="packagePolicyEditor.tsdbExperimentalFeature.switch"
             label={
               <FormattedMessage

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/experimental_datastream_settings.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/experimental_datastream_settings.tsx
@@ -16,6 +16,7 @@ import {
   EuiSpacer,
   EuiTitle,
   EuiLink,
+  EuiIconTip,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
@@ -185,22 +186,56 @@ export const ExperimentDatastreamSettings: React.FunctionComponent<Props> = ({
           />
         </EuiFlexItem>
         <EuiFlexItem>
-          <EuiSwitch
-            checked={newExperimentalIndexingFeature.tsdb ?? false}
-            disabled={isTimeSeriesEnabledByDefault}
-            data-test-subj="packagePolicyEditor.tsdbExperimentalFeature.switch"
-            label={
-              <FormattedMessage
-                id="xpack.fleet.packagePolicyEditor.experimentalFeatures.TSDBLabel"
-                defaultMessage="Time-series indexing (TSDB)"
-              />
-            }
-            onChange={(e) => {
-              onIndexingSettingChange({
-                tsdb: e.target.checked,
-              });
-            }}
-          />
+          {isTimeSeriesEnabledByDefault ? (
+            <EuiFlexGroup>
+              <EuiFlexItem grow={false}>
+                <EuiSwitch
+                  checked={newExperimentalIndexingFeature.tsdb ?? false}
+                  disabled={true}
+                  data-test-subj="packagePolicyEditor.tsdbExperimentalFeature.switchTooltip"
+                  label={
+                    <FormattedMessage
+                      id="xpack.fleet.packagePolicyEditor.experimentalFeatures.TSDBLabel"
+                      defaultMessage="Time-series database (TSDB) indexing"
+                    />
+                  }
+                  onChange={(e) => {
+                    onIndexingSettingChange({
+                      tsdb: e.target.checked,
+                    });
+                  }}
+                />
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiIconTip
+                  content={i18n.translate(
+                    'xpack.fleet.packagePolicyEditor.experimentalFeatures.tooltip',
+                    {
+                      defaultMessage: 'TSDB indexing is enabled by the integration',
+                    }
+                  )}
+                  position="right"
+                  data-test-subj="foo"
+                />
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          ) : (
+            <EuiSwitch
+              checked={newExperimentalIndexingFeature.tsdb ?? false}
+              data-test-subj="packagePolicyEditor.tsdbExperimentalFeature.switch"
+              label={
+                <FormattedMessage
+                  id="xpack.fleet.packagePolicyEditor.experimentalFeatures.TSDBLabel"
+                  defaultMessage="Time-series database (TSDB) indexing"
+                />
+              }
+              onChange={(e) => {
+                onIndexingSettingChange({
+                  tsdb: e.target.checked,
+                });
+              }}
+            />
+          )}
         </EuiFlexItem>
         <EuiFlexItem>
           <EuiSwitch


### PR DESCRIPTION
### Summary

Disable `Time-series indexing (TSDB)` switch in experimental datastream settings if TSDB is enabled in the package itself.

As part of this fix, the following changes are included in compliance with UX rules:
* Rename toggle label from `Time-series indexing (TSDB)` to `Time-series database (TSDB) indexing`.
* When the toggle is disabled, add a question mark icon with a tooltip with text `TSDB indexing is enabled by the integration`.

Closes https://github.com/elastic/kibana/issues/152778

### Screenshots

#### Before

![Screenshot 2023-04-11 at 17 54 45](https://user-images.githubusercontent.com/23701614/231219749-20f157ab-28bb-48c7-8dfb-982f6361f75d.png)

#### After

When the integration does NOT enable TSDB:
![Screenshot 2023-04-11 at 17 26 04](https://user-images.githubusercontent.com/23701614/231220105-32e165ea-de89-40ae-8ff7-18d8ddc96d66.png)

When the integration DOES enable TSDB:
![Screenshot 2023-04-11 at 17 28 12](https://user-images.githubusercontent.com/23701614/231218852-0e4027c6-464f-4787-8484-68f4b862664a.png)

### Steps to test locally

Refer to the [original PR](https://github.com/elastic/kibana/pull/144974) for extended context.

#### Testing a package without TSDB

1. Run Kibana on this branch.
2. Add the System integration (version 1.5.2 at the time of writing); under the `Collect metrics from System instances -> System cpu metrics -> Advanced options` settings, the `Time-series indexing (TSDB)` switch should be off and enabled (you should be able to toggle it on and off).

#### Testing a package with TSDB

1. Update the system integration to use TSDB and run a local package registry:
   1. In the integrations repo, bump the patch version of the system integration: add a changelog entry (1.25.3) and update the version accordingly in the package manifest.
   2. In the manifest of the cpu data stream, add the following to enable TSDB (see [this doc](https://github.com/elastic/integrations/blob/2abe6f635a27996479fee83203149ba2236dec7a/docs/developer_tsdb_migration_guidelines.md) for context):
      ```
      elasticsearch:
        index_mode: "time_series"
      ```
   3. Build the system integration: `cd packages/system && elastic-package build`
   4. Run a local package registry: `elastic-package stack up -d -v  --services package-registry`
   5. Check at https://localhost:8080/search?package=system that the version is correct (1.5.3).
4. Run Kibana on this branch to test the change:
   1. In your `kibana.dev.yml`, add `xpack.fleet.registryUrl: https://localhost:8080` if not there already.
   2. Also in `kibana.dev.yml`, add `xpack.fleet.enableExperimental: ['experimentalDataStreamSettings']` if not there already.
   6. Before running `yarn start`, run `export NODE_EXTRA_CA_CERTS=$HOME/.elastic-package/profiles/default/certs/kibana/ca-cert.pem` in the same shell. This is to set up the certificate needed to access EPR with https.
   7. In Kibana, add the System integration (check that the version is correct); under the `Collect metrics from System instances -> System cpu metrics -> Advanced options` settings, the `Time-series indexing (TSDB)` switch should be on and disabled. There should be a question mark icon with a tooltip.