### PR TITLE
feat(slo): Update custom kql timestamp field select

### DIFF
--- a/x-pack/plugins/observability/public/hooks/slo/use_fetch_index_pattern_fields.ts
+++ b/x-pack/plugins/observability/public/hooks/slo/use_fetch_index_pattern_fields.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useQuery } from '@tanstack/react-query';
+import { useKibana } from '../../utils/kibana_react';
+
+export interface UseFetchIndexPatternFieldsResponse {
+  isLoading: boolean;
+  isSuccess: boolean;
+  isError: boolean;
+  data: Field[] | undefined;
+}
+
+export interface Field {
+  name: string;
+  type: string;
+}
+
+export function useFetchIndexPatternFields(
+  indexPattern?: string
+): UseFetchIndexPatternFieldsResponse {
+  const { http } = useKibana().services;
+
+  const { isLoading, isError, isSuccess, data } = useQuery({
+    queryKey: ['fetchIndices', indexPattern],
+    queryFn: async ({ signal }) => {
+      try {
+        const response = await http.get<{ fields: Field[] }>(
+          `/api/index_patterns/_fields_for_wildcard`,
+          {
+            query: {
+              pattern: indexPattern,
+            },
+            signal,
+          }
+        );
+        return response.fields;
+      } catch (error) {
+        throw new Error(`Something went wrong. Error: ${error}`);
+      }
+    },
+    refetchOnWindowFocus: false,
+    enabled: Boolean(indexPattern),
+  });
+
+  return { isLoading, isError, isSuccess, data };
+}

--- a/x-pack/plugins/observability/public/hooks/slo/use_fetch_index_pattern_fields.ts
+++ b/x-pack/plugins/observability/public/hooks/slo/use_fetch_index_pattern_fields.ts
@@ -26,7 +26,7 @@ export function useFetchIndexPatternFields(
   const { http } = useKibana().services;
 
   const { isLoading, isError, isSuccess, data } = useQuery({
-    queryKey: ['fetchIndices', indexPattern],
+    queryKey: ['fetchIndexPatternFields', indexPattern],
     queryFn: async ({ signal }) => {
       try {
         const response = await http.get<{ fields: Field[] }>(

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/custom_kql/custom_kql_indicator_type_form.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/custom_kql/custom_kql_indicator_type_form.tsx
@@ -46,7 +46,7 @@ export function CustomKqlIndicatorTypeForm() {
         <EuiFlexItem>
           <EuiFormRow
             label={i18n.translate(
-              'xpack.observability.slo.sloEdit.additionalSettings.timestampField.label',
+              'xpack.observability.slo.sloEdit.sliType.customKql.timestampField.label',
               { defaultMessage: 'Timestamp field' }
             )}
           >
@@ -61,14 +61,14 @@ export function CustomKqlIndicatorTypeForm() {
                   {...field}
                   async
                   placeholder={i18n.translate(
-                    'xpack.observability.slo.sloEdit.additionalSettings.timestampField.placeholder',
+                    'xpack.observability.slo.sloEdit.sliType.customKql.timestampField.placeholder',
                     { defaultMessage: 'Select a timestamp field' }
                   )}
                   aria-label={i18n.translate(
-                    'xpack.observability.slo.sloEdit.additionalSettings.timestampField.placeholder',
+                    'xpack.observability.slo.sloEdit.sliType.customKql.timestampField.placeholder',
                     { defaultMessage: 'Select a timestamp field' }
                   )}
-                  data-test-subj="timestampFieldSelect"
+                  data-test-subj="customKqlIndicatorFormTimestampFieldSelect"
                   isClearable={true}
                   isDisabled={!watch('indicator.params.index')}
                   isInvalid={!!fieldState.error}
@@ -89,7 +89,7 @@ export function CustomKqlIndicatorTypeForm() {
                           {
                             value: field.value,
                             label: field.value,
-                            'data-test-subj': `timestampFieldSelectedValue`,
+                            'data-test-subj': `customKqlIndicatorFormTimestampFieldSelectedValue`,
                           },
                         ]
                       : []

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/custom_kql/custom_kql_indicator_type_form.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/custom_kql/custom_kql_indicator_type_form.tsx
@@ -5,35 +5,102 @@
  * 2.0.
  */
 
-import React, { useState } from 'react';
+import React from 'react';
 import {
-  EuiFieldText,
+  EuiComboBox,
+  EuiComboBoxOptionOption,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiFormLabel,
-  EuiIcon,
-  EuiLink,
+  EuiFormRow,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { Controller, useFormContext } from 'react-hook-form';
 import { CreateSLOInput } from '@kbn/slo-schema';
 
+import {
+  Field,
+  useFetchIndexPatternFields,
+} from '../../../../hooks/slo/use_fetch_index_pattern_fields';
 import { IndexSelection } from './index_selection';
 import { QueryBuilder } from '../common/query_builder';
 
+interface Option {
+  label: string;
+  value: string;
+}
+
 export function CustomKqlIndicatorTypeForm() {
   const { control, watch } = useFormContext<CreateSLOInput>();
-  const [isAdditionalSettingsOpen, setAdditionalSettingsOpen] = useState<boolean>(false);
 
-  const handleAdditionalSettingsClick = () => {
-    setAdditionalSettingsOpen(!isAdditionalSettingsOpen);
-  };
+  const { isLoading, data: indexFields } = useFetchIndexPatternFields(
+    watch('indicator.params.index')
+  );
+  const timestampFields = (indexFields ?? []).filter((field) => field.type === 'date');
 
   return (
     <EuiFlexGroup direction="column" gutterSize="l">
-      <EuiFlexItem>
-        <IndexSelection control={control} />
-      </EuiFlexItem>
+      <EuiFlexGroup direction="row" gutterSize="l">
+        <EuiFlexItem>
+          <IndexSelection control={control} />
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiFormRow
+            label={i18n.translate(
+              'xpack.observability.slo.sloEdit.additionalSettings.timestampField.label',
+              { defaultMessage: 'Timestamp field' }
+            )}
+          >
+            <Controller
+              name="indicator.params.timestampField"
+              shouldUnregister
+              defaultValue=""
+              rules={{ required: true }}
+              control={control}
+              render={({ field: { ref, ...field }, fieldState }) => (
+                <EuiComboBox
+                  {...field}
+                  async
+                  placeholder={i18n.translate(
+                    'xpack.observability.slo.sloEdit.additionalSettings.timestampField.placeholder',
+                    { defaultMessage: 'Select a timestamp field' }
+                  )}
+                  aria-label={i18n.translate(
+                    'xpack.observability.slo.sloEdit.additionalSettings.timestampField.placeholder',
+                    { defaultMessage: 'Select a timestamp field' }
+                  )}
+                  data-test-subj="timestampFieldSelect"
+                  isClearable={true}
+                  isDisabled={!watch('indicator.params.index')}
+                  isInvalid={!!fieldState.error}
+                  isLoading={!!watch('indicator.params.index') && isLoading}
+                  onChange={(selected: EuiComboBoxOptionOption[]) => {
+                    if (selected.length) {
+                      return field.onChange(selected[0].value);
+                    }
+
+                    field.onChange('');
+                  }}
+                  options={createOptions(timestampFields)}
+                  selectedOptions={
+                    !!watch('indicator.params.index') &&
+                    !!field.value &&
+                    timestampFields.some((timestampField) => timestampField.name === field.value)
+                      ? [
+                          {
+                            value: field.value,
+                            label: field.value,
+                            'data-test-subj': `timestampFieldSelectedValue`,
+                          },
+                        ]
+                      : []
+                  }
+                  singleSelection={{ asPlainText: true }}
+                />
+              )}
+            />
+          </EuiFormRow>
+        </EuiFlexItem>
+      </EuiFlexGroup>
 
       <EuiFlexItem>
         <QueryBuilder
@@ -88,48 +155,12 @@ export function CustomKqlIndicatorTypeForm() {
           )}
         />
       </EuiFlexItem>
-
-      <EuiFlexGroup direction="column" gutterSize="l">
-        <EuiFlexItem>
-          <EuiLink
-            data-test-subj="customKqlIndicatorFormAdditionalSettingsToggle"
-            onClick={handleAdditionalSettingsClick}
-          >
-            <EuiIcon type={isAdditionalSettingsOpen ? 'arrowDown' : 'arrowRight'} />{' '}
-            {i18n.translate('xpack.observability.slo.sloEdit.sliType.additionalSettings.label', {
-              defaultMessage: 'Additional settings',
-            })}
-          </EuiLink>
-        </EuiFlexItem>
-
-        {isAdditionalSettingsOpen && (
-          <EuiFlexItem>
-            <EuiFormLabel>
-              {i18n.translate(
-                'xpack.observability.slo.sloEdit.additionalSettings.timestampField.label',
-                { defaultMessage: 'Timestamp field' }
-              )}
-            </EuiFormLabel>
-
-            <Controller
-              name="indicator.params.timestampField"
-              shouldUnregister
-              control={control}
-              render={({ field: { ref, ...field } }) => (
-                <EuiFieldText
-                  {...field}
-                  disabled={!watch('indicator.params.index')}
-                  data-test-subj="sloFormAdditionalSettingsTimestampField"
-                  placeholder={i18n.translate(
-                    'xpack.observability.slo.sloEdit.additionalSettings.timestampField.placeholder',
-                    { defaultMessage: 'Timestamp field used in the index, default to @timestamp' }
-                  )}
-                />
-              )}
-            />
-          </EuiFlexItem>
-        )}
-      </EuiFlexGroup>
     </EuiFlexGroup>
   );
+}
+
+function createOptions(fields: Field[]): Option[] {
+  return fields
+    .map((field) => ({ label: field.name, value: field.name }))
+    .sort((a, b) => String(a.label).localeCompare(b.label));
 }

--- a/x-pack/plugins/observability/public/pages/slo_edit/helpers/use_section_form_validation.ts
+++ b/x-pack/plugins/observability/public/pages/slo_edit/helpers/use_section_form_validation.ts
@@ -27,8 +27,12 @@ export function useSectionFormValidation({ getFieldState, getValues, formState, 
             'indicator.params.filter',
             'indicator.params.good',
             'indicator.params.total',
+            'indicator.params.timestampField',
           ] as const
-        ).every((field) => !getFieldState(field).invalid) && !!getValues('indicator.params.index');
+        ).every((field) => !getFieldState(field).invalid) &&
+        (['indicator.params.index', 'indicator.params.timestampField'] as const).every(
+          (field) => !!getValues(field)
+        );
       break;
     case 'sli.apm.transactionDuration':
       isIndicatorSectionValid =


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/154069

This PR changes the timestamp field free text input to a select. This field is moved next to the index pattern select as well as made required for the custom KQL indicator.


## 🎥  Recording


https://user-images.githubusercontent.com/1376800/228885829-285efb34-4081-4c5d-b685-82e55553e96b.mov

