### PR TITLE
[Fleet] Fix warning icon not displaying on 8.7

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/confirm_update.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/confirm_update.tsx
@@ -67,7 +67,7 @@ const ConfirmDescription: React.FunctionComponent<ConfirmDescriptionProps> = ({
       <>
         <EuiSpacer size="s" />
         <EuiCallOut
-          iconType="warning"
+          iconType="alert"
           color="warning"
           size="m"
           title={


### PR DESCRIPTION
Originally reported in https://github.com/elastic/kibana/issues/152234#issuecomment-1491258413

With EUI v76, `warning` icon type was introduced: https://github.com/elastic/kibana/pull/152506

However, the EUI upgrade was only applied on 8.8. The callout here that uses the warning icon was a bug fix backported to 8.7 after the EUI upgrade. In 8.7 the EUI version does not have the `warning` icon type, causing a broken image to be rendered in this callout.

This PR reverts the icon to the legacy `alert` type will only be merged into 8.7.