### PR TITLE
[8.7] [Synthetics] Fixes all spaces params usage in monitors (#153826)

### DIFF
--- a/x-pack/plugins/synthetics/server/alert_rules/status_rule/status_rule_executor.test.ts
+++ b/x-pack/plugins/synthetics/server/alert_rules/status_rule/status_rule_executor.test.ts
@@ -37,7 +37,7 @@ describe('StatusRuleExecutor', () => {
         getSpaceId: jest.fn().mockReturnValue('test-space'),
       },
     },
-    encryptedSavedObjects: mockEncryptedSO,
+    encryptedSavedObjects: mockEncryptedSO(),
   } as unknown as UptimeServerSetup;
 
   const syntheticsService = new SyntheticsService(serverMock);

--- a/x-pack/plugins/synthetics/server/routes/monitor_cruds/edit_monitor.test.ts
+++ b/x-pack/plugins/synthetics/server/routes/monitor_cruds/edit_monitor.test.ts
@@ -53,7 +53,7 @@ describe('syncEditedMonitor', () => {
         buildPackagePolicyFromPackage: jest.fn().mockReturnValue({}),
       },
     },
-    encryptedSavedObjects: mockEncryptedSO,
+    encryptedSavedObjects: mockEncryptedSO(),
   } as unknown as UptimeServerSetup;
 
   const editedMonitor = {

--- a/x-pack/plugins/synthetics/server/saved_objects/synthetics_monitor/get_all_monitors.test.ts
+++ b/x-pack/plugins/synthetics/server/saved_objects/synthetics_monitor/get_all_monitors.test.ts
@@ -37,7 +37,7 @@ describe('processMonitors', () => {
         getSpaceId: jest.fn().mockReturnValue('test-space'),
       },
     },
-    encryptedSavedObjects: mockEncryptedSO,
+    encryptedSavedObjects: mockEncryptedSO(),
   } as unknown as UptimeServerSetup;
 
   const syntheticsService = new SyntheticsService(serverMock);

--- a/x-pack/plugins/synthetics/server/synthetics_service/formatters/browser.ts
+++ b/x-pack/plugins/synthetics/server/synthetics_service/formatters/browser.ts
@@ -19,7 +19,7 @@ import { tlsFormatters } from './tls';
 export type BrowserFormatMap = Record<keyof BrowserFields, Formatter>;
 
 const throttlingFormatter: Formatter = (fields) => {
-  if (!fields[ConfigKey.IS_THROTTLING_ENABLED]) return;
+  if (!fields[ConfigKey.IS_THROTTLING_ENABLED]) return false;
 
   return {
     label: 'no_throttling',

--- a/x-pack/plugins/synthetics/server/synthetics_service/formatters/browser.ts
+++ b/x-pack/plugins/synthetics/server/synthetics_service/formatters/browser.ts
@@ -19,9 +19,10 @@ import { tlsFormatters } from './tls';
 export type BrowserFormatMap = Record<keyof BrowserFields, Formatter>;
 
 const throttlingFormatter: Formatter = (fields) => {
-  if (!fields[ConfigKey.IS_THROTTLING_ENABLED]) return false;
+  if (!fields[ConfigKey.IS_THROTTLING_ENABLED]) return;
 
   return {
+    label: 'no_throttling',
     download: parseInt(
       fields[ConfigKey.DOWNLOAD_SPEED] || DEFAULT_BROWSER_ADVANCED_FIELDS[ConfigKey.DOWNLOAD_SPEED],
       10

--- a/x-pack/plugins/synthetics/server/synthetics_service/formatters/browser.ts
+++ b/x-pack/plugins/synthetics/server/synthetics_service/formatters/browser.ts
@@ -22,7 +22,6 @@ const throttlingFormatter: Formatter = (fields) => {
   if (!fields[ConfigKey.IS_THROTTLING_ENABLED]) return false;
 
   return {
-    label: 'no_throttling',
     download: parseInt(
       fields[ConfigKey.DOWNLOAD_SPEED] || DEFAULT_BROWSER_ADVANCED_FIELDS[ConfigKey.DOWNLOAD_SPEED],
       10

--- a/x-pack/plugins/synthetics/server/synthetics_service/project_monitor/project_monitor_formatter.test.ts
+++ b/x-pack/plugins/synthetics/server/synthetics_service/project_monitor/project_monitor_formatter.test.ts
@@ -122,7 +122,7 @@ describe('ProjectMonitorFormatter', () => {
         getSpaceId: jest.fn().mockReturnValue('test-space'),
       },
     },
-    encryptedSavedObjects: mockEncryptedSO,
+    encryptedSavedObjects: mockEncryptedSO(),
   } as unknown as UptimeServerSetup;
 
   const syntheticsService = new SyntheticsService(serverMock);

--- a/x-pack/plugins/synthetics/server/synthetics_service/project_monitor/project_monitor_formatter_legacy.test.ts
+++ b/x-pack/plugins/synthetics/server/synthetics_service/project_monitor/project_monitor_formatter_legacy.test.ts
@@ -116,7 +116,7 @@ describe('ProjectMonitorFormatterLegacy', () => {
         getSpaceId: jest.fn().mockReturnValue('test-space'),
       },
     },
-    encryptedSavedObjects: mockEncryptedSO,
+    encryptedSavedObjects: mockEncryptedSO(),
   } as unknown as UptimeServerSetup;
 
   const syntheticsService = new SyntheticsService(serverMock);

--- a/x-pack/plugins/synthetics/server/synthetics_service/synthetics_monitor/synthetics_monitor_client.test.ts
+++ b/x-pack/plugins/synthetics/server/synthetics_service/synthetics_monitor/synthetics_monitor_client.test.ts
@@ -233,7 +233,7 @@ const deletePayload = [
     ],
     max_redirects: '0',
     name: 'my mon',
-    params: '',
+    params: '{"username":"elastic"}',
     password: '',
     proxy_url: '',
     schedule: { number: '3', unit: 'm' },

--- a/x-pack/plugins/synthetics/server/synthetics_service/synthetics_monitor/synthetics_monitor_client.test.ts
+++ b/x-pack/plugins/synthetics/server/synthetics_service/synthetics_monitor/synthetics_monitor_client.test.ts
@@ -44,7 +44,7 @@ describe('SyntheticsMonitorClient', () => {
         manifestUrl: 'http://localhost:8080/api/manifest',
       },
     },
-    encryptedSavedObjects: mockEncryptedSO,
+    encryptedSavedObjects: mockEncryptedSO(),
   } as unknown as UptimeServerSetup;
 
   const syntheticsService = new SyntheticsService(serverMock);

--- a/x-pack/plugins/synthetics/server/synthetics_service/synthetics_service.test.ts
+++ b/x-pack/plugins/synthetics/server/synthetics_service/synthetics_service.test.ts
@@ -38,7 +38,7 @@ describe('SyntheticsService', () => {
         manifestUrl: 'http://localhost:8080/api/manifest',
       },
     },
-    encryptedSavedObjects: mockEncryptedSO,
+    encryptedSavedObjects: mockEncryptedSO(),
   } as unknown as UptimeServerSetup;
 
   const getMockedService = (locationsNum: number = 1) => {
@@ -173,6 +173,51 @@ describe('SyntheticsService', () => {
           data: expect.objectContaining({ is_edit: true }),
         })
       );
+    });
+  });
+
+  describe('getSyntheticsParams', () => {
+    it('returns the params for all spaces', async () => {
+      const { service } = getMockedService();
+
+      (axios as jest.MockedFunction<typeof axios>).mockResolvedValue({} as AxiosResponse);
+
+      const params = await service.getSyntheticsParams();
+
+      expect(params).toEqual({
+        '*': {
+          username: 'elastic',
+        },
+      });
+    });
+    it('returns the params for specific space', async () => {
+      const { service } = getMockedService();
+
+      const params = await service.getSyntheticsParams({ spaceId: 'default' });
+
+      expect(params).toEqual({
+        '*': {
+          username: 'elastic',
+        },
+        default: {
+          username: 'elastic',
+        },
+      });
+    });
+    it('returns the space limited params', async () => {
+      const { service } = getMockedService();
+
+      serverMock.encryptedSavedObjects = mockEncryptedSO([
+        { attributes: { key: 'username', value: 'elastic' }, namespaces: ['default'] },
+      ]) as any;
+
+      const params = await service.getSyntheticsParams({ spaceId: 'default' });
+
+      expect(params).toEqual({
+        default: {
+          username: 'elastic',
+        },
+      });
     });
   });
 });

--- a/x-pack/plugins/synthetics/server/synthetics_service/synthetics_service.ts
+++ b/x-pack/plugins/synthetics/server/synthetics_service/synthetics_service.ts
@@ -15,7 +15,7 @@ import {
   TaskManagerStartContract,
 } from '@kbn/task-manager-plugin/server';
 import { Subject } from 'rxjs';
-import { ALL_SPACES_ID } from '@kbn/spaces-plugin/common/constants';
+import { ALL_SPACES_ID, DEFAULT_SPACE_ID } from '@kbn/spaces-plugin/common/constants';
 import { syntheticsParamType } from '../../common/types/saved_objects';
 import { sendErrorTelemetryEvents } from '../routes/telemetry/monitor_upgrade_sender';
 import { UptimeServerSetup } from '../legacy_uptime/lib/adapters';

--- a/x-pack/plugins/synthetics/server/synthetics_service/synthetics_service.ts
+++ b/x-pack/plugins/synthetics/server/synthetics_service/synthetics_service.ts
@@ -492,6 +492,20 @@ export class SyntheticsService {
     // no need to wait here
     finder.close();
 
+    if (paramsBySpace[ALL_SPACES_ID]) {
+      Object.keys(paramsBySpace).forEach((space) => {
+        if (space !== ALL_SPACES_ID) {
+          paramsBySpace[space] = Object.assign(paramsBySpace[ALL_SPACES_ID], paramsBySpace[space]);
+        }
+      });
+      if (spaceId) {
+        paramsBySpace[spaceId] = {
+          ...(paramsBySpace?.[spaceId] ?? {}),
+          ...(paramsBySpace?.[ALL_SPACES_ID] ?? {}),
+        };
+      }
+    }
+
     return paramsBySpace;
   }
 

--- a/x-pack/plugins/synthetics/server/synthetics_service/synthetics_service.ts
+++ b/x-pack/plugins/synthetics/server/synthetics_service/synthetics_service.ts
@@ -15,6 +15,7 @@ import {
   TaskManagerStartContract,
 } from '@kbn/task-manager-plugin/server';
 import { Subject } from 'rxjs';
+import { ALL_SPACES_ID } from '@kbn/spaces-plugin/common/constants';
 import { syntheticsParamType } from '../../common/types/saved_objects';
 import { sendErrorTelemetryEvents } from '../routes/telemetry/monitor_upgrade_sender';
 import { UptimeServerSetup } from '../legacy_uptime/lib/adapters';
@@ -454,13 +455,16 @@ export class SyntheticsService {
       subject.next(
         (monitors ?? []).map((monitor) => {
           const attributes = monitor.attributes as unknown as MonitorFields;
+
+          const monitorSpace = monitor.namespaces?.[0] ?? DEFAULT_SPACE_ID;
+
+          const params = paramsBySpace[monitorSpace];
+
           return formatHeartbeatRequest({
+            params: { ...params, ...(paramsBySpace?.[ALL_SPACES_ID] ?? {}) },
             monitor: normalizeSecrets(monitor).attributes,
             monitorId: monitor.id,
             heartbeatId: attributes[ConfigKey.MONITOR_QUERY_ID],
-            params: monitor.namespaces
-              ? paramsBySpace[monitor.namespaces[0]]
-              : paramsBySpace.default,
           });
         })
       );

--- a/x-pack/plugins/synthetics/server/synthetics_service/utils/mocks.ts
+++ b/x-pack/plugins/synthetics/server/synthetics_service/utils/mocks.ts
@@ -7,16 +7,20 @@
 
 import { EncryptedSavedObjectsClient } from '@kbn/encrypted-saved-objects-plugin/server';
 
-export const mockEncryptedSO = {
+export const mockEncryptedSO = (
+  data: any = [{ attributes: { key: 'username', value: 'elastic' }, namespaces: ['*'] }]
+) => ({
   getClient: jest.fn().mockReturnValue({
     getDecryptedAsInternalUser: jest.fn(),
     createPointInTimeFinderDecryptedAsInternalUser: jest.fn().mockImplementation(() => ({
       close: jest.fn(),
       find: jest.fn().mockReturnValue({
         async *[Symbol.asyncIterator]() {
-          yield { saved_objects: [{ attributes: { key: 'username', value: 'elastic' } }] };
+          yield {
+            saved_objects: data,
+          };
         },
       }),
     })),
   } as jest.Mocked<EncryptedSavedObjectsClient>),
-};
+});


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.7`:
 - [[Synthetics] Fixes all spaces params usage in monitors (#153826)](https://github.com/elastic/kibana/pull/153826)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Shahzad","email":"shahzad31comp@gmail.com"},"sourceCommit":{"committedDate":"2023-03-30T18:09:15Z","message":"[Synthetics] Fixes all spaces params usage in monitors (#153826)\n\nCo-authored-by: Dominique Clarke <dominique.clarke@elastic.co>","sha":"78450b0fae2c695a5e96ffa745ec1043d1e1a332","branchLabelMapping":{"^v8.8.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:uptime","release_note:skip","v8.7.0","v8.8.0"],"number":153826,"url":"https://github.com/elastic/kibana/pull/153826","mergeCommit":{"message":"[Synthetics] Fixes all spaces params usage in monitors (#153826)\n\nCo-authored-by: Dominique Clarke <dominique.clarke@elastic.co>","sha":"78450b0fae2c695a5e96ffa745ec1043d1e1a332"}},"sourceBranch":"main","suggestedTargetBranches":["8.7"],"targetPullRequestStates":[{"branch":"8.7","label":"v8.7.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.8.0","labelRegex":"^v8.8.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/153826","number":153826,"mergeCommit":{"message":"[Synthetics] Fixes all spaces params usage in monitors (#153826)\n\nCo-authored-by: Dominique Clarke <dominique.clarke@elastic.co>","sha":"78450b0fae2c695a5e96ffa745ec1043d1e1a332"}}]}] BACKPORT-->