### PR TITLE
[Security Solution] [Action Connectors] Remove extra `rulesJson` props in mock test for export 

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/logic/export/get_export_all.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/logic/export/get_export_all.test.ts
@@ -406,60 +406,20 @@ describe('getExportAll', () => {
     );
     const rulesJson = JSON.parse(exports.rulesNdjson);
     const detailsJson = JSON.parse(exports.exportDetails);
-    expect(rulesJson).toEqual({
-      author: ['Elastic'],
-      actions: [
-        {
-          group: 'default',
-          id: '456',
-          params: {
-            message: 'Rule {{context.rule.name}} generated {{state.signals_count}} alerts',
+    expect(rulesJson).toEqual(
+      expect.objectContaining({
+        actions: [
+          {
+            group: 'default',
+            id: '456',
+            params: {
+              message: 'Rule {{context.rule.name}} generated {{state.signals_count}} alerts',
+            },
+            action_type_id: '.email',
           },
-          action_type_id: '.email',
-        },
-      ],
-      building_block_type: 'default',
-      created_at: '2019-12-13T16:40:33.400Z',
-      updated_at: '2019-12-13T16:40:33.400Z',
-      created_by: 'elastic',
-      description: 'Detecting root and admin users',
-      enabled: true,
-      false_positives: [],
-      filters: [{ query: { match_phrase: { 'host.name': 'some-host' } } }],
-      from: 'now-6m',
-      id: '04128c15-0d1b-4716-a4c5-46997ac7f3bd',
-      immutable: false,
-      index: ['auditbeat-*', 'filebeat-*', 'packetbeat-*', 'winlogbeat-*'],
-      interval: '5m',
-      rule_id: 'rule-1',
-      language: 'kuery',
-      license: 'Elastic License',
-      output_index: '.siem-signals',
-      max_signals: 10000,
-      risk_score: 50,
-      risk_score_mapping: [],
-      name: 'Detect Root/Admin Users',
-      query: 'user.name: root or user.name: admin',
-      references: ['http://example.com', 'https://example.com'],
-      related_integrations: [],
-      required_fields: [],
-      setup: '',
-      timeline_id: 'some-timeline-id',
-      timeline_title: 'some-timeline-title',
-      meta: { someMeta: 'someField' },
-      severity: 'high',
-      severity_mapping: [],
-      updated_by: 'elastic',
-      tags: [],
-      to: 'now',
-      type: 'query',
-      threat: getThreatMock(),
-      throttle: 'rule',
-      note: '# Investigative notes',
-      version: 1,
-      revision: 0,
-      exceptions_list: getListArrayMock(),
-    });
+        ],
+      })
+    );
     expect(detailsJson).toEqual({
       exported_exception_list_count: 1,
       exported_exception_list_item_count: 1,

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/logic/export/get_export_by_object_ids.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/logic/export/get_export_by_object_ids.test.ts
@@ -416,60 +416,20 @@ describe('get_export_by_object_ids', () => {
       );
       const rulesJson = JSON.parse(exports.rulesNdjson);
       const detailsJson = JSON.parse(exports.exportDetails);
-      expect(rulesJson).toEqual({
-        author: ['Elastic'],
-        actions: [
-          {
-            group: 'default',
-            id: '456',
-            params: {
-              message: 'Rule {{context.rule.name}} generated {{state.signals_count}} alerts',
+      expect(rulesJson).toEqual(
+        expect.objectContaining({
+          actions: [
+            {
+              group: 'default',
+              id: '456',
+              params: {
+                message: 'Rule {{context.rule.name}} generated {{state.signals_count}} alerts',
+              },
+              action_type_id: '.email',
             },
-            action_type_id: '.email',
-          },
-        ],
-        building_block_type: 'default',
-        created_at: '2019-12-13T16:40:33.400Z',
-        updated_at: '2019-12-13T16:40:33.400Z',
-        created_by: 'elastic',
-        description: 'Detecting root and admin users',
-        enabled: true,
-        false_positives: [],
-        filters: [{ query: { match_phrase: { 'host.name': 'some-host' } } }],
-        from: 'now-6m',
-        id: '04128c15-0d1b-4716-a4c5-46997ac7f3bd',
-        immutable: false,
-        index: ['auditbeat-*', 'filebeat-*', 'packetbeat-*', 'winlogbeat-*'],
-        interval: '5m',
-        rule_id: 'rule-1',
-        language: 'kuery',
-        license: 'Elastic License',
-        output_index: '.siem-signals',
-        max_signals: 10000,
-        risk_score: 50,
-        risk_score_mapping: [],
-        name: 'Detect Root/Admin Users',
-        query: 'user.name: root or user.name: admin',
-        references: ['http://example.com', 'https://example.com'],
-        related_integrations: [],
-        required_fields: [],
-        setup: '',
-        timeline_id: 'some-timeline-id',
-        timeline_title: 'some-timeline-title',
-        meta: { someMeta: 'someField' },
-        severity: 'high',
-        severity_mapping: [],
-        updated_by: 'elastic',
-        tags: [],
-        to: 'now',
-        type: 'query',
-        threat: getThreatMock(),
-        throttle: 'rule',
-        note: '# Investigative notes',
-        version: 1,
-        revision: 0,
-        exceptions_list: getListArrayMock(),
-      });
+          ],
+        })
+      );
       expect(detailsJson).toEqual({
         exported_exception_list_count: 0,
         exported_exception_list_item_count: 0,


### PR DESCRIPTION
## Summary

- Remove extra props of the `rulesJson` in both `get_export_all.test.ts`  and `get_export_by_object_ids.test.ts` to validate only actions property.

# Reason  
The issue is the rules introduced a new prop `revision` and it won't be in the `8.7` release, which caused the backport PR to fail, and I need to be compatible with what is in `8.7` so that we avoid any conflicts 

https://github.com/elastic/kibana/pull/154142