### PR TITLE
[Fleet] Fix CPU metrics display when percentage < 0.1

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/services/agent_metrics.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/services/agent_metrics.test.tsx
@@ -1,0 +1,81 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import { formatAgentCPU } from './agent_metrics';
+
+jest.mock('../components/metric_non_available', () => {
+  return {
+    MetricNonAvailable: () => <>N/A</>,
+  };
+});
+
+jest.mock('@elastic/eui', () => {
+  return {
+    ...jest.requireActual('@elastic/eui'),
+    EuiToolTip: (props: any) => <div data-tooltip-content={props.content}>{props.children}</div>,
+  };
+});
+
+describe('Agent metrics helper', () => {
+  describe('formatAgentCPU', () => {
+    it('should return 0% if cpu is 0.00002', () => {
+      const res = formatAgentCPU({
+        cpu_avg: 0.00002,
+        memory_size_byte_avg: 2000,
+      });
+
+      const result = render(<>{res}</>);
+
+      expect(result.asFragment()).toMatchInlineSnapshot(`
+        <DocumentFragment>
+          <div
+            data-tooltip-content="0.0020 %"
+          >
+            0.00 %
+          </div>
+        </DocumentFragment>
+      `);
+    });
+
+    it('should return 5% if cpu is 0.005', () => {
+      const res = formatAgentCPU({
+        cpu_avg: 0.005,
+        memory_size_byte_avg: 2000,
+      });
+
+      const result = render(<>{res}</>);
+
+      expect(result.asFragment()).toMatchInlineSnapshot(`
+        <DocumentFragment>
+          <div
+            data-tooltip-content="0.5000 %"
+          >
+            0.50 %
+          </div>
+        </DocumentFragment>
+      `);
+    });
+
+    it('should return N/A if cpu is undefined', () => {
+      const res = formatAgentCPU({
+        cpu_avg: undefined,
+        memory_size_byte_avg: 2000,
+      });
+
+      const result = render(<>{res}</>);
+
+      expect(result.asFragment()).toMatchInlineSnapshot(`
+        <DocumentFragment>
+          N/A
+        </DocumentFragment>
+      `);
+    });
+  });
+});

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/services/agent_metrics.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/services/agent_metrics.tsx
@@ -6,14 +6,17 @@
  */
 
 import React from 'react';
+import { EuiToolTip } from '@elastic/eui';
 
 import type { AgentMetrics, AgentPolicy } from '../../../../../../common/types';
 
 import { MetricNonAvailable } from '../components';
 
 export function formatAgentCPU(metrics?: AgentMetrics, agentPolicy?: AgentPolicy) {
-  return metrics?.cpu_avg && metrics?.cpu_avg !== 0 ? (
-    `${(metrics.cpu_avg * 100).toFixed(2)} %`
+  return typeof metrics?.cpu_avg !== 'undefined' ? (
+    <EuiToolTip content={`${(metrics.cpu_avg * 100).toFixed(4)} %`}>
+      <>{(metrics.cpu_avg * 100).toFixed(2)} %</>
+    </EuiToolTip>
   ) : (
     <MetricNonAvailable agentPolicy={agentPolicy} />
   );

--- a/x-pack/plugins/fleet/server/services/agents/agent_metrics.ts
+++ b/x-pack/plugins/fleet/server/services/agents/agent_metrics.ts
@@ -54,7 +54,7 @@ async function _fetchAndAssignAgentMetrics(esClient: ElasticsearchClient, agents
     return {
       ...agent,
       metrics: {
-        cpu_avg: results?.sum_cpu ? Math.trunc(results.sum_cpu * 10000) / 10000 : undefined,
+        cpu_avg: results?.sum_cpu ? Math.trunc(results.sum_cpu * 100000) / 100000 : undefined,
         memory_size_byte_avg: results?.sum_memory_size
           ? Math.trunc(results?.sum_memory_size)
           : undefined,

--- a/x-pack/test/fleet_api_integration/apis/agents/list.ts
+++ b/x-pack/test/fleet_api_integration/apis/agents/list.ts
@@ -192,7 +192,7 @@ export default function ({ getService }: FtrProviderContext) {
       const agent1: Agent = apiResponse.items.find((agent: any) => agent.id === 'agent1');
 
       expect(agent1.metrics?.memory_size_byte_avg).to.eql('25510920');
-      expect(agent1.metrics?.cpu_avg).to.eql('0.0166');
+      expect(agent1.metrics?.cpu_avg).to.eql('0.01666');
 
       const agent2: Agent = apiResponse.items.find((agent: any) => agent.id === 'agent2');
       expect(agent2.metrics?.memory_size_byte_avg).equal(undefined);


### PR DESCRIPTION
## Summary

In agent metrics fix CPU usage display when cpu percentage usage is less than 0.1%, I also added a tooltip that show 4 digits of that percentage.

## UI Change

<img width="114" alt="Screenshot 2023-03-31 at 9 25 39 AM" src="https://user-images.githubusercontent.com/1336873/229133039-abfa204c-27c5-4667-95bf-67708fe11bed.png">
<img width="124" alt="Screenshot 2023-03-31 at 9 25 43 AM" src="https://user-images.githubusercontent.com/1336873/229133049-036f4a6f-d7f7-4f7a-8b1a-d35e45a6df1e.png">

## Tests 

How to manually test? Enroll an agent and see that the cpu usage is still correctly displayed

I added some unit test on the helpers that format the CPU usage.


<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->