### PR TITLE
Update E2E setup for Exploratory View app

### DIFF
--- a/.buildkite/pipelines/pull_request/exploratory_view_plugin.yml
+++ b/.buildkite/pipelines/pull_request/exploratory_view_plugin.yml
@@ -1,5 +1,5 @@
 steps:
-  - command: .buildkite/scripts/steps/functional/observability_plugin.sh
+  - command: .buildkite/scripts/steps/functional/exploratory_view_plugin.sh
     label: 'Exploratory View @elastic/synthetics Tests'
     agents:
       queue: n2-4-spot

--- a/.buildkite/scripts/steps/functional/exploratory_view_plugin.sh
+++ b/.buildkite/scripts/steps/functional/exploratory_view_plugin.sh
@@ -9,8 +9,8 @@ source .buildkite/scripts/common/util.sh
 
 export JOB=kibana-observability-plugin
 
-echo "--- Observability plugin @elastic/synthetics Tests"
+echo "--- Exploratory View plugin @elastic/synthetics Tests"
 
 cd "$XPACK_DIR"
 
-node plugins/observability/scripts/e2e.js --kibana-install-dir "$KIBANA_BUILD_LOCATION" ${GREP:+--grep \"${GREP}\"}
+node plugins/exploratory_view/scripts/e2e.js --kibana-install-dir "$KIBANA_BUILD_LOCATION" ${GREP:+--grep \"${GREP}\"}

--- a/x-pack/plugins/observability/scripts/e2e.js
+++ b/x-pack/plugins/observability/scripts/e2e.js
@@ -1,9 +1,0 @@
-/*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0; you may not use this file except in compliance with the Elastic License
- * 2.0.
- */
-
-/* eslint-disable no-console */
-console.log('Disabled.');


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/154755

# 📝Summary

This PR moves the E2E setup from the Observability app which only tested the Exploratory View route, into its own setup for the new dedicated Exploratory View app. 