### PR TITLE
feat(slo): create rule from slo details page

### DIFF
--- a/x-pack/plugins/observability/public/pages/slo_details/components/header_control.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_details/components/header_control.tsx
@@ -41,7 +41,7 @@ export function HeaderControl({ isLoading, slo }: Props) {
     }
   };
 
-  const onCloseAlertFlyout = useCallback(
+  const onCloseRuleFlyout = useCallback(
     () => setRuleFlyoutVisibility(false),
     [setRuleFlyoutVisibility]
   );
@@ -49,6 +49,10 @@ export function HeaderControl({ isLoading, slo }: Props) {
   const handleOpenRuleFlyout = () => {
     closePopover();
     setRuleFlyoutVisibility(true);
+  };
+
+  const handleManageRules = () => {
+    navigateToUrl(basePath.prepend(paths.observability.rules));
   };
 
   return (
@@ -92,8 +96,21 @@ export function HeaderControl({ isLoading, slo }: Props) {
               onClick={handleOpenRuleFlyout}
               data-test-subj="sloDetailsHeaderControlPopoverCreateRule"
             >
-              {i18n.translate('xpack.observability.slo.sloDetails.headerControl.createRule', {
-                defaultMessage: 'Create alert rule',
+              {i18n.translate(
+                'xpack.observability.slo.sloDetails.headerControl.createBurnRateRule',
+                {
+                  defaultMessage: 'Create alert rule',
+                }
+              )}
+            </EuiContextMenuItem>,
+            <EuiContextMenuItem
+              key="manageRules"
+              disabled={!hasWriteCapabilities}
+              onClick={handleManageRules}
+              data-test-subj="sloDetailsHeaderControlPopoverManageRules"
+            >
+              {i18n.translate('xpack.observability.slo.sloDetails.headerControl.manageRules', {
+                defaultMessage: 'Manage rules',
               })}
             </EuiContextMenuItem>,
           ]}
@@ -104,7 +121,7 @@ export function HeaderControl({ isLoading, slo }: Props) {
           consumer={sloFeatureId}
           ruleTypeId={SLO_BURN_RATE_RULE_ID}
           canChangeTrigger={false}
-          onClose={onCloseAlertFlyout}
+          onClose={onCloseRuleFlyout}
           initialValues={{ name: `${slo.name} burn rate` }}
         />
       ) : null}

--- a/x-pack/plugins/observability/public/pages/slo_details/components/header_control.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_details/components/header_control.tsx
@@ -6,7 +6,7 @@
  */
 
 import { EuiButton, EuiContextMenuItem, EuiContextMenuPanel, EuiPopover } from '@elastic/eui';
-import React, { useCallback, useState } from 'react';
+import React, { useState } from 'react';
 import { i18n } from '@kbn/i18n';
 import { SLOWithSummaryResponse } from '@kbn/slo-schema';
 
@@ -43,10 +43,9 @@ export function HeaderControl({ isLoading, slo }: Props) {
     }
   };
 
-  const onCloseRuleFlyout = useCallback(
-    () => setRuleFlyoutVisibility(false),
-    [setRuleFlyoutVisibility]
-  );
+  const onCloseRuleFlyout = () => {
+    setRuleFlyoutVisibility(false);
+  };
 
   const handleOpenRuleFlyout = () => {
     closePopover();

--- a/x-pack/plugins/observability/public/pages/slo_details/slo_details.test.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_details/slo_details.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 
 import { useKibana } from '../../utils/kibana_react';
 import { useParams } from 'react-router-dom';
@@ -56,6 +56,11 @@ const mockKibana = () => {
         basePath: {
           prepend: mockBasePathPrepend,
         },
+      },
+      triggersActionsUi: {
+        getAddRuleFlyout: jest.fn(() => (
+          <div data-test-subj="add-rule-flyout">mocked component</div>
+        )),
       },
       uiSettings: {
         get: (settings: string) => {
@@ -149,8 +154,32 @@ describe('SLO Details Page', () => {
     expect(screen.queryAllByTestId('wideChartLoading').length).toBe(0);
   });
 
+  it("renders a 'Edit' button under actions menu", async () => {
+    const slo = buildSlo();
+    useParamsMock.mockReturnValue(slo.id);
+    useFetchSloDetailsMock.mockReturnValue({ isLoading: false, slo });
+    useLicenseMock.mockReturnValue({ hasAtLeast: () => true });
+
+    render(<SloDetailsPage />);
+
+    fireEvent.click(screen.getByTestId('o11yHeaderControlActionsButton'));
+    expect(screen.queryByTestId('sloDetailsHeaderControlPopoverEdit')).toBeTruthy();
+  });
+
+  it("renders a 'Create alert rule' button under actions menu", async () => {
+    const slo = buildSlo();
+    useParamsMock.mockReturnValue(slo.id);
+    useFetchSloDetailsMock.mockReturnValue({ isLoading: false, slo });
+    useLicenseMock.mockReturnValue({ hasAtLeast: () => true });
+
+    render(<SloDetailsPage />);
+
+    fireEvent.click(screen.getByTestId('o11yHeaderControlActionsButton'));
+    expect(screen.queryByTestId('sloDetailsHeaderControlPopoverCreateRule')).toBeTruthy();
+  });
+
   describe('when an APM SLO is loaded', () => {
-    it("should render a 'Explore in APM' button", async () => {
+    it("renders a 'Explore in APM' button under actions menu", async () => {
       const slo = buildSlo({ indicator: buildApmAvailabilityIndicator() });
       useParamsMock.mockReturnValue(slo.id);
       useFetchSloDetailsMock.mockReturnValue({ isLoading: false, slo });
@@ -158,12 +187,13 @@ describe('SLO Details Page', () => {
 
       render(<SloDetailsPage />);
 
-      expect(screen.queryByTestId('sloDetailsExploreInApmButton')).toBeTruthy();
+      fireEvent.click(screen.getByTestId('o11yHeaderControlActionsButton'));
+      expect(screen.queryByTestId('sloDetailsHeaderControlPopoverExploreInApm')).toBeTruthy();
     });
   });
 
   describe('when an Custom KQL SLO is loaded', () => {
-    it("should not render a 'Explore in APM' button", async () => {
+    it("does not render a 'Explore in APM' button under actions menu", async () => {
       const slo = buildSlo();
       useParamsMock.mockReturnValue(slo.id);
       useFetchSloDetailsMock.mockReturnValue({ isLoading: false, slo });
@@ -171,7 +201,8 @@ describe('SLO Details Page', () => {
 
       render(<SloDetailsPage />);
 
-      expect(screen.queryByTestId('sloDetailsExploreInApmButton')).toBeFalsy();
+      fireEvent.click(screen.getByTestId('o11yHeaderControlActionsButton'));
+      expect(screen.queryByTestId('sloDetailsHeaderControlPopoverExploreInApm')).toBeFalsy();
     });
   });
 });

--- a/x-pack/plugins/observability/public/pages/slo_details/slo_details.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_details/slo_details.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
 import { EuiBreadcrumbProps } from '@elastic/eui/src/components/breadcrumbs/breadcrumb';
-import { EuiButtonEmpty, EuiLoadingSpinner } from '@elastic/eui';
+import { EuiLoadingSpinner } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import type { IBasePath } from '@kbn/core-http-browser';
 import type { SLOWithSummaryResponse } from '@kbn/slo-schema';
@@ -25,8 +25,6 @@ import { HeaderControl } from './components/header_control';
 import { paths } from '../../config/paths';
 import type { SloDetailsPathParams } from './types';
 import type { ObservabilityAppServices } from '../../application/types';
-import { isApmIndicatorType } from '../../utils/slo/indicator';
-import { convertSliApmParamsToApmAppDeeplinkUrl } from '../../utils/slo/convert_sli_apm_params_to_apm_app_deeplink_url';
 
 export function SloDetailsPage() {
   const {
@@ -50,50 +48,11 @@ export function SloDetailsPage() {
     navigateToUrl(basePath.prepend(paths.observability.slos));
   }
 
-  const handleNavigateToApm = () => {
-    if (
-      slo?.indicator.type === 'sli.apm.transactionDuration' ||
-      slo?.indicator.type === 'sli.apm.transactionErrorRate'
-    ) {
-      const {
-        indicator: {
-          params: { environment, filter, service, transactionName, transactionType },
-        },
-        timeWindow: { duration },
-      } = slo;
-
-      const url = convertSliApmParamsToApmAppDeeplinkUrl({
-        duration,
-        environment,
-        filter,
-        service,
-        transactionName,
-        transactionType,
-      });
-
-      navigateToUrl(basePath.prepend(url));
-    }
-  };
-
   return (
     <ObservabilityPageTemplate
       pageHeader={{
         pageTitle: <HeaderTitle isLoading={isLoading} slo={slo} />,
-        rightSideItems: [
-          <HeaderControl isLoading={isLoading} slo={slo} />,
-          !!slo && isApmIndicatorType(slo.indicator.type) ? (
-            <EuiButtonEmpty
-              data-test-subj="sloDetailsExploreInApmButton"
-              disabled={isLoading}
-              iconType="popout"
-              onClick={handleNavigateToApm}
-            >
-              {i18n.translate('xpack.observability.slos.sloDetails.exploreInApm', {
-                defaultMessage: 'Explore in APM',
-              })}
-            </EuiButtonEmpty>
-          ) : null,
-        ],
+        rightSideItems: [<HeaderControl isLoading={isLoading} slo={slo} />],
         bottomBorder: false,
       }}
       data-test-subj="sloDetailsPage"


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/153955

This PR adds an action menu items to create a burn rate rule directly from the slo details page, and moves the Explore in APM into the actions dropdown. 

Screenshots |
-- |
![screencapture-localhost-5601-kibana-app-observability-slos-fe8f8640-cfe6-11ed-9b89-ef64dac6a57b-2023-03-31-13_15_18](https://user-images.githubusercontent.com/1376800/229187118-b177d1aa-1445-4db1-8c3c-3dc6bcdef953.png) |
![screencapture-localhost-5601-kibana-app-observability-slos-352d4a10-cf2a-11ed-89c8-cd3feec31f15-2023-03-31-13_15_07](https://user-images.githubusercontent.com/1376800/229187127-6312f9f7-4d7c-4083-9ff0-526d72c00503.png) |




https://user-images.githubusercontent.com/1376800/229162746-ddfa6e7c-3f4f-47a1-aeb6-1001b07bcab3.mov


