### PR TITLE
[8.7] [dashboard] fix Failing test: Chrome X-Pack UI Functional Tests.x-pack/test/functional/apps/dashboard/group2/sync_colors·ts (#152964)

### DIFF
--- a/test/functional/services/dashboard/add_panel.ts
+++ b/test/functional/services/dashboard/add_panel.ts
@@ -15,6 +15,7 @@ export class DashboardAddPanelService extends FtrService {
   private readonly flyout = this.ctx.getService('flyout');
   private readonly common = this.ctx.getPageObject('common');
   private readonly header = this.ctx.getPageObject('header');
+  private readonly browser = this.ctx.getService('browser');
 
   async clickOpenAddPanel() {
     this.log.debug('DashboardAddPanel.clickOpenAddPanel');
@@ -26,6 +27,8 @@ export class DashboardAddPanelService extends FtrService {
   async clickCreateNewLink() {
     this.log.debug('DashboardAddPanel.clickAddNewPanelButton');
     await this.retry.try(async () => {
+      // prevent query bar auto suggest from blocking button
+      await this.browser.pressKeys(this.browser.keys.ESCAPE);
       await this.testSubjects.click('dashboardAddNewPanelButton');
       await this.testSubjects.waitForDeleted('dashboardAddNewPanelButton');
       await this.header.waitUntilLoadingHasFinished();


### PR DESCRIPTION
Fixes #148557

# Backport

This will backport the following commits from `main` to `8.7`:
 - [[dashboard] fix Failing test: Chrome X-Pack UI Functional Tests.x-pack/test/functional/apps/dashboard/group2/sync_colors·ts (#152964)](https://github.com/elastic/kibana/pull/152964)

<!--- Backport version: 8.9.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Nathan Reese","email":"reese.nathan@elastic.co"},"sourceCommit":{"committedDate":"2023-03-08T21:54:05Z","message":"[dashboard] fix Failing test: Chrome X-Pack UI Functional Tests.x-pack/test/functional/apps/dashboard/group2/sync_colors·ts (#152964)\n\nFixes https://github.com/elastic/kibana/issues/148557\r\n\r\nflaky test runner\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2000\r\n\r\nImage from failed test shows query autosuggest menu is blocking \"create\r\nvisualize\" button. PR fixes issue be pressing escape to close\r\nautosuggest menu if its open.\r\n\r\n\r\n![image](https://user-images.githubusercontent.com/373691/223846637-3e595803-e39d-4392-a84c-69a455f70a42.png)","sha":"edf3a8362488b191cca75500371f0bad5c8e86cc","branchLabelMapping":{"^v8.8.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Dashboard","Team:Presentation","loe:hours","release_note:skip","impact:high","backport:skip","v8.8.0"],"number":152964,"url":"https://github.com/elastic/kibana/pull/152964","mergeCommit":{"message":"[dashboard] fix Failing test: Chrome X-Pack UI Functional Tests.x-pack/test/functional/apps/dashboard/group2/sync_colors·ts (#152964)\n\nFixes https://github.com/elastic/kibana/issues/148557\r\n\r\nflaky test runner\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2000\r\n\r\nImage from failed test shows query autosuggest menu is blocking \"create\r\nvisualize\" button. PR fixes issue be pressing escape to close\r\nautosuggest menu if its open.\r\n\r\n\r\n![image](https://user-images.githubusercontent.com/373691/223846637-3e595803-e39d-4392-a84c-69a455f70a42.png)","sha":"edf3a8362488b191cca75500371f0bad5c8e86cc"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.8.0","labelRegex":"^v8.8.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/152964","number":152964,"mergeCommit":{"message":"[dashboard] fix Failing test: Chrome X-Pack UI Functional Tests.x-pack/test/functional/apps/dashboard/group2/sync_colors·ts (#152964)\n\nFixes https://github.com/elastic/kibana/issues/148557\r\n\r\nflaky test runner\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2000\r\n\r\nImage from failed test shows query autosuggest menu is blocking \"create\r\nvisualize\" button. PR fixes issue be pressing escape to close\r\nautosuggest menu if its open.\r\n\r\n\r\n![image](https://user-images.githubusercontent.com/373691/223846637-3e595803-e39d-4392-a84c-69a455f70a42.png)","sha":"edf3a8362488b191cca75500371f0bad5c8e86cc"}}]}] BACKPORT-->