### PR TITLE
[ML inference] Change ML pipeline body generator to work with field mappings

### DIFF
--- a/x-pack/plugins/enterprise_search/common/ml_inference_pipeline/index.test.ts
+++ b/x-pack/plugins/enterprise_search/common/ml_inference_pipeline/index.test.ts
@@ -188,10 +188,9 @@ describe('generateMlInferencePipelineBody lib function', () => {
   it('should return something expected', () => {
     const actual: MlInferencePipeline = generateMlInferencePipelineBody({
       description: 'my-description',
-      destinationField: 'my-destination-field',
       model: mockModel,
       pipelineName: 'my-pipeline',
-      sourceField: 'my-source-field',
+      fieldMappings: { 'my-source-field': 'my-destination-field' },
     });
 
     expect(actual).toEqual(expected);
@@ -204,10 +203,9 @@ describe('generateMlInferencePipelineBody lib function', () => {
     };
     const actual: MlInferencePipeline = generateMlInferencePipelineBody({
       description: 'my-description',
-      destinationField: 'my-destination-field',
       model: mockTextClassificationModel,
       pipelineName: 'my-pipeline',
-      sourceField: 'my-source-field',
+      fieldMappings: { 'my-source-field': 'my-destination-field' },
     });
 
     expect(actual).toEqual(

--- a/x-pack/plugins/enterprise_search/common/ml_inference_pipeline/index.ts
+++ b/x-pack/plugins/enterprise_search/common/ml_inference_pipeline/index.ts
@@ -31,11 +31,10 @@ export const TEXT_EXPANSION_FRIENDLY_TYPE = 'ELSER';
 
 export interface MlInferencePipelineParams {
   description?: string;
-  destinationField: string;
+  fieldMappings: Record<string, string>;
   inferenceConfig?: InferencePipelineInferenceConfig;
   model: MlTrainedModelConfig;
   pipelineName: string;
-  sourceField: string;
 }
 
 /**
@@ -45,16 +44,18 @@ export interface MlInferencePipelineParams {
  */
 export const generateMlInferencePipelineBody = ({
   description,
-  destinationField,
+  fieldMappings,
   inferenceConfig,
   model,
   pipelineName,
-  sourceField,
 }: MlInferencePipelineParams): MlInferencePipeline => {
   // if model returned no input field, insert a placeholder
   const modelInputField =
     model.input?.field_names?.length > 0 ? model.input.field_names[0] : 'MODEL_INPUT_FIELD';
 
+  // For now this only works for a single field mapping
+  const sourceField = Object.keys(fieldMappings)[0];
+  const destinationField = Object.values(fieldMappings)[0];
   const inferenceType = Object.keys(model.inference_config)[0];
   const remove = getRemoveProcessorForInferenceType(destinationField, inferenceType);
   const set = getSetProcessorForInferenceType(destinationField, inferenceType);

--- a/x-pack/plugins/enterprise_search/common/ml_inference_pipeline/index.ts
+++ b/x-pack/plugins/enterprise_search/common/ml_inference_pipeline/index.ts
@@ -31,7 +31,7 @@ export const TEXT_EXPANSION_FRIENDLY_TYPE = 'ELSER';
 
 export interface MlInferencePipelineParams {
   description?: string;
-  fieldMappings: Record<string, string>;
+  fieldMappings: Record<string, string | undefined>;
   inferenceConfig?: InferencePipelineInferenceConfig;
   model: MlTrainedModelConfig;
   pipelineName: string;
@@ -55,7 +55,7 @@ export const generateMlInferencePipelineBody = ({
 
   // For now this only works for a single field mapping
   const sourceField = Object.keys(fieldMappings)[0];
-  const destinationField = fieldMappings[sourceField];
+  const destinationField = fieldMappings[sourceField] ?? sourceField;
   const inferenceType = Object.keys(model.inference_config)[0];
   const remove = getRemoveProcessorForInferenceType(destinationField, inferenceType);
   const set = getSetProcessorForInferenceType(destinationField, inferenceType);

--- a/x-pack/plugins/enterprise_search/common/ml_inference_pipeline/index.ts
+++ b/x-pack/plugins/enterprise_search/common/ml_inference_pipeline/index.ts
@@ -55,7 +55,7 @@ export const generateMlInferencePipelineBody = ({
 
   // For now this only works for a single field mapping
   const sourceField = Object.keys(fieldMappings)[0];
-  const destinationField = Object.values(fieldMappings)[0];
+  const destinationField = fieldMappings[sourceField];
   const inferenceType = Object.keys(model.inference_config)[0];
   const remove = getRemoveProcessorForInferenceType(destinationField, inferenceType);
   const set = getSetProcessorForInferenceType(destinationField, inferenceType);

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/ml_inference_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/ml_inference_logic.ts
@@ -386,11 +386,11 @@ export const MLInferenceLogic = kea<
         if (!model) return undefined;
 
         return generateMlInferencePipelineBody({
-          destinationField:
-            configuration.destinationField || formatPipelineName(configuration.pipelineName),
           model,
           pipelineName: configuration.pipelineName,
-          sourceField: configuration.sourceField,
+          fieldMappings: {
+            [configuration.sourceField]: configuration.destinationField || formatPipelineName(configuration.pipelineName),
+          },
           inferenceConfig: configuration.inferenceConfig,
         });
       },

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/ml_inference_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/ml_inference_logic.ts
@@ -389,7 +389,8 @@ export const MLInferenceLogic = kea<
           model,
           pipelineName: configuration.pipelineName,
           fieldMappings: {
-            [configuration.sourceField]: configuration.destinationField || formatPipelineName(configuration.pipelineName),
+            [configuration.sourceField]:
+              configuration.destinationField || formatPipelineName(configuration.pipelineName),
           },
           inferenceConfig: configuration.inferenceConfig,
         });

--- a/x-pack/plugins/enterprise_search/server/lib/pipelines/create_pipeline_definitions.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/pipelines/create_pipeline_definitions.ts
@@ -254,6 +254,6 @@ export const formatMlPipelineBody = async (
     pipelineName,
     fieldMappings: {
       [sourceField]: destinationField,
-    }
+    },
   });
 };

--- a/x-pack/plugins/enterprise_search/server/lib/pipelines/create_pipeline_definitions.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/pipelines/create_pipeline_definitions.ts
@@ -249,10 +249,11 @@ export const formatMlPipelineBody = async (
   const models = await esClient.ml.getTrainedModels({ model_id: modelId });
   const model = models.trained_model_configs[0];
   return generateMlInferencePipelineBody({
-    destinationField,
     inferenceConfig,
     model,
     pipelineName,
-    sourceField,
+    fieldMappings: {
+      [sourceField]: destinationField,
+    }
   });
 };


### PR DESCRIPTION
## Summary

This PR changes the structure of the `generateMlInferencePipelineBody()` function to accept multiple field mappings. This is a backward compatible change and it's in preparation of supporting ML inference on multiple fields (e.g. in ELSER).

Specifically the `sourceField` and `destinationField` properties are being replaced with a `fieldMappings` object, in which a source field maps to a destination (target) field. The callers of this function are also updated.

**The pipeline body generator still expects a single field in this mapping and produces a single set of processors.** Modifying that for supporting multiple fields is out of scope of the PR.

Backward compatibility was manually tested, and is covered by unit tests.

![Screenshot 2023-03-31 at 5 51 24 PM](https://user-images.githubusercontent.com/14224983/229239803-a89b65d7-440c-4e88-aab2-9afcc40090b6.png)



### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
