### PR TITLE
[Dashboard] [Controls] Hide hover actions again after drag and drop

### DIFF
--- a/src/plugins/presentation_util/public/components/floating_actions/floating_actions.scss
+++ b/src/plugins/presentation_util/public/components/floating_actions/floating_actions.scss
@@ -13,7 +13,7 @@
     z-index: $euiZLevel9; // the highest possible z-level
   }
 
-  &:hover, &:focus-within {
+  &:hover, &:focus {
     .presentationUtil__floatingActions {
       opacity: 1;
       visibility: visible;


### PR DESCRIPTION
## Describe the bug:
After dragging and dropping a control, one of the elements is retaining focus - therefore, because of keyboard accessibility features that were added, the hover actions think that they still have to be visible. We should find which element is retaining focus (probably the drag and drop handler) and remove that focus once the control is dropped.

Resolves https://github.com/elastic/kibana/issues/153383


## Screenshot/Video
**(Before)**

https://user-images.githubusercontent.com/57623705/227485438-46bf06fa-ebf3-4017-8356-58aba962027f.mov



**(After)**

https://user-images.githubusercontent.com/57623705/227485008-0e79ed38-b161-47a1-86a0-31b38bc858f6.mov



---
This code was written and reviewed by GitStart Community. Growing future engineers, one PR at a time.
