### PR TITLE
[Fleet] Fix functional test failures after new custom logs package released

### DIFF
--- a/x-pack/test/fleet_api_integration/apis/epm/custom_ingest_pipeline.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/custom_ingest_pipeline.ts
@@ -14,14 +14,12 @@ const TEST_INDEX = 'logs-log.log-test';
 
 const CUSTOM_PIPELINE = 'logs-log.log@custom';
 
-let pkgVersion: string;
-
 export default function (providerContext: FtrProviderContext) {
   const { getService } = providerContext;
   const supertest = getService('supertest');
   const es = getService('es');
   const esArchiver = getService('esArchiver');
-
+  const LOG_INTEGRATION_VERSION = '1.1.2';
   describe('custom ingest pipeline for fleet managed datastreams', () => {
     skipIfNoDockerRegistry(providerContext);
     before(async () => {
@@ -29,27 +27,16 @@ export default function (providerContext: FtrProviderContext) {
     });
     setupFleetAndAgents(providerContext);
 
-    // Use the custom log package to test the custom ingest pipeline
     before(async () => {
-      const { body: getPackagesRes } = await supertest.get(
-        `/api/fleet/epm/packages?prerelease=true`
-      );
-      const logPackage = getPackagesRes.items.find((p: any) => p.name === 'log');
-      if (!logPackage) {
-        throw new Error('No log package');
-      }
-
-      pkgVersion = logPackage.version;
-
       await supertest
-        .post(`/api/fleet/epm/packages/log/${pkgVersion}`)
+        .post(`/api/fleet/epm/packages/log/${LOG_INTEGRATION_VERSION}`)
         .set('kbn-xsrf', 'xxxx')
         .send({ force: true })
         .expect(200);
     });
     after(async () => {
       await supertest
-        .delete(`/api/fleet/epm/packages/log/${pkgVersion}`)
+        .delete(`/api/fleet/epm/packages/log/${LOG_INTEGRATION_VERSION}`)
         .set('kbn-xsrf', 'xxxx')
         .send({ force: true })
         .expect(200);

--- a/x-pack/test/fleet_api_integration/apis/epm/final_pipeline.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/final_pipeline.ts
@@ -14,9 +14,9 @@ const TEST_INDEX = 'logs-log.log-test';
 
 const FINAL_PIPELINE_ID = '.fleet_final_pipeline-1';
 
-const FINAL_PIPELINE_VERSION = 1;
+const LOG_INTEGRATION_VERSION = '1.1.2';
 
-let pkgVersion: string;
+const FINAL_PIPELINE_VERSION = 1;
 
 export default function (providerContext: FtrProviderContext) {
   const { getService } = providerContext;
@@ -42,25 +42,15 @@ export default function (providerContext: FtrProviderContext) {
 
     // Use the custom log package to test the fleet final pipeline
     before(async () => {
-      const { body: getPackagesRes } = await supertest.get(
-        `/api/fleet/epm/packages?prerelease=true`
-      );
-      const logPackage = getPackagesRes.items.find((p: any) => p.name === 'log');
-      if (!logPackage) {
-        throw new Error('No log package');
-      }
-
-      pkgVersion = logPackage.version;
-
       await supertest
-        .post(`/api/fleet/epm/packages/log/${pkgVersion}`)
+        .post(`/api/fleet/epm/packages/log/${LOG_INTEGRATION_VERSION}`)
         .set('kbn-xsrf', 'xxxx')
         .send({ force: true })
         .expect(200);
     });
     after(async () => {
       await supertest
-        .delete(`/api/fleet/epm/packages/log/${pkgVersion}`)
+        .delete(`/api/fleet/epm/packages/log/${LOG_INTEGRATION_VERSION}`)
         .set('kbn-xsrf', 'xxxx')
         .send({ force: true })
         .expect(200);


### PR DESCRIPTION
These tests rely on the custom logs package being an integration package, 2.0.0 was released today which is an input package so the index templates are not created on install.