### PR TITLE
[DOCS] Add details to xpack.fleet.outputs settings

### DIFF
--- a/docs/settings/fleet-settings.asciidoc
+++ b/docs/settings/fleet-settings.asciidoc
@@ -142,6 +142,8 @@ If configured in your `kibana.yml`, output settings are grayed out and
 unavailable in the {fleet} UI. To make these settings editable in the UI, do not
 configure them in the configuration file. 
 +
+NOTE: The `xpack.fleet.outputs` settings are intended for advanced configurations such as having multiple outputs. We recommend not enabling the `xpack.fleet.agents.elasticsearch.host` settings when using `xpack.fleet.outputs`.
++
 .Required properties of `xpack.fleet.outputs`
 [%collapsible%open]
 =====
@@ -161,7 +163,9 @@ configure them in the configuration file.
 [%collapsible%open]
 =====
   `is_default`::: 
-    If `true`, this output is the default output.
+    If `true`, the output specified in `xpack.fleet.outputs` will be the one used to send agent data unless there is another one configured specifically for the agent policy.
+  `is_default_monitoring`::: 
+    If `true`, the output specified in `xpack.fleet.outputs` will be the one used to send agent monitoring data unless there is another one configured specifically for the agent policy.
 =====
 +
 Example configuration:


### PR DESCRIPTION
This updates the [Fleet settings in Kibana](https://www.elastic.co/guide/en/kibana/current/fleet-settings-kb.html) page with details for the `xpack.fleet.outputs` settings.

@nchaulet and @jeanfabrice  In addition to what we discussed I updated the `is_default` setting as well, but it probably could use some fixing up (i.e., is the setting for "all non-monitoring data" or something else)?

Preview:

![Screenshot 2023-04-03 at 9 25 55 AM](https://user-images.githubusercontent.com/41695641/229524885-f468deff-947f-4ae8-8f87-5044ca3eae7f.png)


<!--ONMERGE {"backportTargets":["8.6","8.7"]} ONMERGE-->