### PR TITLE
chore(slo): improve burn rate rule reason

### DIFF
--- a/x-pack/plugins/observability/server/lib/rules/slo_burn_rate/executor.ts
+++ b/x-pack/plugins/observability/server/lib/rules/slo_burn_rate/executor.ts
@@ -6,7 +6,7 @@
  */
 
 import { i18n } from '@kbn/i18n';
-
+import numeral from '@elastic/numeral';
 import {
   ALERT_EVALUATION_THRESHOLD,
   ALERT_EVALUATION_VALUE,
@@ -14,9 +14,9 @@ import {
 } from '@kbn/rule-data-utils';
 import { LifecycleRuleExecutor } from '@kbn/rule-registry-plugin/server';
 import { ExecutorType } from '@kbn/alerting-plugin/server';
-
 import { addSpaceIdToPath } from '@kbn/spaces-plugin/server';
 import { IBasePath } from '@kbn/core/server';
+
 import { Duration, toDurationUnit } from '../../../domain/models';
 import { DefaultSLIClient, KibanaSavedObjectsSLORepository } from '../../../services/slo';
 import { computeBurnRate } from '../../../domain/services';
@@ -171,9 +171,9 @@ function buildReason(
       'The burn rate for the past {longWindowDuration} is {longWindowBurnRate} and for the past {shortWindowDuration} is {shortWindowBurnRate}. Alert when above {burnRateThreshold} for both windows',
     values: {
       longWindowDuration: longWindowDuration.format(),
-      longWindowBurnRate,
+      longWindowBurnRate: numeral(longWindowBurnRate).format('0.[00]'),
       shortWindowDuration: shortWindowDuration.format(),
-      shortWindowBurnRate,
+      shortWindowBurnRate: numeral(shortWindowBurnRate).format('0.[00]'),
       burnRateThreshold: params.burnRateThreshold,
     },
   });


### PR DESCRIPTION
## Summary

Resolves [#153962](https://github.com/elastic/kibana/issues/153962)

This PR truncates the burn rate values to 2 decimals at most:

<img width="1459" alt="Screenshot 2023-04-03 at 11 30 02 AM" src="https://user-images.githubusercontent.com/1376800/229558096-0cc63536-8764-46a7-99a1-1403d70f21a2.png">
