### PR TITLE
[Enterprise Search] Search Applications - remove raw field capabilities API response

### DIFF
--- a/x-pack/plugins/enterprise_search/common/types/engines.ts
+++ b/x-pack/plugins/enterprise_search/common/types/engines.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FieldCapsResponse, HealthStatus } from '@elastic/elasticsearch/lib/api/types';
+import { HealthStatus } from '@elastic/elasticsearch/lib/api/types';
 
 export interface EnterpriseSearchEnginesResponse {
   count: number;
@@ -32,7 +32,6 @@ export interface EnterpriseSearchEngineIndex {
 }
 
 export interface EnterpriseSearchEngineFieldCapabilities {
-  field_capabilities: FieldCapsResponse;
   fields: SchemaField[];
   name: string;
   updated_at_millis: number;
@@ -47,7 +46,10 @@ export interface SchemaFieldIndex {
 }
 
 export interface SchemaField {
+  aggregatable: boolean;
   indices: SchemaFieldIndex[];
+  metadata_field?: boolean;
   name: string;
+  searchable: boolean;
   type: string;
 }

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_overview_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_overview_logic.test.ts
@@ -282,35 +282,6 @@ describe('EngineOverviewLogic', () => {
       it('counts the fields from the field capabilities', () => {
         const fieldCapabilities = {
           created: '2023-02-07T19:16:43Z',
-          field_capabilities: {
-            fields: {
-              age: {
-                integer: {
-                  aggregatable: true,
-                  metadata_field: false,
-                  searchable: true,
-                  type: 'integer',
-                },
-              },
-              color: {
-                keyword: {
-                  aggregatable: true,
-                  metadata_field: false,
-                  searchable: true,
-                  type: 'keyword',
-                },
-              },
-              name: {
-                text: {
-                  aggregatable: false,
-                  metadata_field: false,
-                  searchable: true,
-                  type: 'text',
-                },
-              },
-            },
-            indices: ['index-001', 'index-002'],
-          },
           fields: [
             {
               indices: [
@@ -364,77 +335,9 @@ describe('EngineOverviewLogic', () => {
       it('excludes metadata fields from the count', () => {
         const fieldCapabilities = {
           created: '2023-02-07T19:16:43Z',
-          field_capabilities: {
-            fields: {
-              _doc_count: {
-                integer: {
-                  aggregatable: false,
-                  metadata_field: true,
-                  searchable: false,
-                  type: 'integer',
-                },
-              },
-              _id: {
-                _id: {
-                  aggregatable: false,
-                  metadata_field: true,
-                  searchable: true,
-                  type: '_id',
-                },
-              },
-              _index: {
-                _index: {
-                  aggregatable: true,
-                  metadata_field: true,
-                  searchable: true,
-                  type: '_index',
-                },
-              },
-              _source: {
-                _source: {
-                  aggregatable: false,
-                  metadata_field: true,
-                  searchable: false,
-                  type: '_source',
-                },
-              },
-              _version: {
-                _version: {
-                  aggregatable: true,
-                  metadata_field: true,
-                  searchable: false,
-                  type: '_version',
-                },
-              },
-              age: {
-                integer: {
-                  aggregatable: true,
-                  metadata_field: false,
-                  searchable: true,
-                  type: 'integer',
-                },
-              },
-              color: {
-                keyword: {
-                  aggregatable: true,
-                  metadata_field: false,
-                  searchable: true,
-                  type: 'keyword',
-                },
-              },
-              name: {
-                text: {
-                  aggregatable: false,
-                  metadata_field: false,
-                  searchable: true,
-                  type: 'text',
-                },
-              },
-            },
-            indices: ['index-001', 'index-002'],
-          },
           fields: [
             {
+              aggregatable: true,
               indices: [
                 {
                   name: 'index-001',
@@ -445,10 +348,13 @@ describe('EngineOverviewLogic', () => {
                   type: 'integer',
                 },
               ],
+              metadata_field: true,
               name: '_doc_count',
+              searchable: true,
               type: 'integer',
             },
             {
+              aggregatable: true,
               indices: [
                 {
                   name: 'index-001',
@@ -459,10 +365,13 @@ describe('EngineOverviewLogic', () => {
                   type: '_id',
                 },
               ],
+              metadata_field: true,
               name: '_id',
+              searchable: true,
               type: '_id',
             },
             {
+              aggregatable: true,
               indices: [
                 {
                   name: 'index-001',
@@ -473,10 +382,13 @@ describe('EngineOverviewLogic', () => {
                   type: '_index',
                 },
               ],
+              metadata_field: true,
               name: '_index',
+              searchable: true,
               type: '_index',
             },
             {
+              aggregatable: true,
               indices: [
                 {
                   name: 'index-001',
@@ -487,10 +399,13 @@ describe('EngineOverviewLogic', () => {
                   type: '_source',
                 },
               ],
+              metadata_field: true,
               name: '_source',
+              searchable: true,
               type: '_source',
             },
             {
+              aggregatable: true,
               indices: [
                 {
                   name: 'index-001',
@@ -501,10 +416,13 @@ describe('EngineOverviewLogic', () => {
                   type: '_version',
                 },
               ],
+              metadata_field: true,
               name: '_version',
+              searchable: true,
               type: '_version',
             },
             {
+              aggregatable: true,
               indices: [
                 {
                   name: 'index-001',
@@ -515,10 +433,13 @@ describe('EngineOverviewLogic', () => {
                   type: 'integer',
                 },
               ],
+              metadata_field: false,
               name: 'age',
+              searchable: true,
               type: 'integer',
             },
             {
+              aggregatable: true,
               indices: [
                 {
                   name: 'index-001',
@@ -529,10 +450,13 @@ describe('EngineOverviewLogic', () => {
                   type: 'keyword',
                 },
               ],
+              metadata_field: false,
               name: 'color',
+              searchable: true,
               type: 'keyword',
             },
             {
+              aggregatable: false,
               indices: [
                 {
                   name: 'index-001',
@@ -543,7 +467,9 @@ describe('EngineOverviewLogic', () => {
                   type: 'text',
                 },
               ],
+              metadata_field: false,
               name: 'name',
+              searchable: true,
               type: 'text',
             },
           ] as SchemaField[],

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_overview_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_overview_logic.ts
@@ -45,7 +45,8 @@ export const selectDocumentsCount = (indices: EngineOverviewValues['indices']) =
 
 export const selectFieldsCount = (
   engineFieldCapabilitiesData: EngineOverviewValues['engineFieldCapabilitiesData']
-) => engineFieldCapabilitiesData?.fields?.length || 0;
+) =>
+  engineFieldCapabilitiesData?.fields?.filter(({ metadata_field: isMeta }) => !isMeta).length ?? 0;
 
 export const EngineOverviewLogic = kea<MakeLogicType<EngineOverviewValues, EngineOverviewActions>>({
   actions: {},

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_overview_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_overview_logic.ts
@@ -45,10 +45,7 @@ export const selectDocumentsCount = (indices: EngineOverviewValues['indices']) =
 
 export const selectFieldsCount = (
   engineFieldCapabilitiesData: EngineOverviewValues['engineFieldCapabilitiesData']
-) =>
-  Object.values(engineFieldCapabilitiesData?.field_capabilities?.fields ?? {}).filter(
-    (value) => !Object.values(value).some((field) => !!field.metadata_field)
-  ).length;
+) => engineFieldCapabilitiesData?.fields?.length || 0;
 
 export const EngineOverviewLogic = kea<MakeLogicType<EngineOverviewValues, EngineOverviewActions>>({
   actions: {},

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/engine_search_preview_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_search_preview/engine_search_preview_logic.ts
@@ -77,17 +77,11 @@ export const EngineSearchPreviewLogic = kea<
       (data: EngineSearchPreviewValues['engineFieldCapabilitiesData']) => {
         if (!data) return {};
 
-        const resultFields = Object.fromEntries(
-          Object.entries(data.field_capabilities.fields)
-            .filter(([, mappings]) => {
-              return Object.values(mappings).some(({ metadata_field: isMeta }) => !isMeta);
-            })
-            .map(([key]) => {
-              return [key, { raw: {}, snippet: { fallback: true } }];
-            })
+        return Object.fromEntries(
+          data.fields
+            .filter(({ metadata_field: isMeta }) => !isMeta)
+            .map(({ name }) => [name, { raw: {}, snippet: { fallback: true } }])
         );
-
-        return resultFields;
       },
     ],
     searchableFields: [
@@ -96,14 +90,12 @@ export const EngineSearchPreviewLogic = kea<
         if (!data) return {};
 
         const searchableFields = Object.fromEntries(
-          Object.entries(data.field_capabilities.fields)
-            .filter(([, mappings]) =>
-              Object.entries(mappings).some(
-                ([type, { metadata_field: isMeta, searchable: isSearchable }]) =>
-                  type === 'text' && !isMeta && isSearchable
-              )
+          data.fields
+            .filter(
+              ({ type, metadata_field: isMeta, searchable: isSearchable }) =>
+                type === 'text' && !isMeta && isSearchable
             )
-            .map(([key]) => [key, { weight: 1 }])
+            .map(({ name }) => [name, { weight: 1 }])
         );
 
         return searchableFields;
@@ -114,15 +106,9 @@ export const EngineSearchPreviewLogic = kea<
       (data: EngineSearchPreviewValues['engineFieldCapabilitiesData']) => {
         if (!data) return [];
 
-        return Object.entries(data.field_capabilities.fields)
-          .filter(([, mappings]) =>
-            Object.entries(mappings).some(
-              ([, { metadata_field: isMeta, aggregatable }]) =>
-                // Aggregatable are also _sortable_
-                aggregatable && !isMeta
-            )
-          )
-          .map(([field]) => field)
+        return data.fields
+          .filter(({ metadata_field: isMeta, aggregatable }) => aggregatable && !isMeta)
+          .map(({ name }) => name)
           .sort();
       },
     ],

--- a/x-pack/plugins/enterprise_search/server/lib/engines/field_capabilities.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/engines/field_capabilities.test.ts
@@ -48,16 +48,18 @@ describe('engines field_capabilities', () => {
       await expect(
         fetchEngineFieldCapabilities(mockClient as unknown as IScopedClusterClient, mockEngine)
       ).resolves.toEqual({
-        field_capabilities: fieldCapsResponse,
         fields: [
           {
+            aggregatable: false,
             indices: [
               {
                 name: 'index-001',
                 type: 'text',
               },
             ],
+            metadata_field: false,
             name: 'body',
+            searchable: true,
             type: 'text',
           },
         ],
@@ -99,23 +101,29 @@ describe('engines field_capabilities', () => {
       };
       const expectedFields: SchemaField[] = [
         {
+          aggregatable: false,
           indices: [
             {
               name: 'index-001',
               type: 'text',
             },
           ],
+          metadata_field: false,
           name: 'body',
+          searchable: true,
           type: 'text',
         },
         {
+          aggregatable: false,
           indices: [
             {
               name: 'index-001',
               type: 'number',
             },
           ],
+          metadata_field: false,
           name: 'views',
+          searchable: false,
           type: 'number',
         },
       ];
@@ -145,23 +153,29 @@ describe('engines field_capabilities', () => {
       };
       const expectedFields: SchemaField[] = [
         {
+          aggregatable: false,
           indices: [
             {
               name: 'index-001',
               type: 'text',
             },
           ],
+          metadata_field: false,
           name: 'body',
+          searchable: true,
           type: 'text',
         },
         {
+          aggregatable: true,
           indices: [
             {
               name: 'index-001',
               type: 'keyword',
             },
           ],
+          metadata_field: false,
           name: 'body.keyword',
+          searchable: true,
           type: 'keyword',
         },
       ];
@@ -199,33 +213,42 @@ describe('engines field_capabilities', () => {
       };
       const expectedFields: SchemaField[] = [
         {
+          aggregatable: false,
           indices: [
             {
               name: 'index-001',
               type: 'object',
             },
           ],
+          metadata_field: false,
           name: 'name',
+          searchable: false,
           type: 'object',
         },
         {
+          aggregatable: false,
           indices: [
             {
               name: 'index-001',
               type: 'text',
             },
           ],
+          metadata_field: false,
           name: 'name.first',
+          searchable: true,
           type: 'text',
         },
         {
+          aggregatable: false,
           indices: [
             {
               name: 'index-001',
               type: 'text',
             },
           ],
+          metadata_field: false,
           name: 'name.last',
+          searchable: true,
           type: 'text',
         },
       ];
@@ -263,33 +286,42 @@ describe('engines field_capabilities', () => {
       };
       const expectedFields: SchemaField[] = [
         {
+          aggregatable: false,
           indices: [
             {
               name: 'index-001',
               type: 'nested',
             },
           ],
+          metadata_field: false,
           name: 'name',
+          searchable: false,
           type: 'nested',
         },
         {
+          aggregatable: false,
           indices: [
             {
               name: 'index-001',
               type: 'text',
             },
           ],
+          metadata_field: false,
           name: 'name.first',
+          searchable: true,
           type: 'text',
         },
         {
+          aggregatable: false,
           indices: [
             {
               name: 'index-001',
               type: 'text',
             },
           ],
+          metadata_field: false,
           name: 'name.last',
+          searchable: true,
           type: 'text',
         },
       ];
@@ -319,6 +351,7 @@ describe('engines field_capabilities', () => {
       };
       const expectedFields: SchemaField[] = [
         {
+          aggregatable: false,
           indices: [
             {
               name: 'index-001',
@@ -329,7 +362,9 @@ describe('engines field_capabilities', () => {
               type: 'unmapped',
             },
           ],
+          metadata_field: false,
           name: 'body',
+          searchable: true,
           type: 'text',
         },
       ];
@@ -391,6 +426,7 @@ describe('engines field_capabilities', () => {
       };
       const expectedFields: SchemaField[] = [
         {
+          aggregatable: false,
           indices: [
             {
               name: 'index-001',
@@ -401,10 +437,13 @@ describe('engines field_capabilities', () => {
               type: 'object',
             },
           ],
+          metadata_field: false,
           name: 'name',
+          searchable: true,
           type: 'conflict',
         },
         {
+          aggregatable: false,
           indices: [
             {
               name: 'index-001',
@@ -415,10 +454,13 @@ describe('engines field_capabilities', () => {
               type: 'text',
             },
           ],
+          metadata_field: false,
           name: 'name.first',
+          searchable: true,
           type: 'text',
         },
         {
+          aggregatable: false,
           indices: [
             {
               name: 'index-001',
@@ -429,7 +471,9 @@ describe('engines field_capabilities', () => {
               type: 'text',
             },
           ],
+          metadata_field: false,
           name: 'name.last',
+          searchable: true,
           type: 'text',
         },
       ];
@@ -499,6 +543,7 @@ describe('engines field_capabilities', () => {
 
       const expectedFields: SchemaField[] = [
         {
+          aggregatable: false,
           indices: [
             {
               name: 'index-001',
@@ -513,10 +558,13 @@ describe('engines field_capabilities', () => {
               type: 'keyword',
             },
           ],
+          metadata_field: false,
           name: 'name',
+          searchable: true,
           type: 'conflict',
         },
         {
+          aggregatable: false,
           indices: [
             {
               name: 'index-001',
@@ -531,10 +579,13 @@ describe('engines field_capabilities', () => {
               type: 'text',
             },
           ],
+          metadata_field: false,
           name: 'name.first',
+          searchable: true,
           type: 'text',
         },
         {
+          aggregatable: false,
           indices: [
             {
               name: 'index-001',
@@ -549,7 +600,9 @@ describe('engines field_capabilities', () => {
               type: 'unmapped',
             },
           ],
+          metadata_field: false,
           name: 'name.last',
+          searchable: true,
           type: 'text',
         },
       ];
@@ -634,6 +687,7 @@ describe('engines field_capabilities', () => {
       };
       const expectedFields: SchemaField[] = [
         {
+          aggregatable: false,
           indices: [
             {
               name: 'index-001',
@@ -648,10 +702,13 @@ describe('engines field_capabilities', () => {
               type: 'text',
             },
           ],
+          metadata_field: false,
           name: 'body',
+          searchable: true,
           type: 'text',
         },
         {
+          aggregatable: false,
           indices: [
             {
               name: 'index-001',
@@ -666,10 +723,13 @@ describe('engines field_capabilities', () => {
               type: 'unmapped',
             },
           ],
+          metadata_field: false,
           name: 'name',
+          searchable: true,
           type: 'conflict',
         },
         {
+          aggregatable: false,
           indices: [
             {
               name: 'index-001',
@@ -684,10 +744,13 @@ describe('engines field_capabilities', () => {
               type: 'unmapped',
             },
           ],
+          metadata_field: false,
           name: 'name.first',
+          searchable: true,
           type: 'text',
         },
         {
+          aggregatable: false,
           indices: [
             {
               name: 'index-001',
@@ -702,7 +765,9 @@ describe('engines field_capabilities', () => {
               type: 'unmapped',
             },
           ],
+          metadata_field: false,
           name: 'name.last',
+          searchable: true,
           type: 'text',
         },
       ];
@@ -748,6 +813,7 @@ describe('engines field_capabilities', () => {
       };
       const expectedFields: SchemaField[] = [
         {
+          aggregatable: false,
           indices: [
             {
               name: 'index-001',
@@ -758,10 +824,13 @@ describe('engines field_capabilities', () => {
               type: 'object',
             },
           ],
+          metadata_field: false,
           name: 'name',
+          searchable: false,
           type: 'object',
         },
         {
+          aggregatable: false,
           indices: [
             {
               name: 'index-001',
@@ -772,10 +841,13 @@ describe('engines field_capabilities', () => {
               type: 'text',
             },
           ],
+          metadata_field: false,
           name: 'name.first',
+          searchable: true,
           type: 'text',
         },
         {
+          aggregatable: false,
           indices: [
             {
               name: 'index-001',
@@ -786,7 +858,9 @@ describe('engines field_capabilities', () => {
               type: 'unmapped',
             },
           ],
+          metadata_field: false,
           name: 'name.last',
+          searchable: true,
           type: 'text',
         },
       ];
@@ -832,6 +906,7 @@ describe('engines field_capabilities', () => {
       };
       const expectedFields: SchemaField[] = [
         {
+          aggregatable: false,
           indices: [
             {
               name: 'index-001',
@@ -842,10 +917,13 @@ describe('engines field_capabilities', () => {
               type: 'nested',
             },
           ],
+          metadata_field: false,
           name: 'name',
+          searchable: false,
           type: 'nested',
         },
         {
+          aggregatable: false,
           indices: [
             {
               name: 'index-001',
@@ -856,10 +934,13 @@ describe('engines field_capabilities', () => {
               type: 'text',
             },
           ],
+          metadata_field: false,
           name: 'name.first',
+          searchable: true,
           type: 'text',
         },
         {
+          aggregatable: false,
           indices: [
             {
               name: 'index-001',
@@ -870,7 +951,9 @@ describe('engines field_capabilities', () => {
               type: 'unmapped',
             },
           ],
+          metadata_field: false,
           name: 'name.last',
+          searchable: true,
           type: 'text',
         },
       ];
@@ -908,6 +991,7 @@ describe('engines field_capabilities', () => {
       };
       const expectedFields: SchemaField[] = [
         {
+          aggregatable: false,
           indices: [
             {
               name: 'index-001',
@@ -918,10 +1002,13 @@ describe('engines field_capabilities', () => {
               type: 'text',
             },
           ],
+          metadata_field: false,
           name: 'body',
+          searchable: true,
           type: 'text',
         },
         {
+          aggregatable: true,
           indices: [
             {
               name: 'index-001',
@@ -932,7 +1019,9 @@ describe('engines field_capabilities', () => {
               type: 'unmapped',
             },
           ],
+          metadata_field: false,
           name: 'body.keyword',
+          searchable: true,
           type: 'keyword',
         },
       ];
@@ -970,6 +1059,7 @@ describe('engines field_capabilities', () => {
       };
       const expectedFields: SchemaField[] = [
         {
+          aggregatable: false,
           indices: [
             {
               name: 'index-001',
@@ -980,10 +1070,13 @@ describe('engines field_capabilities', () => {
               type: 'object',
             },
           ],
+          metadata_field: false,
           name: 'order',
+          searchable: false,
           type: 'object',
         },
         {
+          aggregatable: false,
           indices: [
             {
               name: 'index-001',
@@ -994,7 +1087,9 @@ describe('engines field_capabilities', () => {
               type: 'number',
             },
           ],
+          metadata_field: false,
           name: 'order.id',
+          searchable: true,
           type: 'conflict',
         },
       ];
@@ -1032,6 +1127,7 @@ describe('engines field_capabilities', () => {
       };
       const expectedFields: SchemaField[] = [
         {
+          aggregatable: false,
           indices: [
             {
               name: 'index-001',
@@ -1042,10 +1138,13 @@ describe('engines field_capabilities', () => {
               type: 'nested',
             },
           ],
+          metadata_field: false,
           name: 'order',
+          searchable: false,
           type: 'nested',
         },
         {
+          aggregatable: false,
           indices: [
             {
               name: 'index-001',
@@ -1056,7 +1155,9 @@ describe('engines field_capabilities', () => {
               type: 'number',
             },
           ],
+          metadata_field: false,
           name: 'order.id',
+          searchable: true,
           type: 'conflict',
         },
       ];

--- a/x-pack/plugins/enterprise_search/server/lib/engines/field_capabilities.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/engines/field_capabilities.ts
@@ -26,7 +26,6 @@ export const fetchEngineFieldCapabilities = async (
   });
   const fields = parseFieldsCapabilities(fieldCapabilities);
   return {
-    field_capabilities: fieldCapabilities,
     fields,
     name,
     updated_at_millis,
@@ -72,10 +71,17 @@ export const parseFieldsCapabilities = (fieldCapsResponse: FieldCapsResponse): S
               type,
             }));
 
+      const searchable = Object.values(typesObject).some((t) => t.searchable);
+      const aggregatable = Object.values(typesObject).some((t) => t.aggregatable);
+      const metadataField = Object.values(typesObject).every((t) => t.metadata_field);
+
       return {
+        aggregatable,
         indices: fieldIndices,
         name: fieldName,
+        searchable,
         type,
+        ...(metadataField === undefined ? {} : { metadata_field: metadataField }),
       };
     })
     .sort((a, b) => a.name.localeCompare(b.name)) as SchemaField[];


### PR DESCRIPTION
## Summary

- Removes raw field capabilities response from the search applications (still referred to as `engines` in much of the code)
- Refactors code paths that relied on the raw field capabilities response to use the parsed `fields` data instead


### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
