### PR TITLE
Update field mappings for ELSER pipelines

### DIFF
--- a/x-pack/plugins/enterprise_search/common/types/error_codes.ts
+++ b/x-pack/plugins/enterprise_search/common/types/error_codes.ts
@@ -11,8 +11,10 @@ export enum ErrorCode {
   CONNECTOR_DOCUMENT_ALREADY_EXISTS = 'connector_document_already_exists',
   CRAWLER_ALREADY_EXISTS = 'crawler_already_exists',
   DOCUMENT_NOT_FOUND = 'document_not_found',
+  ENGINE_NOT_FOUND = 'engine_not_found',
   INDEX_ALREADY_EXISTS = 'index_already_exists',
   INDEX_NOT_FOUND = 'index_not_found',
+  MAPPING_UPDATE_FAILED = 'mapping_update_failed',
   PARAMETER_CONFLICT = 'parameter_conflict',
   PIPELINE_ALREADY_EXISTS = 'pipeline_already_exists',
   PIPELINE_IS_IN_USE = 'pipeline_is_in_use',
@@ -20,5 +22,4 @@ export enum ErrorCode {
   RESOURCE_NOT_FOUND = 'resource_not_found',
   UNAUTHORIZED = 'unauthorized',
   UNCAUGHT_EXCEPTION = 'uncaught_exception',
-  ENGINE_NOT_FOUND = 'engine_not_found',
 }

--- a/x-pack/plugins/enterprise_search/common/types/pipelines.ts
+++ b/x-pack/plugins/enterprise_search/common/types/pipelines.ts
@@ -43,9 +43,16 @@ export interface MlInferenceError {
   timestamp: string | undefined; // Date string
 }
 
-export interface CreateMlInferencePipelineResponse {
-  addedToParentPipeline?: boolean;
-  created?: boolean;
+export interface PreparePipelineAndIndexForMlInferenceResult {
+  added_to_parent_pipeline?: boolean;
+  created_pipeline?: boolean;
+  pipeline_id: string;
+
+  mapping_updated: boolean;
+}
+
+export interface CreatePipelineResult {
+  created: boolean;
   id: string;
 }
 

--- a/x-pack/plugins/enterprise_search/server/lib/indices/pipelines/ml_inference/pipeline_processors/create_ml_inference_pipeline.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/indices/pipelines/ml_inference/pipeline_processors/create_ml_inference_pipeline.ts
@@ -8,38 +8,43 @@
 import { IngestGetPipelineResponse, IngestPipeline } from '@elastic/elasticsearch/lib/api/types';
 import { ElasticsearchClient } from '@kbn/core/server';
 
-import { formatPipelineName } from '../../../../../../common/ml_inference_pipeline';
+import { FieldMapping, formatPipelineName } from '../../../../../../common/ml_inference_pipeline';
 import { ErrorCode } from '../../../../../../common/types/error_codes';
 import type {
-  CreateMlInferencePipelineResponse,
+  PreparePipelineAndIndexForMlInferenceResult,
   InferencePipelineInferenceConfig,
+  CreatePipelineResult,
 } from '../../../../../../common/types/pipelines';
 import { addSubPipelineToIndexSpecificMlPipeline } from '../../../../../utils/create_ml_inference_pipeline';
 import { getPrefixedInferencePipelineProcessorName } from '../../../../../utils/ml_inference_pipeline_utils';
 import { formatMlPipelineBody } from '../../../../pipelines/create_pipeline_definitions';
+import { updateMlInferenceMappings } from '../update_ml_inference_mappings';
 
 /**
  * Creates a Machine Learning Inference pipeline with the given settings, if it doesn't exist yet,
  * then references it in the "parent" ML Inference pipeline that is associated with the index.
+ * Finally, updates the index's mappings to accommodate the specified outputs of the inference model (if able)
  * @param indexName name of the index this pipeline corresponds to.
  * @param pipelineName pipeline name set by the user.
  * @param pipelineDefinition
  * @param modelId model ID selected by the user.
  * @param sourceField The document field that model will read.
  * @param destinationField The document field that the model will write to.
+ * @param fieldMappings The array of objects representing the source field (text) names and target fields (ML output) names
  * @param inferenceConfig The configuration for the model.
  * @param esClient the Elasticsearch Client to use when retrieving pipeline and model details.
  */
-export const createAndReferenceMlInferencePipeline = async (
+export const preparePipelineAndIndexForMlInference = async (
   indexName: string,
   pipelineName: string,
   pipelineDefinition: IngestPipeline | undefined,
   modelId: string | undefined,
   sourceField: string | undefined,
   destinationField: string | null | undefined,
+  fieldMappings: FieldMapping[] | undefined,
   inferenceConfig: InferencePipelineInferenceConfig | undefined,
   esClient: ElasticsearchClient
-): Promise<CreateMlInferencePipelineResponse> => {
+): Promise<PreparePipelineAndIndexForMlInferenceResult> => {
   const createPipelineResult = await createMlInferencePipeline(
     pipelineName,
     pipelineDefinition,
@@ -56,9 +61,15 @@ export const createAndReferenceMlInferencePipeline = async (
     esClient
   );
 
+  const mappingResponse = fieldMappings
+    ? (await updateMlInferenceMappings(indexName, fieldMappings, esClient)).acknowledged
+    : false;
+
   return {
-    ...createPipelineResult,
-    addedToParentPipeline: addSubPipelineResult.addedToParentPipeline,
+    added_to_parent_pipeline: addSubPipelineResult.addedToParentPipeline,
+    created_pipeline: createPipelineResult.created,
+    mapping_updated: mappingResponse,
+    pipeline_id: createPipelineResult.id,
   };
 };
 
@@ -80,7 +91,7 @@ export const createMlInferencePipeline = async (
   destinationField: string | null | undefined,
   inferenceConfig: InferencePipelineInferenceConfig | undefined,
   esClient: ElasticsearchClient
-): Promise<CreateMlInferencePipelineResponse> => {
+): Promise<CreatePipelineResult> => {
   const inferencePipelineGeneratedName = getPrefixedInferencePipelineProcessorName(pipelineName);
 
   // Check that a pipeline with the same name doesn't already exist

--- a/x-pack/plugins/enterprise_search/server/lib/indices/pipelines/ml_inference/update_ml_inference_mappings.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/indices/pipelines/ml_inference/update_ml_inference_mappings.test.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { elasticsearchServiceMock } from '@kbn/core-elasticsearch-server-mocks';
+
+import { ErrorCode } from '../../../../../common/types/error_codes';
+
+import { updateMlInferenceMappings } from './update_ml_inference_mappings';
+
+describe('updateMlInferenceMappings', () => {
+  const indexName = 'my-index';
+
+  const mockClient = elasticsearchServiceMock.createScopedClusterClient();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const expectedMapping = {
+    ml: {
+      properties: {
+        inference: {
+          properties: {
+            input_one_expanded: {
+              properties: {
+                predicted_value: {
+                  type: 'rank_features',
+                },
+                model_id: {
+                  type: 'keyword',
+                },
+              },
+            },
+            input_two_expanded: {
+              properties: {
+                predicted_value: {
+                  type: 'rank_features',
+                },
+                model_id: {
+                  type: 'keyword',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const fieldMappings = [
+    {
+      sourceField: 'input_one',
+      targetField: 'ml.inference.input_one_expanded',
+    },
+    {
+      sourceField: 'input_two',
+      targetField: 'ml.inference.input_two_expanded',
+    },
+  ];
+
+  it('should update mappings for default output', async () => {
+    await updateMlInferenceMappings(indexName, fieldMappings, mockClient.asCurrentUser);
+    expect(mockClient.asCurrentUser.indices.putMapping).toHaveBeenLastCalledWith({
+      index: indexName,
+      properties: expectedMapping,
+    });
+  });
+
+  it('should raise an error if the update fails', async () => {
+    mockClient.asCurrentUser.indices.putMapping.mockImplementation(() =>
+      Promise.reject({
+        meta: {
+          body: {
+            error: {
+              type: 'illegal_argument_exception',
+            },
+          },
+          statusCode: 400,
+        },
+      })
+    );
+    await expect(
+      updateMlInferenceMappings(indexName, fieldMappings, mockClient.asCurrentUser)
+    ).rejects.toThrowError(ErrorCode.MAPPING_UPDATE_FAILED);
+  });
+});

--- a/x-pack/plugins/enterprise_search/server/lib/indices/pipelines/ml_inference/update_ml_inference_mappings.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/indices/pipelines/ml_inference/update_ml_inference_mappings.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
+
+import { FieldMapping } from '../../../../../common/ml_inference_pipeline';
+
+import { ErrorCode } from '../../../../../common/types/error_codes';
+
+import { isIllegalArgumentException } from '../../../../utils/identify_exceptions';
+
+/**
+ * Creates Elasticsearch field mappings so that the outputs of ML Inference pipelines are not indexed as `float` fields
+ * @param indexName - the index whose mapping will be updated
+ * @param fieldMappings - the array of objects representing the source field (text) names and target fields (ML output) names
+ * @param esClient
+ */
+export const updateMlInferenceMappings = async (
+  indexName: string,
+  fieldMappings: FieldMapping[],
+  esClient: ElasticsearchClient
+) => {
+  const sourceFields = fieldMappings.map((fieldMapping) => {
+    return fieldMapping.sourceField;
+  });
+
+  const nonDefaultTargetFields = fieldMappings
+    .filter((fieldMapping) => {
+      return fieldMapping.targetField !== `ml.inference.${fieldMapping.sourceField}_expanded`;
+    })
+    .map((fieldMapping) => {
+      return fieldMapping.targetField;
+    });
+
+  // Today, we only update mappings for ELSER-analyzed fields.
+  const mapping = formElserMappingProperties(sourceFields, nonDefaultTargetFields);
+  try {
+    return await esClient.indices.putMapping({
+      index: indexName,
+      properties: mapping,
+    });
+  } catch (e) {
+    if (isIllegalArgumentException(e)) {
+      throw new Error(ErrorCode.MAPPING_UPDATE_FAILED);
+    } else {
+      throw e;
+    }
+  }
+};
+
+const formElserMappingProperties = (sourceFields: string[], targetFields: string[]) => {
+  return {
+    ml: {
+      properties: {
+        inference: {
+          properties: {
+            ...formDefaultElserMappingProps(sourceFields),
+          },
+        },
+      },
+    },
+    ...targetFields.reduce(
+      (previous, targetField) => ({
+        ...previous,
+        [targetField]: {
+          properties: {
+            model_id: {
+              type: 'keyword',
+            },
+            predicted_value: {
+              type: 'rank_features',
+            },
+          },
+        },
+      }),
+      {}
+    ),
+  };
+};
+
+const formDefaultElserMappingProps = (sourceFields: string[]) => {
+  return sourceFields.reduce(
+    (previous, sourceField) => ({
+      ...previous,
+      [`${sourceField}_expanded`]: {
+        properties: {
+          model_id: {
+            type: 'keyword',
+          },
+          predicted_value: {
+            type: 'rank_features',
+          },
+        },
+      },
+    }),
+    {}
+  );
+};

--- a/x-pack/plugins/enterprise_search/server/lib/indices/pipelines/ml_inference/update_ml_inference_mappings.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/indices/pipelines/ml_inference/update_ml_inference_mappings.ts
@@ -24,20 +24,17 @@ export const updateMlInferenceMappings = async (
   fieldMappings: FieldMapping[],
   esClient: ElasticsearchClient
 ) => {
-  const sourceFields = fieldMappings.map((fieldMapping) => {
-    return fieldMapping.sourceField;
-  });
+  const sourceFields = fieldMappings.map(({ sourceField }) => sourceField);
 
   const nonDefaultTargetFields = fieldMappings
-    .filter((fieldMapping) => {
-      return fieldMapping.targetField !== `ml.inference.${fieldMapping.sourceField}_expanded`;
-    })
-    .map((fieldMapping) => {
-      return fieldMapping.targetField;
-    });
+    .filter(
+      (fieldMapping) =>
+        fieldMapping.targetField !== `ml.inference.${fieldMapping.sourceField}_expanded`
+    )
+    .map((fieldMapping) => fieldMapping.targetField);
 
-  // Today, we only update mappings for ELSER-analyzed fields.
-  const mapping = formElserMappingProperties(sourceFields, nonDefaultTargetFields);
+  // Today, we only update mappings for text_expansion fields.
+  const mapping = generateTextExpansionMappingProperties(sourceFields, nonDefaultTargetFields);
   try {
     return await esClient.indices.putMapping({
       index: indexName,
@@ -52,7 +49,7 @@ export const updateMlInferenceMappings = async (
   }
 };
 
-const formElserMappingProperties = (sourceFields: string[], targetFields: string[]) => {
+const generateTextExpansionMappingProperties = (sourceFields: string[], targetFields: string[]) => {
   return {
     ml: {
       properties: {

--- a/x-pack/plugins/enterprise_search/server/routes/enterprise_search/indices.test.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/enterprise_search/indices.test.ts
@@ -26,7 +26,7 @@ jest.mock(
 jest.mock(
   '../../lib/indices/pipelines/ml_inference/pipeline_processors/create_ml_inference_pipeline',
   () => ({
-    createAndReferenceMlInferencePipeline: jest.fn(),
+    preparePipelineAndIndexForMlInference: jest.fn(),
   })
 );
 jest.mock(
@@ -61,7 +61,7 @@ import { indexOrAliasExists } from '../../lib/indices/exists_index';
 import { getMlInferenceErrors } from '../../lib/indices/pipelines/ml_inference/get_ml_inference_errors';
 import { fetchMlInferencePipelineHistory } from '../../lib/indices/pipelines/ml_inference/get_ml_inference_pipeline_history';
 import { attachMlInferencePipeline } from '../../lib/indices/pipelines/ml_inference/pipeline_processors/attach_ml_pipeline';
-import { createAndReferenceMlInferencePipeline } from '../../lib/indices/pipelines/ml_inference/pipeline_processors/create_ml_inference_pipeline';
+import { preparePipelineAndIndexForMlInference } from '../../lib/indices/pipelines/ml_inference/pipeline_processors/create_ml_inference_pipeline';
 import { deleteMlInferencePipeline } from '../../lib/indices/pipelines/ml_inference/pipeline_processors/delete_ml_inference_pipeline';
 import { detachMlInferencePipeline } from '../../lib/indices/pipelines/ml_inference/pipeline_processors/detach_ml_inference_pipeline';
 import { fetchMlInferencePipelineProcessors } from '../../lib/indices/pipelines/ml_inference/pipeline_processors/get_ml_inference_pipeline_processors';
@@ -306,11 +306,12 @@ describe('Enterprise Search Managed Indices', () => {
     });
 
     it('creates an ML inference pipeline from model and source_field', async () => {
-      (createAndReferenceMlInferencePipeline as jest.Mock).mockImplementationOnce(() => {
+      (preparePipelineAndIndexForMlInference as jest.Mock).mockImplementationOnce(() => {
         return Promise.resolve({
-          id: 'ml-inference-my-pipeline-name',
-          created: true,
-          addedToParentPipeline: true,
+          added_to_parent_pipeline: true,
+          created_pipeline: true,
+          mapping_updated: false,
+          pipeline_id: 'ml-inference-my-pipeline-name',
         });
       });
 
@@ -319,7 +320,7 @@ describe('Enterprise Search Managed Indices', () => {
         body: mockRequestBody,
       });
 
-      expect(createAndReferenceMlInferencePipeline).toHaveBeenCalledWith(
+      expect(preparePipelineAndIndexForMlInference).toHaveBeenCalledWith(
         'my-index-name',
         mockRequestBody.pipeline_name,
         undefined,
@@ -327,37 +328,41 @@ describe('Enterprise Search Managed Indices', () => {
         mockRequestBody.source_field,
         mockRequestBody.destination_field,
         undefined,
+        undefined,
         mockClient.asCurrentUser
       );
 
       expect(mockRouter.response.ok).toHaveBeenCalledWith({
         body: {
           created: 'ml-inference-my-pipeline-name',
+          mapping_updated: false,
         },
         headers: { 'content-type': 'application/json' },
       });
     });
 
     it('creates an ML inference pipeline from pipeline definition', async () => {
-      (createAndReferenceMlInferencePipeline as jest.Mock).mockImplementationOnce(() => {
+      (preparePipelineAndIndexForMlInference as jest.Mock).mockImplementationOnce(() => {
         return Promise.resolve({
-          id: 'ml-inference-my-pipeline-name',
-          created: true,
-          addedToParentPipeline: true,
+          added_to_parent_pipeline: true,
+          created_pipeline: true,
+          mapping_updated: true,
+          pipeline_id: 'ml-inference-my-pipeline-name',
         });
       });
 
       await mockRouter.callRoute({
         params: { indexName: 'my-index-name' },
         body: {
-          pipeline_name: 'my-pipeline-name',
+          field_mappings: [],
           pipeline_definition: {
             processors: [],
           },
+          pipeline_name: 'my-pipeline-name',
         },
       });
 
-      expect(createAndReferenceMlInferencePipeline).toHaveBeenCalledWith(
+      expect(preparePipelineAndIndexForMlInference).toHaveBeenCalledWith(
         'my-index-name',
         mockRequestBody.pipeline_name,
         {
@@ -366,6 +371,7 @@ describe('Enterprise Search Managed Indices', () => {
         undefined,
         undefined,
         undefined,
+        [],
         undefined,
         mockClient.asCurrentUser
       );
@@ -373,13 +379,14 @@ describe('Enterprise Search Managed Indices', () => {
       expect(mockRouter.response.ok).toHaveBeenCalledWith({
         body: {
           created: 'ml-inference-my-pipeline-name',
+          mapping_updated: true,
         },
         headers: { 'content-type': 'application/json' },
       });
     });
 
     it('responds with 409 CONFLICT if the pipeline already exists', async () => {
-      (createAndReferenceMlInferencePipeline as jest.Mock).mockImplementationOnce(() => {
+      (preparePipelineAndIndexForMlInference as jest.Mock).mockImplementationOnce(() => {
         return Promise.reject(new Error(ErrorCode.PIPELINE_ALREADY_EXISTS));
       });
 

--- a/x-pack/plugins/enterprise_search/server/utils/identify_exceptions.ts
+++ b/x-pack/plugins/enterprise_search/server/utils/identify_exceptions.ts
@@ -36,3 +36,6 @@ export const isPipelineIsInUseException = (error: Error) =>
 
 export const isNotFoundException = (error: ElasticsearchResponseError) =>
   error.meta?.statusCode === 404;
+
+export const isIllegalArgumentException = (error: ElasticsearchResponseError) =>
+  error.meta?.body?.error?.type === 'illegal_argument_exception';

--- a/x-pack/plugins/enterprise_search/tsconfig.json
+++ b/x-pack/plugins/enterprise_search/tsconfig.json
@@ -57,5 +57,6 @@
     "@kbn/expressions-plugin",
     "@kbn/react-field",
     "@kbn/field-types",
+    "@kbn/core-elasticsearch-server-mocks",
   ]
 }


### PR DESCRIPTION
## Summary

When creating an ML inference pipeline that uses the new ELSER model, we need to be able to specify which fields to apply it to, and where the resulting values should go. These fields can then determine what mapping changes need to be made to the underlying index (setting `rank_features` fields).

This PR adds `field_mappings` as a param to our kibana endpoint for creating these ML Inference pipelines, and based on that parameter, attempts to update mappings.

A sample request might be:
```
curl -XPOST -u elastic:changeme "http://localhost:5601/mob/internal/enterprise_search/indices/search-test/ml_inference/pipeline_processors" \
-H 'kbn-xsrf: kibana' \
-H 'Content-Type: application/json' \
-d '{
  "field_mappings": {
    "input": "output"
  },
  "pipeline_definition": {
    "description" : "text",
    "processors": []
  },
  "pipeline_name": "test"
}' | jq
```

And sample output might be:
```
{
  "created": "ml-inference-test",
  "mapping_updated": true
}
```
OR
```
{
  "statusCode": 409,
  "error": "Conflict",
  "message": "One or more target fields for this pipeline already exist with a type that is incompatible with the specified model. Ensure that each target field is unique and not already in use.",
  "attributes": {
    "error_code": "mapping_update_failed"
  }
}
```

### Checklist


- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
