### PR TITLE
docs: link to android agent central config docs

### DIFF
--- a/docs/apm/agent-configuration.asciidoc
+++ b/docs/apm/agent-configuration.asciidoc
@@ -34,6 +34,7 @@ including descriptions and default values, will be displayed.
 Supported configurations are also tagged with the image:./images/dynamic-config.svg[] badge in each APM agent's configuration reference:
 
 [horizontal]
+Android agent:: {apm-android-ref}/configuration.html[Configuration reference]
 Go agent:: {apm-go-ref}/configuration.html[Configuration reference]
 iOS agent:: _Not yet supported_
 Java agent:: {apm-java-ref}/configuration.html[Configuration reference]


### PR DESCRIPTION
### Summary

The Android agent officially supports central configuration as of version 0.4.0. This PR links from the central configuration documentation to the Android agent config reference. Closes https://github.com/elastic/observability-docs/issues/2812. cc @LikeTheSalad 

<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->