### PR TITLE
[UnifiedFieldList] Skip requests for time series metric counter field

### DIFF
--- a/src/plugins/unified_field_list/common/utils/field_stats_utils.ts
+++ b/src/plugins/unified_field_list/common/utils/field_stats_utils.ts
@@ -145,7 +145,8 @@ function canProvideAggregatedStatsForField(field: DataViewField): boolean {
     field.type === 'geo_point' ||
     field.type === 'geo_shape' ||
     field.type === 'murmur3' ||
-    field.type === 'attachment'
+    field.type === 'attachment' ||
+    field.timeSeriesMetric === 'counter'
   );
 }
 


### PR DESCRIPTION
Addresses https://github.com/elastic/kibana/issues/152912

## Summary

This PR makes sure that unified field list does not call unsupported aggs for counter fields. Also the messaging will be better: instead of `No field data for the current search.` it will show `Analysis is not available for this field.`

<img width="586" alt="Screenshot 2023-04-04 at 10 38 29" src="https://user-images.githubusercontent.com/1415710/229751286-d4727bcc-a1af-44a4-9684-c54f7c9b6076.png">

We might extend it later with a different view for such fields.
