### PR TITLE
[Cloud Security] Fix dash location in cloud security posture dashboard

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/compliance_charts/cloud_posture_score_chart.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/compliance_charts/cloud_posture_score_chart.tsx
@@ -164,7 +164,7 @@ export const CloudPostureScoreChart = ({
             <EuiFlexGroup
               justifyContent="flexEnd"
               gutterSize="none"
-              alignItems={'baseline'}
+              alignItems="flexStart"
               style={{ paddingRight: euiTheme.size.xl }}
             >
               <CounterLink
@@ -177,7 +177,7 @@ export const CloudPostureScoreChart = ({
                   { defaultMessage: 'Passed findings' }
                 )}
               />
-              &nbsp;{`-`}&nbsp;
+              <EuiText size="s">&nbsp;-&nbsp;</EuiText>
               <CounterLink
                 text="failed"
                 count={data.totalFailed}


### PR DESCRIPTION
## Summary
Fix dash location in the cloud security posture dashboard's posture score chart in Firefox.

Resolves https://github.com/elastic/kibana/issues/153424

<details>

<summary><h2>Screenshots</h2></summary>

### Chrome

##### Before
<img width="1840" alt="Screenshot 2023-04-04 at 14 20 23" src="https://user-images.githubusercontent.com/94899776/229776819-e97dc7fc-0614-4a05-a470-9e7d47580b52.png">

##### After
<img width="1840" alt="Screenshot 2023-04-04 at 14 20 25" src="https://user-images.githubusercontent.com/94899776/229776863-a7ca1237-bb8a-4c04-b967-7ceb77bb6ba4.png">

### Firefox

##### Before
![Screenshot 2023-04-04 at 14 20 28](https://user-images.githubusercontent.com/94899776/229776923-7a649542-138b-4fbf-bddb-2de88b824dd2.png)

##### After
![Screenshot 2023-04-04 at 14 20 30](https://user-images.githubusercontent.com/94899776/229777007-db317290-7d2a-4414-9816-7a59c157bf23.png)


</details>
