### PR TITLE
[Snapshot & Restore] Add support for S3 onezone_ia

### DIFF
--- a/x-pack/plugins/snapshot_restore/__jest__/client_integration/repository_add.test.ts
+++ b/x-pack/plugins/snapshot_restore/__jest__/client_integration/repository_add.test.ts
@@ -593,5 +593,46 @@ describe('<RepositoryAdd />', () => {
         })
       );
     });
+
+    test('should correctly set the onezone_ia storage class', async () => {
+      const { form, actions, component } = testBed;
+
+      const s3Repository = getRepository({
+        type: 's3',
+        settings: {
+          bucket: 'test_bucket',
+          storageClass: 'onezone_ia',
+        },
+      });
+
+      // Fill step 1 required fields and go to step 2
+      form.setInputValue('nameInput', s3Repository.name);
+      actions.selectRepositoryType(s3Repository.type);
+      actions.clickNextButton();
+
+      // Fill step 2
+      form.setInputValue('bucketInput', s3Repository.settings.bucket);
+      form.setSelectValue('storageClassSelect', s3Repository.settings.storageClass);
+
+      await act(async () => {
+        actions.clickSubmitButton();
+      });
+
+      component.update();
+
+      expect(httpSetup.put).toHaveBeenLastCalledWith(
+        `${API_BASE_PATH}repositories`,
+        expect.objectContaining({
+          body: JSON.stringify({
+            name: s3Repository.name,
+            type: s3Repository.type,
+            settings: {
+              bucket: s3Repository.settings.bucket,
+              storageClass: s3Repository.settings.storageClass,
+            },
+          }),
+        })
+      );
+    });
   });
 });

--- a/x-pack/plugins/snapshot_restore/public/application/components/repository_form/type_settings/s3_settings.tsx
+++ b/x-pack/plugins/snapshot_restore/public/application/components/repository_form/type_settings/s3_settings.tsx
@@ -76,6 +76,7 @@ export const S3Settings: React.FunctionComponent<Props> = ({
     'reduced_redundancy',
     'standard_ia',
     'intelligent_tiering',
+    'onezone_ia',
   ].map((option) => ({
     value: option,
     text: option,


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/153617

## Summary

This pr adds the "onezone_ia" option to the storage class field in the repo form for S3.

![Screenshot 2023-04-04 at 15 31 29](https://user-images.githubusercontent.com/1191206/229808936-961817c9-8793-4cdf-8d5d-53467778b89a.png)

