### PR TITLE
chore(slo): Autofill the slo when creating an alert from slo details page

### DIFF
--- a/x-pack/plugins/observability/public/pages/slo_details/components/header_control.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_details/components/header_control.tsx
@@ -151,7 +151,7 @@ export function HeaderControl({ isLoading, slo }: Props) {
           ruleTypeId={SLO_BURN_RATE_RULE_ID}
           canChangeTrigger={false}
           onClose={onCloseRuleFlyout}
-          initialValues={{ name: `${slo.name} burn rate` }}
+          initialValues={{ name: `${slo.name} burn rate`, params: { sloId: slo.id } }}
         />
       ) : null}
     </>


### PR DESCRIPTION
## Summary

This PR enhances the rule creation shortcut from the slo details page by autofilling the slo on the rule flyout.