### PR TITLE
feat(slo): Add active alerts badge in slo details page

### DIFF
--- a/x-pack/plugins/observability/public/components/slo/slo_status_badge/slo_active_alerts_badge.stories.tsx
+++ b/x-pack/plugins/observability/public/components/slo/slo_status_badge/slo_active_alerts_badge.stories.tsx
@@ -7,14 +7,14 @@
 
 import React from 'react';
 import { ComponentStory } from '@storybook/react';
-
 import { EuiFlexGroup } from '@elastic/eui';
-import { KibanaReactStorybookDecorator } from '../../../../utils/kibana_react.storybook_decorator';
+
+import { KibanaReactStorybookDecorator } from '../../../utils/kibana_react.storybook_decorator';
 import { SloActiveAlertsBadge as Component, Props } from './slo_active_alerts_badge';
 
 export default {
   component: Component,
-  title: 'app/SLO/ListPage/Badges/SloActiveAlertsBadge',
+  title: 'app/SLO/Badges/SloActiveAlertsBadge',
   decorators: [KibanaReactStorybookDecorator],
 };
 

--- a/x-pack/plugins/observability/public/components/slo/slo_status_badge/slo_active_alerts_badge.tsx
+++ b/x-pack/plugins/observability/public/components/slo/slo_status_badge/slo_active_alerts_badge.tsx
@@ -48,7 +48,7 @@ export function SloActiveAlertsBadge({ activeAlerts }: Props) {
           'xpack.observability.slo.slo.activeAlertsBadge.ariaLabel',
           { defaultMessage: 'active alerts badge' }
         )}
-        data-test-subj="o11ySlosPageSloActiveAlertsBadge"
+        data-test-subj="o11ySloActiveAlertsBadge"
       >
         {i18n.translate('xpack.observability.slo.slo.activeAlertsBadge.label', {
           defaultMessage: '{count, plural, one {# alert} other {# alerts}}',

--- a/x-pack/plugins/observability/public/components/slo/slo_status_badge/slo_active_alerts_badge.tsx
+++ b/x-pack/plugins/observability/public/components/slo/slo_status_badge/slo_active_alerts_badge.tsx
@@ -8,11 +8,11 @@
 import { EuiBadge, EuiFlexItem } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
-import { paths } from '../../../../config/paths';
-import { useKibana } from '../../../../utils/kibana_react';
+import { paths } from '../../../config/paths';
+import { useKibana } from '../../../utils/kibana_react';
 
-import { ActiveAlerts } from '../../../../hooks/slo/use_fetch_active_alerts';
-import { toAlertsPageQueryFilter } from '../../helpers/alerts_page_query_filter';
+import { ActiveAlerts } from '../../../hooks/slo/use_fetch_active_alerts';
+import { toAlertsPageQueryFilter } from '../../../pages/slos/helpers/alerts_page_query_filter';
 
 export interface Props {
   activeAlerts?: ActiveAlerts;

--- a/x-pack/plugins/observability/public/components/slo/slo_status_badge/slo_status_badge.stories.tsx
+++ b/x-pack/plugins/observability/public/components/slo/slo_status_badge/slo_status_badge.stories.tsx
@@ -7,8 +7,8 @@
 
 import React from 'react';
 import { ComponentStory } from '@storybook/react';
-
 import { EuiFlexGroup } from '@elastic/eui';
+
 import { KibanaReactStorybookDecorator } from '../../../utils/kibana_react.storybook_decorator';
 import { SloStatusBadge as Component, SloStatusProps } from './slo_status_badge';
 import { buildSlo } from '../../../data/slo/slo';

--- a/x-pack/plugins/observability/public/components/slo/slo_status_badge/slo_status_badge.tsx
+++ b/x-pack/plugins/observability/public/components/slo/slo_status_badge/slo_status_badge.tsx
@@ -18,39 +18,37 @@ export function SloStatusBadge({ slo }: SloStatusProps) {
   return (
     <>
       <EuiFlexItem grow={false}>
-        <div>
-          {slo.summary.status === 'NO_DATA' && (
-            <EuiBadge color="default">
-              {i18n.translate('xpack.observability.slo.sloStatusBadge.noData', {
-                defaultMessage: 'No data',
-              })}
-            </EuiBadge>
-          )}
+        {slo.summary.status === 'NO_DATA' && (
+          <EuiBadge color="default">
+            {i18n.translate('xpack.observability.slo.sloStatusBadge.noData', {
+              defaultMessage: 'No data',
+            })}
+          </EuiBadge>
+        )}
 
-          {slo.summary.status === 'HEALTHY' && (
-            <EuiBadge color="success">
-              {i18n.translate('xpack.observability.slo.sloStatusBadge.healthy', {
-                defaultMessage: 'Healthy',
-              })}
-            </EuiBadge>
-          )}
+        {slo.summary.status === 'HEALTHY' && (
+          <EuiBadge color="success">
+            {i18n.translate('xpack.observability.slo.sloStatusBadge.healthy', {
+              defaultMessage: 'Healthy',
+            })}
+          </EuiBadge>
+        )}
 
-          {slo.summary.status === 'DEGRADING' && (
-            <EuiBadge color="warning">
-              {i18n.translate('xpack.observability.slo.sloStatusBadge.degrading', {
-                defaultMessage: 'Degrading',
-              })}
-            </EuiBadge>
-          )}
+        {slo.summary.status === 'DEGRADING' && (
+          <EuiBadge color="warning">
+            {i18n.translate('xpack.observability.slo.sloStatusBadge.degrading', {
+              defaultMessage: 'Degrading',
+            })}
+          </EuiBadge>
+        )}
 
-          {slo.summary.status === 'VIOLATED' && (
-            <EuiBadge color="danger">
-              {i18n.translate('xpack.observability.slo.sloStatusBadge.violated', {
-                defaultMessage: 'Violated',
-              })}
-            </EuiBadge>
-          )}
-        </div>
+        {slo.summary.status === 'VIOLATED' && (
+          <EuiBadge color="danger">
+            {i18n.translate('xpack.observability.slo.sloStatusBadge.violated', {
+              defaultMessage: 'Violated',
+            })}
+          </EuiBadge>
+        )}
       </EuiFlexItem>
       {slo.summary.errorBudget.isEstimated && (
         <EuiFlexItem grow={false}>

--- a/x-pack/plugins/observability/public/pages/slo_details/components/header_title.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_details/components/header_title.tsx
@@ -9,7 +9,9 @@ import { EuiFlexGroup, EuiFlexItem, EuiLoadingSpinner } from '@elastic/eui';
 import { SLOWithSummaryResponse } from '@kbn/slo-schema';
 import React from 'react';
 
+import { useFetchActiveAlerts } from '../../../hooks/slo/use_fetch_active_alerts';
 import { SloStatusBadge } from '../../../components/slo/slo_status_badge';
+import { SloActiveAlertsBadge } from '../../../components/slo/slo_status_badge/slo_active_alerts_badge';
 
 export interface Props {
   slo: SLOWithSummaryResponse | undefined;
@@ -18,6 +20,11 @@ export interface Props {
 
 export function HeaderTitle(props: Props) {
   const { isLoading, slo } = props;
+
+  const { data: activeAlerts } = useFetchActiveAlerts({
+    sloIds: !!slo ? [slo.id] : [],
+  });
+
   if (isLoading) {
     return <EuiLoadingSpinner data-test-subj="loadingTitle" />;
   }
@@ -27,9 +34,12 @@ export function HeaderTitle(props: Props) {
   }
 
   return (
-    <EuiFlexGroup direction="column" gutterSize="xs" responsive={false}>
+    <EuiFlexGroup direction="column" gutterSize="s">
       <EuiFlexItem grow={false}>{slo.name}</EuiFlexItem>
-      <SloStatusBadge slo={slo} />
+      <EuiFlexGroup direction="row" gutterSize="s" alignItems="center" responsive={false}>
+        <SloStatusBadge slo={slo} />
+        <SloActiveAlertsBadge activeAlerts={activeAlerts[slo.id]} />
+      </EuiFlexGroup>
     </EuiFlexGroup>
   );
 }

--- a/x-pack/plugins/observability/public/pages/slos/components/badges/slo_badges.tsx
+++ b/x-pack/plugins/observability/public/pages/slos/components/badges/slo_badges.tsx
@@ -13,7 +13,7 @@ import { SloIndicatorTypeBadge } from './slo_indicator_type_badge';
 import { SloStatusBadge } from '../../../../components/slo/slo_status_badge';
 import { SloTimeWindowBadge } from './slo_time_window_badge';
 import type { ActiveAlerts } from '../../../../hooks/slo/use_fetch_active_alerts';
-import { SloActiveAlertsBadge } from './slo_active_alerts_badge';
+import { SloActiveAlertsBadge } from '../../../../components/slo/slo_status_badge/slo_active_alerts_badge';
 
 export interface Props {
   slo: SLOWithSummaryResponse;


### PR DESCRIPTION
## Summary

This PR enhances the SLO details page by adding the active alerts badge next to the SLO status badge when at least one alert is active for the given SLO.

## Screenshots

![screencapture-localhost-5601-kibana-s-default-app-observability-slos-c60c5c50-d232-11ed-82b1-89a32b1ce30c-2023-04-04-11_53_22](https://user-images.githubusercontent.com/1376800/229848453-2388a908-68fd-4b37-9bc2-6e5f531a5bef.png)



https://user-images.githubusercontent.com/1376800/229848719-b3b82b9a-6a2a-404a-9bc2-ade3365a1538.mov


