### PR TITLE
Sort processors alphabetically by component directory

### DIFF
--- a/x-pack/plugins/ingest_pipelines/public/application/components/pipeline_editor/components/processor_form/processors/index.ts
+++ b/x-pack/plugins/ingest_pipelines/public/application/components/pipeline_editor/components/processor_form/processors/index.ts
@@ -38,12 +38,12 @@ export { Rename } from './rename';
 export { Script } from './script';
 export { SetProcessor } from './set';
 export { SetSecurityUser } from './set_security_user';
-export { Split } from './split';
 export { Sort } from './sort';
+export { Split } from './split';
 export { Trim } from './trim';
 export { Uppercase } from './uppercase';
+export { UriParts } from './uri_parts';
 export { UrlDecode } from './url_decode';
 export { UserAgent } from './user_agent';
-export { UriParts } from './uri_parts';
 
 export type { FormFieldsComponent } from './shared';

--- a/x-pack/plugins/ingest_pipelines/public/application/components/pipeline_editor/components/processor_form/processors/index.ts
+++ b/x-pack/plugins/ingest_pipelines/public/application/components/pipeline_editor/components/processor_form/processors/index.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+// please try to keep this list sorted by module name (e.g. './bar' before './foo')
+
 export { Append } from './append';
 export { Bytes } from './bytes';
 export { Circle } from './circle';


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/95023

I'm auditing the available processors that the UI supports and comparing it to what Elasticsearch actually has to offer. On the  Elasticsearch side I added a sorted list of processors, and the same list on this side is very close to sorted, so I figured it would be  easy to PR a change to actually make it sorted.