### PR TITLE
[Canvas] Fix image upload component not loading for image elements

### DIFF
--- a/src/plugins/presentation_util/common/index.ts
+++ b/src/plugins/presentation_util/common/index.ts
@@ -39,7 +39,9 @@ export {
   getElasticLogo,
   getElasticOutline,
   isValidUrl,
+  isValidHttpUrl,
   resolveWithMissingImage,
+  resolveFromArgs,
   encode,
   parseDataUrl,
 } from './lib';

--- a/x-pack/plugins/canvas/canvas_plugin_src/uis/arguments/image_upload/index.js
+++ b/x-pack/plugins/canvas/canvas_plugin_src/uis/arguments/image_upload/index.js
@@ -14,7 +14,7 @@ import {
   getElasticOutline,
   isValidHttpUrl,
   resolveFromArgs,
-} from '@kbn/presentation-util-plugin/public';
+} from '@kbn/presentation-util-plugin/common';
 import { AssetPicker } from '../../../../public/components/asset_picker';
 import { templateFromReactComponent } from '../../../../public/lib/template_from_react_component';
 import { VALID_IMAGE_TYPES } from '../../../../common/lib/constants';


### PR DESCRIPTION
## Summary

Fixes a regression where the image upload component does not load for Canvas image elements.

Starting with PR #145633 modules in `@kbn/presentation-util-plugin/common` are no longer exported from the `@kbn/presentation-util-plugin/public` module. The imports in the `ImageUpload` module should have also been updated to the `@kbn/presentation-util-plugin/common` module.

Fixes #154356 


<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->