### PR TITLE
[Canvas] Fix `createElement` callback

### DIFF
--- a/x-pack/plugins/canvas/public/components/workpad_header/workpad_header.component.tsx
+++ b/x-pack/plugins/canvas/public/components/workpad_header/workpad_header.component.tsx
@@ -144,17 +144,17 @@ export const WorkpadHeader: FC<Props> = ({
     {
       iconType: 'visText',
       label: elementStrings.markdown.displayName,
-      onClick: () => createElement('markdown'),
+      onClick: createElement('markdown'),
     },
     {
       iconType: 'node',
       label: elementStrings.shape.displayName,
-      onClick: () => createElement('shape'),
+      onClick: createElement('shape'),
     },
     {
       iconType: 'image',
       label: elementStrings.image.displayName,
-      onClick: () => createElement('image'),
+      onClick: createElement('image'),
     },
   ];
 


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/154389

## Summary

The `createElement` callback for the Canvas top nav bar is [curried](https://javascript.info/currying-partials), like so:

https://github.com/elastic/kibana/blob/201c80542c9f11bd8b99caeda3e2ac8af009e4d2/x-pack/plugins/canvas/public/components/workpad_header/workpad_header.component.tsx#L133-L141

In https://github.com/elastic/kibana/pull/151381, I accidentally added **another layer** of currying by anonymizing the function with `() => createElement(...)` in the `onClick` which meant that, when the button was clicked, the `createElement` function wasn't actually called - the `onClick` would have to be changed to  `() => createElement(...)()` instead if we wanted to keep the anonymization. 

However, it's cleaner if we simply don't add this extra layer; i.e. the `onClick` gets `createElement(...)` directly, so that clicking on the button actually calls the `createElement` function.

### Checklist

- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.0","8.7"]} ONMERGE-->