### PR TITLE
[ResponseOps] change event log to use a datastream

### DIFF
--- a/x-pack/plugins/event_log/server/es/context.test.ts
+++ b/x-pack/plugins/event_log/server/es/context.test.ts
@@ -75,7 +75,7 @@ describe('createEsContext', () => {
     elasticsearchClient.indices.existsTemplate.mockResponse(false);
     elasticsearchClient.indices.existsIndexTemplate.mockResponse(false);
     elasticsearchClient.indices.existsAlias.mockResponse(false);
-    const doesAliasExist = await context.esAdapter.doesAliasExist(context.esNames.alias);
+    const doesAliasExist = await context.esAdapter.doesAliasExist(context.esNames.datastream);
     expect(doesAliasExist).toBeFalsy();
 
     const doesIndexTemplateExist = await context.esAdapter.doesIndexTemplateExist(
@@ -99,7 +99,7 @@ describe('createEsContext', () => {
     );
     expect(doesIlmPolicyExist).toBeTruthy();
 
-    const doesAliasExist = await context.esAdapter.doesAliasExist(context.esNames.alias);
+    const doesAliasExist = await context.esAdapter.doesAliasExist(context.esNames.datastream);
     expect(doesAliasExist).toBeTruthy();
 
     const doesIndexTemplateExist = await context.esAdapter.doesIndexTemplateExist(

--- a/x-pack/plugins/event_log/server/es/context.ts
+++ b/x-pack/plugins/event_log/server/es/context.ts
@@ -58,6 +58,7 @@ class EsContextImpl implements EsContext {
     this.esAdapter = new ClusterClientAdapter({
       logger: params.logger,
       elasticsearchClientPromise: params.elasticsearchClientPromise,
+      esNames: this.esNames,
       wait: () => this.readySignal.wait(),
     });
   }

--- a/x-pack/plugins/event_log/server/es/documents.test.ts
+++ b/x-pack/plugins/event_log/server/es/documents.test.ts
@@ -28,7 +28,9 @@ describe('getIndexTemplate()', () => {
     expect(indexTemplate.template.settings.number_of_shards).toBeGreaterThanOrEqual(0);
     expect(indexTemplate.template.settings.auto_expand_replicas).toBe('0-1');
     expect(indexTemplate.template.settings['index.lifecycle.name']).toBe(esNames.ilmPolicy);
-    expect(indexTemplate.template.settings['index.lifecycle.rollover_alias']).toBe(esNames.datastream);
+    expect(indexTemplate.template.settings['index.lifecycle.rollover_alias']).toBe(
+      esNames.datastream
+    );
     expect(indexTemplate.template.settings['index.hidden']).toBe(true);
     expect(indexTemplate.template.mappings).toMatchObject({});
   });

--- a/x-pack/plugins/event_log/server/es/documents.test.ts
+++ b/x-pack/plugins/event_log/server/es/documents.test.ts
@@ -28,7 +28,7 @@ describe('getIndexTemplate()', () => {
     expect(indexTemplate.template.settings.number_of_shards).toBeGreaterThanOrEqual(0);
     expect(indexTemplate.template.settings.auto_expand_replicas).toBe('0-1');
     expect(indexTemplate.template.settings['index.lifecycle.name']).toBe(esNames.ilmPolicy);
-    expect(indexTemplate.template.settings['index.lifecycle.rollover_alias']).toBe(esNames.alias);
+    expect(indexTemplate.template.settings['index.lifecycle.rollover_alias']).toBe(esNames.datastream);
     expect(indexTemplate.template.settings['index.hidden']).toBe(true);
     expect(indexTemplate.template.mappings).toMatchObject({});
   });

--- a/x-pack/plugins/event_log/server/es/documents.ts
+++ b/x-pack/plugins/event_log/server/es/documents.ts
@@ -11,26 +11,49 @@ import mappings from '../../generated/mappings.json';
 // returns the body of an index template used in an ES indices.putTemplate call
 export function getIndexTemplate(esNames: EsNames) {
   const indexTemplateBody = {
+    _meta: {
+      description: 'index template for the Kibana event log',
+      managed: true,
+    },
     index_patterns: [esNames.indexPatternWithVersion],
+    data_stream: {},
+    composed_of: [esNames.componentTemplate],
+    priority: 100,
+  };
+
+  return indexTemplateBody;
+}
+
+// returns the body of a component template used in an ES cluster.putComponentTemplate call
+export function getComponentTemplate(esNames: EsNames) {
+  const componentTemplateBody = {
+    _meta: {
+      description: 'component template for the Kibana event log',
+      managed: true,
+    },
+    name: esNames.componentTemplate,
     template: {
       settings: {
+        hidden: true,
         number_of_shards: 1,
         auto_expand_replicas: '0-1',
         'index.lifecycle.name': esNames.ilmPolicy,
-        'index.lifecycle.rollover_alias': esNames.alias,
-        'index.hidden': true,
       },
       mappings,
     },
   };
 
-  return indexTemplateBody;
+  return componentTemplateBody;
 }
 
 // returns the body of an ilm policy used in an ES PUT _ilm/policy call
 export function getIlmPolicy() {
   return {
     policy: {
+      _meta: {
+        description: 'ilm policy for the Kibana event log',
+        managed: false,
+      },
       phases: {
         hot: {
           actions: {

--- a/x-pack/plugins/event_log/server/es/names.mock.ts
+++ b/x-pack/plugins/event_log/server/es/names.mock.ts
@@ -10,7 +10,7 @@ import { EsNames } from './names';
 const createNamesMock = () => {
   const mock: jest.Mocked<EsNames> = {
     base: '.kibana',
-    alias: '.kibana-event-log-8.0.0',
+    datastream: '.kibana-event-log-8.0.0',
     ilmPolicy: 'kibana-event-log-policy',
     indexPattern: '.kibana-event-log-*',
     indexPatternWithVersion: '.kibana-event-log-8.0.0-*',

--- a/x-pack/plugins/event_log/server/es/names.test.ts
+++ b/x-pack/plugins/event_log/server/es/names.test.ts
@@ -17,7 +17,7 @@ describe('getEsNames()', () => {
     const kibanaVersion = '1.2.3';
     const esNames = getEsNames(base, kibanaVersion);
     expect(esNames.base).toEqual(base);
-    expect(esNames.alias).toEqual(`${base}-event-log-${kibanaVersion}`);
+    expect(esNames.datastream).toEqual(`${base}-event-log-${kibanaVersion}`);
     expect(esNames.ilmPolicy).toEqual(`${base}-event-log-policy`);
     expect(esNames.indexPattern).toEqual(`${base}-event-log-*`);
     expect(esNames.indexPatternWithVersion).toEqual(`${base}-event-log-${kibanaVersion}-*`);

--- a/x-pack/plugins/event_log/server/es/names.ts
+++ b/x-pack/plugins/event_log/server/es/names.ts
@@ -9,12 +9,13 @@ const EVENT_LOG_NAME_SUFFIX = `-event-log`;
 
 export interface EsNames {
   base: string;
-  alias: string;
+  datastream: string;
   ilmPolicy: string;
   indexPattern: string;
   indexPatternWithVersion: string;
   initialIndex: string;
   indexTemplate: string;
+  componentTemplate: string;
 }
 
 export function getEsNames(baseName: string, kibanaVersion: string): EsNames {
@@ -26,11 +27,12 @@ export function getEsNames(baseName: string, kibanaVersion: string): EsNames {
   }${EVENT_LOG_NAME_SUFFIX}-policy`;
   return {
     base: baseName,
-    alias: eventLogNameWithVersion,
+    datastream: eventLogNameWithVersion,
     ilmPolicy: `${eventLogPolicyName}`,
     indexPattern: `${eventLogName}-*`,
     indexPatternWithVersion: `${eventLogNameWithVersion}-*`,
     initialIndex: `${eventLogNameWithVersion}-000001`,
     indexTemplate: `${eventLogNameWithVersion}-template`,
+    componentTemplate: `${eventLogNameWithVersion}-component-template`,
   };
 }

--- a/x-pack/plugins/event_log/server/event_logger.ts
+++ b/x-pack/plugins/event_log/server/event_logger.ts
@@ -95,7 +95,7 @@ export class EventLogger implements IEventLogger {
     }
 
     const doc: Doc = {
-      index: this.esContext.esNames.alias,
+      index: 'this needs to be removed, is ignored for now',
       body: validatedEvent,
     };
 


### PR DESCRIPTION
## Summary

_**closing this in favor of https://github.com/elastic/kibana/pull/154664**_ (but I may change my mind)

Changes event log from using indices, aliases, and ILM manually, to using datastreams.

Partially resolving https://github.com/elastic/kibana/issues/154266

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
