### PR TITLE
SO migration: recognize `document_parsing_exception` as incompatible mapping exceptions

### DIFF
--- a/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/actions/es_errors.test.ts
+++ b/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/actions/es_errors.test.ts
@@ -61,6 +61,14 @@ describe('isIncompatibleMappingExceptionError', () => {
       })
     ).toEqual(true);
   });
+  it('returns true for `document_parsing_exception` errors', () => {
+    expect(
+      isIncompatibleMappingException({
+        type: 'document_parsing_exception',
+        reason: 'idk',
+      })
+    ).toEqual(true);
+  });
   it('returns false undefined', () => {
     expect(isIncompatibleMappingException(undefined)).toEqual(false);
   });

--- a/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/actions/es_errors.ts
+++ b/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/actions/es_errors.ts
@@ -17,7 +17,8 @@ export const isWriteBlockException = (errorCause?: estypes.ErrorCause): boolean 
 export const isIncompatibleMappingException = (errorCause?: estypes.ErrorCause): boolean => {
   return (
     errorCause?.type === 'strict_dynamic_mapping_exception' ||
-    errorCause?.type === 'mapper_parsing_exception'
+    errorCause?.type === 'mapper_parsing_exception' ||
+    errorCause?.type === 'document_parsing_exception'
   );
 };
 

--- a/src/core/server/integration_tests/saved_objects/migrations/group3/actions/actions.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/group3/actions/actions.test.ts
@@ -706,9 +706,7 @@ describe('migration actions', () => {
 
   // Reindex doesn't return any errors on it's own, so we have to test
   // together with waitForReindexTask
-  //
-  // FAILING ES PROMOTION: https://github.com/elastic/kibana/issues/154278
-  describe.skip('reindex & waitForReindexTask', () => {
+  describe('reindex & waitForReindexTask', () => {
     it('resolves right when reindex succeeds without reindex script', async () => {
       const res = (await reindex({
         client,
@@ -1076,7 +1074,6 @@ describe('migration actions', () => {
         }
       `);
     });
-
     it('resolves left wait_for_task_completion_timeout when the task does not finish within the timeout', async () => {
       await waitForIndexStatus({
         client,


### PR DESCRIPTION
## Summary

Fix https://github.com/elastic/kibana/issues/154278
Caused by an upstream change: https://github.com/elastic/elasticsearch/issues/85083