### PR TITLE
[Cases] Deleting file attachments from a case

### DIFF
--- a/x-pack/plugins/cases/public/components/files/add_file.test.tsx
+++ b/x-pack/plugins/cases/public/components/files/add_file.test.tsx
@@ -209,7 +209,10 @@ describe('AddFile', () => {
     userEvent.click(await screen.findByTestId('testMetadata'));
 
     await waitFor(() =>
-      expect(validateMetadata).toHaveBeenCalledWith({ caseId, owner: mockedTestProvidersOwner[0] })
+      expect(validateMetadata).toHaveBeenCalledWith({
+        caseIds: [caseId],
+        owner: mockedTestProvidersOwner[0],
+      })
     );
   });
 

--- a/x-pack/plugins/cases/public/components/files/add_file.tsx
+++ b/x-pack/plugins/cases/public/components/files/add_file.tsx
@@ -138,7 +138,7 @@ const AddFileComponent: React.FC<AddFileProps> = ({ caseId }) => {
               kind={constructFileKindIdByOwner(owner[0] as Owner)}
               onDone={onUploadDone}
               onError={onError}
-              meta={{ caseId, owner: owner[0] }}
+              meta={{ caseIds: [caseId], owner: owner[0] }}
             />
           </EuiModalBody>
         </EuiModal>

--- a/x-pack/plugins/cases/public/components/files/file_delete_button_icon.test.tsx
+++ b/x-pack/plugins/cases/public/components/files/file_delete_button_icon.test.tsx
@@ -40,7 +40,7 @@ describe('FileDeleteButtonIcon', () => {
     expect(useDeleteFileAttachmentMock).toBeCalledTimes(1);
   });
 
-  it('clicking delete button calls deleteFileAttachment with proper params', async () => {
+  it('clicking delete button opens the confirmation modal', async () => {
     appMockRender.render(<FileDeleteButtonIcon caseId={basicCaseId} fileId={basicFileMock.id} />);
 
     const deleteButton = await screen.findByTestId('cases-files-delete-button');
@@ -49,12 +49,27 @@ describe('FileDeleteButtonIcon', () => {
 
     userEvent.click(deleteButton);
 
+    expect(await screen.findAllByTestId('property-actions-confirm-modal'));
+  });
+
+  it('clicking delete button in the confirmation modal calls deleteFileAttachment with proper params', async () => {
+    appMockRender.render(<FileDeleteButtonIcon caseId={basicCaseId} fileId={basicFileMock.id} />);
+
+    const deleteButton = await screen.findByTestId('cases-files-delete-button');
+
+    expect(deleteButton).toBeInTheDocument();
+
+    userEvent.click(deleteButton);
+
+    expect(await screen.findAllByTestId('property-actions-confirm-modal'));
+
+    userEvent.click(await screen.findByTestId('confirmModalConfirmButton'));
+
     await waitFor(() => {
       expect(mutate).toHaveBeenCalledTimes(1);
       expect(mutate).toHaveBeenCalledWith({
         caseId: basicCaseId,
         fileId: basicFileMock.id,
-        successToasterTitle: 'File deleted successfully',
       });
     });
   });

--- a/x-pack/plugins/cases/public/components/files/file_delete_button_icon.test.tsx
+++ b/x-pack/plugins/cases/public/components/files/file_delete_button_icon.test.tsx
@@ -49,7 +49,7 @@ describe('FileDeleteButtonIcon', () => {
 
     userEvent.click(deleteButton);
 
-    expect(await screen.findAllByTestId('property-actions-confirm-modal'));
+    expect(await screen.findByTestId('property-actions-confirm-modal')).toBeInTheDocument();
   });
 
   it('clicking delete button in the confirmation modal calls deleteFileAttachment with proper params', async () => {
@@ -61,7 +61,7 @@ describe('FileDeleteButtonIcon', () => {
 
     userEvent.click(deleteButton);
 
-    expect(await screen.findAllByTestId('property-actions-confirm-modal'));
+    expect(await screen.findByTestId('property-actions-confirm-modal')).toBeInTheDocument();
 
     userEvent.click(await screen.findByTestId('confirmModalConfirmButton'));
 

--- a/x-pack/plugins/cases/public/components/files/file_delete_button_icon.test.tsx
+++ b/x-pack/plugins/cases/public/components/files/file_delete_button_icon.test.tsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import type { AppMockRenderer } from '../../common/mock';
+
+import { createAppMockRenderer } from '../../common/mock';
+import { basicCaseId, basicFileMock } from '../../containers/mock';
+import { useDeleteFileAttachment } from '../../containers/use_delete_file_attachment';
+import { FileDeleteButtonIcon } from './file_delete_button_icon';
+
+jest.mock('../../containers/use_delete_file_attachment');
+
+const useDeleteFileAttachmentMock = useDeleteFileAttachment as jest.Mock;
+
+describe('FileDeleteButtonIcon', () => {
+  let appMockRender: AppMockRenderer;
+  const mutate = jest.fn();
+
+  useDeleteFileAttachmentMock.mockReturnValue({ isLoading: false, mutate });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    appMockRender = createAppMockRenderer();
+  });
+
+  it('renders delete button correctly', async () => {
+    appMockRender.render(<FileDeleteButtonIcon caseId={basicCaseId} fileId={basicFileMock.id} />);
+
+    expect(await screen.findByTestId('cases-files-delete-button')).toBeInTheDocument();
+
+    expect(useDeleteFileAttachmentMock).toBeCalledTimes(1);
+  });
+
+  it('clicking delete button calls deleteFileAttachment with proper params', async () => {
+    appMockRender.render(<FileDeleteButtonIcon caseId={basicCaseId} fileId={basicFileMock.id} />);
+
+    const deleteButton = await screen.findByTestId('cases-files-delete-button');
+
+    expect(deleteButton).toBeInTheDocument();
+
+    userEvent.click(deleteButton);
+
+    await waitFor(() => {
+      expect(mutate).toHaveBeenCalledTimes(1);
+      expect(mutate).toHaveBeenCalledWith({
+        caseId: basicCaseId,
+        fileId: basicFileMock.id,
+        successToasterTitle: 'File deleted successfully',
+      });
+    });
+  });
+});

--- a/x-pack/plugins/cases/public/components/files/file_delete_button_icon.test.tsx
+++ b/x-pack/plugins/cases/public/components/files/file_delete_button_icon.test.tsx
@@ -12,7 +12,7 @@ import userEvent from '@testing-library/user-event';
 
 import type { AppMockRenderer } from '../../common/mock';
 
-import { createAppMockRenderer } from '../../common/mock';
+import { buildCasesPermissions, createAppMockRenderer } from '../../common/mock';
 import { basicCaseId, basicFileMock } from '../../containers/mock';
 import { useDeleteFileAttachment } from '../../containers/use_delete_file_attachment';
 import { FileDeleteButtonIcon } from './file_delete_button_icon';
@@ -72,5 +72,15 @@ describe('FileDeleteButtonIcon', () => {
         fileId: basicFileMock.id,
       });
     });
+  });
+
+  it('delete button is disabled if user has no delete permission', async () => {
+    appMockRender = createAppMockRenderer({
+      permissions: buildCasesPermissions({ delete: false }),
+    });
+
+    appMockRender.render(<FileDeleteButtonIcon caseId={basicCaseId} fileId={basicFileMock.id} />);
+
+    expect(await screen.findByTestId('cases-files-delete-button')).toBeDisabled();
   });
 });

--- a/x-pack/plugins/cases/public/components/files/file_delete_button_icon.tsx
+++ b/x-pack/plugins/cases/public/components/files/file_delete_button_icon.tsx
@@ -10,6 +10,8 @@ import React from 'react';
 import { EuiButtonIcon } from '@elastic/eui';
 import * as i18n from './translations';
 import { useDeleteFileAttachment } from '../../containers/use_delete_file_attachment';
+import { useDeletePropertyAction } from '../user_actions/property_actions/use_delete_property_action';
+import { DeleteAttachmentConfirmationModal } from '../user_actions/delete_attachment_confirmation_modal';
 
 interface FileDeleteButtonIconProps {
   caseId: string;
@@ -19,17 +21,29 @@ interface FileDeleteButtonIconProps {
 const FileDeleteButtonIconComponent: React.FC<FileDeleteButtonIconProps> = ({ caseId, fileId }) => {
   const { isLoading, mutate: deleteFileAttachment } = useDeleteFileAttachment();
 
+  const { showDeletionModal, onModalOpen, onConfirm, onCancel } = useDeletePropertyAction({
+    onDelete: () => deleteFileAttachment({ caseId, fileId }),
+  });
+
   return (
-    <EuiButtonIcon
-      iconType={'trash'}
-      aria-label={i18n.DELETE_FILE}
-      color={'danger'}
-      isDisabled={isLoading}
-      onClick={() =>
-        deleteFileAttachment({ caseId, fileId, successToasterTitle: i18n.FILE_DELETE_SUCCESS })
-      }
-      data-test-subj={'cases-files-delete-button'}
-    />
+    <>
+      <EuiButtonIcon
+        iconType={'trash'}
+        aria-label={i18n.DELETE_FILE}
+        color={'danger'}
+        isDisabled={isLoading}
+        onClick={onModalOpen}
+        data-test-subj={'cases-files-delete-button'}
+      />
+      {showDeletionModal ? (
+        <DeleteAttachmentConfirmationModal
+          title={i18n.DELETE_FILE_TITLE}
+          confirmButtonText={i18n.DELETE}
+          onCancel={onCancel}
+          onConfirm={onConfirm}
+        />
+      ) : null}
+    </>
   );
 };
 FileDeleteButtonIconComponent.displayName = 'FileDeleteButtonIcon';

--- a/x-pack/plugins/cases/public/components/files/file_delete_button_icon.tsx
+++ b/x-pack/plugins/cases/public/components/files/file_delete_button_icon.tsx
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { EuiButtonIcon } from '@elastic/eui';
+import * as i18n from './translations';
+import { useDeleteFileAttachment } from '../../containers/use_delete_file_attachment';
+
+interface FileDeleteButtonIconProps {
+  caseId: string;
+  fileId: string;
+}
+
+const FileDeleteButtonIconComponent: React.FC<FileDeleteButtonIconProps> = ({ caseId, fileId }) => {
+  const { isLoading, mutate: deleteFileAttachment } = useDeleteFileAttachment();
+
+  return (
+    <EuiButtonIcon
+      iconType={'trash'}
+      aria-label={i18n.DELETE_FILE}
+      color={'danger'}
+      isDisabled={isLoading}
+      onClick={() =>
+        deleteFileAttachment({ caseId, fileId, successToasterTitle: i18n.FILE_DELETE_SUCCESS })
+      }
+      data-test-subj={'cases-files-delete-button'}
+    />
+  );
+};
+FileDeleteButtonIconComponent.displayName = 'FileDeleteButtonIcon';
+
+export const FileDeleteButtonIcon = React.memo(FileDeleteButtonIconComponent);

--- a/x-pack/plugins/cases/public/components/files/file_delete_button_icon.tsx
+++ b/x-pack/plugins/cases/public/components/files/file_delete_button_icon.tsx
@@ -12,6 +12,7 @@ import * as i18n from './translations';
 import { useDeleteFileAttachment } from '../../containers/use_delete_file_attachment';
 import { useDeletePropertyAction } from '../user_actions/property_actions/use_delete_property_action';
 import { DeleteAttachmentConfirmationModal } from '../user_actions/delete_attachment_confirmation_modal';
+import { useCasesContext } from '../cases_context/use_cases_context';
 
 interface FileDeleteButtonIconProps {
   caseId: string;
@@ -19,6 +20,7 @@ interface FileDeleteButtonIconProps {
 }
 
 const FileDeleteButtonIconComponent: React.FC<FileDeleteButtonIconProps> = ({ caseId, fileId }) => {
+  const { permissions } = useCasesContext();
   const { isLoading, mutate: deleteFileAttachment } = useDeleteFileAttachment();
 
   const { showDeletionModal, onModalOpen, onConfirm, onCancel } = useDeletePropertyAction({
@@ -31,7 +33,7 @@ const FileDeleteButtonIconComponent: React.FC<FileDeleteButtonIconProps> = ({ ca
         iconType={'trash'}
         aria-label={i18n.DELETE_FILE}
         color={'danger'}
-        isDisabled={isLoading}
+        isDisabled={isLoading || !permissions.delete}
         onClick={onModalOpen}
         data-test-subj={'cases-files-delete-button'}
       />

--- a/x-pack/plugins/cases/public/components/files/file_type.test.tsx
+++ b/x-pack/plugins/cases/public/components/files/file_type.test.tsx
@@ -15,6 +15,7 @@ import { FILE_ATTACHMENT_TYPE } from '../../../common/api';
 import { createAppMockRenderer } from '../../common/mock';
 import { basicCase, basicFileMock } from '../../containers/mock';
 import { getFileType } from './file_type';
+import userEvent from '@testing-library/user-event';
 
 describe('getFileType', () => {
   const fileType = getFileType();
@@ -60,6 +61,30 @@ describe('getFileType', () => {
       appMockRender.render(fileType.getAttachmentViewObject({ ...attachmentViewProps }).actions);
 
       expect(await screen.findByTestId('cases-files-download-button')).toBeInTheDocument();
+    });
+
+    it('actions renders a delete button', async () => {
+      appMockRender = createAppMockRenderer();
+
+      // @ts-ignore
+      appMockRender.render(fileType.getAttachmentViewObject({ ...attachmentViewProps }).actions);
+
+      expect(await screen.findByTestId('cases-files-delete-button')).toBeInTheDocument();
+    });
+
+    it('clicking the delete button in actions opens deletion modal', async () => {
+      appMockRender = createAppMockRenderer();
+
+      // @ts-ignore
+      appMockRender.render(fileType.getAttachmentViewObject({ ...attachmentViewProps }).actions);
+
+      const deleteButton = await screen.findByTestId('cases-files-delete-button');
+
+      expect(deleteButton).toBeInTheDocument();
+
+      userEvent.click(deleteButton);
+
+      expect(await screen.findByTestId('property-actions-confirm-modal')).toBeInTheDocument();
     });
 
     it('empty externalReferenceMetadata returns blank FileAttachmentViewObject', () => {

--- a/x-pack/plugins/cases/public/components/files/file_type.tsx
+++ b/x-pack/plugins/cases/public/components/files/file_type.tsx
@@ -20,6 +20,7 @@ import { FilePreview } from './file_preview';
 import * as i18n from './translations';
 import { isImage, isValidFileExternalReferenceMetadata } from './utils';
 import { useFilePreview } from './use_file_preview';
+import { FileDeleteButtonIcon } from './file_delete_button_icon';
 
 interface FileAttachmentEventProps {
   file: FileJSON;
@@ -39,6 +40,15 @@ const FileAttachmentEvent = ({ file }: FileAttachmentEventProps) => {
 
 FileAttachmentEvent.displayName = 'FileAttachmentEvent';
 
+const FileAttachmentActions = ({ caseId, fileId }: { caseId: string; fileId: string }) => (
+  <>
+    <FileDownloadButtonIcon fileId={fileId} />
+    <FileDeleteButtonIcon caseId={caseId} fileId={fileId} />
+  </>
+);
+
+FileAttachmentActions.displayName = 'FileAttachmentActions';
+
 const getFileAttachmentViewObject = (props: ExternalReferenceAttachmentViewProps) => {
   if (!isValidFileExternalReferenceMetadata(props.externalReferenceMetadata)) {
     return {
@@ -50,6 +60,7 @@ const getFileAttachmentViewObject = (props: ExternalReferenceAttachmentViewProps
   }
 
   const fileId = props.externalReferenceId;
+  const caseId = props.caseData.id;
 
   // @ts-ignore
   const partialFileJSON = props.externalReferenceMetadata?.files[0] as Partial<FileJSON>;
@@ -62,7 +73,7 @@ const getFileAttachmentViewObject = (props: ExternalReferenceAttachmentViewProps
   return {
     event: <FileAttachmentEvent file={file} />,
     timelineAvatar: isImage(file) ? 'image' : 'document',
-    actions: <FileDownloadButtonIcon fileId={fileId} />,
+    actions: <FileAttachmentActions caseId={caseId} fileId={fileId} />,
     hideDefaultActions: true,
   };
 };

--- a/x-pack/plugins/cases/public/components/files/files_table.test.tsx
+++ b/x-pack/plugins/cases/public/components/files/files_table.test.tsx
@@ -131,6 +131,36 @@ describe('FilesTable', () => {
     expect(await screen.findByTestId('cases-files-download-button')).toBeInTheDocument();
   });
 
+  it('delete button renders correctly', async () => {
+    appMockRender.render(<FilesTable {...defaultProps} />);
+
+    expect(mockedFilesClient.getDownloadHref).toBeCalledTimes(1);
+    expect(mockedFilesClient.getDownloadHref).toHaveBeenCalledWith({
+      fileKind: constructFileKindIdByOwner(mockedTestProvidersOwner[0]),
+      id: basicFileMock.id,
+    });
+
+    expect(await screen.findByTestId('cases-files-delete-button')).toBeInTheDocument();
+  });
+
+  it('clicking delete button opens deletion modal', async () => {
+    appMockRender.render(<FilesTable {...defaultProps} />);
+
+    expect(mockedFilesClient.getDownloadHref).toBeCalledTimes(1);
+    expect(mockedFilesClient.getDownloadHref).toHaveBeenCalledWith({
+      fileKind: constructFileKindIdByOwner(mockedTestProvidersOwner[0]),
+      id: basicFileMock.id,
+    });
+
+    const deleteButton = await screen.findByTestId('cases-files-delete-button');
+
+    expect(deleteButton).toBeInTheDocument();
+
+    userEvent.click(deleteButton);
+
+    expect(await screen.findByTestId('property-actions-confirm-modal')).toBeInTheDocument();
+  });
+
   it('go to next page calls onTableChange with correct values', async () => {
     const mockPagination = { pageIndex: 0, pageSize: 1, totalItemCount: 2 };
 

--- a/x-pack/plugins/cases/public/components/files/files_table.test.tsx
+++ b/x-pack/plugins/cases/public/components/files/files_table.test.tsx
@@ -45,7 +45,7 @@ describe('FilesTable', () => {
     expect(await screen.findByTestId('cases-files-table-filetype')).toBeInTheDocument();
     expect(await screen.findByTestId('cases-files-table-date-added')).toBeInTheDocument();
     expect(await screen.findByTestId('cases-files-download-button')).toBeInTheDocument();
-    expect(await screen.findByTestId('cases-files-table-action-delete')).toBeInTheDocument();
+    expect(await screen.findByTestId('cases-files-delete-button')).toBeInTheDocument();
   });
 
   it('renders loading state', async () => {

--- a/x-pack/plugins/cases/public/components/files/files_table.tsx
+++ b/x-pack/plugins/cases/public/components/files/files_table.tsx
@@ -46,7 +46,7 @@ export const FilesTable = ({ caseId, items, pagination, onChange, isLoading }: F
     showPreview();
   };
 
-  const columns = useFilesTableColumns({ showPreview: displayPreview });
+  const columns = useFilesTableColumns({ caseId, showPreview: displayPreview });
 
   return isLoading ? (
     <>

--- a/x-pack/plugins/cases/public/components/files/translations.tsx
+++ b/x-pack/plugins/cases/public/components/files/translations.tsx
@@ -91,6 +91,10 @@ export const DOWNLOAD = i18n.translate('xpack.cases.caseView.files.download', {
   defaultMessage: 'download',
 });
 
-export const FILE_DELETE_SUCCESS = i18n.translate('xpack.cases.caseView.files.deleteSuccess', {
-  defaultMessage: 'File deleted successfully',
+export const DELETE = i18n.translate('xpack.cases.caseView.files.delete', {
+  defaultMessage: 'Delete',
+});
+
+export const DELETE_FILE_TITLE = i18n.translate('xpack.cases.caseView.files.deleteThisFile', {
+  defaultMessage: 'Delete this file?',
 });

--- a/x-pack/plugins/cases/public/components/files/translations.tsx
+++ b/x-pack/plugins/cases/public/components/files/translations.tsx
@@ -90,3 +90,7 @@ export const ADDED_UNKNOWN_FILE = i18n.translate('xpack.cases.caseView.files.add
 export const DOWNLOAD = i18n.translate('xpack.cases.caseView.files.download', {
   defaultMessage: 'download',
 });
+
+export const FILE_DELETE_SUCCESS = i18n.translate('xpack.cases.caseView.files.deleteSuccess', {
+  defaultMessage: 'File deleted successfully',
+});

--- a/x-pack/plugins/cases/public/components/files/use_files_table_columns.test.tsx
+++ b/x-pack/plugins/cases/public/components/files/use_files_table_columns.test.tsx
@@ -10,11 +10,13 @@ import { useFilesTableColumns } from './use_files_table_columns';
 import type { AppMockRenderer } from '../../common/mock';
 import { createAppMockRenderer } from '../../common/mock';
 import { renderHook } from '@testing-library/react-hooks';
+import { basicCase } from '../../containers/mock';
 
-describe('useCasesColumns ', () => {
+describe('useFilesTableColumns ', () => {
   let appMockRender: AppMockRenderer;
 
-  const useCasesColumnsProps: FilesTableColumnsProps = {
+  const useFilesTableColumnsProps: FilesTableColumnsProps = {
+    caseId: basicCase.id,
     showPreview: () => {},
   };
 
@@ -24,7 +26,7 @@ describe('useCasesColumns ', () => {
   });
 
   it('return all files table columns correctly', async () => {
-    const { result } = renderHook(() => useFilesTableColumns(useCasesColumnsProps), {
+    const { result } = renderHook(() => useFilesTableColumns(useFilesTableColumnsProps), {
       wrapper: appMockRender.AppWrapper,
     });
 
@@ -56,14 +58,10 @@ describe('useCasesColumns ', () => {
               "render": [Function],
             },
             Object {
-              "color": "danger",
-              "data-test-subj": "cases-files-table-action-delete",
               "description": "Delete File",
-              "icon": "trash",
               "isPrimary": true,
               "name": "Delete",
-              "onClick": [Function],
-              "type": "icon",
+              "render": [Function],
             },
           ],
           "name": "Actions",

--- a/x-pack/plugins/cases/public/components/files/use_files_table_columns.test.tsx
+++ b/x-pack/plugins/cases/public/components/files/use_files_table_columns.test.tsx
@@ -12,7 +12,7 @@ import { createAppMockRenderer } from '../../common/mock';
 import { renderHook } from '@testing-library/react-hooks';
 import { basicCase } from '../../containers/mock';
 
-describe('useFilesTableColumns ', () => {
+describe('useFilesTableColumns', () => {
   let appMockRender: AppMockRenderer;
 
   const useFilesTableColumnsProps: FilesTableColumnsProps = {

--- a/x-pack/plugins/cases/public/components/files/use_files_table_columns.tsx
+++ b/x-pack/plugins/cases/public/components/files/use_files_table_columns.tsx
@@ -14,12 +14,15 @@ import * as i18n from './translations';
 import { parseMimeType } from './utils';
 import { FileNameLink } from './file_name_link';
 import { FileDownloadButtonIcon } from './file_download_button_icon';
+import { FileDeleteButtonIcon } from './file_delete_button_icon';
 
 export interface FilesTableColumnsProps {
+  caseId: string;
   showPreview: (file: FileJSON) => void;
 }
 
 export const useFilesTableColumns = ({
+  caseId,
   showPreview,
 }: FilesTableColumnsProps): Array<EuiBasicTableColumn<FileJSON>> => {
   return [
@@ -58,11 +61,7 @@ export const useFilesTableColumns = ({
           name: 'Delete',
           isPrimary: true,
           description: i18n.DELETE_FILE,
-          color: 'danger',
-          icon: 'trash',
-          type: 'icon',
-          onClick: () => {},
-          'data-test-subj': 'cases-files-table-action-delete',
+          render: (file: FileJSON) => <FileDeleteButtonIcon caseId={caseId} fileId={file.id} />,
         },
       ],
     },

--- a/x-pack/plugins/cases/public/components/user_actions/content_toolbar.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/content_toolbar.tsx
@@ -21,7 +21,7 @@ const UserActionContentToolbarComponent: React.FC<UserActionContentToolbarProps>
   withCopyLinkAction = true,
   children,
 }) => (
-  <EuiFlexGroup responsive={false} alignItems="center">
+  <EuiFlexGroup responsive={false} alignItems="center" gutterSize="m">
     {withCopyLinkAction ? (
       <EuiFlexItem grow={false}>
         <UserActionCopyLink id={id} />

--- a/x-pack/plugins/cases/public/containers/__mocks__/api.ts
+++ b/x-pack/plugins/cases/public/containers/__mocks__/api.ts
@@ -162,3 +162,13 @@ export const getCaseConnectors = async (
 
 export const getCaseUsers = async (caseId: string, signal: AbortSignal): Promise<CaseUsers> =>
   Promise.resolve(getCaseUsersMockResponse());
+
+export const deleteFileAttachments = async ({
+  caseId,
+  fileIds,
+  signal,
+}: {
+  caseId: string;
+  fileIds: string[];
+  signal: AbortSignal;
+}): Promise<void> => Promise.resolve(undefined);

--- a/x-pack/plugins/cases/public/containers/api.test.tsx
+++ b/x-pack/plugins/cases/public/containers/api.test.tsx
@@ -16,6 +16,7 @@ import {
   INTERNAL_BULK_CREATE_ATTACHMENTS_URL,
   SECURITY_SOLUTION_OWNER,
   INTERNAL_GET_CASE_USER_ACTIONS_STATS_URL,
+  INTERNAL_DELETE_FILE_ATTACHMENTS_URL,
 } from '../../common/constants';
 
 import {
@@ -37,6 +38,7 @@ import {
   postComment,
   getCaseConnectors,
   getCaseUserActionsStats,
+  deleteFileAttachments,
 } from './api';
 
 import {
@@ -59,6 +61,7 @@ import {
   caseUserActionsWithRegisteredAttachmentsSnake,
   basicPushSnake,
   getCaseUserActionsStatsResponse,
+  basicFileMock,
 } from './mock';
 
 import { DEFAULT_FILTER_OPTIONS, DEFAULT_QUERY_PARAMS } from './use_get_cases';
@@ -817,6 +820,30 @@ describe('Cases API', () => {
       fetchMock.mockResolvedValue(caseWithRegisteredAttachmentsSnake);
       const resp = await createAttachments(data, basicCase.id, abortCtrl.signal);
       expect(resp).toEqual(caseWithRegisteredAttachments);
+    });
+  });
+
+  describe('deleteFileAttachments', () => {
+    beforeEach(() => {
+      fetchMock.mockClear();
+      fetchMock.mockResolvedValue(null);
+    });
+
+    it('should be called with correct url, method, signal and body', async () => {
+      const resp = await deleteFileAttachments({
+        caseId: basicCaseId,
+        fileIds: [basicFileMock.id],
+        signal: abortCtrl.signal,
+      });
+      expect(fetchMock).toHaveBeenCalledWith(
+        INTERNAL_DELETE_FILE_ATTACHMENTS_URL.replace('{case_id}', basicCaseId),
+        {
+          method: 'POST',
+          body: JSON.stringify({ ids: [basicFileMock.id] }),
+          signal: abortCtrl.signal,
+        }
+      );
+      expect(resp).toBe(undefined);
     });
   });
 

--- a/x-pack/plugins/cases/public/containers/api.ts
+++ b/x-pack/plugins/cases/public/containers/api.ts
@@ -411,7 +411,7 @@ export const deleteFileAttachments = async ({
   fileIds: string[];
   signal: AbortSignal;
 }): Promise<void> => {
-  await KibanaServices.get().http.fetch<CaseResponse>(
+  await KibanaServices.get().http.fetch(
     INTERNAL_DELETE_FILE_ATTACHMENTS_URL.replace('{case_id}', caseId),
     {
       method: 'POST',

--- a/x-pack/plugins/cases/public/containers/api.ts
+++ b/x-pack/plugins/cases/public/containers/api.ts
@@ -51,6 +51,7 @@ import {
   CASE_TAGS_URL,
   CASES_URL,
   INTERNAL_BULK_CREATE_ATTACHMENTS_URL,
+  INTERNAL_DELETE_FILE_ATTACHMENTS_URL,
 } from '../../common/constants';
 import { getAllConnectorTypesUrl } from '../../common/utils/connectors_api';
 
@@ -399,6 +400,25 @@ export const createAttachments = async (
     }
   );
   return convertCaseToCamelCase(decodeCaseResponse(response));
+};
+
+export const deleteFileAttachments = async ({
+  caseId,
+  fileIds,
+  signal,
+}: {
+  caseId: string;
+  fileIds: string[];
+  signal: AbortSignal;
+}): Promise<void> => {
+  await KibanaServices.get().http.fetch<CaseResponse>(
+    INTERNAL_DELETE_FILE_ATTACHMENTS_URL.replace('{case_id}', caseId),
+    {
+      method: 'POST',
+      body: JSON.stringify({ ids: fileIds }),
+      signal,
+    }
+  );
 };
 
 export const getFeatureIds = async (

--- a/x-pack/plugins/cases/public/containers/constants.ts
+++ b/x-pack/plugins/cases/public/containers/constants.ts
@@ -52,4 +52,5 @@ export const casesMutationsKeys = {
   deleteCases: ['delete-cases'] as const,
   updateCases: ['update-cases'] as const,
   deleteComment: ['delete-comment'] as const,
+  deleteFileAttachment: ['delete-file-attachment'] as const,
 };

--- a/x-pack/plugins/cases/public/containers/translations.ts
+++ b/x-pack/plugins/cases/public/containers/translations.ts
@@ -17,6 +17,10 @@ export const ERROR_DELETING = i18n.translate('xpack.cases.containers.errorDeleti
   defaultMessage: 'Error deleting data',
 });
 
+export const ERROR_DELETING_FILE = i18n.translate('xpack.cases.containers.errorDeletingFile', {
+  defaultMessage: 'Error deleting file',
+});
+
 export const ERROR_UPDATING = i18n.translate('xpack.cases.containers.errorUpdatingTitle', {
   defaultMessage: 'Error updating data',
 });
@@ -49,3 +53,7 @@ export const STATUS_CHANGED_TOASTER_TEXT = i18n.translate(
     defaultMessage: 'Updated the statuses of attached alerts.',
   }
 );
+
+export const FILE_DELETE_SUCCESS = i18n.translate('xpack.cases.containers.deleteSuccess', {
+  defaultMessage: 'File deleted successfully',
+});

--- a/x-pack/plugins/cases/public/containers/use_delete_file_attachment.test.tsx
+++ b/x-pack/plugins/cases/public/containers/use_delete_file_attachment.test.tsx
@@ -1,0 +1,134 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { act, renderHook } from '@testing-library/react-hooks';
+import * as api from './api';
+import { basicCaseId, basicFileMock } from './mock';
+import { useRefreshCaseViewPage } from '../components/case_view/use_on_refresh_case_view_page';
+import { useToasts } from '../common/lib/kibana';
+import type { AppMockRenderer } from '../common/mock';
+import { createAppMockRenderer } from '../common/mock';
+import { useDeleteFileAttachment } from './use_delete_file_attachment';
+
+jest.mock('./api');
+jest.mock('../common/lib/kibana');
+jest.mock('../components/case_view/use_on_refresh_case_view_page');
+
+const successToasterTitle = 'Deleted';
+
+describe('useDeleteFileAttachment', () => {
+  const addSuccess = jest.fn();
+  const addError = jest.fn();
+
+  (useToasts as jest.Mock).mockReturnValue({ addSuccess, addError });
+
+  let appMockRender: AppMockRenderer;
+
+  beforeEach(() => {
+    appMockRender = createAppMockRenderer();
+    jest.clearAllMocks();
+  });
+
+  it('init', async () => {
+    const { result } = renderHook(() => useDeleteFileAttachment(), {
+      wrapper: appMockRender.AppWrapper,
+    });
+
+    expect(result.current).toBeTruthy();
+  });
+
+  it('calls deleteFileAttachment with correct arguments - case', async () => {
+    const spyOnDeleteFileAttachments = jest.spyOn(api, 'deleteFileAttachments');
+
+    const { waitForNextUpdate, result } = renderHook(() => useDeleteFileAttachment(), {
+      wrapper: appMockRender.AppWrapper,
+    });
+
+    act(() => {
+      result.current.mutate({
+        caseId: basicCaseId,
+        fileId: basicFileMock.id,
+        successToasterTitle,
+      });
+    });
+
+    await waitForNextUpdate();
+
+    expect(spyOnDeleteFileAttachments).toHaveBeenCalledWith({
+      caseId: basicCaseId,
+      fileIds: [basicFileMock.id],
+      signal: expect.any(AbortSignal),
+    });
+  });
+
+  it('refreshes the case page view', async () => {
+    const { waitForNextUpdate, result } = renderHook(() => useDeleteFileAttachment(), {
+      wrapper: appMockRender.AppWrapper,
+    });
+
+    act(() =>
+      result.current.mutate({
+        caseId: basicCaseId,
+        fileId: basicFileMock.id,
+        successToasterTitle,
+      })
+    );
+
+    await waitForNextUpdate();
+
+    expect(useRefreshCaseViewPage()).toBeCalled();
+  });
+
+  it('shows a success toaster correctly', async () => {
+    const { waitForNextUpdate, result } = renderHook(() => useDeleteFileAttachment(), {
+      wrapper: appMockRender.AppWrapper,
+    });
+
+    act(() =>
+      result.current.mutate({
+        caseId: basicCaseId,
+        fileId: basicFileMock.id,
+        successToasterTitle,
+      })
+    );
+
+    await waitForNextUpdate();
+
+    expect(addSuccess).toHaveBeenCalledWith({
+      title: successToasterTitle,
+      className: 'eui-textBreakWord',
+    });
+  });
+
+  it('sets isError when fails to delete a file attachment', async () => {
+    const spyOnDeleteFileAttachments = jest.spyOn(api, 'deleteFileAttachments');
+    spyOnDeleteFileAttachments.mockRejectedValue(new Error('Error'));
+
+    const { waitForNextUpdate, result } = renderHook(() => useDeleteFileAttachment(), {
+      wrapper: appMockRender.AppWrapper,
+    });
+
+    act(() =>
+      result.current.mutate({
+        caseId: basicCaseId,
+        fileId: basicFileMock.id,
+        successToasterTitle,
+      })
+    );
+
+    await waitForNextUpdate();
+
+    expect(spyOnDeleteFileAttachments).toBeCalledWith({
+      caseId: basicCaseId,
+      fileIds: [basicFileMock.id],
+      signal: expect.any(AbortSignal),
+    });
+
+    expect(addError).toHaveBeenCalled();
+    expect(result.current.isError).toBe(true);
+  });
+});

--- a/x-pack/plugins/cases/public/containers/use_delete_file_attachment.test.tsx
+++ b/x-pack/plugins/cases/public/containers/use_delete_file_attachment.test.tsx
@@ -18,8 +18,6 @@ jest.mock('./api');
 jest.mock('../common/lib/kibana');
 jest.mock('../components/case_view/use_on_refresh_case_view_page');
 
-const successToasterTitle = 'Deleted';
-
 describe('useDeleteFileAttachment', () => {
   const addSuccess = jest.fn();
   const addError = jest.fn();
@@ -33,14 +31,6 @@ describe('useDeleteFileAttachment', () => {
     jest.clearAllMocks();
   });
 
-  it('init', async () => {
-    const { result } = renderHook(() => useDeleteFileAttachment(), {
-      wrapper: appMockRender.AppWrapper,
-    });
-
-    expect(result.current).toBeTruthy();
-  });
-
   it('calls deleteFileAttachment with correct arguments - case', async () => {
     const spyOnDeleteFileAttachments = jest.spyOn(api, 'deleteFileAttachments');
 
@@ -52,7 +42,6 @@ describe('useDeleteFileAttachment', () => {
       result.current.mutate({
         caseId: basicCaseId,
         fileId: basicFileMock.id,
-        successToasterTitle,
       });
     });
 
@@ -74,7 +63,6 @@ describe('useDeleteFileAttachment', () => {
       result.current.mutate({
         caseId: basicCaseId,
         fileId: basicFileMock.id,
-        successToasterTitle,
       })
     );
 
@@ -92,14 +80,13 @@ describe('useDeleteFileAttachment', () => {
       result.current.mutate({
         caseId: basicCaseId,
         fileId: basicFileMock.id,
-        successToasterTitle,
       })
     );
 
     await waitForNextUpdate();
 
     expect(addSuccess).toHaveBeenCalledWith({
-      title: successToasterTitle,
+      title: 'File deleted successfully',
       className: 'eui-textBreakWord',
     });
   });
@@ -116,7 +103,6 @@ describe('useDeleteFileAttachment', () => {
       result.current.mutate({
         caseId: basicCaseId,
         fileId: basicFileMock.id,
-        successToasterTitle,
       })
     );
 

--- a/x-pack/plugins/cases/public/containers/use_delete_file_attachment.tsx
+++ b/x-pack/plugins/cases/public/containers/use_delete_file_attachment.tsx
@@ -16,7 +16,6 @@ import * as i18n from './translations';
 interface MutationArgs {
   caseId: string;
   fileId: string;
-  successToasterTitle: string;
 }
 
 export const useDeleteFileAttachment = () => {
@@ -30,12 +29,12 @@ export const useDeleteFileAttachment = () => {
     },
     {
       mutationKey: casesMutationsKeys.deleteFileAttachment,
-      onSuccess: (_, { successToasterTitle }) => {
-        showSuccessToast(successToasterTitle);
+      onSuccess: () => {
+        showSuccessToast(i18n.FILE_DELETE_SUCCESS);
         refreshAttachmentsTable();
       },
       onError: (error: ServerError) => {
-        showErrorToast(error, { title: i18n.ERROR_TITLE });
+        showErrorToast(error, { title: i18n.ERROR_DELETING_FILE });
       },
     }
   );

--- a/x-pack/plugins/cases/public/containers/use_delete_file_attachment.tsx
+++ b/x-pack/plugins/cases/public/containers/use_delete_file_attachment.tsx
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useMutation } from '@tanstack/react-query';
+import { casesMutationsKeys } from './constants';
+import type { ServerError } from '../types';
+import { useRefreshCaseViewPage } from '../components/case_view/use_on_refresh_case_view_page';
+import { useCasesToast } from '../common/use_cases_toast';
+import { deleteFileAttachments } from './api';
+import * as i18n from './translations';
+
+interface MutationArgs {
+  caseId: string;
+  fileId: string;
+  successToasterTitle: string;
+}
+
+export const useDeleteFileAttachment = () => {
+  const { showErrorToast, showSuccessToast } = useCasesToast();
+  const refreshCaseViewPage = useRefreshCaseViewPage();
+
+  return useMutation(
+    ({ caseId, fileId }: MutationArgs) => {
+      const abortCtrlRef = new AbortController();
+      return deleteFileAttachments({ caseId, fileIds: [fileId], signal: abortCtrlRef.signal });
+    },
+    {
+      mutationKey: casesMutationsKeys.deleteFileAttachment,
+      onSuccess: (_, { successToasterTitle }) => {
+        showSuccessToast(successToasterTitle);
+        refreshCaseViewPage();
+      },
+      onError: (error: ServerError) => {
+        showErrorToast(error, { title: i18n.ERROR_TITLE });
+      },
+    }
+  );
+};
+
+export type UseDeleteFileAttachment = ReturnType<typeof useDeleteFileAttachment>;

--- a/x-pack/plugins/cases/public/containers/use_delete_file_attachment.tsx
+++ b/x-pack/plugins/cases/public/containers/use_delete_file_attachment.tsx
@@ -21,7 +21,7 @@ interface MutationArgs {
 
 export const useDeleteFileAttachment = () => {
   const { showErrorToast, showSuccessToast } = useCasesToast();
-  const refreshCaseViewPage = useRefreshCaseViewPage();
+  const refreshAttachmentsTable = useRefreshCaseViewPage();
 
   return useMutation(
     ({ caseId, fileId }: MutationArgs) => {
@@ -32,7 +32,7 @@ export const useDeleteFileAttachment = () => {
       mutationKey: casesMutationsKeys.deleteFileAttachment,
       onSuccess: (_, { successToasterTitle }) => {
         showSuccessToast(successToasterTitle);
-        refreshCaseViewPage();
+        refreshAttachmentsTable();
       },
       onError: (error: ServerError) => {
         showErrorToast(error, { title: i18n.ERROR_TITLE });

--- a/x-pack/plugins/cases/public/containers/use_get_case_file_stats.test.tsx
+++ b/x-pack/plugins/cases/public/containers/use_get_case_file_stats.test.tsx
@@ -25,7 +25,7 @@ const expectedCallParams = {
   kind: constructFileKindIdByOwner(mockedTestProvidersOwner[0]),
   page: 1,
   perPage: 1,
-  meta: hookParams,
+  meta: { caseIds: [hookParams.caseId] },
 };
 
 describe('useGetCaseFileStats', () => {

--- a/x-pack/plugins/cases/public/containers/use_get_case_file_stats.tsx
+++ b/x-pack/plugins/cases/public/containers/use_get_case_file_stats.tsx
@@ -43,7 +43,7 @@ export const useGetCaseFileStats = ({
         kind: constructFileKindIdByOwner(owner[0] as Owner),
         page: 1,
         perPage: 1,
-        meta: { caseId },
+        meta: { caseIds: [caseId] },
       });
     },
     {

--- a/x-pack/plugins/cases/public/containers/use_get_case_files.test.tsx
+++ b/x-pack/plugins/cases/public/containers/use_get_case_files.test.tsx
@@ -29,7 +29,7 @@ const expectedCallParams = {
   page: hookParams.page + 1,
   name: `*${hookParams.searchTerm}*`,
   perPage: hookParams.perPage,
-  meta: { caseId: hookParams.caseId },
+  meta: { caseIds: [hookParams.caseId] },
 };
 
 describe('useGetCaseFiles', () => {

--- a/x-pack/plugins/cases/public/containers/use_get_case_files.tsx
+++ b/x-pack/plugins/cases/public/containers/use_get_case_files.tsx
@@ -48,7 +48,7 @@ export const useGetCaseFiles = ({
         page: page + 1,
         ...(searchTerm && { name: `*${searchTerm}*` }),
         perPage,
-        meta: { caseId },
+        meta: { caseIds: [caseId] },
       });
     },
     {


### PR DESCRIPTION
## Summary

In this PR we add the ability to delete files attached to a case.

This can be done in the Case detail view either in the
<details><summary>Files tab</summary>
<img width="720" alt="Screenshot 2023-04-05 at 10 29 39" src="https://user-images.githubusercontent.com/1533137/230027093-072a622d-9fed-47d1-b2ac-bf4bcd14d5da.png">
</details>

or the

<details><summary>Activity tab</summary>
<img width="1436" alt="Screenshot 2023-04-05 at 10 29 53" src="https://user-images.githubusercontent.com/1533137/230027406-509773bc-7aec-4c38-abeb-3487ca531e74.png">
</details>

<details><summary>When a file is deleted the file activity item is replaced by a removed attachment activity item.</summary> 
<img width="1438" alt="Screenshot 2023-04-05 at 10 30 05" src="https://user-images.githubusercontent.com/1533137/230028060-a1804fd4-6484-4cb0-9147-a649c4a29ead.png">
 </details>
