### PR TITLE
[Fleet] Update Fleet API doc link + remove beta badge

### DIFF
--- a/packages/kbn-doc-links/src/get_doc_links.ts
+++ b/packages/kbn-doc-links/src/get_doc_links.ts
@@ -678,6 +678,7 @@ export const getDocLinks = ({ kibanaBranch }: GetDocLinkOptions): DocLinks => {
       packageSignatures: `${FLEET_DOCS}package-signatures.html`,
       secureLogstash: `${FLEET_DOCS}secure-logstash-connections.html`,
       agentPolicy: `${FLEET_DOCS}agent-policy.html`,
+      api: `${FLEET_DOCS}fleet-api-docs.html`,
     },
     ecs: {
       guide: `${ELASTIC_WEBSITE_URL}guide/en/ecs/current/index.html`,

--- a/packages/kbn-doc-links/src/types.ts
+++ b/packages/kbn-doc-links/src/types.ts
@@ -449,6 +449,7 @@ export interface DocLinks {
     onPremRegistry: string;
     secureLogstash: string;
     agentPolicy: string;
+    api: string;
   }>;
   readonly ecs: {
     readonly guide: string;

--- a/src/plugins/es_ui_shared/public/components/view_api_request_flyout/view_api_request_flyout.tsx
+++ b/src/plugins/es_ui_shared/public/components/view_api_request_flyout/view_api_request_flyout.tsx
@@ -30,7 +30,6 @@ import { RedirectAppLinks } from '@kbn/kibana-react-plugin/public';
 type FlyoutProps = Omit<EuiFlyoutProps, 'onClose'>;
 interface ViewApiRequestFlyoutProps {
   title: string;
-  subtitle: string;
   description: string;
   request: string;
   closeFlyout: () => void;
@@ -41,7 +40,6 @@ interface ViewApiRequestFlyoutProps {
 
 export const ApiRequestFlyout: React.FunctionComponent<ViewApiRequestFlyoutProps> = ({
   title,
-  subtitle,
   description,
   request,
   closeFlyout,
@@ -71,9 +69,6 @@ export const ApiRequestFlyout: React.FunctionComponent<ViewApiRequestFlyoutProps
         <EuiTitle>
           <h2 data-test-subj="apiRequestFlyoutTitle">{title}</h2>
         </EuiTitle>
-        <EuiText>
-          <p data-test-subj="apiRequestFlyoutSubtitle">{subtitle}</p>
-        </EuiText>
       </EuiFlyoutHeader>
 
       <EuiFlyoutBody>

--- a/src/plugins/es_ui_shared/public/components/view_api_request_flyout/view_api_request_flyout.tsx
+++ b/src/plugins/es_ui_shared/public/components/view_api_request_flyout/view_api_request_flyout.tsx
@@ -30,6 +30,7 @@ import { RedirectAppLinks } from '@kbn/kibana-react-plugin/public';
 type FlyoutProps = Omit<EuiFlyoutProps, 'onClose'>;
 interface ViewApiRequestFlyoutProps {
   title: string;
+  subtitle: string;
   description: string;
   request: string;
   closeFlyout: () => void;
@@ -40,6 +41,7 @@ interface ViewApiRequestFlyoutProps {
 
 export const ApiRequestFlyout: React.FunctionComponent<ViewApiRequestFlyoutProps> = ({
   title,
+  subtitle,
   description,
   request,
   closeFlyout,
@@ -69,6 +71,9 @@ export const ApiRequestFlyout: React.FunctionComponent<ViewApiRequestFlyoutProps
         <EuiTitle>
           <h2 data-test-subj="apiRequestFlyoutTitle">{title}</h2>
         </EuiTitle>
+        <EuiText>
+          <p data-test-subj="apiRequestFlyoutSubtitle">{subtitle}</p>
+        </EuiText>
       </EuiFlyoutHeader>
 
       <EuiFlyoutBody>

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/documentation/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/documentation/index.tsx
@@ -16,7 +16,6 @@ import {
   EuiSpacer,
   EuiText,
   EuiLink,
-  EuiBetaBadge,
 } from '@elastic/eui';
 import type { EuiInMemoryTableProps } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -48,7 +47,7 @@ export const DocumentationPage: React.FunctionComponent<Props> = ({ packageInfo,
               defaultMessage="This documents all the inputs, streams, and variables available to use this integration programmatically via the Fleet Kibana API. {learnMore}"
               values={{
                 learnMore: (
-                  <EuiLink href={docLinks.links.fleet.guide}>
+                  <EuiLink href={docLinks.links.fleet.api}>
                     <FormattedMessage
                       id="xpack.fleet.epm.packageDetails.apiReference.learnMoreLink"
                       defaultMessage="Learn more"
@@ -58,9 +57,6 @@ export const DocumentationPage: React.FunctionComponent<Props> = ({ packageInfo,
               }}
             />
           </EuiText>
-        </EuiFlexItem>
-        <EuiFlexItem grow={false}>
-          <EuiBetaBadge label="beta" />
         </EuiFlexItem>
       </EuiFlexGroup>
       <EuiSpacer size="m" />

--- a/x-pack/plugins/fleet/public/components/devtools_request_flyout/devtools_request_flyout.tsx
+++ b/x-pack/plugins/fleet/public/components/devtools_request_flyout/devtools_request_flyout.tsx
@@ -7,7 +7,7 @@
 
 import React, { useCallback, useRef } from 'react';
 
-import { EuiBetaBadge, EuiButtonEmpty, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { EuiButtonEmpty, EuiFlexGroup, EuiFlexItem, EuiLink } from '@elastic/eui';
 import type { EuiButtonEmptyProps } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -82,7 +82,7 @@ export const ApiRequestFlyout: React.FunctionComponent<ApiRequestFlyoutProps> = 
     defaultMessage: 'Perform these request against Kibana',
   }),
 }) => {
-  const { application, share } = useStartServices();
+  const { docLinks, application, share } = useStartServices();
 
   return (
     <ViewApiRequestFlyout
@@ -90,8 +90,25 @@ export const ApiRequestFlyout: React.FunctionComponent<ApiRequestFlyoutProps> = 
       title={
         <EuiFlexGroup>
           <EuiFlexItem grow={false}>{title}</EuiFlexItem>
+        </EuiFlexGroup>
+      }
+      subtitle={
+        <EuiFlexGroup>
           <EuiFlexItem grow={false}>
-            <EuiBetaBadge label="beta" />
+            <FormattedMessage
+              id="xpack.fleet.apiRequestFlyout.devtoolsRequestDescription"
+              defaultMessage="{learnMore}"
+              values={{
+                learnMore: (
+                  <EuiLink href={docLinks.links.fleet.api}>
+                    <FormattedMessage
+                      id="xpack.fleet.epm.packageDetails.apiReference.learnMoreLink"
+                      defaultMessage="Learn more about Fleet API"
+                    />
+                  </EuiLink>
+                ),
+              }}
+            />
           </EuiFlexItem>
         </EuiFlexGroup>
       }

--- a/x-pack/plugins/fleet/public/components/devtools_request_flyout/devtools_request_flyout.tsx
+++ b/x-pack/plugins/fleet/public/components/devtools_request_flyout/devtools_request_flyout.tsx
@@ -99,7 +99,7 @@ export const ApiRequestFlyout: React.FunctionComponent<ApiRequestFlyoutProps> = 
                   learnMore: (
                     <EuiLink href={docLinks.links.fleet.api}>
                       <FormattedMessage
-                        id="xpack.fleet.epm.packageDetails.apiReference.learnMoreLink"
+                        id="xpack.fleet.apiRequestFlyout.learnMoreLink"
                         defaultMessage="Learn more about Fleet API"
                       />
                     </EuiLink>

--- a/x-pack/plugins/fleet/public/components/devtools_request_flyout/devtools_request_flyout.tsx
+++ b/x-pack/plugins/fleet/public/components/devtools_request_flyout/devtools_request_flyout.tsx
@@ -7,7 +7,7 @@
 
 import React, { useCallback, useRef } from 'react';
 
-import { EuiButtonEmpty, EuiFlexGroup, EuiFlexItem, EuiLink } from '@elastic/eui';
+import { EuiButtonEmpty, EuiFlexGroup, EuiFlexItem, EuiLink, EuiText } from '@elastic/eui';
 import type { EuiButtonEmptyProps } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -88,27 +88,25 @@ export const ApiRequestFlyout: React.FunctionComponent<ApiRequestFlyoutProps> = 
     <ViewApiRequestFlyout
       // @ts-expect-error ViewApiRequestFlyout title type only allow string
       title={
-        <EuiFlexGroup>
+        <EuiFlexGroup alignItems="baseline">
           <EuiFlexItem grow={false}>{title}</EuiFlexItem>
-        </EuiFlexGroup>
-      }
-      subtitle={
-        <EuiFlexGroup>
           <EuiFlexItem grow={false}>
-            <FormattedMessage
-              id="xpack.fleet.apiRequestFlyout.devtoolsRequestDescription"
-              defaultMessage="{learnMore}"
-              values={{
-                learnMore: (
-                  <EuiLink href={docLinks.links.fleet.api}>
-                    <FormattedMessage
-                      id="xpack.fleet.epm.packageDetails.apiReference.learnMoreLink"
-                      defaultMessage="Learn more about Fleet API"
-                    />
-                  </EuiLink>
-                ),
-              }}
-            />
+            <EuiText size="xs">
+              <FormattedMessage
+                id="xpack.fleet.apiRequestFlyout.devtoolsRequestDescription"
+                defaultMessage="{learnMore}"
+                values={{
+                  learnMore: (
+                    <EuiLink href={docLinks.links.fleet.api}>
+                      <FormattedMessage
+                        id="xpack.fleet.epm.packageDetails.apiReference.learnMoreLink"
+                        defaultMessage="Learn more about Fleet API"
+                      />
+                    </EuiLink>
+                  ),
+                }}
+              />
+            </EuiText>
           </EuiFlexItem>
         </EuiFlexGroup>
       }


### PR DESCRIPTION
### Summary

This PR adds and updates documentation links and removes `beta` badges for the GA of Fleet API in 8.8.0.

This includes the following changes:
1. Elastic Agent integration settings page, `API reference` tab:
  * Update the documentation link to https://www.elastic.co/guide/en/fleet/master/fleet-api-docs.html.
  * Remove the `beta` badge.
2. `Preview API request` flyout:
  * Add a link to the documentation to the title (cf. screenshots).
  * Remove the `beta` badge.

Closes https://github.com/elastic/kibana/issues/152966

### Screenshots

#### Elastic Agent integration settings page, `API reference` tab - Before

![Screenshot 2023-04-05 at 15 01 21](https://user-images.githubusercontent.com/23701614/230091121-c14e02ce-47d4-4748-9152-84b12597243e.png)

#### Elastic Agent integration settings page, `API reference` tab - After

![Screenshot 2023-04-05 at 15 00 23](https://user-images.githubusercontent.com/23701614/230091160-cd750443-e42c-4b8b-97a1-c6c89dbf6dda.png)

#### `Preview API request` flyout - Before

![Screenshot 2023-04-11 at 15 56 36](https://user-images.githubusercontent.com/23701614/231193937-7d03e1eb-0781-4983-916a-1e0ab7b63462.png)

#### `Preview API request` flyout - After

![Screenshot 2023-04-11 at 12 53 27](https://user-images.githubusercontent.com/23701614/231193976-cb91c575-bbd5-4c04-85ac-e3564a4121d9.png)

### Steps to test locally

On this branch, start Kibana in dev.

1. Elastic Agent integration settings page, `API reference` tab:
  1. Go to `<localKibanaUrl>/app/integrations/detail/elastic_agent-1.7.0/api-reference`.
  2. Check that the `beta` badge is removed and that the `Learn more` link point to https://www.elastic.co/guide/en/fleet/master/fleet-api-docs.html.
2. `Preview API request` flyout:
  1. Create a new agent policy: give it a name and click `Preview API request`.
  2. Check that the `beta` badge is removed and that the title has a `Learn more about Fleet API` link that points to https://www.elastic.co/guide/en/fleet/master/fleet-api-docs.html.
  3. Do the same checks when updating an agent policy, creating a package policy and updating a package policy.

### Checklist

- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)
