### PR TITLE
[Fleet] Add labels to all Fleet audit logs

### DIFF
--- a/x-pack/plugins/fleet/server/services/audit_logging.ts
+++ b/x-pack/plugins/fleet/server/services/audit_logging.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { AuditLogger } from '@kbn/security-plugin/server';
+import type { AuditEvent, AuditLogger } from '@kbn/security-plugin/server';
 
 import { appContextService } from './app_context';
 import { getRequestStore } from './request_store';
@@ -15,7 +15,7 @@ class AuditLoggingService {
    * Write a custom audit log record. If a current request is available, the log will include
    * user/session data. If not, an unscoped audit logger will be used.
    */
-  public writeCustomAuditLog(...args: Parameters<AuditLogger['log']>) {
+  public writeCustomAuditLog(args: AuditEvent) {
     const securitySetup = appContextService.getSecuritySetup();
     let auditLogger: AuditLogger | undefined;
 
@@ -27,7 +27,7 @@ class AuditLoggingService {
       auditLogger = securitySetup.audit.withoutRequest;
     }
 
-    auditLogger.log(...args);
+    auditLogger.log({ ...args, labels: { ...args.labels, application: 'elastic/fleet' } });
   }
 
   /**

--- a/x-pack/plugins/fleet/server/services/audit_logging.ts
+++ b/x-pack/plugins/fleet/server/services/audit_logging.ts
@@ -14,6 +14,10 @@ class AuditLoggingService {
   /**
    * Write a custom audit log record. If a current request is available, the log will include
    * user/session data. If not, an unscoped audit logger will be used.
+   *
+   * Note: all Fleet audit logs written via this method will have a `labels.application` value
+   * of `elastic/fleet`. Consumers aren't able to override this value, and a custom `labels.application`
+   * value provided as an argument will be overwritten.
    */
   public writeCustomAuditLog(args: AuditEvent) {
     const securitySetup = appContextService.getSecuritySetup();


### PR DESCRIPTION
## Summary

As I was working on audit logging dashboards, I realized it'd be great to be able to filter to "all Fleet logs" instead of having to manually construct a big KQL query to resolve saved object logs, fleet actions logs, etc etc. 

This PR adds the ECS-compliant [labels](https://www.elastic.co/guide/en/ecs/current/ecs-base.html#field-labels) property to each audit log record with a value of `application: elastic/fleet` which should make writing queries much easier. We'll also preserve any custom `label` values if they're passed, although a custom value for `application` would be overridden by this code. 

![image](https://user-images.githubusercontent.com/6766512/230108750-1e77be56-8191-46fa-a16e-163044563b6e.png)

