### PR TITLE
[Guided onboarding] Fix the value of `data-test-subj` for telemetry

### DIFF
--- a/src/plugins/home/public/application/components/guided_onboarding/getting_started.tsx
+++ b/src/plugins/home/public/application/components/guided_onboarding/getting_started.tsx
@@ -205,7 +205,7 @@ export const GettingStarted = () => {
       <EuiPageTemplate.Section
         alignment="center"
         css={paddingCss}
-        data-test-subj="onboarding--landing-page"
+        data-test-subj="guided-onboarding--landing-page"
       >
         <EuiTitle size="l" className="eui-textCenter">
           <h1>{title}</h1>

--- a/test/functional/page_objects/home_page.ts
+++ b/test/functional/page_objects/home_page.ts
@@ -57,7 +57,7 @@ export class HomePageObject extends FtrService {
   }
 
   async isGuidedOnboardingLandingDisplayed() {
-    return await this.testSubjects.isDisplayed('onboarding--landing-page');
+    return await this.testSubjects.isDisplayed('guided-onboarding--landing-page');
   }
 
   async isHomePageDisplayed() {


### PR DESCRIPTION
## Summary
This PR changes the value of `data-test-subj` on the landing page to fix the telemetry for guided onboarding. In the code, this attribute is only used for testing.

More details in https://github.com/elastic/telemetry/issues/2155. 




<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->