### PR TITLE
[Enterprise Search] Add ingestion name column to indices page

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_indices/indices_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_indices/indices_table.tsx
@@ -16,7 +16,10 @@ import {
   EuiIcon,
   EuiText,
 } from '@elastic/eui';
+
 import { i18n } from '@kbn/i18n';
+
+import { NATIVE_CONNECTOR_DEFINITIONS } from '../../../../../common/connectors/native_connectors';
 
 import { Meta } from '../../../../../common/types';
 import { healthColorsMap } from '../../../shared/constants/health_colors';
@@ -26,8 +29,8 @@ import { EuiLinkTo } from '../../../shared/react_router_helpers';
 import { EuiBadgeTo } from '../../../shared/react_router_helpers/eui_components';
 import { convertMetaToPagination } from '../../../shared/table_pagination';
 import { SEARCH_INDEX_PATH } from '../../routes';
-import { ElasticsearchViewIndex, IngestionMethod } from '../../types';
-import { ingestionMethodToText } from '../../utils/indices';
+import { ElasticsearchViewIndex } from '../../types';
+import { ingestionMethodToText, isConnectorIndex } from '../../utils/indices';
 import {
   ingestionStatusToColor,
   ingestionStatusToText,
@@ -64,8 +67,7 @@ export const IndicesTable: React.FC<IndicesTableProps> = ({
         </EuiLinkTo>
       ),
       sortable: true,
-      truncateText: true,
-      width: '40%',
+      width: '33%',
     },
     {
       field: 'health',
@@ -80,7 +82,6 @@ export const IndicesTable: React.FC<IndicesTableProps> = ({
       ),
       sortable: true,
       truncateText: true,
-      width: '10%',
     },
     {
       field: 'count',
@@ -89,21 +90,43 @@ export const IndicesTable: React.FC<IndicesTableProps> = ({
       }),
       sortable: true,
       truncateText: true,
-      width: '10%',
     },
     {
-      field: 'ingestionMethod',
+      name: i18n.translate(
+        'xpack.enterpriseSearch.content.searchIndices.ingestionName.columnTitle',
+        {
+          defaultMessage: 'Ingestion name',
+        }
+      ),
+      render: (index: ElasticsearchViewIndex) => (
+        <EuiText size="s">
+          {(isConnectorIndex(index) &&
+            index.connector.service_type &&
+            NATIVE_CONNECTOR_DEFINITIONS[index.connector.service_type]?.name) ??
+            '--'}
+        </EuiText>
+      ),
+      truncateText: true,
+    },
+    {
       name: i18n.translate(
         'xpack.enterpriseSearch.content.searchIndices.ingestionMethod.columnTitle',
         {
           defaultMessage: 'Ingestion method',
         }
       ),
-      render: (ingestionMethod: IngestionMethod) => (
-        <EuiText size="s">{ingestionMethodToText(ingestionMethod)}</EuiText>
+      render: (index: ElasticsearchViewIndex) => (
+        <EuiText size="s">
+          {isConnectorIndex(index) && index.connector.is_native
+            ? i18n.translate(
+                'xpack.enterpriseSearch.content.searchIndices.ingestionmethod.nativeConnector',
+                {
+                  defaultMessage: 'Native connector',
+                }
+              )
+            : ingestionMethodToText(index.ingestionMethod)}
+        </EuiText>
       ),
-      truncateText: true,
-      width: '10%',
     },
     {
       name: i18n.translate(
@@ -124,7 +147,6 @@ export const IndicesTable: React.FC<IndicesTableProps> = ({
         );
       },
       truncateText: true,
-      width: '15%',
     },
     {
       actions: [
@@ -182,7 +204,6 @@ export const IndicesTable: React.FC<IndicesTableProps> = ({
       name: i18n.translate('xpack.enterpriseSearch.content.searchIndices.actions.columnTitle', {
         defaultMessage: 'Actions',
       }),
-      width: '10%',
     },
   ];
   return (

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_indices/search_indices.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_indices/search_indices.tsx
@@ -99,7 +99,7 @@ export const SearchIndices: React.FC = () => {
                     {i18n.translate(
                       'xpack.enterpriseSearch.content.searchIndices.create.buttonTitle',
                       {
-                        defaultMessage: 'Create new index',
+                        defaultMessage: 'Create a new index',
                       }
                     )}
                   </EuiButton>


### PR DESCRIPTION
## Summary

This adds an ingestion name column to the indices table for native connectors.
<img width="1362" alt="Screenshot 2023-04-05 at 18 00 27" src="https://user-images.githubusercontent.com/94373878/230138601-af851c7c-8789-4364-b99d-7bdda45493ec.png">

