### PR TITLE
[Security Solution] Remove the name field from the security-rule SO mappings

### DIFF
--- a/src/core/server/integration_tests/saved_objects/migrations/group2/check_registered_types.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/group2/check_registered_types.test.ts
@@ -128,7 +128,7 @@ describe('checking migration metadata changes on all registered SO types', () =>
         "search": "01bc42d635e9ea0588741c4c7a2bbd3feb3ac5dc",
         "search-session": "58a44d14ec991739166b2ec28d718001ab0f4b28",
         "search-telemetry": "1bbaf2db531b97fa04399440fa52d46e86d54dd8",
-        "security-rule": "1ff82dfb2298c3caf6888fc3ef15c6bf7a628877",
+        "security-rule": "151108f4906744a137ddc89f5988310c5b9ba8b6",
         "security-solution-signals-migration": "c2db409c1857d330beb3d6fd188fa186f920302c",
         "siem-detection-engine-rule-actions": "123c130dc38120a470d8db9fed9a4cebd2046445",
         "siem-ui-timeline": "e9d6b3a9fd7af6dc502293c21cbdb309409f3996",

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/logic/rule_assets/prebuilt_rule_assets_type.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/logic/rule_assets/prebuilt_rule_assets_type.ts
@@ -12,9 +12,6 @@ export const PREBUILT_RULE_ASSETS_SO_TYPE = 'security-rule';
 const prebuiltRuleAssetMappings: SavedObjectsType['mappings'] = {
   dynamic: false,
   properties: {
-    name: {
-      type: 'keyword',
-    },
     rule_id: {
       type: 'keyword',
     },


### PR DESCRIPTION
**Related to:** https://github.com/elastic/security-team/issues/6268 (internal)

## Summary

For each of our Saved Object types, we must:

1. Remove any SO field mappings with `index: false` (or `enabled: false`, although a first pass was done in https://github.com/elastic/kibana/pull/149102) from our SO `mappings` declarations
2. Audit and remove any _unused_ SO fields to minimize our footprint

This PR addresses these two requirements for this `security-rule` saved object type (prebuilt rule asset).

## Details

Specifically, the PR removes the `name` field from the mappings because:

- We don't filter, sort, search, or aggregate by it.
- We might need to do it in the future for our prebuilt rule upgrade/installation workflows, but for now we're going to implement filtering, sorting, and pagination on the client side, thus there's no need for this mapping server-side.

<img width="1295" alt="Screenshot 2023-04-05 at 15 19 10" src="https://user-images.githubusercontent.com/7359339/230094740-706a9a78-fec3-469e-a4ad-e8b7d7309c78.png">

Also, we may need to add more fields to this mapping in the future to implement further improvements for the prebuilt rule installation, upgrade, or deprecation workflows.

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
  - [x] The unit test for SO mapping hashes has been updated.
  - [ ] More tests will be added as part of https://github.com/elastic/kibana/issues/148176 and https://github.com/elastic/kibana/issues/148192
