### PR TITLE
[maps] unskip Failing test: Chrome X-Pack UI Functional Tests.x-pack/test/functional/apps/maps/group4/lens/choropleth_chart·ts

### DIFF
--- a/test/functional/services/combo_box.ts
+++ b/test/functional/services/combo_box.ts
@@ -323,4 +323,13 @@ export class ComboBoxService extends FtrService {
     const input = await comboBoxElement.findByTagName('input');
     await input.clearValueWithKeyboard();
   }
+
+  public async isDisabled(comboBoxSelector: string): Promise<boolean> {
+    this.log.debug(`comboBox.isDisabled, comboBoxSelector:${comboBoxSelector}`);
+    const comboBoxElement = await this.testSubjects.find(comboBoxSelector);
+    const toggleListButton = await comboBoxElement.findByTestSubject('comboBoxToggleListButton');
+    const isDisabled = await toggleListButton.getAttribute('disabled');
+    this.log.debug(`isDisabled:${isDisabled}`);
+    return isDisabled?.toLowerCase() === 'true';
+  }
 }

--- a/test/functional/services/combo_box.ts
+++ b/test/functional/services/combo_box.ts
@@ -324,9 +324,8 @@ export class ComboBoxService extends FtrService {
     await input.clearValueWithKeyboard();
   }
 
-  public async isDisabled(comboBoxSelector: string): Promise<boolean> {
-    this.log.debug(`comboBox.isDisabled, comboBoxSelector:${comboBoxSelector}`);
-    const comboBoxElement = await this.testSubjects.find(comboBoxSelector);
+  public async isDisabled(comboBoxElement: WebElementWrapper): Promise<boolean> {
+    this.log.debug(`comboBox.isDisabled`);
     const toggleListButton = await comboBoxElement.findByTestSubject('comboBoxToggleListButton');
     const isDisabled = await toggleListButton.getAttribute('disabled');
     this.log.debug(`isDisabled:${isDisabled}`);

--- a/x-pack/plugins/maps/public/components/ems_file_select.tsx
+++ b/x-pack/plugins/maps/public/components/ems_file_select.tsx
@@ -98,7 +98,7 @@ export class EMSFileSelect extends Component<Props, State> {
         isClearable={false}
         singleSelection={true}
         isDisabled={this.state.emsFileOptions.length === 0}
-        data-test-subj="emsVectorComboBox"
+        data-test-subj="emsFileSelect"
       />
     );
   }

--- a/x-pack/test/functional/apps/maps/group4/lens/choropleth_chart.ts
+++ b/x-pack/test/functional/apps/maps/group4/lens/choropleth_chart.ts
@@ -13,9 +13,13 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const testSubjects = getService('testSubjects');
   const filterBar = getService('filterBar');
 
-  // Failing: See https://github.com/elastic/kibana/issues/154065
-  // Failing: See https://github.com/elastic/kibana/issues/154064
-  describe.skip('choropleth chart', () => {
+  // Test requires access to Elastic Maps Service
+  // Do not skip test if failure is "Test requires access to Elastic Maps Service (EMS). EMS is not available"
+  describe('choropleth chart', () => {
+    before('', async () => {
+      await PageObjects.maps.expectEmsToBeAvailable();
+    });
+
     it('should allow creation of choropleth chart', async () => {
       await PageObjects.visualize.navigateToNewVisualization();
       await PageObjects.visualize.clickVisType('lens');

--- a/x-pack/test/functional/page_objects/gis_page.ts
+++ b/x-pack/test/functional/page_objects/gis_page.ts
@@ -50,8 +50,11 @@ export class GisPageObject extends FtrService {
     await this.clickAddLayer();
     await this.testSubjects.click('emsBoundaries');
     try {
-      await this.testSubjects.exists('emsFileSelect', { timeout: 30000 }); // large timeout for EMS request
-      const isDisabled = await this.comboBox.isDisabled('emsFileSelect');
+      const emsFileElement = await this.testSubjects.find(comboBoxSelector,  { timeout: 120000 }); // large timeout for EMS request
+      if (!emsFileElement) {
+        throw new Error('Unable to find EMS file select');
+      }
+      const isDisabled = await this.comboBox.isDisabled(emsFileElement);
       if (isDisabled) {
         throw new Error('EMS file select is disabled');
       }

--- a/x-pack/test/functional/page_objects/gis_page.ts
+++ b/x-pack/test/functional/page_objects/gis_page.ts
@@ -45,6 +45,7 @@ export class GisPageObject extends FtrService {
   }
 
   async expectEmsToBeAvailable() {
+    this.log.debug(`expectEmsToBeAvailable`);
     await this.openNewMap();
     await this.clickAddLayer();
     await this.testSubjects.click('emsBoundaries');
@@ -52,9 +53,10 @@ export class GisPageObject extends FtrService {
       await this.testSubjects.exists('emsFileSelect', { timeout: 30000 }); // large timeout for EMS request
       const isDisabled = await this.comboBox.isDisabled('emsFileSelect');
       if (isDisabled) {
-        throw new Error();
+        throw new Error('EMS file select is disabled');
       }
     } catch (e) {
+      this.log.debug(`EMS is not available, error: ${e.message}`);
       throw new Error('Test requires access to Elastic Maps Service (EMS). EMS is not available');
     }
   }

--- a/x-pack/test/functional/page_objects/gis_page.ts
+++ b/x-pack/test/functional/page_objects/gis_page.ts
@@ -44,6 +44,21 @@ export class GisPageObject extends FtrService {
     this.basePath = basePath;
   }
 
+  async expectEmsToBeAvailable() {
+    await this.openNewMap();
+    await this.clickAddLayer();
+    await this.testSubjects.click('emsBoundaries');
+    try {
+      await this.testSubjects.exists('emsFileSelect', { timeout: 30000 }); // large timeout for EMS request
+      const isDisabled = await this.comboBox.isDisabled('emsFileSelect');
+      if (isDisabled) {
+        throw new Error();
+      }
+    } catch(e) {
+      throw new Error('Test requires access to Elastic Maps Service (EMS). EMS is not available');
+    }
+  }
+
   async setAbsoluteRange(start: string, end: string) {
     await this.timePicker.setAbsoluteRange(start, end);
     await this.waitForLayersToLoad();

--- a/x-pack/test/functional/page_objects/gis_page.ts
+++ b/x-pack/test/functional/page_objects/gis_page.ts
@@ -54,7 +54,7 @@ export class GisPageObject extends FtrService {
       if (isDisabled) {
         throw new Error();
       }
-    } catch(e) {
+    } catch (e) {
       throw new Error('Test requires access to Elastic Maps Service (EMS). EMS is not available');
     }
   }

--- a/x-pack/test/functional/page_objects/gis_page.ts
+++ b/x-pack/test/functional/page_objects/gis_page.ts
@@ -50,7 +50,7 @@ export class GisPageObject extends FtrService {
     await this.clickAddLayer();
     await this.testSubjects.click('emsBoundaries');
     try {
-      const emsFileElement = await this.testSubjects.find(comboBoxSelector,  { timeout: 120000 }); // large timeout for EMS request
+      const emsFileElement = await this.testSubjects.find('emsFileSelect',  120000 ); // large timeout for EMS request
       if (!emsFileElement) {
         throw new Error('Unable to find EMS file select');
       }

--- a/x-pack/test/functional/page_objects/gis_page.ts
+++ b/x-pack/test/functional/page_objects/gis_page.ts
@@ -50,7 +50,7 @@ export class GisPageObject extends FtrService {
     await this.clickAddLayer();
     await this.testSubjects.click('emsBoundaries');
     try {
-      const emsFileElement = await this.testSubjects.find('emsFileSelect',  120000 ); // large timeout for EMS request
+      const emsFileElement = await this.testSubjects.find('emsFileSelect', 120000); // large timeout for EMS request
       if (!emsFileElement) {
         throw new Error('Unable to find EMS file select');
       }


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/154065

flaky test runner https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2092

Tests failing because of lack of EMS access. The test requires EMS access. Fix is to add check for EMS so failure message points to failure cause. This data can be used to help track faulty CI environments where EMS is not available.