### PR TITLE
[RAM] Fix error message flash and throttle value reset

### DIFF
--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/action_type_form.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/action_type_form.tsx
@@ -258,8 +258,10 @@ export const ActionTypeForm = ({
       )}
       onThrottleChange={useCallback(
         (throttle: number | null, throttleUnit: string) => {
-          setActionThrottle(throttle);
-          setActionThrottleUnit(throttleUnit);
+          if (throttle) {
+            setActionThrottle(throttle);
+            setActionThrottleUnit(throttleUnit);
+          }
           setActionFrequencyProperty(
             'throttle',
             throttle ? `${throttle}${throttleUnit}` : null,

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/rule_form/rule_errors.ts
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/rule_form/rule_errors.ts
@@ -60,7 +60,8 @@ export function validateBaseProperties(
   }
 
   const invalidThrottleActions = ruleObject.actions.filter((a) => {
-    const throttleDuration = a.frequency?.throttle ? parseDuration(a.frequency.throttle) : 0;
+    if (!a.frequency?.throttle) return false;
+    const throttleDuration = parseDuration(a.frequency.throttle);
     const intervalDuration =
       ruleObject.schedule.interval && ruleObject.schedule.interval.length > 1
         ? parseDuration(ruleObject.schedule.interval)


### PR DESCRIPTION
## Summary

Fixes #152943

- Error message will no longer flash when switching notify when to `On custom action intervals`
- Switching away and back to `On custom action intervals` will preserve the throttle value as well as the throttle unit

