### PR TITLE
[Dashboard] Fix z index of toolbar items

### DIFF
--- a/src/plugins/dashboard/public/dashboard_app/top_nav/controls_toolbar_button/controls_toolbar_button.tsx
+++ b/src/plugins/dashboard/public/dashboard_app/top_nav/controls_toolbar_button/controls_toolbar_button.tsx
@@ -8,7 +8,7 @@
 
 import React from 'react';
 
-import { EuiContextMenuPanel } from '@elastic/eui';
+import { EuiContextMenuPanel, useEuiTheme } from '@elastic/eui';
 import { ToolbarPopover } from '@kbn/shared-ux-button-toolbar';
 import type { ControlGroupContainer } from '@kbn/controls-plugin/public';
 
@@ -18,11 +18,15 @@ import { AddTimeSliderControlButton } from './add_time_slider_control_button';
 import { EditControlGroupButton } from './edit_control_group_button';
 
 export function ControlsToolbarButton({ controlGroup }: { controlGroup: ControlGroupContainer }) {
+  const { euiTheme } = useEuiTheme();
+
   return (
     <ToolbarPopover
       ownFocus
-      label={getControlButtonTitle()}
+      repositionOnScroll
       panelPaddingSize="none"
+      label={getControlButtonTitle()}
+      zIndex={Number(euiTheme.levels.header) - 1}
       data-test-subj="dashboard-controls-menu-button"
     >
       {({ closePopover }: { closePopover: () => void }) => (

--- a/src/plugins/dashboard/public/dashboard_app/top_nav/editor_menu.tsx
+++ b/src/plugins/dashboard/public/dashboard_app/top_nav/editor_menu.tsx
@@ -14,6 +14,7 @@ import {
   EuiContextMenuPanelItemDescriptor,
   EuiFlexGroup,
   EuiFlexItem,
+  useEuiTheme,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { ToolbarPopover } from '@kbn/shared-ux-button-toolbar';
@@ -52,6 +53,8 @@ export const EditorMenu = ({ createNewVisType, createNewEmbeddable }: Props) => 
       showNewVisModal,
     },
   } = pluginServices.getServices();
+
+  const { euiTheme } = useEuiTheme();
 
   const embeddableFactories = useMemo(
     () => Array.from(embeddable.getEmbeddableFactories()),
@@ -262,6 +265,8 @@ export const EditorMenu = ({ createNewVisType, createNewEmbeddable }: Props) => 
   };
   return (
     <ToolbarPopover
+      zIndex={Number(euiTheme.levels.header) - 1}
+      repositionOnScroll
       ownFocus
       label={i18n.translate('dashboard.solutionToolbar.editorMenuButtonLabel', {
         defaultMessage: 'Select type',


### PR DESCRIPTION
## Summary
Fixes https://github.com/elastic/kibana/issues/151184

Adds EUI theme props for zindex and reposition on scroll to the `select type` and `controls` dashboard toolbar items so that they reposition properly and don't overlap the header.

![Apr-05-2023 16-38-18](https://user-images.githubusercontent.com/14276393/230206115-a03eb4ed-40f0-451e-a2d5-db605e2279b1.gif)


Note that this PR does not add these props to the dashboard gear menu.