### PR TITLE
[Cloud Posture] add  rule number column sort in findings table

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/pages/configurations/layout/findings_layout.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/configurations/layout/findings_layout.tsx
@@ -149,6 +149,7 @@ const baseColumns = [
         defaultMessage: 'Rule Number',
       }
     ),
+    sortable: true,
     width: '120px',
   },
   {


### PR DESCRIPTION
## Summary


This is part of a Quick Wins [ticket](https://github.com/elastic/security-team/issues/6291) 

This PR adds sorting to Rule Number column in Findings Table

<img width="1080" alt="image" src="https://user-images.githubusercontent.com/17135495/230223437-13fd69b4-e34b-48c5-a2d2-5c20e72df383.png">


