### PR TITLE
[Defend Workflows] Disable automated response actions experimental feature

### DIFF
--- a/x-pack/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/plugins/security_solution/common/experimental_features.ts
@@ -71,7 +71,7 @@ export const allowedExperimentalValues = Object.freeze({
   /**
    * Enables the automated endpoint response action in rule + alerts
    */
-  endpointResponseActionsEnabled: true,
+  endpointResponseActionsEnabled: false,
 
   /**
    * Enables endpoint package level rbac


### PR DESCRIPTION
Set the feature flag to false

The feature is still in development and should be hidden for the time being. Progress tracked [here](https://github.com/elastic/security-team/issues/5849).