### PR TITLE
[Behavorial Analytics] Licence Gate Feature 

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/analytics/components/add_analytics_collections/add_analytics_collection.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/analytics/components/add_analytics_collections/add_analytics_collection.tsx
@@ -14,9 +14,13 @@ import { i18n } from '@kbn/i18n';
 import { AddAnalyticsCollectionModal } from './add_analytics_collection_modal';
 
 interface AddAnalyticsCollectionProps {
+  disabled?: boolean;
   render?: (onClick: () => void) => React.ReactNode;
 }
-export const AddAnalyticsCollection: React.FC<AddAnalyticsCollectionProps> = ({ render }) => {
+export const AddAnalyticsCollection: React.FC<AddAnalyticsCollectionProps> = ({
+  render,
+  disabled,
+}) => {
   const [isModalVisible, setIsModalVisible] = useState(false);
   const closeModal = () => setIsModalVisible(false);
   const showModal = () => setIsModalVisible(true);
@@ -26,7 +30,7 @@ export const AddAnalyticsCollection: React.FC<AddAnalyticsCollectionProps> = ({ 
       {render ? (
         render(showModal)
       ) : (
-        <EuiButton fill iconType="plusInCircle" onClick={showModal}>
+        <EuiButton fill iconType="plusInCircle" onClick={showModal} disabled={disabled}>
           {i18n.translate('xpack.enterpriseSearch.analytics.collections.create.buttonTitle', {
             defaultMessage: 'Create collection',
           })}

--- a/x-pack/plugins/enterprise_search/public/applications/analytics/components/analytics_overview/analytics_overview.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/analytics/components/analytics_overview/analytics_overview.test.tsx
@@ -18,6 +18,9 @@ import { AnalyticsCollection } from '../../../../../common/types/analytics';
 import { AnalyticsCollectionTable } from './analytics_collection_table';
 
 import { AnalyticsOverview } from './analytics_overview';
+import { LicensingCallout } from '../../../enterprise_search_content/components/shared/licensing_callout/licensing_callout';
+import { AnalyticsOverviewEmptyPage } from './analytics_overview_empty_page';
+import { AddAnalyticsCollection } from '../add_analytics_collections/add_analytics_collection';
 
 const mockValues = {
   analyticsCollections: [
@@ -27,6 +30,8 @@ const mockValues = {
     },
   ] as AnalyticsCollection[],
   hasNoAnalyticsCollections: false,
+  hasPlatinumLicense: true,
+  isCloud: false,
 };
 
 const mockActions = {
@@ -49,8 +54,9 @@ describe('AnalyticsOverview', () => {
       const wrapper = shallow(<AnalyticsOverview />);
 
       expect(mockActions.fetchAnalyticsCollections).toHaveBeenCalled();
-
       expect(wrapper.find(AnalyticsCollectionTable)).toHaveLength(0);
+      expect(wrapper.find(AnalyticsOverviewEmptyPage)).toHaveLength(1);
+
     });
 
     it('renders with Data', async () => {
@@ -60,7 +66,34 @@ describe('AnalyticsOverview', () => {
       const wrapper = shallow(<AnalyticsOverview />);
 
       expect(wrapper.find(AnalyticsCollectionTable)).toHaveLength(1);
+      expect(wrapper.find(LicensingCallout)).toHaveLength(0);
       expect(mockActions.fetchAnalyticsCollections).toHaveBeenCalled();
+    });
+
+    it('renders Platinum license callout when not Cloud or Platinum', async () => {
+      setMockValues({
+        ...mockValues,
+        hasPlatinumLicense: false,
+        isCloud: false,
+      });
+      setMockActions(mockActions);
+      const wrapper = shallow(<AnalyticsOverview />);
+  
+      expect(wrapper.find(AnalyticsCollectionTable)).toHaveLength(0);
+      expect(wrapper.find(AnalyticsOverviewEmptyPage)).toHaveLength(0);
+      expect(wrapper.find(LicensingCallout)).toHaveLength(1);
+    });
+  
+    it('Does not render Platinum license callout when Cloud', async () => {
+      setMockValues({
+        ...mockValues,
+        hasPlatinumLicense: false,
+        isCloud: true,
+      });
+      setMockActions(mockActions);
+      const wrapper = shallow(<AnalyticsOverview />);
+  
+      expect(wrapper.find(LicensingCallout)).toHaveLength(0);
     });
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/analytics/components/analytics_overview/analytics_overview.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/analytics/components/analytics_overview/analytics_overview.test.tsx
@@ -15,12 +15,12 @@ import { shallow } from 'enzyme';
 
 import { AnalyticsCollection } from '../../../../../common/types/analytics';
 
+import { LicensingCallout } from '../../../enterprise_search_content/components/shared/licensing_callout/licensing_callout';
+
 import { AnalyticsCollectionTable } from './analytics_collection_table';
 
 import { AnalyticsOverview } from './analytics_overview';
-import { LicensingCallout } from '../../../enterprise_search_content/components/shared/licensing_callout/licensing_callout';
 import { AnalyticsOverviewEmptyPage } from './analytics_overview_empty_page';
-import { AddAnalyticsCollection } from '../add_analytics_collections/add_analytics_collection';
 
 const mockValues = {
   analyticsCollections: [
@@ -56,7 +56,6 @@ describe('AnalyticsOverview', () => {
       expect(mockActions.fetchAnalyticsCollections).toHaveBeenCalled();
       expect(wrapper.find(AnalyticsCollectionTable)).toHaveLength(0);
       expect(wrapper.find(AnalyticsOverviewEmptyPage)).toHaveLength(1);
-
     });
 
     it('renders with Data', async () => {
@@ -78,12 +77,12 @@ describe('AnalyticsOverview', () => {
       });
       setMockActions(mockActions);
       const wrapper = shallow(<AnalyticsOverview />);
-  
+
       expect(wrapper.find(AnalyticsCollectionTable)).toHaveLength(0);
       expect(wrapper.find(AnalyticsOverviewEmptyPage)).toHaveLength(0);
       expect(wrapper.find(LicensingCallout)).toHaveLength(1);
     });
-  
+
     it('Does not render Platinum license callout when Cloud', async () => {
       setMockValues({
         ...mockValues,
@@ -92,7 +91,7 @@ describe('AnalyticsOverview', () => {
       });
       setMockActions(mockActions);
       const wrapper = shallow(<AnalyticsOverview />);
-  
+
       expect(wrapper.find(LicensingCallout)).toHaveLength(0);
     });
   });

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/shared/licensing_callout/licensing_callout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/shared/licensing_callout/licensing_callout.tsx
@@ -18,6 +18,7 @@ export enum LICENSING_FEATURE {
   INFERENCE = 'inference',
   PIPELINES = 'pipelines',
   SEARCH_APPLICATIONS = 'searchApplications',
+  ANALYTICS = 'analytics',
 }
 
 type ContentBlock = Record<LICENSING_FEATURE, string>;
@@ -59,6 +60,13 @@ export const LicensingCallout: React.FC<{ feature: LICENSING_FEATURE }> = ({ fea
           'Search Applications require a Platinum license or higher and are not available to Standard license self-managed deployments. You need to upgrade to use this feature.',
       }
     ),
+    [LICENSING_FEATURE.ANALYTICS]: i18n.translate(
+      'xpack.enterpriseSearch.content.licensingCallout.analytics.contentOne',
+      {
+        defaultMessage:
+          'Behavioral Analytics require a Platinum license or higher and are not available to Standard license self-managed deployments. You need to upgrade to use this feature.',
+      }
+    ),
   };
 
   const secondContentBlock: ContentBlock = {
@@ -95,6 +103,13 @@ export const LicensingCallout: React.FC<{ feature: LICENSING_FEATURE }> = ({ fea
       {
         defaultMessage:
           "Did you know that Search Applications are available with a Standard Elastic Cloud license? Elastic Cloud gives you the flexibility to run where you want. Deploy our managed service on Google Cloud, Microsoft Azure, or Amazon Web Services and we'll handle the maintenance and upkeep for you.",
+      }
+    ),
+    [LICENSING_FEATURE.ANALYTICS]: i18n.translate(
+      'xpack.enterpriseSearch.content.licensingCallout.analytics.contentTwo',
+      {
+        defaultMessage:
+          "Did you know that Behavioral Analytics are available with a Standard Elastic Cloud license? Elastic Cloud gives you the flexibility to run where you want. Deploy our managed service on Google Cloud, Microsoft Azure, or Amazon Web Services and we'll handle the maintenance and upkeep for you.",
       }
     ),
   };


### PR DESCRIPTION
Behavorial analytics is gated when the customer doesn't have a platium licence and not running in the cloud.

![image](https://user-images.githubusercontent.com/49480/230376035-88313be2-9493-44bc-bcec-6f4961a3f68d.png)
