### PR TITLE
[dashboard][docs] add link to debugging dashboard performance blog

### DIFF
--- a/docs/user/dashboard/dashboard-troubleshooting.asciidoc
+++ b/docs/user/dashboard/dashboard-troubleshooting.asciidoc
@@ -1,6 +1,8 @@
 [[dashboard-troubleshooting]]
 == Improve dashboard loading time
 
+Follow https://www.elastic.co/blog/debugging-kibana-dashboards[these approaches] to investigate and diagnose performance issues with Kibana dashboards.
+
 To improve the dashboard loading time, enable *Defer loading panels below the fold* *Lab*, which loads dashboard panels as they become visible on the dashboard.
 
 . In the toolbar, click *Labs*.


### PR DESCRIPTION
https://www.elastic.co/blog/debugging-kibana-dashboards is a great blog post about troubleshooting dashboard performance. This is a quick PR to include the link in dashboard documentation to its easier to find for users.