### PR TITLE
[8.7] [Fleet] Enable Host name format selector by default + remove FQDN feature flag references (#154563)

### DIFF
--- a/x-pack/plugins/fleet/common/experimental_features.ts
+++ b/x-pack/plugins/fleet/common/experimental_features.ts
@@ -18,8 +18,8 @@ export const allowedExperimentalValues = Object.freeze({
   diagnosticFileUploadEnabled: true,
   experimentalDataStreamSettings: false,
   displayAgentMetrics: true,
-  showIntegrationsSubcategories: false,
-  agentFqdnMode: false,
+  showIntegrationsSubcategories: true,
+  agentFqdnMode: true,
 });
 
 type ExperimentalConfigKeys = Array<keyof ExperimentalFeatures>;

--- a/x-pack/plugins/fleet/common/experimental_features.ts
+++ b/x-pack/plugins/fleet/common/experimental_features.ts
@@ -18,7 +18,7 @@ export const allowedExperimentalValues = Object.freeze({
   diagnosticFileUploadEnabled: true,
   experimentalDataStreamSettings: false,
   displayAgentMetrics: true,
-  showIntegrationsSubcategories: true,
+  showIntegrationsSubcategories: false,
   agentFqdnMode: true,
 });
 

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_advanced_fields/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_advanced_fields/index.tsx
@@ -42,7 +42,7 @@ import { AgentPolicyPackageBadge } from '../../../../components';
 import { AgentPolicyDeleteProvider } from '../agent_policy_delete_provider';
 import type { ValidationResults } from '../agent_policy_validation';
 
-import { ExperimentalFeaturesService, policyHasFleetServer } from '../../../../services';
+import { policyHasFleetServer } from '../../../../services';
 
 import {
   useOutputOptions,
@@ -66,7 +66,6 @@ export const AgentPolicyAdvancedOptionsContent: React.FunctionComponent<Props> =
   isEditing = false,
   onDelete = () => {},
 }) => {
-  const { agentFqdnMode: agentFqdnModeEnabled } = ExperimentalFeaturesService.get();
   const { docLinks } = useStartServices();
   const config = useConfig();
   const maxAgentPoliciesWithInactivityTimeout =
@@ -558,66 +557,38 @@ export const AgentPolicyAdvancedOptionsContent: React.FunctionComponent<Props> =
           />
         </EuiFormRow>
       </EuiDescribedFormGroup>
-      {agentFqdnModeEnabled && (
-        <EuiDescribedFormGroup
-          title={
-            <h4>
-              <FormattedMessage
-                id="xpack.fleet.agentPolicyForm.hostnameFormatLabel"
-                defaultMessage="Host name format"
-              />
-              &nbsp;
-              <EuiBetaBadge label="beta" size="s" color="accent" />
-            </h4>
-          }
-          description={
+      <EuiDescribedFormGroup
+        title={
+          <h4>
             <FormattedMessage
-              id="xpack.fleet.agentPolicyForm.hostnameFormatLabelDescription"
-              defaultMessage="Select how you would like agent domain names to be displayed."
+              id="xpack.fleet.agentPolicyForm.hostnameFormatLabel"
+              defaultMessage="Host name format"
             />
-          }
-        >
-          <EuiFormRow fullWidth>
-            <EuiRadioGroup
-              options={[
-                {
-                  id: 'hostname',
-                  label: (
-                    <>
-                      <EuiFlexGroup gutterSize="xs" direction="column">
-                        <EuiFlexItem grow={false}>
-                          <EuiText size="s">
-                            <b>
-                              <FormattedMessage
-                                id="xpack.fleet.agentPolicyForm.hostnameFormatOptionHostname"
-                                defaultMessage="Hostname"
-                              />
-                            </b>
-                          </EuiText>
-                        </EuiFlexItem>
-                        <EuiFlexItem grow={false}>
-                          <EuiText size="s" color="subdued">
-                            <FormattedMessage
-                              id="xpack.fleet.agentPolicyForm.hostnameFormatOptionHostnameExample"
-                              defaultMessage="ex: My-Laptop"
-                            />
-                          </EuiText>
-                        </EuiFlexItem>
-                      </EuiFlexGroup>
-                      <EuiSpacer size="s" />
-                    </>
-                  ),
-                },
-                {
-                  id: 'fqdn',
-                  label: (
+            &nbsp;
+            <EuiBetaBadge label="beta" size="s" color="accent" />
+          </h4>
+        }
+        description={
+          <FormattedMessage
+            id="xpack.fleet.agentPolicyForm.hostnameFormatLabelDescription"
+            defaultMessage="Select how you would like agent domain names to be displayed."
+          />
+        }
+      >
+        <EuiFormRow fullWidth>
+          <EuiRadioGroup
+            options={[
+              {
+                id: 'hostname',
+                label: (
+                  <>
                     <EuiFlexGroup gutterSize="xs" direction="column">
                       <EuiFlexItem grow={false}>
                         <EuiText size="s">
                           <b>
                             <FormattedMessage
-                              id="xpack.fleet.agentPolicyForm.hostnameFormatOptionFqdn"
-                              defaultMessage="Fully Qualified Domain Name (FQDN)"
+                              id="xpack.fleet.agentPolicyForm.hostnameFormatOptionHostname"
+                              defaultMessage="Hostname"
                             />
                           </b>
                         </EuiText>
@@ -625,26 +596,52 @@ export const AgentPolicyAdvancedOptionsContent: React.FunctionComponent<Props> =
                       <EuiFlexItem grow={false}>
                         <EuiText size="s" color="subdued">
                           <FormattedMessage
-                            id="xpack.fleet.agentPolicyForm.hostnameFormatOptionFqdnExample"
-                            defaultMessage="ex: My-Laptop.admin.acme.co"
+                            id="xpack.fleet.agentPolicyForm.hostnameFormatOptionHostnameExample"
+                            defaultMessage="ex: My-Laptop"
                           />
                         </EuiText>
                       </EuiFlexItem>
                     </EuiFlexGroup>
-                  ),
-                },
-              ]}
-              idSelected={agentPolicy.agent_features?.length ? 'fqdn' : 'hostname'}
-              onChange={(id: string) => {
-                updateAgentPolicy({
-                  agent_features: id === 'hostname' ? [] : [{ name: 'fqdn', enabled: true }],
-                });
-              }}
-              name="radio group"
-            />
-          </EuiFormRow>
-        </EuiDescribedFormGroup>
-      )}
+                    <EuiSpacer size="s" />
+                  </>
+                ),
+              },
+              {
+                id: 'fqdn',
+                label: (
+                  <EuiFlexGroup gutterSize="xs" direction="column">
+                    <EuiFlexItem grow={false}>
+                      <EuiText size="s">
+                        <b>
+                          <FormattedMessage
+                            id="xpack.fleet.agentPolicyForm.hostnameFormatOptionFqdn"
+                            defaultMessage="Fully Qualified Domain Name (FQDN)"
+                          />
+                        </b>
+                      </EuiText>
+                    </EuiFlexItem>
+                    <EuiFlexItem grow={false}>
+                      <EuiText size="s" color="subdued">
+                        <FormattedMessage
+                          id="xpack.fleet.agentPolicyForm.hostnameFormatOptionFqdnExample"
+                          defaultMessage="ex: My-Laptop.admin.acme.co"
+                        />
+                      </EuiText>
+                    </EuiFlexItem>
+                  </EuiFlexGroup>
+                ),
+              },
+            ]}
+            idSelected={agentPolicy.agent_features?.length ? 'fqdn' : 'hostname'}
+            onChange={(id: string) => {
+              updateAgentPolicy({
+                agent_features: id === 'hostname' ? [] : [{ name: 'fqdn', enabled: true }],
+              });
+            }}
+            name="radio group"
+          />
+        </EuiFormRow>
+      </EuiDescribedFormGroup>
       {isEditing && 'id' in agentPolicy && !agentPolicy.is_managed ? (
         <EuiDescribedFormGroup
           title={


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.7`:
 - [[Fleet] Enable Host name format selector by default + remove FQDN feature flag references (#154563)](https://github.com/elastic/kibana/pull/154563)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Mark Hopkin","email":"mark.hopkin@elastic.co"},"sourceCommit":{"committedDate":"2023-04-06T15:31:29Z","message":"[Fleet] Enable Host name format selector by default + remove FQDN feature flag references (#154563)\n\n## Summary\r\n\r\nThis pull request enables the feature flag which hid the host name\r\nformat selector in agent policies.\r\n\r\nThe host name selector can be used in any agent policy, go to the agent\r\npolicy settings tab then scroll to the bottom.\r\n\r\nFeature flag was disabled by default in\r\nhttps://github.com/elastic/kibana/pull/152592\r\n\r\nEnabling the feature flag by default also means we can remove references\r\nto it in the code now. (we keep the flag reference so that nobodies\r\nconfig is invalidated)\r\n\r\n**Before:**\r\n<img width=\"896\" alt=\"Screenshot 2023-04-06 at 15 34 57\"\r\nsrc=\"https://user-images.githubusercontent.com/3315046/230411132-364a1b21-3007-4f20-af25-5e6208786120.png\">\r\n\r\n**After:**\r\n<img width=\"925\" alt=\"Screenshot 2023-04-06 at 15 31 53\"\r\nsrc=\"https://user-images.githubusercontent.com/3315046/230410428-879dc975-fb27-434e-bc91-d43185361b71.png\">","sha":"b9d38be8e28a0855662b84cbcb814484728a2f3e","branchLabelMapping":{"^v8.8.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:enhancement","Team:Fleet","v8.8.0","v8.7.1"],"number":154563,"url":"https://github.com/elastic/kibana/pull/154563","mergeCommit":{"message":"[Fleet] Enable Host name format selector by default + remove FQDN feature flag references (#154563)\n\n## Summary\r\n\r\nThis pull request enables the feature flag which hid the host name\r\nformat selector in agent policies.\r\n\r\nThe host name selector can be used in any agent policy, go to the agent\r\npolicy settings tab then scroll to the bottom.\r\n\r\nFeature flag was disabled by default in\r\nhttps://github.com/elastic/kibana/pull/152592\r\n\r\nEnabling the feature flag by default also means we can remove references\r\nto it in the code now. (we keep the flag reference so that nobodies\r\nconfig is invalidated)\r\n\r\n**Before:**\r\n<img width=\"896\" alt=\"Screenshot 2023-04-06 at 15 34 57\"\r\nsrc=\"https://user-images.githubusercontent.com/3315046/230411132-364a1b21-3007-4f20-af25-5e6208786120.png\">\r\n\r\n**After:**\r\n<img width=\"925\" alt=\"Screenshot 2023-04-06 at 15 31 53\"\r\nsrc=\"https://user-images.githubusercontent.com/3315046/230410428-879dc975-fb27-434e-bc91-d43185361b71.png\">","sha":"b9d38be8e28a0855662b84cbcb814484728a2f3e"}},"sourceBranch":"main","suggestedTargetBranches":["8.7"],"targetPullRequestStates":[{"branch":"main","label":"v8.8.0","labelRegex":"^v8.8.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/154563","number":154563,"mergeCommit":{"message":"[Fleet] Enable Host name format selector by default + remove FQDN feature flag references (#154563)\n\n## Summary\r\n\r\nThis pull request enables the feature flag which hid the host name\r\nformat selector in agent policies.\r\n\r\nThe host name selector can be used in any agent policy, go to the agent\r\npolicy settings tab then scroll to the bottom.\r\n\r\nFeature flag was disabled by default in\r\nhttps://github.com/elastic/kibana/pull/152592\r\n\r\nEnabling the feature flag by default also means we can remove references\r\nto it in the code now. (we keep the flag reference so that nobodies\r\nconfig is invalidated)\r\n\r\n**Before:**\r\n<img width=\"896\" alt=\"Screenshot 2023-04-06 at 15 34 57\"\r\nsrc=\"https://user-images.githubusercontent.com/3315046/230411132-364a1b21-3007-4f20-af25-5e6208786120.png\">\r\n\r\n**After:**\r\n<img width=\"925\" alt=\"Screenshot 2023-04-06 at 15 31 53\"\r\nsrc=\"https://user-images.githubusercontent.com/3315046/230410428-879dc975-fb27-434e-bc91-d43185361b71.png\">","sha":"b9d38be8e28a0855662b84cbcb814484728a2f3e"}},{"branch":"8.7","label":"v8.7.1","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->