### PR TITLE
[DOCS] Add known issue with Observability Overview in 8.7.0

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -120,7 +120,7 @@ To review the breaking changes in previous versions, refer to the following:
 Release 8.7.0 has a bug causing the Observability Overview page to show an empty User Experience panel, even when there is RUM data (fixed in {kibana-pull}154419[#154419]).
 
 *Impact* +
-Whilst the User Experience panel is empty on the Observability Overview page, if you have RUM data it will still be available from the User Experience Dashboard.
+While the User Experience panel on the Observability Overview page is empty, any RUM data will still be available from the User Experience Dashboard.
 ====
 // end::known-issue-151698[]
 

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -117,7 +117,7 @@ To review the breaking changes in previous versions, refer to the following:
 [%collapsible]
 ====
 *Details* +
-Releases 8.7.0 has a bug which causes the Observability Overview page shows empty User Experience panel, even when there is RUM data (fixed in {kibana-pull}154419[#154419]).
+Release 8.7.0 has a bug causing the Observability Overview page to show an empty User Experience panel, even when there is RUM data (fixed in {kibana-pull}154419[#154419]).
 
 *Impact* +
 Whilst the User Experience panel is empty on the Observability Overview page, if you have RUM data it will still be available from the User Experience Dashboard.

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -118,6 +118,7 @@ To review the breaking changes in previous versions, refer to the following:
 ====
 *Details* +
 Releases 8.7.0 has a bug which causes the Observability Overview page shows empty User Experience panel, even when there is RUM data (fixed in {kibana-pull}154419[#154419]).
+
 *Impact* +
 Whilst the User Experience panel is empty on the Observability Overview page, if you have RUM data it will still be available from the User Experience Dashboard.
 ====

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -47,6 +47,23 @@ Review important information about the {kib} 8.7.0 release.
 Review the following information about the {kib} 8.7.0 release.
 
 [float]
+[[known-issues-8.7.0]]
+=== Known issues
+
+// tag::known-issue-151698[]
+[discrete]
+.Observability Overview shows empty User Experience panel
+[%collapsible]
+====
+*Details* +
+Release 8.7.0 has a bug causing the Observability Overview page to show an empty User Experience panel, even when there is RUM data (fixed in {kibana-pull}154419[#154419]).
+
+*Impact* +
+While the User Experience panel on the Observability Overview page is empty, any RUM data will still be available from the User Experience Dashboard.
+====
+// end::known-issue-151698[]
+
+[float]
 [[breaking-changes-8.7.0]]
 === Breaking changes
 
@@ -106,23 +123,6 @@ Do not use `/api/fleet/setup/preconfiguration`. To manage preconfigured agent po
 To review the breaking changes in previous versions, refer to the following:
 
 {kibana-ref-all}/8.6/release-notes-8.6.0.html#breaking-changes-8.6.0[8.6.0] | {kibana-ref-all}/8.5/release-notes-8.5.0.html#breaking-changes-8.5.0[8.5.0] | {kibana-ref-all}/8.4/release-notes-8.4.0.html#breaking-changes-8.4.0[8.4.0] | {kibana-ref-all}/8.3/release-notes-8.3.0.html#breaking-changes-8.3.0[8.3.0] | {kibana-ref-all}/8.2/release-notes-8.2.0.html#breaking-changes-8.2.0[8.2.0] | {kibana-ref-all}/8.1/release-notes-8.1.0.html#breaking-changes-8.1.0[8.1.0] | {kibana-ref-all}/8.0/release-notes-8.0.0.html#breaking-changes-8.0.0[8.0.0] | {kibana-ref-all}/8.0/release-notes-8.0.0-rc2.html#breaking-changes-8.0.0-rc2[8.0.0-rc2] | {kibana-ref-all}/8.0/release-notes-8.0.0-rc1.html#breaking-changes-8.0.0-rc1[8.0.0-rc1] | {kibana-ref-all}/8.0/release-notes-8.0.0-beta1.html#breaking-changes-8.0.0-beta1[8.0.0-beta1] | {kibana-ref-all}/8.0/release-notes-8.0.0-alpha2.html#breaking-changes-8.0.0-alpha2[8.0.0-alpha2] | {kibana-ref-all}/8.0/release-notes-8.0.0-alpha1.html#breaking-changes-8.0.0-alpha1[8.0.0-alpha1]
-
-[float]
-[[known-issues-8.7.0]]
-=== Known issues
-
-// tag::known-issue-151698[]
-[discrete]
-.Observability Overview shows empty User Experience panel
-[%collapsible]
-====
-*Details* +
-Release 8.7.0 has a bug causing the Observability Overview page to show an empty User Experience panel, even when there is RUM data (fixed in {kibana-pull}154419[#154419]).
-
-*Impact* +
-While the User Experience panel on the Observability Overview page is empty, any RUM data will still be available from the User Experience Dashboard.
-====
-// end::known-issue-151698[]
 
 [float]
 [[features-8.7.0]]

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -108,6 +108,22 @@ To review the breaking changes in previous versions, refer to the following:
 {kibana-ref-all}/8.6/release-notes-8.6.0.html#breaking-changes-8.6.0[8.6.0] | {kibana-ref-all}/8.5/release-notes-8.5.0.html#breaking-changes-8.5.0[8.5.0] | {kibana-ref-all}/8.4/release-notes-8.4.0.html#breaking-changes-8.4.0[8.4.0] | {kibana-ref-all}/8.3/release-notes-8.3.0.html#breaking-changes-8.3.0[8.3.0] | {kibana-ref-all}/8.2/release-notes-8.2.0.html#breaking-changes-8.2.0[8.2.0] | {kibana-ref-all}/8.1/release-notes-8.1.0.html#breaking-changes-8.1.0[8.1.0] | {kibana-ref-all}/8.0/release-notes-8.0.0.html#breaking-changes-8.0.0[8.0.0] | {kibana-ref-all}/8.0/release-notes-8.0.0-rc2.html#breaking-changes-8.0.0-rc2[8.0.0-rc2] | {kibana-ref-all}/8.0/release-notes-8.0.0-rc1.html#breaking-changes-8.0.0-rc1[8.0.0-rc1] | {kibana-ref-all}/8.0/release-notes-8.0.0-beta1.html#breaking-changes-8.0.0-beta1[8.0.0-beta1] | {kibana-ref-all}/8.0/release-notes-8.0.0-alpha2.html#breaking-changes-8.0.0-alpha2[8.0.0-alpha2] | {kibana-ref-all}/8.0/release-notes-8.0.0-alpha1.html#breaking-changes-8.0.0-alpha1[8.0.0-alpha1]
 
 [float]
+[[known-issues-8.7.0]]
+=== Known issues
+
+// tag::known-issue-151698[]
+[discrete]
+.Observability Overview shows empty User Experience panel
+[%collapsible]
+====
+*Details* +
+Releases 8.7.0 has a bug which causes the Observability Overview page shows empty User Experience panel, even when there is RUM data (fixed in {kibana-pull}154419[#154419]).
+*Impact* +
+Whilst the User Experience panel is empty on the Observability Overview page, if you have RUM data it will still be available from the User Experience Dashboard.
+====
+// end::known-issue-151698[]
+
+[float]
 [[features-8.7.0]]
 === Features
 {kib} 8.7.0 adds the following new and notable features.


### PR DESCRIPTION
## Summary

Relates to https://github.com/elastic/kibana/pull/154419

This PR adds a known issue to the 8.7.0 release notes for a missing User Experience panel in the Observability Overview page.