### PR TITLE
serverless_search: update enterpriseSearch config for current state

### DIFF
--- a/config/serverless.es.yml
+++ b/config/serverless.es.yml
@@ -2,6 +2,12 @@ xpack.apm.enabled: false
 xpack.uptime.enabled: false
 
 enterpriseSearch.enabled: true
+enterpriseSearch.canDeployEntSearch: false
+enterpriseSearch.hasConnectors: false
+enterpriseSearch.hasDefaultIngestPipeline: false
+enterpriseSearch.hasNativeConnectors: false
+enterpriseSearch.hasWebCrawler: false
+
 xpack.serverless.search.enabled: true
 
 uiSettings.overrides.defaultRoute: /app/enterprise_search/content/search_indices


### PR DESCRIPTION
## Summary

Updated the configuration for serverless es to disable enterprise search items that are not available in serverless.
