### PR TITLE
[Enterprise Search] ML Inference - ELSER Call Out

### DIFF
--- a/packages/kbn-doc-links/src/get_doc_links.ts
+++ b/packages/kbn-doc-links/src/get_doc_links.ts
@@ -137,6 +137,7 @@ export const getDocLinks = ({ kibanaBranch }: GetDocLinkOptions): DocLinks => {
       crawlerOverview: `${ENTERPRISE_SEARCH_DOCS}crawler.html`,
       deployTrainedModels: `${MACHINE_LEARNING_DOCS}ml-nlp-deploy-models.html`,
       documentLevelSecurity: `${ELASTICSEARCH_DOCS}document-level-security.html`,
+      elser: `${MACHINE_LEARNING_DOCS}ml-nlp-elser.html`,
       engines: `${ENTERPRISE_SEARCH_DOCS}engines.html`,
       ingestPipelines: `${ENTERPRISE_SEARCH_DOCS}ingest-pipelines.html`,
       languageAnalyzers: `${ELASTICSEARCH_DOCS}analysis-lang-analyzer.html`,

--- a/packages/kbn-doc-links/src/types.ts
+++ b/packages/kbn-doc-links/src/types.ts
@@ -122,6 +122,7 @@ export interface DocLinks {
     readonly crawlerOverview: string;
     readonly deployTrainedModels: string;
     readonly documentLevelSecurity: string;
+    readonly elser: string;
     readonly engines: string;
     readonly ingestPipelines: string;
     readonly languageAnalyzers: string;

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/configure_pipeline.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/configure_pipeline.tsx
@@ -32,6 +32,7 @@ import { docLinks } from '../../../../../shared/doc_links';
 
 import { IndexViewLogic } from '../../index_view_logic';
 
+import { ELSERCallOut } from './elser_callout';
 import { InferenceConfiguration } from './inference_config';
 import { EMPTY_PIPELINE_CONFIGURATION, MLInferenceLogic } from './ml_inference_logic';
 import { MlModelSelectOption } from './model_select_option';
@@ -315,6 +316,8 @@ export const ConfigurePipeline: React.FC = () => {
               </EuiFormRow>
               <InferenceConfiguration />
             </EuiForm>
+            <EuiSpacer />
+            <ELSERCallOut />
           </EuiPanel>
         </EuiFlexItem>
       </EuiFlexGroup>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/configure_pipeline.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/configure_pipeline.tsx
@@ -32,11 +32,11 @@ import { docLinks } from '../../../../../shared/doc_links';
 
 import { IndexViewLogic } from '../../index_view_logic';
 
-import { ELSERCallOut } from './elser_callout';
 import { InferenceConfiguration } from './inference_config';
 import { EMPTY_PIPELINE_CONFIGURATION, MLInferenceLogic } from './ml_inference_logic';
 import { MlModelSelectOption } from './model_select_option';
 import { PipelineSelectOption } from './pipeline_select_option';
+import { TextExpansionCallOut } from './text_expansion_callout';
 import { MODEL_REDACTED_VALUE, MODEL_SELECT_PLACEHOLDER } from './utils';
 
 const MODEL_SELECT_PLACEHOLDER_VALUE = 'model_placeholder$$';
@@ -317,7 +317,7 @@ export const ConfigurePipeline: React.FC = () => {
               <InferenceConfiguration />
             </EuiForm>
             <EuiSpacer />
-            <ELSERCallOut />
+            <TextExpansionCallOut />
           </EuiPanel>
         </EuiFlexItem>
       </EuiFlexGroup>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/elser_callout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/elser_callout.tsx
@@ -5,7 +5,9 @@
  * 2.0.
  */
 
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { useValues } from 'kea';
 
 import {
   EuiBadge,
@@ -18,6 +20,10 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage, FormattedHTMLMessage } from '@kbn/i18n-react';
+
+import { TEXT_EXPANSION_TYPE } from '../../../../../../../common/ml_inference_pipeline';
+
+import { MLInferenceLogic } from './ml_inference_logic';
 
 export interface ELSERCallOutState {
   dismiss: () => void;
@@ -34,6 +40,12 @@ export const ELSER_CALL_OUT_DISMISSED_KEY = 'enterprise-search-elser-callout-dis
 export const useELSERCallOutData = ({
   dismissable = false,
 }: ELSERCallOutProps): ELSERCallOutState => {
+  const { supportedMLModels } = useValues(MLInferenceLogic);
+
+  const doesNotHaveELSERModel = useMemo(() => {
+    return supportedMLModels.every((m) => m.model_type !== TEXT_EXPANSION_TYPE);
+  }, [supportedMLModels]);
+
   const [show, setShow] = useState<boolean>(() => {
     if (!dismissable) return true;
 
@@ -56,7 +68,7 @@ export const useELSERCallOutData = ({
     setShow(false);
   });
 
-  return { dismiss, dismissable, show };
+  return { dismiss, dismissable, show: doesNotHaveELSERModel && show };
 };
 
 export const ELSERCallOut: React.FC<ELSERCallOutProps> = (props) => {

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/elser_callout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/elser_callout.tsx
@@ -21,8 +21,6 @@ import {
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage, FormattedHTMLMessage } from '@kbn/i18n-react';
 
-import { TEXT_EXPANSION_TYPE } from '../../../../../../../common/ml_inference_pipeline';
-
 import { MLInferenceLogic } from './ml_inference_logic';
 
 export interface ELSERCallOutState {
@@ -43,7 +41,7 @@ export const useELSERCallOutData = ({
   const { supportedMLModels } = useValues(MLInferenceLogic);
 
   const doesNotHaveELSERModel = useMemo(() => {
-    return !supportedMLModels.some((m) => m.model_type === TEXT_EXPANSION_TYPE);
+    return !supportedMLModels.some((m) => m.inference_config?.text_expansion);
   }, [supportedMLModels]);
 
   const [show, setShow] = useState<boolean>(() => {

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/elser_callout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/elser_callout.tsx
@@ -66,7 +66,7 @@ export const useELSERCallOutData = ({
 
   const dismiss = useCallback(() => {
     setShow(false);
-  });
+  }, []);
 
   return { dismiss, dismissable, show: doesNotHaveELSERModel && show };
 };
@@ -89,12 +89,14 @@ export const ELSERCallOut: React.FC<ELSERCallOutProps> = (props) => {
             </EuiBadge>
           </EuiFlexItem>
           <EuiFlexItem grow>
-            <EuiTitle color="text" size="xs">
+            <EuiTitle size="xs">
               <h4>
-                <FormattedMessage
-                  id="xpack.enterpriseSearch.content.index.pipelines.elserCallOut.title"
-                  defaultMessage="Improve your results with ELSER"
-                />
+                <EuiText color="text">
+                  <FormattedMessage
+                    id="xpack.enterpriseSearch.content.index.pipelines.elserCallOut.title"
+                    defaultMessage="Improve your results with ELSER"
+                  />
+                </EuiText>
               </h4>
             </EuiTitle>
           </EuiFlexItem>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/elser_callout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/elser_callout.tsx
@@ -14,6 +14,7 @@ import {
   EuiButtonIcon,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiLink,
   EuiPanel,
   EuiText,
   EuiTitle,
@@ -119,6 +120,12 @@ export const ELSERCallOut: React.FC<ELSERCallOutProps> = (props) => {
               tagName="p"
             />
           </EuiText>
+          <EuiLink target="_blank" href="#">
+            <FormattedMessage
+              id="xpack.enterpriseSearch.content.index.pipelines.elserCallOut.learnMoreLink"
+              defaultMessage="Learn more"
+            />
+          </EuiLink>
         </EuiFlexGroup>
       </EuiFlexGroup>
     </EuiPanel>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/elser_callout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/elser_callout.tsx
@@ -1,0 +1,114 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useCallback, useEffect, useState } from 'react';
+
+import {
+  EuiBadge,
+  EuiButtonIcon,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiPanel,
+  EuiText,
+  EuiTitle,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage, FormattedHTMLMessage } from '@kbn/i18n-react';
+
+export interface ELSERCallOutState {
+  dismiss: () => void;
+  dismissable: boolean;
+  show: boolean;
+}
+
+export interface ELSERCallOutProps {
+  dismissable?: boolean;
+}
+
+export const ELSER_CALL_OUT_DISMISSED_KEY = 'enterprise-search-elser-callout-dismissed';
+
+export const useELSERCallOutData = ({
+  dismissable = false,
+}: ELSERCallOutProps): ELSERCallOutState => {
+  const [show, setShow] = useState<boolean>(() => {
+    if (!dismissable) return true;
+
+    try {
+      return localStorage.getItem(ELSER_CALL_OUT_DISMISSED_KEY) !== 'true';
+    } catch {
+      return true;
+    }
+  });
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(ELSER_CALL_OUT_DISMISSED_KEY, JSON.stringify(!show));
+    } catch {
+      return;
+    }
+  }, [show]);
+
+  const dismiss = useCallback(() => {
+    setShow(false);
+  });
+
+  return { dismiss, dismissable, show };
+};
+
+export const ELSERCallOut: React.FC<ELSERCallOutProps> = (props) => {
+  const { dismiss, dismissable, show } = useELSERCallOutData(props);
+
+  if (!show) return null;
+
+  return (
+    <EuiPanel color="success">
+      <EuiFlexGroup direction="column" gutterSize="s">
+        <EuiFlexGroup direction="row" gutterSize="s" alignItems="center">
+          <EuiFlexItem grow={false}>
+            <EuiBadge color="success">
+              <FormattedMessage
+                id="xpack.enterpriseSearch.content.index.pipelines.elserCallOut.titleBadge"
+                defaultMessage="New"
+              />
+            </EuiBadge>
+          </EuiFlexItem>
+          <EuiFlexItem grow>
+            <EuiTitle color="text" size="xs">
+              <h4>
+                <FormattedMessage
+                  id="xpack.enterpriseSearch.content.index.pipelines.elserCallOut.title"
+                  defaultMessage="Improve your results with ELSER"
+                />
+              </h4>
+            </EuiTitle>
+          </EuiFlexItem>
+          {dismissable && (
+            <EuiFlexItem grow={false}>
+              <EuiButtonIcon
+                aria-label={i18n.translate(
+                  'xpack.enterpriseSearch.content.index.pipelines.elserCallOut.dismissButton',
+                  { defaultMessage: 'Dismiss ELSER call out' }
+                )}
+                iconType="cross"
+                onClick={dismiss}
+              />
+            </EuiFlexItem>
+          )}
+        </EuiFlexGroup>
+        <EuiFlexGroup direction="column">
+          <EuiText>
+            <FormattedHTMLMessage
+              id="xpack.enterpriseSearch.content.index.pipelines.elserCallOut.body"
+              defaultMessage="ELSER (Elastic Learned Sparse EncodeR) is our <strong>new trained machine learning model</strong> designed to efficiently utilize context in natural language queries. Usage of this model provides better results than BM25 without further training on your data."
+              tagName="p"
+            />
+          </EuiText>
+        </EuiFlexGroup>
+      </EuiFlexGroup>
+    </EuiPanel>
+  );
+};

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/elser_callout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/elser_callout.tsx
@@ -43,7 +43,7 @@ export const useELSERCallOutData = ({
   const { supportedMLModels } = useValues(MLInferenceLogic);
 
   const doesNotHaveELSERModel = useMemo(() => {
-    return supportedMLModels.every((m) => m.model_type !== TEXT_EXPANSION_TYPE);
+    return !supportedMLModels.some((m) => m.model_type === TEXT_EXPANSION_TYPE);
   }, [supportedMLModels]);
 
   const [show, setShow] = useState<boolean>(() => {

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/text_expansion_callout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/text_expansion_callout.tsx
@@ -24,24 +24,25 @@ import { FormattedMessage, FormattedHTMLMessage } from '@kbn/i18n-react';
 
 import { MLInferenceLogic } from './ml_inference_logic';
 
-export interface ELSERCallOutState {
+export interface TextExpansionCallOutState {
   dismiss: () => void;
   dismissable: boolean;
   show: boolean;
 }
 
-export interface ELSERCallOutProps {
+export interface TextExpansionCallOutProps {
   dismissable?: boolean;
 }
 
-export const ELSER_CALL_OUT_DISMISSED_KEY = 'enterprise-search-elser-callout-dismissed';
+export const TEXT_EXPANSION_CALL_OUT_DISMISSED_KEY =
+  'enterprise-search-text-expansion-callout-dismissed';
 
-export const useELSERCallOutData = ({
+export const useTextExpansionCallOutData = ({
   dismissable = false,
-}: ELSERCallOutProps): ELSERCallOutState => {
+}: TextExpansionCallOutProps): TextExpansionCallOutState => {
   const { supportedMLModels } = useValues(MLInferenceLogic);
 
-  const doesNotHaveELSERModel = useMemo(() => {
+  const doesNotHaveTextExpansionModel = useMemo(() => {
     return !supportedMLModels.some((m) => m.inference_config?.text_expansion);
   }, [supportedMLModels]);
 
@@ -49,7 +50,7 @@ export const useELSERCallOutData = ({
     if (!dismissable) return true;
 
     try {
-      return localStorage.getItem(ELSER_CALL_OUT_DISMISSED_KEY) !== 'true';
+      return localStorage.getItem(TEXT_EXPANSION_CALL_OUT_DISMISSED_KEY) !== 'true';
     } catch {
       return true;
     }
@@ -57,7 +58,7 @@ export const useELSERCallOutData = ({
 
   useEffect(() => {
     try {
-      localStorage.setItem(ELSER_CALL_OUT_DISMISSED_KEY, JSON.stringify(!show));
+      localStorage.setItem(TEXT_EXPANSION_CALL_OUT_DISMISSED_KEY, JSON.stringify(!show));
     } catch {
       return;
     }
@@ -67,11 +68,11 @@ export const useELSERCallOutData = ({
     setShow(false);
   }, []);
 
-  return { dismiss, dismissable, show: doesNotHaveELSERModel && show };
+  return { dismiss, dismissable, show: doesNotHaveTextExpansionModel && show };
 };
 
-export const ELSERCallOut: React.FC<ELSERCallOutProps> = (props) => {
-  const { dismiss, dismissable, show } = useELSERCallOutData(props);
+export const TextExpansionCallOut: React.FC<TextExpansionCallOutProps> = (props) => {
+  const { dismiss, dismissable, show } = useTextExpansionCallOutData(props);
 
   if (!show) return null;
 
@@ -82,7 +83,7 @@ export const ELSERCallOut: React.FC<ELSERCallOutProps> = (props) => {
           <EuiFlexItem grow={false}>
             <EuiBadge color="success">
               <FormattedMessage
-                id="xpack.enterpriseSearch.content.index.pipelines.elserCallOut.titleBadge"
+                id="xpack.enterpriseSearch.content.index.pipelines.textExpansionCallOut.titleBadge"
                 defaultMessage="New"
               />
             </EuiBadge>
@@ -92,7 +93,7 @@ export const ELSERCallOut: React.FC<ELSERCallOutProps> = (props) => {
               <h4>
                 <EuiText color="text">
                   <FormattedMessage
-                    id="xpack.enterpriseSearch.content.index.pipelines.elserCallOut.title"
+                    id="xpack.enterpriseSearch.content.index.pipelines.textExpansionCallOut.title"
                     defaultMessage="Improve your results with ELSER"
                   />
                 </EuiText>
@@ -103,7 +104,7 @@ export const ELSERCallOut: React.FC<ELSERCallOutProps> = (props) => {
             <EuiFlexItem grow={false}>
               <EuiButtonIcon
                 aria-label={i18n.translate(
-                  'xpack.enterpriseSearch.content.index.pipelines.elserCallOut.dismissButton',
+                  'xpack.enterpriseSearch.content.index.pipelines.textExpansionCallOut.dismissButton',
                   { defaultMessage: 'Dismiss ELSER call out' }
                 )}
                 iconType="cross"
@@ -115,14 +116,14 @@ export const ELSERCallOut: React.FC<ELSERCallOutProps> = (props) => {
         <EuiFlexGroup direction="column">
           <EuiText>
             <FormattedHTMLMessage
-              id="xpack.enterpriseSearch.content.index.pipelines.elserCallOut.body"
+              id="xpack.enterpriseSearch.content.index.pipelines.textExpansionCallOut.body"
               defaultMessage="ELSER (Elastic Learned Sparse EncodeR) is our <strong>new trained machine learning model</strong> designed to efficiently utilize context in natural language queries. Usage of this model provides better results than BM25 without further training on your data."
               tagName="p"
             />
           </EuiText>
           <EuiLink target="_blank" href="#">
             <FormattedMessage
-              id="xpack.enterpriseSearch.content.index.pipelines.elserCallOut.learnMoreLink"
+              id="xpack.enterpriseSearch.content.index.pipelines.textExpansionCallOut.learnMoreLink"
               defaultMessage="Learn more"
             />
           </EuiLink>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/text_expansion_callout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/text_expansion_callout.tsx
@@ -22,6 +22,8 @@ import {
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage, FormattedHTMLMessage } from '@kbn/i18n-react';
 
+import { docLinks } from '../../../../../shared/doc_links';
+
 import { MLInferenceLogic } from './ml_inference_logic';
 
 export interface TextExpansionCallOutState {
@@ -121,7 +123,7 @@ export const TextExpansionCallOut: React.FC<TextExpansionCallOutProps> = (props)
               tagName="p"
             />
           </EuiText>
-          <EuiLink target="_blank" href="#">
+          <EuiLink target="_blank" href={docLinks.elser}>
             <FormattedMessage
               id="xpack.enterpriseSearch.content.index.pipelines.textExpansionCallOut.learnMoreLink"
               defaultMessage="Learn more"

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/text_expansion_callout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/text_expansion_callout.tsx
@@ -119,7 +119,7 @@ export const TextExpansionCallOut: React.FC<TextExpansionCallOutProps> = (props)
           <EuiText>
             <FormattedHTMLMessage
               id="xpack.enterpriseSearch.content.index.pipelines.textExpansionCallOut.body"
-              defaultMessage="ELSER (Elastic Learned Sparse EncodeR) is our <strong>new trained machine learning model</strong> designed to efficiently utilize context in natural language queries. Usage of this model provides better results than BM25 without further training on your data."
+              defaultMessage="ELSER (Elastic Learned Sparse EncodeR) is our <strong>new trained machine learning model</strong> designed to efficiently use context in natural language queries. This model delivers better results than BM25 without further training on your data."
               tagName="p"
             />
           </EuiText>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference_pipeline_processors_card.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference_pipeline_processors_card.tsx
@@ -16,6 +16,7 @@ import { IndexNameLogic } from '../index_name_logic';
 
 import { InferencePipelineCard } from './inference_pipeline_card';
 import { AddMLInferencePipelineButton } from './ml_inference/add_ml_inference_button';
+import { ELSERCallOut } from './ml_inference/elser_callout';
 import { PipelinesLogic } from './pipelines_logic';
 
 export const MlInferencePipelineProcessorsCard: React.FC = () => {
@@ -29,6 +30,7 @@ export const MlInferencePipelineProcessorsCard: React.FC = () => {
 
   return (
     <EuiFlexGroup direction="column" gutterSize="s">
+      <ELSERCallOut dismissable />
       <EuiFlexItem>
         <AddMLInferencePipelineButton onClick={() => openAddMlInferencePipelineModal()} />
       </EuiFlexItem>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference_pipeline_processors_card.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference_pipeline_processors_card.tsx
@@ -16,7 +16,7 @@ import { IndexNameLogic } from '../index_name_logic';
 
 import { InferencePipelineCard } from './inference_pipeline_card';
 import { AddMLInferencePipelineButton } from './ml_inference/add_ml_inference_button';
-import { ELSERCallOut } from './ml_inference/elser_callout';
+import { TextExpansionCallOut } from './ml_inference/text_expansion_callout';
 import { PipelinesLogic } from './pipelines_logic';
 
 export const MlInferencePipelineProcessorsCard: React.FC = () => {
@@ -30,7 +30,7 @@ export const MlInferencePipelineProcessorsCard: React.FC = () => {
 
   return (
     <EuiFlexGroup direction="column" gutterSize="s">
-      <ELSERCallOut dismissable />
+      <TextExpansionCallOut dismissable />
       <EuiFlexItem>
         <AddMLInferencePipelineButton onClick={() => openAddMlInferencePipelineModal()} />
       </EuiFlexItem>

--- a/x-pack/plugins/enterprise_search/public/applications/shared/doc_links/doc_links.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/doc_links/doc_links.ts
@@ -72,6 +72,7 @@ class DocLinks {
   public elasticsearchGettingStarted: string;
   public elasticsearchMapping: string;
   public elasticsearchSecureCluster: string;
+  public elser: string;
   public enterpriseSearchConfig: string;
   public enterpriseSearchEngines: string;
   public enterpriseSearchMailService: string;
@@ -190,6 +191,7 @@ class DocLinks {
     this.elasticsearchGettingStarted = '';
     this.elasticsearchMapping = '';
     this.elasticsearchSecureCluster = '';
+    this.elser = '';
     this.enterpriseSearchConfig = '';
     this.enterpriseSearchEngines = '';
     this.enterpriseSearchMailService = '';
@@ -309,6 +311,7 @@ class DocLinks {
     this.elasticsearchGettingStarted = docLinks.links.elasticsearch.gettingStarted;
     this.elasticsearchMapping = docLinks.links.elasticsearch.mapping;
     this.elasticsearchSecureCluster = docLinks.links.elasticsearch.secureCluster;
+    this.elser = docLinks.links.enterpriseSearch.elser;
     this.enterpriseSearchConfig = docLinks.links.enterpriseSearch.configuration;
     this.enterpriseSearchEngines = docLinks.links.enterpriseSearch.engines;
     this.enterpriseSearchMailService = docLinks.links.enterpriseSearch.mailService;


### PR DESCRIPTION
## Summary

- adds (optionally) dismissable call out for new ELSER model
- includes ELSER call out as a dismissable call out in the ml inference pipeline card
- includes ELSER call out as a non-dismissable call out in the add inference pipeline fly out
- only shows the ELSER call out if `text_expansion` isn't an option yet

<details>
<summary>🖼️ Screenshots</summary>

![Screen Shot 2023-04-11 at 09 22 37](https://user-images.githubusercontent.com/1699281/231176400-3bdc39b9-b200-4638-b9f4-4b98316aa73b.png)

![Screen Shot 2023-04-11 at 09 22 41](https://user-images.githubusercontent.com/1699281/231176415-b4e433bb-6023-41b1-8b7c-b93a012f2d88.png)


</details>

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)
