### PR TITLE
[Dashboard] Fix unsaved changes badge React error

### DIFF
--- a/src/plugins/navigation/public/top_nav_menu/top_nav_menu.tsx
+++ b/src/plugins/navigation/public/top_nav_menu/top_nav_menu.tsx
@@ -82,12 +82,12 @@ export function TopNavMenu<QT extends AggregateQuery | Query = Query>(
   }
 
   function createBadge({ badgeText, toolTipProps, ...badgeProps }: Badge, i: number): ReactElement {
-    const badge = (
-      <EuiBadge key={`nav-menu-badge-${i}`} {...badgeProps}>
-        {badgeText}
-      </EuiBadge>
+    const badge = <EuiBadge {...badgeProps}>{badgeText}</EuiBadge>;
+    return (
+      <span key={`nav-menu-badge-${i}`}>
+        {toolTipProps ? <EuiToolTip {...toolTipProps}>{badge}</EuiToolTip> : badge}
+      </span>
     );
-    return toolTipProps ? <EuiToolTip {...toolTipProps}>{badge}</EuiToolTip> : badge;
   }
 
   function renderBadges(): ReactElement | null {

--- a/src/plugins/navigation/public/top_nav_menu/top_nav_menu.tsx
+++ b/src/plugins/navigation/public/top_nav_menu/top_nav_menu.tsx
@@ -82,8 +82,8 @@ export function TopNavMenu<QT extends AggregateQuery | Query = Query>(
   }
 
   function createBadge({ badgeText, toolTipProps, ...badgeProps }: Badge, i: number): ReactElement {
-    const Badge = ({ key }: { key?: string }) => (
-      <EuiBadge {...key} {...badgeProps}>
+    const Badge = ({ key, ...rest }: { key?: string }) => (
+      <EuiBadge key={key} tabIndex={0} {...rest} {...badgeProps}>
         {badgeText}
       </EuiBadge>
     );

--- a/src/plugins/navigation/public/top_nav_menu/top_nav_menu.tsx
+++ b/src/plugins/navigation/public/top_nav_menu/top_nav_menu.tsx
@@ -82,11 +82,19 @@ export function TopNavMenu<QT extends AggregateQuery | Query = Query>(
   }
 
   function createBadge({ badgeText, toolTipProps, ...badgeProps }: Badge, i: number): ReactElement {
-    const badge = <EuiBadge {...badgeProps}>{badgeText}</EuiBadge>;
-    return (
-      <span key={`nav-menu-badge-${i}`}>
-        {toolTipProps ? <EuiToolTip {...toolTipProps}>{badge}</EuiToolTip> : badge}
-      </span>
+    const Badge = ({ key }: { key?: string }) => (
+      <EuiBadge {...key} {...badgeProps}>
+        {badgeText}
+      </EuiBadge>
+    );
+
+    const key = `nav-menu-badge-${i}`;
+    return toolTipProps ? (
+      <EuiToolTip key={key} {...toolTipProps}>
+        <Badge />
+      </EuiToolTip>
+    ) : (
+      <Badge key={key} />
     );
   }
 


### PR DESCRIPTION
## Summary

### Before

Since adding the tooltip to the unsaved changes badge in https://github.com/elastic/kibana/pull/154253, React was throwing an error to the console because the element in the top nav no longer had a unique key:

https://user-images.githubusercontent.com/8698078/230927494-7cc931f8-68c6-4904-b99e-99b1b2872f94.mov

<br>

![image](https://user-images.githubusercontent.com/8698078/230925422-32f8ea9d-8c22-470e-a94e-0aa9eda0b4de.png)


### After

This PR fixes this by adding the key **to the tooltip** if the badge has one; if it doesn't have a tooltip, then the key is added directly to the `EuiBadge` as expected. It also ensures that the tooltip has the proper a11y support (cc @elastic/kibana-accessibility) by adding the badge to the tab order and using the <a href="https://github.com/elastic/eui/blob/main/wiki/component-design.md#pass-through-props">pass-through-props</a> to ensure that the tooltip shows up on focus:


https://user-images.githubusercontent.com/8698078/230929396-5a423c18-4a5f-410c-a3d3-9005022f8060.mov



### Checklist

- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)



### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
