### PR TITLE
Enterprise Search: remove search applications feature flag

### DIFF
--- a/x-pack/plugins/enterprise_search/common/__mocks__/initial_app_data.ts
+++ b/x-pack/plugins/enterprise_search/common/__mocks__/initial_app_data.ts
@@ -29,14 +29,12 @@ export const DEFAULT_INITIAL_APP_DATA = {
   },
   access: {
     hasAppSearchAccess: true,
-    hasSearchEnginesAccess: false,
     hasWorkplaceSearchAccess: true,
   },
   features: {
     hasConnectors: true,
     hasDefaultIngestPipeline: true,
     hasNativeConnectors: true,
-    hasSearchApplications: false,
     hasWebCrawler: true,
   },
   appSearch: {

--- a/x-pack/plugins/enterprise_search/common/constants.ts
+++ b/x-pack/plugins/enterprise_search/common/constants.ts
@@ -167,6 +167,5 @@ export const DEFAULT_PRODUCT_FEATURES: ProductFeatures = {
   hasConnectors: true,
   hasDefaultIngestPipeline: true,
   hasNativeConnectors: true,
-  hasSearchApplications: false,
   hasWebCrawler: true,
 };

--- a/x-pack/plugins/enterprise_search/common/types/index.ts
+++ b/x-pack/plugins/enterprise_search/common/types/index.ts
@@ -33,7 +33,6 @@ export interface ConfiguredLimits {
 
 export interface ProductAccess {
   hasAppSearchAccess: boolean;
-  hasSearchEnginesAccess: boolean;
   hasWorkplaceSearchAccess: boolean;
 }
 
@@ -41,7 +40,6 @@ export interface ProductFeatures {
   hasConnectors: boolean;
   hasDefaultIngestPipeline: boolean;
   hasNativeConnectors: boolean;
-  hasSearchApplications: boolean;
   hasWebCrawler: boolean;
 }
 

--- a/x-pack/plugins/enterprise_search/public/applications/__mocks__/kea_logic/kibana_logic.mock.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/__mocks__/kea_logic/kibana_logic.mock.ts
@@ -44,12 +44,10 @@ export const mockKibanaValues = {
   navigateToUrl: jest.fn(),
   productAccess: {
     hasAppSearchAccess: true,
-    hasSearchEnginesAccess: false,
     hasWorkplaceSearchAccess: true,
   },
   productFeatures: {
     hasNativeConnectors: true,
-    hasSearchApplications: false,
     hasWebCrawler: true,
   },
   uiSettings: uiSettingsServiceMock.createStartContract(),

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engines/engines_router.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engines/engines_router.tsx
@@ -8,11 +8,8 @@
 import React from 'react';
 import { Switch } from 'react-router-dom';
 
-import { useValues } from 'kea';
-
 import { Route } from '@kbn/shared-ux-router';
 
-import { KibanaLogic } from '../../../shared/kibana';
 import { ENGINES_PATH, ENGINE_PATH } from '../../routes';
 
 import { EngineRouter } from '../engine/engine_router';
@@ -21,17 +18,6 @@ import { NotFound } from '../not_found';
 import { EnginesList } from './engines_list';
 
 export const EnginesRouter: React.FC = () => {
-  const { productAccess } = useValues(KibanaLogic);
-  const enginesSectionEnabled = productAccess.hasSearchEnginesAccess;
-  if (!enginesSectionEnabled) {
-    return (
-      <Switch>
-        <Route>
-          <NotFound />
-        </Route>
-      </Switch>
-    );
-  }
   return (
     <Switch>
       <Route exact path={ENGINES_PATH}>

--- a/x-pack/plugins/enterprise_search/public/applications/index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/index.tsx
@@ -46,7 +46,6 @@ export const renderApp = (
 
   const noProductAccess: ProductAccess = {
     hasAppSearchAccess: false,
-    hasSearchEnginesAccess: false,
     hasWorkplaceSearchAccess: false,
   };
   const productAccess = data.access || noProductAccess;

--- a/x-pack/plugins/enterprise_search/public/applications/shared/layout/nav.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/layout/nav.test.tsx
@@ -24,7 +24,6 @@ import {
 
 const DEFAULT_PRODUCT_ACCESS: ProductAccess = {
   hasAppSearchAccess: true,
-  hasSearchEnginesAccess: false,
   hasWorkplaceSearchAccess: true,
 };
 
@@ -36,196 +35,6 @@ describe('useEnterpriseSearchContentNav', () => {
 
   it('returns an array of top-level Enterprise Search nav items', () => {
     const fullProductAccess: ProductAccess = DEFAULT_PRODUCT_ACCESS;
-    setMockValues({ productAccess: fullProductAccess, productFeatures: DEFAULT_PRODUCT_FEATURES });
-
-    expect(useEnterpriseSearchNav()).toEqual([
-      {
-        href: '/app/enterprise_search/overview',
-        id: 'es_overview',
-        name: 'Overview',
-      },
-      {
-        id: 'content',
-        items: [
-          {
-            href: '/app/enterprise_search/content/search_indices',
-            id: 'search_indices',
-            name: 'Indices',
-          },
-          {
-            href: '/app/enterprise_search/content/settings',
-            id: 'settings',
-            items: undefined,
-            name: 'Settings',
-          },
-        ],
-        name: 'Content',
-      },
-      {
-        id: 'enterpriseSearchAnalytics',
-        items: [
-          {
-            href: '/app/enterprise_search/analytics',
-            id: 'analytics_collections',
-            name: 'Collections',
-          },
-        ],
-        name: 'Behavioral Analytics',
-      },
-      {
-        id: 'search',
-        items: [
-          {
-            href: '/app/enterprise_search/elasticsearch',
-            id: 'elasticsearch',
-            name: 'Elasticsearch',
-          },
-          {
-            href: '/app/enterprise_search/search_experiences',
-            id: 'searchExperiences',
-            name: 'Search Experiences',
-          },
-          {
-            href: '/app/enterprise_search/app_search',
-            id: 'app_search',
-            name: 'App Search',
-          },
-          {
-            href: '/app/enterprise_search/workplace_search',
-            id: 'workplace_search',
-            name: 'Workplace Search',
-          },
-        ],
-        name: 'Search',
-      },
-    ]);
-  });
-
-  it('excludes legacy products when the user has no access to them', () => {
-    const noProductAccess: ProductAccess = {
-      ...DEFAULT_PRODUCT_ACCESS,
-      hasAppSearchAccess: false,
-      hasWorkplaceSearchAccess: false,
-    };
-
-    setMockValues({ productAccess: noProductAccess, productFeatures: DEFAULT_PRODUCT_FEATURES });
-    mockKibanaValues.uiSettings.get.mockReturnValue(false);
-
-    const esNav = useEnterpriseSearchNav();
-    const searchNav = esNav?.find((item) => item.id === 'search');
-    expect(searchNav).not.toBeUndefined();
-    expect(searchNav).toEqual({
-      id: 'search',
-      items: [
-        {
-          href: '/app/enterprise_search/elasticsearch',
-          id: 'elasticsearch',
-          name: 'Elasticsearch',
-        },
-        {
-          href: '/app/enterprise_search/search_experiences',
-          id: 'searchExperiences',
-          name: 'Search Experiences',
-        },
-      ],
-      name: 'Search',
-    });
-  });
-
-  it('excludes App Search when the user has no access to it', () => {
-    const workplaceSearchProductAccess: ProductAccess = {
-      ...DEFAULT_PRODUCT_ACCESS,
-      hasAppSearchAccess: false,
-      hasWorkplaceSearchAccess: true,
-    };
-
-    setMockValues({
-      productAccess: workplaceSearchProductAccess,
-      productFeatures: DEFAULT_PRODUCT_FEATURES,
-    });
-
-    const esNav = useEnterpriseSearchNav();
-    const searchNav = esNav?.find((item) => item.id === 'search');
-    expect(searchNav).not.toBeUndefined();
-    expect(searchNav).toEqual({
-      id: 'search',
-      items: [
-        {
-          href: '/app/enterprise_search/elasticsearch',
-          id: 'elasticsearch',
-          name: 'Elasticsearch',
-        },
-        {
-          href: '/app/enterprise_search/search_experiences',
-          id: 'searchExperiences',
-          name: 'Search Experiences',
-        },
-        {
-          href: '/app/enterprise_search/workplace_search',
-          id: 'workplace_search',
-          name: 'Workplace Search',
-        },
-      ],
-      name: 'Search',
-    });
-  });
-
-  it('excludes Workplace Search when the user has no access to it', () => {
-    const appSearchProductAccess: ProductAccess = {
-      ...DEFAULT_PRODUCT_ACCESS,
-      hasWorkplaceSearchAccess: false,
-    };
-
-    setMockValues({
-      productAccess: appSearchProductAccess,
-      productFeatures: DEFAULT_PRODUCT_FEATURES,
-    });
-
-    const esNav = useEnterpriseSearchNav();
-    const searchNav = esNav?.find((item) => item.id === 'search');
-    expect(searchNav).not.toBeUndefined();
-    expect(searchNav).toEqual({
-      id: 'search',
-      items: [
-        {
-          href: '/app/enterprise_search/elasticsearch',
-          id: 'elasticsearch',
-          name: 'Elasticsearch',
-        },
-        {
-          href: '/app/enterprise_search/search_experiences',
-          id: 'searchExperiences',
-          name: 'Search Experiences',
-        },
-        {
-          href: '/app/enterprise_search/app_search',
-          id: 'app_search',
-          name: 'App Search',
-        },
-      ],
-      name: 'Search',
-    });
-  });
-
-  it('excludes engines when feature flag is off', () => {
-    const fullProductAccess: ProductAccess = DEFAULT_PRODUCT_ACCESS;
-    setMockValues({ productAccess: fullProductAccess, productFeatures: DEFAULT_PRODUCT_FEATURES });
-
-    const esNav = useEnterpriseSearchNav();
-    expect(esNav?.find((item) => item.id === 'enginesSearch')).toBeUndefined();
-  });
-});
-
-describe('useEnterpriseSearchContentNav Engines feature flag', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
-  it('returns an array of top-level Enterprise Search nav items', () => {
-    const fullProductAccess: ProductAccess = {
-      ...DEFAULT_PRODUCT_ACCESS,
-      hasSearchEnginesAccess: true,
-    };
     setMockValues({ productAccess: fullProductAccess, productFeatures: DEFAULT_PRODUCT_FEATURES });
 
     expect(useEnterpriseSearchNav()).toEqual([
@@ -302,25 +111,32 @@ describe('useEnterpriseSearchContentNav Engines feature flag', () => {
     ]);
   });
 
-  it('excludes standalone experiences when the user has no access to them', () => {
-    const fullProductAccess: ProductAccess = {
+  it('excludes legacy products when the user has no access to them', () => {
+    const noProductAccess: ProductAccess = {
       ...DEFAULT_PRODUCT_ACCESS,
       hasAppSearchAccess: false,
-      hasSearchEnginesAccess: true,
       hasWorkplaceSearchAccess: false,
     };
-    setMockValues({ productAccess: fullProductAccess, productFeatures: DEFAULT_PRODUCT_FEATURES });
+
+    setMockValues({ productAccess: noProductAccess, productFeatures: DEFAULT_PRODUCT_FEATURES });
+    mockKibanaValues.uiSettings.get.mockReturnValue(false);
 
     const esNav = useEnterpriseSearchNav();
-    expect(esNav?.find((item) => item.id === 'standaloneExperiences')).toBeUndefined();
+    const standAloneNav = esNav?.find((item) => item.id === 'standaloneExperiences');
+    expect(standAloneNav).toBeUndefined();
   });
+
   it('excludes App Search when the user has no access to it', () => {
-    const fullProductAccess: ProductAccess = {
+    const workplaceSearchProductAccess: ProductAccess = {
       ...DEFAULT_PRODUCT_ACCESS,
       hasAppSearchAccess: false,
-      hasSearchEnginesAccess: true,
+      hasWorkplaceSearchAccess: true,
     };
-    setMockValues({ productAccess: fullProductAccess, productFeatures: DEFAULT_PRODUCT_FEATURES });
+
+    setMockValues({
+      productAccess: workplaceSearchProductAccess,
+      productFeatures: DEFAULT_PRODUCT_FEATURES,
+    });
 
     const esNav = useEnterpriseSearchNav();
     const standAloneNav = esNav?.find((item) => item.id === 'standaloneExperiences');
@@ -337,14 +153,17 @@ describe('useEnterpriseSearchContentNav Engines feature flag', () => {
       name: 'Standalone Experiences',
     });
   });
+
   it('excludes Workplace Search when the user has no access to it', () => {
-    const fullProductAccess: ProductAccess = {
+    const appSearchProductAccess: ProductAccess = {
       ...DEFAULT_PRODUCT_ACCESS,
-      hasAppSearchAccess: true,
-      hasSearchEnginesAccess: true,
       hasWorkplaceSearchAccess: false,
     };
-    setMockValues({ productAccess: fullProductAccess, productFeatures: DEFAULT_PRODUCT_FEATURES });
+
+    setMockValues({
+      productAccess: appSearchProductAccess,
+      productFeatures: DEFAULT_PRODUCT_FEATURES,
+    });
 
     const esNav = useEnterpriseSearchNav();
     const standAloneNav = esNav?.find((item) => item.id === 'standaloneExperiences');
@@ -367,11 +186,10 @@ describe('useEnterpriseSearchEngineNav', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockKibanaValues.uiSettings.get.mockReturnValue(true);
-    const fullProductAccess: ProductAccess = {
-      ...DEFAULT_PRODUCT_ACCESS,
-      hasSearchEnginesAccess: true,
-    };
-    setMockValues({ productAccess: fullProductAccess, productFeatures: DEFAULT_PRODUCT_FEATURES });
+    setMockValues({
+      productAccess: DEFAULT_PRODUCT_ACCESS,
+      productFeatures: DEFAULT_PRODUCT_FEATURES,
+    });
   });
 
   it('returns an array of top-level Enterprise Search nav items', () => {
@@ -556,6 +374,27 @@ describe('useEnterpriseSearchAnalyticsNav', () => {
       name: 'Content',
     },
     {
+      id: 'enginesSearch',
+      name: 'Search',
+      items: [
+        {
+          href: '/app/enterprise_search/elasticsearch',
+          id: 'elasticsearch',
+          name: 'Elasticsearch',
+        },
+        {
+          id: 'enterpriseSearchEngines',
+          name: 'Engines',
+          href: '/app/enterprise_search/content/engines',
+        },
+        {
+          id: 'searchExperiences',
+          name: 'Search Experiences',
+          href: '/app/enterprise_search/search_experiences',
+        },
+      ],
+    },
+    {
       id: 'enterpriseSearchAnalytics',
       items: [
         {
@@ -567,18 +406,8 @@ describe('useEnterpriseSearchAnalyticsNav', () => {
       name: 'Behavioral Analytics',
     },
     {
-      id: 'search',
+      id: 'standaloneExperiences',
       items: [
-        {
-          href: '/app/enterprise_search/elasticsearch',
-          id: 'elasticsearch',
-          name: 'Elasticsearch',
-        },
-        {
-          href: '/app/enterprise_search/search_experiences',
-          id: 'searchExperiences',
-          name: 'Search Experiences',
-        },
         {
           href: '/app/enterprise_search/app_search',
           id: 'app_search',
@@ -590,7 +419,7 @@ describe('useEnterpriseSearchAnalyticsNav', () => {
           name: 'Workplace Search',
         },
       ],
-      name: 'Search',
+      name: 'Standalone Experiences',
     },
   ];
 
@@ -615,83 +444,41 @@ describe('useEnterpriseSearchAnalyticsNav', () => {
       integration: '/integration-path',
       overview: '/overview-path',
     });
-    expect(navItems).toEqual([
-      {
-        href: '/app/enterprise_search/overview',
-        id: 'es_overview',
-        name: 'Overview',
-      },
-      {
-        id: 'content',
-        items: [
-          {
-            href: '/app/enterprise_search/content/search_indices',
-            id: 'search_indices',
-            name: 'Indices',
-          },
-        ],
-        name: 'Content',
-      },
-      {
-        id: 'enterpriseSearchAnalytics',
-        items: [
-          {
-            href: '/app/enterprise_search/analytics',
-            id: 'analytics_collections',
-            items: [
-              {
-                id: 'analytics_collections',
-                items: [
-                  {
-                    href: '/app/enterprise_search/analytics/overview-path',
-                    id: 'enterpriseSearchEngineOverview',
-                    name: 'Overview',
-                  },
-                  {
-                    href: '/app/enterprise_search/analytics/explorer-path',
-                    id: 'enterpriseSearchEngineIndices',
-                    name: 'Explorer',
-                  },
-                  {
-                    href: '/app/enterprise_search/analytics/integration-path',
-                    id: 'enterpriseSearchEngineSchema',
-                    name: 'Integration',
-                  },
-                ],
-                name: 'my-test-collection',
-              },
-            ],
-            name: 'Collections',
-          },
-        ],
-        name: 'Behavioral Analytics',
-      },
-      {
-        id: 'search',
-        items: [
-          {
-            href: '/app/enterprise_search/elasticsearch',
-            id: 'elasticsearch',
-            name: 'Elasticsearch',
-          },
-          {
-            href: '/app/enterprise_search/search_experiences',
-            id: 'searchExperiences',
-            name: 'Search Experiences',
-          },
-          {
-            href: '/app/enterprise_search/app_search',
-            id: 'app_search',
-            name: 'App Search',
-          },
-          {
-            href: '/app/enterprise_search/workplace_search',
-            id: 'workplace_search',
-            name: 'Workplace Search',
-          },
-        ],
-        name: 'Search',
-      },
-    ]);
+    const analyticsNav = navItems?.find((item) => item.id === 'enterpriseSearchAnalytics');
+    expect(analyticsNav).not.toBeUndefined();
+    expect(analyticsNav).toEqual({
+      id: 'enterpriseSearchAnalytics',
+      items: [
+        {
+          href: '/app/enterprise_search/analytics',
+          id: 'analytics_collections',
+          items: [
+            {
+              id: 'analytics_collections',
+              items: [
+                {
+                  href: '/app/enterprise_search/analytics/overview-path',
+                  id: 'enterpriseSearchEngineOverview',
+                  name: 'Overview',
+                },
+                {
+                  href: '/app/enterprise_search/analytics/explorer-path',
+                  id: 'enterpriseSearchEngineIndices',
+                  name: 'Explorer',
+                },
+                {
+                  href: '/app/enterprise_search/analytics/integration-path',
+                  id: 'enterpriseSearchEngineSchema',
+                  name: 'Integration',
+                },
+              ],
+              name: 'my-test-collection',
+            },
+          ],
+          name: 'Collections',
+        },
+      ],
+      name: 'Behavioral Analytics',
+    });
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/shared/layout/nav.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/layout/nav.tsx
@@ -32,8 +32,6 @@ import { generateNavLink } from './nav_link_helpers';
 export const useEnterpriseSearchNav = () => {
   const { productAccess, productFeatures } = useValues(KibanaLogic);
 
-  const enginesSectionEnabled = productAccess.hasSearchEnginesAccess;
-
   const navItems: Array<EuiSideNavItemType<unknown>> = [
     {
       id: 'es_overview',
@@ -80,6 +78,44 @@ export const useEnterpriseSearchNav = () => {
       }),
     },
     {
+      id: 'enginesSearch',
+      items: [
+        {
+          id: 'elasticsearch',
+          name: i18n.translate('xpack.enterpriseSearch.nav.elasticsearchTitle', {
+            defaultMessage: 'Elasticsearch',
+          }),
+          ...generateNavLink({
+            shouldNotCreateHref: true,
+            to: ELASTICSEARCH_PLUGIN.URL,
+          }),
+        },
+        {
+          id: 'enterpriseSearchEngines',
+          name: i18n.translate('xpack.enterpriseSearch.nav.enginesTitle', {
+            defaultMessage: 'Engines',
+          }),
+          ...generateNavLink({
+            shouldNotCreateHref: true,
+            to: ENTERPRISE_SEARCH_CONTENT_PLUGIN.URL + ENGINES_PATH,
+          }),
+        },
+        {
+          id: 'searchExperiences',
+          name: i18n.translate('xpack.enterpriseSearch.nav.searchExperiencesTitle', {
+            defaultMessage: 'Search Experiences',
+          }),
+          ...generateNavLink({
+            shouldNotCreateHref: true,
+            to: SEARCH_EXPERIENCES_PLUGIN.URL,
+          }),
+        },
+      ],
+      name: i18n.translate('xpack.enterpriseSearch.nav.searchTitle', {
+        defaultMessage: 'Search',
+      }),
+    },
+    {
       id: 'enterpriseSearchAnalytics',
       items: [
         {
@@ -97,149 +133,47 @@ export const useEnterpriseSearchNav = () => {
         defaultMessage: 'Behavioral Analytics',
       }),
     },
-    {
-      id: 'search',
-      items: [
-        {
-          id: 'elasticsearch',
-          name: i18n.translate('xpack.enterpriseSearch.nav.elasticsearchTitle', {
-            defaultMessage: 'Elasticsearch',
-          }),
-          ...generateNavLink({
-            shouldNotCreateHref: true,
-            to: ELASTICSEARCH_PLUGIN.URL,
-          }),
-        },
-        {
-          id: 'searchExperiences',
-          name: i18n.translate('xpack.enterpriseSearch.nav.searchExperiencesTitle', {
-            defaultMessage: 'Search Experiences',
-          }),
-          ...generateNavLink({
-            shouldNotCreateHref: true,
-            to: SEARCH_EXPERIENCES_PLUGIN.URL,
-          }),
-        },
-        ...(productAccess.hasAppSearchAccess
-          ? [
-              {
-                id: 'app_search',
-                name: i18n.translate('xpack.enterpriseSearch.nav.appSearchTitle', {
-                  defaultMessage: 'App Search',
-                }),
-                ...generateNavLink({
-                  shouldNotCreateHref: true,
-                  to: APP_SEARCH_PLUGIN.URL,
-                }),
-              },
-            ]
-          : []),
-        ...(productAccess.hasWorkplaceSearchAccess
-          ? [
-              {
-                id: 'workplace_search',
-                name: i18n.translate('xpack.enterpriseSearch.nav.workplaceSearchTitle', {
-                  defaultMessage: 'Workplace Search',
-                }),
-                ...generateNavLink({
-                  shouldNotCreateHref: true,
-                  to: WORKPLACE_SEARCH_PLUGIN.URL,
-                }),
-              },
-            ]
-          : []),
-      ],
-      name: i18n.translate('xpack.enterpriseSearch.nav.searchTitle', {
-        defaultMessage: 'Search',
-      }),
-    },
+    ...(productAccess.hasAppSearchAccess || productAccess.hasWorkplaceSearchAccess
+      ? [
+          {
+            id: 'standaloneExperiences',
+            items: [
+              ...(productAccess.hasAppSearchAccess
+                ? [
+                    {
+                      id: 'app_search',
+                      name: i18n.translate('xpack.enterpriseSearch.nav.appSearchTitle', {
+                        defaultMessage: 'App Search',
+                      }),
+                      ...generateNavLink({
+                        shouldNotCreateHref: true,
+                        to: APP_SEARCH_PLUGIN.URL,
+                      }),
+                    },
+                  ]
+                : []),
+              ...(productAccess.hasWorkplaceSearchAccess
+                ? [
+                    {
+                      id: 'workplace_search',
+                      name: i18n.translate('xpack.enterpriseSearch.nav.workplaceSearchTitle', {
+                        defaultMessage: 'Workplace Search',
+                      }),
+                      ...generateNavLink({
+                        shouldNotCreateHref: true,
+                        to: WORKPLACE_SEARCH_PLUGIN.URL,
+                      }),
+                    },
+                  ]
+                : []),
+            ],
+            name: i18n.translate('xpack.enterpriseSearch.nav.standaloneExperiencesTitle', {
+              defaultMessage: 'Standalone Experiences',
+            }),
+          },
+        ]
+      : []),
   ];
-
-  if (enginesSectionEnabled) {
-    return [
-      navItems[0], // Overview
-      navItems[1], // Content
-      {
-        id: 'enginesSearch', // TODO: just search? or wait for that
-        items: [
-          {
-            id: 'elasticsearch',
-            name: i18n.translate('xpack.enterpriseSearch.nav.elasticsearchTitle', {
-              defaultMessage: 'Elasticsearch',
-            }),
-            ...generateNavLink({
-              shouldNotCreateHref: true,
-              to: ELASTICSEARCH_PLUGIN.URL,
-            }),
-          },
-          {
-            id: 'enterpriseSearchEngines',
-            name: i18n.translate('xpack.enterpriseSearch.nav.enginesTitle', {
-              defaultMessage: 'Engines',
-            }),
-            ...generateNavLink({
-              shouldNotCreateHref: true,
-              to: ENTERPRISE_SEARCH_CONTENT_PLUGIN.URL + ENGINES_PATH,
-            }),
-          },
-          {
-            id: 'searchExperiences',
-            name: i18n.translate('xpack.enterpriseSearch.nav.searchExperiencesTitle', {
-              defaultMessage: 'Search Experiences',
-            }),
-            ...generateNavLink({
-              shouldNotCreateHref: true,
-              to: SEARCH_EXPERIENCES_PLUGIN.URL,
-            }),
-          },
-        ],
-        name: i18n.translate('xpack.enterpriseSearch.nav.searchTitle', {
-          defaultMessage: 'Search',
-        }),
-      },
-      navItems[2], // Behavioural Analytics
-      ...(productAccess.hasAppSearchAccess || productAccess.hasWorkplaceSearchAccess
-        ? [
-            {
-              id: 'standaloneExperiences',
-              items: [
-                ...(productAccess.hasAppSearchAccess
-                  ? [
-                      {
-                        id: 'app_search',
-                        name: i18n.translate('xpack.enterpriseSearch.nav.appSearchTitle', {
-                          defaultMessage: 'App Search',
-                        }),
-                        ...generateNavLink({
-                          shouldNotCreateHref: true,
-                          to: APP_SEARCH_PLUGIN.URL,
-                        }),
-                      },
-                    ]
-                  : []),
-                ...(productAccess.hasWorkplaceSearchAccess
-                  ? [
-                      {
-                        id: 'workplace_search',
-                        name: i18n.translate('xpack.enterpriseSearch.nav.workplaceSearchTitle', {
-                          defaultMessage: 'Workplace Search',
-                        }),
-                        ...generateNavLink({
-                          shouldNotCreateHref: true,
-                          to: WORKPLACE_SEARCH_PLUGIN.URL,
-                        }),
-                      },
-                    ]
-                  : []),
-              ],
-              name: i18n.translate('xpack.enterpriseSearch.nav.standaloneExperiencesTitle', {
-                defaultMessage: 'Standalone Experiences',
-              }),
-            },
-          ]
-        : []),
-    ];
-  }
 
   return navItems;
 };

--- a/x-pack/plugins/enterprise_search/server/lib/check_access.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/check_access.test.ts
@@ -62,7 +62,6 @@ describe('checkAccess', () => {
       };
       expect(await checkAccess({ ...mockDependencies, security })).toEqual({
         hasAppSearchAccess: false,
-        hasSearchEnginesAccess: false,
         hasWorkplaceSearchAccess: false,
       });
     });
@@ -75,7 +74,6 @@ describe('checkAccess', () => {
       };
       expect(await checkAccess({ ...mockDependencies, request })).toEqual({
         hasAppSearchAccess: false,
-        hasSearchEnginesAccess: false,
         hasWorkplaceSearchAccess: false,
       });
     });
@@ -86,7 +84,6 @@ describe('checkAccess', () => {
       mockSpaces.spacesService.getActiveSpace.mockResolvedValueOnce(disabledSpace);
       expect(await checkAccess({ ...mockDependencies })).toEqual({
         hasAppSearchAccess: false,
-        hasSearchEnginesAccess: false,
         hasWorkplaceSearchAccess: false,
       });
     });
@@ -100,7 +97,6 @@ describe('checkAccess', () => {
         );
         expect(await checkAccess({ ...mockDependencies })).toEqual({
           hasAppSearchAccess: false,
-          hasSearchEnginesAccess: false,
           hasWorkplaceSearchAccess: false,
         });
       });
@@ -123,7 +119,6 @@ describe('checkAccess', () => {
       it('should not throw', async () => {
         await expect(checkAccess({ ...mockDependencies, spaces: undefined })).resolves.toEqual({
           hasAppSearchAccess: false,
-          hasSearchEnginesAccess: false,
           hasWorkplaceSearchAccess: false,
         });
       });
@@ -151,7 +146,6 @@ describe('checkAccess', () => {
         };
         expect(await checkAccess({ ...mockDependencies, security })).toEqual({
           hasAppSearchAccess: true,
-          hasSearchEnginesAccess: false,
           hasWorkplaceSearchAccess: true,
         });
       });
@@ -167,7 +161,6 @@ describe('checkAccess', () => {
         };
         expect(await checkAccess({ ...mockDependencies, security })).toEqual({
           hasAppSearchAccess: false,
-          hasSearchEnginesAccess: false,
           hasWorkplaceSearchAccess: false,
         });
       });
@@ -189,7 +182,6 @@ describe('checkAccess', () => {
           const config = { host: undefined };
           expect(await checkAccess({ ...mockDependencies, config })).toEqual({
             hasAppSearchAccess: false,
-            hasSearchEnginesAccess: false,
             hasWorkplaceSearchAccess: false,
           });
         });
@@ -200,13 +192,11 @@ describe('checkAccess', () => {
           (callEnterpriseSearchConfigAPI as jest.Mock).mockImplementationOnce(() => ({
             access: {
               hasAppSearchAccess: false,
-              hasSearchEnginesAccess: false,
               hasWorkplaceSearchAccess: true,
             },
           }));
           expect(await checkAccess(mockDependencies)).toEqual({
             hasAppSearchAccess: false,
-            hasSearchEnginesAccess: false,
             hasWorkplaceSearchAccess: true,
           });
         });
@@ -215,7 +205,6 @@ describe('checkAccess', () => {
           (callEnterpriseSearchConfigAPI as jest.Mock).mockImplementationOnce(() => ({}));
           expect(await checkAccess(mockDependencies)).toEqual({
             hasAppSearchAccess: false,
-            hasSearchEnginesAccess: false,
             hasWorkplaceSearchAccess: false,
           });
         });
@@ -227,7 +216,6 @@ describe('checkAccess', () => {
           }));
           expect(await checkAccess(mockDependencies)).toEqual({
             hasAppSearchAccess: false,
-            hasSearchEnginesAccess: false,
             hasWorkplaceSearchAccess: false,
           });
         });

--- a/x-pack/plugins/enterprise_search/server/lib/check_access.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/check_access.ts
@@ -25,12 +25,10 @@ interface CheckAccess {
 
 const ALLOW_ALL_PLUGINS: ProductAccess = {
   hasAppSearchAccess: true,
-  hasSearchEnginesAccess: false, // still false unless Feature Flag explicitly enabled on backend
   hasWorkplaceSearchAccess: true,
 };
 const DENY_ALL_PLUGINS: ProductAccess = {
   hasAppSearchAccess: false,
-  hasSearchEnginesAccess: false,
   hasWorkplaceSearchAccess: false,
 };
 

--- a/x-pack/plugins/enterprise_search/server/lib/enterprise_search_config_api.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/enterprise_search_config_api.test.ts
@@ -72,7 +72,6 @@ describe('callEnterpriseSearchConfigAPI', () => {
       name: 'someuser',
       access: {
         app_search: true,
-        search_engines: true,
         workplace_search: false,
       },
       app_search: {
@@ -126,12 +125,10 @@ describe('callEnterpriseSearchConfigAPI', () => {
       kibanaVersion: '1.0.0',
       access: {
         hasAppSearchAccess: true,
-        hasSearchEnginesAccess: true,
         hasWorkplaceSearchAccess: false,
       },
       features: {
         hasNativeConnectors: true,
-        hasSearchApplications: true,
         hasWebCrawler: true,
       },
       publicUrl: 'http://some.vanity.url',
@@ -145,12 +142,10 @@ describe('callEnterpriseSearchConfigAPI', () => {
       kibanaVersion: '1.0.0',
       access: {
         hasAppSearchAccess: false,
-        hasSearchEnginesAccess: false,
         hasWorkplaceSearchAccess: false,
       },
       features: {
         hasNativeConnectors: true,
-        hasSearchApplications: false,
         hasWebCrawler: true,
       },
       publicUrl: undefined,
@@ -210,7 +205,6 @@ describe('callEnterpriseSearchConfigAPI', () => {
       hasConnectors: false,
       hasDefaultIngestPipeline: false,
       hasNativeConnectors: false,
-      hasSearchApplications: false,
       hasWebCrawler: false,
       host: '',
     };
@@ -218,14 +212,12 @@ describe('callEnterpriseSearchConfigAPI', () => {
     expect(await callEnterpriseSearchConfigAPI({ ...mockDependencies, config })).toEqual({
       access: {
         hasAppSearchAccess: false,
-        hasSearchEnginesAccess: false,
         hasWorkplaceSearchAccess: false,
       },
       features: {
         hasConnectors: false,
         hasDefaultIngestPipeline: false,
         hasNativeConnectors: false,
-        hasSearchApplications: false,
         hasWebCrawler: false,
       },
       kibanaVersion: '1.0.0',

--- a/x-pack/plugins/enterprise_search/server/lib/enterprise_search_config_api.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/enterprise_search_config_api.ts
@@ -48,14 +48,12 @@ export const callEnterpriseSearchConfigAPI = async ({
     return {
       access: {
         hasAppSearchAccess: false,
-        hasSearchEnginesAccess: false, // TODO: update to read ES feature flag, or just refactor out
         hasWorkplaceSearchAccess: false,
       },
       features: {
         hasConnectors: config.hasConnectors,
         hasDefaultIngestPipeline: config.hasDefaultIngestPipeline,
         hasNativeConnectors: config.hasNativeConnectors,
-        hasSearchApplications: false, // TODO: update to read ES feature flag, or just refactor out
         hasWebCrawler: config.hasWebCrawler,
       },
       kibanaVersion: kibanaPackageJson.version,
@@ -103,14 +101,12 @@ export const callEnterpriseSearchConfigAPI = async ({
       kibanaVersion: kibanaPackageJson.version,
       access: {
         hasAppSearchAccess: !!data?.current_user?.access?.app_search,
-        hasSearchEnginesAccess: !!data?.current_user?.access?.search_engines,
         hasWorkplaceSearchAccess: !!data?.current_user?.access?.workplace_search,
       },
       features: {
         hasConnectors: config.hasConnectors,
         hasDefaultIngestPipeline: config.hasDefaultIngestPipeline,
         hasNativeConnectors: config.hasNativeConnectors,
-        hasSearchApplications: !!data?.current_user?.access?.search_engines,
         hasWebCrawler: config.hasWebCrawler,
       },
       publicUrl: stripTrailingSlash(data?.settings?.external_url),


### PR DESCRIPTION
## Summary

Remove the feature flagging of the search applications (engines) section for nav and routes.

![image](https://user-images.githubusercontent.com/1972968/230502703-694c480d-b997-4d9d-bea6-1f5ba763d6be.png)

*Note we should do some more work on the side nav separate from this PR.