### PR TITLE
[Fleet] Fix output ca_trusted_fingerprint validation message

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/output_form_validators.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/output_form_validators.test.tsx
@@ -118,7 +118,9 @@ describe('Output form validation', () => {
         '9F:0A:10:41:14:57:AD:DE:39:82:EF:01:DF:20:D2:E7:AA:53:A8:EF:29:C5:0B:CB:FA:3F:3E:93:AE:BF:63:1B'
       );
 
-      expect(res).toEqual(['CA trusted fingerprint should be a base64 CA sha256 fingerprint']);
+      expect(res).toEqual([
+        'CA trusted fingerprint should be valid HEX encoded SHA-256 of a CA certificate',
+      ]);
     });
   });
 });

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/output_form_validators.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/output_form_validators.tsx
@@ -154,7 +154,8 @@ export function validateCATrustedFingerPrint(value: string) {
   if (value !== '' && !value.match(/^[a-zA-Z0-9]+$/)) {
     return [
       i18n.translate('xpack.fleet.settings.outputForm.caTrusterdFingerprintInvalidErrorMessage', {
-        defaultMessage: 'CA trusted fingerprint should be a base64 CA sha256 fingerprint',
+        defaultMessage:
+          'CA trusted fingerprint should be valid HEX encoded SHA-256 of a CA certificate',
       }),
     ];
   }


### PR DESCRIPTION
## Summary

Update the validation message for the output `ca_trusted_fingerprint`  to remove the mention of `base64` encoded that was not correct at all. 


## UI Changes 

<img width="690" alt="Screenshot 2023-04-10 at 9 25 35 AM" src="https://user-images.githubusercontent.com/1336873/230910613-720dd52c-6b6d-45c4-87f8-89e8b387dd12.png">


## Questions

It is not easy for the users to find the info on how to generate the fingerprint should we add something directly in the UI like this?

<img width="692" alt="Screenshot 2023-04-10 at 9 25 15 AM" src="https://user-images.githubusercontent.com/1336873/230910802-d1b30718-e031-4e65-a137-0717078669b7.png">

@karenzone @insukcho  what do you think? 



