### PR TITLE
chore(slo): require customkql timestamp field

### DIFF
--- a/packages/kbn-slo-schema/src/schema/indicators.ts
+++ b/packages/kbn-slo-schema/src/schema/indicators.ts
@@ -50,17 +50,13 @@ const apmTransactionErrorRateIndicatorSchema = t.type({
 const kqlCustomIndicatorTypeSchema = t.literal('sli.kql.custom');
 const kqlCustomIndicatorSchema = t.type({
   type: kqlCustomIndicatorTypeSchema,
-  params: t.intersection([
-    t.type({
-      index: t.string,
-      filter: t.string,
-      good: t.string,
-      total: t.string,
-    }),
-    t.partial({
-      timestampField: t.string,
-    }),
-  ]),
+  params: t.type({
+    index: t.string,
+    filter: t.string,
+    good: t.string,
+    total: t.string,
+    timestampField: t.string,
+  }),
 });
 
 const indicatorDataSchema = t.type({

--- a/x-pack/plugins/observability/docs/openapi/slo/bundled.yaml
+++ b/x-pack/plugins/observability/docs/openapi/slo/bundled.yaml
@@ -362,6 +362,7 @@ components:
           nullable: false
           required:
             - index
+            - timestampField
           properties:
             index:
               description: The index or index pattern to use

--- a/x-pack/plugins/observability/docs/openapi/slo/components/schemas/indicator_properties_custom_kql.yaml
+++ b/x-pack/plugins/observability/docs/openapi/slo/components/schemas/indicator_properties_custom_kql.yaml
@@ -11,6 +11,7 @@ properties:
     nullable: false
     required:
       - index
+      - timestampField
     properties:
       index:
         description: The index or index pattern to use

--- a/x-pack/plugins/observability/public/data/slo/indicator.ts
+++ b/x-pack/plugins/observability/public/data/slo/indicator.ts
@@ -51,6 +51,7 @@ export const buildCustomKqlIndicator = (
       good: 'latency < 300',
       total: 'latency > 0',
       filter: 'labels.eventId: event-0',
+      timestampField: '@timestamp',
       ...params,
     },
   };

--- a/x-pack/plugins/observability/public/pages/slo_edit/constants.ts
+++ b/x-pack/plugins/observability/public/pages/slo_edit/constants.ts
@@ -62,6 +62,7 @@ export const SLO_EDIT_FORM_DEFAULT_VALUES: CreateSLOInput = {
       filter: '',
       good: '',
       total: '',
+      timestampField: '',
     },
   },
   timeWindow: {

--- a/x-pack/plugins/observability/server/services/slo/fixtures/slo.ts
+++ b/x-pack/plugins/observability/server/services/slo/fixtures/slo.ts
@@ -64,6 +64,7 @@ export const createKQLCustomIndicator = (
     filter: 'labels.groupId: group-3',
     good: 'latency < 300',
     total: '',
+    timestampField: 'log_timestamp',
     ...params,
   },
 });

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/kql_custom.test.ts.snap
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/kql_custom.test.ts.snap
@@ -147,7 +147,7 @@ Object {
     "group_by": Object {
       "@timestamp": Object {
         "date_histogram": Object {
-          "field": "@timestamp",
+          "field": "log_timestamp",
           "fixed_interval": "2m",
         },
       },
@@ -198,7 +198,7 @@ Object {
   "sync": Object {
     "time": Object {
       "delay": "1m",
-      "field": "@timestamp",
+      "field": "log_timestamp",
     },
   },
   "transform_id": Any<String>,
@@ -243,7 +243,7 @@ Object {
     "group_by": Object {
       "@timestamp": Object {
         "date_histogram": Object {
-          "field": "@timestamp",
+          "field": "log_timestamp",
           "fixed_interval": "1m",
         },
       },
@@ -294,7 +294,7 @@ Object {
   "sync": Object {
     "time": Object {
       "delay": "1m",
-      "field": "@timestamp",
+      "field": "log_timestamp",
     },
   },
   "transform_id": Any<String>,

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/kql_custom.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/kql_custom.ts
@@ -29,9 +29,9 @@ export class KQLCustomTransformGenerator extends TransformGenerator {
       this.buildDescription(slo),
       this.buildSource(slo, slo.indicator),
       this.buildDestination(),
-      this.buildGroupBy(slo, this.getTimestampFieldOrDefault(slo.indicator.params.timestampField)),
+      this.buildGroupBy(slo, slo.indicator.params.timestampField),
       this.buildAggregations(slo, slo.indicator),
-      this.buildSettings(slo, this.getTimestampFieldOrDefault(slo.indicator.params.timestampField))
+      this.buildSettings(slo, slo.indicator.params.timestampField)
     );
   }
 
@@ -78,9 +78,5 @@ export class KQLCustomTransformGenerator extends TransformGenerator {
         },
       }),
     };
-  }
-
-  private getTimestampFieldOrDefault(timestampField: string | undefined): string {
-    return !!timestampField && timestampField.length > 0 ? timestampField : '@timestamp';
   }
 }


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/154653

Waiting on https://github.com/elastic/kibana/pull/154666 before merging

This PR makes the custom kql timestamp field mandatory. Open API documentation has been updated accordingly.