### PR TITLE
fix(slo): fulltext search on name

### DIFF
--- a/packages/kbn-slo-schema/src/rest_specs/slo.ts
+++ b/packages/kbn-slo-schema/src/rest_specs/slo.ts
@@ -54,7 +54,7 @@ const getSLOParamsSchema = t.type({
 });
 
 const sortDirectionSchema = t.union([t.literal('asc'), t.literal('desc')]);
-const sortBySchema = t.union([t.literal('name'), t.literal('indicatorType')]);
+const sortBySchema = t.union([t.literal('creationTime'), t.literal('indicatorType')]);
 
 const findSLOParamsSchema = t.partial({
   query: t.partial({

--- a/x-pack/plugins/observability/docs/openapi/slo/bundled.yaml
+++ b/x-pack/plugins/observability/docs/openapi/slo/bundled.yaml
@@ -98,7 +98,7 @@ paths:
           schema:
             type: string
             enum:
-              - name
+              - creationTime
               - indicatorType
             default: name
           example: name

--- a/x-pack/plugins/observability/docs/openapi/slo/paths/s@{spaceid}@api@slos.yaml
+++ b/x-pack/plugins/observability/docs/openapi/slo/paths/s@{spaceid}@api@slos.yaml
@@ -81,7 +81,7 @@ get:
       description: Sort by field
       schema:
         type: string
-        enum: [name, indicatorType]
+        enum: [creationTime, indicatorType]
         default: name
       example: name
     - name: sortDirection

--- a/x-pack/plugins/observability/public/hooks/slo/use_fetch_slo_list.ts
+++ b/x-pack/plugins/observability/public/hooks/slo/use_fetch_slo_list.ts
@@ -42,7 +42,7 @@ const LONG_REFETCH_INTERVAL = 1000 * 60; // 1 minute
 export function useFetchSloList({
   name = '',
   page = 1,
-  sortBy = 'name',
+  sortBy = 'creationTime',
   indicatorTypes = [],
   shouldRefetch,
 }: SLOListParams | undefined = {}): UseFetchSloListResponse {

--- a/x-pack/plugins/observability/public/pages/slos/components/slo_list.tsx
+++ b/x-pack/plugins/observability/public/pages/slos/components/slo_list.tsx
@@ -26,7 +26,7 @@ export function SloList({ autoRefresh }: Props) {
   const [activePage, setActivePage] = useState(0);
 
   const [query, setQuery] = useState('');
-  const [sort, setSort] = useState<SortType>('name');
+  const [sort, setSort] = useState<SortType>('creationTime');
   const [indicatorTypeFilter, setIndicatorTypeFilter] = useState<FilterType[]>([]);
 
   const { isLoading, isError, sloList, refetch } = useFetchSloList({

--- a/x-pack/plugins/observability/public/pages/slos/components/slo_list_search_filter_sort_bar.tsx
+++ b/x-pack/plugins/observability/public/pages/slos/components/slo_list_search_filter_sort_bar.tsx
@@ -32,7 +32,7 @@ export interface SloListSearchFilterSortBarProps {
   onChangeIndicatorTypeFilter: (filter: FilterType[]) => void;
 }
 
-export type SortType = 'name' | 'indicatorType';
+export type SortType = 'creationTime' | 'indicatorType';
 export type FilterType =
   | 'sli.apm.transactionDuration'
   | 'sli.apm.transactionErrorRate'
@@ -46,10 +46,10 @@ export type Item<T> = EuiSelectableOption & {
 
 const SORT_OPTIONS: Array<Item<SortType>> = [
   {
-    label: i18n.translate('xpack.observability.slo.list.sortBy.name', {
-      defaultMessage: 'Name',
+    label: i18n.translate('xpack.observability.slo.list.sortBy.creationTime', {
+      defaultMessage: 'Creation time',
     }),
-    type: 'name',
+    type: 'creationTime',
     checked: 'on',
   },
   {
@@ -108,7 +108,7 @@ export function SloListSearchFilterSortBar({
   };
 
   useEffect(() => {
-    if (selectedSort?.type === 'name' || selectedSort?.type === 'indicatorType') {
+    if (selectedSort?.type === 'creationTime' || selectedSort?.type === 'indicatorType') {
       onChangeSort(selectedSort.type);
     }
   }, [onChangeSort, selectedSort]);

--- a/x-pack/plugins/observability/server/services/slo/find_slo.test.ts
+++ b/x-pack/plugins/observability/server/services/slo/find_slo.test.ts
@@ -33,7 +33,7 @@ describe('FindSLO', () => {
 
       expect(mockRepository.find).toHaveBeenCalledWith(
         { name: undefined },
-        { field: SortField.Name, direction: SortDirection.Asc },
+        { field: SortField.CreationTime, direction: SortDirection.Asc },
         { page: 1, perPage: 25 }
       );
 
@@ -98,7 +98,7 @@ describe('FindSLO', () => {
 
       expect(mockRepository.find).toHaveBeenCalledWith(
         { name: undefined },
-        { field: SortField.Name, direction: SortDirection.Asc },
+        { field: SortField.CreationTime, direction: SortDirection.Asc },
         { page: 1, perPage: 25 }
       );
     });
@@ -112,7 +112,7 @@ describe('FindSLO', () => {
 
       expect(mockRepository.find).toHaveBeenCalledWith(
         { name: 'Availability' },
-        { field: SortField.Name, direction: SortDirection.Asc },
+        { field: SortField.CreationTime, direction: SortDirection.Asc },
         { page: 1, perPage: 25 }
       );
     });
@@ -126,7 +126,7 @@ describe('FindSLO', () => {
 
       expect(mockRepository.find).toHaveBeenCalledWith(
         { indicatorTypes: ['sli.kql.custom'] },
-        { field: SortField.Name, direction: SortDirection.Asc },
+        { field: SortField.CreationTime, direction: SortDirection.Asc },
         { page: 1, perPage: 25 }
       );
     });
@@ -140,7 +140,7 @@ describe('FindSLO', () => {
 
       expect(mockRepository.find).toHaveBeenCalledWith(
         { name: 'My SLO*' },
-        { field: SortField.Name, direction: SortDirection.Asc },
+        { field: SortField.CreationTime, direction: SortDirection.Asc },
         { page: 2, perPage: 100 }
       );
     });
@@ -154,7 +154,7 @@ describe('FindSLO', () => {
 
       expect(mockRepository.find).toHaveBeenCalledWith(
         { name: undefined },
-        { field: SortField.Name, direction: SortDirection.Asc },
+        { field: SortField.CreationTime, direction: SortDirection.Asc },
         { page: 1, perPage: 25 }
       );
     });
@@ -168,7 +168,7 @@ describe('FindSLO', () => {
 
       expect(mockRepository.find).toHaveBeenCalledWith(
         { name: undefined },
-        { field: SortField.Name, direction: SortDirection.Asc },
+        { field: SortField.CreationTime, direction: SortDirection.Asc },
         { page: 1, perPage: 25 }
       );
     });

--- a/x-pack/plugins/observability/server/services/slo/find_slo.ts
+++ b/x-pack/plugins/observability/server/services/slo/find_slo.ts
@@ -73,7 +73,7 @@ function toCriteria(params: FindSLOParams): Criteria {
 
 function toSort(params: FindSLOParams): Sort {
   return {
-    field: params.sortBy === 'indicatorType' ? SortField.IndicatorType : SortField.Name,
+    field: params.sortBy === 'indicatorType' ? SortField.IndicatorType : SortField.CreationTime,
     direction: params.sortDirection === 'desc' ? SortDirection.Desc : SortDirection.Asc,
   };
 }

--- a/x-pack/plugins/observability/server/services/slo/slo_repository.test.ts
+++ b/x-pack/plugins/observability/server/services/slo/slo_repository.test.ts
@@ -121,12 +121,12 @@ describe('KibanaSavedObjectsSLORepository', () => {
   describe('find', () => {
     const DEFAULT_PAGINATION: Pagination = { page: 1, perPage: 25 };
     const DEFAULT_SORTING: Sort = {
-      field: SortField.Name,
+      field: SortField.CreationTime,
       direction: SortDirection.Asc,
     };
 
-    describe('Name filter', () => {
-      it('includes the filter on name with wildcard when provided', async () => {
+    describe('Name search', () => {
+      it('includes the search on name with wildcard when provided', async () => {
         const repository = new KibanaSavedObjectsSLORepository(soClientMock);
         soClientMock.find.mockResolvedValueOnce(createFindResponse([SOME_SLO]));
 
@@ -146,13 +146,15 @@ describe('KibanaSavedObjectsSLORepository', () => {
           type: SO_SLO_TYPE,
           page: 1,
           perPage: 25,
-          filter: `(slo.attributes.name: *availability*)`,
-          sortField: 'name',
+          filter: undefined,
+          search: '*availability*',
+          searchFields: ['name'],
+          sortField: 'created_at',
           sortOrder: 'asc',
         });
       });
 
-      it('includes the filter on name with added wildcard when not provided', async () => {
+      it('includes the search on name with added wildcard when not provided', async () => {
         const repository = new KibanaSavedObjectsSLORepository(soClientMock);
         soClientMock.find.mockResolvedValueOnce(createFindResponse([SOME_SLO]));
 
@@ -172,8 +174,10 @@ describe('KibanaSavedObjectsSLORepository', () => {
           type: SO_SLO_TYPE,
           page: 1,
           perPage: 25,
-          filter: `(slo.attributes.name: *availa*)`,
-          sortField: 'name',
+          filter: undefined,
+          search: '*availa*',
+          searchFields: ['name'],
+          sortField: 'created_at',
           sortOrder: 'asc',
         });
       });
@@ -201,7 +205,9 @@ describe('KibanaSavedObjectsSLORepository', () => {
           page: 1,
           perPage: 25,
           filter: `(slo.attributes.indicator.type: sli.kql.custom)`,
-          sortField: 'name',
+          search: undefined,
+          searchFields: undefined,
+          sortField: 'created_at',
           sortOrder: 'asc',
         });
       });
@@ -227,13 +233,15 @@ describe('KibanaSavedObjectsSLORepository', () => {
           page: 1,
           perPage: 25,
           filter: `(slo.attributes.indicator.type: sli.kql.custom or slo.attributes.indicator.type: sli.apm.transactionDuration)`,
-          sortField: 'name',
+          search: undefined,
+          searchFields: undefined,
+          sortField: 'created_at',
           sortOrder: 'asc',
         });
       });
     });
 
-    it('includes filter on name and indicator types', async () => {
+    it('includes search on name and filter on indicator types', async () => {
       const repository = new KibanaSavedObjectsSLORepository(soClientMock);
       soClientMock.find.mockResolvedValueOnce(createFindResponse([SOME_SLO]));
 
@@ -253,13 +261,15 @@ describe('KibanaSavedObjectsSLORepository', () => {
         type: SO_SLO_TYPE,
         page: 1,
         perPage: 25,
-        filter: `(slo.attributes.name: *latency*) and (slo.attributes.indicator.type: sli.kql.custom or slo.attributes.indicator.type: sli.apm.transactionDuration)`,
-        sortField: 'name',
+        filter: `(slo.attributes.indicator.type: sli.kql.custom or slo.attributes.indicator.type: sli.apm.transactionDuration)`,
+        search: '*latency*',
+        searchFields: ['name'],
+        sortField: 'created_at',
         sortOrder: 'asc',
       });
     });
 
-    it('does not include the filter when no criteria provided', async () => {
+    it('does not include the search or filter when no criteria provided', async () => {
       const repository = new KibanaSavedObjectsSLORepository(soClientMock);
       soClientMock.find.mockResolvedValueOnce(createFindResponse([SOME_SLO]));
 
@@ -275,12 +285,14 @@ describe('KibanaSavedObjectsSLORepository', () => {
         type: SO_SLO_TYPE,
         page: 1,
         perPage: 25,
-        sortField: 'name',
+        search: undefined,
+        searchFields: undefined,
+        sortField: 'created_at',
         sortOrder: 'asc',
       });
     });
 
-    it('sorts by name ascending', async () => {
+    it('sorts by creation time ascending', async () => {
       const repository = new KibanaSavedObjectsSLORepository(soClientMock);
       soClientMock.find.mockResolvedValueOnce(createFindResponse([SOME_SLO]));
 
@@ -290,18 +302,20 @@ describe('KibanaSavedObjectsSLORepository', () => {
         type: SO_SLO_TYPE,
         page: 1,
         perPage: 25,
-        sortField: 'name',
+        search: undefined,
+        searchFields: undefined,
+        sortField: 'created_at',
         sortOrder: 'asc',
       });
     });
 
-    it('sorts by name descending', async () => {
+    it('sorts by creation time descending', async () => {
       const repository = new KibanaSavedObjectsSLORepository(soClientMock);
       soClientMock.find.mockResolvedValueOnce(createFindResponse([SOME_SLO]));
 
       await repository.find(
         {},
-        { field: SortField.Name, direction: SortDirection.Desc },
+        { field: SortField.CreationTime, direction: SortDirection.Desc },
         DEFAULT_PAGINATION
       );
 
@@ -309,7 +323,9 @@ describe('KibanaSavedObjectsSLORepository', () => {
         type: SO_SLO_TYPE,
         page: 1,
         perPage: 25,
-        sortField: 'name',
+        search: undefined,
+        searchFields: undefined,
+        sortField: 'created_at',
         sortOrder: 'desc',
       });
     });
@@ -328,6 +344,8 @@ describe('KibanaSavedObjectsSLORepository', () => {
         type: SO_SLO_TYPE,
         page: 1,
         perPage: 25,
+        search: undefined,
+        searchFields: undefined,
         sortField: 'indicator.type',
         sortOrder: 'asc',
       });


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/154659

This PR introduces a fix for searching through the SLO names since the SO mapping has been changed to "text". We cannot sort by name anymore, so I replaced it by creation time.