### PR TITLE
Properly handle NO DATA with  multiple conditions with a mix of aggregations and document count thresholds

### DIFF
--- a/x-pack/plugins/infra/server/lib/alerting/common/messages.ts
+++ b/x-pack/plugins/infra/server/lib/alerting/common/messages.ts
@@ -138,7 +138,7 @@ export const buildNoDataAlertReason: (alertResult: {
   timeUnit: string;
 }) => string = ({ group, metric, timeSize, timeUnit }) =>
   i18n.translate('xpack.infra.metrics.alerting.threshold.noDataAlertReason', {
-    defaultMessage: '{metric} reported no data in the last {interval} for {group}',
+    defaultMessage: '{metric} reported no data in the last {interval}{group}',
     values: {
       metric,
       interval: `${timeSize}${timeUnit}`,

--- a/x-pack/plugins/infra/server/lib/alerting/metric_threshold/metric_threshold_executor.test.ts
+++ b/x-pack/plugins/infra/server/lib/alerting/metric_threshold/metric_threshold_executor.test.ts
@@ -69,9 +69,11 @@ const logger = {
   get: () => logger,
 } as unknown as Logger;
 
+const STARTED_AT_MOCK_DATE = new Date();
+
 const mockOptions = {
   executionId: '',
-  startedAt: new Date(),
+  startedAt: STARTED_AT_MOCK_DATE,
   previousStartedAt: null,
   state: {
     wrapped: initialRuleState,
@@ -1325,7 +1327,9 @@ describe('The metric threshold alert type', () => {
         },
       ]);
       await execute(true);
-      expect(mostRecentAction(instanceID)).toBeNoDataAction();
+      const recentAction = mostRecentAction(instanceID);
+      expect(recentAction.action.reason).toEqual('test.metric.3 reported no data in the last 1m');
+      expect(recentAction).toBeNoDataAction();
     });
     test('does not send a No Data alert when not configured to do so', async () => {
       setEvaluationResults([
@@ -1346,6 +1350,68 @@ describe('The metric threshold alert type', () => {
       ]);
       await execute(false);
       expect(mostRecentAction(instanceID)).toBe(undefined);
+    });
+  });
+
+  describe('alerts with NO_DATA where one condtion is an aggregation and the other is a document count', () => {
+    afterAll(() => clearInstances());
+    const instanceID = '*';
+    const execute = (alertOnNoData: boolean, sourceId: string = 'default') =>
+      executor({
+        ...mockOptions,
+        services,
+        params: {
+          sourceId,
+          criteria: [
+            {
+              ...baseNonCountCriterion,
+              comparator: Comparator.GT,
+              threshold: [1],
+              metric: 'test.metric.3',
+            },
+            {
+              ...baseCountCriterion,
+              comparator: Comparator.GT,
+              threshold: [30],
+            },
+          ],
+          alertOnNoData,
+        },
+      });
+    test('sends a No Data alert when configured to do so', async () => {
+      setEvaluationResults([
+        {
+          '*': {
+            ...baseNonCountCriterion,
+            comparator: Comparator.LT,
+            threshold: [1],
+            metric: 'test.metric.3',
+            currentValue: null,
+            timestamp: STARTED_AT_MOCK_DATE.toISOString(),
+            shouldFire: false,
+            shouldWarn: false,
+            isNoData: true,
+            bucketKey: { groupBy0: '*' },
+          },
+        },
+        {},
+      ]);
+      await execute(true);
+      const recentAction = mostRecentAction(instanceID);
+      expect(recentAction.action).toEqual({
+        alertDetailsUrl: 'http://localhost:5601/app/observability/alerts/mock-alert-uuid',
+        alertState: 'NO DATA',
+        group: '*',
+        groupByKeys: undefined,
+        metric: { condition0: 'test.metric.3', condition1: 'count' },
+        reason: 'test.metric.3 reported no data in the last 1m',
+        threshold: { condition0: ['1'], condition1: [30] },
+        timestamp: STARTED_AT_MOCK_DATE.toISOString(),
+        value: { condition0: '[NO DATA]', condition1: 0 },
+        viewInAppUrl: 'http://localhost:5601/app/metrics/explorer',
+        tags: [],
+      });
+      expect(recentAction).toBeNoDataAction();
     });
   });
 

--- a/x-pack/plugins/infra/server/lib/alerting/metric_threshold/metric_threshold_executor.ts
+++ b/x-pack/plugins/infra/server/lib/alerting/metric_threshold/metric_threshold_executor.ts
@@ -268,7 +268,7 @@ export const createMetricThresholdExecutor = (libs: InfraBackendLibs) =>
         // check to see if a No Data state has occurred
         if (nextState === AlertStates.NO_DATA) {
           reason = alertResults
-            .filter((result) => result[group].isNoData)
+            .filter((result) => result[group]?.isNoData)
             .map((result) => buildNoDataAlertReason({ ...result[group], group }))
             .join('\n');
         }
@@ -304,17 +304,30 @@ export const createMetricThresholdExecutor = (libs: InfraBackendLibs) =>
           alertState: stateToAlertMessage[nextState],
           group,
           groupByKeys: groupByKeysObjectMapping[group],
-          metric: mapToConditionsLookup(criteria, (c) => c.metric),
+          metric: mapToConditionsLookup(criteria, (c) => {
+            if (c.aggType === 'count') {
+              return 'count';
+            }
+            return c.metric;
+          }),
           reason,
-          threshold: mapToConditionsLookup(
-            alertResults,
-            (result) => formatAlertResult(result[group]).threshold
-          ),
+          threshold: mapToConditionsLookup(alertResults, (result, index) => {
+            const evaluation = result[group];
+            if (!evaluation) {
+              return criteria[index].threshold;
+            }
+            return formatAlertResult(evaluation).threshold;
+          }),
           timestamp,
-          value: mapToConditionsLookup(
-            alertResults,
-            (result) => formatAlertResult(result[group]).currentValue
-          ),
+          value: mapToConditionsLookup(alertResults, (result, index) => {
+            const evaluation = result[group];
+            if (!evaluation && criteria[index].aggType === 'count') {
+              return 0;
+            } else if (!evaluation) {
+              return null;
+            }
+            return formatAlertResult(evaluation).currentValue;
+          }),
           viewInAppUrl: getViewInMetricsAppUrl(libs.basePath, spaceId),
           ...additionalContext,
         });
@@ -342,7 +355,12 @@ export const createMetricThresholdExecutor = (libs: InfraBackendLibs) =>
         alertState: stateToAlertMessage[AlertStates.OK],
         group: recoveredAlertId,
         groupByKeys: groupByKeysObjectForRecovered[recoveredAlertId],
-        metric: mapToConditionsLookup(criteria, (c) => c.metric),
+        metric: mapToConditionsLookup(criteria, (c) => {
+          if (criteria.aggType === 'count') {
+            return 'count';
+          }
+          return c.metric;
+        }),
         timestamp: startedAt.toISOString(),
         threshold: mapToConditionsLookup(criteria, (c) => c.threshold),
         viewInAppUrl: getViewInMetricsAppUrl(libs.basePath, spaceId),


### PR DESCRIPTION
This PR fixes #154553, which arises when a rule containing aggregation-based conditions is combined with document count conditions. In such a case, the aggregation-based conditions may return "NO DATA". Unlike document count-based conditions, which do not typically generate a "NO DATA" response since this is equivalent to zero and only triggers if the user defines the condition as `Document count < 0`; aggregation-based conditions produce a `null` result that is interpreted as "NO DATA".

This PR also improves the "NO DATA" reason message when a group-by field is not defined. The reason message before the change looked like `test.metric.3 reported no data in the last 1m for ` which I changed to `test.metric.3 reported no data in the last 1m` to be more readable.

This also fixes the context variables for document count-based conditions by setting the `metric` context variable to `count`.