### PR TITLE
[Security Solution] Skips flakey Rules Table tests

### DIFF
--- a/x-pack/plugins/security_solution/cypress/e2e/detection_rules/rules_selection.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_rules/rules_selection.cy.ts
@@ -20,7 +20,8 @@ import { cleanKibana } from '../../tasks/common';
 import { login, visitWithoutDateRange } from '../../tasks/login';
 import { DETECTIONS_RULE_MANAGEMENT_URL } from '../../urls/navigation';
 
-describe('Rules selection', () => {
+// TODO: See https://github.com/elastic/kibana/issues/154694
+describe.skip('Rules selection', () => {
   beforeEach(() => {
     cleanKibana();
     login();

--- a/x-pack/plugins/security_solution/cypress/e2e/detection_rules/rules_table_auto_refresh.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_rules/rules_table_auto_refresh.cy.ts
@@ -33,7 +33,8 @@ import { setRowsPerPageTo } from '../../tasks/table_pagination';
 
 const DEFAULT_RULE_REFRESH_INTERVAL_VALUE = 60000;
 
-describe('Alerts detection rules table auto-refresh', () => {
+// TODO: See https://github.com/elastic/kibana/issues/154694
+describe.skip('Alerts detection rules table auto-refresh', () => {
   before(() => {
     cleanKibana();
     login();


### PR DESCRIPTION
## Summary
As detailed in https://github.com/elastic/kibana/issues/154694, need to address some follow-up flake in addition to https://github.com/elastic/kibana/issues/154663. This includes the Rules Table auto-refresh and rule selection suites: 

[rules_table_auto_refresh.cy.ts](https://github.com/elastic/kibana/blob/ca696ac50c0591acf6723e130d2f9278c2d6ef65/x-pack/plugins/security_solution/cypress/e2e/detection_rules/rules_table_auto_refresh.cy.ts#L46)
Failed builds:
* https://buildkite.com/elastic/kibana-pull-request/builds/118556#018762fd-eb9b-4210-a1a7-f28a36e304e7
* https://buildkite.com/elastic/kibana-pull-request/builds/118310#018756a3-4f98-4404-81e5-b55b9644c651

[rules_selection.cy.ts](https://github.com/elastic/kibana/blob/3d146298a43e1ba24d83e0ede2758b87e826d0b6/x-pack/plugins/security_solution/cypress/e2e/detection_rules/rules_selection.cy.ts#L34)
Failed builds:
* https://buildkite.com/elastic/kibana-pull-request/builds/118310#01875708-6710-47a9-bd3f-892e878bbeb1
* https://buildkite.com/elastic/kibana-pull-request/builds/118700#01876bfe-e766-42b7-a99d-bcdd3c02823a