### PR TITLE
[Maps] Enable skipped test

### DIFF
--- a/x-pack/test/functional/apps/maps/group1/sample_data.js
+++ b/x-pack/test/functional/apps/maps/group1/sample_data.js
@@ -18,8 +18,7 @@ export default function ({ getPageObjects, getService, updateBaselines }) {
   // Only update the baseline images from Jenkins session images after comparing them
   // These tests might fail locally because of scaling factors and resolution.
 
-  // Failing: See https://github.com/elastic/kibana/issues/153960
-  describe.skip('maps loaded from sample data', () => {
+  describe('maps loaded from sample data', () => {
     before(async () => {
       //installing the sample data with test user with super user role and then switching roles with limited privileges
       await security.testUser.setRoles(['superuser'], { skipBrowserRefresh: true });


### PR DESCRIPTION
## Summary

This test was failing due to a transient network issue caused by an unexpected certificates rotation on Elastic Maps Service. 

Fixes #153960 


[Flaky test runner](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2109)