### PR TITLE
feat(slo): Add tooltips in creation form

### DIFF
--- a/x-pack/plugins/observability/public/pages/slo_edit/components/apm_availability/apm_availability_indicator_type_form.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/apm_availability/apm_availability_indicator_type_form.tsx
@@ -126,7 +126,7 @@ export function ApmAvailabilityIndicatorTypeForm() {
             isInvalid={getFieldState('indicator.params.goodStatusCodes').invalid}
           >
             <Controller
-              shouldUnregister={true}
+              shouldUnregister
               name="indicator.params.goodStatusCodes"
               control={control}
               defaultValue={['2xx', '3xx', '4xx']}
@@ -156,7 +156,7 @@ export function ApmAvailabilityIndicatorTypeForm() {
 
                     field.onChange([]);
                   }}
-                  isClearable={true}
+                  isClearable
                   data-test-subj="sloEditApmAvailabilityGoodStatusCodesSelector"
                 />
               )}

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/apm_availability/apm_availability_indicator_type_form.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/apm_availability/apm_availability_indicator_type_form.tsx
@@ -11,7 +11,7 @@ import {
   EuiComboBoxOptionOption,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiFormLabel,
+  EuiFormRow,
 } from '@elastic/eui';
 import { Controller, useFormContext } from 'react-hook-form';
 import { i18n } from '@kbn/i18n';
@@ -22,7 +22,7 @@ import { FieldSelector } from '../apm_common/field_selector';
 import { QueryBuilder } from '../common/query_builder';
 
 export function ApmAvailabilityIndicatorTypeForm() {
-  const { control, setValue, watch } = useFormContext<CreateSLOInput>();
+  const { control, setValue, watch, getFieldState } = useFormContext<CreateSLOInput>();
   const { data: apmIndex } = useFetchApmIndex();
   useEffect(() => {
     setValue('indicator.params.index', apmIndex);
@@ -98,47 +98,52 @@ export function ApmAvailabilityIndicatorTypeForm() {
 
       <EuiFlexGroup direction="row" gutterSize="l">
         <EuiFlexItem>
-          <EuiFormLabel>
-            {i18n.translate('xpack.observability.slo.sloEdit.apmAvailability.goodStatusCodes', {
-              defaultMessage: 'Good status codes',
-            })}
-          </EuiFormLabel>
-          <Controller
-            shouldUnregister={true}
-            name="indicator.params.goodStatusCodes"
-            control={control}
-            defaultValue={['2xx', '3xx', '4xx']}
-            rules={{ required: true }}
-            render={({ field: { ref, ...field }, fieldState }) => (
-              <EuiComboBox
-                {...field}
-                aria-label={i18n.translate(
-                  'xpack.observability.slo.sloEdit.apmAvailability.goodStatusCodes.placeholder',
-                  {
-                    defaultMessage: 'Select the good status codes',
-                  }
-                )}
-                placeholder={i18n.translate(
-                  'xpack.observability.slo.sloEdit.apmAvailability.goodStatusCodes.placeholder',
-                  {
-                    defaultMessage: 'Select the good status codes',
-                  }
-                )}
-                isInvalid={!!fieldState.error}
-                options={generateStatusCodeOptions(['2xx', '3xx', '4xx', '5xx'])}
-                selectedOptions={generateStatusCodeOptions(field.value)}
-                onChange={(selected: EuiComboBoxOptionOption[]) => {
-                  if (selected.length) {
-                    return field.onChange(selected.map((opts) => opts.value));
-                  }
-
-                  field.onChange([]);
-                }}
-                isClearable={true}
-                data-test-subj="sloEditApmAvailabilityGoodStatusCodesSelector"
-              />
+          <EuiFormRow
+            label={i18n.translate(
+              'xpack.observability.slo.sloEdit.apmAvailability.goodStatusCodes',
+              {
+                defaultMessage: 'Good status codes',
+              }
             )}
-          />
+            isInvalid={getFieldState('indicator.params.goodStatusCodes').invalid}
+          >
+            <Controller
+              shouldUnregister={true}
+              name="indicator.params.goodStatusCodes"
+              control={control}
+              defaultValue={['2xx', '3xx', '4xx']}
+              rules={{ required: true }}
+              render={({ field: { ref, ...field }, fieldState }) => (
+                <EuiComboBox
+                  {...field}
+                  aria-label={i18n.translate(
+                    'xpack.observability.slo.sloEdit.apmAvailability.goodStatusCodes.placeholder',
+                    {
+                      defaultMessage: 'Select the good status codes',
+                    }
+                  )}
+                  placeholder={i18n.translate(
+                    'xpack.observability.slo.sloEdit.apmAvailability.goodStatusCodes.placeholder',
+                    {
+                      defaultMessage: 'Select the good status codes',
+                    }
+                  )}
+                  isInvalid={fieldState.invalid}
+                  options={generateStatusCodeOptions(['2xx', '3xx', '4xx', '5xx'])}
+                  selectedOptions={generateStatusCodeOptions(field.value)}
+                  onChange={(selected: EuiComboBoxOptionOption[]) => {
+                    if (selected.length) {
+                      return field.onChange(selected.map((opts) => opts.value));
+                    }
+
+                    field.onChange([]);
+                  }}
+                  isClearable={true}
+                  data-test-subj="sloEditApmAvailabilityGoodStatusCodesSelector"
+                />
+              )}
+            />
+          </EuiFormRow>
         </EuiFlexItem>
         <EuiFlexItem>
           <QueryBuilder

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/apm_availability/apm_availability_indicator_type_form.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/apm_availability/apm_availability_indicator_type_form.tsx
@@ -12,6 +12,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiFormRow,
+  EuiIconTip,
 } from '@elastic/eui';
 import { Controller, useFormContext } from 'react-hook-form';
 import { i18n } from '@kbn/i18n';
@@ -38,13 +39,19 @@ export function ApmAvailabilityIndicatorTypeForm() {
           })}
           placeholder={i18n.translate(
             'xpack.observability.slo.sloEdit.apmAvailability.serviceName.placeholder',
-            {
-              defaultMessage: 'Select the APM service',
-            }
+            { defaultMessage: 'Select the APM service' }
           )}
           fieldName="service.name"
           name="indicator.params.service"
           dataTestSubj="apmAvailabilityServiceSelector"
+          tooltip={
+            <EuiIconTip
+              content={i18n.translate('xpack.observability.slo.sloEdit.apm.serviceName.tooltip', {
+                defaultMessage: 'This is the APM service monitored by this SLO.',
+              })}
+              position="top"
+            />
+          }
         />
         <FieldSelector
           label={i18n.translate(
@@ -99,12 +106,23 @@ export function ApmAvailabilityIndicatorTypeForm() {
       <EuiFlexGroup direction="row" gutterSize="l">
         <EuiFlexItem>
           <EuiFormRow
-            label={i18n.translate(
-              'xpack.observability.slo.sloEdit.apmAvailability.goodStatusCodes',
-              {
-                defaultMessage: 'Good status codes',
-              }
-            )}
+            label={
+              <span>
+                {i18n.translate('xpack.observability.slo.sloEdit.apmAvailability.goodStatusCodes', {
+                  defaultMessage: 'Good status codes',
+                })}{' '}
+                <EuiIconTip
+                  content={i18n.translate(
+                    'xpack.observability.slo.sloEdit.apmAvailability.goodStatusCodes.tooltip',
+                    {
+                      defaultMessage:
+                        'Configure the HTTP status codes defining the "good" or "successful" requests for the SLO.',
+                    }
+                  )}
+                  position="top"
+                />
+              </span>
+            }
             isInvalid={getFieldState('indicator.params.goodStatusCodes').invalid}
           >
             <Controller
@@ -160,6 +178,15 @@ export function ApmAvailabilityIndicatorTypeForm() {
                 defaultMessage: 'Custom filter to apply on the index',
               }
             )}
+            tooltip={
+              <EuiIconTip
+                content={i18n.translate('xpack.observability.slo.sloEdit.apm.filter.tooltip', {
+                  defaultMessage:
+                    'This KQL query is used to filter the APM metrics on some relevant criteria for this SLO.',
+                })}
+                position="top"
+              />
+            }
           />
         </EuiFlexItem>
       </EuiFlexGroup>

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/apm_common/field_selector.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/apm_common/field_selector.tsx
@@ -6,10 +6,11 @@
  */
 
 import React, { useState } from 'react';
-import { EuiComboBox, EuiComboBoxOptionOption, EuiFlexItem, EuiFormLabel } from '@elastic/eui';
+import { EuiComboBox, EuiComboBoxOptionOption, EuiFlexItem, EuiFormRow } from '@elastic/eui';
 import { Controller, FieldPath, useFormContext } from 'react-hook-form';
 import { CreateSLOInput } from '@kbn/slo-schema';
 import { i18n } from '@kbn/i18n';
+
 import {
   Suggestion,
   useFetchApmSuggestions,
@@ -37,7 +38,7 @@ export function FieldSelector({
   name,
   placeholder,
 }: Props) {
-  const { control, watch } = useFormContext<CreateSLOInput>();
+  const { control, watch, getFieldState } = useFormContext<CreateSLOInput>();
   const serviceName = watch('indicator.params.service');
   const [search, setSearch] = useState<string>('');
   const { suggestions, isLoading } = useFetchApmSuggestions({
@@ -61,51 +62,51 @@ export function FieldSelector({
 
   return (
     <EuiFlexItem>
-      <EuiFormLabel>{label}</EuiFormLabel>
+      <EuiFormRow label={label} isInvalid={getFieldState(name).invalid}>
+        <Controller
+          shouldUnregister={true}
+          defaultValue=""
+          name={name}
+          control={control}
+          rules={{ required: true }}
+          render={({ field, fieldState }) => (
+            <EuiComboBox
+              {...field}
+              aria-label={placeholder}
+              async
+              data-test-subj={dataTestSubj}
+              isClearable={true}
+              isDisabled={name !== 'indicator.params.service' && !serviceName}
+              isInvalid={fieldState.invalid}
+              isLoading={isLoading}
+              onChange={(selected: EuiComboBoxOptionOption[]) => {
+                if (selected.length) {
+                  return field.onChange(selected[0].value);
+                }
 
-      <Controller
-        shouldUnregister={true}
-        defaultValue=""
-        name={name}
-        control={control}
-        rules={{ required: true }}
-        render={({ field, fieldState }) => (
-          <EuiComboBox
-            {...field}
-            aria-label={placeholder}
-            async
-            data-test-subj={dataTestSubj}
-            isClearable={true}
-            isDisabled={name !== 'indicator.params.service' && !serviceName}
-            isInvalid={!!fieldState.error}
-            isLoading={isLoading}
-            onChange={(selected: EuiComboBoxOptionOption[]) => {
-              if (selected.length) {
-                return field.onChange(selected[0].value);
+                field.onChange('');
+              }}
+              onSearchChange={(value: string) => {
+                setSearch(value);
+              }}
+              options={options}
+              placeholder={placeholder}
+              selectedOptions={
+                !!field.value && typeof field.value === 'string'
+                  ? [
+                      {
+                        value: field.value,
+                        label: field.value,
+                        'data-test-subj': `${dataTestSubj}SelectedValue`,
+                      },
+                    ]
+                  : []
               }
-
-              field.onChange('');
-            }}
-            onSearchChange={(value: string) => {
-              setSearch(value);
-            }}
-            options={options}
-            placeholder={placeholder}
-            selectedOptions={
-              !!field.value && typeof field.value === 'string'
-                ? [
-                    {
-                      value: field.value,
-                      label: field.value,
-                      'data-test-subj': `${dataTestSubj}SelectedValue`,
-                    },
-                  ]
-                : []
-            }
-            singleSelection
-          />
-        )}
-      />
+              singleSelection
+            />
+          )}
+        />
+      </EuiFormRow>
     </EuiFlexItem>
   );
 }

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/apm_common/field_selector.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/apm_common/field_selector.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useState } from 'react';
+import React, { ReactNode, useState } from 'react';
 import { EuiComboBox, EuiComboBoxOptionOption, EuiFlexItem, EuiFormRow } from '@elastic/eui';
 import { Controller, FieldPath, useFormContext } from 'react-hook-form';
 import { CreateSLOInput } from '@kbn/slo-schema';
@@ -28,6 +28,7 @@ export interface Props {
   label: string;
   name: FieldPath<CreateSLOInput>;
   placeholder: string;
+  tooltip?: ReactNode;
 }
 
 export function FieldSelector({
@@ -37,6 +38,7 @@ export function FieldSelector({
   label,
   name,
   placeholder,
+  tooltip,
 }: Props) {
   const { control, watch, getFieldState } = useFormContext<CreateSLOInput>();
   const serviceName = watch('indicator.params.service');
@@ -62,7 +64,18 @@ export function FieldSelector({
 
   return (
     <EuiFlexItem>
-      <EuiFormRow label={label} isInvalid={getFieldState(name).invalid}>
+      <EuiFormRow
+        label={
+          !!tooltip ? (
+            <span>
+              {label} {tooltip}
+            </span>
+          ) : (
+            label
+          )
+        }
+        isInvalid={getFieldState(name).invalid}
+      >
         <Controller
           shouldUnregister={true}
           defaultValue=""

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/apm_common/field_selector.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/apm_common/field_selector.tsx
@@ -77,7 +77,7 @@ export function FieldSelector({
         isInvalid={getFieldState(name).invalid}
       >
         <Controller
-          shouldUnregister={true}
+          shouldUnregister
           defaultValue=""
           name={name}
           control={control}
@@ -88,7 +88,7 @@ export function FieldSelector({
               aria-label={placeholder}
               async
               data-test-subj={dataTestSubj}
-              isClearable={true}
+              isClearable
               isDisabled={name !== 'indicator.params.service' && !serviceName}
               isInvalid={fieldState.invalid}
               isLoading={isLoading}

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/apm_latency/apm_latency_indicator_type_form.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/apm_latency/apm_latency_indicator_type_form.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useEffect } from 'react';
-import { EuiFieldNumber, EuiFlexGroup, EuiFlexItem, EuiFormRow } from '@elastic/eui';
+import { EuiFieldNumber, EuiFlexGroup, EuiFlexItem, EuiFormRow, EuiIconTip } from '@elastic/eui';
 import { Controller, useFormContext } from 'react-hook-form';
 import { i18n } from '@kbn/i18n';
 import type { CreateSLOInput } from '@kbn/slo-schema';
@@ -39,6 +39,14 @@ export function ApmLatencyIndicatorTypeForm() {
           fieldName="service.name"
           name="indicator.params.service"
           dataTestSubj="apmLatencyServiceSelector"
+          tooltip={
+            <EuiIconTip
+              content={i18n.translate('xpack.observability.slo.sloEdit.apm.serviceName.tooltip', {
+                defaultMessage: 'This is the APM service monitored by this SLO.',
+              })}
+              position="top"
+            />
+          }
         />
         <FieldSelector
           label={i18n.translate('xpack.observability.slo.sloEdit.apmLatency.serviceEnvironment', {
@@ -90,10 +98,24 @@ export function ApmLatencyIndicatorTypeForm() {
       <EuiFlexGroup direction="row" gutterSize="l">
         <EuiFlexItem>
           <EuiFormRow
-            label={i18n.translate(
-              'xpack.observability.slo.sloEdit.apmLatency.threshold.placeholder',
-              { defaultMessage: 'Threshold (ms)' }
-            )}
+            label={
+              <span>
+                {i18n.translate(
+                  'xpack.observability.slo.sloEdit.apmLatency.threshold.placeholder',
+                  { defaultMessage: 'Threshold (ms)' }
+                )}{' '}
+                <EuiIconTip
+                  content={i18n.translate(
+                    'xpack.observability.slo.sloEdit.apmLatency.threshold.tooltip',
+                    {
+                      defaultMessage:
+                        'Configure the threshold in milliseconds defining the "good" or "successful" requests for the SLO.',
+                    }
+                  )}
+                  position="top"
+                />
+              </span>
+            }
             isInvalid={getFieldState('indicator.params.threshold').invalid}
           >
             <Controller
@@ -134,6 +156,15 @@ export function ApmLatencyIndicatorTypeForm() {
                 defaultMessage: 'Custom filter to apply on the index',
               }
             )}
+            tooltip={
+              <EuiIconTip
+                content={i18n.translate('xpack.observability.slo.sloEdit.apm.filter.tooltip', {
+                  defaultMessage:
+                    'This KQL query is used to filter the APM metrics on some relevant criteria for this SLO.',
+                })}
+                position="top"
+              />
+            }
           />
         </EuiFlexItem>
       </EuiFlexGroup>

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/apm_latency/apm_latency_indicator_type_form.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/apm_latency/apm_latency_indicator_type_form.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useEffect } from 'react';
-import { EuiFieldNumber, EuiFlexGroup, EuiFlexItem, EuiFormLabel } from '@elastic/eui';
+import { EuiFieldNumber, EuiFlexGroup, EuiFlexItem, EuiFormRow } from '@elastic/eui';
 import { Controller, useFormContext } from 'react-hook-form';
 import { i18n } from '@kbn/i18n';
 import type { CreateSLOInput } from '@kbn/slo-schema';
@@ -16,7 +16,7 @@ import { FieldSelector } from '../apm_common/field_selector';
 import { QueryBuilder } from '../common/query_builder';
 
 export function ApmLatencyIndicatorTypeForm() {
-  const { control, setValue, watch } = useFormContext<CreateSLOInput>();
+  const { control, setValue, watch, getFieldState } = useFormContext<CreateSLOInput>();
   const { data: apmIndex } = useFetchApmIndex();
   useEffect(() => {
     setValue('indicator.params.index', apmIndex);
@@ -89,32 +89,35 @@ export function ApmLatencyIndicatorTypeForm() {
 
       <EuiFlexGroup direction="row" gutterSize="l">
         <EuiFlexItem>
-          <EuiFormLabel>
-            {i18n.translate('xpack.observability.slo.sloEdit.apmLatency.threshold.placeholder', {
-              defaultMessage: 'Threshold (ms)',
-            })}
-          </EuiFormLabel>
-          <Controller
-            shouldUnregister={true}
-            name="indicator.params.threshold"
-            control={control}
-            defaultValue={250}
-            rules={{
-              required: true,
-              min: 0,
-            }}
-            render={({ field: { ref, ...field }, fieldState }) => (
-              <EuiFieldNumber
-                {...field}
-                required
-                isInvalid={fieldState.invalid}
-                value={String(field.value)}
-                data-test-subj="apmLatencyThresholdInput"
-                min={0}
-                onChange={(event) => field.onChange(Number(event.target.value))}
-              />
+          <EuiFormRow
+            label={i18n.translate(
+              'xpack.observability.slo.sloEdit.apmLatency.threshold.placeholder',
+              { defaultMessage: 'Threshold (ms)' }
             )}
-          />
+            isInvalid={getFieldState('indicator.params.threshold').invalid}
+          >
+            <Controller
+              shouldUnregister={true}
+              name="indicator.params.threshold"
+              control={control}
+              defaultValue={250}
+              rules={{
+                required: true,
+                min: 0,
+              }}
+              render={({ field: { ref, ...field }, fieldState }) => (
+                <EuiFieldNumber
+                  {...field}
+                  required
+                  isInvalid={fieldState.invalid}
+                  value={String(field.value)}
+                  data-test-subj="apmLatencyThresholdInput"
+                  min={0}
+                  onChange={(event) => field.onChange(Number(event.target.value))}
+                />
+              )}
+            />
+          </EuiFormRow>
         </EuiFlexItem>
         <EuiFlexItem>
           <QueryBuilder

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/apm_latency/apm_latency_indicator_type_form.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/apm_latency/apm_latency_indicator_type_form.tsx
@@ -119,7 +119,7 @@ export function ApmLatencyIndicatorTypeForm() {
             isInvalid={getFieldState('indicator.params.threshold').invalid}
           >
             <Controller
-              shouldUnregister={true}
+              shouldUnregister
               name="indicator.params.threshold"
               control={control}
               defaultValue={250}

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/common/query_builder.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/common/query_builder.tsx
@@ -51,7 +51,7 @@ export function QueryBuilder({
       fullWidth
     >
       <Controller
-        shouldUnregister={true}
+        shouldUnregister
         defaultValue=""
         name={name}
         control={control}

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/common/query_builder.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/common/query_builder.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { Control, Controller, FieldPath } from 'react-hook-form';
 import { EuiFormRow } from '@elastic/eui';
 import { CreateSLOInput } from '@kbn/slo-schema';
@@ -20,6 +20,7 @@ export interface Props {
   label: string;
   name: FieldPath<CreateSLOInput>;
   placeholder: string;
+  tooltip?: ReactNode;
 }
 
 export function QueryBuilder({
@@ -29,6 +30,7 @@ export function QueryBuilder({
   label,
   name,
   placeholder,
+  tooltip,
 }: Props) {
   const { data, dataViews, docLinks, http, notifications, storage, uiSettings, unifiedSearch } =
     useKibana().services;
@@ -36,7 +38,18 @@ export function QueryBuilder({
   const { dataView } = useCreateDataView({ indexPatternString });
 
   return (
-    <EuiFormRow label={label} fullWidth>
+    <EuiFormRow
+      label={
+        !!tooltip ? (
+          <span>
+            {label} {tooltip}
+          </span>
+        ) : (
+          label
+        )
+      }
+      fullWidth
+    >
       <Controller
         shouldUnregister={true}
         defaultValue=""

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/custom_kql/custom_kql_indicator_type_form.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/custom_kql/custom_kql_indicator_type_form.tsx
@@ -30,7 +30,7 @@ interface Option {
 }
 
 export function CustomKqlIndicatorTypeForm() {
-  const { control, watch } = useFormContext<CreateSLOInput>();
+  const { control, watch, getFieldState } = useFormContext<CreateSLOInput>();
 
   const { isLoading, data: indexFields } = useFetchIndexPatternFields(
     watch('indicator.params.index')
@@ -41,7 +41,7 @@ export function CustomKqlIndicatorTypeForm() {
     <EuiFlexGroup direction="column" gutterSize="l">
       <EuiFlexGroup direction="row" gutterSize="l">
         <EuiFlexItem>
-          <IndexSelection control={control} />
+          <IndexSelection />
         </EuiFlexItem>
         <EuiFlexItem>
           <EuiFormRow
@@ -49,6 +49,7 @@ export function CustomKqlIndicatorTypeForm() {
               'xpack.observability.slo.sloEdit.sliType.customKql.timestampField.label',
               { defaultMessage: 'Timestamp field' }
             )}
+            isInvalid={getFieldState('indicator.params.timestampField').invalid}
           >
             <Controller
               name="indicator.params.timestampField"
@@ -71,7 +72,7 @@ export function CustomKqlIndicatorTypeForm() {
                   data-test-subj="customKqlIndicatorFormTimestampFieldSelect"
                   isClearable={true}
                   isDisabled={!watch('indicator.params.index')}
-                  isInvalid={!!fieldState.error}
+                  isInvalid={fieldState.invalid}
                   isLoading={!!watch('indicator.params.index') && isLoading}
                   onChange={(selected: EuiComboBoxOptionOption[]) => {
                     if (selected.length) {

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/custom_kql/custom_kql_indicator_type_form.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/custom_kql/custom_kql_indicator_type_form.tsx
@@ -71,7 +71,7 @@ export function CustomKqlIndicatorTypeForm() {
                     { defaultMessage: 'Select a timestamp field' }
                   )}
                   data-test-subj="customKqlIndicatorFormTimestampFieldSelect"
-                  isClearable={true}
+                  isClearable
                   isDisabled={!watch('indicator.params.index')}
                   isInvalid={fieldState.invalid}
                   isLoading={!!watch('indicator.params.index') && isLoading}

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/custom_kql/custom_kql_indicator_type_form.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/custom_kql/custom_kql_indicator_type_form.tsx
@@ -12,6 +12,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiFormRow,
+  EuiIconTip,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { Controller, useFormContext } from 'react-hook-form';
@@ -114,10 +115,20 @@ export function CustomKqlIndicatorTypeForm() {
           name="indicator.params.filter"
           placeholder={i18n.translate(
             'xpack.observability.slo.sloEdit.sliType.customKql.customFilter',
-            {
-              defaultMessage: 'Custom filter to apply on the index',
-            }
+            { defaultMessage: 'Custom filter to apply on the index' }
           )}
+          tooltip={
+            <EuiIconTip
+              content={i18n.translate(
+                'xpack.observability.slo.sloEdit.sliType.customKql.customFilter.tooltip',
+                {
+                  defaultMessage:
+                    'This KQL query can be used to filter the documents with some relevant criteria.',
+                }
+              )}
+              position="top"
+            />
+          }
         />
       </EuiFlexItem>
 
@@ -136,6 +147,18 @@ export function CustomKqlIndicatorTypeForm() {
               defaultMessage: 'Define the good events',
             }
           )}
+          tooltip={
+            <EuiIconTip
+              content={i18n.translate(
+                'xpack.observability.slo.sloEdit.sliType.customKql.goodQuery.tooltip',
+                {
+                  defaultMessage:
+                    'This KQL query should return a subset of events that are considered "good" or "successful" for the purpose of calculating the SLO. The query should filter events based on some relevant criteria, such as status codes, error messages, or other relevant fields.',
+                }
+              )}
+              position="top"
+            />
+          }
         />
       </EuiFlexItem>
 
@@ -154,6 +177,18 @@ export function CustomKqlIndicatorTypeForm() {
               defaultMessage: 'Define the total events',
             }
           )}
+          tooltip={
+            <EuiIconTip
+              content={i18n.translate(
+                'xpack.observability.slo.sloEdit.sliType.customKql.totalQuery.tooltip',
+                {
+                  defaultMessage:
+                    'This KQL query should return all events that are relevant to the SLO calculation, including both good and bad events.',
+                }
+              )}
+              position="top"
+            />
+          }
         />
       </EuiFlexItem>
     </EuiFlexGroup>

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/custom_kql/index_selection.stories.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/custom_kql/index_selection.stories.tsx
@@ -10,7 +10,7 @@ import { ComponentStory } from '@storybook/react';
 
 import { FormProvider, useForm } from 'react-hook-form';
 import { KibanaReactStorybookDecorator } from '../../../../utils/kibana_react.storybook_decorator';
-import { IndexSelection as Component, Props } from './index_selection';
+import { IndexSelection as Component } from './index_selection';
 import { SLO_EDIT_FORM_DEFAULT_VALUES } from '../../constants';
 
 export default {
@@ -19,11 +19,11 @@ export default {
   decorators: [KibanaReactStorybookDecorator],
 };
 
-const Template: ComponentStory<typeof Component> = (props: Props) => {
+const Template: ComponentStory<typeof Component> = () => {
   const methods = useForm({ defaultValues: SLO_EDIT_FORM_DEFAULT_VALUES });
   return (
     <FormProvider {...methods}>
-      <Component {...props} control={methods.control} />
+      <Component />
     </FormProvider>
   );
 };

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/custom_kql/index_selection.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/custom_kql/index_selection.tsx
@@ -69,7 +69,7 @@ export function IndexSelection() {
       isInvalid={getFieldState('indicator.params.index').invalid}
     >
       <Controller
-        shouldUnregister={true}
+        shouldUnregister
         defaultValue=""
         name="indicator.params.index"
         control={control}
@@ -85,7 +85,7 @@ export function IndexSelection() {
             )}
             async
             data-test-subj="indexSelection"
-            isClearable={true}
+            isClearable
             isInvalid={fieldState.invalid}
             isLoading={isLoading}
             onChange={(selected: EuiComboBoxOptionOption[]) => {

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/custom_kql/index_selection.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/custom_kql/index_selection.tsx
@@ -6,23 +6,20 @@
  */
 
 import React, { useEffect, useState } from 'react';
-import { Control, Controller } from 'react-hook-form';
+import { Controller, useFormContext } from 'react-hook-form';
 import { EuiComboBox, EuiComboBoxOptionOption, EuiFormRow } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { CreateSLOInput } from '@kbn/slo-schema';
 
 import { useFetchIndices, Index } from '../../../../hooks/use_fetch_indices';
 
-export interface Props {
-  control: Control<CreateSLOInput>;
-}
-
 interface Option {
   label: string;
   options: Array<{ value: string; label: string }>;
 }
 
-export function IndexSelection({ control }: Props) {
+export function IndexSelection() {
+  const { control, getFieldState } = useFormContext<CreateSLOInput>();
   const { isLoading, indices = [] } = useFetchIndices();
   const [indexOptions, setIndexOptions] = useState<Option[]>([]);
 
@@ -69,6 +66,7 @@ export function IndexSelection({ control }: Props) {
           defaultMessage: 'Use * to broaden your query.',
         }
       )}
+      isInvalid={getFieldState('indicator.params.index').invalid}
     >
       <Controller
         shouldUnregister={true}
@@ -88,7 +86,7 @@ export function IndexSelection({ control }: Props) {
             async
             data-test-subj="indexSelection"
             isClearable={true}
-            isInvalid={!!fieldState.error}
+            isInvalid={fieldState.invalid}
             isLoading={isLoading}
             onChange={(selected: EuiComboBoxOptionOption[]) => {
               if (selected.length) {

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/slo_edit_form_description_section.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/slo_edit_form_description_section.tsx
@@ -107,7 +107,7 @@ export function SloEditFormDescriptionSection() {
             })}
           >
             <Controller
-              shouldUnregister={true}
+              shouldUnregister
               name="tags"
               control={control}
               defaultValue={[]}
@@ -153,7 +153,7 @@ export function SloEditFormDescriptionSection() {
                       field.onChange([...values, searchValue]);
                     }
                   }}
-                  isClearable={true}
+                  isClearable
                   data-test-subj="sloEditApmAvailabilityGoodStatusCodesSelector"
                 />
               )}

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/slo_edit_form_description_section.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/slo_edit_form_description_section.tsx
@@ -11,7 +11,7 @@ import {
   EuiFieldText,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiFormLabel,
+  EuiFormRow,
   EuiPanel,
   EuiTextArea,
   useGeneratedHtmlId,
@@ -24,7 +24,7 @@ import type { CreateSLOInput } from '@kbn/slo-schema';
 import { maxWidth } from './slo_edit_form';
 
 export function SloEditFormDescriptionSection() {
-  const { control } = useFormContext<CreateSLOInput>();
+  const { control, getFieldState } = useFormContext<CreateSLOInput>();
   const sloNameId = useGeneratedHtmlId({ prefix: 'sloName' });
   const descriptionId = useGeneratedHtmlId({ prefix: 'sloDescription' });
   const tagsId = useGeneratedHtmlId({ prefix: 'tags' });
@@ -39,118 +39,126 @@ export function SloEditFormDescriptionSection() {
     >
       <EuiFlexGroup direction="column" gutterSize="l">
         <EuiFlexItem>
-          <EuiFormLabel>
-            {i18n.translate('xpack.observability.slo.sloEdit.description.sloName', {
+          <EuiFormRow
+            fullWidth
+            isInvalid={getFieldState('name').invalid}
+            label={i18n.translate('xpack.observability.slo.sloEdit.description.sloName', {
               defaultMessage: 'SLO Name',
             })}
-          </EuiFormLabel>
-
-          <Controller
-            name="name"
-            control={control}
-            rules={{ required: true }}
-            render={({ field: { ref, ...field }, fieldState }) => (
-              <EuiFieldText
-                {...field}
-                fullWidth
-                isInvalid={fieldState.invalid}
-                id={sloNameId}
-                data-test-subj="sloFormNameInput"
-                placeholder={i18n.translate(
-                  'xpack.observability.slo.sloEdit.description.sloNamePlaceholder',
-                  {
-                    defaultMessage: 'Name for the SLO',
-                  }
-                )}
-              />
-            )}
-          />
+          >
+            <Controller
+              name="name"
+              control={control}
+              rules={{ required: true }}
+              render={({ field: { ref, ...field }, fieldState }) => (
+                <EuiFieldText
+                  {...field}
+                  fullWidth
+                  isInvalid={fieldState.invalid}
+                  id={sloNameId}
+                  data-test-subj="sloFormNameInput"
+                  placeholder={i18n.translate(
+                    'xpack.observability.slo.sloEdit.description.sloNamePlaceholder',
+                    {
+                      defaultMessage: 'Name for the SLO',
+                    }
+                  )}
+                />
+              )}
+            />
+          </EuiFormRow>
         </EuiFlexItem>
 
         <EuiFlexItem grow>
-          <EuiFormLabel>
-            {i18n.translate('xpack.observability.slo.sloEdit.description.sloDescription', {
+          <EuiFormRow
+            fullWidth
+            label={i18n.translate('xpack.observability.slo.sloEdit.description.sloDescription', {
               defaultMessage: 'Description',
             })}
-          </EuiFormLabel>
-
-          <Controller
-            name="description"
-            defaultValue=""
-            control={control}
-            rules={{ required: false }}
-            render={({ field: { ref, ...field } }) => (
-              <EuiTextArea
-                {...field}
-                fullWidth
-                id={descriptionId}
-                data-test-subj="sloFormDescriptionTextArea"
-                placeholder={i18n.translate(
-                  'xpack.observability.slo.sloEdit.description.sloDescriptionPlaceholder',
-                  {
-                    defaultMessage: 'A short description of the SLO',
-                  }
-                )}
-              />
-            )}
-          />
+          >
+            <Controller
+              name="description"
+              defaultValue=""
+              control={control}
+              rules={{ required: false }}
+              render={({ field: { ref, ...field } }) => (
+                <EuiTextArea
+                  {...field}
+                  fullWidth
+                  id={descriptionId}
+                  data-test-subj="sloFormDescriptionTextArea"
+                  placeholder={i18n.translate(
+                    'xpack.observability.slo.sloEdit.description.sloDescriptionPlaceholder',
+                    {
+                      defaultMessage: 'A short description of the SLO',
+                    }
+                  )}
+                />
+              )}
+            />
+          </EuiFormRow>
         </EuiFlexItem>
 
         <EuiFlexItem grow>
-          <EuiFormLabel>
-            {i18n.translate('xpack.observability.slo.sloEdit.tags.label', {
+          <EuiFormRow
+            fullWidth
+            label={i18n.translate('xpack.observability.slo.sloEdit.tags.label', {
               defaultMessage: 'Tags',
             })}
-          </EuiFormLabel>
-          <Controller
-            shouldUnregister={true}
-            name="tags"
-            control={control}
-            defaultValue={[]}
-            rules={{ required: false }}
-            render={({ field: { ref, ...field }, fieldState }) => (
-              <EuiComboBox
-                {...field}
-                id={tagsId}
-                fullWidth
-                aria-label={i18n.translate('xpack.observability.slo.sloEdit.tags.placeholder', {
-                  defaultMessage: 'Add tags',
-                })}
-                placeholder={i18n.translate('xpack.observability.slo.sloEdit.tags.placeholder', {
-                  defaultMessage: 'Add tags',
-                })}
-                isInvalid={!!fieldState.error}
-                options={[]}
-                noSuggestions
-                selectedOptions={generateTagOptions(field.value)}
-                onChange={(selected: EuiComboBoxOptionOption[]) => {
-                  if (selected.length) {
-                    return field.onChange(selected.map((opts) => opts.value));
-                  }
+          >
+            <Controller
+              shouldUnregister={true}
+              name="tags"
+              control={control}
+              defaultValue={[]}
+              rules={{ required: false }}
+              render={({ field: { ref, ...field }, fieldState }) => (
+                <EuiComboBox
+                  {...field}
+                  id={tagsId}
+                  fullWidth
+                  aria-label={i18n.translate('xpack.observability.slo.sloEdit.tags.placeholder', {
+                    defaultMessage: 'Add tags',
+                  })}
+                  placeholder={i18n.translate('xpack.observability.slo.sloEdit.tags.placeholder', {
+                    defaultMessage: 'Add tags',
+                  })}
+                  isInvalid={fieldState.invalid}
+                  options={[]}
+                  noSuggestions
+                  selectedOptions={generateTagOptions(field.value)}
+                  onChange={(selected: EuiComboBoxOptionOption[]) => {
+                    if (selected.length) {
+                      return field.onChange(selected.map((opts) => opts.value));
+                    }
 
-                  field.onChange([]);
-                }}
-                onCreateOption={(searchValue: string, options: EuiComboBoxOptionOption[] = []) => {
-                  const normalizedSearchValue = searchValue.trim().toLowerCase();
+                    field.onChange([]);
+                  }}
+                  onCreateOption={(
+                    searchValue: string,
+                    options: EuiComboBoxOptionOption[] = []
+                  ) => {
+                    const normalizedSearchValue = searchValue.trim().toLowerCase();
 
-                  if (!normalizedSearchValue) {
-                    return;
-                  }
-                  const values = field.value ?? [];
+                    if (!normalizedSearchValue) {
+                      return;
+                    }
+                    const values = field.value ?? [];
 
-                  if (
-                    values.findIndex(
-                      (tag) => tag.trim().toLowerCase() === normalizedSearchValue
-                    ) === -1
-                  ) {
-                    field.onChange([...values, searchValue]);
-                  }
-                }}
-                isClearable={true}
-                data-test-subj="sloEditApmAvailabilityGoodStatusCodesSelector"
-              />
-            )}
-          />
+                    if (
+                      values.findIndex(
+                        (tag) => tag.trim().toLowerCase() === normalizedSearchValue
+                      ) === -1
+                    ) {
+                      field.onChange([...values, searchValue]);
+                    }
+                  }}
+                  isClearable={true}
+                  data-test-subj="sloEditApmAvailabilityGoodStatusCodesSelector"
+                />
+              )}
+            />
+          </EuiFormRow>
         </EuiFlexItem>
       </EuiFlexGroup>
     </EuiPanel>

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/slo_edit_form_indicator_section.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/slo_edit_form_indicator_section.tsx
@@ -5,11 +5,12 @@
  * 2.0.
  */
 
-import { EuiFormLabel, EuiPanel, EuiSelect, EuiSpacer } from '@elastic/eui';
+import { EuiFormRow, EuiPanel, EuiSelect, EuiSpacer } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { CreateSLOInput } from '@kbn/slo-schema';
 import React from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
+
 import { SLI_OPTIONS } from '../constants';
 import { ApmAvailabilityIndicatorTypeForm } from './apm_availability/apm_availability_indicator_type_form';
 import { ApmLatencyIndicatorTypeForm } from './apm_latency/apm_latency_indicator_type_form';
@@ -40,25 +41,25 @@ export function SloEditFormIndicatorSection() {
       style={{ maxWidth }}
       data-test-subj="sloEditFormIndicatorSection"
     >
-      <EuiFormLabel>
-        {i18n.translate('xpack.observability.slo.sloEdit.definition.sliType', {
+      <EuiFormRow
+        label={i18n.translate('xpack.observability.slo.sloEdit.definition.sliType', {
           defaultMessage: 'Choose the SLI type',
         })}
-      </EuiFormLabel>
-
-      <Controller
-        name="indicator.type"
-        control={control}
-        rules={{ required: true }}
-        render={({ field: { ref, ...field } }) => (
-          <EuiSelect
-            {...field}
-            required
-            data-test-subj="sloFormIndicatorTypeSelect"
-            options={SLI_OPTIONS}
-          />
-        )}
-      />
+      >
+        <Controller
+          name="indicator.type"
+          control={control}
+          rules={{ required: true }}
+          render={({ field: { ref, ...field } }) => (
+            <EuiSelect
+              {...field}
+              required
+              data-test-subj="sloFormIndicatorTypeSelect"
+              options={SLI_OPTIONS}
+            />
+          )}
+        />
+      </EuiFormRow>
 
       <EuiSpacer size="xxl" />
 

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/slo_edit_form_objective_section.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/slo_edit_form_objective_section.tsx
@@ -10,7 +10,7 @@ import {
   EuiFieldNumber,
   EuiFlexGrid,
   EuiFlexItem,
-  EuiFormLabel,
+  EuiFormRow,
   EuiPanel,
   EuiSelect,
   EuiSpacer,
@@ -25,7 +25,7 @@ import { BUDGETING_METHOD_OPTIONS, TIMEWINDOW_OPTIONS } from '../constants';
 import { maxWidth } from './slo_edit_form';
 
 export function SloEditFormObjectiveSection() {
-  const { control, watch } = useFormContext<CreateSLOInput>();
+  const { control, watch, getFieldState } = useFormContext<CreateSLOInput>();
   const budgetingSelect = useGeneratedHtmlId({ prefix: 'budgetingSelect' });
   const timeWindowSelect = useGeneratedHtmlId({ prefix: 'timeWindowSelect' });
 
@@ -39,81 +39,82 @@ export function SloEditFormObjectiveSection() {
     >
       <EuiFlexGrid columns={3}>
         <EuiFlexItem>
-          <EuiFormLabel>
-            {i18n.translate('xpack.observability.slo.sloEdit.budgetingMethod.label', {
+          <EuiFormRow
+            label={i18n.translate('xpack.observability.slo.sloEdit.budgetingMethod.label', {
               defaultMessage: 'Budgeting method',
             })}
-          </EuiFormLabel>
-
-          <Controller
-            name="budgetingMethod"
-            control={control}
-            rules={{ required: true }}
-            render={({ field: { ref, ...field } }) => (
-              <EuiSelect
-                {...field}
-                required
-                id={budgetingSelect}
-                data-test-subj="sloFormBudgetingMethodSelect"
-                options={BUDGETING_METHOD_OPTIONS}
-              />
-            )}
-          />
+          >
+            <Controller
+              name="budgetingMethod"
+              control={control}
+              rules={{ required: true }}
+              render={({ field: { ref, ...field } }) => (
+                <EuiSelect
+                  {...field}
+                  required
+                  id={budgetingSelect}
+                  data-test-subj="sloFormBudgetingMethodSelect"
+                  options={BUDGETING_METHOD_OPTIONS}
+                />
+              )}
+            />
+          </EuiFormRow>
         </EuiFlexItem>
 
         <EuiFlexItem>
-          <EuiFormLabel>
-            {i18n.translate('xpack.observability.slo.sloEdit.timeWindow.label', {
+          <EuiFormRow
+            label={i18n.translate('xpack.observability.slo.sloEdit.timeWindow.label', {
               defaultMessage: 'Time window',
             })}
-          </EuiFormLabel>
-
-          <Controller
-            name="timeWindow.duration"
-            control={control}
-            rules={{ required: true }}
-            render={({ field: { ref, ...field } }) => (
-              <EuiSelect
-                {...field}
-                required
-                id={timeWindowSelect}
-                data-test-subj="sloFormTimeWindowDurationSelect"
-                options={TIMEWINDOW_OPTIONS}
-                value={String(field.value)}
-              />
-            )}
-          />
+          >
+            <Controller
+              name="timeWindow.duration"
+              control={control}
+              rules={{ required: true }}
+              render={({ field: { ref, ...field } }) => (
+                <EuiSelect
+                  {...field}
+                  required
+                  id={timeWindowSelect}
+                  data-test-subj="sloFormTimeWindowDurationSelect"
+                  options={TIMEWINDOW_OPTIONS}
+                  value={String(field.value)}
+                />
+              )}
+            />
+          </EuiFormRow>
         </EuiFlexItem>
 
         <EuiFlexItem>
-          <EuiFormLabel>
-            {i18n.translate('xpack.observability.slo.sloEdit.targetSlo.label', {
+          <EuiFormRow
+            isInvalid={getFieldState('objective.target').invalid}
+            label={i18n.translate('xpack.observability.slo.sloEdit.targetSlo.label', {
               defaultMessage: 'Target / SLO (%)',
             })}
-          </EuiFormLabel>
-
-          <Controller
-            name="objective.target"
-            control={control}
-            rules={{
-              required: true,
-              min: 0.001,
-              max: 99.999,
-            }}
-            render={({ field: { ref, ...field }, fieldState }) => (
-              <EuiFieldNumber
-                {...field}
-                required
-                isInvalid={fieldState.invalid}
-                data-test-subj="sloFormObjectiveTargetInput"
-                value={String(field.value)}
-                min={0.001}
-                max={99.999}
-                step={0.001}
-                onChange={(event) => field.onChange(Number(event.target.value))}
-              />
-            )}
-          />
+          >
+            <Controller
+              name="objective.target"
+              control={control}
+              rules={{
+                required: true,
+                min: 0.001,
+                max: 99.999,
+              }}
+              render={({ field: { ref, ...field }, fieldState }) => (
+                <EuiFieldNumber
+                  {...field}
+                  required
+                  isInvalid={fieldState.invalid}
+                  data-test-subj="sloFormObjectiveTargetInput"
+                  value={String(field.value)}
+                  min={0.001}
+                  max={99.999}
+                  step={0.001}
+                  onChange={(event) => field.onChange(Number(event.target.value))}
+                />
+              )}
+            />
+          </EuiFormRow>
         </EuiFlexItem>
       </EuiFlexGrid>
 

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/slo_edit_form_objective_section.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/slo_edit_form_objective_section.tsx
@@ -11,6 +11,7 @@ import {
   EuiFlexGrid,
   EuiFlexItem,
   EuiFormRow,
+  EuiIconTip,
   EuiPanel,
   EuiSelect,
   EuiSpacer,
@@ -40,9 +41,23 @@ export function SloEditFormObjectiveSection() {
       <EuiFlexGrid columns={3}>
         <EuiFlexItem>
           <EuiFormRow
-            label={i18n.translate('xpack.observability.slo.sloEdit.budgetingMethod.label', {
-              defaultMessage: 'Budgeting method',
-            })}
+            label={
+              <span>
+                {i18n.translate('xpack.observability.slo.sloEdit.budgetingMethod.label', {
+                  defaultMessage: 'Budgeting method',
+                })}{' '}
+                <EuiIconTip
+                  content={i18n.translate(
+                    'xpack.observability.slo.sloEdit.budgetingMethod.tooltip',
+                    {
+                      defaultMessage:
+                        'Occurrences-based SLO uses the ratio of good events over the total events during the time window. Timeslices-based SLO uses the ratio of good time slices over the total time slices during the time window.',
+                    }
+                  )}
+                  position="top"
+                />
+              </span>
+            }
           >
             <Controller
               name="budgetingMethod"
@@ -63,9 +78,20 @@ export function SloEditFormObjectiveSection() {
 
         <EuiFlexItem>
           <EuiFormRow
-            label={i18n.translate('xpack.observability.slo.sloEdit.timeWindow.label', {
-              defaultMessage: 'Time window',
-            })}
+            label={
+              <span>
+                {i18n.translate('xpack.observability.slo.sloEdit.timeWindow.label', {
+                  defaultMessage: 'Time window',
+                })}{' '}
+                <EuiIconTip
+                  content={i18n.translate('xpack.observability.slo.sloEdit.timeWindow.tooltip', {
+                    defaultMessage:
+                      'The rolling time window duration used to compute the SLO over.',
+                  })}
+                  position="top"
+                />
+              </span>
+            }
           >
             <Controller
               name="timeWindow.duration"
@@ -88,9 +114,19 @@ export function SloEditFormObjectiveSection() {
         <EuiFlexItem>
           <EuiFormRow
             isInvalid={getFieldState('objective.target').invalid}
-            label={i18n.translate('xpack.observability.slo.sloEdit.targetSlo.label', {
-              defaultMessage: 'Target / SLO (%)',
-            })}
+            label={
+              <span>
+                {i18n.translate('xpack.observability.slo.sloEdit.targetSlo.label', {
+                  defaultMessage: 'Target / SLO (%)',
+                })}{' '}
+                <EuiIconTip
+                  content={i18n.translate('xpack.observability.slo.sloEdit.targetSlo.tooltip', {
+                    defaultMessage: 'The target objective in percentage for the SLO.',
+                  })}
+                  position="top"
+                />
+              </span>
+            }
           >
             <Controller
               name="objective.target"

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/slo_edit_form_objective_section_timeslices.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/slo_edit_form_objective_section_timeslices.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { EuiFieldNumber, EuiFlexGrid, EuiFlexItem, EuiFormRow } from '@elastic/eui';
+import { EuiFieldNumber, EuiFlexGrid, EuiFlexItem, EuiFormRow, EuiIconTip } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { Controller, useFormContext } from 'react-hook-form';
 import type { CreateSLOInput } from '@kbn/slo-schema';
@@ -18,9 +18,20 @@ export function SloEditFormObjectiveSectionTimeslices() {
       <EuiFlexItem>
         <EuiFormRow
           isInvalid={getFieldState('objective.timesliceTarget').invalid}
-          label={i18n.translate('xpack.observability.slo.sloEdit.timeSliceTarget.label', {
-            defaultMessage: 'Timeslice target (%)',
-          })}
+          label={
+            <span>
+              {i18n.translate('xpack.observability.slo.sloEdit.timeSliceTarget.label', {
+                defaultMessage: 'Timeslice target (%)',
+              })}{' '}
+              <EuiIconTip
+                content={i18n.translate('xpack.observability.slo.sloEdit.timeSliceTarget.tooltip', {
+                  defaultMessage:
+                    'The individual time slices target used to determine whether the slice is good or bad.',
+                })}
+                position="top"
+              />
+            </span>
+          }
         >
           <Controller
             shouldUnregister={true}
@@ -52,9 +63,19 @@ export function SloEditFormObjectiveSectionTimeslices() {
       <EuiFlexItem>
         <EuiFormRow
           isInvalid={getFieldState('objective.timesliceWindow').invalid}
-          label={i18n.translate('xpack.observability.slo.sloEdit.timesliceWindow.label', {
-            defaultMessage: 'Timeslice window (in minutes)',
-          })}
+          label={
+            <span>
+              {i18n.translate('xpack.observability.slo.sloEdit.timesliceWindow.label', {
+                defaultMessage: 'Timeslice window (in minutes)',
+              })}{' '}
+              <EuiIconTip
+                content={i18n.translate('xpack.observability.slo.sloEdit.timesliceWindow.tooltip', {
+                  defaultMessage: 'The time slice window size used to evaluate the data from.',
+                })}
+                position="top"
+              />
+            </span>
+          }
         >
           <Controller
             shouldUnregister={true}

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/slo_edit_form_objective_section_timeslices.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/slo_edit_form_objective_section_timeslices.tsx
@@ -34,7 +34,7 @@ export function SloEditFormObjectiveSectionTimeslices() {
           }
         >
           <Controller
-            shouldUnregister={true}
+            shouldUnregister
             name="objective.timesliceTarget"
             control={control}
             defaultValue={95}
@@ -78,7 +78,7 @@ export function SloEditFormObjectiveSectionTimeslices() {
           }
         >
           <Controller
-            shouldUnregister={true}
+            shouldUnregister
             name="objective.timesliceWindow"
             defaultValue="1"
             control={control}

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/slo_edit_form_objective_section_timeslices.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/slo_edit_form_objective_section_timeslices.tsx
@@ -6,74 +6,77 @@
  */
 
 import React from 'react';
-import { EuiFieldNumber, EuiFlexGrid, EuiFlexItem, EuiFormLabel } from '@elastic/eui';
+import { EuiFieldNumber, EuiFlexGrid, EuiFlexItem, EuiFormRow } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { Controller, useFormContext } from 'react-hook-form';
 import type { CreateSLOInput } from '@kbn/slo-schema';
 
 export function SloEditFormObjectiveSectionTimeslices() {
-  const { control } = useFormContext<CreateSLOInput>();
+  const { control, getFieldState } = useFormContext<CreateSLOInput>();
   return (
     <EuiFlexGrid columns={3}>
       <EuiFlexItem>
-        <EuiFormLabel>
-          {i18n.translate('xpack.observability.slo.sloEdit.timeSliceTarget.label', {
+        <EuiFormRow
+          isInvalid={getFieldState('objective.timesliceTarget').invalid}
+          label={i18n.translate('xpack.observability.slo.sloEdit.timeSliceTarget.label', {
             defaultMessage: 'Timeslice target (%)',
           })}
-        </EuiFormLabel>
-        <Controller
-          shouldUnregister={true}
-          name="objective.timesliceTarget"
-          control={control}
-          defaultValue={95}
-          rules={{
-            required: true,
-            min: 0.001,
-            max: 99.999,
-          }}
-          render={({ field: { ref, ...field }, fieldState }) => (
-            <EuiFieldNumber
-              {...field}
-              required
-              isInvalid={fieldState.invalid}
-              value={String(field.value)}
-              data-test-subj="sloFormObjectiveTimesliceTargetInput"
-              min={0.001}
-              max={99.999}
-              step={0.001}
-              onChange={(event) => field.onChange(Number(event.target.value))}
-            />
-          )}
-        />
+        >
+          <Controller
+            shouldUnregister={true}
+            name="objective.timesliceTarget"
+            control={control}
+            defaultValue={95}
+            rules={{
+              required: true,
+              min: 0.001,
+              max: 99.999,
+            }}
+            render={({ field: { ref, ...field }, fieldState }) => (
+              <EuiFieldNumber
+                {...field}
+                required
+                isInvalid={fieldState.invalid}
+                value={String(field.value)}
+                data-test-subj="sloFormObjectiveTimesliceTargetInput"
+                min={0.001}
+                max={99.999}
+                step={0.001}
+                onChange={(event) => field.onChange(Number(event.target.value))}
+              />
+            )}
+          />
+        </EuiFormRow>
       </EuiFlexItem>
 
       <EuiFlexItem>
-        <EuiFormLabel>
-          {i18n.translate('xpack.observability.slo.sloEdit.timesliceWindow.label', {
-            defaultMessage: 'Timeslice window (minutes)',
+        <EuiFormRow
+          isInvalid={getFieldState('objective.timesliceWindow').invalid}
+          label={i18n.translate('xpack.observability.slo.sloEdit.timesliceWindow.label', {
+            defaultMessage: 'Timeslice window (in minutes)',
           })}
-        </EuiFormLabel>
-
-        <Controller
-          shouldUnregister={true}
-          name="objective.timesliceWindow"
-          defaultValue="1"
-          control={control}
-          rules={{ required: true, min: 1, max: 120 }}
-          render={({ field: { ref, ...field }, fieldState }) => (
-            <EuiFieldNumber
-              {...field}
-              isInvalid={fieldState.invalid}
-              required
-              data-test-subj="sloFormObjectiveTimesliceWindowInput"
-              value={String(field.value)}
-              min={1}
-              max={120}
-              step={1}
-              onChange={(event) => field.onChange(String(Number(event.target.value)))}
-            />
-          )}
-        />
+        >
+          <Controller
+            shouldUnregister={true}
+            name="objective.timesliceWindow"
+            defaultValue="1"
+            control={control}
+            rules={{ required: true, min: 1, max: 120 }}
+            render={({ field: { ref, ...field }, fieldState }) => (
+              <EuiFieldNumber
+                {...field}
+                isInvalid={fieldState.invalid}
+                required
+                data-test-subj="sloFormObjectiveTimesliceWindowInput"
+                value={String(field.value)}
+                min={1}
+                max={120}
+                step={1}
+                onChange={(event) => field.onChange(String(Number(event.target.value)))}
+              />
+            )}
+          />
+        </EuiFormRow>
       </EuiFlexItem>
     </EuiFlexGrid>
   );


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/154765

This PR adds the tooltips to most of the form fields. I've also refactored the forms to use EuiFormRow instead of a standalone FormLabel. The fields invalid states are better looking and more obvious now.

Screenshot |
-- |
<img width="1139" alt="image" src="https://user-images.githubusercontent.com/1376800/231263370-678f6016-c0c6-4d63-a954-833fc8a296be.png"> |
<img width="1160" alt="image" src="https://user-images.githubusercontent.com/1376800/231263487-977d2fa9-3eb4-46e1-9063-cfb3beb5d203.png"> |
