### PR TITLE
[8.7] [Fleet] Logstash Output - prevent updating data_output_id for preconfigured policies (#154445)

### DIFF
--- a/x-pack/plugins/fleet/server/services/output.test.ts
+++ b/x-pack/plugins/fleet/server/services/output.test.ts
@@ -177,7 +177,6 @@ describe('Output Service', () => {
     mockedAgentPolicyService.removeOutputFromAll.mockReset();
     mockedAppContextService.getInternalUserSOClient.mockReset();
     mockedAppContextService.getEncryptedSavedObjectsSetup.mockReset();
-    mockedAuditLoggingService.writeCustomSoAuditLog.mockReset();
     mockedAgentPolicyService.update.mockReset();
   });
   describe('create', () => {

--- a/x-pack/plugins/fleet/server/services/output.test.ts
+++ b/x-pack/plugins/fleet/server/services/output.test.ts
@@ -177,6 +177,8 @@ describe('Output Service', () => {
     mockedAgentPolicyService.removeOutputFromAll.mockReset();
     mockedAppContextService.getInternalUserSOClient.mockReset();
     mockedAppContextService.getEncryptedSavedObjectsSetup.mockReset();
+    mockedAuditLoggingService.writeCustomSoAuditLog.mockReset();
+    mockedAgentPolicyService.update.mockReset();
   });
   describe('create', () => {
     it('work with a predefined id', async () => {
@@ -431,7 +433,7 @@ describe('Output Service', () => {
         expect.anything(),
         'fleet_server_policy',
         { data_output_id: 'output-test' },
-        { force: true }
+        { force: false }
       );
     });
 
@@ -484,14 +486,6 @@ describe('Output Service', () => {
           type: 'logstash',
         },
         { id: 'output-1' }
-      );
-
-      expect(mockedAgentPolicyService.update).toBeCalledWith(
-        expect.anything(),
-        expect.anything(),
-        'fleet_server_policy',
-        { data_output_id: 'output-test' },
-        { force: true }
       );
     });
   });
@@ -763,6 +757,72 @@ describe('Output Service', () => {
         hosts: ['test:4343'],
         is_default: true,
       });
+
+      expect(soClient.update).toBeCalledWith(expect.anything(), expect.anything(), {
+        type: 'logstash',
+        hosts: ['test:4343'],
+        is_default: true,
+        ca_sha256: null,
+        ca_trusted_fingerprint: null,
+      });
+      expect(mockedAgentPolicyService.update).toBeCalledWith(
+        expect.anything(),
+        expect.anything(),
+        'fleet_server_policy',
+        { data_output_id: 'output-test' },
+        { force: false }
+      );
+    });
+
+    it('Should update fleet server policies with data_output_id=default_output_id and force=true if a default ES output is changed to logstash, from preconfiguration', async () => {
+      const soClient = getMockedSoClient({
+        defaultOutputId: 'output-test',
+      });
+      mockedAgentPolicyService.list.mockResolvedValue({
+        items: [
+          {
+            name: 'fleet server policy',
+            id: 'fleet_server_policy',
+            is_default_fleet_server: true,
+            package_policies: [
+              {
+                name: 'fleet-server-123',
+                package: {
+                  name: 'fleet_server',
+                },
+              },
+            ],
+          },
+          {
+            name: 'agent policy 1',
+            id: 'agent_policy_1',
+            is_managed: false,
+            package_policies: [
+              {
+                name: 'nginx',
+                package: {
+                  name: 'nginx',
+                },
+              },
+            ],
+          },
+        ],
+      } as unknown as ReturnType<typeof mockedAgentPolicyService.list>);
+      mockedAgentPolicyService.hasFleetServerIntegration.mockReturnValue(true);
+
+      await outputService.update(
+        soClient,
+        esClientMock,
+        'output-test',
+        {
+          type: 'logstash',
+          hosts: ['test:4343'],
+          is_default: true,
+        },
+        {
+          fromPreconfiguration: true,
+        }
+      );
 
       expect(soClient.update).toBeCalledWith(expect.anything(), expect.anything(), {
         type: 'logstash',

--- a/x-pack/plugins/fleet/server/services/output.ts
+++ b/x-pack/plugins/fleet/server/services/output.ts
@@ -163,7 +163,8 @@ async function validateTypeChanges(
   id: string,
   data: Partial<Output>,
   originalOutput: Output,
-  defaultDataOutputId: string | null
+  defaultDataOutputId: string | null,
+  fromPreconfiguration: boolean
 ) {
   const mergedIsDefault = data.is_default ?? originalOutput.is_default;
   const fleetServerPolicies = await findPoliciesWithFleetServer(soClient, id, mergedIsDefault);
@@ -176,18 +177,42 @@ async function validateTypeChanges(
     // Validate no policy with fleet server use that policy
     validateLogstashOutputNotUsedInFleetServerPolicy(fleetServerPolicies);
   }
-  // if a logstash output is updated to become default, update the fleet server policies to use the previous ES output or default output
-  if (data?.type === outputType.Logstash && mergedIsDefault) {
+  await updateFleetServerPoliciesDataOutputId(
+    soClient,
+    esClient,
+    data,
+    mergedIsDefault,
+    defaultDataOutputId,
+    fleetServerPolicies,
+    fromPreconfiguration
+  );
+}
+
+async function updateFleetServerPoliciesDataOutputId(
+  soClient: SavedObjectsClientContract,
+  esClient: ElasticsearchClient,
+  data: Partial<Output>,
+  isDefault: boolean,
+  defaultDataOutputId: string | null,
+  fleetServerPolicies: AgentPolicy[],
+  fromPreconfiguration: boolean
+) {
+  // if a logstash output is updated to become default
+  // if fleet server policies are don't have data_output_id or if they are using the new output
+  // update them to use the default output
+  if (data?.type === outputType.Logstash && isDefault) {
     for (const policy of fleetServerPolicies) {
-      await agentPolicyService.update(
-        soClient,
-        esClient,
-        policy.id,
-        { data_output_id: defaultDataOutputId },
-        {
-          force: true,
-        }
-      );
+      if (!policy.data_output_id || policy.data_output_id === data?.id) {
+        await agentPolicyService.update(
+          soClient,
+          esClient,
+          policy.id,
+          {
+            data_output_id: defaultDataOutputId,
+          },
+          { force: fromPreconfiguration }
+        );
+      }
     }
   }
 }
@@ -280,6 +305,7 @@ class OutputService {
     options?: { id?: string; fromPreconfiguration?: boolean; overwrite?: boolean }
   ): Promise<Output> {
     const data: OutputSOAttributes = { ...omit(output, 'ssl') };
+    const defaultDataOutputId = await this.getDefaultDataOutputId(soClient);
 
     if (output.type === outputType.Logstash) {
       await validateLogstashOutputNotUsedInAPMPolicy(soClient, undefined, data.is_default);
@@ -289,34 +315,24 @@ class OutputService {
         );
       }
     }
-
-    if (data.type === outputType.Logstash) {
-      const defaultDataOutputId = await this.getDefaultDataOutputId(soClient);
-      const fleetServerPolicies = await findPoliciesWithFleetServer(soClient);
-      // if a logstash output is updated to become default, update the fleet server policies to use the previous ES output or default output
-      if (data.is_default) {
-        for (const policy of fleetServerPolicies) {
-          await agentPolicyService.update(
-            soClient,
-            esClient,
-            policy.id,
-            { data_output_id: defaultDataOutputId },
-            {
-              force: true,
-            }
-          );
-        }
-      }
-    }
+    const fleetServerPolicies = await findPoliciesWithFleetServer(soClient);
+    await updateFleetServerPoliciesDataOutputId(
+      soClient,
+      esClient,
+      data,
+      data.is_default,
+      defaultDataOutputId,
+      fleetServerPolicies,
+      options?.fromPreconfiguration ?? false
+    );
 
     // ensure only default output exists
     if (data.is_default) {
-      const defaultDataOuputId = await this.getDefaultDataOutputId(soClient);
-      if (defaultDataOuputId) {
+      if (defaultDataOutputId) {
         await this.update(
           soClient,
           esClient,
-          defaultDataOuputId,
+          defaultDataOutputId,
           { is_default: false },
           { fromPreconfiguration: options?.fromPreconfiguration ?? false }
         );
@@ -491,7 +507,15 @@ class OutputService {
     const mergedType = data.type ?? originalOutput.type;
     const defaultDataOutputId = await this.getDefaultDataOutputId(soClient);
 
-    await validateTypeChanges(soClient, esClient, id, data, originalOutput, defaultDataOutputId);
+    await validateTypeChanges(
+      soClient,
+      esClient,
+      id,
+      data,
+      originalOutput,
+      defaultDataOutputId,
+      fromPreconfiguration
+    );
 
     // If the output type changed
     if (data.type && data.type !== originalOutput.type) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.7`:
 - [[Fleet] Logstash Output - prevent updating data_output_id for preconfigured policies (#154445)](https://github.com/elastic/kibana/pull/154445)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Cristina Amico","email":"criamico@users.noreply.github.com"},"sourceCommit":{"committedDate":"2023-04-11T18:38:17Z","message":"[Fleet] Logstash Output - prevent updating data_output_id for preconfigured policies (#154445)\n\nCloses https://github.com/elastic/kibana/issues/154326\r\n\r\n## Summary\r\n\r\nAfter the merge of https://github.com/elastic/kibana/pull/153226, when\r\ncreating/updating a Logstash output as default, the `Elastic Cloud agent\r\npolicy` preconfigured on Cloud gets reassigned to the \"default\" ES\r\npolicy instead than keeping the `Elastic Cloud internal output`.\r\n\r\n<img width=\"1418\" alt=\"Screenshot 2023-04-04 at 12 51 21\"\r\nsrc=\"https://user-images.githubusercontent.com/16084106/230112067-a2767d1a-1191-4877-8dec-546d1590e41f.png\">\r\n\r\nTee bug is fixed by checking if any given fleet server policy is\r\n`preconfigured` or if it has already an assigned `data_output_id`, in\r\nwhich cases it doesn't get updated.\r\n\r\n### Testing\r\n- Create an ES output additional to the default one\r\n- Create a preconfigured fleet server policy and make sure it has\r\n`fleet-server` integration (this is to simulate the preconfigured cloud\r\npolicy)\r\n- Assign the previous output to the preconfigured policy\r\n- Now create a new `logstash` output and make it default\r\n- Check that the preconfigured policy maintains the custom output\r\npreviously assigned\r\n\r\n### Checklist\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n\r\n---------\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>\r\nCo-authored-by: Nicolas Chaulet <nicolas.chaulet@elastic.co>","sha":"a5de314687a195f4b73fb4b10bf6d3f7f5e58fd9","branchLabelMapping":{"^v8.8.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Fleet","backport:prev-minor","v8.8.0"],"number":154445,"url":"https://github.com/elastic/kibana/pull/154445","mergeCommit":{"message":"[Fleet] Logstash Output - prevent updating data_output_id for preconfigured policies (#154445)\n\nCloses https://github.com/elastic/kibana/issues/154326\r\n\r\n## Summary\r\n\r\nAfter the merge of https://github.com/elastic/kibana/pull/153226, when\r\ncreating/updating a Logstash output as default, the `Elastic Cloud agent\r\npolicy` preconfigured on Cloud gets reassigned to the \"default\" ES\r\npolicy instead than keeping the `Elastic Cloud internal output`.\r\n\r\n<img width=\"1418\" alt=\"Screenshot 2023-04-04 at 12 51 21\"\r\nsrc=\"https://user-images.githubusercontent.com/16084106/230112067-a2767d1a-1191-4877-8dec-546d1590e41f.png\">\r\n\r\nTee bug is fixed by checking if any given fleet server policy is\r\n`preconfigured` or if it has already an assigned `data_output_id`, in\r\nwhich cases it doesn't get updated.\r\n\r\n### Testing\r\n- Create an ES output additional to the default one\r\n- Create a preconfigured fleet server policy and make sure it has\r\n`fleet-server` integration (this is to simulate the preconfigured cloud\r\npolicy)\r\n- Assign the previous output to the preconfigured policy\r\n- Now create a new `logstash` output and make it default\r\n- Check that the preconfigured policy maintains the custom output\r\npreviously assigned\r\n\r\n### Checklist\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n\r\n---------\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>\r\nCo-authored-by: Nicolas Chaulet <nicolas.chaulet@elastic.co>","sha":"a5de314687a195f4b73fb4b10bf6d3f7f5e58fd9"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.8.0","labelRegex":"^v8.8.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/154445","number":154445,"mergeCommit":{"message":"[Fleet] Logstash Output - prevent updating data_output_id for preconfigured policies (#154445)\n\nCloses https://github.com/elastic/kibana/issues/154326\r\n\r\n## Summary\r\n\r\nAfter the merge of https://github.com/elastic/kibana/pull/153226, when\r\ncreating/updating a Logstash output as default, the `Elastic Cloud agent\r\npolicy` preconfigured on Cloud gets reassigned to the \"default\" ES\r\npolicy instead than keeping the `Elastic Cloud internal output`.\r\n\r\n<img width=\"1418\" alt=\"Screenshot 2023-04-04 at 12 51 21\"\r\nsrc=\"https://user-images.githubusercontent.com/16084106/230112067-a2767d1a-1191-4877-8dec-546d1590e41f.png\">\r\n\r\nTee bug is fixed by checking if any given fleet server policy is\r\n`preconfigured` or if it has already an assigned `data_output_id`, in\r\nwhich cases it doesn't get updated.\r\n\r\n### Testing\r\n- Create an ES output additional to the default one\r\n- Create a preconfigured fleet server policy and make sure it has\r\n`fleet-server` integration (this is to simulate the preconfigured cloud\r\npolicy)\r\n- Assign the previous output to the preconfigured policy\r\n- Now create a new `logstash` output and make it default\r\n- Check that the preconfigured policy maintains the custom output\r\npreviously assigned\r\n\r\n### Checklist\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n\r\n---------\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>\r\nCo-authored-by: Nicolas Chaulet <nicolas.chaulet@elastic.co>","sha":"a5de314687a195f4b73fb4b10bf6d3f7f5e58fd9"}}]}] BACKPORT-->