### PR TITLE
Use Observability Page Template from Observability Shared in Observability app

### DIFF
--- a/x-pack/plugins/observability/kibana.jsonc
+++ b/x-pack/plugins/observability/kibana.jsonc
@@ -15,34 +15,17 @@
       "dataViews",
       "features",
       "files",
+      "guidedOnboarding",
       "inspector",
       "ruleRegistry",
       "triggersActionsUi",
-      "inspector",
       "unifiedSearch",
       "security",
-      "guidedOnboarding",
-      "share"
+      "share",
+      "observabilityShared"
     ],
-    "optionalPlugins": [
-      "discover",
-      "embeddable",
-      "home",
-      "lens",
-      "licensing",
-      "spaces",
-      "usageCollection"
-    ],
-    "requiredBundles": [
-      "unifiedSearch",
-      "data",
-      "dataViews",
-      "embeddable",
-      "kibanaReact",
-      "kibanaUtils",
-      "lens",
-      "visualizations"
-    ],
+    "optionalPlugins": ["discover", "home", "licensing", "spaces", "usageCollection"],
+    "requiredBundles": ["unifiedSearch", "data", "kibanaReact", "kibanaUtils"],
     "extraPublicDirs": ["common"]
   }
 }

--- a/x-pack/plugins/observability/public/application/index.tsx
+++ b/x-pack/plugins/observability/public/application/index.tsx
@@ -14,6 +14,7 @@ import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { i18n } from '@kbn/i18n';
 import { Route } from '@kbn/shared-ux-router';
 import { AppMountParameters, APP_WRAPPER_CLASS, CoreStart } from '@kbn/core/public';
+import type { LazyObservabilityPageTemplateProps } from '@kbn/observability-shared-plugin/public';
 import { EuiThemeProvider } from '@kbn/kibana-react-plugin/common';
 import {
   KibanaContextProvider,
@@ -22,7 +23,6 @@ import {
 } from '@kbn/kibana-react-plugin/public';
 import { Storage } from '@kbn/kibana-utils-plugin/public';
 import { UsageCollectionSetup } from '@kbn/usage-collection-plugin/public';
-import type { LazyObservabilityPageTemplateProps } from '../components/shared/page_template/lazy_page_template';
 import { HasDataContextProvider } from '../context/has_data_context';
 import { PluginContext } from '../context/plugin_context';
 import { ConfigSchema, ObservabilityPublicPluginsStart } from '../plugin';

--- a/x-pack/plugins/observability/public/plugin.ts
+++ b/x-pack/plugins/observability/public/plugin.ts
@@ -26,6 +26,11 @@ import type { DiscoverStart } from '@kbn/discover-plugin/public';
 import type { EmbeddableStart } from '@kbn/embeddable-plugin/public';
 import type { HomePublicPluginSetup, HomePublicPluginStart } from '@kbn/home-plugin/public';
 import type { ChartsPluginStart } from '@kbn/charts-plugin/public';
+import type {
+  ObservabilitySharedPluginSetup,
+  ObservabilitySharedPluginStart,
+  NavigationEntry,
+} from '@kbn/observability-shared-plugin/public';
 import { CasesDeepLinkId, CasesUiStart, getCasesDeepLinks } from '@kbn/cases-plugin/public';
 import type { LensPublicStart } from '@kbn/lens-plugin/public';
 import {
@@ -45,19 +50,13 @@ import { LicensingPluginStart } from '@kbn/licensing-plugin/public';
 import { UnifiedSearchPublicPluginStart } from '@kbn/unified-search-plugin/public';
 import { RuleDetailsLocatorDefinition } from './locators/rule_details';
 import { observabilityAppId, observabilityFeatureId, casesPath } from '../common';
-import { createLazyObservabilityPageTemplate } from './components/shared';
 import { registerDataHandler } from './data_handler';
 import {
   createObservabilityRuleTypeRegistry,
   ObservabilityRuleTypeRegistry,
 } from './rules/create_observability_rule_type_registry';
 import { createCallObservabilityApi } from './services/call_observability_api';
-import { createNavigationRegistry, NavigationEntry } from './services/navigation_registry';
-import { updateGlobalNavigation } from './update_global_navigation';
-import { getExploratoryViewEmbeddable } from './components/shared/exploratory_view/embeddable';
-import { createExploratoryViewUrl } from './components/shared/exploratory_view/configurations/exploratory_view_url';
 import { createUseRulesLink } from './hooks/create_use_rules_link';
-import getAppDataView from './utils/observability_data_views/get_app_data_view';
 import { registerObservabilityRuleTypes } from './rules/register_observability_rule_types';
 
 export interface ConfigSchema {
@@ -79,6 +78,7 @@ export type ObservabilityPublicSetup = ReturnType<Plugin['setup']>;
 
 export interface ObservabilityPublicPluginsSetup {
   data: DataPublicPluginSetup;
+  observabilityShared: ObservabilitySharedPluginSetup;
   share: SharePluginSetup;
   triggersActionsUi: TriggersAndActionsUIPublicPluginSetup;
   home?: HomePublicPluginSetup;
@@ -93,9 +93,11 @@ export interface ObservabilityPublicPluginsStart {
   dataViews: DataViewsPublicPluginStart;
   discover: DiscoverStart;
   embeddable: EmbeddableStart;
+  exploratoryView: ExploratoryViewPublicPluginsStart;
   guidedOnboarding: GuidedOnboardingPluginStart;
   lens: LensPublicStart;
   licensing: LicensingPluginStart;
+  observabilityShared: ObservabilitySharedPluginStart;
   ruleTypeRegistry: RuleTypeRegistryContract;
   security: SecurityPluginStart;
   share: SharePluginStart;
@@ -118,7 +120,6 @@ export class Plugin
     >
 {
   private readonly appUpdater$ = new BehaviorSubject<AppUpdater>(() => ({}));
-  private readonly navigationRegistry = createNavigationRegistry();
   private observabilityRuleTypeRegistry: ObservabilityRuleTypeRegistry =
     {} as ObservabilityRuleTypeRegistry;
 
@@ -194,7 +195,7 @@ export class Plugin
       // Load application bundle
       const { renderApp } = await import('./application');
       // Get start services
-      const [coreStart, pluginsStart, { navigation }] = await coreSetup.getStartServices();
+      const [coreStart, pluginsStart] = await coreSetup.getStartServices();
 
       const { ruleTypeRegistry, actionTypeRegistry } = pluginsStart.triggersActionsUi;
 
@@ -204,7 +205,7 @@ export class Plugin
         plugins: { ...pluginsStart, ruleTypeRegistry, actionTypeRegistry },
         appMountParameters: params,
         observabilityRuleTypeRegistry: this.observabilityRuleTypeRegistry,
-        ObservabilityPageTemplate: navigation.PageTemplate,
+        ObservabilityPageTemplate: pluginsStart.observabilityShared.navigation.PageTemplate,
         usageCollection: pluginsSetup.usageCollection,
         isDev: this.initContext.env.mode.dev,
         kibanaVersion,
@@ -260,7 +261,7 @@ export class Plugin
       });
     }
 
-    this.navigationRegistry.registerSections(
+    pluginsSetup.observabilityShared.navigation.registerSections(
       from(appUpdater$).pipe(
         map((value) => {
           const deepLinks = value(app)?.deepLinks ?? [];
@@ -308,9 +309,6 @@ export class Plugin
     return {
       dashboard: { register: registerDataHandler },
       observabilityRuleTypeRegistry: this.observabilityRuleTypeRegistry,
-      navigation: {
-        registerSections: this.navigationRegistry.registerSections,
-      },
       useRulesLink: createUseRulesLink(),
     };
   }
@@ -319,19 +317,10 @@ export class Plugin
     const { application } = coreStart;
     const config = this.initContext.config.get();
 
-    updateGlobalNavigation({
+    pluginsStart.observabilityShared.updateGlobalNavigation({
       capabilities: application.capabilities,
       deepLinks: this.deepLinks,
       updater$: this.appUpdater$,
-    });
-
-    const PageTemplate = createLazyObservabilityPageTemplate({
-      currentAppId$: application.currentAppId$,
-      getUrlForApp: application.getUrlForApp,
-      navigateToApp: application.navigateToApp,
-      navigationSections$: this.navigationRegistry.sections$,
-      guidedOnboardingApi: pluginsStart.guidedOnboarding.guidedOnboardingApi,
-      getPageTemplateServices: () => ({ coreStart }),
     });
 
     const getAsyncO11yAlertsTableConfiguration = async () => {
@@ -349,12 +338,6 @@ export class Plugin
 
     return {
       observabilityRuleTypeRegistry: this.observabilityRuleTypeRegistry,
-      navigation: {
-        PageTemplate,
-      },
-      createExploratoryViewUrl,
-      getAppDataView: getAppDataView(pluginsStart.dataViews),
-      ExploratoryViewEmbeddable: getExploratoryViewEmbeddable({ ...coreStart, ...pluginsStart }),
       useRulesLink: createUseRulesLink(),
     };
   }

--- a/x-pack/plugins/observability/tsconfig.json
+++ b/x-pack/plugins/observability/tsconfig.json
@@ -74,7 +74,8 @@
     "@kbn/core-application-browser",
     "@kbn/files-plugin",
     "@kbn/core-theme-browser",
-    "@kbn/core-elasticsearch-server"
+    "@kbn/core-elasticsearch-server",
+    "@kbn/observability-shared-plugin"
   ],
   "exclude": ["target/**/*"]
 }

--- a/x-pack/plugins/observability_shared/public/index.ts
+++ b/x-pack/plugins/observability_shared/public/index.ts
@@ -18,7 +18,7 @@ export type {
 } from './components/page_template/page_template';
 
 export type { NavigationEntry } from './components/page_template/page_template';
-
+export { useObservabilityTourContext } from './components/tour';
 export const plugin = () => {
   return new ObservabilitySharedPlugin();
 };


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/154779

## 📝 Summary

As part of https://github.com/elastic/kibana/issues/154735 a Observability Shared app was created, which exports the Observability Page Template.

This PR updates the Observability app to use the Observability Page Template from Observability Shared.

## ✅ Checklist
- All links and navigation should behave exactly as before.