### PR TITLE
[Fix] Code editor in runtime fields deleting first character

### DIFF
--- a/src/plugins/data_view_field_editor/public/components/field_editor/form_fields/script_field.tsx
+++ b/src/plugins/data_view_field_editor/public/components/field_editor/form_fields/script_field.tsx
@@ -258,7 +258,7 @@ const ScriptFieldComponent = ({ existingConcreteFields, links, placeholder }: Pr
                 height="210px"
                 value={value}
                 onChange={setValue}
-                editorDidMount={onEditorDidMount}
+                // editorDidMount={onEditorDidMount}
                 options={{
                   fontSize: 12,
                   minimap: {

--- a/src/plugins/data_view_field_editor/public/shared_imports.ts
+++ b/src/plugins/data_view_field_editor/public/shared_imports.ts
@@ -27,11 +27,8 @@ export type {
 } from '@kbn/data-views-plugin/common';
 export { KBN_FIELD_TYPES, ES_FIELD_TYPES } from '@kbn/data-plugin/common';
 
-export {
-  createKibanaReactContext,
-  toMountPoint,
-  CodeEditor,
-} from '@kbn/kibana-react-plugin/public';
+export { createKibanaReactContext, toMountPoint } from '@kbn/kibana-react-plugin/public';
+export { CodeEditor } from '@kbn/code-editor';
 
 export type { FieldFormat, SerializedFieldFormat } from '@kbn/field-formats-plugin/common';
 

--- a/src/plugins/data_view_field_editor/tsconfig.json
+++ b/src/plugins/data_view_field_editor/tsconfig.json
@@ -26,6 +26,7 @@
     "@kbn/field-types",
     "@kbn/utility-types",
     "@kbn/config-schema",
+    "@kbn/code-editor",
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/154351 and https://github.com/elastic/kibana/issues/151215

I also updated the import of the Code Editor to the shared ux `@kbn/code-editor package`. 

Behavior before: 

https://user-images.githubusercontent.com/20343860/231284711-bd4d2406-5992-40da-b266-862c5a274f1d.mp4

After: 


https://user-images.githubusercontent.com/20343860/231285775-a81f764c-cb9d-4447-95d2-637e53903dbd.mp4







### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))

