### PR TITLE
[8.7] [Fleet] Fix "Advanced options" toggle in policy editor always showing (#154612)

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_stream.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_stream.tsx
@@ -102,9 +102,6 @@ export const PackagePolicyInputStreamConfig = memo<Props>(
       }
     }, [isDefaultDatastream, containerRef]);
 
-    // Showing advanced options toggle state
-    const [isShowingAdvanced, setIsShowingAdvanced] = useState<boolean>(isDefaultDatastream);
-
     // Errors state
     const hasErrors = forceShowErrors && validationHasErrors(inputStreamValidationResults);
 
@@ -153,6 +150,21 @@ export const PackagePolicyInputStreamConfig = memo<Props>(
     const datasetList = uniq(dataStreamsData?.data_streams) ?? [];
     const datastreams = sortDatastreamsByDataset(datasetList, packageInfo.name);
 
+    // Showing advanced options toggle state
+    const [isShowingAdvanced, setIsShowingAdvanced] = useState<boolean>(isDefaultDatastream);
+    const hasAdvancedOptions = useMemo(() => {
+      return (
+        advancedVars.length > 0 ||
+        (isPackagePolicyEdit && showPipelinesAndMappings) ||
+        isExperimentalDataStreamSettingsEnabled
+      );
+    }, [
+      advancedVars.length,
+      isExperimentalDataStreamSettingsEnabled,
+      isPackagePolicyEdit,
+      showPipelinesAndMappings,
+    ]);
+
     return (
       <>
         <EuiFlexGrid columns={2}>
@@ -182,7 +194,7 @@ export const PackagePolicyInputStreamConfig = memo<Props>(
                     </EuiFlexItem>
                   )}
                   {packageInputStream.data_stream.release &&
-                  packageInputStream.data_stream.release !== 'ga' ? (
+                    packageInputStream.data_stream.release !== 'ga' ? (
                     <EuiFlexItem grow={false}>
                       <InlineReleaseBadge
                         release={mapPackageReleaseToIntegrationCardRelease(
@@ -239,55 +251,72 @@ export const PackagePolicyInputStreamConfig = memo<Props>(
                   </EuiFlexItem>
                 );
               })}
-              {/* Advanced section - always shown since we display experimental indexing settings here */}
-              <Fragment>
-                <EuiFlexItem>
-                  <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
-                    <EuiFlexItem grow={false}>
-                      <EuiButtonEmpty
-                        size="xs"
-                        iconType={isShowingAdvanced ? 'arrowDown' : 'arrowRight'}
-                        onClick={() => setIsShowingAdvanced(!isShowingAdvanced)}
-                        flush="left"
-                      >
-                        <FormattedMessage
-                          id="xpack.fleet.createPackagePolicy.stepConfigure.toggleAdvancedOptionsButtonText"
-                          defaultMessage="Advanced options"
-                        />
-                      </EuiButtonEmpty>
-                    </EuiFlexItem>
-                    {!isShowingAdvanced && hasErrors && advancedVarsWithErrorsCount ? (
+              {/* Advanced section */}
+              {hasAdvancedOptions && (
+                <Fragment>
+                  <EuiFlexItem>
+                    <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
                       <EuiFlexItem grow={false}>
-                        <EuiText color="danger" size="s">
+                        <EuiButtonEmpty
+                          size="xs"
+                          iconType={isShowingAdvanced ? 'arrowDown' : 'arrowRight'}
+                          onClick={() => setIsShowingAdvanced(!isShowingAdvanced)}
+                          flush="left"
+                        >
                           <FormattedMessage
-                            id="xpack.fleet.createPackagePolicy.stepConfigure.errorCountText"
-                            defaultMessage="{count, plural, one {# error} other {# errors}}"
-                            values={{ count: advancedVarsWithErrorsCount }}
+                            id="xpack.fleet.createPackagePolicy.stepConfigure.toggleAdvancedOptionsButtonText"
+                            defaultMessage="Advanced options"
                           />
-                        </EuiText>
+                        </EuiButtonEmpty>
                       </EuiFlexItem>
-                    ) : null}
-                  </EuiFlexGroup>
-                </EuiFlexItem>
-                {isShowingAdvanced ? (
-                  <>
-                    {advancedVars.map((varDef) => {
-                      if (!packagePolicyInputStream.vars) return null;
-                      const { name: varName, type: varType } = varDef;
-                      const value = packagePolicyInputStream.vars?.[varName]?.value;
+                      {!isShowingAdvanced && hasErrors && advancedVarsWithErrorsCount ? (
+                        <EuiFlexItem grow={false}>
+                          <EuiButtonEmpty
+                            size="xs"
+                            iconType={isShowingAdvanced ? 'arrowDown' : 'arrowRight'}
+                            onClick={() => setIsShowingAdvanced(!isShowingAdvanced)}
+                            flush="left"
+                            data-test-subj={`advancedStreamOptionsToggle-${packagePolicyInputStream.id}`}
+                          >
+                            <FormattedMessage
+                              id="xpack.fleet.createPackagePolicy.stepConfigure.toggleAdvancedOptionsButtonText"
+                              defaultMessage="Advanced options"
+                            />
+                          </EuiButtonEmpty>
+                        </EuiFlexItem>
+                      {!isShowingAdvanced && hasErrors && advancedVarsWithErrorsCount ? (
+                        <EuiFlexItem grow={false}>
+                          <EuiText color="danger" size="s">
+                            <FormattedMessage
+                              id="xpack.fleet.createPackagePolicy.stepConfigure.errorCountText"
+                              defaultMessage="{count, plural, one {# error} other {# errors}}"
+                              values={{ count: advancedVarsWithErrorsCount }}
+                            />
+                          </EuiText>
+                        </EuiFlexItem>
+                      ) : null}
+                    </EuiFlexGroup>
+                  </EuiFlexItem>
+                  {isShowingAdvanced ? (
+                    <>
+                      {advancedVars.map((varDef) => {
+                        if (!packagePolicyInputStream.vars) return null;
+                        const { name: varName, type: varType } = varDef;
+                        const value = packagePolicyInputStream.vars?.[varName]?.value;
 
-                      return (
-                        <EuiFlexItem key={varName}>
-                          <PackagePolicyInputVarField
-                            varDef={varDef}
-                            value={value}
-                            onChange={(newValue: any) => {
-                              updatePackagePolicyInputStream({
-                                vars: {
-                                  ...packagePolicyInputStream.vars,
-                                  [varName]: {
-                                    type: varType,
-                                    value: newValue,
+                        return (
+                          <EuiFlexItem key={varName}>
+                            <PackagePolicyInputVarField
+                              varDef={varDef}
+                              value={value}
+                              onChange={(newValue: any) => {
+                                updatePackagePolicyInputStream({
+                                  vars: {
+                                    ...packagePolicyInputStream.vars,
+                                    [varName]: {
+                                      type: varType,
+                                      value: newValue,
+                                    },
                                   },
                                 },
                               });
@@ -299,39 +328,40 @@ export const PackagePolicyInputStreamConfig = memo<Props>(
                             datastreams={datastreams}
                             isEditPage={isEditPage}
                           />
-                        </EuiFlexItem>
-                      );
-                    })}
-                    {/* Only show datastream pipelines and mappings on edit and not for input packages*/}
-                    {isPackagePolicyEdit && showPipelinesAndMappings && (
-                      <>
-                        <EuiFlexItem>
-                          <PackagePolicyEditorDatastreamPipelines
-                            packageInputStream={packagePolicyInputStream}
-                            packageInfo={packageInfo}
-                          />
-                        </EuiFlexItem>
-                        <EuiFlexItem>
-                          <PackagePolicyEditorDatastreamMappings
-                            packageInputStream={packagePolicyInputStream}
-                            packageInfo={packageInfo}
-                          />
-                        </EuiFlexItem>
-                      </>
-                    )}
-                    {/* Experimental index/datastream settings e.g. synthetic source */}
-                    {isExperimentalDataStreamSettingsEnabled && (
-                      <ExperimentDatastreamSettings
-                        registryDataStream={packageInputStream.data_stream}
-                        experimentalDataFeatures={
-                          packagePolicy.package?.experimental_data_stream_features
-                        }
-                        setNewExperimentalDataFeatures={setNewExperimentalDataFeatures}
-                      />
-                    )}
-                  </>
-                ) : null}
-              </Fragment>
+                          </EuiFlexItem>
+                        );
+                      })}
+                      {/* Only show datastream pipelines and mappings on edit and not for input packages*/}
+                      {isPackagePolicyEdit && showPipelinesAndMappings && (
+                        <>
+                          <EuiFlexItem>
+                            <PackagePolicyEditorDatastreamPipelines
+                              packageInputStream={packagePolicyInputStream}
+                              packageInfo={packageInfo}
+                            />
+                          </EuiFlexItem>
+                          <EuiFlexItem>
+                            <PackagePolicyEditorDatastreamMappings
+                              packageInputStream={packagePolicyInputStream}
+                              packageInfo={packageInfo}
+                            />
+                          </EuiFlexItem>
+                        </>
+                      )}
+                      {/* Experimental index/datastream settings e.g. synthetic source */}
+                      {isExperimentalDataStreamSettingsEnabled && (
+                        <ExperimentDatastreamSettings
+                          registryDataStream={packageInputStream.data_stream}
+                          experimentalDataFeatures={
+                            packagePolicy.package?.experimental_data_stream_features
+                          }
+                          setNewExperimentalDataFeatures={setNewExperimentalDataFeatures}
+                        />
+                      )}
+                    </>
+                  ) : null}
+                </Fragment>
+              )}
             </EuiFlexGroup>
           </EuiFlexItem>
         </EuiFlexGrid>

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_stream.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_stream.tsx
@@ -194,7 +194,7 @@ export const PackagePolicyInputStreamConfig = memo<Props>(
                     </EuiFlexItem>
                   )}
                   {packageInputStream.data_stream.release &&
-                    packageInputStream.data_stream.release !== 'ga' ? (
+                  packageInputStream.data_stream.release !== 'ga' ? (
                     <EuiFlexItem grow={false}>
                       <InlineReleaseBadge
                         release={mapPackageReleaseToIntegrationCardRelease(
@@ -303,15 +303,15 @@ export const PackagePolicyInputStreamConfig = memo<Props>(
                                       value: newValue,
                                     },
                                   },
-                              });
-                            }}
-                            errors={inputStreamValidationResults?.vars![varName]}
-                            forceShowErrors={forceShowErrors}
-                            packageType={packageInfo.type}
-                            packageName={packageInfo.name}
-                            datastreams={datastreams}
-                            isEditPage={isEditPage}
-                          />
+                                });
+                              }}
+                              errors={inputStreamValidationResults?.vars![varName]}
+                              forceShowErrors={forceShowErrors}
+                              packageType={packageInfo.type}
+                              packageName={packageInfo.name}
+                              datastreams={datastreams}
+                              isEditPage={isEditPage}
+                            />
                           </EuiFlexItem>
                         );
                       })}

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_stream.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_stream.tsx
@@ -271,21 +271,6 @@ export const PackagePolicyInputStreamConfig = memo<Props>(
                       </EuiFlexItem>
                       {!isShowingAdvanced && hasErrors && advancedVarsWithErrorsCount ? (
                         <EuiFlexItem grow={false}>
-                          <EuiButtonEmpty
-                            size="xs"
-                            iconType={isShowingAdvanced ? 'arrowDown' : 'arrowRight'}
-                            onClick={() => setIsShowingAdvanced(!isShowingAdvanced)}
-                            flush="left"
-                            data-test-subj={`advancedStreamOptionsToggle-${packagePolicyInputStream.id}`}
-                          >
-                            <FormattedMessage
-                              id="xpack.fleet.createPackagePolicy.stepConfigure.toggleAdvancedOptionsButtonText"
-                              defaultMessage="Advanced options"
-                            />
-                          </EuiButtonEmpty>
-                        </EuiFlexItem>
-                      {!isShowingAdvanced && hasErrors && advancedVarsWithErrorsCount ? (
-                        <EuiFlexItem grow={false}>
                           <EuiText color="danger" size="s">
                             <FormattedMessage
                               id="xpack.fleet.createPackagePolicy.stepConfigure.errorCountText"
@@ -318,7 +303,6 @@ export const PackagePolicyInputStreamConfig = memo<Props>(
                                       value: newValue,
                                     },
                                   },
-                                },
                               });
                             }}
                             errors={inputStreamValidationResults?.vars![varName]}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.7`:
 - [[Fleet] Fix "Advanced options" toggle in policy editor always showing (#154612)](https://github.com/elastic/kibana/pull/154612)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Jen Huang","email":"its.jenetic@gmail.com"},"sourceCommit":{"committedDate":"2023-04-11T18:32:05Z","message":"[Fleet] Fix \"Advanced options\" toggle in policy editor always showing (#154612)\n\n## Summary\r\n\r\n_Please review with [whitespace\r\nignore](https://github.com/elastic/kibana/pull/154612/files?diff=unified&w=1)!_\r\n\r\nIn #143097 the conditional for showing `Advanced options` was removed as\r\nwe introduced experimental indexing toggles which are always shown.\r\nHowever in #148418 (8.7) we put the indexing toggles behind a feature\r\nflag. This caused the `Advanced options` toggle to always be shown\r\nregardless of there is any content underneath. I spotted this while\r\ntesting something unrelated.\r\n\r\nThis PR fixes that by adding a condition back that is based on\r\naggregating the conditionals of everything underneath (existence of\r\nadvanced vars, whether pipelines & mappings are shown, and if\r\nexperimental indexing toggles are enabled).","sha":"2636262e093f188e4937d192d302607eeaafff85","branchLabelMapping":{"^v8.8.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Fleet","backport:prev-minor","v8.8.0"],"number":154612,"url":"https://github.com/elastic/kibana/pull/154612","mergeCommit":{"message":"[Fleet] Fix \"Advanced options\" toggle in policy editor always showing (#154612)\n\n## Summary\r\n\r\n_Please review with [whitespace\r\nignore](https://github.com/elastic/kibana/pull/154612/files?diff=unified&w=1)!_\r\n\r\nIn #143097 the conditional for showing `Advanced options` was removed as\r\nwe introduced experimental indexing toggles which are always shown.\r\nHowever in #148418 (8.7) we put the indexing toggles behind a feature\r\nflag. This caused the `Advanced options` toggle to always be shown\r\nregardless of there is any content underneath. I spotted this while\r\ntesting something unrelated.\r\n\r\nThis PR fixes that by adding a condition back that is based on\r\naggregating the conditionals of everything underneath (existence of\r\nadvanced vars, whether pipelines & mappings are shown, and if\r\nexperimental indexing toggles are enabled).","sha":"2636262e093f188e4937d192d302607eeaafff85"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.8.0","labelRegex":"^v8.8.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/154612","number":154612,"mergeCommit":{"message":"[Fleet] Fix \"Advanced options\" toggle in policy editor always showing (#154612)\n\n## Summary\r\n\r\n_Please review with [whitespace\r\nignore](https://github.com/elastic/kibana/pull/154612/files?diff=unified&w=1)!_\r\n\r\nIn #143097 the conditional for showing `Advanced options` was removed as\r\nwe introduced experimental indexing toggles which are always shown.\r\nHowever in #148418 (8.7) we put the indexing toggles behind a feature\r\nflag. This caused the `Advanced options` toggle to always be shown\r\nregardless of there is any content underneath. I spotted this while\r\ntesting something unrelated.\r\n\r\nThis PR fixes that by adding a condition back that is based on\r\naggregating the conditionals of everything underneath (existence of\r\nadvanced vars, whether pipelines & mappings are shown, and if\r\nexperimental indexing toggles are enabled).","sha":"2636262e093f188e4937d192d302607eeaafff85"}}]}] BACKPORT-->