### PR TITLE
Make "Text Assertion" form field optional for Single Page monitors

### DIFF
--- a/.buildkite/scripts/build_kibana.sh
+++ b/.buildkite/scripts/build_kibana.sh
@@ -18,28 +18,27 @@ is_pr_with_label "ci:build-docker-contexts" || BUILD_ARGS+=("--skip-docker-conte
 echo "> node scripts/build" "${BUILD_ARGS[@]}"
 node scripts/build "${BUILD_ARGS[@]}"
 
-echo "--- Build Kibana Docker Image"
-echo "$KIBANA_DOCKER_PASSWORD" | docker login -u "$KIBANA_DOCKER_USERNAME" --password-stdin docker.elastic.co
-node scripts/build \
---skip-initialize \
---skip-generic-folders \
---skip-platform-folders \
---skip-archives \
---docker-images \
---docker-tag-qualifier="$GIT_COMMIT" \
---docker-push \
---skip-docker-ubi \
---skip-docker-ubuntu \
---skip-docker-contexts
-docker logout docker.elastic.co
+if is_pr_with_label "ci:build-cloud-image"; then
+  echo "$KIBANA_DOCKER_PASSWORD" | docker login -u "$KIBANA_DOCKER_USERNAME" --password-stdin docker.elastic.co
+  node scripts/build \
+  --skip-initialize \
+  --skip-generic-folders \
+  --skip-platform-folders \
+  --skip-archives \
+  --docker-images \
+  --docker-tag-qualifier="$GIT_COMMIT" \
+  --docker-push \
+  --skip-docker-ubi \
+  --skip-docker-ubuntu \
+  --skip-docker-contexts
+  docker logout docker.elastic.co
 
-CLOUD_IMAGE=$(docker images --format "{{.Repository}}:{{.Tag}}" docker.elastic.co/kibana-ci/kibana-cloud)
-cat << EOF | buildkite-agent annotate --style "info" --context kibana-cloud-image
+  CLOUD_IMAGE=$(docker images --format "{{.Repository}}:{{.Tag}}" docker.elastic.co/kibana-ci/kibana-cloud)
+  cat << EOF | buildkite-agent annotate --style "info" --context kibana-cloud-image
 
-Kibana cloud image: \`$CLOUD_IMAGE\`
+  Kibana cloud image: \`$CLOUD_IMAGE\`
 EOF
-
-echo "--- DONE - Build Kibana Docker Image"
+fi
 
 echo "--- Archive Kibana Distribution"
 linuxBuild="$(find "$KIBANA_DIR/target" -name 'kibana-*-linux-x86_64.tar.gz')"

--- a/.buildkite/scripts/build_kibana.sh
+++ b/.buildkite/scripts/build_kibana.sh
@@ -18,27 +18,28 @@ is_pr_with_label "ci:build-docker-contexts" || BUILD_ARGS+=("--skip-docker-conte
 echo "> node scripts/build" "${BUILD_ARGS[@]}"
 node scripts/build "${BUILD_ARGS[@]}"
 
-if is_pr_with_label "ci:build-cloud-image"; then
-  echo "$KIBANA_DOCKER_PASSWORD" | docker login -u "$KIBANA_DOCKER_USERNAME" --password-stdin docker.elastic.co
-  node scripts/build \
-  --skip-initialize \
-  --skip-generic-folders \
-  --skip-platform-folders \
-  --skip-archives \
-  --docker-images \
-  --docker-tag-qualifier="$GIT_COMMIT" \
-  --docker-push \
-  --skip-docker-ubi \
-  --skip-docker-ubuntu \
-  --skip-docker-contexts
-  docker logout docker.elastic.co
+echo "--- Build Kibana Docker Image"
+echo "$KIBANA_DOCKER_PASSWORD" | docker login -u "$KIBANA_DOCKER_USERNAME" --password-stdin docker.elastic.co
+node scripts/build \
+--skip-initialize \
+--skip-generic-folders \
+--skip-platform-folders \
+--skip-archives \
+--docker-images \
+--docker-tag-qualifier="$GIT_COMMIT" \
+--docker-push \
+--skip-docker-ubi \
+--skip-docker-ubuntu \
+--skip-docker-contexts
+docker logout docker.elastic.co
 
-  CLOUD_IMAGE=$(docker images --format "{{.Repository}}:{{.Tag}}" docker.elastic.co/kibana-ci/kibana-cloud)
-  cat << EOF | buildkite-agent annotate --style "info" --context kibana-cloud-image
+CLOUD_IMAGE=$(docker images --format "{{.Repository}}:{{.Tag}}" docker.elastic.co/kibana-ci/kibana-cloud)
+cat << EOF | buildkite-agent annotate --style "info" --context kibana-cloud-image
 
-  Kibana cloud image: \`$CLOUD_IMAGE\`
+Kibana cloud image: \`$CLOUD_IMAGE\`
 EOF
-fi
+
+echo "--- DONE - Build Kibana Docker Image"
 
 echo "--- Archive Kibana Distribution"
 linuxBuild="$(find "$KIBANA_DIR/target" -name 'kibana-*-linux-x86_64.tar.gz')"

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/form/field_config.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/form/field_config.tsx
@@ -1090,12 +1090,12 @@ export const FIELD = (readOnly?: boolean): FieldMap => ({
     label: i18n.translate('xpack.synthetics.monitorConfig.textAssertion.label', {
       defaultMessage: 'Text assertion',
     }),
-    required: true,
+    required: false,
     helpText: i18n.translate('xpack.synthetics.monitorConfig.textAssertion.helpText', {
       defaultMessage: 'Consider the page loaded when the specified text is rendered.',
     }),
     validation: () => ({
-      required: true,
+      required: false,
     }),
     props: (): EuiFieldTextProps => ({
       readOnly,

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/form/formatter.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/form/formatter.ts
@@ -26,9 +26,7 @@ export const format = (fields: Record<string, unknown>, readOnly: boolean = fals
   const formattedFields = formatter(fields) as MonitorFields;
   const textAssertion = formattedFields[ConfigKey.TEXT_ASSERTION]
     ? `
-          expect(await page.isVisible('text=${
-            formattedFields[ConfigKey.TEXT_ASSERTION]
-          }')).toBeTruthy();`
+          await page.getByText('${formattedFields[ConfigKey.TEXT_ASSERTION]}').first().waitFor();`
     : ``;
   const formattedMap = {
     [FormMonitorType.SINGLE]: {

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/form/formatter.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/form/formatter.ts
@@ -24,14 +24,17 @@ export const ALLOWED_FIELDS = [ConfigKey.ENABLED, ConfigKey.ALERT_CONFIG];
 
 export const format = (fields: Record<string, unknown>, readOnly: boolean = false) => {
   const formattedFields = formatter(fields) as MonitorFields;
+  const textAssertion = formattedFields[ConfigKey.TEXT_ASSERTION]
+    ? `
+          expect(await page.isVisible('text=${
+            formattedFields[ConfigKey.TEXT_ASSERTION]
+          }')).toBeTruthy();`
+    : ``;
   const formattedMap = {
     [FormMonitorType.SINGLE]: {
       ...formattedFields,
       [ConfigKey.SOURCE_INLINE]: `step('Go to ${formattedFields[ConfigKey.URLS]}', async () => {
-          await page.goto('${formattedFields[ConfigKey.URLS]}');
-          expect(await page.isVisible('text=${
-            formattedFields[ConfigKey.TEXT_ASSERTION]
-          }')).toBeTruthy();
+          await page.goto('${formattedFields[ConfigKey.URLS]}');${textAssertion}
         });`,
       [ConfigKey.FORM_MONITOR_TYPE]: FormMonitorType.SINGLE,
     },


### PR DESCRIPTION
Fixes #153929

## Summary

Makes the "Text Assertion" field optional in Monitor Add/Edit form.