### PR TITLE
Add Create Rule from SLO List item

### DIFF
--- a/x-pack/plugins/observability/public/pages/slos/components/slo_list_item.tsx
+++ b/x-pack/plugins/observability/public/pages/slos/components/slo_list_item.tsx
@@ -21,7 +21,6 @@ import {
 import { i18n } from '@kbn/i18n';
 
 import { HistoricalSummaryResponse, SLOWithSummaryResponse } from '@kbn/slo-schema';
-import { ALERTS_FEATURE_ID } from '@kbn/alerting-plugin/common';
 import { ActiveAlerts } from '../../../hooks/slo/use_fetch_active_alerts';
 import { useCapabilities } from '../../../hooks/slo/use_capabilities';
 import { useKibana } from '../../../utils/kibana_react';
@@ -35,6 +34,7 @@ import {
   transformValuesToCreateSLOInput,
 } from '../../slo_edit/helpers/process_slo_form_values';
 import { SLO_BURN_RATE_RULE_ID } from '../../../../common/constants';
+import { sloFeatureId } from '../../../../common';
 import { paths } from '../../../config/paths';
 
 export interface SloListItemProps {
@@ -189,7 +189,7 @@ export function SloListItem({
                   data-test-subj="sloActionsCreateRule"
                 >
                   {i18n.translate('xpack.observability.slo.slo.item.actions.createRule', {
-                    defaultMessage: 'Create rule',
+                    defaultMessage: 'Create Alert rule',
                   })}
                 </EuiContextMenuItem>,
                 <EuiContextMenuItem
@@ -226,15 +226,12 @@ export function SloListItem({
 
       {isAddRuleFlyoutOpen ? (
         <AddRuleFlyout
-          consumer={ALERTS_FEATURE_ID}
+          consumer={sloFeatureId}
           filteredRuleTypes={filteredRuleTypes}
           ruleTypeId={SLO_BURN_RATE_RULE_ID}
           initialValues={{ name: `${slo.name} Burn Rate rule`, params: { sloId: slo.id } }}
           onClose={() => {
             setIsAddRuleFlyoutOpen(false);
-          }}
-          onSave={() => {
-            return Promise.resolve();
           }}
         />
       ) : null}

--- a/x-pack/plugins/observability/public/pages/slos/slos.test.tsx
+++ b/x-pack/plugins/observability/public/pages/slos/slos.test.tsx
@@ -60,6 +60,7 @@ useDeleteSloMock.mockReturnValue({ mutate: mockDeleteSlo });
 const mockNavigate = jest.fn();
 const mockAddSuccess = jest.fn();
 const mockAddError = jest.fn();
+const mockGetAddRuleFlyout = jest.fn().mockReturnValue(() => <div>Add rule flyout</div>);
 
 const mockKibana = () => {
   useKibanaMock.mockReturnValue({
@@ -77,6 +78,7 @@ const mockKibana = () => {
           addError: mockAddError,
         },
       },
+      triggersActionsUi: { getAddRuleFlyout: mockGetAddRuleFlyout },
       uiSettings: {
         get: (settings: string) => {
           if (settings === 'dateFormat') return 'YYYY-MM-DD';
@@ -197,6 +199,31 @@ describe('SLOs Page', () => {
         button.click();
 
         expect(mockNavigate).toBeCalled();
+      });
+
+      it('allows creating a new rule for an SLO', async () => {
+        useFetchSloListMock.mockReturnValue({ isLoading: false, sloList });
+
+        useFetchHistoricalSummaryMock.mockReturnValue({
+          isLoading: false,
+          sloHistoricalSummaryResponse: historicalSummaryData,
+        });
+
+        await act(async () => {
+          render(<SlosPage />);
+        });
+
+        screen.getAllByLabelText('Actions').at(0)?.click();
+
+        await waitForEuiPopoverOpen();
+
+        const button = screen.getByTestId('sloActionsCreateRule');
+
+        expect(button).toBeTruthy();
+
+        button.click();
+
+        expect(mockGetAddRuleFlyout).toBeCalled();
       });
 
       it('allows deleting an SLO', async () => {


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/154797

## 📝 Summary

This creates functionality that allows users to quickly create a new rule for an SLO from the SLO List page.


https://user-images.githubusercontent.com/535564/231416009-f8a815ff-0a1b-45f2-947f-d9277c670e34.mov



## ✅ Checklist
- On the SLO List page, clicking on the actions menu (three dots) on a SLO Item, should show an option to create a rule for that SLO.
- Upon clicking it, the AddRuleFlyout should appear, with the SLO Burn Rate rule selected, a prefilled name, and the SLO selected