### PR TITLE
Add Hideable React Query Dev Tools

### DIFF
--- a/x-pack/plugins/observability/public/application/hideable_react_query_dev_tools.tsx
+++ b/x-pack/plugins/observability/public/application/hideable_react_query_dev_tools.tsx
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useState } from 'react';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import { EuiButtonIcon } from '@elastic/eui';
+
+export function HideableReactQueryDevTools() {
+  const [isHidden, setIsHidden] = useState(false);
+
+  return !isHidden ? (
+    <div>
+      <EuiButtonIcon
+        data-test-subj="o11yHideableReactQueryDevToolsButton"
+        iconType="cross"
+        color="primary"
+        style={{ zIndex: 99999, position: 'fixed', bottom: '40px', left: '40px' }}
+        onClick={() => setIsHidden(!isHidden)}
+      />
+      <ReactQueryDevtools />
+    </div>
+  ) : null;
+}

--- a/x-pack/plugins/observability/public/application/index.tsx
+++ b/x-pack/plugins/observability/public/application/index.tsx
@@ -10,7 +10,6 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { Router, Switch } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { i18n } from '@kbn/i18n';
 import { Route } from '@kbn/shared-ux-router';
 import { AppMountParameters, APP_WRAPPER_CLASS, CoreStart } from '@kbn/core/public';
@@ -28,6 +27,7 @@ import { PluginContext } from '../context/plugin_context';
 import { ConfigSchema, ObservabilityPublicPluginsStart } from '../plugin';
 import { routes } from '../routes';
 import { ObservabilityRuleTypeRegistry } from '../rules/create_observability_rule_type_registry';
+import { HideableReactQueryDevTools } from './hideable_react_query_dev_tools';
 
 function App() {
   return (
@@ -114,7 +114,7 @@ export const renderApp = ({
                         <HasDataContextProvider>
                           <App />
                         </HasDataContextProvider>
-                        <ReactQueryDevtools />
+                        <HideableReactQueryDevTools />
                       </QueryClientProvider>
                     </RedirectAppLinks>
                   </i18nCore.Context>


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/154809

## Summary

This PR adds a button to the Tan Query Dev Tools component so you can hide the Dev Tools while in development mode.

Upon refreshing the page the tools will be visible again.


https://user-images.githubusercontent.com/535564/231455221-62349851-ee4e-4806-a966-1bf982de595f.mov

