### PR TITLE
[Fleet] Add raw status to Agent details UI

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/actions_menu.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/actions_menu.tsx
@@ -24,7 +24,7 @@ import { isAgentUpgradeable, policyHasFleetServer } from '../../../../services';
 import { AgentRequestDiagnosticsModal } from '../../components/agent_request_diagnostics_modal';
 import { ExperimentalFeaturesService } from '../../../../services';
 
-import { AgentDocumentFlyout } from './agent_document_flyout';
+import { AgentDetailsJsonFlyout } from './agent_details_json_flyout';
 
 export const AgentDetailsActionMenu: React.FunctionComponent<{
   agent: Agent;
@@ -39,7 +39,7 @@ export const AgentDetailsActionMenu: React.FunctionComponent<{
   const [isUnenrollModalOpen, setIsUnenrollModalOpen] = useState(false);
   const [isUpgradeModalOpen, setIsUpgradeModalOpen] = useState(false);
   const [isRequestDiagnosticsModalOpen, setIsRequestDiagnosticsModalOpen] = useState(false);
-  const [isAgentDocumentFlyoutOpen, setIsAgentDocumentFlyoutOpen] = useState<boolean>(false);
+  const [isAgentDetailsJsonFlyoutOpen, setIsAgentDetailsJsonFlyoutOpen] = useState<boolean>(false);
   const isUnenrolling = agent.status === 'unenrolling';
 
   const [isContextMenuOpen, setIsContextMenuOpen] = useState(false);
@@ -112,13 +112,13 @@ export const AgentDetailsActionMenu: React.FunctionComponent<{
       icon="inspect"
       onClick={() => {
         setIsContextMenuOpen(false);
-        setIsAgentDocumentFlyoutOpen(!isAgentDocumentFlyoutOpen);
+        setIsAgentDetailsJsonFlyoutOpen(!isAgentDetailsJsonFlyoutOpen);
       }}
-      key="agentDocument"
+      key="agentDetailsJson"
     >
       <FormattedMessage
-        id="xpack.fleet.agentList.viewAgentDocumentText"
-        defaultMessage="View agent document"
+        id="xpack.fleet.agentList.viewAgentDetailsJsonText"
+        defaultMessage="View agent JSON"
       />
     </EuiContextMenuItem>,
   ];
@@ -185,9 +185,12 @@ export const AgentDetailsActionMenu: React.FunctionComponent<{
           />
         </EuiPortal>
       )}
-      {isAgentDocumentFlyoutOpen && (
+      {isAgentDetailsJsonFlyoutOpen && (
         <EuiPortal>
-          <AgentDocumentFlyout agent={agent} onClose={() => setIsAgentDocumentFlyoutOpen(false)} />
+          <AgentDetailsJsonFlyout
+            agent={agent}
+            onClose={() => setIsAgentDetailsJsonFlyoutOpen(false)}
+          />
         </EuiPortal>
       )}
       <ContextMenuActions

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/actions_menu.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/actions_menu.tsx
@@ -23,6 +23,7 @@ import { useAgentRefresh } from '../hooks';
 import { isAgentUpgradeable, policyHasFleetServer } from '../../../../services';
 import { AgentRequestDiagnosticsModal } from '../../components/agent_request_diagnostics_modal';
 import { ExperimentalFeaturesService } from '../../../../services';
+
 import { AgentDocumentFlyout } from './agent_document_flyout';
 
 export const AgentDetailsActionMenu: React.FunctionComponent<{

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_details/agent_details_overview.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_details/agent_details_overview.tsx
@@ -17,8 +17,6 @@ import {
   EuiIcon,
   EuiSkeletonText,
   EuiToolTip,
-  EuiAccordion,
-  EuiCodeBlock,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage, FormattedRelative } from '@kbn/i18n-react';
@@ -275,21 +273,6 @@ export const AgentDetailsOverviewSection: React.FunctionComponent<{
                 defaultMessage: 'Tags',
               }),
               description: (agent.tags ?? []).length > 0 ? <Tags tags={agent.tags ?? []} /> : '-',
-            },
-            {
-              title: i18n.translate('xpack.fleet.agentDetails.allDetailsLabel', {
-                defaultMessage: 'All details',
-              }),
-              description: (
-                <EuiAccordion
-                  id="xpack.fleet.agentDetails.allDetails"
-                  buttonContent={i18n.translate('xpack.fleet.agentDetails.allDetailsExpand', {
-                    defaultMessage: 'Click to expand',
-                  })}
-                >
-                  <EuiCodeBlock language="json">{JSON.stringify(agent, null, 2)}</EuiCodeBlock>
-                </EuiAccordion>
-              ),
             },
           ].map(({ title, description }) => {
             const tooltip =

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_details/agent_details_overview.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_details/agent_details_overview.tsx
@@ -17,6 +17,8 @@ import {
   EuiIcon,
   EuiSkeletonText,
   EuiToolTip,
+  EuiAccordion,
+  EuiCodeBlock,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage, FormattedRelative } from '@kbn/i18n-react';
@@ -273,6 +275,21 @@ export const AgentDetailsOverviewSection: React.FunctionComponent<{
                 defaultMessage: 'Tags',
               }),
               description: (agent.tags ?? []).length > 0 ? <Tags tags={agent.tags ?? []} /> : '-',
+            },
+            {
+              title: i18n.translate('xpack.fleet.agentDetails.allDetailsLabel', {
+                defaultMessage: 'All details',
+              }),
+              description: (
+                <EuiAccordion
+                  id="xpack.fleet.agentDetails.allDetails"
+                  buttonContent={i18n.translate('xpack.fleet.agentDetails.allDetailsExpand', {
+                    defaultMessage: 'Click to expand',
+                  })}
+                >
+                  <EuiCodeBlock language="json">{JSON.stringify(agent, null, 2)}</EuiCodeBlock>
+                </EuiAccordion>
+              ),
             },
           ].map(({ title, description }) => {
             const tooltip =

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_details_json_flyout.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_details_json_flyout.test.tsx
@@ -9,10 +9,15 @@ import React from 'react';
 import { render } from '@testing-library/react';
 
 import type { Agent } from '../../../../types';
+import { useStartServices } from '../../../../hooks';
 
-import { AgentDocumentFlyout } from './agent_document_flyout';
+import { AgentDetailsJsonFlyout } from './agent_details_json_flyout';
 
-describe('AgentDocumentFlyout', () => {
+jest.mock('../../../../hooks');
+
+const mockUseStartServices = useStartServices as jest.Mock;
+
+describe('AgentDetailsJsonFlyout', () => {
   const agent: Agent = {
     id: '123',
     packages: [],
@@ -23,13 +28,19 @@ describe('AgentDocumentFlyout', () => {
     local_metadata: {},
   };
 
+  beforeEach(() => {
+    mockUseStartServices.mockReturnValue({
+      docLinks: { links: { fleet: { troubleshooting: 'https://elastic.co' } } },
+    });
+  });
+
   const renderComponent = () => {
-    return render(<AgentDocumentFlyout agent={agent} onClose={jest.fn()} />);
+    return render(<AgentDetailsJsonFlyout agent={agent} onClose={jest.fn()} />);
   };
 
   it('renders a title with the agent id if host name is not defined', () => {
     const result = renderComponent();
-    expect(result.getByText("'123' agent document")).toBeInTheDocument();
+    expect(result.getByText("'123' agent details")).toBeInTheDocument();
   });
 
   it('renders a title with the agent host name if defined', () => {
@@ -39,12 +50,12 @@ describe('AgentDocumentFlyout', () => {
       },
     };
     const result = renderComponent();
-    expect(result.getByText("'456' agent document")).toBeInTheDocument();
+    expect(result.getByText("'456' agent details")).toBeInTheDocument();
   });
 
   it('does not add a link to the page after clicking Download', () => {
     const result = renderComponent();
-    const downloadButton = result.getByRole('button', { name: 'Download document' });
+    const downloadButton = result.getByRole('button', { name: 'Download JSON' });
     const anchorMocked = {
       href: '',
       click: jest.fn(),
@@ -57,6 +68,7 @@ describe('AgentDocumentFlyout', () => {
 
     downloadButton.click();
     expect(createElementSpyOn).toBeCalledWith('a');
-    expect(result.queryAllByRole('link')).toHaveLength(0);
+    expect(result.queryAllByRole('link')).toHaveLength(1); // The only link is the one from the flyout's description.
+    expect(result.getByRole('link')).toHaveAttribute('href', 'https://elastic.co');
   });
 });

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_details_json_flyout.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_details_json_flyout.tsx
@@ -17,12 +17,16 @@ import {
   EuiFlyoutBody,
   EuiFlyoutFooter,
   EuiFlyoutHeader,
+  EuiLink,
+  EuiSpacer,
+  EuiText,
   EuiTitle,
 } from '@elastic/eui';
 
 import type { Agent } from '../../../../types';
+import { useStartServices } from '../../../../hooks';
 
-export const AgentDocumentFlyout = memo<{ agent: Agent; onClose: () => void }>(
+export const AgentDetailsJsonFlyout = memo<{ agent: Agent; onClose: () => void }>(
   ({ agent, onClose }) => {
     const agentToJson = JSON.stringify(agent, null, 2);
     const agentName =
@@ -33,9 +37,11 @@ export const AgentDocumentFlyout = memo<{ agent: Agent; onClose: () => void }>(
     const downloadJson = () => {
       const link = document.createElement('a');
       link.href = `data:text/json;charset=utf-8,${encodeURIComponent(agentToJson)}`;
-      link.download = `${agentName}-agent-document.json`;
+      link.download = `${agentName}-agent-details.json`;
       link.click();
     };
+
+    const { docLinks } = useStartServices();
 
     return (
       <EuiFlyout onClose={onClose} size="l" maxWidth={640}>
@@ -43,8 +49,8 @@ export const AgentDocumentFlyout = memo<{ agent: Agent; onClose: () => void }>(
           <EuiTitle size="m">
             <h2>
               <FormattedMessage
-                id="xpack.fleet.agentDetails.agentDocumentFlyoutTitle"
-                defaultMessage="'{name}' agent document"
+                id="xpack.fleet.agentDetails.jsonFlyoutTitle"
+                defaultMessage="'{name}' agent details"
                 values={{
                   name: agentName,
                 }}
@@ -53,6 +59,25 @@ export const AgentDocumentFlyout = memo<{ agent: Agent; onClose: () => void }>(
           </EuiTitle>
         </EuiFlyoutHeader>
         <EuiFlyoutBody>
+          <EuiText>
+            <p>
+              <FormattedMessage
+                id="xpack.fleet.agentDetails.jsonFlyoutDescription"
+                defaultMessage="The JSON below is the raw agent data tracked by Fleet. This data can be useful for debugging or troubleshooting Elastic Agent. For more information, see the {doc}."
+                values={{
+                  doc: (
+                    <EuiLink href={docLinks.links.fleet.troubleshooting}>
+                      <FormattedMessage
+                        id="xpack.fleet.agentDetails.jsonFlyoutDocLink"
+                        defaultMessage="troubleshooting documentation"
+                      />
+                    </EuiLink>
+                  ),
+                }}
+              />
+            </p>
+          </EuiText>
+          <EuiSpacer />
           <EuiCodeBlock language="json">{agentToJson}</EuiCodeBlock>
         </EuiFlyoutBody>
         <EuiFlyoutFooter>
@@ -60,7 +85,7 @@ export const AgentDocumentFlyout = memo<{ agent: Agent; onClose: () => void }>(
             <EuiFlexItem grow={false}>
               <EuiButtonEmpty onClick={onClose} flush="left">
                 <FormattedMessage
-                  id="xpack.fleet.agentDetails.agentDocumentFlyoutCloseButtonLabel"
+                  id="xpack.fleet.agentDetails.agentDetailsJsonFlyoutCloseButtonLabel"
                   defaultMessage="Close"
                 />
               </EuiButtonEmpty>
@@ -68,8 +93,8 @@ export const AgentDocumentFlyout = memo<{ agent: Agent; onClose: () => void }>(
             <EuiFlexItem grow={false}>
               <EuiButton iconType="download" onClick={downloadJson}>
                 <FormattedMessage
-                  id="xpack.fleet.agentDetails.agentDocumentDownloadButtonLabel"
-                  defaultMessage="Download document"
+                  id="xpack.fleet.agentDetails.agentDetailsJsonDownloadButtonLabel"
+                  defaultMessage="Download JSON"
                 />
               </EuiButton>
             </EuiFlexItem>

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_document_flyout.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_document_flyout.test.tsx
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import type { Agent } from '../../../../types';
+import { AgentDocumentFlyout } from './agent_document_flyout';
+
+describe('AgentDocumentFlyout', () => {
+  const agent: Agent = {
+    id: '123',
+    packages: [],
+    type: 'PERMANENT',
+    active: true,
+    enrolled_at: `${Date.now()}`,
+    user_provided_metadata: {},
+    local_metadata: {},
+  };
+
+  const renderComponent = () => {
+    return render(<AgentDocumentFlyout agent={agent} onClose={jest.fn()} />);
+  };
+
+  it('renders a title with the agent id if host name is not defined', () => {
+    const result = renderComponent();
+    expect(result.getByText("'123' agent document")).toBeInTheDocument();
+  });
+
+  it('renders a title with the agent host name if defined', () => {
+    agent.local_metadata = {
+      host: {
+        hostname: '456',
+      },
+    };
+    const result = renderComponent();
+    expect(result.getByText("'456' agent document")).toBeInTheDocument();
+  });
+
+  it('does not add a link to the page after clicking Download', () => {
+    const result = renderComponent();
+    const downloadButton = result.getByRole('button', { name: 'Download document' });
+    const anchorMocked = {
+      href: '',
+      click: jest.fn(),
+      download: '',
+      setAttribute: jest.fn(),
+    } as any;
+    const createElementSpyOn = jest
+      .spyOn(document, 'createElement')
+      .mockReturnValueOnce(anchorMocked);
+
+    downloadButton.click();
+    expect(createElementSpyOn).toBeCalledWith('a');
+    expect(result.queryAllByRole('link')).toHaveLength(0);
+  });
+});

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_document_flyout.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_document_flyout.test.tsx
@@ -7,7 +7,9 @@
 
 import React from 'react';
 import { render } from '@testing-library/react';
+
 import type { Agent } from '../../../../types';
+
 import { AgentDocumentFlyout } from './agent_document_flyout';
 
 describe('AgentDocumentFlyout', () => {

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_document_flyout.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_document_flyout.tsx
@@ -30,7 +30,7 @@ export const AgentDocumentFlyout = memo<{ agent: any; onClose: () => void }>(
 
     const downloadJson = () => {
       const link = document.createElement('a');
-      link.href = `data:text/json;chatset=utf-8,${encodeURIComponent(agentToJson)}`;
+      link.href = `data:text/json;charset=utf-8,${encodeURIComponent(agentToJson)}`;
       link.download = `${agentName}-agent-document.json`;
       link.click();
       link.remove();

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_document_flyout.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_document_flyout.tsx
@@ -19,8 +19,9 @@ import {
   EuiFlyoutHeader,
   EuiTitle,
 } from '@elastic/eui';
+import type { Agent } from '../../../../types';
 
-export const AgentDocumentFlyout = memo<{ agent: any; onClose: () => void }>(
+export const AgentDocumentFlyout = memo<{ agent: Agent; onClose: () => void }>(
   ({ agent, onClose }) => {
     const agentToJson = JSON.stringify(agent, null, 2);
     const agentName =
@@ -33,7 +34,6 @@ export const AgentDocumentFlyout = memo<{ agent: any; onClose: () => void }>(
       link.href = `data:text/json;charset=utf-8,${encodeURIComponent(agentToJson)}`;
       link.download = `${agentName}-agent-document.json`;
       link.click();
-      link.remove();
     };
 
     return (

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_document_flyout.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_document_flyout.tsx
@@ -19,6 +19,7 @@ import {
   EuiFlyoutHeader,
   EuiTitle,
 } from '@elastic/eui';
+
 import type { Agent } from '../../../../types';
 
 export const AgentDocumentFlyout = memo<{ agent: Agent; onClose: () => void }>(

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_document_flyout.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_document_flyout.tsx
@@ -1,0 +1,80 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { memo } from 'react';
+import { FormattedMessage } from '@kbn/i18n-react';
+import {
+  EuiButton,
+  EuiButtonEmpty,
+  EuiCodeBlock,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFlyout,
+  EuiFlyoutBody,
+  EuiFlyoutFooter,
+  EuiFlyoutHeader,
+  EuiTitle,
+} from '@elastic/eui';
+
+export const AgentDocumentFlyout = memo<{ agent: any; onClose: () => void }>(
+  ({ agent, onClose }) => {
+    const agentToJson = JSON.stringify(agent, null, 2);
+    const agentName =
+      typeof agent.local_metadata?.host?.hostname === 'string'
+        ? agent.local_metadata.host.hostname
+        : agent.id;
+
+    const downloadJson = () => {
+      const link = document.createElement('a');
+      link.href = `data:text/json;chatset=utf-8,${encodeURIComponent(agentToJson)}`;
+      link.download = `${agentName}-agent-document.json`;
+      link.click();
+      link.remove();
+    };
+
+    return (
+      <EuiFlyout onClose={onClose} size="l" maxWidth={640}>
+        <EuiFlyoutHeader hasBorder>
+          <EuiTitle size="m">
+            <h2>
+              <FormattedMessage
+                id="xpack.fleet.agentDetails.agentDocumentFlyoutTitle"
+                defaultMessage="'{name}' agent document"
+                values={{
+                  name: agentName,
+                }}
+              />
+            </h2>
+          </EuiTitle>
+        </EuiFlyoutHeader>
+        <EuiFlyoutBody>
+          <EuiCodeBlock language="json">{agentToJson}</EuiCodeBlock>
+        </EuiFlyoutBody>
+        <EuiFlyoutFooter>
+          <EuiFlexGroup justifyContent="spaceBetween">
+            <EuiFlexItem grow={false}>
+              <EuiButtonEmpty onClick={onClose} flush="left">
+                <FormattedMessage
+                  id="xpack.fleet.agentDetails.agentDocumentFlyoutCloseButtonLabel"
+                  defaultMessage="Close"
+                />
+              </EuiButtonEmpty>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiButton iconType="download" onClick={downloadJson}>
+                <FormattedMessage
+                  id="xpack.fleet.agentDetails.agentDocumentDownloadButtonLabel"
+                  defaultMessage="Download document"
+                />
+              </EuiButton>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiFlyoutFooter>
+      </EuiFlyout>
+    );
+  }
+);


### PR DESCRIPTION
## Summary

Make raw agent status discoverable in Fleet UI, under `Agent details` tab.

Closes https://github.com/elastic/kibana/issues/154067

### Screenshots

<img width="1918" alt="Screenshot 2023-04-19 at 12 14 48" src="https://user-images.githubusercontent.com/23701614/233059955-7f066ad5-39cd-4685-b76b-41bc31ede4e8.png">
<img width="1918" alt="Screenshot 2023-04-19 at 13 04 06" src="https://user-images.githubusercontent.com/23701614/233059973-3f1b507f-d0bf-48ab-929b-c567f9814377.png">

### UX checklist

- [ ] Action link title (`View agent JSON`)
- [ ] Flyout title (`{agentName} agent details`)
- [ ] Download button
- [ ] Download button label (`Download JSON`)
- [ ] Downloaded file name (`{agentName}-agent-details.json`)

### Testing steps

1. Run Kibana in dev on this branch.
2. In Fleet, click on an agent to get to the agent details page.
3. There should be a new `View agent JSON` item in the `Actions` menu. Click it.
4. A new flyout should open with the agent details in JSON format. Clicking outside of the flyout or on the `Close` button should close the flyout.
5. The `Download JSON` button should download the JSON correctly.

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)