### PR TITLE
[Fleet] Fix package license check to use new constraints.elastic.subs…

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/packages/install.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/install.test.ts
@@ -136,9 +136,11 @@ describe('install', () => {
     jest
       .spyOn(Registry, 'fetchFindLatestPackageOrThrow')
       .mockImplementation(() => Promise.resolve({ version: '1.3.0' } as any));
-    jest
-      .spyOn(Registry, 'getPackage')
-      .mockImplementation(() => Promise.resolve({ packageInfo: { license: 'basic' } } as any));
+    jest.spyOn(Registry, 'getPackage').mockImplementation(() =>
+      Promise.resolve({
+        packageInfo: { license: 'basic', conditions: { elastic: { subscription: 'basic' } } },
+      } as any)
+    );
 
     mockGetBundledPackages.mockReset();
     (install._installPackage as jest.Mock).mockClear();

--- a/x-pack/plugins/fleet/server/services/epm/packages/install.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/install.ts
@@ -23,6 +23,8 @@ import pRetry from 'p-retry';
 
 import { uniqBy } from 'lodash';
 
+import type { LicenseType } from '@kbn/licensing-plugin/server';
+
 import { isPackagePrerelease, getNormalizedDataStreams } from '../../../../common/services';
 
 import { FLEET_INSTALL_FORMAT_VERSION } from '../../../constants/fleet_es_assets';
@@ -378,6 +380,12 @@ async function installPackageFromRegistry({
   }
 }
 
+function getElasticSubscription(packageInfo: ArchivePackage) {
+  const subscription = packageInfo.conditions?.elastic?.subscription as LicenseType | undefined;
+  // Keep packageInfo.license for backward compatibility
+  return subscription || packageInfo.license || 'basic';
+}
+
 async function installPackageCommon(options: {
   pkgName: string;
   pkgVersion: string;
@@ -451,7 +459,7 @@ async function installPackageCommon(options: {
       }
     }
 
-    if (!licenseService.hasAtLeast(packageInfo.license || 'basic')) {
+    if (!licenseService.hasAtLeast(getElasticSubscription(packageInfo))) {
       const err = new Error(`Requires ${packageInfo.license} license`);
       sendEvent({
         ...telemetryEvent,

--- a/x-pack/plugins/fleet/server/services/epm/packages/install.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/install.ts
@@ -458,9 +458,9 @@ async function installPackageCommon(options: {
         };
       }
     }
-
-    if (!licenseService.hasAtLeast(getElasticSubscription(packageInfo))) {
-      const err = new Error(`Requires ${packageInfo.license} license`);
+    const elasticSubscription = getElasticSubscription(packageInfo);
+    if (!licenseService.hasAtLeast(elasticSubscription)) {
+      const err = new Error(`Requires ${elasticSubscription} license`);
       sendEvent({
         ...telemetryEvent,
         errorMessage: err.message,


### PR DESCRIPTION
closes https://github.com/elastic/kibana/issues/154822

Uses the new `conditions.elastic.subscription` field to check elastic subscription.

Error message when `conditions.elastic.subscription` is set to **enterprise** but ES is under **basic** license.
<img width="832" alt="Screenshot 2023-04-12 at 1 31 21 PM" src="https://user-images.githubusercontent.com/55978943/231538154-fd3c54fd-228a-45f1-b159-6c46ce622c25.png">

