### PR TITLE
[SLO] Add refresh button to SLO Detail page

### DIFF
--- a/x-pack/plugins/observability/public/components/app/burn_rate_rule_editor/burn_rate_rule_editor.tsx
+++ b/x-pack/plugins/observability/public/components/app/burn_rate_rule_editor/burn_rate_rule_editor.tsx
@@ -28,7 +28,9 @@ type Props = Pick<
 
 export function BurnRateRuleEditor(props: Props) {
   const { setRuleParams, ruleParams, errors } = props;
-  const { isLoading: loadingInitialSlo, slo: initialSlo } = useFetchSloDetails(ruleParams?.sloId);
+  const { isLoading: loadingInitialSlo, slo: initialSlo } = useFetchSloDetails({
+    sloId: ruleParams?.sloId,
+  });
 
   const [selectedSlo, setSelectedSlo] = useState<SLOResponse | undefined>(undefined);
   const [longWindowDuration, setLongWindowDuration] = useState<Duration>({

--- a/x-pack/plugins/observability/public/hooks/slo/use_fetch_historical_summary.ts
+++ b/x-pack/plugins/observability/public/hooks/slo/use_fetch_historical_summary.ts
@@ -21,10 +21,13 @@ export interface UseFetchHistoricalSummaryResponse {
 
 export interface Params {
   sloIds: string[];
+  shouldRefetch?: boolean;
 }
 
+const LONG_REFETCH_INTERVAL = 1000 * 60; // 1 minute
 export function useFetchHistoricalSummary({
   sloIds = [],
+  shouldRefetch,
 }: Params): UseFetchHistoricalSummaryResponse {
   const { http } = useKibana().services;
 
@@ -45,6 +48,7 @@ export function useFetchHistoricalSummary({
         // ignore error
       }
     },
+    refetchInterval: shouldRefetch ? LONG_REFETCH_INTERVAL : undefined,
     refetchOnWindowFocus: false,
   });
 

--- a/x-pack/plugins/observability/public/hooks/slo/use_fetch_slo_details.ts
+++ b/x-pack/plugins/observability/public/hooks/slo/use_fetch_slo_details.ts
@@ -26,7 +26,7 @@ export interface UseFetchSloDetailsResponse {
   ) => Promise<QueryObserverResult<GetSLOResponse | undefined, unknown>>;
 }
 
-const LONG_REFETCH_INTERVAL = 1000 * 5; // 1 minute
+const LONG_REFETCH_INTERVAL = 1000 * 60; // 1 minute
 
 export function useFetchSloDetails({
   sloId,

--- a/x-pack/plugins/observability/public/hooks/slo/use_fetch_slo_details.ts
+++ b/x-pack/plugins/observability/public/hooks/slo/use_fetch_slo_details.ts
@@ -15,7 +15,9 @@ import { GetSLOResponse, SLOWithSummaryResponse } from '@kbn/slo-schema';
 import { useKibana } from '../../utils/kibana_react';
 
 export interface UseFetchSloDetailsResponse {
+  isInitialLoading: boolean;
   isLoading: boolean;
+  isRefetching: boolean;
   isSuccess: boolean;
   isError: boolean;
   slo: SLOWithSummaryResponse | undefined;
@@ -24,7 +26,15 @@ export interface UseFetchSloDetailsResponse {
   ) => Promise<QueryObserverResult<GetSLOResponse | undefined, unknown>>;
 }
 
-export function useFetchSloDetails(sloId?: string): UseFetchSloDetailsResponse {
+const LONG_REFETCH_INTERVAL = 1000 * 5; // 1 minute
+
+export function useFetchSloDetails({
+  sloId,
+  shouldRefetch,
+}: {
+  sloId?: string;
+  shouldRefetch?: boolean;
+}): UseFetchSloDetailsResponse {
   const { http } = useKibana().services;
 
   const { isInitialLoading, isLoading, isError, isSuccess, isRefetching, data, refetch } = useQuery(
@@ -43,13 +53,16 @@ export function useFetchSloDetails(sloId?: string): UseFetchSloDetailsResponse {
         }
       },
       enabled: Boolean(sloId),
+      refetchInterval: shouldRefetch ? LONG_REFETCH_INTERVAL : undefined,
       refetchOnWindowFocus: false,
     }
   );
 
   return {
     slo: data,
-    isLoading: isInitialLoading || isLoading || isRefetching,
+    isLoading,
+    isInitialLoading,
+    isRefetching,
     isSuccess,
     isError,
     refetch,

--- a/x-pack/plugins/observability/public/pages/slo_details/components/slo_details.stories.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_details/components/slo_details.stories.tsx
@@ -22,6 +22,7 @@ const Template: ComponentStory<typeof Component> = (props: Props) => <Component 
 
 const defaultProps: Props = {
   slo: buildSlo(),
+  isAutoRefreshing: false,
 };
 
 export const SloDetails = Template.bind({});

--- a/x-pack/plugins/observability/public/pages/slo_details/components/slo_details.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_details/components/slo_details.tsx
@@ -17,11 +17,12 @@ import { SliChartPanel } from './sli_chart_panel';
 
 export interface Props {
   slo: SLOWithSummaryResponse;
+  isAutoRefreshing: boolean;
 }
 
-export function SloDetails({ slo }: Props) {
+export function SloDetails({ slo, isAutoRefreshing }: Props) {
   const { isLoading: historicalSummaryLoading, sloHistoricalSummaryResponse = {} } =
-    useFetchHistoricalSummary({ sloIds: [slo.id] });
+    useFetchHistoricalSummary({ sloIds: [slo.id], shouldRefetch: isAutoRefreshing });
 
   const errorBudgetBurnDownData = formatHistoricalData(
     sloHistoricalSummaryResponse[slo.id],

--- a/x-pack/plugins/observability/public/pages/slo_edit/slo_edit.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/slo_edit.tsx
@@ -38,7 +38,7 @@ export function SloEditPage() {
     },
   ]);
 
-  const { slo, isLoading } = useFetchSloDetails(sloId);
+  const { slo, isLoading } = useFetchSloDetails({ sloId });
 
   if (hasRightLicense === false) {
     navigateToUrl(basePath.prepend(paths.observability.slos));


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/153906

## 📝 Summary

This adds the same Auto Refresh button component to the SLO Detail page as was already on the SLO List page.

It reloads the SLO detail, as well as the summaries on an interval of 60 seconds.
