### PR TITLE
[Synthetics] adjusts the monitor id used in the UI

### DIFF
--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/common/components/monitor_details_panel.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/common/components/monitor_details_panel.tsx
@@ -122,7 +122,7 @@ export const MonitorDetailsPanel = ({
             </>
           )}
           <TitleLabel>{MONITOR_ID_ITEM_TEXT}</TitleLabel>
-          <DescriptionLabel>{configId}</DescriptionLabel>
+          <DescriptionLabel>{monitor.id}</DescriptionLabel>
           <TitleLabel>{MONITOR_TYPE_LABEL}</TitleLabel>
           <DescriptionLabel>
             <MonitorTypeBadge monitor={monitor} />

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/monitor_detail_flyout.test.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/monitor_detail_flyout.test.tsx
@@ -54,7 +54,7 @@ describe('Monitor Detail Flyout', () => {
     const onCloseMock = jest.fn();
     const { getByLabelText } = render(
       <MonitorDetailFlyout
-        configId="test-id"
+        configId="123456"
         id="test-id"
         location="US East"
         locationId="us-east"
@@ -78,7 +78,7 @@ describe('Monitor Detail Flyout', () => {
 
     const { getByText } = render(
       <MonitorDetailFlyout
-        configId="test-id"
+        configId="123456"
         id="test-id"
         location="US East"
         locationId="us-east"
@@ -98,7 +98,7 @@ describe('Monitor Detail Flyout', () => {
 
     const { getByRole } = render(
       <MonitorDetailFlyout
-        configId="test-id"
+        configId="123456"
         id="test-id"
         location="US East"
         locationId="us-east"
@@ -135,7 +135,7 @@ describe('Monitor Detail Flyout', () => {
 
     const { getByRole, getByText, getAllByRole } = render(
       <MonitorDetailFlyout
-        configId="test-id"
+        configId="123456"
         id="test-id"
         location="US East"
         locationId="us-east"

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/monitor_detail_flyout.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/monitor_detail_flyout.tsx
@@ -332,6 +332,7 @@ export function MonitorDetailFlyout(props: Props) {
               configId={configId}
               monitor={{
                 ...monitorSavedObject.attributes,
+                id,
                 updated_at: monitorSavedObject.updated_at!,
                 created_at: monitorSavedObject.created_at!,
               }}

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/monitor_detail_flyout.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/monitor_detail_flyout.tsx
@@ -332,7 +332,6 @@ export function MonitorDetailFlyout(props: Props) {
               configId={configId}
               monitor={{
                 ...monitorSavedObject.attributes,
-                id: monitorSavedObject.id,
                 updated_at: monitorSavedObject.updated_at!,
                 created_at: monitorSavedObject.created_at!,
               }}


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/154454

![image](https://user-images.githubusercontent.com/11356435/231546806-29dd92b9-e970-4fe1-9184-6fbb1547d819.png)
![image](https://user-images.githubusercontent.com/11356435/231546843-e45b6cc7-6082-468d-bb23-5f6c51edbad8.png)
![image](https://user-images.githubusercontent.com/11356435/231546868-18c03aa8-718d-4b76-8e0b-5367985d95a2.png)

### Testing
1. Create a UI monitor.
2. Click on the card for the UI monitor to launch the flyout. Confirm that the monitor id shown is the monitor saved object uuid.
3. Create a project monitor
4. Click on the card for the project monitor to launch the flyout. Confirm that the monitor id shown is the `id-project-space` format that we use for project monitors

<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->