### PR TITLE
[Content management] Update storage context

### DIFF
--- a/src/plugins/content_management/server/core/index.ts
+++ b/src/plugins/content_management/server/core/index.ts
@@ -12,7 +12,12 @@ export type { CoreApi } from './core';
 
 export type { ContentType } from './content_type';
 
-export type { ContentStorage, ContentTypeDefinition, StorageContext } from './types';
+export type {
+  ContentStorage,
+  ContentTypeDefinition,
+  StorageContext,
+  StorageContextGetTransformFn,
+} from './types';
 
 export type { ContentRegistry } from './registry';
 

--- a/src/plugins/content_management/server/core/types.ts
+++ b/src/plugins/content_management/server/core/types.ts
@@ -7,7 +7,11 @@
  */
 
 import type { RequestHandlerContext } from '@kbn/core-http-request-handler-context-server';
-import type { ContentManagementGetTransformsFn, Version } from '@kbn/object-versioning';
+import type {
+  Version,
+  ContentManagementServiceTransforms,
+  ContentManagementServiceDefinitionVersioned,
+} from '@kbn/object-versioning';
 import type { SavedObjectsFindResult } from '@kbn/core-saved-objects-api-server';
 
 import type {
@@ -20,6 +24,11 @@ import type {
   SearchResult,
 } from '../../common';
 
+export type StorageContextGetTransformFn = (
+  definitions: ContentManagementServiceDefinitionVersioned,
+  requestVersion?: Version
+) => ContentManagementServiceTransforms;
+
 /** Context that is sent to all storage instance methods */
 export interface StorageContext {
   requestHandlerContext: RequestHandlerContext;
@@ -28,7 +37,7 @@ export interface StorageContext {
     latest: Version;
   };
   utils: {
-    getTransforms: ContentManagementGetTransformsFn;
+    getTransforms: StorageContextGetTransformFn;
   };
 }
 

--- a/src/plugins/content_management/server/rpc/procedures/bulk_get.test.ts
+++ b/src/plugins/content_management/server/rpc/procedures/bulk_get.test.ts
@@ -9,7 +9,7 @@
 import { omit } from 'lodash';
 
 import { schema } from '@kbn/config-schema';
-import { ContentManagementServiceDefinitionVersioned, Version } from '@kbn/object-versioning';
+import type { ContentManagementServiceDefinitionVersioned, Version } from '@kbn/object-versioning';
 import { validate } from '../../utils';
 import { ContentRegistry } from '../../core/registry';
 import { createMockedStorage } from '../../core/mocks';

--- a/src/plugins/content_management/server/rpc/procedures/bulk_get.test.ts
+++ b/src/plugins/content_management/server/rpc/procedures/bulk_get.test.ts
@@ -9,13 +9,27 @@
 import { omit } from 'lodash';
 
 import { schema } from '@kbn/config-schema';
-import { ContentManagementServiceDefinitionVersioned } from '@kbn/object-versioning';
+import { ContentManagementServiceDefinitionVersioned, Version } from '@kbn/object-versioning';
 import { validate } from '../../utils';
 import { ContentRegistry } from '../../core/registry';
 import { createMockedStorage } from '../../core/mocks';
 import { EventBus } from '../../core/event_bus';
 import { getServiceObjectTransformFactory } from '../services_transforms_factory';
 import { bulkGet } from './bulk_get';
+
+const storageContextGetTransforms = jest.fn();
+const spy = () => storageContextGetTransforms;
+
+jest.mock('@kbn/object-versioning', () => {
+  const original = jest.requireActual('@kbn/object-versioning');
+  return {
+    ...original,
+    getContentManagmentServicesTransforms: (...args: any[]) => {
+      spy()(...args);
+      return original.getContentManagmentServicesTransforms(...args);
+    },
+  };
+});
 
 const { fn, schemas } = bulkGet;
 
@@ -177,7 +191,8 @@ describe('RPC -> bulkGet()', () => {
       const ctx: any = {
         contentRegistry,
         requestHandlerContext,
-        getTransformsFactory: getServiceObjectTransformFactory,
+        getTransformsFactory: (contentTypeId: string, version: Version) =>
+          getServiceObjectTransformFactory(contentTypeId, version, { cacheEnabled: false }),
       };
 
       return { ctx, storage };
@@ -223,6 +238,31 @@ describe('RPC -> bulkGet()', () => {
         ['123', '456'],
         undefined
       );
+    });
+
+    test('should implicitly set the requestVersion in storageContext -> utils -> getTransforms()', async () => {
+      const { ctx, storage } = setup();
+
+      const requestVersion = 1;
+      await fn(ctx, {
+        contentTypeId: FOO_CONTENT_ID,
+        ids: ['123', '456'],
+        version: requestVersion,
+      });
+
+      const [storageContext] = storage.bulkGet.mock.calls[0];
+      storageContext.utils.getTransforms({ 1: {} });
+
+      expect(storageContextGetTransforms).toHaveBeenCalledWith(
+        { 1: {} },
+        requestVersion,
+        expect.any(Object)
+      );
+
+      // We can still pass custom version
+      storageContext.utils.getTransforms({ 1: {} }, 1234);
+
+      expect(storageContextGetTransforms).toHaveBeenCalledWith({ 1: {} }, 1234, expect.any(Object));
     });
 
     describe('validation', () => {
@@ -271,7 +311,7 @@ describe('RPC -> bulkGet()', () => {
           2: {},
         };
 
-        const transforms = getTransforms(definitions, 1);
+        const transforms = getTransforms(definitions);
 
         // Some smoke tests for the getTransforms() utils. Complete test suite is inside
         // the package @kbn/object-versioning

--- a/src/plugins/content_management/server/rpc/procedures/bulk_get.ts
+++ b/src/plugins/content_management/server/rpc/procedures/bulk_get.ts
@@ -8,32 +8,21 @@
 
 import { rpcSchemas } from '../../../common/schemas';
 import type { BulkGetIn } from '../../../common';
-import type { StorageContext } from '../../core';
 import type { ProcedureDefinition } from '../rpc_service';
 import type { Context } from '../types';
 import { BulkGetResponse } from '../../core/crud';
-import { validateRequestVersion } from './utils';
+import { getStorageContext } from './utils';
 
 export const bulkGet: ProcedureDefinition<Context, BulkGetIn<string>, BulkGetResponse> = {
   schemas: rpcSchemas.bulkGet,
-  fn: async (ctx, { contentTypeId, version: _version, ids, options }) => {
-    const contentDefinition = ctx.contentRegistry.getDefinition(contentTypeId);
-    const version = validateRequestVersion(_version, contentDefinition.version.latest);
+  fn: async (ctx, { contentTypeId, version, ids, options }) => {
+    const storageContext = getStorageContext({
+      contentTypeId,
+      version,
+      ctx,
+    });
 
-    // Execute CRUD
     const crudInstance = ctx.contentRegistry.getCrud(contentTypeId);
-    const storageContext: StorageContext = {
-      requestHandlerContext: ctx.requestHandlerContext,
-      version: {
-        request: version,
-        latest: contentDefinition.version.latest,
-      },
-      utils: {
-        getTransforms: ctx.getTransformsFactory(contentTypeId),
-      },
-    };
-    const result = await crudInstance.bulkGet(storageContext, ids, options);
-
-    return result;
+    return crudInstance.bulkGet(storageContext, ids, options);
   },
 };

--- a/src/plugins/content_management/server/rpc/procedures/create.test.ts
+++ b/src/plugins/content_management/server/rpc/procedures/create.test.ts
@@ -9,13 +9,27 @@
 import { omit } from 'lodash';
 
 import { schema } from '@kbn/config-schema';
-import { ContentManagementServiceDefinitionVersioned } from '@kbn/object-versioning';
+import { ContentManagementServiceDefinitionVersioned, Version } from '@kbn/object-versioning';
 import { validate } from '../../utils';
 import { ContentRegistry } from '../../core/registry';
 import { createMockedStorage } from '../../core/mocks';
 import { EventBus } from '../../core/event_bus';
 import { getServiceObjectTransformFactory } from '../services_transforms_factory';
 import { create } from './create';
+
+const storageContextGetTransforms = jest.fn();
+const spy = () => storageContextGetTransforms;
+
+jest.mock('@kbn/object-versioning', () => {
+  const original = jest.requireActual('@kbn/object-versioning');
+  return {
+    ...original,
+    getContentManagmentServicesTransforms: (...args: any[]) => {
+      spy()(...args);
+      return original.getContentManagmentServicesTransforms(...args);
+    },
+  };
+});
 
 const { fn, schemas } = create;
 
@@ -150,7 +164,8 @@ describe('RPC -> create()', () => {
       const ctx: any = {
         contentRegistry,
         requestHandlerContext,
-        getTransformsFactory: getServiceObjectTransformFactory,
+        getTransformsFactory: (contentTypeId: string, version: Version) =>
+          getServiceObjectTransformFactory(contentTypeId, version, { cacheEnabled: false }),
       };
 
       return { ctx, storage };
@@ -189,6 +204,31 @@ describe('RPC -> create()', () => {
         { title: 'Hello' },
         undefined
       );
+    });
+
+    test('should implicitly set the requestVersion in storageContext -> utils -> getTransforms()', async () => {
+      const { ctx, storage } = setup();
+
+      const requestVersion = 1;
+      await fn(ctx, {
+        contentTypeId: FOO_CONTENT_ID,
+        data: { title: 'Hello' },
+        version: requestVersion,
+      });
+
+      const [storageContext] = storage.create.mock.calls[0];
+      storageContext.utils.getTransforms({ 1: {} });
+
+      expect(storageContextGetTransforms).toHaveBeenCalledWith(
+        { 1: {} },
+        requestVersion,
+        expect.any(Object)
+      );
+
+      // We can still pass custom version
+      storageContext.utils.getTransforms({ 1: {} }, 1234);
+
+      expect(storageContextGetTransforms).toHaveBeenCalledWith({ 1: {} }, 1234, expect.any(Object));
     });
 
     describe('validation', () => {
@@ -237,7 +277,7 @@ describe('RPC -> create()', () => {
           2: {},
         };
 
-        const transforms = getTransforms(definitions, 1);
+        const transforms = getTransforms(definitions);
 
         // Some smoke tests for the getTransforms() utils. Complete test suite is inside
         // the package @kbn/object-versioning

--- a/src/plugins/content_management/server/rpc/procedures/create.test.ts
+++ b/src/plugins/content_management/server/rpc/procedures/create.test.ts
@@ -9,7 +9,7 @@
 import { omit } from 'lodash';
 
 import { schema } from '@kbn/config-schema';
-import { ContentManagementServiceDefinitionVersioned, Version } from '@kbn/object-versioning';
+import type { ContentManagementServiceDefinitionVersioned, Version } from '@kbn/object-versioning';
 import { validate } from '../../utils';
 import { ContentRegistry } from '../../core/registry';
 import { createMockedStorage } from '../../core/mocks';

--- a/src/plugins/content_management/server/rpc/procedures/delete.test.ts
+++ b/src/plugins/content_management/server/rpc/procedures/delete.test.ts
@@ -8,7 +8,7 @@
 
 import { omit } from 'lodash';
 
-import { ContentManagementServiceDefinitionVersioned, Version } from '@kbn/object-versioning';
+import type { ContentManagementServiceDefinitionVersioned, Version } from '@kbn/object-versioning';
 import { schema } from '@kbn/config-schema';
 import { validate } from '../../utils';
 import { ContentRegistry } from '../../core/registry';

--- a/src/plugins/content_management/server/rpc/procedures/delete.test.ts
+++ b/src/plugins/content_management/server/rpc/procedures/delete.test.ts
@@ -8,7 +8,7 @@
 
 import { omit } from 'lodash';
 
-import { ContentManagementServiceDefinitionVersioned } from '@kbn/object-versioning';
+import { ContentManagementServiceDefinitionVersioned, Version } from '@kbn/object-versioning';
 import { schema } from '@kbn/config-schema';
 import { validate } from '../../utils';
 import { ContentRegistry } from '../../core/registry';
@@ -16,6 +16,20 @@ import { createMockedStorage } from '../../core/mocks';
 import { EventBus } from '../../core/event_bus';
 import { getServiceObjectTransformFactory } from '../services_transforms_factory';
 import { deleteProc } from './delete';
+
+const storageContextGetTransforms = jest.fn();
+const spy = () => storageContextGetTransforms;
+
+jest.mock('@kbn/object-versioning', () => {
+  const original = jest.requireActual('@kbn/object-versioning');
+  return {
+    ...original,
+    getContentManagmentServicesTransforms: (...args: any[]) => {
+      spy()(...args);
+      return original.getContentManagmentServicesTransforms(...args);
+    },
+  };
+});
 
 const { fn, schemas } = deleteProc;
 
@@ -136,7 +150,8 @@ describe('RPC -> delete()', () => {
       const ctx: any = {
         contentRegistry,
         requestHandlerContext,
-        getTransformsFactory: getServiceObjectTransformFactory,
+        getTransformsFactory: (contentTypeId: string, version: Version) =>
+          getServiceObjectTransformFactory(contentTypeId, version, { cacheEnabled: false }),
       };
 
       return { ctx, storage };
@@ -169,6 +184,31 @@ describe('RPC -> delete()', () => {
         '1234',
         undefined
       );
+    });
+
+    test('should implicitly set the requestVersion in storageContext -> utils -> getTransforms()', async () => {
+      const { ctx, storage } = setup();
+
+      const requestVersion = 1;
+      await fn(ctx, {
+        contentTypeId: FOO_CONTENT_ID,
+        id: '1234',
+        version: requestVersion,
+      });
+
+      const [storageContext] = storage.delete.mock.calls[0];
+      storageContext.utils.getTransforms({ 1: {} });
+
+      expect(storageContextGetTransforms).toHaveBeenCalledWith(
+        { 1: {} },
+        requestVersion,
+        expect.any(Object)
+      );
+
+      // We can still pass custom version
+      storageContext.utils.getTransforms({ 1: {} }, 1234);
+
+      expect(storageContextGetTransforms).toHaveBeenCalledWith({ 1: {} }, 1234, expect.any(Object));
     });
 
     describe('validation', () => {
@@ -217,7 +257,7 @@ describe('RPC -> delete()', () => {
           2: {},
         };
 
-        const transforms = getTransforms(definitions, 1);
+        const transforms = getTransforms(definitions);
 
         // Some smoke tests for the getTransforms() utils. Complete test suite is inside
         // the package @kbn/object-versioning

--- a/src/plugins/content_management/server/rpc/procedures/delete.ts
+++ b/src/plugins/content_management/server/rpc/procedures/delete.ts
@@ -7,31 +7,20 @@
  */
 import { rpcSchemas } from '../../../common/schemas';
 import type { DeleteIn } from '../../../common';
-import type { StorageContext } from '../../core';
 import type { ProcedureDefinition } from '../rpc_service';
 import type { Context } from '../types';
-import { validateRequestVersion } from './utils';
+import { getStorageContext } from './utils';
 
 export const deleteProc: ProcedureDefinition<Context, DeleteIn<string>> = {
   schemas: rpcSchemas.delete,
-  fn: async (ctx, { contentTypeId, id, version: _version, options }) => {
-    const contentDefinition = ctx.contentRegistry.getDefinition(contentTypeId);
-    const version = validateRequestVersion(_version, contentDefinition.version.latest);
+  fn: async (ctx, { contentTypeId, id, version, options }) => {
+    const storageContext = getStorageContext({
+      contentTypeId,
+      version,
+      ctx,
+    });
 
-    // Execute CRUD
     const crudInstance = ctx.contentRegistry.getCrud(contentTypeId);
-    const storageContext: StorageContext = {
-      requestHandlerContext: ctx.requestHandlerContext,
-      version: {
-        request: version,
-        latest: contentDefinition.version.latest,
-      },
-      utils: {
-        getTransforms: ctx.getTransformsFactory(contentTypeId),
-      },
-    };
-    const result = await crudInstance.delete(storageContext, id, options);
-
-    return result;
+    return crudInstance.delete(storageContext, id, options);
   },
 };

--- a/src/plugins/content_management/server/rpc/procedures/get.test.ts
+++ b/src/plugins/content_management/server/rpc/procedures/get.test.ts
@@ -9,7 +9,7 @@
 import { omit } from 'lodash';
 
 import { schema } from '@kbn/config-schema';
-import { ContentManagementServiceDefinitionVersioned, Version } from '@kbn/object-versioning';
+import type { ContentManagementServiceDefinitionVersioned, Version } from '@kbn/object-versioning';
 import { validate } from '../../utils';
 import { ContentRegistry } from '../../core/registry';
 import { createMockedStorage } from '../../core/mocks';

--- a/src/plugins/content_management/server/rpc/procedures/get.test.ts
+++ b/src/plugins/content_management/server/rpc/procedures/get.test.ts
@@ -9,13 +9,27 @@
 import { omit } from 'lodash';
 
 import { schema } from '@kbn/config-schema';
-import { ContentManagementServiceDefinitionVersioned } from '@kbn/object-versioning';
+import { ContentManagementServiceDefinitionVersioned, Version } from '@kbn/object-versioning';
 import { validate } from '../../utils';
 import { ContentRegistry } from '../../core/registry';
 import { createMockedStorage } from '../../core/mocks';
 import { EventBus } from '../../core/event_bus';
 import { getServiceObjectTransformFactory } from '../services_transforms_factory';
 import { get } from './get';
+
+const storageContextGetTransforms = jest.fn();
+const spy = () => storageContextGetTransforms;
+
+jest.mock('@kbn/object-versioning', () => {
+  const original = jest.requireActual('@kbn/object-versioning');
+  return {
+    ...original,
+    getContentManagmentServicesTransforms: (...args: any[]) => {
+      spy()(...args);
+      return original.getContentManagmentServicesTransforms(...args);
+    },
+  };
+});
 
 const { fn, schemas } = get;
 
@@ -143,7 +157,8 @@ describe('RPC -> get()', () => {
       const ctx: any = {
         contentRegistry,
         requestHandlerContext,
-        getTransformsFactory: getServiceObjectTransformFactory,
+        getTransformsFactory: (contentTypeId: string, version: Version) =>
+          getServiceObjectTransformFactory(contentTypeId, version, { cacheEnabled: false }),
       };
 
       return { ctx, storage };
@@ -178,6 +193,27 @@ describe('RPC -> get()', () => {
         '1234',
         undefined
       );
+    });
+
+    test('should implicitly set the requestVersion in storageContext -> utils -> getTransforms()', async () => {
+      const { ctx, storage } = setup();
+
+      const requestVersion = 1;
+      await fn(ctx, { contentTypeId: FOO_CONTENT_ID, id: '1234', version: requestVersion });
+
+      const [storageContext] = storage.get.mock.calls[0];
+      storageContext.utils.getTransforms({ 1: {} });
+
+      expect(storageContextGetTransforms).toHaveBeenCalledWith(
+        { 1: {} },
+        requestVersion,
+        expect.any(Object)
+      );
+
+      // We can still pass custom version
+      storageContext.utils.getTransforms({ 1: {} }, 1234);
+
+      expect(storageContextGetTransforms).toHaveBeenCalledWith({ 1: {} }, 1234, expect.any(Object));
     });
 
     describe('validation', () => {
@@ -226,7 +262,7 @@ describe('RPC -> get()', () => {
           2: {},
         };
 
-        const transforms = getTransforms(definitions, 1);
+        const transforms = getTransforms(definitions);
 
         // Some smoke tests for the getTransforms() utils. Complete test suite is inside
         // the package @kbn/object-versioning

--- a/src/plugins/content_management/server/rpc/procedures/get.ts
+++ b/src/plugins/content_management/server/rpc/procedures/get.ts
@@ -8,31 +8,20 @@
 
 import { rpcSchemas } from '../../../common/schemas';
 import type { GetIn } from '../../../common';
-import type { StorageContext } from '../../core';
 import type { ProcedureDefinition } from '../rpc_service';
 import type { Context } from '../types';
-import { validateRequestVersion } from './utils';
+import { getStorageContext } from './utils';
 
 export const get: ProcedureDefinition<Context, GetIn<string>> = {
   schemas: rpcSchemas.get,
-  fn: async (ctx, { contentTypeId, id, version: _version, options }) => {
-    const contentDefinition = ctx.contentRegistry.getDefinition(contentTypeId);
-    const version = validateRequestVersion(_version, contentDefinition.version.latest);
+  fn: async (ctx, { contentTypeId, id, version, options }) => {
+    const storageContext = getStorageContext({
+      contentTypeId,
+      version,
+      ctx,
+    });
 
-    // Execute CRUD
     const crudInstance = ctx.contentRegistry.getCrud(contentTypeId);
-    const storageContext: StorageContext = {
-      requestHandlerContext: ctx.requestHandlerContext,
-      version: {
-        request: version,
-        latest: contentDefinition.version.latest,
-      },
-      utils: {
-        getTransforms: ctx.getTransformsFactory(contentTypeId),
-      },
-    };
-    const result = await crudInstance.get(storageContext, id, options);
-
-    return result;
+    return crudInstance.get(storageContext, id, options);
   },
 };

--- a/src/plugins/content_management/server/rpc/procedures/msearch.test.ts
+++ b/src/plugins/content_management/server/rpc/procedures/msearch.test.ts
@@ -6,16 +6,17 @@
  * Side Public License, v 1.
  */
 
+import type { Version } from '@kbn/object-versioning';
+import { savedObjectsClientMock } from '@kbn/core-saved-objects-api-server-mocks';
+
+import { MSearchIn, MSearchQuery } from '../../../common';
 import { validate } from '../../utils';
 import { ContentRegistry } from '../../core/registry';
 import { createMockedStorage } from '../../core/mocks';
 import { EventBus } from '../../core/event_bus';
-import { MSearchIn, MSearchQuery } from '../../../common';
-import { mSearch } from './msearch';
-import { getServiceObjectTransformFactory } from '../services_transforms_factory';
 import { MSearchService } from '../../core/msearch';
-import { savedObjectsClientMock } from '@kbn/core-saved-objects-api-server-mocks';
-import { Version } from '@kbn/object-versioning';
+import { getServiceObjectTransformFactory } from '../services_transforms_factory';
+import { mSearch } from './msearch';
 
 const storageContextGetTransforms = jest.fn();
 const spy = () => storageContextGetTransforms;

--- a/src/plugins/content_management/server/rpc/procedures/search.test.ts
+++ b/src/plugins/content_management/server/rpc/procedures/search.test.ts
@@ -8,7 +8,7 @@
 
 import { omit } from 'lodash';
 import { schema } from '@kbn/config-schema';
-import { ContentManagementServiceDefinitionVersioned, Version } from '@kbn/object-versioning';
+import type { ContentManagementServiceDefinitionVersioned, Version } from '@kbn/object-versioning';
 
 import type { SearchQuery } from '../../../common';
 import { validate } from '../../utils';

--- a/src/plugins/content_management/server/rpc/procedures/search.test.ts
+++ b/src/plugins/content_management/server/rpc/procedures/search.test.ts
@@ -8,7 +8,7 @@
 
 import { omit } from 'lodash';
 import { schema } from '@kbn/config-schema';
-import { ContentManagementServiceDefinitionVersioned } from '@kbn/object-versioning';
+import { ContentManagementServiceDefinitionVersioned, Version } from '@kbn/object-versioning';
 
 import type { SearchQuery } from '../../../common';
 import { validate } from '../../utils';
@@ -17,6 +17,20 @@ import { createMockedStorage } from '../../core/mocks';
 import { EventBus } from '../../core/event_bus';
 import { getServiceObjectTransformFactory } from '../services_transforms_factory';
 import { search } from './search';
+
+const storageContextGetTransforms = jest.fn();
+const spy = () => storageContextGetTransforms;
+
+jest.mock('@kbn/object-versioning', () => {
+  const original = jest.requireActual('@kbn/object-versioning');
+  return {
+    ...original,
+    getContentManagmentServicesTransforms: (...args: any[]) => {
+      spy()(...args);
+      return original.getContentManagmentServicesTransforms(...args);
+    },
+  };
+});
 
 const { fn, schemas } = search;
 
@@ -163,7 +177,8 @@ describe('RPC -> search()', () => {
       const ctx: any = {
         contentRegistry,
         requestHandlerContext,
-        getTransformsFactory: getServiceObjectTransformFactory,
+        getTransformsFactory: (contentTypeId: string, version: Version) =>
+          getServiceObjectTransformFactory(contentTypeId, version, { cacheEnabled: false }),
       };
 
       return { ctx, storage };
@@ -206,6 +221,31 @@ describe('RPC -> search()', () => {
         { text: 'Hello' },
         undefined
       );
+    });
+
+    test('should implicitly set the requestVersion in storageContext -> utils -> getTransforms()', async () => {
+      const { ctx, storage } = setup();
+
+      const requestVersion = 1;
+      await fn(ctx, {
+        contentTypeId: FOO_CONTENT_ID,
+        query: { text: 'Hello' },
+        version: requestVersion,
+      });
+
+      const [storageContext] = storage.search.mock.calls[0];
+      storageContext.utils.getTransforms({ 1: {} });
+
+      expect(storageContextGetTransforms).toHaveBeenCalledWith(
+        { 1: {} },
+        requestVersion,
+        expect.any(Object)
+      );
+
+      // We can still pass custom version
+      storageContext.utils.getTransforms({ 1: {} }, 1234);
+
+      expect(storageContextGetTransforms).toHaveBeenCalledWith({ 1: {} }, 1234, expect.any(Object));
     });
 
     describe('validation', () => {
@@ -254,7 +294,7 @@ describe('RPC -> search()', () => {
           2: {},
         };
 
-        const transforms = getTransforms(definitions, 1);
+        const transforms = getTransforms(definitions);
 
         // Some smoke tests for the getTransforms() utils. Complete test suite is inside
         // the package @kbn/object-versioning

--- a/src/plugins/content_management/server/rpc/procedures/search.ts
+++ b/src/plugins/content_management/server/rpc/procedures/search.ts
@@ -8,31 +8,20 @@
 
 import { rpcSchemas } from '../../../common/schemas';
 import type { SearchIn } from '../../../common';
-import type { StorageContext } from '../../core';
 import type { ProcedureDefinition } from '../rpc_service';
 import type { Context } from '../types';
-import { validateRequestVersion } from './utils';
+import { getStorageContext } from './utils';
 
 export const search: ProcedureDefinition<Context, SearchIn<string>> = {
   schemas: rpcSchemas.search,
-  fn: async (ctx, { contentTypeId, version: _version, query, options }) => {
-    const contentDefinition = ctx.contentRegistry.getDefinition(contentTypeId);
-    const version = validateRequestVersion(_version, contentDefinition.version.latest);
+  fn: async (ctx, { contentTypeId, version, query, options }) => {
+    const storageContext = getStorageContext({
+      contentTypeId,
+      version,
+      ctx,
+    });
 
-    // Execute CRUD
     const crudInstance = ctx.contentRegistry.getCrud(contentTypeId);
-    const storageContext: StorageContext = {
-      requestHandlerContext: ctx.requestHandlerContext,
-      version: {
-        request: version,
-        latest: contentDefinition.version.latest,
-      },
-      utils: {
-        getTransforms: ctx.getTransformsFactory(contentTypeId),
-      },
-    };
-    const result = await crudInstance.search(storageContext, query, options);
-
-    return result;
+    return crudInstance.search(storageContext, query, options);
   },
 };

--- a/src/plugins/content_management/server/rpc/procedures/update.test.ts
+++ b/src/plugins/content_management/server/rpc/procedures/update.test.ts
@@ -9,13 +9,27 @@
 import { omit } from 'lodash';
 
 import { schema } from '@kbn/config-schema';
-import { ContentManagementServiceDefinitionVersioned } from '@kbn/object-versioning';
+import { ContentManagementServiceDefinitionVersioned, Version } from '@kbn/object-versioning';
 import { validate } from '../../utils';
 import { ContentRegistry } from '../../core/registry';
 import { createMockedStorage } from '../../core/mocks';
 import { EventBus } from '../../core/event_bus';
 import { getServiceObjectTransformFactory } from '../services_transforms_factory';
 import { update } from './update';
+
+const storageContextGetTransforms = jest.fn();
+const spy = () => storageContextGetTransforms;
+
+jest.mock('@kbn/object-versioning', () => {
+  const original = jest.requireActual('@kbn/object-versioning');
+  return {
+    ...original,
+    getContentManagmentServicesTransforms: (...args: any[]) => {
+      spy()(...args);
+      return original.getContentManagmentServicesTransforms(...args);
+    },
+  };
+});
 
 const { fn, schemas } = update;
 
@@ -157,7 +171,8 @@ describe('RPC -> update()', () => {
       const ctx: any = {
         contentRegistry,
         requestHandlerContext,
-        getTransformsFactory: getServiceObjectTransformFactory,
+        getTransformsFactory: (contentTypeId: string, version: Version) =>
+          getServiceObjectTransformFactory(contentTypeId, version, { cacheEnabled: false }),
       };
 
       return { ctx, storage };
@@ -198,6 +213,32 @@ describe('RPC -> update()', () => {
         { title: 'Hello' },
         undefined
       );
+    });
+
+    test('should implicitly set the requestVersion in storageContext -> utils -> getTransforms()', async () => {
+      const { ctx, storage } = setup();
+
+      const requestVersion = 1;
+      await fn(ctx, {
+        contentTypeId: FOO_CONTENT_ID,
+        version: requestVersion,
+        id: '1234',
+        data: { title: 'Hello' },
+      });
+
+      const [storageContext] = storage.update.mock.calls[0];
+      storageContext.utils.getTransforms({ 1: {} });
+
+      expect(storageContextGetTransforms).toHaveBeenCalledWith(
+        { 1: {} },
+        requestVersion,
+        expect.any(Object)
+      );
+
+      // We can still pass custom version
+      storageContext.utils.getTransforms({ 1: {} }, 1234);
+
+      expect(storageContextGetTransforms).toHaveBeenCalledWith({ 1: {} }, 1234, expect.any(Object));
     });
 
     describe('validation', () => {
@@ -252,7 +293,7 @@ describe('RPC -> update()', () => {
           2: {},
         };
 
-        const transforms = getTransforms(definitions, 1);
+        const transforms = getTransforms(definitions);
 
         // Some smoke tests for the getTransforms() utils. Complete test suite is inside
         // the package @kbn/object-versioning

--- a/src/plugins/content_management/server/rpc/procedures/update.test.ts
+++ b/src/plugins/content_management/server/rpc/procedures/update.test.ts
@@ -7,9 +7,9 @@
  */
 
 import { omit } from 'lodash';
-
 import { schema } from '@kbn/config-schema';
-import { ContentManagementServiceDefinitionVersioned, Version } from '@kbn/object-versioning';
+import type { ContentManagementServiceDefinitionVersioned, Version } from '@kbn/object-versioning';
+
 import { validate } from '../../utils';
 import { ContentRegistry } from '../../core/registry';
 import { createMockedStorage } from '../../core/mocks';

--- a/src/plugins/content_management/server/rpc/procedures/utils.ts
+++ b/src/plugins/content_management/server/rpc/procedures/utils.ts
@@ -8,8 +8,10 @@
 
 import { validateVersion } from '@kbn/object-versioning/lib/utils';
 import type { Version } from '@kbn/object-versioning';
+import type { StorageContext } from '../../core';
+import type { Context as RpcContext } from '../types';
 
-export const validateRequestVersion = (
+const validateRequestVersion = (
   requestVersion: Version | undefined,
   latestVersion: Version
 ): Version => {
@@ -29,4 +31,28 @@ export const validateRequestVersion = (
   }
 
   return requestVersionNumber;
+};
+
+export const getStorageContext = ({
+  contentTypeId,
+  version: _version,
+  ctx: { contentRegistry, requestHandlerContext, getTransformsFactory },
+}: {
+  contentTypeId: string;
+  version?: number;
+  ctx: RpcContext;
+}): StorageContext => {
+  const contentDefinition = contentRegistry.getDefinition(contentTypeId);
+  const version = validateRequestVersion(_version, contentDefinition.version.latest);
+  const storageContext: StorageContext = {
+    requestHandlerContext,
+    version: {
+      request: version,
+      latest: contentDefinition.version.latest,
+    },
+    utils: {
+      getTransforms: getTransformsFactory(contentTypeId),
+    },
+  };
+  return storageContext;
 };

--- a/src/plugins/content_management/server/rpc/procedures/utils.ts
+++ b/src/plugins/content_management/server/rpc/procedures/utils.ts
@@ -51,7 +51,7 @@ export const getStorageContext = ({
       latest: contentDefinition.version.latest,
     },
     utils: {
-      getTransforms: getTransformsFactory(contentTypeId),
+      getTransforms: getTransformsFactory(contentTypeId, version),
     },
   };
   return storageContext;

--- a/src/plugins/content_management/server/rpc/types.ts
+++ b/src/plugins/content_management/server/rpc/types.ts
@@ -6,13 +6,17 @@
  * Side Public License, v 1.
  */
 import type { RequestHandlerContext } from '@kbn/core-http-request-handler-context-server';
-import type { ContentManagementGetTransformsFn } from '@kbn/object-versioning';
-import type { ContentRegistry } from '../core';
+import type { Version } from '@kbn/object-versioning';
+import type { ContentRegistry, StorageContextGetTransformFn } from '../core';
 import type { MSearchService } from '../core/msearch';
 
 export interface Context {
   contentRegistry: ContentRegistry;
   requestHandlerContext: RequestHandlerContext;
-  getTransformsFactory: (contentTypeId: string) => ContentManagementGetTransformsFn;
+  getTransformsFactory: (
+    contentTypeId: string,
+    requestVersion: Version,
+    options?: { cacheEnabled?: boolean }
+  ) => StorageContextGetTransformFn;
   mSearchService: MSearchService;
 }

--- a/x-pack/plugins/maps/server/content_management/maps_storage.ts
+++ b/x-pack/plugins/maps/server/content_management/maps_storage.ts
@@ -92,9 +92,8 @@ export class MapsStorage implements ContentStorage<MapItem, PartialMapItem> {
   async get(ctx: StorageContext, id: string): Promise<MapGetOut> {
     const {
       utils: { getTransforms },
-      version: { request: requestVersion },
     } = ctx;
-    const transforms = getTransforms(cmServicesDefinition, requestVersion);
+    const transforms = getTransforms(cmServicesDefinition);
     const soClient = await savedObjectClientFromRequest(ctx);
 
     // Save data in DB
@@ -138,9 +137,8 @@ export class MapsStorage implements ContentStorage<MapItem, PartialMapItem> {
   ): Promise<MapCreateOut> {
     const {
       utils: { getTransforms },
-      version: { request: requestVersion },
     } = ctx;
-    const transforms = getTransforms(cmServicesDefinition, requestVersion);
+    const transforms = getTransforms(cmServicesDefinition);
 
     // Validate input (data & options) & UP transform them to the latest version
     const { value: dataToLatest, error: dataError } = transforms.create.in.data.up<
@@ -190,9 +188,8 @@ export class MapsStorage implements ContentStorage<MapItem, PartialMapItem> {
   ): Promise<MapUpdateOut> {
     const {
       utils: { getTransforms },
-      version: { request: requestVersion },
     } = ctx;
-    const transforms = getTransforms(cmServicesDefinition, requestVersion);
+    const transforms = getTransforms(cmServicesDefinition);
 
     // Validate input (data & options) & UP transform them to the latest version
     const { value: dataToLatest, error: dataError } = transforms.update.in.data.up<
@@ -248,9 +245,8 @@ export class MapsStorage implements ContentStorage<MapItem, PartialMapItem> {
   ): Promise<MapSearchOut> {
     const {
       utils: { getTransforms },
-      version: { request: requestVersion },
     } = ctx;
-    const transforms = getTransforms(cmServicesDefinition, requestVersion);
+    const transforms = getTransforms(cmServicesDefinition);
     const soClient = await savedObjectClientFromRequest(ctx);
 
     // Validate and UP transform the options


### PR DESCRIPTION
In this PR I've updated the `StorageContext` to implicitly set the `requestVersion` to the `utils.getTransforms()` helper. 

```ts
// Before
async get(ctx: StorageContext, id: string): Promise<MapGetOut> {
  const {
    utils: { getTransforms },
    version: { request: requestVersion }, // need to read the requestVersion
  } = ctx;
  const transforms = getTransforms(cmServicesDefinition, requestVersion); // and pass it to the getTransforms
...


// After
async get(ctx: StorageContext, id: string): Promise<MapGetOut> {
  const { utils: { getTransforms } } = ctx;
  const transforms = getTransforms(cmServicesDefinition); // Implicitly has the request version
  
  // And it can still overridden if need be
  const transforms = getTransforms(cmServicesDefinition, 3); // transforms from version 3
```

Fixes https://github.com/elastic/kibana/issues/154648