### PR TITLE
[Enterprise Search] Add new connector configurable field input types

### DIFF
--- a/x-pack/plugins/enterprise_search/common/connectors/native_connectors.ts
+++ b/x-pack/plugins/enterprise_search/common/connectors/native_connectors.ts
@@ -13,64 +13,76 @@ export const NATIVE_CONNECTOR_DEFINITIONS: Record<string, NativeConnector | unde
   mongodb: {
     configuration: {
       host: {
+        display: 'textbox',
         label: i18n.translate(
           'xpack.enterpriseSearch.nativeConnectors.mongodb.configuration.hostLabel',
           {
             defaultMessage: 'Host',
           }
         ),
-        order: 0,
+        order: 1,
+        sensitive: false,
         value: '',
       },
       user: {
+        display: 'textbox',
         label: i18n.translate(
           'xpack.enterpriseSearch.nativeConnectors.mongodb.configuration.usernameLabel',
           {
             defaultMessage: 'Username',
           }
         ),
-        order: 1,
+        order: 2,
+        sensitive: false,
         value: '',
       },
       password: {
+        display: 'textbox',
         label: i18n.translate(
           'xpack.enterpriseSearch.nativeConnectors.mongodb.configuration.passwordLabel',
           {
             defaultMessage: 'Password',
           }
         ),
-        order: 2,
+        order: 3,
+        sensitive: true,
         value: '',
       },
       database: {
+        display: 'textbox',
         label: i18n.translate(
           'xpack.enterpriseSearch.nativeConnectors.mongodb.configuration.databaseLabel',
           {
             defaultMessage: 'Database',
           }
         ),
-        order: 3,
+        order: 4,
+        sensitive: false,
         value: '',
       },
       collection: {
+        display: 'textbox',
         label: i18n.translate(
           'xpack.enterpriseSearch.nativeConnectors.mongodb.configuration.collectionLabel',
           {
             defaultMessage: 'Collection',
           }
         ),
-        order: 4,
+        order: 5,
+        sensitive: false,
         value: '',
       },
       direct_connection: {
+        display: 'toggle',
         label: i18n.translate(
           'xpack.enterpriseSearch.nativeConnectors.mongodb.configuration.directConnectionLabel',
           {
-            defaultMessage: 'Direct connection (true/false)',
+            defaultMessage: 'Direct connection',
           }
         ),
-        order: 5,
-        value: '',
+        order: 6,
+        sensitive: false,
+        value: true,
       },
     },
     features: {
@@ -89,83 +101,99 @@ export const NATIVE_CONNECTOR_DEFINITIONS: Record<string, NativeConnector | unde
   mysql: {
     configuration: {
       host: {
+        display: 'textbox',
         label: i18n.translate(
           'xpack.enterpriseSearch.nativeConnectors.mysql.configuration.hostLabel',
           {
             defaultMessage: 'Host',
           }
         ),
-        order: 0,
+        order: 1,
+        sensitive: false,
         value: '',
       },
       port: {
+        display: 'numeric',
         label: i18n.translate(
           'xpack.enterpriseSearch.nativeConnectors.mysql.configuration.portLabel',
           {
             defaultMessage: 'Port',
           }
         ),
-        order: 1,
+        order: 2,
+        sensitive: false,
         value: '',
       },
       user: {
+        display: 'textbox',
         label: i18n.translate(
           'xpack.enterpriseSearch.nativeConnectors.mysql.configuration.usernameLabel',
           {
             defaultMessage: 'Username',
           }
         ),
-        order: 2,
+        order: 3,
+        sensitive: false,
         value: '',
       },
       password: {
-        value: '',
-        order: 3,
+        display: 'textbox',
         label: i18n.translate(
           'xpack.enterpriseSearch.nativeConnectors.mysql.configuration.passwordLabel',
           {
             defaultMessage: 'Password',
           }
         ),
+        order: 4,
+        sensitive: true,
+        value: '',
       },
       database: {
+        display: 'textbox',
         label: i18n.translate(
           'xpack.enterpriseSearch.nativeConnectors.mysql.configuration.databaseLabel',
           {
             defaultMessage: 'Database',
           }
         ),
-        order: 4,
+        order: 5,
+        sensitive: false,
         value: '',
       },
       tables: {
+        display: 'textarea',
         label: i18n.translate(
           'xpack.enterpriseSearch.nativeConnectors.mysql.configuration.tablesLabel',
           {
             defaultMessage: 'Tables',
           }
         ),
-        order: 5,
+        order: 6,
+        sensitive: false,
         value: '',
       },
-      ssl_disabled: {
+      ssl_enabled: {
+        display: 'toggle',
         label: i18n.translate(
-          'xpack.enterpriseSearch.nativeConnectors.mysql.configuration.sslDisabledLabel',
+          'xpack.enterpriseSearch.nativeConnectors.mysql.configuration.sslEnabledLabel',
           {
-            defaultMessage: 'Disable SSL (true/false)',
+            defaultMessage: 'Enable SSL',
           }
         ),
-        order: 6,
-        value: 'true',
+        order: 7,
+        sensitive: false,
+        value: false,
       },
       ssl_ca: {
+        display: 'textbox',
         label: i18n.translate(
           'xpack.enterpriseSearch.nativeConnectors.mysql.configuration.sslCertificateLabel',
           {
             defaultMessage: 'SSL certificate',
           }
         ),
-        order: 7,
+        order: 8,
+        sensitive: false,
         value: '',
       },
     },

--- a/x-pack/plugins/enterprise_search/common/types/connectors.ts
+++ b/x-pack/plugins/enterprise_search/common/types/connectors.ts
@@ -204,7 +204,7 @@ export interface ConnectorSyncJob {
 export type ConnectorSyncJobDocument = Omit<ConnectorSyncJob, 'id'>;
 
 export interface NativeConnector {
-  configuration: ConnectorSyncConfiguration;
+  configuration: ConnectorConfiguration;
   features: Connector['features'];
   name: string;
   serviceType: string;

--- a/x-pack/plugins/enterprise_search/common/types/connectors.ts
+++ b/x-pack/plugins/enterprise_search/common/types/connectors.ts
@@ -6,8 +6,10 @@
  */
 
 export interface KeyValuePair {
+  display: string;
   label: string;
   order?: number | null;
+  sensitive: boolean;
   value: string | number | boolean | null;
 }
 

--- a/x-pack/plugins/enterprise_search/common/types/connectors.ts
+++ b/x-pack/plugins/enterprise_search/common/types/connectors.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-export interface KeyValuePair {
+export interface ConnectorConfigProperties {
   display: string;
   label: string;
   order?: number | null;
@@ -13,9 +13,16 @@ export interface KeyValuePair {
   value: string | number | boolean | null;
 }
 
-export type ConnectorConfiguration = Record<string, KeyValuePair | null> & {
+export type ConnectorConfiguration = Record<string, ConnectorConfigProperties | null> & {
   extract_full_html?: { label: string; value: boolean };
 };
+
+export interface ConnectorSyncConfigProperties {
+  label: string;
+  value: string | number | boolean | null;
+}
+
+export type ConnectorSyncConfiguration = Record<string, ConnectorSyncConfigProperties | null>;
 
 export interface ConnectorScheduling {
   enabled: boolean;
@@ -172,7 +179,7 @@ export interface ConnectorSyncJob {
   canceled_at: string | null;
   completed_at: string | null;
   connector: {
-    configuration: ConnectorConfiguration;
+    configuration: ConnectorSyncConfiguration;
     filtering: FilteringRules | FilteringRules[] | null;
     id: string;
     index_name: string;
@@ -197,7 +204,7 @@ export interface ConnectorSyncJob {
 export type ConnectorSyncJobDocument = Omit<ConnectorSyncJob, 'id'>;
 
 export interface NativeConnector {
-  configuration: ConnectorConfiguration;
+  configuration: ConnectorSyncConfiguration;
   features: Connector['features'];
   name: string;
   serviceType: string;

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/__mocks__/search_indices.mock.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/__mocks__/search_indices.mock.ts
@@ -32,7 +32,16 @@ export const indices: ElasticsearchIndexWithIngestion[] = [
   {
     connector: {
       api_key_id: null,
-      configuration: { foo: { label: 'bar', value: 'barbar' } },
+      configuration: {
+        foo: {
+          display: 'textbox',
+          key: 'foo',
+          label: 'bar',
+          order: 1,
+          sensitive: false,
+          value: 'barbar',
+        },
+      },
       custom_scheduling: {
         foo: {
           configuration_overrides: {},
@@ -128,7 +137,16 @@ export const indices: ElasticsearchIndexWithIngestion[] = [
   {
     connector: {
       api_key_id: null,
-      configuration: { foo: { label: 'bar', value: 'barbar' } },
+      configuration: {
+        foo: {
+          display: 'textbox',
+          key: 'foo',
+          label: 'bar',
+          order: 1,
+          sensitive: false,
+          value: 'barbar',
+        },
+      },
       custom_scheduling: {
         foo: {
           configuration_overrides: {},

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/__mocks__/view_index.mock.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/__mocks__/view_index.mock.ts
@@ -42,7 +42,16 @@ export const apiIndex: ApiViewIndex = {
 export const connectorIndex: ConnectorViewIndex = {
   connector: {
     api_key_id: null,
-    configuration: { foo: { label: 'bar', value: 'barbar' } },
+    configuration: {
+      foo: {
+        display: 'textbox',
+        key: 'foo',
+        label: 'bar',
+        order: 1,
+        sensitive: false,
+        value: 'barbar',
+      },
+    },
     custom_scheduling: {
       foo: {
         configuration_overrides: {},
@@ -142,7 +151,16 @@ export const connectorIndex: ConnectorViewIndex = {
 export const crawlerIndex: CrawlerViewIndex = {
   connector: {
     api_key_id: null,
-    configuration: { foo: { label: 'bar', value: 'barbar' } },
+    configuration: {
+      foo: {
+        display: 'textbox',
+        key: 'foo',
+        label: 'bar',
+        order: 1,
+        sensitive: false,
+        value: 'barbar',
+      },
+    },
     custom_scheduling: {
       foo: {
         configuration_overrides: {},

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_configuration_config.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_configuration_config.tsx
@@ -30,8 +30,8 @@ export const ConnectorConfigurationConfig: React.FC = ({ children }) => {
   const { configView, isEditing } = useValues(ConnectorConfigurationLogic);
   const { setIsEditing } = useActions(ConnectorConfigurationLogic);
 
-  const displayList = configView.map(({ label, isPasswordField, value }) => ({
-    description: isPasswordField && !!value ? '********' : value || '--',
+  const displayList = configView.map(({ label, sensitive, value }) => ({
+    description: sensitive && !!value ? '********' : value || '--',
     title: label,
   }));
 

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_configuration_field.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_configuration_field.tsx
@@ -10,6 +10,7 @@ import React from 'react';
 import { useActions, useValues } from 'kea';
 
 import {
+  EuiAccordion,
   EuiFieldText,
   EuiFieldNumber,
   EuiFieldPassword,
@@ -39,11 +40,11 @@ export const ConnectorConfigurationField: React.FC<ConnectorConfigurationFieldPr
   const { status } = useValues(ConnectorConfigurationApiLogic);
   const { setLocalConfigEntry } = useActions(ConnectorConfigurationLogic);
 
-  const { display, label, sensitive, value } = configEntry;
+  const { key, display, label, sensitive, value } = configEntry;
 
   switch (display) {
     case 'textarea':
-      return (
+      const textarea = (
         <EuiTextArea
           value={ensureStringType(value)}
           disabled={status === Status.LOADING}
@@ -51,6 +52,14 @@ export const ConnectorConfigurationField: React.FC<ConnectorConfigurationFieldPr
             setLocalConfigEntry({ ...configEntry, value: event.target.value });
           }}
         />
+      );
+
+      return sensitive ? (
+        <EuiAccordion id={key + '-accordion'} buttonContent={label}>
+          {textarea}
+        </EuiAccordion>
+      ) : (
+        textarea
       );
 
     case 'numeric':

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_configuration_field.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_configuration_field.tsx
@@ -1,0 +1,99 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { useActions, useValues } from 'kea';
+
+import {
+  EuiFieldText,
+  EuiFieldNumber,
+  EuiFieldPassword,
+  EuiSwitch,
+  EuiTextArea,
+} from '@elastic/eui';
+
+import { Status } from '../../../../../../common/types/api';
+
+import { ConnectorConfigurationApiLogic } from '../../../api/connector/update_connector_configuration_api_logic';
+
+import {
+  ConnectorConfigurationLogic,
+  ConfigEntry,
+  ensureStringType,
+  ensureNumberType,
+  ensureBooleanType,
+} from './connector_configuration_logic';
+
+interface ConnectorConfigurationFieldProps {
+  configEntry: ConfigEntry;
+}
+
+export const ConnectorConfigurationField: React.FC<ConnectorConfigurationFieldProps> = ({
+  configEntry,
+}) => {
+  const { status } = useValues(ConnectorConfigurationApiLogic);
+  const { setLocalConfigEntry } = useActions(ConnectorConfigurationLogic);
+
+  const { display, label, sensitive, value } = configEntry;
+
+  switch (display) {
+    case 'textarea':
+      return (
+        <EuiTextArea
+          value={ensureStringType(value)}
+          disabled={status === Status.LOADING}
+          onChange={(event) => {
+            setLocalConfigEntry({ ...configEntry, value: event.target.value });
+          }}
+        />
+      );
+
+    case 'numeric':
+      return (
+        <EuiFieldNumber
+          value={ensureNumberType(value)}
+          disabled={status === Status.LOADING}
+          onChange={(event) => {
+            setLocalConfigEntry({ ...configEntry, value: event.target.value });
+          }}
+        />
+      );
+
+    case 'toggle':
+      return (
+        <EuiSwitch
+          checked={ensureBooleanType(value)}
+          disabled={status === Status.LOADING}
+          label={label}
+          onChange={(event) => {
+            setLocalConfigEntry({ ...configEntry, value: event.target.checked });
+          }}
+        />
+      );
+
+    default:
+      return sensitive ? (
+        <EuiFieldPassword
+          value={ensureStringType(value)}
+          disabled={status === Status.LOADING}
+          type="dual"
+          onChange={(event) => {
+            setLocalConfigEntry({ ...configEntry, value: event.target.value });
+          }}
+        />
+      ) : (
+        <EuiFieldText
+          value={ensureStringType(value)}
+          disabled={status === Status.LOADING}
+          onChange={(event) => {
+            setLocalConfigEntry({ ...configEntry, value: event.target.value });
+          }}
+        />
+      );
+  }
+};

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_configuration_form.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_configuration_form.tsx
@@ -12,12 +12,10 @@ import { useActions, useValues } from 'kea';
 import {
   EuiForm,
   EuiFormRow,
-  EuiFieldText,
   EuiFlexGroup,
   EuiFlexItem,
   EuiButton,
   EuiButtonEmpty,
-  EuiFieldPassword,
 } from '@elastic/eui';
 
 import { i18n } from '@kbn/i18n';
@@ -26,13 +24,14 @@ import { Status } from '../../../../../../common/types/api';
 
 import { ConnectorConfigurationApiLogic } from '../../../api/connector/update_connector_configuration_api_logic';
 
+import { ConnectorConfigurationField } from './connector_configuration_field';
 import { ConnectorConfigurationLogic } from './connector_configuration_logic';
 
 export const ConnectorConfigurationForm = () => {
   const { status } = useValues(ConnectorConfigurationApiLogic);
 
   const { localConfigView } = useValues(ConnectorConfigurationLogic);
-  const { saveConfig, setIsEditing, setLocalConfigEntry } = useActions(ConnectorConfigurationLogic);
+  const { saveConfig, setIsEditing } = useActions(ConnectorConfigurationLogic);
 
   return (
     <EuiForm
@@ -43,26 +42,11 @@ export const ConnectorConfigurationForm = () => {
       component="form"
     >
       {localConfigView.map((configEntry) => {
-        const { key, isPasswordField, label, value } = configEntry;
+        const { key, label } = configEntry;
+
         return (
           <EuiFormRow label={label ?? ''} key={key}>
-            {isPasswordField ? (
-              <EuiFieldPassword
-                value={value}
-                disabled={status === Status.LOADING}
-                onChange={(event) => {
-                  setLocalConfigEntry({ ...configEntry, value: event.target.value });
-                }}
-              />
-            ) : (
-              <EuiFieldText
-                value={value}
-                disabled={status === Status.LOADING}
-                onChange={(event) => {
-                  setLocalConfigEntry({ ...configEntry, value: event.target.value });
-                }}
-              />
-            )}
+            <ConnectorConfigurationField configEntry={configEntry} />
           </EuiFormRow>
         );
       })}

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_configuration_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_configuration_logic.test.ts
@@ -50,58 +50,148 @@ describe('ConnectorConfigurationLogic', () => {
     it('should set config and isEditing on apiSuccess', () => {
       ConnectorConfigurationLogic.actions.setIsEditing(true);
       ConnectorConfigurationApiLogic.actions.apiSuccess({
-        configuration: { foo: { label: 'newBar', value: 'oldBar' } },
+        configuration: {
+          foo: { display: 'textbox', label: 'newBar', order: 1, sensitive: false, value: 'oldBar' },
+        },
         indexName: 'indexName',
       });
       expect(ConnectorConfigurationLogic.values).toEqual({
         ...DEFAULT_VALUES,
-        configState: { foo: { label: 'newBar', value: 'oldBar' } },
-        configView: [{ isPasswordField: false, key: 'foo', label: 'newBar', value: 'oldBar' }],
+        configState: {
+          foo: { display: 'textbox', label: 'newBar', order: 1, sensitive: false, value: 'oldBar' },
+        },
+        configView: [
+          {
+            display: 'textbox',
+            key: 'foo',
+            label: 'newBar',
+            order: 1,
+            sensitive: false,
+            value: 'oldBar',
+          },
+        ],
       });
     });
     it('should set config on setConfigState', () => {
       ConnectorConfigurationLogic.actions.setConfigState({
-        foo: { label: 'thirdBar', value: 'fourthBar' },
+        foo: {
+          display: 'textbox',
+          label: 'thirdBar',
+          order: 1,
+          sensitive: false,
+          value: 'fourthBar',
+        },
       });
       expect(ConnectorConfigurationLogic.values).toEqual({
         ...DEFAULT_VALUES,
-        configState: { foo: { label: 'thirdBar', value: 'fourthBar' } },
-        configView: [{ isPasswordField: false, key: 'foo', label: 'thirdBar', value: 'fourthBar' }],
+        configState: {
+          foo: {
+            display: 'textbox',
+            label: 'thirdBar',
+            order: 1,
+            sensitive: false,
+            value: 'fourthBar',
+          },
+        },
+        configView: [
+          {
+            display: 'textbox',
+            key: 'foo',
+            label: 'thirdBar',
+            order: 1,
+            sensitive: false,
+            value: 'fourthBar',
+          },
+        ],
       });
     });
     describe('setLocalConfigEntry', () => {
       it('should set local config entry and sort keys', () => {
         ConnectorConfigurationLogic.actions.setConfigState({
-          bar: { label: 'foo', value: 'foofoo' },
-          password: { label: 'thirdBar', value: 'fourthBar' },
+          bar: { display: 'textbox', label: 'foo', order: 1, sensitive: false, value: 'foofoo' },
+          password: {
+            display: 'textbox',
+            label: 'thirdBar',
+            order: 2,
+            sensitive: true,
+            value: 'fourthBar',
+          },
         });
         ConnectorConfigurationLogic.actions.setLocalConfigState({
-          bar: { label: 'foo', value: 'foofoo' },
-          password: { label: 'thirdBar', value: 'fourthBar' },
+          bar: { display: 'textbox', label: 'foo', order: 1, sensitive: false, value: 'foofoo' },
+          password: {
+            display: 'textbox',
+            label: 'thirdBar',
+            order: 2,
+            sensitive: true,
+            value: 'fourthBar',
+          },
         });
         ConnectorConfigurationLogic.actions.setLocalConfigEntry({
-          isPasswordField: false,
+          display: 'textbox',
           key: 'bar',
           label: 'foo',
+          order: 1,
+          sensitive: false,
           value: 'fafa',
         });
         expect(ConnectorConfigurationLogic.values).toEqual({
           ...DEFAULT_VALUES,
           configState: {
-            bar: { label: 'foo', value: 'foofoo' },
-            password: { label: 'thirdBar', value: 'fourthBar' },
+            bar: { display: 'textbox', label: 'foo', order: 1, sensitive: false, value: 'foofoo' },
+            password: {
+              display: 'textbox',
+              label: 'thirdBar',
+              order: 2,
+              sensitive: true,
+              value: 'fourthBar',
+            },
           },
           configView: [
-            { isPasswordField: false, key: 'bar', label: 'foo', value: 'foofoo' },
-            { isPasswordField: true, key: 'password', label: 'thirdBar', value: 'fourthBar' },
+            {
+              display: 'textbox',
+              key: 'bar',
+              label: 'foo',
+              order: 1,
+              sensitive: false,
+              value: 'foofoo',
+            },
+            {
+              display: 'textbox',
+              key: 'password',
+              label: 'thirdBar',
+              order: 2,
+              sensitive: true,
+              value: 'fourthBar',
+            },
           ],
           localConfigState: {
-            bar: { label: 'foo', value: 'fafa' },
-            password: { label: 'thirdBar', value: 'fourthBar' },
+            bar: { display: 'textbox', label: 'foo', order: 1, sensitive: false, value: 'fafa' },
+            password: {
+              display: 'textbox',
+              label: 'thirdBar',
+              order: 2,
+              sensitive: true,
+              value: 'fourthBar',
+            },
           },
           localConfigView: [
-            { isPasswordField: false, key: 'bar', label: 'foo', value: 'fafa' },
-            { isPasswordField: true, key: 'password', label: 'thirdBar', value: 'fourthBar' },
+            {
+              display: 'textbox',
+              key: 'bar',
+              label: 'foo',
+              order: 1,
+              sensitive: false,
+              value: 'fafa',
+            },
+            {
+              display: 'textbox',
+              key: 'password',
+              label: 'thirdBar',
+              order: 2,
+              sensitive: true,
+              value: 'fourthBar',
+            },
           ],
         });
       });
@@ -112,7 +202,16 @@ describe('ConnectorConfigurationLogic', () => {
         expect(ConnectorConfigurationLogic.values).toEqual({
           ...DEFAULT_VALUES,
           configState: connectorIndex.connector.configuration,
-          configView: [{ isPasswordField: false, key: 'foo', label: 'bar', value: 'barbar' }],
+          configView: [
+            {
+              display: 'textbox',
+              key: 'foo',
+              label: 'bar',
+              order: 1,
+              sensitive: false,
+              value: 'barbar',
+            },
+          ],
           index: connectorIndex,
         });
       });
@@ -134,14 +233,32 @@ describe('ConnectorConfigurationLogic', () => {
         expect(ConnectorConfigurationLogic.values).toEqual({
           ...DEFAULT_VALUES,
           configState: connectorIndex.connector.configuration,
-          configView: [{ isPasswordField: false, key: 'foo', label: 'bar', value: 'barbar' }],
+          configView: [
+            {
+              display: 'textbox',
+              key: 'foo',
+              label: 'bar',
+              order: 1,
+              sensitive: false,
+              value: 'barbar',
+            },
+          ],
           index: {
             ...connectorIndex,
             connector: { ...connectorIndex.connector, status: ConnectorStatus.NEEDS_CONFIGURATION },
           },
           isEditing: true,
           localConfigState: connectorIndex.connector.configuration,
-          localConfigView: [{ isPasswordField: false, key: 'foo', label: 'bar', value: 'barbar' }],
+          localConfigView: [
+            {
+              display: 'textbox',
+              key: 'foo',
+              label: 'bar',
+              order: 1,
+              sensitive: false,
+              value: 'barbar',
+            },
+          ],
           shouldStartInEditMode: true,
         });
       });
@@ -151,7 +268,7 @@ describe('ConnectorConfigurationLogic', () => {
         ConnectorConfigurationLogic.actions.makeRequest = jest.fn();
         ConnectorConfigurationLogic.actions.fetchIndexApiSuccess(connectorIndex);
         ConnectorConfigurationLogic.actions.setLocalConfigState({
-          foo: { label: 'bar', value: 'Barbara' },
+          foo: { display: 'textbox', label: 'bar', order: 1, sensitive: true, value: 'Barbara' },
         });
         ConnectorConfigurationLogic.actions.saveConfig();
         expect(ConnectorConfigurationLogic.actions.makeRequest).toHaveBeenCalledWith({

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_configuration_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_configuration_logic.ts
@@ -48,12 +48,13 @@ interface ConnectorConfigurationValues {
   shouldStartInEditMode: boolean;
 }
 
-interface ConfigEntry {
-  isPasswordField: boolean;
+export interface ConfigEntry {
+  display: string;
   key: string;
   label: string;
   order?: number;
-  value: string;
+  sensitive: boolean;
+  value: string | number | boolean | null;
 }
 
 /**
@@ -84,6 +85,19 @@ function sortConnectorConfiguration(config: ConnectorConfiguration): ConfigEntry
       }
       return a.key.localeCompare(b.key);
     });
+}
+
+export function ensureStringType(value: string | number | boolean | null): string {
+  return String(value);
+}
+
+export function ensureNumberType(value: string | number | boolean | null): number {
+  const numberValue = Number(value);
+  return isNaN(numberValue) ? 0 : numberValue;
+}
+
+export function ensureBooleanType(value: string | number | boolean | null): boolean {
+  return Boolean(value);
 }
 
 export const ConnectorConfigurationLogic = kea<
@@ -191,9 +205,9 @@ export const ConnectorConfigurationLogic = kea<
     localConfigState: [
       {},
       {
-        setLocalConfigEntry: (configState, { key, label, order, value }) => ({
+        setLocalConfigEntry: (configState, { key, display, label, order, sensitive, value }) => ({
           ...configState,
-          [key]: { label, order, value },
+          [key]: { display, label, order, sensitive, value },
         }),
         setLocalConfigState: (_, { configState }) => configState,
       },
@@ -209,21 +223,11 @@ export const ConnectorConfigurationLogic = kea<
   selectors: ({ selectors }) => ({
     configView: [
       () => [selectors.configState],
-      (configState: ConnectorConfiguration) =>
-        sortConnectorConfiguration(configState).map((config) => ({
-          ...config,
-          isPasswordField:
-            config.key.includes('password') || config.label.toLowerCase().includes('password'),
-        })),
+      (configState: ConnectorConfiguration) => sortConnectorConfiguration(configState),
     ],
     localConfigView: [
       () => [selectors.localConfigState],
-      (configState) =>
-        sortConnectorConfiguration(configState).map((config) => ({
-          ...config,
-          isPasswordField:
-            config.key.includes('password') || config.label.toLowerCase().includes('password'),
-        })),
+      (configState) => sortConnectorConfiguration(configState),
     ],
   }),
 });

--- a/x-pack/plugins/enterprise_search/server/lib/connectors/start_sync.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/connectors/start_sync.ts
@@ -11,7 +11,7 @@ import { CONNECTORS_INDEX, CONNECTORS_JOBS_INDEX } from '../..';
 import { ENTERPRISE_SEARCH_CONNECTOR_CRAWLER_SERVICE_TYPE } from '../../../common/constants';
 
 import {
-  ConnectorConfiguration,
+  ConnectorSyncConfiguration,
   ConnectorDocument,
   ConnectorSyncJobDocument,
   SyncStatus,
@@ -30,7 +30,7 @@ export const startConnectorSync = async (
   });
   const connector = connectorResult._source;
   if (connector) {
-    const configuration: ConnectorConfiguration = nextSyncConfig
+    const configuration: ConnectorSyncConfiguration = nextSyncConfig
       ? {
           ...connector.configuration,
           nextSyncConfig: { label: 'nextSyncConfig', value: nextSyncConfig },

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -13181,7 +13181,6 @@
     "xpack.enterpriseSearch.nativeConnectors.mysql.configuration.passwordLabel": "密码",
     "xpack.enterpriseSearch.nativeConnectors.mysql.configuration.portLabel": "端口",
     "xpack.enterpriseSearch.nativeConnectors.mysql.configuration.sslCertificateLabel": "SSL 证书",
-    "xpack.enterpriseSearch.nativeConnectors.mysql.configuration.sslDisabledLabel": "禁用 SSL (true/false)",
     "xpack.enterpriseSearch.nativeConnectors.mysql.configuration.usernameLabel": "用户名",
     "xpack.enterpriseSearch.nativeConnectors.mysql.name": "MySQL",
     "xpack.enterpriseSearch.nav.analyticsCollectionsTitle": "集合",


### PR DESCRIPTION
## Summary

This PR:

- Extracts field type creation to new react component `ConnectorConfigurationField`.
- Adds the following configurable field input types:
  - textbox
  - numeric
  - switch (boolean)
- Updates the `ConfigEntry` type to have more field properties
- Replaces `isPasswordValue` with configurable field property `sensitive`
- Updates field properties for native connectors (MySQL and MongoDB)

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)
