### PR TITLE
[Cases] Remove no-data gate for Cases page

### DIFF
--- a/x-pack/plugins/observability/public/pages/cases/cases.tsx
+++ b/x-pack/plugins/observability/public/pages/cases/cases.tsx
@@ -7,18 +7,15 @@
 
 import React from 'react';
 
-import { useKibana } from '../../utils/kibana_react';
 import { useGetUserCasesPermissions } from '../../hooks/use_get_user_cases_permissions';
 import { usePluginContext } from '../../hooks/use_plugin_context';
 import { useHasData } from '../../hooks/use_has_data';
 import { Cases } from './components/cases';
 import { LoadingObservability } from '../../components/loading_observability';
 import { CaseFeatureNoPermissions } from './components/feature_no_permissions';
-import { getNoDataConfig } from '../../utils/no_data_config';
 
 export function CasesPage() {
   const userCasesPermissions = useGetUserCasesPermissions();
-  const { docLinks, http } = useKibana().services;
   const { ObservabilityPageTemplate } = usePluginContext();
 
   const { hasAnyData, isAllRequestsComplete } = useHasData();
@@ -27,21 +24,8 @@ export function CasesPage() {
     return <LoadingObservability />;
   }
 
-  // If there is any data, set hasData to true otherwise we need to wait till all the data is loaded before setting hasData to true or false; undefined indicates the data is still loading.
-  const hasData = hasAnyData === true || (isAllRequestsComplete === false ? undefined : false);
-
-  const noDataConfig = getNoDataConfig({
-    hasData,
-    basePath: http.basePath,
-    docsLink: docLinks.links.observability.guide,
-  });
-
   return userCasesPermissions.read ? (
-    <ObservabilityPageTemplate
-      isPageDataLoaded={isAllRequestsComplete}
-      data-test-subj={noDataConfig ? 'noDataPage' : undefined}
-      noDataConfig={noDataConfig}
-    >
+    <ObservabilityPageTemplate isPageDataLoaded data-test-subj="o11yCasesPage">
       <Cases permissions={userCasesPermissions} />
     </ObservabilityPageTemplate>
   ) : (

--- a/x-pack/test/observability_functional/apps/observability/feature_controls/observability_security.ts
+++ b/x-pack/test/observability_functional/apps/observability/feature_controls/observability_security.ts
@@ -36,11 +36,6 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       await kibanaServer.uiSettings.update(config.get('uiSettings.defaults'));
     });
 
-    it('Shows the no data page on load', async () => {
-      await PageObjects.common.navigateToActualUrl('observabilityCases');
-      await PageObjects.observability.expectNoDataPage();
-    });
-
     describe('observability cases all privileges', () => {
       before(async () => {
         await esArchiver.load('x-pack/test/functional/es_archives/infra/metrics_and_logs');


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/154908

## 📝 Summary

This removes the no-data check for the Cases page.

## ✅ Acceptance criteria
- The Cases page should be displayed, regardless of APM, Logs, Infra, Synthetics, Ux, Uptime or Alerts have data.  