### PR TITLE
[Security Solution] Adjust the on-read normalization for the actions and throttle rule fields

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/normalization/rule_actions.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/normalization/rule_actions.test.ts
@@ -86,7 +86,6 @@ describe('Rule actions normalization', () => {
     test('returns first action throttle if rule.notifyWhen is not set', () => {
       expect(
         transformFromAlertThrottle({
-          muteAll: false,
           actions: [
             {
               group: 'group',
@@ -116,7 +115,6 @@ describe('Rule actions normalization', () => {
     test('returns "NOTIFICATION_THROTTLE_RULE" if rule.notifyWhen and first action notifyWhen are not set', () => {
       expect(
         transformFromAlertThrottle({
-          muteAll: false,
           actions: [
             {
               group: 'group',
@@ -145,7 +143,6 @@ describe('Rule actions normalization', () => {
     test('returns "NOTIFICATION_THROTTLE_RULE" if rule.notifyWhen is not set and there are no actions', () => {
       expect(
         transformFromAlertThrottle({
-          muteAll: false,
           actions: [],
         } as unknown as RuleAlertType)
       ).toBe(NOTIFICATION_THROTTLE_RULE);
@@ -154,7 +151,6 @@ describe('Rule actions normalization', () => {
     test('returns "NOTIFICATION_THROTTLE_RULE" if rule.notifyWhen is "onActiveAlert"', () => {
       expect(
         transformFromAlertThrottle({
-          muteAll: false,
           notifyWhen: 'onActiveAlert',
           actions: [],
         } as unknown as RuleAlertType)
@@ -164,7 +160,6 @@ describe('Rule actions normalization', () => {
     test('returns rule.throttle value if rule.notifyWhen is "onThrottleInterval"', () => {
       expect(
         transformFromAlertThrottle({
-          muteAll: false,
           notifyWhen: 'onThrottleInterval',
           throttle: '1d',
           actions: [],
@@ -175,11 +170,40 @@ describe('Rule actions normalization', () => {
     test('returns undefined if rule.notifyWhen is "onThrottleInterval" and rule.throttle is not set', () => {
       expect(
         transformFromAlertThrottle({
-          muteAll: false,
           notifyWhen: 'onThrottleInterval',
           actions: [],
         } as unknown as RuleAlertType)
       ).toBeUndefined();
+    });
+
+    test('returns first action throttle if rule.notifyWhen is not set even if muteAll is set to true', () => {
+      expect(
+        transformFromAlertThrottle({
+          muteAll: true,
+          actions: [
+            {
+              group: 'group',
+              id: 'id-123',
+              actionTypeId: 'id-456',
+              params: {},
+              frequency: {
+                notifyWhen: 'onThrottleInterval',
+                throttle: '1d',
+              },
+            },
+            {
+              group: 'group',
+              id: 'id-123',
+              actionTypeId: 'id-456',
+              params: {},
+              frequency: {
+                notifyWhen: 'onThrottleInterval',
+                throttle: '2d',
+              },
+            },
+          ],
+        } as RuleAlertType)
+      ).toBe('1d');
     });
   });
 

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/normalization/rule_actions.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/normalization/rule_actions.test.ts
@@ -83,75 +83,104 @@ describe('Rule actions normalization', () => {
   });
 
   describe('transformFromAlertThrottle', () => {
-    test('muteAll returns "NOTIFICATION_THROTTLE_NO_ACTIONS" even with notifyWhen set and actions has an array element', () => {
+    test('returns first action throttle if rule.notifyWhen is not set', () => {
       expect(
         transformFromAlertThrottle({
-          muteAll: true,
-          notifyWhen: 'onActiveAlert',
+          muteAll: false,
           actions: [
             {
               group: 'group',
               id: 'id-123',
               actionTypeId: 'id-456',
               params: {},
+              frequency: {
+                notifyWhen: 'onThrottleInterval',
+                throttle: '1d',
+              },
+            },
+            {
+              group: 'group',
+              id: 'id-123',
+              actionTypeId: 'id-456',
+              params: {},
+              frequency: {
+                notifyWhen: 'onThrottleInterval',
+                throttle: '2d',
+              },
             },
           ],
         } as RuleAlertType)
-      ).toEqual(NOTIFICATION_THROTTLE_NO_ACTIONS);
+      ).toBe('1d');
     });
 
-    test('returns "NOTIFICATION_THROTTLE_NO_ACTIONS" if actions is an empty array and we do not have a throttle', () => {
+    test('returns "NOTIFICATION_THROTTLE_RULE" if rule.notifyWhen and first action notifyWhen are not set', () => {
+      expect(
+        transformFromAlertThrottle({
+          muteAll: false,
+          actions: [
+            {
+              group: 'group',
+              id: 'id-123',
+              actionTypeId: 'id-456',
+              params: {},
+              frequency: {
+                throttle: '1d',
+              },
+            },
+            {
+              group: 'group',
+              id: 'id-123',
+              actionTypeId: 'id-456',
+              params: {},
+              frequency: {
+                notifyWhen: 'onThrottleInterval',
+                throttle: '2d',
+              },
+            },
+          ],
+        } as RuleAlertType)
+      ).toBe(NOTIFICATION_THROTTLE_RULE);
+    });
+
+    test('returns "NOTIFICATION_THROTTLE_RULE" if rule.notifyWhen is not set and there are no actions', () => {
+      expect(
+        transformFromAlertThrottle({
+          muteAll: false,
+          actions: [],
+        } as unknown as RuleAlertType)
+      ).toBe(NOTIFICATION_THROTTLE_RULE);
+    });
+
+    test('returns "NOTIFICATION_THROTTLE_RULE" if rule.notifyWhen is "onActiveAlert"', () => {
       expect(
         transformFromAlertThrottle({
           muteAll: false,
           notifyWhen: 'onActiveAlert',
           actions: [],
         } as unknown as RuleAlertType)
-      ).toEqual(NOTIFICATION_THROTTLE_NO_ACTIONS);
+      ).toBe(NOTIFICATION_THROTTLE_RULE);
     });
 
-    test('returns "NOTIFICATION_THROTTLE_NO_ACTIONS" if actions is an empty array and we have a throttle', () => {
+    test('returns rule.throttle value if rule.notifyWhen is "onThrottleInterval"', () => {
       expect(
         transformFromAlertThrottle({
           muteAll: false,
           notifyWhen: 'onThrottleInterval',
-          actions: [],
           throttle: '1d',
+          actions: [],
         } as unknown as RuleAlertType)
-      ).toEqual(NOTIFICATION_THROTTLE_NO_ACTIONS);
+      ).toBe('1d');
     });
 
-    test('it returns "NOTIFICATION_THROTTLE_RULE" if "notifyWhen" is set, muteAll is false and we have an actions array', () => {
+    test('returns undefined if rule.notifyWhen is "onThrottleInterval" and rule.throttle is not set', () => {
       expect(
         transformFromAlertThrottle({
           muteAll: false,
-          notifyWhen: 'onActiveAlert',
-          actions: [
-            {
-              group: 'group',
-              id: 'id-123',
-              actionTypeId: 'id-456',
-              params: {},
-            },
-          ],
-        } as RuleAlertType)
-      ).toEqual(NOTIFICATION_THROTTLE_RULE);
-    });
-
-    test('it returns "NOTIFICATION_THROTTLE_RULE" if "notifyWhen" and "throttle" are not set, but we have an actions array', () => {
-      expect(
-        transformFromAlertThrottle({
-          muteAll: false,
-          actions: [
-            {
-              group: 'group',
-              id: 'id-123',
-              actionTypeId: 'id-456',
-              params: {},
-            },
-          ],
-        } as RuleAlertType)
-      ).toEqual(NOTIFICATION_THROTTLE_RULE);
+          notifyWhen: 'onThrottleInterval',
+          throttle: '1d',
+          actions: [],
+        } as unknown as RuleAlertType)
+      ).toBeUndefined();
     });
   });
 

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/normalization/rule_actions.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/normalization/rule_actions.test.ts
@@ -177,7 +177,6 @@ describe('Rule actions normalization', () => {
         transformFromAlertThrottle({
           muteAll: false,
           notifyWhen: 'onThrottleInterval',
-          throttle: '1d',
           actions: [],
         } as unknown as RuleAlertType)
       ).toBeUndefined();

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/normalization/rule_actions.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/normalization/rule_actions.ts
@@ -84,10 +84,8 @@ export const transformToAlertThrottle = (throttle: string | null | undefined): s
 
 /**
  * Given a throttle from an "alerting" Saved Object (SO) this will transform it into a "security_solution"
- * throttle type. If given the "legacyRuleActions" but we detect that the rule for an unknown reason has actions
- * on it to which should not be typical but possible due to the split nature of the API's, this will prefer the
- * usage of the non-legacy version. Eventually the "legacyRuleActions" should be removed.
- * @param throttle The throttle from a  "alerting" Saved Object (SO)
+ * throttle type
+ * @param throttle The throttle from an "alerting" Saved Object (SO)
  * @returns The "security_solution" throttle
  */
 export const transformFromAlertThrottle = (rule: RuleAlertType): string => {

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/normalization/rule_actions.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/normalization/rule_actions.ts
@@ -84,24 +84,22 @@ export const transformToAlertThrottle = (throttle: string | null | undefined): s
 
 /**
  * Given a throttle from an "alerting" Saved Object (SO) this will transform it into a "security_solution"
- * throttle type
+ * throttle type.
  * @param throttle The throttle from an "alerting" Saved Object (SO)
  * @returns The "security_solution" throttle
  */
-export const transformFromAlertThrottle = (rule: RuleAlertType): string => {
-  if (rule.muteAll || rule.actions.length === 0) {
-    return NOTIFICATION_THROTTLE_NO_ACTIONS;
-  } else if (rule.notifyWhen == null) {
+export const transformFromAlertThrottle = (rule: RuleAlertType): string | undefined => {
+  if (rule.notifyWhen == null) {
     return transformFromFirstActionThrottle(rule);
   } else if (rule.notifyWhen === 'onActiveAlert') {
     return NOTIFICATION_THROTTLE_RULE;
   }
 
-  return rule.throttle ?? NOTIFICATION_THROTTLE_NO_ACTIONS;
+  return rule.throttle ?? undefined;
 };
 
 function transformFromFirstActionThrottle(rule: RuleAlertType) {
-  const frequency = rule.actions[0].frequency ?? null;
+  const frequency = rule.actions[0]?.frequency ?? null;
   if (!frequency || frequency.notifyWhen !== 'onThrottleInterval' || frequency.throttle == null)
     return NOTIFICATION_THROTTLE_RULE;
   return frequency.throttle;


### PR DESCRIPTION
**Addresses:** https://github.com/elastic/kibana/issues/147736

## Summary

This PR removes `throttle` field normalization based on `muteAll`'s value from Security Solution's `transformFromAlertThrottle` helper function used as a part of rule level to action level `throttle` upgrading functionality. 


### Checklist

- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios



<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->