### PR TITLE
[Dashboard] Add support to Dashboard for searching saved objects by tags

### DIFF
--- a/src/plugins/dashboard/public/dashboard_actions/index.ts
+++ b/src/plugins/dashboard/public/dashboard_actions/index.ts
@@ -33,13 +33,19 @@ export const buildAllDashboardActions = async ({
   allowByValueEmbeddables,
 }: BuildAllDashboardActionsProps) => {
   const { uiSettings } = core;
-  const { uiActions, share, presentationUtil, savedObjectsManagement } = plugins;
+  const { uiActions, share, presentationUtil, savedObjectsManagement, savedObjectsTaggingOss } =
+    plugins;
 
   const clonePanelAction = new ClonePanelAction(core.savedObjects);
   uiActions.registerAction(clonePanelAction);
   uiActions.attachAction(CONTEXT_MENU_TRIGGER, clonePanelAction.id);
 
-  const SavedObjectFinder = getSavedObjectFinder(uiSettings, core.http, savedObjectsManagement);
+  const SavedObjectFinder = getSavedObjectFinder(
+    uiSettings,
+    core.http,
+    savedObjectsManagement,
+    savedObjectsTaggingOss?.getTaggingApi()
+  );
   const changeViewAction = new ReplacePanelAction(SavedObjectFinder);
   uiActions.registerAction(changeViewAction);
   uiActions.attachAction(CONTEXT_MENU_TRIGGER, changeViewAction.id);

--- a/src/plugins/dashboard/public/dashboard_container/embeddable/api/add_panel_from_library.ts
+++ b/src/plugins/dashboard/public/dashboard_container/embeddable/api/add_panel_from_library.ts
@@ -22,6 +22,7 @@ export function addFromLibrary(this: DashboardContainer) {
     embeddable: { getEmbeddableFactories, getEmbeddableFactory },
     http,
     savedObjectsManagement,
+    savedObjectsTagging,
   } = pluginServices.getServices();
 
   if (isErrorEmbeddable(this)) return;
@@ -30,7 +31,8 @@ export function addFromLibrary(this: DashboardContainer) {
       SavedObjectFinder: getSavedObjectFinder(
         uiSettings,
         http as HttpStart,
-        savedObjectsManagement
+        savedObjectsManagement,
+        savedObjectsTagging.api
       ),
       reportUiCounter: usageCollection.reportUiCounter,
       getAllFactories: getEmbeddableFactories,

--- a/src/plugins/dashboard/public/services/saved_objects_tagging/saved_objects_tagging_service.ts
+++ b/src/plugins/dashboard/public/services/saved_objects_tagging/saved_objects_tagging_service.ts
@@ -39,6 +39,7 @@ export const savedObjectsTaggingServiceFactory: SavedObjectsTaggingServiceFactor
 
   return {
     hasApi: true,
+    api: taggingApi,
     components,
     hasTagDecoration,
     parseSearchQuery,

--- a/src/plugins/dashboard/public/services/saved_objects_tagging/types.ts
+++ b/src/plugins/dashboard/public/services/saved_objects_tagging/types.ts
@@ -10,7 +10,7 @@ import type { SavedObjectsTaggingApi } from '@kbn/saved-objects-tagging-oss-plug
 
 export interface DashboardSavedObjectsTaggingService {
   hasApi: boolean; // remove this once the entire service is optional
-
+  api?: SavedObjectsTaggingApi;
   components?: SavedObjectsTaggingApi['ui']['components'];
   hasTagDecoration?: SavedObjectsTaggingApi['ui']['hasTagDecoration'];
   parseSearchQuery?: SavedObjectsTaggingApi['ui']['parseSearchQuery'];

--- a/src/plugins/embeddable/kibana.jsonc
+++ b/src/plugins/embeddable/kibana.jsonc
@@ -14,6 +14,7 @@
       "savedObjectsFinder",
       "savedObjectsManagement"
     ],
+    "optionalPlugins": ["savedObjectsTaggingOss"],
     "requiredBundles": [
       "savedObjects",
       "kibanaReact",

--- a/src/plugins/embeddable/public/plugin.tsx
+++ b/src/plugins/embeddable/public/plugin.tsx
@@ -24,6 +24,7 @@ import {
 import { Storage } from '@kbn/kibana-utils-plugin/public';
 import { migrateToLatest, PersistableStateService } from '@kbn/kibana-utils-plugin/common';
 import { SavedObjectsManagementPluginStart } from '@kbn/saved-objects-management-plugin/public';
+import type { SavedObjectTaggingOssPluginStart } from '@kbn/saved-objects-tagging-oss-plugin/public';
 import {
   EmbeddableFactoryRegistry,
   EmbeddableFactoryProvider,
@@ -66,6 +67,7 @@ export interface EmbeddableStartDependencies {
   uiActions: UiActionsStart;
   inspector: InspectorStart;
   savedObjectsManagement: SavedObjectsManagementPluginStart;
+  savedObjectsTaggingOss?: SavedObjectTaggingOssPluginStart;
 }
 
 export interface EmbeddableSetup {
@@ -145,7 +147,12 @@ export class EmbeddablePublicPlugin implements Plugin<EmbeddableSetup, Embeddabl
 
   public start(
     core: CoreStart,
-    { uiActions, inspector, savedObjectsManagement }: EmbeddableStartDependencies
+    {
+      uiActions,
+      inspector,
+      savedObjectsManagement,
+      savedObjectsTaggingOss,
+    }: EmbeddableStartDependencies
   ): EmbeddableStart {
     this.embeddableFactoryDefinitions.forEach((def) => {
       this.embeddableFactories.set(
@@ -212,7 +219,8 @@ export class EmbeddablePublicPlugin implements Plugin<EmbeddableSetup, Embeddabl
             SavedObjectFinder={getSavedObjectFinder(
               core.uiSettings,
               core.http,
-              savedObjectsManagement
+              savedObjectsManagement,
+              savedObjectsTaggingOss?.getTaggingApi()
             )}
             containerContext={containerContext}
             theme={theme}


### PR DESCRIPTION
## Summary

This PR adds support to Dashboard for searching saved objects by tags. The related issue was relabelled from `Team:Presentation` to `Team:DataDiscovery` when it probably didn't need to be, but the changes to support it are super simple, so I figured I might as well open a PR for it.

"Add from library" toolbar button:
<img width="1365" alt="add_from_library" src="https://user-images.githubusercontent.com/25592674/231848323-af160e84-6064-4586-956d-b58c66f04824.png">

"Replace panel" action:
<img width="1365" alt="replace_panel" src="https://user-images.githubusercontent.com/25592674/231848373-82d3859e-2358-422d-b717-4360939c1271.png">

"Add panel" action (I'm not really sure how to actually get this action to show or when it's used so I just hardcoded `isCompatible` to return `true` for testing):
<img width="1365" alt="add_panel" src="https://user-images.githubusercontent.com/25592674/231848785-343ac90b-b8c0-43ed-9c03-9aa04b9fdd92.png">

Note: I don't really understand the Dashboard services abstractions, so I just tacked on the `SavedObjectsTaggingApi` as `api`. If the Presentation team doesn't like this, I'm open to suggestions here, but ultimately we need a way to access the entire `SavedObjectsTaggingApi` from within `add_panel_from_library.ts` (ideally without too much refactoring in this PR unless someone from the Presentation team wants to take over from here).

Resolves #113696.

### Checklist

- [ ] ~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)~
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [ ] ~[Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios~
- [ ] ~Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))~
- [ ] ~Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))~
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))~
- [ ] ~This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)~

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)