### PR TITLE
Change all SLO assets to managed and indices to hidden

### DIFF
--- a/x-pack/plugins/observability/server/assets/component_templates/slo_mappings_template.ts
+++ b/x-pack/plugins/observability/server/assets/component_templates/slo_mappings_template.ts
@@ -43,5 +43,7 @@ export const getSLOMappingsTemplate = (name: string) => ({
   _meta: {
     description: 'Mappings for SLO rollup data',
     version: 1,
+    managed: true,
+    managed_by: 'observability',
   },
 });

--- a/x-pack/plugins/observability/server/assets/component_templates/slo_settings_template.ts
+++ b/x-pack/plugins/observability/server/assets/component_templates/slo_settings_template.ts
@@ -8,10 +8,14 @@
 export const getSLOSettingsTemplate = (name: string) => ({
   name,
   template: {
-    settings: {},
+    settings: {
+      hidden: true,
+    },
   },
   _meta: {
     description: 'Settings for SLO rollup data',
     version: 1,
+    managed: true,
+    managed_by: 'observability',
   },
 });

--- a/x-pack/plugins/observability/server/assets/constants.ts
+++ b/x-pack/plugins/observability/server/assets/constants.ts
@@ -5,9 +5,9 @@
  * 2.0.
  */
 
-export const SLO_COMPONENT_TEMPLATE_MAPPINGS_NAME = 'slo-observability.sli-mappings';
-export const SLO_COMPONENT_TEMPLATE_SETTINGS_NAME = 'slo-observability.sli-settings';
-export const SLO_INDEX_TEMPLATE_NAME = 'slo-observability.sli';
+export const SLO_COMPONENT_TEMPLATE_MAPPINGS_NAME = '.slo-observability.sli-mappings';
+export const SLO_COMPONENT_TEMPLATE_SETTINGS_NAME = '.slo-observability.sli-settings';
+export const SLO_INDEX_TEMPLATE_NAME = '.slo-observability.sli';
 export const SLO_RESOURCES_VERSION = 1;
 export const SLO_INGEST_PIPELINE_NAME = `${SLO_INDEX_TEMPLATE_NAME}.monthly`;
 export const SLO_DESTINATION_INDEX_NAME = `${SLO_INDEX_TEMPLATE_NAME}-v${SLO_RESOURCES_VERSION}`;

--- a/x-pack/plugins/observability/server/assets/index_templates/slo_index_templates.ts
+++ b/x-pack/plugins/observability/server/assets/index_templates/slo_index_templates.ts
@@ -13,5 +13,7 @@ export const getSLOIndexTemplate = (name: string, indexPattern: string, composed
   _meta: {
     description: 'Template for SLO rollup data',
     version: 1,
+    managed: true,
+    managed_by: 'observability',
   },
 });

--- a/x-pack/plugins/observability/server/assets/ingest_templates/slo_pipeline_template.ts
+++ b/x-pack/plugins/observability/server/assets/ingest_templates/slo_pipeline_template.ts
@@ -20,5 +20,7 @@ export const getSLOPipelineTemplate = (id: string, indexNamePrefix: string) => (
   _meta: {
     description: 'SLO ingest pipeline',
     version: 1,
+    managed: true,
+    managed_by: 'observability',
   },
 });

--- a/x-pack/plugins/observability/server/assets/transform_templates/slo_transform_template.ts
+++ b/x-pack/plugins/observability/server/assets/transform_templates/slo_transform_template.ts
@@ -48,5 +48,7 @@ export const getSLOTransformTemplate = (
   },
   _meta: {
     version: 1,
+    managed: true,
+    managed_by: 'observability',
   },
 });

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/apm_transaction_duration.test.ts.snap
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/apm_transaction_duration.test.ts.snap
@@ -142,12 +142,14 @@ Object {
 exports[`APM Transaction Duration Transform Generator returns the expected transform params for timeslices slo 1`] = `
 Object {
   "_meta": Object {
+    "managed": true,
+    "managed_by": "observability",
     "version": 1,
   },
   "description": "Rolled-up SLI data for SLO: irrelevant",
   "dest": Object {
-    "index": "slo-observability.sli-v1",
-    "pipeline": "slo-observability.sli.monthly",
+    "index": ".slo-observability.sli-v1",
+    "pipeline": ".slo-observability.sli.monthly",
   },
   "frequency": "1m",
   "pivot": Object {
@@ -287,12 +289,14 @@ Object {
 exports[`APM Transaction Duration Transform Generator returns the expected transform params with every specified indicator params 1`] = `
 Object {
   "_meta": Object {
+    "managed": true,
+    "managed_by": "observability",
     "version": 1,
   },
   "description": "Rolled-up SLI data for SLO: irrelevant",
   "dest": Object {
-    "index": "slo-observability.sli-v1",
-    "pipeline": "slo-observability.sli.monthly",
+    "index": ".slo-observability.sli-v1",
+    "pipeline": ".slo-observability.sli.monthly",
   },
   "frequency": "1m",
   "pivot": Object {

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/apm_transaction_error_rate.test.ts.snap
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/apm_transaction_error_rate.test.ts.snap
@@ -152,12 +152,14 @@ Object {
 exports[`APM Transaction Error Rate Transform Generator returns the expected transform params for timeslices slo 1`] = `
 Object {
   "_meta": Object {
+    "managed": true,
+    "managed_by": "observability",
     "version": 1,
   },
   "description": "Rolled-up SLI data for SLO: irrelevant",
   "dest": Object {
-    "index": "slo-observability.sli-v1",
-    "pipeline": "slo-observability.sli.monthly",
+    "index": ".slo-observability.sli-v1",
+    "pipeline": ".slo-observability.sli.monthly",
   },
   "frequency": "1m",
   "pivot": Object {
@@ -307,12 +309,14 @@ Object {
 exports[`APM Transaction Error Rate Transform Generator returns the expected transform params with every specified indicator params 1`] = `
 Object {
   "_meta": Object {
+    "managed": true,
+    "managed_by": "observability",
     "version": 1,
   },
   "description": "Rolled-up SLI data for SLO: irrelevant",
   "dest": Object {
-    "index": "slo-observability.sli-v1",
-    "pipeline": "slo-observability.sli.monthly",
+    "index": ".slo-observability.sli-v1",
+    "pipeline": ".slo-observability.sli.monthly",
   },
   "frequency": "1m",
   "pivot": Object {

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/kql_custom.test.ts.snap
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/kql_custom.test.ts.snap
@@ -103,12 +103,14 @@ Object {
 exports[`KQL Custom Transform Generator returns the expected transform params for timeslices slo 1`] = `
 Object {
   "_meta": Object {
+    "managed": true,
+    "managed_by": "observability",
     "version": 1,
   },
   "description": "Rolled-up SLI data for SLO: irrelevant",
   "dest": Object {
-    "index": "slo-observability.sli-v1",
-    "pipeline": "slo-observability.sli.monthly",
+    "index": ".slo-observability.sli-v1",
+    "pipeline": ".slo-observability.sli.monthly",
   },
   "frequency": "1m",
   "pivot": Object {
@@ -208,12 +210,14 @@ Object {
 exports[`KQL Custom Transform Generator returns the expected transform params with every specified indicator params 1`] = `
 Object {
   "_meta": Object {
+    "managed": true,
+    "managed_by": "observability",
     "version": 1,
   },
   "description": "Rolled-up SLI data for SLO: irrelevant",
   "dest": Object {
-    "index": "slo-observability.sli-v1",
-    "pipeline": "slo-observability.sli.monthly",
+    "index": ".slo-observability.sli-v1",
+    "pipeline": ".slo-observability.sli.monthly",
   },
   "frequency": "1m",
   "pivot": Object {


### PR DESCRIPTION
## Summary

This PR adds the Managed label to the transform definitions, ingest pipelines, and index components. It also sets the changes the destination indices to hidden with a dot prefix for the name so they show up as system indices.

#### Transformer with Managed label

<img width="1750" alt="image" src="https://user-images.githubusercontent.com/41702/231869095-56a4049a-f323-4b57-bda7-f16b2110addd.png">

#### Ingest Pipeline with Managed label

<img width="1019" alt="image" src="https://user-images.githubusercontent.com/41702/231869372-4985c421-61b4-46d3-96a3-95869750ec6c.png">

#### Index Components

<img width="1770" alt="image" src="https://user-images.githubusercontent.com/41702/231869650-bf2dd153-2319-4049-bc30-c692c29629f2.png">


#### Hidden data indices

<img width="1776" alt="image" src="https://user-images.githubusercontent.com/41702/231869800-62c6b290-bddd-425f-a20a-7566bcafb0c8.png">