### PR TITLE
[Fleet] Re-enable skipped test on 7.17

### DIFF
--- a/x-pack/test/fleet_api_integration/apis/epm/list.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/list.ts
@@ -21,8 +21,7 @@ export default function (providerContext: FtrProviderContext) {
   // because `this` has to point to the Mocha context
   // see https://mochajs.org/#arrow-functions
 
-  // FAILING 8.8 ES Forward Compatibility on 7.17: https://github.com/elastic/kibana/issues/126034
-  describe.skip('EPM - list', async function () {
+  describe('EPM - list', async function () {
     skipIfNoDockerRegistry(providerContext);
     before(async () => {
       await esArchiver.load('x-pack/test/functional/es_archives/fleet/empty_fleet_server');


### PR DESCRIPTION
## Summary

Closes #126034. Re-enable skipped suite as #154741 has been resolved.