### PR TITLE
[Fleet] Re-enable skipped tests on main

### DIFF
--- a/x-pack/test/fleet_api_integration/apis/index.js
+++ b/x-pack/test/fleet_api_integration/apis/index.js
@@ -14,12 +14,10 @@ export default function ({ loadTestFile, getService }) {
     });
 
     // EPM
-    // FAILING ES PROMOTION: https://github.com/elastic/kibana/issues/154739
-    // loadTestFile(require.resolve('./epm'));
+    loadTestFile(require.resolve('./epm'));
 
     // Fleet setup
-    // FAILING ES PROMOTION: https://github.com/elastic/kibana/issues/154739
-    // loadTestFile(require.resolve('./fleet_setup'));
+    loadTestFile(require.resolve('./fleet_setup'));
 
     // Agents
     loadTestFile(require.resolve('./agents'));
@@ -28,12 +26,10 @@ export default function ({ loadTestFile, getService }) {
     loadTestFile(require.resolve('./enrollment_api_keys/crud'));
 
     // Package policies
-    // FAILING ES PROMOTION: https://github.com/elastic/kibana/issues/154739
-    //
-    // loadTestFile(require.resolve('./package_policy/create'));
-    // loadTestFile(require.resolve('./package_policy/update'));
-    // loadTestFile(require.resolve('./package_policy/get'));
-    //
+    loadTestFile(require.resolve('./package_policy/create'));
+    loadTestFile(require.resolve('./package_policy/update'));
+    loadTestFile(require.resolve('./package_policy/get'));
+
     loadTestFile(require.resolve('./package_policy/delete'));
     loadTestFile(require.resolve('./package_policy/upgrade'));
     loadTestFile(require.resolve('./package_policy/input_package_create_upgrade'));


### PR DESCRIPTION
## Summary

Closes #154739. Re-enables skipped suites now that #154741 is resolved.