### PR TITLE
[Cloud Security] Added UI support for waiting for results

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/components/no_findings_states.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/no_findings_states.tsx
@@ -268,7 +268,7 @@ export const NoFindingsStates = ({ posturetype }: { posturetype: PostureTypes })
       .sort((a, b) => a.localeCompare(b));
   const render = () => {
     if (status === 'not-deployed') return <NotDeployed />; // integration installed, but no agents added
-    if (status === 'indexing') return <Indexing />; // agent added, index timeout hasn't passed since installation
+    if (status === 'indexing' || status === 'waiting_for_results') return <Indexing />; // agent added, index timeout hasn't passed since installation
     if (status === 'index-timeout') return <IndexTimeout />; // agent added, index timeout has passed
     if (status === 'unprivileged')
       return <Unprivileged unprivilegedIndices={unprivilegedIndices || []} />; // user has no privileges for our indices

--- a/x-pack/plugins/cloud_security_posture/public/components/no_vulnerabilities_states.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/no_vulnerabilities_states.tsx
@@ -206,7 +206,7 @@ export const NoVulnerabilitiesStates = () => {
       .sort((a, b) => a.localeCompare(b));
 
   const render = () => {
-    if (status === 'not-deployed' || status === 'indexing')
+    if (status === 'not-deployed' || status === 'indexing' || status === 'waiting_for_results')
       return <ScanningVulnerabilitiesEmptyPrompt />; // integration installed, but no agents added
     if (status === 'index-timeout') return <IndexTimeout />; // agent added, index timeout has passed
     if (status === 'not-installed')


### PR DESCRIPTION
## Summary

Showing indexing prompt when current status is `waiting_for_results`
