### PR TITLE
Fix double-prefixing of 'ml.inference'

### DIFF
--- a/x-pack/plugins/enterprise_search/common/ml_inference_pipeline/index.test.ts
+++ b/x-pack/plugins/enterprise_search/common/ml_inference_pipeline/index.test.ts
@@ -232,6 +232,41 @@ describe('generateMlInferencePipelineBody lib function', () => {
     );
   });
 
+  it('should return something that safely removes redundant prefixes', () => {
+    const mockTextClassificationModel: MlTrainedModelConfig = {
+      ...mockModel,
+      ...{ inference_config: { text_classification: {} } },
+    };
+    const actual: MlInferencePipeline = generateMlInferencePipelineBody({
+      description: 'my-description',
+      model: mockTextClassificationModel,
+      pipelineName: 'my-pipeline',
+      fieldMappings: [{ sourceField: 'my-source-field', targetField: 'ml.inference.my-source-field_expanded' }],
+    });
+
+    expect(actual).toEqual(
+      expect.objectContaining({
+        description: expect.any(String),
+        processors: expect.arrayContaining([
+          expect.objectContaining({
+            remove: {
+              field: 'ml.inference.my-source-field_expanded',
+              ignore_missing: true,
+            },
+          }),
+          expect.objectContaining({
+            inference: expect.objectContaining({
+              field_map: {
+                'my-source-field': 'MODEL_INPUT_FIELD',
+              },
+              target_field: 'ml.inference.my-source-field_expanded',
+            }),
+          }),
+        ]),
+      })
+    );
+  });
+
   it('should return something expected with multiple fields', () => {
     const actual: MlInferencePipeline = generateMlInferencePipelineBody({
       description: 'my-description',

--- a/x-pack/plugins/enterprise_search/common/ml_inference_pipeline/index.test.ts
+++ b/x-pack/plugins/enterprise_search/common/ml_inference_pipeline/index.test.ts
@@ -241,7 +241,9 @@ describe('generateMlInferencePipelineBody lib function', () => {
       description: 'my-description',
       model: mockTextClassificationModel,
       pipelineName: 'my-pipeline',
-      fieldMappings: [{ sourceField: 'my-source-field', targetField: 'ml.inference.my-source-field_expanded' }],
+      fieldMappings: [
+        { sourceField: 'my-source-field', targetField: 'ml.inference.my-source-field_expanded' },
+      ],
     });
 
     expect(actual).toEqual(

--- a/x-pack/plugins/enterprise_search/common/ml_inference_pipeline/index.test.ts
+++ b/x-pack/plugins/enterprise_search/common/ml_inference_pipeline/index.test.ts
@@ -242,7 +242,12 @@ describe('generateMlInferencePipelineBody lib function', () => {
       model: mockTextClassificationModel,
       pipelineName: 'my-pipeline',
       fieldMappings: [
-        { sourceField: 'my-source-field', targetField: 'ml.inference.my-source-field_expanded' },
+        { sourceField: 'my-source-field_1', targetField: 'ml.inference.my-source-field_expanded' },
+        { sourceField: 'my-source-field_2', targetField: 'my-source-ml.inference-field_expanded' },
+        {
+          sourceField: 'my-source-field_3',
+          targetField: 'ml.inference.my-source-2-ml.inference-field_expanded',
+        },
       ],
     });
 
@@ -257,11 +262,39 @@ describe('generateMlInferencePipelineBody lib function', () => {
             },
           }),
           expect.objectContaining({
+            remove: {
+              field: 'ml.inference.my-source-ml.inference-field_expanded',
+              ignore_missing: true,
+            },
+          }),
+          expect.objectContaining({
+            remove: {
+              field: 'ml.inference.my-source-2-ml.inference-field_expanded',
+              ignore_missing: true,
+            },
+          }),
+          expect.objectContaining({
             inference: expect.objectContaining({
               field_map: {
-                'my-source-field': 'MODEL_INPUT_FIELD',
+                'my-source-field_1': 'MODEL_INPUT_FIELD',
               },
               target_field: 'ml.inference.my-source-field_expanded',
+            }),
+          }),
+          expect.objectContaining({
+            inference: expect.objectContaining({
+              field_map: {
+                'my-source-field_2': 'MODEL_INPUT_FIELD',
+              },
+              target_field: 'ml.inference.my-source-ml.inference-field_expanded',
+            }),
+          }),
+          expect.objectContaining({
+            inference: expect.objectContaining({
+              field_map: {
+                'my-source-field_3': 'MODEL_INPUT_FIELD',
+              },
+              target_field: 'ml.inference.my-source-2-ml.inference-field_expanded',
             }),
           }),
         ]),

--- a/x-pack/plugins/enterprise_search/common/ml_inference_pipeline/index.ts
+++ b/x-pack/plugins/enterprise_search/common/ml_inference_pipeline/index.ts
@@ -224,7 +224,9 @@ export const parseMlInferenceParametersFromPipeline = (
     return null;
   }
   return {
-    destination_field: inferenceProcessor.target_field?.replace('ml.inference.', ''),
+    destination_field: inferenceProcessor.target_field
+      ? stripMlInferencePrefix(inferenceProcessor.target_field)
+      : inferenceProcessor.target_field,
     model_id: inferenceProcessor.model_id,
     pipeline_name: name,
     source_field: sourceField,
@@ -258,4 +260,7 @@ export const parseModelStateFromStats = (
 export const parseModelStateReasonFromStats = (trainedModelStats?: Partial<MlTrainedModelStats>) =>
   trainedModelStats?.deployment_stats?.reason;
 
-export const getMlInferencePrefixedFieldName = (fieldName: string) => `ml.inference.${fieldName}`;
+export const getMlInferencePrefixedFieldName = (fieldName: string) =>
+  `ml.inference.${stripMlInferencePrefix(fieldName)}`; // Strip first, then prepend, to prevent against double-prepending
+
+const stripMlInferencePrefix = (fieldName: string) => fieldName.replace('ml.inference.', '');

--- a/x-pack/plugins/enterprise_search/common/ml_inference_pipeline/index.ts
+++ b/x-pack/plugins/enterprise_search/common/ml_inference_pipeline/index.ts
@@ -29,6 +29,7 @@ import {
 
 export const TEXT_EXPANSION_TYPE = SUPPORTED_PYTORCH_TASKS.TEXT_EXPANSION;
 export const TEXT_EXPANSION_FRIENDLY_TYPE = 'ELSER';
+export const ML_INFERENCE_PREFIX = 'ml.inference.';
 
 export interface MlInferencePipelineParams {
   description?: string;
@@ -261,6 +262,9 @@ export const parseModelStateReasonFromStats = (trainedModelStats?: Partial<MlTra
   trainedModelStats?.deployment_stats?.reason;
 
 export const getMlInferencePrefixedFieldName = (fieldName: string) =>
-  `ml.inference.${stripMlInferencePrefix(fieldName)}`; // Strip first, then prepend, to prevent against double-prepending
+  fieldName.startsWith(ML_INFERENCE_PREFIX) ? fieldName : `${ML_INFERENCE_PREFIX}${fieldName}`;
 
-const stripMlInferencePrefix = (fieldName: string) => fieldName.replace('ml.inference.', '');
+const stripMlInferencePrefix = (fieldName: string) =>
+  fieldName.startsWith(ML_INFERENCE_PREFIX)
+    ? fieldName.replace(ML_INFERENCE_PREFIX, '')
+    : fieldName;


### PR DESCRIPTION
## Summary

We were double-prefixing the target field:
<img width="871" alt="screenshot" src="https://user-images.githubusercontent.com/5288246/232129339-890af78c-aef2-4433-b3e7-f9a530f8c121.png">

This strips any existing prefix before appending one. It also adds a test.


### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
