### PR TITLE
Add additional NODE_ENV check for RQ Dev Tools Close Button 

### DIFF
--- a/x-pack/plugins/observability/public/application/hideable_react_query_dev_tools.tsx
+++ b/x-pack/plugins/observability/public/application/hideable_react_query_dev_tools.tsx
@@ -12,7 +12,7 @@ import { EuiButtonIcon } from '@elastic/eui';
 export function HideableReactQueryDevTools() {
   const [isHidden, setIsHidden] = useState(false);
 
-  return !isHidden ? (
+  return !isHidden && process.env.NODE_ENV === 'development' ? (
     <div>
       <EuiButtonIcon
         data-test-subj="o11yHideableReactQueryDevToolsButton"


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/154988.

## 📝 Summary

This adds an additional check to see if the user is running development mode, which determines whether or not we render the RQ Dev tools and the newly added "Close" button to temporarily hide the RQ Dev tools for screenshotting / demo'ing purposes. 

## ✅ Checklist
- It should show the RQ Dev Tools and the Close button in Development mode.
- It should not show the RQ Dev Tools and the Close button in Production mode.
