### PR TITLE
Ignore [Security Solution] Fix error messages on Rule Details page taking too much space

### DIFF
--- a/x-pack/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/execution_log_table/execution_log_columns.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/execution_log_table/execution_log_columns.tsx
@@ -6,8 +6,15 @@
  */
 
 import React from 'react';
+import { css } from '@emotion/react';
 import type { EuiBasicTableColumn } from '@elastic/eui';
-import { EuiLink, EuiText } from '@elastic/eui';
+import {
+  EuiLink,
+  EuiText,
+  EuiButtonIcon,
+  EuiScreenReaderOnly,
+  RIGHT_ALIGNMENT,
+} from '@elastic/eui';
 import type { DocLinksStart } from '@kbn/core/public';
 import { FormattedMessage } from '@kbn/i18n-react';
 
@@ -24,6 +31,37 @@ import { TableHeaderTooltipCell } from '../../../../rule_management_ui/component
 import { RuleDurationFormat } from './rule_duration_format';
 
 import * as i18n from './translations';
+
+type TableColumn = EuiBasicTableColumn<RuleExecutionResult>;
+
+interface UseColumnsArgs {
+  toggleRowExpanded: (item: RuleExecutionResult) => void;
+  isRowExpanded: (item: RuleExecutionResult) => boolean;
+}
+
+export const expanderColumn = ({
+  toggleRowExpanded,
+  isRowExpanded,
+}: UseColumnsArgs): TableColumn => {
+  return {
+    align: RIGHT_ALIGNMENT,
+    width: '40px',
+    isExpander: true,
+    name: (
+      <EuiScreenReaderOnly>
+        <span>{i18n.EXPAND_ROW}</span>
+      </EuiScreenReaderOnly>
+    ),
+    render: (item: RuleExecutionResult) =>
+      item.security_status === 'succeeded' ? null : (
+        <EuiButtonIcon
+          onClick={() => toggleRowExpanded(item)}
+          aria-label={isRowExpanded(item) ? i18n.COLLAPSE : i18n.EXPAND}
+          iconType={isRowExpanded(item) ? 'arrowUp' : 'arrowDown'}
+        />
+      ),
+  };
+};
 
 export const EXECUTION_LOG_COLUMNS: Array<EuiBasicTableColumn<RuleExecutionResult>> = [
   {
@@ -69,20 +107,37 @@ export const EXECUTION_LOG_COLUMNS: Array<EuiBasicTableColumn<RuleExecutionResul
     truncateText: false,
     width: '10%',
   },
-  {
-    field: 'security_message',
-    name: (
-      <TableHeaderTooltipCell
-        title={i18n.COLUMN_MESSAGE}
-        tooltipContent={i18n.COLUMN_MESSAGE_TOOLTIP}
-      />
-    ),
-    render: (value: string) => <>{value}</>,
-    sortable: false,
-    truncateText: false,
-    width: '35%',
-  },
 ];
+
+export const GET_MESSAGE_COLUMN = (width: string) => ({
+  field: 'security_message',
+  name: (
+    <TableHeaderTooltipCell
+      title={i18n.COLUMN_MESSAGE}
+      tooltipContent={i18n.COLUMN_MESSAGE_TOOLTIP}
+    />
+  ),
+  render: (value: string, record: RuleExecutionResult) => {
+    if (record.security_status === 'succeeded') {
+      return value;
+    }
+
+    return (
+      <div
+        css={css`
+          display: -webkit-box;
+          -webkit-line-clamp: 3;
+          -webkit-box-orient: vertical;
+          overflow: hidden;
+        `}
+      >
+        {value}
+      </div>
+    );
+  },
+  sortable: false,
+  width,
+});
 
 export const GET_EXECUTION_LOG_METRICS_COLUMNS = (
   docLinks: DocLinksStart

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/execution_log_table/execution_log_table.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/execution_log_table/execution_log_table.tsx
@@ -20,6 +20,7 @@ import {
   EuiSwitch,
   EuiBasicTable,
   EuiButton,
+  EuiDescriptionList,
 } from '@elastic/eui';
 
 import type { Filter, Query } from '@kbn/es-query';
@@ -60,8 +61,15 @@ import { isAbsoluteTimeRange, isRelativeTimeRange } from '../../../../../common/
 import { SourcererScopeName } from '../../../../../common/store/sourcerer/model';
 import { useExecutionResults } from '../../../../rule_monitoring';
 import { useRuleDetailsContext } from '../rule_details_context';
+import { useExpandableRows } from '../../../../rule_monitoring/components/basic/tables/use_expandable_rows';
+import { TextBlock } from '../../../../rule_monitoring/components/basic/text/text_block';
 import * as i18n from './translations';
-import { EXECUTION_LOG_COLUMNS, GET_EXECUTION_LOG_METRICS_COLUMNS } from './execution_log_columns';
+import {
+  EXECUTION_LOG_COLUMNS,
+  GET_MESSAGE_COLUMN,
+  GET_EXECUTION_LOG_METRICS_COLUMNS,
+  expanderColumn,
+} from './execution_log_columns';
 import { ExecutionLogSearchBar } from './execution_log_search_bar';
 
 const EXECUTION_UUID_FIELD_NAME = 'kibana.alert.rule.execution.uuid';
@@ -361,7 +369,7 @@ const ExecutionLogTableComponent: React.FC<ExecutionLogTableProps> = ({
       {
         field: EXECUTION_UUID_FIELD_NAME,
         name: i18n.COLUMN_ACTIONS,
-        width: '5%',
+        width: '64px',
         actions: [
           {
             name: 'Edit',
@@ -386,13 +394,49 @@ const ExecutionLogTableComponent: React.FC<ExecutionLogTableProps> = ({
     [onFilterByExecutionIdCallback]
   );
 
-  const executionLogColumns = useMemo(
-    () =>
-      showMetricColumns
-        ? [...EXECUTION_LOG_COLUMNS, ...GET_EXECUTION_LOG_METRICS_COLUMNS(docLinks), ...actions]
-        : [...EXECUTION_LOG_COLUMNS, ...actions],
-    [actions, docLinks, showMetricColumns]
+  const getItemId = useCallback((item: RuleExecutionResult): string => {
+    return `${item.execution_uuid}`;
+  }, []);
+
+  const renderExpandedItem = useCallback(
+    (item: RuleExecutionResult) => (
+      <EuiDescriptionList
+        className="eui-fullWidth"
+        listItems={[
+          {
+            title: i18n.ROW_DETAILS_MESSAGE,
+            description: <TextBlock text={item.security_message} />,
+          },
+        ]}
+      />
+    ),
+    []
   );
+
+  const rows = useExpandableRows<RuleExecutionResult>({
+    getItemId,
+    renderItem: renderExpandedItem,
+  });
+
+  const executionLogColumns = useMemo(() => {
+    const columns = [...EXECUTION_LOG_COLUMNS];
+
+    if (showMetricColumns) {
+      columns.push(GET_MESSAGE_COLUMN('20%'), ...GET_EXECUTION_LOG_METRICS_COLUMNS(docLinks));
+    } else {
+      columns.push(GET_MESSAGE_COLUMN('50%'));
+    }
+
+    columns.push(
+      ...actions,
+      expanderColumn({
+        toggleRowExpanded: rows.toggleRowExpanded,
+        isRowExpanded: rows.isRowExpanded,
+      })
+    );
+
+    return columns;
+  }, [actions, docLinks, showMetricColumns, rows.toggleRowExpanded, rows.isRowExpanded]);
 
   return (
     <EuiPanel hasBorder>
@@ -478,6 +522,9 @@ const ExecutionLogTableComponent: React.FC<ExecutionLogTableProps> = ({
         sorting={sorting}
         pagination={pagination}
         onChange={onTableChangeCallback}
+        itemId={getItemId}
+        itemIdToExpandedRowMap={rows.itemIdToExpandedRowMap}
+        isExpandable={true}
       />
     </EuiPanel>
   );

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/execution_log_table/translations.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/execution_log_table/translations.ts
@@ -229,3 +229,31 @@ export const GREATER_THAN_YEAR = i18n.translate(
     defaultMessage: '> 1 Year',
   }
 );
+
+export const ROW_DETAILS_MESSAGE = i18n.translate(
+  'xpack.securitySolution.detectionEngine.ruleDetails.ruleExecutionLog.fullMessage',
+  {
+    defaultMessage: 'Full message',
+  }
+);
+
+export const EXPAND_ROW = i18n.translate(
+  'xpack.securitySolution.detectionEngine.ruleDetails.ruleExecutionLog.expandRow',
+  {
+    defaultMessage: 'Expand rows',
+  }
+);
+
+export const EXPAND = i18n.translate(
+  'xpack.securitySolution.detectionEngine.ruleDetails.ruleExecutionLog.expand',
+  {
+    defaultMessage: 'Expand',
+  }
+);
+
+export const COLLAPSE = i18n.translate(
+  'xpack.securitySolution.detectionEngine.ruleDetails.ruleExecutionLog.collapse',
+  {
+    defaultMessage: 'Collapse',
+  }
+);

--- a/x-pack/plugins/security_solution/public/detections/components/rules/rule_execution_status/copy_text_icon_button.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/rule_execution_status/copy_text_icon_button.test.tsx
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { copyToClipboard } from '@elastic/eui';
+
+import { CopyTextIconButton } from './copy_text_icon_button';
+
+jest.mock('@elastic/eui', () => {
+  const originalModule = jest.requireActual('@elastic/eui');
+  return {
+    ...originalModule,
+    copyToClipboard: jest.fn(),
+  };
+});
+
+describe('CopyTextIconButton', () => {
+  it('clicking a button copies the text', () => {
+    const { getByRole } = render(<CopyTextIconButton textToCopy="Test message" />);
+
+    fireEvent.click(getByRole('button'));
+
+    expect(copyToClipboard).toBeCalledWith('Test message');
+  });
+
+  it('tooltip text changes after clicking the button', async () => {
+    const { getByRole } = render(<CopyTextIconButton textToCopy="Test message" />);
+
+    fireEvent.mouseOver(getByRole('button'), { bubbles: true });
+    expect(await screen.findByText('Copy text')).toBeInTheDocument();
+
+    fireEvent.click(getByRole('button'), { bubbles: true });
+    expect(await screen.findByText('Text copied')).toBeInTheDocument();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+});

--- a/x-pack/plugins/security_solution/public/detections/components/rules/rule_execution_status/copy_text_icon_button.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/rule_execution_status/copy_text_icon_button.tsx
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useRef, useState } from 'react';
+import { copyToClipboard, EuiButtonIcon, EuiToolTip } from '@elastic/eui';
+
+import * as i18n from './translations';
+
+interface CopyTextIconButtonProps {
+  textToCopy: string;
+}
+
+export const CopyTextIconButton: React.FC<CopyTextIconButtonProps> = ({ textToCopy }) => {
+  const buttonRef = useRef<HTMLAnchorElement | null>(null);
+  const [isTextCopied, setTextCopied] = useState(false);
+
+  const onClick = () => {
+    /* 
+        Setting focus explicitly for Safari. 
+        Otherwise the tooltip disappears after you click the button and move the cursor out of its bounds.
+        Also without it the tooltip won't change its state back to "Copy text"
+    */
+    if (buttonRef.current !== null) {
+      buttonRef.current.focus();
+    }
+    copyToClipboard(textToCopy);
+    setTextCopied(true);
+  };
+
+  const onBlur = () => {
+    setTextCopied(false);
+  };
+
+  return (
+    <EuiToolTip content={isTextCopied ? i18n.TEXT_COPIED : i18n.COPY_TEXT}>
+      <EuiButtonIcon
+        buttonRef={buttonRef}
+        aria-label={i18n.COPY_TEXT_TO_CLIPBOARD}
+        color="text"
+        iconType="copy"
+        onClick={onClick}
+        onBlur={onBlur}
+        data-test-subj="copyTextIconButton"
+        role={'button'}
+      />
+    </EuiToolTip>
+  );
+};

--- a/x-pack/plugins/security_solution/public/detections/components/rules/rule_execution_status/rule_status_failed_callout.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/rule_execution_status/rule_status_failed_callout.test.tsx
@@ -52,6 +52,7 @@ describe('RuleStatusFailedCallOut', () => {
     result.getByText('Warning at');
     result.getByText('Jan 27, 2022 @ 15:03:31.176');
     result.getByText(MESSAGE);
+    result.getByTestId('copyTextIconButton');
   });
 
   it('is visible if status is "failed"', () => {
@@ -60,5 +61,6 @@ describe('RuleStatusFailedCallOut', () => {
     result.getByText('Rule failure at');
     result.getByText('Jan 27, 2022 @ 15:03:31.176');
     result.getByText(MESSAGE);
+    result.getByTestId('copyTextIconButton');
   });
 });

--- a/x-pack/plugins/security_solution/public/detections/components/rules/rule_execution_status/rule_status_failed_callout.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/rule_execution_status/rule_status_failed_callout.tsx
@@ -8,6 +8,7 @@
 import React from 'react';
 
 import { EuiCallOut } from '@elastic/eui';
+import { CopyTextIconButton } from './copy_text_icon_button';
 import { FormattedDate } from '../../../../common/components/formatted_date';
 import { RuleExecutionStatus } from '../../../../../common/detection_engine/rule_monitoring';
 
@@ -34,15 +35,29 @@ const RuleStatusFailedCallOutComponent: React.FC<RuleStatusFailedCallOutProps> =
       title={
         <>
           {title} <FormattedDate value={date} fieldName="execution_summary.last_execution.date" />
+          <span
+            css={`
+              float: right;
+            `}
+          >
+            <CopyTextIconButton textToCopy={message} />
+          </span>
         </>
       }
       color={color}
       iconType="warning"
       data-test-subj="ruleStatusFailedCallOut"
     >
-      {message.split('\n').map((line) => (
-        <p>{line}</p>
-      ))}
+      <div
+        css={`
+          max-height: 200px;
+          overflow-y: auto;
+        `}
+      >
+        {message.split('\n').map((line, index) => (
+          <p key={index}>{line}</p>
+        ))}
+      </div>
     </EuiCallOut>
   );
 };

--- a/x-pack/plugins/security_solution/public/detections/components/rules/rule_execution_status/rule_status_failed_callout.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/rule_execution_status/rule_status_failed_callout.tsx
@@ -11,6 +11,7 @@ import { EuiCallOut } from '@elastic/eui';
 import { CopyTextIconButton } from './copy_text_icon_button';
 import { FormattedDate } from '../../../../common/components/formatted_date';
 import { RuleExecutionStatus } from '../../../../../common/detection_engine/rule_monitoring';
+import { TextBlock } from '../../../../detection_engine/rule_monitoring/components/basic/text/text_block';
 
 import * as i18n from './translations';
 
@@ -54,9 +55,10 @@ const RuleStatusFailedCallOutComponent: React.FC<RuleStatusFailedCallOutProps> =
           overflow-y: auto;
         `}
       >
-        {message.split('\n').map((line, index) => (
+        {/* {message.split('\n').map((line, index) => (
           <p key={index}>{line}</p>
-        ))}
+        ))} */}
+        <TextBlock text={message} />
       </div>
     </EuiCallOut>
   );

--- a/x-pack/plugins/security_solution/public/detections/components/rules/rule_execution_status/translations.ts
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/rule_execution_status/translations.ts
@@ -48,3 +48,18 @@ export const PARTIAL_FAILURE_CALLOUT_TITLE = i18n.translate(
     defaultMessage: 'Warning at',
   }
 );
+
+export const COPY_TEXT = i18n.translate('xpack.securitySolution.copyTextIconButton.copyText', {
+  defaultMessage: 'Copy text',
+});
+
+export const COPY_TEXT_TO_CLIPBOARD = i18n.translate(
+  'xpack.securitySolution.copyTextIconButton.copyTextToClipboard',
+  {
+    defaultMessage: 'Copy text to clipboard',
+  }
+);
+
+export const TEXT_COPIED = i18n.translate('xpack.securitySolution.copyTextIconButton.textCopied', {
+  defaultMessage: 'Text copied',
+});

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/utils/search_after_bulk_create.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/utils/search_after_bulk_create.ts
@@ -48,6 +48,28 @@ export const searchAfterAndBulkCreate = async ({
   return withSecuritySpan('searchAfterAndBulkCreate', async () => {
     let toReturn = createSearchAfterReturnType();
 
+    /*
+    throw new Error(`[2023-04-18T10:26:22.346+02:00][DEBUG][plugins.securitySolution.ruleExecution] totalHits: 0 [siem.queryRule][test2][rule id dba013b0-dd1b-11ed-8928-6155599ac787][rule uuid 649f8c4e-dc85-4394-8cc2-fb8a522188f9][exec id 44e0c8ea-29a7-49be-8b71-5359cfe3baa2][space default]
+    [2023-04-18T10:26:22.347+02:00][DEBUG][plugins.securitySolution.ruleExecution] searchResult.hit.hits.length: 0 [siem.queryRule][test2][rule id dba013b0-dd1b-11ed-8928-6155599ac787][rule uuid 649f8c4e-dc85-4394-8cc2-fb8a522188f9][exec id 44e0c8ea-29a7-49be-8b71-5359cfe3baa2][space default]
+    [2023-04-18T10:26:22.347+02:00][DEBUG][plugins.securitySolution.ruleExecution] totalHits was 0, exiting early [siem.queryRule][test2][rule id dba013b0-dd1b-11ed-8928-6155599ac787][rule uuid 649f8c4e-dc85-4394-8cc2-fb8a522188f9][exec id 44e0c8ea-29a7-49be-8b71-5359cfe3baa2][space default]
+    [2023-04-18T10:26:22.347+02:00][DEBUG][plugins.securitySolution.ruleExecution] [+] completed bulk index of 0 [siem.queryRule][test2][rule id dba013b0-dd1b-11ed-8928-6155599ac787][rule uuid 649f8c4e-dc85-4394-8cc2-fb8a522188f9][exec id 44e0c8ea-29a7-49be-8b71-5359cfe3baa2][space default]
+    [2023-04-18T10:26:22.347+02:00][DEBUG][plugins.securitySolution.ruleExecution] [+] Signal Rule execution completed. [siem.queryRule][test2][rule id dba013b0-dd1b-11ed-8928-6155599ac787][rule uuid 649f8c4e-dc85-4394-8cc2-fb8a522188f9][exec id 44e0c8ea-29a7-49be-8b71-5359cfe3baa2][space default]
+    [2023-04-18T10:26:22.347+02:00][DEBUG][plugins.securitySolution.ruleExecution] [+] Finished indexing 0 signals into .alerts-security.alerts-default [siem.queryRule][test2][rule id dba013b0-dd1b-11ed-8928-6155599ac787][rule uuid 649f8c4e-dc85-4394-8cc2-fb8a522188f9][exec id 44e0c8ea-29a7-49be-8b71-5359cfe3baa2][space default]
+    [2023-04-18T10:26:22.347+02:00][INFO ][plugins.securitySolution.ruleExecution] Changing rule status to "succeeded". Rule execution completed successfully [siem.queryRule][test2][rule id dba013b0-dd1b-11ed-8928-6155599ac787][rule uuid 649f8c4e-dc85-4394-8cc2-fb8a522188f9][exec id 44e0c8ea-29a7-49be-8b71-5359cfe3baa2][space default]
+    [2023-04-18T10:26:22.348+02:00][DEBUG][plugins.securitySolution.ruleExecution] [+] Finished indexing 0 signals searched between date ranges [
+      {
+        "to": "2023-04-18T08:26:22.206Z",
+        "from": "2023-04-18T07:21:22.206Z",
+        "maxSignals": 100
+      }
+    ] [siem.queryRule][test2][rule id dba013b0-dd1b-11ed-8928-6155599ac787][rule uuid 649f8c4e-dc85-4394-8cc2-fb8a522188f9][exec id 44e0c8ea-29a7-49be-8b71-5359cfe3baa2][space default]
+    {"log.level":"error","@timestamp":"2023-04-18T08:26:30.843Z","log":{"logger":"elastic-apm-node"},"ecs":{"version":"1.6.0"},"message":"APM Server responded with \"404 Not Found\". This might be because you're running an incompatible version of the APM Server. This agent only supports APM Server v6.5 and above. If you're using an older version of the APM Server, please downgrade this agent to version 1.x or upgrade the APM Server\n{\"ok\":false,\"message\":\"Unknown resource.\"}\n"}
+    [2023-04-18T10:26:34.305+02:00][DEBUG][plugins.securitySolution.endpoint:user-artifact-packager:1.0.0] Last computed manifest not available yet
+    [2023-04-18T10:26:37.241+02:00][DEBUG][plugins.securitySolution.telemetry_events] [task security:telemetry-filterlist-artifact:1.0.0]: attempting to run
+    [2023-04-18T10:26:37.241+02:00][DEBUG][plugins.securitySolution.telemetry_events] [task security:telemetry-filterlist-artifact:1.0.0]: telemetry is not opted-in
+    {"log.level":"error","@timestamp":"2023-04-18T08:26:50.230Z","log":{"logger":"elastic-apm-node"},"ecs":{"version":"1.6.0"},"message":"APM Server responded with \"404 Not Found\". This might be because you're running an incompatible version of the APM Server. This agent only supports APM Server v6.5 and above. If you're using an older version of the APM Server, please downgrade this agent to version 1.x or upgrade the APM Server\n{\"ok\":false,\"message\":\"Unknown resource.\"}\n"}`);
+    */
+
     // sortId tells us where to start our next consecutive search_after query
     let sortIds: estypes.SortResults | undefined;
     let hasSortId = true; // default to true so we execute the search on initial run


### PR DESCRIPTION
## Summary

When a large "last execution" error message is displayed on Rule Details page it takes too much vertical space:  

https://user-images.githubusercontent.com/2946766/214444343-dde0d9cd-6bc7-4aca-a6cf-07891d206888.png

This PR sets max-height for the error callout and adds vertical/horizontal scrolling. It also adds a button to copy the error message content to clipboard.
<img width="1225" alt="Screenshot 2023-04-15 at 13 26 55" src="https://user-images.githubusercontent.com/15949146/232212201-97c4f70e-a5a2-4727-bd46-e7ee8019840a.png">


Another addition is a button to expand a row in the Execution Log to view / copy a full error message.
<img width="1259" alt="Screenshot 2023-04-15 at 12 55 10" src="https://user-images.githubusercontent.com/15949146/232211578-f8ad02e9-3e4c-41dd-9078-f73306eee487.png">



### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
