### PR TITLE
Allow using the `--serverless` CLI flag in serverless-capable distros

### DIFF
--- a/src/cli/serve/serve.js
+++ b/src/cli/serve/serve.js
@@ -110,9 +110,8 @@ function isServerlessCapableDistribution() {
  * @param {'push' | 'unshift'} method
  */
 function maybeAddConfig(name, configs, method) {
-  const path = resolve(getConfigDirectory(), name);
   if (configFileExists(name)) {
-    configs[method](path);
+    configs[method](resolve(getConfigDirectory(), name));
   }
 }
 

--- a/src/cli/serve/serve.js
+++ b/src/cli/serve/serve.js
@@ -78,22 +78,41 @@ const configPathCollector = pathCollector();
 const pluginPathCollector = pathCollector();
 
 /**
+ * @param {string} name The config file name
+ * @returns {boolean} Whether the file exists
+ */
+function configFileExists(name) {
+  const path = resolve(getConfigDirectory(), name);
+  try {
+    return statSync(path).isFile();
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      return false;
+    }
+
+    throw err;
+  }
+}
+
+/**
+ * @returns {boolean} Whether the distribution can run in Serverless mode
+ */
+function isServerlessCapableDistribution() {
+  // For now, checking if the `serverless.yml` config file exists should be enough
+  // We could also check the following as well, but I don't think it's necessary:
+  // VALID_SERVERLESS_PROJECT_MODE.some((projectType) => configFileExists(`serverless.${projectType}.yml`))
+  return configFileExists('serverless.yml');
+}
+
+/**
  * @param {string} name
  * @param {string[]} configs
  * @param {'push' | 'unshift'} method
  */
 function maybeAddConfig(name, configs, method) {
   const path = resolve(getConfigDirectory(), name);
-  try {
-    if (statSync(path).isFile()) {
-      configs[method](path);
-    }
-  } catch (err) {
-    if (err.code === 'ENOENT') {
-      return;
-    }
-
-    throw err;
+  if (configFileExists(name)) {
+    configs[method](path);
   }
 }
 
@@ -233,8 +252,11 @@ export default function (program) {
       .option(
         '--run-examples',
         'Adds plugin paths for all the Kibana example plugins and runs with no base path'
-      )
-      .option('--serverless <oblt|security|es>', 'Start Kibana in a serverless project mode');
+      );
+  }
+
+  if (isServerlessCapableDistribution()) {
+    command.option('--serverless <oblt|security|es>', 'Start Kibana in a serverless project mode');
   }
 
   if (DEV_MODE_SUPPORTED) {


### PR DESCRIPTION
## Summary

At the moment, we only allow using the `--serverless` CLI flag in dev mode. However, we want to use it in our serverless deployments. According to #149878, it is a valid option (apparently, there are no big reasons for it to be dev-only).

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
