### PR TITLE
[Content Management] Remove dep from content_management -> saved_object_finder

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -529,6 +529,7 @@ test/plugin_functional/plugins/saved_objects_hidden_from_http_apis_type @elastic
 test/plugin_functional/plugins/saved_objects_hidden_type @elastic/kibana-core
 src/plugins/saved_objects_management @elastic/kibana-core
 src/plugins/saved_objects @elastic/kibana-core
+packages/kbn-saved-objects-settings @elastic/appex-sharedux
 src/plugins/saved_objects_tagging_oss @elastic/appex-sharedux
 x-pack/plugins/saved_objects_tagging @elastic/appex-sharedux
 src/plugins/saved_search @elastic/kibana-data-discovery

--- a/package.json
+++ b/package.json
@@ -531,6 +531,7 @@
     "@kbn/saved-objects-hidden-type-plugin": "link:test/plugin_functional/plugins/saved_objects_hidden_type",
     "@kbn/saved-objects-management-plugin": "link:src/plugins/saved_objects_management",
     "@kbn/saved-objects-plugin": "link:src/plugins/saved_objects",
+    "@kbn/saved-objects-settings": "link:packages/kbn-saved-objects-settings",
     "@kbn/saved-objects-tagging-oss-plugin": "link:src/plugins/saved_objects_tagging_oss",
     "@kbn/saved-objects-tagging-plugin": "link:x-pack/plugins/saved_objects_tagging",
     "@kbn/saved-search-plugin": "link:src/plugins/saved_search",

--- a/packages/kbn-saved-objects-settings/README.md
+++ b/packages/kbn-saved-objects-settings/README.md
@@ -1,0 +1,3 @@
+# @kbn/saved-objects-settings
+
+Contains constants for some of saved objects related ui settings that had to be re-used between plugins without causing circular dependencies.

--- a/packages/kbn-saved-objects-settings/index.ts
+++ b/packages/kbn-saved-objects-settings/index.ts
@@ -6,5 +6,5 @@
  * Side Public License, v 1.
  */
 
-export { PER_PAGE_SETTING, LISTING_LIMIT_SETTING } from '@kbn/saved-objects-settings';
-export type { SavedObjectCommon, FindQueryHTTP, FindResponseHTTP, FinderAttributes } from './types';
+export const PER_PAGE_SETTING = 'savedObjects:perPage';
+export const LISTING_LIMIT_SETTING = 'savedObjects:listingLimit';

--- a/packages/kbn-saved-objects-settings/jest.config.js
+++ b/packages/kbn-saved-objects-settings/jest.config.js
@@ -6,5 +6,8 @@
  * Side Public License, v 1.
  */
 
-export { PER_PAGE_SETTING, LISTING_LIMIT_SETTING } from '@kbn/saved-objects-settings';
-export type { SavedObjectCommon, FindQueryHTTP, FindResponseHTTP, FinderAttributes } from './types';
+module.exports = {
+  preset: '@kbn/test/jest_node',
+  rootDir: '../..',
+  roots: ['<rootDir>/packages/kbn-saved-objects-settings'],
+};

--- a/packages/kbn-saved-objects-settings/kibana.jsonc
+++ b/packages/kbn-saved-objects-settings/kibana.jsonc
@@ -1,0 +1,5 @@
+{
+  "type": "shared-common",
+  "id": "@kbn/saved-objects-settings",
+  "owner": "@elastic/appex-sharedux"
+}

--- a/packages/kbn-saved-objects-settings/package.json
+++ b/packages/kbn-saved-objects-settings/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@kbn/saved-objects-settings",
+  "private": true,
+  "version": "1.0.0",
+  "license": "SSPL-1.0 OR Elastic License 2.0"
+}

--- a/packages/kbn-saved-objects-settings/tsconfig.json
+++ b/packages/kbn-saved-objects-settings/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "target/types",
+    "types": [
+      "jest",
+      "node"
+    ]
+  },
+  "include": [
+    "**/*.ts",
+  ],
+  "exclude": [
+    "target/**/*"
+  ],
+  "kbn_references": []
+}

--- a/src/plugins/content_management/server/rpc/routes/routes.ts
+++ b/src/plugins/content_management/server/rpc/routes/routes.ts
@@ -8,7 +8,7 @@
 import { schema } from '@kbn/config-schema';
 import type { IRouter } from '@kbn/core/server';
 
-import { LISTING_LIMIT_SETTING, PER_PAGE_SETTING } from '@kbn/saved-objects-finder-plugin/common';
+import { LISTING_LIMIT_SETTING, PER_PAGE_SETTING } from '@kbn/saved-objects-settings';
 import { ProcedureName } from '../../../common';
 import type { ContentRegistry } from '../../core';
 import { MSearchService } from '../../core/msearch';

--- a/src/plugins/content_management/tsconfig.json
+++ b/src/plugins/content_management/tsconfig.json
@@ -14,7 +14,7 @@
     "@kbn/object-versioning",
     "@kbn/core-saved-objects-api-server-mocks",
     "@kbn/core-saved-objects-api-server",
-    "@kbn/saved-objects-finder-plugin",
+    "@kbn/saved-objects-settings",
   ],
   "exclude": [
     "target/**/*",

--- a/src/plugins/saved_objects_finder/tsconfig.json
+++ b/src/plugins/saved_objects_finder/tsconfig.json
@@ -14,6 +14,7 @@
     "@kbn/config-schema",
     "@kbn/core-ui-settings-browser",
     "@kbn/core-http-browser",
+    "@kbn/saved-objects-settings",
   ],
   "exclude": [
     "target/**/*",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1052,6 +1052,8 @@
       "@kbn/saved-objects-management-plugin/*": ["src/plugins/saved_objects_management/*"],
       "@kbn/saved-objects-plugin": ["src/plugins/saved_objects"],
       "@kbn/saved-objects-plugin/*": ["src/plugins/saved_objects/*"],
+      "@kbn/saved-objects-settings": ["packages/kbn-saved-objects-settings"],
+      "@kbn/saved-objects-settings/*": ["packages/kbn-saved-objects-settings/*"],
       "@kbn/saved-objects-tagging-oss-plugin": ["src/plugins/saved_objects_tagging_oss"],
       "@kbn/saved-objects-tagging-oss-plugin/*": ["src/plugins/saved_objects_tagging_oss/*"],
       "@kbn/saved-objects-tagging-plugin": ["x-pack/plugins/saved_objects_tagging"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -4841,6 +4841,10 @@
   version "0.0.0"
   uid ""
 
+"@kbn/saved-objects-settings@link:packages/kbn-saved-objects-settings":
+  version "0.0.0"
+  uid ""
+
 "@kbn/saved-objects-tagging-oss-plugin@link:src/plugins/saved_objects_tagging_oss":
   version "0.0.0"
   uid ""


### PR DESCRIPTION
## Summary

Follow up https://github.com/elastic/kibana/pull/154819, 
@mattkime pointed out a problem that cm can't depend on saved_object_finder https://github.com/elastic/kibana/pull/154819/files#diff-635bc20df585b656afebba3ebf338ff997e735df933f704cc5f253a74b3503ddR17


