### PR TITLE
Use unsigned_long for field indexed_document_volume

### DIFF
--- a/x-pack/plugins/enterprise_search/server/index_management/setup_indices.test.ts
+++ b/x-pack/plugins/enterprise_search/server/index_management/setup_indices.test.ts
@@ -214,7 +214,7 @@ describe('Setup Indices', () => {
       deleted_document_count: { type: 'integer' },
       error: { type: 'keyword' },
       indexed_document_count: { type: 'integer' },
-      indexed_document_volume: { type: 'integer' },
+      indexed_document_volume: { type: 'unsigned_long' },
       last_seen: { type: 'date' },
       metadata: { type: 'object' },
       started_at: { type: 'date' },

--- a/x-pack/plugins/enterprise_search/server/index_management/setup_indices.ts
+++ b/x-pack/plugins/enterprise_search/server/index_management/setup_indices.ts
@@ -238,7 +238,7 @@ const indices: IndexDefinition[] = [
         deleted_document_count: { type: 'integer' },
         error: { type: 'keyword' },
         indexed_document_count: { type: 'integer' },
-        indexed_document_volume: { type: 'integer' },
+        indexed_document_volume: { type: 'unsigned_long' },
         last_seen: { type: 'date' },
         metadata: { type: 'object' },
         started_at: { type: 'date' },


### PR DESCRIPTION
## Summary

### Part of https://github.com/elastic/connectors-python/issues/735

The field `indexed_document_volume` (in bytes) in `.elastic-connectors-sync-jobs` is of type `integer`, which can hold a maximum value of `2^31-1`, which is equivalent to 2-ish GB. This PR changes it to `unsigned_long`, which can hold a maximum value of `2^64-1`, which is equivalent to 18-ish Exa Bytes (1 Exa Byte = 1000 PB).



### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
