### PR TITLE
add BlueOak-1.0.0 to the list of allowed licences

### DIFF
--- a/src/dev/license_checker/config.ts
+++ b/src/dev/license_checker/config.ts
@@ -68,6 +68,7 @@ export const LICENSE_ALLOWED = [
   'Nuclide software',
   'Python-2.0',
   '(Apache-2.0 AND MIT)',
+  'BlueOak-1.0.0',
 ];
 
 // The following list only applies to licenses that


### PR DESCRIPTION
## Summary

Adding `BlueOak-1.0.0` to the list of allowed licenses as it was green-listed. 
We need this license in Kibana [to update Puppeteer](https://github.com/elastic/kibana-team/issues/655) as one of its nested dependencies now uses this license.


