### PR TITLE
[APM] plugin description

### DIFF
--- a/docs/developer/plugin-list.asciidoc
+++ b/docs/developer/plugin-list.asciidoc
@@ -431,7 +431,7 @@ The plugin exposes the static DefaultEditorController class to consume.
 
 
 |{kib-repo}blob/{branch}/x-pack/plugins/apm/readme.md[apm]
-|undefined
+|This plugin provides access to App Monitoring features provided by Elastic. It allows you to monitor your software services and applications in real-time; visualize detailed performance information on your services, identify and analyze errors, and monitor host-level and APM agent-specific metrics like JVM and Go runtime metrics.
 
 
 |{kib-repo}blob/{branch}/x-pack/plugins/asset_manager/README.md[assetManager]

--- a/x-pack/plugins/apm/readme.md
+++ b/x-pack/plugins/apm/readme.md
@@ -1,21 +1,25 @@
-# Documentation for APM UI developers
+# APM
 
-## Getting started
+This plugin provides access to App Monitoring features provided by Elastic. It allows you to monitor your software services and applications in real-time; visualize detailed performance information on your services, identify and analyze errors, and monitor host-level and APM agent-specific metrics like JVM and Go runtime metrics.
+
+## Documentation for APM UI developers
+
+### Getting started
 - [Local setup](./dev_docs/local_setup.md)
 - [Testing (unit, api, e2e, storybook)](./dev_docs/testing.md)
 - [Linting (typescript, eslint, prettier)](./dev_docs/linting.md)
 
-## APM concepts
+### APM concepts
 - [Queries and data model](./dev_docs/apm_queries.md)
 - [Telemetry](./dev_docs/telemetry.md)
 - [Routing and Linking](./dev_docs/routing_and_linking.md)
 
-## Tooling
+### Tooling
 - [VSCode setup instructions](./dev_docs/vscode_setup.md)
 - [Github PR commands](./dev_docs/github_commands.md)
 - [Synthtrace (data generation)](https://github.com/elastic/kibana/blob/main/packages/kbn-apm-synthtrace/README.md)
 - [Query debugging in development and production](./dev_docs/query_debugging_in_development_and_production.md)
 
-## Other resources
+### Other resources
 - [Official APM UI settings docs](https://www.elastic.co/guide/en/kibana/current/apm-settings-in-kibana.html)
 - [Reading Material](./dev_docs/learning_material.md)


### PR DESCRIPTION
While I was checking [some documentation](https://www.elastic.co/guide/en/kibana/current/plugin-list.html) I discovered APM plugin description was `undefined`

<img width="1847" alt="image" src="https://user-images.githubusercontent.com/1313018/231450602-926abacc-b915-42dd-88fb-462643cc8dc1.png">


<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->