### PR TITLE
Setup Node.js environment before instrumenting Kibana with APM.

### DIFF
--- a/src/cli/dev.js
+++ b/src/cli/dev.js
@@ -6,7 +6,6 @@
  * Side Public License, v 1.
  */
 
-require('@kbn/babel-register').install();
-require('./apm')(process.env.ELASTIC_APM_SERVICE_NAME || 'kibana-proxy');
 require('../setup_node_env');
+require('./apm')(process.env.ELASTIC_APM_SERVICE_NAME || 'kibana-proxy');
 require('./cli');

--- a/src/cli/dist.js
+++ b/src/cli/dist.js
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-require('./apm')();
 require('../setup_node_env/dist');
+require('./apm')();
 require('../setup_node_env/root');
 require('./cli');

--- a/src/cli/tsconfig.json
+++ b/src/cli/tsconfig.json
@@ -17,7 +17,6 @@
     "@kbn/config",
     "@kbn/dev-utils",
     "@kbn/apm-config-loader",
-    "@kbn/babel-register",
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
## Summary

It looks like `setup_node_env` doesn't require any packages that [would need to be instrumented by the APM](https://github.com/elastic/apm-agent-nodejs/tree/main/lib/instrumentation/modules), and hence it should be safe to require it before the APM script. Here are the 3rd-party packages that are required via `setup_node_env` scripts (excluding anything that's imported inside of these package, of course):

* `require-in-the-middle`
* `lodash/_isIterateeCall`
* `symbol-observable`
* `source-map-support`
* `core-js/stable`
* `@kbn/babel-register` (only in dev, and it was already imported before APM script)

<!--ONMERGE {"backportTargets":["7.17","8.7"]} ONMERGE-->