### PR TITLE
[Response Ops] [Alerting] Excluding ECS fields of type `constant_keyword` from ECS field map

### DIFF
--- a/packages/kbn-alerts-as-data-utils/src/field_maps/ecs_field_map.ts
+++ b/packages/kbn-alerts-as-data-utils/src/field_maps/ecs_field_map.ts
@@ -9,8 +9,16 @@
 import { EcsFlat } from '@kbn/ecs';
 import { EcsMetadata, FieldMap } from './types';
 
+const EXCLUDED_TYPES = ['constant_keyword'];
+
 export const ecsFieldMap: FieldMap = Object.keys(EcsFlat).reduce((acc, currKey) => {
   const value: EcsMetadata = EcsFlat[currKey as keyof typeof EcsFlat];
+
+  // Exclude excluded types
+  if (EXCLUDED_TYPES.includes(value.type)) {
+    return acc;
+  }
+
   return {
     ...acc,
     [currKey]: {


### PR DESCRIPTION
Fields mapped as `constant_keyword` can cause issues when used in the alerts as data mapping where multiple types of sources are combined into one index. These fields were previously excluded from the ECS field mapping used by alerts as data. We included them because we wanted to use ECS as closely as possible but it is causing downstream issues so we'll continue excluding them until we decide we need them at some point in the future.

## To verify:
1. Start ES & Kibana
2. Inspect the `.alerts-ecs-mappings` component template mapping and verify there are no fields with type `constant_keyword`