### PR TITLE
add xpack.actions.enableFooterInEmail to the docker config list

### DIFF
--- a/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker
+++ b/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker
@@ -205,6 +205,7 @@ kibana_vars=(
     xpack.actions.allowedHosts
     xpack.actions.customHostSettings
     xpack.actions.email.domain_allowlist
+    xpack.actions.enableFooterInEmail
     xpack.actions.enabledActionTypes
     xpack.actions.maxResponseContentLength
     xpack.actions.preconfigured


### PR DESCRIPTION
## Summary

In PR [provide config to turn off email action footer #154919](https://github.com/elastic/kibana/pull/154919), we forgot to add the config to the docker allow-list in `src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker`.

We add it in this PR.
