### PR TITLE
[Cloud Security] Update vulnerability management retention policy to 3 days

### DIFF
--- a/x-pack/plugins/cloud_security_posture/server/create_transforms/latest_vulnerabilities_transforms.ts
+++ b/x-pack/plugins/cloud_security_posture/server/create_transforms/latest_vulnerabilities_transforms.ts
@@ -32,7 +32,7 @@ export const latestVulnerabilitiesTransform: TransformPutTransformRequest = {
   retention_policy: {
     time: {
       field: '@timestamp',
-      max_age: '50h',
+      max_age: '3d',
     },
   },
   latest: {


### PR DESCRIPTION
## Summary

Currently, scanning a cluster of ~90 EC2 instances takes ~12 hours, we assume the user's cluster might take longer than that by x4-x6 times.
Therefore, we've decided to increase the retention policy to 3 days from 2 days as it is today until we will enhance the current capacity
