### PR TITLE
[DOCS] Removes tag from 8.7.1 release notes

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -44,8 +44,6 @@ Review important information about the {kib} 8.7.x releases.
 [[release-notes-8.7.1]]
 == {kib} 8.7.1
 
-coming::[8.7.1]
-
 Review the following information about the {kib} 8.7.1 release.
 
 [float]


### PR DESCRIPTION
## Summary

Removes the `coming` tag from the 8.7.1 release notes.

