### PR TITLE
[AO] - Fix main chart when groupBy field is not indexed for Logs Alert details page

### DIFF
--- a/x-pack/plugins/infra/public/alerting/log_threshold/components/alert_details_app_section/index.tsx
+++ b/x-pack/plugins/infra/public/alerting/log_threshold/components/alert_details_app_section/index.tsx
@@ -41,7 +41,7 @@ const AlertDetailsAppSection = ({
   alert,
   setAlertSummaryFields,
 }: AlertDetailsAppSectionProps) => {
-  const [selectedSeries, setSelectedSeries] = useState<string>('');
+  const [selectedSeries, setSelectedSeries] = useState<string | undefined>();
   const { uiSettings } = useKibanaContextForPlugin().services;
   const { euiTheme } = useEuiTheme();
   const theme = useTheme();
@@ -217,7 +217,7 @@ const AlertDetailsAppSection = ({
                       color={euiTheme.colors.danger}
                     />,
                   ]}
-                  filterSeriesByGroupName={[selectedSeries]}
+                  filterSeriesByGroupName={selectedSeries}
                 />
               </EuiFlexItem>
             </EuiFlexGroup>

--- a/x-pack/plugins/infra/public/alerting/log_threshold/components/expression_editor/criterion_preview_chart.tsx
+++ b/x-pack/plugins/infra/public/alerting/log_threshold/components/expression_editor/criterion_preview_chart.tsx
@@ -60,7 +60,7 @@ interface Props {
   showThreshold: boolean;
   executionTimeRange?: ExecutionTimeRange;
   annotations?: Array<ReactElement<typeof RectAnnotation | typeof LineAnnotation>>;
-  filterSeriesByGroupName?: string[];
+  filterSeriesByGroupName?: string;
 }
 
 export const CriterionPreview: React.FC<Props> = ({
@@ -129,7 +129,7 @@ interface ChartProps {
   showThreshold: boolean;
   executionTimeRange?: ExecutionTimeRange;
   annotations?: Array<ReactElement<typeof RectAnnotation | typeof LineAnnotation>>;
-  filterSeriesByGroupName?: string[];
+  filterSeriesByGroupName?: string;
 }
 
 const CriterionPreviewChart: React.FC<ChartProps> = ({
@@ -189,7 +189,7 @@ const CriterionPreviewChart: React.FC<ChartProps> = ({
     if (!isGrouped) {
       return series;
     }
-    if (filterSeriesByGroupName && filterSeriesByGroupName.length) {
+    if (filterSeriesByGroupName) {
       return series.filter((item) => filterSeriesByGroupName.includes(item.id));
     }
     const sortedByMax = series.sort((a, b) => {


### PR DESCRIPTION
## Summary

It fixes #155083 by showing all the groupBy data and not filtering to the one related to the alert **IF** the source/groupBy field is not persisted,  https://github.com/elastic/kibana/issues/153675 aka not part of:
- cloud
- host
- orchestrator
- container
- labels
- tags 



<img width="1226" alt="Screenshot 2023-04-18 at 00 59 34" src="https://user-images.githubusercontent.com/6838659/232628320-17880f35-1f8b-4a85-9aee-634a902017a2.png">
