### PR TITLE
[Inspector] Improve the display when there are many columns

### DIFF
--- a/src/plugins/data/public/utils/table_inspector_view/components/__snapshots__/data_view.test.tsx.snap
+++ b/src/plugins/data/public/utils/table_inspector_view/components/__snapshots__/data_view.test.tsx.snap
@@ -204,7 +204,7 @@ Array [
     class="euiSpacer euiSpacer--s emotion-euiSpacer-s"
   />,
   <div
-    class="euiBasicTable insDataTableFormat__table"
+    class="euiBasicTable insDataTableFormat__table eui-xScroll css-1f59z3t"
     data-test-subj="inspectorTable"
   >
     <div>
@@ -255,7 +255,7 @@ Array [
         </div>
       </div>
       <table
-        class="euiTable css-0 euiTable--responsive"
+        class="euiTable css-0 euiTable--responsive euiTable--auto"
         id="__table_generated-id"
         tabindex="-1"
       >
@@ -546,7 +546,7 @@ Array [
     class="euiSpacer euiSpacer--s emotion-euiSpacer-s"
   />,
   <div
-    class="euiBasicTable insDataTableFormat__table"
+    class="euiBasicTable insDataTableFormat__table eui-xScroll css-1f59z3t"
     data-test-subj="inspectorTable"
   >
     <div>
@@ -597,7 +597,7 @@ Array [
         </div>
       </div>
       <table
-        class="euiTable css-0 euiTable--responsive"
+        class="euiTable css-0 euiTable--responsive euiTable--auto"
         id="__table_generated-id"
         tabindex="-1"
       >

--- a/src/plugins/data/public/utils/table_inspector_view/components/data_table.tsx
+++ b/src/plugins/data/public/utils/table_inspector_view/components/data_table.tsx
@@ -8,7 +8,8 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-
+import classNames from 'classnames';
+import { css } from '@emotion/react';
 import {
   EuiButtonIcon,
   EuiFlexGroup,
@@ -192,12 +193,25 @@ export class DataTableFormat extends Component<DataTableFormatProps, DataTableFo
 
     return (
       <EuiInMemoryTable
-        className="insDataTableFormat__table"
+        tableLayout="auto"
+        className={classNames('insDataTableFormat__table', 'eui-xScroll')}
         data-test-subj="inspectorTable"
         columns={columns}
         items={rows}
         sorting={true}
         pagination={pagination}
+        css={css`
+          // Set a min width on each column - you can use [data-test-subj] to target specific columns
+          .euiTableHeaderCell {
+            min-width: 100px;
+          }
+
+          // Make sure the pagination follows the scroll
+          > div:last-child {
+            position: sticky;
+            left: 0;
+          }
+        `}
       />
     );
   }

--- a/src/plugins/data/public/utils/table_inspector_view/components/data_table.tsx
+++ b/src/plugins/data/public/utils/table_inspector_view/components/data_table.tsx
@@ -8,7 +8,6 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
 import { css } from '@emotion/react';
 import {
   EuiButtonIcon,
@@ -194,7 +193,7 @@ export class DataTableFormat extends Component<DataTableFormatProps, DataTableFo
     return (
       <EuiInMemoryTable
         tableLayout="auto"
-        className={classNames('insDataTableFormat__table', 'eui-xScroll')}
+        className="insDataTableFormat__table eui-xScroll"
         data-test-subj="inspectorTable"
         columns={columns}
         items={rows}


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/112176

Improves the way the inspector table is rendered when there are multiple columns. I just applied the eui team feedback

**Now**

<img width="1257" alt="image" src="https://user-images.githubusercontent.com/17003240/232727448-561cd07a-84ec-472f-9968-27631ef9f4f1.png">


**Before**
<img width="875" alt="image" src="https://user-images.githubusercontent.com/17003240/232727840-24514f38-0a6f-47a3-89ed-adc0bc7ea2f0.png">
