### PR TITLE
[Lens] Improve sampling notification title

### DIFF
--- a/x-pack/plugins/lens/public/datasources/form_based/utils.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/utils.tsx
@@ -514,7 +514,7 @@ export function getNotifiableFeatures(
       severity: 'info',
       fixableInEditor: false,
       shortMessage: i18n.translate('xpack.lens.indexPattern.samplingPerLayer', {
-        defaultMessage: 'Layers with reduced sampling',
+        defaultMessage: 'Sampling probability by layer',
       }),
       longMessage: (
         <ReducedSamplingSectionEntries


### PR DESCRIPTION
## Summary

Improves the title of the notification popover for sampled data per feedback given

<img width="689" alt="image" src="https://user-images.githubusercontent.com/17003240/232739407-c3a7eb9b-7403-41c4-a427-1999b0fd0b7b.png">
