### PR TITLE
[kbn-failed-test-reporter-cli] truncate report message to fix github api call failure

### DIFF
--- a/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/report_failure.ts
+++ b/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/report_failure.ts
@@ -19,12 +19,24 @@ export async function createFailureIssue(
 ) {
   const title = `Failing test: ${failure.classname} - ${failure.name}`;
 
+  // Github API body length maximum is 65536 characters
+  // Let's keep consistency with Mocha output that is truncated to 8192 characters
+  const failureMaxCharacters = 8192;
+
+  const failureBody =
+    failure.failure.length <= failureMaxCharacters
+      ? failure.failure
+      : [
+          failure.failure.substring(0, failureMaxCharacters),
+          `[report_failure] output truncated to ${failureMaxCharacters} characters`,
+        ].join('\n');
+
   const body = updateIssueMetadata(
     [
       'A test failed on a tracked branch',
       '',
       '```',
-      failure.failure,
+      failureBody,
       '```',
       '',
       `First failure: [CI Build - ${branch}](${buildUrl})`,


### PR DESCRIPTION
## Summary

We recently had a [failure](https://buildkite.com/elastic/kibana-on-merge/builds/29020#018792bc-498a-46d1-9343-fb791823d92e) while calling Github API to open new issue:

```
2023-04-18 07:56:26 CEST	ERROR Error: [post https://api.github.com/repos/elastic/kibana/issues] 422 Unprocessable Entity Error: {"message":"Validation Failed","errors":[{"resource":"Issue","code":"custom","field":"body","message":"body is too long"},{"resource":"Issue","code":"custom","field":"body","message":"body is too long (maximum is 65536 characters)"}],"documentation_url":"https://docs.github.com/rest/reference/issues#create-an-issue"}
2023-04-18 07:56:26 CEST	          at GithubApi.request (github_api.ts:177:17)
2023-04-18 07:56:26 CEST	          at processTicksAndRejections (node:internal/process/task_queues:96:5)
2023-04-18 07:56:26 CEST	          at GithubApi.createIssue (github_api.ts:106:18)
2023-04-18 07:56:26 CEST	          at createFailureIssue (report_failure.ts:39:10)
2023-04-18 07:56:26 CEST	          at description (failed_tests_reporter_cli.ts:153:28)
2023-04-18 07:56:26 CEST	          at run.ts:70:7
2023-04-18 07:56:26 CEST	          at withProcRunner (with_proc_runner.ts:29:5)
2023-04-18 07:56:26 CEST	          at run (run.ts:69:5)
```

It seems like some test might have a very long failure message that reaches Github body length limit and causes a failure.

Since mocha truncates failure message to 8192 chars, I thought it might be a good option for Github issues as well (Having too long message is not very useful anyway) 

<!--ONMERGE {"backportTargets":["7.17","8.7"]} ONMERGE-->