### PR TITLE
[HTTP] Switch default handler resolution based on Kibana config

### DIFF
--- a/packages/core/http/core-http-request-handler-context-server-internal/src/core_route_handler_context.test.ts
+++ b/packages/core/http/core-http-request-handler-context-server-internal/src/core_route_handler_context.test.ts
@@ -12,35 +12,35 @@ import { createCoreRouteHandlerContextParamsMock } from './test_helpers';
 
 describe('#elasticsearch', () => {
   describe('#client', () => {
-    test('returns the results of params.elasticsearch.client.asScoped', () => {
+    test('returns the results of coreStart.elasticsearch.client.asScoped', () => {
       const request = httpServerMock.createKibanaRequest();
-      const params = createCoreRouteHandlerContextParamsMock();
-      const context = new CoreRouteHandlerContext(params, request);
+      const coreStart = createCoreRouteHandlerContextParamsMock();
+      const context = new CoreRouteHandlerContext(coreStart, request);
 
       const client = context.elasticsearch.client;
-      expect(client).toBe(params.elasticsearch.client.asScoped.mock.results[0].value);
+      expect(client).toBe(coreStart.elasticsearch.client.asScoped.mock.results[0].value);
     });
 
     test('lazily created', () => {
       const request = httpServerMock.createKibanaRequest();
-      const params = createCoreRouteHandlerContextParamsMock();
-      const context = new CoreRouteHandlerContext(params, request);
+      const coreStart = createCoreRouteHandlerContextParamsMock();
+      const context = new CoreRouteHandlerContext(coreStart, request);
 
-      expect(params.elasticsearch.client.asScoped).not.toHaveBeenCalled();
+      expect(coreStart.elasticsearch.client.asScoped).not.toHaveBeenCalled();
       const client = context.elasticsearch.client;
-      expect(params.elasticsearch.client.asScoped).toHaveBeenCalled();
+      expect(coreStart.elasticsearch.client.asScoped).toHaveBeenCalled();
       expect(client).toBeDefined();
     });
 
     test('only creates one instance', () => {
       const request = httpServerMock.createKibanaRequest();
-      const params = createCoreRouteHandlerContextParamsMock();
-      const context = new CoreRouteHandlerContext(params, request);
+      const coreStart = createCoreRouteHandlerContextParamsMock();
+      const context = new CoreRouteHandlerContext(coreStart, request);
 
       const client1 = context.elasticsearch.client;
       const client2 = context.elasticsearch.client;
-      expect(params.elasticsearch.client.asScoped.mock.calls.length).toBe(1);
-      const mockResult = params.elasticsearch.client.asScoped.mock.results[0].value;
+      expect(coreStart.elasticsearch.client.asScoped.mock.calls.length).toBe(1);
+      const mockResult = coreStart.elasticsearch.client.asScoped.mock.results[0].value;
       expect(client1).toBe(mockResult);
       expect(client2).toBe(mockResult);
     });
@@ -49,71 +49,71 @@ describe('#elasticsearch', () => {
 
 describe('#savedObjects', () => {
   describe('#client', () => {
-    test('returns the results of params.savedObjects.getScopedClient', () => {
+    test('returns the results of coreStart.savedObjects.getScopedClient', () => {
       const request = httpServerMock.createKibanaRequest();
-      const params = createCoreRouteHandlerContextParamsMock();
-      const context = new CoreRouteHandlerContext(params, request);
+      const coreStart = createCoreRouteHandlerContextParamsMock();
+      const context = new CoreRouteHandlerContext(coreStart, request);
 
       const client = context.savedObjects.client;
-      expect(client).toBe(params.savedObjects.getScopedClient.mock.results[0].value);
+      expect(client).toBe(coreStart.savedObjects.getScopedClient.mock.results[0].value);
     });
 
     test('lazily created', () => {
       const request = httpServerMock.createKibanaRequest();
-      const params = createCoreRouteHandlerContextParamsMock();
-      const context = new CoreRouteHandlerContext(params, request);
+      const coreStart = createCoreRouteHandlerContextParamsMock();
+      const context = new CoreRouteHandlerContext(coreStart, request);
 
       const savedObjects = context.savedObjects;
-      expect(params.savedObjects.getScopedClient).not.toHaveBeenCalled();
+      expect(coreStart.savedObjects.getScopedClient).not.toHaveBeenCalled();
       const client = savedObjects.client;
-      expect(params.savedObjects.getScopedClient).toHaveBeenCalled();
+      expect(coreStart.savedObjects.getScopedClient).toHaveBeenCalled();
       expect(client).toBeDefined();
     });
 
     test('only creates one instance', () => {
       const request = httpServerMock.createKibanaRequest();
-      const params = createCoreRouteHandlerContextParamsMock();
-      const context = new CoreRouteHandlerContext(params, request);
+      const coreStart = createCoreRouteHandlerContextParamsMock();
+      const context = new CoreRouteHandlerContext(coreStart, request);
 
       const client1 = context.savedObjects.client;
       const client2 = context.savedObjects.client;
-      expect(params.savedObjects.getScopedClient.mock.calls.length).toBe(1);
-      const mockResult = params.savedObjects.getScopedClient.mock.results[0].value;
+      expect(coreStart.savedObjects.getScopedClient.mock.calls.length).toBe(1);
+      const mockResult = coreStart.savedObjects.getScopedClient.mock.results[0].value;
       expect(client1).toBe(mockResult);
       expect(client2).toBe(mockResult);
     });
   });
 
   describe('#typeRegistry', () => {
-    test('returns the results of params.savedObjects.getTypeRegistry', () => {
+    test('returns the results of coreStart.savedObjects.getTypeRegistry', () => {
       const request = httpServerMock.createKibanaRequest();
-      const params = createCoreRouteHandlerContextParamsMock();
-      const context = new CoreRouteHandlerContext(params, request);
+      const coreStart = createCoreRouteHandlerContextParamsMock();
+      const context = new CoreRouteHandlerContext(coreStart, request);
 
       const typeRegistry = context.savedObjects.typeRegistry;
-      expect(typeRegistry).toBe(params.savedObjects.getTypeRegistry.mock.results[0].value);
+      expect(typeRegistry).toBe(coreStart.savedObjects.getTypeRegistry.mock.results[0].value);
     });
 
     test('lazily created', () => {
       const request = httpServerMock.createKibanaRequest();
-      const params = createCoreRouteHandlerContextParamsMock();
-      const context = new CoreRouteHandlerContext(params, request);
+      const coreStart = createCoreRouteHandlerContextParamsMock();
+      const context = new CoreRouteHandlerContext(coreStart, request);
 
-      expect(params.savedObjects.getTypeRegistry).not.toHaveBeenCalled();
+      expect(coreStart.savedObjects.getTypeRegistry).not.toHaveBeenCalled();
       const typeRegistry = context.savedObjects.typeRegistry;
-      expect(params.savedObjects.getTypeRegistry).toHaveBeenCalled();
+      expect(coreStart.savedObjects.getTypeRegistry).toHaveBeenCalled();
       expect(typeRegistry).toBeDefined();
     });
 
     test('only creates one instance', () => {
       const request = httpServerMock.createKibanaRequest();
-      const params = createCoreRouteHandlerContextParamsMock();
-      const context = new CoreRouteHandlerContext(params, request);
+      const coreStart = createCoreRouteHandlerContextParamsMock();
+      const context = new CoreRouteHandlerContext(coreStart, request);
 
       const typeRegistry1 = context.savedObjects.typeRegistry;
       const typeRegistry2 = context.savedObjects.typeRegistry;
-      expect(params.savedObjects.getTypeRegistry.mock.calls.length).toBe(1);
-      const mockResult = params.savedObjects.getTypeRegistry.mock.results[0].value;
+      expect(coreStart.savedObjects.getTypeRegistry.mock.calls.length).toBe(1);
+      const mockResult = coreStart.savedObjects.getTypeRegistry.mock.results[0].value;
       expect(typeRegistry1).toBe(mockResult);
       expect(typeRegistry2).toBe(mockResult);
     });
@@ -122,35 +122,35 @@ describe('#savedObjects', () => {
 
 describe('#uiSettings', () => {
   describe('#client', () => {
-    test('returns the results of params.uiSettings.asScopedToClient', () => {
+    test('returns the results of coreStart.uiSettings.asScopedToClient', () => {
       const request = httpServerMock.createKibanaRequest();
-      const params = createCoreRouteHandlerContextParamsMock();
-      const context = new CoreRouteHandlerContext(params, request);
+      const coreStart = createCoreRouteHandlerContextParamsMock();
+      const context = new CoreRouteHandlerContext(coreStart, request);
 
       const client = context.uiSettings.client;
-      expect(client).toBe(params.uiSettings.asScopedToClient.mock.results[0].value);
+      expect(client).toBe(coreStart.uiSettings.asScopedToClient.mock.results[0].value);
     });
 
     test('lazily created', () => {
       const request = httpServerMock.createKibanaRequest();
-      const params = createCoreRouteHandlerContextParamsMock();
-      const context = new CoreRouteHandlerContext(params, request);
+      const coreStart = createCoreRouteHandlerContextParamsMock();
+      const context = new CoreRouteHandlerContext(coreStart, request);
 
-      expect(params.uiSettings.asScopedToClient).not.toHaveBeenCalled();
+      expect(coreStart.uiSettings.asScopedToClient).not.toHaveBeenCalled();
       const client = context.uiSettings.client;
-      expect(params.uiSettings.asScopedToClient).toHaveBeenCalled();
+      expect(coreStart.uiSettings.asScopedToClient).toHaveBeenCalled();
       expect(client).toBeDefined();
     });
 
     test('only creates one instance', () => {
       const request = httpServerMock.createKibanaRequest();
-      const params = createCoreRouteHandlerContextParamsMock();
-      const context = new CoreRouteHandlerContext(params, request);
+      const coreStart = createCoreRouteHandlerContextParamsMock();
+      const context = new CoreRouteHandlerContext(coreStart, request);
 
       const client1 = context.uiSettings.client;
       const client2 = context.uiSettings.client;
-      expect(params.uiSettings.asScopedToClient.mock.calls.length).toBe(1);
-      const mockResult = params.uiSettings.asScopedToClient.mock.results[0].value;
+      expect(coreStart.uiSettings.asScopedToClient.mock.calls.length).toBe(1);
+      const mockResult = coreStart.uiSettings.asScopedToClient.mock.results[0].value;
       expect(client1).toBe(mockResult);
       expect(client2).toBe(mockResult);
     });
@@ -159,35 +159,35 @@ describe('#uiSettings', () => {
 
 describe('#deprecations', () => {
   describe('#client', () => {
-    test('returns the results of params.deprecations.asScopedToClient', () => {
+    test('returns the results of coreStart.deprecations.asScopedToClient', () => {
       const request = httpServerMock.createKibanaRequest();
-      const params = createCoreRouteHandlerContextParamsMock();
-      const context = new CoreRouteHandlerContext(params, request);
+      const coreStart = createCoreRouteHandlerContextParamsMock();
+      const context = new CoreRouteHandlerContext(coreStart, request);
 
       const client = context.deprecations.client;
-      expect(client).toBe(params.deprecations.asScopedToClient.mock.results[0].value);
+      expect(client).toBe(coreStart.deprecations.asScopedToClient.mock.results[0].value);
     });
 
     test('lazily created', () => {
       const request = httpServerMock.createKibanaRequest();
-      const params = createCoreRouteHandlerContextParamsMock();
-      const context = new CoreRouteHandlerContext(params, request);
+      const coreStart = createCoreRouteHandlerContextParamsMock();
+      const context = new CoreRouteHandlerContext(coreStart, request);
 
-      expect(params.deprecations.asScopedToClient).not.toHaveBeenCalled();
+      expect(coreStart.deprecations.asScopedToClient).not.toHaveBeenCalled();
       const client = context.deprecations.client;
-      expect(params.deprecations.asScopedToClient).toHaveBeenCalled();
+      expect(coreStart.deprecations.asScopedToClient).toHaveBeenCalled();
       expect(client).toBeDefined();
     });
 
     test('only creates one instance', () => {
       const request = httpServerMock.createKibanaRequest();
-      const params = createCoreRouteHandlerContextParamsMock();
-      const context = new CoreRouteHandlerContext(params, request);
+      const coreStart = createCoreRouteHandlerContextParamsMock();
+      const context = new CoreRouteHandlerContext(coreStart, request);
 
       const client1 = context.deprecations.client;
       const client2 = context.deprecations.client;
-      expect(params.deprecations.asScopedToClient.mock.calls.length).toBe(1);
-      const mockResult = params.deprecations.asScopedToClient.mock.results[0].value;
+      expect(coreStart.deprecations.asScopedToClient.mock.calls.length).toBe(1);
+      const mockResult = coreStart.deprecations.asScopedToClient.mock.results[0].value;
       expect(client1).toBe(mockResult);
       expect(client2).toBe(mockResult);
     });

--- a/packages/core/http/core-http-request-handler-context-server-internal/src/core_route_handler_context.test.ts
+++ b/packages/core/http/core-http-request-handler-context-server-internal/src/core_route_handler_context.test.ts
@@ -12,35 +12,35 @@ import { createCoreRouteHandlerContextParamsMock } from './test_helpers';
 
 describe('#elasticsearch', () => {
   describe('#client', () => {
-    test('returns the results of coreStart.elasticsearch.client.asScoped', () => {
+    test('returns the results of params.elasticsearch.client.asScoped', () => {
       const request = httpServerMock.createKibanaRequest();
-      const coreStart = createCoreRouteHandlerContextParamsMock();
-      const context = new CoreRouteHandlerContext(coreStart, request);
+      const params = createCoreRouteHandlerContextParamsMock();
+      const context = new CoreRouteHandlerContext(params, request);
 
       const client = context.elasticsearch.client;
-      expect(client).toBe(coreStart.elasticsearch.client.asScoped.mock.results[0].value);
+      expect(client).toBe(params.elasticsearch.client.asScoped.mock.results[0].value);
     });
 
     test('lazily created', () => {
       const request = httpServerMock.createKibanaRequest();
-      const coreStart = createCoreRouteHandlerContextParamsMock();
-      const context = new CoreRouteHandlerContext(coreStart, request);
+      const params = createCoreRouteHandlerContextParamsMock();
+      const context = new CoreRouteHandlerContext(params, request);
 
-      expect(coreStart.elasticsearch.client.asScoped).not.toHaveBeenCalled();
+      expect(params.elasticsearch.client.asScoped).not.toHaveBeenCalled();
       const client = context.elasticsearch.client;
-      expect(coreStart.elasticsearch.client.asScoped).toHaveBeenCalled();
+      expect(params.elasticsearch.client.asScoped).toHaveBeenCalled();
       expect(client).toBeDefined();
     });
 
     test('only creates one instance', () => {
       const request = httpServerMock.createKibanaRequest();
-      const coreStart = createCoreRouteHandlerContextParamsMock();
-      const context = new CoreRouteHandlerContext(coreStart, request);
+      const params = createCoreRouteHandlerContextParamsMock();
+      const context = new CoreRouteHandlerContext(params, request);
 
       const client1 = context.elasticsearch.client;
       const client2 = context.elasticsearch.client;
-      expect(coreStart.elasticsearch.client.asScoped.mock.calls.length).toBe(1);
-      const mockResult = coreStart.elasticsearch.client.asScoped.mock.results[0].value;
+      expect(params.elasticsearch.client.asScoped.mock.calls.length).toBe(1);
+      const mockResult = params.elasticsearch.client.asScoped.mock.results[0].value;
       expect(client1).toBe(mockResult);
       expect(client2).toBe(mockResult);
     });
@@ -49,71 +49,71 @@ describe('#elasticsearch', () => {
 
 describe('#savedObjects', () => {
   describe('#client', () => {
-    test('returns the results of coreStart.savedObjects.getScopedClient', () => {
+    test('returns the results of params.savedObjects.getScopedClient', () => {
       const request = httpServerMock.createKibanaRequest();
-      const coreStart = createCoreRouteHandlerContextParamsMock();
-      const context = new CoreRouteHandlerContext(coreStart, request);
+      const params = createCoreRouteHandlerContextParamsMock();
+      const context = new CoreRouteHandlerContext(params, request);
 
       const client = context.savedObjects.client;
-      expect(client).toBe(coreStart.savedObjects.getScopedClient.mock.results[0].value);
+      expect(client).toBe(params.savedObjects.getScopedClient.mock.results[0].value);
     });
 
     test('lazily created', () => {
       const request = httpServerMock.createKibanaRequest();
-      const coreStart = createCoreRouteHandlerContextParamsMock();
-      const context = new CoreRouteHandlerContext(coreStart, request);
+      const params = createCoreRouteHandlerContextParamsMock();
+      const context = new CoreRouteHandlerContext(params, request);
 
       const savedObjects = context.savedObjects;
-      expect(coreStart.savedObjects.getScopedClient).not.toHaveBeenCalled();
+      expect(params.savedObjects.getScopedClient).not.toHaveBeenCalled();
       const client = savedObjects.client;
-      expect(coreStart.savedObjects.getScopedClient).toHaveBeenCalled();
+      expect(params.savedObjects.getScopedClient).toHaveBeenCalled();
       expect(client).toBeDefined();
     });
 
     test('only creates one instance', () => {
       const request = httpServerMock.createKibanaRequest();
-      const coreStart = createCoreRouteHandlerContextParamsMock();
-      const context = new CoreRouteHandlerContext(coreStart, request);
+      const params = createCoreRouteHandlerContextParamsMock();
+      const context = new CoreRouteHandlerContext(params, request);
 
       const client1 = context.savedObjects.client;
       const client2 = context.savedObjects.client;
-      expect(coreStart.savedObjects.getScopedClient.mock.calls.length).toBe(1);
-      const mockResult = coreStart.savedObjects.getScopedClient.mock.results[0].value;
+      expect(params.savedObjects.getScopedClient.mock.calls.length).toBe(1);
+      const mockResult = params.savedObjects.getScopedClient.mock.results[0].value;
       expect(client1).toBe(mockResult);
       expect(client2).toBe(mockResult);
     });
   });
 
   describe('#typeRegistry', () => {
-    test('returns the results of coreStart.savedObjects.getTypeRegistry', () => {
+    test('returns the results of params.savedObjects.getTypeRegistry', () => {
       const request = httpServerMock.createKibanaRequest();
-      const coreStart = createCoreRouteHandlerContextParamsMock();
-      const context = new CoreRouteHandlerContext(coreStart, request);
+      const params = createCoreRouteHandlerContextParamsMock();
+      const context = new CoreRouteHandlerContext(params, request);
 
       const typeRegistry = context.savedObjects.typeRegistry;
-      expect(typeRegistry).toBe(coreStart.savedObjects.getTypeRegistry.mock.results[0].value);
+      expect(typeRegistry).toBe(params.savedObjects.getTypeRegistry.mock.results[0].value);
     });
 
     test('lazily created', () => {
       const request = httpServerMock.createKibanaRequest();
-      const coreStart = createCoreRouteHandlerContextParamsMock();
-      const context = new CoreRouteHandlerContext(coreStart, request);
+      const params = createCoreRouteHandlerContextParamsMock();
+      const context = new CoreRouteHandlerContext(params, request);
 
-      expect(coreStart.savedObjects.getTypeRegistry).not.toHaveBeenCalled();
+      expect(params.savedObjects.getTypeRegistry).not.toHaveBeenCalled();
       const typeRegistry = context.savedObjects.typeRegistry;
-      expect(coreStart.savedObjects.getTypeRegistry).toHaveBeenCalled();
+      expect(params.savedObjects.getTypeRegistry).toHaveBeenCalled();
       expect(typeRegistry).toBeDefined();
     });
 
     test('only creates one instance', () => {
       const request = httpServerMock.createKibanaRequest();
-      const coreStart = createCoreRouteHandlerContextParamsMock();
-      const context = new CoreRouteHandlerContext(coreStart, request);
+      const params = createCoreRouteHandlerContextParamsMock();
+      const context = new CoreRouteHandlerContext(params, request);
 
       const typeRegistry1 = context.savedObjects.typeRegistry;
       const typeRegistry2 = context.savedObjects.typeRegistry;
-      expect(coreStart.savedObjects.getTypeRegistry.mock.calls.length).toBe(1);
-      const mockResult = coreStart.savedObjects.getTypeRegistry.mock.results[0].value;
+      expect(params.savedObjects.getTypeRegistry.mock.calls.length).toBe(1);
+      const mockResult = params.savedObjects.getTypeRegistry.mock.results[0].value;
       expect(typeRegistry1).toBe(mockResult);
       expect(typeRegistry2).toBe(mockResult);
     });
@@ -122,35 +122,35 @@ describe('#savedObjects', () => {
 
 describe('#uiSettings', () => {
   describe('#client', () => {
-    test('returns the results of coreStart.uiSettings.asScopedToClient', () => {
+    test('returns the results of params.uiSettings.asScopedToClient', () => {
       const request = httpServerMock.createKibanaRequest();
-      const coreStart = createCoreRouteHandlerContextParamsMock();
-      const context = new CoreRouteHandlerContext(coreStart, request);
+      const params = createCoreRouteHandlerContextParamsMock();
+      const context = new CoreRouteHandlerContext(params, request);
 
       const client = context.uiSettings.client;
-      expect(client).toBe(coreStart.uiSettings.asScopedToClient.mock.results[0].value);
+      expect(client).toBe(params.uiSettings.asScopedToClient.mock.results[0].value);
     });
 
     test('lazily created', () => {
       const request = httpServerMock.createKibanaRequest();
-      const coreStart = createCoreRouteHandlerContextParamsMock();
-      const context = new CoreRouteHandlerContext(coreStart, request);
+      const params = createCoreRouteHandlerContextParamsMock();
+      const context = new CoreRouteHandlerContext(params, request);
 
-      expect(coreStart.uiSettings.asScopedToClient).not.toHaveBeenCalled();
+      expect(params.uiSettings.asScopedToClient).not.toHaveBeenCalled();
       const client = context.uiSettings.client;
-      expect(coreStart.uiSettings.asScopedToClient).toHaveBeenCalled();
+      expect(params.uiSettings.asScopedToClient).toHaveBeenCalled();
       expect(client).toBeDefined();
     });
 
     test('only creates one instance', () => {
       const request = httpServerMock.createKibanaRequest();
-      const coreStart = createCoreRouteHandlerContextParamsMock();
-      const context = new CoreRouteHandlerContext(coreStart, request);
+      const params = createCoreRouteHandlerContextParamsMock();
+      const context = new CoreRouteHandlerContext(params, request);
 
       const client1 = context.uiSettings.client;
       const client2 = context.uiSettings.client;
-      expect(coreStart.uiSettings.asScopedToClient.mock.calls.length).toBe(1);
-      const mockResult = coreStart.uiSettings.asScopedToClient.mock.results[0].value;
+      expect(params.uiSettings.asScopedToClient.mock.calls.length).toBe(1);
+      const mockResult = params.uiSettings.asScopedToClient.mock.results[0].value;
       expect(client1).toBe(mockResult);
       expect(client2).toBe(mockResult);
     });
@@ -159,35 +159,35 @@ describe('#uiSettings', () => {
 
 describe('#deprecations', () => {
   describe('#client', () => {
-    test('returns the results of coreStart.deprecations.asScopedToClient', () => {
+    test('returns the results of params.deprecations.asScopedToClient', () => {
       const request = httpServerMock.createKibanaRequest();
-      const coreStart = createCoreRouteHandlerContextParamsMock();
-      const context = new CoreRouteHandlerContext(coreStart, request);
+      const params = createCoreRouteHandlerContextParamsMock();
+      const context = new CoreRouteHandlerContext(params, request);
 
       const client = context.deprecations.client;
-      expect(client).toBe(coreStart.deprecations.asScopedToClient.mock.results[0].value);
+      expect(client).toBe(params.deprecations.asScopedToClient.mock.results[0].value);
     });
 
     test('lazily created', () => {
       const request = httpServerMock.createKibanaRequest();
-      const coreStart = createCoreRouteHandlerContextParamsMock();
-      const context = new CoreRouteHandlerContext(coreStart, request);
+      const params = createCoreRouteHandlerContextParamsMock();
+      const context = new CoreRouteHandlerContext(params, request);
 
-      expect(coreStart.deprecations.asScopedToClient).not.toHaveBeenCalled();
+      expect(params.deprecations.asScopedToClient).not.toHaveBeenCalled();
       const client = context.deprecations.client;
-      expect(coreStart.deprecations.asScopedToClient).toHaveBeenCalled();
+      expect(params.deprecations.asScopedToClient).toHaveBeenCalled();
       expect(client).toBeDefined();
     });
 
     test('only creates one instance', () => {
       const request = httpServerMock.createKibanaRequest();
-      const coreStart = createCoreRouteHandlerContextParamsMock();
-      const context = new CoreRouteHandlerContext(coreStart, request);
+      const params = createCoreRouteHandlerContextParamsMock();
+      const context = new CoreRouteHandlerContext(params, request);
 
       const client1 = context.deprecations.client;
       const client2 = context.deprecations.client;
-      expect(coreStart.deprecations.asScopedToClient.mock.calls.length).toBe(1);
-      const mockResult = coreStart.deprecations.asScopedToClient.mock.results[0].value;
+      expect(params.deprecations.asScopedToClient.mock.calls.length).toBe(1);
+      const mockResult = params.deprecations.asScopedToClient.mock.results[0].value;
       expect(client1).toBe(mockResult);
       expect(client2).toBe(mockResult);
     });

--- a/packages/core/http/core-http-request-handler-context-server-internal/src/core_route_handler_context.ts
+++ b/packages/core/http/core-http-request-handler-context-server-internal/src/core_route_handler_context.ts
@@ -50,15 +50,15 @@ export class CoreRouteHandlerContext implements CoreRequestHandlerContext {
   readonly deprecations: CoreDeprecationsRouteHandlerContext;
   readonly env: Pick<Env, 'mode'>;
 
-  constructor(deps: CoreRouteHandlerContextParams, request: KibanaRequest) {
-    this.elasticsearch = new CoreElasticsearchRouteHandlerContext(deps.elasticsearch, request);
-    this.savedObjects = new CoreSavedObjectsRouteHandlerContext(deps.savedObjects, request);
-    this.uiSettings = new CoreUiSettingsRouteHandlerContext(deps.uiSettings, this.savedObjects);
+  constructor(params: CoreRouteHandlerContextParams, request: KibanaRequest) {
+    this.elasticsearch = new CoreElasticsearchRouteHandlerContext(params.elasticsearch, request);
+    this.savedObjects = new CoreSavedObjectsRouteHandlerContext(params.savedObjects, request);
+    this.uiSettings = new CoreUiSettingsRouteHandlerContext(params.uiSettings, this.savedObjects);
     this.deprecations = new CoreDeprecationsRouteHandlerContext(
-      deps.deprecations,
+      params.deprecations,
       this.elasticsearch,
       this.savedObjects
     );
-    this.env = { mode: deps.env.mode };
+    this.env = { mode: params.env.mode };
   }
 }

--- a/packages/core/http/core-http-request-handler-context-server-internal/src/core_route_handler_context.ts
+++ b/packages/core/http/core-http-request-handler-context-server-internal/src/core_route_handler_context.ts
@@ -7,6 +7,7 @@
  */
 
 import type { KibanaRequest } from '@kbn/core-http-server';
+import type { Env } from '@kbn/config';
 import type { CoreRequestHandlerContext } from '@kbn/core-http-request-handler-context-server';
 import {
   CoreElasticsearchRouteHandlerContext,
@@ -34,6 +35,7 @@ export interface CoreRouteHandlerContextParams {
   savedObjects: InternalSavedObjectsServiceStart;
   uiSettings: InternalUiSettingsServiceStart;
   deprecations: InternalDeprecationsServiceStart;
+  env: Pick<Env, 'mode'>;
 }
 
 /**
@@ -46,18 +48,17 @@ export class CoreRouteHandlerContext implements CoreRequestHandlerContext {
   readonly savedObjects: CoreSavedObjectsRouteHandlerContext;
   readonly uiSettings: CoreUiSettingsRouteHandlerContext;
   readonly deprecations: CoreDeprecationsRouteHandlerContext;
+  readonly env: Pick<Env, 'mode'>;
 
-  constructor(coreStart: CoreRouteHandlerContextParams, request: KibanaRequest) {
-    this.elasticsearch = new CoreElasticsearchRouteHandlerContext(coreStart.elasticsearch, request);
-    this.savedObjects = new CoreSavedObjectsRouteHandlerContext(coreStart.savedObjects, request);
-    this.uiSettings = new CoreUiSettingsRouteHandlerContext(
-      coreStart.uiSettings,
-      this.savedObjects
-    );
+  constructor(deps: CoreRouteHandlerContextParams, request: KibanaRequest) {
+    this.elasticsearch = new CoreElasticsearchRouteHandlerContext(deps.elasticsearch, request);
+    this.savedObjects = new CoreSavedObjectsRouteHandlerContext(deps.savedObjects, request);
+    this.uiSettings = new CoreUiSettingsRouteHandlerContext(deps.uiSettings, this.savedObjects);
     this.deprecations = new CoreDeprecationsRouteHandlerContext(
-      coreStart.deprecations,
+      deps.deprecations,
       this.elasticsearch,
       this.savedObjects
     );
+    this.env = { mode: deps.env.mode };
   }
 }

--- a/packages/core/http/core-http-request-handler-context-server-internal/src/core_route_handler_context.ts
+++ b/packages/core/http/core-http-request-handler-context-server-internal/src/core_route_handler_context.ts
@@ -7,7 +7,6 @@
  */
 
 import type { KibanaRequest } from '@kbn/core-http-server';
-import type { Env } from '@kbn/config';
 import type { CoreRequestHandlerContext } from '@kbn/core-http-request-handler-context-server';
 import {
   CoreElasticsearchRouteHandlerContext,
@@ -35,7 +34,6 @@ export interface CoreRouteHandlerContextParams {
   savedObjects: InternalSavedObjectsServiceStart;
   uiSettings: InternalUiSettingsServiceStart;
   deprecations: InternalDeprecationsServiceStart;
-  env: Pick<Env, 'mode'>;
 }
 
 /**
@@ -48,17 +46,18 @@ export class CoreRouteHandlerContext implements CoreRequestHandlerContext {
   readonly savedObjects: CoreSavedObjectsRouteHandlerContext;
   readonly uiSettings: CoreUiSettingsRouteHandlerContext;
   readonly deprecations: CoreDeprecationsRouteHandlerContext;
-  readonly env: Pick<Env, 'mode'>;
 
-  constructor(params: CoreRouteHandlerContextParams, request: KibanaRequest) {
-    this.elasticsearch = new CoreElasticsearchRouteHandlerContext(params.elasticsearch, request);
-    this.savedObjects = new CoreSavedObjectsRouteHandlerContext(params.savedObjects, request);
-    this.uiSettings = new CoreUiSettingsRouteHandlerContext(params.uiSettings, this.savedObjects);
+  constructor(coreStart: CoreRouteHandlerContextParams, request: KibanaRequest) {
+    this.elasticsearch = new CoreElasticsearchRouteHandlerContext(coreStart.elasticsearch, request);
+    this.savedObjects = new CoreSavedObjectsRouteHandlerContext(coreStart.savedObjects, request);
+    this.uiSettings = new CoreUiSettingsRouteHandlerContext(
+      coreStart.uiSettings,
+      this.savedObjects
+    );
     this.deprecations = new CoreDeprecationsRouteHandlerContext(
-      params.deprecations,
+      coreStart.deprecations,
       this.elasticsearch,
       this.savedObjects
     );
-    this.env = { mode: params.env.mode };
   }
 }

--- a/packages/core/http/core-http-request-handler-context-server-internal/src/test_helpers/core_route_handler_context_params.mock.ts
+++ b/packages/core/http/core-http-request-handler-context-server-internal/src/test_helpers/core_route_handler_context_params.mock.ts
@@ -6,6 +6,7 @@
  * Side Public License, v 1.
  */
 
+import type { Env } from '@kbn/config';
 import { elasticsearchServiceMock } from '@kbn/core-elasticsearch-server-mocks';
 import { savedObjectsServiceMock } from '@kbn/core-saved-objects-server-mocks';
 import { uiSettingsServiceMock } from '@kbn/core-ui-settings-server-mocks';
@@ -17,5 +18,6 @@ export const createCoreRouteHandlerContextParamsMock = () => {
     savedObjects: savedObjectsServiceMock.createInternalStartContract(),
     uiSettings: uiSettingsServiceMock.createStartContract(),
     deprecations: deprecationsServiceMock.createInternalStartContract(),
+    env: { mode: { name: 'production', prod: true, dev: false } } as Env,
   };
 };

--- a/packages/core/http/core-http-request-handler-context-server-internal/src/test_helpers/core_route_handler_context_params.mock.ts
+++ b/packages/core/http/core-http-request-handler-context-server-internal/src/test_helpers/core_route_handler_context_params.mock.ts
@@ -6,7 +6,6 @@
  * Side Public License, v 1.
  */
 
-import type { Env } from '@kbn/config';
 import { elasticsearchServiceMock } from '@kbn/core-elasticsearch-server-mocks';
 import { savedObjectsServiceMock } from '@kbn/core-saved-objects-server-mocks';
 import { uiSettingsServiceMock } from '@kbn/core-ui-settings-server-mocks';
@@ -18,6 +17,5 @@ export const createCoreRouteHandlerContextParamsMock = () => {
     savedObjects: savedObjectsServiceMock.createInternalStartContract(),
     uiSettings: uiSettingsServiceMock.createStartContract(),
     deprecations: deprecationsServiceMock.createInternalStartContract(),
-    env: { mode: { name: 'production', prod: true, dev: false } } as Env,
   };
 };

--- a/packages/core/http/core-http-request-handler-context-server-internal/tsconfig.json
+++ b/packages/core/http/core-http-request-handler-context-server-internal/tsconfig.json
@@ -23,6 +23,7 @@
     "@kbn/core-saved-objects-server-mocks",
     "@kbn/core-ui-settings-server-mocks",
     "@kbn/core-deprecations-server-mocks",
+    "@kbn/config",
   ],
   "exclude": [
     "target/**/*",

--- a/packages/core/http/core-http-request-handler-context-server-internal/tsconfig.json
+++ b/packages/core/http/core-http-request-handler-context-server-internal/tsconfig.json
@@ -23,7 +23,6 @@
     "@kbn/core-saved-objects-server-mocks",
     "@kbn/core-ui-settings-server-mocks",
     "@kbn/core-deprecations-server-mocks",
-    "@kbn/config",
   ],
   "exclude": [
     "target/**/*",

--- a/packages/core/http/core-http-request-handler-context-server/src/request_handler_context.ts
+++ b/packages/core/http/core-http-request-handler-context-server/src/request_handler_context.ts
@@ -11,7 +11,6 @@ import type { ElasticsearchRequestHandlerContext } from '@kbn/core-elasticsearch
 import type { SavedObjectsRequestHandlerContext } from '@kbn/core-saved-objects-server';
 import type { DeprecationsRequestHandlerContext } from '@kbn/core-deprecations-server';
 import type { UiSettingsRequestHandlerContext } from '@kbn/core-ui-settings-server';
-import { Env } from '@kbn/config';
 
 /**
  * The `core` context provided to route handler.
@@ -33,7 +32,6 @@ export interface CoreRequestHandlerContext {
   elasticsearch: ElasticsearchRequestHandlerContext;
   uiSettings: UiSettingsRequestHandlerContext;
   deprecations: DeprecationsRequestHandlerContext;
-  env: Pick<Env, 'mode'>;
 }
 
 /**

--- a/packages/core/http/core-http-request-handler-context-server/src/request_handler_context.ts
+++ b/packages/core/http/core-http-request-handler-context-server/src/request_handler_context.ts
@@ -11,6 +11,7 @@ import type { ElasticsearchRequestHandlerContext } from '@kbn/core-elasticsearch
 import type { SavedObjectsRequestHandlerContext } from '@kbn/core-saved-objects-server';
 import type { DeprecationsRequestHandlerContext } from '@kbn/core-deprecations-server';
 import type { UiSettingsRequestHandlerContext } from '@kbn/core-ui-settings-server';
+import { Env } from '@kbn/config';
 
 /**
  * The `core` context provided to route handler.
@@ -24,6 +25,7 @@ import type { UiSettingsRequestHandlerContext } from '@kbn/core-ui-settings-serv
  *      data client which uses the credentials of the incoming request
  *    - {@link IUiSettingsClient | uiSettings.client} - uiSettings client
  *      which uses the credentials of the incoming request
+ *    - {@link Env | Env.mode} - containing the current environment mode
  * @public
  */
 export interface CoreRequestHandlerContext {
@@ -31,6 +33,7 @@ export interface CoreRequestHandlerContext {
   elasticsearch: ElasticsearchRequestHandlerContext;
   uiSettings: UiSettingsRequestHandlerContext;
   deprecations: DeprecationsRequestHandlerContext;
+  env: Pick<Env, 'mode'>;
 }
 
 /**

--- a/packages/core/http/core-http-request-handler-context-server/src/request_handler_context.ts
+++ b/packages/core/http/core-http-request-handler-context-server/src/request_handler_context.ts
@@ -24,7 +24,6 @@ import type { UiSettingsRequestHandlerContext } from '@kbn/core-ui-settings-serv
  *      data client which uses the credentials of the incoming request
  *    - {@link IUiSettingsClient | uiSettings.client} - uiSettings client
  *      which uses the credentials of the incoming request
- *    - {@link Env | Env.mode} - containing the current environment mode
  * @public
  */
 export interface CoreRequestHandlerContext {

--- a/packages/core/http/core-http-request-handler-context-server/tsconfig.json
+++ b/packages/core/http/core-http-request-handler-context-server/tsconfig.json
@@ -15,8 +15,7 @@
     "@kbn/core-elasticsearch-server",
     "@kbn/core-saved-objects-server",
     "@kbn/core-deprecations-server",
-    "@kbn/core-ui-settings-server",
-    "@kbn/config"
+    "@kbn/core-ui-settings-server"
   ],
   "exclude": [
     "target/**/*",

--- a/packages/core/http/core-http-request-handler-context-server/tsconfig.json
+++ b/packages/core/http/core-http-request-handler-context-server/tsconfig.json
@@ -15,7 +15,8 @@
     "@kbn/core-elasticsearch-server",
     "@kbn/core-saved-objects-server",
     "@kbn/core-deprecations-server",
-    "@kbn/core-ui-settings-server"
+    "@kbn/core-ui-settings-server",
+    "@kbn/config"
   ],
   "exclude": [
     "target/**/*",

--- a/packages/core/http/core-http-router-server-internal/src/router.ts
+++ b/packages/core/http/core-http-router-server-internal/src/router.ts
@@ -122,7 +122,9 @@ function validOptions(
 /** @internal */
 interface RouterOptions {
   /** Whether we are running in development */
-  isDev: boolean;
+  isDev?: boolean;
+  /** Whether we are running in a serverless */
+  isServerless?: boolean;
 }
 
 /**
@@ -142,7 +144,7 @@ export class Router<Context extends RequestHandlerContextBase = RequestHandlerCo
     public readonly routerPath: string,
     private readonly log: Logger,
     private readonly enhanceWithContext: ContextEnhancer<any, any, any, any, any>,
-    private readonly options: RouterOptions = { isDev: false }
+    private readonly options: RouterOptions = { isDev: false, isServerless: false }
   ) {
     const buildMethod =
       <Method extends RouteMethod>(method: Method) =>
@@ -216,7 +218,11 @@ export class Router<Context extends RequestHandlerContextBase = RequestHandlerCo
   private versionedRouter: undefined | VersionedRouter<Context> = undefined;
   public get versioned(): VersionedRouter<Context> {
     if (this.versionedRouter === undefined) {
-      this.versionedRouter = CoreVersionedRouter.from({ router: this, isDev: this.options.isDev });
+      this.versionedRouter = CoreVersionedRouter.from({
+        router: this,
+        isDev: this.options.isDev,
+        defaultHandlerResolutionStrategy: this.options.isServerless ? 'newest' : 'oldest',
+      });
     }
     return this.versionedRouter;
   }

--- a/packages/core/http/core-http-router-server-internal/src/versioned_router/core_versioned_route.test.ts
+++ b/packages/core/http/core-http-router-server-internal/src/versioned_router/core_versioned_route.test.ts
@@ -194,7 +194,7 @@ describe('Versioned route', () => {
     );
 
     const kibanaResponse = await handler!(
-      { core: { env: { mode: { dev: true } } } } as any,
+      {} as any,
       createRequest({
         version: '1',
         body: { foo: 1 },

--- a/packages/core/http/core-http-router-server-internal/src/versioned_router/core_versioned_route.ts
+++ b/packages/core/http/core-http-router-server-internal/src/versioned_router/core_versioned_route.ts
@@ -19,6 +19,8 @@ import type {
   VersionedRouteConfig,
   IKibanaResponse,
 } from '@kbn/core-http-server';
+import type { RequestHandlerContext } from '@kbn/core-http-request-handler-context-server';
+import type { CoreRouteHandlerContext } from '@kbn/core-http-request-handler-context-server-internal';
 import type { Mutable } from 'utility-types';
 import type { Method } from './types';
 import type { CoreVersionedRouter } from './core_versioned_router';

--- a/packages/core/http/core-http-router-server-internal/src/versioned_router/core_versioned_route.ts
+++ b/packages/core/http/core-http-router-server-internal/src/versioned_router/core_versioned_route.ts
@@ -19,8 +19,6 @@ import type {
   VersionedRouteConfig,
   IKibanaResponse,
 } from '@kbn/core-http-server';
-import type { RequestHandlerContext } from '@kbn/core-http-request-handler-context-server';
-import type { CoreRouteHandlerContext } from '@kbn/core-http-request-handler-context-server-internal';
 import type { Mutable } from 'utility-types';
 import type { Method } from './types';
 import type { CoreVersionedRouter } from './core_versioned_router';

--- a/packages/core/http/core-http-router-server-internal/src/versioned_router/core_versioned_route.ts
+++ b/packages/core/http/core-http-router-server-internal/src/versioned_router/core_versioned_route.ts
@@ -5,7 +5,6 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
-
 import { schema } from '@kbn/config-schema';
 import { ELASTIC_HTTP_VERSION_HEADER } from '@kbn/core-http-common';
 import type {
@@ -20,7 +19,7 @@ import type {
   IKibanaResponse,
 } from '@kbn/core-http-server';
 import type { Mutable } from 'utility-types';
-import type { Method } from './types';
+import type { HandlerResolutionStrategy, Method } from './types';
 import type { CoreVersionedRouter } from './core_versioned_router';
 
 import { validate } from './validate';
@@ -80,8 +79,8 @@ export class CoreVersionedRoute implements VersionedRoute {
   }
 
   /** This method assumes that one or more versions handlers are registered  */
-  private getDefaultVersion(): ApiVersion {
-    return resolvers[this.router.defaultHandlerResolutionStrategy]([...this.handlers.keys()]);
+  private getDefaultVersion(strategy: HandlerResolutionStrategy = 'oldest'): ApiVersion {
+    return resolvers[strategy]([...this.handlers.keys()]);
   }
 
   private getAvailableVersionsMessage(): string {
@@ -172,9 +171,12 @@ export class CoreVersionedRoute implements VersionedRoute {
     );
   };
 
-  private getVersion(request: KibanaRequest): ApiVersion {
+  private getVersion(
+    request: KibanaRequest,
+    strategy: HandlerResolutionStrategy = 'oldest'
+  ): ApiVersion {
     const versions = request.headers?.[ELASTIC_HTTP_VERSION_HEADER];
-    return Array.isArray(versions) ? versions[0] : versions ?? this.getDefaultVersion();
+    return Array.isArray(versions) ? versions[0] : versions ?? this.getDefaultVersion(strategy);
   }
 
   private validateVersion(version: string) {

--- a/packages/core/http/core-http-router-server-internal/src/versioned_router/core_versioned_route.ts
+++ b/packages/core/http/core-http-router-server-internal/src/versioned_router/core_versioned_route.ts
@@ -19,7 +19,7 @@ import type {
   IKibanaResponse,
 } from '@kbn/core-http-server';
 import type { Mutable } from 'utility-types';
-import type { HandlerResolutionStrategy, Method } from './types';
+import type { Method } from './types';
 import type { CoreVersionedRouter } from './core_versioned_router';
 
 import { validate } from './validate';
@@ -79,8 +79,8 @@ export class CoreVersionedRoute implements VersionedRoute {
   }
 
   /** This method assumes that one or more versions handlers are registered  */
-  private getDefaultVersion(strategy: HandlerResolutionStrategy = 'oldest'): ApiVersion {
-    return resolvers[strategy]([...this.handlers.keys()]);
+  private getDefaultVersion(): ApiVersion {
+    return resolvers[this.router.defaultHandlerResolutionStrategy]([...this.handlers.keys()]);
   }
 
   private getAvailableVersionsMessage(): string {
@@ -171,12 +171,9 @@ export class CoreVersionedRoute implements VersionedRoute {
     );
   };
 
-  private getVersion(
-    request: KibanaRequest,
-    strategy: HandlerResolutionStrategy = 'oldest'
-  ): ApiVersion {
+  private getVersion(request: KibanaRequest): ApiVersion {
     const versions = request.headers?.[ELASTIC_HTTP_VERSION_HEADER];
-    return Array.isArray(versions) ? versions[0] : versions ?? this.getDefaultVersion(strategy);
+    return Array.isArray(versions) ? versions[0] : versions ?? this.getDefaultVersion();
   }
 
   private validateVersion(version: string) {

--- a/packages/core/http/core-http-router-server-internal/src/versioned_router/core_versioned_router.ts
+++ b/packages/core/http/core-http-router-server-internal/src/versioned_router/core_versioned_router.ts
@@ -9,7 +9,7 @@
 import type { IRouter } from '@kbn/core-http-server';
 import type { VersionedRouter, VersionedRoute, VersionedRouteConfig } from '@kbn/core-http-server';
 import { CoreVersionedRoute } from './core_versioned_route';
-import { HandlerResolutionStrategy, Method, VersionedRouterRoute } from './types';
+import type { HandlerResolutionStrategy, Method, VersionedRouterRoute } from './types';
 
 /** @internal */
 interface Dependencies {

--- a/packages/core/http/core-http-server-internal/src/http_service.ts
+++ b/packages/core/http/core-http-server-internal/src/http_service.ts
@@ -129,7 +129,7 @@ export class HttpService
           path,
           this.log,
           prebootServerRequestHandlerContext.createHandler.bind(null, this.coreContext.coreId),
-          { isDev: this.env.mode.dev }
+          { isDev: this.env.mode.dev, isServerless: this.env.cliArgs.serverless }
         );
 
         registerCallback(router);
@@ -175,6 +175,7 @@ export class HttpService
         const enhanceHandler = this.requestHandlerContext!.createHandler.bind(null, pluginId);
         const router = new Router<Context>(path, this.log, enhanceHandler, {
           isDev: this.env.mode.dev,
+          isServerless: this.env.cliArgs.serverless,
         });
         registerRouter(router);
         return router;

--- a/packages/core/root/core-root-server-internal/src/server.ts
+++ b/packages/core/root/core-root-server-internal/src/server.ts
@@ -444,8 +444,7 @@ export class Server {
       coreId,
       'core',
       (context, req) => {
-        const env = { mode: this.env.mode };
-        return new CoreRouteHandlerContext({ ...this.coreStart!, env }, req);
+        return new CoreRouteHandlerContext(this.coreStart!, req);
       }
     );
   }

--- a/packages/core/root/core-root-server-internal/src/server.ts
+++ b/packages/core/root/core-root-server-internal/src/server.ts
@@ -444,7 +444,8 @@ export class Server {
       coreId,
       'core',
       (context, req) => {
-        return new CoreRouteHandlerContext(this.coreStart!, req);
+        const env = { mode: this.env.mode };
+        return new CoreRouteHandlerContext({ ...this.coreStart!, env }, req);
       }
     );
   }

--- a/packages/kbn-config/src/env.ts
+++ b/packages/kbn-config/src/env.ts
@@ -34,6 +34,7 @@ export interface CliArgs {
   disableOptimizer: boolean;
   cache: boolean;
   dist: boolean;
+  serverless?: boolean;
 }
 
 /** @internal */

--- a/src/core/server/index.ts
+++ b/src/core/server/index.ts
@@ -41,6 +41,7 @@ import type {
   KibanaResponseFactory,
   RouteMethod,
   HttpServiceSetup,
+  IRouterWithVersion,
 } from '@kbn/core-http-server';
 import { configSchema as elasticsearchConfigSchema } from '@kbn/core-elasticsearch-server-internal';
 import type { CapabilitiesSetup, CapabilitiesStart } from '@kbn/core-capabilities-server';
@@ -507,12 +508,12 @@ type PublicRequestHandler<
 export type { PublicRequestHandler as RequestHandler, RequestHandler as BaseRequestHandler };
 
 /**
- * Public version of IRouter, default-scoped to {@link RequestHandlerContext}
+ * Public version of IRouter, default-scoped to {@link RequestHandlerContext} and with versioned router.
  * See [@link IRouter}
  * @public
  */
 type PublicRouter<ContextType extends RequestHandlerContext = RequestHandlerContext> =
-  IRouter<ContextType>;
+  IRouterWithVersion<ContextType>;
 
 export type { PublicRouter as IRouter, IRouter as IBaseRouter };
 

--- a/src/core/server/index.ts
+++ b/src/core/server/index.ts
@@ -41,7 +41,6 @@ import type {
   KibanaResponseFactory,
   RouteMethod,
   HttpServiceSetup,
-  IRouterWithVersion,
 } from '@kbn/core-http-server';
 import { configSchema as elasticsearchConfigSchema } from '@kbn/core-elasticsearch-server-internal';
 import type { CapabilitiesSetup, CapabilitiesStart } from '@kbn/core-capabilities-server';
@@ -508,12 +507,12 @@ type PublicRequestHandler<
 export type { PublicRequestHandler as RequestHandler, RequestHandler as BaseRequestHandler };
 
 /**
- * Public version of IRouter, default-scoped to {@link RequestHandlerContext} and with versioned router.
+ * Public version of IRouter, default-scoped to {@link RequestHandlerContext}
  * See [@link IRouter}
  * @public
  */
 type PublicRouter<ContextType extends RequestHandlerContext = RequestHandlerContext> =
-  IRouterWithVersion<ContextType>;
+  IRouter<ContextType>;
 
 export type { PublicRouter as IRouter, IRouter as IBaseRouter };
 

--- a/src/core/server/integration_tests/http/versioned_router.test.ts
+++ b/src/core/server/integration_tests/http/versioned_router.test.ts
@@ -15,6 +15,7 @@ import { contextServiceMock } from '@kbn/core-http-context-server-mocks';
 import { createHttpServer } from '@kbn/core-http-server-mocks';
 import type { HttpService } from '@kbn/core-http-server-internal';
 import type { IRouterWithVersion } from '@kbn/core-http-server';
+import type { CliArgs } from '@kbn/config';
 
 let server: HttpService;
 let logger: ReturnType<typeof loggingSystemMock.create>;
@@ -23,18 +24,26 @@ describe('Routing versioned requests', () => {
   let router: IRouterWithVersion;
   let supertest: Supertest.SuperTest<Supertest.Test>;
 
+  async function setupServer(cliArgs: Partial<CliArgs> = {}) {
+    logger = loggingSystemMock.create();
+    await server?.stop(); // stop the already started server
+    server = createHttpServer({
+      logger,
+      env: createTestEnv({ envOptions: getEnvOptions({ cliArgs }) }),
+    });
+    await server.preboot({ context: contextServiceMock.createPrebootContract() });
+    const { server: innerServer, createRouter } = await server.setup(setupDeps);
+    router = createRouter('/');
+    supertest = Supertest(innerServer.listener);
+  }
+
   const setupDeps = {
     context: contextServiceMock.createSetupContract(),
     executionContext: executionContextServiceMock.createInternalSetupContract(),
   };
 
   beforeEach(async () => {
-    logger = loggingSystemMock.create();
-    server = createHttpServer({ logger });
-    await server.preboot({ context: contextServiceMock.createPrebootContract() });
-    const { server: innerServer, createRouter } = await server.setup(setupDeps);
-    router = createRouter('/');
-    supertest = Supertest(innerServer.listener);
+    await setupServer();
   });
 
   afterEach(async () => {
@@ -191,17 +200,8 @@ describe('Routing versioned requests', () => {
   });
 
   it('does not run response validation in prod', async () => {
-    logger = loggingSystemMock.create();
-    await server.stop(); // stop the already started server
-    server = createHttpServer({
-      logger,
-      env: createTestEnv({ envOptions: getEnvOptions({ cliArgs: { dev: false } }) }),
-    });
-    await server.preboot({ context: contextServiceMock.createPrebootContract() });
-    const { server: innerServer, createRouter } = await server.setup(setupDeps);
+    await setupServer({ dev: false });
 
-    router = createRouter('/');
-    supertest = Supertest(innerServer.listener);
     router.versioned
       .get({ path: '/my-path', access: 'internal' })
       .addVersion(
@@ -236,5 +236,49 @@ describe('Routing versioned requests', () => {
     ).resolves.toEqual(
       expect.objectContaining({ message: expect.stringMatching(/No handlers registered/) })
     );
+  });
+
+  it('resolves the newest handler on serverless', async () => {
+    await setupServer({ serverless: true });
+
+    router.versioned
+      .get({ path: '/my-path', access: 'public' })
+      .addVersion({ validate: false, version: '2023-04-04' }, async (ctx, req, res) => {
+        return res.ok({ body: { v: 'oldest' } });
+      })
+      .addVersion({ validate: false, version: '2024-04-04' }, async (ctx, req, res) => {
+        return res.ok({ body: { v: 'newest' } });
+      });
+
+    await server.start();
+
+    await expect(
+      supertest
+        .get('/my-path')
+        .expect(200)
+        .then(({ body }) => body.v)
+    ).resolves.toEqual('newest');
+  });
+
+  it('resolves the oldest handler on anything other than serverless', async () => {
+    await setupServer({ serverless: false });
+
+    router.versioned
+      .get({ path: '/my-path', access: 'public' })
+      .addVersion({ validate: false, version: '2023-04-04' }, async (ctx, req, res) => {
+        return res.ok({ body: { v: 'oldest' } });
+      })
+      .addVersion({ validate: false, version: '2024-04-04' }, async (ctx, req, res) => {
+        return res.ok({ body: { v: 'newest' } });
+      });
+
+    await server.start();
+
+    await expect(
+      supertest
+        .get('/my-path')
+        .expect(200)
+        .then(({ body }) => body.v)
+    ).resolves.toEqual('oldest');
   });
 });

--- a/src/core/server/integration_tests/http/versioned_router.test.ts
+++ b/src/core/server/integration_tests/http/versioned_router.test.ts
@@ -11,13 +11,39 @@ import { createTestEnv, getEnvOptions } from '@kbn/config-mocks';
 import { schema } from '@kbn/config-schema';
 import { loggingSystemMock } from '@kbn/core-logging-server-mocks';
 import { executionContextServiceMock } from '@kbn/core-execution-context-server-mocks';
+import { deprecationsServiceMock } from '@kbn/core-deprecations-server-mocks';
+import { elasticsearchServiceMock } from '@kbn/core-elasticsearch-server-mocks';
+import { savedObjectsServiceMock } from '@kbn/core-saved-objects-server-mocks';
+import { uiSettingsServiceMock } from '@kbn/core-ui-settings-server-mocks';
+import { CoreRouteHandlerContext } from '@kbn/core-http-request-handler-context-server-internal';
 import { contextServiceMock } from '@kbn/core-http-context-server-mocks';
 import { createHttpServer } from '@kbn/core-http-server-mocks';
 import type { HttpService } from '@kbn/core-http-server-internal';
 import type { IRouterWithVersion } from '@kbn/core-http-server';
+import type { Env } from '@kbn/config';
 
 let server: HttpService;
 let logger: ReturnType<typeof loggingSystemMock.create>;
+
+const getContextSetup = (
+  { env }: { env: Pick<Env, 'mode'> } = {
+    env: { mode: { dev: false, prod: true, name: 'production' } },
+  }
+) =>
+  contextServiceMock.createSetupContract({
+    core: Promise.resolve(
+      new CoreRouteHandlerContext(
+        {
+          deprecations: deprecationsServiceMock.createInternalStartContract(),
+          elasticsearch: elasticsearchServiceMock.createInternalStart(),
+          savedObjects: savedObjectsServiceMock.createInternalStartContract(),
+          uiSettings: uiSettingsServiceMock.createStartContract(),
+          env,
+        },
+        {} as any
+      )
+    ),
+  });
 
 describe('Routing versioned requests', () => {
   let router: IRouterWithVersion;

--- a/src/core/server/integration_tests/http/versioned_router.test.ts
+++ b/src/core/server/integration_tests/http/versioned_router.test.ts
@@ -11,39 +11,13 @@ import { createTestEnv, getEnvOptions } from '@kbn/config-mocks';
 import { schema } from '@kbn/config-schema';
 import { loggingSystemMock } from '@kbn/core-logging-server-mocks';
 import { executionContextServiceMock } from '@kbn/core-execution-context-server-mocks';
-import { deprecationsServiceMock } from '@kbn/core-deprecations-server-mocks';
-import { elasticsearchServiceMock } from '@kbn/core-elasticsearch-server-mocks';
-import { savedObjectsServiceMock } from '@kbn/core-saved-objects-server-mocks';
-import { uiSettingsServiceMock } from '@kbn/core-ui-settings-server-mocks';
-import { CoreRouteHandlerContext } from '@kbn/core-http-request-handler-context-server-internal';
 import { contextServiceMock } from '@kbn/core-http-context-server-mocks';
 import { createHttpServer } from '@kbn/core-http-server-mocks';
 import type { HttpService } from '@kbn/core-http-server-internal';
 import type { IRouterWithVersion } from '@kbn/core-http-server';
-import type { Env } from '@kbn/config';
 
 let server: HttpService;
 let logger: ReturnType<typeof loggingSystemMock.create>;
-
-const getContextSetup = (
-  { env }: { env: Pick<Env, 'mode'> } = {
-    env: { mode: { dev: false, prod: true, name: 'production' } },
-  }
-) =>
-  contextServiceMock.createSetupContract({
-    core: Promise.resolve(
-      new CoreRouteHandlerContext(
-        {
-          deprecations: deprecationsServiceMock.createInternalStartContract(),
-          elasticsearch: elasticsearchServiceMock.createInternalStart(),
-          savedObjects: savedObjectsServiceMock.createInternalStartContract(),
-          uiSettings: uiSettingsServiceMock.createStartContract(),
-          env,
-        },
-        {} as any
-      )
-    ),
-  });
 
 describe('Routing versioned requests', () => {
   let router: IRouterWithVersion;

--- a/src/core/server/mocks.ts
+++ b/src/core/server/mocks.ts
@@ -129,6 +129,13 @@ function createCoreRequestHandlerContextMock() {
     deprecations: {
       client: deprecationsServiceMock.createClient(),
     },
+    env: {
+      mode: {
+        dev: true,
+        prod: false,
+        name: 'development' as const,
+      },
+    },
   };
 }
 

--- a/src/core/server/mocks.ts
+++ b/src/core/server/mocks.ts
@@ -129,13 +129,6 @@ function createCoreRequestHandlerContextMock() {
     deprecations: {
       client: deprecationsServiceMock.createClient(),
     },
-    env: {
-      mode: {
-        dev: true,
-        prod: false,
-        name: 'development' as const,
-      },
-    },
   };
 }
 

--- a/src/core/tsconfig.json
+++ b/src/core/tsconfig.json
@@ -151,7 +151,6 @@
     "@kbn/core-elasticsearch-client-server-internal",
     "@kbn/tooling-log",
     "@kbn/stdio-dev-helpers",
-    "@kbn/core-http-request-handler-context-server-internal",
   ],
   "exclude": [
     "target/**/*",

--- a/src/core/tsconfig.json
+++ b/src/core/tsconfig.json
@@ -151,6 +151,7 @@
     "@kbn/core-elasticsearch-client-server-internal",
     "@kbn/tooling-log",
     "@kbn/stdio-dev-helpers",
+    "@kbn/core-http-request-handler-context-server-internal",
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
## Summary

When launching Kibana in serverless mode (i.e., with the `--serverless=...` flag we need to by default resolve to the newest request handlers, otherwise to the oldest request handler.

The approach taken in this PR is the same as with https://github.com/elastic/kibana/pull/154907.


### Checklist

- [x] Add integration test