### PR TITLE
Exclude metadata fields from schema page

### DIFF
--- a/x-pack/plugins/enterprise_search/server/lib/engines/field_capabilities.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/engines/field_capabilities.test.ts
@@ -72,6 +72,7 @@ describe('engines field_capabilities', () => {
         fields: '*',
         include_unmapped: true,
         index: ['index-001'],
+        filters: '-metadata',
       });
     });
   });

--- a/x-pack/plugins/enterprise_search/server/lib/engines/field_capabilities.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/engines/field_capabilities.ts
@@ -23,6 +23,7 @@ export const fetchEngineFieldCapabilities = async (
     fields: '*',
     include_unmapped: true,
     index: indices,
+    filters: '-metadata',
   });
   const fields = parseFieldsCapabilities(fieldCapabilities);
   return {


### PR DESCRIPTION
Excludes metadata fields from schema page.

Given a mapping with 2 fields:
```
{
  "books": {
    "mappings": {
      "properties": {
        "author": {
          "type": "text",
          "fields": {
            "keyword": {
              "type": "keyword",
              "ignore_above": 256
            }
          }
        },
        "title": {
          "type": "text",
          "fields": {
            "keyword": {
              "type": "keyword",
              "ignore_above": 256
            }
          }
        }
      }
    }
  }
}
```

before:
<img width="1275" alt="Screenshot 2023-04-18 at 14 25 42" src="https://user-images.githubusercontent.com/16032709/232776695-7027d3aa-0d68-4c1e-a787-906a6c6dbff6.png">

after:
<img width="1287" alt="Screenshot 2023-04-18 at 14 13 25" src="https://user-images.githubusercontent.com/16032709/232776508-9a428350-40a8-43c3-a602-94aad49d8d97.png">
