### PR TITLE
[Telemetry] Saved Objects fields cleanup

### DIFF
--- a/src/core/server/integration_tests/saved_objects/migrations/group2/check_registered_types.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/group2/check_registered_types.test.ts
@@ -143,7 +143,7 @@ describe('checking migration metadata changes on all registered SO types', () =>
         "synthetics-privates-locations": "7d032fc788905e32152029ae7ab3d6038c48ae44",
         "tag": "87f21f07df9cc37001b15a26e413c18f50d1fbfe",
         "task": "533ee80c50c47f0505846bfac73fc10962c5bc45",
-        "telemetry": "561b329aaed3c15b91aaf2075645be3097247612",
+        "telemetry": "3b3b89cf411a2a2e60487cef6ccdbc5df691aeb9",
         "ui-metric": "410a8ad28e0f44b161c960ff0ce950c712b17c52",
         "upgrade-assistant-ml-upgrade-operation": "d8816e5ce32649e7a3a43e2c406c632319ff84bb",
         "upgrade-assistant-reindex-operation": "09ac8ed9c9acf7e8ece8eafe47d7019ea1472144",

--- a/src/plugins/telemetry/server/saved_objects/register_telemetry_saved_object.ts
+++ b/src/plugins/telemetry/server/saved_objects/register_telemetry_saved_object.ts
@@ -17,32 +17,8 @@ export function registerTelemetrySavedObject(
     hidden: true,
     namespaceType: 'agnostic',
     mappings: {
-      properties: {
-        enabled: {
-          type: 'boolean',
-        },
-        sendUsageFrom: {
-          type: 'keyword',
-        },
-        lastReported: {
-          type: 'date',
-        },
-        lastVersionChecked: {
-          type: 'keyword',
-        },
-        userHasSeenNotice: {
-          type: 'boolean',
-        },
-        reportFailureCount: {
-          type: 'integer',
-        },
-        reportFailureVersion: {
-          type: 'keyword',
-        },
-        allowChangingOptInStatus: {
-          type: 'boolean',
-        },
-      },
+      dynamic: false,
+      properties: {},
     },
   });
 }


### PR DESCRIPTION
## Summary

We always fetch the entire document, getting it by ID. We don't need the fields to be in the mappings.

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
