### PR TITLE
[Fleet] Fix package policy validation for select variables

### DIFF
--- a/x-pack/plugins/fleet/common/services/validate_package_policy.test.ts
+++ b/x-pack/plugins/fleet/common/services/validate_package_policy.test.ts
@@ -968,6 +968,27 @@ describe('Fleet - validatePackagePolicyConfig', () => {
       expect(res).toEqual(['Invalid value for select type']);
     });
 
+    it('should return an error message if the value is an empty string', () => {
+      const res = validatePackagePolicyConfig(
+        {
+          type: 'select',
+          value: '',
+        },
+        {
+          name: 'myvariable',
+          type: 'select',
+          options: [
+            { value: 'a', text: 'A' },
+            { value: 'b', text: 'B' },
+          ],
+        },
+        'myvariable',
+        safeLoad
+      );
+
+      expect(res).toEqual(['Invalid value for select type']);
+    });
+
     it('should accept a select with a valid value', () => {
       const res = validatePackagePolicyConfig(
         {

--- a/x-pack/plugins/fleet/common/services/validate_package_policy.ts
+++ b/x-pack/plugins/fleet/common/services/validate_package_policy.ts
@@ -337,7 +337,7 @@ export const validatePackagePolicyConfig = (
     }
   }
 
-  if (varDef.type === 'select' && parsedValue) {
+  if (varDef.type === 'select' && parsedValue !== undefined) {
     if (!varDef.options?.map((o) => o.value).includes(parsedValue)) {
       errors.push(
         i18n.translate('xpack.fleet.packagePolicyValidation.invalidSelectValueErrorMessage', {


### PR DESCRIPTION
## Summary

There is a bug in package policy validation when the variable is of type `select`: empty strings are not correctly rejected as invalid values. This PR fixes this.

Closes https://github.com/elastic/kibana/issues/154905

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
