### PR TITLE
[Enterprise Search] Clarify timezone use for cron schedules

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_scheduling.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_scheduling.tsx
@@ -156,7 +156,7 @@ export const ConnectorSchedulingComponent: React.FC = () => {
                 'xpack.enterpriseSearch.content.indices.connectorScheduling.configured.description',
                 {
                   defaultMessage:
-                    'Your connector is configured and deployed. Configure a one-time sync by clicking the Sync button, or enable a recurring sync schedule. ',
+                    'Your connector is configured and deployed. Configure a one-time sync by clicking the Sync button, or enable a recurring sync schedule. The connector uses UTC as its timezone. ',
                 }
               )}
             </EuiText>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/automatic_crawl_scheduler/automatic_crawl_scheduler.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/automatic_crawl_scheduler/automatic_crawl_scheduler.tsx
@@ -108,7 +108,8 @@ export const AutomaticCrawlScheduler: React.FC = () => {
                       {i18n.translate(
                         'xpack.enterpriseSearch.crawler.automaticCrawlSchedule.cronSchedulingDescription',
                         {
-                          defaultMessage: 'Define the frequency and time for scheduled crawls',
+                          defaultMessage:
+                            'Define the frequency and time for scheduled crawls. The crawler uses UTC as its timezone.',
                         }
                       )}
                     </EuiText>


### PR DESCRIPTION
## Summary

This updates the scheduling for the Elastic Web Crawler and Connectors to be more specific about timezones.