### PR TITLE
[Enterprise Search] Fix Connector scheduling show week information correctly

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/shared/cron_editor/enterprise_search_cron_editor.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/cron_editor/enterprise_search_cron_editor.tsx
@@ -66,10 +66,10 @@ function cronToFrequency(cron: string): Frequency {
   if (fields[3] === '*') {
     return 'DAY';
   }
-  if (fields[4] === '?') {
+  if (fields[4] === '*') {
     return 'WEEK';
   }
-  if (fields[4] === '*') {
+  if (fields[4] === '?') {
     return 'MONTH';
   }
   return 'YEAR';


### PR DESCRIPTION
## Summary

https://user-images.githubusercontent.com/1410658/232858008-ee843f6e-dfb4-40f1-b33f-66fd90bc8d2e.mov

When weekly scheduling selected we were showing the wrong information. This fixes cron string parsing and shows correct information.

## Release note
Fixes connector scheduling now showing correct setting when weekly intervals selected.


### Checklist

Delete any items that are not applicable to this PR.


- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->