### PR TITLE
Update references to EUI team name

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1221,8 +1221,8 @@ x-pack/test/threat_intelligence_cypress @elastic/protections-experience
 # Logstash
 #CC# /x-pack/plugins/logstash/ @elastic/logstash
 
-# EUI design
-/src/plugins/kibana_react/public/page_template/ @elastic/eui-design @elastic/appex-sharedux
+# EUI team
+/src/plugins/kibana_react/public/page_template/ @elastic/eui-team @elastic/appex-sharedux
 
 # Landing page for guided onboarding in Home plugin
 /src/plugins/home/public/application/components/guided_onboarding @elastic/platform-onboarding


### PR DESCRIPTION
## Summary

The EUI team recently changed its GitHub team name to @elastic/eui-team. We're updating all references in Kibana's CODEOWNERS as a result.

### Checklist

N/A, CODEOWNERS change only