### PR TITLE
Revert "Use unsigned_long for field indexed_document_volume"

### DIFF
--- a/x-pack/plugins/enterprise_search/server/index_management/setup_indices.test.ts
+++ b/x-pack/plugins/enterprise_search/server/index_management/setup_indices.test.ts
@@ -214,7 +214,7 @@ describe('Setup Indices', () => {
       deleted_document_count: { type: 'integer' },
       error: { type: 'keyword' },
       indexed_document_count: { type: 'integer' },
-      indexed_document_volume: { type: 'unsigned_long' },
+      indexed_document_volume: { type: 'integer' },
       last_seen: { type: 'date' },
       metadata: { type: 'object' },
       started_at: { type: 'date' },

--- a/x-pack/plugins/enterprise_search/server/index_management/setup_indices.ts
+++ b/x-pack/plugins/enterprise_search/server/index_management/setup_indices.ts
@@ -238,7 +238,7 @@ const indices: IndexDefinition[] = [
         deleted_document_count: { type: 'integer' },
         error: { type: 'keyword' },
         indexed_document_count: { type: 'integer' },
-        indexed_document_volume: { type: 'unsigned_long' },
+        indexed_document_volume: { type: 'integer' },
         last_seen: { type: 'date' },
         metadata: { type: 'object' },
         started_at: { type: 'date' },


### PR DESCRIPTION
Reverts elastic/kibana#155014

See: https://github.com/elastic/connectors-python/issues/735#issuecomment-1513725750