### PR TITLE
[ML] Adds search links for AIOps Labs pages

### DIFF
--- a/x-pack/plugins/ml/public/register_helper/register_search_links/search_deep_links.ts
+++ b/x-pack/plugins/ml/public/register_helper/register_search_links/search_deep_links.ts
@@ -34,28 +34,36 @@ const DATA_FRAME_ANALYTICS_DEEP_LINK: AppDeepLink = {
   path: `/${ML_PAGES.DATA_FRAME_ANALYTICS_JOBS_MANAGE}`,
 };
 
-const EXPLAIN_LOG_RATE_SPIKES_DEEP_LINK: AppDeepLink = {
-  id: 'explainLogRateSpikesDeepLink',
-  title: i18n.translate('xpack.ml.deepLink.explainLogRateSpikes', {
-    defaultMessage: 'Explain Log Rate Spikes',
+const AIOPS_DEEP_LINK: AppDeepLink = {
+  id: 'aiOpsDeepLink',
+  title: i18n.translate('xpack.ml.deepLink.aiOps', {
+    defaultMessage: 'AIOps',
   }),
+  // Default to the index select page for the explain log rate spikes since we don't have an AIops overview page
   path: `/${ML_PAGES.AIOPS_EXPLAIN_LOG_RATE_SPIKES_INDEX_SELECT}`,
-};
-
-const LOG_PATTERN_ANALYSIS_DEEP_LINK: AppDeepLink = {
-  id: 'logPatternAnalysisDeepLink',
-  title: i18n.translate('xpack.ml.deepLink.logPatternAnalysis', {
-    defaultMessage: 'Log Pattern Analysis',
-  }),
-  path: `/${ML_PAGES.AIOPS_LOG_CATEGORIZATION_INDEX_SELECT}`,
-};
-
-const CHANGE_POINT_DETECTION_DEEP_LINK: AppDeepLink = {
-  id: 'changePointDetectionsDeepLink',
-  title: i18n.translate('xpack.ml.deepLink.changePointDetection', {
-    defaultMessage: 'Change Point Detection',
-  }),
-  path: `/${ML_PAGES.AIOPS_CHANGE_POINT_DETECTION_INDEX_SELECT}`,
+  deepLinks: [
+    {
+      id: 'explainLogRateSpikesDeepLink',
+      title: i18n.translate('xpack.ml.deepLink.explainLogRateSpikes', {
+        defaultMessage: 'Explain Log Rate Spikes',
+      }),
+      path: `/${ML_PAGES.AIOPS_EXPLAIN_LOG_RATE_SPIKES_INDEX_SELECT}`,
+    },
+    {
+      id: 'logPatternAnalysisDeepLink',
+      title: i18n.translate('xpack.ml.deepLink.logPatternAnalysis', {
+        defaultMessage: 'Log Pattern Analysis',
+      }),
+      path: `/${ML_PAGES.AIOPS_LOG_CATEGORIZATION_INDEX_SELECT}`,
+    },
+    {
+      id: 'changePointDetectionsDeepLink',
+      title: i18n.translate('xpack.ml.deepLink.changePointDetection', {
+        defaultMessage: 'Change Point Detection',
+      }),
+      path: `/${ML_PAGES.AIOPS_CHANGE_POINT_DETECTION_INDEX_SELECT}`,
+    },
+  ],
 };
 
 const MODEL_MANAGEMENT_DEEP_LINK: AppDeepLink = {
@@ -145,9 +153,7 @@ export function getDeepLinks(isFullLicense: boolean) {
       DATA_FRAME_ANALYTICS_DEEP_LINK,
       MODEL_MANAGEMENT_DEEP_LINK,
       SETTINGS_DEEP_LINK,
-      EXPLAIN_LOG_RATE_SPIKES_DEEP_LINK,
-      LOG_PATTERN_ANALYSIS_DEEP_LINK,
-      CHANGE_POINT_DETECTION_DEEP_LINK
+      AIOPS_DEEP_LINK
     );
   }
 

--- a/x-pack/plugins/ml/public/register_helper/register_search_links/search_deep_links.ts
+++ b/x-pack/plugins/ml/public/register_helper/register_search_links/search_deep_links.ts
@@ -34,6 +34,30 @@ const DATA_FRAME_ANALYTICS_DEEP_LINK: AppDeepLink = {
   path: `/${ML_PAGES.DATA_FRAME_ANALYTICS_JOBS_MANAGE}`,
 };
 
+const EXPLAIN_LOG_RATE_SPIKES_DEEP_LINK: AppDeepLink = {
+  id: 'explainLogRateSpikesDeepLink',
+  title: i18n.translate('xpack.ml.deepLink.explainLogRateSpikes', {
+    defaultMessage: 'Explain Log Rate Spikes',
+  }),
+  path: `/${ML_PAGES.AIOPS_EXPLAIN_LOG_RATE_SPIKES_INDEX_SELECT}`,
+};
+
+const LOG_PATTERN_ANALYSIS_DEEP_LINK: AppDeepLink = {
+  id: 'logPatternAnalysisDeepLink',
+  title: i18n.translate('xpack.ml.deepLink.logPatternAnalysis', {
+    defaultMessage: 'Log Pattern Analysis',
+  }),
+  path: `/${ML_PAGES.AIOPS_LOG_CATEGORIZATION_INDEX_SELECT}`,
+};
+
+const CHANGE_POINT_DETECTION_DEEP_LINK: AppDeepLink = {
+  id: 'changePointDetectionsDeepLink',
+  title: i18n.translate('xpack.ml.deepLink.changePointDetection', {
+    defaultMessage: 'Change Point Detection',
+  }),
+  path: `/${ML_PAGES.AIOPS_CHANGE_POINT_DETECTION_INDEX_SELECT}`,
+};
+
 const MODEL_MANAGEMENT_DEEP_LINK: AppDeepLink = {
   id: 'mlModelManagementDeepLink',
   title: i18n.translate('xpack.ml.deepLink.trainedModels', {
@@ -120,7 +144,10 @@ export function getDeepLinks(isFullLicense: boolean) {
       ANOMALY_DETECTION_DEEP_LINK,
       DATA_FRAME_ANALYTICS_DEEP_LINK,
       MODEL_MANAGEMENT_DEEP_LINK,
-      SETTINGS_DEEP_LINK
+      SETTINGS_DEEP_LINK,
+      EXPLAIN_LOG_RATE_SPIKES_DEEP_LINK,
+      LOG_PATTERN_ANALYSIS_DEEP_LINK,
+      CHANGE_POINT_DETECTION_DEEP_LINK
     );
   }
 

--- a/x-pack/plugins/ml/public/register_helper/register_search_links/search_deep_links.ts
+++ b/x-pack/plugins/ml/public/register_helper/register_search_links/search_deep_links.ts
@@ -68,26 +68,27 @@ const AIOPS_DEEP_LINK: AppDeepLink = {
 
 const MODEL_MANAGEMENT_DEEP_LINK: AppDeepLink = {
   id: 'mlModelManagementDeepLink',
-  title: i18n.translate('xpack.ml.deepLink.trainedModels', {
-    defaultMessage: 'Trained Models',
+  title: i18n.translate('xpack.ml.deepLink.modelManagement', {
+    defaultMessage: 'Model Management',
   }),
   path: `/${ML_PAGES.TRAINED_MODELS_MANAGE}`,
   deepLinks: [
     {
       id: 'mlNodesOverviewDeepLink',
-      title: i18n.translate('xpack.ml.deepLink.modelManagement', {
-        defaultMessage: 'Model Management',
+      title: i18n.translate('xpack.ml.deepLink.trainedModels', {
+        defaultMessage: 'Trained Models',
       }),
       path: `/${ML_PAGES.TRAINED_MODELS_MANAGE}`,
     },
-    {
-      id: 'mlMemoryUsageDeepLink',
-      title: i18n.translate('xpack.ml.deepLink.memoryUsage', {
-        defaultMessage: 'Memory usage',
-      }),
-      path: `/${ML_PAGES.MEMORY_USAGE}`,
-    },
   ],
+};
+
+const MEMORY_USAGE_DEEP_LINK: AppDeepLink = {
+  id: 'mlMemoryUsageDeepLink',
+  title: i18n.translate('xpack.ml.deepLink.memoryUsage', {
+    defaultMessage: 'Memory Usage',
+  }),
+  path: `/${ML_PAGES.MEMORY_USAGE}`,
 };
 
 const DATA_VISUALIZER_DEEP_LINK: AppDeepLink = {
@@ -139,6 +140,14 @@ const SETTINGS_DEEP_LINK: AppDeepLink = {
   ],
 };
 
+const NOTIFICATIONS_DEEP_LINK: AppDeepLink = {
+  id: 'mlNotificationsDeepLink',
+  title: i18n.translate('xpack.ml.deepLink.notifications', {
+    defaultMessage: 'Notifications',
+  }),
+  path: `/${ML_PAGES.NOTIFICATIONS}`,
+};
+
 export function getDeepLinks(isFullLicense: boolean) {
   const deepLinks: AppDeepLink[] = [
     DATA_VISUALIZER_DEEP_LINK,
@@ -152,8 +161,10 @@ export function getDeepLinks(isFullLicense: boolean) {
       ANOMALY_DETECTION_DEEP_LINK,
       DATA_FRAME_ANALYTICS_DEEP_LINK,
       MODEL_MANAGEMENT_DEEP_LINK,
+      MEMORY_USAGE_DEEP_LINK,
       SETTINGS_DEEP_LINK,
-      AIOPS_DEEP_LINK
+      AIOPS_DEEP_LINK,
+      NOTIFICATIONS_DEEP_LINK
     );
   }
 


### PR DESCRIPTION
## Summary

Related meta issue: https://github.com/elastic/kibana/issues/146065

Added deep search links into the top search bar for the AIOps Labs pages - change point detection, log pattern analysis, and explain log rate spikes

<img width="759" alt="image" src="https://user-images.githubusercontent.com/6446462/233172173-70a6283a-603f-4793-993e-e67c38214508.png">

Created deep link for 'Notifications'.

<img width="819" alt="image" src="https://user-images.githubusercontent.com/6446462/233172258-8117011e-227b-4ba1-8497-c59510eaa62f.png">

Moved 'Memory Usage' deep link out of model management into its own link.

<img width="777" alt="image" src="https://user-images.githubusercontent.com/6446462/233172425-48ac1dd1-2b1c-4ebf-a80a-ba7328bf34c5.png">

<img width="697" alt="image" src="https://user-images.githubusercontent.com/6446462/233172483-b1405f39-01a3-48f4-8cbe-faba00773b02.png">





### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


