### PR TITLE
[DOCS] Remove or move book-scoped attributes

### DIFF
--- a/docs/developer/contributing/development-functional-tests.asciidoc
+++ b/docs/developer/contributing/development-functional-tests.asciidoc
@@ -81,7 +81,7 @@ export TEST_BROWSER_HEADLESS=1
 export TEST_THROTTLE_NETWORK=1
 ----------
 
-** When running against a Cloud deployment, some tests are not applicable. To skip tests that do not apply, use --exclude-tag.  An example shell file can be found at: {blob}test/scripts/jenkins_cloud.sh[test/scripts/jenkins_cloud.sh]
+** When running against a Cloud deployment, some tests are not applicable. To skip tests that do not apply, use --exclude-tag.  An example shell file can be found at: {kibana-blob}test/scripts/jenkins_cloud.sh[test/scripts/jenkins_cloud.sh]
 +
 ["source", "shell"]
 ----------
@@ -118,7 +118,7 @@ The tests are written in https://mochajs.org[mocha] using https://github.com/ela
 
 We use https://www.w3.org/TR/webdriver1/[WebDriver Protocol] to run tests in both Chrome and Firefox with the help of https://sites.google.com/a/chromium.org/chromedriver/[chromedriver] and https://firefox-source-docs.mozilla.org/testing/geckodriver/[geckodriver]. When the `FunctionalTestRunner` launches, remote service creates a new webdriver session, which starts the driver and a stripped-down browser instance. We use `browser` service and `webElementWrapper` class to wrap up https://seleniumhq.github.io/selenium/docs/api/javascript/module/selenium-webdriver/[Webdriver API].
 
-The `FunctionalTestRunner` automatically transpiles functional tests using babel, so that tests can use the same ECMAScript features that {kib} source code uses. See {blob}style_guides/js_style_guide.md[style_guides/js_style_guide.md].
+The `FunctionalTestRunner` automatically transpiles functional tests using babel, so that tests can use the same ECMAScript features that {kib} source code uses. See {kibana-blob}style_guides/js_style_guide.md[style_guides/js_style_guide.md].
 
 [discrete]
 ==== Definitions
@@ -270,7 +270,7 @@ The first and only argument to all providers is a Provider API Object. This obje
 Within config files the API has the following properties
 
 [horizontal]
-`log`::: An instance of the {blob}packages/kbn-dev-utils/src/tooling_log/tooling_log.js[`ToolingLog`] that is ready for use
+`log`::: An instance of the {kibana-blob}packages/kbn-dev-utils/src/tooling_log/tooling_log.js[`ToolingLog`] that is ready for use
 `readConfigFile(path)`::: Returns a promise that will resolve to a Config instance that provides the values from the config file at `path`
 
 Within service and PageObject Providers the API is:
@@ -293,17 +293,17 @@ Within a test Provider the API is exactly the same as the service providers API 
 The `FunctionalTestRunner` comes with three built-in services:
 
 **config:**:::
-* Source: {blob}src/functional_test_runner/lib/config/config.ts[src/functional_test_runner/lib/config/config.ts]
-* Schema: {blob}src/functional_test_runner/lib/config/schema.ts[src/functional_test_runner/lib/config/schema.ts]
+* Source: {kibana-blob}src/functional_test_runner/lib/config/config.ts[src/functional_test_runner/lib/config/config.ts]
+* Schema: {kibana-blob}src/functional_test_runner/lib/config/schema.ts[src/functional_test_runner/lib/config/schema.ts]
 * Use `config.get(path)` to read any value from the config file
 
 **log:**:::
-* Source: {blob}packages/kbn-dev-utils/src/tooling_log/tooling_log.js[packages/kbn-dev-utils/src/tooling_log/tooling_log.js]
+* Source: {kibana-blob}packages/kbn-dev-utils/src/tooling_log/tooling_log.js[packages/kbn-dev-utils/src/tooling_log/tooling_log.js]
 * `ToolingLog` instances are readable streams. The instance provided by this service is automatically piped to stdout by the `FunctionalTestRunner` CLI
 * `log.verbose()`, `log.debug()`, `log.info()`, `log.warning()` all work just like console.log but produce more organized output
 
 **lifecycle:**:::
-* Source: {blob}src/functional_test_runner/lib/lifecycle.ts[src/functional_test_runner/lib/lifecycle.ts]
+* Source: {kibana-blob}src/functional_test_runner/lib/lifecycle.ts[src/functional_test_runner/lib/lifecycle.ts]
 * Designed primary for use in services
 * Exposes lifecycle events for basic coordination. Handlers can return a promise and resolve/fail asynchronously
 * Phases include: `beforeLoadTests`, `beforeTests`, `beforeEachTest`, `cleanup`
@@ -314,14 +314,14 @@ The `FunctionalTestRunner` comes with three built-in services:
 The {kib} functional tests define the vast majority of the actual functionality used by tests.
 
 **browser**:::
-* Source: {blob}test/functional/services/browser.ts[test/functional/services/browser.ts]
+* Source: {kibana-blob}test/functional/services/browser.ts[test/functional/services/browser.ts]
 * Higher level wrapper for `remote` service, which exposes available browser actions
 * Popular methods:
 ** `browser.getWindowSize()`
 ** `browser.refresh()`
 
 **testSubjects:**:::
-* Source: {blob}test/functional/services/test_subjects.ts[test/functional/services/test_subjects.ts]
+* Source: {kibana-blob}test/functional/services/test_subjects.ts[test/functional/services/test_subjects.ts]
 * Test subjects are elements that are tagged specifically for selecting from tests
 * Use `testSubjects` over CSS selectors when possible
 * Usage:
@@ -346,21 +346,21 @@ await testSubjects.click(‘containerButton’);
 ** `testSubjects.click(testSubjectSelector)` - Click a test subject in the page; throw if it can't be found after some time
 
 **find:**:::
-* Source: {blob}test/functional/services/find.ts[test/functional/services/find.ts]
+* Source: {kibana-blob}test/functional/services/find.ts[test/functional/services/find.ts]
 * Helpers for `remote.findBy*` methods that log and manage timeouts
 * Popular methods:
 ** `find.byCssSelector()`
 ** `find.allByCssSelector()`
 
 **retry:**:::
-* Source: {blob}test/common/services/retry/retry.ts[test/common/services/retry/retry.ts]
+* Source: {kibana-blob}test/common/services/retry/retry.ts[test/common/services/retry/retry.ts]
 * Helpers for retrying operations
 * Popular methods:
 ** `retry.try(fn, onFailureBlock)` - Execute `fn` in a loop until it succeeds or the default timeout elapses. The optional `onFailureBlock` is executed before each retry attempt.
 ** `retry.tryForTime(ms, fn, onFailureBlock)` - Execute `fn` in a loop until it succeeds or `ms` milliseconds elapses. The optional `onFailureBlock` is executed before each retry attempt.
 
 **kibanaServer:**:::
-* Source: {blob}test/common/services/kibana_server/kibana_server.js[test/common/services/kibana_server/kibana_server.js]
+* Source: {kibana-blob}test/common/services/kibana_server/kibana_server.js[test/common/services/kibana_server/kibana_server.js]
 * Helpers for interacting with {kib}'s server
 * Commonly used methods:
 ** `kibanaServer.uiSettings.update()`
@@ -368,23 +368,23 @@ await testSubjects.click(‘containerButton’);
 ** `kibanaServer.status.getOverallState()`
 
 **esArchiver:**:::
-* Source: {blob}test/common/services/es_archiver.ts[test/common/services/es_archiver.ts]
+* Source: {kibana-blob}test/common/services/es_archiver.ts[test/common/services/es_archiver.ts]
 * Load/unload archives created with the `esArchiver`
 * Popular methods:
 ** `esArchiver.load(path)`
 ** `esArchiver.loadIfNeeded(path)`
 ** `esArchiver.unload(path)`
 
-Full list of services that are used in functional tests can be found here: {blob}test/functional/services[test/functional/services]
+Full list of services that are used in functional tests can be found here: {kibana-blob}test/functional/services[test/functional/services]
 
 
 **Low-level utilities:**:::
 * es
-** Source: {blob}test/common/services/es.ts[test/common/services/es.ts]
+** Source: {kibana-blob}test/common/services/es.ts[test/common/services/es.ts]
 ** {es} client
 ** Higher level options: `kibanaServer.uiSettings` or `esArchiver`
 * remote
-** Source: {blob}test/functional/services/remote/remote.ts[test/functional/services/remote/remote.ts]
+** Source: {kibana-blob}test/functional/services/remote/remote.ts[test/functional/services/remote/remote.ts]
 ** Instance of https://seleniumhq.github.io/selenium/docs/api/javascript/module/selenium-webdriver/index_exports_WebDriver.html[WebDriver] class
 ** Responsible for all communication with the browser
 ** To perform browser actions, use `remote` service

--- a/docs/developer/plugin/external-plugin-functional-tests.asciidoc
+++ b/docs/developer/plugin/external-plugin-functional-tests.asciidoc
@@ -64,7 +64,7 @@ export default async function ({ readConfigFile }) {
     }
 
     // more settings, like timeouts, mochaOpts, etc are
-    // defined in the config schema. See {blob}src/functional_test_runner/lib/config/schema.js[src/functional_test_runner/lib/config/schema.js]
+    // defined in the config schema. See {kibana-blob}src/functional_test_runner/lib/config/schema.js[src/functional_test_runner/lib/config/schema.js]
   };
 }
 

--- a/docs/developer/plugin/external-plugin-localization.asciidoc
+++ b/docs/developer/plugin/external-plugin-localization.asciidoc
@@ -47,9 +47,9 @@ To use {kib} i18n tooling, create a `.i18nrc.json` file with the following confi
 }
 -----------
 
-An example {kib} `.i18nrc.json` is {blob}.i18nrc.json[here].
+An example {kib} `.i18nrc.json` is {kibana-blob}.i18nrc.json[here].
 
-Full documentation about i18n tooling is {blob}src/dev/i18n/README.md[here].
+Full documentation about i18n tooling is {kibana-blob}src/dev/i18n/README.md[here].
 
 [discrete]
 === Extracting default messages

--- a/docs/gs-index.asciidoc
+++ b/docs/gs-index.asciidoc
@@ -9,10 +9,6 @@ release-state can be: released | prerelease | unreleased
 :major-version:  5.4
 :branch:         5.4
 
-:docker-image:   docker.elastic.co/kibana/kibana:{version}
-:es-ref:         https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/
-:security:       https://www.elastic.co/community/security/
-
 include::{docs-root}/shared/attributes.asciidoc[]
 
 include::introduction.asciidoc[]

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,21 +1,9 @@
 [[kibana-guide]]
 = Kibana Guide
 
-:include-xpack:  true
-:lang:           en
 :kib-repo-dir:   {kibana-root}/docs
 
 include::{docs-root}/shared/versions/stack/{source_branch}.asciidoc[]
-
-:docker-repo:     docker.elastic.co/kibana/kibana
-:docker-image:    {docker-repo}:{version}
-:es-docker-repo:  docker.elastic.co/elasticsearch/elasticsearch
-:es-docker-image: {es-docker-repo}:{version}
-:security-ref:    https://www.elastic.co/community/security/
-:Data-source:     Data view
-:data-source:     data view
-:data-sources:    data views
-:a-data-source:   a data view
 
 include::{docs-root}/shared/attributes.asciidoc[]
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -7,8 +7,6 @@ include::{docs-root}/shared/versions/stack/{source_branch}.asciidoc[]
 
 include::{docs-root}/shared/attributes.asciidoc[]
 
-:blob: {kib-repo}blob/{branch}/
-
 include::user/index.asciidoc[]
 
 include::accessibility.asciidoc[]

--- a/docs/maps/connect-to-ems.asciidoc
+++ b/docs/maps/connect-to-ems.asciidoc
@@ -1,6 +1,8 @@
-[role="xpack"]
 [[maps-connect-to-ems]]
 == Connect to Elastic Maps Service
+
+:ems-docker-repo: docker.elastic.co/elastic-maps-service/elastic-maps-server-ubi8
+:ems-docker-image: {ems-docker-repo}:{version}
 
 https://www.elastic.co/elastic-maps-service[Elastic Maps Service (EMS)] is a service that hosts
 tile layers and vector shapes of administrative boundaries.

--- a/docs/maps/index.asciidoc
+++ b/docs/maps/index.asciidoc
@@ -1,7 +1,3 @@
-:ems-docker-repo: docker.elastic.co/elastic-maps-service/elastic-maps-server-ubi8
-:ems-docker-image: {ems-docker-repo}:{version}
-
-[role="xpack"]
 [[maps]]
 = Maps
 

--- a/docs/setup/docker.asciidoc
+++ b/docs/setup/docker.asciidoc
@@ -4,6 +4,11 @@
 <titleabbrev>Install with Docker</titleabbrev>
 ++++
 
+:docker-repo:     docker.elastic.co/kibana/kibana
+:docker-image:    {docker-repo}:{version}
+:es-docker-repo:  docker.elastic.co/elasticsearch/elasticsearch
+:es-docker-image: {es-docker-repo}:{version}
+
 Docker images for {kib} are available from the Elastic Docker registry. The
 base image is https://hub.docker.com/_/ubuntu[ubuntu:20.04].
 


### PR DESCRIPTION
## Summary

This PR removes unused attributes from the documentation. It also moves some attributes that are used only in a single page into that page in preparation for the new documentation system. 

The `blob` attribute is replaced by the global `kibana-blob` attribute, which was created in  https://github.com/elastic/docs/pull/2666.


<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->