### PR TITLE
[codeowners] add appex-qa for ftr-related packages

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -23,7 +23,7 @@ packages/kbn-alerts-as-data-utils @elastic/response-ops
 x-pack/test/alerting_api_integration/common/plugins/alerts_restricted @elastic/response-ops
 packages/kbn-alerts-ui-shared @elastic/response-ops
 packages/kbn-ambient-common-types @elastic/kibana-operations
-packages/kbn-ambient-ftr-types @elastic/kibana-operations
+packages/kbn-ambient-ftr-types @elastic/kibana-operations @elastic/appex-qa
 packages/kbn-ambient-storybook-types @elastic/kibana-operations
 packages/kbn-ambient-ui-types @elastic/kibana-operations
 packages/kbn-analytics @elastic/kibana-core
@@ -331,7 +331,7 @@ x-pack/examples/embedded_lens_example @elastic/kibana-visualizations
 x-pack/plugins/encrypted_saved_objects @elastic/kibana-security
 x-pack/plugins/enterprise_search @elastic/enterprise-search-frontend
 packages/kbn-es @elastic/kibana-operations
-packages/kbn-es-archiver @elastic/kibana-operations
+packages/kbn-es-archiver @elastic/kibana-operations @elastic/appex-qa
 packages/kbn-es-errors @elastic/kibana-core
 packages/kbn-es-query @elastic/kibana-data-discovery
 packages/kbn-es-types @elastic/kibana-core @elastic/apm-ui
@@ -346,7 +346,7 @@ src/plugins/event_annotation @elastic/kibana-visualizations
 x-pack/test/plugin_api_integration/plugins/event_log @elastic/response-ops
 x-pack/plugins/event_log @elastic/response-ops
 packages/kbn-expandable-flyout @elastic/security-threat-hunting-investigations
-packages/kbn-expect @elastic/kibana-operations
+packages/kbn-expect @elastic/kibana-operations @elastic/appex-qa
 x-pack/examples/exploratory_view_example @elastic/uptime
 x-pack/plugins/exploratory_view @elastic/uptime
 src/plugins/expression_error @elastic/kibana-presentation
@@ -364,7 +364,7 @@ src/plugins/chart_expressions/expression_tagcloud @elastic/kibana-visualizations
 src/plugins/chart_expressions/expression_xy @elastic/kibana-visualizations
 examples/expressions_explorer @elastic/kibana-app-services
 src/plugins/expressions @elastic/kibana-visualizations
-packages/kbn-failed-test-reporter-cli @elastic/kibana-operations
+packages/kbn-failed-test-reporter-cli @elastic/kibana-operations @elastic/appex-qa
 x-pack/test/plugin_api_integration/plugins/feature_usage_test @elastic/kibana-security
 x-pack/plugins/features @elastic/kibana-core
 x-pack/test/functional_execution_context/plugins/alerts @elastic/kibana-core
@@ -380,8 +380,8 @@ x-pack/plugins/fleet @elastic/fleet
 packages/kbn-flot-charts @elastic/kibana-operations
 x-pack/test/ui_capabilities/common/plugins/foo_plugin @elastic/kibana-security
 src/plugins/ftr_apis @elastic/kibana-core
-packages/kbn-ftr-common-functional-services @elastic/kibana-operations
-packages/kbn-ftr-screenshot-filename @elastic/kibana-operations
+packages/kbn-ftr-common-functional-services @elastic/kibana-operations @elastic/appex-qa
+packages/kbn-ftr-screenshot-filename @elastic/kibana-operations @elastic/appex-qa
 x-pack/test/functional_with_es_ssl/plugins/cases @elastic/response-ops
 packages/kbn-generate @elastic/kibana-operations
 packages/kbn-generate-csv @elastic/appex-sharedux
@@ -423,7 +423,7 @@ test/interactive_setup_api_integration/plugins/test_endpoints @elastic/kibana-se
 packages/kbn-interpreter @elastic/kibana-visualizations
 packages/kbn-io-ts-utils @elastic/apm-ui
 packages/kbn-jest-serializers @elastic/kibana-operations
-packages/kbn-journeys @elastic/kibana-operations
+packages/kbn-journeys @elastic/kibana-operations @elastic/appex-qa
 packages/kbn-json-ast @elastic/kibana-operations
 test/health_gateway/plugins/status @elastic/kibana-core
 test/plugin_functional/plugins/kbn_sample_panel_action @elastic/kibana-app-services
@@ -665,10 +665,10 @@ src/plugins/telemetry_management_section @elastic/kibana-core
 src/plugins/telemetry @elastic/kibana-core
 test/plugin_functional/plugins/telemetry @elastic/kibana-core
 packages/kbn-telemetry-tools @elastic/kibana-core
-packages/kbn-test @elastic/kibana-operations
+packages/kbn-test @elastic/kibana-operations @elastic/appex-qa
 x-pack/test/licensing_plugin/plugins/test_feature_usage @elastic/kibana-security
-packages/kbn-test-jest-helpers @elastic/kibana-operations
-packages/kbn-test-subj-selector @elastic/kibana-operations
+packages/kbn-test-jest-helpers @elastic/kibana-operations @elastic/appex-qa
+packages/kbn-test-subj-selector @elastic/kibana-operations @elastic/appex-qa
 x-pack/examples/testing_embedded_lens @elastic/kibana-visualizations
 packages/kbn-text-based-editor @elastic/kibana-visualizations
 src/plugins/text_based_languages @elastic/kibana-visualizations

--- a/packages/kbn-ambient-ftr-types/kibana.jsonc
+++ b/packages/kbn-ambient-ftr-types/kibana.jsonc
@@ -1,6 +1,6 @@
 {
   "type": "shared-common",
   "id": "@kbn/ambient-ftr-types",
-  "owner": "@elastic/kibana-operations",
+  "owner": ["@elastic/kibana-operations", "@elastic/appex-qa"],
   "devOnly": true
 }

--- a/packages/kbn-es-archiver/kibana.jsonc
+++ b/packages/kbn-es-archiver/kibana.jsonc
@@ -2,5 +2,5 @@
   "type": "shared-common",
   "id": "@kbn/es-archiver",
   "devOnly": true,
-  "owner": "@elastic/kibana-operations"
+  "owner": ["@elastic/kibana-operations", "@elastic/appex-qa"],
 }

--- a/packages/kbn-expect/kibana.jsonc
+++ b/packages/kbn-expect/kibana.jsonc
@@ -2,5 +2,5 @@
   "type": "shared-common",
   "id": "@kbn/expect",
   "devOnly": true,
-  "owner": "@elastic/kibana-operations"
+  "owner": ["@elastic/kibana-operations", "@elastic/appex-qa"],
 }

--- a/packages/kbn-failed-test-reporter-cli/kibana.jsonc
+++ b/packages/kbn-failed-test-reporter-cli/kibana.jsonc
@@ -1,6 +1,6 @@
 {
   "type": "shared-common",
   "id": "@kbn/failed-test-reporter-cli",
-  "owner": "@elastic/kibana-operations",
+  "owner": ["@elastic/kibana-operations", "@elastic/appex-qa"],
   "devOnly": true
 }

--- a/packages/kbn-ftr-common-functional-services/kibana.jsonc
+++ b/packages/kbn-ftr-common-functional-services/kibana.jsonc
@@ -1,6 +1,6 @@
 {
   "type": "shared-common",
   "id": "@kbn/ftr-common-functional-services",
-  "owner": "@elastic/kibana-operations",
+  "owner": ["@elastic/kibana-operations", "@elastic/appex-qa"],
   "devOnly": true
 }

--- a/packages/kbn-ftr-screenshot-filename/kibana.jsonc
+++ b/packages/kbn-ftr-screenshot-filename/kibana.jsonc
@@ -1,6 +1,6 @@
 {
   "type": "shared-common",
   "id": "@kbn/ftr-screenshot-filename",
-  "owner": "@elastic/kibana-operations",
+  "owner": ["@elastic/kibana-operations", "@elastic/appex-qa"],
   "devOnly": true
 }

--- a/packages/kbn-journeys/kibana.jsonc
+++ b/packages/kbn-journeys/kibana.jsonc
@@ -1,6 +1,6 @@
 {
   "type": "shared-common",
   "id": "@kbn/journeys",
-  "owner": "@elastic/kibana-operations",
+  "owner": ["@elastic/kibana-operations", "@elastic/appex-qa"],
   "devOnly": true
 }

--- a/packages/kbn-test-jest-helpers/kibana.jsonc
+++ b/packages/kbn-test-jest-helpers/kibana.jsonc
@@ -2,5 +2,5 @@
   "type": "shared-common",
   "id": "@kbn/test-jest-helpers",
   "devOnly": true,
-  "owner": "@elastic/kibana-operations"
+  "owner": ["@elastic/kibana-operations", "@elastic/appex-qa"],
 }

--- a/packages/kbn-test-subj-selector/kibana.jsonc
+++ b/packages/kbn-test-subj-selector/kibana.jsonc
@@ -1,6 +1,6 @@
 {
   "type": "shared-common",
   "id": "@kbn/test-subj-selector",
-  "owner": "@elastic/kibana-operations",
+  "owner": ["@elastic/kibana-operations", "@elastic/appex-qa"],
   "devOnly": true
 }

--- a/packages/kbn-test/kibana.jsonc
+++ b/packages/kbn-test/kibana.jsonc
@@ -2,5 +2,5 @@
   "type": "shared-common",
   "id": "@kbn/test",
   "devOnly": true,
-  "owner": "@elastic/kibana-operations"
+  "owner": ["@elastic/kibana-operations", "@elastic/appex-qa"],
 }


### PR DESCRIPTION
## Summary

While elastic/appex-qa  is in process to take ownership over FTR related code, from elastic/kibana-operations  it will be good to keep track on any changes happening and participate in the review process.