### PR TITLE
[Enterprise Search] Render indexed_document_volume in MiB

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/sync_jobs/documents_panel.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/sync_jobs/documents_panel.tsx
@@ -45,7 +45,7 @@ export const SyncJobDocumentsPanel: React.FC<SyncJobDocumentsPanelProps> = (sync
       name: i18n.translate('xpack.enterpriseSearch.content.index.syncJobs.documents.volume', {
         defaultMessage: 'Volume',
       }),
-      render: (volume: number) => new ByteSizeValue(volume).toString(),
+      render: (volume: number) => new ByteSizeValue(volume * 1024 * 1024).toString(),
     },
   ];
   return (

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/sync_jobs/documents_panel.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/sync_jobs/documents_panel.tsx
@@ -48,17 +48,20 @@ export const SyncJobDocumentsPanel: React.FC<SyncJobDocumentsPanelProps> = (sync
       render: (volume: number) =>
         volume < 1
           ? i18n.translate(
-              'xpack.enterpriseSearch.content.index.syncJobs.documents.volume.lessThanOneMB',
+              'xpack.enterpriseSearch.content.index.syncJobs.documents.volume.lessThanOneMBLabel',
               {
                 defaultMessage: 'Less than 1mb',
               }
             )
-          : `${i18n.translate(
-              'xpack.enterpriseSearch.content.index.syncJobs.documents.volume.about',
+          : i18n.translate(
+              'xpack.enterpriseSearch.content.index.syncJobs.documents.volume.aboutLabel',
               {
-                defaultMessage: 'About',
+                defaultMessage: 'About {volume}',
+                values: {
+                  volume: new ByteSizeValue(volume * 1024 * 1024).toString(),
+                },
               }
-            )} ${new ByteSizeValue(volume * 1024 * 1024).toString()}`,
+            ),
     },
   ];
   return (

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/sync_jobs/documents_panel.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/sync_jobs/documents_panel.tsx
@@ -45,7 +45,20 @@ export const SyncJobDocumentsPanel: React.FC<SyncJobDocumentsPanelProps> = (sync
       name: i18n.translate('xpack.enterpriseSearch.content.index.syncJobs.documents.volume', {
         defaultMessage: 'Volume',
       }),
-      render: (volume: number) => new ByteSizeValue(volume * 1024 * 1024).toString(),
+      render: (volume: number) =>
+        volume < 1
+          ? i18n.translate(
+              'xpack.enterpriseSearch.content.index.syncJobs.documents.volume.lessThanOneMB',
+              {
+                defaultMessage: 'Less than 1mb',
+              }
+            )
+          : `${i18n.translate(
+              'xpack.enterpriseSearch.content.index.syncJobs.documents.volume.about',
+              {
+                defaultMessage: 'About',
+              }
+            )} ${new ByteSizeValue(volume * 1024 * 1024).toString()}`,
     },
   ];
   return (


### PR DESCRIPTION
## Part of https://github.com/elastic/connectors-python/issues/735

## Summary

The field type for `indexed_document_volume` is `integer`, which can only represent about 2GB worth of "bytes". To be able to support syncing with larger datasets, `indexed_document_volume` is updated to store the size in `MebiBytes`.

This PR makes sure the size is rendered correctly in UI.

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
