### PR TITLE
[ML] AIOps: Adds filter action for the Change point detection results 

### DIFF
--- a/packages/kbn-es-query/src/filters/build_filters/types.ts
+++ b/packages/kbn-es-query/src/filters/build_filters/types.ts
@@ -82,7 +82,6 @@ export type FilterMeta = {
   key?: string;
   params?: FilterMetaParams;
   value?: string;
-  field?: string;
 };
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions

--- a/packages/kbn-es-query/src/filters/build_filters/types.ts
+++ b/packages/kbn-es-query/src/filters/build_filters/types.ts
@@ -82,6 +82,7 @@ export type FilterMeta = {
   key?: string;
   params?: FilterMetaParams;
   value?: string;
+  field?: string;
 };
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions

--- a/x-pack/plugins/aiops/public/components/change_point_detection/change_points_table.tsx
+++ b/x-pack/plugins/aiops/public/components/change_point_detection/change_points_table.tsx
@@ -165,6 +165,7 @@ export const ChangePointsTable: FC<ChangePointsTableProps> = ({
                       alias: null,
                       index: dataView.id!,
                       key: `${item.group.name}_${item.group.value}`,
+                      // @ts-ignore FilterMeta type definition misses the field property
                       field: item.group.name,
                       params: {
                         query: item.group.value,

--- a/x-pack/plugins/aiops/public/components/change_point_detection/change_points_table.tsx
+++ b/x-pack/plugins/aiops/public/components/change_point_detection/change_points_table.tsx
@@ -164,7 +164,7 @@ export const ChangePointsTable: FC<ChangePointsTableProps> = ({
                       negate: false,
                       alias: null,
                       index: dataView.id!,
-                      key: 'instance',
+                      key: `${item.group.name}_${item.group.value}`,
                       field: item.group.name,
                       params: {
                         query: item.group.value,

--- a/x-pack/plugins/aiops/public/components/change_point_detection/change_points_table.tsx
+++ b/x-pack/plugins/aiops/public/components/change_point_detection/change_points_table.tsx
@@ -189,7 +189,6 @@ export const ChangePointsTable: FC<ChangePointsTableProps> = ({
                 color: 'primary',
                 type: 'icon',
                 onClick: (item) => {
-                  if (!item.group) return;
                   filterManager.addFilters(
                     getFilterConfig(dataView.id!, item as Required<ChangePointAnnotation>, false)!
                   );
@@ -214,7 +213,6 @@ export const ChangePointsTable: FC<ChangePointsTableProps> = ({
                 color: 'primary',
                 type: 'icon',
                 onClick: (item) => {
-                  if (!item.group) return;
                   filterManager.addFilters(
                     getFilterConfig(dataView.id!, item as Required<ChangePointAnnotation>, true)!
                   );


### PR DESCRIPTION
## Summary

Part of https://github.com/elastic/kibana/issues/151592

Adds actions to quickly filter for and filter out split field values. 

![Apr-20-2023 12-41-17](https://user-images.githubusercontent.com/5236598/233342684-0ee7e27e-0ffc-444b-92b0-5bf1a732ed87.gif)

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)