### PR TITLE
extract data quality helpers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -317,6 +317,7 @@ packages/kbn-ebt-tools @elastic/kibana-core
 packages/kbn-ecs @elastic/kibana-core @elastic/security-threat-hunting-investigations
 x-pack/packages/kbn-ecs-data-quality-dashboard @elastic/security-threat-hunting-investigations
 x-pack/plugins/ecs_data_quality_dashboard @elastic/security-threat-hunting-investigations
+x-pack/packages/kbn-ecs-data-quality-utils @elastic/security-threat-hunting-investigations
 test/plugin_functional/plugins/elasticsearch_client_plugin @elastic/kibana-core
 x-pack/test/plugin_api_integration/plugins/elasticsearch_client @elastic/kibana-core
 x-pack/plugins/embeddable_enhanced @elastic/kibana-presentation

--- a/package.json
+++ b/package.json
@@ -356,6 +356,7 @@
     "@kbn/ecs": "link:packages/kbn-ecs",
     "@kbn/ecs-data-quality-dashboard": "link:x-pack/packages/kbn-ecs-data-quality-dashboard",
     "@kbn/ecs-data-quality-dashboard-plugin": "link:x-pack/plugins/ecs_data_quality_dashboard",
+    "@kbn/ecs-data-quality-utils": "link:x-pack/packages/kbn-ecs-data-quality-utils",
     "@kbn/elasticsearch-client-plugin": "link:test/plugin_functional/plugins/elasticsearch_client_plugin",
     "@kbn/elasticsearch-client-xpack-plugin": "link:x-pack/test/plugin_api_integration/plugins/elasticsearch_client",
     "@kbn/embeddable-enhanced-plugin": "link:x-pack/plugins/embeddable_enhanced",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -628,6 +628,8 @@
       "@kbn/ecs-data-quality-dashboard/*": ["x-pack/packages/kbn-ecs-data-quality-dashboard/*"],
       "@kbn/ecs-data-quality-dashboard-plugin": ["x-pack/plugins/ecs_data_quality_dashboard"],
       "@kbn/ecs-data-quality-dashboard-plugin/*": ["x-pack/plugins/ecs_data_quality_dashboard/*"],
+      "@kbn/ecs-data-quality-utils": ["x-pack/packages/kbn-ecs-data-quality-utils"],
+      "@kbn/ecs-data-quality-utils/*": ["x-pack/packages/kbn-ecs-data-quality-utils/*"],
       "@kbn/elasticsearch-client-plugin": ["test/plugin_functional/plugins/elasticsearch_client_plugin"],
       "@kbn/elasticsearch-client-plugin/*": ["test/plugin_functional/plugins/elasticsearch_client_plugin/*"],
       "@kbn/elasticsearch-client-xpack-plugin": ["x-pack/test/plugin_api_integration/plugins/elasticsearch_client"],

--- a/x-pack/packages/kbn-ecs-data-quality-dashboard/impl/data_quality/data_quality_panel/data_quality_summary/summary_actions/check_all/check_index.ts
+++ b/x-pack/packages/kbn-ecs-data-quality-dashboard/impl/data_quality/data_quality_panel/data_quality_summary/summary_actions/check_all/check_index.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import { getUnallowedValueRequestItems } from '../../../allowed_values/helpers';
 import {
   getMappingsProperties,
   getSortedPartitionedFieldMetadata,
@@ -42,20 +41,14 @@ export async function checkIndex({
   try {
     const indexes = await fetchMappings({ abortController, patternOrIndexName: indexName });
 
-    const requestItems = getUnallowedValueRequestItems({
-      ecsMetadata,
-      indexName,
-    });
-
     const searchResults = await fetchUnallowedValues({
       abortController,
       indexName,
-      requestItems,
     });
 
     const unallowedValues = getUnallowedValues({
-      requestItems,
       searchResults,
+      indexName,
     });
 
     const mappingsProperties = getMappingsProperties({

--- a/x-pack/packages/kbn-ecs-data-quality-dashboard/impl/data_quality/data_quality_panel/index_properties/index.tsx
+++ b/x-pack/packages/kbn-ecs-data-quality-dashboard/impl/data_quality/data_quality_panel/index_properties/index.tsx
@@ -97,7 +97,6 @@ const IndexPropertiesComponent: React.FC<Props> = ({
   const requestItems = useMemo(
     () =>
       getUnallowedValueRequestItems({
-        ecsMetadata: EcsFlat as unknown as Record<string, EcsMetadata>,
         indexName,
       }),
     [indexName]

--- a/x-pack/packages/kbn-ecs-data-quality-dashboard/impl/data_quality/types.ts
+++ b/x-pack/packages/kbn-ecs-data-quality-dashboard/impl/data_quality/types.ts
@@ -62,8 +62,6 @@ export interface PartitionedFieldMetadataStats {
 }
 
 export interface UnallowedValueRequestItem {
-  allowedValues: string[];
-  indexFieldName: string;
   indexName: string;
 }
 

--- a/x-pack/packages/kbn-ecs-data-quality-dashboard/impl/data_quality/use_unallowed_values/index.ts
+++ b/x-pack/packages/kbn-ecs-data-quality-dashboard/impl/data_quality/use_unallowed_values/index.ts
@@ -48,11 +48,9 @@ export const useUnallowedValues = ({
         const searchResults = await fetchUnallowedValues({
           abortController,
           indexName,
-          requestItems,
         });
 
         const unallowedValuesMap = getUnallowedValues({
-          requestItems,
           searchResults,
         });
 

--- a/x-pack/packages/kbn-ecs-data-quality-utils/README.md
+++ b/x-pack/packages/kbn-ecs-data-quality-utils/README.md
@@ -1,0 +1,3 @@
+# @kbn/ecs-data-quality-utils
+
+This package contains utils for validating indices against the ECS.

--- a/x-pack/packages/kbn-ecs-data-quality-utils/helpers/get_unallowed_field_requests.test.ts
+++ b/x-pack/packages/kbn-ecs-data-quality-utils/helpers/get_unallowed_field_requests.test.ts
@@ -1,0 +1,110 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getMSearchRequestBody, getMSearchRequestHeader } from './get_unallowed_field_requests';
+
+describe('getMSearchRequest', () => {
+  test('getMSearchRequestHeader', () => {
+    expect(getMSearchRequestHeader('auditbeat')).toMatchInlineSnapshot(`
+      Object {
+        "expand_wildcards": Array [
+          "open",
+        ],
+        "index": "auditbeat",
+      }
+    `);
+  });
+
+  test('getMSearchRequestBody', () => {
+    expect(
+      getMSearchRequestBody({
+        indexFieldName: 'event.category',
+        allowedValues: ['process'],
+      })
+    ).toMatchInlineSnapshot(`
+      Object {
+        "aggregations": Object {
+          "event.category": Object {
+            "terms": Object {
+              "field": "event.category",
+              "order": Object {
+                "_count": "desc",
+              },
+            },
+          },
+        },
+        "query": Object {
+          "bool": Object {
+            "filter": Array [
+              Object {
+                "bool": Object {
+                  "filter": Array [],
+                  "must": Array [],
+                  "must_not": Array [
+                    Object {
+                      "bool": Object {
+                        "minimum_should_match": 1,
+                        "should": Array [
+                          Object {
+                            "match_phrase": Object {
+                              "event.category": "process",
+                            },
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                  "should": Array [],
+                },
+              },
+            ],
+          },
+        },
+        "runtime_mappings": Object {},
+        "size": 0,
+      }
+    `);
+  });
+
+  test('getMSearchRequestBody - without allowedValues', () => {
+    expect(
+      getMSearchRequestBody({
+        indexFieldName: 'event.category',
+        allowedValues: [],
+      })
+    ).toMatchInlineSnapshot(`
+      Object {
+        "aggregations": Object {
+          "event.category": Object {
+            "terms": Object {
+              "field": "event.category",
+              "order": Object {
+                "_count": "desc",
+              },
+            },
+          },
+        },
+        "query": Object {
+          "bool": Object {
+            "filter": Array [
+              Object {
+                "bool": Object {
+                  "filter": Array [],
+                  "must": Array [],
+                  "must_not": Array [],
+                  "should": Array [],
+                },
+              },
+            ],
+          },
+        },
+        "runtime_mappings": Object {},
+        "size": 0,
+      }
+    `);
+  });
+});

--- a/x-pack/packages/kbn-ecs-data-quality-utils/helpers/get_unallowed_field_requests.ts
+++ b/x-pack/packages/kbn-ecs-data-quality-utils/helpers/get_unallowed_field_requests.ts
@@ -9,6 +9,7 @@ import {
   MsearchMultisearchHeader,
   MsearchMultisearchBody,
 } from '@elastic/elasticsearch/lib/api/types';
+
 import { AllowedValuesInputs } from '../schemas/get_unallowed_field_values';
 
 export const getMSearchRequestHeader = (indexName: string): MsearchMultisearchHeader => ({
@@ -17,11 +18,9 @@ export const getMSearchRequestHeader = (indexName: string): MsearchMultisearchHe
 });
 
 export const getMSearchRequestBody = ({
-  indexName,
   indexFieldName,
   allowedValues,
 }: {
-  indexName: string;
   indexFieldName: string;
   allowedValues: AllowedValuesInputs;
 }): MsearchMultisearchBody => ({

--- a/x-pack/packages/kbn-ecs-data-quality-utils/index.ts
+++ b/x-pack/packages/kbn-ecs-data-quality-utils/index.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { MsearchRequestItem } from '@elastic/elasticsearch/lib/api/types';
+import type { ElasticsearchClient } from '@kbn/core/server';
+import { EcsFlat } from '@kbn/ecs';
+import {
+  getMSearchRequestBody,
+  getMSearchRequestHeader,
+} from './helpers/get_unallowed_field_requests';
+
+export interface UnallowedValueRequestItem {
+  allowedValues: string[];
+  indexFieldName: string;
+  indexName: string;
+}
+
+export interface AllowedValue {
+  description?: string;
+  expected_event_types?: string[];
+  name?: string;
+}
+
+export interface EcsMetadata {
+  allowed_values?: AllowedValue[];
+  dashed_name?: string;
+  description?: string;
+  example?: string;
+  flat_name?: string;
+  format?: string;
+  ignore_above?: number;
+  level?: string;
+  name?: string;
+  normalize?: string[];
+  required?: boolean;
+  short?: string;
+  type?: string;
+}
+
+export const hasAllowedValues = ({
+  ecsMetadata,
+  fieldName,
+}: {
+  ecsMetadata: Record<string, EcsMetadata> | null;
+  fieldName: string;
+}): boolean =>
+  ecsMetadata != null ? (ecsMetadata[fieldName]?.allowed_values?.length ?? 0) > 0 : false;
+
+export const getValidValues = (field: EcsMetadata | undefined): string[] =>
+  field?.allowed_values?.flatMap(({ name }) => (name != null ? name : [])) ?? [];
+
+export const getUnallowedValueRequestItems = ({
+  ecsMetadata,
+  indexName,
+}: {
+  ecsMetadata: Record<string, EcsMetadata> | null;
+  indexName: string;
+}): UnallowedValueRequestItem[] =>
+  ecsMetadata != null
+    ? Object.keys(ecsMetadata).reduce<UnallowedValueRequestItem[]>(
+        (acc, fieldName) =>
+          hasAllowedValues({ ecsMetadata, fieldName })
+            ? [
+                ...acc,
+                {
+                  indexName,
+                  indexFieldName: fieldName,
+                  allowedValues: getValidValues(ecsMetadata[fieldName]),
+                },
+              ]
+            : acc,
+        []
+      )
+    : [];
+
+export const getUnallowedFieldValues = (esClient: ElasticsearchClient, indices: string[]) => {
+  const items: UnallowedValueRequestItem[] = indices.flatMap((indexName) =>
+    getUnallowedValueRequestItems({
+      indexName,
+      ecsMetadata: EcsFlat as unknown as Record<string, EcsMetadata>,
+    })
+  );
+
+  const searches: MsearchRequestItem[] = items.reduce<MsearchRequestItem[]>(
+    (acc, { indexName, indexFieldName, allowedValues }) =>
+      acc.concat([
+        getMSearchRequestHeader(indexName),
+        getMSearchRequestBody({ indexFieldName, allowedValues }),
+      ]),
+    []
+  );
+
+  return esClient.msearch({
+    searches,
+  });
+};

--- a/x-pack/packages/kbn-ecs-data-quality-utils/jest.config.js
+++ b/x-pack/packages/kbn-ecs-data-quality-utils/jest.config.js
@@ -5,10 +5,8 @@
  * 2.0.
  */
 
-import type { UnallowedValueRequestItem } from '../../types';
-
-export const getUnallowedValueRequestItems = ({
-  indexName,
-}: {
-  indexName: string;
-}): UnallowedValueRequestItem[] => [{ indexName }];
+module.exports = {
+  preset: '@kbn/test/jest_node',
+  rootDir: '../../..',
+  roots: ['<rootDir>/x-pack/packages/kbn-ecs-data-quality-utils'],
+};

--- a/x-pack/packages/kbn-ecs-data-quality-utils/kibana.jsonc
+++ b/x-pack/packages/kbn-ecs-data-quality-utils/kibana.jsonc
@@ -1,0 +1,5 @@
+{
+  "type": "shared-common",
+  "id": "@kbn/ecs-data-quality-utils",
+  "owner": "@elastic/security-threat-hunting-investigations"
+}

--- a/x-pack/packages/kbn-ecs-data-quality-utils/package.json
+++ b/x-pack/packages/kbn-ecs-data-quality-utils/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@kbn/ecs-data-quality-utils",
+  "private": true,
+  "version": "1.0.0",
+  "license": "SSPL-1.0 OR Elastic License 2.0"
+}

--- a/x-pack/packages/kbn-ecs-data-quality-utils/package.json
+++ b/x-pack/packages/kbn-ecs-data-quality-utils/package.json
@@ -2,5 +2,5 @@
   "name": "@kbn/ecs-data-quality-utils",
   "private": true,
   "version": "1.0.0",
-  "license": "SSPL-1.0 OR Elastic License 2.0"
+  "license": "Elastic License 2.0"
 }

--- a/x-pack/packages/kbn-ecs-data-quality-utils/schemas/get_unallowed_field_values.ts
+++ b/x-pack/packages/kbn-ecs-data-quality-utils/schemas/get_unallowed_field_values.ts
@@ -10,11 +10,3 @@ import * as t from 'io-ts';
 export const AllowedValues = t.array(t.string);
 
 export type AllowedValuesInputs = t.TypeOf<typeof AllowedValues>;
-
-export const GetUnallowedFieldValuesBody = t.array(
-  t.type({
-    indexName: t.string,
-  })
-);
-
-export type GetUnallowedFieldValuesInputs = t.TypeOf<typeof GetUnallowedFieldValuesBody>;

--- a/x-pack/packages/kbn-ecs-data-quality-utils/tsconfig.json
+++ b/x-pack/packages/kbn-ecs-data-quality-utils/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "target/types",
+    "types": [
+      "jest",
+      "node"
+    ]
+  },
+  "include": [
+    "**/*.ts",
+  ],
+  "exclude": [
+    "target/**/*"
+  ],
+  "kbn_references": []
+}

--- a/x-pack/packages/kbn-ecs-data-quality-utils/tsconfig.json
+++ b/x-pack/packages/kbn-ecs-data-quality-utils/tsconfig.json
@@ -13,5 +13,8 @@
   "exclude": [
     "target/**/*"
   ],
-  "kbn_references": []
+  "kbn_references": [
+    "@kbn/core",
+    "@kbn/ecs",
+  ]
 }

--- a/x-pack/plugins/ecs_data_quality_dashboard/server/lib/get_unallowed_field_values.ts
+++ b/x-pack/plugins/ecs_data_quality_dashboard/server/lib/get_unallowed_field_values.ts
@@ -6,27 +6,14 @@
  */
 import type { ElasticsearchClient } from '@kbn/core/server';
 
-import { MsearchRequestItem } from '@elastic/elasticsearch/lib/api/types';
-import {
-  getMSearchRequestBody,
-  getMSearchRequestHeader,
-} from '../helpers/get_unallowed_field_requests';
+import { getUnallowedFieldValues as findUnallowedValues } from '@kbn/ecs-data-quality-utils';
 import { GetUnallowedFieldValuesInputs } from '../schemas/get_unallowed_field_values';
 
 export const getUnallowedFieldValues = (
   esClient: ElasticsearchClient,
   items: GetUnallowedFieldValuesInputs
-) => {
-  const searches: MsearchRequestItem[] = items.reduce<MsearchRequestItem[]>(
-    (acc, { indexName, indexFieldName, allowedValues }) =>
-      acc.concat([
-        getMSearchRequestHeader(indexName),
-        getMSearchRequestBody({ indexName, indexFieldName, allowedValues }),
-      ]),
-    []
+) =>
+  findUnallowedValues(
+    esClient,
+    items.map(({ indexName }) => indexName)
   );
-
-  return esClient.msearch({
-    searches,
-  });
-};

--- a/x-pack/plugins/ecs_data_quality_dashboard/tsconfig.json
+++ b/x-pack/plugins/ecs_data_quality_dashboard/tsconfig.json
@@ -18,6 +18,7 @@
     "@kbn/core-http-request-handler-context-server",
     "@kbn/securitysolution-es-utils",
     "@kbn/securitysolution-io-ts-utils",
+    "@kbn/ecs-data-quality-utils",
   ],
   "exclude": [
     "target/**/*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3989,6 +3989,10 @@
   version "0.0.0"
   uid ""
 
+"@kbn/ecs-data-quality-utils@link:x-pack/packages/kbn-ecs-data-quality-utils":
+  version "0.0.0"
+  uid ""
+
 "@kbn/ecs@link:packages/kbn-ecs":
   version "0.0.0"
   uid ""


### PR DESCRIPTION
## Summary

This PR moves some of the helpers used to determine our data health (used in ECS quality dashboard) to a separate package, for reuse.

The most notable one is `getUnallowedFieldValues`, capable of fetching all the fields that do not fit the `allowed_values` in `ECS` from given indices.


### Checklist

Delete any items that are not applicable to this PR.

- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
