### PR TITLE
[Fleet] Fix logs useless rerender

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/agent_logs.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/agent_logs.tsx
@@ -30,7 +30,7 @@ import semverCoerce from 'semver/functions/coerce';
 import { createStateContainerReactHelpers } from '@kbn/kibana-utils-plugin/public';
 import { RedirectAppLinks } from '@kbn/kibana-react-plugin/public';
 import type { TimeRange } from '@kbn/es-query';
-import { LogStream } from '@kbn/infra-plugin/public';
+import { LogStream, type LogStreamProps } from '@kbn/infra-plugin/public';
 
 import type { Agent, AgentPolicy } from '../../../../../types';
 import { useLink, useStartServices } from '../../../../../hooks';
@@ -49,6 +49,11 @@ const WrapperFlexGroup = styled(EuiFlexGroup)`
 const DatePickerFlexItem = styled(EuiFlexItem)`
   max-width: 312px;
 `;
+
+const LOG_VIEW_SETTINGS: LogStreamProps['logView'] = {
+  type: 'log-view-reference',
+  logViewId: 'default',
+};
 
 export interface AgentLogsProps {
   agent: Agent;
@@ -350,7 +355,7 @@ export const AgentLogsUI: React.FunctionComponent<AgentLogsProps> = memo(
         <EuiFlexItem>
           <EuiPanel paddingSize="none" panelRef={logsPanelRef} grow={false}>
             <LogStream
-              logView={{ type: 'log-view-reference', logViewId: 'default' }}
+              logView={LOG_VIEW_SETTINGS}
               height={logPanelHeight}
               startTimestamp={dateRangeTimestamps.start}
               endTimestamp={dateRangeTimestamps.end}


### PR DESCRIPTION
## Summary

Resolve #154315

The `LogStream` component was rendering every n seconds causing the UI to blink. That PR fix that.

## Details

That PR fix that by removing the creation of a new logView object that we pass as a props each time.

Using React profiler before that change 
<img width="1059" alt="Screenshot 2023-04-19 at 1 53 07 PM" src="https://user-images.githubusercontent.com/1336873/233160130-6c71d2ac-7560-45cb-ba69-1161ca910250.png">


## How to test

Visit the agent details log page and verify that the log stream do not blink after waiting a few seconds.



<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->