### PR TITLE
[ML] Uses two weeks before now for default start time in job start date picker

### DIFF
--- a/x-pack/plugins/ml/public/application/jobs/jobs_list/components/start_datafeed_modal/time_range_selector/time_range_selector.js
+++ b/x-pack/plugins/ml/public/application/jobs/jobs_list/components/start_datafeed_modal/time_range_selector/time_range_selector.js
@@ -27,6 +27,7 @@ export class TimeRangeSelector extends Component {
     };
     this.latestTimestamp = this.props.startTime;
     this.now = this.props.now;
+    this.twoWeeksAgo = moment(this.now).subtract(2, 'weeks').startOf('day');
   }
 
   setStartTab = (tab) => {
@@ -37,6 +38,9 @@ export class TimeRangeSelector extends Component {
         break;
       case 1:
         this.setStartTime(this.now);
+        break;
+      case 2:
+        this.setStartTime(this.twoWeeksAgo);
         break;
       default:
         break;


### PR DESCRIPTION
When starting an anomaly detection job, if you select "Specify start time", the time chosen is two weeks before now, rounded down to the start of the day.

<img width="917" alt="image" src="https://user-images.githubusercontent.com/22172091/233178339-1e198068-aa8b-479a-92cb-085fc34691e0.png">

Fixes https://github.com/elastic/enhancements/issues/16467