### PR TITLE
[DOCS] Removes tag from 7.17.10 release notes

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -83,8 +83,6 @@ Review important information about the {kib} 7.17.x releases.
 [[release-notes-7.17.10]]
 == {kib} 7.17.10
 
-coming::[7.17.10]
-
 Review the following information about the {kib} 7.17.10 release.
 
 [float]


### PR DESCRIPTION
## Summary

Removes the `coming` tag from the 7.17.10 release notes.

