### PR TITLE
[Infrastructure UI] Hosts view remove flyout state from the url after the flyout is closed

### DIFF
--- a/x-pack/plugins/infra/public/pages/metrics/hosts/hooks/use_host_flyout_open_url_state.ts
+++ b/x-pack/plugins/infra/public/pages/metrics/hosts/hooks/use_host_flyout_open_url_state.ts
@@ -9,7 +9,6 @@ import * as rt from 'io-ts';
 import { pipe } from 'fp-ts/lib/pipeable';
 import { fold } from 'fp-ts/lib/Either';
 import { constant, identity } from 'fp-ts/lib/function';
-import useLocalStorage from 'react-use/lib/useLocalStorage';
 import { useUrlState } from '../../../../utils/use_url_state';
 
 export enum FlyoutTabIds {
@@ -24,22 +23,31 @@ export const GET_DEFAULT_TABLE_PROPERTIES = {
   metadataSearch: '',
 };
 const HOST_TABLE_PROPERTIES_URL_STATE_KEY = 'hostFlyoutOpen';
-const FLYOUT_LOCAL_STORAGE_KEY = 'inventoryUI:hostsFlyoutState';
 
 type Action = rt.TypeOf<typeof ActionRT>;
-type SetNewHostFlyoutOpen = (newProp?: Action) => void;
+type SetNewHostFlyoutOpen = (newProp: Action) => void;
+type SetNewHostFlyoutClose = () => void;
 
-export const useHostFlyoutOpenUrl = (): [HostFlyoutOpen, SetNewHostFlyoutOpen] => {
-  const [urlState, setUrlState] = useUrlState<HostFlyoutOpen>({
+export const useHostFlyoutOpen = (): [
+  HostFlyoutOpen,
+  SetNewHostFlyoutOpen,
+  SetNewHostFlyoutClose
+] => {
+  const [urlState, setUrlState] = useUrlState<HostFlyoutUrl>({
     defaultState: '',
     decodeUrlState,
     encodeUrlState,
     urlStateKey: HOST_TABLE_PROPERTIES_URL_STATE_KEY,
   });
 
-  const setHostFlyoutOpen = (newProps?: Action) => setUrlState(newProps ? { ...newProps } : '');
+  const setHostFlyoutOpen = (newProps: Action) =>
+    typeof urlState !== 'string'
+      ? setUrlState({ ...urlState, ...newProps })
+      : setUrlState({ ...GET_DEFAULT_TABLE_PROPERTIES, ...newProps });
 
-  return [urlState, setHostFlyoutOpen];
+  const setFlyoutClosed = () => setUrlState('');
+
+  return [urlState as HostFlyoutOpen, setHostFlyoutOpen, setFlyoutClosed];
 };
 
 const FlyoutTabIdRT = rt.union([rt.literal('metadata'), rt.literal('processes')]);
@@ -62,75 +70,26 @@ const SetMetadataSearchRT = rt.partial({
   metadataSearch: SearchFilterRT,
 });
 
-const ActionRT = rt.type({
-  clickedItemId: ClickedItemIdRT,
-  selectedTabId: FlyoutTabIdRT,
-  searchFilter: SearchFilterRT,
-  metadataSearch: SearchFilterRT,
-});
-
-const HostFlyoutOpenRT = rt.union([
-  rt.type({
-    clickedItemId: ClickedItemIdRT,
-    selectedTabId: FlyoutTabIdRT,
-    searchFilter: SearchFilterRT,
-    metadataSearch: SearchFilterRT,
-  }),
-  rt.string,
-]);
-
-type HostFlyoutOpen = rt.TypeOf<typeof HostFlyoutOpenRT>;
-
-const encodeUrlState = HostFlyoutOpenRT.encode;
-const decodeUrlState = (value: unknown) => {
-  return pipe(HostFlyoutOpenRT.decode(value), fold(constant(undefined), identity));
-};
-
-type ActionProps = rt.TypeOf<typeof ActionPropsRT>;
-type SetNewHostFlyoutOpenLS = (newProps: ActionProps) => void;
-type HostFlyoutOpenLocaleStorage = rt.TypeOf<typeof HostFlyoutOpenLocaleStorageRT>;
-
-const HostFlyoutOpenLocaleStorageRT = rt.type({
-  clickedItemId: ClickedItemIdRT,
-  selectedTabId: FlyoutTabIdRT,
-  searchFilter: SearchFilterRT,
-  metadataSearch: SearchFilterRT,
-});
-
-const ActionPropsRT = rt.intersection([
+const ActionRT = rt.intersection([
   SetClickedItemIdRT,
   SetFlyoutTabId,
   SetSearchFilterRT,
   SetMetadataSearchRT,
 ]);
 
-export const useHostFlyoutOpen = (): [
-  HostFlyoutOpenLocaleStorage,
-  SetNewHostFlyoutOpenLS,
-  SetNewHostFlyoutOpenLS
-] => {
-  const [hostFlyoutOpen, setHostFlyoutOpenUrl] = useHostFlyoutOpenUrl();
+const HostFlyoutOpenRT = rt.type({
+  clickedItemId: ClickedItemIdRT,
+  selectedTabId: FlyoutTabIdRT,
+  searchFilter: SearchFilterRT,
+  metadataSearch: SearchFilterRT,
+});
 
-  const [flyoutState, setFlyoutState] = useLocalStorage<HostFlyoutOpenLocaleStorage>(
-    FLYOUT_LOCAL_STORAGE_KEY,
-    GET_DEFAULT_TABLE_PROPERTIES
-  );
+const HostFlyoutUrlRT = rt.union([HostFlyoutOpenRT, rt.string]);
 
-  const defaultOrLocaleFlyoutData = { ...GET_DEFAULT_TABLE_PROPERTIES, ...flyoutState };
+type HostFlyoutUrl = rt.TypeOf<typeof HostFlyoutUrlRT>;
+type HostFlyoutOpen = rt.TypeOf<typeof HostFlyoutOpenRT>;
 
-  const setHostFlyoutOpen = (newProps: ActionProps) => {
-    setFlyoutState({ ...defaultOrLocaleFlyoutData, ...newProps });
-    setHostFlyoutOpenUrl({ ...defaultOrLocaleFlyoutData, ...newProps });
-  };
-
-  const setFlyoutClosed = (newProps: ActionProps) => {
-    setFlyoutState({ ...defaultOrLocaleFlyoutData, ...newProps });
-    setHostFlyoutOpenUrl();
-  };
-
-  const flyoutData = (
-    !hostFlyoutOpen ? defaultOrLocaleFlyoutData : hostFlyoutOpen
-  ) as HostFlyoutOpenLocaleStorage;
-
-  return [flyoutData, setHostFlyoutOpen, setFlyoutClosed];
+const encodeUrlState = HostFlyoutUrlRT.encode;
+const decodeUrlState = (value: unknown) => {
+  return pipe(HostFlyoutUrlRT.decode(value), fold(constant('undefined'), identity));
 };

--- a/x-pack/plugins/infra/public/pages/metrics/hosts/hooks/use_host_flyout_open_url_state.ts
+++ b/x-pack/plugins/infra/public/pages/metrics/hosts/hooks/use_host_flyout_open_url_state.ts
@@ -9,6 +9,7 @@ import * as rt from 'io-ts';
 import { pipe } from 'fp-ts/lib/pipeable';
 import { fold } from 'fp-ts/lib/Either';
 import { constant, identity } from 'fp-ts/lib/function';
+import useLocalStorage from 'react-use/lib/useLocalStorage';
 import { useUrlState } from '../../../../utils/use_url_state';
 
 export enum FlyoutTabIds {
@@ -23,19 +24,20 @@ export const GET_DEFAULT_TABLE_PROPERTIES = {
   metadataSearch: '',
 };
 const HOST_TABLE_PROPERTIES_URL_STATE_KEY = 'hostFlyoutOpen';
+const FLYOUT_LOCAL_STORAGE_KEY = 'inventoryUI:hostsFlyoutState';
 
 type Action = rt.TypeOf<typeof ActionRT>;
-type SetNewHostFlyoutOpen = (newProps: Action) => void;
+type SetNewHostFlyoutOpen = (newProp?: Action) => void;
 
-export const useHostFlyoutOpen = (): [HostFlyoutOpen, SetNewHostFlyoutOpen] => {
+export const useHostFlyoutOpenUrl = (): [HostFlyoutOpen, SetNewHostFlyoutOpen] => {
   const [urlState, setUrlState] = useUrlState<HostFlyoutOpen>({
-    defaultState: GET_DEFAULT_TABLE_PROPERTIES,
+    defaultState: '',
     decodeUrlState,
     encodeUrlState,
     urlStateKey: HOST_TABLE_PROPERTIES_URL_STATE_KEY,
   });
 
-  const setHostFlyoutOpen = (newProps: Action) => setUrlState({ ...urlState, ...newProps });
+  const setHostFlyoutOpen = (newProps?: Action) => setUrlState(newProps ? { ...newProps } : '');
 
   return [urlState, setHostFlyoutOpen];
 };
@@ -60,23 +62,75 @@ const SetMetadataSearchRT = rt.partial({
   metadataSearch: SearchFilterRT,
 });
 
-const ActionRT = rt.intersection([
-  SetClickedItemIdRT,
-  SetFlyoutTabId,
-  SetSearchFilterRT,
-  SetMetadataSearchRT,
-]);
-
-const HostFlyoutOpenRT = rt.type({
+const ActionRT = rt.type({
   clickedItemId: ClickedItemIdRT,
   selectedTabId: FlyoutTabIdRT,
   searchFilter: SearchFilterRT,
   metadataSearch: SearchFilterRT,
 });
 
+const HostFlyoutOpenRT = rt.union([
+  rt.type({
+    clickedItemId: ClickedItemIdRT,
+    selectedTabId: FlyoutTabIdRT,
+    searchFilter: SearchFilterRT,
+    metadataSearch: SearchFilterRT,
+  }),
+  rt.string,
+]);
+
 type HostFlyoutOpen = rt.TypeOf<typeof HostFlyoutOpenRT>;
 
 const encodeUrlState = HostFlyoutOpenRT.encode;
 const decodeUrlState = (value: unknown) => {
   return pipe(HostFlyoutOpenRT.decode(value), fold(constant(undefined), identity));
+};
+
+type ActionProps = rt.TypeOf<typeof ActionPropsRT>;
+type SetNewHostFlyoutOpenLS = (newProps: ActionProps) => void;
+type HostFlyoutOpenLocaleStorage = rt.TypeOf<typeof HostFlyoutOpenLocaleStorageRT>;
+
+const HostFlyoutOpenLocaleStorageRT = rt.type({
+  clickedItemId: ClickedItemIdRT,
+  selectedTabId: FlyoutTabIdRT,
+  searchFilter: SearchFilterRT,
+  metadataSearch: SearchFilterRT,
+});
+
+const ActionPropsRT = rt.intersection([
+  SetClickedItemIdRT,
+  SetFlyoutTabId,
+  SetSearchFilterRT,
+  SetMetadataSearchRT,
+]);
+
+export const useHostFlyoutOpen = (): [
+  HostFlyoutOpenLocaleStorage,
+  SetNewHostFlyoutOpenLS,
+  SetNewHostFlyoutOpenLS
+] => {
+  const [hostFlyoutOpen, setHostFlyoutOpenUrl] = useHostFlyoutOpenUrl();
+
+  const [flyoutState, setFlyoutState] = useLocalStorage<HostFlyoutOpenLocaleStorage>(
+    FLYOUT_LOCAL_STORAGE_KEY,
+    GET_DEFAULT_TABLE_PROPERTIES
+  );
+
+  const defaultOrLocaleFlyoutData = { ...GET_DEFAULT_TABLE_PROPERTIES, ...flyoutState };
+
+  const setHostFlyoutOpen = (newProps: ActionProps) => {
+    setFlyoutState({ ...defaultOrLocaleFlyoutData, ...newProps });
+    setHostFlyoutOpenUrl({ ...defaultOrLocaleFlyoutData, ...newProps });
+  };
+
+  const setFlyoutClosed = (newProps: ActionProps) => {
+    setFlyoutState({ ...defaultOrLocaleFlyoutData, ...newProps });
+    setHostFlyoutOpenUrl();
+  };
+
+  const flyoutData = (
+    !hostFlyoutOpen ? defaultOrLocaleFlyoutData : hostFlyoutOpen
+  ) as HostFlyoutOpenLocaleStorage;
+
+  return [flyoutData, setHostFlyoutOpen, setFlyoutClosed];
 };

--- a/x-pack/plugins/infra/public/pages/metrics/hosts/hooks/use_hosts_table.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/hosts/hooks/use_hosts_table.tsx
@@ -127,7 +127,7 @@ export const useHostsTable = (nodes: SnapshotNode[], { time }: HostTableParams) 
 
   const [hostFlyoutOpen, setHostFlyoutOpen, setFlyoutClosed] = useHostFlyoutOpen();
 
-  const closeFlyout = () => setFlyoutClosed({ clickedItemId: '' });
+  const closeFlyout = () => setFlyoutClosed();
 
   const reportHostEntryClick = useCallback(
     ({ name, cloudProvider }: HostNodeRow['title']) => {
@@ -166,7 +166,7 @@ export const useHostsTable = (nodes: SnapshotNode[], { time }: HostTableParams) 
                 clickedItemId: id,
               });
               if (id === hostFlyoutOpen.clickedItemId) {
-                setFlyoutClosed({ clickedItemId: '' });
+                setFlyoutClosed();
               } else {
                 setHostFlyoutOpen({ clickedItemId: id });
               }

--- a/x-pack/plugins/infra/public/pages/metrics/hosts/hooks/use_hosts_table.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/hosts/hooks/use_hosts_table.tsx
@@ -125,9 +125,9 @@ export const useHostsTable = (nodes: SnapshotNode[], { time }: HostTableParams) 
     services: { telemetry },
   } = useKibanaContextForPlugin();
 
-  const [hostFlyoutOpen, setHostFlyoutOpen] = useHostFlyoutOpen();
+  const [hostFlyoutOpen, setHostFlyoutOpen, setFlyoutClosed] = useHostFlyoutOpen();
 
-  const closeFlyout = () => setHostFlyoutOpen({ clickedItemId: '' });
+  const closeFlyout = () => setFlyoutClosed({ clickedItemId: '' });
 
   const reportHostEntryClick = useCallback(
     ({ name, cloudProvider }: HostNodeRow['title']) => {
@@ -166,7 +166,7 @@ export const useHostsTable = (nodes: SnapshotNode[], { time }: HostTableParams) 
                 clickedItemId: id,
               });
               if (id === hostFlyoutOpen.clickedItemId) {
-                setHostFlyoutOpen({ clickedItemId: '' });
+                setFlyoutClosed({ clickedItemId: '' });
               } else {
                 setHostFlyoutOpen({ clickedItemId: id });
               }
@@ -244,7 +244,7 @@ export const useHostsTable = (nodes: SnapshotNode[], { time }: HostTableParams) 
         align: 'right',
       },
     ],
-    [hostFlyoutOpen.clickedItemId, reportHostEntryClick, setHostFlyoutOpen, time]
+    [hostFlyoutOpen.clickedItemId, reportHostEntryClick, setFlyoutClosed, setHostFlyoutOpen, time]
   );
 
   return {


### PR DESCRIPTION
Closes #154564

## Summary

This PR removes the flyout state from the URL if the flyout is closed and set the default state if the flyout is open again

## Testing

- Open a single host flyout and change the tab/add filter or search (do not close the flyout yet)
- Copy the URL and verify that you see the same flyout data in a new browser tab/window
- Close the flyout
   - Check the URL (the flyout state should not be there)
   - Copy the URL and verify that you see the flyout data is not there (flyout is still closed and when it's open it has default state (metadata page open)
   - if there are any metadata filters applied they should still be part of the unified search bar

https://user-images.githubusercontent.com/14139027/233397203-d99fc04a-a118-43f8-a43b-6b01d34ab3b8.mov

