### PR TITLE
[Synthetics] Improve toast information for add/update monitor

### DIFF
--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/hooks/use_monitor_save.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/hooks/use_monitor_save.ts
@@ -51,6 +51,7 @@ export const useMonitorSave = ({ monitorData }: { monitorData?: SyntheticsMonito
       dispatch(cleanMonitorListState());
       kibanaService.toasts.addSuccess({
         title: monitorId ? MONITOR_UPDATED_SUCCESS_LABEL : MONITOR_SUCCESS_LABEL,
+        text: monitorId ? MONITOR_UPDATED_SUCCESS_LABEL_SUBTEXT : MONITOR_SUCCESS_LABEL_SUBTEXT,
         toastLifeTimeMs: 3000,
       });
     }
@@ -66,6 +67,13 @@ const MONITOR_SUCCESS_LABEL = i18n.translate(
   }
 );
 
+const MONITOR_SUCCESS_LABEL_SUBTEXT = i18n.translate(
+  'xpack.synthetics.monitorManagement.monitorAddedSuccessMessage.subtext',
+  {
+    defaultMessage: 'Scheduling for first run in progress.',
+  }
+);
+
 const MONITOR_UPDATED_SUCCESS_LABEL = i18n.translate(
   'xpack.synthetics.monitorManagement.monitorEditedSuccessMessage',
   {
@@ -77,5 +85,12 @@ const MONITOR_FAILURE_LABEL = i18n.translate(
   'xpack.synthetics.monitorManagement.monitorFailureMessage',
   {
     defaultMessage: 'Monitor was unable to be saved. Please try again later.',
+  }
+);
+
+const MONITOR_UPDATED_SUCCESS_LABEL_SUBTEXT = i18n.translate(
+  'xpack.synthetics.monitorManagement.monitorFailureMessage',
+  {
+    defaultMessage: 'Scheduling for next run in progress.',
   }
 );

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/hooks/use_monitor_save.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/hooks/use_monitor_save.tsx
@@ -6,8 +6,9 @@
  */
 
 import { FETCH_STATUS, useFetcher } from '@kbn/observability-plugin/public';
+import { toMountPoint, useKibana } from '@kbn/kibana-react-plugin/public';
 import { useParams, useRouteMatch } from 'react-router-dom';
-import { useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { i18n } from '@kbn/i18n';
 import { MONITOR_EDIT_ROUTE } from '../../../../../../common/constants';
@@ -18,6 +19,8 @@ import { cleanMonitorListState } from '../../../state';
 import { useSyntheticsRefreshContext } from '../../../contexts';
 
 export const useMonitorSave = ({ monitorData }: { monitorData?: SyntheticsMonitor }) => {
+  const core = useKibana();
+  const theme$ = core.services.theme?.theme$;
   const dispatch = useDispatch();
   const { refreshApp } = useSyntheticsRefreshContext();
   const { monitorId } = useParams<{ monitorId: string }>();
@@ -51,11 +54,16 @@ export const useMonitorSave = ({ monitorData }: { monitorData?: SyntheticsMonito
       dispatch(cleanMonitorListState());
       kibanaService.toasts.addSuccess({
         title: monitorId ? MONITOR_UPDATED_SUCCESS_LABEL : MONITOR_SUCCESS_LABEL,
-        text: monitorId ? MONITOR_UPDATED_SUCCESS_LABEL_SUBTEXT : MONITOR_SUCCESS_LABEL_SUBTEXT,
+        text: toMountPoint(
+          <p data-test-subj="synthetcsMonitorSaveSubtext">
+            {monitorId ? MONITOR_UPDATED_SUCCESS_LABEL_SUBTEXT : MONITOR_SUCCESS_LABEL_SUBTEXT}
+          </p>,
+          { theme$ }
+        ),
         toastLifeTimeMs: 3000,
       });
     }
-  }, [data, status, monitorId, loading, refreshApp, dispatch]);
+  }, [data, status, monitorId, loading, refreshApp, dispatch, theme$]);
 
   return { status, loading, isEdit };
 };
@@ -70,7 +78,7 @@ const MONITOR_SUCCESS_LABEL = i18n.translate(
 const MONITOR_SUCCESS_LABEL_SUBTEXT = i18n.translate(
   'xpack.synthetics.monitorManagement.monitorAddedSuccessMessage.subtext',
   {
-    defaultMessage: 'Scheduling for first run in progress.',
+    defaultMessage: 'It will next run according to its defined schedule.',
   }
 );
 
@@ -91,6 +99,6 @@ const MONITOR_FAILURE_LABEL = i18n.translate(
 const MONITOR_UPDATED_SUCCESS_LABEL_SUBTEXT = i18n.translate(
   'xpack.synthetics.monitorManagement.monitorFailureMessage',
   {
-    defaultMessage: 'Scheduling for next run in progress.',
+    defaultMessage: 'It will next run according to its defined schedule.',
   }
 );

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/hooks/use_monitor_save.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/hooks/use_monitor_save.tsx
@@ -97,7 +97,7 @@ const MONITOR_FAILURE_LABEL = i18n.translate(
 );
 
 const MONITOR_UPDATED_SUCCESS_LABEL_SUBTEXT = i18n.translate(
-  'xpack.synthetics.monitorManagement.monitorFailureMessage',
+  'xpack.synthetics.monitorManagement.monitorFailureMessage.subtext',
   {
     defaultMessage: 'It will next run according to its defined schedule.',
   }


### PR DESCRIPTION
## Summary

Resolves #155307.

Adds additional copy to let the user know scheduling is in progress for their new/updated monitor, but that the actual time of the next run is indeterminate.

## Testing this PR

Follow the flow of the GIF below, you can create a new monitor and then update it to view the new toast copy.

![20230420110606](https://user-images.githubusercontent.com/18429259/233408449-e50a148f-a35d-4c69-8258-cb43e7c33ec3.gif)

### Checklist


Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
