### PR TITLE
chore(slo): add link to slo details page from alert

### DIFF
--- a/x-pack/plugins/observability/public/rules/register_observability_rule_types.ts
+++ b/x-pack/plugins/observability/public/rules/register_observability_rule_types.ts
@@ -8,6 +8,7 @@ import { lazy } from 'react';
 import { i18n } from '@kbn/i18n';
 import { ALERT_REASON } from '@kbn/rule-data-utils';
 
+import { SLO_ID_FIELD } from '../../common/field_names/infra_metrics';
 import { ConfigSchema } from '../plugin';
 import { ObservabilityRuleTypeRegistry } from './create_observability_rule_type_registry';
 import { SLO_BURN_RATE_RULE_ID } from '../../common/constants';
@@ -25,7 +26,7 @@ export const registerObservabilityRuleTypes = (
     format: ({ fields }) => {
       return {
         reason: fields[ALERT_REASON] ?? '-',
-        link: '/app/observability/slos',
+        link: `/app/observability/slos/${fields[SLO_ID_FIELD]}`,
       };
     },
     iconClass: 'bell',


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/155311

## 📝  Summary

This changes the link of the alert to the slo details page instead of the slo dashboard page.