### PR TITLE
[8.7] [Discover] Address react warnings for legacy table (#154579)

### DIFF
--- a/src/plugins/discover/public/components/doc_table/components/table_header/table_header.tsx
+++ b/src/plugins/discover/public/components/doc_table/components/table_header/table_header.tsx
@@ -47,10 +47,10 @@ export function TableHeader({
   return (
     <tr data-test-subj="docTableHeader" className="kbnDocTableHeader">
       <th style={{ width: '24px' }} />
-      {displayedColumns.map((col) => {
+      {displayedColumns.map((col, index) => {
         return (
           <TableHeaderColumn
-            key={col.name}
+            key={`${col.name}-${index}`}
             {...col}
             customLabel={dataView.getFieldByName(col.name)?.customLabel}
             isTimeColumn={dataView.timeFieldName === col.name}

--- a/src/plugins/discover/public/components/doc_table/components/table_row.tsx
+++ b/src/plugins/discover/public/components/doc_table/components/table_row.tsx
@@ -151,7 +151,8 @@ export const TableRow = ({
       />
     );
   } else {
-    columns.forEach(function (column: string) {
+    columns.forEach(function (column: string, index) {
+      const cellKey = `${column}-${index}`;
       if (useNewFieldsApi && !mapping(column) && row.raw.fields && !row.raw.fields[column]) {
         const innerColumns = Object.fromEntries(
           Object.entries(row.raw.fields).filter(([key]) => {
@@ -161,7 +162,7 @@ export const TableRow = ({
 
         rowCells.push(
           <TableCell
-            key={column}
+            key={cellKey}
             timefield={false}
             sourcefield={true}
             formatted={formatTopLevelObject(row, innerColumns, dataView, maxEntries)}
@@ -180,7 +181,7 @@ export const TableRow = ({
         );
         rowCells.push(
           <TableCell
-            key={column}
+            key={cellKey}
             timefield={false}
             sourcefield={column === '_source'}
             formatted={displayField(column)}

--- a/src/plugins/discover/public/components/doc_table/doc_table_embeddable.tsx
+++ b/src/plugins/discover/public/components/doc_table/doc_table_embeddable.tsx
@@ -121,7 +121,7 @@ export const DocTableEmbeddable = (props: DocTableEmbeddableProps) => {
               </EuiText>
             </EuiFlexItem>
           )}
-          {props.totalHitCount !== 0 && (
+          {Boolean(props.totalHitCount) && (
             <EuiFlexItem grow={false} data-test-subj="toolBarTotalDocsText">
               <TotalDocuments totalHitCount={props.totalHitCount} />
             </EuiFlexItem>

--- a/src/plugins/discover/public/embeddable/saved_search_grid.tsx
+++ b/src/plugins/discover/public/embeddable/saved_search_grid.tsx
@@ -30,7 +30,7 @@ export function DiscoverGridEmbeddable(props: DiscoverGridEmbeddableProps) {
       responsive={false}
       data-test-subj="embeddedSavedSearchDocTable"
     >
-      {props.totalHitCount !== 0 && (
+      {Boolean(props.totalHitCount) && (
         <EuiFlexItem grow={false} style={{ alignSelf: 'flex-end' }}>
           <TotalDocuments totalHitCount={props.totalHitCount} />
         </EuiFlexItem>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.7`:
 - [[Discover] Address react warnings for legacy table (#154579)](https://github.com/elastic/kibana/pull/154579)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Julia Rechkunova","email":"julia.rechkunova@elastic.co"},"sourceCommit":{"committedDate":"2023-04-20T07:11:59Z","message":"[Discover] Address react warnings for legacy table (#154579)\n\n## Summary\r\n\r\nThis PR resolves react warnings for the legacy table:\r\n<details><summary>passing undefined to `TotalDocuments` during\r\nloading</summary>\r\n<pre>\r\nract_devtools_backend.js:2655 Warning: Failed prop type: The prop\r\n`value` is marked as required in `FormattedNumber`, but its value is\r\n`undefined`.\r\nat FormattedNumber\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-src/kbn-ui-shared-deps-src.js:149935:5)\r\nat TotalDocuments\r\n(http://localhost:5601/rzv/9007199254740991/bundles/plugin/discover/1.0.0/discover.chunk.7.js:70:3)\r\n    at div\r\nat\r\nhttp://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:170360:73\r\nat EuiFlexItem\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:109977:23)\r\n    at div\r\nat\r\nhttp://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:170360:73\r\nat\r\nhttp://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:109752:23\r\n    at div\r\nat\r\nhttp://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:170360:73\r\nat EuiFlexItem\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:109977:23)\r\n    at div\r\nat\r\nhttp://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:170360:73\r\nat\r\nhttp://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:109752:23\r\nat DocTableEmbeddable\r\n(http://localhost:5601/rzv/9007199254740991/bundles/plugin/discover/1.0.0/discover.chunk.7.js:309:109)\r\nat PseudoLocaleWrapper\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-src/kbn-ui-shared-deps-src.js:14199:5)\r\nat IntlProvider\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-src/kbn-ui-shared-deps-src.js:149454:5)\r\nat I18nProvider\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-src/kbn-ui-shared-deps-src.js:14130:3)\r\nat DiscoverDocTableEmbeddable\r\n(http://localhost:5601/rzv/9007199254740991/bundles/plugin/discover/1.0.0/discover.chunk.7.js:235:26)\r\nat SavedSearchEmbeddableComponent\r\n(http://localhost:5601/rzv/9007199254740991/bundles/plugin/discover/1.0.0/discover.chunk.7.js:976:3)\r\nat Provider\r\n(http://localhost:5601/rzv/9007199254740991/bundles/plugin/kibanaReact/1.0.0/kibanaReact.plugin.js:1794:15)\r\nat CurrentEuiBreakpointProvider\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:161492:23)\r\nat EuiThemeProvider\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:166432:22)\r\nat EuiCacheProvider\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:138902:20)\r\nat EuiProvider\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:139002:25)\r\nat KibanaThemeProvider\r\n(http://localhost:5601/rzv/9007199254740991/bundles/plugin/kibanaReact/1.0.0/kibanaReact.plugin.js:4625:3)\r\nat PseudoLocaleWrapper\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-src/kbn-ui-shared-deps-src.js:14199:5)\r\nat IntlProvider\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-src/kbn-ui-shared-deps-src.js:149454:5)\r\nat I18nProvider\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-src/kbn-ui-shared-deps-src.js:14130:3)\r\no\r\n</pre>\r\n</details>\r\n\r\n<details><summary>non unique keys for table headers and columns in SQL\r\nmode</summary>\r\n<pre>\r\nract_devtools_backend.js:2655 Warning: Encountered two children with the\r\nsame key, `order_date`. Keys should be unique so that components\r\nmaintain their identity across updates. Non-unique keys may cause\r\nchildren to be duplicated and/or omitted — the behavior is unsupported\r\nand could change in a future version.\r\n    at tr\r\nat TableHeader\r\n(http://localhost:5601/rzv/9007199254740991/bundles/plugin/discover/1.0.0/discover.chunk.3.js:3956:3)\r\n    at thead\r\n    at table\r\nat DocTableInfiniteContent\r\n(http://localhost:5601/rzv/9007199254740991/bundles/plugin/discover/1.0.0/discover.chunk.6.js:15565:3)\r\n    at div\r\nat\r\nhttp://localhost:5601/rzv/9007199254740991/bundles/plugin/discover/1.0.0/discover.chunk.3.js:4710:3\r\nat DocTableInfinite\r\n(http://localhost:5601/rzv/9007199254740991/bundles/plugin/discover/1.0.0/discover.chunk.6.js:15613:79)\r\n    at div\r\nat\r\nhttp://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:170360:73\r\nat EuiFlexItem\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:109977:23)\r\nat DiscoverDocumentsComponent\r\n(http://localhost:5601/rzv/9007199254740991/bundles/plugin/discover/1.0.0/discover.chunk.6.js:6758:3)\r\n    at div\r\nat\r\nhttp://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:170360:73\r\nat\r\nhttp://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:109752:23\r\nat DiscoverMainContent\r\n(http://localhost:5601/rzv/9007199254740991/bundles/plugin/discover/1.0.0/discover.chunk.6.js:7485:3)\r\nat InPortal\r\n(http://localhost:5601/rzv/9007199254740991/bundles/plugin/unifiedHistogram/1.0.0/unifiedHistogram.chunk.0.js:980:28)\r\nat UnifiedHistogramLayout\r\n(http://localhost:5601/rzv/9007199254740991/bundles/plugin/unifiedHistogram/1.0.0/unifiedHistogram.chunk.0.js:3694:3)\r\nat\r\nhttp://localhost:5601/rzv/9007199254740991/bundles/plugin/unifiedHistogram/1.0.0/unifiedHistogram.chunk.0.js:3019:95\r\n    at Suspense\r\nat EuiErrorBoundary\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:108416:81)\r\nat\r\nhttp://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:170360:73\r\nat DiscoverHistogramLayout\r\n(http://localhost:5601/rzv/9007199254740991/bundles/plugin/discover/1.0.0/discover.chunk.6.js:6956:3)\r\n    at div\r\nat\r\nhttp://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:170360:73\r\nat EuiPanel\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:136743:23)\r\nat EuiPageContent_Deprecated\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:133907:31)\r\n    at div\r\nat\r\nhttp://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:170360:73\r\nat EuiFlexItem\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:109977:23)\r\n    at div\r\nat\r\nhttp://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:170360:73\r\nat\r\nhttp://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:109752:23\r\n    at div\r\nat\r\nhttp://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:170360:73\r\nat EuiPageBody\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:133756:23)\r\n    at div\r\nat\r\nhttp://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:170360:73\r\nat EuiPage\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:133610:23)\r\nat DiscoverLayout\r\n(http://localhost:5601/rzv/9007199254740991/bundles/plugin/discover/1.0.0/discover.chunk.6.js:7173:3)\r\nat DiscoverMainProvider\r\n(http://localhost:5601/rzv/9007199254740991/bundles/plugin/discover/1.0.0/discover.chunk.6.js:14340:3)\r\nat DiscoverMainApp\r\n(http://localhost:5601/rzv/9007199254740991/bundles/plugin/discover/1.0.0/discover.chunk.6.js:12539:5)\r\nat DiscoverMainRoute\r\n(http://localhost:5601/rzv/9007199254740991/bundles/plugin/discover/1.0.0/discover.chunk.6.js:12703:86)\r\nat Route\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:361914:29)\r\nat Route\r\n(http://localhost:5601/rzv/9007199254740991/bundles/plugin/discover/1.0.0/discover.chunk.6.js:3677:3)\r\nat Switch\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:362120:29)\r\nat Router\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:361543:30)\r\nat EuiErrorBoundary\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:108416:81)\r\nat Provider\r\n(http://localhost:5601/rzv/9007199254740991/bundles/plugin/kibanaReact/1.0.0/kibanaReact.plugin.js:1794:15)\r\nat CurrentEuiBreakpointProvider\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:161492:23)\r\nat EuiThemeProvider\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:166432:22)\r\nat EuiCacheProvider\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:138902:20)\r\nat EuiProvider\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:139002:25)\r\nat KibanaThemeProvider\r\n(http://localhost:5601/rzv/9007199254740991/bundles/plugin/kibanaReact/1.0.0/kibanaReact.plugin.js:4625:3)\r\nat PseudoLocaleWrapper\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-src/kbn-ui-shared-deps-src.js:14199:5)\r\nat IntlProvider\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-src/kbn-ui-shared-deps-src.js:149454:5)\r\nat I18nProvider\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-src/kbn-ui-shared-deps-src.js:14130:3)\r\no\r\n</pre>\r\n</details>\r\n\r\nThe one regarding array keys is interesting: time field column is\r\nrendered twice in the legacy table (as the first column and later on\r\nagain) in SQL mode. We could consider removing this duplication in\r\ncolumns but this would become a breaking change to the existing\r\nbehaviour, no? So I went with updating the key for now.\r\n\r\nFor testing:\r\n- switch to legacy table via Advanced Settings\r\n  - add a saved search to Dashboard\r\n  - check SQL mode on Discover","sha":"d079fbb0c80fa124ee8499887d146663463581c6","branchLabelMapping":{"^v8.8.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:DataDiscovery","backport:prev-minor","v8.8.0"],"number":154579,"url":"https://github.com/elastic/kibana/pull/154579","mergeCommit":{"message":"[Discover] Address react warnings for legacy table (#154579)\n\n## Summary\r\n\r\nThis PR resolves react warnings for the legacy table:\r\n<details><summary>passing undefined to `TotalDocuments` during\r\nloading</summary>\r\n<pre>\r\nract_devtools_backend.js:2655 Warning: Failed prop type: The prop\r\n`value` is marked as required in `FormattedNumber`, but its value is\r\n`undefined`.\r\nat FormattedNumber\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-src/kbn-ui-shared-deps-src.js:149935:5)\r\nat TotalDocuments\r\n(http://localhost:5601/rzv/9007199254740991/bundles/plugin/discover/1.0.0/discover.chunk.7.js:70:3)\r\n    at div\r\nat\r\nhttp://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:170360:73\r\nat EuiFlexItem\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:109977:23)\r\n    at div\r\nat\r\nhttp://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:170360:73\r\nat\r\nhttp://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:109752:23\r\n    at div\r\nat\r\nhttp://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:170360:73\r\nat EuiFlexItem\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:109977:23)\r\n    at div\r\nat\r\nhttp://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:170360:73\r\nat\r\nhttp://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:109752:23\r\nat DocTableEmbeddable\r\n(http://localhost:5601/rzv/9007199254740991/bundles/plugin/discover/1.0.0/discover.chunk.7.js:309:109)\r\nat PseudoLocaleWrapper\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-src/kbn-ui-shared-deps-src.js:14199:5)\r\nat IntlProvider\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-src/kbn-ui-shared-deps-src.js:149454:5)\r\nat I18nProvider\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-src/kbn-ui-shared-deps-src.js:14130:3)\r\nat DiscoverDocTableEmbeddable\r\n(http://localhost:5601/rzv/9007199254740991/bundles/plugin/discover/1.0.0/discover.chunk.7.js:235:26)\r\nat SavedSearchEmbeddableComponent\r\n(http://localhost:5601/rzv/9007199254740991/bundles/plugin/discover/1.0.0/discover.chunk.7.js:976:3)\r\nat Provider\r\n(http://localhost:5601/rzv/9007199254740991/bundles/plugin/kibanaReact/1.0.0/kibanaReact.plugin.js:1794:15)\r\nat CurrentEuiBreakpointProvider\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:161492:23)\r\nat EuiThemeProvider\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:166432:22)\r\nat EuiCacheProvider\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:138902:20)\r\nat EuiProvider\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:139002:25)\r\nat KibanaThemeProvider\r\n(http://localhost:5601/rzv/9007199254740991/bundles/plugin/kibanaReact/1.0.0/kibanaReact.plugin.js:4625:3)\r\nat PseudoLocaleWrapper\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-src/kbn-ui-shared-deps-src.js:14199:5)\r\nat IntlProvider\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-src/kbn-ui-shared-deps-src.js:149454:5)\r\nat I18nProvider\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-src/kbn-ui-shared-deps-src.js:14130:3)\r\no\r\n</pre>\r\n</details>\r\n\r\n<details><summary>non unique keys for table headers and columns in SQL\r\nmode</summary>\r\n<pre>\r\nract_devtools_backend.js:2655 Warning: Encountered two children with the\r\nsame key, `order_date`. Keys should be unique so that components\r\nmaintain their identity across updates. Non-unique keys may cause\r\nchildren to be duplicated and/or omitted — the behavior is unsupported\r\nand could change in a future version.\r\n    at tr\r\nat TableHeader\r\n(http://localhost:5601/rzv/9007199254740991/bundles/plugin/discover/1.0.0/discover.chunk.3.js:3956:3)\r\n    at thead\r\n    at table\r\nat DocTableInfiniteContent\r\n(http://localhost:5601/rzv/9007199254740991/bundles/plugin/discover/1.0.0/discover.chunk.6.js:15565:3)\r\n    at div\r\nat\r\nhttp://localhost:5601/rzv/9007199254740991/bundles/plugin/discover/1.0.0/discover.chunk.3.js:4710:3\r\nat DocTableInfinite\r\n(http://localhost:5601/rzv/9007199254740991/bundles/plugin/discover/1.0.0/discover.chunk.6.js:15613:79)\r\n    at div\r\nat\r\nhttp://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:170360:73\r\nat EuiFlexItem\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:109977:23)\r\nat DiscoverDocumentsComponent\r\n(http://localhost:5601/rzv/9007199254740991/bundles/plugin/discover/1.0.0/discover.chunk.6.js:6758:3)\r\n    at div\r\nat\r\nhttp://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:170360:73\r\nat\r\nhttp://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:109752:23\r\nat DiscoverMainContent\r\n(http://localhost:5601/rzv/9007199254740991/bundles/plugin/discover/1.0.0/discover.chunk.6.js:7485:3)\r\nat InPortal\r\n(http://localhost:5601/rzv/9007199254740991/bundles/plugin/unifiedHistogram/1.0.0/unifiedHistogram.chunk.0.js:980:28)\r\nat UnifiedHistogramLayout\r\n(http://localhost:5601/rzv/9007199254740991/bundles/plugin/unifiedHistogram/1.0.0/unifiedHistogram.chunk.0.js:3694:3)\r\nat\r\nhttp://localhost:5601/rzv/9007199254740991/bundles/plugin/unifiedHistogram/1.0.0/unifiedHistogram.chunk.0.js:3019:95\r\n    at Suspense\r\nat EuiErrorBoundary\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:108416:81)\r\nat\r\nhttp://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:170360:73\r\nat DiscoverHistogramLayout\r\n(http://localhost:5601/rzv/9007199254740991/bundles/plugin/discover/1.0.0/discover.chunk.6.js:6956:3)\r\n    at div\r\nat\r\nhttp://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:170360:73\r\nat EuiPanel\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:136743:23)\r\nat EuiPageContent_Deprecated\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:133907:31)\r\n    at div\r\nat\r\nhttp://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:170360:73\r\nat EuiFlexItem\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:109977:23)\r\n    at div\r\nat\r\nhttp://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:170360:73\r\nat\r\nhttp://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:109752:23\r\n    at div\r\nat\r\nhttp://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:170360:73\r\nat EuiPageBody\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:133756:23)\r\n    at div\r\nat\r\nhttp://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:170360:73\r\nat EuiPage\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:133610:23)\r\nat DiscoverLayout\r\n(http://localhost:5601/rzv/9007199254740991/bundles/plugin/discover/1.0.0/discover.chunk.6.js:7173:3)\r\nat DiscoverMainProvider\r\n(http://localhost:5601/rzv/9007199254740991/bundles/plugin/discover/1.0.0/discover.chunk.6.js:14340:3)\r\nat DiscoverMainApp\r\n(http://localhost:5601/rzv/9007199254740991/bundles/plugin/discover/1.0.0/discover.chunk.6.js:12539:5)\r\nat DiscoverMainRoute\r\n(http://localhost:5601/rzv/9007199254740991/bundles/plugin/discover/1.0.0/discover.chunk.6.js:12703:86)\r\nat Route\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:361914:29)\r\nat Route\r\n(http://localhost:5601/rzv/9007199254740991/bundles/plugin/discover/1.0.0/discover.chunk.6.js:3677:3)\r\nat Switch\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:362120:29)\r\nat Router\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:361543:30)\r\nat EuiErrorBoundary\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:108416:81)\r\nat Provider\r\n(http://localhost:5601/rzv/9007199254740991/bundles/plugin/kibanaReact/1.0.0/kibanaReact.plugin.js:1794:15)\r\nat CurrentEuiBreakpointProvider\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:161492:23)\r\nat EuiThemeProvider\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:166432:22)\r\nat EuiCacheProvider\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:138902:20)\r\nat EuiProvider\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:139002:25)\r\nat KibanaThemeProvider\r\n(http://localhost:5601/rzv/9007199254740991/bundles/plugin/kibanaReact/1.0.0/kibanaReact.plugin.js:4625:3)\r\nat PseudoLocaleWrapper\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-src/kbn-ui-shared-deps-src.js:14199:5)\r\nat IntlProvider\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-src/kbn-ui-shared-deps-src.js:149454:5)\r\nat I18nProvider\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-src/kbn-ui-shared-deps-src.js:14130:3)\r\no\r\n</pre>\r\n</details>\r\n\r\nThe one regarding array keys is interesting: time field column is\r\nrendered twice in the legacy table (as the first column and later on\r\nagain) in SQL mode. We could consider removing this duplication in\r\ncolumns but this would become a breaking change to the existing\r\nbehaviour, no? So I went with updating the key for now.\r\n\r\nFor testing:\r\n- switch to legacy table via Advanced Settings\r\n  - add a saved search to Dashboard\r\n  - check SQL mode on Discover","sha":"d079fbb0c80fa124ee8499887d146663463581c6"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.8.0","labelRegex":"^v8.8.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/154579","number":154579,"mergeCommit":{"message":"[Discover] Address react warnings for legacy table (#154579)\n\n## Summary\r\n\r\nThis PR resolves react warnings for the legacy table:\r\n<details><summary>passing undefined to `TotalDocuments` during\r\nloading</summary>\r\n<pre>\r\nract_devtools_backend.js:2655 Warning: Failed prop type: The prop\r\n`value` is marked as required in `FormattedNumber`, but its value is\r\n`undefined`.\r\nat FormattedNumber\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-src/kbn-ui-shared-deps-src.js:149935:5)\r\nat TotalDocuments\r\n(http://localhost:5601/rzv/9007199254740991/bundles/plugin/discover/1.0.0/discover.chunk.7.js:70:3)\r\n    at div\r\nat\r\nhttp://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:170360:73\r\nat EuiFlexItem\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:109977:23)\r\n    at div\r\nat\r\nhttp://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:170360:73\r\nat\r\nhttp://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:109752:23\r\n    at div\r\nat\r\nhttp://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:170360:73\r\nat EuiFlexItem\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:109977:23)\r\n    at div\r\nat\r\nhttp://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:170360:73\r\nat\r\nhttp://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:109752:23\r\nat DocTableEmbeddable\r\n(http://localhost:5601/rzv/9007199254740991/bundles/plugin/discover/1.0.0/discover.chunk.7.js:309:109)\r\nat PseudoLocaleWrapper\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-src/kbn-ui-shared-deps-src.js:14199:5)\r\nat IntlProvider\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-src/kbn-ui-shared-deps-src.js:149454:5)\r\nat I18nProvider\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-src/kbn-ui-shared-deps-src.js:14130:3)\r\nat DiscoverDocTableEmbeddable\r\n(http://localhost:5601/rzv/9007199254740991/bundles/plugin/discover/1.0.0/discover.chunk.7.js:235:26)\r\nat SavedSearchEmbeddableComponent\r\n(http://localhost:5601/rzv/9007199254740991/bundles/plugin/discover/1.0.0/discover.chunk.7.js:976:3)\r\nat Provider\r\n(http://localhost:5601/rzv/9007199254740991/bundles/plugin/kibanaReact/1.0.0/kibanaReact.plugin.js:1794:15)\r\nat CurrentEuiBreakpointProvider\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:161492:23)\r\nat EuiThemeProvider\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:166432:22)\r\nat EuiCacheProvider\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:138902:20)\r\nat EuiProvider\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:139002:25)\r\nat KibanaThemeProvider\r\n(http://localhost:5601/rzv/9007199254740991/bundles/plugin/kibanaReact/1.0.0/kibanaReact.plugin.js:4625:3)\r\nat PseudoLocaleWrapper\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-src/kbn-ui-shared-deps-src.js:14199:5)\r\nat IntlProvider\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-src/kbn-ui-shared-deps-src.js:149454:5)\r\nat I18nProvider\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-src/kbn-ui-shared-deps-src.js:14130:3)\r\no\r\n</pre>\r\n</details>\r\n\r\n<details><summary>non unique keys for table headers and columns in SQL\r\nmode</summary>\r\n<pre>\r\nract_devtools_backend.js:2655 Warning: Encountered two children with the\r\nsame key, `order_date`. Keys should be unique so that components\r\nmaintain their identity across updates. Non-unique keys may cause\r\nchildren to be duplicated and/or omitted — the behavior is unsupported\r\nand could change in a future version.\r\n    at tr\r\nat TableHeader\r\n(http://localhost:5601/rzv/9007199254740991/bundles/plugin/discover/1.0.0/discover.chunk.3.js:3956:3)\r\n    at thead\r\n    at table\r\nat DocTableInfiniteContent\r\n(http://localhost:5601/rzv/9007199254740991/bundles/plugin/discover/1.0.0/discover.chunk.6.js:15565:3)\r\n    at div\r\nat\r\nhttp://localhost:5601/rzv/9007199254740991/bundles/plugin/discover/1.0.0/discover.chunk.3.js:4710:3\r\nat DocTableInfinite\r\n(http://localhost:5601/rzv/9007199254740991/bundles/plugin/discover/1.0.0/discover.chunk.6.js:15613:79)\r\n    at div\r\nat\r\nhttp://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:170360:73\r\nat EuiFlexItem\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:109977:23)\r\nat DiscoverDocumentsComponent\r\n(http://localhost:5601/rzv/9007199254740991/bundles/plugin/discover/1.0.0/discover.chunk.6.js:6758:3)\r\n    at div\r\nat\r\nhttp://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:170360:73\r\nat\r\nhttp://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:109752:23\r\nat DiscoverMainContent\r\n(http://localhost:5601/rzv/9007199254740991/bundles/plugin/discover/1.0.0/discover.chunk.6.js:7485:3)\r\nat InPortal\r\n(http://localhost:5601/rzv/9007199254740991/bundles/plugin/unifiedHistogram/1.0.0/unifiedHistogram.chunk.0.js:980:28)\r\nat UnifiedHistogramLayout\r\n(http://localhost:5601/rzv/9007199254740991/bundles/plugin/unifiedHistogram/1.0.0/unifiedHistogram.chunk.0.js:3694:3)\r\nat\r\nhttp://localhost:5601/rzv/9007199254740991/bundles/plugin/unifiedHistogram/1.0.0/unifiedHistogram.chunk.0.js:3019:95\r\n    at Suspense\r\nat EuiErrorBoundary\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:108416:81)\r\nat\r\nhttp://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:170360:73\r\nat DiscoverHistogramLayout\r\n(http://localhost:5601/rzv/9007199254740991/bundles/plugin/discover/1.0.0/discover.chunk.6.js:6956:3)\r\n    at div\r\nat\r\nhttp://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:170360:73\r\nat EuiPanel\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:136743:23)\r\nat EuiPageContent_Deprecated\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:133907:31)\r\n    at div\r\nat\r\nhttp://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:170360:73\r\nat EuiFlexItem\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:109977:23)\r\n    at div\r\nat\r\nhttp://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:170360:73\r\nat\r\nhttp://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:109752:23\r\n    at div\r\nat\r\nhttp://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:170360:73\r\nat EuiPageBody\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:133756:23)\r\n    at div\r\nat\r\nhttp://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:170360:73\r\nat EuiPage\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:133610:23)\r\nat DiscoverLayout\r\n(http://localhost:5601/rzv/9007199254740991/bundles/plugin/discover/1.0.0/discover.chunk.6.js:7173:3)\r\nat DiscoverMainProvider\r\n(http://localhost:5601/rzv/9007199254740991/bundles/plugin/discover/1.0.0/discover.chunk.6.js:14340:3)\r\nat DiscoverMainApp\r\n(http://localhost:5601/rzv/9007199254740991/bundles/plugin/discover/1.0.0/discover.chunk.6.js:12539:5)\r\nat DiscoverMainRoute\r\n(http://localhost:5601/rzv/9007199254740991/bundles/plugin/discover/1.0.0/discover.chunk.6.js:12703:86)\r\nat Route\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:361914:29)\r\nat Route\r\n(http://localhost:5601/rzv/9007199254740991/bundles/plugin/discover/1.0.0/discover.chunk.6.js:3677:3)\r\nat Switch\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:362120:29)\r\nat Router\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:361543:30)\r\nat EuiErrorBoundary\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:108416:81)\r\nat Provider\r\n(http://localhost:5601/rzv/9007199254740991/bundles/plugin/kibanaReact/1.0.0/kibanaReact.plugin.js:1794:15)\r\nat CurrentEuiBreakpointProvider\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:161492:23)\r\nat EuiThemeProvider\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:166432:22)\r\nat EuiCacheProvider\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:138902:20)\r\nat EuiProvider\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js:139002:25)\r\nat KibanaThemeProvider\r\n(http://localhost:5601/rzv/9007199254740991/bundles/plugin/kibanaReact/1.0.0/kibanaReact.plugin.js:4625:3)\r\nat PseudoLocaleWrapper\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-src/kbn-ui-shared-deps-src.js:14199:5)\r\nat IntlProvider\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-src/kbn-ui-shared-deps-src.js:149454:5)\r\nat I18nProvider\r\n(http://localhost:5601/rzv/9007199254740991/bundles/kbn-ui-shared-deps-src/kbn-ui-shared-deps-src.js:14130:3)\r\no\r\n</pre>\r\n</details>\r\n\r\nThe one regarding array keys is interesting: time field column is\r\nrendered twice in the legacy table (as the first column and later on\r\nagain) in SQL mode. We could consider removing this duplication in\r\ncolumns but this would become a breaking change to the existing\r\nbehaviour, no? So I went with updating the key for now.\r\n\r\nFor testing:\r\n- switch to legacy table via Advanced Settings\r\n  - add a saved search to Dashboard\r\n  - check SQL mode on Discover","sha":"d079fbb0c80fa124ee8499887d146663463581c6"}}]}] BACKPORT-->