### PR TITLE
Do not initialize event stream until we log events

### DIFF
--- a/src/plugins/content_management/server/core/core.ts
+++ b/src/plugins/content_management/server/core/core.ts
@@ -28,7 +28,7 @@ export interface CoreApi {
 
 export interface CoreInitializerContext {
   logger: Logger;
-  eventStream: EventStreamService;
+  eventStream?: EventStreamService;
 }
 
 export interface CoreSetup {
@@ -63,14 +63,20 @@ export class Core {
   }
 
   private setupEventStream() {
+    const eventStream = this.ctx.eventStream;
+
     // TODO: This should be cleaned up and support added for all CRUD events.
-    this.eventBus.on('deleteItemSuccess', (event) => {
-      this.ctx.eventStream.addEvent({
-        // TODO: add "subject" field to event
-        predicate: ['delete'],
-        // TODO: the `.contentId` should be easily available on most events.
-        object: [event.contentTypeId, (event as any).contentId],
+    // The work is tracked here: https://github.com/elastic/kibana/issues/153258
+    // and here: https://github.com/elastic/kibana/issues/153260
+    if (eventStream) {
+      this.eventBus.on('deleteItemSuccess', (event) => {
+        eventStream.addEvent({
+          // TODO: add "subject" field to event
+          predicate: ['delete'],
+          // TODO: the `.contentId` should be easily available on most events.
+          object: [event.contentTypeId, (event as any).contentId],
+        });
       });
-    });
+    }
   }
 }


### PR DESCRIPTION
## Summary

This PR pauses event stream initalization until we set up events that we want to log.


### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
