### PR TITLE
[Enterprise Search] Replace connectors ruby references with python

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_configuration.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_configuration.tsx
@@ -120,7 +120,7 @@ export const ConnectorConfiguration: React.FC = () => {
                           values={{
                             link: (
                               <EuiLink
-                                href="https://github.com/elastic/connectors-ruby/tree/main/lib/connectors"
+                                href="https://github.com/elastic/connectors-python/tree/main/lib/connectors"
                                 target="_blank"
                                 external
                               >
@@ -141,7 +141,7 @@ export const ConnectorConfiguration: React.FC = () => {
                           values={{
                             link: (
                               <EuiLink
-                                href="https://github.com/elastic/connectors-ruby/tree/main/config"
+                                href="https://github.com/elastic/connectors-python/tree/blob/config.yml"
                                 target="_blank"
                                 external
                               >
@@ -352,7 +352,7 @@ export const ConnectorConfiguration: React.FC = () => {
                   </EuiFlexItem>
                   <EuiFlexItem>
                     <EuiLink
-                      href="https://github.com/elastic/connectors-ruby#readme"
+                      href="https://github.com/elastic/connectors-python/blob/main/README.md"
                       target="_blank"
                     >
                       {i18n.translate(
@@ -378,7 +378,7 @@ export const ConnectorConfiguration: React.FC = () => {
                   </EuiFlexItem>
                   <EuiFlexItem>
                     <EuiLink
-                      href="https://github.com/elastic/connectors-ruby/issues"
+                      href="https://github.com/elastic/connectors-python/issues"
                       target="_blank"
                     >
                       {i18n.translate(

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_configuration.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_configuration.tsx
@@ -120,7 +120,7 @@ export const ConnectorConfiguration: React.FC = () => {
                           values={{
                             link: (
                               <EuiLink
-                                href="https://github.com/elastic/connectors-python/tree/main/lib/connectors"
+                                href="https://github.com/elastic/connectors-python/tree/main/connectors"
                                 target="_blank"
                                 external
                               >
@@ -141,7 +141,7 @@ export const ConnectorConfiguration: React.FC = () => {
                           values={{
                             link: (
                               <EuiLink
-                                href="https://github.com/elastic/connectors-python/tree/blob/config.yml"
+                                href="https://github.com/elastic/connectors-python/blob/main/config.yml"
                                 target="_blank"
                                 external
                               >

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/custom_connector_configuration_config.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/custom_connector_configuration_config.tsx
@@ -18,16 +18,16 @@ export const ConnectorConfigurationConfig: React.FC = () => {
       <EuiText size="s">
         <FormattedMessage
           id="xpack.enterpriseSearch.content.indices.configurationConnector.config.description.firstParagraph"
-          defaultMessage="Now that your connector is deployed, enhance the deployed connector client for your custom data source. There’s an {link} for you to start adding your data source specific implementation logic."
+          defaultMessage="Now that your connector is deployed, enhance the deployed connector client for your custom data source. There are several {link} you can build on to add your data source specific implementation logic."
           values={{
             link: (
               <EuiLink
-                href="https://github.com/elastic/connectors-ruby/tree/main/lib/connectors/example"
+                href="https://github.com/elastic/connectors-python/tree/main/connectors/sources"
                 target="_blank"
               >
                 {i18n.translate(
                   'xpack.enterpriseSearch.content.indices.configurationConnector.config.connectorClientLink',
-                  { defaultMessage: 'example connector client' }
+                  { defaultMessage: 'connectors' }
                 )}
               </EuiLink>
             ),
@@ -56,7 +56,7 @@ export const ConnectorConfigurationConfig: React.FC = () => {
               </EuiLink>
             ),
             issuesLink: (
-              <EuiLink href="https://github.com/elastic/connectors-ruby/issues" target="_blank">
+              <EuiLink href="https://github.com/elastic/connectors-python/issues" target="_blank">
                 {i18n.translate(
                   'xpack.enterpriseSearch.content.indices.configurationConnector.config.issuesLink',
                   { defaultMessage: 'issue' }

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/custom_connector_configuration_config.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/custom_connector_configuration_config.tsx
@@ -18,7 +18,7 @@ export const ConnectorConfigurationConfig: React.FC = () => {
       <EuiText size="s">
         <FormattedMessage
           id="xpack.enterpriseSearch.content.indices.configurationConnector.config.description.firstParagraph"
-          defaultMessage="Now that your connector is deployed, enhance the deployed connector client for your custom data source. There are several {link} you can build on to add your data source specific implementation logic."
+          defaultMessage="Now that your connector is deployed, enhance the connector client for your custom data source. There are several {link} you can customize with your own additional implementation logic."
           values={{
             link: (
               <EuiLink


### PR DESCRIPTION
## Summary

This replaces all references to the Ruby repository with references to the Python repository for connectors.