### PR TITLE
[Uptime] Add both both ip filters for view host in uptime location for host and monitor

### DIFF
--- a/x-pack/plugins/synthetics/public/apps/locators/overview.test.ts
+++ b/x-pack/plugins/synthetics/public/apps/locators/overview.test.ts
@@ -21,7 +21,9 @@ describe('uptimeOverviewNavigatorParams', () => {
 
   it('creates a path with expected search when ip is specified', async () => {
     const location = await uptimeOverviewNavigatorParams.getLocation({ ip: '127.0.0.1' });
-    expect(location.path).toEqual(`${OVERVIEW_ROUTE}?search=monitor.ip: "127.0.0.1"`);
+    expect(location.path).toEqual(
+      `${OVERVIEW_ROUTE}?search=host.ip: "127.0.0.1" OR monitor.ip: "127.0.0.1"`
+    );
   });
 
   it('creates a path with expected search when hostname is specified', async () => {
@@ -35,7 +37,7 @@ describe('uptimeOverviewNavigatorParams', () => {
       ip: '127.0.0.1',
     });
     expect(location.path).toEqual(
-      `${OVERVIEW_ROUTE}?search=host.name: "elastic.co" OR host.ip: "127.0.0.1"`
+      `${OVERVIEW_ROUTE}?search=host.name: "elastic.co" OR host.ip: "127.0.0.1" OR monitor.ip: "127.0.0.1"`
     );
   });
 
@@ -45,7 +47,7 @@ describe('uptimeOverviewNavigatorParams', () => {
       ip: '10.0.0.1',
     });
     expect(location.path).toEqual(
-      `${OVERVIEW_ROUTE}?search=kubernetes.pod.uid: "foo" OR monitor.ip: "10.0.0.1"`
+      `${OVERVIEW_ROUTE}?search=kubernetes.pod.uid: "foo" OR host.ip: "10.0.0.1" OR monitor.ip: "10.0.0.1"`
     );
   });
 

--- a/x-pack/plugins/synthetics/public/apps/locators/overview.ts
+++ b/x-pack/plugins/synthetics/public/apps/locators/overview.ts
@@ -28,8 +28,8 @@ async function navigate({
   if (pod) searchParams.push(formatSearchKey('kubernetes.pod.uid', pod));
 
   if (ip) {
-    const root = host ? 'host' : 'monitor';
-    searchParams.push(formatSearchKey(`${root}.ip`, ip));
+    searchParams.push(formatSearchKey(`host.ip`, ip));
+    searchParams.push(formatSearchKey(`monitor.ip`, ip));
   }
 
   const searchString = searchParams.join(' OR ');

--- a/x-pack/plugins/synthetics/scripts/e2e.js
+++ b/x-pack/plugins/synthetics/scripts/e2e.js
@@ -12,4 +12,8 @@ const path = require('path');
 
 const e2eDir = path.join(__dirname, '../e2e');
 
-executeSyntheticsRunner(e2eDir);
+try {
+  executeSyntheticsRunner(e2eDir);
+} catch (e) {
+  console.log(e);
+}


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/51960

Instead of using `host.ip` or `monitor.ip` exclusively adjusted the condition to use both filters. 

<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->