### PR TITLE
[Security Solution] Fix flaky install_prebuilt_rules_from_real_package test

### DIFF
--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/group1/fleet_integration.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/group1/fleet_integration.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 import expect from 'expect';
+import { ALL_SAVED_OBJECT_INDICES } from '@kbn/core-saved-objects-server';
 import { FtrProviderContext } from '../../common/ftr_provider_context';
 import {
   deleteAllRules,
@@ -46,6 +47,20 @@ export default ({ getService }: FtrProviderContext): void => {
         overrideExistingPackage: true,
       });
 
+      // Before we proceed, we need to refresh saved object indices. This comment will explain why.
+      // At the previous step we installed the Fleet package with prebuilt detection rules.
+      // Prebuilt rules are assets that Fleet indexes as saved objects of a certain type.
+      // Fleet does this via a savedObjectsClient.import() call with explicit `refresh: false`.
+      // So, despite of the fact that the endpoint waits until the prebuilt rule assets will be
+      // successfully indexed, it doesn't wait until they become "visible" for subsequent read
+      // operations. Which is what we do next: we read these SOs in getPrebuiltRulesAndTimelinesStatus().
+      // Now, the time left until the next refresh can be anything from 0 to the default value, and
+      // it depends on the time when savedObjectsClient.import() call happens relative to the time of
+      // the next refresh. Also, probably the refresh time can be delayed when ES is under load?
+      // Anyway, here we have a race condition between a write and subsequent read operation, and to
+      // fix it deterministically we have to refresh saved object indices and wait until it's done.
+      await es.indices.refresh({ index: ALL_SAVED_OBJECT_INDICES });
+
       // Verify that status is updated after package installation
       const statusAfterPackageInstallation = await getPrebuiltRulesAndTimelinesStatus(supertest);
       expect(statusAfterPackageInstallation.rules_installed).toBe(0);
@@ -56,6 +71,15 @@ export default ({ getService }: FtrProviderContext): void => {
       const response = await installPrebuiltRulesAndTimelines(supertest);
       expect(response.rules_installed).toBe(statusAfterPackageInstallation.rules_not_installed);
       expect(response.rules_updated).toBe(0);
+
+      // Similar to the previous refresh, we need to do it again between the two operations:
+      // - previous write operation: install prebuilt rules and timelines
+      // - subsequent read operation: get prebuilt rules and timelines status
+      // You may ask why? I'm not sure, probably because the write operation can install the Fleet
+      // package under certain circumstances, and it all works with `refresh: false` again.
+      // Anyway, there were flaky runs failing specifically at one of the next assertions,
+      // which means some kind of the same race condition we have here too.
+      await es.indices.refresh({ index: ALL_SAVED_OBJECT_INDICES });
 
       // Verify that status is updated after rules installation
       const statusAfterRuleInstallation = await getPrebuiltRulesAndTimelinesStatus(supertest);


### PR DESCRIPTION
**NOTE:** This PR will be merged to the following base PR: https://github.com/elastic/kibana/pull/154888

## Summary

The Kibana Core team is working on splitting saved objects into multiple indices (see the above PR). @pgayvallet said that the `install_prebuilt_rules_from_real_package` API integration test was incredibly flaky for them -- preventing the CI from running green:

> We had to rerun it like 4 or 5 times before being able to have a green run on detection_engine_api_integration/security_and_space/group1 because of that specific test.

Example builds with failures:

https://buildkite.com/elastic/kibana-pull-request/builds/121292
https://buildkite.com/elastic/kibana-pull-request/builds/121246
https://buildkite.com/elastic/kibana-pull-request/builds/121092

In this PR I'm trying to fix the flake which is apparently caused by a race condition between write and subsequent read operations that this test performs. Please read the comments in the code for detailed explanation.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
