### PR TITLE
[Enterprise Search] Add empty prompt for hidden indices

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/generate_api_key_panel.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/generate_api_key_panel.tsx
@@ -55,7 +55,7 @@ export const GenerateApiKeyPanel: React.FC = () => {
                   <p>
                     {i18n.translate('xpack.enterpriseSearch.content.overview.emptyPrompt.body', {
                       defaultMessage:
-                        'Adding documents to an externally managed index is not recommended.',
+                        'We do not recommend adding documents to an externally managed index.',
                     })}
                   </p>
                 }

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/generate_api_key_panel.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/generate_api_key_panel.tsx
@@ -9,7 +9,15 @@ import React, { useState } from 'react';
 
 import { useActions, useValues } from 'kea';
 
-import { EuiFlexGroup, EuiFlexItem, EuiPanel, EuiSpacer, EuiSwitch, EuiTitle } from '@elastic/eui';
+import {
+  EuiEmptyPrompt,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiPanel,
+  EuiSpacer,
+  EuiSwitch,
+  EuiTitle,
+} from '@elastic/eui';
 
 import { i18n } from '@kbn/i18n';
 
@@ -27,7 +35,7 @@ import { OverviewLogic } from './overview.logic';
 
 export const GenerateApiKeyPanel: React.FC = () => {
   const { apiKey, isGenerateModalOpen } = useValues(OverviewLogic);
-  const { indexName, ingestionMethod } = useValues(IndexViewLogic);
+  const { indexName, ingestionMethod, isHiddenIndex } = useValues(IndexViewLogic);
   const { closeGenerateModal } = useActions(OverviewLogic);
   const { defaultPipeline } = useValues(SettingsLogic);
 
@@ -41,11 +49,29 @@ export const GenerateApiKeyPanel: React.FC = () => {
       <EuiFlexGroup>
         <EuiFlexItem>
           <EuiPanel hasBorder>
-            <EuiFlexGroup direction="column">
-              <EuiFlexItem>
-                <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
-                  <EuiFlexItem>
-                    {indexName[0] !== '.' && (
+            {isHiddenIndex ? (
+              <EuiEmptyPrompt
+                body={
+                  <p>
+                    {i18n.translate('xpack.enterpriseSearch.content.overview.emptyPrompt.body', {
+                      defaultMessage:
+                        'Adding documents to an externally managed index is not recommended.',
+                    })}
+                  </p>
+                }
+                title={
+                  <h2>
+                    {i18n.translate('xpack.enterpriseSearch.content.overview.emptyPrompt.title', {
+                      defaultMessage: 'Index managed externally',
+                    })}
+                  </h2>
+                }
+              />
+            ) : (
+              <EuiFlexGroup direction="column">
+                <EuiFlexItem>
+                  <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
+                    <EuiFlexItem>
                       <EuiTitle size="s">
                         <h2>
                           {i18n.translate(
@@ -54,45 +80,42 @@ export const GenerateApiKeyPanel: React.FC = () => {
                           )}
                         </h2>
                       </EuiTitle>
-                    )}
-                  </EuiFlexItem>
-                  <EuiFlexItem grow={false}>
-                    <EuiSwitch
-                      data-telemetry-id={`entSearchContent-${ingestionMethod}-overview-generateApiKey-optimizedRequest`}
-                      onChange={(event) => setOptimizedRequest(event.target.checked)}
-                      label={i18n.translate(
-                        'xpack.enterpriseSearch.content.overview.optimizedRequest.label',
-                        { defaultMessage: 'View Enterprise Search optimized request' }
-                      )}
-                      checked={optimizedRequest}
-                    />
-                  </EuiFlexItem>
-                  <EuiFlexItem grow={false}>
-                    <EuiFlexGroup justifyContent="flexEnd" alignItems="center">
-                      <EuiFlexItem>
-                        <ClientLibrariesPopover />
-                      </EuiFlexItem>
-                      <EuiFlexItem>
-                        <ManageKeysPopover />
-                      </EuiFlexItem>
-                    </EuiFlexGroup>
-                  </EuiFlexItem>
-                </EuiFlexGroup>
-              </EuiFlexItem>
-              {indexName[0] !== '.' && (
-                <>
-                  <EuiSpacer />
-                  <EuiFlexItem>
-                    <CurlRequest
-                      apiKey={apiKey}
-                      document={DOCUMENTS_API_JSON_EXAMPLE}
-                      indexName={indexName}
-                      pipeline={optimizedRequest ? defaultPipeline : undefined}
-                    />
-                  </EuiFlexItem>
-                </>
-              )}
-            </EuiFlexGroup>
+                    </EuiFlexItem>
+                    <EuiFlexItem grow={false}>
+                      <EuiSwitch
+                        data-telemetry-id={`entSearchContent-${ingestionMethod}-overview-generateApiKey-optimizedRequest`}
+                        onChange={(event) => setOptimizedRequest(event.target.checked)}
+                        label={i18n.translate(
+                          'xpack.enterpriseSearch.content.overview.optimizedRequest.label',
+                          { defaultMessage: 'View Enterprise Search optimized request' }
+                        )}
+                        checked={optimizedRequest}
+                      />
+                    </EuiFlexItem>
+                    <EuiFlexItem grow={false}>
+                      <EuiFlexGroup justifyContent="flexEnd" alignItems="center">
+                        <EuiFlexItem>
+                          <ClientLibrariesPopover />
+                        </EuiFlexItem>
+                        <EuiFlexItem>
+                          <ManageKeysPopover />
+                        </EuiFlexItem>
+                      </EuiFlexGroup>
+                    </EuiFlexItem>
+                  </EuiFlexGroup>
+                </EuiFlexItem>
+
+                <EuiSpacer />
+                <EuiFlexItem>
+                  <CurlRequest
+                    apiKey={apiKey}
+                    document={DOCUMENTS_API_JSON_EXAMPLE}
+                    indexName={indexName}
+                    pipeline={optimizedRequest ? defaultPipeline : undefined}
+                  />
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            )}
           </EuiPanel>
         </EuiFlexItem>
       </EuiFlexGroup>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/index_view_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/index_view_logic.test.ts
@@ -51,6 +51,7 @@ const DEFAULT_VALUES = {
   ingestionStatus: IngestionStatus.CONNECTED,
   isCanceling: false,
   isConnectorIndex: false,
+  isHiddenIndex: false,
   isInitialLoading: false,
   isSyncing: false,
   isWaitingForSync: false,

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/index_view_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/index_view_logic.ts
@@ -237,7 +237,8 @@ export const IndexViewLogic = kea<MakeLogicType<IndexViewValues, IndexViewAction
     ],
     isHiddenIndex: [
       () => [selectors.indexData],
-      (data: FetchIndexApiResponse | undefined) => data?.hidden || data?.name.startsWith('.'),
+      (data: FetchIndexApiResponse | undefined) =>
+        data?.hidden || (data?.name ?? '').startsWith('.'),
     ],
     isSyncing: [
       () => [selectors.indexData, selectors.syncStatus],

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/index_view_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/index_view_logic.ts
@@ -77,6 +77,7 @@ export interface IndexViewValues {
   ingestionMethod: IngestionMethod;
   ingestionStatus: IngestionStatus;
   isCanceling: boolean;
+  isHiddenIndex: boolean;
   isInitialLoading: typeof CachedFetchIndexApiLogic.values.isInitialLoading;
   isSyncing: boolean;
   isWaitingForSync: boolean;
@@ -233,6 +234,10 @@ export const IndexViewLogic = kea<MakeLogicType<IndexViewValues, IndexViewAction
     isConnectorIndex: [
       () => [selectors.indexData],
       (data: FetchIndexApiResponse | undefined) => isConnectorIndex(data),
+    ],
+    isHiddenIndex: [
+      () => [selectors.indexData],
+      (data: FetchIndexApiResponse | undefined) => data?.hidden || data?.name.startsWith('.'),
     ],
     isSyncing: [
       () => [selectors.indexData, selectors.syncStatus],


### PR DESCRIPTION
## Summary

This adds an empty prompt to the index overview page for hidden indices.
<img width="1040" alt="Screenshot 2023-04-20 at 14 50 06" src="https://user-images.githubusercontent.com/94373878/233371589-522888cb-39ed-4554-88fb-4a179ecd2f99.png">


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
