### PR TITLE
feat(slo): Add overview and alerts tab on slo details page

### DIFF
--- a/x-pack/plugins/observability/public/pages/slo_details/components/header_title.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_details/components/header_title.tsx
@@ -9,9 +9,7 @@ import { EuiFlexGroup, EuiFlexItem, EuiLoadingSpinner } from '@elastic/eui';
 import { SLOWithSummaryResponse } from '@kbn/slo-schema';
 import React from 'react';
 
-import { useFetchActiveAlerts } from '../../../hooks/slo/use_fetch_active_alerts';
 import { SloStatusBadge } from '../../../components/slo/slo_status_badge';
-import { SloActiveAlertsBadge } from '../../../components/slo/slo_status_badge/slo_active_alerts_badge';
 
 export interface Props {
   slo: SLOWithSummaryResponse | undefined;
@@ -20,10 +18,6 @@ export interface Props {
 
 export function HeaderTitle(props: Props) {
   const { isLoading, slo } = props;
-
-  const { data: activeAlerts } = useFetchActiveAlerts({
-    sloIds: !!slo ? [slo.id] : [],
-  });
 
   if (isLoading) {
     return <EuiLoadingSpinner data-test-subj="loadingTitle" />;
@@ -38,7 +32,6 @@ export function HeaderTitle(props: Props) {
       <EuiFlexItem grow={false}>{slo.name}</EuiFlexItem>
       <EuiFlexGroup direction="row" gutterSize="s" alignItems="center" responsive={false}>
         <SloStatusBadge slo={slo} />
-        <SloActiveAlertsBadge slo={slo} activeAlerts={activeAlerts[slo.id]} />
       </EuiFlexGroup>
     </EuiFlexGroup>
   );

--- a/x-pack/plugins/observability/public/pages/slo_details/components/slo_details.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_details/components/slo_details.tsx
@@ -5,10 +5,21 @@
  * 2.0.
  */
 
-import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiNotificationBadge,
+  EuiSpacer,
+  EuiTabbedContent,
+  EuiTabbedContentTab,
+} from '@elastic/eui';
 import { SLOWithSummaryResponse } from '@kbn/slo-schema';
-import React from 'react';
+import React, { Fragment } from 'react';
+import { AlertConsumers } from '@kbn/rule-data-utils';
+import { i18n } from '@kbn/i18n';
 
+import { useFetchActiveAlerts } from '../../../hooks/slo/use_fetch_active_alerts';
+import { useKibana } from '../../../utils/kibana_react';
 import { formatHistoricalData } from '../../../utils/slo/chart_data_formatter';
 import { useFetchHistoricalSummary } from '../../../hooks/slo/use_fetch_historical_summary';
 import { ErrorBudgetChartPanel } from './error_budget_chart_panel';
@@ -19,8 +30,18 @@ export interface Props {
   slo: SLOWithSummaryResponse;
   isAutoRefreshing: boolean;
 }
+const ALERTS_TABLE_ID = 'xpack.observability.slo.sloDetails.alertTable';
+const OVERVIEW_TAB = 'overview';
+const ALERTS_TAB = 'alerts';
 
 export function SloDetails({ slo, isAutoRefreshing }: Props) {
+  const {
+    triggersActionsUi: { alertsTableConfigurationRegistry, getAlertsStateTable: AlertsStateTable },
+  } = useKibana().services;
+
+  const { data: activeAlerts } = useFetchActiveAlerts({
+    sloIds: [slo.id],
+  });
   const { isLoading: historicalSummaryLoading, sloHistoricalSummaryResponse = {} } =
     useFetchHistoricalSummary({ sloIds: [slo.id], shouldRefetch: isAutoRefreshing });
 
@@ -30,23 +51,80 @@ export function SloDetails({ slo, isAutoRefreshing }: Props) {
   );
   const historicalSliData = formatHistoricalData(sloHistoricalSummaryResponse[slo.id], 'sli_value');
 
+  const tabs: EuiTabbedContentTab[] = [
+    {
+      id: OVERVIEW_TAB,
+      name: i18n.translate('xpack.observability.slo.sloDetails.tab.overviewLabel', {
+        defaultMessage: 'Overview',
+      }),
+      'data-test-subj': 'overviewTab',
+      content: (
+        <Fragment>
+          <EuiSpacer size="l" />
+          <EuiFlexGroup direction="column" gutterSize="xl">
+            <EuiFlexItem>
+              <Overview slo={slo} />
+            </EuiFlexItem>
+            <EuiFlexGroup direction="column" gutterSize="l">
+              <EuiFlexItem>
+                <SliChartPanel
+                  data={historicalSliData}
+                  isLoading={historicalSummaryLoading}
+                  slo={slo}
+                />
+              </EuiFlexItem>
+              <EuiFlexItem>
+                <ErrorBudgetChartPanel
+                  data={errorBudgetBurnDownData}
+                  isLoading={historicalSummaryLoading}
+                  slo={slo}
+                />
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiFlexGroup>
+        </Fragment>
+      ),
+    },
+    {
+      id: ALERTS_TAB,
+      name: i18n.translate('xpack.observability.slo.sloDetails.tab.alertsLabel', {
+        defaultMessage: 'Alerts',
+      }),
+      'data-test-subj': 'alertsTab',
+      append: (
+        <EuiNotificationBadge className="eui-alignCenter" size="m">
+          {(activeAlerts && activeAlerts[slo.id]?.count) ?? 0}
+        </EuiNotificationBadge>
+      ),
+      content: (
+        <Fragment>
+          <EuiSpacer size="l" />
+          <EuiFlexGroup direction="column" gutterSize="xl">
+            <EuiFlexItem>
+              <AlertsStateTable
+                alertsTableConfigurationRegistry={alertsTableConfigurationRegistry}
+                configurationId={AlertConsumers.OBSERVABILITY}
+                id={ALERTS_TABLE_ID}
+                flyoutSize="s"
+                data-test-subj="alertTable"
+                featureIds={[AlertConsumers.SLO]}
+                query={{ bool: { filter: { term: { 'slo.id': slo.id } } } }}
+                showExpandToDetails={false}
+                showAlertStatusWithFlapping
+                pageSize={100}
+              />
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </Fragment>
+      ),
+    },
+  ];
+
   return (
-    <EuiFlexGroup direction="column" gutterSize="xl">
-      <EuiFlexItem>
-        <Overview slo={slo} />
-      </EuiFlexItem>
-      <EuiFlexGroup direction="column" gutterSize="l">
-        <EuiFlexItem>
-          <SliChartPanel data={historicalSliData} isLoading={historicalSummaryLoading} slo={slo} />
-        </EuiFlexItem>
-        <EuiFlexItem>
-          <ErrorBudgetChartPanel
-            data={errorBudgetBurnDownData}
-            isLoading={historicalSummaryLoading}
-            slo={slo}
-          />
-        </EuiFlexItem>
-      </EuiFlexGroup>
-    </EuiFlexGroup>
+    <EuiTabbedContent
+      data-test-subj="sloDetailsTabbedContent"
+      tabs={tabs}
+      initialSelectedTab={tabs[0]}
+    />
   );
 }

--- a/x-pack/plugins/observability/public/pages/slo_details/slo_details.test.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_details/slo_details.test.tsx
@@ -158,21 +158,6 @@ describe('SLO Details Page', () => {
     expect(screen.queryAllByTestId('wideChartLoading').length).toBe(0);
   });
 
-  it('renders the active alerts badge', async () => {
-    const slo = buildSlo();
-    useLicenseMock.mockReturnValue({ hasAtLeast: () => true });
-    useParamsMock.mockReturnValue(slo.id);
-    useFetchSloDetailsMock.mockReturnValue({ isLoading: false, slo });
-    useFetchActiveAlertsMock.mockReturnValue({
-      isLoading: false,
-      data: { [slo.id]: { count: 2, ruleIds: ['rule-1', 'rule-2'] } },
-    });
-
-    render(<SloDetailsPage />);
-
-    expect(screen.getByTestId('o11ySloActiveAlertsBadge')).toBeTruthy();
-  });
-
   it("renders a 'Edit' button under actions menu", async () => {
     const slo = buildSlo();
     useParamsMock.mockReturnValue(slo.id);
@@ -195,6 +180,24 @@ describe('SLO Details Page', () => {
 
     fireEvent.click(screen.getByTestId('o11yHeaderControlActionsButton'));
     expect(screen.queryByTestId('sloDetailsHeaderControlPopoverCreateRule')).toBeTruthy();
+  });
+
+  it('renders the Overview tab by default', async () => {
+    const slo = buildSlo();
+    useParamsMock.mockReturnValue(slo.id);
+    useFetchSloDetailsMock.mockReturnValue({ isLoading: false, slo });
+    useLicenseMock.mockReturnValue({ hasAtLeast: () => true });
+    useFetchActiveAlertsMock.mockReturnValue({
+      isLoading: false,
+      data: { [slo.id]: { count: 2, ruleIds: ['rule-1', 'rule-2'] } },
+    });
+
+    render(<SloDetailsPage />);
+
+    expect(screen.queryByTestId('overviewTab')).toBeTruthy();
+    expect(screen.queryByTestId('overviewTab')?.getAttribute('aria-selected')).toBe('true');
+    expect(screen.queryByTestId('alertsTab')).toBeTruthy();
+    expect(screen.queryByTestId('alertsTab')?.getAttribute('aria-selected')).toBe('false');
   });
 
   describe('when an APM SLO is loaded', () => {


### PR DESCRIPTION
resolves https://github.com/elastic/kibana/issues/155411

## 📝  Summary

This PR changes the SLO details page to include two tabs: Overview and Alerts.
All the existing content has been moved under Overview, while Alerts contains the Alert Table related to that SLO.


Description | Screenshot 
-- | --
Overview tab, with alerts | ![screencapture-localhost-5601-kibana-app-observability-slos-1c053830-dd36-11ed-bd63-25ae140a5455-2023-04-20-11_06_00](https://user-images.githubusercontent.com/1376800/233408475-94b45c07-5737-4c73-9e68-0d03deada0c8.png)
Alerts tab, with alerts | ![screencapture-localhost-5601-kibana-app-observability-slos-1c053830-dd36-11ed-bd63-25ae140a5455-2023-04-20-11_06_10](https://user-images.githubusercontent.com/1376800/233408561-1f542d7b-e3be-48c3-868e-a95df0a05a0a.png)
Overview tab, without alerts | ![screencapture-localhost-5601-kibana-app-observability-slos-cc7bfb80-dd46-11ed-bd63-25ae140a5455-2023-04-20-11_06_22](https://user-images.githubusercontent.com/1376800/233408869-bed910f3-cf4a-4c62-8c7c-a0c495f54ca7.png)
Alerts tab, without alerts | ![screencapture-localhost-5601-kibana-app-observability-slos-cc7bfb80-dd46-11ed-bd63-25ae140a5455-2023-04-20-11_06_29](https://user-images.githubusercontent.com/1376800/233408663-fb5edf7e-c756-4d49-8f58-27ce078298e7.png)


