### PR TITLE
[Cloud Security] Fix broken dashboard UI and ComplianceScoreBar

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/components/compliance_score_bar.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/compliance_score_bar.tsx
@@ -12,6 +12,9 @@ import React from 'react';
 import { calculatePostureScore } from '../../common/utils/helpers';
 import { statusColors } from '../common/constants';
 
+/**
+ * This component will take 100% of the width set by the parent
+ * */
 export const ComplianceScoreBar = ({
   totalPassed,
   totalFailed,
@@ -25,6 +28,7 @@ export const ComplianceScoreBar = ({
   return (
     <EuiToolTip
       anchorProps={{
+        // ensures the compliance bar takes full width of its parent
         css: css`
           width: 100%;
         `,
@@ -43,7 +47,7 @@ export const ComplianceScoreBar = ({
         justifyContent="flexEnd"
         style={{ gap: euiTheme.size.s }}
       >
-        <EuiFlexItem grow>
+        <EuiFlexItem>
           <EuiFlexGroup
             gutterSize="none"
             style={{
@@ -74,7 +78,7 @@ export const ComplianceScoreBar = ({
         <EuiFlexItem grow={false}>
           <EuiText
             size="xs"
-            style={{ fontWeight: euiTheme.font.weight.bold, minWidth: 10 }}
+            style={{ fontWeight: euiTheme.font.weight.bold }}
           >{`${complianceScore.toFixed(0)}%`}</EuiText>
         </EuiFlexItem>
       </EuiFlexGroup>

--- a/x-pack/plugins/cloud_security_posture/public/components/compliance_score_bar.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/compliance_score_bar.tsx
@@ -6,6 +6,7 @@
  */
 
 import { EuiFlexGroup, EuiFlexItem, EuiText, EuiToolTip, useEuiTheme } from '@elastic/eui';
+import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
 import { calculatePostureScore } from '../../common/utils/helpers';
@@ -22,22 +23,27 @@ export const ComplianceScoreBar = ({
   const complianceScore = calculatePostureScore(totalPassed, totalFailed);
 
   return (
-    <EuiFlexGroup
-      gutterSize="none"
-      alignItems="center"
-      justifyContent="flexEnd"
-      style={{ gap: euiTheme.size.s }}
+    <EuiToolTip
+      anchorProps={{
+        css: css`
+          width: 100%;
+        `,
+      }}
+      content={i18n.translate('xpack.csp.complianceScoreBar.tooltipTitle', {
+        defaultMessage: '{failed} failed and {passed} passed findings',
+        values: {
+          passed: totalPassed,
+          failed: totalFailed,
+        },
+      })}
     >
-      <EuiFlexItem>
-        <EuiToolTip
-          content={i18n.translate('xpack.csp.complianceScoreBar.tooltipTitle', {
-            defaultMessage: '{failed} failed and {passed} passed findings',
-            values: {
-              passed: totalPassed,
-              failed: totalFailed,
-            },
-          })}
-        >
+      <EuiFlexGroup
+        gutterSize="none"
+        alignItems="center"
+        justifyContent="flexEnd"
+        style={{ gap: euiTheme.size.s }}
+      >
+        <EuiFlexItem grow>
           <EuiFlexGroup
             gutterSize="none"
             style={{
@@ -64,14 +70,14 @@ export const ComplianceScoreBar = ({
               />
             )}
           </EuiFlexGroup>
-        </EuiToolTip>
-      </EuiFlexItem>
-      <EuiFlexItem grow={false}>
-        <EuiText
-          size="xs"
-          style={{ fontWeight: euiTheme.font.weight.bold }}
-        >{`${complianceScore.toFixed(0)}%`}</EuiText>
-      </EuiFlexItem>
-    </EuiFlexGroup>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiText
+            size="xs"
+            style={{ fontWeight: euiTheme.font.weight.bold, minWidth: 10 }}
+          >{`${complianceScore.toFixed(0)}%`}</EuiText>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiToolTip>
   );
 };

--- a/x-pack/plugins/cloud_security_posture/public/components/compliance_score_bar.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/compliance_score_bar.tsx
@@ -22,27 +22,22 @@ export const ComplianceScoreBar = ({
   const complianceScore = calculatePostureScore(totalPassed, totalFailed);
 
   return (
-    <EuiToolTip
-      anchorClassName="cspComplianceScoreBarTooltip"
-      content={i18n.translate('xpack.csp.complianceScoreBar.tooltipTitle', {
-        defaultMessage: '{failed} failed and {passed} passed findings',
-        values: {
-          passed: totalPassed,
-          failed: totalFailed,
-        },
-      })}
+    <EuiFlexGroup
+      gutterSize="none"
+      alignItems="center"
+      justifyContent="flexEnd"
+      style={{ gap: euiTheme.size.s }}
     >
-      <EuiFlexGroup
-        gutterSize="none"
-        alignItems="center"
-        justifyContent="flexEnd"
-        style={{
-          height: '32px',
-          cursor: 'pointer',
-          gap: `${euiTheme.size.s}`,
-        }}
-      >
-        <EuiFlexItem>
+      <EuiFlexItem>
+        <EuiToolTip
+          content={i18n.translate('xpack.csp.complianceScoreBar.tooltipTitle', {
+            defaultMessage: '{failed} failed and {passed} passed findings',
+            values: {
+              passed: totalPassed,
+              failed: totalFailed,
+            },
+          })}
+        >
           <EuiFlexGroup
             gutterSize="none"
             style={{
@@ -69,14 +64,14 @@ export const ComplianceScoreBar = ({
               />
             )}
           </EuiFlexGroup>
-        </EuiFlexItem>
-        <EuiFlexItem grow={false}>
-          <EuiText
-            size="xs"
-            style={{ fontWeight: euiTheme.font.weight.bold }}
-          >{`${complianceScore.toFixed(0)}%`}</EuiText>
-        </EuiFlexItem>
-      </EuiFlexGroup>
-    </EuiToolTip>
+        </EuiToolTip>
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiText
+          size="xs"
+          style={{ fontWeight: euiTheme.font.weight.bold }}
+        >{`${complianceScore.toFixed(0)}%`}</EuiText>
+      </EuiFlexItem>
+    </EuiFlexGroup>
   );
 };

--- a/x-pack/plugins/cloud_security_posture/public/components/fleet_extensions/policy_template_form.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/fleet_extensions/policy_template_form.tsx
@@ -182,7 +182,6 @@ export const CspPolicyTemplateForm = memo<PackagePolicyReplaceDefineStepExtensio
     return (
       <div>
         {isEditPage && <EditScreenStepTitle />}
-
         {/* Defines the enabled policy template */}
         {!integration && (
           <>
@@ -195,11 +194,9 @@ export const CspPolicyTemplateForm = memo<PackagePolicyReplaceDefineStepExtensio
             <EuiSpacer size="l" />
           </>
         )}
-
         {/* Shows info on the active policy template */}
         <PolicyTemplateInfo postureType={input.policy_template} />
         <EuiSpacer size="l" />
-
         {/* Defines the single enabled input of the active policy template */}
         <PolicyTemplateInputSelector
           input={input}
@@ -207,7 +204,6 @@ export const CspPolicyTemplateForm = memo<PackagePolicyReplaceDefineStepExtensio
           disabled={isEditPage}
         />
         <EuiSpacer size="l" />
-
         {/* Defines the name/description */}
         <IntegrationSettings
           fields={integrationFields}

--- a/x-pack/plugins/cloud_security_posture/public/components/fleet_extensions/policy_template_form.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/fleet_extensions/policy_template_form.tsx
@@ -182,6 +182,7 @@ export const CspPolicyTemplateForm = memo<PackagePolicyReplaceDefineStepExtensio
     return (
       <div>
         {isEditPage && <EditScreenStepTitle />}
+
         {/* Defines the enabled policy template */}
         {!integration && (
           <>
@@ -194,9 +195,11 @@ export const CspPolicyTemplateForm = memo<PackagePolicyReplaceDefineStepExtensio
             <EuiSpacer size="l" />
           </>
         )}
+
         {/* Shows info on the active policy template */}
         <PolicyTemplateInfo postureType={input.policy_template} />
         <EuiSpacer size="l" />
+
         {/* Defines the single enabled input of the active policy template */}
         <PolicyTemplateInputSelector
           input={input}
@@ -204,6 +207,7 @@ export const CspPolicyTemplateForm = memo<PackagePolicyReplaceDefineStepExtensio
           disabled={isEditPage}
         />
         <EuiSpacer size="l" />
+
         {/* Defines the name/description */}
         <IntegrationSettings
           fields={integrationFields}

--- a/x-pack/plugins/cloud_security_posture/public/components/no_vulnerabilities_states.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/no_vulnerabilities_states.tsx
@@ -13,6 +13,7 @@ import {
   EuiMarkdownFormat,
   EuiLink,
   EuiButton,
+  EuiButtonEmpty,
   EuiFlexGroup,
   EuiFlexItem,
   EuiImage,
@@ -43,7 +44,7 @@ const ScanningVulnerabilitiesEmptyPrompt = () => (
       <h2>
         <FormattedMessage
           id="xpack.csp.noVulnerabilitiesStates.scanningVulnerabilitiesEmptyPrompt.indexingButtonTitle"
-          defaultMessage="Scanning your cloud environment for vulnerabilities"
+          defaultMessage="Scanning your cloud environment"
         />
       </h2>
     }
@@ -51,7 +52,7 @@ const ScanningVulnerabilitiesEmptyPrompt = () => (
       <p>
         <FormattedMessage
           id="xpack.csp.noVulnerabilitiesStates.scanningVulnerabilitiesEmptyPrompt.indexingDescription"
-          defaultMessage="Results should start to appear within a minute"
+          defaultMessage="Results will appear here as soon as they are available"
         />
       </p>
     }
@@ -72,7 +73,7 @@ const VulnerabilitiesFindingsInstalledEmptyPrompt = ({
           <FormattedHTMLMessage
             tagName="h2"
             id="xpack.csp.cloudPosturePage.vulnerabilitiesInstalledEmptyPrompt.promptTitle"
-            defaultMessage="Detect vulnerabilities <br/> in your cloud assets!"
+            defaultMessage="Detect vulnerabilities in your <br/> cloud assets"
           />
         </h2>
       }
@@ -82,17 +83,7 @@ const VulnerabilitiesFindingsInstalledEmptyPrompt = ({
         <p>
           <FormattedMessage
             id="xpack.csp.cloudPosturePage.vulnerabilitiesInstalledEmptyPrompt.promptDescription"
-            defaultMessage="Add the Elastic Vulnerability Management Integration to begin. {learnMore}."
-            values={{
-              learnMore: (
-                <EuiLink href={''} target="_blank">
-                  <FormattedMessage
-                    id="xpack.csp.cloudPosturePage.vulnerabilitiesInstalledEmptyPrompt.learnMoreTitle"
-                    defaultMessage="Learn more about Elastic Vulnerability Management(VM) for Cloud"
-                  />
-                </EuiLink>
-              ),
-            }}
+            defaultMessage="Add the Cloud Native Vulnerability Management integration to begin"
           />
         </p>
       }
@@ -102,9 +93,17 @@ const VulnerabilitiesFindingsInstalledEmptyPrompt = ({
             <EuiButton color="primary" fill href={vulnMgmtIntegrationLink}>
               <FormattedMessage
                 id="xpack.csp.cloudPosturePage.vulnerabilitiesInstalledEmptyPrompt.addVulMngtIntegrationButtonTitle"
-                defaultMessage="Install Elastic Vulnerability Management for Cloud"
+                defaultMessage="Install Cloud Native Vulnerability Management"
               />
             </EuiButton>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiButtonEmpty color="primary" href={'https://ela.st/cnvm'} target="_blank">
+              <FormattedMessage
+                id="xpack.csp.cloudPosturePage.vulnerabilitiesInstalledEmptyPrompt.learnMoreButtonTitle"
+                defaultMessage="Learn more"
+              />
+            </EuiButtonEmpty>
           </EuiFlexItem>
         </EuiFlexGroup>
       }

--- a/x-pack/plugins/cloud_security_posture/public/components/no_vulnerabilities_states.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/no_vulnerabilities_states.tsx
@@ -13,7 +13,6 @@ import {
   EuiMarkdownFormat,
   EuiLink,
   EuiButton,
-  EuiButtonEmpty,
   EuiFlexGroup,
   EuiFlexItem,
   EuiImage,
@@ -44,7 +43,7 @@ const ScanningVulnerabilitiesEmptyPrompt = () => (
       <h2>
         <FormattedMessage
           id="xpack.csp.noVulnerabilitiesStates.scanningVulnerabilitiesEmptyPrompt.indexingButtonTitle"
-          defaultMessage="Scanning your cloud environment"
+          defaultMessage="Scanning your cloud environment for vulnerabilities"
         />
       </h2>
     }
@@ -52,7 +51,7 @@ const ScanningVulnerabilitiesEmptyPrompt = () => (
       <p>
         <FormattedMessage
           id="xpack.csp.noVulnerabilitiesStates.scanningVulnerabilitiesEmptyPrompt.indexingDescription"
-          defaultMessage="Results will appear here as soon as they are available"
+          defaultMessage="Results should start to appear within a minute"
         />
       </p>
     }
@@ -73,7 +72,7 @@ const VulnerabilitiesFindingsInstalledEmptyPrompt = ({
           <FormattedHTMLMessage
             tagName="h2"
             id="xpack.csp.cloudPosturePage.vulnerabilitiesInstalledEmptyPrompt.promptTitle"
-            defaultMessage="Detect vulnerabilities in your <br/> cloud assets"
+            defaultMessage="Detect vulnerabilities <br/> in your cloud assets!"
           />
         </h2>
       }
@@ -83,7 +82,17 @@ const VulnerabilitiesFindingsInstalledEmptyPrompt = ({
         <p>
           <FormattedMessage
             id="xpack.csp.cloudPosturePage.vulnerabilitiesInstalledEmptyPrompt.promptDescription"
-            defaultMessage="Add the Cloud Native Vulnerability Management integration to begin"
+            defaultMessage="Add the Elastic Vulnerability Management Integration to begin. {learnMore}."
+            values={{
+              learnMore: (
+                <EuiLink href={''} target="_blank">
+                  <FormattedMessage
+                    id="xpack.csp.cloudPosturePage.vulnerabilitiesInstalledEmptyPrompt.learnMoreTitle"
+                    defaultMessage="Learn more about Elastic Vulnerability Management(VM) for Cloud"
+                  />
+                </EuiLink>
+              ),
+            }}
           />
         </p>
       }
@@ -93,17 +102,9 @@ const VulnerabilitiesFindingsInstalledEmptyPrompt = ({
             <EuiButton color="primary" fill href={vulnMgmtIntegrationLink}>
               <FormattedMessage
                 id="xpack.csp.cloudPosturePage.vulnerabilitiesInstalledEmptyPrompt.addVulMngtIntegrationButtonTitle"
-                defaultMessage="Install Cloud Native Vulnerability Management"
+                defaultMessage="Install Elastic Vulnerability Management for Cloud"
               />
             </EuiButton>
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiButtonEmpty color="primary" href={'https://ela.st/cnvm'} target="_blank">
-              <FormattedMessage
-                id="xpack.csp.cloudPosturePage.vulnerabilitiesInstalledEmptyPrompt.learnMoreButtonTitle"
-                defaultMessage="Learn more"
-              />
-            </EuiButtonEmpty>
           </EuiFlexItem>
         </EuiFlexGroup>
       }

--- a/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/compliance_charts/risks_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/compliance_charts/risks_table.tsx
@@ -90,7 +90,9 @@ export const RisksTable = ({
             compact
               ? css`
                   thead {
-                    display: none;
+                    .euiTableCellContent {
+                      padding: 0;
+                    }
                   }
                   .euiTable .euiTableRow .euiTableRowCell {
                     border-top: none;

--- a/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/dashboard_sections/benchmarks_section.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/dashboard_sections/benchmarks_section.tsx
@@ -186,25 +186,31 @@ export const BenchmarksSection = ({
             />
           </EuiFlexItem>
           <EuiFlexItem grow={dashboardColumnsGrow.third}>
-            <RisksTable
-              compact
-              data={cluster.groupedFindingsEvaluation}
-              maxItems={3}
-              onCellClick={(resourceTypeName) =>
-                navToFailedFindingsByClusterAndSection(cluster, resourceTypeName)
-              }
-              viewAllButtonTitle={i18n.translate(
-                'xpack.csp.dashboard.risksTable.clusterCardViewAllButtonTitle',
-                {
-                  defaultMessage: 'View all failed findings for this {postureAsset}',
-                  values: {
-                    postureAsset:
-                      dashboardType === CSPM_POLICY_TEMPLATE ? 'cloud account' : 'cluster',
-                  },
+            <div
+              style={{
+                paddingRight: euiTheme.size.base,
+              }}
+            >
+              <RisksTable
+                compact
+                data={cluster.groupedFindingsEvaluation}
+                maxItems={3}
+                onCellClick={(resourceTypeName) =>
+                  navToFailedFindingsByClusterAndSection(cluster, resourceTypeName)
                 }
-              )}
-              onViewAllClick={() => navToFailedFindingsByCluster(cluster)}
-            />
+                viewAllButtonTitle={i18n.translate(
+                  'xpack.csp.dashboard.risksTable.clusterCardViewAllButtonTitle',
+                  {
+                    defaultMessage: 'View all failed findings for this {postureAsset}',
+                    values: {
+                      postureAsset:
+                        dashboardType === CSPM_POLICY_TEMPLATE ? 'cloud account' : 'cluster',
+                    },
+                  }
+                )}
+                onViewAllClick={() => navToFailedFindingsByCluster(cluster)}
+              />
+            </div>
           </EuiFlexItem>
         </EuiFlexGroup>
       ))}

--- a/x-pack/plugins/cloud_security_posture/public/pages/configurations/latest_findings_by_resource/findings_by_resource_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/configurations/latest_findings_by_resource/findings_by_resource_table.tsx
@@ -17,7 +17,6 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import numeral from '@elastic/numeral';
 import { generatePath, Link } from 'react-router-dom';
 import { i18n } from '@kbn/i18n';
-import { css } from '@emotion/react';
 import { ColumnNameWithTooltip } from '../../../components/column_name_with_tooltip';
 import { ComplianceScoreBar } from '../../../components/compliance_score_bar';
 import * as TEST_SUBJECTS from '../test_subjects';
@@ -179,19 +178,10 @@ const baseColumns: Array<EuiTableFieldDataColumnType<FindingsByResourcePage>> = 
       />
     ),
     render: (complianceScore: FindingsByResourcePage['compliance_score'], data) => (
-      <div
-        css={css`
-          width: 100%;
-          .cspComplianceScoreBarTooltip {
-            width: 100%;
-          }
-        `}
-      >
-        <ComplianceScoreBar
-          totalPassed={data.findings.passed_findings}
-          totalFailed={data.findings.failed_findings}
-        />
-      </div>
+      <ComplianceScoreBar
+        totalPassed={data.findings.passed_findings}
+        totalFailed={data.findings.failed_findings}
+      />
     ),
     dataType: 'number',
   },


### PR DESCRIPTION
Resolves #155132

## Summary

I had to revert https://github.com/elastic/kibana/pull/154506
Its purpose was to include the tooltip on the cells but somewhere along the process of improving the table it seems to have broken the dashboard. I've wrapped to tooltip around the entire `<ComplianceScoreBar />` so now the tooltip should be visible easier. before it was only showing when hovering the bar itself, now you can over the percentage or around the bar as well.

I've also readded the padding that was applied to the risks table in the benchmark section to make it aligned with the table from the summary section.

![image](https://user-images.githubusercontent.com/51442161/233423182-089a92d9-d192-4fda-ad3c-b5eea2e74899.png)

![Screen Shot 2023-04-20 at 19 13 32](https://user-images.githubusercontent.com/51442161/233426276-98a33504-73d3-4ab3-b834-d3681d65bbef.png)


https://user-images.githubusercontent.com/51442161/233425566-ce66b70d-5b49-4d81-a758-47b2822d8632.mov


https://user-images.githubusercontent.com/51442161/233432205-d3b02fe1-3368-4b60-bfe0-64908eb72336.mov

