### PR TITLE
[Controls] Use Internal User to Get Value of `allow_expensive_queries`

### DIFF
--- a/src/plugins/controls/public/services/options_list/options_list_service.ts
+++ b/src/plugins/controls/public/services/options_list/options_list_service.ts
@@ -99,7 +99,7 @@ class OptionsListService implements ControlsOptionsListService {
   private cachedAllowExpensiveQueries = memoize(async () => {
     const { allowExpensiveQueries } = await this.http.get<{
       allowExpensiveQueries: boolean;
-    }>('/api/kibana/controls/optionsList/getClusterSettings');
+    }>('/api/kibana/controls/optionsList/getExpensiveQueriesSetting');
     return allowExpensiveQueries;
   });
 

--- a/src/plugins/controls/server/options_list/options_list_cluster_settings_route.ts
+++ b/src/plugins/controls/server/options_list/options_list_cluster_settings_route.ts
@@ -18,6 +18,10 @@ export const setupOptionsListClusterSettingsRoute = ({ http }: CoreSetup) => {
     },
     async (context, _, response) => {
       try {
+        /**
+         *  using internal user here because in many cases the logged in user will not have the monitor permission required
+         * to check cluster settings. This endpoint does not take a query, params, or a body, so there is no chance of leaking info.
+         */
         const esClient = (await context.core).elasticsearch.client.asInternalUser;
         const settings = await esClient.cluster.getSettings({
           include_defaults: true,


### PR DESCRIPTION
## Summary
This PR changes the way we access `allow_expensive_queries` to use the internal user. The internal user will have `monitor` permissions in _almost_ every case, so this PR also removes the fallback added in https://github.com/elastic/kibana/pull/155082.

Additionally, because we're now using the internal user, this PR renames `getClusterSettings` endpoint for Controls into a `getExpensiveQueriesSetting` endpoint to be more specific.

I tested this PR by:
- Creating a new role that has no `monitor` privilege and assigning a user to that role
- Logging in as that user and ensuring that the controls are using expensive queries
- Logging back in as the elastic user and setting
  ```
  PUT _cluster/settings
  {
    "transient": {
	  "search.allow_expensive_queries": "false"
    }
  }
  ```
- Logging in as the user without monitor privilege again and ensuring that the Controls are now **not** using the expensive queries.

<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->