### PR TITLE
[RAM] Fix maintenance window status not archived when there are no events, but past expiration date

### DIFF
--- a/x-pack/plugins/alerting/server/maintenance_window_client/get_maintenance_window_date_and_status.test.ts
+++ b/x-pack/plugins/alerting/server/maintenance_window_client/get_maintenance_window_date_and_status.test.ts
@@ -69,6 +69,16 @@ describe('getMaintenanceWindowDateAndStatus', () => {
     expect(result.eventEndTime).toEqual('2023-03-25T01:00:00.000Z');
     expect(result.status).toEqual('archived');
 
+    result = getMaintenanceWindowDateAndStatus({
+      events: [],
+      dateToCompare: new Date(),
+      expirationDate: moment().subtract(1, 'minute').toDate(),
+    });
+
+    expect(result.eventStartTime).toEqual(null);
+    expect(result.eventEndTime).toEqual(null);
+    expect(result.status).toEqual('archived');
+
     jest.useFakeTimers().setSystemTime(new Date('2023-03-28T00:30:00.000Z'));
     result = getMaintenanceWindowDateAndStatus({
       events,

--- a/x-pack/plugins/alerting/server/maintenance_window_client/get_maintenance_window_date_and_status.ts
+++ b/x-pack/plugins/alerting/server/maintenance_window_client/get_maintenance_window_date_and_status.ts
@@ -30,12 +30,15 @@ export const getMaintenanceWindowDateAndStatus = ({
   dateToCompare: Date;
   expirationDate: Date;
 }): MaintenanceWindowDateAndStatus => {
-  // No events, status is finished
+  // No events, status is finished or archived
   if (!events.length) {
+    const status = moment.utc(expirationDate).isBefore(dateToCompare)
+      ? MaintenanceWindowStatus.Archived
+      : MaintenanceWindowStatus.Finished;
     return {
       eventStartTime: null,
       eventEndTime: null,
-      status: MaintenanceWindowStatus.Finished,
+      status,
     };
   }
 


### PR DESCRIPTION
## Summary

Fix a small bug when the user archives a maintenance window with no events, the maintenance window is considered finished, but it should be archived.

### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios