### PR TITLE
[cli] Fix regression preventing `--config` from overriding default `kibana.yml`

### DIFF
--- a/src/cli/serve/serve.js
+++ b/src/cli/serve/serve.js
@@ -279,7 +279,23 @@ export default function (program) {
 
   command.action(async function (opts) {
     const unknownOptions = this.getUnknownOptions();
-    const configs = [getConfigPath(), ...getEnvConfigs(), ...(opts.config || [])];
+    
+    const defaultConfig = getConfigPath();
+    const cliConfigs = opts.config || [];
+    const envConfigs = getEnvConfigs();
+
+    // CLI override || ENV override || config/kibana.yml 
+    const configs = [];
+    if (cliConfigs.length) {
+      configs.push(...cliConfigs)
+    }
+    if (!configs.length && envConfigs.length) {
+      configs.push(...envConfigs)
+    }
+    if (!configs.length) {
+      configs.push(defaultConfig)
+    }
+
     const serverlessMode = getServerlessProjectMode(opts);
 
     // we "unshift" .serverless. config so that it only overrides defaults

--- a/src/cli/serve/serve.js
+++ b/src/cli/serve/serve.js
@@ -279,21 +279,21 @@ export default function (program) {
 
   command.action(async function (opts) {
     const unknownOptions = this.getUnknownOptions();
-    
+
     const defaultConfig = getConfigPath();
     const cliConfigs = opts.config || [];
     const envConfigs = getEnvConfigs();
 
-    // CLI override || ENV override || config/kibana.yml 
+    // CLI override || ENV override || config/kibana.yml
     const configs = [];
     if (cliConfigs.length) {
-      configs.push(...cliConfigs)
+      configs.push(...cliConfigs);
     }
     if (!configs.length && envConfigs.length) {
-      configs.push(...envConfigs)
+      configs.push(...envConfigs);
     }
     if (!configs.length) {
-      configs.push(defaultConfig)
+      configs.push(defaultConfig);
     }
 
     const serverlessMode = getServerlessProjectMode(opts);


### PR DESCRIPTION
Introduced in https://github.com/elastic/kibana/pull/149878
Fixes https://github.com/elastic/kibana/issues/155154