### PR TITLE
[TriggersActionsUi] Optimize data fetching for RuleAdd

### DIFF
--- a/x-pack/plugins/observability/public/pages/rules/rules.tsx
+++ b/x-pack/plugins/observability/public/pages/rules/rules.tsx
@@ -18,7 +18,6 @@ import { useKibana } from '../../utils/kibana_react';
 import { usePluginContext } from '../../hooks/use_plugin_context';
 import { useBreadcrumbs } from '../../hooks/use_breadcrumbs';
 import { useGetFilteredRuleTypes } from '../../hooks/use_get_filtered_rule_types';
-import { useQueryClient } from '@tanstack/react-query';
 
 export function RulesPage() {
   const {

--- a/x-pack/plugins/observability/public/pages/rules/rules.tsx
+++ b/x-pack/plugins/observability/public/pages/rules/rules.tsx
@@ -10,7 +10,7 @@ import { useHistory } from 'react-router-dom';
 import { EuiButton, EuiFlexGroup, EuiFlexItem, EuiButtonEmpty } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { RuleStatus, useLoadRuleTypes } from '@kbn/triggers-actions-ui-plugin/public';
+import { RuleStatus, useLoadRuleTypesQuery } from '@kbn/triggers-actions-ui-plugin/public';
 import { ALERTS_FEATURE_ID } from '@kbn/alerting-plugin/common';
 import { createKbnUrlStateStorage } from '@kbn/kibana-utils-plugin/public';
 
@@ -18,6 +18,7 @@ import { useKibana } from '../../utils/kibana_react';
 import { usePluginContext } from '../../hooks/use_plugin_context';
 import { useBreadcrumbs } from '../../hooks/use_breadcrumbs';
 import { useGetFilteredRuleTypes } from '../../hooks/use_get_filtered_rule_types';
+import { useQueryClient } from '@tanstack/react-query';
 
 export function RulesPage() {
   const {
@@ -47,7 +48,9 @@ export function RulesPage() {
   ]);
 
   const filteredRuleTypes = useGetFilteredRuleTypes();
-  const { ruleTypes } = useLoadRuleTypes({
+  const {
+    ruleTypesState: { ruleTypes },
+  } = useLoadRuleTypesQuery({
     filteredRuleTypes,
   });
 

--- a/x-pack/plugins/triggers_actions_ui/public/application/app.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/app.tsx
@@ -45,7 +45,14 @@ const TriggersActionsUIHome = lazy(() => import('./home'));
 const RuleDetailsRoute = lazy(
   () => import('./sections/rule_details/components/rule_details_route')
 );
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      cacheTime: 900000,
+      staleTime: 900000,
+    },
+  },
+});
 
 export interface TriggersAndActionsUiServices extends CoreStart {
   actions: ActionsPublicPluginSetup;

--- a/x-pack/plugins/triggers_actions_ui/public/application/hooks/index.ts
+++ b/x-pack/plugins/triggers_actions_ui/public/application/hooks/index.ts
@@ -7,3 +7,4 @@
 
 export { useSubAction } from './use_sub_action';
 export { useLoadRuleTypes } from './use_load_rule_types';
+export { useLoadRuleTypesQuery } from './use_load_rule_types_query';

--- a/x-pack/plugins/triggers_actions_ui/public/application/hooks/use_load_rule_types_query.ts
+++ b/x-pack/plugins/triggers_actions_ui/public/application/hooks/use_load_rule_types_query.ts
@@ -46,8 +46,8 @@ export const useLoadRuleTypesQuery = ({
     notifications: { toasts },
   } = useKibana().services;
 
-  const queryFn = () => {
-    return loadRuleTypes({ http });
+  const queryFn = async () => {
+    return await loadRuleTypes({ http });
   };
 
   const onErrorFn = () => {
@@ -63,8 +63,8 @@ export const useLoadRuleTypesQuery = ({
     queryFn,
     onError: onErrorFn,
     refetchOnWindowFocus: false,
-    staleTime: 9000000,
-    cacheTime: 9000000,
+    staleTime: 5 * 60 * 1000,
+    cacheTime: 5 * 60 * 1000,
     enabled,
   });
   const ruleTypes = data ? data.filter((item) => filteredRuleTypes.includes(item.id)) : [];

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/rule_form/rule_add.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/rule_form/rule_add.tsx
@@ -30,12 +30,12 @@ import { hasShowActionsCapability } from '../../lib/capabilities';
 import RuleAddFooter from './rule_add_footer';
 import { HealthContextProvider } from '../../context/health_context';
 import { useKibana } from '../../../common/lib/kibana';
+import { useLoadRuleTypesQuery } from '../../hooks';
 import { hasRuleChanged, haveRuleParamsChanged } from './has_rule_changed';
 import { getRuleWithInvalidatedFields } from '../../lib/value_validators';
 import { DEFAULT_RULE_INTERVAL } from '../../constants';
 import { triggersActionsUiConfig } from '../../../common/lib/config_api';
 import { getInitialInterval } from './get_initial_interval';
-import { useLoadRuleTypesQuery } from '../../hooks';
 
 const RuleAdd = ({
   consumer,
@@ -111,12 +111,16 @@ const RuleAdd = ({
 
   const {
     ruleTypesState: {
-      unfilteredRuleTypeIndex: ruleTypeIndex,
+      unfilteredRuleTypeIndex: ruleTypeIndexFromHook,
       isLoading: ruleTypesIsLoading,
       isError: ruleTypesLoadError,
       ruleTypes,
     },
-  } = useLoadRuleTypesQuery({ filteredRuleTypes: filteredRuleTypes || [], enabled: true });
+  } = useLoadRuleTypesQuery({
+    filteredRuleTypes: filteredRuleTypes || [],
+    enabled: !props.ruleTypeIndex,
+  });
+  const ruleTypeIndex = !props.ruleTypeIndex ? ruleTypeIndexFromHook : props.ruleTypeIndex;
 
   useEffect(() => {
     if (isEmpty(rule.params) && !isEmpty(initialRuleParams)) {

--- a/x-pack/plugins/triggers_actions_ui/public/index.ts
+++ b/x-pack/plugins/triggers_actions_ui/public/index.ts
@@ -122,7 +122,7 @@ export {
   deprecatedMessage,
 } from './common';
 
-export { useLoadRuleTypes, useSubAction } from './application/hooks';
+export { useLoadRuleTypes, useLoadRuleTypesQuery, useSubAction } from './application/hooks';
 
 export type {
   TriggersAndActionsUIPublicPluginSetup,


### PR DESCRIPTION
## 📝 Summary

This refactors some parts of the RuleAdd component.

**Changes:**
* Uses React Query hook (`useLoadRuleTypesQuery`) in RuleForm. 
* Increases cache time for this hook to 5 minutes. 
* This way RuleList and RuleAdd form can reuse the responses as a common user journey is to visit the Rules page which renders the RuleList and then click "Add Rule" which renders RuleForm > RuleAdd. 
* Removes the useEffect which also triggered a call to fetch the rule types
* Exposes the `useLoadRuleTypesQuery` hook to outside (as we can also use it in Observability).

**What it looks like:**
Old (Edge oblt):

https://user-images.githubusercontent.com/535564/233458143-e21f6248-686d-40a3-8675-5d82b6e8c71b.mov



New (Dev build using a CSS cluster):

https://user-images.githubusercontent.com/535564/233455742-59f45ede-8b5f-45e8-a8c2-e58614a217aa.mov


