### PR TITLE
feat(slo): add feedback button

### DIFF
--- a/x-pack/plugins/observability/public/components/slo/feedback_button/feedback_button.tsx
+++ b/x-pack/plugins/observability/public/components/slo/feedback_button/feedback_button.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiButton } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import React from 'react';
+
+const SLO_FEEDBACK_LINK = 'https://ela.st/slo-feedback';
+
+export function FeedbackButton() {
+  return (
+    <EuiButton
+      data-test-subj="sloFeedbackButton"
+      href={SLO_FEEDBACK_LINK}
+      target="_blank"
+      color="warning"
+      iconType="editorComment"
+    >
+      {i18n.translate('xpack.observability.slo.feedbackButtonLabel', {
+        defaultMessage: 'Tell us what you think!',
+      })}
+    </EuiButton>
+  );
+}

--- a/x-pack/plugins/observability/public/pages/slo_details/slo_details.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_details/slo_details.tsx
@@ -26,6 +26,7 @@ import { paths } from '../../config/paths';
 import type { SloDetailsPathParams } from './types';
 import type { ObservabilityAppServices } from '../../application/types';
 import { AutoRefreshButton } from '../slos/components/auto_refresh_button';
+import { FeedbackButton } from '../../components/slo/feedback_button/feedback_button';
 
 export function SloDetailsPage() {
   const {
@@ -69,6 +70,7 @@ export function SloDetailsPage() {
             isAutoRefreshing={isAutoRefreshing}
             onClick={handleToggleAutoRefresh}
           />,
+          <FeedbackButton />,
         ],
         bottomBorder: false,
       }}

--- a/x-pack/plugins/observability/public/pages/slo_edit/slo_edit.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/slo_edit.tsx
@@ -16,6 +16,7 @@ import { useBreadcrumbs } from '../../hooks/use_breadcrumbs';
 import { useFetchSloDetails } from '../../hooks/slo/use_fetch_slo_details';
 import { useLicense } from '../../hooks/use_license';
 import { SloEditForm } from './components/slo_edit_form';
+import { FeedbackButton } from '../../components/slo/feedback_button/feedback_button';
 
 export function SloEditPage() {
   const {
@@ -58,7 +59,7 @@ export function SloEditPage() {
           : i18n.translate('xpack.observability.sloCreatePageTitle', {
               defaultMessage: 'Create new SLO',
             }),
-        rightSideItems: [],
+        rightSideItems: [<FeedbackButton />],
         bottomBorder: false,
       }}
       data-test-subj="slosEditPage"

--- a/x-pack/plugins/observability/public/pages/slos/slos.tsx
+++ b/x-pack/plugins/observability/public/pages/slos/slos.tsx
@@ -21,6 +21,7 @@ import { AutoRefreshButton } from './components/auto_refresh_button';
 import { paths } from '../../config/paths';
 import type { ObservabilityAppServices } from '../../application/types';
 import { HeaderTitle } from './components/header_title';
+import { FeedbackButton } from '../../components/slo/feedback_button/feedback_button';
 
 export function SlosPage() {
   const {
@@ -69,7 +70,7 @@ export function SlosPage() {
         rightSideItems: [
           <EuiButton
             color="primary"
-            data-test-subj="slosPage-createNewSloButton"
+            data-test-subj="slosPageCreateNewSloButton"
             disabled={!hasWriteCapabilities}
             fill
             onClick={handleClickCreateSlo}
@@ -82,6 +83,7 @@ export function SlosPage() {
             isAutoRefreshing={isAutoRefreshing}
             onClick={handleToggleAutoRefresh}
           />,
+          <FeedbackButton />,
         ],
         bottomBorder: false,
       }}


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/155467

## Summary

This PR adds the feedback button into the SLO dashboard page, SLO details page and the SLO create/edit form page.

This button currently opens a new tab to https://ela.st/slo-feedback, we need to make that URL redirects to a google form, and also create the google form.

Page | Screenshot
-- | --
SLO Details |![screencapture-localhost-5601-kibana-app-observability-slos-d84c5b60-dfb9-11ed-befc-0ffcfbeecd0d-2023-04-20-20_47_13](https://user-images.githubusercontent.com/1376800/233515356-f59ebf40-aa11-4533-91c2-0fbed48d534e.png)
SLO Dashboard | ![screencapture-localhost-5601-kibana-app-observability-slos-2023-04-20-20_47_56](https://user-images.githubusercontent.com/1376800/233515306-29da1331-f676-4c66-88b6-adbe5e4bb55a.png)
SLO Form | ![screencapture-localhost-5601-kibana-app-observability-slos-create-2023-04-20-20_48_03](https://user-images.githubusercontent.com/1376800/233515326-92f15c8c-017b-44ca-bda4-64554db1089b.png)

