### PR TITLE
[Lens] Apply default label on field change for counter rate

### DIFF
--- a/x-pack/plugins/lens/public/datasources/form_based/operations/layer_helpers.test.ts
+++ b/x-pack/plugins/lens/public/datasources/form_based/operations/layer_helpers.test.ts
@@ -29,10 +29,12 @@ import { getFieldByNameFactory } from '../pure_helpers';
 import { generateId } from '../../../id_generator';
 import { createMockedFullReference, createMockedManagedReference } from './mocks';
 import {
+  CounterRateIndexPatternColumn,
   FiltersIndexPatternColumn,
   FormulaIndexPatternColumn,
   GenericIndexPatternColumn,
   MathIndexPatternColumn,
+  MaxIndexPatternColumn,
   MovingAverageIndexPatternColumn,
   OperationDefinition,
 } from './definitions';
@@ -1355,6 +1357,47 @@ describe('state_helpers', () => {
             shouldResetLabel: undefined,
           }).columns.col1
         ).toEqual(expect.objectContaining({ label: 'Average of bytes' }));
+      });
+
+      it('should update default label when referenced column gets a field change', () => {
+        expect(
+          replaceColumn({
+            layer: {
+              indexPatternId: '1',
+              columnOrder: ['col1'],
+              columns: {
+                col1: {
+                  label: 'MyDefaultLabel',
+                  dataType: 'number',
+                  operationType: 'counter_rate',
+                  isBucketed: false,
+                  scale: 'ratio',
+                  references: ['col2'],
+                  timeScale: 's',
+                  timeShift: '',
+                  filter: undefined,
+                  params: undefined,
+                } as CounterRateIndexPatternColumn,
+                col2: {
+                  label: 'Max of bytes',
+                  dataType: 'number',
+                  operationType: 'max',
+                  scale: 'ratio',
+                  sourceField: indexPattern.fields[2].displayName,
+                } as MaxIndexPatternColumn,
+              },
+            },
+            indexPattern,
+            columnId: 'col2',
+            op: 'max',
+            field: indexPattern.fields[3],
+            visualizationGroups: [],
+          }).columns.col1
+        ).toEqual(
+          expect.objectContaining({
+            label: 'Counter rate of memory per second',
+          })
+        );
       });
     });
 

--- a/x-pack/plugins/lens/public/datasources/form_based/operations/layer_helpers.ts
+++ b/x-pack/plugins/lens/public/datasources/form_based/operations/layer_helpers.ts
@@ -836,12 +836,16 @@ export function replaceColumn({
       { ...layer, columns: { ...layer.columns, [columnId]: newColumn } },
       columnId
     );
-    return adjustColumnReferencesForChangedColumn(
-      {
-        ...newLayer,
-        columnOrder: getColumnOrder(newLayer),
-      },
-      columnId
+
+    return updateDefaultLabels(
+      adjustColumnReferencesForChangedColumn(
+        {
+          ...newLayer,
+          columnOrder: getColumnOrder(newLayer),
+        },
+        columnId
+      ),
+      indexPattern
     );
   } else if (operationDefinition.input === 'managedReference') {
     // Just changing a param in a formula column should trigger


### PR DESCRIPTION
## Summary

Fix #154449 

![counter_rate_field_change](https://user-images.githubusercontent.com/924948/233646312-9d7b32af-20ed-426b-970f-6a58697deb2a.gif)

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
