### PR TITLE
[SecuritySolution] Fix flaky cypress timeline templates test

### DIFF
--- a/x-pack/plugins/security_solution/cypress/e2e/timeline_templates/export.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/timeline_templates/export.cy.ts
@@ -15,7 +15,7 @@ import {
 import { TIMELINE_TEMPLATES_URL } from '../../urls/navigation';
 import { createTimelineTemplate } from '../../tasks/api_calls/timelines';
 import { cleanKibana } from '../../tasks/common';
-import { setRowsPerPageTo } from '../../tasks/table_pagination';
+import { searchByTitle } from '../../tasks/table_pagination';
 
 describe('Export timelines', () => {
   before(() => {
@@ -27,13 +27,14 @@ describe('Export timelines', () => {
     createTimelineTemplate(getTimelineTemplate()).then((response) => {
       cy.wrap(response).as('templateResponse');
       cy.wrap(response.body.data.persistTimeline.timeline.savedObjectId).as('templateId');
+      cy.wrap(response.body.data.persistTimeline.timeline.title).as('templateTitle');
     });
     login();
   });
 
   it('Exports a custom timeline template', function () {
     visitWithoutDateRange(TIMELINE_TEMPLATES_URL);
-    setRowsPerPageTo(20);
+    searchByTitle(this.templateTitle);
     exportTimeline(this.templateId);
 
     cy.wait('@export').then(({ response }) => {

--- a/x-pack/plugins/security_solution/cypress/screens/table_pagination.ts
+++ b/x-pack/plugins/security_solution/cypress/screens/table_pagination.ts
@@ -19,3 +19,5 @@ export const TABLE_FIRST_PAGE = tablePageSelector(1);
 export const TABLE_SECOND_PAGE = tablePageSelector(2);
 
 export const TABLE_SORT_COLUMN_BTN = '[data-test-subj="tableHeaderSortButton"]';
+
+export const TABLE_SEARCH_BAR = '[data-test-subj="search-bar"]';

--- a/x-pack/plugins/security_solution/cypress/tasks/table_pagination.ts
+++ b/x-pack/plugins/security_solution/cypress/tasks/table_pagination.ts
@@ -10,6 +10,7 @@ import {
   rowsPerPageSelector,
   tablePageSelector,
   TABLE_PER_PAGE_POPOVER_BTN,
+  TABLE_SEARCH_BAR,
   TABLE_SORT_COLUMN_BTN,
 } from '../screens/table_pagination';
 
@@ -31,6 +32,14 @@ export const setRowsPerPageTo = (rowsCount: number) => {
   cy.get(rowsPerPageSelector(rowsCount))
     .pipe(($el) => $el.trigger('click'))
     .should('not.exist');
+};
+
+export const searchByTitle = (title: string) => {
+  cy.get(LOADING_SPINNER).should('not.exist');
+  cy.get(TABLE_PER_PAGE_POPOVER_BTN).should('exist');
+  cy.get(TABLE_SEARCH_BAR).click({ force: true });
+  // EuiSearchBox needs the "search" event to be triggered, {enter} doesn't work
+  cy.get(TABLE_SEARCH_BAR).type(`"${title}"`).trigger('search');
 };
 
 export const expectRowsPerPage = (rowsCount: number) => {


### PR DESCRIPTION
## Summary

The test was guessing the created template was on page `2` but, depending on the template data inserted, sometimes it is found on page `3`. 
This PR changes the test approach to search for the template name, so we don't rely on guessing the page.

