### PR TITLE
[Security Solution] expandable flyout small cleanup

### DIFF
--- a/x-pack/plugins/security_solution/public/flyout/right/components/highlighted_fields.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/right/components/highlighted_fields.test.tsx
@@ -54,7 +54,7 @@ describe('<HighlightedFields />', () => {
       browserFields: {},
     } as unknown as RightPanelContext;
 
-    const { baseElement } = render(
+    const { container } = render(
       <ExpandableFlyoutContext.Provider value={flyoutContextValue}>
         <RightPanelContext.Provider value={panelContextValue}>
           <HighlightedFields />
@@ -62,11 +62,7 @@ describe('<HighlightedFields />', () => {
       </ExpandableFlyoutContext.Provider>
     );
 
-    expect(baseElement).toMatchInlineSnapshot(`
-      <body>
-        <div />
-      </body>
-    `);
+    expect(container).toBeEmptyDOMElement();
   });
 
   it('should render empty component if browserFields is null', () => {
@@ -78,7 +74,7 @@ describe('<HighlightedFields />', () => {
       browserFields: null,
     } as unknown as RightPanelContext;
 
-    const { baseElement } = render(
+    const { container } = render(
       <ExpandableFlyoutContext.Provider value={flyoutContextValue}>
         <RightPanelContext.Provider value={panelContextValue}>
           <HighlightedFields />
@@ -86,11 +82,7 @@ describe('<HighlightedFields />', () => {
       </ExpandableFlyoutContext.Provider>
     );
 
-    expect(baseElement).toMatchInlineSnapshot(`
-      <body>
-        <div />
-      </body>
-    `);
+    expect(container).toBeEmptyDOMElement();
   });
 
   it('should render empty component if eventId is null', () => {
@@ -102,7 +94,7 @@ describe('<HighlightedFields />', () => {
       browserFields: {},
     } as unknown as RightPanelContext;
 
-    const { baseElement } = render(
+    const { container } = render(
       <ExpandableFlyoutContext.Provider value={flyoutContextValue}>
         <RightPanelContext.Provider value={panelContextValue}>
           <HighlightedFields />
@@ -110,10 +102,6 @@ describe('<HighlightedFields />', () => {
       </ExpandableFlyoutContext.Provider>
     );
 
-    expect(baseElement).toMatchInlineSnapshot(`
-      <body>
-        <div />
-      </body>
-    `);
+    expect(container).toBeEmptyDOMElement();
   });
 });

--- a/x-pack/plugins/security_solution/public/flyout/right/components/highlighted_fields.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/right/components/highlighted_fields.tsx
@@ -33,7 +33,7 @@ export const HighlightedFields: FC = () => {
   }, [eventId, indexName, openRightPanel, scopeId]);
 
   if (!dataFormattedForFieldBrowser || !browserFields || !eventId) {
-    return <></>;
+    return null;
   }
 
   return (

--- a/x-pack/plugins/security_solution/public/flyout/right/components/mitre_attack.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/right/components/mitre_attack.test.tsx
@@ -33,16 +33,12 @@ describe('<MitreAttack />', () => {
       },
     } as unknown as RightPanelContext;
 
-    const { baseElement } = render(
+    const { container } = render(
       <RightPanelContext.Provider value={contextValue}>
         <MitreAttack />
       </RightPanelContext.Provider>
     );
 
-    expect(baseElement).toMatchInlineSnapshot(`
-      <body>
-        <div />
-      </body>
-    `);
+    expect(container).toBeEmptyDOMElement();
   });
 });

--- a/x-pack/plugins/security_solution/public/flyout/right/components/reason.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/right/components/reason.test.tsx
@@ -37,17 +37,13 @@ describe('<Reason />', () => {
       dataAsNestedObject: {},
     } as unknown as RightPanelContext;
 
-    const { baseElement } = render(
+    const { container } = render(
       <RightPanelContext.Provider value={panelContextValue}>
         <Reason />
       </RightPanelContext.Provider>
     );
 
-    expect(baseElement).toMatchInlineSnapshot(`
-      <body>
-        <div />
-      </body>
-    `);
+    expect(container).toBeEmptyDOMElement();
   });
 
   it('should render null if dataAsNestedObject is null', () => {
@@ -55,17 +51,13 @@ describe('<Reason />', () => {
       dataFormattedForFieldBrowser: [],
     } as unknown as RightPanelContext;
 
-    const { baseElement } = render(
+    const { container } = render(
       <RightPanelContext.Provider value={panelContextValue}>
         <Reason />
       </RightPanelContext.Provider>
     );
 
-    expect(baseElement).toMatchInlineSnapshot(`
-      <body>
-        <div />
-      </body>
-    `);
+    expect(container).toBeEmptyDOMElement();
   });
   it('should render null if renderer is null', () => {
     const panelContextValue = {
@@ -73,16 +65,12 @@ describe('<Reason />', () => {
       dataFormattedForFieldBrowser: [],
     } as unknown as RightPanelContext;
 
-    const { baseElement } = render(
+    const { container } = render(
       <RightPanelContext.Provider value={panelContextValue}>
         <Reason />
       </RightPanelContext.Provider>
     );
 
-    expect(baseElement).toMatchInlineSnapshot(`
-      <body>
-        <div />
-      </body>
-    `);
+    expect(container).toBeEmptyDOMElement();
   });
 });

--- a/x-pack/plugins/security_solution/public/flyout/right/components/risk_score.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/right/components/risk_score.test.tsx
@@ -38,17 +38,13 @@ describe('<RiskScore />', () => {
       getFieldsData: jest.fn(),
     } as unknown as RightPanelContext;
 
-    const { baseElement } = render(
+    const { container } = render(
       <RightPanelContext.Provider value={contextValue}>
         <RiskScore />
       </RightPanelContext.Provider>
     );
 
-    expect(baseElement).toMatchInlineSnapshot(`
-      <body>
-        <div />
-      </body>
-    `);
+    expect(container).toBeEmptyDOMElement();
   });
 
   it('should render empty component if getFieldsData is invalid', () => {
@@ -56,16 +52,12 @@ describe('<RiskScore />', () => {
       getFieldsData: jest.fn().mockImplementation(() => 123),
     } as unknown as RightPanelContext;
 
-    const { baseElement } = render(
+    const { container } = render(
       <RightPanelContext.Provider value={contextValue}>
         <RiskScore />
       </RightPanelContext.Provider>
     );
 
-    expect(baseElement).toMatchInlineSnapshot(`
-      <body>
-        <div />
-      </body>
-    `);
+    expect(container).toBeEmptyDOMElement();
   });
 });

--- a/x-pack/plugins/security_solution/public/flyout/right/components/severity.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/right/components/severity.test.tsx
@@ -38,17 +38,13 @@ describe('<DocumentSeverity />', () => {
       getFieldsData: jest.fn(),
     } as unknown as RightPanelContext;
 
-    const { baseElement } = render(
+    const { container } = render(
       <RightPanelContext.Provider value={contextValue}>
         <DocumentSeverity />
       </RightPanelContext.Provider>
     );
 
-    expect(baseElement).toMatchInlineSnapshot(`
-      <body>
-        <div />
-      </body>
-    `);
+    expect(container).toBeEmptyDOMElement();
   });
 
   it('should render empty component if getFieldsData is invalid array', () => {
@@ -56,17 +52,13 @@ describe('<DocumentSeverity />', () => {
       getFieldsData: jest.fn().mockImplementation(() => ['abc']),
     } as unknown as RightPanelContext;
 
-    const { baseElement } = render(
+    const { container } = render(
       <RightPanelContext.Provider value={contextValue}>
         <DocumentSeverity />
       </RightPanelContext.Provider>
     );
 
-    expect(baseElement).toMatchInlineSnapshot(`
-      <body>
-        <div />
-      </body>
-    `);
+    expect(container).toBeEmptyDOMElement();
   });
 
   it('should render empty component if getFieldsData is invalid string', () => {
@@ -74,16 +66,12 @@ describe('<DocumentSeverity />', () => {
       getFieldsData: jest.fn().mockImplementation(() => 'abc'),
     } as unknown as RightPanelContext;
 
-    const { baseElement } = render(
+    const { container } = render(
       <RightPanelContext.Provider value={contextValue}>
         <DocumentSeverity />
       </RightPanelContext.Provider>
     );
 
-    expect(baseElement).toMatchInlineSnapshot(`
-      <body>
-        <div />
-      </body>
-    `);
+    expect(container).toBeEmptyDOMElement();
   });
 });


### PR DESCRIPTION
## Summary

A PR to cleanup a couple of very small things in the Security Solution expandable flyout folder:
- return null instead of empty fragment as it is [recommended by the React team](https://legacy.reactjs.org/docs/conditional-rendering.html#preventing-component-from-rendering)
- replace `toMatchInlineSnapshot` by `toBeEmptyDOMElement` for more consistent result