### PR TITLE
[Cases] Rounding the file size to avoid decimals

### DIFF
--- a/x-pack/plugins/cases/server/telemetry/queries/utils.test.ts
+++ b/x-pack/plugins/cases/server/telemetry/queries/utils.test.ts
@@ -565,6 +565,88 @@ describe('utils', () => {
     });
 
     describe('files', () => {
+      it('rounds the average file size when it is a decimal', () => {
+        const attachmentFramework: AttachmentFrameworkAggsResult = {
+          externalReferenceTypes: {
+            buckets: [
+              {
+                doc_count: 5,
+                key: '.files',
+                references: {
+                  cases: {
+                    max: {
+                      value: 10,
+                    },
+                  },
+                },
+              },
+            ],
+          },
+          persistableReferenceTypes: {
+            buckets: [],
+          },
+        };
+
+        expect(
+          getAttachmentsFrameworkStats({
+            attachmentAggregations: attachmentFramework,
+            totalCasesForOwner: 5,
+            filesAggregations: {
+              averageSize: { value: 1.1 },
+              topMimeTypes: {
+                buckets: [],
+              },
+            },
+          }).attachmentFramework.files
+        ).toMatchInlineSnapshot(`
+          Object {
+            "average": 1,
+            "averageSize": 1,
+            "maxOnACase": 10,
+            "topMimeTypes": Array [],
+            "total": 5,
+          }
+        `);
+      });
+
+      it('sets the average file size to 0 when the aggregation does not exist', () => {
+        const attachmentFramework: AttachmentFrameworkAggsResult = {
+          externalReferenceTypes: {
+            buckets: [
+              {
+                doc_count: 5,
+                key: '.files',
+                references: {
+                  cases: {
+                    max: {
+                      value: 10,
+                    },
+                  },
+                },
+              },
+            ],
+          },
+          persistableReferenceTypes: {
+            buckets: [],
+          },
+        };
+
+        expect(
+          getAttachmentsFrameworkStats({
+            attachmentAggregations: attachmentFramework,
+            totalCasesForOwner: 5,
+          }).attachmentFramework.files
+        ).toMatchInlineSnapshot(`
+          Object {
+            "average": 1,
+            "averageSize": 0,
+            "maxOnACase": 10,
+            "topMimeTypes": Array [],
+            "total": 5,
+          }
+        `);
+      });
+
       it('sets the files stats to empty when the file aggregation results is the empty version', () => {
         const attachmentFramework: AttachmentFrameworkAggsResult = {
           externalReferenceTypes: {

--- a/x-pack/plugins/cases/server/telemetry/queries/utils.ts
+++ b/x-pack/plugins/cases/server/telemetry/queries/utils.ts
@@ -230,7 +230,7 @@ export const getAttachmentsFrameworkStats = ({
     return emptyAttachmentFramework();
   }
 
-  const averageFileSize = filesAggregations?.averageSize?.value;
+  const averageFileSize = getAverageFileSize(filesAggregations);
   const topMimeTypes = filesAggregations?.topMimeTypes;
 
   return {
@@ -251,6 +251,14 @@ export const getAttachmentsFrameworkStats = ({
       }),
     },
   };
+};
+
+const getAverageFileSize = (filesAggregations?: FileAttachmentAggsResult) => {
+  if (filesAggregations?.averageSize?.value == null) {
+    return 0;
+  }
+
+  return Math.round(filesAggregations.averageSize.value);
 };
 
 const getAttachmentRegistryStats = (


### PR DESCRIPTION
This PR fixes a bug in the telemetry code around the average file size. A float can be returned by the average aggregation. To avoid the float we'll round it before saving the value in the document.