### PR TITLE
[Maps] fix maps listing page 'Cannot update a component while rendering a different component'

### DIFF
--- a/x-pack/plugins/maps/public/routes/list_page/load_list_and_render.tsx
+++ b/x-pack/plugins/maps/public/routes/list_page/load_list_and_render.tsx
@@ -5,8 +5,7 @@
  * 2.0.
  */
 
-import React, { Component, useState, useEffect } from 'react';
-import { i18n } from '@kbn/i18n';
+import React, { useState, useEffect } from 'react';
 import { Redirect } from 'react-router-dom';
 import { EmbeddableStateTransfer } from '@kbn/embeddable-plugin/public';
 import { ScopedHistory } from '@kbn/core/public';
@@ -43,6 +42,8 @@ export function LoadListAndRender(props: Props) {
     return () => {
       ignore = true;
     };
+  // only run on mount
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
   
   if (!mapsLoaded) {

--- a/x-pack/plugins/maps/public/routes/list_page/load_list_and_render.tsx
+++ b/x-pack/plugins/maps/public/routes/list_page/load_list_and_render.tsx
@@ -21,19 +21,20 @@ interface Props {
 export function LoadListAndRender(props: Props) {
   const [mapsLoaded, setMapsLoaded] = useState(false);
   const [hasSavedMaps, setHasSavedMaps] = useState(true);
-  
+
   useEffect(() => {
     props.stateTransfer.clearEditorState(APP_ID);
 
     let ignore = false;
-    mapsClient.search({ limit: 1 })
-      .then(results => {
+    mapsClient
+      .search({ limit: 1 })
+      .then((results) => {
         if (!ignore) {
           setHasSavedMaps(results.hits.length > 0);
           setMapsLoaded(true);
         }
       })
-      .catch(err => {
+      .catch((err) => {
         if (!ignore) {
           setMapsLoaded(true);
           setHasSavedMaps(false);
@@ -42,14 +43,14 @@ export function LoadListAndRender(props: Props) {
     return () => {
       ignore = true;
     };
-  // only run on mount
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // only run on mount
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-  
+
   if (!mapsLoaded) {
     // do not render loading state to avoid UI flash when listing page is displayed
     return null;
   }
-  
+
   return hasSavedMaps ? <MapsListView history={props.history} /> : <Redirect to="/map" />;
 }

--- a/x-pack/plugins/maps/public/routes/list_page/maps_list_view.tsx
+++ b/x-pack/plugins/maps/public/routes/list_page/maps_list_view.tsx
@@ -72,9 +72,10 @@ function MapsListViewComp({ history }: Props) {
   const listingLimit = getUiSettings().get(SAVED_OBJECTS_LIMIT_SETTING);
   const initialPageSize = getUiSettings().get(SAVED_OBJECTS_PER_PAGE_SETTING);
 
+  // TLDR; render should be side effect free
+  //
   // setBreadcrumbs fires observables which cause state changes in ScreenReaderRouteAnnouncements.
   // wrap chrome updates in useEffect to avoid potentially causing state changes in other component during render phase.
-  // TLDR render should be side effect free
   useEffect(() => {
     getCoreChrome().docTitle.change(APP_NAME);
     getCoreChrome().setBreadcrumbs([{ text: APP_NAME }]);

--- a/x-pack/plugins/maps/public/routes/list_page/maps_list_view.tsx
+++ b/x-pack/plugins/maps/public/routes/list_page/maps_list_view.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useCallback, memo } from 'react';
+import React, { useCallback, memo, useEffect } from 'react';
 import type { SavedObjectsFindOptionsReference, ScopedHistory } from '@kbn/core/public';
 import { METRIC_TYPE } from '@kbn/analytics';
 import { i18n } from '@kbn/i18n';
@@ -72,8 +72,13 @@ function MapsListViewComp({ history }: Props) {
   const listingLimit = getUiSettings().get(SAVED_OBJECTS_LIMIT_SETTING);
   const initialPageSize = getUiSettings().get(SAVED_OBJECTS_PER_PAGE_SETTING);
 
-  getCoreChrome().docTitle.change(APP_NAME);
-  getCoreChrome().setBreadcrumbs([{ text: APP_NAME }]);
+  // setBreadcrumbs fires observables which cause state changes in ScreenReaderRouteAnnouncements.
+  // wrap chrome updates in useEffect to avoid potentially causing state changes in other component during render phase.
+  // TLDR render should be side effect free
+  useEffect(() => {
+    getCoreChrome().docTitle.change(APP_NAME);
+    getCoreChrome().setBreadcrumbs([{ text: APP_NAME }]);
+  }, []);
 
   const findMaps = useCallback(
     async (

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -20566,7 +20566,6 @@
     "xpack.maps.mapActions.removeFeatureError": "无法从索引中移除特征。",
     "xpack.maps.mapListing.entityName": "地图",
     "xpack.maps.mapListing.entityNamePlural": "地图",
-    "xpack.maps.mapListing.errorAttemptingToLoadSavedMaps": "无法加载地图",
     "xpack.maps.mapSavedObjectLabel": "地图",
     "xpack.maps.mapSettingsPanel.addCustomIcon": "添加定制图标",
     "xpack.maps.mapSettingsPanel.autoFitToBoundsLocationLabel": "使地图自动适应数据边界",


### PR DESCRIPTION
To view problem
1) Install sample data set
2) Open maps listing page. Notice the following console warning
    <img width="400" alt="Screen Shot 2023-04-21 at 9 19 16 AM" src="https://user-images.githubusercontent.com/373691/233705813-75efc248-d0e4-40da-bc26-aa01b2e21b00.png">

PR removes side effect during `MapsListViewComp` render that caused [ScreenReaderRouteAnnouncements](https://github.com/elastic/kibana/blob/0cd7973e1ff4693094e802b2cd3b6d711007bc5c/packages/core/chrome/core-chrome-browser-internal/src/ui/header/screen_reader_a11y.tsx) to update state.

PR also refactors LoadListAndRender into a functional component with hooks. That change is not needed but was done to isolate the issue. Figured its worth keeping.


