### PR TITLE
chore(slo): change no rule badge style

### DIFF
--- a/x-pack/plugins/observability/public/pages/slos/components/badges/slo_rules_badge.tsx
+++ b/x-pack/plugins/observability/public/pages/slos/components/badges/slo_rules_badge.tsx
@@ -6,9 +6,10 @@
  */
 
 import React from 'react';
-import { EuiBadge, EuiIcon, EuiToolTip } from '@elastic/eui';
+import { EuiBadge, EuiToolTip } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { Rule } from '@kbn/triggers-actions-ui-plugin/public';
+
 import { SloRule } from '../../../../hooks/slo/use_fetch_rules_for_slo';
 
 export interface Props {
@@ -26,16 +27,9 @@ export function SloRulesBadge({ rules, onClick }: Props) {
       })}
       display="block"
     >
-      <EuiBadge
-        color=""
-        css={{ cursor: 'pointer' }}
-        onClick={onClick}
-        onClickAriaLabel={i18n.translate('xpack.observability.slo.slo.rulesBadge.label', {
-          defaultMessage: 'Create new rule',
-        })}
-      >
-        <EuiIcon color="danger" type="warning" />
-      </EuiBadge>
+      <span onClick={onClick} onKeyDown={onClick}>
+        <EuiBadge isDisabled color="default" iconType="alert" css={{ cursor: 'pointer' }} />
+      </span>
     </EuiToolTip>
   );
 }


### PR DESCRIPTION
## Summary

This PR changes the style for the no rule badge to follow expected design.
I've had to "hack" the badge with a span around to handle the click with it, because the badge must be "disabled" to follow the design

<img width="466" alt="image" src="https://user-images.githubusercontent.com/1376800/233707908-c1e24bb2-8176-491e-8177-638dc803fb07.png">
