### PR TITLE
[dashboard][maps] fix 'by value' map does not fill dashboard panel on initial page load

### DIFF
--- a/x-pack/plugins/maps/public/connected_components/mb_map/mb_map.tsx
+++ b/x-pack/plugins/maps/public/connected_components/mb_map/mb_map.tsx
@@ -283,11 +283,10 @@ export class MbMap extends Component<Props, State> {
   }
 
   _initResizerChecker() {
+    this.state.mbMap?.resize(); // ensure map is sized for container prior to monitoring
     this._checker = new ResizeChecker(this._containerRef!);
     this._checker.on('resize', () => {
-      if (this.state.mbMap) {
-        this.state.mbMap.resize();
-      }
+      this.state.mbMap?.resize();
     });
   }
 


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/155553

Following steps in issue now renders map as expected
<img width="600" alt="Screen Shot 2023-04-21 at 1 18 54 PM" src="https://user-images.githubusercontent.com/373691/233717520-7e25b4a9-1639-4b5e-9dfc-3816f4f35153.png">
