### PR TITLE
feat(slo): Synchronize cursor on SLO charts

### DIFF
--- a/x-pack/plugins/observability/public/pages/slo_details/components/wide_chart.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_details/components/wide_chart.tsx
@@ -15,10 +15,11 @@ import {
   ScaleType,
   Settings,
 } from '@elastic/charts';
-import React from 'react';
+import React, { useRef } from 'react';
 import { EuiIcon, EuiLoadingChart, useEuiTheme } from '@elastic/eui';
 import numeral from '@elastic/numeral';
 import moment from 'moment';
+import { useActiveCursor } from '@kbn/charts-plugin/public';
 
 import { ChartData } from '../../../typings';
 import { useKibana } from '../../../utils/kibana_react';
@@ -45,18 +46,29 @@ export function WideChart({ chart, data, id, isLoading, state }: Props) {
   const color = state === 'error' ? euiTheme.colors.danger : euiTheme.colors.success;
   const ChartComponent = chart === 'area' ? AreaSeries : LineSeries;
 
+  const chartRef = useRef(null);
+  const handleCursorUpdate = useActiveCursor(charts.activeCursor, chartRef, {
+    isDateHistogram: true,
+  });
+
   if (isLoading) {
     return <EuiLoadingChart size="m" mono data-test-subj="wideChartLoading" />;
   }
 
   return (
-    <Chart size={{ height: 150, width: '100%' }}>
+    <Chart size={{ height: 150, width: '100%' }} ref={chartRef}>
       <Settings
         baseTheme={baseTheme}
         showLegend={false}
         theme={[theme]}
         tooltip="vertical"
         noResults={<EuiIcon type="visualizeApp" size="l" color="subdued" title="no results" />}
+        onPointerUpdate={handleCursorUpdate}
+        externalPointerEvents={{
+          tooltip: { visible: true },
+        }}
+        pointerUpdateDebounce={0}
+        pointerUpdateTrigger={'x'}
       />
       <Axis
         id="bottom"

--- a/x-pack/plugins/observability/public/pages/slo_details/slo_details.test.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_details/slo_details.test.tsx
@@ -54,7 +54,7 @@ const mockKibana = () => {
   useKibanaMock.mockReturnValue({
     services: {
       application: { navigateToUrl: mockNavigate },
-      charts: chartPluginMock.createSetupContract(),
+      charts: chartPluginMock.createStartContract(),
       http: {
         basePath: {
           prepend: mockBasePathPrepend,

--- a/x-pack/plugins/observability/public/utils/kibana_react.storybook_decorator.tsx
+++ b/x-pack/plugins/observability/public/utils/kibana_react.storybook_decorator.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 import React, { ComponentType } from 'react';
-import { of } from 'rxjs';
+import { of, Subject } from 'rxjs';
 import { QueryClientProvider, QueryClient } from '@tanstack/react-query';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
 import { AppMountParameters } from '@kbn/core-application-browser';
@@ -65,6 +65,7 @@ export function KibanaReactStorybookDecorator(Story: ComponentType) {
             useChartsBaseTheme: () => {},
             useChartsTheme: () => {},
           },
+          activeCursor: () => {},
         },
         data: {},
         dataViews: {

--- a/x-pack/plugins/observability/public/utils/kibana_react.storybook_decorator.tsx
+++ b/x-pack/plugins/observability/public/utils/kibana_react.storybook_decorator.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 import React, { ComponentType } from 'react';
-import { of, Subject } from 'rxjs';
+import { of } from 'rxjs';
 import { QueryClientProvider, QueryClient } from '@tanstack/react-query';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
 import { AppMountParameters } from '@kbn/core-application-browser';


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/155558

## Summary

This PR adds cursor synchronization between the two charts in the SLO details page.

<img width="1712" alt="image" src="https://user-images.githubusercontent.com/1376800/233724398-2412995a-f00a-4964-a84f-c7a4af97d243.png">
