### PR TITLE
[Dashboard] Removes Reload on Clone / Replace Panel

### DIFF
--- a/src/plugins/dashboard/public/dashboard_actions/replace_panel_flyout.tsx
+++ b/src/plugins/dashboard/public/dashboard_actions/replace_panel_flyout.tsx
@@ -81,7 +81,6 @@ export class ReplacePanelFlyout extends React.Component<Props> {
         } as DashboardPanelState,
       },
     });
-    container.reload();
 
     this.showToast(name);
     this.props.onClose();

--- a/src/plugins/dashboard/public/dashboard_container/embeddable/api/panel_management.ts
+++ b/src/plugins/dashboard/public/dashboard_container/embeddable/api/panel_management.ts
@@ -86,11 +86,7 @@ export async function replacePanel(
     };
   }
 
-  await this.updateInput({
-    panels,
-    lastReloadRequestTime: new Date().getTime(),
-  });
-
+  await this.updateInput({ panels });
   return panelId;
 }
 


### PR DESCRIPTION
## Summary
Closes https://github.com/elastic/kibana/issues/155556

Removes the page reload on clone and replace panel to make them feel snappier.