### PR TITLE
[NewsFeed] Remove React warning for flyout list

### DIFF
--- a/src/plugins/newsfeed/public/components/flyout_list.tsx
+++ b/src/plugins/newsfeed/public/components/flyout_list.tsx
@@ -32,11 +32,11 @@ import { NewsLoadingPrompt } from './loading_news';
 export const NewsfeedFlyout = (props: Partial<EuiFlyoutProps> & { showPlainSpinner: boolean }) => {
   const { newsFetchResult, setFlyoutVisible } = useContext(NewsfeedContext);
   const closeFlyout = useCallback(() => setFlyoutVisible(false), [setFlyoutVisible]);
-
+  const { showPlainSpinner, ...rest } = props;
   return (
     <EuiPortal>
       <EuiFlyout
-        {...props}
+        {...rest}
         onClose={closeFlyout}
         size="s"
         aria-labelledby="flyoutSmallTitle"


### PR DESCRIPTION
## Summary

Fixes: https://github.com/elastic/kibana/issues/154923

The problem was the `showPlainSpinner` was passed as part of the props to `EuiFlyout` component, which was trying to pass it as a DOM attribute. Removing this from props gets rid of the warning.

Would be nice if we could get this in before 8.8 FF. 
xoxo

cc @Dosant @rshen91 


### Checklist

Delete any items that are not applicable to this PR.

~- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)~
~- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
~- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios~
~- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))~
~- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))~
~- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
~- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))~
~- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)~


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
