### PR TITLE
[6.8][dev tools] correct confusing http method convertion #13775

### DIFF
--- a/src/legacy/core_plugins/console/public/src/es.js
+++ b/src/legacy/core_plugins/console/public/src/es.js
@@ -35,11 +35,6 @@ export function getContentType(body) {
 export function send(method, path, data) {
   const wrappedDfd = $.Deferred();  // eslint-disable-line new-cap
 
-  const isGetRequest = /^get$/i.test(method);
-  if (data && isGetRequest) {
-    method = 'POST';
-  }
-
   const options = {
     url: '../api/console/proxy?' + formatQueryString({ path, method }),
     data,


### PR DESCRIPTION
Remove the confusing http method conversion from GET to POST with http body.

 Conversion in dev tools is confusing and causes mistake. As common sense, GET method will NEVER modify data. But the method conversion will make mistake. This is very dangerous and even can not revert! 

For example, a new comer writes the following script by mistake and just wants to know the details in get doc process or just forgets to remove the body in last PUT request. It will update the doc !!!  This is a DISASTER in product environment! Hope the issue could be fixed! 

GET my-index/_doc/1
{
   "profile":true
}