### PR TITLE
[Cases] Close FilePreview with Escape key.

### DIFF
--- a/x-pack/plugins/cases/public/components/files/file_preview.test.tsx
+++ b/x-pack/plugins/cases/public/components/files/file_preview.test.tsx
@@ -7,6 +7,7 @@
 import React from 'react';
 
 import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import type { AppMockRenderer } from '../../common/mock';
 
@@ -34,5 +35,24 @@ describe('FilePreview', () => {
     );
 
     expect(await screen.findByTestId('cases-files-image-preview')).toBeInTheDocument();
+  });
+
+  it('pressing escape calls closePreview', async () => {
+    const closePreview = jest.fn();
+
+    appMockRender.render(<FilePreview closePreview={closePreview} selectedFile={basicFileMock} />);
+
+    await waitFor(() =>
+      expect(appMockRender.getFilesClient().getDownloadHref).toHaveBeenCalledWith({
+        id: basicFileMock.id,
+        fileKind: constructFileKindIdByOwner(mockedTestProvidersOwner[0]),
+      })
+    );
+
+    expect(await screen.findByTestId('cases-files-image-preview')).toBeInTheDocument();
+
+    userEvent.keyboard('{esc}');
+
+    await waitFor(() => expect(closePreview).toHaveBeenCalled());
   });
 });

--- a/x-pack/plugins/cases/public/components/files/file_preview.tsx
+++ b/x-pack/plugins/cases/public/components/files/file_preview.tsx
@@ -4,12 +4,12 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import React from 'react';
+import React, { useEffect } from 'react';
 import styled from 'styled-components';
 
 import type { FileJSON } from '@kbn/shared-ux-file-types';
 
-import { EuiOverlayMask, EuiFocusTrap, EuiImage } from '@elastic/eui';
+import { EuiOverlayMask, EuiFocusTrap, EuiImage, keys } from '@elastic/eui';
 import { useFilesContext } from '@kbn/shared-ux-file-context';
 
 import type { Owner } from '../../../common/constants/types';
@@ -35,6 +35,20 @@ const StyledOverlayMask = styled(EuiOverlayMask)`
 export const FilePreview = ({ closePreview, selectedFile }: FilePreviewProps) => {
   const { client: filesClient } = useFilesContext();
   const { owner } = useCasesContext();
+
+  useEffect(() => {
+    const keyboardListener = (event: KeyboardEvent) => {
+      if (event.key === keys.ESCAPE || event.code === 'Escape') {
+        closePreview();
+      }
+    };
+
+    window.addEventListener('keyup', keyboardListener);
+
+    return () => {
+      window.removeEventListener('keyup', keyboardListener);
+    };
+  }, [closePreview]);
 
   return (
     <StyledOverlayMask>


### PR DESCRIPTION
Fixes #155036

## Summary

Allow users to close the file preview in cases by using the Escape key.

(e2e coming in a different PR with other tests)