### PR TITLE
[Cloud Posture] [Vulnerability Management] Add `beta` tooltip info (findings page)

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/findings.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/findings.tsx
@@ -59,6 +59,13 @@ export const Findings = () => {
                   display: block;
                 `}
                 label="Beta"
+                tooltipContent={
+                  <FormattedMessage
+                    id="xpack.csp.findings.betaLabel"
+                    defaultMessage="This functionality is in beta and is subject to change. The design and code is less mature than official generally available features and is being provided as-is with no warranties. Beta features are not subject to the support service level agreement of official generally available features."
+                  />
+                }
+                tooltipPosition="bottom"
               />
             </EuiFlexItem>
           </EuiFlexGroup>


### PR DESCRIPTION
## What does this PR do?
This PR adds a tooltip for the `BETA` badge in the Security > Findings > Vulnerabilities Tab.

### Issue References
https://github.com/elastic/kibana/issues/155171

### Video/Screenshot Demo 

https://user-images.githubusercontent.com/50892465/233399658-3aae4dbb-b0c4-4e50-8b09-61d48bff85ea.mp4

---
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.
