### PR TITLE
Fleet: allow Universal Profiling symbolizer permissions on indices

### DIFF
--- a/x-pack/plugins/fleet/common/constants/epm.ts
+++ b/x-pack/plugins/fleet/common/constants/epm.ts
@@ -16,6 +16,7 @@ export const FLEET_ENDPOINT_PACKAGE = 'endpoint';
 export const FLEET_APM_PACKAGE = 'apm';
 export const FLEET_SYNTHETICS_PACKAGE = 'synthetics';
 export const FLEET_KUBERNETES_PACKAGE = 'kubernetes';
+export const FLEET_UNIVERSAL_PROFILING_SYMBOLIZER_PACKAGE = 'profiler_symbolizer';
 export const FLEET_CLOUD_SECURITY_POSTURE_PACKAGE = 'cloud_security_posture';
 export const FLEET_CLOUD_SECURITY_POSTURE_KSPM_POLICY_TEMPLATE = 'kspm';
 

--- a/x-pack/plugins/fleet/server/services/agent_policies/package_policies_to_agent_permissions.test.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policies/package_policies_to_agent_permissions.test.ts
@@ -12,7 +12,8 @@ import type { PackagePolicy, RegistryDataStream } from '../../types';
 import type { DataStreamMeta } from './package_policies_to_agent_permissions';
 import {
   getDataStreamPrivileges,
-  storedPackagePoliciesToAgentPermissions, UNIVERSAL_PROFILING_PERMISSIONS,
+  storedPackagePoliciesToAgentPermissions,
+  UNIVERSAL_PROFILING_PERMISSIONS,
 } from './package_policies_to_agent_permissions';
 
 const packageInfoCache = new Map();
@@ -144,7 +145,7 @@ packageInfoCache.set('profiler_symbolizer-8.8.0-preview', {
   version: '8.8.0-preview',
   license: 'basic',
   description:
-      ' Fleet-wide, whole-system, continuous profiling with zero instrumentation. Symbolize native frames.',
+    ' Fleet-wide, whole-system, continuous profiling with zero instrumentation. Symbolize native frames.',
   type: 'integration',
   release: 'beta',
   categories: ['monitoring', 'elastic_stack'],
@@ -439,8 +440,8 @@ describe('storedPackagePoliciesToAgentPermissions()', () => {
     ];
 
     const permissions = await storedPackagePoliciesToAgentPermissions(
-        packageInfoCache,
-        packagePolicies
+      packageInfoCache,
+      packagePolicies
     );
 
     expect(permissions).toMatchObject({
@@ -448,7 +449,7 @@ describe('storedPackagePoliciesToAgentPermissions()', () => {
         indices: [
           {
             names: ['profiling-*'],
-            privileges: UNIVERSAL_PROFILING_PERMISSIONS
+            privileges: UNIVERSAL_PROFILING_PERMISSIONS,
           },
         ],
       },

--- a/x-pack/plugins/fleet/server/services/agent_policies/package_policies_to_agent_permissions.test.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policies/package_policies_to_agent_permissions.test.ts
@@ -12,7 +12,7 @@ import type { PackagePolicy, RegistryDataStream } from '../../types';
 import type { DataStreamMeta } from './package_policies_to_agent_permissions';
 import {
   getDataStreamPrivileges,
-  storedPackagePoliciesToAgentPermissions,
+  storedPackagePoliciesToAgentPermissions, UNIVERSAL_PROFILING_PERMISSIONS,
 } from './package_policies_to_agent_permissions';
 
 const packageInfoCache = new Map();
@@ -109,6 +109,56 @@ packageInfoCache.set('osquery_manager-0.3.0', {
     },
   ],
   latestVersion: '0.3.0',
+  notice: undefined,
+  status: 'not_installed',
+  assets: {
+    kibana: {
+      csp_rule_template: [],
+      dashboard: [],
+      visualization: [],
+      search: [],
+      index_pattern: [],
+      map: [],
+      lens: [],
+      security_rule: [],
+      ml_module: [],
+      tag: [],
+      osquery_pack_asset: [],
+      osquery_saved_query: [],
+    },
+    elasticsearch: {
+      component_template: [],
+      ingest_pipeline: [],
+      ilm_policy: [],
+      transform: [],
+      index_template: [],
+      data_stream_ilm_policy: [],
+      ml_model: [],
+    },
+  },
+});
+packageInfoCache.set('profiler_symbolizer-8.8.0-preview', {
+  format_version: '2.7.0',
+  name: 'profiler_symbolizer',
+  title: 'Universal Profiling Symbolizer',
+  version: '8.8.0-preview',
+  license: 'basic',
+  description:
+      ' Fleet-wide, whole-system, continuous profiling with zero instrumentation. Symbolize native frames.',
+  type: 'integration',
+  release: 'beta',
+  categories: ['monitoring', 'elastic_stack'],
+  icons: [
+    {
+      src: '/img/logo_profiling_symbolizer.svg',
+      title: 'logo symbolizer',
+      size: '32x32',
+      type: 'image/svg+xml',
+    },
+  ],
+  owner: { github: 'elastic/profiling' },
+  data_streams: [],
+  latestVersion: '8.8.0-preview',
   notice: undefined,
   status: 'not_installed',
   assets: {
@@ -358,6 +408,47 @@ describe('storedPackagePoliciesToAgentPermissions()', () => {
           {
             names: ['logs-osquery_manager.result-test'],
             privileges: ['auto_configure', 'create_doc'],
+          },
+        ],
+      },
+    });
+  });
+
+  it('Returns the Universal Profiling permissions for profiler_symbolizer package', async () => {
+    const packagePolicies: PackagePolicy[] = [
+      {
+        id: 'package-policy-uuid-test-123',
+        name: 'test-policy',
+        namespace: '',
+        enabled: true,
+        package: { name: 'profiler_symbolizer', version: '8.8.0-preview', title: 'Test Package' },
+        inputs: [
+          {
+            type: 'pf-elastic-symbolizer',
+            enabled: true,
+            streams: [],
+          },
+        ],
+        created_at: '',
+        updated_at: '',
+        created_by: '',
+        updated_by: '',
+        revision: 1,
+        policy_id: '',
+      },
+    ];
+
+    const permissions = await storedPackagePoliciesToAgentPermissions(
+        packageInfoCache,
+        packagePolicies
+    );
+
+    expect(permissions).toMatchObject({
+      'package-policy-uuid-test-123': {
+        indices: [
+          {
+            names: ['profiling-*'],
+            privileges: UNIVERSAL_PROFILING_PERMISSIONS
           },
         ],
       },

--- a/x-pack/plugins/fleet/server/services/agent_policies/package_policies_to_agent_permissions.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policies/package_policies_to_agent_permissions.ts
@@ -16,6 +16,7 @@ import { PACKAGE_POLICY_DEFAULT_INDEX_PRIVILEGES } from '../../constants';
 
 import type { PackagePolicy } from '../../types';
 import { pkgToPkgKey } from '../epm/registry';
+import { FLEET_UNIVERSAL_PROFILING_SYMBOLIZER_PACKAGE } from "@kbn/fleet-plugin/common/constants";
 
 export const DEFAULT_CLUSTER_PERMISSIONS = ['monitor'];
 
@@ -54,7 +55,7 @@ export async function storedPackagePoliciesToAgentPermissions(
 
       // Special handling for Universal Profiling packages, as it does not use data streams _only_,
       // but also indices that do not adhere to the convention.
-      if (pkg.name === 'profiler_symbolizer') {
+      if (pkg.name===FLEET_UNIVERSAL_PROFILING_SYMBOLIZER_PACKAGE) {
         return Promise.resolve(universalProfilingPermissions(packagePolicy.id));
       }
 

--- a/x-pack/plugins/fleet/server/services/agent_policies/package_policies_to_agent_permissions.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policies/package_policies_to_agent_permissions.ts
@@ -26,7 +26,7 @@ export const UNIVERSAL_PROFILING_PERMISSIONS = [
   'create',
   'write',
   'index',
-  'view_index_metadata'
+  'view_index_metadata',
 ];
 
 export async function storedPackagePoliciesToAgentPermissions(
@@ -54,7 +54,7 @@ export async function storedPackagePoliciesToAgentPermissions(
 
       // Special handling for Universal Profiling packages, as it does not use data streams _only_,
       // but also indices that do not adhere to the convention.
-      if (pkg.name==='profiler_symbolizer') {
+      if (pkg.name === 'profiler_symbolizer') {
         return Promise.resolve(universalProfilingPermissions(packagePolicy.id));
       }
 
@@ -183,8 +183,8 @@ export function getDataStreamPrivileges(dataStream: DataStreamMeta, namespace: s
   }
 
   const privileges = dataStream?.elasticsearch?.privileges?.indices?.length
-      ? dataStream.elasticsearch.privileges.indices
-      :PACKAGE_POLICY_DEFAULT_INDEX_PRIVILEGES;
+    ? dataStream.elasticsearch.privileges.indices
+    : PACKAGE_POLICY_DEFAULT_INDEX_PRIVILEGES;
 
   return {
     names: [index],
@@ -197,10 +197,12 @@ async function universalProfilingPermissions(packagePolicyId: string): Promise<[
   return [
     packagePolicyId,
     {
-      indices: [{
-        names: [profilingIndexPattern],
-        privileges: UNIVERSAL_PROFILING_PERMISSIONS,
-      }]
-    }
+      indices: [
+        {
+          names: [profilingIndexPattern],
+          privileges: UNIVERSAL_PROFILING_PERMISSIONS,
+        },
+      ],
+    },
   ];
 }

--- a/x-pack/plugins/fleet/server/services/agent_policies/package_policies_to_agent_permissions.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policies/package_policies_to_agent_permissions.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import { FLEET_UNIVERSAL_PROFILING_SYMBOLIZER_PACKAGE } from '../../../common/constants';
+
 import { getNormalizedDataStreams } from '../../../common/services';
 
 import type {
@@ -16,7 +18,6 @@ import { PACKAGE_POLICY_DEFAULT_INDEX_PRIVILEGES } from '../../constants';
 
 import type { PackagePolicy } from '../../types';
 import { pkgToPkgKey } from '../epm/registry';
-import { FLEET_UNIVERSAL_PROFILING_SYMBOLIZER_PACKAGE } from "@kbn/fleet-plugin/common/constants";
 
 export const DEFAULT_CLUSTER_PERMISSIONS = ['monitor'];
 
@@ -55,7 +56,7 @@ export async function storedPackagePoliciesToAgentPermissions(
 
       // Special handling for Universal Profiling packages, as it does not use data streams _only_,
       // but also indices that do not adhere to the convention.
-      if (pkg.name===FLEET_UNIVERSAL_PROFILING_SYMBOLIZER_PACKAGE) {
+      if (pkg.name === FLEET_UNIVERSAL_PROFILING_SYMBOLIZER_PACKAGE) {
         return Promise.resolve(universalProfilingPermissions(packagePolicy.id));
       }
 


### PR DESCRIPTION
## Summary

For the introduction of the Universal Profiling symbolizer in Cloud, Fleet needs an update.
The reason for Universal Profiling symbolizer to be different from other packages running via Fleet is that:

1. it ingests data into indicesm not only data-streams
2. it uses a non-conventional naming scheme for indices

### Checklist

Delete any items that are not applicable to this PR.

- [X] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [X] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)


### For maintainers

- [X] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
