### PR TITLE
[Dashboard] [Controls] Fix unsaved changes bug on empty dashboard

### DIFF
--- a/src/plugins/dashboard/public/dashboard_container/state/diffing/dashboard_diffing_integration.ts
+++ b/src/plugins/dashboard/public/dashboard_container/state/diffing/dashboard_diffing_integration.ts
@@ -7,7 +7,7 @@
  */
 import { omit } from 'lodash';
 import { AnyAction, Middleware } from 'redux';
-import { debounceTime, Observable, Subject, switchMap } from 'rxjs';
+import { debounceTime, Observable, startWith, Subject, switchMap } from 'rxjs';
 
 import { DashboardContainerInput } from '../../../../common';
 import type { DashboardDiffFunctions } from './dashboard_diffing_functions';
@@ -90,6 +90,7 @@ export function startDiffingDashboardState(
   this.subscriptions.add(
     checkForUnsavedChangesSubject$
       .pipe(
+        startWith(null),
         debounceTime(CHANGE_CHECK_DEBOUNCE),
         switchMap(() => {
           return new Observable((observer) => {


### PR DESCRIPTION
## Summary

### Before

When loading a dashboard with no panels but at least one control, the `diffingMiddleware` was not being fired - this caused a bug where making selections in the control (which were not saved into the dashboard) would not trigger unsaved changes on reload/refresh:

https://user-images.githubusercontent.com/8698078/234059128-d94b5656-a7f7-4a14-bb32-d29065b0a475.mov

### After

This was because, when the dashboard had no children, no Redux state changes were being dispatched to the Dashboard container which meant that the middleware was never triggered - this is fixed by adding `startWith(null)` ([reference](https://rxjs.dev/api/index/function/startWith)) to the `checkForUnsavedChangesSubject$` subscription so that it always fires **on load**.



https://user-images.githubusercontent.com/8698078/234066255-7f44621e-0631-4195-a593-351a14a59860.mov




### Checklist

- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
