### PR TITLE
[Cases] Fixing flaky tests relating to bulk creation of attachments and alerts

### DIFF
--- a/x-pack/test/cases_api_integration/common/lib/alerts.ts
+++ b/x-pack/test/cases_api_integration/common/lib/alerts.ts
@@ -31,12 +31,13 @@ import { postCaseReq } from './mock';
 
 export const createSecuritySolutionAlerts = async (
   supertest: SuperTest.SuperTest<SuperTest.Test>,
-  log: ToolingLog
+  log: ToolingLog,
+  numberOfSignals: number = 1
 ): Promise<estypes.SearchResponse<DetectionAlert & RiskEnrichmentFields>> => {
   const rule = getRuleForSignalTesting(['auditbeat-*']);
   const { id } = await createRule(supertest, log, rule);
   await waitForRuleSuccess({ supertest, log, id });
-  await waitForSignalsToBePresent(supertest, log, 1, [id]);
+  await waitForSignalsToBePresent(supertest, log, numberOfSignals, [id]);
   const signals = await getSignalsByIds(supertest, log, [id]);
 
   return signals;

--- a/x-pack/test/cases_api_integration/common/lib/api/attachments.ts
+++ b/x-pack/test/cases_api_integration/common/lib/api/attachments.ts
@@ -128,7 +128,7 @@ export const createCaseAndBulkCreateAttachments = async ({
 
 export const getAttachments = (numberOfAttachments: number): BulkCreateCommentRequest => {
   return [...Array(numberOfAttachments)].map((_, index) => {
-    if (index % 0) {
+    if (index % 10 === 0) {
       return {
         type: CommentType.user,
         comment: `Test ${index + 1}`,

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/delete_cases.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/delete_cases.ts
@@ -244,7 +244,7 @@ export default ({ getService }: FtrProviderContext): void => {
         beforeEach(async () => {
           await esArchiver.load('x-pack/test/functional/es_archives/auditbeat/hosts');
           await createSignalsIndex(supertest, log);
-          const signals = await createSecuritySolutionAlerts(supertest, log);
+          const signals = await createSecuritySolutionAlerts(supertest, log, 2);
           alerts = [signals.hits.hits[0], signals.hits.hits[1]];
         });
 

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/comments/delete_comment.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/comments/delete_comment.ts
@@ -54,7 +54,7 @@ export default ({ getService }: FtrProviderContext): void => {
   const log = getService('log');
   const supertestWithoutAuth = getService('supertestWithoutAuth');
 
-  describe('delete_comment', () => {
+  describe.only('delete_comment', () => {
     afterEach(async () => {
       await deleteCasesByESQuery(es);
       await deleteComments(es);
@@ -126,7 +126,7 @@ export default ({ getService }: FtrProviderContext): void => {
         beforeEach(async () => {
           await esArchiver.load('x-pack/test/functional/es_archives/auditbeat/hosts');
           await createSignalsIndex(supertest, log);
-          const signals = await createSecuritySolutionAlerts(supertest, log);
+          const signals = await createSecuritySolutionAlerts(supertest, log, 2);
           alerts = [signals.hits.hits[0], signals.hits.hits[1]];
         });
 

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/comments/delete_comment.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/comments/delete_comment.ts
@@ -54,7 +54,7 @@ export default ({ getService }: FtrProviderContext): void => {
   const log = getService('log');
   const supertestWithoutAuth = getService('supertestWithoutAuth');
 
-  describe.only('delete_comment', () => {
+  describe('delete_comment', () => {
     afterEach(async () => {
       await deleteCasesByESQuery(es);
       await deleteComments(es);

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/comments/delete_comments.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/comments/delete_comments.ts
@@ -66,7 +66,7 @@ export default ({ getService }: FtrProviderContext): void => {
   const log = getService('log');
   const supertestWithoutAuth = getService('supertestWithoutAuth');
 
-  describe('delete_comments', () => {
+  describe.only('delete_comments', () => {
     afterEach(async () => {
       await deleteCasesByESQuery(es);
       await deleteComments(es);
@@ -128,7 +128,7 @@ export default ({ getService }: FtrProviderContext): void => {
         beforeEach(async () => {
           await esArchiver.load('x-pack/test/functional/es_archives/auditbeat/hosts');
           await createSignalsIndex(supertest, log);
-          const signals = await createSecuritySolutionAlerts(supertest, log);
+          const signals = await createSecuritySolutionAlerts(supertest, log, 2);
           alerts = [signals.hits.hits[0], signals.hits.hits[1]];
         });
 

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/comments/delete_comments.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/comments/delete_comments.ts
@@ -66,7 +66,7 @@ export default ({ getService }: FtrProviderContext): void => {
   const log = getService('log');
   const supertestWithoutAuth = getService('supertestWithoutAuth');
 
-  describe.only('delete_comments', () => {
+  describe('delete_comments', () => {
     afterEach(async () => {
       await deleteCasesByESQuery(es);
       await deleteComments(es);

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/internal/bulk_create_attachments.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/internal/bulk_create_attachments.ts
@@ -109,7 +109,7 @@ export default ({ getService }: FtrProviderContext): void => {
     );
   };
 
-  describe.only('bulk_create_attachments', () => {
+  describe('bulk_create_attachments', () => {
     afterEach(async () => {
       await deleteAllCaseItems(es);
     });


### PR DESCRIPTION
This PR fixes some flaky tests. I believe there were two issues.
1. There were a few places we were only waiting for 1 alert to be created but we were expecting 2 alerts to be there which resulted in undefined when accessing the second alert and produced the _can't find _id_
2. The bulk create attachments code doesn't _**really**_ guarantee creating the attachments in the order they are listed within the request. This is because we do a `Promise.all` and quickly loop over the attachments to create the timestamp. I believe this was creating attachments with the same `created_at` value which means that they could be returned in the `case.comments` in a different order. The solution here is to compare the arrays ignoring the ordering.

Fixes: #154469 #154558 #154676 #154751 #154859 #154849 #154858 #154850 #154875 #155067 #155062 #155046 #155160 #155235 #155555 #155557 #155569, #155703, #155666

Flaky test run: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2164 🟢 