### PR TITLE
[ML] Data Frame Analytics creation wizard: add ability to add time field to result data view

### DIFF
--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/components/details_step/details_step_time_field.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/components/details_step/details_step_time_field.tsx
@@ -1,0 +1,69 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { FC } from 'react';
+import { EuiFormRow, EuiSelect } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { i18n } from '@kbn/i18n';
+
+interface Props {
+  dataViewAvailableTimeFields: string[];
+  dataViewTimeField: string | undefined;
+  onTimeFieldChanged: (e: React.ChangeEvent<HTMLSelectElement>) => void;
+}
+
+export const DetailsStepTimeField: FC<Props> = ({
+  dataViewAvailableTimeFields,
+  dataViewTimeField,
+  onTimeFieldChanged,
+}) => {
+  const noTimeFieldLabel = i18n.translate(
+    'xpack.ml.dataframe.analytics.create.detailsStep.noTimeFieldOptionLabel',
+    {
+      defaultMessage: "I don't want to use the time field option",
+    }
+  );
+
+  const noTimeFieldOption = {
+    text: noTimeFieldLabel,
+    value: undefined,
+  };
+
+  const disabledDividerOption = {
+    disabled: true,
+    text: '───',
+    value: '',
+  };
+
+  return (
+    <EuiFormRow
+      label={
+        <FormattedMessage
+          id="xpack.ml.dataframe.analytics.create.detailsStep.dataViewTimeFieldLabel"
+          defaultMessage="Time field for Kibana data view"
+        />
+      }
+      helpText={
+        <FormattedMessage
+          id="xpack.ml.dataframe.analytics.create.detailsStep.dataViewTimeFieldHelpText"
+          defaultMessage="Select a primary time field for use with the global time filter."
+        />
+      }
+    >
+      <EuiSelect
+        options={[
+          ...dataViewAvailableTimeFields.map((text) => ({ text })),
+          disabledDividerOption,
+          noTimeFieldOption,
+        ]}
+        value={dataViewTimeField}
+        onChange={onTimeFieldChanged}
+        data-test-subj="mlDataFrameAnalyticsCreateDataViewTimeFieldSelect"
+      />
+    </EuiFormRow>
+  );
+};

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_management/hooks/use_create_analytics_form/state.ts
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_management/hooks/use_create_analytics_form/state.ts
@@ -114,6 +114,7 @@ export interface State {
     sourceIndexContainsNumericalFields: boolean;
     sourceIndexFieldsCheckFailed: boolean;
     standardizationEnabled: undefined | string;
+    timeFieldName: undefined | string;
     trainingPercent: number;
     useEstimatedMml: boolean;
   };
@@ -199,6 +200,7 @@ export const getInitialState = (): State => ({
     sourceIndexContainsNumericalFields: true,
     sourceIndexFieldsCheckFailed: false,
     standardizationEnabled: 'true',
+    timeFieldName: undefined,
     trainingPercent: 80,
     useEstimatedMml: true,
   },

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_management/hooks/use_create_analytics_form/use_create_analytics_form.ts
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_management/hooks/use_create_analytics_form/use_create_analytics_form.ts
@@ -177,6 +177,7 @@ export const useCreateAnalyticsForm = (): CreateAnalyticsFormProps => {
           await mlContext.dataViewsContract.createAndSave(
             {
               title: dataViewName,
+              ...(form.timeFieldName ? { timeFieldName: form.timeFieldName } : {}),
             },
             false,
             true


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/155432

This PR
 - adds a timefield dropdown allowing user to select a timefield for the result dataview
 - defaults the timefield to that of the source data view (if one exists)


<img width="971" alt="image" src="https://user-images.githubusercontent.com/6446462/234129267-0640651d-e5a6-4886-871b-a3298cd1285b.png">

<img width="1021" alt="image" src="https://user-images.githubusercontent.com/6446462/234129299-ce970930-40d4-49e6-b627-7ecbc3c8e4a4.png">

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

