### PR TITLE
[serverless-docker] Allow using SERVERLESS env var

### DIFF
--- a/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker
+++ b/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker
@@ -414,6 +414,7 @@ kibana_vars=(
     xpack.task_manager.event_loop_delay.monitor
     xpack.task_manager.event_loop_delay.warn_threshold
     xpack.uptime.index
+    serverless
 )
 
 longopts=''


### PR DESCRIPTION
## Summary

This is a follow-up to #155284.

It allows using the Env Var `SERVERLESS={projectType}` when running the Serverless docker image to trigger Kibana with `--serverless={projectType}`.

Note: When the serverless option is not supported, Kibana throws a config validation error like below:

```
[FATAL][root] Error: Unknown configuration key(s): "serverless". Check for spelling errors and ensure that expected plugins are installed.
```


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
