### PR TITLE
[RAM] Maintenance Window - Ensure APIs require platinum license

### DIFF
--- a/x-pack/plugins/alerting/server/lib/license_state.mock.ts
+++ b/x-pack/plugins/alerting/server/lib/license_state.mock.ts
@@ -12,6 +12,7 @@ export const createLicenseStateMock = () => {
     clean: jest.fn(),
     getLicenseInformation: jest.fn(),
     ensureLicenseForRuleType: jest.fn(),
+    ensureLicenseForMaintenanceWindow: jest.fn(),
     getLicenseCheckForRuleType: jest.fn().mockResolvedValue({
       isValid: true,
     }),

--- a/x-pack/plugins/alerting/server/lib/license_state.ts
+++ b/x-pack/plugins/alerting/server/lib/license_state.ts
@@ -147,6 +147,31 @@ export class LicenseState {
     }
   }
 
+  public ensureLicenseForMaintenanceWindow() {
+    if (!this.license || !this.license?.isAvailable) {
+      throw Boom.forbidden(
+        i18n.translate(
+          'xpack.alerting.serverSideErrors.maintenanceWindow.unavailableLicenseErrorMessage',
+          {
+            defaultMessage:
+              'Maintenance window is disabled because license information is not available at this time.',
+          }
+        )
+      );
+    }
+    if (!this.license.hasAtLeast('platinum')) {
+      throw Boom.forbidden(
+        i18n.translate(
+          'xpack.alerting.serverSideErrors.maintenanceWindow.invalidLicenseErrorMessage',
+          {
+            defaultMessage:
+              'Maintenance window is disabled because it requires a platinum license. Go to License Management to view upgrade options.',
+          }
+        )
+      );
+    }
+  }
+
   public ensureLicenseForRuleType<
     Params extends RuleTypeParams,
     ExtractedParams extends RuleTypeParams,

--- a/x-pack/plugins/alerting/server/routes/maintenance_window/active_maintenance_windows.test.ts
+++ b/x-pack/plugins/alerting/server/routes/maintenance_window/active_maintenance_windows.test.ts
@@ -106,6 +106,9 @@ describe('activeMaintenanceWindowsRoute', () => {
     });
     const [, handler] = router.get.mock.calls[0];
     const [context, req, res] = mockHandlerArguments({ maintenanceWindowClient }, { body: {} });
-    expect(handler(context, req, res)).rejects.toMatchInlineSnapshot(`[Error: Failure]`);
+
+    await handler(context, req, res);
+
+    expect(res.ok).toHaveBeenLastCalledWith({ body: [] });
   });
 });

--- a/x-pack/plugins/alerting/server/routes/maintenance_window/active_maintenance_windows.test.ts
+++ b/x-pack/plugins/alerting/server/routes/maintenance_window/active_maintenance_windows.test.ts
@@ -94,4 +94,18 @@ describe('activeMaintenanceWindowsRoute', () => {
     const [context, req, res] = mockHandlerArguments({ maintenanceWindowClient }, { body: {} });
     expect(handler(context, req, res)).rejects.toMatchInlineSnapshot(`[Error: Failure]`);
   });
+
+  test('ensures only platinum license can access API', async () => {
+    const licenseState = licenseStateMock.create();
+    const router = httpServiceMock.createRouter();
+
+    activeMaintenanceWindowsRoute(router, licenseState);
+
+    (licenseState.ensureLicenseForMaintenanceWindow as jest.Mock).mockImplementation(() => {
+      throw new Error('Failure');
+    });
+    const [, handler] = router.get.mock.calls[0];
+    const [context, req, res] = mockHandlerArguments({ maintenanceWindowClient }, { body: {} });
+    expect(handler(context, req, res)).rejects.toMatchInlineSnapshot(`[Error: Failure]`);
+  });
 });

--- a/x-pack/plugins/alerting/server/routes/maintenance_window/active_maintenance_windows.ts
+++ b/x-pack/plugins/alerting/server/routes/maintenance_window/active_maintenance_windows.ts
@@ -25,8 +25,16 @@ export const activeMaintenanceWindowsRoute = (
     },
     router.handleLegacyErrors(
       verifyAccessAndContext(licenseState, async function (context, req, res) {
-        licenseState.ensureLicenseForMaintenanceWindow();
-
+        // We do not want to throw for this route because other solutions
+        // will be using it to determine whether or not they should
+        // display a callout in their rules list.
+        try {
+          licenseState.ensureLicenseForMaintenanceWindow();
+        } catch (e) {
+          return res.ok({
+            body: [],
+          });
+        }
         const maintenanceWindowClient = (await context.alerting).getMaintenanceWindowClient();
         const result = await maintenanceWindowClient.getActiveMaintenanceWindows({});
 

--- a/x-pack/plugins/alerting/server/routes/maintenance_window/active_maintenance_windows.ts
+++ b/x-pack/plugins/alerting/server/routes/maintenance_window/active_maintenance_windows.ts
@@ -25,6 +25,8 @@ export const activeMaintenanceWindowsRoute = (
     },
     router.handleLegacyErrors(
       verifyAccessAndContext(licenseState, async function (context, req, res) {
+        licenseState.ensureLicenseForMaintenanceWindow();
+
         const maintenanceWindowClient = (await context.alerting).getMaintenanceWindowClient();
         const result = await maintenanceWindowClient.getActiveMaintenanceWindows({});
 

--- a/x-pack/plugins/alerting/server/routes/maintenance_window/archive_maintenance_window.test.ts
+++ b/x-pack/plugins/alerting/server/routes/maintenance_window/archive_maintenance_window.test.ts
@@ -114,4 +114,19 @@ describe('archiveMaintenanceWindowRoute', () => {
     );
     expect(handler(context, req, res)).rejects.toMatchInlineSnapshot(`[Error: Failure]`);
   });
+
+  test('ensures only platinum license can access API', async () => {
+    const licenseState = licenseStateMock.create();
+    const router = httpServiceMock.createRouter();
+
+    archiveMaintenanceWindowRoute(router, licenseState);
+
+    (licenseState.ensureLicenseForMaintenanceWindow as jest.Mock).mockImplementation(() => {
+      throw new Error('Failure');
+    });
+
+    const [, handler] = router.post.mock.calls[0];
+    const [context, req, res] = mockHandlerArguments({ maintenanceWindowClient }, { body: {} });
+    expect(handler(context, req, res)).rejects.toMatchInlineSnapshot(`[Error: Failure]`);
+  });
 });

--- a/x-pack/plugins/alerting/server/routes/maintenance_window/archive_maintenance_window.ts
+++ b/x-pack/plugins/alerting/server/routes/maintenance_window/archive_maintenance_window.ts
@@ -37,6 +37,8 @@ export const archiveMaintenanceWindowRoute = (
     },
     router.handleLegacyErrors(
       verifyAccessAndContext(licenseState, async function (context, req, res) {
+        licenseState.ensureLicenseForMaintenanceWindow();
+
         const maintenanceWindowClient = (await context.alerting).getMaintenanceWindowClient();
         const { id } = req.params;
         const { archive } = req.body;

--- a/x-pack/plugins/alerting/server/routes/maintenance_window/create_maintenance_window.test.ts
+++ b/x-pack/plugins/alerting/server/routes/maintenance_window/create_maintenance_window.test.ts
@@ -96,4 +96,19 @@ describe('createMaintenanceWindowRoute', () => {
     );
     expect(handler(context, req, res)).rejects.toMatchInlineSnapshot(`[Error: Failure]`);
   });
+
+  test('ensures only platinum license can access API', async () => {
+    const licenseState = licenseStateMock.create();
+    const router = httpServiceMock.createRouter();
+
+    createMaintenanceWindowRoute(router, licenseState);
+
+    (licenseState.ensureLicenseForMaintenanceWindow as jest.Mock).mockImplementation(() => {
+      throw new Error('Failure');
+    });
+
+    const [, handler] = router.post.mock.calls[0];
+    const [context, req, res] = mockHandlerArguments({ maintenanceWindowClient }, { body: {} });
+    expect(handler(context, req, res)).rejects.toMatchInlineSnapshot(`[Error: Failure]`);
+  });
 });

--- a/x-pack/plugins/alerting/server/routes/maintenance_window/create_maintenance_window.ts
+++ b/x-pack/plugins/alerting/server/routes/maintenance_window/create_maintenance_window.ts
@@ -52,6 +52,8 @@ export const createMaintenanceWindowRoute = (
     },
     router.handleLegacyErrors(
       verifyAccessAndContext(licenseState, async function (context, req, res) {
+        licenseState.ensureLicenseForMaintenanceWindow();
+
         const maintenanceWindowClient = (await context.alerting).getMaintenanceWindowClient();
         const maintenanceWindow = await maintenanceWindowClient.create(rewriteQueryReq(req.body));
         return res.ok({

--- a/x-pack/plugins/alerting/server/routes/maintenance_window/delete_maintenance_window.test.ts
+++ b/x-pack/plugins/alerting/server/routes/maintenance_window/delete_maintenance_window.test.ts
@@ -87,4 +87,19 @@ describe('deleteMaintenanceWindowRoute', () => {
     );
     expect(handler(context, req, res)).rejects.toMatchInlineSnapshot(`[Error: Failure]`);
   });
+
+  test('ensures only platinum license can access API', async () => {
+    const licenseState = licenseStateMock.create();
+    const router = httpServiceMock.createRouter();
+
+    deleteMaintenanceWindowRoute(router, licenseState);
+
+    (licenseState.ensureLicenseForMaintenanceWindow as jest.Mock).mockImplementation(() => {
+      throw new Error('Failure');
+    });
+
+    const [, handler] = router.delete.mock.calls[0];
+    const [context, req, res] = mockHandlerArguments({ maintenanceWindowClient }, { body: {} });
+    expect(handler(context, req, res)).rejects.toMatchInlineSnapshot(`[Error: Failure]`);
+  });
 });

--- a/x-pack/plugins/alerting/server/routes/maintenance_window/delete_maintenance_window.ts
+++ b/x-pack/plugins/alerting/server/routes/maintenance_window/delete_maintenance_window.ts
@@ -32,6 +32,8 @@ export const deleteMaintenanceWindowRoute = (
     },
     router.handleLegacyErrors(
       verifyAccessAndContext(licenseState, async function (context, req, res) {
+        licenseState.ensureLicenseForMaintenanceWindow();
+
         const maintenanceWindowClient = (await context.alerting).getMaintenanceWindowClient();
         const { id } = req.params;
         await maintenanceWindowClient.delete({ id });

--- a/x-pack/plugins/alerting/server/routes/maintenance_window/find_maintenance_windows.test.ts
+++ b/x-pack/plugins/alerting/server/routes/maintenance_window/find_maintenance_windows.test.ts
@@ -95,4 +95,18 @@ describe('findMaintenanceWindowsRoute', () => {
     const [context, req, res] = mockHandlerArguments({ maintenanceWindowClient }, { body: {} });
     expect(handler(context, req, res)).rejects.toMatchInlineSnapshot(`[Error: Failure]`);
   });
+
+  test('ensures only platinum license can access API', async () => {
+    const licenseState = licenseStateMock.create();
+    const router = httpServiceMock.createRouter();
+
+    findMaintenanceWindowsRoute(router, licenseState);
+
+    (licenseState.ensureLicenseForMaintenanceWindow as jest.Mock).mockImplementation(() => {
+      throw new Error('Failure');
+    });
+    const [, handler] = router.get.mock.calls[0];
+    const [context, req, res] = mockHandlerArguments({ maintenanceWindowClient }, { body: {} });
+    expect(handler(context, req, res)).rejects.toMatchInlineSnapshot(`[Error: Failure]`);
+  });
 });

--- a/x-pack/plugins/alerting/server/routes/maintenance_window/find_maintenance_windows.ts
+++ b/x-pack/plugins/alerting/server/routes/maintenance_window/find_maintenance_windows.ts
@@ -25,6 +25,8 @@ export const findMaintenanceWindowsRoute = (
     },
     router.handleLegacyErrors(
       verifyAccessAndContext(licenseState, async function (context, req, res) {
+        licenseState.ensureLicenseForMaintenanceWindow();
+
         const maintenanceWindowClient = (await context.alerting).getMaintenanceWindowClient();
         const result = await maintenanceWindowClient.find();
 

--- a/x-pack/plugins/alerting/server/routes/maintenance_window/finish_maintenance_window.test.ts
+++ b/x-pack/plugins/alerting/server/routes/maintenance_window/finish_maintenance_window.test.ts
@@ -90,4 +90,18 @@ describe('finishMaintenanceWindowRoute', () => {
     );
     expect(handler(context, req, res)).rejects.toMatchInlineSnapshot(`[Error: Failure]`);
   });
+
+  test('ensures only platinum license can access API', async () => {
+    const licenseState = licenseStateMock.create();
+    const router = httpServiceMock.createRouter();
+
+    finishMaintenanceWindowRoute(router, licenseState);
+
+    (licenseState.ensureLicenseForMaintenanceWindow as jest.Mock).mockImplementation(() => {
+      throw new Error('Failure');
+    });
+    const [, handler] = router.post.mock.calls[0];
+    const [context, req, res] = mockHandlerArguments({ maintenanceWindowClient }, { body: {} });
+    expect(handler(context, req, res)).rejects.toMatchInlineSnapshot(`[Error: Failure]`);
+  });
 });

--- a/x-pack/plugins/alerting/server/routes/maintenance_window/finish_maintenance_window.ts
+++ b/x-pack/plugins/alerting/server/routes/maintenance_window/finish_maintenance_window.ts
@@ -32,6 +32,8 @@ export const finishMaintenanceWindowRoute = (
     },
     router.handleLegacyErrors(
       verifyAccessAndContext(licenseState, async function (context, req, res) {
+        licenseState.ensureLicenseForMaintenanceWindow();
+
         const maintenanceWindowClient = (await context.alerting).getMaintenanceWindowClient();
         const maintenanceWindow = await maintenanceWindowClient.finish(req.params);
         return res.ok({

--- a/x-pack/plugins/alerting/server/routes/maintenance_window/get_maintenance_window.test.ts
+++ b/x-pack/plugins/alerting/server/routes/maintenance_window/get_maintenance_window.test.ts
@@ -90,4 +90,18 @@ describe('getMaintenanceWindowRoute', () => {
     );
     expect(handler(context, req, res)).rejects.toMatchInlineSnapshot(`[Error: Failure]`);
   });
+
+  test('ensures only platinum license can access API', async () => {
+    const licenseState = licenseStateMock.create();
+    const router = httpServiceMock.createRouter();
+
+    getMaintenanceWindowRoute(router, licenseState);
+
+    (licenseState.ensureLicenseForMaintenanceWindow as jest.Mock).mockImplementation(() => {
+      throw new Error('Failure');
+    });
+    const [, handler] = router.get.mock.calls[0];
+    const [context, req, res] = mockHandlerArguments({ maintenanceWindowClient }, { body: {} });
+    expect(handler(context, req, res)).rejects.toMatchInlineSnapshot(`[Error: Failure]`);
+  });
 });

--- a/x-pack/plugins/alerting/server/routes/maintenance_window/get_maintenance_window.ts
+++ b/x-pack/plugins/alerting/server/routes/maintenance_window/get_maintenance_window.ts
@@ -32,6 +32,8 @@ export const getMaintenanceWindowRoute = (
     },
     router.handleLegacyErrors(
       verifyAccessAndContext(licenseState, async function (context, req, res) {
+        licenseState.ensureLicenseForMaintenanceWindow();
+
         const maintenanceWindowClient = (await context.alerting).getMaintenanceWindowClient();
         const { id } = req.params;
         const maintenanceWindow = await maintenanceWindowClient.get({ id });

--- a/x-pack/plugins/alerting/server/routes/maintenance_window/update_maintenance_window.test.ts
+++ b/x-pack/plugins/alerting/server/routes/maintenance_window/update_maintenance_window.test.ts
@@ -115,4 +115,18 @@ describe('updateMaintenanceWindowRoute', () => {
     );
     expect(handler(context, req, res)).rejects.toMatchInlineSnapshot(`[Error: Failure]`);
   });
+
+  test('ensures only platinum license can access API', async () => {
+    const licenseState = licenseStateMock.create();
+    const router = httpServiceMock.createRouter();
+
+    updateMaintenanceWindowRoute(router, licenseState);
+
+    (licenseState.ensureLicenseForMaintenanceWindow as jest.Mock).mockImplementation(() => {
+      throw new Error('Failure');
+    });
+    const [, handler] = router.post.mock.calls[0];
+    const [context, req, res] = mockHandlerArguments({ maintenanceWindowClient }, { body: {} });
+    expect(handler(context, req, res)).rejects.toMatchInlineSnapshot(`[Error: Failure]`);
+  });
 });

--- a/x-pack/plugins/alerting/server/routes/maintenance_window/update_maintenance_window.ts
+++ b/x-pack/plugins/alerting/server/routes/maintenance_window/update_maintenance_window.ts
@@ -60,6 +60,8 @@ export const updateMaintenanceWindowRoute = (
     },
     router.handleLegacyErrors(
       verifyAccessAndContext(licenseState, async function (context, req, res) {
+        licenseState.ensureLicenseForMaintenanceWindow();
+
         const maintenanceWindowClient = (await context.alerting).getMaintenanceWindowClient();
         const maintenanceWindow = await maintenanceWindowClient.update({
           id: req.params.id,


### PR DESCRIPTION
## Summary
Resolves: https://github.com/elastic/kibana/issues/155665

This PR adds a check so only platinum license users are allowed to use the maintenance window APIs.

### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
