### PR TITLE
[Cloud Posture] fix sequence count when integration is in edit mode

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/components/fleet_extensions/policy_template_form.test.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/fleet_extensions/policy_template_form.test.tsx
@@ -44,11 +44,9 @@ describe('<CspPolicyTemplateForm />', () => {
   const WrappedComponent = ({
     newPolicy,
     edit = false,
-    currentPackagePolicyCount,
   }: {
     edit?: boolean;
     newPolicy: NewPackagePolicy;
-    currentPackagePolicyCount: number | undefined;
   }) => (
     <TestProvider>
       {edit && (
@@ -56,7 +54,6 @@ describe('<CspPolicyTemplateForm />', () => {
           policy={newPolicy as PackagePolicy}
           newPolicy={newPolicy}
           onChange={onChange}
-          currentPackagePolicyCount={currentPackagePolicyCount}
           packageInfo={{} as PackageInfo}
           isEditPage={true}
         />
@@ -65,7 +62,6 @@ describe('<CspPolicyTemplateForm />', () => {
         <CspPolicyTemplateForm
           newPolicy={newPolicy}
           onChange={onChange}
-          currentPackagePolicyCount={currentPackagePolicyCount}
           packageInfo={{} as PackageInfo}
           isEditPage={false}
         />
@@ -79,16 +75,9 @@ describe('<CspPolicyTemplateForm />', () => {
 
   it('updates package policy namespace to default when it changes', () => {
     const policy = getMockPolicyK8s();
-    const { rerender } = render(
-      <WrappedComponent currentPackagePolicyCount={1} newPolicy={policy} />
-    );
+    const { rerender } = render(<WrappedComponent newPolicy={policy} />);
 
-    rerender(
-      <WrappedComponent
-        currentPackagePolicyCount={1}
-        newPolicy={{ ...policy, namespace: 'some-namespace' }}
-      />
-    );
+    rerender(<WrappedComponent newPolicy={{ ...policy, namespace: 'some-namespace' }} />);
 
     // Listen to the onChange triggered by the test (re-render with new policy namespace)
     // It should ensure the initial state is valid.
@@ -103,9 +92,7 @@ describe('<CspPolicyTemplateForm />', () => {
 
   it('renders and updates name field', () => {
     const policy = getMockPolicyK8s();
-    const { getByLabelText } = render(
-      <WrappedComponent currentPackagePolicyCount={1} newPolicy={policy} />
-    );
+    const { getByLabelText } = render(<WrappedComponent newPolicy={policy} />);
     const name = getByLabelText('Name');
     expect(name).toBeInTheDocument();
 
@@ -121,9 +108,7 @@ describe('<CspPolicyTemplateForm />', () => {
 
   it('renders and updates description field', () => {
     const policy = getMockPolicyK8s();
-    const { getByLabelText } = render(
-      <WrappedComponent currentPackagePolicyCount={1} newPolicy={policy} />
-    );
+    const { getByLabelText } = render(<WrappedComponent newPolicy={policy} />);
     const description = getByLabelText('Description');
     expect(description).toBeInTheDocument();
 
@@ -138,9 +123,7 @@ describe('<CspPolicyTemplateForm />', () => {
   });
 
   it('renders KSPM input selector', () => {
-    const { getByLabelText } = render(
-      <WrappedComponent currentPackagePolicyCount={1} newPolicy={getMockPolicyK8s()} />
-    );
+    const { getByLabelText } = render(<WrappedComponent newPolicy={getMockPolicyK8s()} />);
 
     const option1 = getByLabelText('Self-Managed');
     const option2 = getByLabelText('EKS');
@@ -156,9 +139,7 @@ describe('<CspPolicyTemplateForm />', () => {
     const k8sPolicy = getMockPolicyK8s();
     const eksPolicy = getMockPolicyEKS();
 
-    const { getByLabelText } = render(
-      <WrappedComponent currentPackagePolicyCount={1} newPolicy={k8sPolicy} />
-    );
+    const { getByLabelText } = render(<WrappedComponent newPolicy={k8sPolicy} />);
     const option = getByLabelText('EKS');
     userEvent.click(option);
 
@@ -171,9 +152,7 @@ describe('<CspPolicyTemplateForm />', () => {
   });
 
   it('renders CSPM input selector', () => {
-    const { getByLabelText } = render(
-      <WrappedComponent currentPackagePolicyCount={1} newPolicy={getMockPolicyAWS()} />
-    );
+    const { getByLabelText } = render(<WrappedComponent newPolicy={getMockPolicyAWS()} />);
 
     const option1 = getByLabelText('Amazon Web Services');
     const option2 = getByLabelText('GCP');
@@ -190,7 +169,7 @@ describe('<CspPolicyTemplateForm />', () => {
 
   it('renders disabled KSPM input when editing', () => {
     const { getByLabelText } = render(
-      <WrappedComponent currentPackagePolicyCount={1} newPolicy={getMockPolicyK8s()} edit={true} />
+      <WrappedComponent newPolicy={getMockPolicyK8s()} edit={true} />
     );
 
     const option1 = getByLabelText('Self-Managed');
@@ -205,7 +184,7 @@ describe('<CspPolicyTemplateForm />', () => {
 
   it('renders disabled CSPM input when editing', () => {
     const { getByLabelText } = render(
-      <WrappedComponent currentPackagePolicyCount={1} newPolicy={getMockPolicyAWS()} edit={true} />
+      <WrappedComponent newPolicy={getMockPolicyAWS()} edit={true} />
     );
 
     const option1 = getByLabelText('Amazon Web Services');
@@ -242,7 +221,7 @@ describe('<CspPolicyTemplateForm />', () => {
     (useParams as jest.Mock).mockReturnValue({
       integration: 'kspm',
     });
-    render(<WrappedComponent currentPackagePolicyCount={1} newPolicy={policy} />);
+    render(<WrappedComponent newPolicy={policy} />);
 
     // 1st call happens on mount and selects the default policy template enabled input
     expect(onChange).toHaveBeenNthCalledWith(1, {
@@ -284,7 +263,7 @@ describe('<CspPolicyTemplateForm />', () => {
       })
     );
 
-    render(<WrappedComponent currentPackagePolicyCount={1} newPolicy={policy} />);
+    render(<WrappedComponent newPolicy={policy} />);
 
     // 1st call happens on mount and selects the default policy template enabled input
     expect(onChange).toHaveBeenNthCalledWith(1, {
@@ -326,7 +305,7 @@ describe('<CspPolicyTemplateForm />', () => {
       })
     );
 
-    render(<WrappedComponent currentPackagePolicyCount={1} newPolicy={policy} />);
+    render(<WrappedComponent newPolicy={policy} />);
 
     // 1st call happens on mount and selects the default policy template enabled input
     expect(onChange).toHaveBeenNthCalledWith(1, {
@@ -364,9 +343,7 @@ describe('<CspPolicyTemplateForm />', () => {
         'aws.credentials.type': { value: 'assume_role' },
       });
 
-      const { getByLabelText } = render(
-        <WrappedComponent currentPackagePolicyCount={1} newPolicy={policy} />
-      );
+      const { getByLabelText } = render(<WrappedComponent newPolicy={policy} />);
       const option = getByLabelText('Assume role');
 
       expect(option).toBeChecked();
@@ -378,9 +355,7 @@ describe('<CspPolicyTemplateForm />', () => {
       policy = getPosturePolicy(policy, inputKey, {
         'aws.credentials.type': { value: 'assume_role' },
       });
-      const { getByLabelText } = render(
-        <WrappedComponent currentPackagePolicyCount={1} newPolicy={policy} />
-      );
+      const { getByLabelText } = render(<WrappedComponent newPolicy={policy} />);
 
       userEvent.type(getByLabelText('Role ARN'), 'a');
       policy = getPosturePolicy(policy, inputKey, { role_arn: { value: 'a' } });
@@ -398,9 +373,7 @@ describe('<CspPolicyTemplateForm />', () => {
         'aws.credentials.type': { value: 'direct_access_keys' },
       });
 
-      const { getByLabelText } = render(
-        <WrappedComponent currentPackagePolicyCount={1} newPolicy={policy} />
-      );
+      const { getByLabelText } = render(<WrappedComponent newPolicy={policy} />);
       const option = getByLabelText('Direct access keys');
 
       expect(option).toBeChecked();
@@ -413,9 +386,7 @@ describe('<CspPolicyTemplateForm />', () => {
       policy = getPosturePolicy(policy, inputKey, {
         'aws.credentials.type': { value: 'direct_access_keys' },
       });
-      const { getByLabelText, rerender } = render(
-        <WrappedComponent currentPackagePolicyCount={1} newPolicy={policy} />
-      );
+      const { getByLabelText, rerender } = render(<WrappedComponent newPolicy={policy} />);
 
       userEvent.type(getByLabelText('Access Key ID'), 'a');
       policy = getPosturePolicy(policy, inputKey, { access_key_id: { value: 'a' } });
@@ -426,7 +397,7 @@ describe('<CspPolicyTemplateForm />', () => {
         updatedPolicy: policy,
       });
 
-      rerender(<WrappedComponent currentPackagePolicyCount={1} newPolicy={policy} />);
+      rerender(<WrappedComponent newPolicy={policy} />);
 
       userEvent.type(getByLabelText('Secret Access Key'), 'b');
       policy = getPosturePolicy(policy, inputKey, { secret_access_key: { value: 'b' } });
@@ -443,9 +414,7 @@ describe('<CspPolicyTemplateForm />', () => {
         'aws.credentials.type': { value: 'temporary_keys' },
       });
 
-      const { getByLabelText } = render(
-        <WrappedComponent currentPackagePolicyCount={1} newPolicy={policy} />
-      );
+      const { getByLabelText } = render(<WrappedComponent newPolicy={policy} />);
       const option = getByLabelText('Temporary keys');
 
       expect(option).toBeChecked();
@@ -459,9 +428,7 @@ describe('<CspPolicyTemplateForm />', () => {
       policy = getPosturePolicy(policy, inputKey, {
         'aws.credentials.type': { value: 'temporary_keys' },
       });
-      const { getByLabelText, rerender } = render(
-        <WrappedComponent currentPackagePolicyCount={1} newPolicy={policy} />
-      );
+      const { getByLabelText, rerender } = render(<WrappedComponent newPolicy={policy} />);
 
       userEvent.type(getByLabelText('Access Key ID'), 'a');
       policy = getPosturePolicy(policy, inputKey, { access_key_id: { value: 'a' } });
@@ -472,7 +439,7 @@ describe('<CspPolicyTemplateForm />', () => {
         updatedPolicy: policy,
       });
 
-      rerender(<WrappedComponent currentPackagePolicyCount={1} newPolicy={policy} />);
+      rerender(<WrappedComponent newPolicy={policy} />);
 
       userEvent.type(getByLabelText('Secret Access Key'), 'b');
       policy = getPosturePolicy(policy, inputKey, { secret_access_key: { value: 'b' } });
@@ -482,7 +449,7 @@ describe('<CspPolicyTemplateForm />', () => {
         updatedPolicy: policy,
       });
 
-      rerender(<WrappedComponent currentPackagePolicyCount={1} newPolicy={policy} />);
+      rerender(<WrappedComponent newPolicy={policy} />);
 
       userEvent.type(getByLabelText('Session Token'), 'a');
       policy = getPosturePolicy(policy, inputKey, { session_token: { value: 'a' } });
@@ -499,9 +466,7 @@ describe('<CspPolicyTemplateForm />', () => {
         'aws.credentials.type': { value: 'shared_credentials' },
       });
 
-      const { getByLabelText } = render(
-        <WrappedComponent currentPackagePolicyCount={1} newPolicy={policy} />
-      );
+      const { getByLabelText } = render(<WrappedComponent newPolicy={policy} />);
       const option = getByLabelText('Shared credentials');
 
       expect(option).toBeChecked();
@@ -514,9 +479,7 @@ describe('<CspPolicyTemplateForm />', () => {
       policy = getPosturePolicy(policy, inputKey, {
         'aws.credentials.type': { value: 'shared_credentials' },
       });
-      const { getByLabelText, rerender } = render(
-        <WrappedComponent currentPackagePolicyCount={1} newPolicy={policy} />
-      );
+      const { getByLabelText, rerender } = render(<WrappedComponent newPolicy={policy} />);
 
       userEvent.type(getByLabelText('Shared Credential File'), 'a');
       policy = getPosturePolicy(policy, inputKey, {
@@ -529,7 +492,7 @@ describe('<CspPolicyTemplateForm />', () => {
         updatedPolicy: policy,
       });
 
-      rerender(<WrappedComponent currentPackagePolicyCount={1} newPolicy={policy} />);
+      rerender(<WrappedComponent newPolicy={policy} />);
 
       userEvent.type(getByLabelText('Credential Profile Name'), 'b');
       policy = getPosturePolicy(policy, inputKey, {

--- a/x-pack/plugins/cloud_security_posture/public/components/fleet_extensions/policy_template_form.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/fleet_extensions/policy_template_form.tsx
@@ -97,14 +97,6 @@ export const CspPolicyTemplateForm = memo<PackagePolicyReplaceDefineStepExtensio
       (updatedPolicy: NewPackagePolicy) => onChange({ isValid: true, updatedPolicy }),
       [onChange]
     );
-
-    const getSetupStatus = useCspSetupStatusApi();
-    const installedPackagePolicyCount = Object.entries(getSetupStatus?.data ?? {})?.find(
-      ([key, _value]) => key === integration
-    )?.[1]?.installedPackagePolicies;
-
-    const currentPackagePolicyCount =
-      typeof installedPackagePolicyCount === 'number' ? installedPackagePolicyCount + 1 : undefined;
     /**
      * - Updates policy inputs by user selection
      * - Updates hidden policy vars
@@ -154,7 +146,6 @@ export const CspPolicyTemplateForm = memo<PackagePolicyReplaceDefineStepExtensio
       integration,
       newPolicy,
       updatePolicy,
-      currentPackagePolicyCount,
     });
 
     useEnsureDefaultNamespace({ newPolicy, input, updatePolicy });
@@ -243,15 +234,21 @@ const usePolicyTemplateInitialName = ({
   integration,
   newPolicy,
   updatePolicy,
-  currentPackagePolicyCount,
 }: {
   isEditPage: boolean;
   isLoading: boolean;
   integration: CloudSecurityPolicyTemplate | undefined;
   newPolicy: NewPackagePolicy;
-  currentPackagePolicyCount: number | undefined;
   updatePolicy: (policy: NewPackagePolicy) => void;
 }) => {
+  const getSetupStatus = useCspSetupStatusApi();
+  const installedPackagePolicyCount = Object.entries(getSetupStatus?.data ?? {})?.find(
+    ([key, _value]) => key === integration
+  )?.[1]?.installedPackagePolicies;
+
+  const currentPackagePolicyCount =
+    typeof installedPackagePolicyCount === 'number' ? installedPackagePolicyCount + 1 : undefined;
+
   useEffect(() => {
     if (!integration) return;
     if (isEditPage) return;

--- a/x-pack/plugins/fleet/public/types/ui_extensions.ts
+++ b/x-pack/plugins/fleet/public/types/ui_extensions.ts
@@ -35,6 +35,7 @@ export type PackagePolicyReplaceDefineStepExtensionComponentProps = (
 ) & {
   validationResults?: PackagePolicyValidationResults;
   agentPolicy?: AgentPolicy;
+  currentPackagePolicyCount: number | undefined;
   packageInfo: PackageInfo;
 };
 
@@ -50,6 +51,7 @@ export interface PackagePolicyEditExtensionComponentProps {
   policy: PackagePolicy;
   /** The new (updated) integration policy that will be saved */
   newPolicy: NewPackagePolicy;
+  currentPackagePolicyCount: number | undefined;
   /**
    * A callback that should be executed anytime a change to the Integration Policy needs to
    * be reported back to the Fleet Policy Edit page.
@@ -74,6 +76,7 @@ export type PackagePolicyResponseExtensionComponent =
   ComponentType<PackagePolicyResponseExtensionComponentProps>;
 
 export interface PackagePolicyResponseExtensionComponentProps {
+  currentPackagePolicyCount: number | undefined;
   /** The current agent to retrieve response from */
   agent: Agent;
   /** A callback function to set the `needs attention` state */

--- a/x-pack/plugins/fleet/public/types/ui_extensions.ts
+++ b/x-pack/plugins/fleet/public/types/ui_extensions.ts
@@ -35,7 +35,6 @@ export type PackagePolicyReplaceDefineStepExtensionComponentProps = (
 ) & {
   validationResults?: PackagePolicyValidationResults;
   agentPolicy?: AgentPolicy;
-  currentPackagePolicyCount: number | undefined;
   packageInfo: PackageInfo;
 };
 
@@ -51,7 +50,6 @@ export interface PackagePolicyEditExtensionComponentProps {
   policy: PackagePolicy;
   /** The new (updated) integration policy that will be saved */
   newPolicy: NewPackagePolicy;
-  currentPackagePolicyCount: number | undefined;
   /**
    * A callback that should be executed anytime a change to the Integration Policy needs to
    * be reported back to the Fleet Policy Edit page.
@@ -76,7 +74,6 @@ export type PackagePolicyResponseExtensionComponent =
   ComponentType<PackagePolicyResponseExtensionComponentProps>;
 
 export interface PackagePolicyResponseExtensionComponentProps {
-  currentPackagePolicyCount: number | undefined;
   /** The current agent to retrieve response from */
   agent: Agent;
   /** A callback function to set the `needs attention` state */


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.
 Before, if we add another subsequent CSP integration, then the integration name sequence number doesn't increase.  The current implementation always takes the first default digit which is 1. This causes errors to be thrown. We need to make the integration name unique. 

- The proposed solution is to find the current integration's `installedPackagePolicies` using the`useCspSetupStatusApi`  hook. Once we have the count, increment the installedPackagePolicies by 1 to create a unique integration name with the current package policy count.

<img width="1714" alt="Screen Shot 2023-04-24 at 7 50 44 PM" src="https://user-images.githubusercontent.com/17135495/234168157-265670e9-5634-4af2-8cdf-d162e6374bf9.png">
<img width="1148" alt="Screen Shot 2023-04-24 at 7 51 03 PM" src="https://user-images.githubusercontent.com/17135495/234168202-4675c6b4-23cd-4d55-b439-c4414f7541ca.png">
