### PR TITLE
[Discover] Add a deprecation badge to legacy stats setting

### DIFF
--- a/packages/kbn-doc-links/src/get_doc_links.ts
+++ b/packages/kbn-doc-links/src/get_doc_links.ts
@@ -419,6 +419,7 @@ export const getDocLinks = ({ kibanaBranch }: GetDocLinkOptions): DocLinks => {
       dashboardSettings: `${KIBANA_DOCS}advanced-options.html#kibana-dashboard-settings`,
       indexManagement: `${ELASTICSEARCH_DOCS}index-mgmt.html`,
       kibanaSearchSettings: `${KIBANA_DOCS}advanced-options.html#kibana-search-settings`,
+      discoverSettings: `${KIBANA_DOCS}advanced-options.html#kibana-discover-settings`,
       visualizationSettings: `${KIBANA_DOCS}advanced-options.html#kibana-visualization-settings`,
       timelionSettings: `${KIBANA_DOCS}advanced-options.html#kibana-timelion-settings`,
       savedObjectsApiList: `${KIBANA_DOCS}saved-objects-api.html#saved-objects-api`,

--- a/src/plugins/discover/server/ui_settings.ts
+++ b/src/plugins/discover/server/ui_settings.ts
@@ -141,6 +141,7 @@ export const getUiSettings: (docLinks: DocLinksServiceSetup) => Record<string, U
       message: i18n.translate('discover.advancedSettings.showLegacyFieldStatsTextDeprecation', {
         defaultMessage: 'This setting is deprecated and will not be supported in a future version.',
       }),
+      docLinksKey: 'discoverSettings',
     },
   },
   [DOC_HIDE_TIME_COLUMN_SETTING]: {

--- a/src/plugins/discover/server/ui_settings.ts
+++ b/src/plugins/discover/server/ui_settings.ts
@@ -137,6 +137,11 @@ export const getUiSettings: (docLinks: DocLinksServiceSetup) => Record<string, U
     }),
     category: ['discover'],
     schema: schema.boolean(),
+    deprecation: {
+      message: i18n.translate('discover.advancedSettings.showLegacyFieldStatsTextDeprecation', {
+        defaultMessage: 'This setting is deprecated and will not be supported in a future version.',
+      }),
+    },
   },
   [DOC_HIDE_TIME_COLUMN_SETTING]: {
     name: i18n.translate('discover.advancedSettings.docTableHideTimeColumnTitle', {


### PR DESCRIPTION
## Summary

We are adding a deprecation badge in 8.8 and removing this setting in 8.9 https://github.com/elastic/kibana/pull/155503

<img width="946" alt="Screenshot 2023-04-25 at 10 28 21" src="https://user-images.githubusercontent.com/1415710/234220005-401bb636-df3f-44a1-ae83-4a30df99ec87.png">
