### PR TITLE
[failed test reporter] no github issues for WebDriver invalid session id

### DIFF
--- a/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/get_failures.ts
+++ b/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/get_failures.ts
@@ -35,7 +35,10 @@ const getText = (node?: Array<string | { _: string }>) => {
 const isLikelyIrrelevant = (name: string, failure: string) => {
   if (
     failure.includes('NoSuchSessionError: This driver instance does not have a valid session ID') ||
-    failure.includes('NoSuchSessionError: Tried to run command without establishing a connection')
+    failure.includes(
+      'NoSuchSessionError: Tried to run command without establishing a connection'
+    ) ||
+    failure.includes('NoSuchSessionError: invalid session id')
   ) {
     return true;
   }

--- a/test/functional/services/common/screenshots.ts
+++ b/test/functional/services/common/screenshots.ts
@@ -9,6 +9,7 @@
 import { resolve, dirname } from 'path';
 import { writeFile, readFileSync, mkdir } from 'fs';
 import { promisify } from 'util';
+import { NoSuchSessionError } from 'selenium-webdriver/lib/error';
 
 import del from 'del';
 
@@ -92,6 +93,12 @@ export class ScreenshotsService extends FtrService {
     } catch (err) {
       this.log.error('SCREENSHOT FAILED');
       this.log.error(err);
+      if (err instanceof NoSuchSessionError) {
+        // https://developer.mozilla.org/en-US/docs/Web/WebDriver/Errors/InvalidSessionID
+        this.log.error(
+          `WebDriver session is no longer valid.\nProbably Chrome process crashed when it tried to use more memory than what was available.`
+        );
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

This PR adds `NoSuchSessionError: invalid session id` to the irrelevant failures, so that we don't open github issues for it.

The issue is often related to test infrastructure (worker) and occurs when Chrome process is reaching the available memory limits. It doesn't fail regularly but when it fails multiple github issues are [reported](https://github.com/elastic/kibana/issues?q=is%3Aissue+NoSuchSessionError+is%3Aopen) and we usually just close them as CI related.
  

<!--ONMERGE {"backportTargets":["7.17","8.7"]} ONMERGE-->