### PR TITLE
[ML] AIOps: Stabilize flaky functional tests.

### DIFF
--- a/x-pack/test/functional/apps/aiops/explain_log_rate_spikes.ts
+++ b/x-pack/test/functional/apps/aiops/explain_log_rate_spikes.ts
@@ -233,7 +233,6 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     });
   }
 
-  // FLAKY: https://github.com/elastic/kibana/issues/155222
   describe('explain log rate spikes', async function () {
     for (const testData of explainLogRateSpikesTestData) {
       describe(`with '${testData.sourceIndexOrSavedSearch}'`, function () {

--- a/x-pack/test/functional/apps/aiops/explain_log_rate_spikes.ts
+++ b/x-pack/test/functional/apps/aiops/explain_log_rate_spikes.ts
@@ -155,80 +155,80 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       // The group switch should be disabled by default
       await aiops.explainLogRateSpikesPage.assertSpikeAnalysisGroupSwitchExists(false);
 
-      // Enabled grouping
-      await aiops.explainLogRateSpikesPage.clickSpikeAnalysisGroupSwitch(false);
-
-      await aiops.explainLogRateSpikesAnalysisGroupsTable.assertSpikeAnalysisTableExists();
-
       if (!isTestDataExpectedWithSampleProbability(testData.expected)) {
+        // Enabled grouping
+        await aiops.explainLogRateSpikesPage.clickSpikeAnalysisGroupSwitch(false);
+
+        await aiops.explainLogRateSpikesAnalysisGroupsTable.assertSpikeAnalysisTableExists();
+
         const analysisGroupsTable =
           await aiops.explainLogRateSpikesAnalysisGroupsTable.parseAnalysisTable();
         expect(orderBy(analysisGroupsTable, 'group')).to.be.eql(
           orderBy(testData.expected.analysisGroupsTable, 'group')
         );
-      }
 
-      await ml.testExecution.logTestStep('expand table row');
-      await aiops.explainLogRateSpikesAnalysisGroupsTable.assertExpandRowButtonExists();
-      await aiops.explainLogRateSpikesAnalysisGroupsTable.expandRow();
-
-      if (!isTestDataExpectedWithSampleProbability(testData.expected)) {
-        const analysisTable = await aiops.explainLogRateSpikesAnalysisTable.parseAnalysisTable();
-        expect(orderBy(analysisTable, ['fieldName', 'fieldValue'])).to.be.eql(
-          orderBy(testData.expected.analysisTable, ['fieldName', 'fieldValue'])
-        );
-      }
-
-      await ml.testExecution.logTestStep('open the field filter');
-      await aiops.explainLogRateSpikesPage.assertFieldFilterPopoverButtonExists(false);
-      await aiops.explainLogRateSpikesPage.clickFieldFilterPopoverButton(true);
-      await aiops.explainLogRateSpikesPage.assertFieldSelectorFieldNameList(
-        testData.expected.fieldSelectorPopover
-      );
-
-      await ml.testExecution.logTestStep('filter fields');
-      await aiops.explainLogRateSpikesPage.setFieldSelectorSearch(testData.fieldSelectorSearch);
-      await aiops.explainLogRateSpikesPage.assertFieldSelectorFieldNameList([
-        testData.fieldSelectorSearch,
-      ]);
-      await aiops.explainLogRateSpikesPage.clickFieldSelectorDisableAllSelectedButton();
-      await aiops.explainLogRateSpikesPage.assertFieldFilterApplyButtonExists(
-        !testData.fieldSelectorApplyAvailable
-      );
-
-      if (testData.fieldSelectorApplyAvailable) {
-        await ml.testExecution.logTestStep('regroup results');
-        await aiops.explainLogRateSpikesPage.clickFieldFilterApplyButton();
+        await ml.testExecution.logTestStep('expand table row');
+        await aiops.explainLogRateSpikesAnalysisGroupsTable.assertExpandRowButtonExists();
+        await aiops.explainLogRateSpikesAnalysisGroupsTable.expandRow();
 
         if (!isTestDataExpectedWithSampleProbability(testData.expected)) {
-          const filteredAnalysisGroupsTable =
-            await aiops.explainLogRateSpikesAnalysisGroupsTable.parseAnalysisTable();
-          expect(orderBy(filteredAnalysisGroupsTable, 'group')).to.be.eql(
-            orderBy(testData.expected.filteredAnalysisGroupsTable, 'group')
+          const analysisTable = await aiops.explainLogRateSpikesAnalysisTable.parseAnalysisTable();
+          expect(orderBy(analysisTable, ['fieldName', 'fieldValue'])).to.be.eql(
+            orderBy(testData.expected.analysisTable, ['fieldName', 'fieldValue'])
           );
         }
-      }
 
-      if (testData.action !== undefined) {
-        await ml.testExecution.logTestStep('check all table row actions are present');
-        await aiops.explainLogRateSpikesAnalysisGroupsTable.assertRowActions(
-          testData.action.tableRowId
-        );
-
-        await ml.testExecution.logTestStep('click log pattern analysis action');
-        await aiops.explainLogRateSpikesAnalysisGroupsTable.clickRowAction(
-          testData.action.tableRowId,
-          testData.action.type
+        await ml.testExecution.logTestStep('open the field filter');
+        await aiops.explainLogRateSpikesPage.assertFieldFilterPopoverButtonExists(false);
+        await aiops.explainLogRateSpikesPage.clickFieldFilterPopoverButton(true);
+        await aiops.explainLogRateSpikesPage.assertFieldSelectorFieldNameList(
+          testData.expected.fieldSelectorPopover
         );
 
-        await ml.testExecution.logTestStep('check log pattern analysis page loaded correctly');
-        await aiops.logPatternAnalysisPageProvider.assertLogCategorizationPageExists();
-        await aiops.logPatternAnalysisPageProvider.assertTotalDocumentCount(
-          testData.action.expected.totalDocCount
+        await ml.testExecution.logTestStep('filter fields');
+        await aiops.explainLogRateSpikesPage.setFieldSelectorSearch(testData.fieldSelectorSearch);
+        await aiops.explainLogRateSpikesPage.assertFieldSelectorFieldNameList([
+          testData.fieldSelectorSearch,
+        ]);
+        await aiops.explainLogRateSpikesPage.clickFieldSelectorDisableAllSelectedButton();
+        await aiops.explainLogRateSpikesPage.assertFieldFilterApplyButtonExists(
+          !testData.fieldSelectorApplyAvailable
         );
-        await aiops.logPatternAnalysisPageProvider.assertQueryInput(
-          testData.action.expected.queryBar
-        );
+
+        if (testData.fieldSelectorApplyAvailable) {
+          await ml.testExecution.logTestStep('regroup results');
+          await aiops.explainLogRateSpikesPage.clickFieldFilterApplyButton();
+
+          if (!isTestDataExpectedWithSampleProbability(testData.expected)) {
+            const filteredAnalysisGroupsTable =
+              await aiops.explainLogRateSpikesAnalysisGroupsTable.parseAnalysisTable();
+            expect(orderBy(filteredAnalysisGroupsTable, 'group')).to.be.eql(
+              orderBy(testData.expected.filteredAnalysisGroupsTable, 'group')
+            );
+          }
+        }
+
+        if (testData.action !== undefined) {
+          await ml.testExecution.logTestStep('check all table row actions are present');
+          await aiops.explainLogRateSpikesAnalysisGroupsTable.assertRowActions(
+            testData.action.tableRowId
+          );
+
+          await ml.testExecution.logTestStep('click log pattern analysis action');
+          await aiops.explainLogRateSpikesAnalysisGroupsTable.clickRowAction(
+            testData.action.tableRowId,
+            testData.action.type
+          );
+
+          await ml.testExecution.logTestStep('check log pattern analysis page loaded correctly');
+          await aiops.logPatternAnalysisPageProvider.assertLogCategorizationPageExists();
+          await aiops.logPatternAnalysisPageProvider.assertTotalDocumentCount(
+            testData.action.expected.totalDocCount
+          );
+          await aiops.logPatternAnalysisPageProvider.assertQueryInput(
+            testData.action.expected.queryBar
+          );
+        }
       }
     });
   }

--- a/x-pack/test/functional/apps/aiops/explain_log_rate_spikes.ts
+++ b/x-pack/test/functional/apps/aiops/explain_log_rate_spikes.ts
@@ -234,7 +234,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   }
 
   // FLAKY: https://github.com/elastic/kibana/issues/155222
-  describe.skip('explain log rate spikes', async function () {
+  describe('explain log rate spikes', async function () {
     for (const testData of explainLogRateSpikesTestData) {
       describe(`with '${testData.sourceIndexOrSavedSearch}'`, function () {
         before(async () => {

--- a/x-pack/test/functional/services/aiops/explain_log_rate_spikes_page.ts
+++ b/x-pack/test/functional/services/aiops/explain_log_rate_spikes_page.ts
@@ -46,20 +46,25 @@ export function ExplainLogRateSpikesPageProvider({
     },
 
     async setQueryInput(query: string) {
-      const aiopsQueryInput = await testSubjects.find('aiopsQueryInput');
+      await retry.tryForTime(30 * 1000, async () => {
+        const aiopsQueryInput = await testSubjects.find('aiopsQueryInput');
 
-      await aiopsQueryInput.clearValueWithKeyboard();
-      const queryBarEmpty = await aiopsQueryInput.getVisibleText();
-      expect(queryBarEmpty).to.eql('', `Expected query bar to be emptied, got '${queryBarEmpty}'`);
+        await aiopsQueryInput.clearValueWithKeyboard();
+        const queryBarEmpty = await aiopsQueryInput.getVisibleText();
+        expect(queryBarEmpty).to.eql(
+          '',
+          `Expected query bar to be emptied, got '${queryBarEmpty}'`
+        );
 
-      await aiopsQueryInput.type(query);
-      await aiopsQueryInput.pressKeys(browser.keys.ENTER);
-      await header.waitUntilLoadingHasFinished();
-      const queryBarText = await aiopsQueryInput.getVisibleText();
-      expect(queryBarText).to.eql(
-        query,
-        `Expected query bar text to be '${query}' (got '${queryBarText}')`
-      );
+        await aiopsQueryInput.type(query);
+        await aiopsQueryInput.pressKeys(browser.keys.ENTER);
+        await header.waitUntilLoadingHasFinished();
+        const queryBarText = await aiopsQueryInput.getVisibleText();
+        expect(queryBarText).to.eql(
+          query,
+          `Expected query bar text to be '${query}' (got '${queryBarText}')`
+        );
+      });
     },
 
     async assertSamplingProbabilityMissing() {

--- a/x-pack/test/functional/services/aiops/explain_log_rate_spikes_page.ts
+++ b/x-pack/test/functional/services/aiops/explain_log_rate_spikes_page.ts
@@ -47,6 +47,11 @@ export function ExplainLogRateSpikesPageProvider({
 
     async setQueryInput(query: string) {
       const aiopsQueryInput = await testSubjects.find('aiopsQueryInput');
+
+      await aiopsQueryInput.clearValueWithKeyboard();
+      const queryBarEmpty = await aiopsQueryInput.getVisibleText();
+      expect(queryBarEmpty).to.eql('', `Expected query bar to be emptied, got '${queryBarEmpty}'`);
+
       await aiopsQueryInput.type(query);
       await aiopsQueryInput.pressKeys(browser.keys.ENTER);
       await header.waitUntilLoadingHasFinished();


### PR DESCRIPTION
## Summary

Fixes #155222.

Stabilize flaky functional tests: Empty the query input before adding new content and retry, don't assert results for runs with random sampling being triggered.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->