### PR TITLE
Clear sessions when unmounting app

### DIFF
--- a/x-pack/plugins/observability/public/application/application.test.tsx
+++ b/x-pack/plugins/observability/public/application/application.test.tsx
@@ -28,54 +28,61 @@ describe('renderApp', () => {
     global.console = originalConsole;
   });
 
-  it('renders', async () => {
-    const plugins = {
-      usageCollection: { reportUiCounter: noop },
-      data: {
-        query: {
+  const mockSearchSessionClear = jest.fn();
+
+  const plugins = {
+    usageCollection: { reportUiCounter: noop },
+    data: {
+      query: {
+        timefilter: {
           timefilter: {
-            timefilter: {
-              setTime: jest.fn(),
-              getTime: jest.fn().mockReturnValue({}),
-              getTimeDefaults: jest.fn().mockReturnValue({}),
-              getRefreshInterval: jest.fn().mockReturnValue({}),
-              getRefreshIntervalDefaults: jest.fn().mockReturnValue({}),
-            },
+            setTime: jest.fn(),
+            getTime: jest.fn().mockReturnValue({}),
+            getTimeDefaults: jest.fn().mockReturnValue({}),
+            getRefreshInterval: jest.fn().mockReturnValue({}),
+            getRefreshIntervalDefaults: jest.fn().mockReturnValue({}),
           },
         },
       },
-    } as unknown as ObservabilityPublicPluginsStart;
-
-    const core = {
-      application: { currentAppId$: new Observable(), navigateToUrl: noop },
-      chrome: {
-        docTitle: { change: noop },
-        setBreadcrumbs: noop,
-        setHelpExtension: noop,
-      },
-      i18n: { Context: ({ children }: { children: React.ReactNode }) => children },
-      uiSettings: { get: () => false },
-      http: { basePath: { prepend: (path: string) => path } },
-      theme: themeServiceMock.createStartContract(),
-    } as unknown as CoreStart;
-
-    const params = {
-      element: window.document.createElement('div'),
-      history: createMemoryHistory(),
-      setHeaderActionMenu: noop,
-      theme$: themeServiceMock.createTheme$(),
-    } as unknown as AppMountParameters;
-
-    const config = {
-      unsafe: {
-        alertDetails: {
-          logs: { enabled: false },
-          metrics: { enabled: false },
-          uptime: { enabled: false },
+      search: {
+        session: {
+          clear: mockSearchSessionClear,
         },
       },
-    } as ConfigSchema;
+    },
+  } as unknown as ObservabilityPublicPluginsStart;
 
+  const core = {
+    application: { currentAppId$: new Observable(), navigateToUrl: noop },
+    chrome: {
+      docTitle: { change: noop },
+      setBreadcrumbs: noop,
+      setHelpExtension: noop,
+    },
+    i18n: { Context: ({ children }: { children: React.ReactNode }) => children },
+    uiSettings: { get: () => false },
+    http: { basePath: { prepend: (path: string) => path } },
+    theme: themeServiceMock.createStartContract(),
+  } as unknown as CoreStart;
+
+  const params = {
+    element: window.document.createElement('div'),
+    history: createMemoryHistory(),
+    setHeaderActionMenu: noop,
+    theme$: themeServiceMock.createTheme$(),
+  } as unknown as AppMountParameters;
+
+  const config = {
+    unsafe: {
+      alertDetails: {
+        logs: { enabled: false },
+        metrics: { enabled: false },
+        uptime: { enabled: false },
+      },
+    },
+  } as ConfigSchema;
+
+  it('renders', async () => {
     expect(() => {
       const unmount = renderApp({
         core,
@@ -90,9 +97,30 @@ describe('renderApp', () => {
           },
           reportUiCounter: jest.fn(),
         },
-        kibanaVersion: '8.7.0',
+        kibanaVersion: '8.8.0',
       });
       unmount();
     }).not.toThrowError();
+  });
+
+  it('should clear search sessions when unmounting', () => {
+    const unmount = renderApp({
+      core,
+      config,
+      plugins,
+      appMountParameters: params,
+      observabilityRuleTypeRegistry: createObservabilityRuleTypeRegistryMock(),
+      ObservabilityPageTemplate: KibanaPageTemplate,
+      usageCollection: {
+        components: {
+          ApplicationUsageTrackingProvider: (props) => null,
+        },
+        reportUiCounter: jest.fn(),
+      },
+      kibanaVersion: '8.8.0',
+    });
+    unmount();
+
+    expect(mockSearchSessionClear).toBeCalled();
   });
 });

--- a/x-pack/plugins/observability/public/application/index.tsx
+++ b/x-pack/plugins/observability/public/application/index.tsx
@@ -131,7 +131,7 @@ export const renderApp = ({
     // This needs to be present to fix https://github.com/elastic/kibana/issues/155704
     // as the Overview page renders the UX Section component. That component renders a Lens embeddable
     // via the ExploratoryView app, which uses search sessions. Therefore on unmounting we need to clear
-    // these sessions. 
+    // these sessions.
     plugins.data.search.session.clear();
     ReactDOM.unmountComponentAtNode(element);
   };

--- a/x-pack/plugins/observability/public/application/index.tsx
+++ b/x-pack/plugins/observability/public/application/index.tsx
@@ -128,6 +128,8 @@ export const renderApp = ({
     element
   );
   return () => {
+    // This needs to be present to fix https://github.com/elastic/kibana/issues/155704
+    plugins.data.search.session.clear();
     ReactDOM.unmountComponentAtNode(element);
   };
 };

--- a/x-pack/plugins/observability/public/application/index.tsx
+++ b/x-pack/plugins/observability/public/application/index.tsx
@@ -129,6 +129,9 @@ export const renderApp = ({
   );
   return () => {
     // This needs to be present to fix https://github.com/elastic/kibana/issues/155704
+    // as the Overview page renders the UX Section component. That component renders a Lens embeddable
+    // via the ExploratoryView app, which uses search sessions. Therefore on unmounting we need to clear
+    // these sessions. 
     plugins.data.search.session.clear();
     ReactDOM.unmountComponentAtNode(element);
   };


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/155704

## 📝 Summary

The UX Section on the Observability App > Overview page uses `<ExploratoryViewEmbeddable />` from the Exploratory View plugin via `getExploratoryViewEmbeddable()`.

The Exploratory View app uses Lens.

Lens uses the Data service. 

The Data Service tracks all open connections to Elasticsearch via the Session Service (`src/plugins/data/public/search/session/session_service.ts`).

If an open connection is found when unmounting an app, `session_service` throws an error: https://github.com/elastic/kibana/blob/main/src/plugins/data/public/search/session/session_service.ts#L279-L283

So once Observability uses the `<ExploratoryViewEmbeddable />` component anywhere in Observability code, we also need to clear session upon unmounting. This PR does that.

## ✅ Checklist
- Make sure your environment renders the UX widget on the Observability Overview page
- wait for the overview page to load
- In the side nav, click on any link to another app. This should happen without error.
