### PR TITLE
[Security Solution] [Investigation Guides] Use new timeline with arrow icon

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/markdown_editor/plugins/insight/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/markdown_editor/plugins/insight/index.tsx
@@ -223,7 +223,7 @@ const InsightComponent = ({
           keepDataView={true}
           data-test-subj="insight-investigate-in-timeline-button"
         >
-          <EuiIcon type="timeline" />
+          <EuiIcon type="timelineArrow" />
           {` ${label} (${numeral(totalCount).format(resultFormat)})`}
         </InvestigateInTimelineButton>
         <div>{description}</div>
@@ -484,10 +484,10 @@ const exampleInsight = `${insightPrefix}
 }}`;
 
 export const plugin = {
-  name: 'insights',
+  name: 'investigate',
   button: {
-    label: 'Insights',
-    iconType: 'aggregate',
+    label: 'Investigate in timeline',
+    iconType: 'timelineArrow',
   },
   helpText: (
     <div>


### PR DESCRIPTION
## Summary

This pr is meant to be merged after https://github.com/elastic/eui/pull/6731 is merged, released, and said release is used in Kibana. Updates the investigation/insight markdown plugin and button to use a new "timelineArrow" icon, instead of the placeholder currently in use. 
![image](https://user-images.githubusercontent.com/56408403/234310640-b6cf4f8a-4c38-4ca9-9326-8c5ff4978ed1.png)
![image](https://user-images.githubusercontent.com/56408403/234310672-0a28e8c1-155a-4fc1-81e1-aa3c36067931.png)


### Checklist


- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)



