### PR TITLE
[Fleet] always create agent upload write indices

### DIFF
--- a/x-pack/plugins/fleet/server/mocks/index.ts
+++ b/x-pack/plugins/fleet/server/mocks/index.ts
@@ -63,7 +63,7 @@ export const createAppContextStartContractMock = (
     securitySetup: securityMock.createSetup(),
     securityStart: securityMock.createStart(),
     logger: loggingSystemMock.create().get(),
-    experimentalFeatures: {} as ExperimentalFeatures,
+    experimentalFeatures: { diagnosticFileUploadEnabled: true } as ExperimentalFeatures,
     isProductionMode: true,
     configInitialValue: {
       agents: { enabled: true, elasticsearch: {} },

--- a/x-pack/plugins/fleet/server/services/setup.test.ts
+++ b/x-pack/plugins/fleet/server/services/setup.test.ts
@@ -28,7 +28,12 @@ jest.mock('./download_source');
 jest.mock('./epm/packages');
 jest.mock('./managed_package_policies');
 jest.mock('./setup/upgrade_package_install_version');
-jest.mock('./epm/elasticsearch/template/install');
+jest.mock('./epm/elasticsearch/template/install', () => {
+  return {
+    ...jest.requireActual('./epm/elasticsearch/template/install'),
+    ensureFileUploadWriteIndices: jest.fn(),
+  };
+});
 
 const mockedMethodThrowsError = (mockFn: jest.Mock) =>
   mockFn.mockImplementation(() => {

--- a/x-pack/plugins/fleet/server/services/setup.ts
+++ b/x-pack/plugins/fleet/server/services/setup.ts
@@ -211,7 +211,6 @@ export async function ensureFleetFileUploadIndices(
     pkgNames: [...FILE_STORAGE_INTEGRATION_NAMES],
   });
 
-  if (!installedFileUploadIntegrations.length) return [];
   const integrationNames = installedFileUploadIntegrations.map(({ name }) => name);
   if (!integrationNames.includes(FLEET_ELASTIC_AGENT_PACKAGE)) {
     integrationNames.push(FLEET_ELASTIC_AGENT_PACKAGE);

--- a/x-pack/plugins/fleet/server/services/setup.ts
+++ b/x-pack/plugins/fleet/server/services/setup.ts
@@ -12,7 +12,11 @@ import pMap from 'p-map';
 import type { ElasticsearchClient, SavedObjectsClientContract } from '@kbn/core/server';
 import { DEFAULT_SPACE_ID } from '@kbn/spaces-plugin/common/constants';
 
-import { AUTO_UPDATE_PACKAGES, FILE_STORAGE_INTEGRATION_NAMES } from '../../common/constants';
+import {
+  AUTO_UPDATE_PACKAGES,
+  FILE_STORAGE_INTEGRATION_NAMES,
+  FLEET_ELASTIC_AGENT_PACKAGE,
+} from '../../common/constants';
 import type { PreconfigurationError } from '../../common/constants';
 import type {
   DefaultPackagesInstallationError,
@@ -209,6 +213,9 @@ export async function ensureFleetFileUploadIndices(
 
   if (!installedFileUploadIntegrations.length) return [];
   const integrationNames = installedFileUploadIntegrations.map(({ name }) => name);
+  if (!integrationNames.includes(FLEET_ELASTIC_AGENT_PACKAGE)) {
+    integrationNames.push(FLEET_ELASTIC_AGENT_PACKAGE);
+  }
   logger.debug(`Ensuring file upload write indices for ${integrationNames}`);
   return ensureFileUploadWriteIndices({
     esClient,


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/155483

Always create file upload write indices for elastic_agent package, so that Request diagnostics of a managed Fleet Server works before installing Elastic Agent package.

To verify:
- Go to a fresh cloud deployment without Elastic Agent installed
- Go to the managed Fleet Server and click Request Diagnostics on Agent Details
- Expect the action to work
- Check in Stack Management that the `.fleet-files-agent-000001` index is created.

Verified on pr link that the agent write index is created before Elastic Agent package is installed:

https://kibana-pr-155729.kb.us-west2.gcp.elastic-cloud.com:9243/app/management/data/index_management/indices?includeHiddenIndices=true

<img width="777" alt="image" src="https://user-images.githubusercontent.com/90178898/234502605-cd91bbc2-0938-41ef-8455-1700f139a3ee.png">
<img width="1538" alt="image" src="https://user-images.githubusercontent.com/90178898/234502727-74e84a2a-3126-4346-8328-cdb10ed26b8f.png">



### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.7"]} ONMERGE-->