### PR TITLE
[dot-kibana-split] Make indices.getMapping() resilient to intermitent failures

### DIFF
--- a/packages/core/saved-objects/core-saved-objects-migration-server-internal/tsconfig.json
+++ b/packages/core/saved-objects/core-saved-objects-migration-server-internal/tsconfig.json
@@ -30,6 +30,7 @@
     "@kbn/safer-lodash-set",
     "@kbn/logging-mocks",
     "@kbn/core-saved-objects-base-server-mocks",
+    "@kbn/core-elasticsearch-server-internal",
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
When the migrator logic kicks in at startup, it checks the `indexTypesMap` stored in the main SO index (aka `.kibana`).
It does so by using `esClient.indices.getMapping()` method.

Should this method fail due to temporary ES failures (i.e. retriable errors), we want this logic to retry forever, rather than failing and bringing the whole Kibana down.