### PR TITLE
[8.4] [Screenshotting] fix revision number used for mac and windows downloads of chromium (#155313)

### DIFF
--- a/src/dev/chromium_version.ts
+++ b/src/dev/chromium_version.ts
@@ -46,7 +46,7 @@ async function getChromiumRevision(
   kibanaPuppeteerVersion: PuppeteerRelease,
   log: ToolingLog
 ): Promise<ChromiumRevision> {
-  const url = `https://raw.githubusercontent.com/puppeteer/puppeteer/v${kibanaPuppeteerVersion}/src/revisions.ts`;
+  const url = `https://raw.githubusercontent.com/puppeteer/puppeteer/v${kibanaPuppeteerVersion}/packages/puppeteer-core/src/revisions.ts`;
   let body: string;
   try {
     log.info(`Fetching code from Puppeteer source: ${url}`);
@@ -103,7 +103,12 @@ async function getChromiumCommit(
     throw new Error(`Could not find a Chromium commit! Check ${url} in a browser.`);
   }
 
+  const baseUrl = 'https://commondatastorage.googleapis.com/chromium-browser-snapshots';
+
   log.info(`Found Chromium commit ${commit} from revision ${revision}.`);
+  log.info(`Mac x64 download:     ${baseUrl}/Mac/${revision}/chrome-mac.zip`);
+  log.info(`Mac ARM download:     ${baseUrl}/Mac_Arm/${revision}/chrome-mac.zip`);
+  log.info(`Windows x64 download: ${baseUrl}/Win/${revision}/chrome-win.zip`);
   return commit;
 }
 

--- a/x-pack/plugins/screenshotting/server/browsers/chromium/paths.ts
+++ b/x-pack/plugins/screenshotting/server/browsers/chromium/paths.ts
@@ -18,7 +18,7 @@ export interface PackageInfo {
   location: 'custom' | 'common';
 }
 
-const REVISION = 1036745;
+const REVISION = 1045629;
 
 enum BaseUrl {
   // see https://www.chromium.org/getting-involved/download-chromium
@@ -45,8 +45,8 @@ export class ChromiumArchivePaths {
       platform: 'darwin',
       architecture: 'x64',
       archiveFilename: 'chrome-mac.zip',
-      archiveChecksum: '5afc0d49865d55b69ea1ff65b9cc5794',
-      binaryChecksum: '4a7a663b2656d66ce975b00a30df3ab4',
+      archiveChecksum: '028606a28586800b70d249d050a360d5',
+      binaryChecksum: 'db876895b31ed6923cb1e99fea12062e',
       binaryRelativePath: 'chrome-mac/Chromium.app/Contents/MacOS/Chromium',
       location: 'common',
       archivePath: 'Mac',
@@ -56,8 +56,8 @@ export class ChromiumArchivePaths {
       platform: 'darwin',
       architecture: 'arm64',
       archiveFilename: 'chrome-mac.zip',
-      archiveChecksum: '5afc0d49865d55b69ea1ff65b9cc5794',
-      binaryChecksum: '4a7a663b2656d66ce975b00a30df3ab4',
+      archiveChecksum: '727029f573d3b85be596b80b810b0237',
+      binaryChecksum: '8668272094c610c15bad15b068f8f73c',
       binaryRelativePath: 'chrome-mac/Chromium.app/Contents/MacOS/Chromium',
       location: 'common',
       archivePath: 'Mac_Arm',
@@ -87,8 +87,8 @@ export class ChromiumArchivePaths {
       platform: 'win32',
       architecture: 'x64',
       archiveFilename: 'chrome-win.zip',
-      archiveChecksum: '42db052673414b89d8cb45657c1a6aeb',
-      binaryChecksum: '1b6eef775198ffd48fb9669ac0c818f7',
+      archiveChecksum: '2e24beb0e1d7201bad98b8c231c63d97',
+      binaryChecksum: '47b1e6d9179fb8cadeef9c8939dce12d',
       binaryRelativePath: path.join('chrome-win', 'chrome.exe'),
       location: 'common',
       archivePath: 'Win',


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.7` to `8.4`:
 - [[Screenshotting] fix revision number used for mac and windows downloads of chromium (#155313)](https://github.com/elastic/kibana/pull/155313)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Tim Sullivan","email":"tsullivan@users.noreply.github.com"},"sourceCommit":{"committedDate":"2023-04-25T17:07:51Z","message":"[Screenshotting] fix revision number used for mac and windows downloads of chromium (#155313)\n\n## Summary\r\n\r\nCloses https://github.com/elastic/kibana/issues/155681\r\n\r\nFixes an issue where Mac and Windows Chromium downloads are referencing\r\na bucket from an older version of Kibana.\r\n\r\n### Checklist\r\n\r\n- [ ] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- This has not completed since designing tests around this will take\r\nsome time: https://github.com/elastic/kibana/issues/155753\r\n\r\n### Release note\r\nFixed an issue for Windows and Mac where the Reporting plugin downloaded\r\nan older version of Chromium. All OS types are now synchronized to\r\n107.0.5296.0","sha":"4217ec2e4b606744ddf3ff3c366d769b6169d764","branchLabelMapping":{"^v8.7.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:SharedUX","v8.4.4","v8.5.4","v8.6.3","v8.7.2"],"number":155313,"url":"https://github.com/elastic/kibana/pull/155313","mergeCommit":{"message":"[Screenshotting] fix revision number used for mac and windows downloads of chromium (#155313)\n\n## Summary\r\n\r\nCloses https://github.com/elastic/kibana/issues/155681\r\n\r\nFixes an issue where Mac and Windows Chromium downloads are referencing\r\na bucket from an older version of Kibana.\r\n\r\n### Checklist\r\n\r\n- [ ] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- This has not completed since designing tests around this will take\r\nsome time: https://github.com/elastic/kibana/issues/155753\r\n\r\n### Release note\r\nFixed an issue for Windows and Mac where the Reporting plugin downloaded\r\nan older version of Chromium. All OS types are now synchronized to\r\n107.0.5296.0","sha":"4217ec2e4b606744ddf3ff3c366d769b6169d764"}},"sourceBranch":"8.7","suggestedTargetBranches":["8.4","8.5","8.6"],"targetPullRequestStates":[{"branch":"8.4","label":"v8.4.4","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.5","label":"v8.5.4","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.6","label":"v8.6.3","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.7","label":"v8.7.2","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/155313","number":155313,"mergeCommit":{"message":"[Screenshotting] fix revision number used for mac and windows downloads of chromium (#155313)\n\n## Summary\r\n\r\nCloses https://github.com/elastic/kibana/issues/155681\r\n\r\nFixes an issue where Mac and Windows Chromium downloads are referencing\r\na bucket from an older version of Kibana.\r\n\r\n### Checklist\r\n\r\n- [ ] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- This has not completed since designing tests around this will take\r\nsome time: https://github.com/elastic/kibana/issues/155753\r\n\r\n### Release note\r\nFixed an issue for Windows and Mac where the Reporting plugin downloaded\r\nan older version of Chromium. All OS types are now synchronized to\r\n107.0.5296.0","sha":"4217ec2e4b606744ddf3ff3c366d769b6169d764"}}]}] BACKPORT-->