### PR TITLE
[artifacts/serverless] Fix expected image name

### DIFF
--- a/.buildkite/scripts/steps/artifacts/docker_image.sh
+++ b/.buildkite/scripts/steps/artifacts/docker_image.sh
@@ -46,7 +46,6 @@ docker image push "$KIBANA_IMAGE_OUTPUT-arm64"
 docker image push "$KIBANA_IMAGE_OUTPUT-amd64"
 
 echo "--- Create manifest"
-docker rmi "$KIBANA_IMAGE_OUTPUT"
 docker manifest create \
   "$KIBANA_IMAGE_OUTPUT" \
   --amend "$KIBANA_IMAGE_OUTPUT-arm64" \

--- a/.buildkite/scripts/steps/artifacts/docker_image.sh
+++ b/.buildkite/scripts/steps/artifacts/docker_image.sh
@@ -7,13 +7,14 @@ set -euo pipefail
 source .buildkite/scripts/steps/artifacts/env.sh
 
 GIT_ABBREV_COMMIT=${BUILDKITE_COMMIT:0:12}
-KIBANA_IMAGE="docker.elastic.co/kibana-ci/kibana:git-$GIT_ABBREV_COMMIT"
+KIBANA_IMAGE_INPUT="docker.elastic.co/kibana-ci/kibana-serverless:git-$GIT_ABBREV_COMMIT"
+KIBANA_IMAGE_OUTPUT="docker.elastic.co/kibana-ci/kibana:git-$GIT_ABBREV_COMMIT"
 
 echo "--- Verify manifest does not already exist"
 echo "$KIBANA_DOCKER_PASSWORD" | docker login -u "$KIBANA_DOCKER_USERNAME" --password-stdin docker.elastic.co
 trap 'docker logout docker.elastic.co' EXIT
 
-if docker manifest inspect $KIBANA_IMAGE &> /dev/null; then
+if docker manifest inspect $KIBANA_IMAGE_OUTPUT &> /dev/null; then
   echo "Manifest already exists, exiting"
   exit 1
 fi
@@ -32,37 +33,37 @@ node scripts/build \
   --skip-docker-contexts
 
 echo "--- Tag images"
-docker rmi "$KIBANA_IMAGE"
+docker rmi "$KIBANA_IMAGE_OUTPUT"
 docker load < "target/kibana-serverless-$BASE_VERSION-docker-image.tar.gz"
-docker tag "$KIBANA_IMAGE" "$KIBANA_IMAGE-amd64"
+docker tag "$KIBANA_IMAGE_INPUT" "$KIBANA_IMAGE_OUTPUT-amd64"
 
-docker rmi "$KIBANA_IMAGE"
+docker rmi "$KIBANA_IMAGE_OUTPUT"
 docker load < "target/kibana-serverless-$BASE_VERSION-docker-image-aarch64.tar.gz"
-docker tag "$KIBANA_IMAGE" "$KIBANA_IMAGE-arm64"
+docker tag "$KIBANA_IMAGE_INPUT" "$KIBANA_IMAGE_OUTPUT-arm64"
 
 echo "--- Push images"
-docker image push "$KIBANA_IMAGE-arm64"
-docker image push "$KIBANA_IMAGE-amd64"
+docker image push "$KIBANA_IMAGE_OUTPUT-arm64"
+docker image push "$KIBANA_IMAGE_OUTPUT-amd64"
 
 echo "--- Create manifest"
-docker rmi "$KIBANA_IMAGE"
+docker rmi "$KIBANA_IMAGE_OUTPUT"
 docker manifest create \
-  "$KIBANA_IMAGE" \
-  --amend "$KIBANA_IMAGE-arm64" \
-  --amend "$KIBANA_IMAGE-amd64"
+  "$KIBANA_IMAGE_OUTPUT" \
+  --amend "$KIBANA_IMAGE_OUTPUT-arm64" \
+  --amend "$KIBANA_IMAGE_OUTPUT-amd64"
 
 echo "--- Push manifest"
-docker manifest push "$KIBANA_IMAGE"
+docker manifest push "$KIBANA_IMAGE_OUTPUT"
 docker logout docker.elastic.co
 
 cat << EOF | buildkite-agent annotate --style "info" --context image
   ### Container Images
 
-  Manifest: \`$KIBANA_IMAGE\`
+  Manifest: \`$KIBANA_IMAGE_OUTPUT\`
 
-  AMD64: \`$KIBANA_IMAGE-amd64\`
+  AMD64: \`$KIBANA_IMAGE_OUTPUT-amd64\`
 
-  ARM64: \`$KIBANA_IMAGE-arm64\`
+  ARM64: \`$KIBANA_IMAGE_OUTPUT-arm64\`
 EOF
 
 echo "--- Build dependencies report"

--- a/.buildkite/scripts/steps/artifacts/docker_image.sh
+++ b/.buildkite/scripts/steps/artifacts/docker_image.sh
@@ -33,11 +33,11 @@ node scripts/build \
   --skip-docker-contexts
 
 echo "--- Tag images"
-docker rmi "$KIBANA_IMAGE_OUTPUT"
+docker rmi "$KIBANA_IMAGE_INPUT"
 docker load < "target/kibana-serverless-$BASE_VERSION-docker-image.tar.gz"
 docker tag "$KIBANA_IMAGE_INPUT" "$KIBANA_IMAGE_OUTPUT-amd64"
 
-docker rmi "$KIBANA_IMAGE_OUTPUT"
+docker rmi "$KIBANA_IMAGE_INPUT"
 docker load < "target/kibana-serverless-$BASE_VERSION-docker-image-aarch64.tar.gz"
 docker tag "$KIBANA_IMAGE_INPUT" "$KIBANA_IMAGE_OUTPUT-arm64"
 

--- a/src/dev/build/tasks/os_packages/create_os_package_tasks.ts
+++ b/src/dev/build/tasks/os_packages/create_os_package_tasks.ts
@@ -81,7 +81,7 @@ export const CreateDockerUbuntu: Task = {
 };
 
 export const CreateDockerServerless: Task = {
-  description: 'Creating Docker Ubuntu image',
+  description: 'Creating Docker Serverless image',
 
   async run(config, log, build) {
     await runDockerGenerator(config, log, build, {


### PR DESCRIPTION
In #155284 we introduced a separation between our default docker image and a new serverless image, adding a set of yml configuration files in the serverless image.  During this process we named the new image `kibana-serverless`, but missed the update in our manifest creation when the image is re-tagged.  This fixes the image name.