### PR TITLE
[Synthetics] Make error popover disappear `onMouseLeave` of metric item card

### DIFF
--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/metric_item.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/metric_item.tsx
@@ -12,7 +12,7 @@ import { DARK_THEME } from '@elastic/charts';
 import { useTheme } from '@kbn/observability-plugin/public';
 import { useDispatch, useSelector } from 'react-redux';
 import moment from 'moment';
-import { toggleErrorPopoverOpen } from '../../../../state';
+import { selectErrorPopoverState, toggleErrorPopoverOpen } from '../../../../state';
 import { useLocationName, useStatusByLocationOverview } from '../../../../hooks';
 import { formatDuration } from '../../../../utils/formatting';
 import { MonitorOverviewItem } from '../../../../../../../common/runtime_types';
@@ -63,6 +63,7 @@ export const MetricItem = ({
 }) => {
   const [isMouseOver, setIsMouseOver] = useState(false);
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const isErrorPopoverOpen = useSelector(selectErrorPopoverState);
   const locationName =
     useLocationName({ locationId: monitor.location?.id })?.label || monitor.location?.id;
   const { status, timestamp, ping, configIdByLocation } = useStatusByLocationOverview(
@@ -86,6 +87,9 @@ export const MetricItem = ({
           }
         }}
         onMouseLeave={() => {
+          if (isErrorPopoverOpen) {
+            dispatch(toggleErrorPopoverOpen(null));
+          }
           if (isMouseOver) {
             setIsMouseOver(false);
           }

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/metric_item_icon.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/metric_item_icon.tsx
@@ -103,8 +103,7 @@ export const MetricItemIcon = ({
               onMouseLeave={() => {
                 if (isPopoverOpen) {
                   return;
-                }
-                if (timer.current) {
+                } else if (timer.current) {
                   clearTimeout(timer.current);
                 }
               }}


### PR DESCRIPTION
## Summary

Resolves #152365.

Adds a condition to `<MetricItem />`'s `onMouseLeave` handler to hide the popover, so if the user triggers the popover and then leaves, the element, the error popover will disappear. The popover should remain visible if the user transitions to the popover itself to interact with its contents, or if they remain on the metric item or the icon button that triggers the reveal.

### Before

![20230425170843](https://user-images.githubusercontent.com/18429259/234404432-75788765-cac3-46c6-b614-3d0b0303ff44.gif)


### After

![20230425170727](https://user-images.githubusercontent.com/18429259/234404182-11496368-3113-4bf9-ae31-9ac5d94b9356.gif)


## Testing

Create a monitor that will have errors, an easy way is to add a `throw Error('message');` to your synthetic journey code.

From there, view the error popover on the monitor's Overview card and observe that now the popover will disappear when the mouse leaves the parent element.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
