### PR TITLE
[Screenshotting] minor improvement to chromium version-check script

### DIFF
--- a/src/dev/chromium_version.ts
+++ b/src/dev/chromium_version.ts
@@ -103,7 +103,12 @@ async function getChromiumCommit(
     throw new Error(`Could not find a Chromium commit! Check ${url} in a browser.`);
   }
 
+  const baseUrl = 'https://commondatastorage.googleapis.com/chromium-browser-snapshots';
+
   log.info(`Found Chromium commit ${commit} from revision ${revision}.`);
+  log.info(`Mac x64 download:     ${baseUrl}/Mac/${revision}/chrome-mac.zip`);
+  log.info(`Mac ARM download:     ${baseUrl}/Mac_Arm/${revision}/chrome-mac.zip`);
+  log.info(`Windows x64 download: ${baseUrl}/Win/${revision}/chrome-win.zip`);
   return commit;
 }
 


### PR DESCRIPTION
Adds a minor improvement to the script for checking the version of Chromium. The change shows the download path for each type of OS for which we can use the stock build for the screenshotting feature.

Forward-ported from this fix in 8.7: https://github.com/elastic/kibana/pull/155313