### PR TITLE
[Security Solution] Fixes security_solution storybooks always rendering in a flyout

### DIFF
--- a/x-pack/plugins/security_solution/public/timelines/components/side_panel/new_user_detail/user_details_content.stories.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/side_panel/new_user_detail/user_details_content.stories.tsx
@@ -6,21 +6,20 @@
  */
 
 import React from 'react';
-import { storiesOf, addDecorator } from '@storybook/react';
+import { storiesOf } from '@storybook/react';
 import { EuiFlyout, EuiFlyoutBody } from '@elastic/eui';
 import { UserDetailsContentComponent } from './user_details_content';
 import { StorybookProviders } from '../../../../common/mock/storybook_providers';
 import { mockManagedUser, mockObservedUser, mockRiskScoreState } from './__mocks__';
 
-addDecorator((storyFn) => (
-  <StorybookProviders>
-    <EuiFlyout size="m" onClose={() => {}}>
-      <EuiFlyoutBody>{storyFn()}</EuiFlyoutBody>
-    </EuiFlyout>
-  </StorybookProviders>
-));
-
 storiesOf('UserDetailsContent', module)
+  .addDecorator((storyFn) => (
+    <StorybookProviders>
+      <EuiFlyout size="m" onClose={() => {}}>
+        <EuiFlyoutBody>{storyFn()}</EuiFlyoutBody>
+      </EuiFlyout>
+    </StorybookProviders>
+  ))
   .add('default', () => (
     <UserDetailsContentComponent
       userName="test"


### PR DESCRIPTION
With https://github.com/elastic/kibana/pull/154310 a global decorator was added which caused all `security_solution` stories to be rendered in a flyout. This PR changes the decorator to be local instead so the `UserDetailsContentComponent` still renders in a flyout as expected, but all other components are still within the main canvas.

### Before
<p align="center">
  <img width="400" src="https://user-images.githubusercontent.com/2946766/234429269-46cf527d-f7f2-4229-9ca1-ae227ce8e1b6.png" /> <img width="400" alt="image" src="https://user-images.githubusercontent.com/2946766/234429444-f38229ef-1113-4416-9bb4-233cc058ee44.png">
</p> 


### After
<p align="center">
  <img width="400" src="https://user-images.githubusercontent.com/2946766/234429580-82c99bb1-9064-4fc3-8b16-446fc418729d.png" /> <img width="400" alt="image" src="https://user-images.githubusercontent.com/2946766/234429444-f38229ef-1113-4416-9bb4-233cc058ee44.png">
</p> 




