### PR TITLE
[Search Sessions] Fix flaky partial results test in search examples

### DIFF
--- a/examples/search_examples/server/fibonacci_strategy.ts
+++ b/examples/search_examples/server/fibonacci_strategy.ts
@@ -8,6 +8,7 @@
 
 import { v4 as uuidv4 } from 'uuid';
 import { ISearchStrategy } from '@kbn/data-plugin/server';
+import { of } from 'rxjs';
 import { FibonacciRequest, FibonacciResponse } from '../common/types';
 
 export const fibonacciStrategyProvider = (): ISearchStrategy<
@@ -40,10 +41,7 @@ export const fibonacciStrategyProvider = (): ISearchStrategy<
       const took = Date.now() - started;
       const values = sequence.slice(0, loaded);
 
-      // Usually we'd do something like "of()" but for some reason it breaks in tests with the error
-      // "You provided an invalid object where a stream was expected." which is why we have to cast
-      // down below as well
-      return [{ id, loaded, total, isRunning, isPartial, rawResponse: { took, values } }];
+      return of({ id, loaded, total, isRunning, isPartial, rawResponse: { took, values } });
     },
     cancel: async (id: string) => {
       responseMap.delete(id);

--- a/x-pack/test/examples/search_examples/partial_results_example.ts
+++ b/x-pack/test/examples/search_examples/partial_results_example.ts
@@ -14,8 +14,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const PageObjects = getPageObjects(['common']);
   const retry = getService('retry');
 
-  // FLAKY: https://github.com/elastic/kibana/issues/116038
-  describe.skip('Partial results example', () => {
+  describe('Partial results example', () => {
     before(async () => {
       await PageObjects.common.navigateToApp('searchExamples');
       await testSubjects.click('/search');


### PR DESCRIPTION
## Summary

Unskip and fix flaky partial results test in search examples plugin.

Flaky test runner x100: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2172.

Fixes #116038.

### Checklist

- [ ] ~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)~
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] ~Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))~
- [ ] ~Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))~
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))~
- [ ] ~This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)~

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->