### PR TITLE
[Security Solution][Alerts] Format alerts for per-alert action context variables

### DIFF
--- a/x-pack/plugins/rule_registry/server/utils/create_persistence_rule_type_wrapper.ts
+++ b/x-pack/plugins/rule_registry/server/utils/create_persistence_rule_type_wrapper.ts
@@ -195,7 +195,7 @@ export const createPersistenceRuleTypeWrapper: CreatePersistenceRuleTypeWrapper 
                         start: Date.parse(alert[TIMESTAMP]),
                         end: Date.parse(alert[TIMESTAMP]),
                       }),
-                      alerts: [alert],
+                      alerts: [formatAlert?.(alert) ?? alert],
                     })
                 );
 
@@ -387,7 +387,7 @@ export const createPersistenceRuleTypeWrapper: CreatePersistenceRuleTypeWrapper 
                         start: Date.parse(alert[TIMESTAMP]),
                         end: Date.parse(alert[TIMESTAMP]),
                       }),
-                      alerts: [alert],
+                      alerts: [formatAlert?.(alert) ?? alert],
                     })
                 );
 

--- a/x-pack/plugins/security_solution/common/utils/expand_dotted.test.ts
+++ b/x-pack/plugins/security_solution/common/utils/expand_dotted.test.ts
@@ -70,6 +70,18 @@ describe('Expand Dotted', () => {
     });
   });
 
+  it('overwrites earlier fields when later fields conflict', () => {
+    const simpleDottedObj = {
+      'kibana.test.1': 'the spice must flow',
+      'kibana.test': 2,
+    };
+    expect(expandDottedObject(simpleDottedObj)).toEqual({
+      kibana: {
+        test: 2,
+      },
+    });
+  });
+
   it('expands non dotted field without changing it other than reference', () => {
     const simpleDottedObj = {
       test: { value: '123' },

--- a/x-pack/plugins/security_solution/common/utils/expand_dotted.ts
+++ b/x-pack/plugins/security_solution/common/utils/expand_dotted.ts
@@ -5,16 +5,7 @@
  * 2.0.
  */
 
-import { merge } from '@kbn/std';
-
-const expandDottedField = (dottedFieldName: string, val: unknown): object => {
-  const parts = dottedFieldName.split('.');
-  if (parts.length === 1) {
-    return { [parts[0]]: val };
-  } else {
-    return { [parts[0]]: expandDottedField(parts.slice(1).join('.'), val) };
-  }
-};
+import { setWith } from 'lodash';
 
 /*
  * Expands an object with "dotted" fields to a nested object with unflattened fields.
@@ -48,8 +39,9 @@ export const expandDottedObject = (dottedObj: object) => {
   if (Array.isArray(dottedObj)) {
     return dottedObj;
   }
-  return Object.entries(dottedObj).reduce(
-    (acc, [key, val]) => merge(acc, expandDottedField(key, val)),
-    {}
-  );
+  const returnObj = {};
+  Object.entries(dottedObj).forEach(([key, value]) => {
+    setWith(returnObj, key, value, Object);
+  });
+  return returnObj;
 };


### PR DESCRIPTION
## Summary

Closes [#155812](https://github.com/elastic/kibana/issues/155812)

In https://github.com/elastic/kibana/pull/155384, detection rules were switched to support per-alert actions. When passing the context variable, it was suggested that we should be calling formatAlert to format the alert for notifications, however doing that causes some test failures because formatAlert is fairly heavyweight and bunch of tests were timing out.

Thanks to @marshallmain we have this much faster `expandDottedObject` that solves the issue with the very slow `formatAlert`.
