### PR TITLE
Bump `moment-timezone` to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -841,7 +841,7 @@
     "minimatch": "^3.1.2",
     "moment": "^2.29.4",
     "moment-duration-format": "^2.3.2",
-    "moment-timezone": "^0.5.34",
+    "moment-timezone": "^0.5.43",
     "monaco-editor": "^0.24.0",
     "monaco-yaml": "3.2.1",
     "mustache": "^2.3.2",

--- a/x-pack/plugins/license_management/__jest__/__snapshots__/license_page_header.test.js.snap
+++ b/x-pack/plugins/license_management/__jest__/__snapshots__/license_page_header.test.js.snap
@@ -93,7 +93,7 @@ Array [
               >
                 Your license will expire on 
                 <strong>
-                  October 12, 2099 7:00 PM EST
+                  October 12, 2099 8:00 PM EDT
                 </strong>
               </span>
             </p>

--- a/yarn.lock
+++ b/yarn.lock
@@ -21295,14 +21295,14 @@ moment-duration-format@^2.3.2:
   resolved "https://registry.yarnpkg.com/moment-duration-format/-/moment-duration-format-2.3.2.tgz#5fa2b19b941b8d277122ff3f87a12895ec0d6212"
   integrity sha512-cBMXjSW+fjOb4tyaVHuaVE/A5TqkukDWiOfxxAjY+PEqmmBQlLwn+8OzwPiG3brouXKY5Un4pBjAeB6UToXHaQ==
 
-moment-timezone@^0.5.34:
-  version "0.5.34"
-  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.34.tgz#a75938f7476b88f155d3504a9343f7519d9a405c"
-  integrity sha512-3zAEHh2hKUs3EXLESx/wsgw6IQdusOT8Bxm3D9UrHPQR7zlMmzwybC8zHEM1tQ4LJwP7fcxrWr8tuBg05fFCbg==
+moment-timezone@^0.5.43:
+  version "0.5.43"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.43.tgz#3dd7f3d0c67f78c23cd1906b9b2137a09b3c4790"
+  integrity sha512-72j3aNyuIsDxdF1i7CEgV2FfxM1r6aaqJyLB2vwb33mXYyoyLly+F1zbWqhA3/bVIoJ4szlUoMbUnVdid32NUQ==
   dependencies:
-    moment ">= 2.9.0"
+    moment "^2.29.4"
 
-"moment@>= 2.9.0", moment@>=1.6.0, moment@>=2.14.0, moment@^2.10.6, moment@^2.29.4:
+moment@>=1.6.0, moment@>=2.14.0, moment@^2.10.6, moment@^2.29.4:
   version "2.29.4"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
   integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==


### PR DESCRIPTION
## Summary

Fix https://github.com/elastic/kibana/issues/155792

Bump `moment-timezone` from `0.5.34` to `0.5.43` (latest version) to include latest timezone changes

## Release Note

Fix a bug causing the latest timezone changes to not be taken into account for date formatting (e.g Mexico 2023) 


<!--ONMERGE {"backportTargets":["7.17","8.8"]} ONMERGE-->