### PR TITLE
[Fleet] removed experimental from openapi README

### DIFF
--- a/x-pack/plugins/fleet/common/openapi/README.md
+++ b/x-pack/plugins/fleet/common/openapi/README.md
@@ -1,12 +1,12 @@
-# OpenAPI (Experimental)
-
-> **_NOTE:_** This spec is experimental and may be incomplete or change later.
+# OpenAPI
 
 The current self-contained spec file, available [as JSON](https://raw.githubusercontent.com/elastic/kibana/master/x-pack/plugins/fleet/common/openapi/bundled.json) or [as YAML](https://raw.githubusercontent.com/elastic/kibana/master/x-pack/plugins/fleet/common/openapi/bundled.yaml), can be used for online tools like those found at https://openapi.tools/.
 
 For example, [click here to view the specification in the Swagger UI](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/elastic/kibana/master/x-pack/plugins/fleet/common/openapi/bundled.json).
 
 A guide about the openApi specification can be found at [https://swagger.io/docs/specification/about/](https://swagger.io/docs/specification/about/).
+
+Fleet API docs: https://www.elastic.co/guide/en/fleet/master/fleet-apis.html
 
 ## The `openapi` folder
 


### PR DESCRIPTION
## Summary

Small pr to remove Experimental from the Fleet openapi README.

Related to https://github.com/elastic/kibana/issues/123150
