### PR TITLE
[Security Solution] Fix rule snooze description on the rule editing page

### DIFF
--- a/packages/kbn-doc-links/src/get_doc_links.ts
+++ b/packages/kbn-doc-links/src/get_doc_links.ts
@@ -399,6 +399,7 @@ export const getDocLinks = ({ kibanaBranch }: GetDocLinkOptions): DocLinks => {
         value_lists: `${SECURITY_SOLUTION_DOCS}value-lists-exceptions.html`,
       },
       privileges: `${SECURITY_SOLUTION_DOCS}endpoint-management-req.html`,
+      manageDetectionRules: `${SECURITY_SOLUTION_DOCS}rules-ui-management.html`,
     },
     query: {
       eql: `${ELASTICSEARCH_DOCS}eql.html`,

--- a/packages/kbn-doc-links/src/types.ts
+++ b/packages/kbn-doc-links/src/types.ts
@@ -302,6 +302,7 @@ export interface DocLinks {
       value_lists: string;
     };
     readonly privileges: string;
+    readonly manageDetectionRules: string;
   };
   readonly query: {
     readonly eql: string;

--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_rule_actions/rule_snooze_section.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_rule_actions/rule_snooze_section.tsx
@@ -6,8 +6,7 @@
  */
 
 import React from 'react';
-import { css } from '@emotion/react';
-import { EuiFlexGroup, EuiFlexItem, EuiText, useEuiTheme } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
 import type { RuleObjectId } from '../../../../../common/detection_engine/rule_schema';
 import { RuleSnoozeBadge } from '../../../../detection_engine/rule_management/components/rule_snooze_badge';
 import * as i18n from './translations';
@@ -17,26 +16,14 @@ interface RuleSnoozeSectionProps {
 }
 
 export function RuleSnoozeSection({ ruleId }: RuleSnoozeSectionProps): JSX.Element {
-  const { euiTheme } = useEuiTheme();
-
   return (
-    <section>
-      <EuiText size="s">{i18n.RULE_SNOOZE_DESCRIPTION}</EuiText>
-      <EuiFlexGroup
-        alignItems="center"
-        css={css`
-          margin-top: ${euiTheme.size.s};
-        `}
-      >
-        <EuiFlexItem grow={false}>
-          <RuleSnoozeBadge ruleId={ruleId} showTooltipInline />
-        </EuiFlexItem>
-        <EuiFlexItem>
-          <EuiText size="s">
-            <strong>{i18n.SNOOZED_ACTIONS_WARNING}</strong>
-          </EuiText>
-        </EuiFlexItem>
-      </EuiFlexGroup>
-    </section>
+    <EuiFlexGroup direction="column" gutterSize="s">
+      <EuiFlexItem>
+        <EuiText size="s">{i18n.RULE_SNOOZE_DESCRIPTION}</EuiText>
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <RuleSnoozeBadge ruleId={ruleId} showTooltipInline />
+      </EuiFlexItem>
+    </EuiFlexGroup>
   );
 }

--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_rule_actions/translations.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_rule_actions/translations.tsx
@@ -8,8 +8,8 @@
 import React from 'react';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { getDocLinks } from '@kbn/doc-links';
 import { EuiLink } from '@elastic/eui';
+import { useKibana } from '../../../../common/lib/kibana';
 
 export const COMPLETE_WITHOUT_ENABLING = i18n.translate(
   'xpack.securitySolution.detectionEngine.createRule.stepScheduleRule.completeWithoutEnablingTitle',
@@ -33,10 +33,6 @@ export const NO_ACTIONS_READ_PERMISSIONS = i18n.translate(
   }
 );
 
-const ruleSnoozeDocsLink = `${
-  getDocLinks({ kibanaBranch: 'main' }).alerting.guide
-}#controlling-rules`;
-
 const RULE_SNOOZE_DOCS_LINK_TEXT = i18n.translate(
   'xpack.securitySolution.detectionEngine.createRule.stepRuleActions.docsLinkText',
   {
@@ -44,16 +40,29 @@ const RULE_SNOOZE_DOCS_LINK_TEXT = i18n.translate(
   }
 );
 
-export const RULE_SNOOZE_DESCRIPTION = (
-  <FormattedMessage
-    id="xpack.securitySolution.detectionEngine.createRule.stepRuleActions.snoozeDescription"
-    defaultMessage="Select when automated actions should be performed. If a rule is snoozed actions will not be performed. Learn more about actions in our {docs}."
-    values={{
-      docs: (
-        <EuiLink href={ruleSnoozeDocsLink} target="_blank">
-          {RULE_SNOOZE_DOCS_LINK_TEXT}
-        </EuiLink>
-      ),
-    }}
-  />
-);
+function RuleSnoozeDescription(): JSX.Element {
+  const {
+    docLinks: {
+      links: {
+        securitySolution: { manageDetectionRules },
+      },
+    },
+  } = useKibana().services;
+  const manageDetectionRulesSnoozeSection = `${manageDetectionRules}#snooze-rules-ui`;
+
+  return (
+    <FormattedMessage
+      id="xpack.securitySolution.detectionEngine.createRule.stepRuleActions.snoozeDescription"
+      defaultMessage="Select when automated actions should be performed. If a rule is snoozed actions will not be performed. Learn more about actions in our {docs}."
+      values={{
+        docs: (
+          <EuiLink href={manageDetectionRulesSnoozeSection} target="_blank">
+            {RULE_SNOOZE_DOCS_LINK_TEXT}
+          </EuiLink>
+        ),
+      }}
+    />
+  );
+}
+
+export const RULE_SNOOZE_DESCRIPTION = <RuleSnoozeDescription />;

--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_rule_actions/translations.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_rule_actions/translations.tsx
@@ -48,7 +48,7 @@ function RuleSnoozeDescription(): JSX.Element {
       },
     },
   } = useKibana().services;
-  const manageDetectionRulesSnoozeSection = `${manageDetectionRules}#snooze-rules-ui`;
+  const manageDetectionRulesSnoozeSection = `${manageDetectionRules}#edit-rules-settings`;
 
   return (
     <FormattedMessage

--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_rule_actions/translations.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_rule_actions/translations.tsx
@@ -36,7 +36,7 @@ export const NO_ACTIONS_READ_PERMISSIONS = i18n.translate(
 const RULE_SNOOZE_DOCS_LINK_TEXT = i18n.translate(
   'xpack.securitySolution.detectionEngine.createRule.stepRuleActions.docsLinkText',
   {
-    defaultMessage: 'docs',
+    defaultMessage: 'Learn more',
   }
 );
 
@@ -53,7 +53,7 @@ function RuleSnoozeDescription(): JSX.Element {
   return (
     <FormattedMessage
       id="xpack.securitySolution.detectionEngine.createRule.stepRuleActions.snoozeDescription"
-      defaultMessage="Select when automated actions should be performed. If a rule is snoozed actions will not be performed. Learn more about actions in our {docs}."
+      defaultMessage="Choose when to perform actions or snooze them. Notifications are not created for snoozed actions. {docs}."
       values={{
         docs: (
           <EuiLink href={manageDetectionRulesSnoozeSection} target="_blank">

--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_rule_actions/translations.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_rule_actions/translations.tsx
@@ -5,7 +5,11 @@
  * 2.0.
  */
 
+import React from 'react';
 import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { getDocLinks } from '@kbn/doc-links';
+import { EuiLink } from '@elastic/eui';
 
 export const COMPLETE_WITHOUT_ENABLING = i18n.translate(
   'xpack.securitySolution.detectionEngine.createRule.stepScheduleRule.completeWithoutEnablingTitle',
@@ -29,17 +33,27 @@ export const NO_ACTIONS_READ_PERMISSIONS = i18n.translate(
   }
 );
 
-export const RULE_SNOOZE_DESCRIPTION = i18n.translate(
-  'xpack.securitySolution.detectionEngine.createRule.stepRuleActions.snoozeDescription',
+const ruleSnoozeDocsLink = `${
+  getDocLinks({ kibanaBranch: 'main' }).alerting.guide
+}#controlling-rules`;
+
+const RULE_SNOOZE_DOCS_LINK_TEXT = i18n.translate(
+  'xpack.securitySolution.detectionEngine.createRule.stepRuleActions.docsLinkText',
   {
-    defaultMessage:
-      'Select when automated actions should be performed if a rule evaluates as true.',
+    defaultMessage: 'docs',
   }
 );
 
-export const SNOOZED_ACTIONS_WARNING = i18n.translate(
-  'xpack.securitySolution.detectionEngine.createRule.stepRuleActions.snoozedActionsWarning',
-  {
-    defaultMessage: 'Actions will not be performed until it is unsnoozed.',
-  }
+export const RULE_SNOOZE_DESCRIPTION = (
+  <FormattedMessage
+    id="xpack.securitySolution.detectionEngine.createRule.stepRuleActions.snoozeDescription"
+    defaultMessage="Select when automated actions should be performed. If a rule is snoozed actions will not be performed. Learn more about actions in our {docs}."
+    values={{
+      docs: (
+        <EuiLink href={ruleSnoozeDocsLink} target="_blank">
+          {RULE_SNOOZE_DOCS_LINK_TEXT}
+        </EuiLink>
+      ),
+    }}
+  />
 );


### PR DESCRIPTION
**Addresses:** https://github.com/elastic/kibana/issues/147737
**Relates to:** https://github.com/elastic/kibana/pull/155612

## Summary

After merging https://github.com/elastic/kibana/pull/155612 back there is one issue is left unresolved described in this [comment](https://github.com/elastic/kibana/pull/155612#discussion_r1175545697):

> Looks like we show the `Actions will not be preformed until it is unsnoozed` message unconditionally, i.e. regardless of whether the rule is snoozed or not. Since it's in bold it feels like a warning in the case where it doesn't really matter:

> Can we hide it when the rule is not snoozed? If it's not trivial, can we make it look less dangerous by making the font regular and playing with the copy a little bit? E.g. `If snoozed actions will not be triggered`.

This PR resolves rule snooze description text issue. As snooze settings are resolved outside the security solution plugin having any logic to conditionally display a message will increase the complexity. This way the message was changes to avoid any text to appear conditionally.

*Before:*

<img width="703" alt="Screenshot 2023-04-24 at 18 36 31" src="https://user-images.githubusercontent.com/7359339/234060523-fe9161a1-0e83-4d39-a193-81c946d95106.png">

*After:*

![image](https://user-images.githubusercontent.com/3775283/236254424-533a6502-49ba-444e-87e5-9cda7e84c315.png)


### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)



<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->