### PR TITLE
Update CODEOWNERS to proper team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -286,9 +286,9 @@ packages/core/usage-data/core-usage-data-base-server-internal @elastic/kibana-co
 packages/core/usage-data/core-usage-data-server @elastic/kibana-core
 packages/core/usage-data/core-usage-data-server-internal @elastic/kibana-core
 packages/core/usage-data/core-usage-data-server-mocks @elastic/kibana-core
-packages/core/user-settings/core-user-settings-server @elastic/kibana-security
-packages/core/user-settings/core-user-settings-server-internal @elastic/kibana-security
-packages/core/user-settings/core-user-settings-server-mocks @elastic/kibana-security
+packages/core/user-settings/core-user-settings-server @elastic/platform-security
+packages/core/user-settings/core-user-settings-server-internal @elastic/platform-security
+packages/core/user-settings/core-user-settings-server-mocks @elastic/platform-security
 x-pack/plugins/cross_cluster_replication @elastic/platform-deployment-management
 packages/kbn-crypto @elastic/kibana-security
 packages/kbn-crypto-browser @elastic/kibana-core

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -286,9 +286,9 @@ packages/core/usage-data/core-usage-data-base-server-internal @elastic/kibana-co
 packages/core/usage-data/core-usage-data-server @elastic/kibana-core
 packages/core/usage-data/core-usage-data-server-internal @elastic/kibana-core
 packages/core/usage-data/core-usage-data-server-mocks @elastic/kibana-core
-packages/core/user-settings/core-user-settings-server @elastic/platform-security
-packages/core/user-settings/core-user-settings-server-internal @elastic/platform-security
-packages/core/user-settings/core-user-settings-server-mocks @elastic/platform-security
+packages/core/user-settings/core-user-settings-server @elastic/kibana-security
+packages/core/user-settings/core-user-settings-server-internal @elastic/kibana-security
+packages/core/user-settings/core-user-settings-server-mocks @elastic/kibana-security
 x-pack/plugins/cross_cluster_replication @elastic/platform-deployment-management
 packages/kbn-crypto @elastic/kibana-security
 packages/kbn-crypto-browser @elastic/kibana-core

--- a/packages/core/user-settings/core-user-settings-server-internal/kibana.jsonc
+++ b/packages/core/user-settings/core-user-settings-server-internal/kibana.jsonc
@@ -1,5 +1,5 @@
 {
   "type": "shared-common",
   "id": "@kbn/core-user-settings-server-internal",
-  "owner": "@elastic/platform-security",
+  "owner": "@elastic/kibana-security",
 }

--- a/packages/core/user-settings/core-user-settings-server-mocks/kibana.jsonc
+++ b/packages/core/user-settings/core-user-settings-server-mocks/kibana.jsonc
@@ -1,5 +1,5 @@
 {
   "type": "shared-common",
   "id": "@kbn/core-user-settings-server-mocks",
-  "owner": "@elastic/platform-security",
+  "owner": "@elastic/kibana-security",
 }

--- a/packages/core/user-settings/core-user-settings-server/kibana.jsonc
+++ b/packages/core/user-settings/core-user-settings-server/kibana.jsonc
@@ -1,5 +1,5 @@
 {
   "type": "shared-common",
   "id": "@kbn/core-user-settings-server",
-  "owner": "@elastic/platform-security",
+  "owner": "@elastic/kibana-security",
 }


### PR DESCRIPTION
## Summary

Changing `platform-security` to `kibana-security` for newly added packages


