### PR TITLE
[Enterprise Search] Add XPath selector as option to extraction rules

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/crawler_domain_detail/extraction_rules/edit_field_rule_flyout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/crawler_domain_detail/extraction_rules/edit_field_rule_flyout.tsx
@@ -234,7 +234,7 @@ export const EditFieldRuleFlyout: React.FC<EditFieldRuleFlyoutProps> = ({
                             ? i18n.translate(
                                 'xpack.enterpriseSearch.content.indices.extractionRules.editContentField.content.htmlLabel',
                                 {
-                                  defaultMessage: 'CSS selector',
+                                  defaultMessage: 'CSS selector or XPath expression',
                                 }
                               )
                             : i18n.translate(
@@ -286,7 +286,8 @@ export const EditFieldRuleFlyout: React.FC<EditFieldRuleFlyoutProps> = ({
                           {i18n.translate(
                             'xpack.enterpriseSearch.content.indices.extractionRules.editRule.contentField.cssSelectorsLink',
                             {
-                              defaultMessage: 'Learn more about CSS selectors',
+                              defaultMessage:
+                                'Learn more about CSS selectors and XPath expressions',
                             }
                           )}
                         </EuiLink>


### PR DESCRIPTION
## Summary

This adds some text to clarify that you can use XPath expressions for extraction rules.

<img width="1459" alt="image" src="https://user-images.githubusercontent.com/94373878/234588960-5127f1b1-9c97-4aa8-a2f7-6066a7fb9d67.png">
