### PR TITLE
[Lens] Move palette over when transitioning to other visualizations

### DIFF
--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/suggestion_helpers.ts
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/suggestion_helpers.ts
@@ -64,7 +64,7 @@ export function getSuggestions({
   visualizeTriggerFieldContext?: VisualizeFieldContext | VisualizeEditorContext;
   activeData?: Record<string, Datatable>;
   dataViews: DataViewsState;
-  mainPalette?: PaletteOutput;
+  mainPalette?: PaletteOutput<unknown>;
 }): Suggestion[] {
   const datasources = Object.entries(datasourceMap).filter(
     ([datasourceId]) => datasourceStates[datasourceId] && !datasourceStates[datasourceId].isLoading
@@ -231,7 +231,7 @@ function getVisualizationSuggestions(
   datasourceSuggestion: DatasourceSuggestion & { datasourceId: string },
   currentVisualizationState: unknown,
   subVisualizationId?: string,
-  mainPalette?: PaletteOutput,
+  mainPalette?: PaletteOutput<unknown>,
   isFromContext?: boolean,
   activeData?: Record<string, Datatable>
 ) {

--- a/x-pack/plugins/lens/public/types.ts
+++ b/x-pack/plugins/lens/public/types.ts
@@ -898,7 +898,7 @@ export interface SuggestionRequest<T = unknown> {
    * State is only passed if the visualization is active.
    */
   state?: T;
-  mainPalette?: PaletteOutput;
+  mainPalette?: PaletteOutput<unknown>;
   isFromContext?: boolean;
   /**
    * The visualization needs to know which table is being suggested
@@ -1037,7 +1037,7 @@ export interface Visualization<T = unknown, P = T> {
    */
   getUsedDataViews?: (state?: T) => string[];
 
-  getMainPalette?: (state: T) => undefined | PaletteOutput;
+  getMainPalette?: (state: T) => undefined | PaletteOutput<unknown>;
 
   /**
    * Supported triggers of this visualization type when embedded somewhere

--- a/x-pack/plugins/lens/public/visualizations/datatable/visualization.tsx
+++ b/x-pack/plugins/lens/public/visualizations/datatable/visualization.tsx
@@ -191,13 +191,13 @@ export const getDatatableVisualization = ({
           layerId: table.layerId,
           layerType: LayerTypes.DATA,
           columns: table.columns.map((col, columnIndex) => ({
-            ...(oldColumnSettings[col.columnId] || {}),
-            isTransposed: usesTransposing && columnIndex < lastTransposedColumnIndex,
-            columnId: col.columnId,
             colorMode: canApplyPalette ? 'cell' : 'none',
             palette: canApplyPalette
               ? (mainPalette as PaletteOutput<CustomPaletteParams>)
               : undefined,
+            ...(oldColumnSettings[col.columnId] || {}),
+            isTransposed: usesTransposing && columnIndex < lastTransposedColumnIndex,
+            columnId: col.columnId,
           })),
         },
         previewIcon: IconChartDatatable,

--- a/x-pack/plugins/lens/public/visualizations/gauge/suggestions.ts
+++ b/x-pack/plugins/lens/public/visualizations/gauge/suggestions.ts
@@ -6,7 +6,7 @@
  */
 
 import { i18n } from '@kbn/i18n';
-import type { GaugeShape } from '@kbn/expression-gauge-plugin/common';
+import { GaugeColorModes, GaugeShape } from '@kbn/expression-gauge-plugin/common';
 import {
   GaugeShapes,
   GaugeTicksPositions,
@@ -14,6 +14,7 @@ import {
 } from '@kbn/expression-gauge-plugin/common';
 import { IconChartHorizontalBullet, IconChartVerticalBullet } from '@kbn/chart-icons';
 import { LayerTypes } from '@kbn/expression-xy-plugin/public';
+import type { PaletteOutput, CustomPaletteParams } from '@kbn/coloring';
 import type { TableSuggestion, Visualization } from '../../types';
 import type { GaugeVisualizationState } from './constants';
 
@@ -29,6 +30,7 @@ export const getSuggestions: Visualization<GaugeVisualizationState>['getSuggesti
   state,
   keptLayerIds,
   subVisualizationId,
+  mainPalette,
 }) => {
   const isGauge = Boolean(
     state && (state.minAccessor || state.maxAccessor || state.goalAccessor || state.metricAccessor)
@@ -61,6 +63,8 @@ export const getSuggestions: Visualization<GaugeVisualizationState>['getSuggesti
       layerType: LayerTypes.DATA,
       ticksPosition: GaugeTicksPositions.AUTO,
       labelMajorMode: GaugeLabelMajorModes.AUTO,
+      colorMode: Boolean(mainPalette) ? GaugeColorModes.PALETTE : GaugeColorModes.NONE,
+      palette: mainPalette as PaletteOutput<CustomPaletteParams>,
     },
     title: i18n.translate('xpack.lens.gauge.gaugeLabel', {
       defaultMessage: 'Gauge',

--- a/x-pack/plugins/lens/public/visualizations/gauge/suggestions.ts
+++ b/x-pack/plugins/lens/public/visualizations/gauge/suggestions.ts
@@ -57,14 +57,14 @@ export const getSuggestions: Visualization<GaugeVisualizationState>['getSuggesti
 
   const baseSuggestion = {
     state: {
+      colorMode: Boolean(mainPalette) ? GaugeColorModes.PALETTE : GaugeColorModes.NONE,
+      palette: mainPalette as PaletteOutput<CustomPaletteParams>,
       ...state,
       shape,
       layerId: table.layerId,
       layerType: LayerTypes.DATA,
       ticksPosition: GaugeTicksPositions.AUTO,
       labelMajorMode: GaugeLabelMajorModes.AUTO,
-      colorMode: Boolean(mainPalette) ? GaugeColorModes.PALETTE : GaugeColorModes.NONE,
-      palette: mainPalette as PaletteOutput<CustomPaletteParams>,
     },
     title: i18n.translate('xpack.lens.gauge.gaugeLabel', {
       defaultMessage: 'Gauge',

--- a/x-pack/plugins/lens/public/visualizations/gauge/visualization.tsx
+++ b/x-pack/plugins/lens/public/visualizations/gauge/visualization.tsx
@@ -233,6 +233,10 @@ export const getGaugeVisualization = ({
   },
   getSuggestions,
 
+  getMainPalette({ palette }) {
+    return palette;
+  },
+
   getConfiguration({ state, frame }) {
     const hasColoring = Boolean(state.colorMode !== 'none' && state.palette?.params?.stops);
 

--- a/x-pack/plugins/lens/public/visualizations/legacy_metric/metric_suggestions.ts
+++ b/x-pack/plugins/lens/public/visualizations/legacy_metric/metric_suggestions.ts
@@ -7,6 +7,7 @@
 
 import { IconChartMetric } from '@kbn/chart-icons';
 import { LayerTypes } from '@kbn/expression-xy-plugin/public';
+import type { PaletteOutput, CustomPaletteParams } from '@kbn/coloring';
 import { SuggestionRequest, VisualizationSuggestion, TableSuggestion } from '../../types';
 import type { LegacyMetricState } from '../../../common/types';
 import { legacyMetricSupportedTypes } from './visualization';
@@ -20,6 +21,7 @@ export function getSuggestions({
   table,
   state,
   keptLayerIds,
+  mainPalette,
 }: SuggestionRequest<LegacyMetricState>): Array<VisualizationSuggestion<LegacyMetricState>> {
   // We only render metric charts for single-row queries. We require a single, numeric column.
   if (
@@ -39,10 +41,13 @@ export function getSuggestions({
     return [];
   }
 
-  return [getSuggestion(table)];
+  return [getSuggestion(table, mainPalette as PaletteOutput<CustomPaletteParams>)];
 }
 
-function getSuggestion(table: TableSuggestion): VisualizationSuggestion<LegacyMetricState> {
+function getSuggestion(
+  table: TableSuggestion,
+  palette?: PaletteOutput<CustomPaletteParams>
+): VisualizationSuggestion<LegacyMetricState> {
   const col = table.columns[0];
   const title = table.label || col.operation.label;
 
@@ -54,6 +59,8 @@ function getSuggestion(table: TableSuggestion): VisualizationSuggestion<LegacyMe
       layerId: table.layerId,
       accessor: col.columnId,
       layerType: LayerTypes.DATA,
+      colorMode: palette ? 'Background' : 'None',
+      palette,
     },
   };
 }

--- a/x-pack/plugins/lens/public/visualizations/legacy_metric/visualization.tsx
+++ b/x-pack/plugins/lens/public/visualizations/legacy_metric/visualization.tsx
@@ -264,6 +264,10 @@ export const getLegacyMetricVisualization = ({
     }
   },
 
+  getMainPalette({ palette }) {
+    return palette;
+  },
+
   toExpression: (state, datasourceLayers, attributes, datasourceExpressionsByLayers) =>
     toExpression(
       paletteService,

--- a/x-pack/plugins/lens/public/visualizations/metric/suggestions.ts
+++ b/x-pack/plugins/lens/public/visualizations/metric/suggestions.ts
@@ -56,10 +56,10 @@ export const getSuggestions: Visualization<MetricVisualizationState>['getSuggest
 
   const baseSuggestion = {
     state: {
+      palette: mainPalette as PaletteOutput<CustomPaletteParams>,
       ...state,
       layerId: table.layerId,
       layerType: LayerTypes.DATA,
-      palette: mainPalette as PaletteOutput<CustomPaletteParams>,
     },
     title: metricLabel,
     previewIcon: IconChartMetric,

--- a/x-pack/plugins/lens/public/visualizations/metric/suggestions.ts
+++ b/x-pack/plugins/lens/public/visualizations/metric/suggestions.ts
@@ -7,6 +7,7 @@
 
 import { IconChartMetric } from '@kbn/chart-icons';
 import { LayerTypes } from '@kbn/expression-xy-plugin/public';
+import type { PaletteOutput, CustomPaletteParams } from '@kbn/coloring';
 import type { TableSuggestion, Visualization } from '../../types';
 import { metricLabel, MetricVisualizationState, supportedDataTypes } from './visualization';
 
@@ -20,6 +21,7 @@ export const getSuggestions: Visualization<MetricVisualizationState>['getSuggest
   table,
   state,
   keptLayerIds,
+  mainPalette,
 }) => {
   const isActive = Boolean(state);
 
@@ -57,6 +59,7 @@ export const getSuggestions: Visualization<MetricVisualizationState>['getSuggest
       ...state,
       layerId: table.layerId,
       layerType: LayerTypes.DATA,
+      palette: mainPalette as PaletteOutput<CustomPaletteParams>,
     },
     title: metricLabel,
     previewIcon: IconChartMetric,

--- a/x-pack/plugins/lens/public/visualizations/metric/visualization.tsx
+++ b/x-pack/plugins/lens/public/visualizations/metric/visualization.tsx
@@ -373,6 +373,10 @@ export const getMetricVisualization = ({
     };
   },
 
+  getMainPalette({ palette }) {
+    return palette;
+  },
+
   getSuggestions,
 
   initialize(addNewLayer, state, mainPalette) {


### PR DESCRIPTION
## Summary

This PR is a PoC for the palette transition described in #154483 

The aim of this PR is to play a bit with the feature and investigate on the following points:
* should it transition also the color mode over?
* what about the different coloring logic from visualization type to visualization type?
* does it make sense to apply the same logic also to Heatmap?
* In this PoC the palette transitioning for datatable is applied only when a single metric column is defined, is that correct?

![color_palette_transition](https://user-images.githubusercontent.com/924948/234593290-3888925e-4ff0-4ac4-87b4-3c49d5007539.gif)


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
