### PR TITLE
[Infrastructure UI] Fix hosts sticky search bar position

### DIFF
--- a/x-pack/plugins/infra/public/pages/metrics/hosts/components/search_bar/unified_search_bar.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/hosts/components/search_bar/unified_search_bar.tsx
@@ -16,7 +16,6 @@ import {
   EuiFlexItem,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
-import { METRICS_APP_DATA_TEST_SUBJ } from '../../../../../apps/metrics_app';
 import { useKibanaContextForPlugin } from '../../../../../hooks/use_kibana';
 import { useUnifiedSearchContext } from '../../hooks/use_unified_search';
 import { ControlsContent } from './controls_content';

--- a/x-pack/plugins/infra/public/pages/metrics/hosts/components/search_bar/unified_search_bar.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/hosts/components/search_bar/unified_search_bar.tsx
@@ -101,7 +101,7 @@ const StickyContainer = (props: { children: React.ReactNode }) => {
   const { euiTheme } = useEuiTheme();
 
   const top = useMemo(() => {
-    const wrapper = document.querySelector(`[data-test-subj="${METRICS_APP_DATA_TEST_SUBJ}"]`);
+    const wrapper = document.querySelector(`[data-test-subj="kibanaChrome"]`);
     if (!wrapper) {
       return `calc(${euiTheme.size.xxxl} * 2)`;
     }


### PR DESCRIPTION
## 📓 Summary

The sticky search bar was miscalculating the top position because it was referring to the wrong root element.