### PR TITLE
[Security Solution][Investigations] - Add tests and handle building block alerts

### DIFF
--- a/x-pack/plugins/security_solution/cypress/e2e/detection_alerts/alerts_details.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_alerts/alerts_details.cy.ts
@@ -90,13 +90,13 @@ describe('Alert details flyout', () => {
   });
 
   describe('Url state management', { testIsolation: false }, () => {
-    const testRule = getNewRule();
     before(() => {
       cleanKibana();
+      esArchiverLoad('query_alert');
       login();
-      createRule(testRule);
       visit(ALERTS_URL);
       waitForAlertsToPopulate();
+      expandFirstAlert();
     });
 
     it('should store the flyout state in the url when it is opened', () => {
@@ -118,7 +118,7 @@ describe('Alert details flyout', () => {
       cy.reload();
       cy.get(OVERVIEW_RULE).should('be.visible');
       cy.get(OVERVIEW_RULE).then((field) => {
-        expect(field).to.contain(testRule.name);
+        expect(field).to.contain('Endpoint Security');
       });
     });
 
@@ -145,13 +145,10 @@ describe('Alert details flyout', () => {
       expandFirstAlert();
       openTable();
       filterBy('kibana.alert.url');
-      cy.get('[data-test-subj="event-field-kibana.alert.url"]')
-        .invoke('text')
-        .then((url) => {
-          cy.visit(url);
-          cy.get(ALERTS_COUNT).should('have.text', '1 alert');
-          cy.get(OVERVIEW_RULE).should('be.visible');
-        });
+      cy.get('[data-test-subj="formatted-field-kibana.alert.url"]').should(
+        'have.text',
+        'http://localhost:5601/app/security/alerts/redirect/ecc6bd780c84fde32347f45de2d6acf599e1cc4d69575fd90b74244e81d5db6e?index=.alerts-security.alerts-default&timestamp=2023-04-27T11:03:57.908Z'
+      );
     });
   });
 });

--- a/x-pack/plugins/security_solution/cypress/e2e/detection_alerts/alerts_details.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_alerts/alerts_details.cy.ts
@@ -140,5 +140,18 @@ describe('Alert details flyout', () => {
           cy.get(OVERVIEW_RULE).should('be.visible');
         });
     });
+
+    it('should have the `kibana.alert.url` field set', () => {
+      expandFirstAlert();
+      openTable();
+      filterBy('kibana.alert.url');
+      cy.get('[data-test-subj="event-field-kibana.alert.url"]')
+        .invoke('text')
+        .then((url) => {
+          cy.visit(url);
+          cy.get(ALERTS_COUNT).should('have.text', '1 alert');
+          cy.get(OVERVIEW_RULE).should('be.visible');
+        });
+    });
   });
 });

--- a/x-pack/plugins/security_solution/cypress/e2e/detection_alerts/alerts_details.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_alerts/alerts_details.cy.ts
@@ -21,7 +21,7 @@ import { cleanKibana } from '../../tasks/common';
 import { waitForAlertsToPopulate } from '../../tasks/create_new_rule';
 import { esArchiverLoad, esArchiverUnload } from '../../tasks/es_archiver';
 import { login, visit, visitWithoutDateRange } from '../../tasks/login';
-import { getUnmappedRule, getNewRule } from '../../objects/rule';
+import { getUnmappedRule } from '../../objects/rule';
 import { ALERTS_URL } from '../../urls/navigation';
 import { tablePageSelector } from '../../screens/table_pagination';
 import { ALERTS_COUNT } from '../../screens/alerts';
@@ -147,7 +147,7 @@ describe('Alert details flyout', () => {
       filterBy('kibana.alert.url');
       cy.get('[data-test-subj="formatted-field-kibana.alert.url"]').should(
         'have.text',
-        'http://localhost:5601/app/security/alerts/redirect/ecc6bd780c84fde32347f45de2d6acf599e1cc4d69575fd90b74244e81d5db6e?index=.alerts-security.alerts-default&timestamp=2023-04-27T11:03:57.908Z'
+        'http://localhost:5601/app/security/alerts/redirect/eabbdefc23da981f2b74ab58b82622a97bb9878caa11bc914e2adfacc94780f1?index=.alerts-security.alerts-default&timestamp=2023-04-27T11:03:57.906Z'
       );
     });
   });

--- a/x-pack/plugins/security_solution/public/common/hooks/flyout/use_init_flyout_url_param.ts
+++ b/x-pack/plugins/security_solution/public/common/hooks/flyout/use_init_flyout_url_param.ts
@@ -10,10 +10,10 @@ import { useCallback, useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
 
 import {
-  dataTableActions,
   dataTableSelectors,
-  tableDefaults,
   TableId,
+  tableDefaults,
+  dataTableActions,
 } from '@kbn/securitysolution-data-table';
 import { useInitializeUrlParam } from '../../utils/global_query_string';
 import { URL_PARAM_KEY } from '../use_url_state';
@@ -39,16 +39,28 @@ export const useInitFlyoutFromUrlParam = () => {
   }, []);
 
   const loadExpandedDetailFromUrl = useCallback(() => {
-    const { initialized, isLoading, totalCount } = dataTableCurrent;
+    const { initialized, isLoading, totalCount, additionalFilters } = dataTableCurrent;
     const isTableLoaded = initialized && !isLoading && totalCount > 0;
-    if (urlDetails && isTableLoaded) {
-      updateHasLoadedUrlDetails(true);
-      dispatch(
-        dataTableActions.toggleDetailPanel({
-          id: TableId.alertsOnAlertsPage,
-          ...urlDetails,
-        })
-      );
+    if (urlDetails) {
+      if (!additionalFilters.showBuildingBlockAlerts) {
+        // We want to show building block alerts when loading the flyout in case the alert is a building block alert
+        dispatch(
+          dataTableActions.updateShowBuildingBlockAlertsFilter({
+            id: TableId.alertsOnAlertsPage,
+            showBuildingBlockAlerts: true,
+          })
+        );
+      }
+
+      if (isTableLoaded) {
+        updateHasLoadedUrlDetails(true);
+        dispatch(
+          dataTableActions.toggleDetailPanel({
+            id: TableId.alertsOnAlertsPage,
+            ...urlDetails,
+          })
+        );
+      }
     }
   }, [dataTableCurrent, dispatch, urlDetails]);
 

--- a/x-pack/plugins/security_solution/public/detections/pages/alerts/alert_details_redirect.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/alerts/alert_details_redirect.test.tsx
@@ -1,0 +1,132 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React from 'react';
+import { render } from '@testing-library/react';
+import { Router } from 'react-router-dom';
+import { AlertDetailsRedirect } from './alert_details_redirect';
+import {
+  createSecuritySolutionStorageMock,
+  mockGlobalState,
+  SUB_PLUGINS_REDUCER,
+  TestProviders,
+} from '../../../common/mock';
+import { createStore } from '../../../common/store';
+import { kibanaObservable } from '@kbn/timelines-plugin/public/mock';
+import {
+  ALERTS_PATH,
+  ALERT_DETAILS_REDIRECT_PATH,
+  DEFAULT_ALERTS_INDEX,
+} from '../../../../common/constants';
+import { mockHistory } from '../../../common/utils/route/mocks';
+
+jest.mock('../../../common/lib/kibana');
+
+const testAlertId = 'test-alert-id';
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: () => ({
+    alertId: testAlertId,
+  }),
+}));
+
+const testIndex = '.someTestIndex';
+const testTimestamp = '2023-04-20T12:00:00.000Z';
+const mockPathname = `${ALERT_DETAILS_REDIRECT_PATH}/${testAlertId}`;
+
+describe('AlertDetailsRedirect', () => {
+  const { storage } = createSecuritySolutionStorageMock();
+  const store = createStore(mockGlobalState, SUB_PLUGINS_REDUCER, kibanaObservable, storage);
+  afterEach(() => {
+    mockHistory.replace.mockClear();
+  });
+
+  describe('with index and timestamp query parameters set', () => {
+    it('redirects to the expected path with the correct query parameters', () => {
+      const testSearch = `?index=${testIndex}&timestamp=${testTimestamp}`;
+      const historyMock = {
+        ...mockHistory,
+        location: {
+          hash: '',
+          pathname: mockPathname,
+          search: testSearch,
+          state: '',
+        },
+      };
+      render(
+        <TestProviders store={store}>
+          <Router history={historyMock}>
+            <AlertDetailsRedirect />
+          </Router>
+        </TestProviders>
+      );
+
+      expect(historyMock.replace).toHaveBeenCalledWith({
+        hash: '',
+        pathname: ALERTS_PATH,
+        search: `?query=(language:kuery,query:'_id: ${testAlertId}')&timerange=(global:(linkTo:!(timeline,socTrends),timerange:(from:'${testTimestamp}',kind:absolute,to:'2023-04-20T12:05:00.000Z')),timeline:(linkTo:!(global,socTrends),timerange:(from:'2020-07-07T08:20:18.966Z',fromStr:now/d,kind:relative,to:'2020-07-08T08:20:18.966Z',toStr:now/d)))&eventFlyout=(panelView:eventDetail,params:(eventId:${testAlertId},indexName:${testIndex}))`,
+        state: undefined,
+      });
+    });
+  });
+
+  describe('with only index query parameter set', () => {
+    it('redirects to the expected path with the default global timestamp settings', () => {
+      const testSearch = `?index=${testIndex}`;
+      const historyMock = {
+        ...mockHistory,
+        location: {
+          hash: '',
+          pathname: mockPathname,
+          search: testSearch,
+          state: '',
+        },
+      };
+      render(
+        <TestProviders store={store}>
+          <Router history={historyMock}>
+            <AlertDetailsRedirect />
+          </Router>
+        </TestProviders>
+      );
+
+      expect(historyMock.replace).toHaveBeenCalledWith({
+        hash: '',
+        pathname: ALERTS_PATH,
+        search: `?query=(language:kuery,query:'_id: ${testAlertId}')&timerange=(global:(linkTo:!(timeline,socTrends),timerange:(from:'2020-07-07T08:20:18.966Z',kind:absolute,to:'2020-07-08T08:25:18.966Z')),timeline:(linkTo:!(global,socTrends),timerange:(from:'2020-07-07T08:20:18.966Z',fromStr:now/d,kind:relative,to:'2020-07-08T08:20:18.966Z',toStr:now/d)))&eventFlyout=(panelView:eventDetail,params:(eventId:${testAlertId},indexName:${testIndex}))`,
+        state: undefined,
+      });
+    });
+  });
+
+  describe('with no query parameters set', () => {
+    it('redirects to the expected path with the proper default alerts index and default global timestamp setting', () => {
+      const historyMock = {
+        ...mockHistory,
+        location: {
+          hash: '',
+          pathname: mockPathname,
+          search: '',
+          state: '',
+        },
+      };
+      render(
+        <TestProviders store={store}>
+          <Router history={historyMock}>
+            <AlertDetailsRedirect />
+          </Router>
+        </TestProviders>
+      );
+
+      expect(historyMock.replace).toHaveBeenCalledWith({
+        hash: '',
+        pathname: ALERTS_PATH,
+        search: `?query=(language:kuery,query:'_id: ${testAlertId}')&timerange=(global:(linkTo:!(timeline,socTrends),timerange:(from:'2020-07-07T08:20:18.966Z',kind:absolute,to:'2020-07-08T08:25:18.966Z')),timeline:(linkTo:!(global,socTrends),timerange:(from:'2020-07-07T08:20:18.966Z',fromStr:now/d,kind:relative,to:'2020-07-08T08:20:18.966Z',toStr:now/d)))&eventFlyout=(panelView:eventDetail,params:(eventId:${testAlertId},indexName:.internal${DEFAULT_ALERTS_INDEX}-default))`,
+        state: undefined,
+      });
+    });
+  });
+});

--- a/x-pack/plugins/security_solution/public/detections/pages/alerts/alert_details_redirect.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/alerts/alert_details_redirect.tsx
@@ -32,9 +32,9 @@ export const AlertDetailsRedirect = () => {
 
   // Default to the existing global timerange if we don't get this query param for whatever reason
   const fromTime = timestamp ?? globalTimerange.from;
-  // Add 1 millisecond to the alert timestamp as the alert table is non-inclusive of the end time
-  // So we have to extend slightly beyond the range of the timestamp of the given alert
-  const toTime = moment(timestamp ?? globalTimerange.to).add('1', 'millisecond');
+  // Add 5 minutes to the alert timestamp as the alert table is non-inclusive of the end time
+  // This also provides padding time if the user clears the `_id` filter after redirect to see other alerts
+  const toTime = moment(timestamp ?? globalTimerange.to).add('5', 'minutes');
 
   const timerange = encode({
     global: {

--- a/x-pack/test/security_solution_cypress/config.ts
+++ b/x-pack/test/security_solution_cypress/config.ts
@@ -46,6 +46,7 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
         // See https://github.com/elastic/kibana/pull/125396 for details
         '--xpack.alerting.rules.minimumScheduleInterval.value=1s',
         '--xpack.ruleRegistry.unsafe.legacyMultiTenancy.enabled=true',
+        '--server.publicBaseUrl=http://localhost:5620',
         `--xpack.securitySolution.enableExperimental=${JSON.stringify([
           'alertDetailsPageEnabled',
           'chartEmbeddablesEnabled',

--- a/x-pack/test/security_solution_cypress/config.ts
+++ b/x-pack/test/security_solution_cypress/config.ts
@@ -46,7 +46,6 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
         // See https://github.com/elastic/kibana/pull/125396 for details
         '--xpack.alerting.rules.minimumScheduleInterval.value=1s',
         '--xpack.ruleRegistry.unsafe.legacyMultiTenancy.enabled=true',
-        '--server.publicBaseUrl=http://localhost:5620',
         `--xpack.securitySolution.enableExperimental=${JSON.stringify([
           'alertDetailsPageEnabled',
           'chartEmbeddablesEnabled',

--- a/x-pack/test/security_solution_cypress/es_archives/query_alert/data.json
+++ b/x-pack/test/security_solution_cypress/es_archives/query_alert/data.json
@@ -1,0 +1,419 @@
+{
+  "type": "doc",
+  "value": {
+    "id": "eabbdefc23da981f2b74ab58b82622a97bb9878caa11bc914e2adfacc94780f1",
+    "index": ".internal.alerts-security.alerts-default-000001",
+    "source": {
+      "@timestamp": "2023-04-27T11:03:57.906Z",
+      "Endpoint": {
+        "capabilities": [
+          "isolation",
+          "kill_process",
+          "suspend_process",
+          "running_processes",
+          "get_file",
+          "execute"
+        ],
+        "configuration": {
+          "isolation": true
+        },
+        "policy": {
+          "applied": {
+            "endpoint_policy_version": 3,
+            "id": "C2A9093E-E289-4C0A-AA44-8C32A414FA7A",
+            "name": "With Eventing",
+            "status": "success",
+            "version": 5
+          }
+        },
+        "state": {
+          "isolation": true
+        },
+        "status": "enrolled"
+      },
+      "agent": {
+        "id": "b563ce99-e373-4a1f-a5fe-97e956140aeb",
+        "type": "endpoint",
+        "version": "8.8.0"
+      },
+      "data_stream": {
+        "dataset": "endpoint.alerts",
+        "namespace": "default",
+        "type": "logs"
+      },
+      "dll": [
+        {
+          "Ext": {
+            "compile_time": 1534424710,
+            "malware_classification": {
+              "identifier": "Whitelisted",
+              "score": 0,
+              "threshold": 0,
+              "version": "3.0.0"
+            },
+            "mapped_address": 5362483200,
+            "mapped_size": 0
+          },
+          "code_signature": {
+            "subject_name": "Cybereason Inc",
+            "trusted": true
+          },
+          "hash": {
+            "md5": "1f2d082566b0fc5f2c238a5180db7451",
+            "sha1": "ca85243c0af6a6471bdaa560685c51eefd6dbc0d",
+            "sha256": "8ad40c90a611d36eb8f9eb24fa04f7dbca713db383ff55a03aa0f382e92061a2"
+          },
+          "path": "C:\\Program Files\\Cybereason ActiveProbe\\AmSvc.exe",
+          "pe": {
+            "architecture": "x64"
+          }
+        }
+      ],
+      "ecs": {
+        "version": "1.4.0"
+      },
+      "elastic": {
+        "agent": {
+          "id": "b563ce99-e373-4a1f-a5fe-97e956140aeb"
+        }
+      },
+      "event.action": "creation",
+      "event.agent_id_status": "auth_metadata_missing",
+      "event.category": "malware",
+      "event.code": "malicious_file",
+      "event.dataset": "endpoint",
+      "event.id": "b28993d4-8b8a-4f0f-9f54-84a89bad66ae",
+      "event.ingested": "2023-04-27T10:58:03Z",
+      "event.kind": "signal",
+      "event.module": "endpoint",
+      "event.sequence": 5826,
+      "event.type": "creation",
+      "file": {
+        "Ext": {
+          "code_signature": [
+            {
+              "subject_name": "bad signer",
+              "trusted": false
+            }
+          ],
+          "malware_classification": {
+            "identifier": "endpointpe",
+            "score": 1,
+            "threshold": 0.66,
+            "version": "3.0.33"
+          },
+          "quarantine_message": "fake quarantine message",
+          "quarantine_result": true,
+          "temp_file_path": "C:/temp/fake_malware.exe"
+        },
+        "accessed": 1682752652103,
+        "created": 1682752652103,
+        "hash": {
+          "md5": "fake file md5",
+          "sha1": "fake file sha1",
+          "sha256": "fake file sha256"
+        },
+        "mtime": 1682752652103,
+        "name": "fake_malware.exe",
+        "owner": "SYSTEM",
+        "path": "C:/fake_malware.exe",
+        "size": 3456
+      },
+      "host": {
+        "architecture": "wtnozeqvub",
+        "hostname": "Host-fwarau82er",
+        "id": "4260adf9-5e63-445d-92c6-e03359bcd342",
+        "ip": [
+          "10.249.37.72",
+          "10.150.39.243",
+          "10.186.17.170"
+        ],
+        "mac": [
+          "f5-f-97-dc-20-67",
+          "b5-56-ca-98-81-ca",
+          "22-86-39-4c-87-33"
+        ],
+        "name": "Host-fwarau82er",
+        "os": {
+          "Ext": {
+            "variant": "Darwin"
+          },
+          "family": "Darwin",
+          "full": "macOS Monterey",
+          "name": "macOS",
+          "platform": "macOS",
+          "version": "12.6.1"
+        }
+      },
+      "kibana.alert.ancestors": [
+        {
+          "depth": 0,
+          "id": "vT9cwocBh3b8EMpD8lsi",
+          "index": ".ds-logs-endpoint.alerts-default-2023.04.27-000001",
+          "type": "event"
+        }
+      ],
+      "kibana.alert.depth": 1,
+      "kibana.alert.last_detected": "2023-04-27T11:03:57.993Z",
+      "kibana.alert.original_event.action": "creation",
+      "kibana.alert.original_event.agent_id_status": "auth_metadata_missing",
+      "kibana.alert.original_event.category": "malware",
+      "kibana.alert.original_event.code": "malicious_file",
+      "kibana.alert.original_event.dataset": "endpoint",
+      "kibana.alert.original_event.id": "b28993d4-8b8a-4f0f-9f54-84a89bad66ae",
+      "kibana.alert.original_event.ingested": "2023-04-27T10:58:03Z",
+      "kibana.alert.original_event.kind": "alert",
+      "kibana.alert.original_event.module": "endpoint",
+      "kibana.alert.original_event.sequence": 5826,
+      "kibana.alert.original_event.type": "creation",
+      "kibana.alert.original_time": "2023-04-29T07:17:32.103Z",
+      "kibana.alert.reason": "malware event with process malware writer, file fake_malware.exe, on Host-fwarau82er created medium alert Endpoint Security.",
+      "kibana.alert.risk_score": 47,
+      "kibana.alert.rule.actions": [
+      ],
+      "kibana.alert.rule.author": [
+        "Elastic"
+      ],
+      "kibana.alert.rule.category": "Custom Query Rule",
+      "kibana.alert.rule.consumer": "siem",
+      "kibana.alert.rule.created_at": "2023-04-27T10:58:27.546Z",
+      "kibana.alert.rule.created_by": "elastic",
+      "kibana.alert.rule.description": "Generates a detection alert each time an Elastic Endpoint Security alert is received. Enabling this rule allows you to immediately begin investigating your Endpoint alerts.",
+      "kibana.alert.rule.enabled": true,
+      "kibana.alert.rule.exceptions_list": [
+        {
+          "id": "endpoint_list",
+          "list_id": "endpoint_list",
+          "namespace_type": "agnostic",
+          "type": "endpoint"
+        }
+      ],
+      "kibana.alert.rule.execution.uuid": "ebf843ff-e0e1-47f8-9ed2-cc8066afbcef",
+      "kibana.alert.rule.false_positives": [
+      ],
+      "kibana.alert.rule.from": "now-10m",
+      "kibana.alert.rule.immutable": true,
+      "kibana.alert.rule.indices": [
+        "logs-endpoint.alerts-*"
+      ],
+      "kibana.alert.rule.interval": "5m",
+      "kibana.alert.rule.license": "Elastic License v2",
+      "kibana.alert.rule.max_signals": 10000,
+      "kibana.alert.rule.name": "Endpoint Security",
+      "kibana.alert.rule.parameters": {
+        "author": [
+          "Elastic"
+        ],
+        "description": "Generates a detection alert each time an Elastic Endpoint Security alert is received. Enabling this rule allows you to immediately begin investigating your Endpoint alerts.",
+        "exceptions_list": [
+          {
+            "id": "endpoint_list",
+            "list_id": "endpoint_list",
+            "namespace_type": "agnostic",
+            "type": "endpoint"
+          }
+        ],
+        "false_positives": [
+        ],
+        "from": "now-10m",
+        "immutable": true,
+        "index": [
+          "logs-endpoint.alerts-*"
+        ],
+        "language": "kuery",
+        "license": "Elastic License v2",
+        "max_signals": 10000,
+        "query": "event.kind:alert and event.module:(endpoint and not endgame)\n",
+        "references": [
+        ],
+        "related_integrations": [
+          {
+            "package": "endpoint",
+            "version": "^8.2.0"
+          }
+        ],
+        "required_fields": [
+          {
+            "ecs": true,
+            "name": "event.kind",
+            "type": "keyword"
+          },
+          {
+            "ecs": true,
+            "name": "event.module",
+            "type": "keyword"
+          }
+        ],
+        "risk_score": 47,
+        "risk_score_mapping": [
+          {
+            "field": "event.risk_score",
+            "operator": "equals",
+            "value": ""
+          }
+        ],
+        "rule_id": "9a1a2dae-0b5f-4c3d-8305-a268d404c306",
+        "rule_name_override": "message",
+        "setup": "",
+        "severity": "medium",
+        "severity_mapping": [
+          {
+            "field": "event.severity",
+            "operator": "equals",
+            "severity": "low",
+            "value": "21"
+          },
+          {
+            "field": "event.severity",
+            "operator": "equals",
+            "severity": "medium",
+            "value": "47"
+          },
+          {
+            "field": "event.severity",
+            "operator": "equals",
+            "severity": "high",
+            "value": "73"
+          },
+          {
+            "field": "event.severity",
+            "operator": "equals",
+            "severity": "critical",
+            "value": "99"
+          }
+        ],
+        "threat": [
+        ],
+        "timestamp_override": "event.ingested",
+        "to": "now",
+        "type": "query",
+        "version": 101
+      },
+      "kibana.alert.rule.producer": "siem",
+      "kibana.alert.rule.references": [
+      ],
+      "kibana.alert.rule.revision": 0,
+      "kibana.alert.rule.risk_score": 47,
+      "kibana.alert.rule.risk_score_mapping": [
+        {
+          "field": "event.risk_score",
+          "operator": "equals",
+          "value": ""
+        }
+      ],
+      "kibana.alert.rule.rule_id": "9a1a2dae-0b5f-4c3d-8305-a268d404c306",
+      "kibana.alert.rule.rule_name_override": "message",
+      "kibana.alert.rule.rule_type_id": "siem.queryRule",
+      "kibana.alert.rule.severity": "medium",
+      "kibana.alert.rule.severity_mapping": [
+        {
+          "field": "event.severity",
+          "operator": "equals",
+          "severity": "low",
+          "value": "21"
+        },
+        {
+          "field": "event.severity",
+          "operator": "equals",
+          "severity": "medium",
+          "value": "47"
+        },
+        {
+          "field": "event.severity",
+          "operator": "equals",
+          "severity": "high",
+          "value": "73"
+        },
+        {
+          "field": "event.severity",
+          "operator": "equals",
+          "severity": "critical",
+          "value": "99"
+        }
+      ],
+      "kibana.alert.rule.tags": [
+        "Elastic",
+        "Endpoint Security"
+      ],
+      "kibana.alert.rule.threat": [
+      ],
+      "kibana.alert.rule.timestamp_override": "event.ingested",
+      "kibana.alert.rule.to": "now",
+      "kibana.alert.rule.type": "query",
+      "kibana.alert.rule.updated_at": "2023-04-27T10:58:27.546Z",
+      "kibana.alert.rule.updated_by": "elastic",
+      "kibana.alert.rule.uuid": "7015a3e2-e4ea-11ed-8c11-49608884878f",
+      "kibana.alert.rule.version": 101,
+      "kibana.alert.severity": "medium",
+      "kibana.alert.start": "2023-04-27T11:03:57.993Z",
+      "kibana.alert.status": "active",
+      "kibana.alert.url": "http://localhost:5601/app/security/alerts/redirect/eabbdefc23da981f2b74ab58b82622a97bb9878caa11bc914e2adfacc94780f1?index=.alerts-security.alerts-default&timestamp=2023-04-27T11:03:57.906Z",
+      "kibana.alert.uuid": "eabbdefc23da981f2b74ab58b82622a97bb9878caa11bc914e2adfacc94780f1",
+      "kibana.alert.workflow_status": "open",
+      "kibana.space_ids": [
+        "default"
+      ],
+      "kibana.version": "8.8.0",
+      "process": {
+        "Ext": {
+          "ancestry": [
+            "qa5jgw1wr7",
+            "5k1hclygc6"
+          ],
+          "code_signature": [
+            {
+              "subject_name": "bad signer",
+              "trusted": false
+            }
+          ],
+          "token": {
+            "domain": "NT AUTHORITY",
+            "integrity_level": 16384,
+            "integrity_level_name": "system",
+            "privileges": [
+              {
+                "description": "Replace a process level token",
+                "enabled": false,
+                "name": "SeAssignPrimaryTokenPrivilege"
+              }
+            ],
+            "sid": "S-1-5-18",
+            "type": "tokenPrimary",
+            "user": "SYSTEM"
+          },
+          "user": "SYSTEM"
+        },
+        "entity_id": "nqh8ts6ves",
+        "entry_leader": {
+          "entity_id": "jnm38bel0w",
+          "name": "fake entry",
+          "pid": 791
+        },
+        "executable": "C:/malware.exe",
+        "group_leader": {
+          "entity_id": "jnm38bel0w",
+          "name": "fake leader",
+          "pid": 848
+        },
+        "hash": {
+          "md5": "fake md5",
+          "sha1": "fake sha1",
+          "sha256": "fake sha256"
+        },
+        "name": "malware writer",
+        "parent": {
+          "entity_id": "qa5jgw1wr7",
+          "pid": 1
+        },
+        "pid": 2,
+        "session_leader": {
+          "entity_id": "jnm38bel0w",
+          "name": "fake session",
+          "pid": 909
+        },
+        "start": 1682752652103,
+        "uptime": 0
+      }
+    }
+  }
+}

--- a/x-pack/test/security_solution_cypress/es_archives/query_alert/mappings.json
+++ b/x-pack/test/security_solution_cypress/es_archives/query_alert/mappings.json
@@ -1,0 +1,7904 @@
+{
+  "type": "index",
+  "value": {
+    "aliases": {
+      ".alerts-security.alerts-default": {
+        "is_write_index": true
+      },
+      ".siem-signals-default": {
+        "is_write_index": false
+      }
+    },
+    "index": ".internal.alerts-security.alerts-default-000001",
+    "mappings": {
+      "_meta": {
+        "kibana": {
+          "version": "8.8.0"
+        },
+        "managed": true,
+        "namespace": "default"
+      },
+      "dynamic": "false",
+      "properties": {
+        "@timestamp": {
+          "type": "date"
+        },
+        "agent": {
+          "properties": {
+            "build": {
+              "properties": {
+                "original": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "ephemeral_id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "type": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "version": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "client": {
+          "properties": {
+            "address": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "as": {
+              "properties": {
+                "number": {
+                  "type": "long"
+                },
+                "organization": {
+                  "properties": {
+                    "name": {
+                      "fields": {
+                        "text": {
+                          "type": "match_only_text"
+                        }
+                      },
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                }
+              }
+            },
+            "bytes": {
+              "type": "long"
+            },
+            "domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "geo": {
+              "properties": {
+                "city_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "continent_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "continent_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "country_iso_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "country_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "location": {
+                  "type": "geo_point"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "postal_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "region_iso_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "region_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "timezone": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "ip": {
+              "type": "ip"
+            },
+            "mac": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "nat": {
+              "properties": {
+                "ip": {
+                  "type": "ip"
+                },
+                "port": {
+                  "type": "long"
+                }
+              }
+            },
+            "packets": {
+              "type": "long"
+            },
+            "port": {
+              "type": "long"
+            },
+            "registered_domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "subdomain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "top_level_domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "user": {
+              "properties": {
+                "domain": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "email": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "full_name": {
+                  "fields": {
+                    "text": {
+                      "type": "match_only_text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "group": {
+                  "properties": {
+                    "domain": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "hash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "fields": {
+                    "text": {
+                      "type": "match_only_text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "roles": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            }
+          }
+        },
+        "cloud": {
+          "properties": {
+            "account": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "availability_zone": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "instance": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "machine": {
+              "properties": {
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "origin": {
+              "properties": {
+                "account": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "availability_zone": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "instance": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "machine": {
+                  "properties": {
+                    "type": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "project": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "provider": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "region": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "service": {
+                  "properties": {
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                }
+              }
+            },
+            "project": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "provider": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "region": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "service": {
+              "properties": {
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "target": {
+              "properties": {
+                "account": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "availability_zone": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "instance": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "machine": {
+                  "properties": {
+                    "type": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "project": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "provider": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "region": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "service": {
+                  "properties": {
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "container": {
+          "properties": {
+            "cpu": {
+              "properties": {
+                "usage": {
+                  "scaling_factor": 1000,
+                  "type": "scaled_float"
+                }
+              }
+            },
+            "disk": {
+              "properties": {
+                "read": {
+                  "properties": {
+                    "bytes": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "write": {
+                  "properties": {
+                    "bytes": {
+                      "type": "long"
+                    }
+                  }
+                }
+              }
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "image": {
+              "properties": {
+                "hash": {
+                  "properties": {
+                    "all": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "tag": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "labels": {
+              "type": "object"
+            },
+            "memory": {
+              "properties": {
+                "usage": {
+                  "scaling_factor": 1000,
+                  "type": "scaled_float"
+                }
+              }
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "network": {
+              "properties": {
+                "egress": {
+                  "properties": {
+                    "bytes": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "ingress": {
+                  "properties": {
+                    "bytes": {
+                      "type": "long"
+                    }
+                  }
+                }
+              }
+            },
+            "runtime": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "destination": {
+          "properties": {
+            "address": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "as": {
+              "properties": {
+                "number": {
+                  "type": "long"
+                },
+                "organization": {
+                  "properties": {
+                    "name": {
+                      "fields": {
+                        "text": {
+                          "type": "match_only_text"
+                        }
+                      },
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                }
+              }
+            },
+            "bytes": {
+              "type": "long"
+            },
+            "domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "geo": {
+              "properties": {
+                "city_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "continent_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "continent_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "country_iso_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "country_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "location": {
+                  "type": "geo_point"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "postal_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "region_iso_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "region_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "timezone": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "ip": {
+              "type": "ip"
+            },
+            "mac": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "nat": {
+              "properties": {
+                "ip": {
+                  "type": "ip"
+                },
+                "port": {
+                  "type": "long"
+                }
+              }
+            },
+            "packets": {
+              "type": "long"
+            },
+            "port": {
+              "type": "long"
+            },
+            "registered_domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "subdomain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "top_level_domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "user": {
+              "properties": {
+                "domain": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "email": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "full_name": {
+                  "fields": {
+                    "text": {
+                      "type": "match_only_text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "group": {
+                  "properties": {
+                    "domain": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "hash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "fields": {
+                    "text": {
+                      "type": "match_only_text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "roles": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            }
+          }
+        },
+        "device": {
+          "properties": {
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "manufacturer": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "model": {
+              "properties": {
+                "identifier": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            }
+          }
+        },
+        "dll": {
+          "properties": {
+            "code_signature": {
+              "properties": {
+                "digest_algorithm": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "exists": {
+                  "type": "boolean"
+                },
+                "signing_id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "status": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "subject_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "team_id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "timestamp": {
+                  "type": "date"
+                },
+                "trusted": {
+                  "type": "boolean"
+                },
+                "valid": {
+                  "type": "boolean"
+                }
+              }
+            },
+            "hash": {
+              "properties": {
+                "md5": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "sha1": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "sha256": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "sha384": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "sha512": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "ssdeep": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "tlsh": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "path": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "pe": {
+              "properties": {
+                "architecture": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "company": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "description": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "file_version": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "imphash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "original_file_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "pehash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "product": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            }
+          }
+        },
+        "dns": {
+          "properties": {
+            "answers": {
+              "properties": {
+                "class": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "data": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "ttl": {
+                  "type": "long"
+                },
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "header_flags": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "op_code": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "question": {
+              "properties": {
+                "class": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "registered_domain": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "subdomain": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "top_level_domain": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "resolved_ip": {
+              "type": "ip"
+            },
+            "response_code": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "type": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "ecs": {
+          "properties": {
+            "version": {
+              "type": "keyword"
+            }
+          }
+        },
+        "email": {
+          "properties": {
+            "attachments": {
+              "properties": {
+                "file": {
+                  "properties": {
+                    "extension": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "hash": {
+                      "properties": {
+                        "md5": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "sha1": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "sha256": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "sha384": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "sha512": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "ssdeep": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "tlsh": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
+                    },
+                    "mime_type": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "size": {
+                      "type": "long"
+                    }
+                  }
+                }
+              },
+              "type": "nested"
+            },
+            "bcc": {
+              "properties": {
+                "address": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "cc": {
+              "properties": {
+                "address": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "content_type": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "delivery_timestamp": {
+              "type": "date"
+            },
+            "direction": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "from": {
+              "properties": {
+                "address": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "local_id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "message_id": {
+              "type": "wildcard"
+            },
+            "origination_timestamp": {
+              "type": "date"
+            },
+            "reply_to": {
+              "properties": {
+                "address": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "sender": {
+              "properties": {
+                "address": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "subject": {
+              "fields": {
+                "text": {
+                  "type": "match_only_text"
+                }
+              },
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "to": {
+              "properties": {
+                "address": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "x_mailer": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "error": {
+          "properties": {
+            "code": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "message": {
+              "type": "match_only_text"
+            },
+            "stack_trace": {
+              "fields": {
+                "text": {
+                  "type": "match_only_text"
+                }
+              },
+              "type": "wildcard"
+            },
+            "type": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "event": {
+          "properties": {
+            "action": {
+              "type": "keyword"
+            },
+            "agent_id_status": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "category": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "code": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "created": {
+              "type": "date"
+            },
+            "dataset": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "duration": {
+              "type": "long"
+            },
+            "end": {
+              "type": "date"
+            },
+            "hash": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "ingested": {
+              "type": "date"
+            },
+            "kind": {
+              "type": "keyword"
+            },
+            "module": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "original": {
+              "type": "keyword"
+            },
+            "outcome": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "provider": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "reason": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "reference": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "risk_score": {
+              "type": "float"
+            },
+            "risk_score_norm": {
+              "type": "float"
+            },
+            "sequence": {
+              "type": "long"
+            },
+            "severity": {
+              "type": "long"
+            },
+            "start": {
+              "type": "date"
+            },
+            "timezone": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "type": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "url": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "faas": {
+          "properties": {
+            "coldstart": {
+              "type": "boolean"
+            },
+            "execution": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "trigger": {
+              "properties": {
+                "request_id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              },
+              "type": "nested"
+            },
+            "version": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "file": {
+          "properties": {
+            "accessed": {
+              "type": "date"
+            },
+            "attributes": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "code_signature": {
+              "properties": {
+                "digest_algorithm": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "exists": {
+                  "type": "boolean"
+                },
+                "signing_id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "status": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "subject_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "team_id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "timestamp": {
+                  "type": "date"
+                },
+                "trusted": {
+                  "type": "boolean"
+                },
+                "valid": {
+                  "type": "boolean"
+                }
+              }
+            },
+            "created": {
+              "type": "date"
+            },
+            "ctime": {
+              "type": "date"
+            },
+            "device": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "directory": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "drive_letter": {
+              "ignore_above": 1,
+              "type": "keyword"
+            },
+            "elf": {
+              "properties": {
+                "architecture": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "byte_order": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "cpu_type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "creation_date": {
+                  "type": "date"
+                },
+                "exports": {
+                  "type": "flattened"
+                },
+                "header": {
+                  "properties": {
+                    "abi_version": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "class": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "data": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "entrypoint": {
+                      "type": "long"
+                    },
+                    "object_version": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "os_abi": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "type": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "version": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "imports": {
+                  "type": "flattened"
+                },
+                "sections": {
+                  "properties": {
+                    "chi2": {
+                      "type": "long"
+                    },
+                    "entropy": {
+                      "type": "long"
+                    },
+                    "flags": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "physical_offset": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "physical_size": {
+                      "type": "long"
+                    },
+                    "type": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "virtual_address": {
+                      "type": "long"
+                    },
+                    "virtual_size": {
+                      "type": "long"
+                    }
+                  },
+                  "type": "nested"
+                },
+                "segments": {
+                  "properties": {
+                    "sections": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "type": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  },
+                  "type": "nested"
+                },
+                "shared_libraries": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "telfhash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "extension": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "fork_name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "gid": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "group": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "hash": {
+              "properties": {
+                "md5": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "sha1": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "sha256": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "sha384": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "sha512": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "ssdeep": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "tlsh": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "inode": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "mime_type": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "mode": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "mtime": {
+              "type": "date"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "owner": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "path": {
+              "fields": {
+                "text": {
+                  "type": "match_only_text"
+                }
+              },
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "pe": {
+              "properties": {
+                "architecture": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "company": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "description": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "file_version": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "imphash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "original_file_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "pehash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "product": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "size": {
+              "type": "long"
+            },
+            "target_path": {
+              "fields": {
+                "text": {
+                  "type": "match_only_text"
+                }
+              },
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "type": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "uid": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "x509": {
+              "properties": {
+                "alternative_names": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "issuer": {
+                  "properties": {
+                    "common_name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "country": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "distinguished_name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "locality": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "organization": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "organizational_unit": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "state_or_province": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "not_after": {
+                  "type": "date"
+                },
+                "not_before": {
+                  "type": "date"
+                },
+                "public_key_algorithm": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "public_key_curve": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "public_key_exponent": {
+                  "type": "long"
+                },
+                "public_key_size": {
+                  "type": "long"
+                },
+                "serial_number": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "signature_algorithm": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "subject": {
+                  "properties": {
+                    "common_name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "country": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "distinguished_name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "locality": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "organization": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "organizational_unit": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "state_or_province": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "version_number": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            }
+          }
+        },
+        "group": {
+          "properties": {
+            "domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "host": {
+          "properties": {
+            "architecture": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "boot": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "cpu": {
+              "properties": {
+                "usage": {
+                  "scaling_factor": 1000,
+                  "type": "scaled_float"
+                }
+              }
+            },
+            "disk": {
+              "properties": {
+                "read": {
+                  "properties": {
+                    "bytes": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "write": {
+                  "properties": {
+                    "bytes": {
+                      "type": "long"
+                    }
+                  }
+                }
+              }
+            },
+            "domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "geo": {
+              "properties": {
+                "city_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "continent_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "continent_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "country_iso_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "country_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "location": {
+                  "type": "geo_point"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "postal_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "region_iso_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "region_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "timezone": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "hostname": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "ip": {
+              "type": "ip"
+            },
+            "mac": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "network": {
+              "properties": {
+                "egress": {
+                  "properties": {
+                    "bytes": {
+                      "type": "long"
+                    },
+                    "packets": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "ingress": {
+                  "properties": {
+                    "bytes": {
+                      "type": "long"
+                    },
+                    "packets": {
+                      "type": "long"
+                    }
+                  }
+                }
+              }
+            },
+            "os": {
+              "properties": {
+                "family": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "full": {
+                  "fields": {
+                    "text": {
+                      "type": "match_only_text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "kernel": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "fields": {
+                    "text": {
+                      "type": "match_only_text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "platform": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "version": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "pid_ns_ino": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "risk": {
+              "properties": {
+                "calculated_level": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "calculated_score": {
+                  "type": "float"
+                },
+                "calculated_score_norm": {
+                  "type": "float"
+                },
+                "static_level": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "static_score": {
+                  "type": "float"
+                },
+                "static_score_norm": {
+                  "type": "float"
+                }
+              }
+            },
+            "type": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "uptime": {
+              "type": "long"
+            }
+          }
+        },
+        "http": {
+          "properties": {
+            "request": {
+              "properties": {
+                "body": {
+                  "properties": {
+                    "bytes": {
+                      "type": "long"
+                    },
+                    "content": {
+                      "fields": {
+                        "text": {
+                          "type": "match_only_text"
+                        }
+                      },
+                      "type": "wildcard"
+                    }
+                  }
+                },
+                "bytes": {
+                  "type": "long"
+                },
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "method": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "mime_type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "referrer": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "response": {
+              "properties": {
+                "body": {
+                  "properties": {
+                    "bytes": {
+                      "type": "long"
+                    },
+                    "content": {
+                      "fields": {
+                        "text": {
+                          "type": "match_only_text"
+                        }
+                      },
+                      "type": "wildcard"
+                    }
+                  }
+                },
+                "bytes": {
+                  "type": "long"
+                },
+                "mime_type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "status_code": {
+                  "type": "long"
+                }
+              }
+            },
+            "version": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "kibana": {
+          "properties": {
+            "alert": {
+              "properties": {
+                "action_group": {
+                  "type": "keyword"
+                },
+                "ancestors": {
+                  "properties": {
+                    "depth": {
+                      "type": "long"
+                    },
+                    "id": {
+                      "type": "keyword"
+                    },
+                    "index": {
+                      "type": "keyword"
+                    },
+                    "rule": {
+                      "type": "keyword"
+                    },
+                    "type": {
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "building_block_type": {
+                  "type": "keyword"
+                },
+                "case_ids": {
+                  "type": "keyword"
+                },
+                "depth": {
+                  "type": "long"
+                },
+                "duration": {
+                  "properties": {
+                    "us": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "end": {
+                  "type": "date"
+                },
+                "flapping": {
+                  "type": "boolean"
+                },
+                "flapping_history": {
+                  "type": "boolean"
+                },
+                "group": {
+                  "properties": {
+                    "id": {
+                      "type": "keyword"
+                    },
+                    "index": {
+                      "type": "integer"
+                    }
+                  }
+                },
+                "instance": {
+                  "properties": {
+                    "id": {
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "last_detected": {
+                  "type": "date"
+                },
+                "maintenance_window_ids": {
+                  "type": "keyword"
+                },
+                "new_terms": {
+                  "type": "keyword"
+                },
+                "original_event": {
+                  "properties": {
+                    "action": {
+                      "type": "keyword"
+                    },
+                    "agent_id_status": {
+                      "type": "keyword"
+                    },
+                    "category": {
+                      "type": "keyword"
+                    },
+                    "code": {
+                      "type": "keyword"
+                    },
+                    "created": {
+                      "type": "date"
+                    },
+                    "dataset": {
+                      "type": "keyword"
+                    },
+                    "duration": {
+                      "type": "keyword"
+                    },
+                    "end": {
+                      "type": "date"
+                    },
+                    "hash": {
+                      "type": "keyword"
+                    },
+                    "id": {
+                      "type": "keyword"
+                    },
+                    "ingested": {
+                      "type": "date"
+                    },
+                    "kind": {
+                      "type": "keyword"
+                    },
+                    "module": {
+                      "type": "keyword"
+                    },
+                    "original": {
+                      "type": "keyword"
+                    },
+                    "outcome": {
+                      "type": "keyword"
+                    },
+                    "provider": {
+                      "type": "keyword"
+                    },
+                    "reason": {
+                      "type": "keyword"
+                    },
+                    "reference": {
+                      "type": "keyword"
+                    },
+                    "risk_score": {
+                      "type": "float"
+                    },
+                    "risk_score_norm": {
+                      "type": "float"
+                    },
+                    "sequence": {
+                      "type": "long"
+                    },
+                    "severity": {
+                      "type": "long"
+                    },
+                    "start": {
+                      "type": "date"
+                    },
+                    "timezone": {
+                      "type": "keyword"
+                    },
+                    "type": {
+                      "type": "keyword"
+                    },
+                    "url": {
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "original_time": {
+                  "type": "date"
+                },
+                "reason": {
+                  "type": "keyword"
+                },
+                "risk_score": {
+                  "type": "float"
+                },
+                "rule": {
+                  "properties": {
+                    "author": {
+                      "type": "keyword"
+                    },
+                    "building_block_type": {
+                      "type": "keyword"
+                    },
+                    "category": {
+                      "type": "keyword"
+                    },
+                    "consumer": {
+                      "type": "keyword"
+                    },
+                    "created_at": {
+                      "type": "date"
+                    },
+                    "created_by": {
+                      "type": "keyword"
+                    },
+                    "description": {
+                      "type": "keyword"
+                    },
+                    "enabled": {
+                      "type": "keyword"
+                    },
+                    "exceptions_list": {
+                      "type": "object"
+                    },
+                    "execution": {
+                      "properties": {
+                        "uuid": {
+                          "type": "keyword"
+                        }
+                      }
+                    },
+                    "false_positives": {
+                      "type": "keyword"
+                    },
+                    "from": {
+                      "type": "keyword"
+                    },
+                    "immutable": {
+                      "type": "keyword"
+                    },
+                    "interval": {
+                      "type": "keyword"
+                    },
+                    "license": {
+                      "type": "keyword"
+                    },
+                    "max_signals": {
+                      "type": "long"
+                    },
+                    "name": {
+                      "type": "keyword"
+                    },
+                    "note": {
+                      "type": "keyword"
+                    },
+                    "parameters": {
+                      "ignore_above": 4096,
+                      "type": "flattened"
+                    },
+                    "producer": {
+                      "type": "keyword"
+                    },
+                    "references": {
+                      "type": "keyword"
+                    },
+                    "revision": {
+                      "type": "long"
+                    },
+                    "rule_id": {
+                      "type": "keyword"
+                    },
+                    "rule_name_override": {
+                      "type": "keyword"
+                    },
+                    "rule_type_id": {
+                      "type": "keyword"
+                    },
+                    "tags": {
+                      "type": "keyword"
+                    },
+                    "threat": {
+                      "properties": {
+                        "framework": {
+                          "type": "keyword"
+                        },
+                        "tactic": {
+                          "properties": {
+                            "id": {
+                              "type": "keyword"
+                            },
+                            "name": {
+                              "type": "keyword"
+                            },
+                            "reference": {
+                              "type": "keyword"
+                            }
+                          }
+                        },
+                        "technique": {
+                          "properties": {
+                            "id": {
+                              "type": "keyword"
+                            },
+                            "name": {
+                              "type": "keyword"
+                            },
+                            "reference": {
+                              "type": "keyword"
+                            },
+                            "subtechnique": {
+                              "properties": {
+                                "id": {
+                                  "type": "keyword"
+                                },
+                                "name": {
+                                  "type": "keyword"
+                                },
+                                "reference": {
+                                  "type": "keyword"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "timeline_id": {
+                      "type": "keyword"
+                    },
+                    "timeline_title": {
+                      "type": "keyword"
+                    },
+                    "timestamp_override": {
+                      "type": "keyword"
+                    },
+                    "to": {
+                      "type": "keyword"
+                    },
+                    "type": {
+                      "type": "keyword"
+                    },
+                    "updated_at": {
+                      "type": "date"
+                    },
+                    "updated_by": {
+                      "type": "keyword"
+                    },
+                    "uuid": {
+                      "type": "keyword"
+                    },
+                    "version": {
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "severity": {
+                  "type": "keyword"
+                },
+                "start": {
+                  "type": "date"
+                },
+                "status": {
+                  "type": "keyword"
+                },
+                "suppression": {
+                  "properties": {
+                    "docs_count": {
+                      "type": "long"
+                    },
+                    "end": {
+                      "type": "date"
+                    },
+                    "start": {
+                      "type": "date"
+                    },
+                    "terms": {
+                      "properties": {
+                        "field": {
+                          "type": "keyword"
+                        },
+                        "value": {
+                          "type": "keyword"
+                        }
+                      }
+                    }
+                  }
+                },
+                "system_status": {
+                  "type": "keyword"
+                },
+                "threshold_result": {
+                  "properties": {
+                    "cardinality": {
+                      "properties": {
+                        "field": {
+                          "type": "keyword"
+                        },
+                        "value": {
+                          "type": "long"
+                        }
+                      }
+                    },
+                    "count": {
+                      "type": "long"
+                    },
+                    "from": {
+                      "type": "date"
+                    },
+                    "terms": {
+                      "properties": {
+                        "field": {
+                          "type": "keyword"
+                        },
+                        "value": {
+                          "type": "keyword"
+                        }
+                      }
+                    }
+                  }
+                },
+                "time_range": {
+                  "format": "epoch_millis||strict_date_optional_time",
+                  "type": "date_range"
+                },
+                "url": {
+                  "ignore_above": 2048,
+                  "index": false,
+                  "type": "keyword"
+                },
+                "uuid": {
+                  "type": "keyword"
+                },
+                "workflow_reason": {
+                  "type": "keyword"
+                },
+                "workflow_status": {
+                  "type": "keyword"
+                },
+                "workflow_user": {
+                  "type": "keyword"
+                }
+              }
+            },
+            "space_ids": {
+              "type": "keyword"
+            },
+            "version": {
+              "type": "version"
+            }
+          }
+        },
+        "labels": {
+          "type": "object"
+        },
+        "log": {
+          "properties": {
+            "file": {
+              "properties": {
+                "path": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "level": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "logger": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "origin": {
+              "properties": {
+                "file": {
+                  "properties": {
+                    "line": {
+                      "type": "long"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "function": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "syslog": {
+              "properties": {
+                "appname": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "facility": {
+                  "properties": {
+                    "code": {
+                      "type": "long"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "hostname": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "msgid": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "priority": {
+                  "type": "long"
+                },
+                "procid": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "severity": {
+                  "properties": {
+                    "code": {
+                      "type": "long"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "structured_data": {
+                  "type": "flattened"
+                },
+                "version": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            }
+          }
+        },
+        "message": {
+          "type": "match_only_text"
+        },
+        "network": {
+          "properties": {
+            "application": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "bytes": {
+              "type": "long"
+            },
+            "community_id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "direction": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "forwarded_ip": {
+              "type": "ip"
+            },
+            "iana_number": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "inner": {
+              "properties": {
+                "vlan": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                }
+              }
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "packets": {
+              "type": "long"
+            },
+            "protocol": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "transport": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "type": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "vlan": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            }
+          }
+        },
+        "observer": {
+          "properties": {
+            "egress": {
+              "properties": {
+                "interface": {
+                  "properties": {
+                    "alias": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "vlan": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "zone": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "geo": {
+              "properties": {
+                "city_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "continent_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "continent_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "country_iso_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "country_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "location": {
+                  "type": "geo_point"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "postal_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "region_iso_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "region_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "timezone": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "hostname": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "ingress": {
+              "properties": {
+                "interface": {
+                  "properties": {
+                    "alias": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "vlan": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "zone": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "ip": {
+              "type": "ip"
+            },
+            "mac": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "os": {
+              "properties": {
+                "family": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "full": {
+                  "fields": {
+                    "text": {
+                      "type": "match_only_text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "kernel": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "fields": {
+                    "text": {
+                      "type": "match_only_text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "platform": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "version": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "product": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "serial_number": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "type": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "vendor": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "version": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "orchestrator": {
+          "properties": {
+            "api_version": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "cluster": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "url": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "version": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "namespace": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "organization": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "resource": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "ip": {
+                  "type": "ip"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "parent": {
+                  "properties": {
+                    "type": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "type": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "organization": {
+          "properties": {
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "name": {
+              "fields": {
+                "text": {
+                  "type": "match_only_text"
+                }
+              },
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "package": {
+          "properties": {
+            "architecture": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "build_version": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "checksum": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "description": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "install_scope": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "installed": {
+              "type": "date"
+            },
+            "license": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "path": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "reference": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "size": {
+              "type": "long"
+            },
+            "type": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "version": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "process": {
+          "properties": {
+            "args": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "args_count": {
+              "type": "long"
+            },
+            "code_signature": {
+              "properties": {
+                "digest_algorithm": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "exists": {
+                  "type": "boolean"
+                },
+                "signing_id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "status": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "subject_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "team_id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "timestamp": {
+                  "type": "date"
+                },
+                "trusted": {
+                  "type": "boolean"
+                },
+                "valid": {
+                  "type": "boolean"
+                }
+              }
+            },
+            "command_line": {
+              "fields": {
+                "text": {
+                  "type": "match_only_text"
+                }
+              },
+              "type": "wildcard"
+            },
+            "elf": {
+              "properties": {
+                "architecture": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "byte_order": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "cpu_type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "creation_date": {
+                  "type": "date"
+                },
+                "exports": {
+                  "type": "flattened"
+                },
+                "header": {
+                  "properties": {
+                    "abi_version": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "class": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "data": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "entrypoint": {
+                      "type": "long"
+                    },
+                    "object_version": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "os_abi": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "type": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "version": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "imports": {
+                  "type": "flattened"
+                },
+                "sections": {
+                  "properties": {
+                    "chi2": {
+                      "type": "long"
+                    },
+                    "entropy": {
+                      "type": "long"
+                    },
+                    "flags": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "physical_offset": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "physical_size": {
+                      "type": "long"
+                    },
+                    "type": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "virtual_address": {
+                      "type": "long"
+                    },
+                    "virtual_size": {
+                      "type": "long"
+                    }
+                  },
+                  "type": "nested"
+                },
+                "segments": {
+                  "properties": {
+                    "sections": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "type": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  },
+                  "type": "nested"
+                },
+                "shared_libraries": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "telfhash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "end": {
+              "type": "date"
+            },
+            "entity_id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "entry_leader": {
+              "properties": {
+                "args": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "args_count": {
+                  "type": "long"
+                },
+                "attested_groups": {
+                  "properties": {
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "attested_user": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "fields": {
+                        "text": {
+                          "type": "match_only_text"
+                        }
+                      },
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "command_line": {
+                  "fields": {
+                    "text": {
+                      "type": "match_only_text"
+                    }
+                  },
+                  "type": "wildcard"
+                },
+                "entity_id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "entry_meta": {
+                  "properties": {
+                    "source": {
+                      "properties": {
+                        "ip": {
+                          "type": "ip"
+                        }
+                      }
+                    },
+                    "type": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "executable": {
+                  "fields": {
+                    "text": {
+                      "type": "match_only_text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "group": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "interactive": {
+                  "type": "boolean"
+                },
+                "name": {
+                  "fields": {
+                    "text": {
+                      "type": "match_only_text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "parent": {
+                  "properties": {
+                    "entity_id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "pid": {
+                      "type": "long"
+                    },
+                    "session_leader": {
+                      "properties": {
+                        "entity_id": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "pid": {
+                          "type": "long"
+                        },
+                        "start": {
+                          "type": "date"
+                        }
+                      }
+                    },
+                    "start": {
+                      "type": "date"
+                    }
+                  }
+                },
+                "pid": {
+                  "type": "long"
+                },
+                "real_group": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "real_user": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "fields": {
+                        "text": {
+                          "type": "match_only_text"
+                        }
+                      },
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "same_as_process": {
+                  "type": "boolean"
+                },
+                "saved_group": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "saved_user": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "fields": {
+                        "text": {
+                          "type": "match_only_text"
+                        }
+                      },
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "start": {
+                  "type": "date"
+                },
+                "supplemental_groups": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "tty": {
+                  "properties": {
+                    "char_device": {
+                      "properties": {
+                        "major": {
+                          "type": "long"
+                        },
+                        "minor": {
+                          "type": "long"
+                        }
+                      }
+                    }
+                  }
+                },
+                "user": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "fields": {
+                        "text": {
+                          "type": "match_only_text"
+                        }
+                      },
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "working_directory": {
+                  "fields": {
+                    "text": {
+                      "type": "match_only_text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "env_vars": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "executable": {
+              "fields": {
+                "text": {
+                  "type": "match_only_text"
+                }
+              },
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "exit_code": {
+              "type": "long"
+            },
+            "group_leader": {
+              "properties": {
+                "args": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "args_count": {
+                  "type": "long"
+                },
+                "command_line": {
+                  "fields": {
+                    "text": {
+                      "type": "match_only_text"
+                    }
+                  },
+                  "type": "wildcard"
+                },
+                "entity_id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "executable": {
+                  "fields": {
+                    "text": {
+                      "type": "match_only_text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "group": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "interactive": {
+                  "type": "boolean"
+                },
+                "name": {
+                  "fields": {
+                    "text": {
+                      "type": "match_only_text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "pid": {
+                  "type": "long"
+                },
+                "real_group": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "real_user": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "fields": {
+                        "text": {
+                          "type": "match_only_text"
+                        }
+                      },
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "same_as_process": {
+                  "type": "boolean"
+                },
+                "saved_group": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "saved_user": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "fields": {
+                        "text": {
+                          "type": "match_only_text"
+                        }
+                      },
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "start": {
+                  "type": "date"
+                },
+                "supplemental_groups": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "tty": {
+                  "properties": {
+                    "char_device": {
+                      "properties": {
+                        "major": {
+                          "type": "long"
+                        },
+                        "minor": {
+                          "type": "long"
+                        }
+                      }
+                    }
+                  }
+                },
+                "user": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "fields": {
+                        "text": {
+                          "type": "match_only_text"
+                        }
+                      },
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "working_directory": {
+                  "fields": {
+                    "text": {
+                      "type": "match_only_text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "hash": {
+              "properties": {
+                "md5": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "sha1": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "sha256": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "sha384": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "sha512": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "ssdeep": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "tlsh": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "interactive": {
+              "type": "boolean"
+            },
+            "io": {
+              "properties": {
+                "bytes_skipped": {
+                  "properties": {
+                    "length": {
+                      "type": "long"
+                    },
+                    "offset": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "max_bytes_per_process_exceeded": {
+                  "type": "boolean"
+                },
+                "text": {
+                  "type": "wildcard"
+                },
+                "total_bytes_captured": {
+                  "type": "long"
+                },
+                "total_bytes_skipped": {
+                  "type": "long"
+                },
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "name": {
+              "fields": {
+                "text": {
+                  "type": "match_only_text"
+                }
+              },
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "parent": {
+              "properties": {
+                "args": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "args_count": {
+                  "type": "long"
+                },
+                "code_signature": {
+                  "properties": {
+                    "digest_algorithm": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "exists": {
+                      "type": "boolean"
+                    },
+                    "signing_id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "status": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "subject_name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "team_id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "timestamp": {
+                      "type": "date"
+                    },
+                    "trusted": {
+                      "type": "boolean"
+                    },
+                    "valid": {
+                      "type": "boolean"
+                    }
+                  }
+                },
+                "command_line": {
+                  "fields": {
+                    "text": {
+                      "type": "match_only_text"
+                    }
+                  },
+                  "type": "wildcard"
+                },
+                "elf": {
+                  "properties": {
+                    "architecture": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "byte_order": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "cpu_type": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "creation_date": {
+                      "type": "date"
+                    },
+                    "exports": {
+                      "type": "flattened"
+                    },
+                    "header": {
+                      "properties": {
+                        "abi_version": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "class": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "data": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "entrypoint": {
+                          "type": "long"
+                        },
+                        "object_version": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "os_abi": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "type": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "version": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
+                    },
+                    "imports": {
+                      "type": "flattened"
+                    },
+                    "sections": {
+                      "properties": {
+                        "chi2": {
+                          "type": "long"
+                        },
+                        "entropy": {
+                          "type": "long"
+                        },
+                        "flags": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "physical_offset": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "physical_size": {
+                          "type": "long"
+                        },
+                        "type": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "virtual_address": {
+                          "type": "long"
+                        },
+                        "virtual_size": {
+                          "type": "long"
+                        }
+                      },
+                      "type": "nested"
+                    },
+                    "segments": {
+                      "properties": {
+                        "sections": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "type": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      },
+                      "type": "nested"
+                    },
+                    "shared_libraries": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "telfhash": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "end": {
+                  "type": "date"
+                },
+                "entity_id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "executable": {
+                  "fields": {
+                    "text": {
+                      "type": "match_only_text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "exit_code": {
+                  "type": "long"
+                },
+                "group": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "group_leader": {
+                  "properties": {
+                    "entity_id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "pid": {
+                      "type": "long"
+                    },
+                    "start": {
+                      "type": "date"
+                    }
+                  }
+                },
+                "hash": {
+                  "properties": {
+                    "md5": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "sha1": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "sha256": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "sha384": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "sha512": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "ssdeep": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "tlsh": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "interactive": {
+                  "type": "boolean"
+                },
+                "name": {
+                  "fields": {
+                    "text": {
+                      "type": "match_only_text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "pe": {
+                  "properties": {
+                    "architecture": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "company": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "description": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "file_version": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "imphash": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "original_file_name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "pehash": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "product": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "pgid": {
+                  "type": "long"
+                },
+                "pid": {
+                  "type": "long"
+                },
+                "real_group": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "real_user": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "fields": {
+                        "text": {
+                          "type": "match_only_text"
+                        }
+                      },
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "saved_group": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "saved_user": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "fields": {
+                        "text": {
+                          "type": "match_only_text"
+                        }
+                      },
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "start": {
+                  "type": "date"
+                },
+                "supplemental_groups": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "thread": {
+                  "properties": {
+                    "id": {
+                      "type": "long"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "title": {
+                  "fields": {
+                    "text": {
+                      "type": "match_only_text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "tty": {
+                  "properties": {
+                    "char_device": {
+                      "properties": {
+                        "major": {
+                          "type": "long"
+                        },
+                        "minor": {
+                          "type": "long"
+                        }
+                      }
+                    }
+                  }
+                },
+                "uptime": {
+                  "type": "long"
+                },
+                "user": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "fields": {
+                        "text": {
+                          "type": "match_only_text"
+                        }
+                      },
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "working_directory": {
+                  "fields": {
+                    "text": {
+                      "type": "match_only_text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "pe": {
+              "properties": {
+                "architecture": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "company": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "description": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "file_version": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "imphash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "original_file_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "pehash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "product": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "pgid": {
+              "type": "long"
+            },
+            "pid": {
+              "type": "long"
+            },
+            "previous": {
+              "properties": {
+                "args": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "args_count": {
+                  "type": "long"
+                },
+                "executable": {
+                  "fields": {
+                    "text": {
+                      "type": "match_only_text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "real_group": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "real_user": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "fields": {
+                    "text": {
+                      "type": "match_only_text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "saved_group": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "saved_user": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "fields": {
+                    "text": {
+                      "type": "match_only_text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "session_leader": {
+              "properties": {
+                "args": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "args_count": {
+                  "type": "long"
+                },
+                "command_line": {
+                  "fields": {
+                    "text": {
+                      "type": "match_only_text"
+                    }
+                  },
+                  "type": "wildcard"
+                },
+                "entity_id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "executable": {
+                  "fields": {
+                    "text": {
+                      "type": "match_only_text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "group": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "interactive": {
+                  "type": "boolean"
+                },
+                "name": {
+                  "fields": {
+                    "text": {
+                      "type": "match_only_text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "parent": {
+                  "properties": {
+                    "entity_id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "pid": {
+                      "type": "long"
+                    },
+                    "session_leader": {
+                      "properties": {
+                        "entity_id": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "pid": {
+                          "type": "long"
+                        },
+                        "start": {
+                          "type": "date"
+                        }
+                      }
+                    },
+                    "start": {
+                      "type": "date"
+                    }
+                  }
+                },
+                "pid": {
+                  "type": "long"
+                },
+                "real_group": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "real_user": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "fields": {
+                        "text": {
+                          "type": "match_only_text"
+                        }
+                      },
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "same_as_process": {
+                  "type": "boolean"
+                },
+                "saved_group": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "saved_user": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "fields": {
+                        "text": {
+                          "type": "match_only_text"
+                        }
+                      },
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "start": {
+                  "type": "date"
+                },
+                "supplemental_groups": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "tty": {
+                  "properties": {
+                    "char_device": {
+                      "properties": {
+                        "major": {
+                          "type": "long"
+                        },
+                        "minor": {
+                          "type": "long"
+                        }
+                      }
+                    }
+                  }
+                },
+                "user": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "fields": {
+                        "text": {
+                          "type": "match_only_text"
+                        }
+                      },
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "working_directory": {
+                  "fields": {
+                    "text": {
+                      "type": "match_only_text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "start": {
+              "type": "date"
+            },
+            "supplemental_groups": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "thread": {
+              "properties": {
+                "id": {
+                  "type": "long"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "title": {
+              "fields": {
+                "text": {
+                  "type": "match_only_text"
+                }
+              },
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "tty": {
+              "properties": {
+                "char_device": {
+                  "properties": {
+                    "major": {
+                      "type": "long"
+                    },
+                    "minor": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "columns": {
+                  "type": "long"
+                },
+                "rows": {
+                  "type": "long"
+                }
+              }
+            },
+            "uptime": {
+              "type": "long"
+            },
+            "user": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "fields": {
+                    "text": {
+                      "type": "match_only_text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "working_directory": {
+              "fields": {
+                "text": {
+                  "type": "match_only_text"
+                }
+              },
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "registry": {
+          "properties": {
+            "data": {
+              "properties": {
+                "bytes": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "strings": {
+                  "type": "wildcard"
+                },
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "hive": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "key": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "path": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "value": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "related": {
+          "properties": {
+            "hash": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "hosts": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "ip": {
+              "type": "ip"
+            },
+            "user": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "rule": {
+          "properties": {
+            "author": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "category": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "description": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "license": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "reference": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "ruleset": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "uuid": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "version": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "server": {
+          "properties": {
+            "address": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "as": {
+              "properties": {
+                "number": {
+                  "type": "long"
+                },
+                "organization": {
+                  "properties": {
+                    "name": {
+                      "fields": {
+                        "text": {
+                          "type": "match_only_text"
+                        }
+                      },
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                }
+              }
+            },
+            "bytes": {
+              "type": "long"
+            },
+            "domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "geo": {
+              "properties": {
+                "city_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "continent_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "continent_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "country_iso_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "country_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "location": {
+                  "type": "geo_point"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "postal_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "region_iso_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "region_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "timezone": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "ip": {
+              "type": "ip"
+            },
+            "mac": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "nat": {
+              "properties": {
+                "ip": {
+                  "type": "ip"
+                },
+                "port": {
+                  "type": "long"
+                }
+              }
+            },
+            "packets": {
+              "type": "long"
+            },
+            "port": {
+              "type": "long"
+            },
+            "registered_domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "subdomain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "top_level_domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "user": {
+              "properties": {
+                "domain": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "email": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "full_name": {
+                  "fields": {
+                    "text": {
+                      "type": "match_only_text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "group": {
+                  "properties": {
+                    "domain": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "hash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "fields": {
+                    "text": {
+                      "type": "match_only_text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "roles": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            }
+          }
+        },
+        "service": {
+          "properties": {
+            "address": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "environment": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "ephemeral_id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "node": {
+              "properties": {
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "role": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "roles": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "origin": {
+              "properties": {
+                "address": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "environment": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "ephemeral_id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "node": {
+                  "properties": {
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "role": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "roles": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "state": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "version": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "state": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "target": {
+              "properties": {
+                "address": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "environment": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "ephemeral_id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "node": {
+                  "properties": {
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "role": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "roles": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "state": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "version": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "type": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "version": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "signal": {
+          "properties": {
+            "ancestors": {
+              "properties": {
+                "depth": {
+                  "path": "kibana.alert.ancestors.depth",
+                  "type": "alias"
+                },
+                "id": {
+                  "path": "kibana.alert.ancestors.id",
+                  "type": "alias"
+                },
+                "index": {
+                  "path": "kibana.alert.ancestors.index",
+                  "type": "alias"
+                },
+                "type": {
+                  "path": "kibana.alert.ancestors.type",
+                  "type": "alias"
+                }
+              }
+            },
+            "depth": {
+              "path": "kibana.alert.depth",
+              "type": "alias"
+            },
+            "group": {
+              "properties": {
+                "id": {
+                  "path": "kibana.alert.group.id",
+                  "type": "alias"
+                },
+                "index": {
+                  "path": "kibana.alert.group.index",
+                  "type": "alias"
+                }
+              }
+            },
+            "original_event": {
+              "properties": {
+                "action": {
+                  "path": "kibana.alert.original_event.action",
+                  "type": "alias"
+                },
+                "category": {
+                  "path": "kibana.alert.original_event.category",
+                  "type": "alias"
+                },
+                "code": {
+                  "path": "kibana.alert.original_event.code",
+                  "type": "alias"
+                },
+                "created": {
+                  "path": "kibana.alert.original_event.created",
+                  "type": "alias"
+                },
+                "dataset": {
+                  "path": "kibana.alert.original_event.dataset",
+                  "type": "alias"
+                },
+                "duration": {
+                  "path": "kibana.alert.original_event.duration",
+                  "type": "alias"
+                },
+                "end": {
+                  "path": "kibana.alert.original_event.end",
+                  "type": "alias"
+                },
+                "hash": {
+                  "path": "kibana.alert.original_event.hash",
+                  "type": "alias"
+                },
+                "id": {
+                  "path": "kibana.alert.original_event.id",
+                  "type": "alias"
+                },
+                "kind": {
+                  "path": "kibana.alert.original_event.kind",
+                  "type": "alias"
+                },
+                "module": {
+                  "path": "kibana.alert.original_event.module",
+                  "type": "alias"
+                },
+                "outcome": {
+                  "path": "kibana.alert.original_event.outcome",
+                  "type": "alias"
+                },
+                "provider": {
+                  "path": "kibana.alert.original_event.provider",
+                  "type": "alias"
+                },
+                "reason": {
+                  "path": "kibana.alert.original_event.reason",
+                  "type": "alias"
+                },
+                "risk_score": {
+                  "path": "kibana.alert.original_event.risk_score",
+                  "type": "alias"
+                },
+                "risk_score_norm": {
+                  "path": "kibana.alert.original_event.risk_score_norm",
+                  "type": "alias"
+                },
+                "sequence": {
+                  "path": "kibana.alert.original_event.sequence",
+                  "type": "alias"
+                },
+                "severity": {
+                  "path": "kibana.alert.original_event.severity",
+                  "type": "alias"
+                },
+                "start": {
+                  "path": "kibana.alert.original_event.start",
+                  "type": "alias"
+                },
+                "timezone": {
+                  "path": "kibana.alert.original_event.timezone",
+                  "type": "alias"
+                },
+                "type": {
+                  "path": "kibana.alert.original_event.type",
+                  "type": "alias"
+                }
+              }
+            },
+            "original_time": {
+              "path": "kibana.alert.original_time",
+              "type": "alias"
+            },
+            "reason": {
+              "path": "kibana.alert.reason",
+              "type": "alias"
+            },
+            "rule": {
+              "properties": {
+                "author": {
+                  "path": "kibana.alert.rule.author",
+                  "type": "alias"
+                },
+                "building_block_type": {
+                  "path": "kibana.alert.building_block_type",
+                  "type": "alias"
+                },
+                "created_at": {
+                  "path": "kibana.alert.rule.created_at",
+                  "type": "alias"
+                },
+                "created_by": {
+                  "path": "kibana.alert.rule.created_by",
+                  "type": "alias"
+                },
+                "description": {
+                  "path": "kibana.alert.rule.description",
+                  "type": "alias"
+                },
+                "enabled": {
+                  "path": "kibana.alert.rule.enabled",
+                  "type": "alias"
+                },
+                "false_positives": {
+                  "path": "kibana.alert.rule.false_positives",
+                  "type": "alias"
+                },
+                "from": {
+                  "path": "kibana.alert.rule.from",
+                  "type": "alias"
+                },
+                "id": {
+                  "path": "kibana.alert.rule.uuid",
+                  "type": "alias"
+                },
+                "immutable": {
+                  "path": "kibana.alert.rule.immutable",
+                  "type": "alias"
+                },
+                "interval": {
+                  "path": "kibana.alert.rule.interval",
+                  "type": "alias"
+                },
+                "license": {
+                  "path": "kibana.alert.rule.license",
+                  "type": "alias"
+                },
+                "max_signals": {
+                  "path": "kibana.alert.rule.max_signals",
+                  "type": "alias"
+                },
+                "name": {
+                  "path": "kibana.alert.rule.name",
+                  "type": "alias"
+                },
+                "note": {
+                  "path": "kibana.alert.rule.note",
+                  "type": "alias"
+                },
+                "references": {
+                  "path": "kibana.alert.rule.references",
+                  "type": "alias"
+                },
+                "risk_score": {
+                  "path": "kibana.alert.risk_score",
+                  "type": "alias"
+                },
+                "rule_id": {
+                  "path": "kibana.alert.rule.rule_id",
+                  "type": "alias"
+                },
+                "rule_name_override": {
+                  "path": "kibana.alert.rule.rule_name_override",
+                  "type": "alias"
+                },
+                "severity": {
+                  "path": "kibana.alert.severity",
+                  "type": "alias"
+                },
+                "tags": {
+                  "path": "kibana.alert.rule.tags",
+                  "type": "alias"
+                },
+                "threat": {
+                  "properties": {
+                    "framework": {
+                      "path": "kibana.alert.rule.threat.framework",
+                      "type": "alias"
+                    },
+                    "tactic": {
+                      "properties": {
+                        "id": {
+                          "path": "kibana.alert.rule.threat.tactic.id",
+                          "type": "alias"
+                        },
+                        "name": {
+                          "path": "kibana.alert.rule.threat.tactic.name",
+                          "type": "alias"
+                        },
+                        "reference": {
+                          "path": "kibana.alert.rule.threat.tactic.reference",
+                          "type": "alias"
+                        }
+                      }
+                    },
+                    "technique": {
+                      "properties": {
+                        "id": {
+                          "path": "kibana.alert.rule.threat.technique.id",
+                          "type": "alias"
+                        },
+                        "name": {
+                          "path": "kibana.alert.rule.threat.technique.name",
+                          "type": "alias"
+                        },
+                        "reference": {
+                          "path": "kibana.alert.rule.threat.technique.reference",
+                          "type": "alias"
+                        },
+                        "subtechnique": {
+                          "properties": {
+                            "id": {
+                              "path": "kibana.alert.rule.threat.technique.subtechnique.id",
+                              "type": "alias"
+                            },
+                            "name": {
+                              "path": "kibana.alert.rule.threat.technique.subtechnique.name",
+                              "type": "alias"
+                            },
+                            "reference": {
+                              "path": "kibana.alert.rule.threat.technique.subtechnique.reference",
+                              "type": "alias"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "timeline_id": {
+                  "path": "kibana.alert.rule.timeline_id",
+                  "type": "alias"
+                },
+                "timeline_title": {
+                  "path": "kibana.alert.rule.timeline_title",
+                  "type": "alias"
+                },
+                "timestamp_override": {
+                  "path": "kibana.alert.rule.timestamp_override",
+                  "type": "alias"
+                },
+                "to": {
+                  "path": "kibana.alert.rule.to",
+                  "type": "alias"
+                },
+                "type": {
+                  "path": "kibana.alert.rule.type",
+                  "type": "alias"
+                },
+                "updated_at": {
+                  "path": "kibana.alert.rule.updated_at",
+                  "type": "alias"
+                },
+                "updated_by": {
+                  "path": "kibana.alert.rule.updated_by",
+                  "type": "alias"
+                },
+                "version": {
+                  "path": "kibana.alert.rule.version",
+                  "type": "alias"
+                }
+              }
+            },
+            "status": {
+              "path": "kibana.alert.workflow_status",
+              "type": "alias"
+            },
+            "threshold_result": {
+              "properties": {
+                "cardinality": {
+                  "properties": {
+                    "field": {
+                      "path": "kibana.alert.threshold_result.cardinality.field",
+                      "type": "alias"
+                    },
+                    "value": {
+                      "path": "kibana.alert.threshold_result.cardinality.value",
+                      "type": "alias"
+                    }
+                  }
+                },
+                "count": {
+                  "path": "kibana.alert.threshold_result.count",
+                  "type": "alias"
+                },
+                "from": {
+                  "path": "kibana.alert.threshold_result.from",
+                  "type": "alias"
+                },
+                "terms": {
+                  "properties": {
+                    "field": {
+                      "path": "kibana.alert.threshold_result.terms.field",
+                      "type": "alias"
+                    },
+                    "value": {
+                      "path": "kibana.alert.threshold_result.terms.value",
+                      "type": "alias"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "source": {
+          "properties": {
+            "address": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "as": {
+              "properties": {
+                "number": {
+                  "type": "long"
+                },
+                "organization": {
+                  "properties": {
+                    "name": {
+                      "fields": {
+                        "text": {
+                          "type": "match_only_text"
+                        }
+                      },
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                }
+              }
+            },
+            "bytes": {
+              "type": "long"
+            },
+            "domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "geo": {
+              "properties": {
+                "city_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "continent_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "continent_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "country_iso_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "country_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "location": {
+                  "type": "geo_point"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "postal_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "region_iso_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "region_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "timezone": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "ip": {
+              "type": "ip"
+            },
+            "mac": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "nat": {
+              "properties": {
+                "ip": {
+                  "type": "ip"
+                },
+                "port": {
+                  "type": "long"
+                }
+              }
+            },
+            "packets": {
+              "type": "long"
+            },
+            "port": {
+              "type": "long"
+            },
+            "registered_domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "subdomain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "top_level_domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "user": {
+              "properties": {
+                "domain": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "email": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "full_name": {
+                  "fields": {
+                    "text": {
+                      "type": "match_only_text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "group": {
+                  "properties": {
+                    "domain": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "hash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "fields": {
+                    "text": {
+                      "type": "match_only_text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "roles": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            }
+          }
+        },
+        "span": {
+          "properties": {
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "tags": {
+          "type": "keyword"
+        },
+        "threat": {
+          "properties": {
+            "enrichments": {
+              "properties": {
+                "indicator": {
+                  "properties": {
+                    "as": {
+                      "properties": {
+                        "number": {
+                          "type": "long"
+                        },
+                        "organization": {
+                          "properties": {
+                            "name": {
+                              "fields": {
+                                "text": {
+                                  "type": "match_only_text"
+                                }
+                              },
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "confidence": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "description": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "email": {
+                      "properties": {
+                        "address": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
+                    },
+                    "file": {
+                      "properties": {
+                        "accessed": {
+                          "type": "date"
+                        },
+                        "attributes": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "code_signature": {
+                          "properties": {
+                            "digest_algorithm": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "exists": {
+                              "type": "boolean"
+                            },
+                            "signing_id": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "status": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "subject_name": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "team_id": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "timestamp": {
+                              "type": "date"
+                            },
+                            "trusted": {
+                              "type": "boolean"
+                            },
+                            "valid": {
+                              "type": "boolean"
+                            }
+                          }
+                        },
+                        "created": {
+                          "type": "date"
+                        },
+                        "ctime": {
+                          "type": "date"
+                        },
+                        "device": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "directory": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "drive_letter": {
+                          "ignore_above": 1,
+                          "type": "keyword"
+                        },
+                        "elf": {
+                          "properties": {
+                            "architecture": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "byte_order": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "cpu_type": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "creation_date": {
+                              "type": "date"
+                            },
+                            "exports": {
+                              "type": "flattened"
+                            },
+                            "header": {
+                              "properties": {
+                                "abi_version": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "class": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "data": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "entrypoint": {
+                                  "type": "long"
+                                },
+                                "object_version": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "os_abi": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "type": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "version": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                }
+                              }
+                            },
+                            "imports": {
+                              "type": "flattened"
+                            },
+                            "sections": {
+                              "properties": {
+                                "chi2": {
+                                  "type": "long"
+                                },
+                                "entropy": {
+                                  "type": "long"
+                                },
+                                "flags": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "name": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "physical_offset": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "physical_size": {
+                                  "type": "long"
+                                },
+                                "type": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "virtual_address": {
+                                  "type": "long"
+                                },
+                                "virtual_size": {
+                                  "type": "long"
+                                }
+                              },
+                              "type": "nested"
+                            },
+                            "segments": {
+                              "properties": {
+                                "sections": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "type": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                }
+                              },
+                              "type": "nested"
+                            },
+                            "shared_libraries": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "telfhash": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            }
+                          }
+                        },
+                        "extension": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "fork_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "gid": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "group": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "hash": {
+                          "properties": {
+                            "md5": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "sha1": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "sha256": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "sha384": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "sha512": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "ssdeep": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "tlsh": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            }
+                          }
+                        },
+                        "inode": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "mime_type": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "mode": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "mtime": {
+                          "type": "date"
+                        },
+                        "name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "owner": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "path": {
+                          "fields": {
+                            "text": {
+                              "type": "match_only_text"
+                            }
+                          },
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "pe": {
+                          "properties": {
+                            "architecture": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "company": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "description": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "file_version": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "imphash": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "original_file_name": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "pehash": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "product": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            }
+                          }
+                        },
+                        "size": {
+                          "type": "long"
+                        },
+                        "target_path": {
+                          "fields": {
+                            "text": {
+                              "type": "match_only_text"
+                            }
+                          },
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "type": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "uid": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "x509": {
+                          "properties": {
+                            "alternative_names": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "issuer": {
+                              "properties": {
+                                "common_name": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "country": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "distinguished_name": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "locality": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "organization": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "organizational_unit": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "state_or_province": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                }
+                              }
+                            },
+                            "not_after": {
+                              "type": "date"
+                            },
+                            "not_before": {
+                              "type": "date"
+                            },
+                            "public_key_algorithm": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "public_key_curve": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "public_key_exponent": {
+                              "type": "long"
+                            },
+                            "public_key_size": {
+                              "type": "long"
+                            },
+                            "serial_number": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "signature_algorithm": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "subject": {
+                              "properties": {
+                                "common_name": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "country": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "distinguished_name": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "locality": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "organization": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "organizational_unit": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "state_or_province": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                }
+                              }
+                            },
+                            "version_number": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "first_seen": {
+                      "type": "date"
+                    },
+                    "geo": {
+                      "properties": {
+                        "city_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "continent_code": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "continent_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "country_iso_code": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "country_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "location": {
+                          "type": "geo_point"
+                        },
+                        "name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "postal_code": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "region_iso_code": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "region_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "timezone": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
+                    },
+                    "ip": {
+                      "type": "ip"
+                    },
+                    "last_seen": {
+                      "type": "date"
+                    },
+                    "marking": {
+                      "properties": {
+                        "tlp": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "tlp_version": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
+                    },
+                    "modified_at": {
+                      "type": "date"
+                    },
+                    "port": {
+                      "type": "long"
+                    },
+                    "provider": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "reference": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "registry": {
+                      "properties": {
+                        "data": {
+                          "properties": {
+                            "bytes": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "strings": {
+                              "type": "wildcard"
+                            },
+                            "type": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            }
+                          }
+                        },
+                        "hive": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "key": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "path": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "value": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
+                    },
+                    "scanner_stats": {
+                      "type": "long"
+                    },
+                    "sightings": {
+                      "type": "long"
+                    },
+                    "type": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "url": {
+                      "properties": {
+                        "domain": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "extension": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "fragment": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "full": {
+                          "fields": {
+                            "text": {
+                              "type": "match_only_text"
+                            }
+                          },
+                          "type": "wildcard"
+                        },
+                        "original": {
+                          "fields": {
+                            "text": {
+                              "type": "match_only_text"
+                            }
+                          },
+                          "type": "wildcard"
+                        },
+                        "password": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "path": {
+                          "type": "wildcard"
+                        },
+                        "port": {
+                          "type": "long"
+                        },
+                        "query": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "registered_domain": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "scheme": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "subdomain": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "top_level_domain": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "username": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
+                    },
+                    "x509": {
+                      "properties": {
+                        "alternative_names": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "issuer": {
+                          "properties": {
+                            "common_name": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "country": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "distinguished_name": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "locality": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "organization": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "organizational_unit": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "state_or_province": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            }
+                          }
+                        },
+                        "not_after": {
+                          "type": "date"
+                        },
+                        "not_before": {
+                          "type": "date"
+                        },
+                        "public_key_algorithm": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "public_key_curve": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "public_key_exponent": {
+                          "type": "long"
+                        },
+                        "public_key_size": {
+                          "type": "long"
+                        },
+                        "serial_number": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "signature_algorithm": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "subject": {
+                          "properties": {
+                            "common_name": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "country": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "distinguished_name": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "locality": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "organization": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "organizational_unit": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "state_or_province": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            }
+                          }
+                        },
+                        "version_number": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
+                    }
+                  }
+                },
+                "matched": {
+                  "properties": {
+                    "atomic": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "field": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "index": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "occurred": {
+                      "type": "date"
+                    },
+                    "type": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                }
+              },
+              "type": "nested"
+            },
+            "feed": {
+              "properties": {
+                "dashboard_id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "description": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "reference": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "framework": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "group": {
+              "properties": {
+                "alias": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "reference": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "indicator": {
+              "properties": {
+                "as": {
+                  "properties": {
+                    "number": {
+                      "type": "long"
+                    },
+                    "organization": {
+                      "properties": {
+                        "name": {
+                          "fields": {
+                            "text": {
+                              "type": "match_only_text"
+                            }
+                          },
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
+                    }
+                  }
+                },
+                "confidence": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "description": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "email": {
+                  "properties": {
+                    "address": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "file": {
+                  "properties": {
+                    "accessed": {
+                      "type": "date"
+                    },
+                    "attributes": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "code_signature": {
+                      "properties": {
+                        "digest_algorithm": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "exists": {
+                          "type": "boolean"
+                        },
+                        "signing_id": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "status": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "subject_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "team_id": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "timestamp": {
+                          "type": "date"
+                        },
+                        "trusted": {
+                          "type": "boolean"
+                        },
+                        "valid": {
+                          "type": "boolean"
+                        }
+                      }
+                    },
+                    "created": {
+                      "type": "date"
+                    },
+                    "ctime": {
+                      "type": "date"
+                    },
+                    "device": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "directory": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "drive_letter": {
+                      "ignore_above": 1,
+                      "type": "keyword"
+                    },
+                    "elf": {
+                      "properties": {
+                        "architecture": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "byte_order": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "cpu_type": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "creation_date": {
+                          "type": "date"
+                        },
+                        "exports": {
+                          "type": "flattened"
+                        },
+                        "header": {
+                          "properties": {
+                            "abi_version": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "class": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "data": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "entrypoint": {
+                              "type": "long"
+                            },
+                            "object_version": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "os_abi": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "type": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "version": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            }
+                          }
+                        },
+                        "imports": {
+                          "type": "flattened"
+                        },
+                        "sections": {
+                          "properties": {
+                            "chi2": {
+                              "type": "long"
+                            },
+                            "entropy": {
+                              "type": "long"
+                            },
+                            "flags": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "name": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "physical_offset": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "physical_size": {
+                              "type": "long"
+                            },
+                            "type": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "virtual_address": {
+                              "type": "long"
+                            },
+                            "virtual_size": {
+                              "type": "long"
+                            }
+                          },
+                          "type": "nested"
+                        },
+                        "segments": {
+                          "properties": {
+                            "sections": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "type": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            }
+                          },
+                          "type": "nested"
+                        },
+                        "shared_libraries": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "telfhash": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
+                    },
+                    "extension": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "fork_name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "gid": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "group": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "hash": {
+                      "properties": {
+                        "md5": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "sha1": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "sha256": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "sha384": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "sha512": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "ssdeep": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "tlsh": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
+                    },
+                    "inode": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "mime_type": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "mode": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "mtime": {
+                      "type": "date"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "owner": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "path": {
+                      "fields": {
+                        "text": {
+                          "type": "match_only_text"
+                        }
+                      },
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "pe": {
+                      "properties": {
+                        "architecture": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "company": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "description": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "file_version": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "imphash": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "original_file_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "pehash": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "product": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
+                    },
+                    "size": {
+                      "type": "long"
+                    },
+                    "target_path": {
+                      "fields": {
+                        "text": {
+                          "type": "match_only_text"
+                        }
+                      },
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "type": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "uid": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "x509": {
+                      "properties": {
+                        "alternative_names": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "issuer": {
+                          "properties": {
+                            "common_name": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "country": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "distinguished_name": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "locality": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "organization": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "organizational_unit": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "state_or_province": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            }
+                          }
+                        },
+                        "not_after": {
+                          "type": "date"
+                        },
+                        "not_before": {
+                          "type": "date"
+                        },
+                        "public_key_algorithm": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "public_key_curve": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "public_key_exponent": {
+                          "type": "long"
+                        },
+                        "public_key_size": {
+                          "type": "long"
+                        },
+                        "serial_number": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "signature_algorithm": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "subject": {
+                          "properties": {
+                            "common_name": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "country": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "distinguished_name": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "locality": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "organization": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "organizational_unit": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "state_or_province": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            }
+                          }
+                        },
+                        "version_number": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
+                    }
+                  }
+                },
+                "first_seen": {
+                  "type": "date"
+                },
+                "geo": {
+                  "properties": {
+                    "city_name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "continent_code": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "continent_name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "country_iso_code": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "country_name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "location": {
+                      "type": "geo_point"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "postal_code": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "region_iso_code": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "region_name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "timezone": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "ip": {
+                  "type": "ip"
+                },
+                "last_seen": {
+                  "type": "date"
+                },
+                "marking": {
+                  "properties": {
+                    "tlp": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "tlp_version": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "modified_at": {
+                  "type": "date"
+                },
+                "port": {
+                  "type": "long"
+                },
+                "provider": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "reference": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "registry": {
+                  "properties": {
+                    "data": {
+                      "properties": {
+                        "bytes": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "strings": {
+                          "type": "wildcard"
+                        },
+                        "type": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
+                    },
+                    "hive": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "key": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "path": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "value": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "scanner_stats": {
+                  "type": "long"
+                },
+                "sightings": {
+                  "type": "long"
+                },
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "url": {
+                  "properties": {
+                    "domain": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "extension": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "fragment": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "full": {
+                      "fields": {
+                        "text": {
+                          "type": "match_only_text"
+                        }
+                      },
+                      "type": "wildcard"
+                    },
+                    "original": {
+                      "fields": {
+                        "text": {
+                          "type": "match_only_text"
+                        }
+                      },
+                      "type": "wildcard"
+                    },
+                    "password": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "path": {
+                      "type": "wildcard"
+                    },
+                    "port": {
+                      "type": "long"
+                    },
+                    "query": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "registered_domain": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "scheme": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "subdomain": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "top_level_domain": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "username": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "x509": {
+                  "properties": {
+                    "alternative_names": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "issuer": {
+                      "properties": {
+                        "common_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "country": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "distinguished_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "locality": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "organization": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "organizational_unit": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "state_or_province": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
+                    },
+                    "not_after": {
+                      "type": "date"
+                    },
+                    "not_before": {
+                      "type": "date"
+                    },
+                    "public_key_algorithm": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "public_key_curve": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "public_key_exponent": {
+                      "type": "long"
+                    },
+                    "public_key_size": {
+                      "type": "long"
+                    },
+                    "serial_number": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "signature_algorithm": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "subject": {
+                      "properties": {
+                        "common_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "country": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "distinguished_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "locality": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "organization": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "organizational_unit": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "state_or_province": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
+                    },
+                    "version_number": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                }
+              }
+            },
+            "software": {
+              "properties": {
+                "alias": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "platforms": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "reference": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "tactic": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "reference": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "technique": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "fields": {
+                    "text": {
+                      "type": "match_only_text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "reference": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "subtechnique": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "fields": {
+                        "text": {
+                          "type": "match_only_text"
+                        }
+                      },
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "reference": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tls": {
+          "properties": {
+            "cipher": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "client": {
+              "properties": {
+                "certificate": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "certificate_chain": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "hash": {
+                  "properties": {
+                    "md5": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "sha1": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "sha256": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "issuer": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "ja3": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "not_after": {
+                  "type": "date"
+                },
+                "not_before": {
+                  "type": "date"
+                },
+                "server_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "subject": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "supported_ciphers": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "x509": {
+                  "properties": {
+                    "alternative_names": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "issuer": {
+                      "properties": {
+                        "common_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "country": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "distinguished_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "locality": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "organization": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "organizational_unit": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "state_or_province": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
+                    },
+                    "not_after": {
+                      "type": "date"
+                    },
+                    "not_before": {
+                      "type": "date"
+                    },
+                    "public_key_algorithm": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "public_key_curve": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "public_key_exponent": {
+                      "type": "long"
+                    },
+                    "public_key_size": {
+                      "type": "long"
+                    },
+                    "serial_number": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "signature_algorithm": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "subject": {
+                      "properties": {
+                        "common_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "country": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "distinguished_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "locality": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "organization": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "organizational_unit": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "state_or_province": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
+                    },
+                    "version_number": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                }
+              }
+            },
+            "curve": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "established": {
+              "type": "boolean"
+            },
+            "next_protocol": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "resumed": {
+              "type": "boolean"
+            },
+            "server": {
+              "properties": {
+                "certificate": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "certificate_chain": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "hash": {
+                  "properties": {
+                    "md5": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "sha1": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "sha256": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "issuer": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "ja3s": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "not_after": {
+                  "type": "date"
+                },
+                "not_before": {
+                  "type": "date"
+                },
+                "subject": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "x509": {
+                  "properties": {
+                    "alternative_names": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "issuer": {
+                      "properties": {
+                        "common_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "country": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "distinguished_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "locality": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "organization": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "organizational_unit": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "state_or_province": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
+                    },
+                    "not_after": {
+                      "type": "date"
+                    },
+                    "not_before": {
+                      "type": "date"
+                    },
+                    "public_key_algorithm": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "public_key_curve": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "public_key_exponent": {
+                      "type": "long"
+                    },
+                    "public_key_size": {
+                      "type": "long"
+                    },
+                    "serial_number": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "signature_algorithm": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "subject": {
+                      "properties": {
+                        "common_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "country": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "distinguished_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "locality": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "organization": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "organizational_unit": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "state_or_province": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
+                    },
+                    "version_number": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                }
+              }
+            },
+            "version": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "version_protocol": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "trace": {
+          "properties": {
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "transaction": {
+          "properties": {
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "url": {
+          "properties": {
+            "domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "extension": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "fragment": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "full": {
+              "fields": {
+                "text": {
+                  "type": "match_only_text"
+                }
+              },
+              "type": "wildcard"
+            },
+            "original": {
+              "fields": {
+                "text": {
+                  "type": "match_only_text"
+                }
+              },
+              "type": "wildcard"
+            },
+            "password": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "path": {
+              "type": "wildcard"
+            },
+            "port": {
+              "type": "long"
+            },
+            "query": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "registered_domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "scheme": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "subdomain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "top_level_domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "username": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "user": {
+          "properties": {
+            "changes": {
+              "properties": {
+                "domain": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "email": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "full_name": {
+                  "fields": {
+                    "text": {
+                      "type": "match_only_text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "group": {
+                  "properties": {
+                    "domain": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "hash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "fields": {
+                    "text": {
+                      "type": "match_only_text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "roles": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "effective": {
+              "properties": {
+                "domain": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "email": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "full_name": {
+                  "fields": {
+                    "text": {
+                      "type": "match_only_text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "group": {
+                  "properties": {
+                    "domain": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "hash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "fields": {
+                    "text": {
+                      "type": "match_only_text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "roles": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "email": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "full_name": {
+              "fields": {
+                "text": {
+                  "type": "match_only_text"
+                }
+              },
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "group": {
+              "properties": {
+                "domain": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "hash": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "name": {
+              "fields": {
+                "text": {
+                  "type": "match_only_text"
+                }
+              },
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "risk": {
+              "properties": {
+                "calculated_level": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "calculated_score": {
+                  "type": "float"
+                },
+                "calculated_score_norm": {
+                  "type": "float"
+                },
+                "static_level": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "static_score": {
+                  "type": "float"
+                },
+                "static_score_norm": {
+                  "type": "float"
+                }
+              }
+            },
+            "roles": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "target": {
+              "properties": {
+                "domain": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "email": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "full_name": {
+                  "fields": {
+                    "text": {
+                      "type": "match_only_text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "group": {
+                  "properties": {
+                    "domain": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "hash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "fields": {
+                    "text": {
+                      "type": "match_only_text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "roles": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            }
+          }
+        },
+        "user_agent": {
+          "properties": {
+            "device": {
+              "properties": {
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "original": {
+              "fields": {
+                "text": {
+                  "type": "match_only_text"
+                }
+              },
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "os": {
+              "properties": {
+                "family": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "full": {
+                  "fields": {
+                    "text": {
+                      "type": "match_only_text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "kernel": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "fields": {
+                    "text": {
+                      "type": "match_only_text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "platform": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "version": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "version": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "vulnerability": {
+          "properties": {
+            "category": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "classification": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "description": {
+              "fields": {
+                "text": {
+                  "type": "match_only_text"
+                }
+              },
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "enumeration": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "reference": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "report_id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "scanner": {
+              "properties": {
+                "vendor": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "score": {
+              "properties": {
+                "base": {
+                  "type": "float"
+                },
+                "environmental": {
+                  "type": "float"
+                },
+                "temporal": {
+                  "type": "float"
+                },
+                "version": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "severity": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        }
+      }
+    },
+    "settings": {
+      "index": {
+        "auto_expand_replicas": "0-1",
+        "hidden": "true",
+        "lifecycle": {
+          "name": ".alerts-ilm-policy",
+          "rollover_alias": ".alerts-security.alerts-default"
+        },
+        "mapping": {
+          "total_fields": {
+            "limit": "2500"
+          }
+        },
+        "number_of_replicas": "0",
+        "number_of_shards": "1"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

This PR accomplishes a few things:

1. Make sure eql building block alerts show up when redirecting directly to the alerts page (demo of this fix below)
2. Bumps up the time window from 1 ms to 5 min, to make it easier to see other alerts when clearing out the filters
3. Add unit tests for the `alert_details_redirect.tsx` component
4. Adds a cypress test to test the presence of `kibana.alert.url` in an alert document and updates the config with the `publicBaseUrl` field which is needed for the field to be present.

**Before the eql fix:**


https://user-images.githubusercontent.com/17211684/234636355-507b33fc-5211-4b02-9818-d1ba78fee115.mov



**After the eql fix:**

https://user-images.githubusercontent.com/17211684/234635657-bdbdc2cf-8a3e-4e5c-a14e-04f878f09e7b.mov





<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->