### PR TITLE
Add `Advanced Analytics (UEBA)` package subcategory under `Security` category

### DIFF
--- a/src/plugins/custom_integrations/common/index.ts
+++ b/src/plugins/custom_integrations/common/index.ts
@@ -15,6 +15,7 @@ export const PLUGIN_NAME = 'customIntegrations';
 export const INTEGRATION_CATEGORY_DISPLAY: {
   [key: string]: { title: string; parent_id?: string };
 } = {
+  advanced_analytics_ueba: { title: 'Advanced Analytics (UEBA', parent_id: 'security' },
   analytics_engine: { title: 'Analytics Engine', parent_id: 'observability' },
   application_observability: { title: 'Application', parent_id: 'observability' },
   app_search: { title: 'Application Search', parent_id: 'enterprise_search' },

--- a/x-pack/plugins/fleet/common/types/models/package_spec.ts
+++ b/x-pack/plugins/fleet/common/types/models/package_spec.ts
@@ -36,6 +36,7 @@ export interface PackageSpecManifest {
 export type PackageSpecPackageType = 'integration' | 'input';
 
 export type PackageSpecCategory =
+  | 'advanced_analytics_ueba'
   | 'analytics_engine'
   | 'application_observability'
   | 'app_search'


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.

Add `Advanced Analytics (UEBA)` subcategory under Security

* https://github.com/elastic/package-spec/issues/499

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

(This PR doesn't add new features, thus deleting the table in the boilerplate)


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
