### PR TITLE
[Synthetics] Only allow params to be saved against specific namespaces

### DIFF
--- a/x-pack/plugins/synthetics/server/synthetics_service/synthetics_service.ts
+++ b/x-pack/plugins/synthetics/server/synthetics_service/synthetics_service.ts
@@ -473,7 +473,7 @@ export class SyntheticsService {
   async getSyntheticsParams({ spaceId }: { spaceId?: string } = {}) {
     const encryptedClient = this.server.encryptedSavedObjects.getClient();
 
-    const paramsBySpace: Record<string, Record<string, string>> = {};
+    const paramsBySpace: Record<string, Record<string, string>> = Object.create(null);
 
     const finder =
       await encryptedClient.createPointInTimeFinderDecryptedAsInternalUser<SyntheticsParamSO>({
@@ -486,7 +486,7 @@ export class SyntheticsService {
       response.saved_objects.forEach((param) => {
         param.namespaces?.forEach((namespace) => {
           if (!paramsBySpace[namespace]) {
-            paramsBySpace[namespace] = {};
+            paramsBySpace[namespace] = Object.create(null);
           }
           paramsBySpace[namespace][param.attributes.key] = param.attributes.value;
         });


### PR DESCRIPTION
## Summary

We had an issue backporting some changes in a previous patch, and some of the code from the update did not make it into 8.7. This PR introduces a commit that did not fully merge.
