### PR TITLE
[Discover] [Dashboard] [Embeddable] Fix saved search embeddable full screen mode not working

### DIFF
--- a/src/plugins/dashboard/public/dashboard_container/component/grid/_dashboard_grid.scss
+++ b/src/plugins/dashboard/public/dashboard_container/component/grid/_dashboard_grid.scss
@@ -38,11 +38,12 @@
 /**
  * When a single panel is expanded, all the other panels moved offscreen.
  * Shifting the rendered panels offscreen prevents a quick flash when redrawing the panels on minimize
+ * 1. We need to mark this as important because react grid layout sets the top/left of the panels inline.
  */
 .dshDashboardGrid__item--hidden {
   position: absolute;
-  top: -9999px;
-  left: -9999px;
+  top: -9999px !important; /* 1 */
+  left: -9999px !important; /* 1 */
 }
 
 /**

--- a/src/plugins/dashboard/public/dashboard_container/component/grid/dashboard_grid.tsx
+++ b/src/plugins/dashboard/public/dashboard_container/component/grid/dashboard_grid.tsx
@@ -129,6 +129,10 @@ export const DashboardGrid = ({ viewportWidth }: { viewportWidth: number }) => {
       onResizeStop={onLayoutChange}
       isResizable={!expandedPanelId}
       isDraggable={!expandedPanelId}
+      // CSS transforms break dashboard panels that use position: fixed,
+      // for example the saved search embeddable full screen mode
+      // https://github.com/elastic/kibana/issues/151499
+      useCSSTransforms={false}
       rowHeight={DASHBOARD_GRID_HEIGHT}
       margin={useMargins ? [DASHBOARD_MARGIN_SIZE, DASHBOARD_MARGIN_SIZE] : [0, 0]}
       draggableHandle={'.embPanel--dragHandle'}

--- a/src/plugins/discover/public/components/discover_grid/discover_grid.tsx
+++ b/src/plugins/discover/public/components/discover_grid/discover_grid.tsx
@@ -20,6 +20,7 @@ import {
   EuiLoadingSpinner,
   EuiIcon,
   EuiDataGridRefProps,
+  useEuiTheme,
 } from '@elastic/eui';
 import type { DataView } from '@kbn/data-views-plugin/public';
 import type { SortOrder } from '@kbn/saved-search-plugin/public';
@@ -27,6 +28,7 @@ import { Filter } from '@kbn/es-query';
 import { FieldFormatsStart } from '@kbn/field-formats-plugin/public';
 import { ToastsStart, IUiSettingsClient, HttpStart } from '@kbn/core/public';
 import { DataViewFieldEditorStart } from '@kbn/data-view-field-editor-plugin/public';
+import { css } from '@emotion/react';
 import { DocViewFilterFn } from '../../services/doc_views/doc_views_types';
 import { getSchemaDetectors } from './discover_grid_schema';
 import { DiscoverGridFlyout } from './discover_grid_flyout';
@@ -525,6 +527,15 @@ export const DiscoverGrid = ({
     onUpdateRowHeight,
   });
 
+  // Ensure the data grid has a higher z-index than other elements
+  // on the page (for example, when embedded in a dashboard panel)
+  const { euiTheme } = useEuiTheme();
+  const gridCss = css`
+    .euiDataGrid--fullScreen {
+      z-index: ${euiTheme.levels.modal};
+    }
+  `;
+
   if (!rowCount && isLoading) {
     return (
       <div className="euiDataGrid__loading">
@@ -588,6 +599,7 @@ export const DiscoverGrid = ({
             'dscDiscoverGrid__table',
             isPlainRecord ? 'dscDiscoverGrid__textLanguageMode' : 'dscDiscoverGrid__documentsMode'
           )}
+          css={gridCss}
         >
           <EuiDataGridMemoized
             aria-describedby={randomId}


### PR DESCRIPTION
## Summary

This PR fixes two issues:
- Saved search embeddable full screen button not working.
- Saved search embeddable full screen mode being overlapped by Dashboard elements.

The overlapping elements was just a z index issue, but the full screen button not working was caused by using `position: fixed` on an element (the full screen data grid) within an element that uses CSS transforms (`react-grid-layout` grid items).

It looks like recently we enabled `useCSSTransforms` on `react-grid-layout` in Dashboard (#153610 / #153693) as a performance optimization which resulted in the grid items using CSS transforms for their positioning, and the saved search embeddable full screen button no longer working. From what I could find, there doesn't seem to be a way to work around this behaviour, so I ended up reverting to `useCSSTransforms={false}`.

Video of the issue:
<video src="https://user-images.githubusercontent.com/25592674/234727794-12eff719-04a5-453c-830c-dfbda1bedcf7.mov" />

Resources:
- https://stackoverflow.com/questions/15194313/transform3d-not-working-with-position-fixed-children/15256339
- https://bugs.chromium.org/p/chromium/issues/detail?id=20574
- https://mtsknn.fi/blog/breaking-css-position-fixed

Fixes #151499.

### Checklist

- [ ] ~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)~
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] ~Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))~
- [ ] ~Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))~
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))~
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)