### PR TITLE
[Discover] [Unified Histogram] Fix reset search button not fully resetting Unified Histogram state

### DIFF
--- a/src/plugins/discover/public/application/main/components/layout/use_discover_histogram.test.tsx
+++ b/src/plugins/discover/public/application/main/components/layout/use_discover_histogram.test.tsx
@@ -144,6 +144,7 @@ describe('useDiscoverHistogram', () => {
     beforeEach(() => {
       mockCheckHitCount.mockClear();
     });
+
     it('should subscribe to state changes', async () => {
       const { hook } = await renderUseDiscoverHistogram();
       const api = createMockUnifiedHistogramApi();
@@ -218,6 +219,7 @@ describe('useDiscoverHistogram', () => {
       act(() => {
         hook.result.current.ref(api);
       });
+      stateContainer.appState.update({ hideChart: true, interval: '1m', breakdownField: 'test' });
       expect(api.setTotalHits).toHaveBeenCalled();
       expect(api.setChartHidden).toHaveBeenCalled();
       expect(api.setTimeInterval).toHaveBeenCalled();
@@ -233,7 +235,7 @@ describe('useDiscoverHistogram', () => {
 
     it('should exclude totalHitsStatus and totalHitsResult from Unified Histogram state updates after the first load', async () => {
       const stateContainer = getStateContainer();
-      const { hook, initialProps } = await renderUseDiscoverHistogram({ stateContainer });
+      const { hook } = await renderUseDiscoverHistogram({ stateContainer });
       const containerState = stateContainer.appState.getState();
       const state = {
         timeInterval: containerState.interval,
@@ -255,13 +257,14 @@ describe('useDiscoverHistogram', () => {
       act(() => {
         hook.result.current.ref(api);
       });
+      stateContainer.appState.update({ hideChart: true });
       expect(Object.keys(params ?? {})).toEqual([
         'totalHitsStatus',
         'totalHitsResult',
         'chartHidden',
       ]);
       params = {};
-      hook.rerender({ ...initialProps, hideChart: true });
+      stateContainer.appState.update({ hideChart: false });
       act(() => {
         subject$.next({
           ...state,

--- a/src/plugins/discover/public/application/main/components/layout/use_discover_histogram.test.tsx
+++ b/src/plugins/discover/public/application/main/components/layout/use_discover_histogram.test.tsx
@@ -227,9 +227,9 @@ describe('useDiscoverHistogram', () => {
       expect(Object.keys(params ?? {})).toEqual([
         'totalHitsStatus',
         'totalHitsResult',
-        'chartHidden',
-        'timeInterval',
         'breakdownField',
+        'timeInterval',
+        'chartHidden',
       ]);
     });
 

--- a/src/plugins/discover/public/application/main/components/layout/use_discover_histogram.ts
+++ b/src/plugins/discover/public/application/main/components/layout/use_discover_histogram.ts
@@ -322,6 +322,11 @@ export const useDiscoverHistogram = ({
   };
 };
 
+// Use pairwise to diff the previous and current state (starting with undefined to ensure
+// pairwise triggers after a single emission), and return an object containing only the
+// changed properties. By only including the changed properties, we avoid accidentally
+// overwriting other state properties that may have been updated between the time this
+// obersverable was triggered and the time the state changes are applied.
 const createUnifiedHistogramStateObservable = (state$?: Observable<UnifiedHistogramState>) => {
   return state$?.pipe(
     startWith(undefined),

--- a/src/plugins/discover/public/application/main/components/layout/use_discover_histogram.ts
+++ b/src/plugins/discover/public/application/main/components/layout/use_discover_histogram.ts
@@ -136,16 +136,16 @@ export const useDiscoverHistogram = ({
   useEffect(() => {
     const subscription = createAppStateObservable(stateContainer.appState.state$).subscribe(
       (changes) => {
-        if ('chartHidden' in changes && typeof changes.chartHidden === 'boolean') {
-          unifiedHistogram?.setChartHidden(changes.chartHidden);
+        if ('breakdownField' in changes) {
+          unifiedHistogram?.setBreakdownField(changes.breakdownField);
         }
 
         if ('timeInterval' in changes && changes.timeInterval) {
           unifiedHistogram?.setTimeInterval(changes.timeInterval);
         }
 
-        if ('breakdownField' in changes) {
-          unifiedHistogram?.setBreakdownField(changes.breakdownField);
+        if ('chartHidden' in changes && typeof changes.chartHidden === 'boolean') {
+          unifiedHistogram?.setChartHidden(changes.chartHidden);
         }
       }
     );
@@ -366,16 +366,16 @@ const createAppStateObservable = (state$: Observable<DiscoverAppState>) => {
         return changes;
       }
 
-      if (prev?.hideChart !== curr.hideChart) {
-        changes.chartHidden = curr.hideChart;
+      if (prev?.breakdownField !== curr.breakdownField) {
+        changes.breakdownField = curr.breakdownField;
       }
 
       if (prev?.interval !== curr.interval) {
         changes.timeInterval = curr.interval;
       }
 
-      if (prev?.breakdownField !== curr.breakdownField) {
-        changes.breakdownField = curr.breakdownField;
+      if (prev?.hideChart !== curr.hideChart) {
+        changes.chartHidden = curr.hideChart;
       }
 
       return changes;

--- a/src/plugins/unified_histogram/public/chart/chart.tsx
+++ b/src/plugins/unified_histogram/public/chart/chart.tsx
@@ -192,7 +192,7 @@ export function Chart({
     chartToolButtonCss,
   } = useChartStyles(chartVisible);
 
-  const lensAttributes = useMemo(
+  const lensAttributesContext = useMemo(
     () =>
       getLensAttributes({
         title: chart?.title,
@@ -218,7 +218,7 @@ export function Chart({
     services,
     dataView,
     relativeTimeRange: originalRelativeTimeRange ?? relativeTimeRange,
-    lensAttributes,
+    lensAttributes: lensAttributesContext.attributes,
   });
 
   return (
@@ -340,7 +340,7 @@ export function Chart({
               chart={chart}
               getTimeRange={getTimeRange}
               refetch$={refetch$}
-              lensAttributes={lensAttributes}
+              lensAttributesContext={lensAttributesContext}
               isPlainRecord={isPlainRecord}
               disableTriggers={disableTriggers}
               disabledActions={disabledActions}

--- a/src/plugins/unified_histogram/public/chart/histogram.test.tsx
+++ b/src/plugins/unified_histogram/public/chart/histogram.test.tsx
@@ -66,7 +66,7 @@ function mountComponent() {
       to: '2020-05-14T11:20:13.590',
     }),
     refetch$,
-    lensAttributes: getMockLensAttributes(),
+    lensAttributesContext: getMockLensAttributes(),
     onTotalHitsChange: jest.fn(),
     onChartLoad: jest.fn(),
   };
@@ -91,7 +91,7 @@ describe('Histogram', () => {
     const originalProps = getLensProps({
       searchSessionId: props.request.searchSessionId,
       getTimeRange: props.getTimeRange,
-      attributes: getMockLensAttributes(),
+      attributes: getMockLensAttributes().attributes,
       onLoad: lensProps.onLoad,
     });
     expect(lensProps).toEqual(originalProps);

--- a/src/plugins/unified_histogram/public/chart/histogram.tsx
+++ b/src/plugins/unified_histogram/public/chart/histogram.tsx
@@ -14,7 +14,7 @@ import type { DefaultInspectorAdapters } from '@kbn/expressions-plugin/common';
 import type { IKibanaSearchResponse } from '@kbn/data-plugin/public';
 import type { estypes } from '@elastic/elasticsearch';
 import type { TimeRange } from '@kbn/es-query';
-import type { LensEmbeddableInput, TypedLensByValueInput } from '@kbn/lens-plugin/public';
+import type { LensEmbeddableInput } from '@kbn/lens-plugin/public';
 import { RequestStatus } from '@kbn/inspector-plugin/public';
 import type { Observable } from 'rxjs';
 import {
@@ -31,6 +31,7 @@ import { buildBucketInterval } from './utils/build_bucket_interval';
 import { useTimeRange } from './hooks/use_time_range';
 import { useStableCallback } from './hooks/use_stable_callback';
 import { useLensProps } from './hooks/use_lens_props';
+import type { LensAttributesContext } from './utils/get_lens_attributes';
 
 export interface HistogramProps {
   services: UnifiedHistogramServices;
@@ -41,7 +42,7 @@ export interface HistogramProps {
   isPlainRecord?: boolean;
   getTimeRange: () => TimeRange;
   refetch$: Observable<UnifiedHistogramInputMessage>;
-  lensAttributes: TypedLensByValueInput['attributes'];
+  lensAttributesContext: LensAttributesContext;
   disableTriggers?: LensEmbeddableInput['disableTriggers'];
   disabledActions?: LensEmbeddableInput['disabledActions'];
   onTotalHitsChange?: (status: UnifiedHistogramFetchStatus, result?: number | Error) => void;
@@ -59,7 +60,7 @@ export function Histogram({
   isPlainRecord,
   getTimeRange,
   refetch$,
-  lensAttributes: attributes,
+  lensAttributesContext: attributesContext,
   disableTriggers,
   disabledActions,
   onTotalHitsChange,
@@ -78,6 +79,8 @@ export function Histogram({
   });
   const chartRef = useRef<HTMLDivElement | null>(null);
   const { height: containerHeight, width: containerWidth } = useResizeObserver(chartRef.current);
+  const { attributes } = attributesContext;
+
   useEffect(() => {
     if (attributes.visualizationType === 'lnsMetric') {
       const size = containerHeight < containerWidth ? containerHeight : containerWidth;
@@ -131,11 +134,11 @@ export function Histogram({
     }
   );
 
-  const lensProps = useLensProps({
+  const { lensProps, requestData } = useLensProps({
     request,
     getTimeRange,
     refetch$,
-    attributes,
+    attributesContext,
     onLoad,
   });
 
@@ -172,6 +175,7 @@ export function Histogram({
       <div
         data-test-subj="unifiedHistogramChart"
         data-time-range={timeRangeText}
+        data-request-data={requestData}
         css={chartCss}
         ref={chartRef}
       >

--- a/src/plugins/unified_histogram/public/chart/hooks/use_lens_props.test.ts
+++ b/src/plugins/unified_histogram/public/chart/hooks/use_lens_props.test.ts
@@ -20,7 +20,7 @@ describe('useLensProps', () => {
     const getTimeRange = jest.fn();
     const refetch$ = new Subject<UnifiedHistogramInputMessage>();
     const onLoad = jest.fn();
-    const attributes = getLensAttributes({
+    const attributesContext = getLensAttributes({
       title: 'test',
       filters: [],
       query: {
@@ -40,15 +40,15 @@ describe('useLensProps', () => {
         },
         getTimeRange,
         refetch$,
-        attributes,
+        attributesContext,
         onLoad,
       });
     });
-    expect(lensProps.result.current).toEqual(
+    expect(lensProps.result.current.lensProps).toEqual(
       getLensProps({
         searchSessionId: 'id',
         getTimeRange,
-        attributes,
+        attributes: attributesContext.attributes,
         onLoad,
       })
     );
@@ -58,7 +58,7 @@ describe('useLensProps', () => {
     const getTimeRange = jest.fn();
     const refetch$ = new Subject<UnifiedHistogramInputMessage>();
     const onLoad = jest.fn();
-    const attributes = getLensAttributes({
+    const attributesContext = getLensAttributes({
       title: 'test',
       filters: [],
       query: {
@@ -78,15 +78,15 @@ describe('useLensProps', () => {
         },
         getTimeRange,
         refetch$,
-        attributes,
+        attributesContext,
         onLoad,
       });
     });
-    expect(lensProps.result.current).toEqual(
+    expect(lensProps.result.current.lensProps).toEqual(
       getLensProps({
         searchSessionId: 'id',
         getTimeRange,
-        attributes,
+        attributes: attributesContext.attributes,
         onLoad,
       })
     );
@@ -103,7 +103,7 @@ describe('useLensProps', () => {
       },
       getTimeRange,
       refetch$,
-      attributes: getLensAttributes({
+      attributesContext: getLensAttributes({
         title: 'test',
         filters: [],
         query: {

--- a/src/plugins/unified_histogram/public/chart/utils/get_lens_attributes.test.ts
+++ b/src/plugins/unified_histogram/public/chart/utils/get_lens_attributes.test.ts
@@ -57,134 +57,142 @@ describe('getLensAttributes', () => {
       })
     ).toMatchInlineSnapshot(`
       Object {
-        "references": Array [
-          Object {
-            "id": "index-pattern-with-timefield-id",
-            "name": "indexpattern-datasource-current-indexpattern",
-            "type": "index-pattern",
-          },
-          Object {
-            "id": "index-pattern-with-timefield-id",
-            "name": "indexpattern-datasource-layer-unifiedHistogram",
-            "type": "index-pattern",
-          },
-        ],
-        "state": Object {
-          "datasourceStates": Object {
-            "formBased": Object {
-              "layers": Object {
-                "unifiedHistogram": Object {
-                  "columnOrder": Array [
-                    "date_column",
-                    "count_column",
-                  ],
-                  "columns": Object {
-                    "count_column": Object {
-                      "dataType": "number",
-                      "isBucketed": false,
-                      "label": "Count of records",
-                      "operationType": "count",
-                      "params": Object {
-                        "format": Object {
-                          "id": "number",
-                          "params": Object {
-                            "decimals": 0,
-                          },
-                        },
-                      },
-                      "scale": "ratio",
-                      "sourceField": "___records___",
-                    },
-                    "date_column": Object {
-                      "dataType": "date",
-                      "isBucketed": true,
-                      "label": "timestamp",
-                      "operationType": "date_histogram",
-                      "params": Object {
-                        "interval": "auto",
-                      },
-                      "scale": "interval",
-                      "sourceField": "timestamp",
-                    },
-                  },
-                },
-              },
-            },
-          },
-          "filters": Array [
+        "attributes": Object {
+          "references": Array [
             Object {
-              "$state": Object {
-                "store": "appState",
-              },
-              "meta": Object {
-                "alias": null,
-                "disabled": false,
-                "index": "index-pattern-with-timefield-id",
-                "key": "extension",
-                "negate": false,
-                "params": Object {
-                  "query": "js",
-                },
-                "type": "phrase",
-              },
-              "query": Object {
-                "match": Object {
-                  "extension": Object {
-                    "query": "js",
-                    "type": "phrase",
-                  },
-                },
-              },
+              "id": "index-pattern-with-timefield-id",
+              "name": "indexpattern-datasource-current-indexpattern",
+              "type": "index-pattern",
+            },
+            Object {
+              "id": "index-pattern-with-timefield-id",
+              "name": "indexpattern-datasource-layer-unifiedHistogram",
+              "type": "index-pattern",
             },
           ],
-          "query": Object {
-            "language": "kuery",
-            "query": "extension : css",
-          },
-          "visualization": Object {
-            "axisTitlesVisibilitySettings": Object {
-              "x": false,
-              "yLeft": false,
-              "yRight": false,
-            },
-            "fittingFunction": "None",
-            "gridlinesVisibilitySettings": Object {
-              "x": true,
-              "yLeft": true,
-              "yRight": false,
-            },
-            "layers": Array [
-              Object {
-                "accessors": Array [
-                  "count_column",
-                ],
-                "layerId": "unifiedHistogram",
-                "layerType": "data",
-                "seriesType": "bar_stacked",
-                "xAccessor": "date_column",
-                "yConfig": Array [
-                  Object {
-                    "forAccessor": "count_column",
+          "state": Object {
+            "datasourceStates": Object {
+              "formBased": Object {
+                "layers": Object {
+                  "unifiedHistogram": Object {
+                    "columnOrder": Array [
+                      "date_column",
+                      "count_column",
+                    ],
+                    "columns": Object {
+                      "count_column": Object {
+                        "dataType": "number",
+                        "isBucketed": false,
+                        "label": "Count of records",
+                        "operationType": "count",
+                        "params": Object {
+                          "format": Object {
+                            "id": "number",
+                            "params": Object {
+                              "decimals": 0,
+                            },
+                          },
+                        },
+                        "scale": "ratio",
+                        "sourceField": "___records___",
+                      },
+                      "date_column": Object {
+                        "dataType": "date",
+                        "isBucketed": true,
+                        "label": "timestamp",
+                        "operationType": "date_histogram",
+                        "params": Object {
+                          "interval": "auto",
+                        },
+                        "scale": "interval",
+                        "sourceField": "timestamp",
+                      },
+                    },
                   },
-                ],
+                },
+              },
+            },
+            "filters": Array [
+              Object {
+                "$state": Object {
+                  "store": "appState",
+                },
+                "meta": Object {
+                  "alias": null,
+                  "disabled": false,
+                  "index": "index-pattern-with-timefield-id",
+                  "key": "extension",
+                  "negate": false,
+                  "params": Object {
+                    "query": "js",
+                  },
+                  "type": "phrase",
+                },
+                "query": Object {
+                  "match": Object {
+                    "extension": Object {
+                      "query": "js",
+                      "type": "phrase",
+                    },
+                  },
+                },
               },
             ],
-            "legend": Object {
-              "isVisible": true,
-              "position": "right",
+            "query": Object {
+              "language": "kuery",
+              "query": "extension : css",
             },
-            "preferredSeriesType": "bar_stacked",
-            "showCurrentTimeMarker": true,
-            "tickLabelsVisibilitySettings": Object {
-              "x": true,
-              "yLeft": true,
-              "yRight": false,
+            "visualization": Object {
+              "axisTitlesVisibilitySettings": Object {
+                "x": false,
+                "yLeft": false,
+                "yRight": false,
+              },
+              "fittingFunction": "None",
+              "gridlinesVisibilitySettings": Object {
+                "x": true,
+                "yLeft": true,
+                "yRight": false,
+              },
+              "layers": Array [
+                Object {
+                  "accessors": Array [
+                    "count_column",
+                  ],
+                  "layerId": "unifiedHistogram",
+                  "layerType": "data",
+                  "seriesType": "bar_stacked",
+                  "xAccessor": "date_column",
+                  "yConfig": Array [
+                    Object {
+                      "forAccessor": "count_column",
+                    },
+                  ],
+                },
+              ],
+              "legend": Object {
+                "isVisible": true,
+                "position": "right",
+              },
+              "preferredSeriesType": "bar_stacked",
+              "showCurrentTimeMarker": true,
+              "tickLabelsVisibilitySettings": Object {
+                "x": true,
+                "yLeft": true,
+                "yRight": false,
+              },
+              "valueLabels": "hide",
             },
-            "valueLabels": "hide",
           },
+          "title": "test",
+          "visualizationType": "lnsXY",
         },
-        "title": "test",
-        "visualizationType": "lnsXY",
+        "requestData": Object {
+          "breakdownField": undefined,
+          "dataViewId": "index-pattern-with-timefield-id",
+          "timeField": "timestamp",
+          "timeInterval": "auto",
+        },
       }
     `);
   });
@@ -205,152 +213,160 @@ describe('getLensAttributes', () => {
       })
     ).toMatchInlineSnapshot(`
       Object {
-        "references": Array [
-          Object {
-            "id": "index-pattern-with-timefield-id",
-            "name": "indexpattern-datasource-current-indexpattern",
-            "type": "index-pattern",
-          },
-          Object {
-            "id": "index-pattern-with-timefield-id",
-            "name": "indexpattern-datasource-layer-unifiedHistogram",
-            "type": "index-pattern",
-          },
-        ],
-        "state": Object {
-          "datasourceStates": Object {
-            "formBased": Object {
-              "layers": Object {
-                "unifiedHistogram": Object {
-                  "columnOrder": Array [
-                    "breakdown_column",
-                    "date_column",
-                    "count_column",
-                  ],
-                  "columns": Object {
-                    "breakdown_column": Object {
-                      "dataType": "string",
-                      "isBucketed": true,
-                      "label": "Top 3 values of extension",
-                      "operationType": "terms",
-                      "params": Object {
-                        "missingBucket": false,
-                        "orderBy": Object {
-                          "columnId": "count_column",
-                          "type": "column",
-                        },
-                        "orderDirection": "desc",
-                        "otherBucket": true,
-                        "parentFormat": Object {
-                          "id": "terms",
-                        },
-                        "size": 3,
-                      },
-                      "scale": "ordinal",
-                      "sourceField": "extension",
-                    },
-                    "count_column": Object {
-                      "dataType": "number",
-                      "isBucketed": false,
-                      "label": "Count of records",
-                      "operationType": "count",
-                      "params": Object {
-                        "format": Object {
-                          "id": "number",
-                          "params": Object {
-                            "decimals": 0,
-                          },
-                        },
-                      },
-                      "scale": "ratio",
-                      "sourceField": "___records___",
-                    },
-                    "date_column": Object {
-                      "dataType": "date",
-                      "isBucketed": true,
-                      "label": "timestamp",
-                      "operationType": "date_histogram",
-                      "params": Object {
-                        "interval": "auto",
-                      },
-                      "scale": "interval",
-                      "sourceField": "timestamp",
-                    },
-                  },
-                },
-              },
-            },
-          },
-          "filters": Array [
+        "attributes": Object {
+          "references": Array [
             Object {
-              "$state": Object {
-                "store": "appState",
-              },
-              "meta": Object {
-                "alias": null,
-                "disabled": false,
-                "index": "index-pattern-with-timefield-id",
-                "key": "extension",
-                "negate": false,
-                "params": Object {
-                  "query": "js",
-                },
-                "type": "phrase",
-              },
-              "query": Object {
-                "match": Object {
-                  "extension": Object {
-                    "query": "js",
-                    "type": "phrase",
-                  },
-                },
-              },
+              "id": "index-pattern-with-timefield-id",
+              "name": "indexpattern-datasource-current-indexpattern",
+              "type": "index-pattern",
+            },
+            Object {
+              "id": "index-pattern-with-timefield-id",
+              "name": "indexpattern-datasource-layer-unifiedHistogram",
+              "type": "index-pattern",
             },
           ],
-          "query": Object {
-            "language": "kuery",
-            "query": "extension : css",
-          },
-          "visualization": Object {
-            "axisTitlesVisibilitySettings": Object {
-              "x": false,
-              "yLeft": false,
-              "yRight": false,
+          "state": Object {
+            "datasourceStates": Object {
+              "formBased": Object {
+                "layers": Object {
+                  "unifiedHistogram": Object {
+                    "columnOrder": Array [
+                      "breakdown_column",
+                      "date_column",
+                      "count_column",
+                    ],
+                    "columns": Object {
+                      "breakdown_column": Object {
+                        "dataType": "string",
+                        "isBucketed": true,
+                        "label": "Top 3 values of extension",
+                        "operationType": "terms",
+                        "params": Object {
+                          "missingBucket": false,
+                          "orderBy": Object {
+                            "columnId": "count_column",
+                            "type": "column",
+                          },
+                          "orderDirection": "desc",
+                          "otherBucket": true,
+                          "parentFormat": Object {
+                            "id": "terms",
+                          },
+                          "size": 3,
+                        },
+                        "scale": "ordinal",
+                        "sourceField": "extension",
+                      },
+                      "count_column": Object {
+                        "dataType": "number",
+                        "isBucketed": false,
+                        "label": "Count of records",
+                        "operationType": "count",
+                        "params": Object {
+                          "format": Object {
+                            "id": "number",
+                            "params": Object {
+                              "decimals": 0,
+                            },
+                          },
+                        },
+                        "scale": "ratio",
+                        "sourceField": "___records___",
+                      },
+                      "date_column": Object {
+                        "dataType": "date",
+                        "isBucketed": true,
+                        "label": "timestamp",
+                        "operationType": "date_histogram",
+                        "params": Object {
+                          "interval": "auto",
+                        },
+                        "scale": "interval",
+                        "sourceField": "timestamp",
+                      },
+                    },
+                  },
+                },
+              },
             },
-            "fittingFunction": "None",
-            "gridlinesVisibilitySettings": Object {
-              "x": true,
-              "yLeft": true,
-              "yRight": false,
-            },
-            "layers": Array [
+            "filters": Array [
               Object {
-                "accessors": Array [
-                  "count_column",
-                ],
-                "layerId": "unifiedHistogram",
-                "layerType": "data",
-                "seriesType": "bar_stacked",
-                "splitAccessor": "breakdown_column",
-                "xAccessor": "date_column",
+                "$state": Object {
+                  "store": "appState",
+                },
+                "meta": Object {
+                  "alias": null,
+                  "disabled": false,
+                  "index": "index-pattern-with-timefield-id",
+                  "key": "extension",
+                  "negate": false,
+                  "params": Object {
+                    "query": "js",
+                  },
+                  "type": "phrase",
+                },
+                "query": Object {
+                  "match": Object {
+                    "extension": Object {
+                      "query": "js",
+                      "type": "phrase",
+                    },
+                  },
+                },
               },
             ],
-            "legend": Object {
-              "isVisible": true,
-              "position": "right",
+            "query": Object {
+              "language": "kuery",
+              "query": "extension : css",
             },
-            "preferredSeriesType": "bar_stacked",
-            "showCurrentTimeMarker": true,
-            "tickLabelsVisibilitySettings": Object {
-              "x": true,
-              "yLeft": true,
-              "yRight": false,
+            "visualization": Object {
+              "axisTitlesVisibilitySettings": Object {
+                "x": false,
+                "yLeft": false,
+                "yRight": false,
+              },
+              "fittingFunction": "None",
+              "gridlinesVisibilitySettings": Object {
+                "x": true,
+                "yLeft": true,
+                "yRight": false,
+              },
+              "layers": Array [
+                Object {
+                  "accessors": Array [
+                    "count_column",
+                  ],
+                  "layerId": "unifiedHistogram",
+                  "layerType": "data",
+                  "seriesType": "bar_stacked",
+                  "splitAccessor": "breakdown_column",
+                  "xAccessor": "date_column",
+                },
+              ],
+              "legend": Object {
+                "isVisible": true,
+                "position": "right",
+              },
+              "preferredSeriesType": "bar_stacked",
+              "showCurrentTimeMarker": true,
+              "tickLabelsVisibilitySettings": Object {
+                "x": true,
+                "yLeft": true,
+                "yRight": false,
+              },
+              "valueLabels": "hide",
             },
-            "valueLabels": "hide",
           },
+          "title": "test",
+          "visualizationType": "lnsXY",
         },
-        "title": "test",
-        "visualizationType": "lnsXY",
+        "requestData": Object {
+          "breakdownField": "extension",
+          "dataViewId": "index-pattern-with-timefield-id",
+          "timeField": "timestamp",
+          "timeInterval": "auto",
+        },
       }
     `);
   });
@@ -371,134 +387,142 @@ describe('getLensAttributes', () => {
       })
     ).toMatchInlineSnapshot(`
       Object {
-        "references": Array [
-          Object {
-            "id": "index-pattern-with-timefield-id",
-            "name": "indexpattern-datasource-current-indexpattern",
-            "type": "index-pattern",
-          },
-          Object {
-            "id": "index-pattern-with-timefield-id",
-            "name": "indexpattern-datasource-layer-unifiedHistogram",
-            "type": "index-pattern",
-          },
-        ],
-        "state": Object {
-          "datasourceStates": Object {
-            "formBased": Object {
-              "layers": Object {
-                "unifiedHistogram": Object {
-                  "columnOrder": Array [
-                    "date_column",
-                    "count_column",
-                  ],
-                  "columns": Object {
-                    "count_column": Object {
-                      "dataType": "number",
-                      "isBucketed": false,
-                      "label": "Count of records",
-                      "operationType": "count",
-                      "params": Object {
-                        "format": Object {
-                          "id": "number",
-                          "params": Object {
-                            "decimals": 0,
-                          },
-                        },
-                      },
-                      "scale": "ratio",
-                      "sourceField": "___records___",
-                    },
-                    "date_column": Object {
-                      "dataType": "date",
-                      "isBucketed": true,
-                      "label": "timestamp",
-                      "operationType": "date_histogram",
-                      "params": Object {
-                        "interval": "auto",
-                      },
-                      "scale": "interval",
-                      "sourceField": "timestamp",
-                    },
-                  },
-                },
-              },
-            },
-          },
-          "filters": Array [
+        "attributes": Object {
+          "references": Array [
             Object {
-              "$state": Object {
-                "store": "appState",
-              },
-              "meta": Object {
-                "alias": null,
-                "disabled": false,
-                "index": "index-pattern-with-timefield-id",
-                "key": "extension",
-                "negate": false,
-                "params": Object {
-                  "query": "js",
-                },
-                "type": "phrase",
-              },
-              "query": Object {
-                "match": Object {
-                  "extension": Object {
-                    "query": "js",
-                    "type": "phrase",
-                  },
-                },
-              },
+              "id": "index-pattern-with-timefield-id",
+              "name": "indexpattern-datasource-current-indexpattern",
+              "type": "index-pattern",
+            },
+            Object {
+              "id": "index-pattern-with-timefield-id",
+              "name": "indexpattern-datasource-layer-unifiedHistogram",
+              "type": "index-pattern",
             },
           ],
-          "query": Object {
-            "language": "kuery",
-            "query": "extension : css",
-          },
-          "visualization": Object {
-            "axisTitlesVisibilitySettings": Object {
-              "x": false,
-              "yLeft": false,
-              "yRight": false,
-            },
-            "fittingFunction": "None",
-            "gridlinesVisibilitySettings": Object {
-              "x": true,
-              "yLeft": true,
-              "yRight": false,
-            },
-            "layers": Array [
-              Object {
-                "accessors": Array [
-                  "count_column",
-                ],
-                "layerId": "unifiedHistogram",
-                "layerType": "data",
-                "seriesType": "bar_stacked",
-                "xAccessor": "date_column",
-                "yConfig": Array [
-                  Object {
-                    "forAccessor": "count_column",
+          "state": Object {
+            "datasourceStates": Object {
+              "formBased": Object {
+                "layers": Object {
+                  "unifiedHistogram": Object {
+                    "columnOrder": Array [
+                      "date_column",
+                      "count_column",
+                    ],
+                    "columns": Object {
+                      "count_column": Object {
+                        "dataType": "number",
+                        "isBucketed": false,
+                        "label": "Count of records",
+                        "operationType": "count",
+                        "params": Object {
+                          "format": Object {
+                            "id": "number",
+                            "params": Object {
+                              "decimals": 0,
+                            },
+                          },
+                        },
+                        "scale": "ratio",
+                        "sourceField": "___records___",
+                      },
+                      "date_column": Object {
+                        "dataType": "date",
+                        "isBucketed": true,
+                        "label": "timestamp",
+                        "operationType": "date_histogram",
+                        "params": Object {
+                          "interval": "auto",
+                        },
+                        "scale": "interval",
+                        "sourceField": "timestamp",
+                      },
+                    },
                   },
-                ],
+                },
+              },
+            },
+            "filters": Array [
+              Object {
+                "$state": Object {
+                  "store": "appState",
+                },
+                "meta": Object {
+                  "alias": null,
+                  "disabled": false,
+                  "index": "index-pattern-with-timefield-id",
+                  "key": "extension",
+                  "negate": false,
+                  "params": Object {
+                    "query": "js",
+                  },
+                  "type": "phrase",
+                },
+                "query": Object {
+                  "match": Object {
+                    "extension": Object {
+                      "query": "js",
+                      "type": "phrase",
+                    },
+                  },
+                },
               },
             ],
-            "legend": Object {
-              "isVisible": true,
-              "position": "right",
+            "query": Object {
+              "language": "kuery",
+              "query": "extension : css",
             },
-            "preferredSeriesType": "bar_stacked",
-            "showCurrentTimeMarker": true,
-            "tickLabelsVisibilitySettings": Object {
-              "x": true,
-              "yLeft": true,
-              "yRight": false,
+            "visualization": Object {
+              "axisTitlesVisibilitySettings": Object {
+                "x": false,
+                "yLeft": false,
+                "yRight": false,
+              },
+              "fittingFunction": "None",
+              "gridlinesVisibilitySettings": Object {
+                "x": true,
+                "yLeft": true,
+                "yRight": false,
+              },
+              "layers": Array [
+                Object {
+                  "accessors": Array [
+                    "count_column",
+                  ],
+                  "layerId": "unifiedHistogram",
+                  "layerType": "data",
+                  "seriesType": "bar_stacked",
+                  "xAccessor": "date_column",
+                  "yConfig": Array [
+                    Object {
+                      "forAccessor": "count_column",
+                    },
+                  ],
+                },
+              ],
+              "legend": Object {
+                "isVisible": true,
+                "position": "right",
+              },
+              "preferredSeriesType": "bar_stacked",
+              "showCurrentTimeMarker": true,
+              "tickLabelsVisibilitySettings": Object {
+                "x": true,
+                "yLeft": true,
+                "yRight": false,
+              },
+              "valueLabels": "hide",
             },
-            "valueLabels": "hide",
           },
+          "title": "test",
+          "visualizationType": "lnsXY",
         },
-        "title": "test",
-        "visualizationType": "lnsXY",
+        "requestData": Object {
+          "breakdownField": "scripted",
+          "dataViewId": "index-pattern-with-timefield-id",
+          "timeField": "timestamp",
+          "timeInterval": "auto",
+        },
       }
     `);
   });
@@ -516,194 +540,202 @@ describe('getLensAttributes', () => {
       })
     ).toMatchInlineSnapshot(`
       Object {
-        "references": Array [
-          Object {
-            "id": "index-pattern-with-timefield-id",
-            "name": "indexpattern-datasource-current-indexpattern",
-            "type": "index-pattern",
-          },
-          Object {
-            "id": "index-pattern-with-timefield-id",
-            "name": "indexpattern-datasource-layer-unifiedHistogram",
-            "type": "index-pattern",
-          },
-        ],
-        "state": Object {
-          "datasourceStates": Object {
-            "textBased": Object {
-              "fieldList": Array [],
-              "indexPatternRefs": Array [],
-              "initialContext": Object {
-                "contextualFields": Array [
-                  "Dest",
-                  "AvgTicketPrice",
-                ],
-                "dataViewSpec": Object {
-                  "allowNoIndex": false,
-                  "fields": Object {
-                    "AvgTicketPrice": Object {
-                      "aggregatable": true,
-                      "count": 0,
-                      "esTypes": Array [
-                        "float",
-                      ],
-                      "format": Object {
-                        "id": "number",
-                        "params": Object {
-                          "pattern": "$0,0.[00]",
+        "attributes": Object {
+          "references": Array [
+            Object {
+              "id": "index-pattern-with-timefield-id",
+              "name": "indexpattern-datasource-current-indexpattern",
+              "type": "index-pattern",
+            },
+            Object {
+              "id": "index-pattern-with-timefield-id",
+              "name": "indexpattern-datasource-layer-unifiedHistogram",
+              "type": "index-pattern",
+            },
+          ],
+          "state": Object {
+            "datasourceStates": Object {
+              "textBased": Object {
+                "fieldList": Array [],
+                "indexPatternRefs": Array [],
+                "initialContext": Object {
+                  "contextualFields": Array [
+                    "Dest",
+                    "AvgTicketPrice",
+                  ],
+                  "dataViewSpec": Object {
+                    "allowNoIndex": false,
+                    "fields": Object {
+                      "AvgTicketPrice": Object {
+                        "aggregatable": true,
+                        "count": 0,
+                        "esTypes": Array [
+                          "float",
+                        ],
+                        "format": Object {
+                          "id": "number",
+                          "params": Object {
+                            "pattern": "$0,0.[00]",
+                          },
                         },
+                        "isMapped": true,
+                        "name": "AvgTicketPrice",
+                        "readFromDocValues": true,
+                        "scripted": false,
+                        "searchable": true,
+                        "shortDotsEnable": false,
+                        "type": "number",
                       },
-                      "isMapped": true,
-                      "name": "AvgTicketPrice",
-                      "readFromDocValues": true,
-                      "scripted": false,
-                      "searchable": true,
-                      "shortDotsEnable": false,
-                      "type": "number",
-                    },
-                    "Dest": Object {
-                      "aggregatable": true,
-                      "count": 0,
-                      "esTypes": Array [
-                        "keyword",
-                      ],
-                      "format": Object {
-                        "id": "string",
+                      "Dest": Object {
+                        "aggregatable": true,
+                        "count": 0,
+                        "esTypes": Array [
+                          "keyword",
+                        ],
+                        "format": Object {
+                          "id": "string",
+                        },
+                        "isMapped": true,
+                        "name": "Dest",
+                        "readFromDocValues": true,
+                        "scripted": false,
+                        "searchable": true,
+                        "shortDotsEnable": false,
+                        "type": "string",
                       },
-                      "isMapped": true,
-                      "name": "Dest",
-                      "readFromDocValues": true,
-                      "scripted": false,
-                      "searchable": true,
-                      "shortDotsEnable": false,
-                      "type": "string",
-                    },
-                    "timestamp": Object {
-                      "aggregatable": true,
-                      "count": 0,
-                      "esTypes": Array [
-                        "date",
-                      ],
-                      "format": Object {
-                        "id": "date",
+                      "timestamp": Object {
+                        "aggregatable": true,
+                        "count": 0,
+                        "esTypes": Array [
+                          "date",
+                        ],
+                        "format": Object {
+                          "id": "date",
+                        },
+                        "isMapped": true,
+                        "name": "timestamp",
+                        "readFromDocValues": true,
+                        "scripted": false,
+                        "searchable": true,
+                        "shortDotsEnable": false,
+                        "type": "date",
                       },
-                      "isMapped": true,
-                      "name": "timestamp",
-                      "readFromDocValues": true,
-                      "scripted": false,
-                      "searchable": true,
-                      "shortDotsEnable": false,
-                      "type": "date",
                     },
+                    "id": "d3d7af60-4c81-11e8-b3d7-01146121b73d",
+                    "name": "Kibana Sample Data Flights",
+                    "sourceFilters": Array [],
+                    "timeFieldName": "timestamp",
+                    "title": "kibana_sample_data_flights",
+                    "version": "WzM1ODA3LDFd",
                   },
-                  "id": "d3d7af60-4c81-11e8-b3d7-01146121b73d",
-                  "name": "Kibana Sample Data Flights",
-                  "sourceFilters": Array [],
-                  "timeFieldName": "timestamp",
-                  "title": "kibana_sample_data_flights",
-                  "version": "WzM1ODA3LDFd",
-                },
-                "fieldName": "",
-                "query": Object {
-                  "sql": "SELECT Dest, AvgTicketPrice FROM \\"kibana_sample_data_flights\\"",
-                },
-              },
-              "layers": Object {
-                "46aa21fa-b747-4543-bf90-0b40007c546d": Object {
-                  "allColumns": Array [
-                    Object {
-                      "columnId": "81e332d6-ee37-42a8-a646-cea4fc75d2d3",
-                      "fieldName": "Dest",
-                      "meta": Object {
-                        "type": "string",
-                      },
-                    },
-                    Object {
-                      "columnId": "5b9b8b76-0836-4a12-b9c0-980c9900502f",
-                      "fieldName": "AvgTicketPrice",
-                      "meta": Object {
-                        "type": "number",
-                      },
-                    },
-                  ],
-                  "columns": Array [
-                    Object {
-                      "columnId": "81e332d6-ee37-42a8-a646-cea4fc75d2d3",
-                      "fieldName": "Dest",
-                      "meta": Object {
-                        "type": "string",
-                      },
-                    },
-                    Object {
-                      "columnId": "5b9b8b76-0836-4a12-b9c0-980c9900502f",
-                      "fieldName": "AvgTicketPrice",
-                      "meta": Object {
-                        "type": "number",
-                      },
-                    },
-                  ],
-                  "index": "d3d7af60-4c81-11e8-b3d7-01146121b73d",
+                  "fieldName": "",
                   "query": Object {
                     "sql": "SELECT Dest, AvgTicketPrice FROM \\"kibana_sample_data_flights\\"",
                   },
-                  "timeField": "timestamp",
                 },
-              },
-            },
-          },
-          "filters": Array [
-            Object {
-              "$state": Object {
-                "store": "appState",
-              },
-              "meta": Object {
-                "alias": null,
-                "disabled": false,
-                "index": "index-pattern-with-timefield-id",
-                "key": "extension",
-                "negate": false,
-                "params": Object {
-                  "query": "js",
-                },
-                "type": "phrase",
-              },
-              "query": Object {
-                "match": Object {
-                  "extension": Object {
-                    "query": "js",
-                    "type": "phrase",
+                "layers": Object {
+                  "46aa21fa-b747-4543-bf90-0b40007c546d": Object {
+                    "allColumns": Array [
+                      Object {
+                        "columnId": "81e332d6-ee37-42a8-a646-cea4fc75d2d3",
+                        "fieldName": "Dest",
+                        "meta": Object {
+                          "type": "string",
+                        },
+                      },
+                      Object {
+                        "columnId": "5b9b8b76-0836-4a12-b9c0-980c9900502f",
+                        "fieldName": "AvgTicketPrice",
+                        "meta": Object {
+                          "type": "number",
+                        },
+                      },
+                    ],
+                    "columns": Array [
+                      Object {
+                        "columnId": "81e332d6-ee37-42a8-a646-cea4fc75d2d3",
+                        "fieldName": "Dest",
+                        "meta": Object {
+                          "type": "string",
+                        },
+                      },
+                      Object {
+                        "columnId": "5b9b8b76-0836-4a12-b9c0-980c9900502f",
+                        "fieldName": "AvgTicketPrice",
+                        "meta": Object {
+                          "type": "number",
+                        },
+                      },
+                    ],
+                    "index": "d3d7af60-4c81-11e8-b3d7-01146121b73d",
+                    "query": Object {
+                      "sql": "SELECT Dest, AvgTicketPrice FROM \\"kibana_sample_data_flights\\"",
+                    },
+                    "timeField": "timestamp",
                   },
                 },
               },
             },
-          ],
-          "query": Object {
-            "language": "kuery",
-            "query": "extension : css",
-          },
-          "visualization": Object {
-            "gridConfig": Object {
-              "isCellLabelVisible": false,
-              "isXAxisLabelVisible": true,
-              "isXAxisTitleVisible": false,
-              "isYAxisLabelVisible": true,
-              "isYAxisTitleVisible": false,
-              "type": "heatmap_grid",
+            "filters": Array [
+              Object {
+                "$state": Object {
+                  "store": "appState",
+                },
+                "meta": Object {
+                  "alias": null,
+                  "disabled": false,
+                  "index": "index-pattern-with-timefield-id",
+                  "key": "extension",
+                  "negate": false,
+                  "params": Object {
+                    "query": "js",
+                  },
+                  "type": "phrase",
+                },
+                "query": Object {
+                  "match": Object {
+                    "extension": Object {
+                      "query": "js",
+                      "type": "phrase",
+                    },
+                  },
+                },
+              },
+            ],
+            "query": Object {
+              "language": "kuery",
+              "query": "extension : css",
             },
-            "layerId": "46aa21fa-b747-4543-bf90-0b40007c546d",
-            "layerType": "data",
-            "legend": Object {
-              "isVisible": true,
-              "position": "right",
-              "type": "heatmap_legend",
+            "visualization": Object {
+              "gridConfig": Object {
+                "isCellLabelVisible": false,
+                "isXAxisLabelVisible": true,
+                "isXAxisTitleVisible": false,
+                "isYAxisLabelVisible": true,
+                "isYAxisTitleVisible": false,
+                "type": "heatmap_grid",
+              },
+              "layerId": "46aa21fa-b747-4543-bf90-0b40007c546d",
+              "layerType": "data",
+              "legend": Object {
+                "isVisible": true,
+                "position": "right",
+                "type": "heatmap_legend",
+              },
+              "shape": "heatmap",
+              "valueAccessor": "5b9b8b76-0836-4a12-b9c0-980c9900502f",
+              "xAccessor": "81e332d6-ee37-42a8-a646-cea4fc75d2d3",
             },
-            "shape": "heatmap",
-            "valueAccessor": "5b9b8b76-0836-4a12-b9c0-980c9900502f",
-            "xAccessor": "81e332d6-ee37-42a8-a646-cea4fc75d2d3",
           },
+          "title": "test",
+          "visualizationType": "lnsHeatmap",
         },
-        "title": "test",
-        "visualizationType": "lnsHeatmap",
+        "requestData": Object {
+          "breakdownField": undefined,
+          "dataViewId": "index-pattern-with-timefield-id",
+          "timeField": "timestamp",
+          "timeInterval": "auto",
+        },
       }
     `);
   });

--- a/src/plugins/unified_histogram/public/chart/utils/get_lens_attributes.ts
+++ b/src/plugins/unified_histogram/public/chart/utils/get_lens_attributes.ts
@@ -19,6 +19,18 @@ import type {
 } from '@kbn/lens-plugin/public';
 import { fieldSupportsBreakdown } from './field_supports_breakdown';
 
+export interface LensRequestData {
+  dataViewId?: string;
+  timeField?: string;
+  timeInterval?: string;
+  breakdownField?: string;
+}
+
+export interface LensAttributesContext {
+  attributes: TypedLensByValueInput['attributes'];
+  requestData: LensRequestData;
+}
+
 export const getLensAttributes = ({
   title,
   filters,
@@ -35,7 +47,7 @@ export const getLensAttributes = ({
   timeInterval: string | undefined;
   breakdownField: DataViewField | undefined;
   suggestion: Suggestion | undefined;
-}) => {
+}): LensAttributesContext => {
   const showBreakdown = breakdownField && fieldSupportsBreakdown(breakdownField);
 
   let columnOrder = ['date_column', 'count_column'];
@@ -169,8 +181,7 @@ export const getLensAttributes = ({
           yRight: false,
         },
       };
-
-  return {
+  const attributes = {
     title:
       title ??
       i18n.translate('unifiedHistogram.lensTitle', {
@@ -196,4 +207,14 @@ export const getLensAttributes = ({
     },
     visualizationType: suggestion ? suggestion.visualizationId : 'lnsXY',
   } as TypedLensByValueInput['attributes'];
+
+  return {
+    attributes,
+    requestData: {
+      dataViewId: dataView.id,
+      timeField: dataView.timeFieldName,
+      timeInterval,
+      breakdownField: breakdownField?.name,
+    },
+  };
 };


### PR DESCRIPTION
## Summary

This PR fixes an issue where resetting a saved search would not fully reset the Unified Histogram state. The issue was caused by multiple state values changing in quick succession which resulted in some state getting overwritten, so I've updated `use_discover_state` to batch state updates and improve diffing when state changes.

Fixes #151395.

### Checklist

- [ ] ~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)~
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] ~Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))~
- [ ] ~Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))~
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))~
- [ ] ~This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)~

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->