### PR TITLE
[Discover] Fix flaky saved objects tagging functional test

### DIFF
--- a/x-pack/test/saved_object_tagging/functional/tests/discover_integration.ts
+++ b/x-pack/test/saved_object_tagging/functional/tests/discover_integration.ts
@@ -20,6 +20,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     'timePicker',
     'discover',
   ]);
+  const retry = getService('retry');
 
   /**
    * Select tags in the searchbar's tag filter.
@@ -118,6 +119,16 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
       it('allows to create a tag from the tag selector', async () => {
         await PageObjects.discover.clickSaveSearchButton();
+        const searchName = 'search-with-new-tag';
+        // preventing an occasional flakiness when the saved object wasn't set and the form can't be submitted
+        await retry.waitFor(
+          `saved search title is set to ${searchName} and save button is clickable`,
+          async () => {
+            const saveButton = await testSubjects.find('confirmSaveSavedObjectButton');
+            await testSubjects.setValue('savedObjectTitle', searchName);
+            return (await saveButton.getAttribute('disabled')) !== 'true';
+          }
+        );
         await testSubjects.setValue('savedObjectTitle', 'search-with-new-tag');
         await testSubjects.click('savedObjectTagSelector');
         await testSubjects.click(`tagSelectorOption-action__create`);


### PR DESCRIPTION
## Summary

This PR fixes an occasional flaky test of Discover's saved search tagging 
Flaky test runner 100x says it's ok:
https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2179

Fixes #150249

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
