### PR TITLE
[Serverless] ES should ignore the version mismatch

### DIFF
--- a/packages/core/elasticsearch/core-elasticsearch-server-internal/src/elasticsearch_service.ts
+++ b/packages/core/elasticsearch/core-elasticsearch-server-internal/src/elasticsearch_service.ts
@@ -97,7 +97,8 @@ export class ElasticsearchService
     const esNodesCompatibility$ = pollEsNodesVersion({
       internalClient: this.client.asInternalUser,
       log: this.log,
-      ignoreVersionMismatch: config.ignoreVersionMismatch,
+      ignoreVersionMismatch:
+        config.ignoreVersionMismatch || this.coreContext.env.cliArgs.serverless === true,
       esVersionCheckInterval: config.healthCheckDelay.asMilliseconds(),
       kibanaVersion: this.kibanaVersion,
     }).pipe(takeUntil(this.stop$), shareReplay({ refCount: true, bufferSize: 1 }));


### PR DESCRIPTION
## Summary

Resolves #154650.

After Kibana bumped the version to 8.9.0, all serverless promotion builds started failing because 

```
Server Error, caused by: http request failed [GET https://{host}:{port}/api/status] with status code [503] and response [Kibana server is not ready yet]
```

~I think it might be~ It is related to this check that is holding Kibana from being able to start. (just confirmed it by pulling the last working docker image and the new one).

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
