### PR TITLE
[Serverless] Unskip CLI flag test

### DIFF
--- a/src/cli/serve/integration_tests/serverless_config_flag.test.ts
+++ b/src/cli/serve/integration_tests/serverless_config_flag.test.ts
@@ -59,7 +59,6 @@ describe('cli serverless project type', () => {
     20 * 1000
   );
 
-  // Skipping this one because on CI it fails to read the config file
   it.each(['es', 'oblt', 'security'])(
     'writes the serverless project type %s in config/serverless.recent.yml',
     async (mode) => {

--- a/src/cli/serve/integration_tests/serverless_config_flag.test.ts
+++ b/src/cli/serve/integration_tests/serverless_config_flag.test.ts
@@ -6,15 +6,38 @@
  * Side Public License, v 1.
  */
 
-import { spawn, spawnSync } from 'child_process';
+import { spawn, spawnSync, ChildProcessWithoutNullStreams } from 'child_process';
+import type { Readable } from 'stream';
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
-import { filter, firstValueFrom, from, take, concatMap } from 'rxjs';
+import { filter, firstValueFrom, from, concatMap } from 'rxjs';
 
 import { REPO_ROOT } from '@kbn/repo-info';
 import { getConfigDirectory } from '@kbn/utils';
 
 describe('cli serverless project type', () => {
+  let child: ChildProcessWithoutNullStreams | undefined;
+
+  afterEach(() => {
+    child?.kill('SIGKILL');
+    child = undefined;
+  });
+
+  async function waitForMessage(stream: Readable, expectedMsg: string) {
+    let leftover = '';
+    return await firstValueFrom(
+      from(stream).pipe(
+        concatMap((chunk: Buffer) => {
+          const data = leftover + chunk.toString('utf-8');
+          const msgs = data.split('\n');
+          leftover = msgs.pop() ?? '';
+          return msgs;
+        }),
+        filter((msg) => msg.includes(expectedMsg) || msg.includes('FATAL'))
+      )
+    );
+  }
+
   it(
     'exits with statusCode 1 and logs an error when serverless project type is invalid',
     () => {
@@ -41,47 +64,32 @@ describe('cli serverless project type', () => {
     'writes the serverless project type %s in config/serverless.recent.yml',
     async (mode) => {
       // Making sure `--serverless` translates into the `serverless` config entry, and validates against the accepted values
-      const child = spawn(process.execPath, ['scripts/kibana', `--serverless=${mode}`], {
+      child = spawn(process.execPath, ['scripts/kibana', `--serverless=${mode}`], {
         cwd: REPO_ROOT,
       });
 
-      // Wait for some lines in the logs
-      await firstValueFrom(from(child.stdout).pipe(take(20)));
+      // Wait until Kibana starts bootstrapping (at that point the file should be present)
+      const found = await waitForMessage(child.stdout, 'Kibana process configured with roles');
+      expect(found).not.toContain('FATAL');
 
       expect(
         readFileSync(resolve(getConfigDirectory(), 'serverless.recent.yml'), 'utf-8')
       ).toContain(`serverless: ${mode}\n`);
-
-      child.kill('SIGKILL');
     }
   );
 
   it.each(['es', 'oblt', 'security'])(
     'Kibana does not crash when running project type %s',
     async (mode) => {
-      const child = spawn(process.execPath, ['scripts/kibana', `--serverless=${mode}`], {
+      child = spawn(process.execPath, ['scripts/kibana', `--serverless=${mode}`], {
         cwd: REPO_ROOT,
       });
 
       // Wait until Kibana starts listening to the port
-      let leftover = '';
-      const found = await firstValueFrom(
-        from(child.stdout).pipe(
-          concatMap((chunk: Buffer) => {
-            const data = leftover + chunk.toString('utf-8');
-            const msgs = data.split('\n');
-            leftover = msgs.pop() ?? '';
-            return msgs;
-          }),
-          filter(
-            (msg) =>
-              msg.includes('http server running at http://localhost:5601') || msg.includes('FATAL')
-          )
-        )
+      const found = await waitForMessage(
+        child.stdout,
+        'http server running at http://localhost:5601'
       );
-
-      child.kill('SIGKILL');
-
       expect(found).not.toContain('FATAL');
     }
   );

--- a/src/cli/serve/integration_tests/serverless_config_flag.test.ts
+++ b/src/cli/serve/integration_tests/serverless_config_flag.test.ts
@@ -37,7 +37,7 @@ describe('cli serverless project type', () => {
   );
 
   // Skipping this one because on CI it fails to read the config file
-  it.skip.each(['es', 'oblt', 'security'])(
+  it.each(['es', 'oblt', 'security'])(
     'writes the serverless project type %s in config/serverless.recent.yml',
     async (mode) => {
       // Making sure `--serverless` translates into the `serverless` config entry, and validates against the accepted values
@@ -45,8 +45,8 @@ describe('cli serverless project type', () => {
         cwd: REPO_ROOT,
       });
 
-      // Wait for 5 lines in the logs
-      await firstValueFrom(from(child.stdout).pipe(take(5)));
+      // Wait for some lines in the logs
+      await firstValueFrom(from(child.stdout).pipe(take(20)));
 
       expect(
         readFileSync(resolve(getConfigDirectory(), 'serverless.recent.yml'), 'utf-8')

--- a/src/cli/serve/serve.js
+++ b/src/cli/serve/serve.js
@@ -125,11 +125,9 @@ function maybeSetRecentConfig(file, projectType, isDevMode, configs, method) {
   }
 
   try {
-    if (projectType === true) {
-      if (!existsSync(path)) {
-        writeMode('es');
-      }
-    } else {
+    if (!existsSync(path)) {
+      writeMode(projectType === true ? 'es' : projectType);
+    } else if (typeof projectType === 'string') {
       const data = readFileSync(path, 'utf-8');
       const match = data.match(/serverless: (\w+)\n/);
       if (!match || match[1] !== projectType) {
@@ -139,10 +137,6 @@ function maybeSetRecentConfig(file, projectType, isDevMode, configs, method) {
 
     configs[method](path);
   } catch (err) {
-    if (err.code === 'ENOENT') {
-      return;
-    }
-
     throw err;
   }
 }


### PR DESCRIPTION
## Summary

We only created new files when --serverless was called without a project type. This PR fixes that. It also refactors the handling and killing of the child process so that it doesn't leak from one test to another.

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
