### PR TITLE
Update session.ts to use URL safe IDs

### DIFF
--- a/x-pack/plugins/security/server/session_management/session.ts
+++ b/x-pack/plugins/security/server/session_management/session.ts
@@ -247,8 +247,8 @@ export class Session {
     >
   ) {
     const [sid, aad] = await Promise.all([
-      this.randomBytes(SID_BYTE_LENGTH).then((sidBuffer) => sidBuffer.toString('base64')),
-      this.randomBytes(AAD_BYTE_LENGTH).then((aadBuffer) => aadBuffer.toString('base64')),
+      this.randomBytes(SID_BYTE_LENGTH).then((sidBuffer) => sidBuffer.toString('base64url')),
+      this.randomBytes(AAD_BYTE_LENGTH).then((aadBuffer) => aadBuffer.toString('base64url')),
     ]);
 
     const sessionLogger = this.getLoggerForSID(sid);


### PR DESCRIPTION
## Summary

This changes the encoding for sessions to use URL safe base64 instead of the default base64. Occasionally the security plugin will create a base64 representation with a forward slash which errors in elasticsearch as a forward slash cannot be used in a document ID.

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
