### PR TITLE
[Cases ] Fix removal file label in user activity

### DIFF
--- a/x-pack/plugins/cases/public/components/files/file_type.test.tsx
+++ b/x-pack/plugins/cases/public/components/files/file_type.test.tsx
@@ -27,6 +27,7 @@ describe('getFileType', () => {
       icon: 'document',
       displayName: 'File Attachment Type',
       getAttachmentViewObject: expect.any(Function),
+      getAttachmentRemovalObject: expect.any(Function),
     });
   });
 
@@ -182,6 +183,13 @@ describe('getFileType', () => {
           hideDefaultActions: true,
         })
       );
+    });
+  });
+
+  describe('getFileAttachmentRemovalObject', () => {
+    it('event renders the right message', async () => {
+      // @ts-ignore
+      expect(fileType.getAttachmentRemovalObject().event).toBe('removed file');
     });
   });
 });

--- a/x-pack/plugins/cases/public/components/files/file_type.tsx
+++ b/x-pack/plugins/cases/public/components/files/file_type.tsx
@@ -103,4 +103,5 @@ export const getFileType = (): ExternalReferenceAttachmentType => ({
   icon: 'document',
   displayName: 'File Attachment Type',
   getAttachmentViewObject: getFileAttachmentViewObject,
+  getAttachmentRemovalObject: () => ({ event: i18n.REMOVED_FILE }),
 });

--- a/x-pack/plugins/cases/public/components/files/translations.tsx
+++ b/x-pack/plugins/cases/public/components/files/translations.tsx
@@ -113,3 +113,7 @@ export const DELETE = i18n.translate('xpack.cases.caseView.files.delete', {
 export const DELETE_FILE_TITLE = i18n.translate('xpack.cases.caseView.files.deleteThisFile', {
   defaultMessage: 'Delete this file?',
 });
+
+export const REMOVED_FILE = i18n.translate('xpack.cases.caseView.files.removedFile', {
+  defaultMessage: 'removed file',
+});


### PR DESCRIPTION
## Summary

When deleting a file user action the message displayed should be "<user> removed file".

before
<img width="1059" alt="Screenshot 2023-04-27 at 17 08 14" src="https://user-images.githubusercontent.com/1533137/234906123-48452699-a1ee-4452-b2ed-2ec3d4422ac3.png">


after
<img width="1063" alt="Screenshot 2023-04-27 at 17 07 56" src="https://user-images.githubusercontent.com/1533137/234906310-4cc9c752-da76-441e-b3de-3d6194e821cb.png">


<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->