### PR TITLE
[8.8] [Cases ]Add getAttachmentRemovalObject to file type. (#156031)

### DIFF
--- a/x-pack/plugins/cases/public/components/files/file_type.test.tsx
+++ b/x-pack/plugins/cases/public/components/files/file_type.test.tsx
@@ -27,6 +27,7 @@ describe('getFileType', () => {
       icon: 'document',
       displayName: 'File Attachment Type',
       getAttachmentViewObject: expect.any(Function),
+      getAttachmentRemovalObject: expect.any(Function),
     });
   });
 
@@ -182,6 +183,13 @@ describe('getFileType', () => {
           hideDefaultActions: true,
         })
       );
+    });
+  });
+
+  describe('getFileAttachmentRemovalObject', () => {
+    it('event renders the right message', async () => {
+      // @ts-ignore
+      expect(fileType.getAttachmentRemovalObject().event).toBe('removed file');
     });
   });
 });

--- a/x-pack/plugins/cases/public/components/files/file_type.tsx
+++ b/x-pack/plugins/cases/public/components/files/file_type.tsx
@@ -103,4 +103,5 @@ export const getFileType = (): ExternalReferenceAttachmentType => ({
   icon: 'document',
   displayName: 'File Attachment Type',
   getAttachmentViewObject: getFileAttachmentViewObject,
+  getAttachmentRemovalObject: () => ({ event: i18n.REMOVED_FILE }),
 });

--- a/x-pack/plugins/cases/public/components/files/translations.tsx
+++ b/x-pack/plugins/cases/public/components/files/translations.tsx
@@ -113,3 +113,7 @@ export const DELETE = i18n.translate('xpack.cases.caseView.files.delete', {
 export const DELETE_FILE_TITLE = i18n.translate('xpack.cases.caseView.files.deleteThisFile', {
   defaultMessage: 'Delete this file?',
 });
+
+export const REMOVED_FILE = i18n.translate('xpack.cases.caseView.files.removedFile', {
+  defaultMessage: 'removed file',
+});


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.8`:
 - [[Cases ]Add getAttachmentRemovalObject to file type. (#156031)](https://github.com/elastic/kibana/pull/156031)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Antonio","email":"antonio.coelho@elastic.co"},"sourceCommit":{"committedDate":"2023-04-27T16:17:11Z","message":"[Cases ]Add getAttachmentRemovalObject to file type. (#156031)\n\n## Summary\r\n\r\nWhen deleting a file user action the message displayed should be \"<user>\r\nremoved file\".\r\n\r\nbefore\r\n<img width=\"1059\" alt=\"Screenshot 2023-04-27 at 17 08 14\"\r\nsrc=\"https://user-images.githubusercontent.com/1533137/234906123-48452699-a1ee-4452-b2ed-2ec3d4422ac3.png\">\r\n\r\n\r\nafter\r\n<img width=\"1063\" alt=\"Screenshot 2023-04-27 at 17 07 56\"\r\nsrc=\"https://user-images.githubusercontent.com/1533137/234906310-4cc9c752-da76-441e-b3de-3d6194e821cb.png\">","sha":"3480acddd8dd96fc936b2c9f170afed0baaa9002","branchLabelMapping":{"^v8.9.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","Team:ResponseOps","Feature:Cases","backport:prev-minor","v8.9.0"],"number":156031,"url":"https://github.com/elastic/kibana/pull/156031","mergeCommit":{"message":"[Cases ]Add getAttachmentRemovalObject to file type. (#156031)\n\n## Summary\r\n\r\nWhen deleting a file user action the message displayed should be \"<user>\r\nremoved file\".\r\n\r\nbefore\r\n<img width=\"1059\" alt=\"Screenshot 2023-04-27 at 17 08 14\"\r\nsrc=\"https://user-images.githubusercontent.com/1533137/234906123-48452699-a1ee-4452-b2ed-2ec3d4422ac3.png\">\r\n\r\n\r\nafter\r\n<img width=\"1063\" alt=\"Screenshot 2023-04-27 at 17 07 56\"\r\nsrc=\"https://user-images.githubusercontent.com/1533137/234906310-4cc9c752-da76-441e-b3de-3d6194e821cb.png\">","sha":"3480acddd8dd96fc936b2c9f170afed0baaa9002"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.9.0","labelRegex":"^v8.9.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/156031","number":156031,"mergeCommit":{"message":"[Cases ]Add getAttachmentRemovalObject to file type. (#156031)\n\n## Summary\r\n\r\nWhen deleting a file user action the message displayed should be \"<user>\r\nremoved file\".\r\n\r\nbefore\r\n<img width=\"1059\" alt=\"Screenshot 2023-04-27 at 17 08 14\"\r\nsrc=\"https://user-images.githubusercontent.com/1533137/234906123-48452699-a1ee-4452-b2ed-2ec3d4422ac3.png\">\r\n\r\n\r\nafter\r\n<img width=\"1063\" alt=\"Screenshot 2023-04-27 at 17 07 56\"\r\nsrc=\"https://user-images.githubusercontent.com/1533137/234906310-4cc9c752-da76-441e-b3de-3d6194e821cb.png\">","sha":"3480acddd8dd96fc936b2c9f170afed0baaa9002"}}]}] BACKPORT-->