### PR TITLE
[Enterprise Search] Fix copy, typo in code snippet

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_connect/engine_api_integration.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/engine/engine_connect/engine_api_integration.tsx
@@ -19,7 +19,7 @@ import { EngineApiLogic } from './engine_api_logic';
 
 import { elasticsearchUrl } from './search_application_api';
 
-const SearchUISnippet = (esUrl: string, engineName: string, apiKey: string) => `6
+const SearchUISnippet = (esUrl: string, engineName: string, apiKey: string) => `
 import EnginesAPIConnector from "@elastic/search-ui-engines-connector";
 
 const connector = new EnginesAPIConnector({
@@ -74,7 +74,7 @@ export const EngineApiIntegrationStage: React.FC = () => {
         <p>
           {i18n.translate('xpack.enterpriseSearch.content.engine.api.step3.intro', {
             defaultMessage:
-              'Learn how to integrate with your search application with the language clients maintained by Elastic to help build your search experience.',
+              'Use the following code snippets to connect to your search application.',
           })}
         </p>
       </EuiText>


### PR DESCRIPTION
- Updates copy
- Removes stray "6" from start of Search UI snippet

<img width="1214" alt="capture" src="https://user-images.githubusercontent.com/32779855/234936095-eb803bd6-632d-4793-b0cc-b195a573431d.png">


<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->