### PR TITLE
[Synthetics] enable api key when devUrl is set

### DIFF
--- a/x-pack/plugins/synthetics/server/routes/synthetics_service/enablement.ts
+++ b/x-pack/plugins/synthetics/server/routes/synthetics_service/enablement.ts
@@ -30,7 +30,8 @@ export const getSyntheticsEnablementRoute: SyntheticsRestApiRouteFactory = (libs
         });
       }
       const regenerationRequired = !isEnabled || !isValid;
-      const shouldEnableApiKey = server.config.service?.manifestUrl || server.config.service?.devUrl;
+      const shouldEnableApiKey =
+        server.config.service?.manifestUrl || server.config.service?.devUrl;
       if (canEnable && regenerationRequired && shouldEnableApiKey) {
         await generateAndSaveServiceAPIKey({
           request,

--- a/x-pack/plugins/synthetics/server/routes/synthetics_service/enablement.ts
+++ b/x-pack/plugins/synthetics/server/routes/synthetics_service/enablement.ts
@@ -30,7 +30,8 @@ export const getSyntheticsEnablementRoute: SyntheticsRestApiRouteFactory = (libs
         });
       }
       const regenerationRequired = !isEnabled || !isValid;
-      if (canEnable && regenerationRequired && server.config.service?.manifestUrl) {
+      const shouldEnableApiKey = server.config.service?.manifestUrl || server.config.service?.devUrl;
+      if (canEnable && regenerationRequired && shouldEnableApiKey) {
         await generateAndSaveServiceAPIKey({
           request,
           authSavedObjectsClient: savedObjectsClient,

--- a/x-pack/plugins/synthetics/server/synthetics_service/get_api_key.ts
+++ b/x-pack/plugins/synthetics/server/synthetics_service/get_api_key.ts
@@ -171,7 +171,7 @@ export const getSyntheticsEnablement = async ({ server }: { server: UptimeServer
 
   const { canEnable, canManageApiKeys } = hasPrivileges;
 
-  if (!config.service?.manifestUrl) {
+  if (!config.service?.manifestUrl && !config.service?.devUrl) {
     return {
       canEnable: true,
       canManageApiKeys,


### PR DESCRIPTION
## Summary

Makes sure an ApiKey for synthetics is created when the config `xpack.uptime.service.devUrl` is set in kibana.yaml

Before this small fix, it wasn't possible for Kibana to communicate with the service when working locally:

```
[ERROR][plugins.synthetics] API key is not valid. Cannot push monitor configuration to synthetics public testing locations
```

Screenshot:
--
![Screenshot 2023-04-27 at 18 32 04](https://user-images.githubusercontent.com/15065076/234940680-ce5a130b-a24f-4c28-a6f8-46b0a778b6cc.png)




<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->