### PR TITLE
[Dashboard] Fix flaky Dashboard create tests

### DIFF
--- a/src/plugins/dashboard/public/dashboard_container/embeddable/create/create_dashboard.test.ts
+++ b/src/plugins/dashboard/public/dashboard_container/embeddable/create/create_dashboard.test.ts
@@ -31,317 +31,306 @@ import { DashboardCreationOptions } from '../dashboard_container_factory';
 import { DEFAULT_DASHBOARD_INPUT } from '../../../dashboard_constants';
 
 const embeddableId = 'create-dat-dashboard';
-for (const i of Array(200)
-  .fill(null)
-  .map((_, i) => i)) {
-  describe(`test run ${i}`, () => {
-    test('throws error when no data views are available', async () => {
-      pluginServices.getServices().data.dataViews.getDefaultDataView = jest
-        .fn()
-        .mockReturnValue(undefined);
-      await expect(async () => {
-        await createDashboard(embeddableId);
-      }).rejects.toThrow('Dashboard requires at least one data view before it can be initialized.');
 
-      // reset get default data view
-      pluginServices.getServices().data.dataViews.getDefaultDataView = jest
-        .fn()
-        .mockResolvedValue({});
+test('throws error when no data views are available', async () => {
+  pluginServices.getServices().data.dataViews.getDefaultDataView = jest
+    .fn()
+    .mockReturnValue(undefined);
+  await expect(async () => {
+    await createDashboard(embeddableId);
+  }).rejects.toThrow('Dashboard requires at least one data view before it can be initialized.');
+
+  // reset get default data view
+  pluginServices.getServices().data.dataViews.getDefaultDataView = jest.fn().mockResolvedValue({});
+});
+
+test('throws error when provided validation function returns invalid', async () => {
+  const creationOptions: DashboardCreationOptions = {
+    validateLoadedSavedObject: jest.fn().mockImplementation(() => false),
+  };
+  await expect(async () => {
+    await createDashboard(embeddableId, creationOptions, 0, 'test-id');
+  }).rejects.toThrow('Dashboard failed saved object result validation');
+});
+
+test('pulls state from dashboard saved object when given a saved object id', async () => {
+  pluginServices.getServices().dashboardSavedObject.loadDashboardStateFromSavedObject = jest
+    .fn()
+    .mockResolvedValue({
+      dashboardInput: {
+        ...DEFAULT_DASHBOARD_INPUT,
+        description: `wow would you look at that? Wow.`,
+      },
     });
+  const dashboard = await createDashboard(embeddableId, {}, 0, 'wow-such-id');
+  expect(
+    pluginServices.getServices().dashboardSavedObject.loadDashboardStateFromSavedObject
+  ).toHaveBeenCalledWith({ id: 'wow-such-id' });
+  expect(dashboard.getState().explicitInput.description).toBe(`wow would you look at that? Wow.`);
+});
 
-    test('throws error when provided validation function returns invalid', async () => {
-      const creationOptions: DashboardCreationOptions = {
-        validateLoadedSavedObject: jest.fn().mockImplementation(() => false),
-      };
-      await expect(async () => {
-        await createDashboard(embeddableId, creationOptions, 0, 'test-id');
-      }).rejects.toThrow('Dashboard failed saved object result validation');
+test('pulls state from session storage which overrides state from saved object', async () => {
+  pluginServices.getServices().dashboardSavedObject.loadDashboardStateFromSavedObject = jest
+    .fn()
+    .mockResolvedValue({
+      dashboardInput: {
+        ...DEFAULT_DASHBOARD_INPUT,
+        description: 'wow this description is okay',
+      },
     });
+  pluginServices.getServices().dashboardSessionStorage.getState = jest
+    .fn()
+    .mockReturnValue({ description: 'wow this description marginally better' });
+  const dashboard = await createDashboard(
+    embeddableId,
+    { useSessionStorageIntegration: true },
+    0,
+    'wow-such-id'
+  );
+  expect(dashboard.getState().explicitInput.description).toBe(
+    'wow this description marginally better'
+  );
+});
 
-    test('pulls state from dashboard saved object when given a saved object id', async () => {
-      pluginServices.getServices().dashboardSavedObject.loadDashboardStateFromSavedObject = jest
-        .fn()
-        .mockResolvedValue({
-          dashboardInput: {
-            ...DEFAULT_DASHBOARD_INPUT,
-            description: `wow would you look at that? Wow.`,
-          },
-        });
-      const dashboard = await createDashboard(embeddableId, {}, 0, 'wow-such-id');
-      expect(
-        pluginServices.getServices().dashboardSavedObject.loadDashboardStateFromSavedObject
-      ).toHaveBeenCalledWith({ id: 'wow-such-id' });
-      expect(dashboard.getState().explicitInput.description).toBe(
-        `wow would you look at that? Wow.`
-      );
+test('pulls state from creation options initial input which overrides all other state sources', async () => {
+  pluginServices.getServices().dashboardSavedObject.loadDashboardStateFromSavedObject = jest
+    .fn()
+    .mockResolvedValue({
+      dashboardInput: {
+        ...DEFAULT_DASHBOARD_INPUT,
+        description: 'wow this description is okay',
+      },
     });
+  pluginServices.getServices().dashboardSessionStorage.getState = jest
+    .fn()
+    .mockReturnValue({ description: 'wow this description marginally better' });
+  const dashboard = await createDashboard(
+    embeddableId,
+    {
+      useSessionStorageIntegration: true,
+      initialInput: { description: 'wow this description is a masterpiece' },
+    },
+    0,
+    'wow-such-id'
+  );
+  expect(dashboard.getState().explicitInput.description).toBe(
+    'wow this description is a masterpiece'
+  );
+});
 
-    test('pulls state from session storage which overrides state from saved object', async () => {
-      pluginServices.getServices().dashboardSavedObject.loadDashboardStateFromSavedObject = jest
-        .fn()
-        .mockResolvedValue({
-          dashboardInput: {
-            ...DEFAULT_DASHBOARD_INPUT,
-            description: 'wow this description is okay',
-          },
-        });
-      pluginServices.getServices().dashboardSessionStorage.getState = jest
-        .fn()
-        .mockReturnValue({ description: 'wow this description marginally better' });
-      const dashboard = await createDashboard(
-        embeddableId,
-        { useSessionStorageIntegration: true },
-        0,
-        'wow-such-id'
-      );
-      expect(dashboard.getState().explicitInput.description).toBe(
-        'wow this description marginally better'
-      );
-    });
-
-    test('pulls state from creation options initial input which overrides all other state sources', async () => {
-      pluginServices.getServices().dashboardSavedObject.loadDashboardStateFromSavedObject = jest
-        .fn()
-        .mockResolvedValue({
-          dashboardInput: {
-            ...DEFAULT_DASHBOARD_INPUT,
-            description: 'wow this description is okay',
-          },
-        });
-      pluginServices.getServices().dashboardSessionStorage.getState = jest
-        .fn()
-        .mockReturnValue({ description: 'wow this description marginally better' });
-      const dashboard = await createDashboard(
-        embeddableId,
-        {
-          useSessionStorageIntegration: true,
-          initialInput: { description: 'wow this description is a masterpiece' },
-        },
-        0,
-        'wow-such-id'
-      );
-      expect(dashboard.getState().explicitInput.description).toBe(
-        'wow this description is a masterpiece'
-      );
-    });
-
-    test('applies filters and query from state to query service', async () => {
-      const filters: Filter[] = [
-        { meta: { alias: 'test', disabled: false, negate: false, index: 'test' } },
-      ];
-      const query = { language: 'kql', query: 'query' };
-      await createDashboard(embeddableId, {
-        useUnifiedSearchIntegration: true,
-        unifiedSearchSettings: {
-          kbnUrlStateStorage: createKbnUrlStateStorage(),
-        },
-        initialInput: { filters, query },
-      });
-      expect(pluginServices.getServices().data.query.queryString.setQuery).toHaveBeenCalledWith(
-        query
-      );
-      expect(
-        pluginServices.getServices().data.query.filterManager.setAppFilters
-      ).toHaveBeenCalledWith(filters);
-    });
-
-    test('applies time range and refresh interval from initial input to query service if time restore is on', async () => {
-      const timeRange = { from: new Date().toISOString(), to: new Date().toISOString() };
-      const refreshInterval = { pause: false, value: 42 };
-      await createDashboard(embeddableId, {
-        useUnifiedSearchIntegration: true,
-        unifiedSearchSettings: {
-          kbnUrlStateStorage: createKbnUrlStateStorage(),
-        },
-        initialInput: { timeRange, refreshInterval, timeRestore: true },
-      });
-      expect(
-        pluginServices.getServices().data.query.timefilter.timefilter.setTime
-      ).toHaveBeenCalledWith(timeRange);
-      expect(
-        pluginServices.getServices().data.query.timefilter.timefilter.setRefreshInterval
-      ).toHaveBeenCalledWith(refreshInterval);
-    });
-
-    test('applied time range from query service to initial input if time restore is off', async () => {
-      const timeRange = { from: new Date().toISOString(), to: new Date().toISOString() };
-      pluginServices.getServices().data.query.timefilter.timefilter.getTime = jest
-        .fn()
-        .mockReturnValue(timeRange);
-      const dashboard = await createDashboard(embeddableId, {
-        useUnifiedSearchIntegration: true,
-        unifiedSearchSettings: {
-          kbnUrlStateStorage: createKbnUrlStateStorage(),
-        },
-      });
-      expect(dashboard.getState().explicitInput.timeRange).toEqual(timeRange);
-    });
-
-    test('replaces panel with incoming embeddable if id matches existing panel', async () => {
-      const incomingEmbeddable: EmbeddablePackageState = {
-        type: CONTACT_CARD_EMBEDDABLE,
-        input: {
-          id: 'i_match',
-          firstName: 'wow look at this replacement wow',
-        } as ContactCardEmbeddableInput,
-        embeddableId: 'i_match',
-      };
-      const dashboard = await createDashboard(embeddableId, {
-        incomingEmbeddable,
-        initialInput: {
-          panels: {
-            i_match: getSampleDashboardPanel<ContactCardEmbeddableInput>({
-              explicitInput: {
-                id: 'i_match',
-                firstName: 'oh no, I am about to get replaced',
-              },
-              type: CONTACT_CARD_EMBEDDABLE,
-            }),
-          },
-        },
-      });
-      expect(dashboard.getState().explicitInput.panels.i_match.explicitInput).toStrictEqual(
-        expect.objectContaining({
-          id: 'i_match',
-          firstName: 'wow look at this replacement wow',
-        })
-      );
-    });
-
-    test('creates new embeddable with incoming embeddable if id does not match existing panel', async () => {
-      const incomingEmbeddable: EmbeddablePackageState = {
-        type: CONTACT_CARD_EMBEDDABLE,
-        input: {
-          id: 'i_match',
-          firstName: 'wow look at this new panel wow',
-        } as ContactCardEmbeddableInput,
-        embeddableId: 'i_match',
-      };
-      const mockContactCardFactory = {
-        create: jest.fn().mockReturnValue({ destroy: jest.fn() }),
-        getDefaultInput: jest.fn().mockResolvedValue({}),
-      };
-      pluginServices.getServices().embeddable.getEmbeddableFactory = jest
-        .fn()
-        .mockReturnValue(mockContactCardFactory);
-
-      const dashboard = await createDashboard(embeddableId, {
-        incomingEmbeddable,
-        initialInput: {
-          panels: {
-            i_do_not_match: getSampleDashboardPanel<ContactCardEmbeddableInput>({
-              explicitInput: {
-                id: 'i_do_not_match',
-                firstName: 'phew... I will not be replaced',
-              },
-              type: CONTACT_CARD_EMBEDDABLE,
-            }),
-          },
-        },
-      });
-
-      // flush promises
-      await new Promise((r) => setTimeout(r, 1));
-      expect(mockContactCardFactory.create).toHaveBeenCalledWith(
-        expect.objectContaining({
-          id: 'i_match',
-          firstName: 'wow look at this new panel wow',
-        }),
-        expect.any(Object)
-      );
-    });
-
-    test('creates a control group from the control group factory and waits for it to be initialized', async () => {
-      const mockControlGroupContainer = {
-        destroy: jest.fn(),
-        render: jest.fn(),
-        updateInput: jest.fn(),
-        untilInitialized: jest.fn(),
-        getInput: jest.fn().mockReturnValue({}),
-        getInput$: jest.fn().mockReturnValue(new Observable()),
-        getOutput$: jest.fn().mockReturnValue(new Observable()),
-      } as unknown as ControlGroupContainer;
-      const mockControlGroupFactory = {
-        create: jest.fn().mockReturnValue(mockControlGroupContainer),
-      } as unknown as ControlGroupContainerFactory;
-      pluginServices.getServices().embeddable.getEmbeddableFactory = jest
-        .fn()
-        .mockReturnValue(mockControlGroupFactory);
-      await createDashboard(embeddableId, {
-        useControlGroupIntegration: true,
-        initialInput: {
-          controlGroupInput: { controlStyle: 'twoLine' } as unknown as ControlGroupInput,
-        },
-      });
-      // flush promises
-      await new Promise((r) => setTimeout(r, 1));
-      expect(pluginServices.getServices().embeddable.getEmbeddableFactory).toHaveBeenCalledWith(
-        'control_group'
-      );
-      expect(mockControlGroupFactory.create).toHaveBeenCalledWith(
-        expect.objectContaining({ controlStyle: 'twoLine' })
-      );
-      expect(mockControlGroupContainer.untilInitialized).toHaveBeenCalled();
-    });
-
-    /*
-     * dashboard.getInput$() subscriptions are used to update:
-     * 1) dashboard instance searchSessionId state
-     * 2) child input on parent input changes
-     *
-     * Rxjs subscriptions are executed in the order that they are created.
-     * This test ensures that searchSessionId update subscription is created before child input subscription
-     * to ensure child input subscription includes updated searchSessionId.
-     */
-    test('searchSessionId is updated prior to child embeddable parent subscription execution', async () => {
-      const embeddableFactory = {
-        create: new ContactCardEmbeddableFactory((() => null) as any, {} as any),
-        getDefaultInput: jest.fn().mockResolvedValue({
-          timeRange: {
-            to: 'now',
-            from: 'now-15m',
-          },
-        }),
-      };
-      pluginServices.getServices().embeddable.getEmbeddableFactory = jest
-        .fn()
-        .mockReturnValue(embeddableFactory);
-      let sessionCount = 0;
-      pluginServices.getServices().data.search.session.start = () => {
-        sessionCount++;
-        return `searchSessionId${sessionCount}`;
-      };
-      const dashboard = await createDashboard(embeddableId, {
-        searchSessionSettings: {
-          getSearchSessionIdFromURL: () => undefined,
-          removeSessionIdFromUrl: () => {},
-          createSessionRestorationDataProvider: () => {},
-        } as unknown as DashboardCreationOptions['searchSessionSettings'],
-      });
-      const embeddable = await dashboard.addNewEmbeddable<
-        ContactCardEmbeddableInput,
-        ContactCardEmbeddableOutput,
-        ContactCardEmbeddable
-      >(CONTACT_CARD_EMBEDDABLE, {
-        firstName: 'Bob',
-      });
-
-      expect(embeddable.getInput().searchSessionId).toBe('searchSessionId1');
-
-      dashboard.updateInput({
-        timeRange: {
-          to: 'now',
-          from: 'now-7d',
-        },
-      });
-
-      expect(sessionCount).toBeGreaterThan(1);
-      const embeddableInput = embeddable.getInput();
-      expect((embeddableInput as any).timeRange).toEqual({
-        to: 'now',
-        from: 'now-7d',
-      });
-      expect(embeddableInput.searchSessionId).toBe(`searchSessionId${sessionCount}`);
-    });
+test('applies filters and query from state to query service', async () => {
+  const filters: Filter[] = [
+    { meta: { alias: 'test', disabled: false, negate: false, index: 'test' } },
+  ];
+  const query = { language: 'kql', query: 'query' };
+  await createDashboard(embeddableId, {
+    useUnifiedSearchIntegration: true,
+    unifiedSearchSettings: {
+      kbnUrlStateStorage: createKbnUrlStateStorage(),
+    },
+    initialInput: { filters, query },
   });
-}
+  expect(pluginServices.getServices().data.query.queryString.setQuery).toHaveBeenCalledWith(query);
+  expect(pluginServices.getServices().data.query.filterManager.setAppFilters).toHaveBeenCalledWith(
+    filters
+  );
+});
+
+test('applies time range and refresh interval from initial input to query service if time restore is on', async () => {
+  const timeRange = { from: new Date().toISOString(), to: new Date().toISOString() };
+  const refreshInterval = { pause: false, value: 42 };
+  await createDashboard(embeddableId, {
+    useUnifiedSearchIntegration: true,
+    unifiedSearchSettings: {
+      kbnUrlStateStorage: createKbnUrlStateStorage(),
+    },
+    initialInput: { timeRange, refreshInterval, timeRestore: true },
+  });
+  expect(
+    pluginServices.getServices().data.query.timefilter.timefilter.setTime
+  ).toHaveBeenCalledWith(timeRange);
+  expect(
+    pluginServices.getServices().data.query.timefilter.timefilter.setRefreshInterval
+  ).toHaveBeenCalledWith(refreshInterval);
+});
+
+test('applied time range from query service to initial input if time restore is off', async () => {
+  const timeRange = { from: new Date().toISOString(), to: new Date().toISOString() };
+  pluginServices.getServices().data.query.timefilter.timefilter.getTime = jest
+    .fn()
+    .mockReturnValue(timeRange);
+  const dashboard = await createDashboard(embeddableId, {
+    useUnifiedSearchIntegration: true,
+    unifiedSearchSettings: {
+      kbnUrlStateStorage: createKbnUrlStateStorage(),
+    },
+  });
+  expect(dashboard.getState().explicitInput.timeRange).toEqual(timeRange);
+});
+
+test('replaces panel with incoming embeddable if id matches existing panel', async () => {
+  const incomingEmbeddable: EmbeddablePackageState = {
+    type: CONTACT_CARD_EMBEDDABLE,
+    input: {
+      id: 'i_match',
+      firstName: 'wow look at this replacement wow',
+    } as ContactCardEmbeddableInput,
+    embeddableId: 'i_match',
+  };
+  const dashboard = await createDashboard(embeddableId, {
+    incomingEmbeddable,
+    initialInput: {
+      panels: {
+        i_match: getSampleDashboardPanel<ContactCardEmbeddableInput>({
+          explicitInput: {
+            id: 'i_match',
+            firstName: 'oh no, I am about to get replaced',
+          },
+          type: CONTACT_CARD_EMBEDDABLE,
+        }),
+      },
+    },
+  });
+  expect(dashboard.getState().explicitInput.panels.i_match.explicitInput).toStrictEqual(
+    expect.objectContaining({
+      id: 'i_match',
+      firstName: 'wow look at this replacement wow',
+    })
+  );
+});
+
+test('creates new embeddable with incoming embeddable if id does not match existing panel', async () => {
+  const incomingEmbeddable: EmbeddablePackageState = {
+    type: CONTACT_CARD_EMBEDDABLE,
+    input: {
+      id: 'i_match',
+      firstName: 'wow look at this new panel wow',
+    } as ContactCardEmbeddableInput,
+    embeddableId: 'i_match',
+  };
+  const mockContactCardFactory = {
+    create: jest.fn().mockReturnValue({ destroy: jest.fn() }),
+    getDefaultInput: jest.fn().mockResolvedValue({}),
+  };
+  pluginServices.getServices().embeddable.getEmbeddableFactory = jest
+    .fn()
+    .mockReturnValue(mockContactCardFactory);
+
+  await createDashboard(embeddableId, {
+    incomingEmbeddable,
+    initialInput: {
+      panels: {
+        i_do_not_match: getSampleDashboardPanel<ContactCardEmbeddableInput>({
+          explicitInput: {
+            id: 'i_do_not_match',
+            firstName: 'phew... I will not be replaced',
+          },
+          type: CONTACT_CARD_EMBEDDABLE,
+        }),
+      },
+    },
+  });
+
+  // flush promises
+  await new Promise((r) => setTimeout(r, 1));
+  expect(mockContactCardFactory.create).toHaveBeenCalledWith(
+    expect.objectContaining({
+      id: 'i_match',
+      firstName: 'wow look at this new panel wow',
+    }),
+    expect.any(Object)
+  );
+});
+
+test('creates a control group from the control group factory and waits for it to be initialized', async () => {
+  const mockControlGroupContainer = {
+    destroy: jest.fn(),
+    render: jest.fn(),
+    updateInput: jest.fn(),
+    untilInitialized: jest.fn(),
+    getInput: jest.fn().mockReturnValue({}),
+    getInput$: jest.fn().mockReturnValue(new Observable()),
+    getOutput$: jest.fn().mockReturnValue(new Observable()),
+  } as unknown as ControlGroupContainer;
+  const mockControlGroupFactory = {
+    create: jest.fn().mockReturnValue(mockControlGroupContainer),
+  } as unknown as ControlGroupContainerFactory;
+  pluginServices.getServices().embeddable.getEmbeddableFactory = jest
+    .fn()
+    .mockReturnValue(mockControlGroupFactory);
+  await createDashboard(embeddableId, {
+    useControlGroupIntegration: true,
+    initialInput: {
+      controlGroupInput: { controlStyle: 'twoLine' } as unknown as ControlGroupInput,
+    },
+  });
+  // flush promises
+  await new Promise((r) => setTimeout(r, 1));
+  expect(pluginServices.getServices().embeddable.getEmbeddableFactory).toHaveBeenCalledWith(
+    'control_group'
+  );
+  expect(mockControlGroupFactory.create).toHaveBeenCalledWith(
+    expect.objectContaining({ controlStyle: 'twoLine' })
+  );
+  expect(mockControlGroupContainer.untilInitialized).toHaveBeenCalled();
+});
+
+/*
+ * dashboard.getInput$() subscriptions are used to update:
+ * 1) dashboard instance searchSessionId state
+ * 2) child input on parent input changes
+ *
+ * Rxjs subscriptions are executed in the order that they are created.
+ * This test ensures that searchSessionId update subscription is created before child input subscription
+ * to ensure child input subscription includes updated searchSessionId.
+ */
+test('searchSessionId is updated prior to child embeddable parent subscription execution', async () => {
+  const embeddableFactory = {
+    create: new ContactCardEmbeddableFactory((() => null) as any, {} as any),
+    getDefaultInput: jest.fn().mockResolvedValue({
+      timeRange: {
+        to: 'now',
+        from: 'now-15m',
+      },
+    }),
+  };
+  pluginServices.getServices().embeddable.getEmbeddableFactory = jest
+    .fn()
+    .mockReturnValue(embeddableFactory);
+  let sessionCount = 0;
+  pluginServices.getServices().data.search.session.start = () => {
+    sessionCount++;
+    return `searchSessionId${sessionCount}`;
+  };
+  const dashboard = await createDashboard(embeddableId, {
+    searchSessionSettings: {
+      getSearchSessionIdFromURL: () => undefined,
+      removeSessionIdFromUrl: () => {},
+      createSessionRestorationDataProvider: () => {},
+    } as unknown as DashboardCreationOptions['searchSessionSettings'],
+  });
+  const embeddable = await dashboard.addNewEmbeddable<
+    ContactCardEmbeddableInput,
+    ContactCardEmbeddableOutput,
+    ContactCardEmbeddable
+  >(CONTACT_CARD_EMBEDDABLE, {
+    firstName: 'Bob',
+  });
+
+  expect(embeddable.getInput().searchSessionId).toBe('searchSessionId1');
+
+  dashboard.updateInput({
+    timeRange: {
+      to: 'now',
+      from: 'now-7d',
+    },
+  });
+
+  expect(sessionCount).toBeGreaterThan(1);
+  const embeddableInput = embeddable.getInput();
+  expect((embeddableInput as any).timeRange).toEqual({
+    to: 'now',
+    from: 'now-7d',
+  });
+  expect(embeddableInput.searchSessionId).toBe(`searchSessionId${sessionCount}`);
+});

--- a/src/plugins/dashboard/public/dashboard_container/embeddable/create/create_dashboard.test.ts
+++ b/src/plugins/dashboard/public/dashboard_container/embeddable/create/create_dashboard.test.ts
@@ -6,6 +6,8 @@
  * Side Public License, v 1.
  */
 
+import { Observable } from 'rxjs';
+
 import {
   ContactCardEmbeddable,
   ContactCardEmbeddableFactory,
@@ -26,293 +28,320 @@ import { createDashboard } from './create_dashboard';
 import { getSampleDashboardPanel } from '../../../mocks';
 import { pluginServices } from '../../../services/plugin_services';
 import { DashboardCreationOptions } from '../dashboard_container_factory';
-import { Observable } from 'rxjs';
+import { DEFAULT_DASHBOARD_INPUT } from '../../../dashboard_constants';
 
 const embeddableId = 'create-dat-dashboard';
+for (const i of Array(200)
+  .fill(null)
+  .map((_, i) => i)) {
+  describe(`test run ${i}`, () => {
+    test('throws error when no data views are available', async () => {
+      pluginServices.getServices().data.dataViews.getDefaultDataView = jest
+        .fn()
+        .mockReturnValue(undefined);
+      await expect(async () => {
+        await createDashboard(embeddableId);
+      }).rejects.toThrow('Dashboard requires at least one data view before it can be initialized.');
 
-test('throws error when no data views are available', async () => {
-  pluginServices.getServices().data.dataViews.getDefaultDataView = jest
-    .fn()
-    .mockReturnValue(undefined);
-  await expect(async () => {
-    await createDashboard(embeddableId);
-  }).rejects.toThrow('Dashboard requires at least one data view before it can be initialized.');
+      // reset get default data view
+      pluginServices.getServices().data.dataViews.getDefaultDataView = jest
+        .fn()
+        .mockResolvedValue({});
+    });
 
-  // reset get default data view
-  pluginServices.getServices().data.dataViews.getDefaultDataView = jest.fn().mockResolvedValue({});
-});
+    test('throws error when provided validation function returns invalid', async () => {
+      const creationOptions: DashboardCreationOptions = {
+        validateLoadedSavedObject: jest.fn().mockImplementation(() => false),
+      };
+      await expect(async () => {
+        await createDashboard(embeddableId, creationOptions, 0, 'test-id');
+      }).rejects.toThrow('Dashboard failed saved object result validation');
+    });
 
-test('throws error when provided validation function returns invalid', async () => {
-  const creationOptions: DashboardCreationOptions = {
-    validateLoadedSavedObject: jest.fn().mockImplementation(() => false),
-  };
-  await expect(async () => {
-    await createDashboard(embeddableId, creationOptions, 0, 'test-id');
-  }).rejects.toThrow('Dashboard failed saved object result validation');
-});
-
-test('pulls state from dashboard saved object when given a saved object id', async () => {
-  pluginServices.getServices().dashboardSavedObject.loadDashboardStateFromSavedObject = jest
-    .fn()
-    .mockResolvedValue({ dashboardInput: { description: 'wow would you look at that? Wow.' } });
-  const dashboard = await createDashboard(embeddableId, {}, 0, 'wow-such-id');
-  expect(
-    pluginServices.getServices().dashboardSavedObject.loadDashboardStateFromSavedObject
-  ).toHaveBeenCalledWith({ id: 'wow-such-id' });
-  expect(dashboard.getState().explicitInput.description).toBe('wow would you look at that? Wow.');
-});
-
-test('pulls state from session storage which overrides state from saved object', async () => {
-  pluginServices.getServices().dashboardSavedObject.loadDashboardStateFromSavedObject = jest
-    .fn()
-    .mockResolvedValue({ dashboardInput: { description: 'wow this description is okay' } });
-  pluginServices.getServices().dashboardSessionStorage.getState = jest
-    .fn()
-    .mockReturnValue({ description: 'wow this description marginally better' });
-  const dashboard = await createDashboard(
-    embeddableId,
-    { useSessionStorageIntegration: true },
-    0,
-    'wow-such-id'
-  );
-  expect(dashboard.getState().explicitInput.description).toBe(
-    'wow this description marginally better'
-  );
-});
-
-test('pulls state from creation options initial input which overrides all other state sources', async () => {
-  pluginServices.getServices().dashboardSavedObject.loadDashboardStateFromSavedObject = jest
-    .fn()
-    .mockResolvedValue({ dashboardInput: { description: 'wow this description is okay' } });
-  pluginServices.getServices().dashboardSessionStorage.getState = jest
-    .fn()
-    .mockReturnValue({ description: 'wow this description marginally better' });
-  const dashboard = await createDashboard(
-    embeddableId,
-    {
-      useSessionStorageIntegration: true,
-      initialInput: { description: 'wow this description is a masterpiece' },
-    },
-    0,
-    'wow-such-id'
-  );
-  expect(dashboard.getState().explicitInput.description).toBe(
-    'wow this description is a masterpiece'
-  );
-});
-
-test('applies filters and query from state to query service', async () => {
-  const filters: Filter[] = [
-    { meta: { alias: 'test', disabled: false, negate: false, index: 'test' } },
-  ];
-  const query = { language: 'kql', query: 'query' };
-  await createDashboard(embeddableId, {
-    useUnifiedSearchIntegration: true,
-    unifiedSearchSettings: {
-      kbnUrlStateStorage: createKbnUrlStateStorage(),
-    },
-    initialInput: { filters, query },
-  });
-  expect(pluginServices.getServices().data.query.queryString.setQuery).toHaveBeenCalledWith(query);
-  expect(pluginServices.getServices().data.query.filterManager.setAppFilters).toHaveBeenCalledWith(
-    filters
-  );
-});
-
-test('applies time range and refresh interval from initial input to query service if time restore is on', async () => {
-  const timeRange = { from: new Date().toISOString(), to: new Date().toISOString() };
-  const refreshInterval = { pause: false, value: 42 };
-  await createDashboard(embeddableId, {
-    useUnifiedSearchIntegration: true,
-    unifiedSearchSettings: {
-      kbnUrlStateStorage: createKbnUrlStateStorage(),
-    },
-    initialInput: { timeRange, refreshInterval, timeRestore: true },
-  });
-  expect(
-    pluginServices.getServices().data.query.timefilter.timefilter.setTime
-  ).toHaveBeenCalledWith(timeRange);
-  expect(
-    pluginServices.getServices().data.query.timefilter.timefilter.setRefreshInterval
-  ).toHaveBeenCalledWith(refreshInterval);
-});
-
-test('applied time range from query service to initial input if time restore is off', async () => {
-  const timeRange = { from: new Date().toISOString(), to: new Date().toISOString() };
-  pluginServices.getServices().data.query.timefilter.timefilter.getTime = jest
-    .fn()
-    .mockReturnValue(timeRange);
-  const dashboard = await createDashboard(embeddableId, {
-    useUnifiedSearchIntegration: true,
-    unifiedSearchSettings: {
-      kbnUrlStateStorage: createKbnUrlStateStorage(),
-    },
-  });
-  expect(dashboard.getState().explicitInput.timeRange).toEqual(timeRange);
-});
-
-test('replaces panel with incoming embeddable if id matches existing panel', async () => {
-  const incomingEmbeddable: EmbeddablePackageState = {
-    type: CONTACT_CARD_EMBEDDABLE,
-    input: {
-      id: 'i_match',
-      firstName: 'wow look at this replacement wow',
-    } as ContactCardEmbeddableInput,
-    embeddableId: 'i_match',
-  };
-  const dashboard = await createDashboard(embeddableId, {
-    incomingEmbeddable,
-    initialInput: {
-      panels: {
-        i_match: getSampleDashboardPanel<ContactCardEmbeddableInput>({
-          explicitInput: {
-            id: 'i_match',
-            firstName: 'oh no, I am about to get replaced',
+    test('pulls state from dashboard saved object when given a saved object id', async () => {
+      pluginServices.getServices().dashboardSavedObject.loadDashboardStateFromSavedObject = jest
+        .fn()
+        .mockResolvedValue({
+          dashboardInput: {
+            ...DEFAULT_DASHBOARD_INPUT,
+            description: `wow would you look at that? Wow.`,
           },
-          type: CONTACT_CARD_EMBEDDABLE,
-        }),
-      },
-    },
-  });
-  expect(dashboard.getState().explicitInput.panels.i_match.explicitInput).toStrictEqual(
-    expect.objectContaining({
-      id: 'i_match',
-      firstName: 'wow look at this replacement wow',
-    })
-  );
-});
+        });
+      const dashboard = await createDashboard(embeddableId, {}, 0, 'wow-such-id');
+      expect(
+        pluginServices.getServices().dashboardSavedObject.loadDashboardStateFromSavedObject
+      ).toHaveBeenCalledWith({ id: 'wow-such-id' });
+      expect(dashboard.getState().explicitInput.description).toBe(
+        `wow would you look at that? Wow.`
+      );
+    });
 
-test('creates new embeddable with incoming embeddable if id does not match existing panel', async () => {
-  const incomingEmbeddable: EmbeddablePackageState = {
-    type: CONTACT_CARD_EMBEDDABLE,
-    input: {
-      id: 'i_match',
-      firstName: 'wow look at this new panel wow',
-    } as ContactCardEmbeddableInput,
-    embeddableId: 'i_match',
-  };
-  const mockContactCardFactory = {
-    create: jest.fn().mockReturnValue({ destroy: jest.fn() }),
-    getDefaultInput: jest.fn().mockResolvedValue({}),
-  };
-  pluginServices.getServices().embeddable.getEmbeddableFactory = jest
-    .fn()
-    .mockReturnValue(mockContactCardFactory);
-
-  await createDashboard(embeddableId, {
-    incomingEmbeddable,
-    initialInput: {
-      panels: {
-        i_do_not_match: getSampleDashboardPanel<ContactCardEmbeddableInput>({
-          explicitInput: {
-            id: 'i_do_not_match',
-            firstName: 'phew... I will not be replaced',
+    test('pulls state from session storage which overrides state from saved object', async () => {
+      pluginServices.getServices().dashboardSavedObject.loadDashboardStateFromSavedObject = jest
+        .fn()
+        .mockResolvedValue({
+          dashboardInput: {
+            ...DEFAULT_DASHBOARD_INPUT,
+            description: 'wow this description is okay',
           },
-          type: CONTACT_CARD_EMBEDDABLE,
+        });
+      pluginServices.getServices().dashboardSessionStorage.getState = jest
+        .fn()
+        .mockReturnValue({ description: 'wow this description marginally better' });
+      const dashboard = await createDashboard(
+        embeddableId,
+        { useSessionStorageIntegration: true },
+        0,
+        'wow-such-id'
+      );
+      expect(dashboard.getState().explicitInput.description).toBe(
+        'wow this description marginally better'
+      );
+    });
+
+    test('pulls state from creation options initial input which overrides all other state sources', async () => {
+      pluginServices.getServices().dashboardSavedObject.loadDashboardStateFromSavedObject = jest
+        .fn()
+        .mockResolvedValue({
+          dashboardInput: {
+            ...DEFAULT_DASHBOARD_INPUT,
+            description: 'wow this description is okay',
+          },
+        });
+      pluginServices.getServices().dashboardSessionStorage.getState = jest
+        .fn()
+        .mockReturnValue({ description: 'wow this description marginally better' });
+      const dashboard = await createDashboard(
+        embeddableId,
+        {
+          useSessionStorageIntegration: true,
+          initialInput: { description: 'wow this description is a masterpiece' },
+        },
+        0,
+        'wow-such-id'
+      );
+      expect(dashboard.getState().explicitInput.description).toBe(
+        'wow this description is a masterpiece'
+      );
+    });
+
+    test('applies filters and query from state to query service', async () => {
+      const filters: Filter[] = [
+        { meta: { alias: 'test', disabled: false, negate: false, index: 'test' } },
+      ];
+      const query = { language: 'kql', query: 'query' };
+      await createDashboard(embeddableId, {
+        useUnifiedSearchIntegration: true,
+        unifiedSearchSettings: {
+          kbnUrlStateStorage: createKbnUrlStateStorage(),
+        },
+        initialInput: { filters, query },
+      });
+      expect(pluginServices.getServices().data.query.queryString.setQuery).toHaveBeenCalledWith(
+        query
+      );
+      expect(
+        pluginServices.getServices().data.query.filterManager.setAppFilters
+      ).toHaveBeenCalledWith(filters);
+    });
+
+    test('applies time range and refresh interval from initial input to query service if time restore is on', async () => {
+      const timeRange = { from: new Date().toISOString(), to: new Date().toISOString() };
+      const refreshInterval = { pause: false, value: 42 };
+      await createDashboard(embeddableId, {
+        useUnifiedSearchIntegration: true,
+        unifiedSearchSettings: {
+          kbnUrlStateStorage: createKbnUrlStateStorage(),
+        },
+        initialInput: { timeRange, refreshInterval, timeRestore: true },
+      });
+      expect(
+        pluginServices.getServices().data.query.timefilter.timefilter.setTime
+      ).toHaveBeenCalledWith(timeRange);
+      expect(
+        pluginServices.getServices().data.query.timefilter.timefilter.setRefreshInterval
+      ).toHaveBeenCalledWith(refreshInterval);
+    });
+
+    test('applied time range from query service to initial input if time restore is off', async () => {
+      const timeRange = { from: new Date().toISOString(), to: new Date().toISOString() };
+      pluginServices.getServices().data.query.timefilter.timefilter.getTime = jest
+        .fn()
+        .mockReturnValue(timeRange);
+      const dashboard = await createDashboard(embeddableId, {
+        useUnifiedSearchIntegration: true,
+        unifiedSearchSettings: {
+          kbnUrlStateStorage: createKbnUrlStateStorage(),
+        },
+      });
+      expect(dashboard.getState().explicitInput.timeRange).toEqual(timeRange);
+    });
+
+    test('replaces panel with incoming embeddable if id matches existing panel', async () => {
+      const incomingEmbeddable: EmbeddablePackageState = {
+        type: CONTACT_CARD_EMBEDDABLE,
+        input: {
+          id: 'i_match',
+          firstName: 'wow look at this replacement wow',
+        } as ContactCardEmbeddableInput,
+        embeddableId: 'i_match',
+      };
+      const dashboard = await createDashboard(embeddableId, {
+        incomingEmbeddable,
+        initialInput: {
+          panels: {
+            i_match: getSampleDashboardPanel<ContactCardEmbeddableInput>({
+              explicitInput: {
+                id: 'i_match',
+                firstName: 'oh no, I am about to get replaced',
+              },
+              type: CONTACT_CARD_EMBEDDABLE,
+            }),
+          },
+        },
+      });
+      expect(dashboard.getState().explicitInput.panels.i_match.explicitInput).toStrictEqual(
+        expect.objectContaining({
+          id: 'i_match',
+          firstName: 'wow look at this replacement wow',
+        })
+      );
+    });
+
+    test('creates new embeddable with incoming embeddable if id does not match existing panel', async () => {
+      const incomingEmbeddable: EmbeddablePackageState = {
+        type: CONTACT_CARD_EMBEDDABLE,
+        input: {
+          id: 'i_match',
+          firstName: 'wow look at this new panel wow',
+        } as ContactCardEmbeddableInput,
+        embeddableId: 'i_match',
+      };
+      const mockContactCardFactory = {
+        create: jest.fn().mockReturnValue({ destroy: jest.fn() }),
+        getDefaultInput: jest.fn().mockResolvedValue({}),
+      };
+      pluginServices.getServices().embeddable.getEmbeddableFactory = jest
+        .fn()
+        .mockReturnValue(mockContactCardFactory);
+
+      const dashboard = await createDashboard(embeddableId, {
+        incomingEmbeddable,
+        initialInput: {
+          panels: {
+            i_do_not_match: getSampleDashboardPanel<ContactCardEmbeddableInput>({
+              explicitInput: {
+                id: 'i_do_not_match',
+                firstName: 'phew... I will not be replaced',
+              },
+              type: CONTACT_CARD_EMBEDDABLE,
+            }),
+          },
+        },
+      });
+
+      // flush promises
+      await new Promise((r) => setTimeout(r, 1));
+      expect(mockContactCardFactory.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'i_match',
+          firstName: 'wow look at this new panel wow',
         }),
-      },
-    },
-  });
-  // flush promises
-  await new Promise((r) => setTimeout(r, 1));
-  expect(mockContactCardFactory.create).toHaveBeenCalledWith(
-    expect.objectContaining({
-      id: 'i_match',
-      firstName: 'wow look at this new panel wow',
-    }),
-    expect.any(Object)
-  );
-});
+        expect.any(Object)
+      );
+    });
 
-test('creates a control group from the control group factory and waits for it to be initialized', async () => {
-  const mockControlGroupContainer = {
-    destroy: jest.fn(),
-    render: jest.fn(),
-    updateInput: jest.fn(),
-    untilInitialized: jest.fn(),
-    getInput: jest.fn().mockReturnValue({}),
-    getInput$: jest.fn().mockReturnValue(new Observable()),
-    getOutput$: jest.fn().mockReturnValue(new Observable()),
-  } as unknown as ControlGroupContainer;
-  const mockControlGroupFactory = {
-    create: jest.fn().mockReturnValue(mockControlGroupContainer),
-  } as unknown as ControlGroupContainerFactory;
-  pluginServices.getServices().embeddable.getEmbeddableFactory = jest
-    .fn()
-    .mockReturnValue(mockControlGroupFactory);
-  await createDashboard(embeddableId, {
-    useControlGroupIntegration: true,
-    initialInput: {
-      controlGroupInput: { controlStyle: 'twoLine' } as unknown as ControlGroupInput,
-    },
-  });
-  // flush promises
-  await new Promise((r) => setTimeout(r, 1));
-  expect(pluginServices.getServices().embeddable.getEmbeddableFactory).toHaveBeenCalledWith(
-    'control_group'
-  );
-  expect(mockControlGroupFactory.create).toHaveBeenCalledWith(
-    expect.objectContaining({ controlStyle: 'twoLine' })
-  );
-  expect(mockControlGroupContainer.untilInitialized).toHaveBeenCalled();
-});
+    test('creates a control group from the control group factory and waits for it to be initialized', async () => {
+      const mockControlGroupContainer = {
+        destroy: jest.fn(),
+        render: jest.fn(),
+        updateInput: jest.fn(),
+        untilInitialized: jest.fn(),
+        getInput: jest.fn().mockReturnValue({}),
+        getInput$: jest.fn().mockReturnValue(new Observable()),
+        getOutput$: jest.fn().mockReturnValue(new Observable()),
+      } as unknown as ControlGroupContainer;
+      const mockControlGroupFactory = {
+        create: jest.fn().mockReturnValue(mockControlGroupContainer),
+      } as unknown as ControlGroupContainerFactory;
+      pluginServices.getServices().embeddable.getEmbeddableFactory = jest
+        .fn()
+        .mockReturnValue(mockControlGroupFactory);
+      await createDashboard(embeddableId, {
+        useControlGroupIntegration: true,
+        initialInput: {
+          controlGroupInput: { controlStyle: 'twoLine' } as unknown as ControlGroupInput,
+        },
+      });
+      // flush promises
+      await new Promise((r) => setTimeout(r, 1));
+      expect(pluginServices.getServices().embeddable.getEmbeddableFactory).toHaveBeenCalledWith(
+        'control_group'
+      );
+      expect(mockControlGroupFactory.create).toHaveBeenCalledWith(
+        expect.objectContaining({ controlStyle: 'twoLine' })
+      );
+      expect(mockControlGroupContainer.untilInitialized).toHaveBeenCalled();
+    });
 
-/*
- * dashboard.getInput$() subscriptions are used to update:
- * 1) dashboard instance searchSessionId state
- * 2) child input on parent input changes
- *
- * Rxjs subscriptions are executed in the order that they are created.
- * This test ensures that searchSessionId update subscription is created before child input subscription
- * to ensure child input subscription includes updated searchSessionId.
- */
-test('searchSessionId is updated prior to child embeddable parent subscription execution', async () => {
-  const embeddableFactory = {
-    create: new ContactCardEmbeddableFactory((() => null) as any, {} as any),
-    getDefaultInput: jest.fn().mockResolvedValue({
-      timeRange: {
+    /*
+     * dashboard.getInput$() subscriptions are used to update:
+     * 1) dashboard instance searchSessionId state
+     * 2) child input on parent input changes
+     *
+     * Rxjs subscriptions are executed in the order that they are created.
+     * This test ensures that searchSessionId update subscription is created before child input subscription
+     * to ensure child input subscription includes updated searchSessionId.
+     */
+    test('searchSessionId is updated prior to child embeddable parent subscription execution', async () => {
+      const embeddableFactory = {
+        create: new ContactCardEmbeddableFactory((() => null) as any, {} as any),
+        getDefaultInput: jest.fn().mockResolvedValue({
+          timeRange: {
+            to: 'now',
+            from: 'now-15m',
+          },
+        }),
+      };
+      pluginServices.getServices().embeddable.getEmbeddableFactory = jest
+        .fn()
+        .mockReturnValue(embeddableFactory);
+      let sessionCount = 0;
+      pluginServices.getServices().data.search.session.start = () => {
+        sessionCount++;
+        return `searchSessionId${sessionCount}`;
+      };
+      const dashboard = await createDashboard(embeddableId, {
+        searchSessionSettings: {
+          getSearchSessionIdFromURL: () => undefined,
+          removeSessionIdFromUrl: () => {},
+          createSessionRestorationDataProvider: () => {},
+        } as unknown as DashboardCreationOptions['searchSessionSettings'],
+      });
+      const embeddable = await dashboard.addNewEmbeddable<
+        ContactCardEmbeddableInput,
+        ContactCardEmbeddableOutput,
+        ContactCardEmbeddable
+      >(CONTACT_CARD_EMBEDDABLE, {
+        firstName: 'Bob',
+      });
+
+      expect(embeddable.getInput().searchSessionId).toBe('searchSessionId1');
+
+      dashboard.updateInput({
+        timeRange: {
+          to: 'now',
+          from: 'now-7d',
+        },
+      });
+
+      expect(sessionCount).toBeGreaterThan(1);
+      const embeddableInput = embeddable.getInput();
+      expect((embeddableInput as any).timeRange).toEqual({
         to: 'now',
-        from: 'now-15m',
-      },
-    }),
-  };
-  pluginServices.getServices().embeddable.getEmbeddableFactory = jest
-    .fn()
-    .mockReturnValue(embeddableFactory);
-  let sessionCount = 0;
-  pluginServices.getServices().data.search.session.start = () => {
-    sessionCount++;
-    return `searchSessionId${sessionCount}`;
-  };
-  const dashboard = await createDashboard(embeddableId, {
-    searchSessionSettings: {
-      getSearchSessionIdFromURL: () => undefined,
-      removeSessionIdFromUrl: () => {},
-      createSessionRestorationDataProvider: () => {},
-    } as unknown as DashboardCreationOptions['searchSessionSettings'],
+        from: 'now-7d',
+      });
+      expect(embeddableInput.searchSessionId).toBe(`searchSessionId${sessionCount}`);
+    });
   });
-  const embeddable = await dashboard.addNewEmbeddable<
-    ContactCardEmbeddableInput,
-    ContactCardEmbeddableOutput,
-    ContactCardEmbeddable
-  >(CONTACT_CARD_EMBEDDABLE, {
-    firstName: 'Bob',
-  });
-
-  expect(embeddable.getInput().searchSessionId).toBe('searchSessionId1');
-
-  dashboard.updateInput({
-    timeRange: {
-      to: 'now',
-      from: 'now-7d',
-    },
-  });
-
-  expect(sessionCount).toBeGreaterThan(1);
-  const embeddableInput = embeddable.getInput();
-  expect((embeddableInput as any).timeRange).toEqual({
-    to: 'now',
-    from: 'now-7d',
-  });
-  expect(embeddableInput.searchSessionId).toBe(`searchSessionId${sessionCount}`);
-});
+}

--- a/src/plugins/dashboard/public/dashboard_container/embeddable/dashboard_container.tsx
+++ b/src/plugins/dashboard/public/dashboard_container/embeddable/dashboard_container.tsx
@@ -153,8 +153,7 @@ export class DashboardContainer extends Container<InheritedChildInput, Dashboard
     this.dashboardCreationStartTime = dashboardCreationStartTime;
 
     // start diffing dashboard state
-    const { diffingMiddleware, checkForUnsavedChangesSubject$ } =
-      startDiffingDashboardState.bind(this)(creationOptions);
+    const diffingMiddleware = startDiffingDashboardState.bind(this)(creationOptions);
 
     // build redux embeddable tools
     const reduxTools = reduxToolsPackage.createReduxEmbeddableTools<
@@ -179,8 +178,6 @@ export class DashboardContainer extends Container<InheritedChildInput, Dashboard
     this.getState = reduxTools.getState;
     this.dispatch = reduxTools.dispatch;
     this.select = reduxTools.select;
-
-    checkForUnsavedChangesSubject$?.next(null);
   }
 
   public getDashboardSavedObjectId() {

--- a/src/plugins/dashboard/public/dashboard_container/embeddable/dashboard_container.tsx
+++ b/src/plugins/dashboard/public/dashboard_container/embeddable/dashboard_container.tsx
@@ -153,7 +153,8 @@ export class DashboardContainer extends Container<InheritedChildInput, Dashboard
     this.dashboardCreationStartTime = dashboardCreationStartTime;
 
     // start diffing dashboard state
-    const diffingMiddleware = startDiffingDashboardState.bind(this)(creationOptions);
+    const { diffingMiddleware, checkForUnsavedChangesSubject$ } =
+      startDiffingDashboardState.bind(this)(creationOptions);
 
     // build redux embeddable tools
     const reduxTools = reduxToolsPackage.createReduxEmbeddableTools<
@@ -178,6 +179,8 @@ export class DashboardContainer extends Container<InheritedChildInput, Dashboard
     this.getState = reduxTools.getState;
     this.dispatch = reduxTools.dispatch;
     this.select = reduxTools.select;
+
+    checkForUnsavedChangesSubject$?.next(null);
   }
 
   public getDashboardSavedObjectId() {

--- a/src/plugins/dashboard/public/dashboard_container/state/diffing/dashboard_diffing_integration.ts
+++ b/src/plugins/dashboard/public/dashboard_container/state/diffing/dashboard_diffing_integration.ts
@@ -87,6 +87,7 @@ export function startDiffingDashboardState(
   this.subscriptions.add(
     checkForUnsavedChangesSubject$
       .pipe(
+        startWith(null),
         debounceTime(CHANGE_CHECK_DEBOUNCE),
         switchMap(() => {
           return new Observable((observer) => {
@@ -120,7 +121,7 @@ export function startDiffingDashboardState(
     }
     next(action);
   };
-  return { diffingMiddleware, checkForUnsavedChangesSubject$ };
+  return diffingMiddleware;
 }
 
 /**

--- a/src/plugins/dashboard/public/dashboard_container/state/diffing/dashboard_diffing_integration.ts
+++ b/src/plugins/dashboard/public/dashboard_container/state/diffing/dashboard_diffing_integration.ts
@@ -87,7 +87,6 @@ export function startDiffingDashboardState(
   this.subscriptions.add(
     checkForUnsavedChangesSubject$
       .pipe(
-        startWith(null),
         debounceTime(CHANGE_CHECK_DEBOUNCE),
         switchMap(() => {
           return new Observable((observer) => {
@@ -121,7 +120,7 @@ export function startDiffingDashboardState(
     }
     next(action);
   };
-  return diffingMiddleware;
+  return { diffingMiddleware, checkForUnsavedChangesSubject$ };
 }
 
 /**


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/155777

## Summary

The `"replaces panel with incoming embeddable if id matches existing panel"` test was **not** the flaky one, even though it was the one that showed the failure; it was actually one of the previous `"pulls state <...>"` tests that was failing, which was pretty confusing to catch 🤦 

Basically, because we are [running the unsaved changes check on load now](https://github.com/elastic/kibana/pull/155648), depending on the timing of the `debounce` on the `checkForUnsavedChangesSubject$` subscription it would sometimes run for the `"pulls state <...>"` tests (but not always) - so whenever it **would** run, because the mocked `loadDashboardStateFromSavedObject` was only returning a partial Dashboard input, this would result in trying to get the property of `undefined` when checking for filter changes, panel changes, etc.

This is fixed by ensuring that the `loadDashboardStateFromSavedObject` returns a complete Dashboard input, with all the required keys, for all of the relevant tests. Note that, since you can't test Jest unit tests using the flaky test runner, I was able to run it multiple times by surrounding all the tests with the following in order to ensure that it was no longer flaky:

```typescript
for (const i of Array(x)
  .fill(null)
  .map((_, i) => i)) {
  describe(`test run ${i}`, () => {
    <...> // all the tests go here
  });
};
```

I did this with `x = 200`, and the entire test suite passed 200 times in a row :+1: 

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->