### PR TITLE
[D4C] Fix to unused selector badge showing when selector used as exclude

### DIFF
--- a/x-pack/plugins/cloud_defend/public/components/control_general_view/index.tsx
+++ b/x-pack/plugins/cloud_defend/public/components/control_general_view/index.tsx
@@ -338,8 +338,9 @@ export const ControlGeneralView = ({ policy, onChange, show }: ViewDeps) => {
       </EuiFlexItem>
 
       {selectors.map((selector, i) => {
-        const usedByResponse = !!responses.find((response) =>
-          response.match.includes(selector.name)
+        const usedByResponse = !!responses.find(
+          (response) =>
+            response.match.includes(selector.name) || response?.exclude?.includes(selector.name)
         );
 
         return (


### PR DESCRIPTION
## Summary

Defend for containers (policy UI) fix:
- Fix to unused selector badge showing when selector used as exclude

<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->