### PR TITLE
[on hold] [ResponseOps] change AAD indices to data streams

### DIFF
--- a/x-pack/plugins/alerting/server/alerts_service/lib/create_or_update_index_template.ts
+++ b/x-pack/plugins/alerting/server/alerts_service/lib/create_or_update_index_template.ts
@@ -43,7 +43,8 @@ export const getIndexTemplate = ({
   return {
     name: indexPatterns.template,
     body: {
-      index_patterns: [indexPatterns.pattern],
+      data_stream: { hidden: true },
+      index_patterns: [indexPatterns.alias],
       composed_of: componentTemplateRefs,
       template: {
         settings: {
@@ -51,7 +52,7 @@ export const getIndexTemplate = ({
           hidden: true,
           'index.lifecycle': {
             name: ilmPolicyName,
-            rollover_alias: indexPatterns.alias,
+            // rollover_alias: indexPatterns.alias,
           },
           'index.mapping.total_fields.limit': totalFieldsLimit,
         },

--- a/x-pack/plugins/alerting/server/alerts_service/resource_installer_utils.ts
+++ b/x-pack/plugins/alerting/server/alerts_service/resource_installer_utils.ts
@@ -40,11 +40,11 @@ export const getIndexTemplateAndPattern = ({
   const pattern = `${context}.alerts`;
   const patternWithNamespace = `${pattern}-${concreteNamespace}`;
   return {
-    template: `.alerts-${patternWithNamespace}-index-template`,
-    pattern: `.internal.alerts-${patternWithNamespace}-*`,
+    template: `.alerts-${patternWithNamespace}-index-template`, // still used
+    pattern: `.internal.alerts-${patternWithNamespace}-*`, // no longer used
     basePattern: `.alerts-${pattern}-*`,
-    name: `.internal.alerts-${patternWithNamespace}-000001`,
-    alias: `.alerts-${patternWithNamespace}`,
+    name: `.internal.alerts-${patternWithNamespace}-000001`, // no longer used
+    alias: `.alerts-${patternWithNamespace}`, // data stream name
     ...(secondaryAlias ? { secondaryAlias: `${secondaryAlias}-${concreteNamespace}` } : {}),
   };
 };


### PR DESCRIPTION
will probably go with this PR instead: https://github.com/elastic/kibana/pull/160572

resolves https://github.com/elastic/kibana/issues/154266

## Summary

Change the alerts-as-data indices from ILM-backed aliases/indices to data streams.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
