### PR TITLE
[SLO] Update link to documentation

### DIFF
--- a/x-pack/plugins/observability/public/pages/slos_welcome/slos_welcome.tsx
+++ b/x-pack/plugins/observability/public/pages/slos_welcome/slos_welcome.tsx
@@ -182,7 +182,7 @@ export function SlosWelcomePage() {
             &nbsp;
             <EuiLink
               data-test-subj="o11ySloListWelcomePromptReadTheDocsLink"
-              href="#"
+              href="https://www.elastic.co/guide/en/observability/current/slo.html"
               target="_blank"
             >
               {i18n.translate('xpack.observability.slo.sloList.welcomePrompt.learnMoreLink', {


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/147749

## 📝 Summary

This updates the link to the SLO documentation on the SLO welcome screen.



<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->