### PR TITLE
[Cases] Fix attachment's renderer memoization

### DIFF
--- a/x-pack/plugins/cases/public/components/user_actions/comment/registered_attachments.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/comment/registered_attachments.tsx
@@ -50,10 +50,10 @@ type BuilderArgs<C, R> = Pick<
 /**
  * Provides a render function for attachment type
  */
-const getAttachmentRenderer = memoize((attachmentViewObject: AttachmentViewObject) => {
+const getAttachmentRenderer = memoize(() => {
   let AttachmentElement: React.ReactElement;
 
-  const renderCallback = (props: object) => {
+  const renderCallback = (attachmentViewObject: AttachmentViewObject, props: object) => {
     if (!attachmentViewObject.children) return;
 
     if (!AttachmentElement) {
@@ -120,7 +120,7 @@ export const createRegisteredAttachmentUserActionBuilder = <
 
     const attachmentViewObject = attachmentType.getAttachmentViewObject(props);
 
-    const renderer = getAttachmentRenderer(attachmentViewObject);
+    const renderer = getAttachmentRenderer();
     const actions = attachmentViewObject.getActions?.(props) ?? [];
     const [primaryActions, nonPrimaryActions] = partition(actions, 'isPrimary');
     const visiblePrimaryActions = primaryActions.slice(0, 2);
@@ -164,7 +164,7 @@ export const createRegisteredAttachmentUserActionBuilder = <
             />
           </UserActionContentToolbar>
         ),
-        children: renderer(props),
+        children: renderer(attachmentViewObject, props),
       },
     ];
   },


### PR DESCRIPTION
## Summary

PR https://github.com/elastic/kibana/pull/154436 changed the memoization function (my fault 🙂) and that caused the attachments to rerender each time a user does an action in cases. This PR fixes this issue.

**Before:**


https://user-images.githubusercontent.com/7871006/235171360-62be773f-8317-4762-9f14-0310d3825a1e.mov

**After:**


https://user-images.githubusercontent.com/7871006/235171429-5e06f9c4-9c0a-4148-8580-bde2360169af.mov



### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->