### PR TITLE
[Security Solution][Investigations] - remove flaky cypress test

### DIFF
--- a/x-pack/plugins/security_solution/cypress/e2e/detection_alerts/alerts_details.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_alerts/alerts_details.cy.ts
@@ -116,9 +116,7 @@ describe('Alert details flyout', () => {
       cy.get(OVERVIEW_RULE).should('be.visible');
       cy.reload();
       cy.get(OVERVIEW_RULE).should('be.visible');
-      cy.get(OVERVIEW_RULE).then((field) => {
-        expect(field).to.contain('Endpoint Security');
-      });
+      cy.get(OVERVIEW_RULE).should('contain', 'Endpoint Security');
     });
 
     it('should show the copy link button for the flyout', () => {

--- a/x-pack/plugins/security_solution/cypress/e2e/detection_alerts/alerts_details.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_alerts/alerts_details.cy.ts
@@ -24,7 +24,6 @@ import { login, visit, visitWithoutDateRange } from '../../tasks/login';
 import { getUnmappedRule } from '../../objects/rule';
 import { ALERTS_URL } from '../../urls/navigation';
 import { tablePageSelector } from '../../screens/table_pagination';
-import { ALERTS_COUNT } from '../../screens/alerts';
 
 describe('Alert details flyout', () => {
   describe('With unmapped fields', { testIsolation: false }, () => {
@@ -96,24 +95,24 @@ describe('Alert details flyout', () => {
       login();
       visit(ALERTS_URL);
       waitForAlertsToPopulate();
+    });
+
+    beforeEach(() => {
       expandFirstAlert();
     });
 
     it('should store the flyout state in the url when it is opened', () => {
-      expandFirstAlert();
       cy.get(OVERVIEW_RULE).should('be.visible');
       cy.url().should('include', 'eventFlyout=');
     });
 
     it('should remove the flyout state from the url when it is closed', () => {
-      expandFirstAlert();
       cy.get(OVERVIEW_RULE).should('be.visible');
       closeAlertFlyout();
       cy.url().should('not.include', 'eventFlyout=');
     });
 
     it('should open the alert flyout when the page is refreshed', () => {
-      expandFirstAlert();
       cy.get(OVERVIEW_RULE).should('be.visible');
       cy.reload();
       cy.get(OVERVIEW_RULE).should('be.visible');
@@ -123,32 +122,15 @@ describe('Alert details flyout', () => {
     });
 
     it('should show the copy link button for the flyout', () => {
-      expandFirstAlert();
       cy.get(COPY_ALERT_FLYOUT_LINK).should('be.visible');
     });
 
-    it('should open the flyout given the custom url', () => {
-      expandFirstAlert();
-      openTable();
-      filterBy('_id');
-      cy.get('[data-test-subj="event-field-_id"]')
-        .invoke('text')
-        .then((alertId) => {
-          cy.visit(`http://localhost:5620/app/security/alerts/redirect/${alertId}`);
-          cy.get('[data-test-subj="unifiedQueryInput"]').should('have.text', `_id: ${alertId}`);
-          cy.get(ALERTS_COUNT).should('have.text', '1 alert');
-          cy.get(OVERVIEW_RULE).should('be.visible');
-        });
-    });
-
     it('should have the `kibana.alert.url` field set', () => {
-      expandFirstAlert();
+      const alertUrl =
+        'http://localhost:5601/app/security/alerts/redirect/eabbdefc23da981f2b74ab58b82622a97bb9878caa11bc914e2adfacc94780f1?index=.alerts-security.alerts-default&timestamp=2023-04-27T11:03:57.906Z';
       openTable();
       filterBy('kibana.alert.url');
-      cy.get('[data-test-subj="formatted-field-kibana.alert.url"]').should(
-        'have.text',
-        'http://localhost:5601/app/security/alerts/redirect/eabbdefc23da981f2b74ab58b82622a97bb9878caa11bc914e2adfacc94780f1?index=.alerts-security.alerts-default&timestamp=2023-04-27T11:03:57.906Z'
-      );
+      cy.get('[data-test-subj="formatted-field-kibana.alert.url"]').should('have.text', alertUrl);
     });
   });
 });

--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/mocked_data/isolate.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/mocked_data/isolate.cy.ts
@@ -67,7 +67,8 @@ describe('Isolate command', () => {
     beforeEach(() => {
       login();
     });
-    it('should allow filtering endpoint by Isolated status', () => {
+    // FLAKY: https://github.com/elastic/security-team/issues/6518
+    it.skip('should allow filtering endpoint by Isolated status', () => {
       cy.visit(APP_PATH + getEndpointListPath({ name: 'endpointList' }));
       closeAllToasts();
       filterOutIsolatedHosts();

--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/mocked_data/response_actions.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/mocked_data/response_actions.cy.ts
@@ -150,7 +150,7 @@ describe('Response actions', () => {
       cleanupRule(ruleId);
     });
 
-    // flaky
+    // FLAKY: https://github.com/elastic/security-team/issues/6518
     it.skip('All response action controls are disabled', () => {
       visitRuleActions(ruleId);
       cy.getByTestSubj('response-actions-wrapper').within(() => {


### PR DESCRIPTION
This PR removes a flaky test which fails when trying to visit a url. Further investigation is needed to determine why the test sometimes visits the login screen when trying to visit the given url, but for the time being should be removed to unblock future PRs.  

<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->