### PR TITLE
[8.8] [Enterprise Search] Add XPath selector as option to extraction rules (#155877)

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/crawler_domain_detail/extraction_rules/edit_field_rule_flyout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/crawler_domain_detail/extraction_rules/edit_field_rule_flyout.tsx
@@ -234,7 +234,7 @@ export const EditFieldRuleFlyout: React.FC<EditFieldRuleFlyoutProps> = ({
                             ? i18n.translate(
                                 'xpack.enterpriseSearch.content.indices.extractionRules.editContentField.content.htmlLabel',
                                 {
-                                  defaultMessage: 'CSS selector',
+                                  defaultMessage: 'CSS selector or XPath expression',
                                 }
                               )
                             : i18n.translate(
@@ -286,7 +286,8 @@ export const EditFieldRuleFlyout: React.FC<EditFieldRuleFlyoutProps> = ({
                           {i18n.translate(
                             'xpack.enterpriseSearch.content.indices.extractionRules.editRule.contentField.cssSelectorsLink',
                             {
-                              defaultMessage: 'Learn more about CSS selectors',
+                              defaultMessage:
+                                'Learn more about CSS selectors and XPath expressions',
                             }
                           )}
                         </EuiLink>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.8`:
 - [[Enterprise Search] Add XPath selector as option to extraction rules (#155877)](https://github.com/elastic/kibana/pull/155877)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Sander Philipse","email":"94373878+sphilipse@users.noreply.github.com"},"sourceCommit":{"committedDate":"2023-04-26T19:15:08Z","message":"[Enterprise Search] Add XPath selector as option to extraction rules (#155877)\n\n## Summary\r\n\r\nThis adds some text to clarify that you can use XPath expressions for\r\nextraction rules.\r\n\r\n<img width=\"1459\" alt=\"image\"\r\nsrc=\"https://user-images.githubusercontent.com/94373878/234588960-5127f1b1-9c97-4aa8-a2f7-6066a7fb9d67.png\">","sha":"0a119b63bdbae6b5996f9a981df8dea103fa6319","branchLabelMapping":{"^v8.8.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["backport","release_note:skip","Team:EnterpriseSearch","v8.8.0"],"number":155877,"url":"https://github.com/elastic/kibana/pull/155877","mergeCommit":{"message":"[Enterprise Search] Add XPath selector as option to extraction rules (#155877)\n\n## Summary\r\n\r\nThis adds some text to clarify that you can use XPath expressions for\r\nextraction rules.\r\n\r\n<img width=\"1459\" alt=\"image\"\r\nsrc=\"https://user-images.githubusercontent.com/94373878/234588960-5127f1b1-9c97-4aa8-a2f7-6066a7fb9d67.png\">","sha":"0a119b63bdbae6b5996f9a981df8dea103fa6319"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.8.0","labelRegex":"^v8.8.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/155877","number":155877,"mergeCommit":{"message":"[Enterprise Search] Add XPath selector as option to extraction rules (#155877)\n\n## Summary\r\n\r\nThis adds some text to clarify that you can use XPath expressions for\r\nextraction rules.\r\n\r\n<img width=\"1459\" alt=\"image\"\r\nsrc=\"https://user-images.githubusercontent.com/94373878/234588960-5127f1b1-9c97-4aa8-a2f7-6066a7fb9d67.png\">","sha":"0a119b63bdbae6b5996f9a981df8dea103fa6319"}}]}] BACKPORT-->