### PR TITLE
[DOCS] List privileges to add alerts to cases

### DIFF
--- a/docs/management/cases/setup-cases.asciidoc
+++ b/docs/management/cases/setup-cases.asciidoc
@@ -35,6 +35,11 @@ least once, which creates a user profile.
 | Give access to view and delete cases | `Read` for the *Cases* feature under
 *Management* with the deletion sub-feature enabled.
 
+| Give access to add alerts to cases
+a|
+* `All` for the *Cases* feature under *Management*.
+* `Read` for an *{observability}* or *Security* feature that has alerts
+
 | Revoke all access to cases | `None` for the *Cases* feature under *Management*.
 
 |=== 


### PR DESCRIPTION
Relates to https://github.com/elastic/kibana/issues/146864

This PR updates https://www.elastic.co/guide/en/kibana/master/setup-cases.html to include the necessary privileges for adding alerts to cases.