### PR TITLE
feat(slo): Add burn rate rule documentation link

### DIFF
--- a/x-pack/plugins/observability/public/rules/register_observability_rule_types.ts
+++ b/x-pack/plugins/observability/public/rules/register_observability_rule_types.ts
@@ -31,7 +31,7 @@ export const registerObservabilityRuleTypes = (
     },
     iconClass: 'bell',
     documentationUrl(docLinks) {
-      return '/unknown/docs';
+      return 'https://www.elastic.co/guide/en/observability/current/slo-burn-rate-alert.html';
     },
     ruleParamsExpression: lazy(() => import('../components/app/burn_rate_rule_editor')),
     validate: validateBurnRateRule,


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/147860

## Summary

This PR adds the slo burn rate rule documentation link in the rule UI. 

The link was taken from here: https://github.com/elastic/observability-docs/issues/2461#issuecomment-1529934175

![image](https://user-images.githubusercontent.com/1376800/235493963-1cb4ef56-248a-488e-b76d-37284ba5d5cb.png)


<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->