### PR TITLE
[RAM] Edit maintenance window feature privilege label

### DIFF
--- a/x-pack/plugins/alerting/server/maintenance_window_feature.ts
+++ b/x-pack/plugins/alerting/server/maintenance_window_feature.ts
@@ -17,7 +17,7 @@ import {
 export const maintenanceWindowFeature: KibanaFeatureConfig = {
   id: MAINTENANCE_WINDOW_FEATURE_ID,
   name: i18n.translate('xpack.alerting.feature.maintenanceWindowFeatureName', {
-    defaultMessage: 'Maintenance Window',
+    defaultMessage: 'Maintenance Windows',
   }),
   category: DEFAULT_APP_CATEGORIES.management,
   app: [],


### PR DESCRIPTION
## Summary

Relates to https://github.com/elastic/kibana/pull/156191

This PR updates the feature name in the list of Kibana feature privileges from "Maintenance Window" to "Maintenance Windows", so that it matches the app label.

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/26471269/235512714-90cf41b7-358a-4d69-9891-e5b4137703f5.png)


### After

![image](https://user-images.githubusercontent.com/26471269/235512620-af220652-c0e0-4555-907c-1003370b1c0b.png)


<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->