### PR TITLE
[8.8] [Security Solution] [Timeline] Fix timeline draft collision with concurrent users (#155663)

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/timeline/saved_object/timelines/index.ts
+++ b/x-pack/plugins/security_solution/server/lib/timeline/saved_object/timelines/index.ts
@@ -173,6 +173,13 @@ const getTimelineFavoriteFilter = ({
 const combineFilters = (filters: Array<string | null>) =>
   filters.filter((f) => f != null).join(' and ');
 
+const getTimelinesCreatedAndUpdatedByCurrentUser = ({ request }: { request: FrameworkRequest }) => {
+  const username = request.user?.username ?? UNAUTHENTICATED_USER;
+  const updatedBy = `siem-ui-timeline.attributes.updatedBy: ${username}`;
+  const createdBy = `siem-ui-timeline.attributes.createdBy: ${username}`;
+  return combineFilters([updatedBy, createdBy]);
+};
+
 export const getExistingPrepackagedTimelines = async (
   request: FrameworkRequest,
   countsOnly?: boolean,
@@ -279,10 +286,14 @@ export const getDraftTimeline = async (
   request: FrameworkRequest,
   timelineType: TimelineTypeLiteralWithNull
 ): Promise<ResponseTimelines> => {
+  const filter = combineFilters([
+    getTimelineTypeFilter(timelineType ?? null, TimelineStatus.draft),
+    getTimelinesCreatedAndUpdatedByCurrentUser({ request }),
+  ]);
   const options: SavedObjectsFindOptions = {
     type: timelineSavedObjectType,
     perPage: 1,
-    filter: getTimelineTypeFilter(timelineType, TimelineStatus.draft),
+    filter,
     sortField: 'created',
     sortOrder: 'desc',
   };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.8`:
 - [[Security Solution] [Timeline] Fix timeline draft collision with concurrent users (#155663)](https://github.com/elastic/kibana/pull/155663)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Kevin Qualters","email":"56408403+kqualters-elastic@users.noreply.github.com"},"sourceCommit":{"committedDate":"2023-05-01T20:08:03Z","message":"[Security Solution] [Timeline] Fix timeline draft collision with concurrent users (#155663)\n\n## Summary\r\n\r\nThis pr fixes an issue where two users who both have draft timelines\r\nopen will actually be using the same underlying saved object, which\r\nwould cause a host of issues. Adds attributes.createdBy and\r\nattributes.updatedBy to the savedObjectsClient.find filter used to\r\nretrieve drafts, so that each user has their own draft. This should\r\nallow the reaping of unused drafts to function as before.\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"7a7936e192086f9697a73fd393679422fe59dcaa","branchLabelMapping":{"^v8.9.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Threat Hunting:Investigations","v8.8.0","v8.9.0"],"number":155663,"url":"https://github.com/elastic/kibana/pull/155663","mergeCommit":{"message":"[Security Solution] [Timeline] Fix timeline draft collision with concurrent users (#155663)\n\n## Summary\r\n\r\nThis pr fixes an issue where two users who both have draft timelines\r\nopen will actually be using the same underlying saved object, which\r\nwould cause a host of issues. Adds attributes.createdBy and\r\nattributes.updatedBy to the savedObjectsClient.find filter used to\r\nretrieve drafts, so that each user has their own draft. This should\r\nallow the reaping of unused drafts to function as before.\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"7a7936e192086f9697a73fd393679422fe59dcaa"}},"sourceBranch":"main","suggestedTargetBranches":["8.8"],"targetPullRequestStates":[{"branch":"8.8","label":"v8.8.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.9.0","labelRegex":"^v8.9.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/155663","number":155663,"mergeCommit":{"message":"[Security Solution] [Timeline] Fix timeline draft collision with concurrent users (#155663)\n\n## Summary\r\n\r\nThis pr fixes an issue where two users who both have draft timelines\r\nopen will actually be using the same underlying saved object, which\r\nwould cause a host of issues. Adds attributes.createdBy and\r\nattributes.updatedBy to the savedObjectsClient.find filter used to\r\nretrieve drafts, so that each user has their own draft. This should\r\nallow the reaping of unused drafts to function as before.\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"7a7936e192086f9697a73fd393679422fe59dcaa"}}]}] BACKPORT-->