### PR TITLE
feat(slo): delete associated rules when deleting an SLO

### DIFF
--- a/x-pack/plugins/observability/server/routes/register_routes.ts
+++ b/x-pack/plugins/observability/server/routes/register_routes.ts
@@ -10,10 +10,11 @@ import {
   parseEndpoint,
   routeValidationObject,
 } from '@kbn/server-route-repository';
-import { CoreSetup, Logger, RouteRegistrar } from '@kbn/core/server';
+import { CoreSetup, KibanaRequest, Logger, RouteRegistrar } from '@kbn/core/server';
 import Boom from '@hapi/boom';
 import { errors } from '@elastic/elasticsearch';
 import { RuleDataPluginService } from '@kbn/rule-registry-plugin/server';
+import { RulesClientApi } from '@kbn/alerting-plugin/server/types';
 
 import { ObservabilityRequestHandlerContext } from '../types';
 import { AbstractObservabilityServerRouteRepository } from './types';
@@ -28,6 +29,7 @@ interface RegisterRoutes {
 
 export interface RegisterRoutesDependencies {
   ruleDataService: RuleDataPluginService;
+  getRulesClientWithRequest: (request: KibanaRequest) => RulesClientApi;
 }
 
 export function registerRoutes({ repository, core, logger, dependencies }: RegisterRoutes) {

--- a/x-pack/plugins/observability/server/services/slo/delete_slo.ts
+++ b/x-pack/plugins/observability/server/services/slo/delete_slo.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { RulesClientApi } from '@kbn/alerting-plugin/server/types';
 import { ElasticsearchClient } from '@kbn/core/server';
 import { getSLOTransformId, SLO_INDEX_TEMPLATE_NAME } from '../../assets/constants';
 
@@ -15,7 +16,8 @@ export class DeleteSLO {
   constructor(
     private repository: SLORepository,
     private transformManager: TransformManager,
-    private esClient: ElasticsearchClient
+    private esClient: ElasticsearchClient,
+    private rulesClient: RulesClientApi
   ) {}
 
   public async execute(sloId: string): Promise<void> {
@@ -26,6 +28,7 @@ export class DeleteSLO {
     await this.transformManager.uninstall(sloTransformId);
 
     await this.deleteRollupData(slo.id);
+    await this.deleteAssociatedRules(slo.id);
     await this.repository.deleteById(slo.id);
   }
 
@@ -38,6 +41,12 @@ export class DeleteSLO {
           'slo.id': sloId,
         },
       },
+    });
+  }
+
+  private async deleteAssociatedRules(sloId: string): Promise<void> {
+    await this.rulesClient.bulkDeleteRules({
+      filter: `alert.attributes.params.sloId:${sloId}`,
     });
   }
 }

--- a/x-pack/plugins/observability/server/services/slo/delete_slo.ts
+++ b/x-pack/plugins/observability/server/services/slo/delete_slo.ts
@@ -45,8 +45,12 @@ export class DeleteSLO {
   }
 
   private async deleteAssociatedRules(sloId: string): Promise<void> {
-    await this.rulesClient.bulkDeleteRules({
-      filter: `alert.attributes.params.sloId:${sloId}`,
-    });
+    try {
+      await this.rulesClient.bulkDeleteRules({
+        filter: `alert.attributes.params.sloId:${sloId}`,
+      });
+    } catch (err) {
+      // no-op: bulkDeleteRules throws if no rules are found.
+    }
   }
 }


### PR DESCRIPTION
resolves https://github.com/elastic/kibana/issues/155007

## 📝  Summary

When deleting an SLO, we enforce the deletion of any existing rules. 


## 🧪  Manual testing

1. Create an SLO (using KQL for example)
2. Create two rules on it
3. Create another SLO **without** rules
4. Delete the first SLO: the corresponding rules should be deleted as well.
5. Delete the second SLO: no error should be logged in the Kibana console.

<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->