### PR TITLE
[Tech Debt] Remove deprecated `EuiLoadingContent`

### DIFF
--- a/examples/controls_example/public/edit_example.tsx
+++ b/examples/controls_example/public/edit_example.tsx
@@ -14,11 +14,11 @@ import {
   EuiButtonGroup,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiSkeletonTitle,
   EuiPanel,
   EuiSpacer,
   EuiText,
   EuiTitle,
+  EuiSkeletonRectangle,
 } from '@elastic/eui';
 import { ViewMode } from '@kbn/embeddable-plugin/public';
 import { OPTIONS_LIST_CONTROL, RANGE_SLIDER_CONTROL } from '@kbn/controls-plugin/common';
@@ -77,7 +77,7 @@ export const EditExample = () => {
     setIsLoading(true);
 
     // simulated async load await
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await new Promise((resolve) => setTimeout(resolve, 6000));
 
     let input: Partial<ControlGroupInput> = {};
     const inputAsString = localStorage.getItem(INPUT_KEY);
@@ -180,7 +180,7 @@ export const EditExample = () => {
         {isLoading ? (
           <>
             <EuiSpacer />
-            <EuiSkeletonTitle css={{ width: '100%' }} />
+            <EuiSkeletonRectangle width="100%" height="2em" />
           </>
         ) : null}
         <ControlGroupRenderer

--- a/examples/controls_example/public/edit_example.tsx
+++ b/examples/controls_example/public/edit_example.tsx
@@ -177,8 +177,6 @@ export const EditExample = () => {
             </EuiButton>
           </EuiFlexItem>
         </EuiFlexGroup>
-        {/* Can't wrap the ControlGroupRenderer in the `EuiSkeletonTitle` component like it's
-             upposed to be used since it's the one that sets loading to false. */}
         {isLoading ? (
           <>
             <EuiSpacer />

--- a/examples/controls_example/public/edit_example.tsx
+++ b/examples/controls_example/public/edit_example.tsx
@@ -14,7 +14,7 @@ import {
   EuiButtonGroup,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiLoadingContent,
+  EuiSkeletonText,
   EuiPanel,
   EuiSpacer,
   EuiText,
@@ -180,7 +180,7 @@ export const EditExample = () => {
         {isLoading ? (
           <>
             <EuiSpacer />
-            <EuiLoadingContent lines={1} />
+            <EuiSkeletonText lines={1} />
           </>
         ) : null}
         <ControlGroupRenderer

--- a/examples/controls_example/public/edit_example.tsx
+++ b/examples/controls_example/public/edit_example.tsx
@@ -14,7 +14,7 @@ import {
   EuiButtonGroup,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiSkeletonText,
+  EuiSkeletonTitle,
   EuiPanel,
   EuiSpacer,
   EuiText,
@@ -177,10 +177,12 @@ export const EditExample = () => {
             </EuiButton>
           </EuiFlexItem>
         </EuiFlexGroup>
+        {/* Can't wrap the ControlGroupRenderer in the `EuiSkeletonTitle` component like it's
+             upposed to be used since it's the one that sets loading to false. */}
         {isLoading ? (
           <>
             <EuiSpacer />
-            <EuiSkeletonText lines={1} />
+            <EuiSkeletonTitle css={{ width: '100%' }} />
           </>
         ) : null}
         <ControlGroupRenderer

--- a/src/plugins/dashboard/public/dashboard_actions/filters_notification_popover_contents.tsx
+++ b/src/plugins/dashboard/public/dashboard_actions/filters_notification_popover_contents.tsx
@@ -44,7 +44,6 @@ export function FiltersNotificationPopoverContents({ context }: FiltersNotificat
     Promise.all([
       (embeddable as IEmbeddable & FilterableEmbeddable).getFilters(),
       (embeddable as IEmbeddable & FilterableEmbeddable).getQuery(),
-      new Promise<void>((res) => setTimeout(() => res(), 1000)),
     ]).then(([embeddableFilters, embeddableQuery]) => {
       setFilters(embeddableFilters);
       if (embeddableQuery) {
@@ -56,7 +55,6 @@ export function FiltersNotificationPopoverContents({ context }: FiltersNotificat
           setQueryString(embeddableQuery[language as keyof AggregateQuery]);
         }
       }
-      console.log('set loading');
       setIsLoading(false);
     });
   });

--- a/src/plugins/dashboard/public/dashboard_actions/filters_notification_popover_contents.tsx
+++ b/src/plugins/dashboard/public/dashboard_actions/filters_notification_popover_contents.tsx
@@ -9,7 +9,7 @@
 import React, { useMemo, useState } from 'react';
 import useMount from 'react-use/lib/useMount';
 
-import { EuiCodeBlock, EuiFlexGroup, EuiForm, EuiFormRow, EuiLoadingContent } from '@elastic/eui';
+import { EuiCodeBlock, EuiFlexGroup, EuiForm, EuiFormRow, EuiSkeletonText } from '@elastic/eui';
 import { FilterableEmbeddable, IEmbeddable } from '@kbn/embeddable-plugin/public';
 import { FilterItems } from '@kbn/unified-search-plugin/public';
 import { css } from '@emotion/react';
@@ -44,6 +44,7 @@ export function FiltersNotificationPopoverContents({ context }: FiltersNotificat
     Promise.all([
       (embeddable as IEmbeddable & FilterableEmbeddable).getFilters(),
       (embeddable as IEmbeddable & FilterableEmbeddable).getQuery(),
+      new Promise<void>((res) => setTimeout(() => res(), 1000)),
     ]).then(([embeddableFilters, embeddableQuery]) => {
       setFilters(embeddableFilters);
       if (embeddableQuery) {
@@ -55,21 +56,22 @@ export function FiltersNotificationPopoverContents({ context }: FiltersNotificat
           setQueryString(embeddableQuery[language as keyof AggregateQuery]);
         }
       }
+      console.log('set loading');
       setIsLoading(false);
     });
   });
 
   return (
-    <>
+    <EuiForm
+      component="div"
+      css={css`
+        min-width: 300px;
+      `}
+    >
       {isLoading ? (
-        <EuiLoadingContent lines={3} />
+        <EuiSkeletonText lines={3} />
       ) : (
-        <EuiForm
-          component="div"
-          css={css`
-            min-width: 300px;
-          `}
-        >
+        <>
           {queryString !== '' && (
             <EuiFormRow
               label={dashboardFilterNotificationActionStrings.getQueryTitle()}
@@ -93,8 +95,8 @@ export function FiltersNotificationPopoverContents({ context }: FiltersNotificat
               </EuiFlexGroup>
             </EuiFormRow>
           )}
-        </EuiForm>
+        </>
       )}
-    </>
+    </EuiForm>
   );
 }

--- a/src/plugins/dashboard/public/dashboard_actions/filters_notification_popover_contents.tsx
+++ b/src/plugins/dashboard/public/dashboard_actions/filters_notification_popover_contents.tsx
@@ -67,31 +67,29 @@ export function FiltersNotificationPopoverContents({ context }: FiltersNotificat
       `}
     >
       <EuiSkeletonText isLoading={isLoading} lines={3}>
-        <>
-          {queryString !== '' && (
-            <EuiFormRow
-              label={dashboardFilterNotificationActionStrings.getQueryTitle()}
-              display="rowCompressed"
+        {queryString !== '' && (
+          <EuiFormRow
+            label={dashboardFilterNotificationActionStrings.getQueryTitle()}
+            display="rowCompressed"
+          >
+            <EuiCodeBlock
+              language={queryLanguage}
+              paddingSize="none"
+              transparentBackground
+              aria-labelledby={`${dashboardFilterNotificationActionStrings.getQueryTitle()}: ${queryString}`}
+              tabIndex={0} // focus so that keyboard controls will not skip over the code block
             >
-              <EuiCodeBlock
-                language={queryLanguage}
-                paddingSize="none"
-                transparentBackground
-                aria-labelledby={`${dashboardFilterNotificationActionStrings.getQueryTitle()}: ${queryString}`}
-                tabIndex={0} // focus so that keyboard controls will not skip over the code block
-              >
-                {queryString}
-              </EuiCodeBlock>
-            </EuiFormRow>
-          )}
-          {filters && filters.length > 0 && (
-            <EuiFormRow label={dashboardFilterNotificationActionStrings.getFiltersTitle()}>
-              <EuiFlexGroup wrap={true} gutterSize="xs">
-                <FilterItems filters={filters} indexPatterns={dataViews} readOnly={true} />
-              </EuiFlexGroup>
-            </EuiFormRow>
-          )}
-        </>
+              {queryString}
+            </EuiCodeBlock>
+          </EuiFormRow>
+        )}
+        {filters && filters.length > 0 && (
+          <EuiFormRow label={dashboardFilterNotificationActionStrings.getFiltersTitle()}>
+            <EuiFlexGroup wrap={true} gutterSize="xs">
+              <FilterItems filters={filters} indexPatterns={dataViews} readOnly={true} />
+            </EuiFlexGroup>
+          </EuiFormRow>
+        )}
       </EuiSkeletonText>
     </EuiForm>
   );

--- a/src/plugins/dashboard/public/dashboard_actions/filters_notification_popover_contents.tsx
+++ b/src/plugins/dashboard/public/dashboard_actions/filters_notification_popover_contents.tsx
@@ -66,9 +66,7 @@ export function FiltersNotificationPopoverContents({ context }: FiltersNotificat
         min-width: 300px;
       `}
     >
-      {isLoading ? (
-        <EuiSkeletonText lines={3} />
-      ) : (
+      <EuiSkeletonText isLoading={isLoading} lines={3}>
         <>
           {queryString !== '' && (
             <EuiFormRow
@@ -94,7 +92,7 @@ export function FiltersNotificationPopoverContents({ context }: FiltersNotificat
             </EuiFormRow>
           )}
         </>
-      )}
+      </EuiSkeletonText>
     </EuiForm>
   );
 }

--- a/src/plugins/kibana_react/public/code_editor/index.tsx
+++ b/src/plugins/kibana_react/public/code_editor/index.tsx
@@ -7,7 +7,7 @@
  */
 
 import React from 'react';
-import { EuiDelayRender, EuiErrorBoundary, EuiLoadingContent } from '@elastic/eui';
+import { EuiDelayRender, EuiErrorBoundary, EuiSkeletonText } from '@elastic/eui';
 
 import { useUiSetting } from '../ui_settings';
 import type { Props } from './code_editor';
@@ -25,7 +25,7 @@ const Fallback: React.FunctionComponent<{ height: Props['height'] }> = ({ height
       {/* when height is known, set minHeight to avoid layout shift */}
       <div style={height ? { minHeight: height } : {}}>
         <EuiDelayRender>
-          <EuiLoadingContent lines={3} />
+          <EuiSkeletonText lines={3} />
         </EuiDelayRender>
       </div>
     </>

--- a/src/plugins/kibana_react/public/markdown/index.tsx
+++ b/src/plugins/kibana_react/public/markdown/index.tsx
@@ -7,13 +7,13 @@
  */
 
 import React from 'react';
-import { EuiLoadingContent, EuiDelayRender } from '@elastic/eui';
+import { EuiSkeletonText, EuiDelayRender } from '@elastic/eui';
 import type { MarkdownSimpleProps } from './markdown_simple';
 import type { MarkdownProps } from './markdown';
 
 const Fallback = () => (
   <EuiDelayRender>
-    <EuiLoadingContent lines={3} />
+    <EuiSkeletonText lines={3} />
   </EuiDelayRender>
 );
 


### PR DESCRIPTION
## Summary

This PR removes the deprecated `EuiLoadingContent` in favour of the new `EuiSkeletonText` + `EuiSkeletonRectangle` components in all Presentation-owned files.

cc @elastic/eui-team 


### Checklist

- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)



### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
