### PR TITLE
[Unified search] Fixes the bar suggestions method selection

### DIFF
--- a/src/plugins/unified_search/public/filter_bar/filter_editor/phrase_suggestor.tsx
+++ b/src/plugins/unified_search/public/filter_bar/filter_editor/phrase_suggestor.tsx
@@ -88,7 +88,7 @@ export class PhraseSuggestorUI<T extends PhraseSuggestorProps> extends React.Com
       signal: this.abortController.signal,
       useTimeRange: timeRangeForSuggestionsOverride,
       boolFilter: buildQueryFromFilters(filtersForSuggestions, undefined).filter,
-      method: filtersForSuggestions?.length ? 'terms_agg' : 'terms_enum',
+      method: filtersForSuggestions?.length ? 'terms_agg' : undefined,
     });
 
     this.setState({ suggestions, isLoading: false });

--- a/src/plugins/unified_search/public/query_string_input/query_string_input.tsx
+++ b/src/plugins/unified_search/public/query_string_input/query_string_input.tsx
@@ -286,7 +286,7 @@ export default class QueryStringInputUI extends PureComponent<QueryStringInputPr
           signal: this.abortController.signal,
           useTimeRange: this.props.timeRangeForSuggestionsOverride,
           boolFilter: buildQueryFromFilters(this.props.filtersForSuggestions, undefined).filter,
-          method: this.props.filtersForSuggestions?.length ? 'terms_agg' : 'terms_enum',
+          method: this.props.filtersForSuggestions?.length ? 'terms_agg' : undefined,
         })) || [];
       return [...suggestions, ...recentSearchSuggestions];
     } catch (e) {


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/155801

Fixes the bug described here https://github.com/elastic/kibana/issues/155801

The bug was introduced by https://github.com/elastic/kibana/pull/154522/files

If the filtersForSuggestions prop is there, we want to default to terms_agg, otherwise we want to keep it as undefined to use the advanced settings method.

<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->