### PR TITLE
Fix throughput chart on APM alert details page

### DIFF
--- a/x-pack/plugins/apm/public/components/alerting/ui_components/alert_details_app_section/index.tsx
+++ b/x-pack/plugins/apm/public/components/alerting/ui_components/alert_details_app_section/index.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { formatAlertEvaluationValue } from '@kbn/observability-plugin/public';
 import {
@@ -17,7 +17,7 @@ import {
   ALERT_RULE_UUID,
 } from '@kbn/rule-data-utils';
 import moment from 'moment';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { SERVICE_ENVIRONMENT } from '../../../../../common/es_fields/apm';
 import { ChartPointerEventContextProvider } from '../../../../context/chart_pointer_event/chart_pointer_event_context';
@@ -92,7 +92,6 @@ export function AlertDetailsAppSection({
   const params = rule.params;
   const environment = alert.fields[SERVICE_ENVIRONMENT];
   const latencyAggregationType = getAggsTypeFromRule(params.aggregationType);
-  const [latencyMaxY, setLatencyMaxY] = useState(0);
 
   // duration is us, convert it to MS
   const alertDurationMS = alert.fields[ALERT_DURATION]! / 1000;
@@ -166,8 +165,8 @@ export function AlertDetailsAppSection({
               latencyAggregationType={latencyAggregationType}
               comparisonEnabled={comparisonEnabled}
               offset={offset}
-              setLatencyMaxY={setLatencyMaxY}
             />
+            <EuiSpacer size="s" />
             <EuiFlexGroup direction="row" gutterSize="s">
               <ThroughputChart
                 transactionType={transactionType}
@@ -177,7 +176,6 @@ export function AlertDetailsAppSection({
                 end={end}
                 comparisonChartTheme={comparisonChartTheme}
                 comparisonEnabled={comparisonEnabled}
-                latencyMaxY={latencyMaxY}
                 offset={offset}
                 timeZone={timeZone}
               />

--- a/x-pack/plugins/apm/public/components/alerting/ui_components/alert_details_app_section/latency_chart/latency_chart.tsx
+++ b/x-pack/plugins/apm/public/components/alerting/ui_components/alert_details_app_section/latency_chart/latency_chart.tsx
@@ -45,7 +45,6 @@ function LatencyChart({
   comparisonEnabled,
   offset,
   timeZone,
-  setLatencyMaxY,
 }: {
   alert: TopAlert;
   transactionType: string;
@@ -58,7 +57,6 @@ function LatencyChart({
   comparisonEnabled: boolean;
   offset: string;
   timeZone: string;
-  setLatencyMaxY: React.Dispatch<React.SetStateAction<number>>;
 }) {
   const preferred = usePreferredDataSourceAndBucketSize({
     start,
@@ -150,7 +148,6 @@ function LatencyChart({
     comparisonEnabled && isTimeComparison(offset) ? previousPeriod : undefined,
   ].filter(filterNil);
   const latencyMaxY = getMaxY(timeseriesLatency);
-  setLatencyMaxY(latencyMaxY);
   const latencyFormatter = getDurationFormatter(latencyMaxY);
   return (
     <EuiFlexItem>

--- a/x-pack/plugins/apm/public/components/alerting/ui_components/alert_details_app_section/throughput_chart.tsx
+++ b/x-pack/plugins/apm/public/components/alerting/ui_components/alert_details_app_section/throughput_chart.tsx
@@ -17,16 +17,15 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
-import { getDurationFormatter } from '@kbn/observability-plugin/common';
 import {
   ChartType,
   getTimeSeriesColor,
 } from '../../../shared/charts/helper/get_timeseries_color';
 import { useFetcher } from '../../../../hooks/use_fetcher';
 import { TimeseriesChart } from '../../../shared/charts/timeseries_chart';
-import { getResponseTimeTickFormatter } from '../../../shared/charts/transaction_charts/helper';
 import { usePreferredDataSourceAndBucketSize } from '../../../../hooks/use_preferred_data_source_and_bucket_size';
 import { ApmDocumentType } from '../../../../../common/document_type';
+import { asExactTransactionRate } from '../../../../../common/utils/formatters';
 
 const INITIAL_STATE = {
   currentPeriod: [],
@@ -40,7 +39,6 @@ function ThroughputChart({
   end,
   comparisonChartTheme,
   comparisonEnabled,
-  latencyMaxY,
   offset,
   timeZone,
 }: {
@@ -51,7 +49,6 @@ function ThroughputChart({
   end: string;
   comparisonChartTheme: RecursivePartial<Theme>;
   comparisonEnabled: boolean;
-  latencyMaxY: number;
   offset: string;
   timeZone: string;
 }) {
@@ -118,8 +115,6 @@ function ThroughputChart({
       : []),
   ];
 
-  const latencyFormatter = getDurationFormatter(latencyMaxY);
-
   return (
     <EuiFlexItem>
       <EuiPanel hasBorder={true}>
@@ -154,7 +149,7 @@ function ThroughputChart({
           fetchStatus={statusThroughput}
           customTheme={comparisonChartTheme}
           timeseries={timeseriesThroughput}
-          yLabelFormat={getResponseTimeTickFormatter(latencyFormatter)}
+          yLabelFormat={asExactTransactionRate}
           timeZone={timeZone}
         />
       </EuiPanel>


### PR DESCRIPTION
Fixes #154802
Fixes #153137
## Summary

Fix the Y-axis label and tooltip:

<img src="https://user-images.githubusercontent.com/12370520/235647500-5efb80c4-5c93-47b3-bd69-6518ae330a4b.png" width="500" />

## 🧪 How to test
- Create an APM Latency threshold alert
- Go to the alert details page and check the throughput chart for the correct label and tooltip

<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->