### PR TITLE
Fix alert details page name

### DIFF
--- a/x-pack/plugins/observability/public/pages/alert_details/components/page_title.test.tsx
+++ b/x-pack/plugins/observability/public/pages/alert_details/components/page_title.test.tsx
@@ -28,9 +28,7 @@ describe('Page Title', () => {
   it('should display Log threshold title', () => {
     const { getByTestId } = renderComp(defaultProps);
 
-    expect(getByTestId('page-title-container').children.item(0)?.textContent).toEqual(
-      'Log threshold breached'
-    );
+    expect(getByTestId('page-title-container').textContent).toContain('Log threshold breached');
   });
 
   it('should display Anomaly title', () => {
@@ -46,9 +44,7 @@ describe('Page Title', () => {
 
     const { getByTestId } = renderComp(props);
 
-    expect(getByTestId('page-title-container').children.item(0)?.textContent).toEqual(
-      'Anomaly detected'
-    );
+    expect(getByTestId('page-title-container').textContent).toContain('Anomaly detected');
   });
 
   it('should display Inventory title', () => {
@@ -64,7 +60,7 @@ describe('Page Title', () => {
 
     const { getByTestId } = renderComp(props);
 
-    expect(getByTestId('page-title-container').children.item(0)?.textContent).toEqual(
+    expect(getByTestId('page-title-container').textContent).toContain(
       'Inventory threshold breached'
     );
   });

--- a/x-pack/plugins/observability/public/pages/alert_details/components/page_title.tsx
+++ b/x-pack/plugins/observability/public/pages/alert_details/components/page_title.tsx
@@ -35,15 +35,13 @@ export interface PageTitleProps {
 }
 
 export function pageTitleContent(ruleCategory: string) {
-  return (
-    <FormattedMessage
-      id="xpack.observability.pages.alertDetails.pageTitle.title"
-      values={{
-        ruleCategory,
-      }}
-      defaultMessage="{ruleCategory} {ruleCategory, select, Anomaly {detected} Inventory {threshold breached} other {breached}}"
-    />
-  );
+  return i18n.translate('xpack.observability.pages.alertDetails.pageTitle.title', {
+    defaultMessage:
+      '{ruleCategory} {ruleCategory, select, Anomaly {detected} Inventory {threshold breached} other {breached}}',
+    values: {
+      ruleCategory,
+    },
+  });
 }
 
 export function PageTitle({ alert }: PageTitleProps) {


### PR DESCRIPTION
Fixes #156163

## Summary

This PR fixes the alert details page name:

<img src="https://user-images.githubusercontent.com/12370520/235664034-4038bf82-387d-4dfb-ad03-0cf0e5e3b1a6.png" width="500"/>

<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->