### PR TITLE
[ML] Rename ELSER model id

### DIFF
--- a/x-pack/packages/ml/trained_models_utils/src/constants/trained_models.ts
+++ b/x-pack/packages/ml/trained_models_utils/src/constants/trained_models.ts
@@ -50,7 +50,7 @@ export const BUILT_IN_MODEL_TAG = 'prepackaged';
 export const CURATED_MODEL_TAG = 'curated';
 
 export const CURATED_MODEL_DEFINITIONS = {
-  '.elser_model_1_SNAPSHOT': {
+  '.elser_model_1': {
     config: {
       input: {
         field_names: ['text_field'],

--- a/x-pack/packages/ml/trained_models_utils/src/constants/trained_models.ts
+++ b/x-pack/packages/ml/trained_models_utils/src/constants/trained_models.ts
@@ -57,7 +57,7 @@ export const CURATED_MODEL_DEFINITIONS = {
       },
     },
     description: i18n.translate('xpack.ml.trainedModels.modelsList.elserDescription', {
-      defaultMessage: 'Elastic Learned Sparse EncodeR',
+      defaultMessage: 'Elastic Learned Sparse EncodeR v1 (Tech Preview)',
     }),
   },
 } as const;

--- a/x-pack/plugins/ml/public/application/components/technical_preview_badge/technical_preview_badge.tsx
+++ b/x-pack/plugins/ml/public/application/components/technical_preview_badge/technical_preview_badge.tsx
@@ -11,13 +11,13 @@ import { EuiBetaBadge } from '@elastic/eui';
 
 import { i18n } from '@kbn/i18n';
 
-export const TechnicalPreviewBadge: FC = () => {
+export const TechnicalPreviewBadge: FC<{ compressed?: boolean }> = ({ compressed = false }) => {
   return (
     <EuiBetaBadge
       label={i18n.translate('xpack.ml.navMenu.trainedModelsTabBetaLabel', {
         defaultMessage: 'Technical preview',
       })}
-      size="m"
+      size={compressed ? 's' : 'm'}
       color="hollow"
       tooltipContent={i18n.translate('xpack.ml.navMenu.trainedModelsTabBetaTooltipContent', {
         defaultMessage:

--- a/x-pack/plugins/ml/public/application/model_management/models_list.tsx
+++ b/x-pack/plugins/ml/public/application/model_management/models_list.tsx
@@ -409,6 +409,7 @@ export const ModelsList: FC<Props> = ({
       truncateText: false,
       'data-test-subj': 'mlModelsTableColumnDescription',
       render: (description: string) => {
+        if (!description) return null;
         const isTechPreview = description.includes('(Tech Preview)');
         return (
           <>

--- a/x-pack/plugins/ml/public/application/model_management/models_list.tsx
+++ b/x-pack/plugins/ml/public/application/model_management/models_list.tsx
@@ -39,6 +39,7 @@ import {
   CURATED_MODEL_TYPE,
   MODEL_STATE,
 } from '@kbn/ml-trained-models-utils/src/constants/trained_models';
+import { TechnicalPreviewBadge } from '../components/technical_preview_badge';
 import { useModelActions } from './model_actions';
 import { ModelsTableToConfigMapping } from '.';
 import { ModelsBarStats, StatsBar } from '../components/stats_bar';
@@ -407,6 +408,15 @@ export const ModelsList: FC<Props> = ({
       sortable: false,
       truncateText: false,
       'data-test-subj': 'mlModelsTableColumnDescription',
+      render: (description: string) => {
+        const isTechPreview = description.includes('(Tech Preview)');
+        return (
+          <>
+            {description.replace('(Tech Preview)', '')}
+            {isTechPreview ? <TechnicalPreviewBadge compressed /> : null}
+          </>
+        );
+      },
     },
     {
       field: ModelsTableToConfigMapping.type,


### PR DESCRIPTION
## Summary

- Renames ELSER model id
- Adds a technical preview badge 

<img width="1611" alt="image" src="https://user-images.githubusercontent.com/5236598/235689215-7da84d8c-96fa-436a-8030-89f8fe371e9d.png">



<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->