### PR TITLE
[Security Solution] Fix color coding of severities is different at Entity analytics

### DIFF
--- a/x-pack/plugins/security_solution/public/explore/components/risk_score/severity/common/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/explore/components/risk_score/severity/common/index.test.tsx
@@ -16,6 +16,7 @@ import { EuiHealth } from '@elastic/eui';
 import { euiThemeVars } from '@kbn/ui-theme';
 import { RiskSeverity } from '../../../../../../common/search_strategy';
 import { RiskScore } from '.';
+import { SEVERITY_COLOR } from '../../../../../overview/components/detection_response/utils';
 
 jest.mock('@elastic/eui', () => {
   const original = jest.requireActual('@elastic/eui');
@@ -37,7 +38,7 @@ describe('RiskScore', () => {
     expect(container).toHaveTextContent(RiskSeverity.critical);
 
     expect(EuiHealth as jest.Mock).toHaveBeenLastCalledWith(
-      expect.objectContaining({ color: euiThemeVars.euiColorDanger }),
+      expect.objectContaining({ color: SEVERITY_COLOR.critical }),
       context
     );
   });
@@ -52,7 +53,7 @@ describe('RiskScore', () => {
     expect(container).toHaveTextContent(RiskSeverity.high);
 
     expect(EuiHealth as jest.Mock).toHaveBeenLastCalledWith(
-      expect.objectContaining({ color: euiThemeVars.euiColorVis9_behindText }),
+      expect.objectContaining({ color: SEVERITY_COLOR.high }),
       context
     );
   });
@@ -67,7 +68,7 @@ describe('RiskScore', () => {
     expect(container).toHaveTextContent(RiskSeverity.moderate);
 
     expect(EuiHealth as jest.Mock).toHaveBeenLastCalledWith(
-      expect.objectContaining({ color: euiThemeVars.euiColorWarning }),
+      expect.objectContaining({ color: SEVERITY_COLOR.medium }),
       context
     );
   });
@@ -82,7 +83,7 @@ describe('RiskScore', () => {
     expect(container).toHaveTextContent(RiskSeverity.low);
 
     expect(EuiHealth as jest.Mock).toHaveBeenLastCalledWith(
-      expect.objectContaining({ color: euiThemeVars.euiColorVis0 }),
+      expect.objectContaining({ color: SEVERITY_COLOR.low }),
       context
     );
   });

--- a/x-pack/plugins/security_solution/public/explore/components/risk_score/severity/common/index.tsx
+++ b/x-pack/plugins/security_solution/public/explore/components/risk_score/severity/common/index.tsx
@@ -14,13 +14,14 @@ import { euiLightVars } from '@kbn/ui-theme';
 
 import { WithHoverActions } from '../../../../../common/components/with_hover_actions';
 import { RiskSeverity } from '../../../../../../common/search_strategy';
+import { SEVERITY_COLOR } from '../../../../../overview/components/detection_response/utils';
 
 export const RISK_SEVERITY_COLOUR: { [k in RiskSeverity]: string } = {
   [RiskSeverity.unknown]: euiLightVars.euiColorMediumShade,
-  [RiskSeverity.low]: euiLightVars.euiColorVis0,
-  [RiskSeverity.moderate]: euiLightVars.euiColorWarning,
-  [RiskSeverity.high]: euiLightVars.euiColorVis9_behindText,
-  [RiskSeverity.critical]: euiLightVars.euiColorDanger,
+  [RiskSeverity.low]: SEVERITY_COLOR.low,
+  [RiskSeverity.moderate]: SEVERITY_COLOR.medium,
+  [RiskSeverity.high]: SEVERITY_COLOR.high,
+  [RiskSeverity.critical]: SEVERITY_COLOR.critical,
 };
 
 const RiskBadge = styled.div<{ $severity: RiskSeverity; $hideBackgroundColor: boolean }>`

--- a/x-pack/plugins/security_solution/public/overview/components/entity_analytics/header/index.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/entity_analytics/header/index.tsx
@@ -32,9 +32,10 @@ import { useQueryInspector } from '../../../../common/components/page/manage_que
 import { ENTITY_ANALYTICS_ANOMALIES_PANEL } from '../anomalies';
 import { isJobStarted } from '../../../../../common/machine_learning/helpers';
 import { FormattedCount } from '../../../../common/components/formatted_number';
+import { SEVERITY_COLOR } from '../../detection_response/utils';
 
 const StyledEuiTitle = styled(EuiTitle)`
-  color: ${({ theme: { eui } }) => eui.euiColorDanger};
+  color: ${({ theme: { eui } }) => SEVERITY_COLOR.critical};
 `;
 
 const HOST_RISK_QUERY_ID = 'hostRiskScoreKpiQuery';


### PR DESCRIPTION
issue: https://github.com/elastic/kibana/issues/143043

## Summary

Fix color coding of severities is different at Entity Analytics by using the same colors of alert severity.

**Before:**
![195068297-4893ff3e-184a-4deb-b551-28d55f4994fd](https://user-images.githubusercontent.com/1490444/235682183-272d0739-7a65-42d4-b1ef-83751cf57ab0.jpg)




**After:**

![Screenshot 2023-05-02 at 14 40 23](https://user-images.githubusercontent.com/1490444/235678297-f4a05f1c-95f6-4895-a7b1-fd6645e55f7b.png)
![Screenshot 2023-05-02 at 14 40 03](https://user-images.githubusercontent.com/1490444/235678383-0eefe697-5669-496d-b0b8-44433f519754.png)
![Screenshot 2023-05-02 at 14 37 45](https://user-images.githubusercontent.com/1490444/235678609-257b8eb1-8b86-4064-8fbf-0c0b188174ae.png)

![Screenshot 2023-05-02 at 15 32 22](https://user-images.githubusercontent.com/1490444/235681736-609b484c-bd08-4379-b76b-6a47c3a016ba.png)


<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->