### PR TITLE
[ML] Anomaly Detection Settings: Fix key attribute for filter list table 

### DIFF
--- a/x-pack/plugins/ml/public/application/settings/filter_lists/list/table.js
+++ b/x-pack/plugins/ml/public/application/settings/filter_lists/list/table.js
@@ -136,6 +136,7 @@ function renderToolsRight(
   return [
     <NewFilterButton key="new_filter_list" canCreateFilter={canCreateFilter} />,
     <DeleteFilterListModal
+      key="delete_filter_list"
       canDeleteFilter={canDeleteFilter}
       selectedFilterLists={selectedFilterLists}
       refreshFilterLists={refreshFilterLists}


### PR DESCRIPTION
## Summary

Part of https://github.com/elastic/kibana/issues/148228.

Fixes the React dev mode warning "Warning: Each child in a list should have a unique "key" prop." by adding a key attribute to the `DeleteFilterListModal` component.

### Checklist

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->