### PR TITLE
[OAS PoC] Example cases to versioned router

### DIFF
--- a/packages/core/http/core-http-router-server-internal/src/versioned_router/validate.ts
+++ b/packages/core/http/core-http-router-server-internal/src/versioned_router/validate.ts
@@ -12,9 +12,8 @@ import {
   type RouteValidationFunction,
   RouteValidationError,
 } from '@kbn/core-http-server';
-import { z, extractErrorMessage } from '@kbn/zod';
+import { z, extractErrorMessage, instanceofZodType } from '@kbn/zod';
 import type { ApiVersion } from '@kbn/core-http-server';
-import { instanceofZodType } from '@kbn/zod';
 import { RouteValidator } from '../validator';
 
 function makeValidationFunction(schema: z.ZodTypeAny): RouteValidationFunction<unknown> {

--- a/x-pack/plugins/cases/common/constants/index.ts
+++ b/x-pack/plugins/cases/common/constants/index.ts
@@ -173,3 +173,6 @@ export const LOCAL_STORAGE_KEYS = {
   casesQueryParams: 'cases.list.queryParams',
   casesFilterOptions: 'cases.list.filterOptions',
 };
+
+/** Naming and value all WIP, just needed a shared constant for now */
+export const PUBLIC_VERSION_2023_05_02 = '2023-05-02';

--- a/x-pack/plugins/cases/server/routes/api/cases/tags/get_tags.ts
+++ b/x-pack/plugins/cases/server/routes/api/cases/tags/get_tags.ts
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { schema } from '@kbn/schema';
+import { z } from '@kbn/zod';
 import { type VersionedRouter } from '@kbn/core-http-server';
 import type { CasesRequestHandlerContext } from '../../../../types';
 import type { AllTagsFindRequest } from '../../../../../common/api';
@@ -23,13 +23,13 @@ export function registerGetTagsRoute(router: VersionedRouter<CasesRequestHandler
         version: PUBLIC_VERSION_2023_05_02,
         validate: {
           request: {
-            query: schema.object({
-              owner: schema.oneOf([schema.arrayOf(schema.string()), schema.string()]),
+            query: z.object({
+              owner: z.union([z.array(z.string()), z.string()]),
             }),
           },
           response: {
             200: {
-              body: schema.arrayOf(schema.string()),
+              body: z.array(z.string()),
             },
           },
         },

--- a/x-pack/plugins/cases/server/routes/api/cases/tags/get_tags.ts
+++ b/x-pack/plugins/cases/server/routes/api/cases/tags/get_tags.ts
@@ -4,27 +4,49 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-
+import { schema } from '@kbn/schema';
+import { type VersionedRouter } from '@kbn/core-http-server';
+import type { CasesRequestHandlerContext } from '../../../../types';
 import type { AllTagsFindRequest } from '../../../../../common/api';
-import { CASE_TAGS_URL } from '../../../../../common/constants';
+import { CASE_TAGS_URL, PUBLIC_VERSION_2023_05_02 } from '../../../../../common/constants';
 import { createCaseError } from '../../../../common/error';
-import { createCasesRoute } from '../../create_cases_route';
 
-export const getTagsRoute = createCasesRoute({
-  method: 'get',
-  path: CASE_TAGS_URL,
-  handler: async ({ context, request, response }) => {
-    try {
-      const caseContext = await context.cases;
-      const client = await caseContext.getCasesClient();
-      const options = request.query as AllTagsFindRequest;
+export function registerGetTagsRoute(router: VersionedRouter<CasesRequestHandlerContext>) {
+  router
+    .get({
+      path: CASE_TAGS_URL,
+      access: 'public',
+      description: 'Get all case tags',
+    })
+    .addVersion(
+      {
+        version: PUBLIC_VERSION_2023_05_02,
+        validate: {
+          request: {
+            query: schema.object({
+              owner: schema.oneOf([schema.arrayOf(schema.string()), schema.string()]),
+            }),
+          },
+          response: {
+            200: {
+              body: schema.arrayOf(schema.string()),
+            },
+          },
+        },
+      },
+      async (context, request, response) => {
+        try {
+          const caseContext = await context.cases;
+          const client = await caseContext.getCasesClient();
+          const options = request.query as AllTagsFindRequest;
 
-      return response.ok({ body: await client.cases.getTags({ ...options }) });
-    } catch (error) {
-      throw createCaseError({
-        message: `Failed to retrieve tags in route: ${error}`,
-        error,
-      });
-    }
-  },
-});
+          return response.ok({ body: await client.cases.getTags({ ...options }) });
+        } catch (error) {
+          throw createCaseError({
+            message: `Failed to retrieve tags in route: ${error}`,
+            error,
+          });
+        }
+      }
+    );
+}

--- a/x-pack/plugins/cases/server/routes/api/get_external_routes.ts
+++ b/x-pack/plugins/cases/server/routes/api/get_external_routes.ts
@@ -16,7 +16,7 @@ import { getReportersRoute } from './cases/reporters/get_reporters';
 import { getStatusRoute } from './stats/get_status';
 import { getUserActionsRoute } from './user_actions/get_all_user_actions';
 import type { CaseRoute } from './types';
-import { getTagsRoute } from './cases/tags/get_tags';
+// import { getTagsRoute } from './cases/tags/get_tags';
 import { deleteAllCommentsRoute } from './comments/delete_all_comments';
 import { deleteCommentRoute } from './comments/delete_comment';
 import { findCommentsRoute } from './comments/find_comments';
@@ -47,7 +47,7 @@ export const getExternalRoutes = () =>
     getStatusRoute,
     getCasesByAlertIdRoute,
     getReportersRoute,
-    getTagsRoute,
+    // getTagsRoute,
     deleteCommentRoute,
     deleteAllCommentsRoute,
     findCommentsRoute,

--- a/x-pack/plugins/cases/server/routes/api/register_routes.ts
+++ b/x-pack/plugins/cases/server/routes/api/register_routes.ts
@@ -9,6 +9,7 @@ import { schema } from '@kbn/config-schema';
 import type { Headers, RouteRegistrar } from '@kbn/core/server';
 import type { CasesRequestHandlerContext } from '../../types';
 import type { RegisterRoutesDeps } from './types';
+import { registerGetTagsRoute } from './cases/tags/get_tags';
 import {
   escapeHatch,
   getIsKibanaRequest,
@@ -72,6 +73,8 @@ const logAndIncreaseDeprecationTelemetryCounters = ({
 
 export const registerRoutes = (deps: RegisterRoutesDeps) => {
   const { router, routes, logger, kibanaVersion, telemetryUsageCounter } = deps;
+
+  registerGetTagsRoute(router.versioned);
 
   routes.forEach((route) => {
     const { method, path, params, options, routerOptions, handler } = route;

--- a/x-pack/plugins/cases/server/types.ts
+++ b/x-pack/plugins/cases/server/types.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import type { IRouter, CustomRequestHandlerContext, KibanaRequest } from '@kbn/core/server';
+import type { IRouterWithVersion } from '@kbn/core-http-server';
+import type { CustomRequestHandlerContext, KibanaRequest } from '@kbn/core/server';
 import type {
   ActionTypeConfig,
   ActionTypeSecrets,
@@ -31,7 +32,7 @@ export type CasesRequestHandlerContext = CustomRequestHandlerContext<{
 /**
  * @internal
  */
-export type CasesRouter = IRouter<CasesRequestHandlerContext>;
+export type CasesRouter = IRouterWithVersion<CasesRequestHandlerContext>;
 
 export type RegisterActionType = <
   Config extends ActionTypeConfig = ActionTypeConfig,

--- a/x-pack/plugins/cases/tsconfig.json
+++ b/x-pack/plugins/cases/tsconfig.json
@@ -63,8 +63,8 @@
     "@kbn/saved-objects-finder-plugin",
     "@kbn/saved-objects-management-plugin",
     "@kbn/utility-types-jest",
-    "@kbn/schema",
     "@kbn/core-http-server",
+    "@kbn/zod",
   ],
   "exclude": [
     "target/**/*",

--- a/x-pack/plugins/cases/tsconfig.json
+++ b/x-pack/plugins/cases/tsconfig.json
@@ -63,6 +63,8 @@
     "@kbn/saved-objects-finder-plugin",
     "@kbn/saved-objects-management-plugin",
     "@kbn/utility-types-jest",
+    "@kbn/schema",
+    "@kbn/core-http-server",
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
## Summary

Wrap Cases' "Get tags" route in a versioned router with capability to generate OAS spec. This is just to demonstrate how the OAS spec will look for a given route and not intended as a recommended refactor.

## How to test

Check out this branch locally then:

```
node ./scripts/generate_oas.js
```

See the output file in `packages/kbn-generate-oas/openapi.json`.

<details>
<summary>Should see something like</summary>

```json
{
  "openapi": "3.0.0",
  "info": {
    "title": "Kibana OpenAPI spec",
    "version": "0.0.0"
  },
  "servers": [
    {
      "url": "/"
    }
  ],
  "paths": {
    "/api/cases/tags": {
      "get": {
        "responses": {
          "200": {
            "description": "Get all case tags",
            "content": {
              "application/json; Elastic-Api-Version=2023-05-02": {
                "schema": {
                  "type": "array",
                  "items": {
                    "type": "string"
                  }
                }
              }
            }
          }
        },
        "parameters": [
          {
            "name": "owner",
            "in": "query",
            "required": true,
            "schema": {
              "anyOf": [
                {
                  "type": "array",
                  "items": {
                    "type": "string"
                  }
                },
                {
                  "type": "string"
                }
              ]
            }
          }
        ],
        "operationId": "/api/cases/tags#0"
      }
    }
  },
  "security": [
    {
      "basicAuth": []
    },
    {
      "apiKeyAuth": []
    }
  ]
}
```

</details>

Can be compared with existing spec https://github.com/elastic/kibana/blob/b9613994b11ce23bf511f097d3f4b2a974bfce93/x-pack/plugins/cases/docs/openapi/paths/s%40%7Bspaceid%7D%40api%40cases%40tags.yaml#L8