### PR TITLE
[Security Solution] Fixes typo in edit rules step

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_rule_actions/translations.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_rule_actions/translations.tsx
@@ -40,6 +40,6 @@ export const RULE_SNOOZE_DESCRIPTION = i18n.translate(
 export const SNOOZED_ACTIONS_WARNING = i18n.translate(
   'xpack.securitySolution.detectionEngine.createRule.stepRuleActions.snoozedActionsWarning',
   {
-    defaultMessage: 'Actions will not be preformed until it is unsnoozed.',
+    defaultMessage: 'Actions will not be performed until it is unsnoozed.',
   }
 );


### PR DESCRIPTION
## Summary

Fixes a little typo introduced with the rule snooze functionality when editing a rule.

Before:
<img width="976" alt="Screenshot 2023-05-02 at 16 12 14" src="https://user-images.githubusercontent.com/17427073/235696574-c70154e7-97dc-4f27-b733-803fdee81e96.png">

After:
<img width="1003" alt="Screenshot 2023-05-02 at 16 21 43" src="https://user-images.githubusercontent.com/17427073/235696607-7c161bd5-865d-405b-9c08-0ae6cd8d0e6c.png">


<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->