### PR TITLE
[Guided onboarding] Fix the missing help link

### DIFF
--- a/x-pack/plugins/cloud_integrations/cloud_links/kibana.jsonc
+++ b/x-pack/plugins/cloud_integrations/cloud_links/kibana.jsonc
@@ -10,7 +10,7 @@
     "optionalPlugins": [
       "cloud",
       "security",
-      "guided_onboarding"
+      "guidedOnboarding"
     ]
   }
 }

--- a/x-pack/test/functional_cloud/tests/cloud_links.ts
+++ b/x-pack/test/functional_cloud/tests/cloud_links.ts
@@ -30,10 +30,22 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await PageObjects.header.waitUntilLoadingHasFinished();
     });
 
-    it('The button "Setup guides" is loaded', async () => {
-      expect(await find.byCssSelector('[data-test-subj="guideButtonRedirect"]')).to.not.be(null);
-      const cloudLink = await find.byLinkText('Setup guides');
-      expect(cloudLink).to.not.be(null);
+    describe('Guided onboarding', () => {
+      it('The button "Setup guides" is loaded', async () => {
+        expect(await find.byCssSelector('[data-test-subj="guideButtonRedirect"]')).to.not.be(null);
+        const cloudLink = await find.byLinkText('Setup guides');
+        expect(cloudLink).to.not.be(null);
+      });
+
+      it('The help link "Setup guides" is added', async () => {
+        await PageObjects.common.clickAndValidate(
+          'helpMenuButton',
+          'cloudOnboardingSetupGuideLink'
+        );
+        expect(
+          await find.byCssSelector('[data-test-subj="cloudOnboardingSetupGuideLink"]')
+        ).to.not.be(null);
+      });
     });
 
     it('"Manage this deployment" is appended to the nav list', async () => {


### PR DESCRIPTION
## Summary

This PR fixes a bug introduced in https://github.com/elastic/kibana/pull/155065/ that I noticed when testing guided onboarding for v8.9.0: the help link was missing from the help menu. I added a functional test for the help link but we also need a test that the link is hidden when the user doesn't have access to guided onboarding (opened an issue for that [here](https://github.com/elastic/kibana/issues/156410)). 

### How to test
1. Add xpack.cloud.id: 'testID' to /config/kibana.dev.yml
2. Start ES with yarn es snapshot and Kibana with `yarn start``
3. Check that the help link "Setup guides" is displayed in the help menu

### Screenshot 
<img width="336" alt="Screenshot 2023-05-02 at 17 27 20" src="https://user-images.githubusercontent.com/6585477/235712599-812b422d-3092-45b3-a726-37f6b90e81c1.png">


<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->