### PR TITLE
[Canvas] Update function reference docs

### DIFF
--- a/docs/canvas/canvas-function-reference.asciidoc
+++ b/docs/canvas/canvas-function-reference.asciidoc
@@ -1160,7 +1160,7 @@ Alias: `param`
 
 Alias: `timeField`
 |`string`
-|The time field to use in the time range filter set in the context.
+|The time field to use in the time range filter, which is set in the context.
 
 |`timezone`
 
@@ -1954,7 +1954,7 @@ Alias: `expression`
 
 |`castColumns` †
 |`string`
-|The ids of columns to cast to numbers before applying the formula
+|The column ids that are cast to numbers before the formula is applied.
 
 |`copyMetaFrom`
 |`string`, `null`

--- a/docs/canvas/canvas-function-reference.asciidoc
+++ b/docs/canvas/canvas-function-reference.asciidoc
@@ -1018,6 +1018,8 @@ Aliases: `q`, `query`
 Default: `"-_index:.kibana"`
 
 |`index`
+
+Alias: `dataView`
 |`string`
 |An index or data view. For example, `"logstash-*"`.
 
@@ -1087,6 +1089,8 @@ Default: `1000`
 |A comma-separated list of fields. For better performance, use fewer fields.
 
 |`index`
+
+Alias: `dataView`
 |`string`
 |An index or data view. For example, `"logstash-*"`.
 
@@ -1128,7 +1132,7 @@ kibana
 ----
 This retrieves the `Carrier`, `FlightDelayMin`, and `AvgTicketPrice` fields from the "kibana_sample_data_flights" index.
 
-*Accepts:* `filter`
+*Accepts:* `kibana_context`, `null`
 
 [cols="3*^<"]
 |===
@@ -1151,6 +1155,12 @@ Default: `1000`
 Alias: `param`
 |`string`, `number`, `boolean`
 |A parameter to be passed to the SQL query.
+
+|`timeField`
+
+Alias: `timeField`
+|`string`
+|The time field to use in the time range filter set in the context.
 
 |`timezone`
 
@@ -1177,19 +1187,6 @@ exactly "state" value="running"
 exactly "age" value=50 filterGroup="group2"
 exactly column="project" value="beats"
 ----
-
-*Code example*
-[source,text]
-----
-kibana
-| selectFilter
-| exactly column=project value=elasticsearch
-| demodata
-| pointseries x=project y="mean(age)"
-| plot defaultStyle={seriesStyle bars=1}
-| render
-----
-The `exactly` filter here is added to existing filters retrieved by the `filters` function and further filters down the data to only have `"elasticsearch"` data. The `exactly` filter only applies to this one specific element and will not affect other elements in the workpad.
 
 *Accepts:* `filter`
 
@@ -1270,7 +1267,7 @@ Aliases: `exp`, `expression`, `fn`, `function`
 [[filters_fn]]
 === `filters`
 
-Aggregates element filters from the workpad for use elsewhere, usually a data source.
+Aggregates element filters from the workpad for use elsewhere, usually a data source. <<filters_fn>> is deprecated and will be removed in a future release. Use `kibana | selectFilter` instead.
 
 *Expression syntax*
 [source,js]
@@ -1935,7 +1932,7 @@ Alias: `expression`
 [[mathColumn_fn]]
 === `mathColumn`
 
-Adds a column by evaluating TinyMath on each row. This function is optimized for math, so it performs better than the mapColumn with a math
+Adds a column by evaluating `TinyMath` on each row. This function is optimized for math and performs better than using a math expression in <<mapColumn_fn>>.
 
 *Accepts:* `datatable`
 
@@ -1954,6 +1951,10 @@ Aliases: `column`, `name`
 Alias: `expression`
 |`string`
 |An evaluated `TinyMath` expression. See https://www.elastic.co/guide/en/kibana/current/canvas-tinymath-functions.html.
+
+|`castColumns` †
+|`string`
+|The ids of columns to cast to numbers before applying the formula
 
 |`copyMetaFrom`
 |`string`, `null`


### PR DESCRIPTION
## Summary

Closes #141526.

This updates the function reference docs for Canvas expressions. The main update here is the deprecation message added to `filters` function. I'm also removing an expression example that doesn't work.

<img width="866" alt="Screenshot 2023-05-02 at 9 26 54 AM" src="https://user-images.githubusercontent.com/1697105/235727031-8ece820e-3db5-42c7-ba11-e94d647a8b84.png">


@KOTungseth These changes impact as early as v8.4. Should I backport all the way back through 8.4?

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.4","8.5","8.6","8.7","8.8"]} ONMERGE-->