### PR TITLE
[8.8] [Security Solution] Fixes typo in edit rules step (#156397)

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_rule_actions/translations.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_rule_actions/translations.tsx
@@ -40,6 +40,6 @@ export const RULE_SNOOZE_DESCRIPTION = i18n.translate(
 export const SNOOZED_ACTIONS_WARNING = i18n.translate(
   'xpack.securitySolution.detectionEngine.createRule.stepRuleActions.snoozedActionsWarning',
   {
-    defaultMessage: 'Actions will not be preformed until it is unsnoozed.',
+    defaultMessage: 'Actions will not be performed until it is unsnoozed.',
   }
 );


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.8`:
 - [[Security Solution] Fixes typo in edit rules step (#156397)](https://github.com/elastic/kibana/pull/156397)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Gloria Hornero","email":"gloria.hornero@elastic.co"},"sourceCommit":{"committedDate":"2023-05-02T15:57:16Z","message":"[Security Solution] Fixes typo in edit rules step (#156397)","sha":"ee9d782793971cb8812c6cad3e2051c23836fb6c","branchLabelMapping":{"^v8.9.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Detections and Resp","Team: SecuritySolution","Team:Detection Rules","v8.8.0","v8.9.0"],"number":156397,"url":"https://github.com/elastic/kibana/pull/156397","mergeCommit":{"message":"[Security Solution] Fixes typo in edit rules step (#156397)","sha":"ee9d782793971cb8812c6cad3e2051c23836fb6c"}},"sourceBranch":"main","suggestedTargetBranches":["8.8"],"targetPullRequestStates":[{"branch":"8.8","label":"v8.8.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.9.0","labelRegex":"^v8.9.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/156397","number":156397,"mergeCommit":{"message":"[Security Solution] Fixes typo in edit rules step (#156397)","sha":"ee9d782793971cb8812c6cad3e2051c23836fb6c"}}]}] BACKPORT-->