### PR TITLE
Don't trigger summary actions when there are no alerts to report

### DIFF
--- a/x-pack/plugins/alerting/server/task_runner/execution_handler.test.ts
+++ b/x-pack/plugins/alerting/server/task_runner/execution_handler.test.ts
@@ -1299,7 +1299,7 @@ describe('Execution Handler', () => {
       `);
   });
 
-  test('does not schedule actions for the summarized alerts that are filtered out', async () => {
+  test('does not schedule actions for the summarized alerts that are filtered out (for each alert)', async () => {
     getSummarizedAlertsMock.mockResolvedValue({
       new: {
         count: 0,
@@ -1360,6 +1360,66 @@ describe('Execution Handler', () => {
     expect(defaultExecutionParams.logger.debug).toHaveBeenCalledWith(
       '(2) alerts have been filtered out for: testActionTypeId:111'
     );
+  });
+
+  test('does not schedule actions for the summarized alerts that are filtered out (summary of alerts onThrottleInterval)', async () => {
+    getSummarizedAlertsMock.mockResolvedValue({
+      new: {
+        count: 0,
+        data: [],
+      },
+      ongoing: {
+        count: 0,
+        data: [],
+      },
+      recovered: { count: 0, data: [] },
+    });
+    const executionHandler = new ExecutionHandler(
+      generateExecutionParams({
+        rule: {
+          ...defaultExecutionParams.rule,
+          mutedInstanceIds: ['foo'],
+          actions: [
+            {
+              id: '1',
+              uuid: '111',
+              group: null,
+              actionTypeId: 'testActionTypeId',
+              frequency: {
+                summary: true,
+                notifyWhen: 'onThrottleInterval',
+                throttle: '1h',
+              },
+              params: {
+                message:
+                  'New: {{alerts.new.count}} Ongoing: {{alerts.ongoing.count}} Recovered: {{alerts.recovered.count}}',
+              },
+              alertsFilter: {
+                query: { kql: 'kibana.alert.rule.name:foo', dsl: '{}', filters: [] },
+              },
+            },
+          ],
+        },
+      })
+    );
+
+    await executionHandler.run({
+      ...generateAlert({ id: 1 }),
+      ...generateAlert({ id: 2 }),
+    });
+
+    expect(getSummarizedAlertsMock).toHaveBeenCalledWith({
+      ruleId: '1',
+      spaceId: 'test1',
+      end: new Date('1970-01-01T00:01:30.000Z'),
+      start: new Date('1969-12-31T23:01:30.000Z'),
+      excludedAlertInstanceIds: ['foo'],
+      alertsFilter: {
+        query: { kql: 'kibana.alert.rule.name:foo', dsl: '{}', filters: [] },
+      },
+    });
+    expect(actionsClient.bulkEnqueueExecution).not.toHaveBeenCalled();
+    expect(alertingEventLogger.logAction).not.toHaveBeenCalled();
   });
 
   test('does not schedule actions for the for-each type alerts that are filtered out', async () => {

--- a/x-pack/plugins/alerting/server/task_runner/execution_handler.ts
+++ b/x-pack/plugins/alerting/server/task_runner/execution_handler.ts
@@ -44,7 +44,6 @@ import {
   isActionOnInterval,
   isSummaryAction,
   isSummaryActionOnInterval,
-  isSummaryActionPerRuleRun,
   isSummaryActionThrottled,
 } from './rule_action_helper';
 
@@ -511,10 +510,7 @@ export class ExecutionHandler<
       }
 
       if (isSummaryAction(action)) {
-        if (summarizedAlerts) {
-          if (isSummaryActionPerRuleRun(action) && summarizedAlerts.all.count === 0) {
-            continue;
-          }
+        if (summarizedAlerts && summarizedAlerts.all.count !== 0) {
           executables.push({ action, summarizedAlerts });
         }
         continue;

--- a/x-pack/plugins/alerting/server/task_runner/rule_action_helper.ts
+++ b/x-pack/plugins/alerting/server/task_runner/rule_action_helper.ts
@@ -28,13 +28,6 @@ export const isActionOnInterval = (action?: RuleAction) => {
   );
 };
 
-export const isSummaryActionPerRuleRun = (action: RuleAction) => {
-  if (!action.frequency) {
-    return false;
-  }
-  return action.frequency.notifyWhen === RuleNotifyWhenTypeValues[1] && action.frequency.summary;
-};
-
 export const isSummaryActionOnInterval = (action: RuleAction) => {
   return isActionOnInterval(action) && action.frequency?.summary;
 };


### PR DESCRIPTION
Resolves: #155708

Currently we always trigger summary actions on custom interval even if there are no alerts to report.
This PR changes this behaviour to skip summary actions when there are no alerts.

## To verify
Create a Security Rule with a summary action that is on custom interval (`Summary of alerts` -> `Custom Frequency`)
Add an alerts filter to filter out all the alerts (e.g. by using host name that doesn't exist)
Expect the summary action not to be triggered.


<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->