### PR TITLE
[Enterprise Search] Bug fix: Show correct index doc counts when viewing search applications

### DIFF
--- a/x-pack/plugins/enterprise_search/server/lib/engines/fetch_indices_stats.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/engines/fetch_indices_stats.test.ts
@@ -22,11 +22,16 @@ describe('fetchIndicesStats lib function', () => {
     indices: {
       'test-index-name-1': {
         health: 'GREEN',
-        primaries: { docs: [{}] },
+        primaries: {
+          docs: {
+            count: 200,
+            deleted: 0,
+          },
+        },
         status: 'open',
         total: {
           docs: {
-            count: 200,
+            count: 400,
             deleted: 0,
           },
         },
@@ -34,7 +39,12 @@ describe('fetchIndicesStats lib function', () => {
       },
       'test-index-name-2': {
         health: 'YELLOW',
-        primaries: { docs: [{}] },
+        primaries: {
+          docs: {
+            count: 0,
+            deleted: 0,
+          },
+        },
         status: 'closed',
         total: {
           docs: {
@@ -46,11 +56,16 @@ describe('fetchIndicesStats lib function', () => {
       },
       'test-index-name-3': {
         health: 'RED',
-        primaries: { docs: [{}] },
+        primaries: {
+          docs: {
+            count: 150,
+            deleted: 0,
+          },
+        },
         status: 'open',
         total: {
           docs: {
-            count: 150,
+            count: 300,
             deleted: 0,
           },
         },

--- a/x-pack/plugins/enterprise_search/server/lib/engines/fetch_indices_stats.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/engines/fetch_indices_stats.ts
@@ -18,7 +18,7 @@ export const fetchIndicesStats = async (client: IScopedClusterClient, indices: s
   const indicesWithStats = indices.map((indexName: string) => {
     const indexStats = indicesStats[indexName];
     const hydratedIndex: EnterpriseSearchEngineIndex = {
-      count: indexStats?.total?.docs?.count ?? 0,
+      count: indexStats?.primaries?.docs?.count ?? 0,
       health: indexStats?.health ?? 'unknown',
       name: indexName,
     };


### PR DESCRIPTION
## Summary

Fixes a bug where replicas would be counted when reporting the total document count in indices associated with a search application.

Thanks to @efegurkan for the help!

<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->