### PR TITLE
[ML] Data Frame Analytics creation wizard: ensure preview datagrid displays expected fields

### DIFF
--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/hooks/use_index_data.ts
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/hooks/use_index_data.ts
@@ -19,7 +19,6 @@ import { extractErrorMessage } from '@kbn/ml-error-utils';
 import { isRuntimeMappings } from '../../../../../../common/util/runtime_field_utils';
 import { RuntimeMappings } from '../../../../../../common/types/fields';
 import { DEFAULT_SAMPLER_SHARD_SIZE } from '../../../../../../common/constants/field_histograms';
-import { newJobCapsServiceAnalytics } from '../../../../services/new_job_capabilities/new_job_capabilities_service_analytics';
 
 import { DataLoader } from '../../../../datavisualizer/index_based/data_loader';
 
@@ -60,7 +59,7 @@ function getRuntimeFieldColumns(runtimeMappings: RuntimeMappings) {
 }
 
 function getIndexPatternColumns(indexPattern: DataView, fieldsFilter: string[]) {
-  const { fields } = newJobCapsServiceAnalytics;
+  const { fields } = indexPattern;
 
   return fields
     .filter((field) => fieldsFilter.includes(field.name))
@@ -117,9 +116,9 @@ export const useIndexData = (
 
         // Get all field names for each returned doc and flatten it
         // to a list of unique field names used across all docs.
-        const allKibanaIndexPatternFields = getFieldsFromKibanaIndexPattern(indexPattern);
+        const allDataViewFields = getFieldsFromKibanaIndexPattern(indexPattern);
         const populatedFields = [...new Set(docs.map(Object.keys).flat(1))]
-          .filter((d) => allKibanaIndexPatternFields.includes(d))
+          .filter((d) => allDataViewFields.includes(d))
           .sort();
 
         setStatus(INDEX_STATUS.LOADED);


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/154009

This PR ensures the column field check for the data grid preview in DFA uses the Data view fields.

BEFORE:

<img width="1214" alt="image" src="https://user-images.githubusercontent.com/6446462/228678497-ffe65bf9-1b4c-4f56-bb3d-fe69ac941e62.png">

AFTER: 

<img width="1178" alt="image" src="https://user-images.githubusercontent.com/6446462/235797816-34425648-a470-4631-b6c2-ba453f62752d.png">

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)




<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->