### PR TITLE
chore(observability): remove alerts table configuration boilerplate

### DIFF
--- a/x-pack/plugins/observability/public/components/use_get_alert_flyout_components.tsx
+++ b/x-pack/plugins/observability/public/components/use_get_alert_flyout_components.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useCallback, useMemo } from 'react';
+import React from 'react';
 import { AlertsTableFlyoutBaseProps } from '@kbn/triggers-actions-ui-plugin/public';
 
 import type { ObservabilityRuleTypeRegistry } from '../rules/create_observability_rule_type_registry';
@@ -19,36 +19,18 @@ export { AlertsFlyout } from './alerts_flyout';
 export const useGetAlertFlyoutComponents = (
   observabilityRuleTypeRegistry: ObservabilityRuleTypeRegistry
 ) => {
-  const body = useCallback(
-    (props: AlertsTableFlyoutBaseProps) => {
+  return {
+    body: (props: AlertsTableFlyoutBaseProps) => {
       const alert = parseAlert(observabilityRuleTypeRegistry)(props.alert);
       return <AlertsFlyoutBody alert={alert} id={props.id} />;
     },
-    [observabilityRuleTypeRegistry]
-  );
-
-  const header = useCallback(
-    (props: AlertsTableFlyoutBaseProps) => {
+    header: (props: AlertsTableFlyoutBaseProps) => {
       const alert = parseAlert(observabilityRuleTypeRegistry)(props.alert);
       return <AlertsFlyoutHeader alert={alert} />;
     },
-    [observabilityRuleTypeRegistry]
-  );
-
-  const footer = useCallback(
-    (props: AlertsTableFlyoutBaseProps) => {
+    footer: (props: AlertsTableFlyoutBaseProps) => {
       const alert = parseAlert(observabilityRuleTypeRegistry)(props.alert);
       return <AlertsFlyoutFooter isInApp={false} alert={alert} />;
     },
-    [observabilityRuleTypeRegistry]
-  );
-
-  return useMemo(
-    () => ({
-      body,
-      header,
-      footer,
-    }),
-    [body, header, footer]
-  );
+  };
 };

--- a/x-pack/plugins/observability/public/plugin.ts
+++ b/x-pack/plugins/observability/public/plugin.ts
@@ -60,6 +60,7 @@ import {
 import { createCallObservabilityApi } from './services/call_observability_api';
 import { createUseRulesLink } from './hooks/create_use_rules_link';
 import { registerObservabilityRuleTypes } from './rules/register_observability_rule_types';
+import { getAlertsTableConfiguration } from './components/alerts_table/get_alerts_table_configuration';
 
 export interface ConfigSchema {
   unsafe: {
@@ -328,18 +329,12 @@ export class Plugin
       updater$: this.appUpdater$,
     });
 
-    const getAsyncO11yAlertsTableConfiguration = async () => {
-      const { getAlertsTableConfiguration } = await import(
-        './components/alerts_table/get_alerts_table_configuration'
-      );
-      return getAlertsTableConfiguration(this.observabilityRuleTypeRegistry, config);
-    };
+    const alertsTableConfig = getAlertsTableConfiguration(
+      this.observabilityRuleTypeRegistry,
+      config
+    );
 
-    const { alertsTableConfigurationRegistry } = pluginsStart.triggersActionsUi;
-
-    getAsyncO11yAlertsTableConfiguration().then((alertsTableConfig) => {
-      alertsTableConfigurationRegistry.register(alertsTableConfig);
-    });
+    pluginsStart.triggersActionsUi.alertsTableConfigurationRegistry.register(alertsTableConfig);
 
     return {
       observabilityRuleTypeRegistry: this.observabilityRuleTypeRegistry,


### PR DESCRIPTION
## 📝  Summary

While looking at how the alerts table configuration was done, I noticed some boilerplate that I think is unnecessary. This PR simplifies this configuration.