### PR TITLE
[SecuritySolution] Unsync highlight state between visualizations

### DIFF
--- a/x-pack/plugins/cases/public/components/markdown_editor/plugins/lens/processor.tsx
+++ b/x-pack/plugins/cases/public/components/markdown_editor/plugins/lens/processor.tsx
@@ -53,6 +53,8 @@ const LensMarkDownRendererComponent: React.FC<LensMarkDownRendererProps> = ({
         executionContext={{
           type: 'cases',
         }}
+        syncTooltips={false}
+        syncCursor={false}
       />
       <LensChartTooltipFix />
     </Container>

--- a/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/__snapshots__/external_alert.test.ts.snap
+++ b/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/__snapshots__/external_alert.test.ts.snap
@@ -190,6 +190,11 @@ Object {
       "query": "host.name: *",
     },
     "visualization": Object {
+      "axisTitlesVisibilitySettings": Object {
+        "x": false,
+        "yLeft": false,
+        "yRight": true,
+      },
       "layers": Array [
         Object {
           "accessors": Array [
@@ -211,6 +216,7 @@ Object {
       "preferredSeriesType": "bar_stacked",
       "title": "Empty XY chart",
       "valueLabels": "hide",
+      "valuesInLegend": true,
       "yLeftExtent": Object {
         "mode": "full",
       },

--- a/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/alerts/alerts_histogram.test.ts
+++ b/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/alerts/alerts_histogram.test.ts
@@ -47,8 +47,6 @@ describe('getAlertsHistogramLensAttributes', () => {
     expect(result?.current).toMatchSnapshot();
   });
 
-
-
   it('should render with extra options - filters', () => {
     const { result } = renderHook(
       () =>

--- a/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/alerts/alerts_histogram.test.ts
+++ b/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/alerts/alerts_histogram.test.ts
@@ -47,6 +47,8 @@ describe('getAlertsHistogramLensAttributes', () => {
     expect(result?.current).toMatchSnapshot();
   });
 
+
+
   it('should render with extra options - filters', () => {
     const { result } = renderHook(
       () =>

--- a/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/event.test.ts
+++ b/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/event.test.ts
@@ -480,4 +480,19 @@ describe('getEventsHistogramLensAttributes', () => {
       })
     );
   });
+
+  it('should render values in legend', () => {
+    const { result } = renderHook(
+      () =>
+        useLensAttributes({
+          getLensAttributes: getEventsHistogramLensAttributes,
+          stackByField: 'event.dataset',
+        }),
+      { wrapper }
+    );
+
+    expect(result?.current?.state?.visualization).toEqual(
+      expect.objectContaining({ valuesInLegend: true })
+    );
+  });
 });

--- a/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/events.ts
+++ b/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/events.ts
@@ -49,6 +49,7 @@ export const getEventsHistogramLensAttributes: GetLensAttributes = (
           yLeft: false,
           yRight: true,
         },
+        valuesInLegend: true,
       },
       query: {
         query: '',

--- a/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/external_alert.test.ts
+++ b/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/external_alert.test.ts
@@ -43,4 +43,19 @@ describe('getExternalAlertLensAttributes', () => {
 
     expect(result?.current).toMatchSnapshot();
   });
+
+  it('should render values in legend', () => {
+    const { result } = renderHook(
+      () =>
+        useLensAttributes({
+          getLensAttributes: getExternalAlertLensAttributes,
+          stackByField: 'event.dataset',
+        }),
+      { wrapper }
+    );
+
+    expect(result?.current?.state?.visualization).toEqual(
+      expect.objectContaining({ valuesInLegend: true })
+    );
+  });
 });

--- a/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/external_alert.ts
+++ b/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/external_alert.ts
@@ -42,6 +42,12 @@ export const getExternalAlertLensAttributes: GetLensAttributes = (
         yLeftExtent: {
           mode: 'full',
         },
+        axisTitlesVisibilitySettings: {
+          x: false,
+          yLeft: false,
+          yRight: true,
+        },
+        valuesInLegend: true,
       },
       query: {
         query: '',

--- a/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/__snapshots__/dns_top_domains.test.ts.snap
+++ b/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/__snapshots__/dns_top_domains.test.ts.snap
@@ -237,6 +237,7 @@ Object {
         "yRight": true,
       },
       "valueLabels": "hide",
+      "valuesInLegend": true,
       "yLeftExtent": Object {
         "mode": "full",
       },

--- a/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/dns_top_domains.test.ts
+++ b/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/dns_top_domains.test.ts
@@ -157,4 +157,10 @@ describe('getDnsTopDomainsLensAttributes', () => {
       }
     `);
   });
+
+  it('should render values in legend', () => {
+    expect(result?.current?.state?.visualization).toEqual(
+      expect.objectContaining({ valuesInLegend: true })
+    );
+  });
 });

--- a/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/dns_top_domains.ts
+++ b/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/dns_top_domains.ts
@@ -36,6 +36,7 @@ export const getDnsTopDomainsLensAttributes: GetLensAttributes = (
           yLeft: false,
           yRight: false,
         },
+        valuesInLegend: true,
         tickLabelsVisibilitySettings: {
           x: true,
           yLeft: true,

--- a/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_embeddable.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_embeddable.test.tsx
@@ -123,4 +123,9 @@ describe('LensEmbeddable', () => {
   it('should render with searchSessionId', () => {
     expect(mockEmbeddableComponent.mock.calls[0][0].searchSessionId).toEqual(mockSearchSessionId);
   });
+
+  it('should not sync highlight state between visualizations', () => {
+    expect(mockEmbeddableComponent.mock.calls[0][0].syncTooltips).toEqual(false);
+    expect(mockEmbeddableComponent.mock.calls[0][0].syncCursor).toEqual(false);
+  });
 });

--- a/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_embeddable.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_embeddable.tsx
@@ -271,6 +271,8 @@ const LensEmbeddableComponent: React.FC<LensEmbeddableComponentProps> = ({
             extraActions={actions}
             searchSessionId={searchSessionId}
             showInspector={false}
+            syncTooltips={false}
+            syncCursor={false}
           />
         </LensComponentWrapper>
       )}


### PR DESCRIPTION
## Summary

issue: https://github.com/elastic/kibana/issues/156325

Before

![alerts](https://user-images.githubusercontent.com/4459398/235551083-f101aba4-7a32-41e8-95a0-4cf50dd09005.gif)


After

https://user-images.githubusercontent.com/6295984/235792908-c7832d7f-7424-4d11-b4f7-52acaa0fa7aa.mov



### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->