### PR TITLE
[Cloud security] Fix runtime fields scripts - checking field exist

### DIFF
--- a/x-pack/plugins/cloud_security_posture/common/runtime_mappings/get_belongs_to_runtime_mapping.ts
+++ b/x-pack/plugins/cloud_security_posture/common/runtime_mappings/get_belongs_to_runtime_mapping.ts
@@ -23,7 +23,7 @@ export const getBelongsToRuntimeMapping = (): MappingRuntimeFields => ({
 
         if (!postureTypeAvailable) {
           def belongs_to = orchestratorIdAvailable ?
-            doc["orchestrator.cluster.id"].empty : doc["cluster_id"].value;
+            doc["orchestrator.cluster.id"].value : doc["cluster_id"].value;
           emit(belongs_to);
         } else {
           def policy_template_type = doc["rule.benchmark.posture_type"].value;
@@ -33,12 +33,12 @@ export const getBelongsToRuntimeMapping = (): MappingRuntimeFields => ({
             emit(belongs_to);
           } else if (policy_template_type == "kspm") {
             def belongs_to = orchestratorIdAvailable ?
-              doc["orchestrator.cluster.id"].empty : doc["cluster_id"].value;
+              doc["orchestrator.cluster.id"].value : doc["cluster_id"].value;
             emit(belongs_to);
           } else {
             // Default behaviour when policy_template_type is unknown
             def belongs_to = orchestratorIdAvailable ?
-              doc["orchestrator.cluster.id"].empty : doc["cluster_id"].value;
+              doc["orchestrator.cluster.id"].value : doc["cluster_id"].value;
             emit(belongs_to);
           }
         }

--- a/x-pack/plugins/cloud_security_posture/common/runtime_mappings/get_belongs_to_runtime_mapping.ts
+++ b/x-pack/plugins/cloud_security_posture/common/runtime_mappings/get_belongs_to_runtime_mapping.ts
@@ -16,35 +16,31 @@ export const getBelongsToRuntimeMapping = (): MappingRuntimeFields => ({
     type: 'keyword',
     script: {
       source: `
-        if (!doc.containsKey('rule.benchmark.posture_type'))
-          {
-            def belongs_to = doc["cluster_id"].value;
+        def postureTypeAvailable = doc.containsKey("rule.benchmark.posture_type") &&
+          !doc["rule.benchmark.posture_type"].empty;
+        def orchestratorIdAvailable = doc.containsKey("orchestrator.cluster.id") &&
+          !doc["orchestrator.cluster.id"].empty;
+
+        if (!postureTypeAvailable) {
+          def belongs_to = orchestratorIdAvailable ?
+            doc["orchestrator.cluster.id"].empty : doc["cluster_id"].value;
+          emit(belongs_to);
+        } else {
+          def policy_template_type = doc["rule.benchmark.posture_type"].value;
+
+          if (policy_template_type == "cspm") {
+            def belongs_to = doc["cloud.account.name"].value;
             emit(belongs_to);
-            return
+          } else if (policy_template_type == "kspm") {
+            def belongs_to = orchestratorIdAvailable ?
+              doc["orchestrator.cluster.id"].empty : doc["cluster_id"].value;
+            emit(belongs_to);
+          } else {
+            // Default behaviour when policy_template_type is unknown
+            def belongs_to = orchestratorIdAvailable ?
+              doc["orchestrator.cluster.id"].empty : doc["cluster_id"].value;
+            emit(belongs_to);
           }
-        else
-        {
-          if(doc["rule.benchmark.posture_type"].size() > 0)
-            {
-              def policy_template_type = doc["rule.benchmark.posture_type"].value;
-              if (policy_template_type == "cspm")
-              {
-                def belongs_to = doc["cloud.account.name"].value;
-                emit(belongs_to);
-                return
-              }
-
-              if (policy_template_type == "kspm")
-              {
-                def belongs_to = doc["cluster_id"].value;
-                emit(belongs_to);
-                return
-              }
-            }
-
-            def belongs_to = doc["cluster_id"].value;
-            emit(belongs_to);
-            return
         }
       `,
     },

--- a/x-pack/plugins/cloud_security_posture/common/runtime_mappings/get_identifier_runtime_mapping.ts
+++ b/x-pack/plugins/cloud_security_posture/common/runtime_mappings/get_identifier_runtime_mapping.ts
@@ -16,35 +16,30 @@ export const getIdentifierRuntimeMapping = (): MappingRuntimeFields => ({
     type: 'keyword',
     script: {
       source: `
-        if (!doc.containsKey('rule.benchmark.posture_type'))
-          {
-            def identifier = doc["cluster_id"].value;
+        def postureTypeAvailable = doc.containsKey("rule.benchmark.posture_type") &&
+          !doc["rule.benchmark.posture_type"].empty;
+        def orchestratorIdAvailable = doc.containsKey("orchestrator.cluster.id") &&
+          !doc["orchestrator.cluster.id"].empty;
+
+        if (!postureTypeAvailable) {
+          def identifier = orchestratorIdAvailable ?
+            doc["orchestrator.cluster.id"].empty : doc["cluster_id"].value;
+          emit(identifier);
+        } else {
+          def policy_template_type = doc["rule.benchmark.posture_type"].value;
+
+          if (policy_template_type == "cspm") {
+            emit(doc["cloud.account.id"].value);
+          } else if (policy_template_type == "kspm") {
+            def identifier = orchestratorIdAvailable ?
+              doc["orchestrator.cluster.id"].empty : doc["cluster_id"].value;
             emit(identifier);
-            return
+          } else {
+            // Default behaviour when policy_template_type is unknown
+            def identifier = orchestratorIdAvailable ?
+              doc["orchestrator.cluster.id"].empty : doc["cluster_id"].value;
+            emit(identifier);
           }
-        else
-        {
-          if(doc["rule.benchmark.posture_type"].size() > 0)
-            {
-              def policy_template_type = doc["rule.benchmark.posture_type"].value;
-              if (policy_template_type == "cspm")
-              {
-                def identifier = doc["cloud.account.id"].value;
-                emit(identifier);
-                return
-              }
-
-              if (policy_template_type == "kspm")
-              {
-                def identifier = doc["cluster_id"].value;
-                emit(identifier);
-                return
-              }
-            }
-
-            def identifier = doc["cluster_id"].value;
-            emit(identifier);
-            return
         }
       `,
     },

--- a/x-pack/plugins/cloud_security_posture/common/runtime_mappings/get_identifier_runtime_mapping.ts
+++ b/x-pack/plugins/cloud_security_posture/common/runtime_mappings/get_identifier_runtime_mapping.ts
@@ -23,7 +23,7 @@ export const getIdentifierRuntimeMapping = (): MappingRuntimeFields => ({
 
         if (!postureTypeAvailable) {
           def identifier = orchestratorIdAvailable ?
-            doc["orchestrator.cluster.id"].empty : doc["cluster_id"].value;
+            doc["orchestrator.cluster.id"].value : doc["cluster_id"].value;
           emit(identifier);
         } else {
           def policy_template_type = doc["rule.benchmark.posture_type"].value;
@@ -32,12 +32,12 @@ export const getIdentifierRuntimeMapping = (): MappingRuntimeFields => ({
             emit(doc["cloud.account.id"].value);
           } else if (policy_template_type == "kspm") {
             def identifier = orchestratorIdAvailable ?
-              doc["orchestrator.cluster.id"].empty : doc["cluster_id"].value;
+              doc["orchestrator.cluster.id"].value : doc["cluster_id"].value;
             emit(identifier);
           } else {
             // Default behaviour when policy_template_type is unknown
             def identifier = orchestratorIdAvailable ?
-              doc["orchestrator.cluster.id"].empty : doc["cluster_id"].value;
+              doc["orchestrator.cluster.id"].value : doc["cluster_id"].value;
             emit(identifier);
           }
         }

--- a/x-pack/plugins/cloud_security_posture/common/runtime_mappings/get_safe_kspm_cluster_id_runtime_mapping.ts
+++ b/x-pack/plugins/cloud_security_posture/common/runtime_mappings/get_safe_kspm_cluster_id_runtime_mapping.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { MappingRuntimeFields } from '@elastic/elasticsearch/lib/api/types';
+
+/**
+ * Creates the `safe_posture_type` runtime field with the value of either
+ * `kspm` or `cspm` based on the value of `rule.benchmark.posture_type`
+ */
+export const getSafeKspmClusterIdRuntimeMapping = (): MappingRuntimeFields => ({
+  safe_kspm_cluster_id: {
+    type: 'keyword',
+    script: {
+      source: `
+        def orchestratorIdAvailable = doc.containsKey("orchestrator.cluster.id") &&
+          !doc["orchestrator.cluster.id"].empty;
+        def clusterIdAvailable = doc.containsKey("cluster_id") &&
+          !doc["cluster_id"].empty;
+
+        if (orchestratorIdAvailable) {
+          emit(doc["orchestrator.cluster.id"].value);
+        } else if (clusterIdAvailable) {
+          emit(doc["cluster_id"].value);
+        }
+      `,
+    },
+  },
+});

--- a/x-pack/plugins/cloud_security_posture/common/runtime_mappings/get_safe_posture_type_runtime_mapping.ts
+++ b/x-pack/plugins/cloud_security_posture/common/runtime_mappings/get_safe_posture_type_runtime_mapping.ts
@@ -21,8 +21,7 @@ export const getSafePostureTypeRuntimeMapping = (): MappingRuntimeFields => ({
 
         if (!postureTypeAvailable) {
           // Before 8.7 release
-          def safe_posture_type = 'kspm';
-          emit(safe_posture_type);
+          emit("kspm");
         } else {
           emit(doc["rule.benchmark.posture_type"].value);
         }

--- a/x-pack/plugins/cloud_security_posture/common/runtime_mappings/get_safe_posture_type_runtime_mapping.ts
+++ b/x-pack/plugins/cloud_security_posture/common/runtime_mappings/get_safe_posture_type_runtime_mapping.ts
@@ -16,17 +16,15 @@ export const getSafePostureTypeRuntimeMapping = (): MappingRuntimeFields => ({
     type: 'keyword',
     script: {
       source: `
-        if (!doc.containsKey('rule.benchmark.posture_type'))
-          {
-            def safe_posture_type = 'kspm';
-            emit(safe_posture_type);
-            return
-          }
-        else
-        {
-            def safe_posture_type = doc["rule.benchmark.posture_type"].value;
-            emit(safe_posture_type);
-            return
+        def postureTypeAvailable = doc.containsKey("rule.benchmark.posture_type") &&
+          !doc["rule.benchmark.posture_type"].empty;
+
+        if (!postureTypeAvailable) {
+          // Before 8.7 release
+          def safe_posture_type = 'kspm';
+          emit(safe_posture_type);
+        } else {
+          emit(doc["rule.benchmark.posture_type"].value);
         }
       `,
     },

--- a/x-pack/plugins/cloud_security_posture/common/schemas/csp_finding.ts
+++ b/x-pack/plugins/cloud_security_posture/common/schemas/csp_finding.ts
@@ -27,6 +27,7 @@ export interface CspFinding {
 
 interface CspFindingOrchestrator {
   cluster?: {
+    id?: string;
     name?: string;
   };
 }

--- a/x-pack/plugins/cloud_security_posture/public/pages/configurations/latest_findings_by_resource/resource_findings/use_resource_findings.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/configurations/latest_findings_by_resource/resource_findings/use_resource_findings.ts
@@ -10,6 +10,7 @@ import { IKibanaSearchRequest, IKibanaSearchResponse } from '@kbn/data-plugin/co
 import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { Pagination } from '@elastic/eui';
 import { number } from 'io-ts';
+import { getSafeKspmClusterIdRuntimeMapping } from '../../../../../common/runtime_mappings/get_safe_kspm_cluster_id_runtime_mapping';
 import { CspFinding } from '../../../../../common/schemas/csp_finding';
 import { getAggregationCount, getFindingsCountAggQuery } from '../../utils/utils';
 import { useKibana } from '../../../../common/hooks/use_kibana';
@@ -49,6 +50,9 @@ const getResourceFindingsQuery = ({
   index: CSP_LATEST_FINDINGS_DATA_VIEW,
   body: {
     size: MAX_FINDINGS_TO_LOAD,
+    runtime_mappings: {
+      ...getSafeKspmClusterIdRuntimeMapping(),
+    },
     query: {
       ...query,
       bool: {
@@ -63,7 +67,7 @@ const getResourceFindingsQuery = ({
         terms: { field: 'cloud.account.name' },
       },
       clusterId: {
-        terms: { field: 'cluster_id' },
+        terms: { field: 'safe_kspm_cluster_id' },
       },
       resourceSubType: {
         terms: { field: 'resource.sub_type' },

--- a/x-pack/plugins/cloud_security_posture/server/lib/check_index_status.ts
+++ b/x-pack/plugins/cloud_security_posture/server/lib/check_index_status.ts
@@ -15,17 +15,18 @@ export const checkIndexStatus = async (
   logger: Logger,
   postureType?: PostureTypes
 ): Promise<IndexStatus> => {
-  const query = !postureType
-    ? undefined
-    : {
-        bool: {
-          filter: {
-            term: {
-              safe_posture_type: postureType,
+  const query =
+    !postureType || postureType === 'all' || postureType === 'vuln_mgmt'
+      ? undefined
+      : {
+          bool: {
+            filter: {
+              term: {
+                safe_posture_type: postureType,
+              },
             },
           },
-        },
-      };
+        };
 
   try {
     const queryResult = await esClient.search({

--- a/x-pack/plugins/cloud_security_posture/server/lib/check_index_status.ts
+++ b/x-pack/plugins/cloud_security_posture/server/lib/check_index_status.ts
@@ -6,6 +6,7 @@
  */
 
 import { ElasticsearchClient, type Logger } from '@kbn/core/server';
+import { getSafePostureTypeRuntimeMapping } from '../../common/runtime_mappings/get_safe_posture_type_runtime_mapping';
 import { IndexStatus, PostureTypes } from '../../common/types';
 
 export const checkIndexStatus = async (
@@ -20,7 +21,7 @@ export const checkIndexStatus = async (
         bool: {
           filter: {
             term: {
-              'rule.benchmark.posture_type': postureType,
+              safe_posture_type: postureType,
             },
           },
         },
@@ -29,6 +30,9 @@ export const checkIndexStatus = async (
   try {
     const queryResult = await esClient.search({
       index,
+      runtime_mappings: {
+        ...getSafePostureTypeRuntimeMapping(),
+      },
       query,
       size: 1,
     });


### PR DESCRIPTION
## Summary

This PR address to an issue we have with backward and forward compatibility

For a robust check of the existence of a field, and that it has a value we first need to use `doc.containsKey` and afterwards to check it is not empty using `empty` property: `doc["field.path"].empty`


### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### How to test this
I would recommend using first the Dev Tools to check the runtime fields is correct
For example, I run a query with aggs to see when things break and when not

List of edge cases I've checked:
- What happens when field's mapping doesn't exist
- What happens when field's mapping exist but there are documents without that field
- Checking happy flow
- Checking field that doesn't exist and doesn't have mappings


Here is the query

```
  GET /logs-cloud_security_posture.findings_latest-default/_search
  {
    "size": 10,
    "runtime_mappings": { 
      "asset_identifier": {
        "type": "keyword",
        "script": {
          "source": """
          emit(doc["rule.benchmark.posture_type"].empty ? "empty" : doc["rule.benchmark.posture_type"].value)
          """}
      }
    },
    "query": {
      "match": {
        "asset_identifier": "empty"
      }
    },
    "aggs": {
      "score_by_cluster_id": {
        "terms": {
          "field": "asset_identifier"
        }
      }
    }
  }
```

<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->