### PR TITLE
Fix missing Chart name in Alert Trend Inspect Modal Title

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/header_section/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/header_section/index.tsx
@@ -68,7 +68,7 @@ export interface HeaderSectionProps extends HeaderProps {
   toggleQuery?: (status: boolean) => void;
   toggleStatus?: boolean;
   title: string | React.ReactNode;
-  inspectTitle?: string;
+  inspectTitle?: React.ReactNode;
   titleSize?: EuiTitleSize;
   tooltip?: string;
 }
@@ -193,7 +193,7 @@ const HeaderSectionComponent: React.FC<HeaderSectionProps> = ({
                       queryId={id}
                       multiple={inspectMultiple}
                       showInspectButton={showInspectButton}
-                      title={inspectTitle != null ? inspectTitle : title}
+                      title={inspectTitle ?? title}
                     />
                   </EuiFlexItem>
                 )}

--- a/x-pack/plugins/security_solution/public/common/components/visualization_actions/types.ts
+++ b/x-pack/plugins/security_solution/public/common/components/visualization_actions/types.ts
@@ -65,7 +65,7 @@ export interface LensEmbeddableComponentProps {
   height?: string;
   id: string;
   inputsModelId?: InputsModelId.global | InputsModelId.timeline;
-  inspectTitle?: string;
+  inspectTitle?: React.ReactNode;
   lensAttributes?: LensAttributes;
   onLoad?: OnEmbeddableLoaded;
   scopeId?: SourcererScopeName;

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/alerts_histogram_panel/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/alerts_histogram_panel/index.tsx
@@ -85,7 +85,7 @@ interface AlertsHistogramPanelProps {
   extraActions?: Action[];
   filters?: Filter[];
   headerChildren?: React.ReactNode;
-  inspectTitle?: string;
+  inspectTitle?: React.ReactNode;
   legendPosition?: Position;
   onFieldSelected?: (field: string) => void;
   /** Override all defaults, and only display this field */
@@ -444,7 +444,7 @@ export const AlertsHistogramPanel = memo<AlertsHistogramPanelProps>(
                 getLensAttributes={getLensAttributes}
                 height={ChartHeight}
                 id={visualizationId}
-                inspectTitle={inspectTitle}
+                inspectTitle={inspectTitle ?? title}
                 scopeId={SourcererScopeName.detections}
                 stackByField={selectedStackByOption}
                 timerange={timerange}


### PR DESCRIPTION
issue: https://github.com/elastic/kibana/issues/155032

## Summary

Add a title to the "inspect model".


**BEFORE**
<img width="500" src="https://user-images.githubusercontent.com/1490444/235864517-e04b1f20-454c-4ae7-9ad2-84ffc378cb82.png">

**AFTER**
<img width="500" src="https://user-images.githubusercontent.com/1490444/235864520-46b9b5d4-9f87-41cc-b71e-e5531a73a26a.png">




<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->