### PR TITLE
Fix Alerts table inspect modal incomplete title

### DIFF
--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/empty_state.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/empty_state.tsx
@@ -19,6 +19,7 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import { GetInspectQuery } from '../../../types';
 import icon from './assets/illustration_product_no_results_magnifying_glass.svg';
 import { InspectButton } from './toolbar/components/inspect';
+import { ALERTS_TABLE_TITLE } from './translations';
 
 const heights = {
   tall: 490,
@@ -40,7 +41,7 @@ export const EmptyState: React.FC<{
       <EuiFlexGroup alignItems="flexEnd" justifyContent="flexEnd">
         {showInpectButton && (
           <EuiFlexItem grow={false}>
-            <InspectButton getInspectQuery={getInspectQuery} />
+            <InspectButton getInspectQuery={getInspectQuery} inspectTitle={ALERTS_TABLE_TITLE} />
           </EuiFlexItem>
         )}
         {controls?.right && <EuiFlexItem grow={false}>{controls.right}</EuiFlexItem>}

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/toolbar/components/inspect/index.test.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/toolbar/components/inspect/index.test.tsx
@@ -27,7 +27,13 @@ describe('Inspect Button', () => {
   });
 
   test('open Inspect Modal', async () => {
-    render(<InspectButton showInspectButton getInspectQuery={getInspectQuery} />);
+    render(
+      <InspectButton
+        inspectTitle={'Inspect Title'}
+        showInspectButton
+        getInspectQuery={getInspectQuery}
+      />
+    );
     fireEvent.click(await screen.findByTestId('inspect-icon-button'));
 
     expect(await screen.findByTestId('mocker-modal')).toBeInTheDocument();

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/toolbar/components/inspect/index.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/toolbar/components/inspect/index.tsx
@@ -34,9 +34,13 @@ interface InspectButtonProps {
   onCloseInspect?: () => void;
   showInspectButton?: boolean;
   getInspectQuery: GetInspectQuery;
+  inspectTitle: string;
 }
 
-const InspectButtonComponent: React.FC<InspectButtonProps> = ({ getInspectQuery }) => {
+const InspectButtonComponent: React.FC<InspectButtonProps> = ({
+  getInspectQuery,
+  inspectTitle,
+}) => {
   const [isShowingModal, setIsShowingModal] = useState(false);
 
   const onOpenModal = () => {
@@ -63,6 +67,7 @@ const InspectButtonComponent: React.FC<InspectButtonProps> = ({ getInspectQuery 
           closeModal={onCloseModal}
           data-test-subj="inspect-modal"
           getInspectQuery={getInspectQuery}
+          title={inspectTitle}
         />
       )}
     </>

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/toolbar/components/inspect/modal.test.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/toolbar/components/inspect/modal.test.tsx
@@ -34,6 +34,7 @@ describe('Modal Inspect', () => {
   const closeModal = jest.fn();
   const defaultProps: ModalInspectProps = {
     closeModal,
+    title: 'Inspect',
     getInspectQuery: () => ({
       request: [getRequest()],
       response: [response],

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/toolbar/components/inspect/modal.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/toolbar/components/inspect/modal.tsx
@@ -45,6 +45,7 @@ DescriptionListStyled.displayName = 'DescriptionListStyled';
 export interface ModalInspectProps {
   closeModal: () => void;
   getInspectQuery: GetInspectQuery;
+  title: string;
 }
 
 interface Request {
@@ -91,7 +92,7 @@ const stringify = (object: Request | Response): string => {
   }
 };
 
-const ModalInspectQueryComponent = ({ closeModal, getInspectQuery }: ModalInspectProps) => {
+const ModalInspectQueryComponent = ({ closeModal, getInspectQuery, title }: ModalInspectProps) => {
   const { request, response } = getInspectQuery();
   // using index 0 as there will be only one request and response for now
   const parsedRequest: Request = parse(request[0]);
@@ -200,7 +201,9 @@ const ModalInspectQueryComponent = ({ closeModal, getInspectQuery }: ModalInspec
   return (
     <MyEuiModal onClose={closeModal} data-test-subj="modal-inspect-euiModal">
       <EuiModalHeader>
-        <EuiModalHeaderTitle>{i18n.INSPECT}</EuiModalHeaderTitle>
+        <EuiModalHeaderTitle>
+          {i18n.INSPECT} {title}
+        </EuiModalHeaderTitle>
       </EuiModalHeader>
 
       <EuiModalBody>

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/toolbar/toolbar_visibility.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/toolbar/toolbar_visibility.tsx
@@ -17,6 +17,7 @@ import { LastUpdatedAt } from './components/last_updated_at';
 import { FieldBrowser } from '../../field_browser';
 import { FieldBrowserOptions } from '../../field_browser/types';
 import { InspectButton } from './components/inspect';
+import { ALERTS_TABLE_TITLE } from '../translations';
 
 const BulkActionsToolbar = lazy(() => import('../bulk_actions/components/toolbar'));
 
@@ -33,7 +34,9 @@ const rightControl = ({
 }) => {
   return (
     <>
-      {showInspectButton && <InspectButton getInspectQuery={getInspectQuery} />}
+      {showInspectButton && (
+        <InspectButton inspectTitle={ALERTS_TABLE_TITLE} getInspectQuery={getInspectQuery} />
+      )}
       <LastUpdatedAt updatedAt={updatedAt} />
       {controls?.right}
     </>

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/translations.ts
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/translations.ts
@@ -35,3 +35,10 @@ export const ALERTS_TABLE_CONTROL_COLUMNS_VIEW_DETAILS_LABEL = i18n.translate(
     defaultMessage: 'View details',
   }
 );
+
+export const ALERTS_TABLE_TITLE = i18n.translate(
+  'xpack.triggersActionsUI.sections.alertsTable.title',
+  {
+    defaultMessage: 'Alerts table',
+  }
+);


### PR DESCRIPTION
issue: https://github.com/elastic/kibana/issues/156267

## Summary

Add a title to "Alerts Table inspect modal".

**BEFORE**

<img width="751" alt="Screenshot 2023-05-03 at 15 55 58" src="https://user-images.githubusercontent.com/1490444/235937998-caedf8f5-6645-440f-af1d-8618e8012d8b.png">

**AFTER**

<img width="769" alt="Screenshot 2023-05-03 at 15 58 30" src="https://user-images.githubusercontent.com/1490444/235938006-6c303f9d-8b81-43d0-b536-ae23f1f5bfd1.png">






<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->