### PR TITLE
[Security Solution][Fix] Set doc count to 0 when empty aggregated data

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/matrix_histogram/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/matrix_histogram/index.test.tsx
@@ -348,6 +348,14 @@ describe('Matrix Histogram Component', () => {
       mockUseVisualizationResponse.mockReturnValue([
         { aggregations: [{ buckets: [] }], hits: { total: 999 } },
       ]);
+      mockUseMatrix.mockReturnValue([
+        false,
+        {
+          data: [],
+          inspect: false,
+          totalCount: 0,
+        },
+      ]);
       wrapper.setProps({ endDate: 100 });
       wrapper.update();
 

--- a/x-pack/plugins/security_solution/public/common/components/matrix_histogram/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/matrix_histogram/index.test.tsx
@@ -45,8 +45,11 @@ jest.mock('./utils', () => ({
   getCustomChartData: jest.fn().mockReturnValue(true),
 }));
 
+const mockUseVisualizationResponse = jest.fn(() => [
+  { aggregations: [{ buckets: [{ key: '1234' }] }], hits: { total: 999 } },
+]);
 jest.mock('../visualization_actions/use_visualization_response', () => ({
-  useVisualizationResponse: jest.fn().mockReturnValue([{ hits: { total: 999 } }]),
+  useVisualizationResponse: () => mockUseVisualizationResponse(),
 }));
 
 const mockLocation = jest.fn().mockReturnValue({ pathname: '/test' });
@@ -338,6 +341,26 @@ describe('Matrix Histogram Component', () => {
 
       expect(wrapper.find(`[data-test-subj="header-section-subtitle"]`).text()).toEqual(
         'Showing: 999 events'
+      );
+    });
+
+    test('it should render visualization count as subtitle when buckets are not empty', () => {
+      mockUseVisualizationResponse.mockReturnValue([
+        { aggregations: [{ buckets: [] }], hits: { total: 999 } },
+      ]);
+      mockUseMatrix.mockReturnValue([
+        false,
+        {
+          data: [],
+          inspect: false,
+          totalCount: 0,
+        },
+      ]);
+      wrapper.setProps({ endDate: 100 });
+      wrapper.update();
+
+      expect(wrapper.find(`[data-test-subj="header-section-subtitle"]`).text()).toEqual(
+        'Showing: 0 events'
       );
     });
   });

--- a/x-pack/plugins/security_solution/public/common/components/matrix_histogram/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/matrix_histogram/index.test.tsx
@@ -344,17 +344,9 @@ describe('Matrix Histogram Component', () => {
       );
     });
 
-    test('it should render visualization count as subtitle when buckets are not empty', () => {
+    test('it should render 0 as subtitle when buckets are empty', () => {
       mockUseVisualizationResponse.mockReturnValue([
         { aggregations: [{ buckets: [] }], hits: { total: 999 } },
-      ]);
-      mockUseMatrix.mockReturnValue([
-        false,
-        {
-          data: [],
-          inspect: false,
-          totalCount: 0,
-        },
       ]);
       wrapper.setProps({ endDate: 100 });
       wrapper.update();

--- a/x-pack/plugins/security_solution/public/common/components/matrix_histogram/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/matrix_histogram/index.tsx
@@ -11,6 +11,7 @@ import styled from 'styled-components';
 
 import { EuiFlexGroup, EuiFlexItem, EuiProgress, EuiSelect, EuiSpacer } from '@elastic/eui';
 import { useDispatch } from 'react-redux';
+import type { AggregationsTermsAggregateBase } from '@elastic/elasticsearch/lib/api/types';
 import * as i18n from './translations';
 import { HeaderSection } from '../header_section';
 import { Panel } from '../panel';
@@ -30,7 +31,11 @@ import { setAbsoluteRangeDatePicker } from '../../store/inputs/actions';
 import { InputsModelId } from '../../store/inputs/constants';
 import { HoverVisibilityContainer } from '../hover_visibility_container';
 import { VisualizationActions } from '../visualization_actions/actions';
-import type { GetLensAttributes, LensAttributes } from '../visualization_actions/types';
+import type {
+  GetLensAttributes,
+  LensAttributes,
+  VisualizationResponse,
+} from '../visualization_actions/types';
 import { useQueryToggle } from '../../containers/query_toggle';
 import { useIsExperimentalFeatureEnabled } from '../../hooks/use_experimental_features';
 import { VISUALIZATION_ACTIONS_BUTTON_CLASS } from '../visualization_actions/utils';
@@ -72,6 +77,11 @@ const HistogramPanel = styled(Panel)<{ height?: number }>`
 `;
 
 const CHART_HEIGHT = '150px';
+
+const visualizationResponseHasData = (response: VisualizationResponse): boolean =>
+  Object.values<AggregationsTermsAggregateBase<unknown[]>>(response.aggregations ?? {}).some(
+    ({ buckets }) => buckets.length > 0
+  );
 
 export const MatrixHistogramComponent: React.FC<MatrixHistogramComponentProps> = ({
   chartHeight,
@@ -201,8 +211,10 @@ export const MatrixHistogramComponent: React.FC<MatrixHistogramComponentProps> =
 
     if (typeof subtitle === 'function') {
       if (isChartEmbeddablesEnabled) {
-        const visualizationCount =
-          visualizationResponse != null ? visualizationResponse[0].hits.total : 0;
+        if (!visualizationResponse || !visualizationResponseHasData(visualizationResponse[0])) {
+          return subtitle(0);
+        }
+        const visualizationCount = visualizationResponse[0].hits.total;
         return visualizationCount >= 0 ? subtitle(visualizationCount) : null;
       } else {
         return totalCount >= 0 ? subtitle(totalCount) : null;


### PR DESCRIPTION
## Summary

bug: https://github.com/elastic/kibana/issues/155228

Despite the hit count may be greater than 0 in the aggregation response, it is possible it won't contain any data, this happens when the aggregated field is empty in all documents, such as the `kibana.alert.rule.name` field. 

In this situation, we should display `0 events` in the visualization subtitle.

![screenshot](https://user-images.githubusercontent.com/17747913/235885604-4caf99e8-6826-45a1-967e-32168a88adab.png)



<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->