### PR TITLE
[Security Solution] Remove 'Tech Preview' labels from EA workflows

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/event_details/cti_details/risk_summary.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/cti_details/risk_summary.tsx
@@ -48,6 +48,13 @@ const RiskSummaryComponent: React.FC<RiskEntity> = ({ risk, riskEntity, original
               riskScoreEntity={riskEntity}
             />
           }
+          toolTipTitle={
+            <RiskScoreHeaderTitle
+              title={i18n.RISK_DATA_TITLE(riskEntity)}
+              riskScoreEntity={riskEntity}
+              showTechnicalPreviewBadge
+            />
+          }
           toolTipContent={
             <FormattedMessage
               id="xpack.securitySolution.alertDetails.overview.riskDataTooltipContent"

--- a/x-pack/plugins/security_solution/public/common/components/event_details/cti_details/threat_summary_view.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/cti_details/threat_summary_view.tsx
@@ -79,7 +79,8 @@ export const EnrichedDataRow: React.FC<{
 export const ThreatSummaryPanelHeader: React.FC<{
   title: string | React.ReactNode;
   toolTipContent: React.ReactNode;
-}> = ({ title, toolTipContent }) => {
+  toolTipTitle?: React.ReactNode;
+}> = ({ title, toolTipContent, toolTipTitle }) => {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
 
   const onClick = useCallback(() => {
@@ -111,7 +112,7 @@ export const ThreatSummaryPanelHeader: React.FC<{
             />
           }
         >
-          <EuiPopoverTitle>{title}</EuiPopoverTitle>
+          <EuiPopoverTitle>{toolTipTitle ?? title}</EuiPopoverTitle>
           <EuiText size="s" style={{ width: '270px' }}>
             {toolTipContent}
           </EuiText>

--- a/x-pack/plugins/security_solution/public/explore/components/risk_score/enable_risk_score/index.tsx
+++ b/x-pack/plugins/security_solution/public/explore/components/risk_score/enable_risk_score/index.tsx
@@ -49,7 +49,10 @@ const EnableRiskScoreComponent = ({
 
   return (
     <EuiPanel hasBorder>
-      <HeaderSection title={<RiskScoreHeaderTitle riskScoreEntity={entityType} />} titleSize="s" />
+      <HeaderSection
+        title={<RiskScoreHeaderTitle riskScoreEntity={entityType} showTechnicalPreviewBadge />}
+        titleSize="s"
+      />
       <EuiEmptyPrompt
         title={<h2>{text.cta}</h2>}
         body={

--- a/x-pack/plugins/security_solution/public/explore/components/risk_score/risk_score_onboarding/risk_score_header_title.tsx
+++ b/x-pack/plugins/security_solution/public/explore/components/risk_score/risk_score_onboarding/risk_score_header_title.tsx
@@ -14,15 +14,19 @@ import { TECHNICAL_PREVIEW } from './translations';
 const RiskScoreHeaderTitleComponent = ({
   riskScoreEntity,
   title,
+  showTechnicalPreviewBadge = false,
 }: {
   riskScoreEntity: RiskScoreEntity;
   title?: string;
+  showTechnicalPreviewBadge?: boolean;
 }) => {
   return (
     <>
       {title ??
         (riskScoreEntity === RiskScoreEntity.user ? i18n.USER_RISK_TITLE : i18n.HOST_RISK_TITLE)}
-      <NavItemBetaBadge text={TECHNICAL_PREVIEW} className="eui-alignMiddle" />
+      {showTechnicalPreviewBadge && (
+        <NavItemBetaBadge text={TECHNICAL_PREVIEW} className="eui-alignMiddle" />
+      )}
     </>
   );
 };

--- a/x-pack/plugins/security_solution/public/explore/hosts/pages/details/nav_tabs.test.tsx
+++ b/x-pack/plugins/security_solution/public/explore/hosts/pages/details/nav_tabs.test.tsx
@@ -81,18 +81,4 @@ describe('navTabsHostDetails', () => {
 
     expect(sessionsTab).not.toBeTruthy();
   });
-
-  test('it should display Beta badge for risk tab', () => {
-    const tabs = navTabsHostDetails({
-      hasMlUserPermissions: false,
-      isRiskyHostsEnabled: true,
-      hostName: mockHostName,
-    });
-
-    const riskTab = Object.values<TabNavigationItemProps>(tabs).find(
-      (item) => item.id === HostsTableType.risk
-    );
-
-    expect(riskTab?.isBeta).toEqual(true);
-  });
 });

--- a/x-pack/plugins/security_solution/public/explore/hosts/pages/details/nav_tabs.tsx
+++ b/x-pack/plugins/security_solution/public/explore/hosts/pages/details/nav_tabs.tsx
@@ -10,7 +10,6 @@ import * as i18n from '../translations';
 import type { HostDetailsNavTab } from './types';
 import { HostsTableType } from '../../store/model';
 import { HOSTS_PATH } from '../../../../../common/constants';
-import { TECHNICAL_PREVIEW } from '../../../../overview/pages/translations';
 
 const getTabsOnHostDetailsUrl = (hostName: string, tabName: HostsTableType) =>
   `${HOSTS_PATH}/name/${hostName}/${tabName}`;
@@ -58,10 +57,6 @@ export const navTabsHostDetails = ({
       name: i18n.NAVIGATION_HOST_RISK_TITLE,
       href: getTabsOnHostDetailsUrl(hostName, HostsTableType.risk),
       disabled: false,
-      isBeta: true,
-      betaOptions: {
-        text: TECHNICAL_PREVIEW,
-      },
     },
     [HostsTableType.sessions]: {
       id: HostsTableType.sessions,

--- a/x-pack/plugins/security_solution/public/explore/hosts/pages/nav_tabs.tsx
+++ b/x-pack/plugins/security_solution/public/explore/hosts/pages/nav_tabs.tsx
@@ -10,7 +10,6 @@ import * as i18n from './translations';
 import { HostsTableType } from '../store/model';
 import type { HostsNavTab } from './navigation/types';
 import { HOSTS_PATH } from '../../../../common/constants';
-import { TECHNICAL_PREVIEW } from '../../../overview/pages/translations';
 
 const getTabsOnHostsUrl = (tabName: HostsTableType) => `${HOSTS_PATH}/${tabName}`;
 
@@ -54,10 +53,6 @@ export const navTabsHosts = ({
       name: i18n.NAVIGATION_HOST_RISK_TITLE,
       href: getTabsOnHostsUrl(HostsTableType.risk),
       disabled: false,
-      isBeta: true,
-      betaOptions: {
-        text: TECHNICAL_PREVIEW,
-      },
     },
     [HostsTableType.sessions]: {
       id: HostsTableType.sessions,

--- a/x-pack/plugins/security_solution/public/explore/users/pages/details/nav_tabs.tsx
+++ b/x-pack/plugins/security_solution/public/explore/users/pages/details/nav_tabs.tsx
@@ -10,7 +10,6 @@ import * as i18n from '../translations';
 import type { UsersDetailsNavTab } from './types';
 import { UsersTableType } from '../../store/model';
 import { USERS_PATH } from '../../../../../common/constants';
-import { TECHNICAL_PREVIEW } from '../../../../overview/pages/translations';
 
 const getTabsOnUsersDetailsUrl = (userName: string, tabName: UsersTableType) =>
   `${USERS_PATH}/name/${userName}/${tabName}`;
@@ -46,10 +45,6 @@ export const navTabsUsersDetails = (
       name: i18n.NAVIGATION_RISK_TITLE,
       href: getTabsOnUsersDetailsUrl(userName, UsersTableType.risk),
       disabled: false,
-      isBeta: true,
-      betaOptions: {
-        text: TECHNICAL_PREVIEW,
-      },
     },
   };
 

--- a/x-pack/plugins/security_solution/public/explore/users/pages/nav_tabs.tsx
+++ b/x-pack/plugins/security_solution/public/explore/users/pages/nav_tabs.tsx
@@ -10,7 +10,6 @@ import * as i18n from './translations';
 import { UsersTableType } from '../store/model';
 import type { UsersNavTab } from './navigation/types';
 import { USERS_PATH } from '../../../../common/constants';
-import { TECHNICAL_PREVIEW } from '../../../overview/pages/translations';
 
 const getTabsOnUsersUrl = (tabName: UsersTableType) => `${USERS_PATH}/${tabName}`;
 
@@ -50,10 +49,6 @@ export const navTabsUsers = (
       name: i18n.NAVIGATION_RISK_TITLE,
       href: getTabsOnUsersUrl(UsersTableType.risk),
       disabled: false,
-      isBeta: true,
-      betaOptions: {
-        text: TECHNICAL_PREVIEW,
-      },
     },
   };
 


### PR DESCRIPTION
issue: https://github.com/elastic/security-team/issues/6544

## Summary

## Remove the `Technical Preview` label from the following UI pages
- [x] (Must Do) Entity Analytics dashboard panels

![Image](https://user-images.githubusercontent.com/82123779/235752482-90772171-99d4-4db1-b875-6fb3a00cd91e.png)

- [x] (Must Do) Alert Flyout

![Image](https://user-images.githubusercontent.com/82123779/235752377-e95c0c92-357b-4b5f-b03f-776457000b1f.png)

- [x] All Hosts/ Users
![Image](https://user-images.githubusercontent.com/82123779/235752578-951241aa-1f1f-4693-99d0-636e2e53e449.png)

- [x] Host/ User Details

![Image](https://user-images.githubusercontent.com/82123779/235752661-4a03db27-94a0-451f-bf58-ef911573c5e1.png)

![Image](https://user-images.githubusercontent.com/82123779/235752854-46263685-7440-44db-9d3b-bb9177f55c6a.png)


- [x] Host/ Users Flyout

![Image](https://user-images.githubusercontent.com/82123779/235753556-256bb920-82f6-4129-8cdf-00a88286fc88.png)




## Retain the `Technical Preview` label in the following (No Changes):
- [x] Enablement workflow from the EA dashboard
- [x] Information message in flouts
<img width="719" alt="image" src="https://user-images.githubusercontent.com/79533936/235903678-f982d483-7064-4172-ad1a-3a18b155c430.png">


<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->