### PR TITLE
[Enterprise Search] Fix custom connector not selectable

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/select_connector/select_connector.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/select_connector/select_connector.tsx
@@ -119,7 +119,7 @@ export const SelectConnector: React.FC = () => {
                 <EuiButton
                   data-test-subj="entSearchContent-connector-selectConnector-selectAndConfigure"
                   data-telemetry-id="entSearchContent-connector-selectConnector-selectAndConfigure"
-                  disabled={!selectedConnector}
+                  disabled={selectedConnector === null}
                   fill
                   color="primary"
                   type="submit"


### PR DESCRIPTION

## Summary

Custom connector has empty string "" as service type and it is nullish in JS/TS. Selection is fixed and Continue button is now selectable for custom connectors by checking value to be null instead.

Before:

https://user-images.githubusercontent.com/1410658/235914298-c8230681-3520-4e08-b364-e65237661aec.mov


After:

https://user-images.githubusercontent.com/1410658/235914179-3f655131-b5bf-454e-b3ab-384863a21607.mov



<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->