### PR TITLE
[Enterprise Search] Fix incorrect gating of Enterprise Seach

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/index.tsx
@@ -114,7 +114,7 @@ export const renderApp = (
           <CloudContext>
             <Provider store={store}>
               <Router history={params.history}>
-                <App {...initialData} />
+                <App access={productAccess} {...initialData} />
                 <Toasts />
               </Router>
             </Provider>


### PR DESCRIPTION
## Summary

This fixes an issue where we were incorrectly telling the user they didn't have access to Enterprise Search, because we weren't passing the correct product access settings to the Overview component.