### PR TITLE
[Security Solution] [Fix] Alert Page Controls do not recover from invalid query.

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/filter_group/filter_group.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/filter_group/filter_group.test.tsx
@@ -95,7 +95,11 @@ const getStoreWithCustomState = (newState: typeof state = state) => {
   return createStore(newState, SUB_PLUGINS_REDUCER, kibanaObservable, storage);
 };
 
-const TestComponent: FC<ComponentProps<typeof TestProviders>> = (props) => (
+const TestComponent: FC<
+  ComponentProps<typeof TestProviders> & {
+    filterGroupProps?: Partial<ComponentProps<typeof FilterGroup>>;
+  }
+> = (props) => (
   <TestProviders store={getStoreWithCustomState()} {...props}>
     <FilterGroup
       initialControls={DEFAULT_DETECTION_PAGE_FILTERS}
@@ -103,6 +107,7 @@ const TestComponent: FC<ComponentProps<typeof TestProviders>> = (props) => (
       chainingSystem="HIERARCHICAL"
       onFilterChange={onFilterChangeMock}
       onInit={onInitMock}
+      {...props.filterGroupProps}
     />
   </TestProviders>
 );
@@ -523,6 +528,34 @@ describe(' Filter Group Component ', () => {
       fireEvent.mouseOver(screen.getByTestId(TEST_IDS.SAVE_CONTROL));
       await waitFor(() => {
         expect(screen.queryByTestId(TEST_IDS.SAVE_CHANGE_POPOVER)).toBeVisible();
+      });
+    });
+    it('should update controlGroup with new filters and queries when valid query is supplied', async () => {
+      const validQuery = { query: { language: 'kuery', query: '' } };
+      // pass an invalid query
+      render(<TestComponent filterGroupProps={validQuery} />);
+
+      await waitFor(() => {
+        expect(controlGroupMock.updateInput).toHaveBeenNthCalledWith(
+          1,
+          expect.objectContaining({
+            filters: undefined,
+            query: validQuery.query,
+          })
+        );
+      });
+    });
+
+    it('should not update controlGroup with new filters and queries when invalid query is supplied', async () => {
+      const invalidQuery = { query: { language: 'kuery', query: '\\' } };
+      // pass an invalid query
+      render(<TestComponent filterGroupProps={invalidQuery} />);
+
+      await waitFor(() => {
+        expect(controlGroupMock.updateInput).not.toHaveBeenCalledWith({
+          filters: [],
+          query: invalidQuery,
+        });
       });
     });
   });

--- a/x-pack/plugins/security_solution/public/common/components/filter_group/filter_group.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/filter_group/filter_group.test.tsx
@@ -552,10 +552,12 @@ describe(' Filter Group Component ', () => {
       render(<TestComponent filterGroupProps={invalidQuery} />);
 
       await waitFor(() => {
-        expect(controlGroupMock.updateInput).not.toHaveBeenCalledWith({
-          filters: [],
-          query: invalidQuery,
-        });
+        expect(controlGroupMock.updateInput).toHaveBeenCalledWith(
+          expect.objectContaining({
+            filters: [],
+            query: undefined,
+          })
+        );
       });
     });
   });

--- a/x-pack/plugins/security_solution/public/common/components/filter_group/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/filter_group/index.tsx
@@ -158,6 +158,7 @@ const FilterGroupComponent = (props: PropsWithChildren<FilterGroupProps>) => {
       indexPattern: { fields: [], title: '' },
     });
 
+    // we only need to handle kqlError because control group can handle Lucene error
     if (kqlError) {
       /*
        * Based on the behaviour from other components,


### PR DESCRIPTION
## Summary

This PR handles #156016 .

Previously, if user supplied an invalid kql or lucene query, Alert Page controls will go in error state and not recover until user reloaded the page or navigated away and back to the Alert Page. 

This PR prevents Alert Page Controls going in that error state.

| Before | After |
|--|--|
| <video src="https://user-images.githubusercontent.com/7485038/235931286-6da23567-4ae8-454a-92b8-a595a20f5655.mov" /> | <video src="https://user-images.githubusercontent.com/7485038/235930584-485df881-d22c-44f3-9d53-f673820eb673.mov" /> |

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->