### PR TITLE
[Synthetics] Keep date params when location changing on monitor details

### DIFF
--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_details_location.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_details_location.tsx
@@ -8,6 +8,7 @@ import React, { useCallback } from 'react';
 
 import { useParams, useRouteMatch } from 'react-router-dom';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
+import { useGetUrlParams } from '../../hooks';
 import { MONITOR_ERRORS_ROUTE, MONITOR_HISTORY_ROUTE } from '../../../../../common/constants';
 import { ClientPluginsStart } from '../../../../plugin';
 import { PLUGIN } from '../../../../../common/constants/plugin';
@@ -19,12 +20,16 @@ export const MonitorDetailsLocation = ({ isDisabled }: { isDisabled?: boolean })
   const { monitor } = useSelectedMonitor();
   const { monitorId } = useParams<{ monitorId: string }>();
 
+  const { dateRangeStart, dateRangeEnd } = useGetUrlParams();
+
   const selectedLocation = useSelectedLocation();
 
   const { services } = useKibana<ClientPluginsStart>();
 
   const isErrorsTab = useRouteMatch(MONITOR_ERRORS_ROUTE);
   const isHistoryTab = useRouteMatch(MONITOR_HISTORY_ROUTE);
+
+  const params = `&dateRangeStart=${dateRangeStart}&dateRangeEnd=${dateRangeEnd}`;
 
   return (
     <MonitorLocationSelect
@@ -36,19 +41,19 @@ export const MonitorDetailsLocation = ({ isDisabled }: { isDisabled?: boolean })
         (id, label) => {
           if (isErrorsTab) {
             services.application.navigateToApp(PLUGIN.SYNTHETICS_PLUGIN_ID, {
-              path: `/monitor/${monitorId}/errors?locationId=${id}`,
+              path: `/monitor/${monitorId}/errors?locationId=${id}${params}`,
             });
           } else if (isHistoryTab) {
             services.application.navigateToApp(PLUGIN.SYNTHETICS_PLUGIN_ID, {
-              path: `/monitor/${monitorId}/history/?locationId=${id}`,
+              path: `/monitor/${monitorId}/history/?locationId=${id}${params}`,
             });
           } else {
             services.application.navigateToApp(PLUGIN.SYNTHETICS_PLUGIN_ID, {
-              path: `/monitor/${monitorId}?locationId=${id}`,
+              path: `/monitor/${monitorId}?locationId=${id}${params}`,
             });
           }
         },
-        [isErrorsTab, isHistoryTab, monitorId, services.application]
+        [isErrorsTab, isHistoryTab, monitorId, params, services.application]
       )}
     />
   );


### PR DESCRIPTION
## Summary
Fixes https://github.com/elastic/kibana/issues/155652
Keep date params when location changing on monitor details


### Testing

- Go to monitor details page on a monitor with multiple locations
- Switch to history tab, change date range
- Switch location, date should persist

<img width="1773" alt="image" src="https://user-images.githubusercontent.com/3505601/235950303-3dbcb881-f88a-48ba-bf42-10208025de33.png">


<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->