### PR TITLE
[Enterprise Search] Add beta badge to sync rules

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/sync_rules/connector_rules.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/sync_rules/connector_rules.tsx
@@ -23,6 +23,8 @@ import {
 
 import { i18n } from '@kbn/i18n';
 
+import { BetaBadge } from '../../../../../shared/beta/beta_badge';
+
 import { docLinks } from '../../../../../shared/doc_links';
 
 import { FilteringRulesTable } from '../../../shared/filtering_rules_table/filtering_rules_table';
@@ -67,13 +69,20 @@ export const ConnectorSyncRules: React.FC = () => {
         <EuiFlexItem>
           <EuiFlexGroup justifyContent="spaceBetween">
             <EuiFlexItem>
-              <EuiTitle size="s">
-                <h3>
-                  {i18n.translate('xpack.enterpriseSearch.index.connector.syncRules.title', {
-                    defaultMessage: 'Sync rules ',
-                  })}
-                </h3>
-              </EuiTitle>
+              <EuiFlexGroup alignItems="center" justifyContent="flexStart" gutterSize="s">
+                <EuiFlexItem grow={false}>
+                  <EuiTitle size="s">
+                    <h3>
+                      {i18n.translate('xpack.enterpriseSearch.index.connector.syncRules.title', {
+                        defaultMessage: 'Sync rules ',
+                      })}
+                    </h3>
+                  </EuiTitle>
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                  <BetaBadge />
+                </EuiFlexItem>
+              </EuiFlexGroup>
               <EuiSpacer />
               <EuiText size="s">
                 <p>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/sync_rules/edit_sync_rules_flyout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/sync_rules/edit_sync_rules_flyout.tsx
@@ -24,6 +24,7 @@ import {
 import { i18n } from '@kbn/i18n';
 
 import { FilteringValidation } from '../../../../../../../common/types/connectors';
+import { BetaCallOut } from '../../../../../shared/beta/beta_callout';
 
 import { AdvancedSyncRules } from './advanced_sync_rules';
 import { EditSyncRulesTab } from './edit_sync_rules_tab';
@@ -103,6 +104,16 @@ export const EditSyncRulesFlyout: React.FC<EditFilteringFlyoutProps> = ({
             )}
           </h2>
         </EuiTitle>
+        <EuiSpacer />
+        <BetaCallOut
+          description={i18n.translate(
+            'xpack.enterpriseSearch.content.index.connector.syncRules.flyout.betaDescription',
+            {
+              defaultMessage:
+                'Sync rules is a beta feature. Beta features are subject to change and are not covered by the support SLA of general release (GA) features. Elastic plans to promote this feature to GA in a future release.',
+            }
+          )}
+        />
         <EuiSpacer />
         <EuiText size="s">
           {i18n.translate(

--- a/x-pack/plugins/enterprise_search/public/applications/shared/beta/beta_badge.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/beta/beta_badge.tsx
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { EuiBadge } from '@elastic/eui';
+
+import { BETA_LABEL } from '../constants';
+
+export const BetaBadge: React.FC = () => {
+  return <EuiBadge iconType="beaker">{BETA_LABEL}</EuiBadge>;
+};

--- a/x-pack/plugins/enterprise_search/public/applications/shared/beta/beta_callout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/beta/beta_callout.tsx
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { EuiCallOut } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+
+interface BetaCallOutProps {
+  description: string;
+}
+
+export const BetaCallOut: React.FC<BetaCallOutProps> = ({ description }) => {
+  return (
+    <EuiCallOut
+      color="warning"
+      iconType="beaker"
+      title={i18n.translate('xpack.enterpriseSearch.betaCalloutTitle', {
+        defaultMessage: 'Beta feature',
+      })}
+    >
+      {description}
+    </EuiCallOut>
+  );
+};


### PR DESCRIPTION
## Summary

This adds a beta badge and callout to the sync rules page for connec
<img width="1009" alt="Screenshot 2023-05-03 at 16 08 58" src="https://user-images.githubusercontent.com/94373878/235943197-fecf2e11-daab-4c6a-a99e-cbf8b865f461.png">
tors.
<img width="1193" alt="Screenshot 2023-05-03 at 16 15 02" src="https://user-images.githubusercontent.com/94373878/235943190-e6d86a36-3e08-415c-8a29-bc886e1a9951.png">


<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->