### PR TITLE
[RAM] Alerts Table breaking when adding first column in fields browser

### DIFF
--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/hooks/use_columns/toggle_column.test.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/hooks/use_columns/toggle_column.test.tsx
@@ -47,4 +47,21 @@ describe('toggleColumn', () => {
       ]
     `);
   });
+
+  it('adds a column even if no column is currently shown', async () => {
+    expect(
+      toggleColumn({
+        column: { id: '_id', schema: 'string' },
+        columns: [],
+        defaultColumns: [],
+      })
+    ).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "id": "_id",
+          "schema": "string",
+        },
+      ]
+    `);
+  });
 });

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/hooks/use_columns/toggle_column.ts
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/hooks/use_columns/toggle_column.ts
@@ -33,6 +33,10 @@ const insert = ({
     return [...columns.slice(0, defaultIndex), column, ...columns.slice(defaultIndex)];
   }
 
+  if (columns.length === 0) {
+    return [column];
+  }
+
   // if the column isn't shown and it's not part of the default config
   // push it into the second position. Behaviour copied by t_grid, security
   // does this to insert right after the timestamp column


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/156001

We previously overlooked a scenario where no columns were displayed. When generating the output array of columns, the code would insert an empty entry at the beginning because 'columns[0]' was undefined ([check current code](https://github.com/elastic/kibana/blob/main/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/hooks/use_columns/toggle_column.ts#L39)), which later caused an error. To resolve this issue without processing again all elements in the entire array, we now check if the current columns display array is empty. If it is, we return a new array containing only the user-added column and exit early.

<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->