### PR TITLE
[Enterprise Search] Switch to production ELSER model

### DIFF
--- a/x-pack/plugins/enterprise_search/common/ml_inference_pipeline/index.ts
+++ b/x-pack/plugins/enterprise_search/common/ml_inference_pipeline/index.ts
@@ -30,7 +30,7 @@ import {
 export const TEXT_EXPANSION_TYPE = SUPPORTED_PYTORCH_TASKS.TEXT_EXPANSION;
 export const TEXT_EXPANSION_FRIENDLY_TYPE = 'ELSER';
 export const ML_INFERENCE_PREFIX = 'ml.inference.';
-export const ELSER_MODEL_ID = '.elser_model_1_SNAPSHOT';
+export const ELSER_MODEL_ID = '.elser_model_1';
 
 export interface MlInferencePipelineParams {
   description?: string;


### PR DESCRIPTION
## Summary

This PR switches the ELSER model to the production one `.elser_model_1`.

This has been manually tested with the Elasticsearch [8.8.0-SNAPSHOT Docker image from May 2](https://artifacts-snapshot.elastic.co/elasticsearch/8.8.0-6ba23699/summary-8.8.0-SNAPSHOT.html).

![ELSER_prod_model](https://user-images.githubusercontent.com/14224983/235962097-9b7c15b5-2249-4900-b358-9f2906e3d10e.gif)

<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->