### PR TITLE
[Cases] Explicitly mapping cases SOs attributes

### DIFF
--- a/x-pack/plugins/cases/server/services/cases/transform.test.ts
+++ b/x-pack/plugins/cases/server/services/cases/transform.test.ts
@@ -24,6 +24,7 @@ import {
 } from '../../common/constants';
 import { getNoneCaseConnector } from '../../common/utils';
 import { CasePersistedSeverity, CasePersistedStatus } from '../../common/types/case';
+import { mockCases } from '../../mocks';
 
 describe('case transforms', () => {
   describe('transformUpdateResponseToExternalModel', () => {
@@ -241,6 +242,41 @@ describe('case transforms', () => {
         expect(transformedAttributes.attributes.status).toBe(expectedStatusValue);
       }
     );
+
+    it('returns the case attributes with null values correctly', () => {
+      const theCase = mockCases[0];
+
+      expect(
+        transformUpdateResponseToExternalModel({
+          type: 'a',
+          id: '1',
+          references: undefined,
+          attributes: {
+            ...theCase.attributes,
+            total_alerts: 0,
+            total_comments: 0,
+            connector: {
+              name: theCase.attributes.connector.name,
+              fields: [],
+              type: theCase.attributes.connector.type,
+            },
+            severity: 0,
+            status: 0,
+          },
+        }).attributes
+      ).toEqual(theCase.attributes);
+    });
+
+    it('does not return undefined values', () => {
+      expect(
+        transformUpdateResponseToExternalModel({
+          type: 'a',
+          id: '1',
+          references: undefined,
+          attributes: {},
+        }).attributes
+      ).toEqual({});
+    });
   });
 
   describe('transformAttributesToESModel', () => {
@@ -430,6 +466,25 @@ describe('case transforms', () => {
         'status'
       );
     });
+
+    it('returns the case attributes with null values correctly', () => {
+      const theCase = mockCases[0];
+
+      expect(transformAttributesToESModel(theCase.attributes).attributes).toEqual({
+        ...theCase.attributes,
+        connector: {
+          name: theCase.attributes.connector.name,
+          fields: [],
+          type: theCase.attributes.connector.type,
+        },
+        severity: 0,
+        status: 0,
+      });
+    });
+
+    it('does not return undefined values', () => {
+      expect(transformAttributesToESModel({}).attributes).toEqual({});
+    });
   });
 
   describe('transformSavedObjectToExternalModel', () => {
@@ -553,6 +608,30 @@ describe('case transforms', () => {
       expect(transformAttributesToESModel({ status: undefined }).attributes).not.toHaveProperty(
         'status'
       );
+    });
+
+    it('returns the case attributes with null values correctly', () => {
+      const theCase = mockCases[0];
+
+      expect(
+        transformSavedObjectToExternalModel({
+          type: 'a',
+          id: '1',
+          references: [],
+          attributes: {
+            ...theCase.attributes,
+            total_alerts: 0,
+            total_comments: 0,
+            connector: {
+              name: theCase.attributes.connector.name,
+              fields: [],
+              type: theCase.attributes.connector.type,
+            },
+            severity: 0,
+            status: 0,
+          },
+        }).attributes
+      ).toEqual(theCase.attributes);
     });
   });
 });

--- a/x-pack/plugins/cases/server/services/cases/transform.ts
+++ b/x-pack/plugins/cases/server/services/cases/transform.ts
@@ -84,7 +84,19 @@ export function transformUpdateResponseToExternalModel(
   return {
     ...updatedCase,
     attributes: {
-      ...restUpdateAttributes,
+      description: restUpdateAttributes.description,
+      title: restUpdateAttributes.title,
+      tags: restUpdateAttributes.tags,
+      settings: restUpdateAttributes.settings,
+      owner: restUpdateAttributes.owner,
+      assignees: restUpdateAttributes.assignees,
+      duration: restUpdateAttributes.duration,
+      closed_at: restUpdateAttributes.closed_at,
+      closed_by: restUpdateAttributes.closed_by,
+      created_at: restUpdateAttributes.created_at,
+      created_by: restUpdateAttributes.created_by,
+      updated_at: restUpdateAttributes.updated_at,
+      updated_by: restUpdateAttributes.updated_by,
       ...((severity || severity === 0) && { severity: SEVERITY_ESMODEL_TO_EXTERNAL[severity] }),
       ...((status || status === 0) && { status: STATUS_ESMODEL_TO_EXTERNAL[status] }),
       ...(transformedConnector && { connector: transformedConnector }),
@@ -129,7 +141,19 @@ export function transformAttributesToESModel(caseAttributes: Partial<CaseTransfo
 
   return {
     attributes: {
-      ...restAttributes,
+      ...(restAttributes.description && { description: restAttributes.description }),
+      ...(restAttributes.title && { title: restAttributes.title }),
+      ...(restAttributes.tags && { tags: restAttributes.tags }),
+      ...(restAttributes.settings && { settings: restAttributes.settings }),
+      ...(restAttributes.owner && { owner: restAttributes.owner }),
+      ...(restAttributes.assignees && { assignees: restAttributes.assignees }),
+      ...(restAttributes.duration && { duration: restAttributes.duration }),
+      ...(restAttributes.closed_at && { closed_at: restAttributes.closed_at }),
+      ...(restAttributes.closed_by && { closed_by: restAttributes.closed_by }),
+      ...(restAttributes.created_at && { created_at: restAttributes.created_at }),
+      ...(restAttributes.created_by && { created_by: restAttributes.created_by }),
+      ...(restAttributes.updated_at && { updated_at: restAttributes.updated_at }),
+      ...(restAttributes.updated_by && { updated_by: restAttributes.updated_by }),
       ...transformedConnector,
       ...transformedExternalService,
       ...(severity && { severity: SEVERITY_EXTERNAL_TO_ESMODEL[severity] }),
@@ -214,7 +238,19 @@ export function transformSavedObjectToExternalModel(
   return {
     ...caseSavedObject,
     attributes: {
-      ...caseSavedObjectAttributes,
+      description: caseSavedObjectAttributes.description,
+      title: caseSavedObjectAttributes.title,
+      tags: caseSavedObjectAttributes.tags,
+      settings: caseSavedObjectAttributes.settings,
+      owner: caseSavedObjectAttributes.owner,
+      assignees: caseSavedObjectAttributes.assignees,
+      duration: caseSavedObjectAttributes.duration,
+      closed_at: caseSavedObjectAttributes.closed_at,
+      closed_by: caseSavedObjectAttributes.closed_by,
+      created_at: caseSavedObjectAttributes.created_at,
+      created_by: caseSavedObjectAttributes.created_by,
+      updated_at: caseSavedObjectAttributes.updated_at,
+      updated_by: caseSavedObjectAttributes.updated_by,
       severity,
       status,
       connector,
@@ -236,7 +272,12 @@ function transformESExternalService(
   }
 
   return {
-    ...externalService,
+    connector_name: externalService.connector_name,
+    external_id: externalService.external_id,
+    external_title: externalService.external_title,
+    external_url: externalService.external_url,
+    pushed_at: externalService.pushed_at,
+    pushed_by: externalService.pushed_by,
     connector_id: connectorIdRef?.id ?? NONE_CONNECTOR_ID,
   };
 }

--- a/x-pack/plugins/cases/server/services/cases/transform.ts
+++ b/x-pack/plugins/cases/server/services/cases/transform.ts
@@ -84,19 +84,7 @@ export function transformUpdateResponseToExternalModel(
   return {
     ...updatedCase,
     attributes: {
-      description: restUpdateAttributes.description,
-      title: restUpdateAttributes.title,
-      tags: restUpdateAttributes.tags,
-      settings: restUpdateAttributes.settings,
-      owner: restUpdateAttributes.owner,
-      assignees: restUpdateAttributes.assignees,
-      duration: restUpdateAttributes.duration,
-      closed_at: restUpdateAttributes.closed_at,
-      closed_by: restUpdateAttributes.closed_by,
-      created_at: restUpdateAttributes.created_at,
-      created_by: restUpdateAttributes.created_by,
-      updated_at: restUpdateAttributes.updated_at,
-      updated_by: restUpdateAttributes.updated_by,
+      ...mapNonTransformedSOAttributes(restUpdateAttributes),
       ...((severity || severity === 0) && { severity: SEVERITY_ESMODEL_TO_EXTERNAL[severity] }),
       ...((status || status === 0) && { status: STATUS_ESMODEL_TO_EXTERNAL[status] }),
       ...(transformedConnector && { connector: transformedConnector }),
@@ -141,19 +129,7 @@ export function transformAttributesToESModel(caseAttributes: Partial<CaseTransfo
 
   return {
     attributes: {
-      ...(restAttributes.description && { description: restAttributes.description }),
-      ...(restAttributes.title && { title: restAttributes.title }),
-      ...(restAttributes.tags && { tags: restAttributes.tags }),
-      ...(restAttributes.settings && { settings: restAttributes.settings }),
-      ...(restAttributes.owner && { owner: restAttributes.owner }),
-      ...(restAttributes.assignees && { assignees: restAttributes.assignees }),
-      ...(restAttributes.duration && { duration: restAttributes.duration }),
-      ...(restAttributes.closed_at && { closed_at: restAttributes.closed_at }),
-      ...(restAttributes.closed_by && { closed_by: restAttributes.closed_by }),
-      ...(restAttributes.created_at && { created_at: restAttributes.created_at }),
-      ...(restAttributes.created_by && { created_by: restAttributes.created_by }),
-      ...(restAttributes.updated_at && { updated_at: restAttributes.updated_at }),
-      ...(restAttributes.updated_by && { updated_by: restAttributes.updated_by }),
+      ...mapNonTransformedSOAttributes(restAttributes),
       ...transformedConnector,
       ...transformedExternalService,
       ...(severity && { severity: SEVERITY_EXTERNAL_TO_ESMODEL[severity] }),
@@ -281,3 +257,51 @@ function transformESExternalService(
     connector_id: connectorIdRef?.id ?? NONE_CONNECTOR_ID,
   };
 }
+
+const mapNonTransformedSOAttributes = (
+  attr: Partial<
+    Omit<CaseTransformedAttributes, 'connector' | 'status' | 'severity' | 'external_service'>
+  >
+) => {
+  return {
+    ...(attr.description !== undefined && {
+      description: attr.description,
+    }),
+    ...(attr.title !== undefined && {
+      title: attr.title,
+    }),
+    ...(attr.tags !== undefined && {
+      tags: attr.tags,
+    }),
+    ...(attr.settings !== undefined && {
+      settings: attr.settings,
+    }),
+    ...(attr.owner !== undefined && {
+      owner: attr.owner,
+    }),
+    ...(attr.assignees !== undefined && {
+      assignees: attr.assignees,
+    }),
+    ...(attr.duration !== undefined && {
+      duration: attr.duration,
+    }),
+    ...(attr.closed_at !== undefined && {
+      closed_at: attr.closed_at,
+    }),
+    ...(attr.closed_by !== undefined && {
+      closed_by: attr.closed_by,
+    }),
+    ...(attr.created_at !== undefined && {
+      created_at: attr.created_at,
+    }),
+    ...(attr.created_by !== undefined && {
+      created_by: attr.created_by,
+    }),
+    ...(attr.updated_at !== undefined && {
+      updated_at: attr.updated_at,
+    }),
+    ...(attr.updated_by !== undefined && {
+      updated_by: attr.updated_by,
+    }),
+  };
+};

--- a/x-pack/plugins/cases/server/services/cases/types.ts
+++ b/x-pack/plugins/cases/server/services/cases/types.ts
@@ -9,7 +9,6 @@ import type { KueryNode } from '@kbn/es-query';
 import type { SavedObjectsClientContract } from '@kbn/core/server';
 import type { Case } from '../../../common/api';
 import type { IndexRefresh } from '../types';
-import type { User } from '../../common/types/user';
 import type {
   CaseSavedObjectTransformed,
   CaseTransformedAttributes,
@@ -19,11 +18,6 @@ import type { SavedObjectFindOptionsKueryNode } from '../../common/types';
 export interface GetCaseIdsByAlertIdArgs {
   alertId: string;
   filter?: KueryNode;
-}
-
-export interface PushedArgs {
-  pushed_at: string;
-  pushed_by: User;
 }
 
 export interface GetCaseArgs {
@@ -54,7 +48,7 @@ export interface PostCaseArgs extends IndexRefresh {
 
 export interface PatchCase extends IndexRefresh {
   caseId: string;
-  updatedAttributes: Partial<CaseTransformedAttributes & PushedArgs>;
+  updatedAttributes: Partial<CaseTransformedAttributes>;
   originalCase: CaseSavedObjectTransformed;
   version?: string;
 }


### PR DESCRIPTION
## Summary

This PR maps the SO attributes explicitly when returning a case SO from within the case service.

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
