### PR TITLE
[Security Solution] Add a migration to unmute custom Security Solution rules

### DIFF
--- a/x-pack/plugins/alerting/server/saved_objects/migrations/8.8/index.ts
+++ b/x-pack/plugins/alerting/server/saved_objects/migrations/8.8/index.ts
@@ -76,6 +76,8 @@ function addSecuritySolutionActionsFrequency(
 function unmuteSecuritySolutionCustomRules(
   doc: SavedObjectUnsanitizedDoc<RawRule>
 ): SavedObjectUnsanitizedDoc<RawRule> {
+  // only security custom rules were muted if there is no actions prior 8.8
+  // there is no reason to unmute prebuilt rules
   // "doc.attributes.params.immutable" is set to "true" for prebuilt rules
   if (!isDetectionEngineAADRuleType(doc) || doc.attributes.params.immutable) {
     return doc;

--- a/x-pack/plugins/alerting/server/saved_objects/migrations/8.8/index.ts
+++ b/x-pack/plugins/alerting/server/saved_objects/migrations/8.8/index.ts
@@ -73,9 +73,30 @@ function addSecuritySolutionActionsFrequency(
   return doc;
 }
 
+function unmuteSecuritySolutionCustomRules(
+  doc: SavedObjectUnsanitizedDoc<RawRule>
+): SavedObjectUnsanitizedDoc<RawRule> {
+  if (!isDetectionEngineAADRuleType(doc) || doc.attributes.params.immutable) {
+    return doc;
+  }
+
+  return {
+    ...doc,
+    attributes: {
+      ...doc.attributes,
+      muteAll: false,
+    },
+  };
+}
+
 export const getMigrations880 = (encryptedSavedObjects: EncryptedSavedObjectsPluginSetup) =>
   createEsoMigration(
     encryptedSavedObjects,
     (doc: SavedObjectUnsanitizedDoc<RawRule>): doc is SavedObjectUnsanitizedDoc<RawRule> => true,
-    pipeMigrations(addActionUuid, addRevision, addSecuritySolutionActionsFrequency)
+    pipeMigrations(
+      addActionUuid,
+      addRevision,
+      addSecuritySolutionActionsFrequency,
+      unmuteSecuritySolutionCustomRules
+    )
   );

--- a/x-pack/plugins/alerting/server/saved_objects/migrations/8.8/index.ts
+++ b/x-pack/plugins/alerting/server/saved_objects/migrations/8.8/index.ts
@@ -76,6 +76,7 @@ function addSecuritySolutionActionsFrequency(
 function unmuteSecuritySolutionCustomRules(
   doc: SavedObjectUnsanitizedDoc<RawRule>
 ): SavedObjectUnsanitizedDoc<RawRule> {
+  // "doc.attributes.params.immutable" is set to "true" for prebuilt rules
   if (!isDetectionEngineAADRuleType(doc) || doc.attributes.params.immutable) {
     return doc;
   }

--- a/x-pack/plugins/alerting/server/saved_objects/migrations/8.8/index.ts
+++ b/x-pack/plugins/alerting/server/saved_objects/migrations/8.8/index.ts
@@ -76,10 +76,7 @@ function addSecuritySolutionActionsFrequency(
 function unmuteSecuritySolutionCustomRules(
   doc: SavedObjectUnsanitizedDoc<RawRule>
 ): SavedObjectUnsanitizedDoc<RawRule> {
-  // only security custom rules were muted if there is no actions prior 8.8
-  // there is no reason to unmute prebuilt rules
-  // "doc.attributes.params.immutable" is set to "true" for prebuilt rules
-  if (!isDetectionEngineAADRuleType(doc) || doc.attributes.params.immutable) {
+  if (!isDetectionEngineAADRuleType(doc)) {
     return doc;
   }
 

--- a/x-pack/plugins/alerting/server/saved_objects/migrations/index.test.ts
+++ b/x-pack/plugins/alerting/server/saved_objects/migrations/index.test.ts
@@ -2653,20 +2653,26 @@ describe('successful migrations', () => {
       ]);
     });
 
-    test('migrates rule to include revision and defaults revision to 0', () => {
-      const migration880 = getMigrations(encryptedSavedObjectsSetup, {}, isPreconfigured)['8.8.0'];
+    describe('security rule version to revision', () => {
+      test('migrates rule to include revision and defaults revision to 0', () => {
+        const migration880 = getMigrations(encryptedSavedObjectsSetup, {}, isPreconfigured)[
+          '8.8.0'
+        ];
 
-      const rule = getMockData();
-      const migratedAlert880 = migration880(rule, migrationContext);
-      expect(migratedAlert880.attributes.revision).toEqual(0);
-    });
+        const rule = getMockData();
+        const migratedAlert880 = migration880(rule, migrationContext);
+        expect(migratedAlert880.attributes.revision).toEqual(0);
+      });
 
-    test('migrates security rule version to revision', () => {
-      const migration880 = getMigrations(encryptedSavedObjectsSetup, {}, isPreconfigured)['8.8.0'];
+      test('migrates security rule version to revision', () => {
+        const migration880 = getMigrations(encryptedSavedObjectsSetup, {}, isPreconfigured)[
+          '8.8.0'
+        ];
 
-      const rule = getMockData({ alertTypeId: ruleTypeMappings.eql, params: { version: 2 } });
-      const migratedAlert880 = migration880(rule, migrationContext);
-      expect(migratedAlert880.attributes.revision).toEqual(2);
+        const rule = getMockData({ alertTypeId: ruleTypeMappings.eql, params: { version: 2 } });
+        const migratedAlert880 = migration880(rule, migrationContext);
+        expect(migratedAlert880.attributes.revision).toEqual(2);
+      });
     });
 
     describe('migrate actions frequency for Security Solution ', () => {
@@ -2712,6 +2718,51 @@ describe('successful migrations', () => {
           }
         );
         expect(updatedActions).toEqual(rule.attributes.actions);
+      });
+    });
+
+    describe('unmute security rules', () => {
+      test.each(Object.values(ruleTypeMappings))(
+        'unmutes custom rules of type "%s" successfully',
+        (ruleType) => {
+          const migration880 = getMigrations(encryptedSavedObjectsSetup, {}, isPreconfigured)[
+            '8.8.0'
+          ];
+
+          const rule = getMockData({ alertTypeId: ruleType, muteAll: true });
+          const migratedAlert880 = migration880(rule, migrationContext);
+
+          expect(migratedAlert880.attributes.muteAll).toBeFalsy();
+        }
+      );
+
+      test('ignores prebuilt rules', () => {
+        const migration880 = getMigrations(encryptedSavedObjectsSetup, {}, isPreconfigured)[
+          '8.8.0'
+        ];
+
+        const rule = getMockData({
+          alertTypeId: ruleTypeMappings.query,
+          muteAll: true,
+          params: { immutable: true },
+        });
+        const migratedAlert880 = migration880(rule, migrationContext);
+
+        expect(migratedAlert880.attributes.muteAll).toBeTruthy();
+      });
+
+      test('ignores non security rules', () => {
+        const migration880 = getMigrations(encryptedSavedObjectsSetup, {}, isPreconfigured)[
+          '8.8.0'
+        ];
+
+        const rule = getMockData({
+          alertTypeId: 'unknown',
+          muteAll: true,
+        });
+        const migratedAlert880 = migration880(rule, migrationContext);
+
+        expect(migratedAlert880.attributes.muteAll).toBeTruthy();
       });
     });
   });

--- a/x-pack/plugins/alerting/server/saved_objects/migrations/index.test.ts
+++ b/x-pack/plugins/alerting/server/saved_objects/migrations/index.test.ts
@@ -2736,21 +2736,6 @@ describe('successful migrations', () => {
         }
       );
 
-      test('ignores prebuilt rules', () => {
-        const migration880 = getMigrations(encryptedSavedObjectsSetup, {}, isPreconfigured)[
-          '8.8.0'
-        ];
-
-        const rule = getMockData({
-          alertTypeId: ruleTypeMappings.query,
-          muteAll: true,
-          params: { immutable: true },
-        });
-        const migratedAlert880 = migration880(rule, migrationContext);
-
-        expect(migratedAlert880.attributes.muteAll).toBeTruthy();
-      });
-
       test('ignores non security rules', () => {
         const migration880 = getMigrations(encryptedSavedObjectsSetup, {}, isPreconfigured)[
           '8.8.0'

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/migrations.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/migrations.ts
@@ -692,5 +692,26 @@ export default function createGetTests({ getService }: FtrProviderContext) {
         }),
       ]);
     });
+
+    it('8.8 unmutes only security custom rules', async () => {
+      const nonSecurityRuleId = 'alert:74f3e6d7-b7bb-477d-ac28-92ee22728e6e';
+      const securityImmutableRuleId = 'alert:8990af61-c09a-11ec-9164-4bfd6fc32c43';
+      const securityCustomRuleId = 'alert:88bc8c21-07ba-42eb-ad9c-06820275ac10';
+
+      const { docs } = await es.mget({
+        index: ALERTING_CASES_SAVED_OBJECT_INDEX,
+        body: { ids: [securityCustomRuleId, nonSecurityRuleId, securityImmutableRuleId] },
+      });
+
+      expect(
+        (docs[0] as estypes.GetGetResult<{ alert: RawRule }>)?._source?.alert.muteAll
+      ).toBeFalsy();
+      expect(
+        (docs[1] as estypes.GetGetResult<{ alert: RawRule }>)?._source?.alert.muteAll
+      ).toBeTruthy();
+      expect(
+        (docs[2] as estypes.GetGetResult<{ alert: RawRule }>)?._source?.alert.muteAll
+      ).toBeTruthy();
+    });
   });
 }

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/migrations.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/migrations.ts
@@ -693,25 +693,26 @@ export default function createGetTests({ getService }: FtrProviderContext) {
       ]);
     });
 
-    it('8.8 unmutes only security custom rules', async () => {
-      const nonSecurityRuleId = 'alert:74f3e6d7-b7bb-477d-ac28-92ee22728e6e';
-      const securityImmutableRuleId = 'alert:8990af61-c09a-11ec-9164-4bfd6fc32c43';
+    it('8.8 unmutes only security rules', async () => {
       const securityCustomRuleId = 'alert:88bc8c21-07ba-42eb-ad9c-06820275ac10';
+      const securityImmutableRuleId = 'alert:8990af61-c09a-11ec-9164-4bfd6fc32c43';
+      const nonSecurityRuleId = 'alert:74f3e6d7-b7bb-477d-ac28-92ee22728e6e';
 
-      const { docs } = await es.mget({
+      const { docs } = await es.mget<{ alert: RawRule }>({
         index: ALERTING_CASES_SAVED_OBJECT_INDEX,
-        body: { ids: [securityCustomRuleId, nonSecurityRuleId, securityImmutableRuleId] },
+        body: { ids: [securityCustomRuleId, securityImmutableRuleId, nonSecurityRuleId] },
       });
 
-      expect(
-        (docs[0] as estypes.GetGetResult<{ alert: RawRule }>)?._source?.alert.muteAll
-      ).toBeFalsy();
-      expect(
-        (docs[1] as estypes.GetGetResult<{ alert: RawRule }>)?._source?.alert.muteAll
-      ).toBeTruthy();
-      expect(
-        (docs[2] as estypes.GetGetResult<{ alert: RawRule }>)?._source?.alert.muteAll
-      ).toBeTruthy();
+      const securityCustomRuleMuteAll =
+        '_source' in docs[0] ? docs[0]._source?.alert.muteAll : undefined;
+      const securityImmutableRuleMuteAll =
+        '_source' in docs[1] ? docs[1]._source?.alert.muteAll : undefined;
+      const nonSecurityRuleMuteAll =
+        '_source' in docs[2] ? docs[2]._source?.alert.muteAll : undefined;
+
+      expect(securityCustomRuleMuteAll).toBeFalsy();
+      expect(securityImmutableRuleMuteAll).toBeFalsy();
+      expect(nonSecurityRuleMuteAll).toBeTruthy();
     });
   });
 }

--- a/x-pack/test/functional/es_archives/alerts/data.json
+++ b/x-pack/test/functional/es_archives/alerts/data.json
@@ -14,7 +14,7 @@
         "createdAt": "2020-06-17T15:35:38.497Z",
         "createdBy": "elastic",
         "enabled": true,
-        "muteAll": false,
+        "muteAll": true,
         "mutedInstanceIds": [
         ],
         "name": "always-firing-alert",
@@ -1023,7 +1023,7 @@
            "createdBy":"elastic",
            "updatedBy":"elastic",
            "createdAt":"2021-07-27T20:42:55.896Z",
-           "muteAll":false,
+           "muteAll":true,
            "mutedInstanceIds":[
               
            ],
@@ -1406,5 +1406,68 @@
         "alert": "8.0.1"
       }
     }
+  }
+}
+
+{
+  "type":"doc",
+  "value":{
+     "id":"alert:88bc8c21-07ba-42eb-ad9c-06820275ac10",
+     "index":".kibana_1",
+     "source":{
+        "alert":{
+           "name":"Test unmuting of a custom security rule",
+           "alertTypeId":"siem.queryRule",
+           "consumer":"siem",
+           "params":{
+              "immutable":false,
+              "ruleId":"bf9638eb-8d3c-4f40-83d7-8c40a7c80f2e",
+              "author":[],
+              "description":"Test unmuting of a custom security rule",
+              "falsePositives":[],
+              "from":"now-36000060s",
+              "license":"",
+              "outputIndex":".siem-signals-default",
+              "meta":{
+                 "from":"10000h"
+              },
+              "maxSignals":100,
+              "riskScore":21,
+              "riskScoreMapping":[],
+              "severity":"low",
+              "severityMapping":[],
+              "threat":[],
+              "to":"now",
+              "references":[],
+              "version":0,
+              "exceptionsList":[],
+              "type":"query",
+              "language":"kuery",
+              "index":["test-index"],
+              "query":"*:*",
+              "filters":[]
+           },
+           "schedule":{
+              "interval":"5m"
+           },
+           "enabled":false,
+           "actions": [],
+           "apiKeyOwner":null,
+           "apiKey":null,
+           "createdBy":"elastic",
+           "updatedBy":"elastic",
+           "createdAt":"2023-03-27T20:42:55.896Z",
+           "muteAll":true,
+           "mutedInstanceIds":[],
+           "scheduledTaskId":null,
+           "tags":[]
+        },
+        "type":"alert",
+        "migrationVersion":{
+           "alert":"8.7.0"
+        },
+        "updated_at":"2023-03-27T20:42:55.896Z",
+        "references":[]
+     }
   }
 }


### PR DESCRIPTION
**Addresses:** https://github.com/elastic/kibana/issues/156352

## Summary

This PR adds a migration to unmute all Security Solution's custom rules while migrating to Kibana `8.8`. As we added support for rule snoozing in `8.8` https://github.com/elastic/security-team/issues/5308 users are able to manage muting of rule notifications. Prior `8.8` Security Solution's custom rules were muted under the hood if there is no actions.



<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->