### PR TITLE
[Security solution] Grouping bug fixes from BC1

### DIFF
--- a/packages/kbn-securitysolution-grouping/src/components/accordion_panel/helpers.ts
+++ b/packages/kbn-securitysolution-grouping/src/components/accordion_panel/helpers.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-export const createGroupFilter = (selectedGroup: string, query?: string) =>
+export const createGroupFilter = (selectedGroup: string, query?: string | null) =>
   query && selectedGroup
     ? [
         {

--- a/packages/kbn-securitysolution-grouping/src/components/accordion_panel/index.test.tsx
+++ b/packages/kbn-securitysolution-grouping/src/components/accordion_panel/index.test.tsx
@@ -19,6 +19,7 @@ const ruleDesc = 'Rule description';
 const testProps = {
   isLoading: false,
   groupBucket: {
+    selectedGroup: 'kibana.alert.rule.name',
     key: [ruleName, ruleDesc],
     key_as_string: `${ruleName}|${ruleDesc}`,
     doc_count: 98,

--- a/packages/kbn-securitysolution-grouping/src/components/accordion_panel/index.test.tsx
+++ b/packages/kbn-securitysolution-grouping/src/components/accordion_panel/index.test.tsx
@@ -8,20 +8,21 @@
 
 import { fireEvent, render } from '@testing-library/react';
 import { GroupPanel } from '.';
-import { createGroupFilter } from './helpers';
+import { createGroupFilter, getNullGroupFilter } from './helpers';
 import React from 'react';
 
 const onToggleGroup = jest.fn();
 const renderChildComponent = jest.fn();
 const ruleName = 'Rule name';
-const ruleDesc = 'Rule description';
+const selectedGroup = 'kibana.alert.rule.name';
 
 const testProps = {
   isLoading: false,
+  isNullGroup: false,
   groupBucket: {
-    selectedGroup: 'kibana.alert.rule.name',
-    key: [ruleName, ruleDesc],
-    key_as_string: `${ruleName}|${ruleDesc}`,
+    selectedGroup,
+    key: [ruleName, ruleName],
+    key_as_string: `${ruleName}|${ruleName}`,
     doc_count: 98,
     hostsCountAggregation: {
       value: 5,
@@ -55,7 +56,7 @@ const testProps = {
     },
   },
   renderChildComponent,
-  selectedGroup: 'kibana.alert.rule.name',
+  selectedGroup,
   onGroupClose: () => {},
 };
 
@@ -70,7 +71,12 @@ describe('grouping accordion panel', () => {
       createGroupFilter(testProps.selectedGroup, ruleName)
     );
   });
-  it('does not create query without a valid groupFieldValue', () => {
+  it('creates the query for the selectedGroup attribute when the group is null', () => {
+    const { getByTestId } = render(<GroupPanel {...testProps} isNullGroup />);
+    expect(getByTestId('grouping-accordion')).toBeInTheDocument();
+    expect(renderChildComponent).toHaveBeenCalledWith(getNullGroupFilter(testProps.selectedGroup));
+  });
+  it('does not render accordion or create query without a valid groupFieldValue', () => {
     const { queryByTestId } = render(
       <GroupPanel
         {...testProps}
@@ -83,6 +89,11 @@ describe('grouping accordion panel', () => {
     );
     expect(queryByTestId('grouping-accordion')).not.toBeInTheDocument();
     expect(renderChildComponent).not.toHaveBeenCalled();
+  });
+  it('Does not render accordion or create query when groupBucket.selectedGroup !== selectedGroup', () => {
+    const { queryByTestId } = render(<GroupPanel {...testProps} selectedGroup="source.ip" />);
+    expect(queryByTestId('grouping-accordion')).not.toBeInTheDocument();
+    expect(testProps.renderChildComponent).not.toHaveBeenCalled();
   });
   it('When onToggleGroup not defined, does nothing on toggle', () => {
     const { container } = render(<GroupPanel {...testProps} />);

--- a/packages/kbn-securitysolution-grouping/src/components/accordion_panel/index.tsx
+++ b/packages/kbn-securitysolution-grouping/src/components/accordion_panel/index.tsx
@@ -86,13 +86,13 @@ const GroupPanelComponent = <T,>({
     [groupBucket.key, groupBucket.selectedGroup, selectedGroup]
   );
 
-  const groupFilters = useMemo(() => {
-    if (groupFieldValue === null) return [];
-
-    return isNullGroup
-      ? getNullGroupFilter(selectedGroup)
-      : createGroupFilter(selectedGroup, groupFieldValue);
-  }, [groupFieldValue, isNullGroup, selectedGroup]);
+  const groupFilters = useMemo(
+    () =>
+      isNullGroup
+        ? getNullGroupFilter(selectedGroup)
+        : createGroupFilter(selectedGroup, groupFieldValue),
+    [groupFieldValue, isNullGroup, selectedGroup]
+  );
 
   const onToggle = useCallback(
     (isOpen) => {

--- a/packages/kbn-securitysolution-grouping/src/components/accordion_panel/index.tsx
+++ b/packages/kbn-securitysolution-grouping/src/components/accordion_panel/index.tsx
@@ -10,7 +10,7 @@ import { EuiAccordion, EuiFlexGroup, EuiFlexItem, EuiTitle, EuiIconTip } from '@
 import type { Filter } from '@kbn/es-query';
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import { firstNonNullValue } from '../../helpers';
-import type { RawBucket } from '../types';
+import type { GroupingBucket } from '../types';
 import { createGroupFilter, getNullGroupFilter } from './helpers';
 
 interface GroupPanelProps<T> {
@@ -18,14 +18,14 @@ interface GroupPanelProps<T> {
   customAccordionClassName?: string;
   extraAction?: React.ReactNode;
   forceState?: 'open' | 'closed';
-  groupBucket: RawBucket<T>;
+  groupBucket: GroupingBucket<T>;
   groupPanelRenderer?: JSX.Element;
   groupingLevel?: number;
   isLoading: boolean;
   isNullGroup?: boolean;
   nullGroupMessage?: string;
   onGroupClose: () => void;
-  onToggleGroup?: (isOpen: boolean, groupBucket: RawBucket<T>) => void;
+  onToggleGroup?: (isOpen: boolean, groupBucket: GroupingBucket<T>) => void;
   renderChildComponent: (groupFilter: Filter[]) => React.ReactElement;
   selectedGroup: string;
 }
@@ -81,16 +81,18 @@ const GroupPanelComponent = <T,>({
       lastForceState.current = 'open';
     }
   }, [onGroupClose, forceState, selectedGroup]);
-
-  const groupFieldValue = useMemo(() => firstNonNullValue(groupBucket.key), [groupBucket.key]);
-
-  const groupFilters = useMemo(
-    () =>
-      isNullGroup
-        ? getNullGroupFilter(selectedGroup)
-        : createGroupFilter(selectedGroup, groupFieldValue),
-    [groupFieldValue, isNullGroup, selectedGroup]
+  const groupFieldValue = useMemo(
+    () => (groupBucket.selectedGroup === selectedGroup ? firstNonNullValue(groupBucket.key) : null),
+    [groupBucket.key, groupBucket.selectedGroup, selectedGroup]
   );
+
+  const groupFilters = useMemo(() => {
+    if (groupFieldValue === null) return [];
+
+    return isNullGroup
+      ? getNullGroupFilter(selectedGroup)
+      : createGroupFilter(selectedGroup, groupFieldValue);
+  }, [groupFieldValue, isNullGroup, selectedGroup]);
 
   const onToggle = useCallback(
     (isOpen) => {

--- a/packages/kbn-securitysolution-grouping/src/components/grouping.mock.tsx
+++ b/packages/kbn-securitysolution-grouping/src/components/grouping.mock.tsx
@@ -24,6 +24,7 @@ export const mockGroupingProps = {
         {
           key: [host1Name],
           key_as_string: `${host1Name}`,
+          selectedGroup: 'host.name',
           doc_count: 1,
           hostsCountAggregation: {
             value: 1,
@@ -56,6 +57,7 @@ export const mockGroupingProps = {
         {
           key: [host2Name],
           key_as_string: `${host2Name}`,
+          selectedGroup: 'host.name',
           doc_count: 1,
           hostsCountAggregation: {
             value: 1,
@@ -88,6 +90,7 @@ export const mockGroupingProps = {
         {
           key: ['-'],
           key_as_string: `-`,
+          selectedGroup: 'host.name',
           isNullGroup: true,
           doc_count: 11,
           hostsCountAggregation: {

--- a/packages/kbn-securitysolution-grouping/src/components/types.ts
+++ b/packages/kbn-securitysolution-grouping/src/components/types.ts
@@ -16,15 +16,16 @@ export const NONE_GROUP_KEY = 'none';
 
 export type RawBucket<T> = GenericBuckets & T;
 
-export interface GroupingBucket {
+export type GroupingBucket<T> = RawBucket<T> & {
+  selectedGroup: string;
   isNullGroup?: boolean;
-}
+};
 
 /** Defines the shape of the aggregation returned by Elasticsearch */
 // TODO: write developer docs for these fields
 export interface RootAggregation<T> {
   groupByFields?: {
-    buckets?: Array<RawBucket<T> & GroupingBucket>;
+    buckets?: Array<GroupingBucket<T>>;
   };
   groupsCount?: {
     value?: number | null;

--- a/packages/kbn-securitysolution-grouping/src/containers/query/index.test.ts
+++ b/packages/kbn-securitysolution-grouping/src/containers/query/index.test.ts
@@ -161,16 +161,19 @@ describe('group selector', () => {
         {
           key: ['20.80.64.28', '20.80.64.28'],
           key_as_string: '20.80.64.28|20.80.64.28',
+          selectedGroup: 'source.ip',
           doc_count: 75,
         },
         {
           key: ['0.0.0.0', '0.0.0.0'],
           key_as_string: '0.0.0.0|0.0.0.0',
+          selectedGroup: 'source.ip',
           doc_count: 75,
         },
         {
           key: ['0.0.0.0', '::'],
           key_as_string: '0.0.0.0|::',
+          selectedGroup: 'source.ip',
           doc_count: 75,
         },
       ],
@@ -186,23 +189,26 @@ describe('group selector', () => {
     },
   };
   it('parseGroupingQuery finds and flags the null group', () => {
-    const result = parseGroupingQuery(groupingAggs);
+    const result = parseGroupingQuery('source.ip', groupingAggs);
     expect(result).toEqual({
       groupByFields: {
         buckets: [
           {
             key: ['20.80.64.28'],
             key_as_string: '20.80.64.28',
+            selectedGroup: 'source.ip',
             doc_count: 75,
           },
           {
             key: ['0.0.0.0'],
             key_as_string: '0.0.0.0',
+            selectedGroup: 'source.ip',
             doc_count: 75,
           },
           {
             key: [getEmptyValue()],
             key_as_string: getEmptyValue(),
+            selectedGroup: 'source.ip',
             isNullGroup: true,
             doc_count: 75,
           },
@@ -220,7 +226,7 @@ describe('group selector', () => {
     });
   });
   it('parseGroupingQuery adjust group count when null field group is present', () => {
-    const result: GroupingAggregation<{}> = parseGroupingQuery({
+    const result: GroupingAggregation<{}> = parseGroupingQuery('source.ip', {
       ...groupingAggs,
       unitsCountWithoutNull: { value: 99 },
     });

--- a/packages/kbn-securitysolution-grouping/src/containers/query/index.ts
+++ b/packages/kbn-securitysolution-grouping/src/containers/query/index.ts
@@ -119,9 +119,11 @@ export const getGroupingQuery = ({
 /**
  * Parses the grouping query response to add the isNullGroup
  * flag to the buckets and to format the bucket keys
- * @param buckets buckets returned from the grouping query
+ * @param selectedGroup from the grouping query
+ * @param aggs aggs returned from the grouping query
  */
 export const parseGroupingQuery = <T>(
+  selectedGroup: string,
   aggs?: GroupingAggregation<T>
 ): GroupingAggregation<T> | {} => {
   if (!aggs) {
@@ -138,11 +140,13 @@ export const parseGroupingQuery = <T>(
       ? {
           ...group,
           key: [group.key[0]],
+          selectedGroup,
           key_as_string: group.key[0],
         }
       : {
           ...group,
           key: [emptyValue],
+          selectedGroup,
           key_as_string: emptyValue,
           isNullGroup: true,
         };

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/alerts_sub_grouping.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/alerts_sub_grouping.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useCallback, useEffect, useMemo, useRef } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import type { Filter, Query } from '@kbn/es-query';
 import { buildEsQuery } from '@kbn/es-query';
@@ -193,17 +193,17 @@ export const GroupedSubLevelComponent: React.FC<AlertsTableComponentProps> = ({
     skip: isNoneGroup([selectedGroup]),
   });
 
-  const queriedGroup = useRef('');
+  const [queriedGroup, setQueriedGroup] = useState('');
 
   const aggs = useMemo(
-    // queriedGroup.current because `selectedGroup` updates before the query response
-    () => parseGroupingQuery(queriedGroup.current, alertsGroupsData?.aggregations),
-    [alertsGroupsData?.aggregations]
+    // queriedGroup because `selectedGroup` updates before the query response
+    () => parseGroupingQuery(queriedGroup, alertsGroupsData?.aggregations),
+    [alertsGroupsData?.aggregations, queriedGroup]
   );
 
   useEffect(() => {
     if (!isNoneGroup([selectedGroup])) {
-      queriedGroup.current = queryGroups?.aggs?.groupsCount?.cardinality?.field ?? '';
+      setQueriedGroup(queryGroups?.aggs?.groupsCount?.cardinality?.field ?? '');
       setAlertsQuery(queryGroups);
     }
   }, [queryGroups, selectedGroup, setAlertsQuery]);

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/alerts_sub_grouping.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/alerts_sub_grouping.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useCallback, useEffect, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import type { Filter, Query } from '@kbn/es-query';
 import { buildEsQuery } from '@kbn/es-query';
@@ -193,13 +193,17 @@ export const GroupedSubLevelComponent: React.FC<AlertsTableComponentProps> = ({
     skip: isNoneGroup([selectedGroup]),
   });
 
+  const queriedGroup = useRef('');
+
   const aggs = useMemo(
-    () => parseGroupingQuery(alertsGroupsData?.aggregations),
-    [alertsGroupsData]
+    // queriedGroup.current because `selectedGroup` updates before the query response
+    () => parseGroupingQuery(queriedGroup.current, alertsGroupsData?.aggregations),
+    [alertsGroupsData?.aggregations]
   );
 
   useEffect(() => {
     if (!isNoneGroup([selectedGroup])) {
+      queriedGroup.current = queryGroups?.aggs?.groupsCount?.cardinality?.field ?? '';
       setAlertsQuery(queryGroups);
     }
   }, [queryGroups, selectedGroup, setAlertsQuery]);

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/grouping_settings/group_stats.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/grouping_settings/group_stats.test.tsx
@@ -51,7 +51,7 @@ describe('getStats', () => {
     });
     expect(
       badgesUserName.find(
-        (badge) => badge.badge != null && badge.title === `IP's:` && badge.badge.value === 1
+        (badge) => badge.badge != null && badge.title === `Hosts:` && badge.badge.value === 1
       )
     ).toBeTruthy();
   });

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/grouping_settings/group_stats.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/grouping_settings/group_stats.tsx
@@ -136,7 +136,7 @@ export const getStats = (
       return [
         ...severityStat,
         {
-          title: i18n.STATS_GROUP_IPS,
+          title: i18n.STATS_GROUP_HOSTS,
           badge: {
             value: bucket.hostsCountAggregation?.value ?? 0,
           },
@@ -153,7 +153,7 @@ export const getStats = (
       return [
         ...severityStat,
         {
-          title: i18n.STATS_GROUP_IPS,
+          title: i18n.STATS_GROUP_HOSTS,
           badge: {
             value: bucket.hostsCountAggregation?.value ?? 0,
           },

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/grouping_settings/query_builder.ts
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/grouping_settings/query_builder.ts
@@ -167,16 +167,9 @@ const getAggregationsByGroupField = (field: string): NamedAggregation[] => {
             },
           },
           {
-            usersCountAggregation: {
+            hostsCountAggregation: {
               cardinality: {
                 field: 'host.name',
-              },
-            },
-          },
-          {
-            usersCountAggregation: {
-              cardinality: {
-                field: 'user.name',
               },
             },
           },
@@ -208,7 +201,7 @@ const getAggregationsByGroupField = (field: string): NamedAggregation[] => {
             },
           },
           {
-            usersCountAggregation: {
+            hostsCountAggregation: {
               cardinality: {
                 field: 'host.name',
               },


### PR DESCRIPTION
## Summary

Resolves [[Security Solution] IP count is zero on alert grouping statistics](https://github.com/elastic/kibana/issues/156334)
This was a silly one. We had labels of `IP's` where it should have been `Hosts`. Updated the labels.

Resolves [[Security Solution] Error message appears when unselecting alert group](https://github.com/elastic/kibana/issues/156337)
The `selectedGroup` was updating before the response updates. The response value is the basis for the `groupFilter`.  There was a race condition where the we made a filter with the previous response value and new `selectedGroup`, for example: `['source.ip']: 'a host name'`.  This triggered the error seen in the issue. Resolved by saving the `selectedGroup` at the time of the response and a check to make sure the response `selectedGroup` is the same as the new `selectedGroup` in order to display the response value.


<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->