### PR TITLE
[Unified search] Fixes the css priority order for the filter pills

### DIFF
--- a/src/plugins/unified_search/public/filter_bar/filter_item/filter_item.scss
+++ b/src/plugins/unified_search/public/filter_bar/filter_item/filter_item.scss
@@ -23,7 +23,6 @@
   background-color: transparentize($euiColorLightShade, .5);
   text-decoration: line-through;
   font-weight: $euiFontWeightRegular;
-  font-style: italic;
 }
 
 .euiBadge.globalFilterItem-isError, .globalFilterItem-isWarning {

--- a/src/plugins/unified_search/public/filter_bar/filter_item/filter_item.scss
+++ b/src/plugins/unified_search/public/filter_bar/filter_item/filter_item.scss
@@ -4,7 +4,7 @@
  * 1.  Allow wrapping of long filter items
  */
 
-.globalFilterItem {
+ .euiBadge.globalFilterItem {
   line-height: $euiSize;
   border: none;
   color: $euiTextColor;
@@ -18,7 +18,7 @@
   }
 }
 
-.globalFilterItem-isDisabled {
+.euiBadge.globalFilterItem-isDisabled {
   color: $euiColorDarkShade;
   background-color: transparentize($euiColorLightShade, .5);
   text-decoration: line-through;
@@ -26,7 +26,7 @@
   font-style: italic;
 }
 
-.globalFilterItem-isError, .globalFilterItem-isWarning {
+.euiBadge.globalFilterItem-isError, .globalFilterItem-isWarning {
   .globalFilterLabel__value {
     font-weight: $euiFontWeightBold;
   }

--- a/src/plugins/unified_search/public/filter_bar/filter_item/filter_item.scss
+++ b/src/plugins/unified_search/public/filter_bar/filter_item/filter_item.scss
@@ -4,7 +4,7 @@
  * 1.  Allow wrapping of long filter items
  */
 
- .euiBadge.globalFilterItem {
+.euiBadge.globalFilterItem {
   line-height: $euiSize;
   border: none;
   color: $euiTextColor;


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/156446

There were cases were the css defined by our custom class were overwritten by the eui badge classes. This doesn't happen always, I could replicate it only when the legacy input controls are present. 

<img width="2504" alt="image" src="https://user-images.githubusercontent.com/17003240/236125401-d81925de-09e6-4580-9be0-3e1315c40d41.png">


<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->