### PR TITLE
[Discover] Enable sharing for text based languages

### DIFF
--- a/src/plugins/discover/public/application/main/components/top_nav/get_top_nav_links.test.ts
+++ b/src/plugins/discover/public/application/main/components/top_nav/get_top_nav_links.test.ts
@@ -132,6 +132,13 @@ test('getTopNavLinks result for sql mode', () => {
         "testId": "discoverOpenButton",
       },
       Object {
+        "description": "Share Search",
+        "id": "share",
+        "label": "Share",
+        "run": [Function],
+        "testId": "shareTopNavButton",
+      },
+      Object {
         "description": "Open Inspector for search",
         "id": "inspect",
         "label": "Inspect",

--- a/src/plugins/discover/public/application/main/components/top_nav/get_top_nav_links.tsx
+++ b/src/plugins/discover/public/application/main/components/top_nav/get_top_nav_links.tsx
@@ -159,11 +159,23 @@ export const getTopNavLinks = ({
     }),
     testId: 'shareTopNavButton',
     run: async (anchorElement: HTMLElement) => {
-      const updatedDataView = await persistDataView(dataView);
-      if (!services.share || !updatedDataView) {
+      if (!services.share) {
         return;
       }
-      const sharingData = await getSharingData(searchSource, state.appState.getState(), services);
+      // this prompts the user to save the dataview if adhoc dataview is detected
+      // for text based languages we don't want this check
+      if (!isPlainRecord) {
+        const updatedDataView = await persistDataView(dataView);
+        if (!updatedDataView) {
+          return;
+        }
+      }
+      const sharingData = await getSharingData(
+        searchSource,
+        state.appState.getState(),
+        services,
+        isPlainRecord
+      );
 
       services.share.toggleShareContextMenu({
         anchorElement,
@@ -208,7 +220,7 @@ export const getTopNavLinks = ({
     ...(services.capabilities.advancedSettings.save ? [options] : []),
     newSearch,
     openSearch,
-    ...(!isPlainRecord ? [shareSearch] : []),
+    shareSearch,
     ...(services.triggersActionsUi &&
     services.capabilities.management?.insightsAndAlerting?.triggersActions &&
     !isPlainRecord

--- a/src/plugins/discover/public/utils/get_sharing_data.test.ts
+++ b/src/plugins/discover/public/utils/get_sharing_data.test.ts
@@ -197,6 +197,41 @@ describe('getSharingData', () => {
     `);
   });
 
+  test('fields do not have prepended timeField for text based languages', async () => {
+    const index = { ...dataViewMock } as DataView;
+    index.timeFieldName = 'cool-timefield';
+
+    const searchSourceMock = createSearchSourceMock({ index });
+    const result = await getSharingData(
+      searchSourceMock,
+      {
+        columns: [
+          'cool-field-1',
+          'cool-field-2',
+          'cool-field-3',
+          'cool-field-4',
+          'cool-field-5',
+          'cool-field-6',
+        ],
+      },
+      services,
+      true
+    );
+    expect(result).toMatchInlineSnapshot(`
+      Object {
+        "columns": Array [
+          "cool-field-1",
+          "cool-field-2",
+          "cool-field-3",
+          "cool-field-4",
+          "cool-field-5",
+          "cool-field-6",
+        ],
+        "getSearchSource": [Function],
+      }
+    `);
+  });
+
   test('fields conditionally do not have prepended timeField', async () => {
     services.uiSettings = {
       get: (key: string) => {

--- a/src/plugins/discover/public/utils/get_sharing_data.ts
+++ b/src/plugins/discover/public/utils/get_sharing_data.ts
@@ -32,7 +32,8 @@ import {
 export async function getSharingData(
   currentSearchSource: ISearchSource,
   state: DiscoverAppState | SavedSearch,
-  services: { uiSettings: IUiSettingsClient; data: DataPublicPluginStart }
+  services: { uiSettings: IUiSettingsClient; data: DataPublicPluginStart },
+  isPlainRecord?: boolean
 ) {
   const { uiSettings: config, data } = services;
   const searchSource = currentSearchSource.createCopy();
@@ -57,7 +58,7 @@ export async function getSharingData(
     // conditionally add the time field column:
     let timeFieldName: string | undefined;
     const hideTimeColumn = config.get(DOC_HIDE_TIME_COLUMN_SETTING);
-    if (!hideTimeColumn && index && index.timeFieldName) {
+    if (!hideTimeColumn && index && index.timeFieldName && !isPlainRecord) {
       timeFieldName = index.timeFieldName;
     }
     if (timeFieldName && !columns.includes(timeFieldName)) {

--- a/test/functional/apps/discover/group2/_sql_view.ts
+++ b/test/functional/apps/discover/group2/_sql_view.ts
@@ -70,7 +70,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         expect(await testSubjects.exists('unifiedHistogramChart')).to.be(false);
         expect(await testSubjects.exists('unifiedHistogramQueryHits')).to.be(true);
         expect(await testSubjects.exists('discoverAlertsButton')).to.be(false);
-        expect(await testSubjects.exists('shareTopNavButton')).to.be(false);
+        expect(await testSubjects.exists('shareTopNavButton')).to.be(true);
         expect(await testSubjects.exists('docTableExpandToggleColumn')).to.be(false);
         expect(await testSubjects.exists('dataGridColumnSortingButton')).to.be(false);
         expect(await testSubjects.exists('fieldListFiltersFieldTypeFilterToggle')).to.be(true);


### PR DESCRIPTION
## Summary

Part of https://github.com/elastic/kibana/issues/154331
Enables the sharing menu for text based languages

<img width="2497" alt="image" src="https://user-images.githubusercontent.com/17003240/236152022-62aebfd0-3863-4ba9-8d2b-f6a6fc6a0bf6.png">

There are 2 significant changes from the dataview mode
1. The timefield is not populated on the csv report
2. We dont check if there is a persisted dataview. We don't want this for text based languages mode as this mode won't work with dataviews.

### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios