### PR TITLE
[Security Solution] Add technical preview tag to risk info panel and risk table tooltip

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/header_section/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/header_section/index.test.tsx
@@ -69,6 +69,21 @@ describe('HeaderSection', () => {
     expect(wrapper.find('[data-test-subj="header-section-subtitle"]').first().exists()).toBe(true);
   });
 
+  test('it renders the tooltip when provided', () => {
+    const tooltipContent = 'test tooltip content';
+    const tooltipTitle = 'test tooltip title';
+
+    const wrapper = mount(
+      <TestProviders>
+        <HeaderSection title="Test title" tooltip={tooltipContent} tooltipTitle={tooltipTitle} />
+      </TestProviders>
+    );
+
+    expect(wrapper.find('EuiIconTip').exists()).toBe(true);
+    expect(wrapper.find('EuiIconTip').prop('content')).toBe(tooltipContent);
+    expect(wrapper.find('EuiIconTip').prop('title')).toBe(tooltipTitle);
+  });
+
   test('it renders supplements when children provided', () => {
     const wrapper = mount(
       <TestProviders>

--- a/x-pack/plugins/security_solution/public/common/components/header_section/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/header_section/index.tsx
@@ -71,6 +71,7 @@ export interface HeaderSectionProps extends HeaderProps {
   inspectTitle?: React.ReactNode;
   titleSize?: EuiTitleSize;
   tooltip?: string;
+  tooltipTitle?: string;
 }
 
 export const getHeaderAlignment = ({
@@ -111,6 +112,7 @@ const HeaderSectionComponent: React.FC<HeaderSectionProps> = ({
   toggleQuery,
   toggleStatus = true,
   tooltip,
+  tooltipTitle,
 }) => {
   const toggle = useCallback(() => {
     if (toggleQuery) {
@@ -174,6 +176,7 @@ const HeaderSectionComponent: React.FC<HeaderSectionProps> = ({
                               {' '}
                               <EuiIconTip
                                 color="subdued"
+                                title={tooltipTitle}
                                 content={tooltip}
                                 size="l"
                                 type="iInCircle"

--- a/x-pack/plugins/security_solution/public/explore/components/risk_score/risk_information/index.tsx
+++ b/x-pack/plugins/security_solution/public/explore/components/risk_score/risk_information/index.tsx
@@ -21,15 +21,19 @@ import {
   EuiText,
   EuiTitle,
   useGeneratedHtmlId,
+  EuiBetaBadge,
+  useEuiTheme,
 } from '@elastic/eui';
 import React from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { css } from '@emotion/react';
 import { getRiskEntityTranslation } from '../translations';
 import * as i18n from './translations';
 import { useOnOpenCloseHandler } from '../../../../helper_hooks';
 import { RiskScore } from '../severity/common';
 import { RiskScoreEntity, RiskSeverity } from '../../../../../common/search_strategy';
 import { RiskScoreDocLink } from '../risk_score_onboarding/risk_score_doc_link';
+import { TECHNICAL_PREVIEW } from '../risk_score_onboarding/translations';
 
 const getTableColumns = (riskEntity: RiskScoreEntity): Array<EuiBasicTableColumn<TableItem>> => [
   {
@@ -109,6 +113,7 @@ const RiskInformationFlyout = ({
   handleOnClose: () => void;
   riskEntity: RiskScoreEntity;
 }) => {
+  const { euiTheme } = useEuiTheme();
   const simpleFlyoutTitleId = useGeneratedHtmlId({
     prefix: 'RiskInformation',
   });
@@ -125,6 +130,14 @@ const RiskInformationFlyout = ({
         <EuiTitle size="m">
           <h2 id={simpleFlyoutTitleId}>{i18n.TITLE(riskEntity)}</h2>
         </EuiTitle>
+        <EuiBetaBadge
+          label={TECHNICAL_PREVIEW}
+          size="s"
+          css={css`
+            color: ${euiTheme.colors.text};
+            margin-top: ${euiTheme.size.xxs};
+          `}
+        />
       </EuiFlyoutHeader>
       <EuiFlyoutBody>
         <EuiText size="s">

--- a/x-pack/plugins/security_solution/public/overview/components/entity_analytics/common/translations.ts
+++ b/x-pack/plugins/security_solution/public/overview/components/entity_analytics/common/translations.ts
@@ -40,3 +40,10 @@ export const USER_RISK_TABLE_TOOLTIP = i18n.translate(
       'The user risk table is not affected by the time range. This table shows the latest recorded risk score for each user.',
   }
 );
+
+export const RISK_TABLE_TOOLTIP_TITLE = i18n.translate(
+  'xpack.securitySolution.entityAnalytics.riskDashboard.tableTooltipTitle',
+  {
+    defaultMessage: 'In Technical Preview',
+  }
+);

--- a/x-pack/plugins/security_solution/public/overview/components/entity_analytics/risk_score/index.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/entity_analytics/risk_score/index.tsx
@@ -172,7 +172,12 @@ const EntityAnalyticsRiskScoresComponent = ({ riskEntity }: { riskEntity: RiskSc
           id={entity.tableQueryId}
           toggleStatus={toggleStatus}
           toggleQuery={setToggleStatus}
-          tooltip={commonI18n.HOST_RISK_TABLE_TOOLTIP}
+          tooltip={
+            riskEntity === RiskScoreEntity.host
+              ? commonI18n.HOST_RISK_TABLE_TOOLTIP
+              : commonI18n.USER_RISK_TABLE_TOOLTIP
+          }
+          tooltipTitle={commonI18n.RISK_TABLE_TOOLTIP_TITLE}
         >
           <RiskScoreHeaderContent
             entityDocLink={entity.docLink}


### PR DESCRIPTION
## Summary

issue: https://github.com/elastic/security-team/issues/6544
Mockup: https://github.com/elastic/security-team/issues/6544#issuecomment-1533372409

* Add tech preview tooltip title to risk score tables
* [extra] Fix user risk score table tooltip content (I found this bug during the implementation)
* Add tech preview badge to risk info panel


<img height="699" alt="Screenshot 2023-05-04 at 11 26 21" src="https://user-images.githubusercontent.com/1490444/236165628-cdbb0df6-61ca-4fab-98ee-70c6875aa218.png">
<img width="1518" alt="Screenshot 2023-05-04 at 11 26 58" src="https://user-images.githubusercontent.com/1490444/236165646-3d80c7b6-a6ea-4dc9-a87a-671c81c6e82f.png">
<img width="1492" alt="Screenshot 2023-05-04 at 11 27 07" src="https://user-images.githubusercontent.com/1490444/236165655-72f62659-7e6e-421d-9d11-0da481732b98.png">



### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->