### PR TITLE
[Synthetics] Prevent location id query param on form

### DIFF
--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/monitor_details_portal.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/monitor_details_portal.tsx
@@ -16,18 +16,24 @@ interface Props {
   name: string;
   configId: string;
   locationId?: string;
+  updateUrl?: boolean;
 }
 
-export const MonitorDetailsLinkPortal = ({ name, configId, locationId }: Props) => {
+export const MonitorDetailsLinkPortal = ({ name, configId, locationId, updateUrl }: Props) => {
   return (
     <InPortal node={MonitorDetailsLinkPortalNode}>
-      <MonitorDetailsLink name={name} configId={configId} locationId={locationId} />
+      <MonitorDetailsLink
+        name={name}
+        configId={configId}
+        locationId={locationId}
+        updateUrl={updateUrl}
+      />
     </InPortal>
   );
 };
 
-export const MonitorDetailsLink = ({ name, configId, locationId }: Props) => {
-  const selectedLocation = useSelectedLocation();
+export const MonitorDetailsLink = ({ name, configId, locationId, updateUrl }: Props) => {
+  const selectedLocation = useSelectedLocation(updateUrl);
 
   let locId = locationId;
 

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/monitor_edit_page.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/monitor_edit_page.tsx
@@ -99,6 +99,7 @@ export const MonitorEditPage: React.FC = () => {
         <MonitorDetailsLinkPortal
           configId={data?.attributes[ConfigKey.CONFIG_ID]}
           name={data?.attributes.name}
+          updateUrl={false}
         />
       </MonitorForm>
     </>

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/hooks/use_selected_location.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/hooks/use_selected_location.tsx
@@ -10,7 +10,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { selectSelectedLocationId, setMonitorDetailsLocationAction } from '../../../state';
 import { useUrlParams, useLocations } from '../../../hooks';
 
-export const useSelectedLocation = () => {
+export const useSelectedLocation = (updateUrl = true) => {
   const [getUrlParams, updateUrlParams] = useUrlParams();
   const { locations } = useLocations();
   const selectedLocationId = useSelector(selectSelectedLocationId);
@@ -21,7 +21,7 @@ export const useSelectedLocation = () => {
   useEffect(() => {
     if (!urlLocationId) {
       const firstLocationId = locations?.[0]?.id;
-      if (firstLocationId) {
+      if (firstLocationId && updateUrl) {
         updateUrlParams({ locationId: firstLocationId }, true);
       }
     }
@@ -29,7 +29,7 @@ export const useSelectedLocation = () => {
     if (urlLocationId && selectedLocationId !== urlLocationId) {
       dispatch(setMonitorDetailsLocationAction(urlLocationId));
     }
-  }, [dispatch, updateUrlParams, locations, urlLocationId, selectedLocationId]);
+  }, [dispatch, updateUrlParams, locations, urlLocationId, selectedLocationId, updateUrl]);
 
   return useMemo(
     () => locations.find((loc) => loc.id === urlLocationId) ?? null,


### PR DESCRIPTION
## Summary

 Prevent location id query param on form.

Earlier form was appending `location_id` to url

<img width="1041" alt="image" src="https://user-images.githubusercontent.com/3505601/236409084-f251a27c-83e2-4688-972c-e3708a678e76.png">


<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->