### PR TITLE
[Visualizations][Lens] Hide incompatible actions from the panels

### DIFF
--- a/src/plugins/visualizations/public/actions/edit_in_lens_action.tsx
+++ b/src/plugins/visualizations/public/actions/edit_in_lens_action.tsx
@@ -17,7 +17,13 @@ import { IEmbeddable, ViewMode } from '@kbn/embeddable-plugin/public';
 import { Action } from '@kbn/ui-actions-plugin/public';
 import { VisualizeEmbeddable } from '../embeddable';
 import { DASHBOARD_VISUALIZATION_PANEL_TRIGGER } from '../triggers';
-import { getUiActions, getApplication, getEmbeddable, getUsageCollection } from '../services';
+import {
+  getUiActions,
+  getApplication,
+  getEmbeddable,
+  getUsageCollection,
+  getCapabilities,
+} from '../services';
 
 export const ACTION_EDIT_IN_LENS = 'ACTION_EDIT_IN_LENS';
 
@@ -116,7 +122,8 @@ export class EditInLensAction implements Action<EditInLensContext> {
 
   async isCompatible(context: ActionExecutionContext<EditInLensContext>) {
     const { embeddable } = context;
-    if (!isVisualizeEmbeddable(embeddable)) {
+    const { visualize } = getCapabilities();
+    if (!isVisualizeEmbeddable(embeddable) || !visualize.show) {
       return false;
     }
     const vis = embeddable.getVis();

--- a/src/plugins/visualizations/public/embeddable/create_vis_embeddable_from_object.ts
+++ b/src/plugins/visualizations/public/embeddable/create_vis_embeddable_from_object.ts
@@ -62,6 +62,7 @@ export const createVisEmbeddableFromObject =
       const capabilities = {
         visualizeSave: Boolean(getCapabilities().visualize.save),
         dashboardSave: Boolean(getCapabilities().dashboard?.showWriteControls),
+        visualizeOpen: Boolean(getCapabilities().visualize?.show),
       };
 
       return createVisualizeEmbeddableAsync(

--- a/src/plugins/visualizations/public/embeddable/visualize_embeddable.tsx
+++ b/src/plugins/visualizations/public/embeddable/visualize_embeddable.tsx
@@ -62,7 +62,7 @@ export interface VisualizeEmbeddableConfiguration {
   indexPatterns?: DataView[];
   editPath: string;
   editUrl: string;
-  capabilities: { visualizeSave: boolean; dashboardSave: boolean };
+  capabilities: { visualizeSave: boolean; dashboardSave: boolean; visualizeOpen: boolean };
   deps: VisualizeEmbeddableFactoryDeps;
 }
 
@@ -171,7 +171,9 @@ export class VisualizeEmbeddable
 
     if (this.attributeService) {
       const isByValue = !this.inputIsRefType(initialInput);
-      const editable = capabilities.visualizeSave || (isByValue && capabilities.dashboardSave);
+      const editable =
+        capabilities.visualizeSave ||
+        (isByValue && capabilities.dashboardSave && capabilities.visualizeOpen);
       this.updateOutput({ ...this.getOutput(), editable });
     }
 

--- a/x-pack/plugins/lens/public/embeddable/embeddable.test.tsx
+++ b/x-pack/plugins/lens/public/embeddable/embeddable.test.tsx
@@ -1192,4 +1192,25 @@ describe('embeddable', () => {
       })
     );
   });
+
+  it('should not be editable for no visualize library privileges', async () => {
+    const embeddable = new Embeddable(
+      getEmbeddableProps({
+        capabilities: {
+          canSaveDashboards: false,
+          canSaveVisualizations: true,
+          canOpenVisualizations: false,
+          discover: {},
+          navLinks: {},
+        },
+      }),
+      {
+        timeRange: {
+          from: 'now-15m',
+          to: 'now',
+        },
+      } as LensEmbeddableInput
+    );
+    expect(embeddable.getOutput().editable).toBeUndefined();
+  });
 });

--- a/x-pack/plugins/lens/public/embeddable/embeddable.test.tsx
+++ b/x-pack/plugins/lens/public/embeddable/embeddable.test.tsx
@@ -166,6 +166,7 @@ describe('embeddable', () => {
       capabilities: {
         canSaveDashboards: true,
         canSaveVisualizations: true,
+        canOpenVisualizations: true,
         discover: {},
         navLinks: {},
       },
@@ -361,6 +362,7 @@ describe('embeddable', () => {
         capabilities: {
           canSaveDashboards: true,
           canSaveVisualizations: true,
+          canOpenVisualizations: true,
           discover: {},
           navLinks: {},
         },
@@ -413,6 +415,7 @@ describe('embeddable', () => {
         capabilities: {
           canSaveDashboards: true,
           canSaveVisualizations: true,
+          canOpenVisualizations: true,
           discover: {},
           navLinks: {},
         },
@@ -940,6 +943,7 @@ describe('embeddable', () => {
           capabilities: {
             canSaveDashboards: true,
             canSaveVisualizations: true,
+            canOpenVisualizations: true,
             discover: {},
             navLinks: {},
           },
@@ -1039,6 +1043,7 @@ describe('embeddable', () => {
           capabilities: {
             canSaveDashboards: true,
             canSaveVisualizations: true,
+            canOpenVisualizations: true,
             discover: {},
             navLinks: {},
           },
@@ -1135,6 +1140,7 @@ describe('embeddable', () => {
         capabilities: {
           canSaveDashboards: true,
           canSaveVisualizations: true,
+          canOpenVisualizations: true,
           discover: {},
           navLinks: {},
         },

--- a/x-pack/plugins/lens/public/embeddable/embeddable.tsx
+++ b/x-pack/plugins/lens/public/embeddable/embeddable.tsx
@@ -208,6 +208,7 @@ export interface LensEmbeddableDeps {
   getTriggerCompatibleActions?: UiActionsStart['getTriggerCompatibleActions'];
   capabilities: {
     canSaveVisualizations: boolean;
+    canOpenVisualizations: boolean;
     canSaveDashboards: boolean;
     navLinks: Capabilities['navLinks'];
     discover: Capabilities['discover'];
@@ -1353,7 +1354,9 @@ export class Embeddable
   private getIsEditable() {
     return (
       this.deps.capabilities.canSaveVisualizations ||
-      (!this.inputIsRefType(this.getInput()) && this.deps.capabilities.canSaveDashboards)
+      (!this.inputIsRefType(this.getInput()) &&
+        this.deps.capabilities.canSaveDashboards &&
+        this.deps.capabilities.canOpenVisualizations)
     );
   }
 

--- a/x-pack/plugins/lens/public/embeddable/embeddable_factory.ts
+++ b/x-pack/plugins/lens/public/embeddable/embeddable_factory.ts
@@ -140,6 +140,7 @@ export class EmbeddableFactory implements EmbeddableFactoryDefinition {
           capabilities: {
             canSaveDashboards: Boolean(capabilities.dashboard?.showWriteControls),
             canSaveVisualizations: Boolean(capabilities.visualize.save),
+            canOpenVisualizations: Boolean(capabilities.visualize.show),
             navLinks: capabilities.navLinks,
             discover: capabilities.discover,
           },


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/156119
Closes https://github.com/elastic/kibana/issues/156114

This PR

1. Removes the convert to Lens action if visualize permissions are set to None
<img width="467" alt="image" src="https://user-images.githubusercontent.com/17003240/236183482-b6e3cfe9-a77b-44d5-9909-1580c0796db2.png">

2. Removes the edit actions if visualize permisions are set to None
<img width="938" alt="image" src="https://user-images.githubusercontent.com/17003240/236183601-9a715339-2ab7-47d8-8b89-c10bdb03938e.png">


### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios