### PR TITLE
[8.8] [TSVB] Remove flakiness on resetPage (#156484)

### DIFF
--- a/test/functional/apps/visualize/group4/_tsvb_chart.ts
+++ b/test/functional/apps/visualize/group4/_tsvb_chart.ts
@@ -44,7 +44,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await visualize.navigateToNewVisualization();
       await visualize.clickVisualBuilder();
       await visualBuilder.checkVisualBuilderIsPresent();
-      await visualBuilder.resetPage();
+      await visualBuilder.setTime();
     });
 
     describe('metric', () => {
@@ -430,7 +430,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     describe('switch panel interval test', () => {
       beforeEach(async () => {
-        await visualBuilder.resetPage();
+        await visualBuilder.setTime();
         await visualBuilder.clickMetric();
         await visualBuilder.checkMetricTabIsPresent();
         await visualBuilder.clickPanelOptions('metric');
@@ -551,7 +551,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       beforeEach(async () => {
-        await visualBuilder.resetPage();
+        await visualBuilder.setTime();
         await visualBuilder.selectAggType('Average');
         await visualBuilder.setFieldForAggregation('bytes');
         await visualBuilder.setMetricsGroupByTerms('machine.os.raw');

--- a/test/functional/apps/visualize/group5/_tsvb_time_series.ts
+++ b/test/functional/apps/visualize/group5/_tsvb_time_series.ts
@@ -45,7 +45,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
     describe('Time Series', () => {
       beforeEach(async () => {
-        await visualBuilder.resetPage();
+        await visualBuilder.setTime();
         await visualBuilder.clickPanelOptions('timeSeries');
         await visualBuilder.setDropLastBucket(true);
         await visualBuilder.clickDataTab('timeSeries');

--- a/test/functional/apps/visualize/group6/_tsvb_markdown.ts
+++ b/test/functional/apps/visualize/group6/_tsvb_markdown.ts
@@ -37,7 +37,9 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     describe('markdown', () => {
       before(async () => {
         await visualize.initTests();
-        await visualBuilder.resetPage();
+        await visualize.navigateToNewVisualization();
+        await visualize.clickVisualBuilder();
+        await visualBuilder.checkVisualBuilderIsPresent();
         await visualBuilder.clickMarkdown();
         await timePicker.setAbsoluteRange(
           'Sep 22, 2015 @ 06:00:00.000',
@@ -149,7 +151,10 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
       describe('applying field formats from Advanced Settings for values', () => {
         before(async () => {
-          await visualBuilder.resetPage();
+          await visualize.navigateToNewVisualization();
+          await visualize.clickVisualBuilder();
+          await visualBuilder.checkVisualBuilderIsPresent();
+          await visualBuilder.setTime();
           await visualBuilder.clickMarkdown();
           await visualBuilder.markdownSwitchSubTab('markdown');
           await visualBuilder.enterMarkdown('{{ average_of_bytes.last.formatted }}');

--- a/test/functional/apps/visualize/group6/_tsvb_table.ts
+++ b/test/functional/apps/visualize/group6/_tsvb_table.ts
@@ -26,7 +26,10 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     });
     describe('table', () => {
       beforeEach(async () => {
-        await visualBuilder.resetPage('Sep 22, 2015 @ 06:00:00.000', 'Sep 22, 2015 @ 11:00:00.000');
+        await visualize.navigateToNewVisualization();
+        await visualize.clickVisualBuilder();
+        await visualBuilder.checkVisualBuilderIsPresent();
+        await visualBuilder.setTime('Sep 22, 2015 @ 06:00:00.000', 'Sep 22, 2015 @ 11:00:00.000');
         await visualBuilder.clickTable();
 
         await visualBuilder.checkTableTabIsPresent();

--- a/test/functional/apps/visualize/group6/_tsvb_tsdb_basic.ts
+++ b/test/functional/apps/visualize/group6/_tsvb_tsdb_basic.ts
@@ -11,7 +11,7 @@ import expect from '@kbn/expect';
 import { FtrProviderContext } from '../../../ftr_provider_context';
 
 export default function ({ getPageObjects, getService }: FtrProviderContext) {
-  const { visualBuilder } = getPageObjects(['visualBuilder']);
+  const { visualBuilder, visualize } = getPageObjects(['visualBuilder', 'visualize']);
   const log = getService('log');
   const kibanaServer = getService('kibanaServer');
   const esArchiver = getService('esArchiver');
@@ -43,7 +43,10 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     });
 
     beforeEach(async () => {
-      await visualBuilder.resetPage();
+      await visualize.navigateToNewVisualization();
+      await visualize.clickVisualBuilder();
+      await visualBuilder.checkVisualBuilderIsPresent();
+      await visualBuilder.setTime();
     });
 
     it('should render from a tsdb dataView regular fields with no issues', async () => {

--- a/test/functional/page_objects/visual_builder_page.ts
+++ b/test/functional/page_objects/visual_builder_page.ts
@@ -45,9 +45,16 @@ export class VisualBuilderPageObject extends FtrService {
     this.log.debug('Wait for initializing TSVB editor');
     await this.checkVisualBuilderIsPresent();
     this.log.debug('Set absolute time range from "' + fromTime + '" to "' + toTime + '"');
-    await this.timePicker.setAbsoluteRange(fromTime, toTime);
+    await this.setTime(fromTime, toTime);
     // 2 sec sleep until https://github.com/elastic/kibana/issues/46353 is fixed
     await this.common.sleep(2000);
+  }
+
+  public async setTime(
+    fromTime = 'Sep 19, 2015 @ 06:31:44.000',
+    toTime = 'Sep 22, 2015 @ 18:31:44.000'
+  ) {
+    await this.timePicker.setAbsoluteRange(fromTime, toTime);
   }
 
   public async checkTabIsLoaded(testSubj: string, name: string) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.8`:
 - [[TSVB] Remove flakiness on resetPage (#156484)](https://github.com/elastic/kibana/pull/156484)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Stratoula Kalafateli","email":"efstratia.kalafateli@elastic.co"},"sourceCommit":{"committedDate":"2023-05-04T09:33:29Z","message":"[TSVB] Remove flakiness on resetPage (#156484)\n\n## Summary\r\n\r\nCloses https://github.com/elastic/kibana/issues/156457\r\nCloses https://github.com/elastic/kibana/issues/156452\r\nCloses https://github.com/elastic/kibana/issues/156439\r\nCloses https://github.com/elastic/kibana/issues/156400\r\nCloses https://github.com/elastic/kibana/issues/156599\r\nCloses https://github.com/elastic/kibana/issues/156502\r\nCloses https://github.com/elastic/kibana/issues/156501\r\n\r\nthe resetPage function is creating this flakiness. I cant figure out why\r\nbut is on the navigateToUrl function. Sometimes it reports #create and\r\nsometimes without the hash. The navigateToUrl is not needed as it is\r\nalready done on another function. The only thing that is needed is the\r\nsetTimePicker function.\r\n\r\nFlaky runer (100 times)\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2210","sha":"e5f6f96e9cd365fd8ae8e7f250ab3d67f56514f3","branchLabelMapping":{"^v8.9.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:TSVB","Team:Visualizations","release_note:skip","backport:skip","v8.9.0"],"number":156484,"url":"https://github.com/elastic/kibana/pull/156484","mergeCommit":{"message":"[TSVB] Remove flakiness on resetPage (#156484)\n\n## Summary\r\n\r\nCloses https://github.com/elastic/kibana/issues/156457\r\nCloses https://github.com/elastic/kibana/issues/156452\r\nCloses https://github.com/elastic/kibana/issues/156439\r\nCloses https://github.com/elastic/kibana/issues/156400\r\nCloses https://github.com/elastic/kibana/issues/156599\r\nCloses https://github.com/elastic/kibana/issues/156502\r\nCloses https://github.com/elastic/kibana/issues/156501\r\n\r\nthe resetPage function is creating this flakiness. I cant figure out why\r\nbut is on the navigateToUrl function. Sometimes it reports #create and\r\nsometimes without the hash. The navigateToUrl is not needed as it is\r\nalready done on another function. The only thing that is needed is the\r\nsetTimePicker function.\r\n\r\nFlaky runer (100 times)\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2210","sha":"e5f6f96e9cd365fd8ae8e7f250ab3d67f56514f3"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.9.0","labelRegex":"^v8.9.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/156484","number":156484,"mergeCommit":{"message":"[TSVB] Remove flakiness on resetPage (#156484)\n\n## Summary\r\n\r\nCloses https://github.com/elastic/kibana/issues/156457\r\nCloses https://github.com/elastic/kibana/issues/156452\r\nCloses https://github.com/elastic/kibana/issues/156439\r\nCloses https://github.com/elastic/kibana/issues/156400\r\nCloses https://github.com/elastic/kibana/issues/156599\r\nCloses https://github.com/elastic/kibana/issues/156502\r\nCloses https://github.com/elastic/kibana/issues/156501\r\n\r\nthe resetPage function is creating this flakiness. I cant figure out why\r\nbut is on the navigateToUrl function. Sometimes it reports #create and\r\nsometimes without the hash. The navigateToUrl is not needed as it is\r\nalready done on another function. The only thing that is needed is the\r\nsetTimePicker function.\r\n\r\nFlaky runer (100 times)\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2210","sha":"e5f6f96e9cd365fd8ae8e7f250ab3d67f56514f3"}}]}] BACKPORT-->