### PR TITLE
[ML] Rename `curated` model type to `elastic`

### DIFF
--- a/x-pack/packages/ml/trained_models_utils/src/constants/trained_models.ts
+++ b/x-pack/packages/ml/trained_models_utils/src/constants/trained_models.ts
@@ -40,16 +40,13 @@ export const BUILT_IN_MODEL_TYPE = i18n.translate(
   { defaultMessage: 'built-in' }
 );
 
-export const CURATED_MODEL_TYPE = i18n.translate(
-  'xpack.ml.trainedModels.modelsList.curatedModelLabel',
-  { defaultMessage: 'curated' }
-);
+export const ELASTIC_MODEL_TYPE = 'elastic';
 
 export const BUILT_IN_MODEL_TAG = 'prepackaged';
 
-export const CURATED_MODEL_TAG = 'curated';
+export const ELASTIC_MODEL_TAG = 'elastic';
 
-export const CURATED_MODEL_DEFINITIONS = {
+export const ELASTIC_MODEL_DEFINITIONS = {
   '.elser_model_1': {
     config: {
       input: {

--- a/x-pack/plugins/ml/public/application/model_management/model_actions.tsx
+++ b/x-pack/plugins/ml/public/application/model_management/model_actions.tsx
@@ -16,7 +16,7 @@ import {
   TRAINED_MODEL_TYPE,
 } from '@kbn/ml-trained-models-utils';
 import {
-  CURATED_MODEL_TAG,
+  ELASTIC_MODEL_TAG,
   MODEL_STATE,
 } from '@kbn/ml-trained-models-utils/src/constants/trained_models';
 import { useTrainedModelsApiService } from '../services/ml_api_service/trained_models';
@@ -357,7 +357,7 @@ export function useModelActions({
         icon: 'download',
         type: 'icon',
         isPrimary: true,
-        available: (item) => item.tags.includes(CURATED_MODEL_TAG),
+        available: (item) => item.tags.includes(ELASTIC_MODEL_TAG),
         enabled: (item) => !item.state && !isLoading,
         onClick: async (item) => {
           try {

--- a/x-pack/plugins/ml/public/application/model_management/models_list.tsx
+++ b/x-pack/plugins/ml/public/application/model_management/models_list.tsx
@@ -34,9 +34,9 @@ import {
 } from '@kbn/ml-trained-models-utils';
 import { isDefined } from '@kbn/ml-is-defined';
 import {
-  CURATED_MODEL_DEFINITIONS,
-  CURATED_MODEL_TAG,
-  CURATED_MODEL_TYPE,
+  ELASTIC_MODEL_DEFINITIONS,
+  ELASTIC_MODEL_TAG,
+  ELASTIC_MODEL_TYPE,
   MODEL_STATE,
 } from '@kbn/ml-trained-models-utils/src/constants/trained_models';
 import { TechnicalPreviewBadge } from '../components/technical_preview_badge';
@@ -143,8 +143,8 @@ export const ModelsList: FC<Props> = ({
     []
   );
 
-  const isCuratedModel = useCallback(
-    (item: ModelItem) => item.tags.includes(CURATED_MODEL_TAG),
+  const isElasticModel = useCallback(
+    (item: ModelItem) => item.tags.includes(ELASTIC_MODEL_TAG),
     []
   );
 
@@ -196,7 +196,7 @@ export const ModelsList: FC<Props> = ({
                   model.model_type,
                   ...Object.keys(model.inference_config),
                   ...(isBuiltInModel(model as ModelItem) ? [BUILT_IN_MODEL_TYPE] : []),
-                  ...(isCuratedModel(model as ModelItem) ? [CURATED_MODEL_TYPE] : []),
+                  ...(isElasticModel(model as ModelItem) ? [ELASTIC_MODEL_TYPE] : []),
                 ],
               }
             : {}),
@@ -286,7 +286,7 @@ export const ModelsList: FC<Props> = ({
         });
 
         const curatedModels = models.filter((model) =>
-          CURATED_MODEL_DEFINITIONS.hasOwnProperty(model.model_id)
+          ELASTIC_MODEL_DEFINITIONS.hasOwnProperty(model.model_id)
         );
         if (curatedModels.length > 0) {
           for (const model of curatedModels) {
@@ -545,7 +545,7 @@ export const ModelsList: FC<Props> = ({
         selectable: (item) =>
           !isPopulatedObject(item.pipelines) &&
           !isBuiltInModel(item) &&
-          !(isCuratedModel(item) && !item.state),
+          !(isElasticModel(item) && !item.state),
         onSelectionChange: (selectedItems) => {
           setSelectedModels(selectedItems);
         },
@@ -584,13 +584,13 @@ export const ModelsList: FC<Props> = ({
 
   const resultItems = useMemo<ModelItem[]>(() => {
     const idSet = new Set(items.map((i) => i.model_id));
-    const notDownloaded: ModelItem[] = Object.entries(CURATED_MODEL_DEFINITIONS)
+    const notDownloaded: ModelItem[] = Object.entries(ELASTIC_MODEL_DEFINITIONS)
       .filter(([modelId]) => !idSet.has(modelId))
       .map(([modelId, modelDefinition]) => {
         return {
           model_id: modelId,
-          type: [CURATED_MODEL_TYPE],
-          tags: [CURATED_MODEL_TAG],
+          type: [ELASTIC_MODEL_TYPE],
+          tags: [ELASTIC_MODEL_TAG],
           putModelConfig: modelDefinition.config,
           description: modelDefinition.description,
         } as ModelItem;

--- a/x-pack/plugins/ml/public/application/model_management/models_list.tsx
+++ b/x-pack/plugins/ml/public/application/model_management/models_list.tsx
@@ -285,11 +285,11 @@ export const ModelsList: FC<Props> = ({
             : '';
         });
 
-        const curatedModels = models.filter((model) =>
+        const elasticModels = models.filter((model) =>
           ELASTIC_MODEL_DEFINITIONS.hasOwnProperty(model.model_id)
         );
-        if (curatedModels.length > 0) {
-          for (const model of curatedModels) {
+        if (elasticModels.length > 0) {
+          for (const model of elasticModels) {
             if (model.state === MODEL_STATE.STARTED) {
               // no need to check for the download status if the model has been deployed
               continue;


### PR DESCRIPTION
## Summary

Rename the `curated` model type and tag to `elastic`




<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->