### PR TITLE
[Logs onboarding] StepsFooter outside of main panel

### DIFF
--- a/x-pack/plugins/observability_onboarding/public/components/app/custom_logs/wizard/collect_logs.tsx
+++ b/x-pack/plugins/observability_onboarding/public/components/app/custom_logs/wizard/collect_logs.tsx
@@ -42,7 +42,21 @@ export function CollectLogs() {
   }
 
   return (
-    <StepPanel title="">
+    <StepPanel
+      title=""
+      panelFooter={
+        <StepPanelFooter
+          items={[
+            <EuiButton color="ghost" fill onClick={onBack}>
+              Back
+            </EuiButton>,
+            <EuiButton color="primary" fill onClick={onContinue}>
+              Continue
+            </EuiButton>,
+          ]}
+        />
+      }
+    >
       <StepPanelContent>
         <EuiText color="subdued">
           <p>
@@ -90,16 +104,6 @@ export function CollectLogs() {
           </EuiFlexItem>
         </EuiFlexGroup>
       </StepPanelContent>
-      <StepPanelFooter
-        items={[
-          <EuiButton color="ghost" fill onClick={onBack}>
-            Back
-          </EuiButton>,
-          <EuiButton color="primary" fill onClick={onContinue}>
-            Continue
-          </EuiButton>,
-        ]}
-      />
     </StepPanel>
   );
 }

--- a/x-pack/plugins/observability_onboarding/public/components/app/custom_logs/wizard/configure_logs.tsx
+++ b/x-pack/plugins/observability_onboarding/public/components/app/custom_logs/wizard/configure_logs.tsx
@@ -63,7 +63,26 @@ export function ConfigureLogs() {
   }
 
   return (
-    <StepPanel title="Choose what logs to collect">
+    <StepPanel
+      title="Choose what logs to collect"
+      panelFooter={
+        <StepPanelFooter
+          items={[
+            <EuiButton color="ghost" fill onClick={onBack}>
+              Back
+            </EuiButton>,
+            <EuiButton
+              color="primary"
+              fill
+              onClick={onContinue}
+              isDisabled={!(logsType && uploadType)}
+            >
+              Continue
+            </EuiButton>,
+          ]}
+        />
+      }
+    >
       <StepPanelContent>
         <LogsTypeSection
           title="System logs"
@@ -152,21 +171,6 @@ export function ConfigureLogs() {
           </EuiFlexGroup>
         </LogsTypeSection>
       </StepPanelContent>
-      <StepPanelFooter
-        items={[
-          <EuiButton color="ghost" fill onClick={onBack}>
-            Back
-          </EuiButton>,
-          <EuiButton
-            color="primary"
-            fill
-            onClick={onContinue}
-            isDisabled={!(logsType && uploadType)}
-          >
-            Continue
-          </EuiButton>,
-        ]}
-      />
     </StepPanel>
   );
 }

--- a/x-pack/plugins/observability_onboarding/public/components/app/custom_logs/wizard/import_data.tsx
+++ b/x-pack/plugins/observability_onboarding/public/components/app/custom_logs/wizard/import_data.tsx
@@ -42,7 +42,21 @@ export function CollectLogs() {
   }
 
   return (
-    <StepPanel title="">
+    <StepPanel
+      title=""
+      panelFooter={
+        <StepPanelFooter
+          items={[
+            <EuiButton color="ghost" fill onClick={onBack}>
+              Back
+            </EuiButton>,
+            <EuiButton color="primary" fill onClick={onContinue}>
+              Continue
+            </EuiButton>,
+          ]}
+        />
+      }
+    >
       <StepPanelContent>
         <EuiText color="subdued">
           <p>
@@ -90,16 +104,6 @@ export function CollectLogs() {
           </EuiFlexItem>
         </EuiFlexGroup>
       </StepPanelContent>
-      <StepPanelFooter
-        items={[
-          <EuiButton color="ghost" fill onClick={onBack}>
-            Back
-          </EuiButton>,
-          <EuiButton color="primary" fill onClick={onContinue}>
-            Continue
-          </EuiButton>,
-        ]}
-      />
     </StepPanel>
   );
 }

--- a/x-pack/plugins/observability_onboarding/public/components/app/custom_logs/wizard/inspect.tsx
+++ b/x-pack/plugins/observability_onboarding/public/components/app/custom_logs/wizard/inspect.tsx
@@ -17,7 +17,18 @@ import { useWizard } from '.';
 export function Inspect() {
   const { goBack, getState, getPath, getUsage } = useWizard();
   return (
-    <StepPanel title="Inspect wizard">
+    <StepPanel
+      title="Inspect wizard"
+      panelFooter={
+        <StepPanelFooter
+          items={[
+            <EuiButton color="ghost" fill onClick={goBack}>
+              Back
+            </EuiButton>,
+          ]}
+        />
+      }
+    >
       <StepPanelContent>
         <EuiTitle size="s">
           <h3>State</h3>
@@ -34,13 +45,6 @@ export function Inspect() {
         </EuiTitle>
         <pre>{JSON.stringify(getUsage(), null, 4)}</pre>
       </StepPanelContent>
-      <StepPanelFooter
-        items={[
-          <EuiButton color="ghost" fill onClick={goBack}>
-            Back
-          </EuiButton>,
-        ]}
-      />
     </StepPanel>
   );
 }

--- a/x-pack/plugins/observability_onboarding/public/components/app/custom_logs/wizard/install_elastic_agent.tsx
+++ b/x-pack/plugins/observability_onboarding/public/components/app/custom_logs/wizard/install_elastic_agent.tsx
@@ -58,7 +58,21 @@ export function InstallElasticAgent() {
   }
 
   return (
-    <StepPanel title="Install the Elastic Agent">
+    <StepPanel
+      title="Install the Elastic Agent"
+      panelFooter={
+        <StepPanelFooter
+          items={[
+            <EuiButton color="ghost" fill onClick={onBack}>
+              Back
+            </EuiButton>,
+            <EuiButton color="primary" fill onClick={onContinue}>
+              Continue
+            </EuiButton>,
+          ]}
+        />
+      }
+    >
       <StepPanelContent>
         <EuiText color="subdued">
           <p>
@@ -130,16 +144,6 @@ export function InstallElasticAgent() {
           </EuiFlexGroup>
         </LogsTypeSection>
       </StepPanelContent>
-      <StepPanelFooter
-        items={[
-          <EuiButton color="ghost" fill onClick={onBack}>
-            Back
-          </EuiButton>,
-          <EuiButton color="primary" fill onClick={onContinue}>
-            Continue
-          </EuiButton>,
-        ]}
-      />
     </StepPanel>
   );
 }

--- a/x-pack/plugins/observability_onboarding/public/components/app/custom_logs/wizard/name_logs.tsx
+++ b/x-pack/plugins/observability_onboarding/public/components/app/custom_logs/wizard/name_logs.tsx
@@ -33,7 +33,26 @@ export function NameLogs() {
   }
 
   return (
-    <StepPanel title="Give your logs a name">
+    <StepPanel
+      title="Give your logs a name"
+      panelFooter={
+        <StepPanelFooter
+          items={[
+            <EuiButtonEmpty href="/app/observability/overview">
+              Skip for now
+            </EuiButtonEmpty>,
+            <EuiButton
+              color="primary"
+              fill
+              onClick={onContinue}
+              isDisabled={!datasetName}
+            >
+              Save and Continue
+            </EuiButton>,
+          ]}
+        />
+      }
+    >
       <StepPanelContent>
         <EuiText color="subdued">
           <p>Pick a name for your logs, this will become your dataset name.</p>
@@ -52,21 +71,6 @@ export function NameLogs() {
           </EuiFormRow>
         </EuiForm>
       </StepPanelContent>
-      <StepPanelFooter
-        items={[
-          <EuiButtonEmpty href="/app/observability/overview">
-            Skip for now
-          </EuiButtonEmpty>,
-          <EuiButton
-            color="primary"
-            fill
-            onClick={onContinue}
-            isDisabled={!datasetName}
-          >
-            Save and Continue
-          </EuiButton>,
-        ]}
-      />
     </StepPanel>
   );
 }

--- a/x-pack/plugins/observability_onboarding/public/components/app/custom_logs/wizard/select_logs.tsx
+++ b/x-pack/plugins/observability_onboarding/public/components/app/custom_logs/wizard/select_logs.tsx
@@ -45,6 +45,18 @@ export function SelectLogs() {
           defaultMessage: 'What logs do you want to collect?',
         }
       )}
+      panelFooter={
+        <StepPanelFooter
+          items={[
+            <EuiButton color="ghost" fill onClick={onBack}>
+              {i18n.translate('xpack.observability_onboarding.steps.back', {
+                defaultMessage: 'Back',
+              })}
+            </EuiButton>,
+            <></>,
+          ]}
+        />
+      }
     >
       <StepPanelContent>
         <EuiFlexGroup>
@@ -187,16 +199,6 @@ export function SelectLogs() {
           </EuiLink>
         </LogsTypeSection>
       </StepPanelContent>
-      <StepPanelFooter
-        items={[
-          <EuiButton color="ghost" fill onClick={onBack}>
-            {i18n.translate('xpack.observability_onboarding.steps.back', {
-              defaultMessage: 'Back',
-            })}
-          </EuiButton>,
-          <></>,
-        ]}
-      />
     </StepPanel>
   );
 }

--- a/x-pack/plugins/observability_onboarding/public/components/shared/step_panel.tsx
+++ b/x-pack/plugins/observability_onboarding/public/components/shared/step_panel.tsx
@@ -11,29 +11,35 @@ import {
   EuiFlexItem,
   EuiPanel,
   EuiPanelProps,
+  EuiSpacer,
   EuiTitle,
 } from '@elastic/eui';
 
 interface StepPanelProps {
   title: string;
   panelProps?: EuiPanelProps;
+  panelFooter?: ReactNode;
   children?: ReactNode;
 }
 
 export function StepPanel(props: StepPanelProps) {
-  const { title, children } = props;
+  const { title, children, panelFooter } = props;
   const panelProps = props.panelProps ?? null;
   return (
-    <EuiPanel {...panelProps}>
-      <EuiFlexGroup direction="column">
-        <EuiFlexItem>
-          <EuiTitle size="m">
-            <h2>{title}</h2>
-          </EuiTitle>
-        </EuiFlexItem>
-        {children}
-      </EuiFlexGroup>
-    </EuiPanel>
+    <>
+      <EuiPanel {...panelProps}>
+        <EuiFlexGroup direction="column">
+          <EuiFlexItem>
+            <EuiTitle size="m">
+              <h2>{title}</h2>
+            </EuiTitle>
+          </EuiFlexItem>
+          {children}
+        </EuiFlexGroup>
+      </EuiPanel>
+      <EuiSpacer size="l" />
+      {panelFooter}
+    </>
   );
 }
 


### PR DESCRIPTION
In [recent designs](https://www.figma.com/proto/pwCYy8HrwDXcT3LJtIKclP/Logs%2B---Onboarding-flow?node-id=1120-480962&scaling=scale-down&page-id=1019%3A467571&starting-point-node-id=1039%3A479166) the options to move backwards and forward in the wizard are outside of the main panel

<img width="1453" alt="image" src="https://user-images.githubusercontent.com/1313018/236216521-da2fd78a-b34d-45f6-b084-809ed615dadc.png">

In this PR we are adding the `panelFooter` property to `StepPanel` so we have control over that aspect. This is how it will look like after this PR:

<img width="1747" alt="image" src="https://user-images.githubusercontent.com/1313018/236216810-26b28103-6456-4da5-b42d-df0ed6c3c022.png">
