### PR TITLE
[ML] Fixing expired license redirection

### DIFF
--- a/x-pack/plugins/ml/public/application/app.tsx
+++ b/x-pack/plugins/ml/public/application/app.tsx
@@ -20,6 +20,7 @@ import { toMountPoint, wrapWithTheme } from '@kbn/kibana-react-plugin/public';
 import { KibanaContextProvider, KibanaThemeProvider } from '@kbn/kibana-react-plugin/public';
 import { StorageContextProvider } from '@kbn/ml-local-storage';
 
+import { firstValueFrom } from 'rxjs';
 import { mlCapabilities } from './capabilities/check_capabilities';
 import { ML_STORAGE_KEYS } from '../../common/types/storage';
 import { ML_APP_LOCATOR, ML_PAGES } from '../../common/constants/locator';
@@ -74,10 +75,19 @@ export type MlGlobalServices = ReturnType<typeof getMlGlobalServices>;
 
 const App: FC<AppProps> = ({ coreStart, deps, appMountParams }) => {
   const redirectToMlAccessDeniedPage = async () => {
-    const accessDeniedPageUrl = await deps.share.url.locators.get(ML_APP_LOCATOR)!.getUrl({
-      page: ML_PAGES.ACCESS_DENIED,
-    });
-    await coreStart.application.navigateToUrl(accessDeniedPageUrl);
+    // access maybe be denied to an expired license, so check the license status first
+    // if the license has expired, redirect to the license management page
+    const license = await firstValueFrom(deps.licensing.license$);
+    const redirectPage =
+      license.status === 'expired'
+        ? deps.share.url.locators.get('LICENSE_MANAGEMENT_LOCATOR')!.getUrl({
+            page: 'dashboard',
+          })
+        : deps.share.url.locators.get(ML_APP_LOCATOR)!.getUrl({
+            page: ML_PAGES.ACCESS_DENIED,
+          });
+
+    await coreStart.application.navigateToUrl(await redirectPage);
   };
 
   const pageDeps = {

--- a/x-pack/plugins/ml/public/application/app.tsx
+++ b/x-pack/plugins/ml/public/application/app.tsx
@@ -75,7 +75,7 @@ export type MlGlobalServices = ReturnType<typeof getMlGlobalServices>;
 
 const App: FC<AppProps> = ({ coreStart, deps, appMountParams }) => {
   const redirectToMlAccessDeniedPage = async () => {
-    // access maybe be denied to an expired license, so check the license status first
+    // access maybe be denied due to an expired license, so check the license status first
     // if the license has expired, redirect to the license management page
     const license = await firstValueFrom(deps.licensing.license$);
     const redirectPage =


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/150539

When handling route resolver errors, we now check to see if the error was triggered by an expired license, if so we redirect to the license management page rather than the access denied page.

This is hard to test as you need an expired license. One way to spoof this is by editing code in the licensing plugin to inject expired license details. 

```
response.license.expiry_date_in_millis = 1683205426704;
response.license.status = 'expired';
```
Adding this below [this line](https://github.com/elastic/kibana/blob/411ff0d0aefe795afe4b642dcf19e68ca42d75f2/x-pack/plugins/licensing/server/plugin.ts#L184).




<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->