### PR TITLE
[Security Solution] {{state.signals_count}} Object not working (#156472)

### DIFF
--- a/x-pack/plugins/rule_registry/server/utils/create_persistence_rule_type_wrapper.ts
+++ b/x-pack/plugins/rule_registry/server/utils/create_persistence_rule_type_wrapper.ts
@@ -184,6 +184,9 @@ export const createPersistenceRuleTypeWrapper: CreatePersistenceRuleTypeWrapper 
                 createdAlerts.forEach((alert) =>
                   options.services.alertFactory
                     .create(alert._id)
+                    .replaceState({
+                      signals_count: 1,
+                    })
                     .scheduleActions(type.defaultActionGroupId, {
                       rule: mapKeys(snakeCase, {
                         ...options.params,
@@ -376,6 +379,9 @@ export const createPersistenceRuleTypeWrapper: CreatePersistenceRuleTypeWrapper 
                 createdAlerts.forEach((alert) =>
                   options.services.alertFactory
                     .create(alert._id)
+                    .replaceState({
+                      signals_count: 1,
+                    })
                     .scheduleActions(type.defaultActionGroupId, {
                       rule: mapKeys(snakeCase, {
                         ...options.params,


### PR DESCRIPTION
## Summary

Original ticket: https://github.com/elastic/kibana/issues/156472

These changes adds `{{state.signals_count}}` object to be available in message body for the `"For each alert"` option.


<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->