### PR TITLE
[AO] - Fix missing active alert annotation for latency chart

### DIFF
--- a/x-pack/plugins/apm/public/components/alerting/ui_components/alert_details_app_section/index.tsx
+++ b/x-pack/plugins/apm/public/components/alerting/ui_components/alert_details_app_section/index.tsx
@@ -126,7 +126,8 @@ export function AlertDetailsAppSection({
           .toISOString();
 
   const rangeTo = alert.active
-    ? 'now'
+    ? // Add one minute to chart range to ensure that the active alert annotation is shown when seconds are involved.
+      moment().add(1, 'minute').toISOString()
     : moment(alert.fields[ALERT_END])
         .add(ruleWindowSizeMS, 'millisecond')
         .toISOString();


### PR DESCRIPTION
## Summary

Fixes #156494 by extending the chart time range +1 minute. 


<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->