### PR TITLE
[Enterprise Search] refactor(SearchApplications): rename telemetry ids

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/applications/components/engine/add_indices_flyout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/applications/components/engine/add_indices_flyout.tsx
@@ -104,7 +104,7 @@ export const AddIndicesFlyout: React.FC<AddIndicesFlyoutProps> = ({ onClose }) =
           <EuiFlexItem grow={false}>
             <EuiButton
               fill
-              data-telemetry-id="entSearchContent-engines-indices-addNewIndices-submit"
+              data-telemetry-id="entSearchApplications-indices-addNewIndices-submit"
               iconType="plusInCircle"
               onClick={submitSelectedIndices}
             >
@@ -116,7 +116,7 @@ export const AddIndicesFlyout: React.FC<AddIndicesFlyoutProps> = ({ onClose }) =
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiButtonEmpty
-              data-telemetry-id="entSearchContent-engines-indices-addNewIndices-cancel"
+              data-telemetry-id="entSearchApplications-indices-addNewIndices-cancel"
               flush="left"
               onClick={onClose}
             >

--- a/x-pack/plugins/enterprise_search/public/applications/applications/components/engine/engine_connect/engine_api_integration.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/applications/components/engine/engine_connect/engine_api_integration.tsx
@@ -85,7 +85,7 @@ export const EngineApiIntegrationStage: React.FC = () => {
             key={tabId}
             isSelected={selectedTab === tabId}
             onClick={() => setSelectedTab(tabId as TabId)}
-            data-telemetry-id={`entSearchContent-engines-api-integration-tab-${tabId}`}
+            data-telemetry-id={`entSearchApplications-api-integration-tab-${tabId}`}
           >
             {tab.title}
           </EuiTab>

--- a/x-pack/plugins/enterprise_search/public/applications/applications/components/engine/engine_connect/generate_engine_api_key_modal/generate_engine_api_key_modal.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/applications/components/engine/engine_connect/generate_engine_api_key_modal/generate_engine_api_key_modal.tsx
@@ -75,7 +75,7 @@ export const GenerateEngineApiKeyModal: React.FC<GenerateEngineApiKeyModalProps>
                       <EuiFlexItem>
                         <EuiFormRow label="Name your API key" fullWidth>
                           <EuiFieldText
-                            data-telemetry-id="entSearchContent-engines-api-generateEngineApiKeyModal-editName"
+                            data-telemetry-id="entSearchApplications-api-generateEngineApiKeyModal-editName"
                             fullWidth
                             placeholder="Type a name for your API key"
                             onChange={(event) => setKeyName(event.currentTarget.value)}
@@ -87,7 +87,7 @@ export const GenerateEngineApiKeyModal: React.FC<GenerateEngineApiKeyModalProps>
 
                       <EuiFlexItem grow={false}>
                         <EuiButton
-                          data-telemetry-id="entSearchContent-engines-api-generateEngineApiKeyModal-generateApiKeyButton"
+                          data-telemetry-id="entSearchApplications-api-generateEngineApiKeyModal-generateApiKeyButton"
                           data-test-subj="generateApiKeyButton"
                           iconSide="left"
                           iconType="plusInCircle"
@@ -127,7 +127,7 @@ export const GenerateEngineApiKeyModal: React.FC<GenerateEngineApiKeyModalProps>
                         </EuiFlexItem>
                         <EuiFlexItem grow={false}>
                           <EuiButtonIcon
-                            data-telemetry-id="entSearchContent-engines-api-generateEngineApiKeyModal-csvDownloadButton"
+                            data-telemetry-id="entSearchApplications-api-generateEngineApiKeyModal-csvDownloadButton"
                             aria-label={i18n.translate(
                               'xpack.enterpriseSearch.content.engine.api.generateEngineApiKeyModal.csvDownloadButton',
                               { defaultMessage: 'Download API key' }
@@ -166,7 +166,7 @@ export const GenerateEngineApiKeyModal: React.FC<GenerateEngineApiKeyModalProps>
       <EuiModalFooter>
         {apiKey ? (
           <EuiButton
-            data-telemetry-id="entSearchContent-engines-api-generateEngineApiKeyModal-done"
+            data-telemetry-id="entSearchApplications-api-generateEngineApiKeyModal-done"
             fill
             onClick={onClose}
           >
@@ -179,7 +179,7 @@ export const GenerateEngineApiKeyModal: React.FC<GenerateEngineApiKeyModalProps>
           </EuiButton>
         ) : (
           <EuiButtonEmpty
-            data-telemetry-id="entSearchContent-engines-api-generateEngineApiKeyModal-cancel"
+            data-telemetry-id="entSearchApplications-api-generateEngineApiKeyModal-cancel"
             onClick={onClose}
           >
             {i18n.translate(

--- a/x-pack/plugins/enterprise_search/public/applications/applications/components/engine/engine_connect/search_application_api.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/applications/components/engine/engine_connect/search_application_api.tsx
@@ -63,7 +63,7 @@ export const SearchApplicationAPI = () => {
               )}{' '}
               <EuiLink
                 href={docLinks.apiKeys}
-                data-telemetry-id="entSearchContent-searchApplications-api-step1-learnMoreLink"
+                data-telemetry-id="entSearchApplications-searchApplication-api-step1-learnMoreLink"
                 external
                 target="_blank"
               >
@@ -83,7 +83,7 @@ export const SearchApplicationAPI = () => {
                 iconSide="left"
                 iconType="plusInCircleFilled"
                 onClick={openGenerateModal}
-                data-telemetry-id="entSearchContent-searchApplications-api-step1-createApiKeyButton"
+                data-telemetry-id="entSearchApplications-searchApplication-api-step1-createApiKeyButton"
               >
                 {i18n.translate(
                   'xpack.enterpriseSearch.content.searchApplication.api.step1.createAPIKeyButton',
@@ -97,7 +97,7 @@ export const SearchApplicationAPI = () => {
               <EuiButton
                 iconSide="left"
                 iconType="popout"
-                data-telemetry-id="entSearchContent-searchApplications-api-step1-viewKeysButton"
+                data-telemetry-id="entSearchApplications-searchApplication-api-step1-viewKeysButton"
                 onClick={() =>
                   KibanaLogic.values.navigateToUrl('/app/management/security/api_keys', {
                     shouldNotCreateHref: true,

--- a/x-pack/plugins/enterprise_search/public/applications/applications/components/engine/engine_indices.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/applications/components/engine/engine_indices.tsx
@@ -70,7 +70,7 @@ export const EngineIndices: React.FC = () => {
       setConfirmRemoveIndex(index.name);
       sendEnterpriseSearchTelemetry({
         action: 'clicked',
-        metric: 'entSearchContent-engines-indices-removeIndex',
+        metric: 'entSearchApplications-indices-removeIndex',
       });
     },
     type: 'icon',
@@ -225,7 +225,7 @@ export const EngineIndices: React.FC = () => {
             setConfirmRemoveIndex(null);
             sendEnterpriseSearchTelemetry({
               action: 'clicked',
-              metric: 'entSearchContent-engines-indices-removeIndexConfirm',
+              metric: 'entSearchApplications-indices-removeIndexConfirm',
             });
           }}
           title={i18n.translate(

--- a/x-pack/plugins/enterprise_search/public/applications/applications/components/engine/engine_search_preview/engine_search_preview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/applications/components/engine/engine_search_preview/engine_search_preview.tsx
@@ -256,7 +256,7 @@ const ConfigurationPopover: React.FC<ConfigurationPopOverProps> = ({
                 openDeleteEngineModal();
                 sendEnterpriseSearchTelemetry({
                   action: 'clicked',
-                  metric: 'entSearchContent-engines-engineView-deleteEngine',
+                  metric: 'entSearchApplications-engineView-deleteEngine',
                 });
               }
             }}

--- a/x-pack/plugins/enterprise_search/public/applications/applications/components/engine/header_docs_action.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/applications/components/engine/header_docs_action.tsx
@@ -15,7 +15,7 @@ export const EngineHeaderDocsAction: React.FC = () => (
   <EuiFlexGroup gutterSize="s">
     <EuiFlexItem>
       <EuiButtonEmpty
-        data-telemetry-id="entSearchContent-engines-engineHeader-documentationLink"
+        data-telemetry-id="entSearchApplications-engineHeader-documentationLink"
         data-test-subj="engine-documentation-link"
         href={docLinks.enterpriseSearchEngines}
         target="_blank"

--- a/x-pack/plugins/enterprise_search/public/applications/applications/components/engine/search_application_content.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/applications/components/engine/search_application_content.tsx
@@ -127,7 +127,7 @@ export const SearchApplicationContent = () => {
         pageTitle,
         rightSideItems: [
           <EuiButton
-            data-telemetry-id="entSearchContent-engines-indices-addNewIndices"
+            data-telemetry-id="entSearchApplications-indices-addNewIndices"
             data-test-subj="engine-add-new-indices-btn"
             iconType="plusInCircle"
             fill

--- a/x-pack/plugins/enterprise_search/public/applications/applications/components/engines/components/tables/engines_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/applications/components/engines/components/tables/engines_table.tsx
@@ -66,7 +66,7 @@ export const EnginesListTable: React.FC<EnginesListTableProps> = ({
       render: (name: string) => (
         <EuiLinkTo
           data-test-subj="engine-link"
-          data-telemetry-id="entSearchContent-engines-table-viewEngine"
+          data-telemetry-id="entSearchApplications-table-viewEngine"
           to={generateEncodedPath(ENGINE_PATH, { engineName: name })}
         >
           {name}
@@ -95,7 +95,7 @@ export const EnginesListTable: React.FC<EnginesListTableProps> = ({
           size="s"
           className="engineListTableFlyoutButton"
           data-test-subj="engineListTableIndicesFlyoutButton"
-          data-telemetry-id="entSearchContent-engines-table-viewEngineIndices"
+          data-telemetry-id="entSearchApplications-table-viewEngineIndices"
           onClick={() => viewEngineIndices(engine.name)}
         >
           <FormattedMessage
@@ -151,7 +151,7 @@ export const EnginesListTable: React.FC<EnginesListTableProps> = ({
             onDelete(engine);
             sendEnterpriseSearchTelemetry({
               action: 'clicked',
-              metric: 'entSearchContent-engines-table-deleteEngine',
+              metric: 'entSearchApplications-table-deleteEngine',
             });
           },
         },

--- a/x-pack/plugins/enterprise_search/public/applications/applications/components/engines/create_engine_flyout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/applications/components/engines/create_engine_flyout.tsx
@@ -96,7 +96,7 @@ export const CreateEngineFlyout = ({ onClose }: CreateEngineFlyoutProps) => {
                   <EuiLink
                     href={docLinks.enterpriseSearchEngines}
                     target="_blank"
-                    data-telemetry-id="entSearchContent-engines-createEngine-docsLink"
+                    data-telemetry-id="entSearchApplications-createEngine-docsLink"
                     external
                   >
                     {i18n.translate(
@@ -183,7 +183,7 @@ export const CreateEngineFlyout = ({ onClose }: CreateEngineFlyoutProps) => {
           <EuiFlexItem grow={false}>
             <EuiButtonEmpty
               disabled={formDisabled}
-              data-telemetry-id="entSearchContent-engines-createEngine-cancel"
+              data-telemetry-id="entSearchApplications-createEngine-cancel"
               onClick={onClose}
             >
               {CANCEL_BUTTON_LABEL}
@@ -193,7 +193,7 @@ export const CreateEngineFlyout = ({ onClose }: CreateEngineFlyoutProps) => {
           <EuiFlexItem grow={false}>
             <EuiButton
               isDisabled={createDisabled || formDisabled}
-              data-telemetry-id="entSearchContent-engines-createEngine-submit"
+              data-telemetry-id="entSearchApplications-createEngine-submit"
               fill
               iconType="plusInCircle"
               onClick={() => {

--- a/x-pack/plugins/enterprise_search/public/applications/applications/components/engines/delete_engine_modal.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/applications/components/engines/delete_engine_modal.tsx
@@ -35,7 +35,7 @@ export const DeleteEngineModal: React.FC<DeleteEngineModalProps> = ({ engineName
         deleteEngine({ engineName });
         sendEnterpriseSearchTelemetry({
           action: 'clicked',
-          metric: 'entSearchContent-engines-engineView-deleteEngineConfirm',
+          metric: 'entSearchApplications-engineView-deleteEngineConfirm',
         });
       }}
       cancelButtonText={CANCEL_BUTTON_LABEL}

--- a/x-pack/plugins/enterprise_search/public/applications/applications/components/engines/engines_list.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/applications/components/engines/engines_list.tsx
@@ -68,7 +68,7 @@ export const CreateEngineButton: React.FC<CreateEngineButtonProps> = ({ disabled
             fill
             iconType="plusInCircle"
             data-test-subj="enterprise-search-content-engines-creation-button"
-            data-telemetry-id="entSearchContent-engines-list-createEngine"
+            data-telemetry-id="entSearchApplications-list-createEngine"
             isDisabled={disabled}
             onClick={() => KibanaLogic.values.navigateToUrl(ENGINE_CREATION_PATH)}
           >
@@ -176,7 +176,7 @@ export const EnginesList: React.FC<ListProps> = ({ createEngineFlyoutOpen }) => 
                     data-test-subj="engines-documentation-link"
                     href={docLinks.enterpriseSearchEngines}
                     target="_blank"
-                    data-telemetry-id="entSearchContent-engines-documentation-viewDocumentaion"
+                    data-telemetry-id="entSearchApplications-documentation-viewDocumentaion"
                   >
                     {i18n.translate(
                       'xpack.enterpriseSearch.content.searchApplications.documentation',

--- a/x-pack/plugins/enterprise_search/public/applications/applications/components/engines/engines_list_flyout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/applications/components/engines/engines_list_flyout.tsx
@@ -66,7 +66,7 @@ export const EngineListIndicesFlyout: React.FC = () => {
       render: (indexName: string) => (
         <EuiLinkTo
           data-test-subj="engine-index-link"
-          data-telemetry-id="entSearchContent-engines-list-viewIndex"
+          data-telemetry-id="entSearchApplications-list-viewIndex"
           to={`${ENTERPRISE_SEARCH_CONTENT_PLUGIN.URL}/${generateEncodedPath(SEARCH_INDEX_PATH, {
             indexName,
           })}`}


### PR DESCRIPTION
## Summary

Renamed `entSearchContent` to `entSearchApplications` in data-telemetry-ids now that search applications is no longer under content.


<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->