### PR TITLE
[Security Solution][Endpoint] Fix hover color for `processes` response action output data rows

### DIFF
--- a/x-pack/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/get_processes_action.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/get_processes_action.tsx
@@ -20,7 +20,7 @@ import type { ActionRequestComponentProps } from '../types';
 // @ts-expect-error TS2769
 const StyledEuiBasicTable = styled(EuiBasicTable)`
   table {
-    background-color: ${({ theme: { eui } }) => eui.euiPageBackgroundColor};
+    background-color: transparent;
   }
   .euiTableHeaderCell {
     border-bottom: ${(props) => props.theme.eui.euiBorderThin};
@@ -30,7 +30,7 @@ const StyledEuiBasicTable = styled(EuiBasicTable)`
   }
   .euiTableRow {
     &:hover {
-      background-color: white !important;
+      background-color: ${({ theme: { eui } }) => eui.euiColorEmptyShade} !important;
     }
     .euiTableRowCell {
       border-top: none !important;


### PR DESCRIPTION
## Summary

- Fixes the color used to highlight a row from the output of the `processes` response action so that selected content (via mouse) is still legible when the kibana dark theme is used.

Fixes: #154594


<img width="905" alt="image" src="https://user-images.githubusercontent.com/56442535/236314077-50b19f65-281a-424c-936d-5795a3aa4a3a.png">


_________



<details><summary>Click here to view selection prior to this change</summary>

![Your content here](https://user-images.githubusercontent.com/5582679/230469847-13afbf3f-715b-425d-83bc-c68724de452e.png)

</details>




<!--ONMERGE {"backportTargets":["8.7","8.8"]} ONMERGE-->