### PR TITLE
[RAM] Change truncated 'run action every' to visible 'run every'

### DIFF
--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/action_notify_when.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/action_notify_when.tsx
@@ -330,7 +330,7 @@ export const ActionNotifyWhen = ({
                       prepend={i18n.translate(
                         'xpack.triggersActionsUI.sections.ruleForm.frequencyNotifyWhen.label',
                         {
-                          defaultMessage: 'Run action every',
+                          defaultMessage: 'Run every',
                         }
                       )}
                       onChange={(e) => {


### PR DESCRIPTION
## Summary

#155804 introduced this bug:

<img width="568" alt="Screenshot 2023-05-04 at 3 43 05 PM" src="https://user-images.githubusercontent.com/1445834/236325207-6ba7ba7d-c056-4444-9cf4-f3e6287c271b.png">


After:

<img width="562" alt="Screenshot 2023-05-04 at 3 45 09 PM" src="https://user-images.githubusercontent.com/1445834/236325256-34926a1a-8630-469f-8bdc-01f375648779.png">





<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->