### PR TITLE
[DOCS] Add canonical URLs to 8.5 Kibana Guide

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -39,7 +39,8 @@ Review important information about the {kib} 8.5.x releases.
 //* <<release-notes-8.0.0-alpha1>>
 
 --
-[[release-notes-8.5.3]]
+
+[id="release-notes-8.5.3",canonical-url="https://www.elastic.co/guide/en/kibana/current/release-notes.html"]
 == {kib} 8.5.3
 
 Review the following information about the {kib} 8.5.3 release.
@@ -239,7 +240,7 @@ Uptime::
 * Adjust forumla for synthetics monitor availability {kibana-pull}144868[#144868]
 * TLS alert - do not alert when status cannot be determined {kibana-pull}144767[#144767]
 
-[[release-notes-8.5.0]]
+[id="release-notes-8.5.0",canonical-url="https://www.elastic.co/guide/en/kibana/current/release-notes.html"]
 == {kib} 8.5.0
 
 Review the following information about the {kib} 8.5.0 release.

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,4 +1,4 @@
-[[kibana-guide]]
+[id="kibana-guide",canonical-url="https://www.elastic.co/guide/en/kibana/current/index.html"]
 = Kibana Guide
 
 :include-xpack:  true

--- a/docs/setup/docker.asciidoc
+++ b/docs/setup/docker.asciidoc
@@ -1,4 +1,4 @@
-[[docker]]
+[id="docker",canonical-url="https://www.elastic.co/guide/en/kibana/current/docker.html"]
 === Install {kib} with Docker
 ++++
 <titleabbrev>Install with Docker</titleabbrev>

--- a/docs/user/ml/index.asciidoc
+++ b/docs/user/ml/index.asciidoc
@@ -1,5 +1,5 @@
 [role="xpack"]
-[[xpack-ml]]
+[id="xpack-ml",canonical-url="https://www.elastic.co/guide/en/kibana/current/xpack-ml.html"]
 = {ml-cap}
 
 [partintro]
@@ -99,7 +99,8 @@ image::user/ml/images/classification.png[{classification-cap} results in {kib}]
 For more information about the {dfanalytics} feature, see
 {ml-docs}/ml-dfanalytics.html[{ml-cap} {dfanalytics}].
 
-[[xpack-ml-aiops]]
+[[]]
+[id="xpack-ml-aiops",canonical-url="https://www.elastic.co/guide/en/kibana/current/xpack-ml-aiops.html"]
 == AIOps Labs
 
 AIOps Labs is a part of {ml-app} in {kib} which provides features that use 

--- a/docs/user/ml/index.asciidoc
+++ b/docs/user/ml/index.asciidoc
@@ -99,7 +99,6 @@ image::user/ml/images/classification.png[{classification-cap} results in {kib}]
 For more information about the {dfanalytics} feature, see
 {ml-docs}/ml-dfanalytics.html[{ml-cap} {dfanalytics}].
 
-[[]]
 [id="xpack-ml-aiops",canonical-url="https://www.elastic.co/guide/en/kibana/current/xpack-ml-aiops.html"]
 == AIOps Labs
 

--- a/docs/user/whats-new.asciidoc
+++ b/docs/user/whats-new.asciidoc
@@ -1,4 +1,4 @@
-[[whats-new]]
+[id="whats-new",canonical-url="https://www.elastic.co/guide/en/kibana/current/whats-new.html"]
 == What's new in {minor-version}
 
 Here are the highlights of what's new and improved in {minor-version}.


### PR DESCRIPTION
## Summary

Adds [canonical URL](https://developers.google.com/search/docs/advanced/crawling/consolidate-duplicate-urls) to pages in the 8.5.0 Kibana Guide that have similar or duplicate content in the current Kibana Guide.