### PR TITLE
[DOCS] Add canonical URLs to 8.4 Kibana Guide

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -36,7 +36,7 @@ Review important information about the {kib} 8.4.x releases.
 
 --
 
-[[release-notes-8.4.3]]
+[id="release-notes-8.4.3",canonical-url="https://www.elastic.co/guide/en/kibana/current/release-notes.html"]
 == {kib} 8.4.3
 
 Review the following information about the {kib} 8.4.3 release.
@@ -178,7 +178,7 @@ Alerting::
 Lens & Visualizations::
 * Fixes table pagination in *Lens* and *Aggregation-based* visualization editors {kibana-pull}139160[#139160]
 
-[[release-notes-8.4.0]]
+[id="release-notes-8.4.0",canonical-url="https://www.elastic.co/guide/en/kibana/current/release-notes.html"]
 == {kib} 8.4.0
 
 Review the following information about the {kib} 8.4.0 release.

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,4 +1,4 @@
-[[kibana-guide]]
+[id="kibana-guide",canonical-url="https://www.elastic.co/guide/en/kibana/current/index.html"]
 = Kibana Guide
 
 :include-xpack:  true

--- a/docs/setup/docker.asciidoc
+++ b/docs/setup/docker.asciidoc
@@ -1,4 +1,4 @@
-[[docker]]
+[id="docker",canonical-url="https://www.elastic.co/guide/en/kibana/current/docker.html"]
 === Install {kib} with Docker
 ++++
 <titleabbrev>Install with Docker</titleabbrev>

--- a/docs/user/ml/index.asciidoc
+++ b/docs/user/ml/index.asciidoc
@@ -99,7 +99,7 @@ image::user/ml/images/outliers.png[{oldetection-cap} results in {kib}]
 For more information about the {dfanalytics} feature, see
 {ml-docs}/ml-dfanalytics.html[{ml-cap} {dfanalytics}].
 
-[[xpack-ml-aiops]]
+[id="xpack-ml-aiops",canonical-url="https://www.elastic.co/guide/en/kibana/current/xpack-ml-aiops.html"]
 == AIOps
 
 AIOps is a part of {ml-app} in {kib} which provides features that use advanced 

--- a/docs/user/whats-new.asciidoc
+++ b/docs/user/whats-new.asciidoc
@@ -1,4 +1,4 @@
-[[whats-new]]
+[id="whats-new",canonical-url="https://www.elastic.co/guide/en/kibana/current/whats-new.html"]
 == What's new in {minor-version}
 
 Here are the highlights of what's new and improved in {minor-version}.


### PR DESCRIPTION
## Summary

Adds [canonical URL](https://developers.google.com/search/docs/advanced/crawling/consolidate-duplicate-urls) to pages in the 8.4.0 Kibana Guide that have similar or duplicate content in the current Kibana Guide.