### PR TITLE
[DOCS] Add canonical URLs to 8.3 Kibana Guide

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -112,7 +112,7 @@ Fleet::
 Lens & Visualizations::
 Fixes normalizeTable performance bottleneck in *Lens* {kibana-pull}135792[#135792]
 
-[[release-notes-8.3.2]]
+[id="release-notes-8.3.2",canonical-url="https://www.elastic.co/guide/en/kibana/current/release-notes.html"]
 == {kib} 8.3.2
 
 Review the following information about the {kib} 8.3.2 release.
@@ -246,7 +246,7 @@ Platform::
 * Fixes an issue where importing/copying the same saved object to the same space multiple times using the "Check for existing objects" option could fail or cause duplicates to be created {kibana-pull}135358[#135358]
 * Fixes a bug where {es} nodes that stopped, then started again, were unreachable by {kib} for a given amount of requests when {kib} was configured to connect to multiple {es} nodes {kibana-pull}134628[#134628]
 
-[[release-notes-8.3.0]]
+[id="release-notes-8.3.0",canonical-url="https://www.elastic.co/guide/en/kibana/current/release-notes.html"]
 == {kib} 8.3.0
 
 Review the following information about the {kib} 8.3.0 release.

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,4 +1,4 @@
-[[kibana-guide]]
+[id="kibana-guide",canonical-url="https://www.elastic.co/guide/en/kibana/current/index.html"]
 = Kibana Guide
 
 :include-xpack:  true

--- a/docs/setup/docker.asciidoc
+++ b/docs/setup/docker.asciidoc
@@ -1,4 +1,4 @@
-[[docker]]
+[id="docker",canonical-url="https://www.elastic.co/guide/en/kibana/current/docker.html"]
 === Install {kib} with Docker
 ++++
 <titleabbrev>Install with Docker</titleabbrev>

--- a/docs/user/whats-new.asciidoc
+++ b/docs/user/whats-new.asciidoc
@@ -1,4 +1,4 @@
-[[whats-new]]
+[id="whats-new",canonical-url="https://www.elastic.co/guide/en/kibana/current/whats-new.html"]
 == What's new in {minor-version}
 
 Here are the highlights of what's new and improved in {minor-version}.


### PR DESCRIPTION
## Summary

Adds [canonical URL](https://developers.google.com/search/docs/advanced/crawling/consolidate-duplicate-urls) to pages in the 8.3.0 Kibana Guide that have similar or duplicate content in the current Kibana Guide.