### PR TITLE
[Dashboard] Fix flaky time picker tests

### DIFF
--- a/test/functional/apps/dashboard/group1/create_and_add_embeddables.ts
+++ b/test/functional/apps/dashboard/group1/create_and_add_embeddables.ts
@@ -205,7 +205,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
           const originalPanelCount = await PageObjects.dashboard.getPanelCount();
           expect(originalPanelCount).to.eql(0);
           await dashboardVisualizations.createAndEmbedMetric('Embedding Vis Test');
-          await PageObjects.dashboard.waitForRenderComplete();
           await dashboardExpect.metricValuesExist(['0']);
           const panelCount = await PageObjects.dashboard.getPanelCount();
           expect(panelCount).to.eql(1);
@@ -217,7 +216,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
             name: 'Embedding Markdown Test',
             markdown: 'Nice to meet you, markdown is my name',
           });
-          await PageObjects.dashboard.waitForRenderComplete();
           await dashboardExpect.markdownWithValuesExists(['Nice to meet you, markdown is my name']);
           const panelCount = await PageObjects.dashboard.getPanelCount();
           expect(panelCount).to.eql(2);

--- a/test/functional/apps/dashboard/group3/dashboard_time_picker.ts
+++ b/test/functional/apps/dashboard/group3/dashboard_time_picker.ts
@@ -58,7 +58,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         name: 'saved search',
         fields: ['bytes', 'agent'],
       });
-      await PageObjects.dashboard.waitForRenderComplete();
 
       const isLegacyDefault = await PageObjects.discover.useLegacyTable();
       if (isLegacyDefault) {
@@ -93,7 +92,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         name: 'saved search',
         fields: ['bytes', 'agent'],
       });
-      await PageObjects.dashboard.waitForRenderComplete();
       log.debug('added saved search');
       const currentUrl = await browser.getCurrentUrl();
       const kibanaBaseUrl = currentUrl.substring(0, currentUrl.indexOf('#'));

--- a/test/functional/apps/dashboard/group3/dashboard_time_picker.ts
+++ b/test/functional/apps/dashboard/group3/dashboard_time_picker.ts
@@ -58,6 +58,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         name: 'saved search',
         fields: ['bytes', 'agent'],
       });
+      await PageObjects.dashboard.waitForRenderComplete();
 
       const isLegacyDefault = await PageObjects.discover.useLegacyTable();
       if (isLegacyDefault) {
@@ -92,6 +93,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         name: 'saved search',
         fields: ['bytes', 'agent'],
       });
+      await PageObjects.dashboard.waitForRenderComplete();
       log.debug('added saved search');
       const currentUrl = await browser.getCurrentUrl();
       const kibanaBaseUrl = currentUrl.substring(0, currentUrl.indexOf('#'));
@@ -129,6 +131,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         '2015-09-19 06:31:44.000',
         '2015-09-23 18:31:44.000'
       );
+      await PageObjects.dashboard.waitForRenderComplete();
       await pieChart.expectPieSliceCount(10);
     });
   });

--- a/test/functional/apps/dashboard/group5/empty_dashboard.ts
+++ b/test/functional/apps/dashboard/group5/empty_dashboard.ts
@@ -55,7 +55,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         name: 'Dashboard Test Markdown',
         markdown: 'Markdown text',
       });
-      await PageObjects.dashboard.waitForRenderComplete();
       await dashboardExpect.markdownWithValuesExists(['Markdown text']);
     });
 

--- a/test/functional/page_objects/dashboard_page.ts
+++ b/test/functional/page_objects/dashboard_page.ts
@@ -664,6 +664,7 @@ export class DashboardPageObject extends FtrService {
 
   public async addVisualizations(visualizations: string[]) {
     await this.dashboardAddPanel.addVisualizations(visualizations);
+    await this.waitForRenderComplete();
   }
 
   public async setSaveAsNewCheckBox(checked: boolean) {

--- a/test/functional/services/dashboard/visualizations.ts
+++ b/test/functional/services/dashboard/visualizations.ts
@@ -30,6 +30,8 @@ export class DashboardVisualizationsService extends FtrService {
     await this.dashboardAddPanel.clickAddNewEmbeddableLink('metrics');
     await this.visualize.clickVisualBuilder();
     await this.visualize.saveVisualizationExpectSuccess(name);
+    await this.header.waitUntilLoadingHasFinished();
+    await this.dashboard.waitForRenderComplete();
   }
 
   async createSavedSearch({
@@ -80,6 +82,7 @@ export class DashboardVisualizationsService extends FtrService {
       await this.dashboard.switchToEditMode();
     }
     await this.dashboardAddPanel.addSavedSearch(name);
+    await this.dashboard.waitForRenderComplete();
   }
 
   async createAndAddMarkdown({ name, markdown }: { name: string; markdown: string }) {
@@ -95,6 +98,8 @@ export class DashboardVisualizationsService extends FtrService {
       saveAsNew: false,
       redirectToOrigin: true,
     });
+    await this.header.waitUntilLoadingHasFinished();
+    await this.dashboard.waitForRenderComplete();
   }
 
   async createAndEmbedMetric(name: string) {
@@ -109,6 +114,8 @@ export class DashboardVisualizationsService extends FtrService {
     await this.testSubjects.click('savedObjectTitlelogstash-*');
     await this.testSubjects.exists('visualizesaveAndReturnButton');
     await this.testSubjects.click('visualizesaveAndReturnButton');
+    await this.header.waitUntilLoadingHasFinished();
+    await this.dashboard.waitForRenderComplete();
   }
 
   async createAndEmbedMarkdown({ name, markdown }: { name: string; markdown: string }) {
@@ -121,5 +128,7 @@ export class DashboardVisualizationsService extends FtrService {
     await this.visEditor.setMarkdownTxt(markdown);
     await this.visEditor.clickGo();
     await this.testSubjects.click('visualizesaveAndReturnButton');
+    await this.header.waitUntilLoadingHasFinished();
+    await this.dashboard.waitForRenderComplete();
   }
 }


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/155603

## Summary

For the test that failed above, the failure screenshot shows that we weren't waiting long enough for the pie chart to load before calling `expectEmptyPieChart`:

![image](https://user-images.githubusercontent.com/8698078/236501367-290f481c-d17b-4d0a-a696-f50020fbd605.png)

Rather than adding a `wait` for just the single failing test, I figured we should probably **always** wait for the page and visualizations to load when adding visualizations - so, I added `dashboard.waitForRenderComplete` to any methods I could find in the Dashboard page object and the Dashboard visualizations service where panels were being added.

Note that, if adding a given visualization also requires navigating to and from the Dashboard app, I also added `header.waitUntilLoadingHasFinished` before `dashboard.waitForRenderComplete` so that we can wait for the Dashboard app to load first before ensuring the visualizations have also loaded. This should hopefully prevent any **other** tests that rely on adding a visualization to be less flaky.

### Flaky Test Runner

<a href="https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2228"><img src="https://user-images.githubusercontent.com/8698078/236513873-d97f7c61-e8ee-4f5f-b76d-13998e62dadc.png"/></a>

### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
