### PR TITLE
[ML] Fix insufficient license message

### DIFF
--- a/x-pack/plugins/ml/public/application/management/jobs_list/components/insufficient_license_page.tsx
+++ b/x-pack/plugins/ml/public/application/management/jobs_list/components/insufficient_license_page.tsx
@@ -61,7 +61,6 @@ export const InsufficientLicensePage: FC<Props> = ({ basePath }) => (
                     defaultMessage="Upgrade your subscription"
                   />
                 </EuiButtonEmpty>
-                ,
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
                 <EuiButton
@@ -76,7 +75,6 @@ export const InsufficientLicensePage: FC<Props> = ({ basePath }) => (
                     defaultMessage="Start trial"
                   />
                 </EuiButton>
-                ,
               </EuiFlexItem>
             </EuiFlexGroup>
           </EuiFlexItem>


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/155962#issuecomment-1534726970

This PR removes commas that were mistakenly left in the UI message.

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/6585477/236210361-a92f294d-d8d0-4787-bbfe-651bb726d339.png)

### After

![image](https://user-images.githubusercontent.com/26471269/236347226-b684ca28-f281-4dd7-b464-abd7b060b9e2.png)


<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->