### PR TITLE
[Saved Search] Update saved search schema to allow empty `sort` arrays

### DIFF
--- a/src/plugins/saved_search/server/saved_objects/search.ts
+++ b/src/plugins/saved_search/server/saved_objects/search.ts
@@ -53,8 +53,8 @@ export function getSavedSearchObjectType(
         columns: schema.arrayOf(schema.string(), { defaultValue: [] }),
         sort: schema.oneOf(
           [
-            schema.arrayOf(schema.arrayOf(schema.string(), { minSize: 2, maxSize: 2 })),
-            schema.arrayOf(schema.string(), { minSize: 2, maxSize: 2 }),
+            schema.arrayOf(schema.arrayOf(schema.string(), { maxSize: 2 })),
+            schema.arrayOf(schema.string(), { maxSize: 2 }),
           ],
           { defaultValue: [] }
         ),


### PR DESCRIPTION
## Summary

This PR removes the `minSize` restriction added in #154016 from the saved search schema `sort` property, which was causing AWS integrations to fail.

Before:
![broken](https://user-images.githubusercontent.com/25592674/236355150-112e103b-00ef-4f0d-baa5-35de6b944152.gif)

After:
![working](https://user-images.githubusercontent.com/25592674/236355167-1185279b-84ef-4570-8762-90944c839c4d.gif)

Fixes #156724.

### Checklist

- [ ] ~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)~
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] ~Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))~
- [ ] ~Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))~
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))~
- [ ] ~This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)~

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->