### PR TITLE
[Discover] [Dashboard] [Embeddable] Hide full screen button for saved search embeddables

### DIFF
--- a/src/plugins/discover/public/components/discover_grid/discover_grid.tsx
+++ b/src/plugins/discover/public/components/discover_grid/discover_grid.tsx
@@ -136,6 +136,10 @@ export interface DiscoverGridProps {
    */
   showTimeCol: boolean;
   /**
+   * Determines whether the full screen button should be displayed
+   */
+  showFullScreenButton: boolean;
+  /**
    * Manage user sorting control
    */
   isSortEnabled?: boolean;
@@ -228,6 +232,7 @@ export const DiscoverGrid = ({
   setExpandedDoc,
   settings,
   showTimeCol,
+  showFullScreenButton = true,
   sort,
   useNewFieldsApi,
   isSortEnabled = true,
@@ -510,14 +515,16 @@ export const DiscoverGrid = ({
             showSortSelector: isSortEnabled,
             additionalControls,
             showDisplaySelector,
+            showFullScreenSelector: showFullScreenButton,
           }
         : {
             ...toolbarVisibilityDefaults,
             showSortSelector: isSortEnabled,
             additionalControls,
             showDisplaySelector,
+            showFullScreenSelector: showFullScreenButton,
           },
-    [showDisplaySelector, defaultColumns, additionalControls, isSortEnabled]
+    [defaultColumns, isSortEnabled, additionalControls, showDisplaySelector, showFullScreenButton]
   );
 
   const rowHeightsOptions = useRowHeightsOptions({

--- a/src/plugins/discover/public/components/discover_grid/discover_grid.tsx
+++ b/src/plugins/discover/public/components/discover_grid/discover_grid.tsx
@@ -138,7 +138,7 @@ export interface DiscoverGridProps {
   /**
    * Determines whether the full screen button should be displayed
    */
-  showFullScreenButton: boolean;
+  showFullScreenButton?: boolean;
   /**
    * Manage user sorting control
    */

--- a/src/plugins/discover/public/embeddable/saved_search_embeddable_component.tsx
+++ b/src/plugins/discover/public/embeddable/saved_search_embeddable_component.tsx
@@ -31,6 +31,7 @@ export function SavedSearchEmbeddableComponent({
   return (
     <DiscoverGridEmbeddableMemoized
       {...(searchProps as DiscoverGridEmbeddableProps)}
+      showFullScreenButton={false}
       className="dscDiscoverGrid"
     />
   );

--- a/test/functional/apps/discover/embeddable/_saved_search_embeddable.ts
+++ b/test/functional/apps/discover/embeddable/_saved_search_embeddable.ts
@@ -139,5 +139,10 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await testSubjects.missingOrFail('embeddableError');
       expect(await PageObjects.discover.getSavedSearchDocumentCount()).to.be('4,633 documents');
     });
+
+    it('should not show the full screen button', async () => {
+      await addSearchEmbeddableToDashboard();
+      await testSubjects.missingOrFail('dataGridFullScreenButton');
+    });
   });
 }


### PR DESCRIPTION
## Summary

This PR hides the full screen button for saved search embeddables since the full screen mode can result in display issues when parent elements use CSS transforms.

Originally I was trying to figure out how to only hide the full screen button when used in a dashboard, but it turns out that saved searches embedded in Canvas have the same issue, so I think it makes sense to just disable the full screen button entirely for saved search embeddables until we have a reason to do otherwise:
![canvas_saved_search](https://user-images.githubusercontent.com/25592674/236359826-b1491477-b658-48f8-81d6-0ebc8e63e7be.gif)

Resolves #151499.

### Checklist

- [ ] ~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)~
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] ~Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))~
- [ ] ~Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))~
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))~
- [ ] ~This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)~

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->