### PR TITLE
[DOCS] Automate observability case file screenshot

### DIFF
--- a/x-pack/test/screenshot_creation/apps/response_ops_docs/observability_cases/list_view.ts
+++ b/x-pack/test/screenshot_creation/apps/response_ops_docs/observability_cases/list_view.ts
@@ -7,12 +7,18 @@
 
 import { CommentType } from '@kbn/cases-plugin/common/api';
 import { FtrProviderContext } from '../../../ftr_provider_context';
+import { createAndUploadFile } from '../../../../cases_api_integration/common/lib/api';
+import { OBSERVABILITY_FILE_KIND } from '../../../../cases_api_integration/common/lib/constants';
 
-export default function ({ getService }: FtrProviderContext) {
+export default function ({ getPageObject, getService }: FtrProviderContext) {
+  const common = getPageObject('common');
   const cases = getService('cases');
   const commonScreenshots = getService('commonScreenshots');
-
   const screenshotDirectories = ['response_ops_docs', 'observability_cases'];
+  const supertest = getService('supertest');
+  const testSubjects = getService('testSubjects');
+  let caseIdMonitoring: string;
+  let caseOwnerMonitoring: string;
 
   describe('list view', function () {
     before(async () => {
@@ -39,17 +45,35 @@ export default function ({ getService }: FtrProviderContext) {
       });
       await cases.api.setStatus(caseIdLogs, caseVersionLogs, 'closed');
 
-      const { id: caseIdMonitoring } = await cases.api.createCase({
+      const caseMonitoring = await cases.api.createCase({
         title: 'Monitor uptime',
         tags: ['swimlane'],
         description: 'Test.',
         owner: 'observability',
       });
+      caseIdMonitoring = caseMonitoring.id;
+      caseOwnerMonitoring = caseMonitoring.owner;
+
       const { version: caseVersionMonitoring } = await cases.api.createAttachment({
         caseId: caseIdMonitoring,
         params: { comment: 'test comment', type: CommentType.user, owner: 'observability' },
       });
+
       await cases.api.setStatus(caseIdMonitoring, caseVersionMonitoring, 'in-progress');
+
+      await createAndUploadFile({
+        supertest,
+        createFileParams: {
+          name: 'testfile',
+          kind: OBSERVABILITY_FILE_KIND,
+          mimeType: 'image/png',
+          meta: {
+            caseIds: [caseIdMonitoring],
+            owner: [caseOwnerMonitoring],
+          },
+        },
+        data: 'abc',
+      });
     });
 
     after(async () => {
@@ -58,7 +82,19 @@ export default function ({ getService }: FtrProviderContext) {
 
     it('cases list screenshot', async () => {
       await cases.navigation.navigateToApp('observability/cases', 'cases-all-title');
-      await commonScreenshots.takeScreenshot('cases', screenshotDirectories, 1400, 1024);
+      await commonScreenshots.takeScreenshot('cases', screenshotDirectories, 1700, 1024);
+    });
+
+    it('case detail screenshot', async () => {
+      await common.navigateToUrlWithBrowserHistory('observability', `/cases/${caseIdMonitoring}`);
+      const filesTab = await testSubjects.find('case-view-tab-title-files');
+      await filesTab.click();
+      await commonScreenshots.takeScreenshot(
+        'observabiity-case-files',
+        screenshotDirectories,
+        1400,
+        1024
+      );
     });
   });
 }


### PR DESCRIPTION
## Summary

Relates to https://github.com/elastic/observability-docs/pull/2914, https://github.com/elastic/kibana/issues/154881

This PR automates a screenshot for https://www.elastic.co/guide/en/observability/master/manage-cases.html. The screenshot captures the "Files" tab in an Observability case that has a single image attachment.

The PR also widens another existing screenshot, so that the columns aren't so compressed in the output.



<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->