### PR TITLE
[Lens] Fixes all1 problem on delete icon

### DIFF
--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/layer_panel.scss
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/layer_panel.scss
@@ -66,8 +66,11 @@
 
 .lnsLayerPanel__dimensionRemove {
   margin-right: $euiSizeS;
-  visibility: hidden;
   opacity: 0;
+
+  &:focus {
+    opacity: 1;
+  }
 }
 
 .lnsLayerPanel__dimension {


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/156715

Fixes the keyboard accessibility problem on delete icon of dimension panel


![2](https://user-images.githubusercontent.com/17003240/236398875-2577dfa3-d41c-4ae7-96dd-411d6682ecd6.gif)


<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->