### PR TITLE
[Fleet] Update secret values (API only)

### DIFF
--- a/x-pack/plugins/fleet/common/services/validate_package_policy.test.ts
+++ b/x-pack/plugins/fleet/common/services/validate_package_policy.test.ts
@@ -1030,5 +1030,53 @@ describe('Fleet - validatePackagePolicyConfig', () => {
 
       expect(res).toBeNull();
     });
+    it('should accept a secret ref instead of a text value for a secret field', () => {
+      const res = validatePackagePolicyConfig(
+        {
+          value: { isSecretRef: true, id: 'secret1' },
+        },
+        {
+          name: 'secret_variable',
+          type: 'text',
+          secret: true,
+        },
+        'secret_variable',
+        safeLoad
+      );
+
+      expect(res).toBeNull();
+    });
+    it('secret refs should always have an id', () => {
+      const res = validatePackagePolicyConfig(
+        {
+          value: { isSecretRef: true },
+        },
+        {
+          name: 'secret_variable',
+          type: 'text',
+          secret: true,
+        },
+        'secret_variable',
+        safeLoad
+      );
+
+      expect(res).toEqual(['Secret reference is invalid, id must be a string']);
+    });
+    it('secret ref id should be a string', () => {
+      const res = validatePackagePolicyConfig(
+        {
+          value: { isSecretRef: true, id: 123 },
+        },
+        {
+          name: 'secret_variable',
+          type: 'text',
+          secret: true,
+        },
+        'secret_variable',
+        safeLoad
+      );
+
+      expect(res).toEqual(['Secret reference is invalid, id must be a string']);
+    });
   });
 });

--- a/x-pack/plugins/fleet/common/services/validate_package_policy.ts
+++ b/x-pack/plugins/fleet/common/services/validate_package_policy.ts
@@ -234,6 +234,23 @@ export const validatePackagePolicyConfig = (
     }
   }
 
+  if (varDef.secret === true && parsedValue && parsedValue.isSecretRef === true) {
+    if (
+      parsedValue.id === undefined ||
+      parsedValue.id === '' ||
+      typeof parsedValue.id !== 'string'
+    ) {
+      errors.push(
+        i18n.translate('xpack.fleet.packagePolicyValidation.invalidSecretReference', {
+          defaultMessage: 'Secret reference is invalid, id must be a string',
+        })
+      );
+
+      return errors;
+    }
+    return null;
+  }
+
   if (varDef.type === 'yaml') {
     try {
       parsedValue = safeLoadYaml(value);

--- a/x-pack/plugins/fleet/server/services/package_policy.ts
+++ b/x-pack/plugins/fleet/server/services/package_policy.ts
@@ -113,7 +113,7 @@ import { updateDatastreamExperimentalFeatures } from './epm/packages/update';
 import type { PackagePolicyClient, PackagePolicyService } from './package_policy_service';
 import { installAssetsForInputPackagePolicy } from './epm/packages/install';
 import { auditLoggingService } from './audit_logging';
-import { extractAndUpdateSecrets, extractAndWriteSecrets } from './secrets';
+import { extractAndUpdateSecrets, extractAndWriteSecrets, deleteSecrets } from './secrets';
 
 export type InputsOverride = Partial<NewPackagePolicyInput> & {
   vars?: Array<NewPackagePolicyInput['vars'] & { name: string }>;
@@ -645,6 +645,7 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
 
     let enrichedPackagePolicy: UpdatePackagePolicy;
     let secretReferences: PolicySecretReference[] | undefined;
+    let secretsToDelete: PolicySecretReference[] | undefined;
 
     try {
       enrichedPackagePolicy = await packagePolicyService.runExternalCallbacks(
@@ -710,7 +711,7 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
 
         restOfPackagePolicy = secretsRes.packagePolicyUpdate;
         secretReferences = secretsRes.secretReferences;
-
+        secretsToDelete = secretsRes.secretsToDelete;
         inputs = restOfPackagePolicy.inputs as PackagePolicyInput[];
       }
 
@@ -789,7 +790,11 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
       pkgName: newPolicy.package!.name,
       currentVersion: newPolicy.package!.version,
     });
-    await Promise.all([bumpPromise, assetRemovePromise]);
+    const deleteSecretsPromise = secretsToDelete?.length
+      ? deleteSecrets({ esClient, ids: secretsToDelete.map((s) => s.id) })
+      : Promise.resolve();
+
+    await Promise.all([bumpPromise, assetRemovePromise, deleteSecretsPromise]);
 
     sendUpdatePackagePolicyTelemetryEvent(soClient, [packagePolicyUpdate], [oldPackagePolicy]);
 

--- a/x-pack/plugins/fleet/server/services/package_policy.ts
+++ b/x-pack/plugins/fleet/server/services/package_policy.ts
@@ -113,7 +113,11 @@ import { updateDatastreamExperimentalFeatures } from './epm/packages/update';
 import type { PackagePolicyClient, PackagePolicyService } from './package_policy_service';
 import { installAssetsForInputPackagePolicy } from './epm/packages/install';
 import { auditLoggingService } from './audit_logging';
-import { extractAndUpdateSecrets, extractAndWriteSecrets, deleteSecrets } from './secrets';
+import {
+  extractAndUpdateSecrets,
+  extractAndWriteSecrets,
+  deleteSecretsIfNotReferenced as deleteSecrets,
+} from './secrets';
 
 export type InputsOverride = Partial<NewPackagePolicyInput> & {
   vars?: Array<NewPackagePolicyInput['vars'] & { name: string }>;
@@ -791,7 +795,7 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
       currentVersion: newPolicy.package!.version,
     });
     const deleteSecretsPromise = secretsToDelete?.length
-      ? deleteSecrets({ esClient, ids: secretsToDelete.map((s) => s.id) })
+      ? deleteSecrets({ esClient, soClient, ids: secretsToDelete.map((s) => s.id) })
       : Promise.resolve();
 
     await Promise.all([bumpPromise, assetRemovePromise, deleteSecretsPromise]);
@@ -805,8 +809,7 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
     soClient: SavedObjectsClientContract,
     esClient: ElasticsearchClient,
     packagePolicyUpdates: Array<NewPackagePolicy & { version?: string; id: string }>,
-    options?: { user?: AuthenticatedUser; force?: boolean },
-    currentVersion?: string
+    options?: { user?: AuthenticatedUser; force?: boolean }
   ): Promise<{
     updatedPolicies: PackagePolicy[] | null;
     failedPolicies: Array<{
@@ -831,6 +834,7 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
     }
 
     const packageInfos = await getPackageInfoForPackagePolicies(packagePolicyUpdates, soClient);
+    const allSecretsToDelete: PolicySecretReference[] = [];
 
     const policiesToUpdate: Array<SavedObjectsBulkUpdateObject<PackagePolicySOAttributes>> = [];
     const failedPolicies: Array<{
@@ -847,8 +851,11 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
           throw new Error('Package policy not found');
         }
 
+        let secretReferences: PolicySecretReference[] | undefined;
+
         // id and version are not part of the saved object attributes
-        const { version, id: _id, ...restOfPackagePolicy } = packagePolicy;
+        // eslint-disable-next-line prefer-const
+        let { version, id: _id, ...restOfPackagePolicy } = packagePolicy;
 
         if (packagePolicyUpdate.is_managed && !options?.force) {
           throw new PackagePolicyRestrictionRelatedError(`Cannot update package policy ${id}`);
@@ -864,7 +871,21 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
           );
           if (pkgInfo) {
             validatePackagePolicyOrThrow(packagePolicy, pkgInfo);
+            const { secretsStorage: secretsStorageEnabled } =
+              appContextService.getExperimentalFeatures();
+            if (secretsStorageEnabled) {
+              const secretsRes = await extractAndUpdateSecrets({
+                oldPackagePolicy,
+                packagePolicyUpdate: { ...restOfPackagePolicy, inputs },
+                packageInfo: pkgInfo,
+                esClient,
+              });
 
+              restOfPackagePolicy = secretsRes.packagePolicyUpdate;
+              secretReferences = secretsRes.secretReferences;
+              allSecretsToDelete.push(...secretsRes.secretsToDelete);
+              inputs = restOfPackagePolicy.inputs as PackagePolicyInput[];
+            }
             inputs = await _compilePackagePolicyInputs(pkgInfo, packagePolicy.vars || {}, inputs);
             elasticsearchPrivileges = pkgInfo.elasticsearch?.privileges;
           }
@@ -885,6 +906,7 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
             ...(elasticsearchPrivileges && {
               elasticsearch: { privileges: elasticsearchPrivileges },
             }),
+            ...(secretReferences?.length && { secret_references: secretReferences }),
             revision: oldPackagePolicy.revision + 1,
             updated_at: new Date().toISOString(),
             updated_by: options?.user?.username ?? 'system',
@@ -928,7 +950,11 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
       });
     });
 
-    await Promise.all([bumpPromise, removeAssetPromise]);
+    const deleteSecretsPromise = allSecretsToDelete.length
+      ? deleteSecrets({ esClient, soClient, ids: allSecretsToDelete.map((s) => s.id) })
+      : Promise.resolve();
+
+    await Promise.all([bumpPromise, removeAssetPromise, deleteSecretsPromise]);
 
     sendUpdatePackagePolicyTelemetryEvent(soClient, packagePolicyUpdates, oldPackagePolicies);
 

--- a/x-pack/plugins/fleet/server/services/secrets.test.ts
+++ b/x-pack/plugins/fleet/server/services/secrets.test.ts
@@ -14,7 +14,7 @@
 
 import type { NewPackagePolicy, PackageInfo } from '../types';
 
-import { getPolicySecretPaths } from './secrets';
+import { getPolicySecretPaths, diffSecretPaths } from './secrets';
 
 describe('getPolicySecretPaths', () => {
   describe('integration package with one policy template', () => {
@@ -564,6 +564,186 @@ describe('getPolicySecretPaths', () => {
           },
         },
       ]);
+    });
+  });
+});
+
+describe('diffSecretPaths', () => {
+  it('should return empty array if no secrets', () => {
+    expect(diffSecretPaths([], [])).toEqual({
+      toCreate: [],
+      toDelete: [],
+      noChange: [],
+    });
+  });
+  it('should return empty array if single secret not changed', () => {
+    const paths = [
+      {
+        path: 'somepath',
+        value: {
+          value: {
+            isSecretRef: true,
+            id: 'secret-1',
+          },
+        },
+      },
+    ];
+    expect(diffSecretPaths(paths, paths)).toEqual({
+      toCreate: [],
+      toDelete: [],
+      noChange: paths,
+    });
+  });
+  it('should return empty array if multiple secrets not changed', () => {
+    const paths = [
+      {
+        path: 'somepath',
+        value: {
+          value: {
+            isSecretRef: true,
+            id: 'secret-1',
+          },
+        },
+      },
+      {
+        path: 'somepath2',
+        value: {
+          value: {
+            isSecretRef: true,
+            id: 'secret-2',
+          },
+        },
+      },
+      {
+        path: 'somepath3',
+        value: {
+          value: {
+            isSecretRef: true,
+            id: 'secret-3',
+          },
+        },
+      },
+    ];
+
+    expect(diffSecretPaths(paths, paths.slice().reverse())).toEqual({
+      toCreate: [],
+      toDelete: [],
+      noChange: paths,
+    });
+  });
+  it('single secret modified', () => {
+    const paths1 = [
+      {
+        path: 'somepath1',
+        value: {
+          value: {
+            isSecretRef: true,
+            id: 'secret-1',
+          },
+        },
+      },
+      {
+        path: 'somepath2',
+        value: {
+          value: { isSecretRef: true, id: 'secret-2' },
+        },
+      },
+    ];
+
+    const paths2 = [
+      paths1[0],
+      {
+        path: 'somepath2',
+        value: { value: 'newvalue' },
+      },
+    ];
+
+    expect(diffSecretPaths(paths1, paths2)).toEqual({
+      toCreate: [
+        {
+          path: 'somepath2',
+          value: { value: 'newvalue' },
+        },
+      ],
+      toDelete: [
+        {
+          path: 'somepath2',
+          value: {
+            value: {
+              isSecretRef: true,
+              id: 'secret-2',
+            },
+          },
+        },
+      ],
+      noChange: [paths1[0]],
+    });
+  });
+  it('double secret modified', () => {
+    const paths1 = [
+      {
+        path: 'somepath1',
+        value: {
+          value: {
+            isSecretRef: true,
+            id: 'secret-1',
+          },
+        },
+      },
+      {
+        path: 'somepath2',
+        value: {
+          value: {
+            isSecretRef: true,
+            id: 'secret-2',
+          },
+        },
+      },
+    ];
+
+    const paths2 = [
+      {
+        path: 'somepath1',
+        value: { value: 'newvalue1' },
+      },
+      {
+        path: 'somepath2',
+        value: { value: 'newvalue2' },
+      },
+    ];
+
+    expect(diffSecretPaths(paths1, paths2)).toEqual({
+      toCreate: [
+        {
+          path: 'somepath1',
+          value: { value: 'newvalue1' },
+        },
+        {
+          path: 'somepath2',
+          value: { value: 'newvalue2' },
+        },
+      ],
+      toDelete: [
+        {
+          path: 'somepath1',
+          value: {
+            value: {
+              isSecretRef: true,
+              id: 'secret-1',
+            },
+          },
+        },
+        {
+          path: 'somepath2',
+          value: {
+            value: {
+              isSecretRef: true,
+              id: 'secret-2',
+            },
+          },
+        },
+      ],
+      noChange: [],
     });
   });
 });

--- a/x-pack/plugins/fleet/server/services/secrets.test.ts
+++ b/x-pack/plugins/fleet/server/services/secrets.test.ts
@@ -100,6 +100,25 @@ describe('getPolicySecretPaths', () => {
         },
       ]);
     });
+    it('policy with package level secret vars and only one set', () => {
+      const packagePolicy = {
+        vars: {
+          'pkg-secret-1': {
+            value: 'pkg-secret-1-val',
+          },
+        },
+        inputs: [],
+      } as unknown as NewPackagePolicy;
+
+      expect(getPolicySecretPaths(packagePolicy, mockIntegrationPackage)).toEqual([
+        {
+          path: 'vars.pkg-secret-1',
+          value: {
+            value: 'pkg-secret-1-val',
+          },
+        },
+      ]);
+    });
     it('policy with input level secret vars', () => {
       const packagePolicy = {
         inputs: [
@@ -744,6 +763,39 @@ describe('diffSecretPaths', () => {
         },
       ],
       noChange: [],
+    });
+  });
+
+  it('single secret added', () => {
+    const paths1 = [
+      {
+        path: 'somepath1',
+        value: {
+          value: {
+            isSecretRef: true,
+            id: 'secret-1',
+          },
+        },
+      },
+    ];
+
+    const paths2 = [
+      paths1[0],
+      {
+        path: 'somepath2',
+        value: { value: 'newvalue' },
+      },
+    ];
+
+    expect(diffSecretPaths(paths1, paths2)).toEqual({
+      toCreate: [
+        {
+          path: 'somepath2',
+          value: { value: 'newvalue' },
+        },
+      ],
+      toDelete: [],
+      noChange: [paths1[0]],
     });
   });
 });

--- a/x-pack/plugins/fleet/server/services/secrets.ts
+++ b/x-pack/plugins/fleet/server/services/secrets.ts
@@ -134,11 +134,14 @@ export async function deleteSecretsIfNotReferenced(opts: {
   if (!secretsToDelete.length) {
     return;
   }
-
-  await _deleteSecrets({
-    esClient,
-    ids: secretsToDelete,
-  });
+  try {
+    await _deleteSecrets({
+      esClient,
+      ids: secretsToDelete,
+    });
+  } catch (e) {
+    logger.warn(`Error cleaning up secrets ${ids.join(', ')}: ${e}`);
+  }
 }
 
 export async function findPackagePoliciesUsingSecrets(opts: {

--- a/x-pack/plugins/fleet/server/services/secrets.ts
+++ b/x-pack/plugins/fleet/server/services/secrets.ts
@@ -181,7 +181,6 @@ export async function findPackagePoliciesUsingSecrets(opts: {
   return res;
 }
 
-// use deleteSecretsIfNotReferenced
 export async function _deleteSecrets(opts: {
   esClient: ElasticsearchClient;
   ids: string[];

--- a/x-pack/test/fleet_api_integration/apis/fixtures/test_packages/secrets/1.0.0/data_stream/log/manifest.yml
+++ b/x-pack/test/fleet_api_integration/apis/fixtures/test_packages/secrets/1.0.0/data_stream/log/manifest.yml
@@ -8,6 +8,5 @@ streams:
         type: text
         title: Stream Var Secret
         multi: false
-        required: true
         show_user: true
         secret: true

--- a/x-pack/test/fleet_api_integration/apis/fixtures/test_packages/secrets/1.0.0/manifest.yml
+++ b/x-pack/test/fleet_api_integration/apis/fixtures/test_packages/secrets/1.0.0/manifest.yml
@@ -47,6 +47,5 @@ policy_templates:
             type: text
             title: Input Var Secret
             multi: false
-            required: true
             show_user: true
             secret: true

--- a/x-pack/test/fleet_api_integration/apis/index.js
+++ b/x-pack/test/fleet_api_integration/apis/index.js
@@ -17,20 +17,8 @@ export default function ({ loadTestFile, getService }) {
     // Fleet setup
     loadTestFile(require.resolve('./fleet_setup')); // ~ 6s
 
-    // Enrollment API keys
-    loadTestFile(require.resolve('./enrollment_api_keys/crud'));
+    loadTestFile(require.resolve('./policy_secrets')); // ~40s
 
-    // Package policies
-    loadTestFile(require.resolve('./policy_secrets'));
-    loadTestFile(require.resolve('./package_policy/create'));
-    loadTestFile(require.resolve('./package_policy/update'));
-    loadTestFile(require.resolve('./package_policy/get'));
-    loadTestFile(require.resolve('./package_policy/delete'));
-    loadTestFile(require.resolve('./package_policy/upgrade'));
-    loadTestFile(require.resolve('./package_policy/input_package_create_upgrade'));
-
-    // Agent policies
-    loadTestFile(require.resolve('./agent_policy'));
     loadTestFile(require.resolve('./enrollment_api_keys/crud')); // ~ 20s
 
     // Data Streams


### PR DESCRIPTION
## Summary

Part of https://github.com/elastic/kibana/issues/154731

Allow secrets to be updated via the API. When a secret value is updated, the secret reference is replaced with a "raw" value we detect this on the API and create a new secret document.

Once a secret reference is updated, we clean up the old secret document if it is not in use by another policy. This check is a simple lookup of the secret_references array on policies. 

API integration tests updated.
