### PR TITLE
[Synthetics] Include step metrics bounds in waterfall network requests

### DIFF
--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/step_details_page/common/network_data/data_formatting.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/step_details_page/common/network_data/data_formatting.ts
@@ -8,6 +8,7 @@
 import { euiPaletteColorBlind } from '@elastic/eui';
 import moment from 'moment';
 
+import { MarkerItems } from '../../step_waterfall_chart/waterfall/context/waterfall_context';
 import { NetworkEvent } from '../../../../../../../common/runtime_types';
 import { WaterfallData, WaterfallMetadata } from './types';
 import {
@@ -128,7 +129,8 @@ export const getSeriesAndDomain = (
   items: NetworkEvent[],
   onlyHighlighted = false,
   query?: string,
-  activeFilters?: string[]
+  activeFilters?: string[],
+  markerItems?: MarkerItems
 ) => {
   const getValueForOffset = (item: NetworkEvent) => {
     return item.requestSentTime;
@@ -243,6 +245,12 @@ export const getSeriesAndDomain = (
   let filteredSeries = series;
   if (onlyHighlighted) {
     filteredSeries = series.filter((item) => item.config.isHighlighted);
+  }
+
+  if (markerItems && markerItems.length > 0) {
+    // set domain to include marker items, whichever has higher time value
+    const highestMarkerTime = Math.max(...markerItems.map((item) => item.offset));
+    domain.max = Math.max(domain.max, highestMarkerTime);
   }
 
   return { series: filteredSeries, domain, metadata, totalHighlightedRequests };

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/step_details_page/step_waterfall_chart/waterfall/waterfall_chart_wrapper.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/step_details_page/step_waterfall_chart/waterfall/waterfall_chart_wrapper.tsx
@@ -55,8 +55,8 @@ export const WaterfallChartWrapper: React.FC<Props> = ({
   const hasFilters = activeFilters.length > 0;
 
   const { series, domain, metadata, totalHighlightedRequests } = useMemo(() => {
-    return getSeriesAndDomain(networkData, onlyHighlighted, query, activeFilters);
-  }, [networkData, query, activeFilters, onlyHighlighted]);
+    return getSeriesAndDomain(networkData, onlyHighlighted, query, activeFilters, markerItems);
+  }, [networkData, query, activeFilters, onlyHighlighted, markerItems]);
 
   const sidebarItems = useMemo(() => {
     return getSidebarItems(networkData, onlyHighlighted ?? false, query, activeFilters);


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/155810

Include step metrics bounds in waterfall traces, step metrics will be shown even if they happen after network request time values

### After

<img width="1778" alt="image" src="https://user-images.githubusercontent.com/3505601/236425361-34e0da54-88e8-4e4c-9561-219768016a76.png">


### Before
<img width="1779" alt="image" src="https://user-images.githubusercontent.com/3505601/236425586-c4ccc18d-4bcc-432e-bdbf-5e466c2ffefe.png">


<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->