### PR TITLE
[Enterprise Search][Behavioral Analytics] Add validation for collection name

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/analytics/components/add_analytics_collections/add_analytics_collection_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/analytics/components/add_analytics_collections/add_analytics_collection_logic.test.ts
@@ -151,6 +151,20 @@ describe('addAnalyticsCollectionLogic', () => {
         });
       });
     });
+
+    describe('setNameValue', () => {
+      it('should call an error if name is not valid', () => {
+        AddAnalyticsCollectionLogic.actions.setNameValue('Invalid');
+        expect(AddAnalyticsCollectionLogic.values.inputError).toBeTruthy();
+      });
+
+      it('should remove error if name become valid', () => {
+        AddAnalyticsCollectionLogic.actions.setNameValue('Invalid');
+        expect(AddAnalyticsCollectionLogic.values.inputError).toBeTruthy();
+        AddAnalyticsCollectionLogic.actions.setNameValue('valid');
+        expect(AddAnalyticsCollectionLogic.values.inputError).toBeFalsy();
+      });
+    });
   });
 
   describe('selectors', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/analytics/components/add_analytics_collections/add_analytics_collection_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/analytics/components/add_analytics_collections/add_analytics_collection_logic.ts
@@ -27,6 +27,7 @@ import {
 import { COLLECTION_OVERVIEW_PATH } from '../../routes';
 
 const SERVER_ERROR_CODE = 500;
+const NAME_VALIDATION = new RegExp(/^[a-z0-9\-]+$/);
 
 export interface AddAnalyticsCollectionsActions {
   apiError: Actions<
@@ -111,6 +112,16 @@ export const AddAnalyticsCollectionLogic = kea<
       const { name } = values;
       actions.makeRequest({ name });
     },
+    setNameValue: ({ name }) => {
+      if (!NAME_VALIDATION.test(name)) {
+        actions.setInputError(
+          i18n.translate('xpack.enterpriseSearch.analytics.collectionsCreate.invalidName', {
+            defaultMessage:
+              'Collection name can only contain lowercase letters, numbers, and hyphens',
+          })
+        );
+      }
+    },
   }),
   path: ['enterprise_search', 'analytics', 'add_analytics_collection'],
   reducers: {
@@ -130,8 +141,8 @@ export const AddAnalyticsCollectionLogic = kea<
   },
   selectors: ({ selectors }) => ({
     canSubmit: [
-      () => [selectors.isLoading, selectors.name],
-      (isLoading, name) => !isLoading && name.length > 0,
+      () => [selectors.isLoading, selectors.name, selectors.inputError],
+      (isLoading, name, inputError) => !isLoading && name.length > 0 && !inputError,
     ],
     isLoading: [() => [selectors.status], (status: Status) => status === Status.LOADING],
     isSuccess: [() => [selectors.status], (status: Status) => status === Status.SUCCESS],


### PR DESCRIPTION
Use validation for creationg collection name. Allowed only lowercase letters, numbers and hyphens
<img width="686" alt="image" src="https://user-images.githubusercontent.com/17390745/236435878-bc3e2e04-2e22-4572-a55a-c78c5727016b.png">


<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->