### PR TITLE
[Lens] Fix field formatters tests

### DIFF
--- a/test/functional/services/field_editor.ts
+++ b/test/functional/services/field_editor.ts
@@ -112,5 +112,6 @@ export class FieldEditorService extends FtrService {
 
   public async waitUntilClosed() {
     await this.testSubjects.waitForDeleted('fieldEditor');
+    await this.testSubjects.missingOrFail('fieldEditor');
   }
 }

--- a/test/functional/services/field_editor.ts
+++ b/test/functional/services/field_editor.ts
@@ -13,7 +13,6 @@ export class FieldEditorService extends FtrService {
   private readonly testSubjects = this.ctx.getService('testSubjects');
   private readonly retry = this.ctx.getService('retry');
   private readonly find = this.ctx.getService('find');
-  private readonly common = this.ctx.getPageObject('common');
 
   public async setName(name: string, clearFirst = false, typeCharByChar = false) {
     await this.testSubjects.setValue('nameField > input', name, {
@@ -109,11 +108,5 @@ export class FieldEditorService extends FtrService {
         timeout: 1000,
       });
     });
-  }
-
-  public async waitUntilClosed() {
-    await this.testSubjects.waitForDeleted('fieldEditor');
-    await this.testSubjects.missingOrFail('fieldEditor');
-    await this.common.sleep(1000);
   }
 }

--- a/test/functional/services/field_editor.ts
+++ b/test/functional/services/field_editor.ts
@@ -13,6 +13,7 @@ export class FieldEditorService extends FtrService {
   private readonly testSubjects = this.ctx.getService('testSubjects');
   private readonly retry = this.ctx.getService('retry');
   private readonly find = this.ctx.getService('find');
+  private readonly common = this.ctx.getPageObject('common');
 
   public async setName(name: string, clearFirst = false, typeCharByChar = false) {
     await this.testSubjects.setValue('nameField > input', name, {
@@ -113,5 +114,6 @@ export class FieldEditorService extends FtrService {
   public async waitUntilClosed() {
     await this.testSubjects.waitForDeleted('fieldEditor');
     await this.testSubjects.missingOrFail('fieldEditor');
+    await this.common.sleep(1000);
   }
 }

--- a/x-pack/test/functional/apps/lens/group2/field_formatters.ts
+++ b/x-pack/test/functional/apps/lens/group2/field_formatters.ts
@@ -45,8 +45,10 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await fieldEditor.setFormat(FIELD_FORMAT_IDS.URL);
         await fieldEditor.setUrlFieldFormat('https://www.elastic.co?{{value}}');
         await fieldEditor.save();
-        await fieldEditor.waitUntilClosed();
-        await PageObjects.header.waitUntilLoadingHasFinished();
+        await Promise.all([
+          PageObjects.header.waitUntilLoadingHasFinished(),
+          fieldEditor.waitUntilClosed(),
+        ]);
         await PageObjects.lens.searchField('runtime');
         await PageObjects.lens.waitForField('runtimefield');
         await PageObjects.lens.dragFieldToWorkspace('runtimefield');
@@ -67,8 +69,10 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await fieldEditor.setFormat(FIELD_FORMAT_IDS.STATIC_LOOKUP);
         await fieldEditor.setStaticLookupFormat('CN', 'China');
         await fieldEditor.save();
-        await fieldEditor.waitUntilClosed();
-        await PageObjects.header.waitUntilLoadingHasFinished();
+        await Promise.all([
+          PageObjects.header.waitUntilLoadingHasFinished(),
+          fieldEditor.waitUntilClosed(),
+        ]);
       });
       await PageObjects.lens.waitForVisualization();
       expect(await PageObjects.lens.getDatatableCellText(0, 0)).to.eql('China');
@@ -83,8 +87,10 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await fieldEditor.setFormat(FIELD_FORMAT_IDS.COLOR);
         await fieldEditor.setColorFormat('CN', '#ffffff', '#ff0000');
         await fieldEditor.save();
-        await fieldEditor.waitUntilClosed();
-        await PageObjects.header.waitUntilLoadingHasFinished();
+        await Promise.all([
+          PageObjects.header.waitUntilLoadingHasFinished(),
+          fieldEditor.waitUntilClosed(),
+        ]);
       });
       await PageObjects.lens.waitForVisualization();
       const styleObj = await PageObjects.lens.getDatatableCellSpanStyle(0, 0);
@@ -101,8 +107,10 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await fieldEditor.setFormat(FIELD_FORMAT_IDS.STRING);
         await fieldEditor.setStringFormat('lower');
         await fieldEditor.save();
-        await fieldEditor.waitUntilClosed();
-        await PageObjects.header.waitUntilLoadingHasFinished();
+        await Promise.all([
+          PageObjects.header.waitUntilLoadingHasFinished(),
+          fieldEditor.waitUntilClosed(),
+        ]);
       });
       await PageObjects.lens.waitForVisualization();
       expect(await PageObjects.lens.getDatatableCellText(0, 0)).to.eql('cn');
@@ -117,8 +125,10 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await fieldEditor.setFormat(FIELD_FORMAT_IDS.TRUNCATE);
         await fieldEditor.setTruncateFormatLength('3');
         await fieldEditor.save();
-        await fieldEditor.waitUntilClosed();
-        await PageObjects.header.waitUntilLoadingHasFinished();
+        await Promise.all([
+          PageObjects.header.waitUntilLoadingHasFinished(),
+          fieldEditor.waitUntilClosed(),
+        ]);
       });
       await PageObjects.lens.waitForVisualization();
       expect(await PageObjects.lens.getDatatableCellText(0, 0)).to.eql('dal...');

--- a/x-pack/test/functional/apps/lens/group2/field_formatters.ts
+++ b/x-pack/test/functional/apps/lens/group2/field_formatters.ts
@@ -20,6 +20,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   ]);
   const retry = getService('retry');
   const fieldEditor = getService('fieldEditor');
+  const testSubjects = getService('testSubjects');
 
   describe('lens fields formatters tests', () => {
     before(async () => {
@@ -30,6 +31,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     });
 
     afterEach(async () => {
+      await testSubjects.missingOrFail('fieldEditor');
       await PageObjects.lens.clickField('runtimefield');
       await PageObjects.lens.removeField('runtimefield');
       await fieldEditor.confirmDelete();
@@ -45,10 +47,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await fieldEditor.setFormat(FIELD_FORMAT_IDS.URL);
         await fieldEditor.setUrlFieldFormat('https://www.elastic.co?{{value}}');
         await fieldEditor.save();
-        await Promise.all([
-          PageObjects.header.waitUntilLoadingHasFinished(),
-          fieldEditor.waitUntilClosed(),
-        ]);
+        await PageObjects.header.waitUntilLoadingHasFinished();
         await PageObjects.lens.searchField('runtime');
         await PageObjects.lens.waitForField('runtimefield');
         await PageObjects.lens.dragFieldToWorkspace('runtimefield');
@@ -69,10 +68,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await fieldEditor.setFormat(FIELD_FORMAT_IDS.STATIC_LOOKUP);
         await fieldEditor.setStaticLookupFormat('CN', 'China');
         await fieldEditor.save();
-        await Promise.all([
-          PageObjects.header.waitUntilLoadingHasFinished(),
-          fieldEditor.waitUntilClosed(),
-        ]);
+        await PageObjects.header.waitUntilLoadingHasFinished();
       });
       await PageObjects.lens.waitForVisualization();
       expect(await PageObjects.lens.getDatatableCellText(0, 0)).to.eql('China');
@@ -87,10 +83,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await fieldEditor.setFormat(FIELD_FORMAT_IDS.COLOR);
         await fieldEditor.setColorFormat('CN', '#ffffff', '#ff0000');
         await fieldEditor.save();
-        await Promise.all([
-          PageObjects.header.waitUntilLoadingHasFinished(),
-          fieldEditor.waitUntilClosed(),
-        ]);
+        await PageObjects.header.waitUntilLoadingHasFinished();
       });
       await PageObjects.lens.waitForVisualization();
       const styleObj = await PageObjects.lens.getDatatableCellSpanStyle(0, 0);
@@ -107,10 +100,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await fieldEditor.setFormat(FIELD_FORMAT_IDS.STRING);
         await fieldEditor.setStringFormat('lower');
         await fieldEditor.save();
-        await Promise.all([
-          PageObjects.header.waitUntilLoadingHasFinished(),
-          fieldEditor.waitUntilClosed(),
-        ]);
+        await PageObjects.header.waitUntilLoadingHasFinished();
       });
       await PageObjects.lens.waitForVisualization();
       expect(await PageObjects.lens.getDatatableCellText(0, 0)).to.eql('cn');
@@ -125,10 +115,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await fieldEditor.setFormat(FIELD_FORMAT_IDS.TRUNCATE);
         await fieldEditor.setTruncateFormatLength('3');
         await fieldEditor.save();
-        await Promise.all([
-          PageObjects.header.waitUntilLoadingHasFinished(),
-          fieldEditor.waitUntilClosed(),
-        ]);
+        await PageObjects.header.waitUntilLoadingHasFinished();
       });
       await PageObjects.lens.waitForVisualization();
       expect(await PageObjects.lens.getDatatableCellText(0, 0)).to.eql('dal...');


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
