### PR TITLE
[APM] Show stack trace on errors when only available as plain text

### DIFF
--- a/x-pack/plugins/apm/public/components/app/error_group_details/error_sampler/error_sample_detail.tsx
+++ b/x-pack/plugins/apm/public/components/app/error_group_details/error_sampler/error_sample_detail.tsx
@@ -48,6 +48,7 @@ import { Summary } from '../../../shared/summary';
 import { HttpInfoSummaryItem } from '../../../shared/summary/http_info_summary_item';
 import { UserAgentSummaryItem } from '../../../shared/summary/user_agent_summary_item';
 import { TimestampTooltip } from '../../../shared/timestamp_tooltip';
+import { PlaintextStacktrace } from './plaintext_stacktrace';
 import { TransactionTab } from '../../transaction_details/waterfall_with_summary/transaction_tabs';
 import { ErrorSampleCoPilotPrompt } from './error_sample_co_pilot_prompt';
 import { ErrorTab, ErrorTabKey, getTabs } from './error_tabs';
@@ -379,14 +380,24 @@ export function ErrorSampleDetailTabContent({
   const codeLanguage = error?.service.language?.name;
   const exceptions = error?.error.exception || [];
   const logStackframes = error?.error.log?.stacktrace;
-
+  const isPlaintextException =
+    !!error?.error.stack_trace &&
+    exceptions.length === 1 &&
+    !exceptions[0].stacktrace;
   switch (currentTab.key) {
     case ErrorTabKey.LogStackTrace:
       return (
         <Stacktrace stackframes={logStackframes} codeLanguage={codeLanguage} />
       );
     case ErrorTabKey.ExceptionStacktrace:
-      return (
+      return isPlaintextException ? (
+        <PlaintextStacktrace
+          message={exceptions[0].message}
+          type={exceptions[0].type}
+          stacktrace={error?.error.stack_trace}
+          codeLanguage={codeLanguage}
+        />
+      ) : (
         <ExceptionStacktrace
           codeLanguage={codeLanguage}
           exceptions={exceptions}

--- a/x-pack/plugins/apm/public/components/app/error_group_details/error_sampler/plaintext_stacktrace.tsx
+++ b/x-pack/plugins/apm/public/components/app/error_group_details/error_sampler/plaintext_stacktrace.tsx
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiCodeBlock } from '@elastic/eui';
+import { ExceptionStacktraceTitle } from './exception_stacktrace_title';
+
+interface PlaintextStacktraceProps {
+  codeLanguage?: string;
+  message?: string;
+  stacktrace?: string;
+  type?: string;
+}
+
+export function PlaintextStacktrace({
+  codeLanguage,
+  message,
+  stacktrace,
+  type,
+}: PlaintextStacktraceProps) {
+  return (
+    <>
+      <ExceptionStacktraceTitle
+        type={type}
+        message={message}
+        codeLanguage={codeLanguage}
+      />
+      {stacktrace && (
+        <EuiCodeBlock isCopyable={true} language={codeLanguage}>
+          {stacktrace}
+        </EuiCodeBlock>
+      )}
+    </>
+  );
+}

--- a/x-pack/plugins/apm/typings/es_schemas/raw/error_raw.ts
+++ b/x-pack/plugins/apm/typings/es_schemas/raw/error_raw.ts
@@ -56,6 +56,7 @@ export interface ErrorRaw extends APMBaseDoc {
     exception?: Exception[];
     page?: Page; // special property for RUM: shared by error and transaction
     log?: Log;
+    stack_trace?: string;
     custom?: Record<string, unknown>;
   };
 


### PR DESCRIPTION
## Summary

Closes #124204

Shows plaintext stacktrace when it's only available as a value in `error.stack_trace` (which is mostly the case with OTel and mobile agents).

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

