### PR TITLE
[HTTP] Add example of using http fetch's `version` parameter

### DIFF
--- a/dev_docs/tutorials/versioning_http_apis.mdx
+++ b/dev_docs/tutorials/versioning_http_apis.mdx
@@ -290,7 +290,7 @@ Core exposes a versioned router that ensures your endpoint's behaviour and forma
     // BREAKING CHANGES: Enforce min/max length on fooString
     .addVersion(
       {
-        version: '2023-03-01',
+        version: '2025-03-01',
         validate: {
           request: {
             query: schema.object({
@@ -312,6 +312,26 @@ Core exposes a versioned router that ensures your endpoint's behaviour and forma
         await ctx.fooService.create(req.body.fooString, req.params.id, req.query.name);
         return res.ok({ body: { fooName: req.body.fooString } });
       }
+```
+
+#### Use `http.fetch` to send a version
+
+Core's `http.fetch` (and helpers like `http.get`) accept an optional `version` parameter. The `versioned` parameter can be used to send your request to the corresponding handler of the route.
+
+```ts
+import type { CoreSetup, Plugin } from '@kbn/core/public';
+
+export class MyPlugin implements Plugin {
+  setup(core: CoreSetup): FilesSetup {
+    // Example call using core's http.fetch
+    core.http.post('/api/my-app/foo/1', {
+      version: '2023-10-31',
+      headers: { 'content-type': 'application/json' },
+      query: { name: 'example' },
+      body: JSON.stringify({ fooString: 'string' }),
+    });
+  }
+}
 ```
 
 #### Additional reading

--- a/dev_docs/tutorials/versioning_http_apis.mdx
+++ b/dev_docs/tutorials/versioning_http_apis.mdx
@@ -335,4 +335,4 @@ export class MyPlugin implements Plugin {
 ```
 
 #### Additional reading
-For a more details on the versioning specification see [this document](https://docs.google.com/document/d/1YpF6hXIHZaHvwNaQAxWFzexUF1nbqACTtH2IfDu0ldA/edit?usp=sharing).
+For more details on the versioning specification see [this document](https://docs.google.com/document/d/1YpF6hXIHZaHvwNaQAxWFzexUF1nbqACTtH2IfDu0ldA/edit?usp=sharing).

--- a/dev_docs/tutorials/versioning_http_apis.mdx
+++ b/dev_docs/tutorials/versioning_http_apis.mdx
@@ -316,7 +316,7 @@ Core exposes a versioned router that ensures your endpoint's behaviour and forma
 
 #### Use `http.fetch` to send a version
 
-Core's `http.fetch` (and helpers like `http.get`) accept an optional `version` parameter. The `versioned` parameter can be used to send your request to the corresponding handler of the route.
+Core's `http.fetch` (and helpers like `http.get`) accept an optional `version` parameter. The `version` parameter can be used to send your request to the corresponding handler of the route.
 
 ```ts
 import type { CoreSetup, Plugin } from '@kbn/core/public';

--- a/dev_docs/tutorials/versioning_http_apis.mdx
+++ b/dev_docs/tutorials/versioning_http_apis.mdx
@@ -238,7 +238,7 @@ Core exposes a versioned router that ensures your endpoint's behaviour and forma
     })
     .addVersion(
       {
-        version: '2023-01-01', // The public version of this API
+        version: '2023-10-31', // The public version of this API
         validate: {
           request: {
             query: schema.object({
@@ -264,7 +264,7 @@ Core exposes a versioned router that ensures your endpoint's behaviour and forma
     // BREAKING CHANGE: { foo: string } => { fooString: string } in response body
     .addVersion(
       {
-        version: '2023-02-01',
+        version: '2024-10-31',
         validate: {
           request: {
             query: schema.object({


### PR DESCRIPTION
## Summary

Added an example to the HTTP versioning tutorial of how a version can be sent using `http.fetch`.

Also changed the example to use a more realistic version like `2023-10-31`.


<img width="945" alt="Screenshot 2023-05-05 at 14 00 01" src="https://user-images.githubusercontent.com/8155004/236452199-a15284ee-e23b-49e1-9b49-fb80c0225b1a.png">

