### PR TITLE
[ResponseOps] [Maintenance Windows] Fix date format on the table

### DIFF
--- a/x-pack/plugins/alerting/public/pages/maintenance_windows/components/maintenance_windows_list.test.tsx
+++ b/x-pack/plugins/alerting/public/pages/maintenance_windows/components/maintenance_windows_list.test.tsx
@@ -116,10 +116,10 @@ describe('MaintenanceWindowsList', () => {
     expect(result.getAllByText('Archived')).toHaveLength(1);
 
     // check the startDate formatting
-    expect(result.getAllByText('04/05/23 00:00 AM')).toHaveLength(4);
+    expect(result.getAllByText('04/05/23 12:00 AM')).toHaveLength(4);
 
     // check the endDate formatting
-    expect(result.getAllByText('05/05/23 00:00 AM')).toHaveLength(4);
+    expect(result.getAllByText('05/05/23 12:00 AM')).toHaveLength(4);
 
     // check if action menu is there
     expect(result.getAllByTestId('table-actions-icon-button')).toHaveLength(items.length);

--- a/x-pack/plugins/alerting/public/pages/maintenance_windows/components/maintenance_windows_list.tsx
+++ b/x-pack/plugins/alerting/public/pages/maintenance_windows/components/maintenance_windows_list.tsx
@@ -60,7 +60,7 @@ const COLUMNS: Array<EuiBasicTableColumn<MaintenanceWindowFindResponse>> = [
     render: (startDate: string, item: MaintenanceWindowFindResponse) => {
       return (
         <EuiFlexGroup responsive={false} alignItems="center">
-          <EuiFlexItem grow={false}>{formatDate(startDate, 'MM/DD/YY HH:mm A')}</EuiFlexItem>
+          <EuiFlexItem grow={false}>{formatDate(startDate, 'MM/DD/YY hh:mm A')}</EuiFlexItem>
           {item.events.length > 1 ? (
             <EuiFlexItem grow={false}>
               <UpcomingEventsPopover maintenanceWindowFindResponse={item} />
@@ -75,7 +75,7 @@ const COLUMNS: Array<EuiBasicTableColumn<MaintenanceWindowFindResponse>> = [
     field: 'eventEndTime',
     name: i18n.TABLE_END_TIME,
     dataType: 'date',
-    render: (endDate: string) => formatDate(endDate, 'MM/DD/YY HH:mm A'),
+    render: (endDate: string) => formatDate(endDate, 'MM/DD/YY hh:mm A'),
   },
 ];
 

--- a/x-pack/plugins/alerting/public/pages/maintenance_windows/components/upcoming_events_popover.tsx
+++ b/x-pack/plugins/alerting/public/pages/maintenance_windows/components/upcoming_events_popover.tsx
@@ -107,7 +107,7 @@ export const UpcomingEventsPopover: React.FC<UpcomingEventsPopoverProps> = React
                 </EuiFlexItem>
                 <EuiFlexItem grow={false}>
                   <EuiText color="subdued" size="s">
-                    {formatDate(event.gte, 'MM/DD/YY HH:mm A')}
+                    {formatDate(event.gte, 'MM/DD/YY hh:mm A')}
                   </EuiText>
                 </EuiFlexItem>
               </EuiFlexGroup>


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/156852

## Summary

Removes 24-clock date formatting

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->