### PR TITLE
[Serverless] Telemetry default config

### DIFF
--- a/config/serverless.yml
+++ b/config/serverless.yml
@@ -17,3 +17,7 @@ xpack.license_management.enabled: false
 # Other disabled plugins
 #xpack.canvas.enabled: false #only disabable in dev-mode
 xpack.reporting.enabled: false
+
+# Telemetry enabled by default and not disableable via UI
+telemetry.optIn: true
+telemetry.allowChangingOptInStatus: false


### PR DESCRIPTION
## Summary

We want serverless to have telemetry opted-in by default and not to show the banner nor the UI components to being able to opt-out. Our EULA should allow us to collect telemetry.


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
