### PR TITLE
Change token used for skip-failed-test permission check

### DIFF
--- a/.github/workflows/skip-failed-test.yml
+++ b/.github/workflows/skip-failed-test.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           permission: admin
           teams: appex-qa
-          token: ${{secrets.GITHUB_TOKEN}}
+          token: ${{secrets.KIBANAMACHINE_TOKEN}}
 
       - name: Checkout kibana-operations
         uses: actions/checkout@v2


### PR DESCRIPTION
The default Github actions token (`GITHUB_TOKEN`) doesn't have the required permission to do a team membership check, so the appex-qa team is still not able to skip tests. I believe this will fix it.