### PR TITLE
[7.17] [Telemetry] Change Privacy Statement Link (#156845)

### DIFF
--- a/docs/settings/telemetry-settings.asciidoc
+++ b/docs/settings/telemetry-settings.asciidoc
@@ -11,7 +11,7 @@ can focus our efforts on making them even better.
 You can control whether this data is sent from the {kib} servers, or if it should be sent
 from the user's browser, in case a firewall is blocking the connections from the server. Additionally, you can decide to completely disable this feature either in the config file or in {kib} via *Management > Kibana > Advanced Settings > Usage Data*.
 
-See our https://www.elastic.co/legal/privacy-statement[Privacy Statement] to learn more.
+Refer to our https://www.elastic.co/legal/product-privacy-statement[Privacy Statement] to learn more.
 
 [float]
 [[telemetry-general-settings]]

--- a/src/plugins/telemetry/common/constants.ts
+++ b/src/plugins/telemetry/common/constants.ts
@@ -43,7 +43,7 @@ export const PATH_TO_ADVANCED_SETTINGS = '/app/management/kibana/settings';
 /**
  * Link to the Elastic Telemetry privacy statement.
  */
-export const PRIVACY_STATEMENT_URL = `https://www.elastic.co/legal/privacy-statement`;
+export const PRIVACY_STATEMENT_URL = `https://www.elastic.co/legal/product-privacy-statement`;
 
 /**
  * The telemetry payload content encryption encoding

--- a/src/plugins/telemetry/public/components/__snapshots__/opt_in_message.test.tsx.snap
+++ b/src/plugins/telemetry/public/components/__snapshots__/opt_in_message.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`OptInMessage renders as expected 1`] = `
     values={
       Object {
         "privacyStatementLink": <EuiLink
-          href="https://www.elastic.co/legal/privacy-statement"
+          href="https://www.elastic.co/legal/product-privacy-statement"
           rel="noopener"
           target="_blank"
         >

--- a/src/plugins/telemetry/public/components/__snapshots__/opted_in_notice_banner.test.tsx.snap
+++ b/src/plugins/telemetry/public/components/__snapshots__/opted_in_notice_banner.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`OptInDetailsComponent renders as expected 1`] = `
           />
         </EuiLink>,
         "privacyStatementLink": <EuiLink
-          href="https://www.elastic.co/legal/privacy-statement"
+          href="https://www.elastic.co/legal/product-privacy-statement"
           onClick={[Function]}
           rel="noopener"
           target="_blank"

--- a/src/plugins/telemetry_management_section/public/components/__snapshots__/telemetry_management_section.test.tsx.snap
+++ b/src/plugins/telemetry_management_section/public/components/__snapshots__/telemetry_management_section.test.tsx.snap
@@ -64,7 +64,7 @@ exports[`TelemetryManagementSectionComponent renders as expected 1`] = `
                     values={
                       Object {
                         "privacyStatementLink": <EuiLink
-                          href="https://www.elastic.co/legal/privacy-statement"
+                          href="https://www.elastic.co/legal/product-privacy-statement"
                           target="_blank"
                         >
                           <FormattedMessage


### PR DESCRIPTION
## Summary

Manual backport of https://github.com/elastic/kibana/pull/156845 because the package split makes backporting it impossible.
