### PR TITLE
[8.8] [Security Solution] Fix rule snooze description on the rule editing page (#155850)

### DIFF
--- a/packages/kbn-doc-links/src/get_doc_links.ts
+++ b/packages/kbn-doc-links/src/get_doc_links.ts
@@ -399,6 +399,7 @@ export const getDocLinks = ({ kibanaBranch }: GetDocLinkOptions): DocLinks => {
         value_lists: `${SECURITY_SOLUTION_DOCS}value-lists-exceptions.html`,
       },
       privileges: `${SECURITY_SOLUTION_DOCS}endpoint-management-req.html`,
+      manageDetectionRules: `${SECURITY_SOLUTION_DOCS}rules-ui-management.html`,
     },
     query: {
       eql: `${ELASTICSEARCH_DOCS}eql.html`,

--- a/packages/kbn-doc-links/src/types.ts
+++ b/packages/kbn-doc-links/src/types.ts
@@ -302,6 +302,7 @@ export interface DocLinks {
       value_lists: string;
     };
     readonly privileges: string;
+    readonly manageDetectionRules: string;
   };
   readonly query: {
     readonly eql: string;

--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_rule_actions/rule_snooze_section.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_rule_actions/rule_snooze_section.tsx
@@ -6,8 +6,7 @@
  */
 
 import React from 'react';
-import { css } from '@emotion/react';
-import { EuiFlexGroup, EuiFlexItem, EuiText, useEuiTheme } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
 import type { RuleObjectId } from '../../../../../common/detection_engine/rule_schema';
 import { RuleSnoozeBadge } from '../../../../detection_engine/rule_management/components/rule_snooze_badge';
 import * as i18n from './translations';
@@ -17,26 +16,14 @@ interface RuleSnoozeSectionProps {
 }
 
 export function RuleSnoozeSection({ ruleId }: RuleSnoozeSectionProps): JSX.Element {
-  const { euiTheme } = useEuiTheme();
-
   return (
-    <section>
-      <EuiText size="s">{i18n.RULE_SNOOZE_DESCRIPTION}</EuiText>
-      <EuiFlexGroup
-        alignItems="center"
-        css={css`
-          margin-top: ${euiTheme.size.s};
-        `}
-      >
-        <EuiFlexItem grow={false}>
-          <RuleSnoozeBadge ruleId={ruleId} showTooltipInline />
-        </EuiFlexItem>
-        <EuiFlexItem>
-          <EuiText size="s">
-            <strong>{i18n.SNOOZED_ACTIONS_WARNING}</strong>
-          </EuiText>
-        </EuiFlexItem>
-      </EuiFlexGroup>
-    </section>
+    <EuiFlexGroup direction="column" gutterSize="s">
+      <EuiFlexItem>
+        <EuiText size="s">{i18n.RULE_SNOOZE_DESCRIPTION}</EuiText>
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <RuleSnoozeBadge ruleId={ruleId} showTooltipInline />
+      </EuiFlexItem>
+    </EuiFlexGroup>
   );
 }

--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_rule_actions/translations.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_rule_actions/translations.tsx
@@ -5,7 +5,11 @@
  * 2.0.
  */
 
+import React from 'react';
 import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { EuiLink } from '@elastic/eui';
+import { useKibana } from '../../../../common/lib/kibana';
 
 export const COMPLETE_WITHOUT_ENABLING = i18n.translate(
   'xpack.securitySolution.detectionEngine.createRule.stepScheduleRule.completeWithoutEnablingTitle',
@@ -29,17 +33,36 @@ export const NO_ACTIONS_READ_PERMISSIONS = i18n.translate(
   }
 );
 
-export const RULE_SNOOZE_DESCRIPTION = i18n.translate(
-  'xpack.securitySolution.detectionEngine.createRule.stepRuleActions.snoozeDescription',
+const RULE_SNOOZE_DOCS_LINK_TEXT = i18n.translate(
+  'xpack.securitySolution.detectionEngine.createRule.stepRuleActions.docsLinkText',
   {
-    defaultMessage:
-      'Select when automated actions should be performed if a rule evaluates as true.',
+    defaultMessage: 'Learn more',
   }
 );
 
-export const SNOOZED_ACTIONS_WARNING = i18n.translate(
-  'xpack.securitySolution.detectionEngine.createRule.stepRuleActions.snoozedActionsWarning',
-  {
-    defaultMessage: 'Actions will not be performed until it is unsnoozed.',
-  }
-);
+function RuleSnoozeDescription(): JSX.Element {
+  const {
+    docLinks: {
+      links: {
+        securitySolution: { manageDetectionRules },
+      },
+    },
+  } = useKibana().services;
+  const manageDetectionRulesSnoozeSection = `${manageDetectionRules}#edit-rules-settings`;
+
+  return (
+    <FormattedMessage
+      id="xpack.securitySolution.detectionEngine.createRule.stepRuleActions.snoozeDescription"
+      defaultMessage="Choose when to perform actions or snooze them. Notifications are not created for snoozed actions. {docs}."
+      values={{
+        docs: (
+          <EuiLink href={manageDetectionRulesSnoozeSection} target="_blank">
+            {RULE_SNOOZE_DOCS_LINK_TEXT}
+          </EuiLink>
+        ),
+      }}
+    />
+  );
+}
+
+export const RULE_SNOOZE_DESCRIPTION = <RuleSnoozeDescription />;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.8`:
 - [[Security Solution] Fix rule snooze description on the rule editing page (#155850)](https://github.com/elastic/kibana/pull/155850)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Maxim Palenov","email":"maxim.palenov@elastic.co"},"sourceCommit":{"committedDate":"2023-05-05T16:14:41Z","message":"[Security Solution] Fix rule snooze description on the rule editing page (#155850)\n\n**Addresses:** https://github.com/elastic/kibana/issues/147737\r\n**Relates to:** https://github.com/elastic/kibana/pull/155612\r\n\r\n## Summary\r\n\r\nAfter merging https://github.com/elastic/kibana/pull/155612 back there is one issue is left unresolved described in this [comment](https://github.com/elastic/kibana/pull/155612#discussion_r1175545697):\r\n\r\n> Looks like we show the `Actions will not be preformed until it is unsnoozed` message unconditionally, i.e. regardless of whether the rule is snoozed or not. Since it's in bold it feels like a warning in the case where it doesn't really matter:\r\n\r\n> Can we hide it when the rule is not snoozed? If it's not trivial, can we make it look less dangerous by making the font regular and playing with the copy a little bit? E.g. `If snoozed actions will not be triggered`.\r\n\r\nThis PR resolves rule snooze description text issue. As snooze settings are resolved outside the security solution plugin having any logic to conditionally display a message will increase the complexity. This way the message was changes to avoid any text to appear conditionally.\r\n\r\n*Before:*\r\n\r\n<img width=\"703\" alt=\"Screenshot 2023-04-24 at 18 36 31\" src=\"https://user-images.githubusercontent.com/7359339/234060523-fe9161a1-0e83-4d39-a193-81c946d95106.png\">\r\n\r\n*After:*\r\n\r\n![image](https://user-images.githubusercontent.com/3775283/236254424-533a6502-49ba-444e-87e5-9cda7e84c315.png)\r\n\r\n\r\n### Checklist\r\n\r\n- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)","sha":"6714d926ee041d61c627037189263905918303b3","branchLabelMapping":{"^v8.9.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","Team:Detections and Resp","Team: SecuritySolution","Feature:Rule Management","Team:Detection Rules","ui-copy","v8.8.0","v8.9.0"],"number":155850,"url":"https://github.com/elastic/kibana/pull/155850","mergeCommit":{"message":"[Security Solution] Fix rule snooze description on the rule editing page (#155850)\n\n**Addresses:** https://github.com/elastic/kibana/issues/147737\r\n**Relates to:** https://github.com/elastic/kibana/pull/155612\r\n\r\n## Summary\r\n\r\nAfter merging https://github.com/elastic/kibana/pull/155612 back there is one issue is left unresolved described in this [comment](https://github.com/elastic/kibana/pull/155612#discussion_r1175545697):\r\n\r\n> Looks like we show the `Actions will not be preformed until it is unsnoozed` message unconditionally, i.e. regardless of whether the rule is snoozed or not. Since it's in bold it feels like a warning in the case where it doesn't really matter:\r\n\r\n> Can we hide it when the rule is not snoozed? If it's not trivial, can we make it look less dangerous by making the font regular and playing with the copy a little bit? E.g. `If snoozed actions will not be triggered`.\r\n\r\nThis PR resolves rule snooze description text issue. As snooze settings are resolved outside the security solution plugin having any logic to conditionally display a message will increase the complexity. This way the message was changes to avoid any text to appear conditionally.\r\n\r\n*Before:*\r\n\r\n<img width=\"703\" alt=\"Screenshot 2023-04-24 at 18 36 31\" src=\"https://user-images.githubusercontent.com/7359339/234060523-fe9161a1-0e83-4d39-a193-81c946d95106.png\">\r\n\r\n*After:*\r\n\r\n![image](https://user-images.githubusercontent.com/3775283/236254424-533a6502-49ba-444e-87e5-9cda7e84c315.png)\r\n\r\n\r\n### Checklist\r\n\r\n- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)","sha":"6714d926ee041d61c627037189263905918303b3"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"8.8","label":"v8.8.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/156888","number":156888,"state":"OPEN"},{"branch":"main","label":"v8.9.0","labelRegex":"^v8.9.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/155850","number":155850,"mergeCommit":{"message":"[Security Solution] Fix rule snooze description on the rule editing page (#155850)\n\n**Addresses:** https://github.com/elastic/kibana/issues/147737\r\n**Relates to:** https://github.com/elastic/kibana/pull/155612\r\n\r\n## Summary\r\n\r\nAfter merging https://github.com/elastic/kibana/pull/155612 back there is one issue is left unresolved described in this [comment](https://github.com/elastic/kibana/pull/155612#discussion_r1175545697):\r\n\r\n> Looks like we show the `Actions will not be preformed until it is unsnoozed` message unconditionally, i.e. regardless of whether the rule is snoozed or not. Since it's in bold it feels like a warning in the case where it doesn't really matter:\r\n\r\n> Can we hide it when the rule is not snoozed? If it's not trivial, can we make it look less dangerous by making the font regular and playing with the copy a little bit? E.g. `If snoozed actions will not be triggered`.\r\n\r\nThis PR resolves rule snooze description text issue. As snooze settings are resolved outside the security solution plugin having any logic to conditionally display a message will increase the complexity. This way the message was changes to avoid any text to appear conditionally.\r\n\r\n*Before:*\r\n\r\n<img width=\"703\" alt=\"Screenshot 2023-04-24 at 18 36 31\" src=\"https://user-images.githubusercontent.com/7359339/234060523-fe9161a1-0e83-4d39-a193-81c946d95106.png\">\r\n\r\n*After:*\r\n\r\n![image](https://user-images.githubusercontent.com/3775283/236254424-533a6502-49ba-444e-87e5-9cda7e84c315.png)\r\n\r\n\r\n### Checklist\r\n\r\n- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)","sha":"6714d926ee041d61c627037189263905918303b3"}}]}] BACKPORT-->