### PR TITLE
[Security Solution] Actions with conditional logic cannot be added through bulk actions (#156866)

### DIFF
--- a/x-pack/plugins/security_solution/common/detection_engine/rule_management/api/rules/bulk_actions/request_schema.ts
+++ b/x-pack/plugins/security_solution/common/detection_engine/rule_management/api/rules/bulk_actions/request_schema.ts
@@ -9,6 +9,7 @@ import * as t from 'io-ts';
 
 import { NonEmptyArray, TimeDuration } from '@kbn/securitysolution-io-ts-types';
 import {
+  RuleActionAlertsFilter,
   RuleActionFrequency,
   RuleActionGroup,
   RuleActionId,
@@ -95,8 +96,8 @@ const BulkActionEditPayloadTimeline = t.type({
  * per rulesClient.bulkEdit rules actions operation contract (x-pack/plugins/alerting/server/rules_client/rules_client.ts)
  * normalized rule action object is expected (NormalizedAlertAction) as value for the edit operation
  */
-type NormalizedRuleAction = t.TypeOf<typeof NormalizedRuleAction>;
-const NormalizedRuleAction = t.exact(
+export type NormalizedRuleAction = t.TypeOf<typeof NormalizedRuleAction>;
+export const NormalizedRuleAction = t.exact(
   t.intersection([
     t.type({
       group: RuleActionGroup,
@@ -104,6 +105,7 @@ const NormalizedRuleAction = t.exact(
       params: RuleActionParams,
     }),
     t.partial({ frequency: RuleActionFrequency }),
+    t.partial({ alerts_filter: RuleActionAlertsFilter }),
   ])
 );
 

--- a/x-pack/plugins/security_solution/common/detection_engine/transform_actions.test.ts
+++ b/x-pack/plugins/security_solution/common/detection_engine/transform_actions.test.ts
@@ -8,11 +8,15 @@
 import {
   transformRuleToAlertAction,
   transformAlertToRuleAction,
+  transformNormalizedRuleToAlertAction,
+  transformAlertToNormalizedRuleAction,
   transformRuleToAlertResponseAction,
   transformAlertToRuleResponseAction,
 } from './transform_actions';
 import type { ResponseAction, RuleResponseAction } from './rule_response_actions/schemas';
 import { RESPONSE_ACTION_TYPES } from './rule_response_actions/schemas';
+import type { NormalizedRuleAction } from './rule_management/api/rules/bulk_actions/request_schema';
+import type { RuleAction } from '@kbn/alerting-plugin/common';
 
 describe('transform_actions', () => {
   test('it should transform RuleAlertAction[] to RuleAction[]', () => {
@@ -46,6 +50,42 @@ describe('transform_actions', () => {
       action_type_id: alertAction.actionTypeId,
       params: alertAction.params,
       uuid: '111',
+    });
+  });
+  test('it should transform NormalizedRuleAction[] to NormalizedAlertAction[]', () => {
+    const ruleAction: NormalizedRuleAction = {
+      id: 'id',
+      group: 'group',
+      params: {},
+      frequency: { summary: true, throttle: null, notifyWhen: 'onActiveAlert' },
+      alerts_filter: { query: { kql: '*', filters: [] } },
+    };
+    const alertAction = transformNormalizedRuleToAlertAction(ruleAction);
+    expect(alertAction).toEqual({
+      id: ruleAction.id,
+      group: ruleAction.group,
+      params: ruleAction.params,
+      frequency: ruleAction.frequency,
+      alertsFilter: ruleAction.alerts_filter,
+    });
+  });
+  test('it should transform RuleAction[] to NormalizedRuleAction[]', () => {
+    const alertAction: RuleAction = {
+      id: 'id',
+      group: 'group',
+      actionTypeId: 'actionTypeId',
+      params: {},
+      uuid: '111',
+      frequency: { summary: true, throttle: null, notifyWhen: 'onActiveAlert' },
+      alertsFilter: { query: { kql: '*', filters: [] } },
+    };
+    const ruleAction = transformAlertToNormalizedRuleAction(alertAction);
+    expect(ruleAction).toEqual({
+      id: alertAction.id,
+      group: alertAction.group,
+      params: alertAction.params,
+      frequency: alertAction.frequency,
+      alerts_filter: alertAction.alertsFilter,
     });
   });
   test('it should transform ResponseAction[] to RuleResponseAction[]', () => {

--- a/x-pack/plugins/security_solution/common/detection_engine/transform_actions.ts
+++ b/x-pack/plugins/security_solution/common/detection_engine/transform_actions.ts
@@ -6,6 +6,8 @@
  */
 
 import type { RuleAction } from '@kbn/alerting-plugin/common';
+import type { NormalizedAlertAction } from '@kbn/alerting-plugin/server/rules_client';
+import type { NormalizedRuleAction } from './rule_management/api/rules/bulk_actions/request_schema';
 import type { ResponseAction, RuleResponseAction } from './rule_response_actions/schemas';
 import { RESPONSE_ACTION_TYPES } from './rule_response_actions/schemas';
 import type { RuleAlertAction } from './types';
@@ -43,6 +45,34 @@ export const transformAlertToRuleAction = ({
   action_type_id: actionTypeId,
   ...(alertsFilter && { alerts_filter: alertsFilter }),
   ...(uuid && { uuid }),
+  ...(frequency && { frequency }),
+});
+
+export const transformNormalizedRuleToAlertAction = ({
+  group,
+  id,
+  params,
+  frequency,
+  alerts_filter: alertsFilter,
+}: NormalizedRuleAction): NormalizedAlertAction => ({
+  group,
+  id,
+  params,
+  ...(alertsFilter && { alertsFilter }),
+  ...(frequency && { frequency }),
+});
+
+export const transformAlertToNormalizedRuleAction = ({
+  group,
+  id,
+  params,
+  frequency,
+  alertsFilter,
+}: RuleAction): NormalizedRuleAction => ({
+  group,
+  id,
+  params,
+  ...(alertsFilter && { alerts_filter: alertsFilter }),
   ...(frequency && { frequency }),
 });
 

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/bulk_actions/forms/rule_actions_form.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/bulk_actions/forms/rule_actions_form.tsx
@@ -13,6 +13,7 @@ import type {
   ActionTypeRegistryContract,
 } from '@kbn/triggers-actions-ui-plugin/public';
 
+import { transformAlertToNormalizedRuleAction } from '../../../../../../../common/detection_engine/transform_actions';
 import type { FormSchema } from '../../../../../../shared_imports';
 import {
   useForm,
@@ -104,7 +105,7 @@ const RuleActionsFormComponent = ({ rulesCount, onClose, onConfirm }: RuleAction
     onConfirm({
       type: editAction,
       value: {
-        actions: actions.map(({ actionTypeId, ...action }) => action),
+        actions: actions.map(transformAlertToNormalizedRuleAction),
       },
     });
   }, [form, onConfirm]);

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/logic/bulk_actions/action_to_rules_client_operation.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/logic/bulk_actions/action_to_rules_client_operation.ts
@@ -6,6 +6,7 @@
  */
 
 import type { BulkEditOperation } from '@kbn/alerting-plugin/server';
+import { transformNormalizedRuleToAlertAction } from '../../../../../../common/detection_engine/transform_actions';
 
 import type { BulkActionEditForRuleAttributes } from '../../../../../../common/detection_engine/rule_management/api/rules/bulk_actions/request_schema';
 import { BulkActionEditType } from '../../../../../../common/detection_engine/rule_management/api/rules/bulk_actions/request_schema';
@@ -55,7 +56,9 @@ export const bulkEditActionToRulesClientOperation = (
         {
           field: 'actions',
           operation: 'add',
-          value: transformToActionFrequency(action.value.actions, action.value.throttle),
+          value: transformToActionFrequency(action.value.actions, action.value.throttle).map(
+            transformNormalizedRuleToAlertAction
+          ),
         },
       ];
 
@@ -64,7 +67,9 @@ export const bulkEditActionToRulesClientOperation = (
         {
           field: 'actions',
           operation: 'set',
-          value: transformToActionFrequency(action.value.actions, action.value.throttle),
+          value: transformToActionFrequency(action.value.actions, action.value.throttle).map(
+            transformNormalizedRuleToAlertAction
+          ),
         },
       ];
 


### PR DESCRIPTION
## Summary

Original ticket: https://github.com/elastic/kibana/issues/156866

These changes fix the issue with the conditional actions in bulk editing. We did not add action filter attributes to the bulk editing scheme.

More details here https://github.com/elastic/kibana/issues/156866#issuecomment-1536469202


<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->