### PR TITLE
[Enterprise Search] Rename 'Not deployed' models status to 'Not started'

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_model_health.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_model_health.test.tsx
@@ -52,7 +52,7 @@ describe('TrainedModelHealth', () => {
       <TrainedModelHealth modelState={modelState} modelStateReason={modelStateReason} />
     );
     const health = wrapper.find(EuiHealth);
-    expect(health.prop('children')).toEqual('Not deployed');
+    expect(health.prop('children')).toEqual('Not started');
     expect(health.prop('color')).toEqual('danger');
   });
   it('renders model stopping', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_model_health.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_model_health.tsx
@@ -61,14 +61,14 @@ const modelDeploymentFailedText = i18n.translate(
 const modelNotDeployedText = i18n.translate(
   'xpack.enterpriseSearch.inferencePipelineCard.modelState.notDeployed',
   {
-    defaultMessage: 'Not deployed',
+    defaultMessage: 'Not started',
   }
 );
 const modelNotDeployedTooltip = i18n.translate(
   'xpack.enterpriseSearch.inferencePipelineCard.modelState.notDeployed.tooltip',
   {
     defaultMessage:
-      'This trained model is not currently deployed. Visit the trained models page to make changes',
+      'This trained model is not currently started. Visit the trained models page to make changes',
   }
 );
 


### PR DESCRIPTION
## Summary

Change label of model status to "Not started" in the Pipelines tab as it aligns better with ELSER model states.

![Screenshot 2023-05-05 at 3 44 44 PM](https://user-images.githubusercontent.com/14224983/236555137-eecf5ccc-5e42-43a4-a3ec-0863d6bfdde3.png)


### Checklist

Delete any items that are not applicable to this PR.
- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->