### PR TITLE
Remove legacy alerts listing from the observability overview

### DIFF
--- a/x-pack/plugins/observability/public/pages/overview/components/empty_sections.tsx
+++ b/x-pack/plugins/observability/public/pages/overview/components/empty_sections.tsx
@@ -13,7 +13,6 @@ import { i18n } from '@kbn/i18n';
 import { HttpSetup } from '@kbn/core/public';
 
 import { ISection } from '../../../typings/section';
-import { paths } from '../../../config/paths';
 import { ObservabilityAppServices } from '../../../application/types';
 import { FETCH_STATUS } from '../../../hooks/use_fetcher';
 import { useHasData } from '../../../hooks/use_has_data';
@@ -133,21 +132,6 @@ const getEmptySections = ({ http }: { http: HttpSetup }): ISection[] => {
         defaultMessage: 'Install RUM Agent',
       }),
       href: http.basePath.prepend('/app/home#/tutorial/apm'),
-    },
-    {
-      id: 'alert',
-      title: i18n.translate('xpack.observability.emptySection.apps.alert.title', {
-        defaultMessage: 'No alerts found.',
-      }),
-      icon: 'watchesApp',
-      description: i18n.translate('xpack.observability.emptySection.apps.alert.description', {
-        defaultMessage:
-          'Detect complex conditions within Observability and trigger actions when those conditions are met.',
-      }),
-      linkTitle: i18n.translate('xpack.observability.emptySection.apps.alert.link', {
-        defaultMessage: 'Create rule',
-      }),
-      href: http.basePath.prepend(paths.observability.rules),
     },
   ];
 };


### PR DESCRIPTION
## What does this PR do?
This PR removes the legacy alerts listing from the observability overview page, as a new alerts widget has been added to replace it. 

### Issue References
Issue: https://github.com/elastic/kibana/issues/155445

### Loom/Screenshot Demo 
* **Fix:** 
<img width="1523" alt="Screenshot 2023-04-27 at 02 30 19" src="https://user-images.githubusercontent.com/57623705/234736977-160e3833-84ae-4a86-8524-33abac97ee64.png">


---
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.
