### PR TITLE
[D4C] kubernetesResourceLabel -> kubernetesPodLabel

### DIFF
--- a/x-pack/plugins/cloud_defend/public/components/control_general_view/translations.ts
+++ b/x-pack/plugins/cloud_defend/public/components/control_general_view/translations.ts
@@ -124,13 +124,10 @@ export const unusedSelectorHelp = i18n.translate('xpack.cloudDefend.unusedSelect
   defaultMessage: 'This selector is not in use by any response.',
 });
 
-export const errorInvalidResourceLabel = i18n.translate(
-  'xpack.cloudDefend.errorInvalidResourceLabel',
-  {
-    defaultMessage:
-      '"Orchestrator resource label" values must have the format: "key:value". A wildcard "*" can be used at the end of the value. e.g. "key:val*". To match on an empty label value, use "key:".',
-  }
-);
+export const errorInvalidPodLabel = i18n.translate('xpack.cloudDefend.errorInvalidPodLabel', {
+  defaultMessage:
+    'Kubernetes pod label values must have the format: "key:value". A wildcard "*" can be used at the end of the value. e.g. "key:val*". To match on an empty label value, use "key:".',
+});
 
 export const errorInvalidFullContainerImageName = i18n.translate(
   'xpack.cloudDefend.errorInvalidFullContainerImageName',

--- a/x-pack/plugins/cloud_defend/public/components/control_yaml_view/hooks/policy_schema.json
+++ b/x-pack/plugins/cloud_defend/public/components/control_yaml_view/hooks/policy_schema.json
@@ -81,10 +81,10 @@
           "required": ["kubernetesNamespace"]
         },
         {
-          "required": ["kubernetesResourceLabel"]
+          "required": ["kubernetesPodLabel"]
         },
         {
-          "required": ["kubernetesResourceName"]
+          "required": ["kubernetesPodName"]
         },
         {
           "required": ["targetFilePath"]
@@ -157,7 +157,7 @@
             "type": "string"
           }
         },
-        "kubernetesResourceLabel": {
+        "kubernetesPodLabel": {
           "type": "array",
           "minItems": 1,
           "items": {
@@ -165,7 +165,7 @@
             "pattern": "^([a-zA-Z0-9\\.\\-]+\\/)?[a-zA-Z0-9\\.\\-]+:[a-zA-Z0-9\\.\\-\\_]*\\*?$"
           }
         },
-        "kubernetesResourceName": {
+        "kubernetesPodName": {
           "type": "array",
           "minItems": 1,
           "items": {
@@ -229,10 +229,10 @@
           "required": ["kubernetesNamespace"]
         },
         {
-          "required": ["kubernetesResourceLabel"]
+          "required": ["kubernetesPodLabel"]
         },
         {
-          "required": ["kubernetesResourceName"]
+          "required": ["kubernetesPodName"]
         },
         {
           "required": ["processExecutable"]
@@ -299,7 +299,7 @@
             "type": "string"
           }
         },
-        "kubernetesResourceLabel": {
+        "kubernetesPodLabel": {
           "type": "array",
           "minItems": 1,
           "items": {
@@ -307,7 +307,7 @@
             "pattern": "^([a-zA-Z0-9\\.\\-]+\\/)?[a-zA-Z0-9\\.\\-]+:[a-zA-Z0-9\\.\\-\\_]*\\*?$"
           }
         },
-        "kubernetesResourceName": {
+        "kubernetesPodName": {
           "type": "array",
           "minItems": 1,
           "items": {

--- a/x-pack/plugins/cloud_defend/public/types.ts
+++ b/x-pack/plugins/cloud_defend/public/types.ts
@@ -70,8 +70,8 @@ export type SelectorCondition =
   | 'kubernetesClusterId'
   | 'kubernetesClusterName'
   | 'kubernetesNamespace'
-  | 'kubernetesResourceLabel'
-  | 'kubernetesResourceName'
+  | 'kubernetesPodLabel'
+  | 'kubernetesPodName'
   | 'targetFilePath'
   | 'ignoreVolumeFiles'
   | 'ignoreVolumeMounts'
@@ -117,11 +117,11 @@ export const SelectorConditionsMap: SelectorConditionsMapProps = {
   kubernetesClusterId: { type: 'stringArray' },
   kubernetesClusterName: { type: 'stringArray' },
   kubernetesNamespace: { type: 'stringArray' },
-  kubernetesResourceName: { type: 'stringArray' },
-  kubernetesResourceLabel: {
+  kubernetesPodName: { type: 'stringArray' },
+  kubernetesPodLabel: {
     type: 'stringArray',
     pattern: '^([a-zA-Z0-9\\.\\-]+\\/)?[a-zA-Z0-9\\.\\-]+:[a-zA-Z0-9\\.\\-\\_]*\\*?$',
-    patternError: i18n.errorInvalidResourceLabel,
+    patternError: i18n.errorInvalidPodLabel,
   },
   operation: {
     type: 'stringArray',
@@ -153,8 +153,8 @@ export interface Selector {
   kubernetesClusterId?: string[];
   kubernetesClusterName?: string[];
   kubernetesNamespace?: string[];
-  kubernetesResourceLabel?: string[];
-  kubernetesResourceName?: string[];
+  kubernetesPodLabel?: string[];
+  kubernetesPodName?: string[];
 
   // selector properties
   targetFilePath?: string[];


### PR DESCRIPTION
## Summary

Renames one of our selector conditions.

As per:
https://github.com/elastic/integrations/tree/main/packages/cloud_defend/docs

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->