### PR TITLE
[Serverless] expose ServerlessPluginStart.setServerlessNavigation

### DIFF
--- a/x-pack/plugins/serverless/public/plugin.tsx
+++ b/x-pack/plugins/serverless/public/plugin.tsx
@@ -5,22 +5,20 @@
  * 2.0.
  */
 
+import type { CoreSetup, CoreStart, Plugin, PluginInitializerContext } from '@kbn/core/public';
+import { KibanaThemeProvider } from '@kbn/kibana-react-plugin/public';
+import { ProjectSwitcher, ProjectSwitcherKibanaProvider } from '@kbn/serverless-project-switcher';
+import type { ProjectType } from '@kbn/serverless-types';
 import React from 'react';
 import ReactDOM from 'react-dom';
-
-import { KibanaThemeProvider } from '@kbn/kibana-react-plugin/public';
-import { CoreSetup, CoreStart, Plugin, PluginInitializerContext } from '@kbn/core/public';
-import { ProjectSwitcher, ProjectSwitcherKibanaProvider } from '@kbn/serverless-project-switcher';
-import { ProjectType } from '@kbn/serverless-types';
-
-import {
+import { API_SWITCH_PROJECT as projectChangeAPIUrl } from '../common';
+import type { ServerlessConfig } from './config';
+import type {
   ServerlessPluginSetup,
-  ServerlessPluginStart,
   ServerlessPluginSetupDependencies,
+  ServerlessPluginStart,
   ServerlessPluginStartDependencies,
 } from './types';
-import { ServerlessConfig } from './config';
-import { API_SWITCH_PROJECT as projectChangeAPIUrl } from '../common';
 
 export class ServerlessPlugin
   implements
@@ -62,7 +60,11 @@ export class ServerlessPlugin
     core.chrome.setChromeStyle('project');
     management.setIsSidebarEnabled(false);
 
-    return {};
+    return {
+      setServerlessNavigation: (navigation: React.ComponentType) => {
+        core.chrome.project.setSideNavComponent(navigation);
+      },
+    };
   }
 
   public stop() {}

--- a/x-pack/plugins/serverless/public/types.ts
+++ b/x-pack/plugins/serverless/public/types.ts
@@ -5,13 +5,15 @@
  * 2.0.
  */
 
+import type { ComponentType } from 'react';
 import type { ManagementSetup, ManagementStart } from '@kbn/management-plugin/public';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface ServerlessPluginSetup {}
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface ServerlessPluginStart {}
+export interface ServerlessPluginStart {
+  setServerlessNavigation: (component: ComponentType) => void;
+}
 
 export interface ServerlessPluginSetupDependencies {
   management: ManagementSetup;

--- a/x-pack/plugins/serverless_search/public/plugin.ts
+++ b/x-pack/plugins/serverless_search/public/plugin.ts
@@ -26,9 +26,9 @@ export class ServerlessSearchPlugin
 
   public start(
     core: CoreStart,
-    _startDeps: ServerlessSearchPluginStartDependencies
+    { serverless }: ServerlessSearchPluginStartDependencies
   ): ServerlessSearchPluginStart {
-    core.chrome.project.setSideNavComponent(createComponent(core));
+    serverless.setServerlessNavigation(createComponent(core));
     return {};
   }
 

--- a/x-pack/plugins/serverless_search/public/types.ts
+++ b/x-pack/plugins/serverless_search/public/types.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { ServerlessPluginStart } from '@kbn/serverless/public';
 import { ManagementSetup, ManagementStart } from '@kbn/management-plugin/public';
 import {
   EnterpriseSearchPublicSetup,
@@ -25,4 +26,5 @@ export interface ServerlessSearchPluginSetupDependencies {
 export interface ServerlessSearchPluginStartDependencies {
   enterpriseSearch: EnterpriseSearchPublicStart;
   management: ManagementStart;
+  serverless: ServerlessPluginStart;
 }

--- a/x-pack/plugins/serverless_search/tsconfig.json
+++ b/x-pack/plugins/serverless_search/tsconfig.json
@@ -15,10 +15,11 @@
     "target/**/*"
   ],
   "kbn_references": [
-    "@kbn/core",
     "@kbn/config-schema",
+    "@kbn/core",
     "@kbn/enterprise-search-plugin",
     "@kbn/management-plugin",
-    "@kbn/shared-ux-chrome-navigation",
+    "@kbn/serverless",
+    "@kbn/shared-ux-chrome-navigation"
   ]
 }


### PR DESCRIPTION
## Summary

Addresses https://github.com/elastic/kibana/pull/156600#discussion_r1185996989

TODO: restrict non-serverless plugins against using the project API from ChromeStart