### PR TITLE
Fix Enterprise Search guide links

### DIFF
--- a/x-pack/plugins/enterprise_search/common/guided_onboarding/search_guide_config.ts
+++ b/x-pack/plugins/enterprise_search/common/guided_onboarding/search_guide_config.ts
@@ -8,16 +8,14 @@
 import type { GuideConfig, StepConfig } from '@kbn/guided-onboarding';
 import { i18n } from '@kbn/i18n';
 
-import { INGESTION_METHOD_IDS } from '../constants';
-
 export const appSearchGuideId = 'appSearch';
 export const websiteSearchGuideId = 'websiteSearch';
 export const databaseSearchGuideId = 'databaseSearch';
 
-const apiMethods = {
-  [appSearchGuideId]: INGESTION_METHOD_IDS.API,
-  [databaseSearchGuideId]: INGESTION_METHOD_IDS.CONNECTOR,
-  [websiteSearchGuideId]: INGESTION_METHOD_IDS.CRAWLER,
+const apiRoutes = {
+  [appSearchGuideId]: 'api',
+  [databaseSearchGuideId]: 'select_connector',
+  [websiteSearchGuideId]: 'crawler',
 };
 
 export type EnterpriseSearchGuideIds =
@@ -25,7 +23,7 @@ export type EnterpriseSearchGuideIds =
   | typeof websiteSearchGuideId
   | typeof databaseSearchGuideId;
 
-const getAddDataStep: (method?: INGESTION_METHOD_IDS) => StepConfig = (method) => {
+const getAddDataStep: (method?: EnterpriseSearchGuideIds) => StepConfig = (method) => {
   return {
     id: 'add_data',
     title: i18n.translate('xpack.enterpriseSearch.guideConfig.addDataStep.title', {
@@ -37,7 +35,7 @@ const getAddDataStep: (method?: INGESTION_METHOD_IDS) => StepConfig = (method) =
     }),
     location: {
       appID: 'enterpriseSearchContent',
-      path: `/search_indices/new_index?${method ? 'method=' + method : ''}`,
+      path: `/search_indices/new_index/${method ? apiRoutes[method] : ''}`,
     },
   };
 };
@@ -86,7 +84,7 @@ const getGuideConfig: (telemetryId: EnterpriseSearchGuideIds) => GuideConfig = (
       defaultMessage: `We'll help you build a search experience with your data using Elastic's web crawler, connectors, and APIs.`,
     }),
     guideName: 'Enterprise Search',
-    steps: [getAddDataStep(apiMethods[telemetryId]), getSearchExperienceStep()],
+    steps: [getAddDataStep(telemetryId), getSearchExperienceStep()],
   };
 };
 


### PR DESCRIPTION
## Summary

Fixes Enterprise Search guided onboarding links which broke due to UI changes recently.



https://user-images.githubusercontent.com/1410658/236779703-010884f0-7708-43e0-8f77-e3e0be456452.mov




<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->