### PR TITLE
Hide preview charts in APM rules

### DIFF
--- a/x-pack/plugins/apm/public/components/alerting/rule_types/error_count_rule_type/index.tsx
+++ b/x-pack/plugins/apm/public/components/alerting/rule_types/error_count_rule_type/index.tsx
@@ -17,10 +17,8 @@ import {
 import { EuiFormRow } from '@elastic/eui';
 import { EuiSpacer } from '@elastic/eui';
 import { ENVIRONMENT_ALL } from '../../../../../common/environment_filter_values';
-import { asInteger } from '../../../../../common/utils/formatters';
 import { useFetcher } from '../../../../hooks/use_fetcher';
 import { createCallApmApi } from '../../../../services/rest/create_call_apm_api';
-import { ChartPreview } from '../../ui_components/chart_preview';
 import {
   EnvironmentField,
   ErrorGroupingKeyField,
@@ -162,14 +160,15 @@ export function ErrorCountRuleType(props: Props) {
     />,
   ];
 
-  const chartPreview = (
-    <ChartPreview
-      series={[{ data: data?.errorCountChartPreview ?? [] }]}
-      threshold={params.threshold}
-      yTickFormat={asInteger}
-      uiSettings={services.uiSettings}
-    />
-  );
+  // hide preview chart until https://github.com/elastic/kibana/pull/156625 gets merged
+  // const chartPreview = (
+  //   <ChartPreview
+  //     series={[{ data: data?.errorCountChartPreview ?? [] }]}
+  //     threshold={params.threshold}
+  //     yTickFormat={asInteger}
+  //     uiSettings={services.uiSettings}
+  //   />
+  // );
 
   const groupAlertsBy = (
     <>

--- a/x-pack/plugins/apm/public/components/alerting/rule_types/error_count_rule_type/index.tsx
+++ b/x-pack/plugins/apm/public/components/alerting/rule_types/error_count_rule_type/index.tsx
@@ -209,7 +209,7 @@ export function ErrorCountRuleType(props: Props) {
       groupAlertsBy={groupAlertsBy}
       setRuleParams={setRuleParams}
       setRuleProperty={setRuleProperty}
-      chartPreview={chartPreview}
+      // chartPreview={chartPreview}
     />
   );
 }

--- a/x-pack/plugins/apm/public/components/alerting/rule_types/error_count_rule_type/index.tsx
+++ b/x-pack/plugins/apm/public/components/alerting/rule_types/error_count_rule_type/index.tsx
@@ -209,7 +209,7 @@ export function ErrorCountRuleType(props: Props) {
       groupAlertsBy={groupAlertsBy}
       setRuleParams={setRuleParams}
       setRuleProperty={setRuleProperty}
-      // chartPreview={chartPreview}
+      // chartPreview={chartPreview} // hide preview chart until https://github.com/elastic/kibana/pull/156625 gets merged
     />
   );
 }

--- a/x-pack/plugins/apm/public/components/alerting/rule_types/error_count_rule_type/index.tsx
+++ b/x-pack/plugins/apm/public/components/alerting/rule_types/error_count_rule_type/index.tsx
@@ -17,8 +17,10 @@ import {
 import { EuiFormRow } from '@elastic/eui';
 import { EuiSpacer } from '@elastic/eui';
 import { ENVIRONMENT_ALL } from '../../../../../common/environment_filter_values';
+import { asInteger } from '../../../../../common/utils/formatters';
 import { useFetcher } from '../../../../hooks/use_fetcher';
 import { createCallApmApi } from '../../../../services/rest/create_call_apm_api';
+import { ChartPreview } from '../../ui_components/chart_preview';
 import {
   EnvironmentField,
   ErrorGroupingKeyField,
@@ -161,14 +163,15 @@ export function ErrorCountRuleType(props: Props) {
   ];
 
   // hide preview chart until https://github.com/elastic/kibana/pull/156625 gets merged
-  // const chartPreview = (
-  //   <ChartPreview
-  //     series={[{ data: data?.errorCountChartPreview ?? [] }]}
-  //     threshold={params.threshold}
-  //     yTickFormat={asInteger}
-  //     uiSettings={services.uiSettings}
-  //   />
-  // );
+  const showChartPreview = false;
+  const chartPreview = showChartPreview ? (
+    <ChartPreview
+      series={[{ data: data?.errorCountChartPreview ?? [] }]}
+      threshold={params.threshold}
+      yTickFormat={asInteger}
+      uiSettings={services.uiSettings}
+    />
+  ) : null;
 
   const groupAlertsBy = (
     <>
@@ -208,7 +211,7 @@ export function ErrorCountRuleType(props: Props) {
       groupAlertsBy={groupAlertsBy}
       setRuleParams={setRuleParams}
       setRuleProperty={setRuleProperty}
-      // chartPreview={chartPreview} // hide preview chart until https://github.com/elastic/kibana/pull/156625 gets merged
+      chartPreview={chartPreview}
     />
   );
 }

--- a/x-pack/plugins/apm/public/components/alerting/rule_types/transaction_duration_rule_type/index.tsx
+++ b/x-pack/plugins/apm/public/components/alerting/rule_types/transaction_duration_rule_type/index.tsx
@@ -26,6 +26,7 @@ import {
   getMaxY,
   getResponseTimeTickFormatter,
 } from '../../../shared/charts/transaction_charts/helper';
+import { ChartPreview } from '../../ui_components/chart_preview';
 import {
   EnvironmentField,
   IsAboveField,
@@ -147,14 +148,15 @@ export function TransactionDurationRuleType(props: Props) {
   const thresholdMs = params.threshold * 1000;
 
   // hide preview chart until https://github.com/elastic/kibana/pull/156625 gets merged
-  // const chartPreview = (
-  //   <ChartPreview
-  //     series={latencyChartPreview}
-  //     threshold={thresholdMs}
-  //     yTickFormat={yTickFormat}
-  //     uiSettings={services.uiSettings}
-  //   />
-  // );
+  const showChartPreview = false;
+  const chartPreview = showChartPreview ? (
+    <ChartPreview
+      series={latencyChartPreview}
+      threshold={thresholdMs}
+      yTickFormat={yTickFormat}
+      uiSettings={services.uiSettings}
+    />
+  ) : null;
 
   const onGroupByChange = useCallback(
     (group: string[] | null) => {
@@ -275,7 +277,7 @@ export function TransactionDurationRuleType(props: Props) {
   return (
     <ApmRuleParamsContainer
       minimumWindowSize={{ value: 5, unit: TIME_UNITS.MINUTE }}
-      // chartPreview={chartPreview} // hide preview chart until https://github.com/elastic/kibana/pull/156625 gets merged
+      chartPreview={chartPreview}
       defaultParams={params}
       fields={fields}
       groupAlertsBy={groupAlertsBy}

--- a/x-pack/plugins/apm/public/components/alerting/rule_types/transaction_duration_rule_type/index.tsx
+++ b/x-pack/plugins/apm/public/components/alerting/rule_types/transaction_duration_rule_type/index.tsx
@@ -275,7 +275,7 @@ export function TransactionDurationRuleType(props: Props) {
   return (
     <ApmRuleParamsContainer
       minimumWindowSize={{ value: 5, unit: TIME_UNITS.MINUTE }}
-      chartPreview={chartPreview}
+      // chartPreview={chartPreview}
       defaultParams={params}
       fields={fields}
       groupAlertsBy={groupAlertsBy}

--- a/x-pack/plugins/apm/public/components/alerting/rule_types/transaction_duration_rule_type/index.tsx
+++ b/x-pack/plugins/apm/public/components/alerting/rule_types/transaction_duration_rule_type/index.tsx
@@ -275,7 +275,7 @@ export function TransactionDurationRuleType(props: Props) {
   return (
     <ApmRuleParamsContainer
       minimumWindowSize={{ value: 5, unit: TIME_UNITS.MINUTE }}
-      // chartPreview={chartPreview}
+      // chartPreview={chartPreview} // hide preview chart until https://github.com/elastic/kibana/pull/156625 gets merged
       defaultParams={params}
       fields={fields}
       groupAlertsBy={groupAlertsBy}

--- a/x-pack/plugins/apm/public/components/alerting/rule_types/transaction_duration_rule_type/index.tsx
+++ b/x-pack/plugins/apm/public/components/alerting/rule_types/transaction_duration_rule_type/index.tsx
@@ -26,7 +26,6 @@ import {
   getMaxY,
   getResponseTimeTickFormatter,
 } from '../../../shared/charts/transaction_charts/helper';
-import { ChartPreview } from '../../ui_components/chart_preview';
 import {
   EnvironmentField,
   IsAboveField,
@@ -147,14 +146,15 @@ export function TransactionDurationRuleType(props: Props) {
   // The threshold from the form is in ms. Convert to µs.
   const thresholdMs = params.threshold * 1000;
 
-  const chartPreview = (
-    <ChartPreview
-      series={latencyChartPreview}
-      threshold={thresholdMs}
-      yTickFormat={yTickFormat}
-      uiSettings={services.uiSettings}
-    />
-  );
+  // hide preview chart until https://github.com/elastic/kibana/pull/156625 gets merged
+  // const chartPreview = (
+  //   <ChartPreview
+  //     series={latencyChartPreview}
+  //     threshold={thresholdMs}
+  //     yTickFormat={yTickFormat}
+  //     uiSettings={services.uiSettings}
+  //   />
+  // );
 
   const onGroupByChange = useCallback(
     (group: string[] | null) => {

--- a/x-pack/plugins/apm/public/components/alerting/rule_types/transaction_error_rate_rule_type/index.tsx
+++ b/x-pack/plugins/apm/public/components/alerting/rule_types/transaction_error_rate_rule_type/index.tsx
@@ -222,7 +222,7 @@ export function TransactionErrorRateRuleType(props: Props) {
       defaultParams={params}
       setRuleParams={setRuleParams}
       setRuleProperty={setRuleProperty}
-      // chartPreview={chartPreview}
+      // chartPreview={chartPreview} // hide preview chart until https://github.com/elastic/kibana/pull/156625 gets merged
     />
   );
 }

--- a/x-pack/plugins/apm/public/components/alerting/rule_types/transaction_error_rate_rule_type/index.tsx
+++ b/x-pack/plugins/apm/public/components/alerting/rule_types/transaction_error_rate_rule_type/index.tsx
@@ -17,10 +17,8 @@ import {
 import { EuiFormRow } from '@elastic/eui';
 import { EuiSpacer } from '@elastic/eui';
 import { ENVIRONMENT_ALL } from '../../../../../common/environment_filter_values';
-import { asPercent } from '../../../../../common/utils/formatters';
 import { useFetcher } from '../../../../hooks/use_fetcher';
 import { createCallApmApi } from '../../../../services/rest/create_call_apm_api';
-import { ChartPreview } from '../../ui_components/chart_preview';
 import {
   EnvironmentField,
   IsAboveField,
@@ -171,14 +169,15 @@ export function TransactionErrorRateRuleType(props: Props) {
     />,
   ];
 
-  const chartPreview = (
-    <ChartPreview
-      series={[{ data: data?.errorRateChartPreview ?? [] }]}
-      yTickFormat={(d: number | null) => asPercent(d, 1)}
-      threshold={thresholdAsPercent}
-      uiSettings={services.uiSettings}
-    />
-  );
+  // hide preview chart until https://github.com/elastic/kibana/pull/156625 gets merged
+  // const chartPreview = (
+  //   <ChartPreview
+  //     series={[{ data: data?.errorRateChartPreview ?? [] }]}
+  //     yTickFormat={(d: number | null) => asPercent(d, 1)}
+  //     threshold={thresholdAsPercent}
+  //     uiSettings={services.uiSettings}
+  //   />
+  // );
 
   const groupAlertsBy = (
     <>

--- a/x-pack/plugins/apm/public/components/alerting/rule_types/transaction_error_rate_rule_type/index.tsx
+++ b/x-pack/plugins/apm/public/components/alerting/rule_types/transaction_error_rate_rule_type/index.tsx
@@ -222,7 +222,7 @@ export function TransactionErrorRateRuleType(props: Props) {
       defaultParams={params}
       setRuleParams={setRuleParams}
       setRuleProperty={setRuleProperty}
-      chartPreview={chartPreview}
+      // chartPreview={chartPreview}
     />
   );
 }

--- a/x-pack/plugins/apm/public/components/alerting/rule_types/transaction_error_rate_rule_type/index.tsx
+++ b/x-pack/plugins/apm/public/components/alerting/rule_types/transaction_error_rate_rule_type/index.tsx
@@ -17,8 +17,10 @@ import {
 import { EuiFormRow } from '@elastic/eui';
 import { EuiSpacer } from '@elastic/eui';
 import { ENVIRONMENT_ALL } from '../../../../../common/environment_filter_values';
+import { asPercent } from '../../../../../common/utils/formatters';
 import { useFetcher } from '../../../../hooks/use_fetcher';
 import { createCallApmApi } from '../../../../services/rest/create_call_apm_api';
+import { ChartPreview } from '../../ui_components/chart_preview';
 import {
   EnvironmentField,
   IsAboveField,
@@ -170,14 +172,15 @@ export function TransactionErrorRateRuleType(props: Props) {
   ];
 
   // hide preview chart until https://github.com/elastic/kibana/pull/156625 gets merged
-  // const chartPreview = (
-  //   <ChartPreview
-  //     series={[{ data: data?.errorRateChartPreview ?? [] }]}
-  //     yTickFormat={(d: number | null) => asPercent(d, 1)}
-  //     threshold={thresholdAsPercent}
-  //     uiSettings={services.uiSettings}
-  //   />
-  // );
+  const showChartPreview = false;
+  const chartPreview = showChartPreview ? (
+    <ChartPreview
+      series={[{ data: data?.errorRateChartPreview ?? [] }]}
+      yTickFormat={(d: number | null) => asPercent(d, 1)}
+      threshold={thresholdAsPercent}
+      uiSettings={services.uiSettings}
+    />
+  ) : null;
 
   const groupAlertsBy = (
     <>
@@ -221,7 +224,7 @@ export function TransactionErrorRateRuleType(props: Props) {
       defaultParams={params}
       setRuleParams={setRuleParams}
       setRuleProperty={setRuleProperty}
-      // chartPreview={chartPreview} // hide preview chart until https://github.com/elastic/kibana/pull/156625 gets merged
+      chartPreview={chartPreview}
     />
   );
 }


### PR DESCRIPTION
Hides preview charts in the following APM rules until https://github.com/elastic/kibana/pull/156625 (WIP) gets merged.

- APM Latency threshold
- APM Failed transaction rate
- APM Error count threshold

<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->