### PR TITLE
[Bug][Security Solution][Investigations] - check for additional filters object

### DIFF
--- a/x-pack/plugins/security_solution/public/common/hooks/flyout/use_init_flyout_url_param.ts
+++ b/x-pack/plugins/security_solution/public/common/hooks/flyout/use_init_flyout_url_param.ts
@@ -42,7 +42,7 @@ export const useInitFlyoutFromUrlParam = () => {
     const { initialized, isLoading, totalCount, additionalFilters } = dataTableCurrent;
     const isTableLoaded = initialized && !isLoading && totalCount > 0;
     if (urlDetails) {
-      if (!additionalFilters.showBuildingBlockAlerts) {
+      if (!additionalFilters || !additionalFilters.showBuildingBlockAlerts) {
         // We want to show building block alerts when loading the flyout in case the alert is a building block alert
         dispatch(
           dataTableActions.updateShowBuildingBlockAlertsFilter({


### PR DESCRIPTION
## Summary

It is possible that the `additionalFilters` object was not set on a user's existing configuration of the alert table in local storage if they never interacted with it since the feature was added. The object  is set on new initialization of the alert table, but for prior configurations, only gets set if the user has interacted with the `additionalFilters` dropdown in the alert page. This resulted in a type error when redirecting, which this PR fixes. 


<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->