### PR TITLE
[Enterprise Search] fix(search apps): limit search preview to text fields

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/applications/components/engine/engine_search_preview/engine_search_preview_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/applications/components/engine/engine_search_preview/engine_search_preview_logic.ts
@@ -90,12 +90,7 @@ export const EngineSearchPreviewLogic = kea<
         if (!data) return {};
 
         const searchableFields = Object.fromEntries(
-          data.fields
-            .filter(
-              ({ type, metadata_field: isMeta, searchable: isSearchable }) =>
-                type === 'text' && !isMeta && isSearchable
-            )
-            .map(({ name }) => [name, { weight: 1 }])
+          data.fields.filter(({ type }) => type === 'text').map(({ name }) => [name, { weight: 1 }])
         );
 
         return searchableFields;


### PR DESCRIPTION
## Summary

Limiting the search apps search preview page to only search text fields to resolve issues with the search erroring for some mappings. We will resolve this better for 8.9 but this is a quick fix for 8.8
