### PR TITLE
[Lens] Remove misleading comment

### DIFF
--- a/x-pack/plugins/lens/public/state_management/fullscreen_middleware.ts
+++ b/x-pack/plugins/lens/public/state_management/fullscreen_middleware.ts
@@ -9,7 +9,6 @@ import { Dispatch, MiddlewareAPI, Action } from '@reduxjs/toolkit';
 import { LensGetState, LensStoreDeps } from '.';
 import { setToggleFullscreen } from './lens_slice';
 
-/** cancels updates to the store that don't change the state */
 export const fullscreenMiddleware = (storeDeps: LensStoreDeps) => (store: MiddlewareAPI) => {
   return (next: Dispatch) => (action: Action) => {
     if (setToggleFullscreen.match(action)) {


### PR DESCRIPTION
## Summary

This middleware was clearly copied from `optimizing_middleware.ts` along with a comment. The comment does not apply to the fullscreen middleware. Removing to avoid confusion.