### PR TITLE
[Synthetics] Fix - Monitor Add/Edit form saves monitor with duplicate name

### DIFF
--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/form/submit.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/form/submit.tsx
@@ -29,6 +29,7 @@ export const ActionBar = ({ readOnly = false }: { readOnly: boolean }) => {
     handleSubmit,
     formState: { errors, defaultValues },
     getValues,
+    getFieldState,
   } = useFormContext();
 
   const [monitorPendingDeletion, setMonitorPendingDeletion] = useState<SyntheticsMonitor | null>(
@@ -47,7 +48,12 @@ export const ActionBar = ({ readOnly = false }: { readOnly: boolean }) => {
   const canSavePrivateLocation = !hasAnyPrivateLocationSelected || canSaveIntegrations;
 
   const formSubmitter = (formData: Record<string, any>) => {
-    if (!Object.keys(errors).length) {
+    // An additional invalid field check to account for customHook managed validation
+    const isAnyFieldInvalid = Object.keys(getValues()).some(
+      (fieldKey) => getFieldState(fieldKey).invalid
+    );
+
+    if (!Object.keys(errors).length && !isAnyFieldInvalid) {
       setMonitorData(format(formData, readOnly));
     }
   };


### PR DESCRIPTION
Fixes #154855

## Summary

Adds a simple check to fix the reported issue. A more thorough refactor is covered [here](https://github.com/elastic/kibana/pull/156626) which may be merged in future releases.

<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->