### PR TITLE
[7.x] chore(NA): list auto generated files by tooling in the .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,7 @@ report.asciidoc
 
 # Automatically generated and user-modifiable
 /tsconfig.refs.json
+*.type_check.json
 
 # Yarn local mirror content
 .yarn-local-mirror
@@ -97,4 +98,9 @@ report.asciidoc
 
 # Exclude renovate config file (we only need it on master)
 renovate.json5
-/packages/kbn-synthetic-package-map/synthetic-packages.json
+
+# Exclude auto generated files from tooling 
+/packages/*/synthetic-packages.json
+/packages/*/package-map.json
+/packages/*/config-paths.json
+/x-pack/plugins/screenshotting/chromium


### PR DESCRIPTION
This PR adds a couple of missing files in the `.gitignore` for `7.17` that put us in dangerous of committing by mistake a lot of auto generated files into this branch.