### PR TITLE
feat(slo): Create SLO with specified ID

### DIFF
--- a/packages/kbn-slo-schema/src/rest_specs/slo.ts
+++ b/packages/kbn-slo-schema/src/rest_specs/slo.ts
@@ -33,7 +33,7 @@ const createSLOParamsSchema = t.type({
       budgetingMethod: budgetingMethodSchema,
       objective: objectiveSchema,
     }),
-    t.partial({ settings: optionalSettingsSchema, tags: tagsSchema }),
+    t.partial({ id: sloIdSchema, settings: optionalSettingsSchema, tags: tagsSchema }),
   ]),
 });
 

--- a/x-pack/plugins/observability/docs/openapi/slo/bundled.yaml
+++ b/x-pack/plugins/observability/docs/openapi/slo/bundled.yaml
@@ -51,6 +51,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/4xx_response'
+        '409':
+          description: Conflict - The SLO id already exists
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/4xx_response'
       servers:
         - url: https://localhost:5601
     get:
@@ -690,6 +696,10 @@ components:
         - budgetingMethod
         - objective
       properties:
+        id:
+          description: A unique identifier for the SLO. Must be between 8 and 36 chars
+          type: string
+          example: my-super-slo-id
         name:
           description: A name for the SLO.
           type: string

--- a/x-pack/plugins/observability/docs/openapi/slo/components/schemas/create_slo_request.yaml
+++ b/x-pack/plugins/observability/docs/openapi/slo/components/schemas/create_slo_request.yaml
@@ -10,6 +10,10 @@ required:
   - budgetingMethod
   - objective
 properties:
+  id:
+    description: A unique identifier for the SLO. Must be between 8 and 36 chars
+    type: string
+    example: my-super-slo-id
   name:
     description: A name for the SLO.
     type: string

--- a/x-pack/plugins/observability/docs/openapi/slo/paths/s@{spaceid}@api@slos.yaml
+++ b/x-pack/plugins/observability/docs/openapi/slo/paths/s@{spaceid}@api@slos.yaml
@@ -34,6 +34,12 @@ post:
         application/json:
           schema:
             $ref: '../components/schemas/4xx_response.yaml'
+    '409':
+      description: Conflict - The SLO id already exists
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/4xx_response.yaml'
   servers:
     - url: https://localhost:5601
 

--- a/x-pack/plugins/observability/server/domain/services/validate_slo.ts
+++ b/x-pack/plugins/observability/server/domain/services/validate_slo.ts
@@ -23,6 +23,10 @@ import { SLO } from '../models';
  * @param slo {SLO}
  */
 export function validateSLO(slo: SLO) {
+  if (!isValidId(slo.id)) {
+    throw new IllegalArgumentError('Invalid id');
+  }
+
   if (!isValidTargetNumber(slo.objective.target)) {
     throw new IllegalArgumentError('Invalid objective.target');
   }
@@ -68,6 +72,12 @@ function validateSettings(slo: SLO) {
   if (!isValidSyncDelaySettings(slo.settings.syncDelay)) {
     throw new IllegalArgumentError('Invalid settings.sync_delay');
   }
+}
+
+function isValidId(id: string): boolean {
+  const MIN_ID_LENGTH = 8;
+  const MAX_ID_LENGTH = 36;
+  return MIN_ID_LENGTH <= id.length && id.length <= MAX_ID_LENGTH;
 }
 
 function isValidTargetNumber(value: number): boolean {

--- a/x-pack/plugins/observability/server/errors/errors.ts
+++ b/x-pack/plugins/observability/server/errors/errors.ts
@@ -15,6 +15,7 @@ export class ObservabilityError extends Error {
 }
 
 export class SLONotFound extends ObservabilityError {}
+export class SLOIdConflict extends ObservabilityError {}
 export class InternalQueryError extends ObservabilityError {}
 export class NotSupportedError extends ObservabilityError {}
 export class IllegalArgumentError extends ObservabilityError {}

--- a/x-pack/plugins/observability/server/errors/handler.ts
+++ b/x-pack/plugins/observability/server/errors/handler.ts
@@ -5,11 +5,15 @@
  * 2.0.
  */
 
-import { ObservabilityError, SLONotFound } from './errors';
+import { ObservabilityError, SLOIdConflict, SLONotFound } from './errors';
 
 export function getHTTPResponseCode(error: ObservabilityError): number {
   if (error instanceof SLONotFound) {
     return 404;
+  }
+
+  if (error instanceof SLOIdConflict) {
+    return 409;
   }
 
   return 400;

--- a/x-pack/plugins/observability/server/lib/rules/slo_burn_rate/executor.test.ts
+++ b/x-pack/plugins/observability/server/lib/rules/slo_burn_rate/executor.test.ts
@@ -6,7 +6,12 @@
  */
 
 import { v4 as uuidv4 } from 'uuid';
-import { IBasePath, IUiSettingsClient, SavedObjectsClientContract } from '@kbn/core/server';
+import {
+  IBasePath,
+  IUiSettingsClient,
+  SavedObjectsClientContract,
+  SavedObjectsFindResponse,
+} from '@kbn/core/server';
 import {
   ElasticsearchClientMock,
   elasticsearchServiceMock,
@@ -26,8 +31,8 @@ import {
   ALERT_REASON,
 } from '@kbn/rule-data-utils';
 import { ALERT_ACTION, getRuleExecutor } from './executor';
-import { aStoredSLO, createSLO } from '../../../services/slo/fixtures/slo';
-import { SLO } from '../../../domain/models';
+import { createSLO } from '../../../services/slo/fixtures/slo';
+import { SLO, StoredSLO } from '../../../domain/models';
 import { SharePluginStart } from '@kbn/share-plugin/server';
 import { dataViewPluginMocks } from '@kbn/data-views-plugin/public/mocks';
 import {
@@ -38,6 +43,9 @@ import {
   AlertStates,
 } from './types';
 import { SLO_ID_FIELD, SLO_REVISION_FIELD } from '../../../../common/field_names/infra_metrics';
+import { SLONotFound } from '../../../errors';
+import { SO_SLO_TYPE } from '../../../saved_objects';
+import { sloSchema } from '@kbn/slo-schema';
 
 const commonEsResponse = {
   took: 100,
@@ -52,6 +60,21 @@ const commonEsResponse = {
     hits: [],
   },
 };
+
+function createFindResponse(sloList: SLO[]): SavedObjectsFindResponse<StoredSLO> {
+  return {
+    page: 1,
+    per_page: 25,
+    total: sloList.length,
+    saved_objects: sloList.map((slo) => ({
+      id: slo.id,
+      attributes: sloSchema.encode(slo),
+      type: SO_SLO_TYPE,
+      references: [],
+      score: 1,
+    })),
+  };
+}
 
 const BURN_RATE_THRESHOLD = 2;
 const BURN_RATE_ABOVE_THRESHOLD = BURN_RATE_THRESHOLD + 0.01;
@@ -103,7 +126,7 @@ describe('BurnRateRuleExecutor', () => {
   });
 
   it('throws when the slo is not found', async () => {
-    soClientMock.get.mockRejectedValue(new Error('NotFound'));
+    soClientMock.find.mockRejectedValue(new SLONotFound('SLO [inexistent] not found'));
     const executor = getRuleExecutor({ basePath: basePathMock });
 
     await expect(
@@ -124,7 +147,7 @@ describe('BurnRateRuleExecutor', () => {
 
   it('returns early when the slo is disabled', async () => {
     const slo = createSLO({ objective: { target: 0.9 }, enabled: false });
-    soClientMock.get.mockResolvedValue(aStoredSLO(slo));
+    soClientMock.find.mockResolvedValueOnce(createFindResponse([slo]));
     const executor = getRuleExecutor({ basePath: basePathMock });
 
     const result = await executor({
@@ -148,7 +171,7 @@ describe('BurnRateRuleExecutor', () => {
 
   it('does not schedule an alert when both windows burn rates are below the threshold', async () => {
     const slo = createSLO({ objective: { target: 0.9 } });
-    soClientMock.get.mockResolvedValue(aStoredSLO(slo));
+    soClientMock.find.mockResolvedValueOnce(createFindResponse([slo]));
     esClientMock.search.mockResolvedValue(
       generateEsResponse(slo, BURN_RATE_BELOW_THRESHOLD, BURN_RATE_BELOW_THRESHOLD)
     );
@@ -173,7 +196,7 @@ describe('BurnRateRuleExecutor', () => {
 
   it('does not schedule an alert when the long window burn rate is below the threshold', async () => {
     const slo = createSLO({ objective: { target: 0.9 } });
-    soClientMock.get.mockResolvedValue(aStoredSLO(slo));
+    soClientMock.find.mockResolvedValueOnce(createFindResponse([slo]));
     esClientMock.search.mockResolvedValue(
       generateEsResponse(slo, BURN_RATE_ABOVE_THRESHOLD, BURN_RATE_BELOW_THRESHOLD)
     );
@@ -198,7 +221,7 @@ describe('BurnRateRuleExecutor', () => {
 
   it('does not schedule an alert when the short window burn rate is below the threshold', async () => {
     const slo = createSLO({ objective: { target: 0.9 } });
-    soClientMock.get.mockResolvedValue(aStoredSLO(slo));
+    soClientMock.find.mockResolvedValueOnce(createFindResponse([slo]));
     esClientMock.search.mockResolvedValue(
       generateEsResponse(slo, BURN_RATE_BELOW_THRESHOLD, BURN_RATE_ABOVE_THRESHOLD)
     );
@@ -223,7 +246,7 @@ describe('BurnRateRuleExecutor', () => {
 
   it('schedules an alert when both windows burn rate have reached the threshold', async () => {
     const slo = createSLO({ objective: { target: 0.9 } });
-    soClientMock.get.mockResolvedValue(aStoredSLO(slo));
+    soClientMock.find.mockResolvedValueOnce(createFindResponse([slo]));
     esClientMock.search.mockResolvedValue(
       generateEsResponse(slo, BURN_RATE_THRESHOLD, BURN_RATE_THRESHOLD)
     );
@@ -274,7 +297,7 @@ describe('BurnRateRuleExecutor', () => {
 
   it('sets the context on the recovered alerts', async () => {
     const slo = createSLO({ objective: { target: 0.9 } });
-    soClientMock.get.mockResolvedValue(aStoredSLO(slo));
+    soClientMock.find.mockResolvedValueOnce(createFindResponse([slo]));
     esClientMock.search.mockResolvedValue(
       generateEsResponse(slo, BURN_RATE_BELOW_THRESHOLD, BURN_RATE_ABOVE_THRESHOLD)
     );

--- a/x-pack/plugins/observability/server/lib/rules/slo_burn_rate/executor.test.ts
+++ b/x-pack/plugins/observability/server/lib/rules/slo_burn_rate/executor.test.ts
@@ -126,12 +126,12 @@ describe('BurnRateRuleExecutor', () => {
   });
 
   it('throws when the slo is not found', async () => {
-    soClientMock.find.mockRejectedValue(new SLONotFound('SLO [inexistent] not found'));
+    soClientMock.find.mockRejectedValue(new SLONotFound('SLO [non-existent] not found'));
     const executor = getRuleExecutor({ basePath: basePathMock });
 
     await expect(
       executor({
-        params: someRuleParams({ sloId: 'inexistent', burnRateThreshold: BURN_RATE_THRESHOLD }),
+        params: someRuleParams({ sloId: 'non-existent', burnRateThreshold: BURN_RATE_THRESHOLD }),
         startedAt: new Date(),
         services: servicesMock,
         executionId: 'irrelevant',

--- a/x-pack/plugins/observability/server/services/slo/create_slo.test.ts
+++ b/x-pack/plugins/observability/server/services/slo/create_slo.test.ts
@@ -51,7 +51,8 @@ describe('CreateSLO', () => {
           enabled: true,
           createdAt: expect.any(Date),
           updatedAt: expect.any(Date),
-        })
+        }),
+        { throwOnConflict: true }
       );
       expect(mockTransformManager.install).toHaveBeenCalledWith(
         expect.objectContaining({ ...sloParams, id: expect.any(String) })
@@ -86,7 +87,8 @@ describe('CreateSLO', () => {
           enabled: true,
           createdAt: expect.any(Date),
           updatedAt: expect.any(Date),
-        })
+        }),
+        { throwOnConflict: true }
       );
     });
   });

--- a/x-pack/plugins/observability/server/services/slo/create_slo.ts
+++ b/x-pack/plugins/observability/server/services/slo/create_slo.ts
@@ -55,7 +55,7 @@ export class CreateSLO {
     const now = new Date();
     return {
       ...params,
-      id: uuidv1(),
+      id: params.id ?? uuidv1(),
       settings: {
         syncDelay: params.settings?.syncDelay ?? new Duration(1, DurationUnit.Minute),
         frequency: params.settings?.frequency ?? new Duration(1, DurationUnit.Minute),

--- a/x-pack/plugins/observability/server/services/slo/create_slo.ts
+++ b/x-pack/plugins/observability/server/services/slo/create_slo.ts
@@ -27,7 +27,7 @@ export class CreateSLO {
     validateSLO(slo);
 
     await this.resourceInstaller.ensureCommonResourcesInstalled();
-    await this.repository.save(slo);
+    await this.repository.save(slo, { throwOnConflict: true });
 
     let sloTransformId;
     try {

--- a/x-pack/plugins/observability/server/services/slo/slo_repository.test.ts
+++ b/x-pack/plugins/observability/server/services/slo/slo_repository.test.ts
@@ -5,11 +5,7 @@
  * 2.0.
  */
 
-import {
-  SavedObjectsClientContract,
-  SavedObjectsErrorHelpers,
-  SavedObjectsFindResponse,
-} from '@kbn/core/server';
+import { SavedObjectsClientContract, SavedObjectsFindResponse } from '@kbn/core/server';
 import { savedObjectsClientMock } from '@kbn/core/server/mocks';
 import { sloSchema } from '@kbn/slo-schema';
 

--- a/x-pack/plugins/observability/server/services/slo/slo_repository.test.ts
+++ b/x-pack/plugins/observability/server/services/slo/slo_repository.test.ts
@@ -23,7 +23,7 @@ import {
   SortField,
 } from './slo_repository';
 import { createAPMTransactionDurationIndicator, createSLO, aStoredSLO } from './fixtures/slo';
-import { SLONotFound } from '../../errors';
+import { SLOIdConflict, SLONotFound } from '../../errors';
 
 const SOME_SLO = createSLO({ indicator: createAPMTransactionDurationIndicator() });
 const ANOTHER_SLO = createSLO();
@@ -52,7 +52,7 @@ describe('KibanaSavedObjectsSLORepository', () => {
 
   describe('validation', () => {
     it('findById throws when an SLO is not found', async () => {
-      soClientMock.get.mockRejectedValueOnce(SavedObjectsErrorHelpers.createGenericNotFoundError());
+      soClientMock.find.mockResolvedValueOnce(createFindResponse([]));
       const repository = new KibanaSavedObjectsSLORepository(soClientMock);
 
       await expect(repository.findById('inexistant-slo-id')).rejects.toThrowError(
@@ -61,9 +61,7 @@ describe('KibanaSavedObjectsSLORepository', () => {
     });
 
     it('deleteById throws when an SLO is not found', async () => {
-      soClientMock.delete.mockRejectedValueOnce(
-        SavedObjectsErrorHelpers.createGenericNotFoundError()
-      );
+      soClientMock.find.mockResolvedValueOnce(createFindResponse([]));
       const repository = new KibanaSavedObjectsSLORepository(soClientMock);
 
       await expect(repository.deleteById('inexistant-slo-id')).rejects.toThrowError(
@@ -72,27 +70,79 @@ describe('KibanaSavedObjectsSLORepository', () => {
     });
   });
 
-  it('saves the SLO', async () => {
-    soClientMock.create.mockResolvedValueOnce(aStoredSLO(SOME_SLO));
-    const repository = new KibanaSavedObjectsSLORepository(soClientMock);
+  describe('saving an SLO', () => {
+    it('saves the new SLO', async () => {
+      const slo = createSLO({ id: 'my-id' });
+      soClientMock.find.mockResolvedValueOnce(createFindResponse([]));
+      soClientMock.create.mockResolvedValueOnce(aStoredSLO(slo));
+      const repository = new KibanaSavedObjectsSLORepository(soClientMock);
 
-    const savedSLO = await repository.save(SOME_SLO);
+      const savedSLO = await repository.save(slo);
 
-    expect(savedSLO).toEqual(SOME_SLO);
-    expect(soClientMock.create).toHaveBeenCalledWith(SO_SLO_TYPE, sloSchema.encode(SOME_SLO), {
-      id: SOME_SLO.id,
-      overwrite: true,
+      expect(savedSLO).toEqual(slo);
+      expect(soClientMock.find).toHaveBeenCalledWith({
+        type: SO_SLO_TYPE,
+        page: 1,
+        perPage: 1,
+        filter: `slo.attributes.id:(${slo.id})`,
+      });
+      expect(soClientMock.create).toHaveBeenCalledWith(SO_SLO_TYPE, sloSchema.encode(slo), {
+        id: undefined,
+        overwrite: true,
+      });
+    });
+
+    it('throws when the SLO id already exists and "throwOnConflict" is true', async () => {
+      const slo = createSLO({ id: 'my-id' });
+      soClientMock.find.mockResolvedValueOnce(createFindResponse([slo]));
+      const repository = new KibanaSavedObjectsSLORepository(soClientMock);
+
+      await expect(repository.save(slo, { throwOnConflict: true })).rejects.toThrowError(
+        new SLOIdConflict(`SLO [my-id] already exists`)
+      );
+      expect(soClientMock.find).toHaveBeenCalledWith({
+        type: SO_SLO_TYPE,
+        page: 1,
+        perPage: 1,
+        filter: `slo.attributes.id:(${slo.id})`,
+      });
+    });
+
+    it('updates the existing SLO', async () => {
+      const slo = createSLO({ id: 'my-id' });
+      soClientMock.find.mockResolvedValueOnce(createFindResponse([slo]));
+      soClientMock.create.mockResolvedValueOnce(aStoredSLO(slo));
+      const repository = new KibanaSavedObjectsSLORepository(soClientMock);
+
+      const savedSLO = await repository.save(slo);
+
+      expect(savedSLO).toEqual(slo);
+      expect(soClientMock.find).toHaveBeenCalledWith({
+        type: SO_SLO_TYPE,
+        page: 1,
+        perPage: 1,
+        filter: `slo.attributes.id:(${slo.id})`,
+      });
+      expect(soClientMock.create).toHaveBeenCalledWith(SO_SLO_TYPE, sloSchema.encode(slo), {
+        id: 'my-id',
+        overwrite: true,
+      });
     });
   });
 
   it('finds an existing SLO', async () => {
     const repository = new KibanaSavedObjectsSLORepository(soClientMock);
-    soClientMock.get.mockResolvedValueOnce(aStoredSLO(SOME_SLO));
+    soClientMock.find.mockResolvedValueOnce(createFindResponse([SOME_SLO]));
 
     const foundSLO = await repository.findById(SOME_SLO.id);
 
     expect(foundSLO).toEqual(SOME_SLO);
-    expect(soClientMock.get).toHaveBeenCalledWith(SO_SLO_TYPE, SOME_SLO.id);
+    expect(soClientMock.find).toHaveBeenCalledWith({
+      type: SO_SLO_TYPE,
+      page: 1,
+      perPage: 1,
+      filter: `slo.attributes.id:(${SOME_SLO.id})`,
+    });
   });
 
   it('finds all SLOs by ids', async () => {
@@ -112,9 +162,16 @@ describe('KibanaSavedObjectsSLORepository', () => {
 
   it('deletes an SLO', async () => {
     const repository = new KibanaSavedObjectsSLORepository(soClientMock);
+    soClientMock.find.mockResolvedValueOnce(createFindResponse([SOME_SLO]));
 
     await repository.deleteById(SOME_SLO.id);
 
+    expect(soClientMock.find).toHaveBeenCalledWith({
+      type: SO_SLO_TYPE,
+      page: 1,
+      perPage: 1,
+      filter: `slo.attributes.id:(${SOME_SLO.id})`,
+    });
     expect(soClientMock.delete).toHaveBeenCalledWith(SO_SLO_TYPE, SOME_SLO.id);
   });
 


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/156425

## 📝  Summary

This PR allows the option to provide an slo id upon creation. The slo id must be between 8 and 36 characters.
When the id is not specified, we fallback on a uuidv1.
Since the slo id is not always a uuidv1, we cannot keep using the slo id as the related saved object ID. Therefore, the slo repository has been updated.

When creating an SLO with an ID already in use, we return a 409 Conflict.


## 🖼️ Screenshots

Screenshots |
-- |
![image](https://user-images.githubusercontent.com/1376800/236920263-c13058a4-c902-41ce-b71a-40b11eeb1309.png) |
![image](https://user-images.githubusercontent.com/1376800/236920358-a5a53507-a4af-476c-9313-2629ce667c1b.png) |
![image](https://user-images.githubusercontent.com/1376800/236920431-5f7bbd13-668d-48ab-9757-bf6f8b8b3ee3.png) |


## 🥼 Testing

Create an SLO with a provided ID, the response should be a 200. Then, retry and the response should become 409.
```
curl --request POST \
  --url http://localhost:5601/kibana/api/observability/slos \
  --header 'Authorization: Basic ZWxhc3RpYzpjaGFuZ2VtZQ==' \
  --header 'Content-Type: application/json' \
  --header 'kbn-xsrf: oui' \
  --data '{
	"id": "my-own-id",
	"name": "latency logs service c7352bb3-8bce-4777-9a24-56a7cb8e3684 1683652240",
	"description": "latency from logs",
	"indicator": {
		"type": "sli.kql.custom",
		"params": {
			"index":  "service-logs*",
			"good": "latency < 150",
			"total": "",
			"filter": "host:5a3b50ed-13ed-48db-9b10-377b856507ca",
			"timestampField": "@timestamp"
		}
	},
	"timeWindow": {
		"duration": "30d",
		"isRolling": true
	},
	"budgetingMethod": "occurrences",
	"objective": {
		"target": 0.90
	}
}'
```