### PR TITLE
logstash-central-management: add pipeline.ecs_compatibility to UI

### DIFF
--- a/x-pack/plugins/logstash/common/constants/tooltips.ts
+++ b/x-pack/plugins/logstash/common/constants/tooltips.ts
@@ -18,6 +18,17 @@ export const TOOLTIPS = {
         'Default value: Number of the host’s CPU cores',
     }),
 
+    'pipeline.ecs_compatibility': i18n.translate('xpack.logstash.ecsCompatibilityTooltip', {
+      defaultMessage:
+        'Plugins running in an ECS-compatibility mode will avoid implicitly clashing with the Elastic ' +
+        'Common Schema and will enrich events with ECS-related fields like `event.original`. ' +
+        'This flag sets the default behavior for all plugins in the pipeline, which can be overridden ' +
+        'by individual plugins. ' +
+        'Disabling ECS will cause plugins to operate in a mode that is structurally-compatible with ' +
+        'legacy Logstash 7.x but may clash with the ECS schema.\n\n' +
+        'Default value: inherit (`v8` on Logstash 8.x, `disabled` on Logstash 7.x)',
+    }),
+
     'pipeline.batch.size': i18n.translate('xpack.logstash.pipelineBatchSizeTooltip', {
       defaultMessage:
         'The maximum number of events an individual worker thread will collect ' +

--- a/x-pack/plugins/logstash/public/application/components/pipeline_editor/constants.js
+++ b/x-pack/plugins/logstash/public/application/components/pipeline_editor/constants.js
@@ -46,7 +46,7 @@ export const PIPELINE_EDITOR = {
         defaultMessage: 'ECS 8.x (aligns with Elastic Stack 8.x)',
       }),
       value: 'v8',
-    }
+    },
   ],
   QUEUE_TYPES: [
     {

--- a/x-pack/plugins/logstash/public/application/components/pipeline_editor/constants.js
+++ b/x-pack/plugins/logstash/public/application/components/pipeline_editor/constants.js
@@ -18,6 +18,36 @@ export const PIPELINE_EDITOR = {
     defaultMessage:
       'Pipeline ID must begin with a letter or underscore and contain only letters, underscores, dashes, and numbers',
   }),
+  ECS_COMPATIBILITIES: [
+    {
+      'data-test-subj': 'selectECS-inherit',
+      text: i18n.translate('xpack.logstash.ecsCompatibilities.unspecifiedLabel', {
+        defaultMessage: 'inherit',
+      }),
+      value: null,
+    },
+    {
+      'data-test-subj': 'selectECS-disabled',
+      text: i18n.translate('xpack.logstash.ecsCompatibilities.disabledLabel', {
+        defaultMessage: 'disabled (no ECS-related operations)',
+      }),
+      value: 'disabled',
+    },
+    {
+      'data-test-subj': 'selectECS-v1',
+      text: i18n.translate('xpack.logstash.ecsCompatibilities.v1Label', {
+        defaultMessage: 'ECS 1.x (aligns with Elastic Stack 7.x)',
+      }),
+      value: 'v1',
+    },
+    {
+      'data-test-subj': 'selectECS-v8',
+      text: i18n.translate('xpack.logstash.ecsCompatibilities.v8Label', {
+        defaultMessage: 'ECS 8.x (aligns with Elastic Stack 8.x)',
+      }),
+      value: 'v8',
+    }
+  ],
   QUEUE_TYPES: [
     {
       'data-test-subj': 'selectQueueType-memory',

--- a/x-pack/plugins/logstash/public/application/components/pipeline_editor/pipeline_editor.js
+++ b/x-pack/plugins/logstash/public/application/components/pipeline_editor/pipeline_editor.js
@@ -56,6 +56,7 @@ class PipelineEditorUi extends React.Component {
           'pipeline.batch.delay': settings['pipeline.batch.delay'],
           'pipeline.batch.size': settings['pipeline.batch.size'],
           'pipeline.workers': pipelineWorkers,
+          'pipeline.ecs_compatibility': settings['pipeline.ecs_compatibility'],
           'queue.checkpoint.writes': settings['queue.checkpoint.writes'],
           'queue.max_bytes': settings['queue.max_bytes.number'] + settings['queue.max_bytes.units'],
           'queue.type': settings['queue.type'],
@@ -180,6 +181,10 @@ class PipelineEditorUi extends React.Component {
   handleMaxByteUnitChange = (value) => {
     this.setState({ maxBytesUnit: value });
     this.handleSettingChange('queue.max_bytes', this.state.maxBytesNumber + value);
+  };
+
+  handleEcsChange = (value) => {
+    this.handleSettingChange('pipeline.ecs_compatibility', (isEmpty(value) ? null : value));
   };
 
   handleSettingChange = (settingName, value) => {
@@ -356,6 +361,24 @@ class PipelineEditorUi extends React.Component {
               value={this.state.pipeline.settings['pipeline.workers']}
             />
           </EuiFormRow>
+          <EuiFormRow
+            label={
+              <FormLabelWithIconTip
+                formRowLabelText={intl.formatMessage({
+                  id: 'xpack.logstash.pipelineEditor.pipelineECSCompatibilityFormRowLabel',
+                  defaultMessage: 'ECS Compatibility Mode',
+                })}
+                formRowTooltipText={TOOLTIPS.settings['pipeline.ecs_compatibility']}
+              />
+            }
+          >
+            <EuiSelect
+              data-test-subj="inputECSCompatibility"
+              onChange={ (e) => this.handleEcsChange(e.target.value) }
+              options={PIPELINE_EDITOR.ECS_COMPATIBILITIES}
+              value={this.state.pipeline.settings['pipeline.ecs_compatibility']}
+            />
+          </EuiFormRow>
           <EuiSpacer />
           <EuiFlexGroup>
             <FlexItemSetting
@@ -505,6 +528,7 @@ PipelineEditorUi.propTypes = {
       'pipeline.batch.delay': PropTypes.number.isRequired,
       'pipeline.batch.size': PropTypes.number.isRequired,
       'pipeline.workers': PropTypes.number,
+      'pipeline.ecs_compatibility': PropTypes.string,
       'queue.checkpoint.writes': PropTypes.number.isRequired,
       'queue.max_bytes': PropTypes.number,
       'queue.type': PropTypes.string.isRequired,

--- a/x-pack/plugins/logstash/public/application/components/pipeline_editor/pipeline_editor.js
+++ b/x-pack/plugins/logstash/public/application/components/pipeline_editor/pipeline_editor.js
@@ -184,7 +184,7 @@ class PipelineEditorUi extends React.Component {
   };
 
   handleEcsChange = (value) => {
-    this.handleSettingChange('pipeline.ecs_compatibility', (isEmpty(value) ? null : value));
+    this.handleSettingChange('pipeline.ecs_compatibility', isEmpty(value) ? null : value);
   };
 
   handleSettingChange = (settingName, value) => {
@@ -374,7 +374,7 @@ class PipelineEditorUi extends React.Component {
           >
             <EuiSelect
               data-test-subj="inputECSCompatibility"
-              onChange={ (e) => this.handleEcsChange(e.target.value) }
+              onChange={(e) => this.handleEcsChange(e.target.value)}
               options={PIPELINE_EDITOR.ECS_COMPATIBILITIES}
               value={this.state.pipeline.settings['pipeline.ecs_compatibility']}
             />

--- a/x-pack/plugins/logstash/public/application/components/pipeline_editor/pipeline_editor.test.js
+++ b/x-pack/plugins/logstash/public/application/components/pipeline_editor/pipeline_editor.test.js
@@ -109,6 +109,24 @@ describe('PipelineEditor component', () => {
     expect(wrapper.instance().state.pipeline.settings['pipeline.workers']).toBe(12);
   });
 
+  it('updates pipeline ecs_compatibility', () => {
+    const wrapper = shallowWithIntl(<PipelineEditor.WrappedComponent {...props} />);
+    wrapper.find(`[data-test-subj="inputECSCompatibility"]`).simulate('change', { target: { value: 'disabled' } });
+    expect(wrapper.instance().state.pipeline.settings['pipeline.workers']).toBe('disabled');
+
+    wrapper.find(`[data-test-subj="inputECSCompatibility"]`).simulate('change', { target: { value: '' } });
+    expect(wrapper.instance().state.pipeline.settings['pipeline.workers']).toBe(null);
+
+    wrapper.find(`[data-test-subj="inputECSCompatibility"]`).simulate('change', { target: { value: 'v8' } });
+    expect(wrapper.instance().state.pipeline.settings['pipeline.workers']).toBe('v8');
+
+    wrapper.find(`[data-test-subj="inputECSCompatibility"]`).simulate('change', { target: { value: 'v1' } });
+    expect(wrapper.instance().state.pipeline.settings['pipeline.workers']).toBe('v1');
+
+    wrapper.find(`[data-test-subj="inputECSCompatibility"]`).simulate('change', { target: { value: null } });
+    expect(wrapper.instance().state.pipeline.settings['pipeline.workers']).toBe(null);
+  });
+
   it('updates pipeline batch size', () => {
     const wrapper = shallowWithIntl(<PipelineEditor.WrappedComponent {...props} />);
     wrapper
@@ -135,6 +153,7 @@ describe('PipelineEditor component', () => {
     expect(wrapper.instance().state.pipeline.settings['pipeline.workers']).toBe(10);
     expect(wrapper.instance().state.pipeline.settings['pipeline.batch.size']).toBe(11);
     expect(wrapper.instance().state.pipeline.settings['pipeline.batch.delay']).toBe(12);
+    expect(wrapper.instance().state.pipeline.settings['queue.max_bytes']).toBe("13gb");
     expect(wrapper.instance().state.pipeline.settings['queue.checkpoint.writes']).toBe(14);
   });
 

--- a/x-pack/plugins/logstash/public/application/components/pipeline_editor/pipeline_editor.test.js
+++ b/x-pack/plugins/logstash/public/application/components/pipeline_editor/pipeline_editor.test.js
@@ -111,19 +111,29 @@ describe('PipelineEditor component', () => {
 
   it('updates pipeline ecs_compatibility', () => {
     const wrapper = shallowWithIntl(<PipelineEditor.WrappedComponent {...props} />);
-    wrapper.find(`[data-test-subj="inputECSCompatibility"]`).simulate('change', { target: { value: 'disabled' } });
+    wrapper
+      .find(`[data-test-subj="inputECSCompatibility"]`)
+      .simulate('change', { target: { value: 'disabled' } });
     expect(wrapper.instance().state.pipeline.settings['pipeline.workers']).toBe('disabled');
 
-    wrapper.find(`[data-test-subj="inputECSCompatibility"]`).simulate('change', { target: { value: '' } });
+    wrapper
+      .find(`[data-test-subj="inputECSCompatibility"]`)
+      .simulate('change', { target: { value: '' } });
     expect(wrapper.instance().state.pipeline.settings['pipeline.workers']).toBe(null);
 
-    wrapper.find(`[data-test-subj="inputECSCompatibility"]`).simulate('change', { target: { value: 'v8' } });
+    wrapper
+      .find(`[data-test-subj="inputECSCompatibility"]`)
+      .simulate('change', { target: { value: 'v8' } });
     expect(wrapper.instance().state.pipeline.settings['pipeline.workers']).toBe('v8');
 
-    wrapper.find(`[data-test-subj="inputECSCompatibility"]`).simulate('change', { target: { value: 'v1' } });
+    wrapper
+      .find(`[data-test-subj="inputECSCompatibility"]`)
+      .simulate('change', { target: { value: 'v1' } });
     expect(wrapper.instance().state.pipeline.settings['pipeline.workers']).toBe('v1');
 
-    wrapper.find(`[data-test-subj="inputECSCompatibility"]`).simulate('change', { target: { value: null } });
+    wrapper
+      .find(`[data-test-subj="inputECSCompatibility"]`)
+      .simulate('change', { target: { value: null } });
     expect(wrapper.instance().state.pipeline.settings['pipeline.workers']).toBe(null);
   });
 
@@ -153,7 +163,7 @@ describe('PipelineEditor component', () => {
     expect(wrapper.instance().state.pipeline.settings['pipeline.workers']).toBe(10);
     expect(wrapper.instance().state.pipeline.settings['pipeline.batch.size']).toBe(11);
     expect(wrapper.instance().state.pipeline.settings['pipeline.batch.delay']).toBe(12);
-    expect(wrapper.instance().state.pipeline.settings['queue.max_bytes']).toBe("13gb");
+    expect(wrapper.instance().state.pipeline.settings['queue.max_bytes']).toBe('13gb');
     expect(wrapper.instance().state.pipeline.settings['queue.checkpoint.writes']).toBe(14);
   });
 

--- a/x-pack/plugins/logstash/public/models/pipeline/pipeline.js
+++ b/x-pack/plugins/logstash/public/models/pipeline/pipeline.js
@@ -15,6 +15,7 @@ const settingsDefaults = {
   'pipeline.workers': null, // Defaults to number of CPU cores
   'pipeline.batch.size': 125,
   'pipeline.batch.delay': 50,
+  'pipeline.ecs_compatibility': null, // Defaults to LS-core setting
   'queue.type': 'memory',
   'queue.max_bytes.number': 1,
   'queue.max_bytes.units': 'gb',


### PR DESCRIPTION
## Summary

This is a ham-fisted attempt to propagate Logstash's `pipeline.ecs_compatibility` setting to the Logstash Central Management UI (made by a very-not-front-end-engineer).

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
