### PR TITLE
[Synthetics] Fix mis-match between test results in ping list

### DIFF
--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/common/monitor_test_result/browser_steps_list.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/common/monitor_test_result/browser_steps_list.tsx
@@ -201,6 +201,7 @@ export const BrowserStepsList = ({
       name: RESULT_LABEL,
       render: (pingStatus: string, item: JourneyStep) => (
         <ResultDetails
+          testNowMode={testNowMode}
           step={item}
           pingStatus={pingStatus}
           isExpanded={Boolean(itemIdToExpandedRowMap[item._id]) && !testNowMode}
@@ -362,6 +363,7 @@ const MobileRowDetails = ({
                 title: RESULT_LABEL,
                 description: (
                   <ResultDetails
+                    testNowMode={isTestNowMode}
                     step={journeyStep}
                     pingStatus={journeyStep?.synthetics?.step?.status ?? 'skipped'}
                     isExpanded={isExpanded && !isTestNowMode}

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/common/monitor_test_result/result_details.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/common/monitor_test_result/result_details.tsx
@@ -19,24 +19,28 @@ import { parseBadgeStatus, StatusBadge } from './status_badge';
 import { useStepPrevMetrics } from '../../step_details_page/hooks/use_step_prev_metrics';
 
 export const ResultDetails = ({
+  testNowMode,
   pingStatus,
   isExpanded,
   step,
 }: {
   pingStatus: string;
   isExpanded: boolean;
+  testNowMode: boolean;
   step: JourneyStep;
 }) => {
   return (
     <div>
       <EuiText className="eui-textNoWrap" size="s">
         <StatusBadge status={parseBadgeStatus(pingStatus)} />{' '}
-        {i18n.translate('xpack.synthetics.step.duration.label', {
-          defaultMessage: 'after {value}',
-          values: {
-            value: formatMillisecond((step.synthetics?.step?.duration.us ?? 0) / 1000, {}),
-          },
-        })}
+        {!testNowMode
+          ? i18n.translate('xpack.synthetics.step.duration.label', {
+              defaultMessage: 'after {value}',
+              values: {
+                value: formatMillisecond((step.synthetics?.step?.duration.us ?? 0) / 1000, {}),
+              },
+            })
+          : ''}
       </EuiText>
 
       {isExpanded && (

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/test_runs_table.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/test_runs_table.tsx
@@ -21,7 +21,10 @@ import {
 } from '@elastic/eui';
 import { Criteria } from '@elastic/eui/src/components/basic_table/basic_table';
 import { EuiTableSortingType } from '@elastic/eui/src/components/basic_table/table_types';
-import { ExpandRowColumn } from '../../test_now_mode/simple/ping_list/columns/expand_row';
+import {
+  ExpandRowColumn,
+  toggleDetails,
+} from '../../test_now_mode/simple/ping_list/columns/expand_row';
 import { useExpandedPingList } from '../../test_now_mode/simple/ping_list/use_ping_expanded';
 import { THUMBNAIL_SCREENSHOT_SIZE_MOBILE } from '../../common/screenshot/screenshot_size';
 import { getErrorDetailsUrl } from '../monitor_errors/errors_list';
@@ -158,6 +161,17 @@ export const TestRunsTable = ({
         ),
       },
     },
+    ...(!isBrowserMonitor
+      ? [
+          {
+            align: 'left',
+            field: 'monitor.ip',
+            name: i18n.translate('xpack.synthetics.pingList.ipAddressColumnLabel', {
+              defaultMessage: 'IP',
+            }),
+          },
+        ]
+      : []),
     {
       align: 'left',
       valign: 'middle',
@@ -211,9 +225,6 @@ export const TestRunsTable = ({
   ] as Array<EuiBasicTableColumn<Ping>>;
 
   const getRowProps = (item: Ping) => {
-    if (item.monitor.type !== MONITOR_TYPES.BROWSER) {
-      return {};
-    }
     return {
       'data-test-subj': `row-${item.monitor.check_group}`,
       onClick: (evt: MouseEvent) => {
@@ -224,13 +235,17 @@ export const TestRunsTable = ({
           targetElem.tagName !== 'path' &&
           !targetElem.parentElement?.classList.contains('euiLink')
         ) {
-          history.push(
-            getTestRunDetailRelativeLink({
-              monitorId,
-              checkGroup: item.monitor.check_group,
-              locationId: selectedLocation?.id,
-            })
-          );
+          if (item.monitor.type !== MONITOR_TYPES.BROWSER) {
+            toggleDetails(item, expandedRows, setExpandedRows);
+          } else {
+            history.push(
+              getTestRunDetailRelativeLink({
+                monitorId,
+                checkGroup: item.monitor.check_group,
+                locationId: selectedLocation?.id,
+              })
+            );
+          }
         }
       },
     };

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/test_runs_table.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/test_runs_table.tsx
@@ -21,6 +21,8 @@ import {
 } from '@elastic/eui';
 import { Criteria } from '@elastic/eui/src/components/basic_table/basic_table';
 import { EuiTableSortingType } from '@elastic/eui/src/components/basic_table/table_types';
+import { ExpandRowColumn } from '../../test_now_mode/simple/ping_list/columns/expand_row';
+import { useExpandedPingList } from '../../test_now_mode/simple/ping_list/use_ping_expanded';
 import { THUMBNAIL_SCREENSHOT_SIZE_MOBILE } from '../../common/screenshot/screenshot_size';
 import { getErrorDetailsUrl } from '../monitor_errors/errors_list';
 
@@ -87,6 +89,8 @@ export const TestRunsTable = ({
 
   const isBrowserMonitor = monitor?.[ConfigKey.MONITOR_TYPE] === DataStream.BROWSER;
 
+  const { expandedRows, setExpandedRows } = useExpandedPingList(pings);
+
   const sorting: EuiTableSortingType<Ping> = {
     sort: {
       field: sortField as keyof Ping,
@@ -104,7 +108,7 @@ export const TestRunsTable = ({
     }
   };
 
-  const columns: Array<EuiBasicTableColumn<Ping>> = [
+  const columns = [
     ...((isBrowserMonitor
       ? [
           {
@@ -188,7 +192,23 @@ export const TestRunsTable = ({
         show: false,
       },
     },
-  ];
+    ...(!isBrowserMonitor
+      ? [
+          {
+            align: 'right',
+            width: '24px',
+            isExpander: true,
+            render: (item: Ping) => (
+              <ExpandRowColumn
+                item={item}
+                expandedRows={expandedRows}
+                setExpandedRows={setExpandedRows}
+              />
+            ),
+          },
+        ]
+      : []),
+  ] as Array<EuiBasicTableColumn<Ping>>;
 
   const getRowProps = (item: Ping) => {
     if (item.monitor.type !== MONITOR_TYPES.BROWSER) {
@@ -224,6 +244,9 @@ export const TestRunsTable = ({
         pings={pings}
       />
       <EuiBasicTable
+        itemId="docId"
+        isExpandable={true}
+        itemIdToExpandedRowMap={expandedRows}
         css={{ overflowX: isTabletOrGreater ? 'auto' : undefined }}
         compressed={false}
         loading={pingsLoading}

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/test_now_mode/simple/ping_list/ping_list_table.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/test_now_mode/simple/ping_list/ping_list_table.tsx
@@ -5,10 +5,11 @@
  * 2.0.
  */
 
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { EuiBasicTable } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import styled from 'styled-components';
+import { useExpandedPingList } from './use_ping_expanded';
 import { formatDuration } from '../../../../utils/formatting';
 import { Ping } from '../../../../../../../common/runtime_types';
 import * as I18LABELS from './translations';
@@ -26,21 +27,7 @@ interface Props {
 }
 
 export function PingListTable({ loading, error, pings, onChange }: Props) {
-  const [expandedRows, setExpandedRows] = useState<Record<string, JSX.Element>>({});
-
-  const expandedIdsToRemove = JSON.stringify(
-    Object.keys(expandedRows).filter((e) => !pings.some(({ docId }) => docId === e))
-  );
-
-  useEffect(() => {
-    const parsed = JSON.parse(expandedIdsToRemove);
-    if (parsed.length) {
-      parsed.forEach((docId: string) => {
-        delete expandedRows[docId];
-      });
-      setExpandedRows(expandedRows);
-    }
-  }, [expandedIdsToRemove, expandedRows]);
+  const { expandedRows, setExpandedRows } = useExpandedPingList(pings);
 
   const hasStatus = pings.reduce(
     (hasHttpStatus: boolean, currentPing) =>

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/test_now_mode/simple/ping_list/use_ping_expanded.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/test_now_mode/simple/ping_list/use_ping_expanded.tsx
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useEffect, useState } from 'react';
+import { Ping } from '../../../../../../../common/runtime_types';
+
+export const useExpandedPingList = (pings: Ping[]) => {
+  const [expandedRows, setExpandedRows] = useState<Record<string, JSX.Element>>({});
+
+  const expandedIdsToRemove = JSON.stringify(
+    Object.keys(expandedRows).filter((e) => !pings.some(({ docId }) => docId === e))
+  );
+
+  useEffect(() => {
+    const parsed = JSON.parse(expandedIdsToRemove);
+    if (parsed.length) {
+      parsed.forEach((docId: string) => {
+        delete expandedRows[docId];
+      });
+      setExpandedRows(expandedRows);
+    }
+  }, [expandedIdsToRemove, expandedRows]);
+
+  return { expandedRows, setExpandedRows };
+};


### PR DESCRIPTION
## Summary

Small UI tweaks !!

Hide duplicate duration in manual test run browser step list

### After
<img width="1775" alt="image" src="https://github.com/elastic/kibana/assets/3505601/41575c24-ccae-4563-b7cf-dd5e1eb134e5">

### Before

<img width="1777" alt="image" src="https://github.com/elastic/kibana/assets/3505601/f603c507-8fbb-456f-949a-23229f36f26f">



Test details ping list 
<img width="1778" alt="image" src="https://github.com/elastic/kibana/assets/3505601/bc81ffdc-450b-4637-bac7-f32fd27b71dd">


Test now ping list

<img width="1791" alt="image" src="https://github.com/elastic/kibana/assets/3505601/fb7fb576-1ed2-4f21-a7b2-7f89153d85c8">



<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->