### PR TITLE
Update configuring-reporting.asciidoc

### DIFF
--- a/docs/setup/configuring-reporting.asciidoc
+++ b/docs/setup/configuring-reporting.asciidoc
@@ -182,13 +182,13 @@ PUT localhost:5601/api/security/role/custom_reporting_user
 
 If you are using an external identity provider, such as LDAP or Active Directory, you can assign roles to individual users or groups of users. Role mappings are configured in {ref}/mapping-roles.html[`config/role_mapping.yml`].
 
-For example, assign the `kibana_admin` and `reporting_user` roles to the Bill Murray user:
+For example, assign the `kibana_admin` and `custom_reporting_user` roles to the Bill Murray user:
 
 [source,yaml]
 --------------------------------------------------------------------------------
 kibana_admin:
   - "cn=Bill Murray,dc=example,dc=com"
-reporting_user:
+custom_reporting_user:
   - "cn=Bill Murray,dc=example,dc=com"
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
Change `reporting_user`to `custom_reporting_user` when using role_mapping file because `reporting_user`is a deprecated parameter

The fact that the official documentation pushes to use a deprecated parameter when using an external identity provider and the role_mappings.yml file makes it look like this is the right way to go, when in fact you should be using dedicated roles for reporting as specified in step 3 https://www.elastic.co/guide/en/kibana/8.7/secure-reporting.html#grant-user-access:~:text=Specify%20the%20role%20settings.

## Summary

Improve documentation In order to avoid confusion


### Checklist

Delete any items that are not applicable to this PR.

- [ ] The clarity of the explanations must follow the model of the official documentation
- [ ] Avoid syntax and spelling mistakes


