### PR TITLE
[Search Application] Fix documentation links

### DIFF
--- a/packages/kbn-doc-links/src/get_doc_links.ts
+++ b/packages/kbn-doc-links/src/get_doc_links.ts
@@ -155,6 +155,8 @@ export const getDocLinks = ({ kibanaBranch }: GetDocLinkOptions): DocLinks => {
       machineLearningStart: `${ENTERPRISE_SEARCH_DOCS}machine-learning-start.html`,
       mailService: `${ENTERPRISE_SEARCH_DOCS}mailer-configuration.html`,
       mlDocumentEnrichment: `${ENTERPRISE_SEARCH_DOCS}document-enrichment.html`,
+      searchApplications: `${ENTERPRISE_SEARCH_DOCS}search-applications.html`,
+      searchTemplates: `${ELASTICSEARCH_DOCS}search-template.html`,
       start: `${ENTERPRISE_SEARCH_DOCS}start.html`,
       syncRules: `${ENTERPRISE_SEARCH_DOCS}sync-rules.html`,
       troubleshootSetup: `${ENTERPRISE_SEARCH_DOCS}troubleshoot-setup.html`,

--- a/packages/kbn-doc-links/src/types.ts
+++ b/packages/kbn-doc-links/src/types.ts
@@ -140,6 +140,8 @@ export interface DocLinks {
     readonly machineLearningStart: string;
     readonly mailService: string;
     readonly mlDocumentEnrichment: string;
+    readonly searchApplications: string;
+    readonly searchTemplates: string;
     readonly start: string;
     readonly syncRules: string;
     readonly troubleshootSetup: string;

--- a/x-pack/plugins/enterprise_search/public/applications/applications/components/engine/engine_search_preview/engine_search_preview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/applications/components/engine/engine_search_preview/engine_search_preview.tsx
@@ -349,7 +349,7 @@ export const EngineSearchPreview: React.FC = () => {
               <EuiSpacer size="m" />
               <Sorting sortableFields={sortableFields} />
               <EuiSpacer size="m" />
-              <EuiLink href={docLinks.enterpriseSearchEngines} target="_blank">
+              <EuiLink href={docLinks.searchTemplates} target="_blank">
                 <FormattedMessage
                   id="xpack.enterpriseSearch.content.engine.searchPreview.improveResultsLink"
                   defaultMessage="Improve these results"

--- a/x-pack/plugins/enterprise_search/public/applications/applications/components/engines/create_engine_flyout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/applications/components/engines/create_engine_flyout.tsx
@@ -94,14 +94,14 @@ export const CreateEngineFlyout = ({ onClose }: CreateEngineFlyoutProps) => {
               values={{
                 enginesDocsLink: (
                   <EuiLink
-                    href={docLinks.enterpriseSearchEngines}
+                    href={docLinks.searchApplications}
                     target="_blank"
                     data-telemetry-id="entSearchApplications-createEngine-docsLink"
                     external
                   >
                     {i18n.translate(
                       'xpack.enterpriseSearch.content.engines.createEngine.header.docsLink',
-                      { defaultMessage: 'Search Application documentation' }
+                      { defaultMessage: 'Search Applications documentation' }
                     )}
                   </EuiLink>
                 ),

--- a/x-pack/plugins/enterprise_search/public/applications/applications/components/engines/engines_list.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/applications/components/engines/engines_list.tsx
@@ -174,7 +174,7 @@ export const EnginesList: React.FC<ListProps> = ({ createEngineFlyoutOpen }) => 
                 documentationUrl: (
                   <EuiLink
                     data-test-subj="engines-documentation-link"
-                    href={docLinks.enterpriseSearchEngines}
+                    href={docLinks.searchApplications}
                     target="_blank"
                     data-telemetry-id="entSearchApplications-documentation-viewDocumentaion"
                   >

--- a/x-pack/plugins/enterprise_search/public/applications/shared/doc_links/doc_links.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/doc_links/doc_links.ts
@@ -98,6 +98,8 @@ class DocLinks {
   public queryDsl: string;
   public searchUIAppSearch: string;
   public searchUIElasticsearch: string;
+  public searchApplications: string;
+  public searchTemplates: string;
   public start: string;
   public syncRules: string;
   public workplaceSearchApiKeys: string;
@@ -227,6 +229,8 @@ class DocLinks {
     this.queryDsl = '';
     this.searchUIAppSearch = '';
     this.searchUIElasticsearch = '';
+    this.searchApplications = '';
+    this.searchTemplates = '';
     this.start = '';
     this.syncRules = '';
     this.workplaceSearchApiKeys = '';
@@ -358,6 +362,8 @@ class DocLinks {
     this.queryDsl = docLinks.links.query.queryDsl;
     this.searchUIAppSearch = docLinks.links.searchUI.appSearch;
     this.searchUIElasticsearch = docLinks.links.searchUI.elasticsearch;
+    this.searchApplications = docLinks.links.enterpriseSearch.searchApplications;
+    this.searchTemplates = docLinks.links.enterpriseSearch.searchTemplates;
     this.start = docLinks.links.enterpriseSearch.start;
     this.syncRules = docLinks.links.enterpriseSearch.syncRules;
     this.workplaceSearchApiKeys = docLinks.links.workplaceSearch.apiKeys;


### PR DESCRIPTION
Update links to documentation
- ✔️ Search Application(s) documentation links from main page
- ✔️ Search Preview page "Improve your results"

<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->