### PR TITLE
Adds documentation to clarify kibana-keystore behaviour

### DIFF
--- a/docs/setup/secure-settings.asciidoc
+++ b/docs/setup/secure-settings.asciidoc
@@ -36,6 +36,8 @@ bin/kibana-keystore list
 [[add-string-to-keystore]]
 === Add string settings
 
+NOTE: Your input will be JSON-parsed, to allow for object/array input configurations. To enforce string inputs, use "double quotes" around your input.
+
 Sensitive string settings, like authentication credentials for Elasticsearch
 can be added using the `add` command:
 

--- a/docs/setup/secure-settings.asciidoc
+++ b/docs/setup/secure-settings.asciidoc
@@ -36,7 +36,7 @@ bin/kibana-keystore list
 [[add-string-to-keystore]]
 === Add string settings
 
-NOTE: Your input will be JSON-parsed, to allow for object/array input configurations. To enforce string inputs, use "double quotes" around your input.
+NOTE: Your input will be JSON-parsed to allow for object/array input configurations. To enforce string values, use "double quotes" around your input.
 
 Sensitive string settings, like authentication credentials for Elasticsearch
 can be added using the `add` command:

--- a/src/cli_keystore/add.js
+++ b/src/cli_keystore/add.js
@@ -64,7 +64,9 @@ export async function add(keystore, key, options = {}) {
 export function addCli(program, keystore) {
   program
     .command('add <key>')
-    .description('Add a string setting to the keystore')
+    .description(
+      'Add a setting to the keystore. Note: The value will be JSON parsed. Use quotes to force string inputs.'
+    )
     .option('-f, --force', 'overwrite existing setting without prompting')
     .option('-x, --stdin', 'read setting value from stdin')
     .option('-s, --silent', 'prevent all logging')


### PR DESCRIPTION
## Summary
Addresses #155474 

We've discussed with the team, and decided that we'd retain current behaviour, and adjust the docs and notes around the behaviour.

fix(keystore): add warning note to explain that input is being JSON parsed
docs(keystore): add documentation to clarify behavior

### Checklist

- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["7.17","8.8"]} ONMERGE-->