### PR TITLE
fix(slo): enforce write capabilities on welcome and form pages

### DIFF
--- a/x-pack/plugins/observability/public/pages/slo_edit/slo_edit.test.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/slo_edit.test.tsx
@@ -24,6 +24,7 @@ import { kibanaStartMock } from '../../utils/kibana_react.mock';
 import { buildSlo } from '../../data/slo/slo';
 import { paths } from '../../config/paths';
 import { SloEditPage } from './slo_edit';
+import { useCapabilities } from '../../hooks/slo/use_capabilities';
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
@@ -37,6 +38,7 @@ jest.mock('../../hooks/slo/use_fetch_slo_details');
 jest.mock('../../hooks/slo/use_create_slo');
 jest.mock('../../hooks/slo/use_update_slo');
 jest.mock('../../hooks/slo/use_fetch_apm_suggestions');
+jest.mock('../../hooks/slo/use_capabilities');
 
 const mockUseKibanaReturnValue = kibanaStartMock.startContract();
 
@@ -51,6 +53,7 @@ const useFetchSloMock = useFetchSloDetails as jest.Mock;
 const useCreateSloMock = useCreateSlo as jest.Mock;
 const useUpdateSloMock = useUpdateSlo as jest.Mock;
 const useFetchApmSuggestionsMock = useFetchApmSuggestions as jest.Mock;
+const useCapabilitiesMock = useCapabilities as jest.Mock;
 
 const mockAddSuccess = jest.fn();
 const mockAddError = jest.fn();
@@ -121,6 +124,10 @@ describe('SLO Edit Page', () => {
 
   describe('when the incorrect license is found', () => {
     beforeEach(() => {
+      useCapabilitiesMock.mockReturnValue({
+        hasWriteCapabilities: true,
+        hasReadCapabilities: true,
+      });
       useLicenseMock.mockReturnValue({ hasAtLeast: () => false });
     });
 
@@ -161,7 +168,54 @@ describe('SLO Edit Page', () => {
 
   describe('when the correct license is found', () => {
     beforeEach(() => {
+      useCapabilitiesMock.mockReturnValue({
+        hasWriteCapabilities: true,
+        hasReadCapabilities: true,
+      });
       useLicenseMock.mockReturnValue({ hasAtLeast: () => true });
+    });
+
+    describe('with no write permission', () => {
+      beforeEach(() => {
+        useCapabilitiesMock.mockReturnValue({
+          hasWriteCapabilities: false,
+          hasReadCapabilities: true,
+        });
+      });
+
+      it('redirects to the slo list page', async () => {
+        jest.spyOn(Router, 'useParams').mockReturnValue({ sloId: '1234' });
+        jest
+          .spyOn(Router, 'useLocation')
+          .mockReturnValue({ pathname: 'foo', search: '', state: '', hash: '' });
+
+        useFetchSloMock.mockReturnValue({ isLoading: false, slo: undefined });
+
+        useFetchIndicesMock.mockReturnValue({
+          isLoading: false,
+          indices: [{ name: 'some-index' }],
+        });
+
+        useCreateSloMock.mockReturnValue({
+          isLoading: false,
+          isSuccess: false,
+          isError: false,
+          mutate: jest.fn(),
+          mutateAsync: jest.fn(),
+        });
+
+        useUpdateSloMock.mockReturnValue({
+          isLoading: false,
+          isSuccess: false,
+          isError: false,
+          mutate: jest.fn(),
+          mutateAsync: jest.fn(),
+        });
+
+        render(<SloEditPage />);
+
+        expect(mockNavigate).toBeCalledWith(mockBasePathPrepend(paths.observability.slos));
+      });
     });
 
     describe('when no sloId route param is provided', () => {

--- a/x-pack/plugins/observability/public/pages/slo_edit/slo_edit.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/slo_edit.tsx
@@ -17,12 +17,14 @@ import { useFetchSloDetails } from '../../hooks/slo/use_fetch_slo_details';
 import { useLicense } from '../../hooks/use_license';
 import { SloEditForm } from './components/slo_edit_form';
 import { FeedbackButton } from '../../components/slo/feedback_button/feedback_button';
+import { useCapabilities } from '../../hooks/slo/use_capabilities';
 
 export function SloEditPage() {
   const {
     application: { navigateToUrl },
     http: { basePath },
   } = useKibana().services;
+  const { hasWriteCapabilities } = useCapabilities();
   const { ObservabilityPageTemplate } = usePluginContext();
 
   const { sloId } = useParams<{ sloId: string | undefined }>();
@@ -41,7 +43,7 @@ export function SloEditPage() {
 
   const { slo, isInitialLoading } = useFetchSloDetails({ sloId });
 
-  if (hasRightLicense === false) {
+  if (hasRightLicense === false || !hasWriteCapabilities) {
     navigateToUrl(basePath.prepend(paths.observability.slos));
   }
 

--- a/x-pack/plugins/observability/public/pages/slos_welcome/slos_welcome.test.tsx
+++ b/x-pack/plugins/observability/public/pages/slos_welcome/slos_welcome.test.tsx
@@ -73,6 +73,19 @@ describe('SLOs Welcome Page', () => {
         useFetchSloListMock.mockReturnValue({ isLoading: false, emptySloList });
       });
 
+      it('disables the create slo button when no write capabilities', async () => {
+        useCapabilitiesMock.mockReturnValue({
+          hasWriteCapabilities: false,
+          hasReadCapabilities: true,
+        });
+
+        render(<SlosWelcomePage />);
+        expect(screen.queryByTestId('slosPageWelcomePrompt')).toBeTruthy();
+
+        const createNewSloButton = screen.queryByTestId('o11ySloListWelcomePromptCreateSloButton');
+        expect(createNewSloButton).toBeDisabled();
+      });
+
       it('should display the welcome message with a Create new SLO button which should navigate to the SLO Creation page', async () => {
         render(<SlosWelcomePage />);
         expect(screen.queryByTestId('slosPageWelcomePrompt')).toBeTruthy();

--- a/x-pack/plugins/observability/public/pages/slos_welcome/slos_welcome.tsx
+++ b/x-pack/plugins/observability/public/pages/slos_welcome/slos_welcome.tsx
@@ -24,12 +24,14 @@ import { usePluginContext } from '../../hooks/use_plugin_context';
 import { useFetchSloList } from '../../hooks/slo/use_fetch_slo_list';
 import { paths } from '../../config/paths';
 import illustration from './assets/illustration.svg';
+import { useCapabilities } from '../../hooks/slo/use_capabilities';
 
 export function SlosWelcomePage() {
   const {
     application: { navigateToUrl },
     http: { basePath },
   } = useKibana().services;
+  const { hasWriteCapabilities } = useCapabilities();
   const { ObservabilityPageTemplate } = usePluginContext();
 
   const { hasAtLeast } = useLicense();
@@ -108,6 +110,7 @@ export function SlosWelcomePage() {
                       fill
                       color="primary"
                       onClick={handleClickCreateSlo}
+                      disabled={!hasWriteCapabilities}
                     >
                       {i18n.translate('xpack.observability.slo.sloList.welcomePrompt.buttonLabel', {
                         defaultMessage: 'Create SLO',


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/157150

## Summary

This PR fixes the welcome and form pages when a user has not the write capabilities:
- The Create SLO button is disabled on the welcome page
- User is redirected back to slo list page when accessing the form page (through URL for example)



<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->