### PR TITLE
[Fleet] Do not show error state on input if there are no errors

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_var_field.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_var_field.tsx
@@ -60,7 +60,7 @@ export const PackagePolicyInputVarField: React.FunctionComponent<{
   }) => {
     const [isDirty, setIsDirty] = useState<boolean>(false);
     const { multi, required, type, title, name, description, options } = varDef;
-    const isInvalid = (isDirty || forceShowErrors) && !!varErrors;
+    const isInvalid = (isDirty || forceShowErrors) && !!varErrors?.length;
     const errors = isInvalid ? varErrors : null;
     const fieldLabel = title || name;
     const fieldTestSelector = fieldLabel.replace(/\s/g, '-').toLowerCase();


### PR DESCRIPTION
## Summary
Fixes this bug, where there was previously an error with a policy input but it has been corrected by the user, we still show it in the error state without an error message:
<img width="1030" alt="Screenshot 2023-05-09 at 12 26 04" src="https://github.com/elastic/kibana/assets/3315046/4381523a-d839-4425-af5f-0f56e6aa9199">

Note there is no error message, where a correct error input looks like this:
<img width="379" alt="Screenshot 2023-05-09 at 12 27 44" src="https://github.com/elastic/kibana/assets/3315046/4b7a498a-ac9a-46d8-94e1-525f4b090cfd">

The error is simply that `[]` is truthy so was showing as having errors


<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->