### PR TITLE
[Ingest Pipelines] Unskip functional and a11y tests

### DIFF
--- a/x-pack/test/accessibility/apps/ingest_node_pipelines.ts
+++ b/x-pack/test/accessibility/apps/ingest_node_pipelines.ts
@@ -14,10 +14,7 @@ export default function ({ getService, getPageObjects }: any) {
   const log = getService('log');
   const a11y = getService('a11y'); /* this is the wrapping service around axe */
 
-  // FAILING VERSION BUMP: https://github.com/elastic/kibana/issues/155924
-  // Failing: See https://github.com/elastic/kibana/issues/155928
-  // Failing: See https://github.com/elastic/kibana/issues/155928
-  describe.skip('Ingest Pipelines Accessibility', async () => {
+  describe('Ingest Pipelines Accessibility', async () => {
     before(async () => {
       await putSamplePipeline(esClient);
       await common.navigateToApp('ingestPipelines');

--- a/x-pack/test/functional/apps/ingest_pipelines/ingest_pipelines.ts
+++ b/x-pack/test/functional/apps/ingest_pipelines/ingest_pipelines.ts
@@ -26,8 +26,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
   const es = getService('es');
   const security = getService('security');
 
-  // FAILING VERSION BUMP: https://github.com/elastic/kibana/issues/155914
-  describe.skip('Ingest Pipelines', function () {
+  describe('Ingest Pipelines', function () {
     this.tags('smoke');
     before(async () => {
       await security.testUser.setRoles(['ingest_pipelines_user']);


### PR DESCRIPTION
## Summary
Fixes https://github.com/elastic/kibana/issues/156015
Fixes https://github.com/elastic/kibana/issues/156014
Fixes https://github.com/elastic/kibana/issues/155924 
Fixes https://github.com/elastic/kibana/issues/155914

The Ingest Pipelines tests were broken because of a new pipeline introduced in https://github.com/elastic/elasticsearch/pull/95198 but there was a fix added in https://github.com/elastic/elasticsearch/pull/95621. The last PR fixes the error where it was not possible to delete the pipeline in the tests. This PR unskips the tests since they should now work as expected. 


<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->