### PR TITLE
[Fleet] Improve security of Agent k8s manifest

### DIFF
--- a/x-pack/plugins/fleet/server/services/elastic_agent_manifest.ts
+++ b/x-pack/plugins/fleet/server/services/elastic_agent_manifest.ts
@@ -345,8 +345,8 @@ spec:
             - name: FLEET_ENROLL
               value: "1"
             # Set to true to communicate with Fleet with either insecure HTTP or unverified HTTPS
-            - name: FLEET_INSECURE
-              value: "true"
+            # - name: FLEET_INSECURE
+            #   value: "true"
             # Fleet Server URL to enroll the Elastic Agent into
             # FLEET_URL can be found in Kibana, go to Management > Fleet > Settings
             - name: FLEET_URL
@@ -355,14 +355,13 @@ spec:
             # If FLEET_ENROLLMENT_TOKEN is empty then KIBANA_HOST, KIBANA_FLEET_USERNAME, KIBANA_FLEET_PASSWORD are needed
             - name: FLEET_ENROLLMENT_TOKEN
               value: "token-id"
-            - name: KIBANA_HOST
-              value: "http://kibana:5601"
-            # The basic authentication username used to connect to Kibana and retrieve a service_token to enable Fleet
-            - name: KIBANA_FLEET_USERNAME
-              value: "elastic"
-            # The basic authentication password used to connect to Kibana and retrieve a service_token to enable Fleet
-            - name: KIBANA_FLEET_PASSWORD
-              value: "changeme"
+            # The basic authentication username used to connect to Kibana and retrieve an enrollment. Only required when to this agent runs Fleet Server.
+            # - name: KIBANA_HOST
+            #   value: "http://kibana:5601"
+            # - name: KIBANA_FLEET_USERNAME
+            #   value: "elastic"
+            # - name: KIBANA_FLEET_PASSWORD
+            #   value: "changeme"
             - name: NODE_NAME
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
## Summary

This improves the default configuration given to users when install Agent on Kubernetes.
- Comments out the `FLEET_INSECURE` option to enforce HTTPS certification validation
	- This will probably not work for on-prem users who use "quick setup" for Fleet Server and have auto-generated certs.
	- If we have a way to easily uncomment this only when we know a user has set up Fleet this way, we can do that instead. Otherwise we should ship the product with secure defaults.
- Comments out the Kibana configuration options to prevent reaching out to Kibana unnecessarily and adds better comments explaining when this is needed

I will update tests once I have a general 👍 from stakeholders

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)