### PR TITLE
[Security Solution][Endpoint] add `upload` console response action

### DIFF
--- a/x-pack/plugins/security_solution/common/endpoint/data_generators/endpoint_action_generator.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/data_generators/endpoint_action_generator.ts
@@ -122,6 +122,32 @@ export class EndpointActionGenerator extends BaseDataGenerator {
       }
     }
 
+    if (command === 'upload' && !output) {
+      let uploadOutput = output as ActionResponseOutput<ResponseActionUploadOutputContent>;
+
+      if (overrides.error) {
+        uploadOutput = {
+          type: 'json',
+          content: {
+            code: 'ra_upload_some-error',
+            path: '',
+            disk_free_space: 0,
+          },
+        };
+      } else {
+        uploadOutput = {
+          type: 'json',
+          content: {
+            code: 'ra_upload_success',
+            path: '/disk1/file/saved/here',
+            disk_free_space: 4825566125475,
+          },
+        };
+      }
+
+      output = uploadOutput as typeof output;
+    }
+
     return merge(
       {
         '@timestamp': timeStamp.toISOString(),

--- a/x-pack/plugins/security_solution/common/endpoint/data_generators/endpoint_action_generator.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/data_generators/endpoint_action_generator.ts
@@ -138,7 +138,7 @@ export class EndpointActionGenerator extends BaseDataGenerator {
         uploadOutput = {
           type: 'json',
           content: {
-            code: 'ra_upload_success',
+            code: 'ra_upload_file-success',
             path: '/disk1/file/saved/here',
             disk_free_space: 4825566125475,
           },

--- a/x-pack/plugins/security_solution/common/endpoint/data_generators/endpoint_action_generator.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/data_generators/endpoint_action_generator.ts
@@ -268,21 +268,30 @@ export class EndpointActionGenerator extends BaseDataGenerator {
     }
 
     if (command === 'upload') {
-      if (!details.parameters) {
-        (
-          details as ActionDetails<
-            ResponseActionUploadOutputContent,
-            ResponseActionUploadParameters
-          >
-        ).parameters = {
-          file: {
-            file_id: 'file-x-y-z',
-            file_name: 'foo.txt',
-            size: 1234,
-            sha256: 'file-hash-sha-256',
+      const uploadActionDetails = details as ActionDetails<
+        ResponseActionUploadOutputContent,
+        ResponseActionUploadParameters
+      >;
+
+      uploadActionDetails.parameters = {
+        file: {
+          file_id: 'file-x-y-z',
+          file_name: 'foo.txt',
+          size: 1234,
+          sha256: 'file-hash-sha-256',
+        },
+      };
+
+      uploadActionDetails.outputs = {
+        'agent-a': {
+          type: 'json',
+          content: {
+            code: 'ra_upload_file-success',
+            path: '/path/to/uploaded/file',
+            disk_free_space: 1234567,
           },
-        };
-      }
+        },
+      };
     }
 
     return merge(details, overrides as ActionDetails) as unknown as ActionDetails<

--- a/x-pack/plugins/security_solution/common/endpoint/schema/actions.test.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/schema/actions.test.ts
@@ -659,7 +659,7 @@ describe('actions schemas', () => {
       }).not.toThrow();
     });
 
-    it('should allow `override` parameter', () => {
+    it('should allow `overwrite` parameter', () => {
       expect(() => {
         UploadActionRequestSchema.body.validate({
           endpoint_ids: ['endpoint_id'],
@@ -676,10 +676,10 @@ describe('actions schemas', () => {
         UploadActionRequestSchema.body.validate({
           endpoint_ids: ['endpoint_id'],
           parameters: {
-            override: true,
+            overwrite: true,
           },
         });
-      }).toThrow();
+      }).toThrow('[file]: expected value of type [Stream] but got [undefined]');
     });
 
     it('should error if `file` is not a Stream', () => {
@@ -691,7 +691,7 @@ describe('actions schemas', () => {
           },
           file: {},
         });
-      }).toThrow();
+      }).toThrow('[file]: expected value of type [Stream] but got [Object]');
     });
   });
 });

--- a/x-pack/plugins/security_solution/common/endpoint/schema/actions.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/schema/actions.ts
@@ -245,7 +245,7 @@ export const UploadActionRequestSchema = {
     ...BaseActionRequestSchema,
 
     parameters: schema.object({
-      overwrite: schema.maybe(schema.boolean()),
+      overwrite: schema.maybe(schema.boolean({ defaultValue: false })),
     }),
 
     file: schema.stream(),

--- a/x-pack/plugins/security_solution/common/endpoint/schema/actions.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/schema/actions.ts
@@ -252,4 +252,13 @@ export const UploadActionRequestSchema = {
   }),
 };
 
-export type UploadActionRequestBody = TypeOf<typeof UploadActionRequestSchema.body>;
+/** Type used by the server's API for `upload` action */
+export type UploadActionApiRequestBody = TypeOf<typeof UploadActionRequestSchema.body>;
+
+/**
+ * Type used on the UI side. The `file` definition is different on the UI side, thus the
+ * need for a separate type.
+ */
+export type UploadActionUIRequestBody = Omit<UploadActionApiRequestBody, 'file'> & {
+  file: File;
+};

--- a/x-pack/plugins/security_solution/common/endpoint/service/authz/authz.test.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/service/authz/authz.test.ts
@@ -11,7 +11,7 @@ import { createFleetAuthzMock } from '@kbn/fleet-plugin/common/mocks';
 import { createLicenseServiceMock } from '../../../license/mocks';
 import type { EndpointAuthzKeyList } from '../../types/authz';
 import {
-  commandToRBACMap,
+  RESPONSE_CONSOLE_ACTION_COMMANDS_TO_RBAC_FEATURE_CONTROL,
   CONSOLE_RESPONSE_ACTION_COMMANDS,
   type ResponseConsoleRbacControls,
 } from '../response_actions/constants';
@@ -129,7 +129,7 @@ describe('Endpoint Authz service', () => {
       const responseConsolePrivileges = CONSOLE_RESPONSE_ACTION_COMMANDS.slice().reduce<
         ResponseConsoleRbacControls[]
       >((acc, e) => {
-        const item = commandToRBACMap[e];
+        const item = RESPONSE_CONSOLE_ACTION_COMMANDS_TO_RBAC_FEATURE_CONTROL[e];
         if (!acc.includes(item)) {
           acc.push(item);
         }

--- a/x-pack/plugins/security_solution/common/endpoint/service/response_actions/constants.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/service/response_actions/constants.ts
@@ -4,6 +4,8 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+import type { EndpointAuthzKeyList } from '../../types/authz';
+
 export const RESPONSE_ACTION_STATUS = ['failed', 'pending', 'successful'] as const;
 export type ResponseActionStatus = typeof RESPONSE_ACTION_STATUS[number];
 
@@ -66,19 +68,21 @@ export type ResponseConsoleRbacControls =
   | 'writeExecuteOperations';
 
 /**
- * maps the console command to the RBAC control that is required to access it via console
+ * maps the console command to the RBAC control (kibana feature control) that is required to access it via console
  */
-export const commandToRBACMap: Record<ConsoleResponseActionCommands, ResponseConsoleRbacControls> =
-  Object.freeze({
-    isolate: 'writeHostIsolation',
-    release: 'writeHostIsolation',
-    'kill-process': 'writeProcessOperations',
-    'suspend-process': 'writeProcessOperations',
-    processes: 'writeProcessOperations',
-    'get-file': 'writeFileOperations',
-    execute: 'writeExecuteOperations',
-    upload: 'writeFileOperations',
-  });
+export const RESPONSE_CONSOLE_ACTION_COMMANDS_TO_RBAC_FEATURE_CONTROL: Record<
+  ConsoleResponseActionCommands,
+  ResponseConsoleRbacControls
+> = Object.freeze({
+  isolate: 'writeHostIsolation',
+  release: 'writeHostIsolation',
+  'kill-process': 'writeProcessOperations',
+  'suspend-process': 'writeProcessOperations',
+  processes: 'writeProcessOperations',
+  'get-file': 'writeFileOperations',
+  execute: 'writeExecuteOperations',
+  upload: 'writeFileOperations',
+});
 
 export const RESPONSE_ACTION_API_COMMANDS_TO_CONSOLE_COMMAND_MAP = Object.freeze<
   Record<ResponseActionsApiCommandNames, ConsoleResponseActionCommands>
@@ -91,6 +95,35 @@ export const RESPONSE_ACTION_API_COMMANDS_TO_CONSOLE_COMMAND_MAP = Object.freeze
   'kill-process': 'kill-process',
   'suspend-process': 'suspend-process',
   upload: 'upload',
+});
+
+export const CONSOLE_RESPONSE_ACTION_COMMANDS_TO_ENDPOINT_CAPABILITY = Object.freeze<
+  Record<ConsoleResponseActionCommands, EndpointCapabilities>
+>({
+  isolate: 'isolation',
+  release: 'isolation',
+  execute: 'execute',
+  'get-file': 'get_file',
+  processes: 'running_processes',
+  'kill-process': 'kill_process',
+  'suspend-process': 'suspend_process',
+  upload: 'upload_file',
+});
+
+/**
+ * The list of console commands mapped to the required EndpointAuthz to access that command
+ */
+export const RESPONSE_CONSOLE_ACTION_COMMANDS_TO_REQUIRED_AUTHZ = Object.freeze<
+  Record<ConsoleResponseActionCommands, EndpointAuthzKeyList[number]>
+>({
+  isolate: 'canIsolateHost',
+  release: 'canUnIsolateHost',
+  execute: 'canWriteFileOperations',
+  'get-file': 'canWriteFileOperations',
+  processes: 'canGetRunningProcesses',
+  'kill-process': 'canKillProcess',
+  'suspend-process': 'canSuspendProcess',
+  upload: 'canWriteExecuteOperations',
 });
 
 // 4 hrs in seconds

--- a/x-pack/plugins/security_solution/common/endpoint/service/response_actions/constants.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/service/response_actions/constants.ts
@@ -118,7 +118,7 @@ export const RESPONSE_CONSOLE_ACTION_COMMANDS_TO_REQUIRED_AUTHZ = Object.freeze<
 >({
   isolate: 'canIsolateHost',
   release: 'canUnIsolateHost',
-  execute: 'canWriteFileOperations',
+  execute: 'canWriteExecuteOperations',
   'get-file': 'canWriteFileOperations',
   upload: 'canWriteFileOperations',
   processes: 'canGetRunningProcesses',

--- a/x-pack/plugins/security_solution/common/endpoint/service/response_actions/constants.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/service/response_actions/constants.ts
@@ -97,7 +97,7 @@ export const RESPONSE_ACTION_API_COMMANDS_TO_CONSOLE_COMMAND_MAP = Object.freeze
   upload: 'upload',
 });
 
-export const CONSOLE_RESPONSE_ACTION_COMMANDS_TO_ENDPOINT_CAPABILITY = Object.freeze<
+export const RESPONSE_CONSOLE_ACTION_COMMANDS_TO_ENDPOINT_CAPABILITY = Object.freeze<
   Record<ConsoleResponseActionCommands, EndpointCapabilities>
 >({
   isolate: 'isolation',

--- a/x-pack/plugins/security_solution/common/endpoint/service/response_actions/constants.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/service/response_actions/constants.ts
@@ -120,10 +120,10 @@ export const RESPONSE_CONSOLE_ACTION_COMMANDS_TO_REQUIRED_AUTHZ = Object.freeze<
   release: 'canUnIsolateHost',
   execute: 'canWriteFileOperations',
   'get-file': 'canWriteFileOperations',
+  upload: 'canWriteFileOperations',
   processes: 'canGetRunningProcesses',
   'kill-process': 'canKillProcess',
   'suspend-process': 'canSuspendProcess',
-  upload: 'canWriteExecuteOperations',
 });
 
 // 4 hrs in seconds

--- a/x-pack/plugins/security_solution/common/endpoint/types/actions.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/types/actions.ts
@@ -316,6 +316,13 @@ export interface PendingActionsResponse {
 
 export type PendingActionsRequestQuery = TypeOf<typeof ActionStatusRequestSchema.query>;
 
+export interface ActionDetailsAgentState {
+  isCompleted: boolean;
+  wasSuccessful: boolean;
+  errors: undefined | string[];
+  completedAt: string | undefined;
+}
+
 export interface ActionDetails<
   TOutputContent extends object = object,
   TParameters extends EndpointActionDataParameterTypes = EndpointActionDataParameterTypes
@@ -360,15 +367,7 @@ export interface ActionDetails<
    * A map by Agent ID holding information about the action for the specific agent.
    * Helpful when action is sent to multiple agents
    */
-  agentState: Record<
-    string,
-    {
-      isCompleted: boolean;
-      wasSuccessful: boolean;
-      errors: undefined | string[];
-      completedAt: string | undefined;
-    }
-  >;
+  agentState: Record<string, ActionDetailsAgentState>;
   /**  action status */
   status: ResponseActionStatus;
   /** user that created the action */

--- a/x-pack/plugins/security_solution/common/endpoint/types/actions.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/types/actions.ts
@@ -13,7 +13,7 @@ import type {
   NoParametersRequestSchema,
   ResponseActionBodySchema,
   KillOrSuspendProcessRequestSchema,
-  UploadActionRequestBody,
+  UploadActionApiRequestBody,
 } from '../schema/actions';
 import type {
   ResponseActionStatus,
@@ -477,7 +477,7 @@ export interface ActionFileInfoApiResponse {
  * NOTE: Most of the parameters below are NOT accepted via the API. They are inserted into
  * the action's parameters via the API route handler
  */
-export type ResponseActionUploadParameters = UploadActionRequestBody['parameters'] & {
+export type ResponseActionUploadParameters = UploadActionApiRequestBody['parameters'] & {
   file: {
     sha256: string;
     size: number;

--- a/x-pack/plugins/security_solution/common/endpoint/types/actions.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/types/actions.ts
@@ -487,6 +487,7 @@ export type ResponseActionUploadParameters = UploadActionApiRequestBody['paramet
 };
 
 export interface ResponseActionUploadOutputContent {
+  code: string;
   /** Full path to the file on the host machine where it was saved */
   path: string;
   /** The free space available (after saving the file) of the drive where the file was saved to, In Bytes  */

--- a/x-pack/plugins/security_solution/public/management/components/console/components/console_state/state_update_handlers/handle_execute_command.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/console/components/console_state/state_update_handlers/handle_execute_command.test.tsx
@@ -259,6 +259,14 @@ describe('When a Console command is entered by the user', () => {
     });
   });
 
+  it.todo('should validate argument with `mustHaveValue=non-empty-string');
+
+  it.todo('should validate argument with `mustHaveValue=truthy');
+
+  it.todo('should validate argument with `mustHaveValue=number');
+
+  it.todo('should validate argument with `mustHaveValue=number-greater-than-zero');
+
   it('should show success when one exclusive argument is used', async () => {
     render();
     enterCommand('cmd6 --foo 234');

--- a/x-pack/plugins/security_solution/public/management/components/console/components/console_state/state_update_handlers/handle_execute_command.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/console/components/console_state/state_update_handlers/handle_execute_command.test.tsx
@@ -10,7 +10,8 @@ import type { AppContextTestRender } from '../../../../../../common/mock/endpoin
 import { getConsoleTestSetup } from '../../../mocks';
 import type { ConsoleTestSetup } from '../../../mocks';
 import { waitFor } from '@testing-library/react';
-import type { ConsoleProps } from '../../../types';
+import type { ConsoleProps, CommandArgDefinition, CommandDefinition } from '../../../types';
+import { executionTranslations } from './translations';
 
 describe('When a Console command is entered by the user', () => {
   let render: (props?: Partial<ConsoleProps>) => ReturnType<AppContextTestRender['render']>;
@@ -259,14 +260,6 @@ describe('When a Console command is entered by the user', () => {
     });
   });
 
-  it.todo('should validate argument with `mustHaveValue=non-empty-string');
-
-  it.todo('should validate argument with `mustHaveValue=truthy');
-
-  it.todo('should validate argument with `mustHaveValue=number');
-
-  it.todo('should validate argument with `mustHaveValue=number-greater-than-zero');
-
   it('should show success when one exclusive argument is used', async () => {
     render();
     enterCommand('cmd6 --foo 234');
@@ -282,6 +275,67 @@ describe('When a Console command is entered by the user', () => {
 
     await waitFor(() => {
       expect(renderResult.getByTestId('exec-output')).toBeTruthy();
+    });
+  });
+
+  describe('Argument value validators', () => {
+    let command: CommandDefinition;
+
+    const setValidation = (validation: CommandArgDefinition['mustHaveValue']): void => {
+      command.args!.foo.mustHaveValue = validation;
+    };
+
+    beforeEach(() => {
+      command = commands.find(({ name }) => name === 'cmd3')!;
+      command.args!.foo.allowMultiples = false;
+    });
+
+    it('should validate argument with `mustHaveValue=non-empty-string', async () => {
+      setValidation('non-empty-string');
+      const { getByTestId } = render();
+      enterCommand('cmd3 --foo=""');
+
+      await waitFor(() => {
+        expect(getByTestId('test-badArgument-message')).toHaveTextContent(
+          executionTranslations.mustHaveValue('foo')
+        );
+      });
+    });
+
+    it('should validate argument with `mustHaveValue=truthy', async () => {
+      setValidation('truthy');
+      const { getByTestId } = render();
+      enterCommand('cmd3 --foo=""');
+
+      await waitFor(() => {
+        expect(getByTestId('test-badArgument-message')).toHaveTextContent(
+          executionTranslations.mustHaveValue('foo')
+        );
+      });
+    });
+
+    it('should validate argument with `mustHaveValue=number', async () => {
+      setValidation('number');
+      const { getByTestId } = render();
+      enterCommand('cmd3 --foo="hi"');
+
+      await waitFor(() => {
+        expect(getByTestId('test-badArgument-message')).toHaveTextContent(
+          executionTranslations.mustBeNumber('foo')
+        );
+      });
+    });
+
+    it('should validate argument with `mustHaveValue=number-greater-than-zero', async () => {
+      setValidation('number-greater-than-zero');
+      const { getByTestId } = render();
+      enterCommand('cmd3 --foo="0"');
+
+      await waitFor(() => {
+        expect(getByTestId('test-badArgument-message')).toHaveTextContent(
+          executionTranslations.mustBeGreaterThanZero('foo')
+        );
+      });
     });
   });
 });

--- a/x-pack/plugins/security_solution/public/management/components/console/components/console_state/state_update_handlers/handle_execute_command.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/console/components/console_state/state_update_handlers/handle_execute_command.tsx
@@ -343,6 +343,12 @@ export const handleExecuteCommand: ConsoleStoreReducer<
                 }
                 break;
 
+              case 'truthy':
+                if (typeof argValue !== 'number' && !argValue) {
+                  dataValidationError = executionTranslations.mustHaveValue(argName);
+                }
+                break;
+
               case 'number':
               case 'number-greater-than-zero':
                 {

--- a/x-pack/plugins/security_solution/public/management/components/console/components/console_state/state_update_handlers/handle_execute_command.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/console/components/console_state/state_update_handlers/handle_execute_command.tsx
@@ -344,7 +344,7 @@ export const handleExecuteCommand: ConsoleStoreReducer<
                 break;
 
               case 'truthy':
-                if (typeof argValue !== 'number' && !argValue) {
+                if (!argValue) {
                   dataValidationError = executionTranslations.mustHaveValue(argName);
                 }
                 break;

--- a/x-pack/plugins/security_solution/public/management/components/console/console.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/console/console.tsx
@@ -77,6 +77,7 @@ const ConsoleWindow = styled.div`
     &-historyViewport {
       height: 100%;
       overflow-x: hidden;
+      white-space: pre-wrap;
     }
 
     // min-width setting is needed for flex items to ensure that overflow works as expected

--- a/x-pack/plugins/security_solution/public/management/components/console/mocks.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/console/mocks.tsx
@@ -29,17 +29,9 @@ interface ConsoleSelectorsAndActionsMock {
   getInputText: () => string;
   openHelpPanel: () => void;
   closeHelpPanel: () => void;
-}
-
-export interface ConsoleTestSetup
-  extends Pick<
-    AppContextTestRender,
-    'startServices' | 'coreStart' | 'depsStart' | 'queryClient' | 'history' | 'setExperimentalFlag'
-  > {
-  renderConsole(props?: Partial<ConsoleProps>): ReturnType<AppContextTestRender['render']>;
-
-  commands: CommandDefinition[];
-
+  /** Clicks on the submit button on the far right of the console's input area */
+  submitCommand: () => void;
+  /** Enters a command into the console's input area */
   enterCommand(
     cmd: string,
     options?: Partial<{
@@ -52,6 +44,18 @@ export interface ConsoleTestSetup
       useKeyboard: boolean;
     }>
   ): void;
+}
+
+export interface ConsoleTestSetup
+  extends Pick<
+    AppContextTestRender,
+    'startServices' | 'coreStart' | 'depsStart' | 'queryClient' | 'history' | 'setExperimentalFlag'
+  > {
+  renderConsole(props?: Partial<ConsoleProps>): ReturnType<AppContextTestRender['render']>;
+
+  commands: CommandDefinition[];
+
+  enterCommand: ConsoleSelectorsAndActionsMock['enterCommand'];
 
   selectors: ConsoleSelectorsAndActionsMock;
 }
@@ -90,6 +94,12 @@ export const getConsoleSelectorsAndActionMock = (
       renderResult.getByTestId(`${dataTestSubj}-sidePanel-headerCloseButton`).click();
     }
   };
+  const submitCommand: ConsoleSelectorsAndActionsMock['submitCommand'] = () => {
+    renderResult.getByTestId(`${dataTestSubj}-inputTextSubmitButton`).click();
+  };
+  const enterCommand: ConsoleSelectorsAndActionsMock['enterCommand'] = (cmd, options = {}) => {
+    enterConsoleCommand(renderResult, cmd, options);
+  };
 
   return {
     getInputText,
@@ -97,6 +107,8 @@ export const getConsoleSelectorsAndActionMock = (
     getRightOfCursorInputText,
     openHelpPanel,
     closeHelpPanel,
+    submitCommand,
+    enterCommand,
   };
 };
 
@@ -205,6 +217,17 @@ export const getConsoleTestSetup = (): ConsoleTestSetup => {
       closeHelpPanel: () => {
         initSelectorsIfNeeded();
         return selectors.closeHelpPanel();
+      },
+      submitCommand: () => {
+        initSelectorsIfNeeded();
+        return selectors.submitCommand();
+      },
+      enterCommand: (
+        cmd: string,
+        options?: Partial<{ inputOnly: boolean; useKeyboard: boolean }>
+      ) => {
+        initSelectorsIfNeeded();
+        return selectors.enterCommand(cmd, options);
       },
     },
   };

--- a/x-pack/plugins/security_solution/public/management/components/console/types.ts
+++ b/x-pack/plugins/security_solution/public/management/components/console/types.ts
@@ -46,8 +46,7 @@ export interface CommandArgDefinition {
    *   the value entered will first be `trim()`'d.
    * - `number`: user's value will be converted to a Number and ensured to be a `safe integer`
    * - `number-greater-than-zero`: user's value must be a number greater than zero
-   * - `truthy`: The argument must have a value and the values must be "truthy"
-   *   (no `null` or `undefined`). Note that `0` (zero) will be considered `truthy`
+   * - `truthy`: The argument must have a value and the values must be "truthy" (evaluate to `Boolean` true)
    */
   mustHaveValue?: boolean | 'non-empty-string' | 'number' | 'number-greater-than-zero' | 'truthy';
   exclusiveOr?: boolean;

--- a/x-pack/plugins/security_solution/public/management/components/console/types.ts
+++ b/x-pack/plugins/security_solution/public/management/components/console/types.ts
@@ -46,8 +46,10 @@ export interface CommandArgDefinition {
    *   the value entered will first be `trim()`'d.
    * - `number`: user's value will be converted to a Number and ensured to be a `safe integer`
    * - `number-greater-than-zero`: user's value must be a number greater than zero
+   * - `truthy`: The argument must have a value and the values must be "truthy"
+   *   (no `null` or `undefined`). Note that `0` (zero) will be considered `truthy`
    */
-  mustHaveValue?: boolean | 'non-empty-string' | 'number' | 'number-greater-than-zero';
+  mustHaveValue?: boolean | 'non-empty-string' | 'number' | 'number-greater-than-zero' | 'truthy';
   exclusiveOr?: boolean;
   /**
    * Validate the individual values given to this argument.

--- a/x-pack/plugins/security_solution/public/management/components/console_argument_selectors/file_selector.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/console_argument_selectors/file_selector.tsx
@@ -122,6 +122,7 @@ export const ArgumentFileSelector = memo<
             onChange={handleFileSelection}
             fullWidth
             display="large"
+            data-test-subj="console-arg-file-picker"
           />
         )}
       </EuiPopover>

--- a/x-pack/plugins/security_solution/public/management/components/endpoint_action_failure_message/endpoint_action_failure_message.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/endpoint_action_failure_message/endpoint_action_failure_message.tsx
@@ -14,10 +14,11 @@ import type { ActionDetails, MaybeImmutable } from '../../../../common/endpoint/
 
 interface EndpointActionFailureMessageProps {
   action: MaybeImmutable<ActionDetails<{ code?: string }>>;
+  'data-test-subj'?: string;
 }
 
 export const EndpointActionFailureMessage = memo<EndpointActionFailureMessageProps>(
-  ({ action }) => {
+  ({ action, 'data-test-subj': dataTestSubj }) => {
     return useMemo(() => {
       if (!action.isCompleted || action.wasSuccessful) {
         return null;
@@ -55,7 +56,7 @@ export const EndpointActionFailureMessage = memo<EndpointActionFailureMessagePro
       }
 
       return (
-        <>
+        <div data-test-subj={dataTestSubj}>
           <FormattedMessage
             id="xpack.securitySolution.endpointResponseActions.actionError.errorMessage"
             defaultMessage="The following { errorCount, plural, =1 {error was} other {errors were}} encountered:"
@@ -63,9 +64,16 @@ export const EndpointActionFailureMessage = memo<EndpointActionFailureMessagePro
           />
           <EuiSpacer size="s" />
           <div>{errors.join(' | ')}</div>
-        </>
+        </div>
       );
-    }, [action]);
+    }, [
+      action.agents,
+      action.errors,
+      action.isCompleted,
+      action.outputs,
+      action.wasSuccessful,
+      dataTestSubj,
+    ]);
   }
 );
 EndpointActionFailureMessage.displayName = 'EndpointActionFailureMessage';

--- a/x-pack/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/integration_tests/upload_action.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/integration_tests/upload_action.test.tsx
@@ -1,0 +1,203 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  type EndpointCapabilities,
+  ENDPOINT_CAPABILITIES,
+} from '../../../../../../common/endpoint/service/response_actions/constants';
+import {
+  type AppContextTestRender,
+  createAppRootMockRenderer,
+} from '../../../../../common/mock/endpoint';
+import { responseActionsHttpMocks } from '../../../../mocks/response_actions_http_mocks';
+import {
+  ConsoleManagerTestComponent,
+  getConsoleManagerMockRenderResultQueriesAndActions,
+} from '../../../console/components/console_manager/mocks';
+import type { EndpointPrivileges } from '../../../../../../common/endpoint/types';
+import { getEndpointAuthzInitialStateMock } from '../../../../../../common/endpoint/service/authz/mocks';
+import { getEndpointConsoleCommands } from '../..';
+import React from 'react';
+import { getConsoleSelectorsAndActionMock } from '../../../console/mocks';
+import { waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { executionTranslations } from '../../../console/components/console_state/state_update_handlers/translations';
+import { UPLOAD_ROUTE } from '../../../../../../common/endpoint/constants';
+import type { HttpFetchOptionsWithPath } from '@kbn/core-http-browser';
+import {
+  INSUFFICIENT_PRIVILEGES_FOR_COMMAND,
+  UPGRADE_ENDPOINT_FOR_RESPONDER,
+} from '../../../../../common/translations';
+
+describe('When using `upload` response action', () => {
+  let render: (
+    capabilities?: EndpointCapabilities[]
+  ) => Promise<ReturnType<AppContextTestRender['render']>>;
+  let renderResult: ReturnType<AppContextTestRender['render']>;
+  let apiMocks: ReturnType<typeof responseActionsHttpMocks>;
+  let consoleManagerMockAccess: ReturnType<
+    typeof getConsoleManagerMockRenderResultQueriesAndActions
+  >;
+  let endpointPrivileges: EndpointPrivileges;
+  let endpointCapabilities: typeof ENDPOINT_CAPABILITIES;
+  let file: File;
+  let console: ReturnType<typeof getConsoleSelectorsAndActionMock>;
+
+  beforeEach(() => {
+    const mockedContext = createAppRootMockRenderer();
+
+    mockedContext.setExperimentalFlag({ responseActionUploadEnabled: true });
+    apiMocks = responseActionsHttpMocks(mockedContext.coreStart.http);
+    endpointPrivileges = { ...getEndpointAuthzInitialStateMock(), loading: false };
+    endpointCapabilities = [...ENDPOINT_CAPABILITIES];
+
+    const fileContent = new Blob(['test']);
+    file = new File([fileContent], 'test.json', { type: 'application/JSON' });
+
+    render = async () => {
+      renderResult = mockedContext.render(
+        <ConsoleManagerTestComponent
+          registerConsoleProps={() => {
+            return {
+              consoleProps: {
+                'data-test-subj': 'test',
+                commands: getEndpointConsoleCommands({
+                  endpointAgentId: 'a.b.c',
+                  endpointCapabilities,
+                  endpointPrivileges,
+                }),
+              },
+            };
+          }}
+        />
+      );
+
+      console = getConsoleSelectorsAndActionMock(renderResult);
+      consoleManagerMockAccess = getConsoleManagerMockRenderResultQueriesAndActions(renderResult);
+
+      await consoleManagerMockAccess.clickOnRegisterNewConsole();
+      await consoleManagerMockAccess.openRunningConsole();
+
+      return renderResult;
+    };
+  });
+
+  afterEach(() => {
+    // @ts-expect-error assignment of `undefined` to avoid leak from one test to the other
+    console = undefined;
+    // @ts-expect-error assignment of `undefined` to avoid leak from one test to the other
+    consoleManagerMockAccess = undefined;
+  });
+
+  it('should require `--file` argument', async () => {
+    await render();
+    console.enterCommand('upload');
+
+    await waitFor(() => {
+      expect(renderResult.getByTestId('test-badArgument-message')).toHaveTextContent(
+        executionTranslations.missingArguments('--file')
+      );
+    });
+  });
+
+  it('should error if `--file` argument is not set (no file selected)', async () => {
+    await render();
+    console.enterCommand('upload --file');
+
+    await waitFor(() => {
+      expect(renderResult.getByTestId('test-badArgument-message')).toHaveTextContent(
+        executionTranslations.mustHaveValue('file')
+      );
+    });
+  });
+
+  it('should call upload api with expected payload', async () => {
+    const { getByTestId } = await render();
+    console.enterCommand('upload --file', { inputOnly: true });
+
+    await waitFor(() => {
+      userEvent.upload(getByTestId('console-arg-file-picker'), file);
+    });
+
+    console.submitCommand();
+
+    await waitFor(() => {
+      expect(apiMocks.responseProvider.upload).toHaveBeenCalledWith({
+        body: expect.any(FormData),
+        headers: {
+          'Content-Type': undefined,
+        },
+        path: UPLOAD_ROUTE,
+      });
+    });
+
+    const apiBody = (
+      apiMocks.responseProvider.upload.mock.lastCall as unknown as [HttpFetchOptionsWithPath]
+    )?.[0].body as FormData;
+
+    expect(apiBody.get('file')).toEqual(file);
+    expect(apiBody.get('endpoint_ids')).toEqual('["a.b.c"]');
+    expect(apiBody.get('parameters')).toEqual('{}');
+  });
+
+  it('should allow `--overwrite` argument', async () => {
+    const { getByTestId } = await render();
+    console.enterCommand('upload --overwrite --file', { inputOnly: true });
+
+    await waitFor(() => {
+      userEvent.upload(getByTestId('console-arg-file-picker'), file);
+    });
+
+    console.submitCommand();
+
+    await waitFor(() => {
+      expect(apiMocks.responseProvider.upload).toHaveBeenCalled();
+    });
+
+    const apiBody = (
+      apiMocks.responseProvider.upload.mock.lastCall as unknown as [HttpFetchOptionsWithPath]
+    )?.[0].body as FormData;
+
+    expect(apiBody.get('parameters')).toEqual('{"overwrite":true}');
+  });
+
+  it('should show an error if user has no authz to file operations', async () => {
+    endpointPrivileges.canWriteFileOperations = false;
+    const { getByTestId } = await render();
+    console.enterCommand('upload --overwrite --file', { inputOnly: true });
+
+    await waitFor(() => {
+      userEvent.upload(getByTestId('console-arg-file-picker'), file);
+    });
+
+    console.submitCommand();
+
+    await waitFor(() => {
+      expect(getByTestId('test-validationError-message').textContent).toEqual(
+        INSUFFICIENT_PRIVILEGES_FOR_COMMAND
+      );
+    });
+  });
+
+  it('should show an error if the endpoint does not support `upload_file` capability', async () => {
+    endpointCapabilities = [] as unknown as typeof ENDPOINT_CAPABILITIES;
+    const { getByTestId } = await render();
+    console.enterCommand('upload --overwrite --file', { inputOnly: true });
+
+    await waitFor(() => {
+      userEvent.upload(getByTestId('console-arg-file-picker'), file);
+    });
+
+    console.submitCommand();
+
+    await waitFor(() => {
+      expect(getByTestId('test-validationError-message').textContent).toEqual(
+        UPGRADE_ENDPOINT_FOR_RESPONDER
+      );
+    });
+  });
+});

--- a/x-pack/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/upload_action.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/upload_action.tsx
@@ -38,7 +38,7 @@ export const UploadActionResult = memo<
 
     const reqBody: UploadActionUIRequestBody = {
       endpoint_ids: [endpointId],
-      comment: comment?.[0],
+      ...(comment?.[0] ? { comment: comment?.[0] } : {}),
       parameters:
         overwrite !== undefined
           ? {

--- a/x-pack/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/upload_action.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/upload_action.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, { memo, useMemo } from 'react';
+import { EndpointUploadActionResult } from '../../endpoint_upload_action_result';
 import type { UploadActionUIRequestBody } from '../../../../../common/endpoint/schema/actions';
 import { useConsoleActionSubmitter } from '../hooks/use_console_action_submitter';
 import { useSendUploadEndpointRequest } from '../../../hooks/response_actions/use_send_upload_endpoint_request';
@@ -53,6 +54,14 @@ export const UploadActionResult = memo<
     dataTestSubj: 'upload',
   });
 
-  return <div>{'UploadActionResult placeholder'}</div>;
+  if (actionDetails?.isCompleted && actionDetails.wasSuccessful) {
+    return (
+      <ResultComponent>
+        <EndpointUploadActionResult action={actionDetails} />
+      </ResultComponent>
+    );
+  }
+
+  return result;
 });
 UploadActionResult.displayName = 'UploadActionResult';

--- a/x-pack/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/upload_action.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/upload_action.tsx
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { memo } from 'react';
+import type { ActionRequestComponentProps } from '../types';
+
+export const UploadActionResult = memo<
+  ActionRequestComponentProps<{
+    file: File;
+    overwrite?: boolean;
+  }>
+>((props) => {
+  return <div>{'UploadActionResult placeholder'}</div>;
+});
+UploadActionResult.displayName = 'UploadActionResult';

--- a/x-pack/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/upload_action.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/upload_action.tsx
@@ -6,6 +6,10 @@
  */
 
 import React, { memo, useMemo } from 'react';
+import type {
+  ResponseActionUploadParameters,
+  ResponseActionUploadOutputContent,
+} from '../../../../../common/endpoint/types';
 import { EndpointUploadActionResult } from '../../endpoint_upload_action_result';
 import type { UploadActionUIRequestBody } from '../../../../../common/endpoint/schema/actions';
 import { useConsoleActionSubmitter } from '../hooks/use_console_action_submitter';
@@ -13,10 +17,14 @@ import { useSendUploadEndpointRequest } from '../../../hooks/response_actions/us
 import type { ActionRequestComponentProps } from '../types';
 
 export const UploadActionResult = memo<
-  ActionRequestComponentProps<{
-    file: File;
-    overwrite?: boolean;
-  }>
+  ActionRequestComponentProps<
+    {
+      file: File;
+      overwrite?: boolean;
+    },
+    ResponseActionUploadOutputContent,
+    ResponseActionUploadParameters
+  >
 >(({ command, setStore, store, status, setStatus, ResultComponent }) => {
   const actionCreator = useSendUploadEndpointRequest();
 
@@ -43,7 +51,11 @@ export const UploadActionResult = memo<
     return reqBody;
   }, [command.args.args, command.commandDefinition?.meta?.endpointId]);
 
-  const { result, actionDetails } = useConsoleActionSubmitter<UploadActionUIRequestBody>({
+  const { result, actionDetails } = useConsoleActionSubmitter<
+    UploadActionUIRequestBody,
+    ResponseActionUploadOutputContent,
+    ResponseActionUploadParameters
+  >({
     ResultComponent,
     setStore,
     store,

--- a/x-pack/plugins/security_solution/public/management/components/endpoint_responder/hooks/use_console_action_submitter.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/endpoint_responder/hooks/use_console_action_submitter.tsx
@@ -21,39 +21,50 @@ import type {
   ActionDetails,
   Immutable,
   ResponseActionApiResponse,
+  EndpointActionDataParameterTypes,
 } from '../../../../../common/endpoint/types';
 import type { CommandExecutionComponentProps } from '../../console';
 
-export interface ConsoleActionSubmitter<TActionOutputContent extends object = object> {
+export interface ConsoleActionSubmitter<
+  TActionOutputContent extends object = object,
+  TParameters extends EndpointActionDataParameterTypes = EndpointActionDataParameterTypes
+> {
   /**
    * The ui to be returned to the console. This UI will display different states of the action,
    * including pending, error conditions and generic success messages.
    */
   result: JSX.Element;
-  actionDetails: Immutable<ActionDetails<TActionOutputContent>> | undefined;
+  actionDetails: Immutable<ActionDetails<TActionOutputContent, TParameters>> | undefined;
 }
 
 /**
  * Command store state for response action api state.
  */
-export interface CommandResponseActionApiState<TActionOutputContent extends object = object> {
+export interface CommandResponseActionApiState<
+  TActionOutputContent extends object = object,
+  TParameters extends EndpointActionDataParameterTypes = EndpointActionDataParameterTypes
+> {
   actionApiState?: {
     request: {
       sent: boolean;
       actionId: string | undefined;
       error: IHttpFetchError | undefined;
     };
-    actionDetails: ActionDetails<TActionOutputContent> | undefined;
+    actionDetails: ActionDetails<TActionOutputContent, TParameters> | undefined;
     actionDetailsError: IHttpFetchError | undefined;
   };
 }
 
 export interface UseConsoleActionSubmitterOptions<
   TReqBody extends BaseActionRequestBody = BaseActionRequestBody,
-  TActionOutputContent extends object = object
+  TActionOutputContent extends object = object,
+  TParameters extends EndpointActionDataParameterTypes = EndpointActionDataParameterTypes
 > extends Pick<
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    CommandExecutionComponentProps<any, CommandResponseActionApiState<TActionOutputContent>>,
+    CommandExecutionComponentProps<
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      any,
+      CommandResponseActionApiState<TActionOutputContent, TParameters>
+    >,
     'ResultComponent' | 'setStore' | 'store' | 'status' | 'setStatus'
   > {
   actionCreator: UseMutationResult<ResponseActionApiResponse, IHttpFetchError, TReqBody>;
@@ -88,7 +99,8 @@ export interface UseConsoleActionSubmitterOptions<
  */
 export const useConsoleActionSubmitter = <
   TReqBody extends BaseActionRequestBody = BaseActionRequestBody,
-  TActionOutputContent extends object = object
+  TActionOutputContent extends object = object,
+  TParameters extends EndpointActionDataParameterTypes = EndpointActionDataParameterTypes
 >({
   actionCreator,
   actionRequestBody,
@@ -102,14 +114,17 @@ export const useConsoleActionSubmitter = <
   successMessage,
 }: UseConsoleActionSubmitterOptions<
   TReqBody,
-  TActionOutputContent
->): ConsoleActionSubmitter<TActionOutputContent> => {
+  TActionOutputContent,
+  TParameters
+>): ConsoleActionSubmitter<TActionOutputContent, TParameters> => {
   const isMounted = useIsMounted();
   const getTestId = useTestIdGenerator(dataTestSubj);
   const isPending = status === 'pending';
 
   const currentActionState = useMemo<
-    Immutable<Required<CommandResponseActionApiState<TActionOutputContent>>['actionApiState']>
+    Immutable<
+      Required<CommandResponseActionApiState<TActionOutputContent, TParameters>>['actionApiState']
+    >
   >(
     () =>
       store.actionApiState ?? {
@@ -131,21 +146,23 @@ export const useConsoleActionSubmitter = <
     error: actionRequestError,
   } = currentActionState.request;
 
-  const { data: apiActionDetailsResponse, error: apiActionDetailsError } =
-    useGetActionDetails<TActionOutputContent>(actionId ?? '-', {
-      enabled: Boolean(actionId) && isPending,
-      refetchInterval: isPending ? ACTION_DETAILS_REFRESH_INTERVAL : false,
-    });
+  const { data: apiActionDetailsResponse, error: apiActionDetailsError } = useGetActionDetails<
+    TActionOutputContent,
+    TParameters
+  >(actionId ?? '-', {
+    enabled: Boolean(actionId) && isPending,
+    refetchInterval: isPending ? ACTION_DETAILS_REFRESH_INTERVAL : false,
+  });
 
   // Create the action request if not yet done
   useEffect(() => {
     if (!actionRequestSent && actionRequestBody && isMounted()) {
       const updatedRequestState: Required<
-        CommandResponseActionApiState<TActionOutputContent>
+        CommandResponseActionApiState<TActionOutputContent, TParameters>
       >['actionApiState']['request'] = {
         ...(
           currentActionState as Required<
-            CommandResponseActionApiState<TActionOutputContent>
+            CommandResponseActionApiState<TActionOutputContent, TParameters>
           >['actionApiState']
         ).request,
         sent: true,

--- a/x-pack/plugins/security_solution/public/management/components/endpoint_responder/lib/console_commands_definition.ts
+++ b/x-pack/plugins/security_solution/public/management/components/endpoint_responder/lib/console_commands_definition.ts
@@ -521,7 +521,7 @@ export const getEndpointConsoleCommands = ({
               defaultMessage: 'The file that will be sent to the host',
             }
           ),
-          mustHaveValue: true,
+          mustHaveValue: 'truthy',
           SelectorComponent: ArgumentFileSelector,
         },
         overwrite: {

--- a/x-pack/plugins/security_solution/public/management/components/endpoint_responder/lib/console_commands_definition.ts
+++ b/x-pack/plugins/security_solution/public/management/components/endpoint_responder/lib/console_commands_definition.ts
@@ -35,7 +35,7 @@ import { getCommandAboutInfo } from './get_command_about_info';
 
 import { validateUnitOfTime } from './utils';
 import {
-  CONSOLE_RESPONSE_ACTION_COMMANDS_TO_ENDPOINT_CAPABILITY,
+  RESPONSE_CONSOLE_ACTION_COMMANDS_TO_ENDPOINT_CAPABILITY,
   RESPONSE_CONSOLE_ACTION_COMMANDS_TO_REQUIRED_AUTHZ,
 } from '../../../../../common/endpoint/service/response_actions/constants';
 
@@ -87,7 +87,7 @@ const capabilitiesAndPrivilegesValidator = (command: Command): true | string => 
   const privileges = command.commandDefinition.meta.privileges;
   const endpointCapabilities: EndpointCapabilities[] = command.commandDefinition.meta.capabilities;
   const commandName = command.commandDefinition.name as ConsoleResponseActionCommands;
-  const responderCapability = CONSOLE_RESPONSE_ACTION_COMMANDS_TO_ENDPOINT_CAPABILITY[commandName];
+  const responderCapability = RESPONSE_CONSOLE_ACTION_COMMANDS_TO_ENDPOINT_CAPABILITY[commandName];
   let errorMessage = '';
   if (!responderCapability) {
     errorMessage = errorMessage.concat(UPGRADE_ENDPOINT_FOR_RESPONDER);
@@ -149,7 +149,7 @@ export const getEndpointConsoleCommands = ({
 
   const doesEndpointSupportCommand = (commandName: ConsoleResponseActionCommands) => {
     const responderCapability =
-      CONSOLE_RESPONSE_ACTION_COMMANDS_TO_ENDPOINT_CAPABILITY[commandName];
+      RESPONSE_CONSOLE_ACTION_COMMANDS_TO_ENDPOINT_CAPABILITY[commandName];
     if (responderCapability) {
       return endpointCapabilities.includes(responderCapability);
     }

--- a/x-pack/plugins/security_solution/public/management/components/endpoint_responder/types.ts
+++ b/x-pack/plugins/security_solution/public/management/components/endpoint_responder/types.ts
@@ -7,7 +7,10 @@
 
 import type { CommandResponseActionApiState } from './hooks/use_console_action_submitter';
 import type { ManagedConsoleExtensionComponentProps } from '../console';
-import type { HostMetadata } from '../../../../common/endpoint/types';
+import type {
+  HostMetadata,
+  EndpointActionDataParameterTypes,
+} from '../../../../common/endpoint/types';
 import type { CommandExecutionComponentProps } from '../console/types';
 
 export interface EndpointCommandDefinitionMeta {
@@ -18,9 +21,12 @@ export type EndpointResponderExtensionComponentProps = ManagedConsoleExtensionCo
   endpoint: HostMetadata;
 }>;
 
-export type ActionRequestComponentProps<TArgs extends object = object> =
-  CommandExecutionComponentProps<
-    { comment?: string } & TArgs,
-    CommandResponseActionApiState,
-    EndpointCommandDefinitionMeta
-  >;
+export type ActionRequestComponentProps<
+  TArgs extends object = object,
+  TActionOutputContent extends object = object,
+  TParameters extends EndpointActionDataParameterTypes = EndpointActionDataParameterTypes
+> = CommandExecutionComponentProps<
+  { comment?: string } & TArgs,
+  CommandResponseActionApiState<TActionOutputContent, TParameters>,
+  EndpointCommandDefinitionMeta
+>;

--- a/x-pack/plugins/security_solution/public/management/components/endpoint_upload_action_result/endpoint_upload_action_result.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/endpoint_upload_action_result/endpoint_upload_action_result.test.tsx
@@ -1,0 +1,118 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { AppContextTestRender } from '../../../common/mock/endpoint';
+import { createAppRootMockRenderer } from '../../../common/mock/endpoint';
+import { EndpointUploadActionResult } from './endpoint_upload_action_result';
+import type {
+  ActionDetails,
+  ResponseActionUploadOutputContent,
+  ResponseActionUploadParameters,
+} from '../../../../common/endpoint/types';
+import React from 'react';
+import { EndpointActionGenerator } from '../../../../common/endpoint/data_generators/endpoint_action_generator';
+
+describe('Endpoint Upload Action Result component', () => {
+  let appTestContext: AppContextTestRender;
+  let renderResult: ReturnType<AppContextTestRender['render']>;
+  let render: () => ReturnType<AppContextTestRender['render']>;
+  let action: ActionDetails<ResponseActionUploadOutputContent, ResponseActionUploadParameters>;
+  let agentId: string | undefined;
+
+  const addAgentToAction = () => {
+    action.agents.push('agent-b');
+    action.outputs!['agent-b'] = {
+      type: 'json',
+      content: {
+        code: 'ra_upload_file-success',
+        path: '/path/to/uploaded/file',
+        disk_free_space: 1234567,
+      },
+    };
+    action.agentState['agent-b'] = {
+      wasSuccessful: true,
+      isCompleted: true,
+      completedAt: new Date().toISOString(),
+      errors: undefined,
+    };
+    action.hosts['agent-b'] = {
+      name: 'agent-b',
+    };
+  };
+
+  beforeEach(() => {
+    appTestContext = createAppRootMockRenderer();
+    agentId = undefined;
+    action = new EndpointActionGenerator('seed').generateActionDetails<
+      ResponseActionUploadOutputContent,
+      ResponseActionUploadParameters
+    >({
+      command: 'upload',
+    });
+
+    render = () => {
+      renderResult = appTestContext.render(
+        <EndpointUploadActionResult action={action} agentId={agentId} data-test-subj="test" />
+      );
+
+      return renderResult;
+    };
+  });
+
+  it('should show success action result for single agent', () => {
+    agentId = action.agents.at(0);
+    const { getByTestId } = render();
+
+    expect(getByTestId('test')).toHaveTextContent(
+      'File saved to: /path/to/uploaded/fileFree disk space on drive: 1.18MB'
+    );
+  });
+
+  it('should show success action result for multiple agents', () => {
+    addAgentToAction();
+    const { getByTestId } = render();
+
+    expect(getByTestId('test')).toHaveTextContent(
+      'Host: Host-agent-aFile saved to: /path/to/uploaded/fileFree disk space on drive: 1.18MB' +
+        'Host: agent-bFile saved to: /path/to/uploaded/fileFree disk space on drive: 1.18MB'
+    );
+  });
+
+  it('should render nothing if action is not `upload`', () => {
+    const consoleWarnSpy = jest.spyOn(console, 'warn');
+    action.command = 'isolate';
+    const { queryByTestId } = render();
+
+    expect(queryByTestId('test')).toBeNull();
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      'EndpointUploadActionResult: called with a non-upload action'
+    );
+  });
+
+  it('should show pending if no response was received yet', () => {
+    action.isCompleted = false;
+    action.agentState['agent-a'].isCompleted = false;
+    const { getByTestId } = render();
+
+    expect(getByTestId('test')).toHaveTextContent('Action pending.');
+  });
+
+  it('should show error for agent responses that failed', () => {
+    addAgentToAction();
+    // Set the second agent to be at error
+    action.agentState['agent-b'].wasSuccessful = false;
+    action.agentState['agent-b'].errors = ['some error here'];
+    action.errors = ['some error here'];
+    action.wasSuccessful = false;
+    const { getByTestId } = render();
+
+    expect(getByTestId('test')).toHaveTextContent(
+      'Host: Host-agent-aFile saved to: /path/to/uploaded/fileFree disk space on drive: 1.18MB' +
+        'Host: agent-bThe following error was encountered:some error here'
+    );
+  });
+});

--- a/x-pack/plugins/security_solution/public/management/components/endpoint_upload_action_result/endpoint_upload_action_result.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/endpoint_upload_action_result/endpoint_upload_action_result.tsx
@@ -1,0 +1,108 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { FormattedMessage } from '@kbn/i18n-react';
+import React, { memo } from 'react';
+import { EuiText } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import numeral from '@elastic/numeral';
+import { EndpointActionFailureMessage } from '../endpoint_action_failure_message';
+import type {
+  ActionDetails,
+  ResponseActionUploadOutputContent,
+  ResponseActionUploadParameters,
+} from '../../../../common/endpoint/types';
+import { useTestIdGenerator } from '../../hooks/use_test_id_generator';
+
+interface EndpointUploadActionResultProps {
+  action: ActionDetails<ResponseActionUploadOutputContent, ResponseActionUploadParameters>;
+  /** The agent id to display the result for. If undefined, the first agent will be used */
+  agentId?: string;
+  'data-test-subj'?: string;
+}
+
+const LABELS = Object.freeze<Record<string, string>>({
+  path: i18n.translate('xpack.securitySolution.uploadActionResult.savedTo', {
+    defaultMessage: 'File saved to',
+  }),
+
+  disk_free_space: i18n.translate('xpack.securitySolution.uploadActionResult.freeDiskSpace', {
+    defaultMessage: 'Free disk space on drive',
+  }),
+
+  noAgentResponse: i18n.translate('xpack.securitySolution.uploadActionResult.missingAgentResult', {
+    defaultMessage: 'Error: Agent result missing',
+  }),
+});
+
+export const EndpointUploadActionResult = memo<EndpointUploadActionResultProps>(
+  ({ action, agentId, 'data-test-subj': dataTestSubj }) => {
+    const getTestId = useTestIdGenerator(dataTestSubj);
+
+    const agentState = action?.agentState[agentId ?? action.agents[0]];
+    const agentResult = action?.outputs?.[agentId ?? action.agents[0]];
+
+    if (action.command !== 'upload') {
+      return null;
+    }
+
+    // Use case: action log
+    if (!agentState.isCompleted) {
+      return (
+        <div data-test-subj={getTestId('pending')}>
+          <FormattedMessage
+            id="xpack.securitySolution.uploadActionResult.pendingMessage"
+            defaultMessage="Action pending."
+          />
+        </div>
+      );
+    }
+
+    // if we don't have an agent result (for whatever reason)
+    if (!agentResult) {
+      return <div data-test-subj={getTestId('noResultError')}>{LABELS.noAgentResponse}</div>;
+    }
+
+    // Error result
+    if (!agentState.wasSuccessful) {
+      return (
+        <EndpointActionFailureMessage
+          action={action as ActionDetails}
+          data-test-subj={getTestId('error')}
+        />
+      );
+    }
+
+    return (
+      <div data-test-subj={getTestId('success')}>
+        <KeyValueDisplay name={LABELS.path} value={agentResult.content.path} />
+        <KeyValueDisplay
+          name={LABELS.disk_free_space}
+          value={numeral(agentResult.content.disk_free_space).format('0.00b')}
+        />
+      </div>
+    );
+  }
+);
+EndpointUploadActionResult.displayName = 'EndpointUploadActionResult';
+
+export interface KeyValueDisplayProps {
+  name: string;
+  value: string;
+}
+const KeyValueDisplay = memo<KeyValueDisplayProps>(({ name, value }) => {
+  return (
+    <EuiText className="eui-textBreakWord" size="s">
+      <strong>
+        {name}
+        {': '}
+      </strong>
+      {value}
+    </EuiText>
+  );
+});
+KeyValueDisplay.displayName = 'KeyValueDisplay';

--- a/x-pack/plugins/security_solution/public/management/components/endpoint_upload_action_result/endpoint_upload_action_result.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/endpoint_upload_action_result/endpoint_upload_action_result.tsx
@@ -11,6 +11,7 @@ import React, { memo, useMemo } from 'react';
 import { EuiSpacer, EuiText } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import numeral from '@elastic/numeral';
+import { css } from '@emotion/react';
 import { EndpointActionFailureMessage } from '../endpoint_action_failure_message';
 import type {
   ActionDetails,
@@ -98,7 +99,7 @@ export const EndpointUploadActionResult = memo<EndpointUploadActionResultProps>(
     }
 
     return (
-      <>
+      <div data-test-subj={getTestId()}>
         {outputs.map(({ name, state, result }) => {
           // Use case: action log
           if (!state.isCompleted) {
@@ -156,7 +157,7 @@ export const EndpointUploadActionResult = memo<EndpointUploadActionResultProps>(
             </HostUploadResult>
           );
         })}
-      </>
+      </div>
     );
   }
 );
@@ -171,7 +172,7 @@ const KeyValueDisplay = memo<KeyValueDisplayProps>(({ name, value }) => {
     <EuiText
       className="eui-textBreakWord"
       size="s"
-      css={`
+      css={css`
         white-space: pre-wrap;
       `}
     >

--- a/x-pack/plugins/security_solution/public/management/components/endpoint_upload_action_result/endpoint_upload_action_result.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/endpoint_upload_action_result/endpoint_upload_action_result.tsx
@@ -18,6 +18,7 @@ import type {
   ResponseActionUploadParameters,
   ActionDetailsAgentState,
   ActionResponseOutput,
+  MaybeImmutable,
 } from '../../../../common/endpoint/types';
 import { useTestIdGenerator } from '../../hooks/use_test_id_generator';
 
@@ -46,14 +47,20 @@ const LABELS = Object.freeze<Record<string, string>>({
 });
 
 interface EndpointUploadActionResultProps {
-  action: ActionDetails<ResponseActionUploadOutputContent, ResponseActionUploadParameters>;
+  action: MaybeImmutable<
+    ActionDetails<ResponseActionUploadOutputContent, ResponseActionUploadParameters>
+  >;
   /** The agent id to display the result for. If undefined, the output for ALL agents will be displayed */
   agentId?: string;
   'data-test-subj'?: string;
 }
 
 export const EndpointUploadActionResult = memo<EndpointUploadActionResultProps>(
-  ({ action, agentId, 'data-test-subj': dataTestSubj }) => {
+  ({ action: _action, agentId, 'data-test-subj': dataTestSubj }) => {
+    const action = _action as ActionDetails<
+      ResponseActionUploadOutputContent,
+      ResponseActionUploadParameters
+    >;
     const getTestId = useTestIdGenerator(dataTestSubj);
 
     type DisplayHosts = Array<{

--- a/x-pack/plugins/security_solution/public/management/components/endpoint_upload_action_result/index.ts
+++ b/x-pack/plugins/security_solution/public/management/components/endpoint_upload_action_result/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { EndpointUploadActionResult } from './endpoint_upload_action_result';

--- a/x-pack/plugins/security_solution/public/management/hooks/response_actions/use_get_action_details.ts
+++ b/x-pack/plugins/security_solution/public/management/hooks/response_actions/use_get_action_details.ts
@@ -11,19 +11,25 @@ import { useQuery } from '@tanstack/react-query';
 import { useHttp } from '../../../common/lib/kibana';
 import { resolvePathVariables } from '../../../common/utils/resolve_path_variables';
 import { ACTION_DETAILS_ROUTE } from '../../../../common/endpoint/constants';
-import type { ActionDetailsApiResponse } from '../../../../common/endpoint/types';
+import type {
+  ActionDetailsApiResponse,
+  EndpointActionDataParameterTypes,
+} from '../../../../common/endpoint/types';
 
-export const useGetActionDetails = <TOutputType extends object = object>(
+export const useGetActionDetails = <
+  TOutputType extends object = object,
+  TParameters extends EndpointActionDataParameterTypes = EndpointActionDataParameterTypes
+>(
   actionId: string,
-  options: UseQueryOptions<ActionDetailsApiResponse<TOutputType>, IHttpFetchError> = {}
-): UseQueryResult<ActionDetailsApiResponse<TOutputType>, IHttpFetchError> => {
+  options: UseQueryOptions<ActionDetailsApiResponse<TOutputType, TParameters>, IHttpFetchError> = {}
+): UseQueryResult<ActionDetailsApiResponse<TOutputType, TParameters>, IHttpFetchError> => {
   const http = useHttp();
 
-  return useQuery<ActionDetailsApiResponse<TOutputType>, IHttpFetchError>({
+  return useQuery<ActionDetailsApiResponse<TOutputType, TParameters>, IHttpFetchError>({
     queryKey: ['get-action-details', actionId],
     ...options,
     queryFn: () => {
-      return http.get<ActionDetailsApiResponse<TOutputType>>(
+      return http.get<ActionDetailsApiResponse<TOutputType, TParameters>>(
         resolvePathVariables(ACTION_DETAILS_ROUTE, { action_id: actionId.trim() || 'undefined' })
       );
     },

--- a/x-pack/plugins/security_solution/public/management/hooks/response_actions/use_send_upload_endpoint_request.ts
+++ b/x-pack/plugins/security_solution/public/management/hooks/response_actions/use_send_upload_endpoint_request.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { UseMutationOptions, UseMutationResult } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
+import type { IHttpFetchError } from '@kbn/core-http-browser';
+import type { ResponseActionApiResponse } from '../../../../common/endpoint/types';
+import { useHttp } from '../../../common/lib/kibana';
+import { UPLOAD_ROUTE } from '../../../../common/endpoint/constants';
+import type { UploadActionUIRequestBody } from '../../../../common/endpoint/schema/actions';
+
+export const useSendUploadEndpointRequest = (
+  options?: UseMutationOptions<
+    ResponseActionApiResponse,
+    IHttpFetchError,
+    UploadActionUIRequestBody
+  >
+): UseMutationResult<ResponseActionApiResponse, IHttpFetchError, UploadActionUIRequestBody> => {
+  const http = useHttp();
+
+  return useMutation<ResponseActionApiResponse, IHttpFetchError, UploadActionUIRequestBody>(
+    ({ file, ...payload }) => {
+      const formData = new FormData();
+
+      formData.append('file', file, file.name);
+
+      for (const [key, value] of Object.entries(payload)) {
+        formData.append(key, JSON.stringify(value));
+      }
+
+      return http.post<ResponseActionApiResponse>(UPLOAD_ROUTE, {
+        body: formData,
+        headers: {
+          'Content-Type': undefined, // Important in order to let the browser set the appropriate content type
+        },
+      });
+    },
+    options
+  );
+};

--- a/x-pack/plugins/security_solution/public/management/mocks/response_actions_http_mocks.ts
+++ b/x-pack/plugins/security_solution/public/management/mocks/response_actions_http_mocks.ts
@@ -19,6 +19,7 @@ import {
   GET_FILE_ROUTE,
   ACTION_AGENT_FILE_INFO_ROUTE,
   EXECUTE_ROUTE,
+  UPLOAD_ROUTE,
 } from '../../../common/endpoint/constants';
 import type { ResponseProvidersInterface } from '../../common/mock/endpoint/http_handler_mock_factory';
 import { httpHandlerMockFactory } from '../../common/mock/endpoint/http_handler_mock_factory';
@@ -34,6 +35,8 @@ import type {
   ActionFileInfoApiResponse,
   ResponseActionExecuteOutputContent,
   ResponseActionsExecuteParameters,
+  ResponseActionUploadOutputContent,
+  ResponseActionUploadParameters,
 } from '../../../common/endpoint/types';
 
 export type ResponseActionsHttpMocksInterface = ResponseProvidersInterface<{
@@ -58,6 +61,11 @@ export type ResponseActionsHttpMocksInterface = ResponseProvidersInterface<{
   fileInfo: () => ActionFileInfoApiResponse;
 
   execute: () => ActionDetailsApiResponse<ResponseActionExecuteOutputContent>;
+
+  upload: () => ActionDetailsApiResponse<
+    ResponseActionUploadOutputContent,
+    ResponseActionUploadParameters
+  >;
 }>;
 
 export const responseActionsHttpMocks = httpHandlerMockFactory<ResponseActionsHttpMocksInterface>([
@@ -216,6 +224,25 @@ export const responseActionsHttpMocks = httpHandlerMockFactory<ResponseActionsHt
         outputs: {
           'a.b.c': generator.generateExecuteActionResponseOutput(),
         },
+      });
+
+      return { data: response };
+    },
+  },
+  {
+    id: 'upload',
+    path: UPLOAD_ROUTE,
+    method: 'post',
+    handler: (): ActionDetailsApiResponse<
+      ResponseActionUploadOutputContent,
+      ResponseActionUploadParameters
+    > => {
+      const generator = new EndpointActionGenerator('seed');
+      const response = generator.generateActionDetails<
+        ResponseActionUploadOutputContent,
+        ResponseActionUploadParameters
+      >({
+        command: 'upload',
       });
 
       return { data: response };

--- a/x-pack/plugins/security_solution/server/endpoint/routes/actions/file_upload_handler.test.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/routes/actions/file_upload_handler.test.ts
@@ -7,7 +7,7 @@
 
 import type { HttpApiTestSetupMock } from '../../mocks';
 import { createHttpApiTestSetupMock } from '../../mocks';
-import type { UploadActionRequestBody } from '../../../../common/endpoint/schema/actions';
+import type { UploadActionApiRequestBody } from '../../../../common/endpoint/schema/actions';
 import type { getActionFileUploadHandler } from './file_upload_handler';
 import { registerActionFileUploadRoute } from './file_upload_handler';
 import { UPLOAD_ROUTE } from '../../../../common/endpoint/constants';
@@ -31,7 +31,7 @@ const deleteFileMock = _deleteFile as jest.Mock;
 const setFileActionIdMock = _setFileActionId as jest.Mock;
 
 describe('Upload response action create API handler', () => {
-  type UploadHttpApiTestSetupMock = HttpApiTestSetupMock<never, never, UploadActionRequestBody>;
+  type UploadHttpApiTestSetupMock = HttpApiTestSetupMock<never, never, UploadActionApiRequestBody>;
 
   let testSetup: UploadHttpApiTestSetupMock;
   let httpRequestMock: ReturnType<UploadHttpApiTestSetupMock['createRequestMock']>;
@@ -39,7 +39,7 @@ describe('Upload response action create API handler', () => {
   let httpResponseMock: UploadHttpApiTestSetupMock['httpResponseMock'];
 
   beforeEach(() => {
-    testSetup = createHttpApiTestSetupMock<never, never, UploadActionRequestBody>();
+    testSetup = createHttpApiTestSetupMock<never, never, UploadActionApiRequestBody>();
 
     ({ httpHandlerContextMock, httpResponseMock } = testSetup);
     httpRequestMock = testSetup.createRequestMock();
@@ -116,7 +116,7 @@ describe('Upload response action create API handler', () => {
         },
       });
 
-      const reqBody: UploadActionRequestBody = {
+      const reqBody: UploadActionApiRequestBody = {
         file: fileContent,
         endpoint_ids: ['123-456'],
         parameters: {

--- a/x-pack/plugins/security_solution/server/endpoint/routes/actions/file_upload_handler.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/routes/actions/file_upload_handler.ts
@@ -13,7 +13,7 @@ import type {
 } from '../../../../common/endpoint/types';
 import { UPLOAD_ROUTE } from '../../../../common/endpoint/constants';
 import {
-  type UploadActionRequestBody,
+  type UploadActionApiRequestBody,
   UploadActionRequestSchema,
 } from '../../../../common/endpoint/schema/actions';
 import { withEndpointAuthz } from '../with_endpoint_authz';
@@ -59,7 +59,12 @@ export const registerActionFileUploadRoute = (
 
 export const getActionFileUploadHandler = (
   endpointContext: EndpointAppContext
-): RequestHandler<never, never, UploadActionRequestBody, SecuritySolutionRequestHandlerContext> => {
+): RequestHandler<
+  never,
+  never,
+  UploadActionApiRequestBody,
+  SecuritySolutionRequestHandlerContext
+> => {
   const logger = endpointContext.logFactory.get('uploadAction');
   const maxFileBytes = endpointContext.serverConfig.maxUploadResponseActionFileBytes;
 

--- a/x-pack/plugins/security_solution/server/endpoint/routes/actions/file_upload_handler.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/routes/actions/file_upload_handler.ts
@@ -114,7 +114,15 @@ export const getActionFileUploadHandler = (
           { casesClient }
         );
 
-      await setFileActionId(esClient, logger, data);
+      // Update the file meta to include the action id, and if any errors (unlikely),
+      // then just log them and still allow api to return success since the action has
+      // already been created and potentially dispatched to Endpoint. Action ID is not
+      // need by the Endpoint or fleet-server's API, so no need to fail here
+      try {
+        await setFileActionId(esClient, logger, data);
+      } catch (e) {
+        logger.warn(`Attempt to update File meta with Action ID failed: ${e.message}`, e);
+      }
 
       return res.ok({
         body: {

--- a/x-pack/plugins/security_solution/server/endpoint/routes/actions/file_upload_handler.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/routes/actions/file_upload_handler.ts
@@ -117,7 +117,7 @@ export const getActionFileUploadHandler = (
       // Update the file meta to include the action id, and if any errors (unlikely),
       // then just log them and still allow api to return success since the action has
       // already been created and potentially dispatched to Endpoint. Action ID is not
-      // need by the Endpoint or fleet-server's API, so no need to fail here
+      // needed by the Endpoint or fleet-server's API, so no need to fail here
       try {
         await setFileActionId(esClient, logger, data);
       } catch (e) {


### PR DESCRIPTION
## Summary

- Add the `upload` response action to the endpoint console


______

**NOTE**:

- functionality is currently behind feature flag: `xpack.securitySolution.enableExperimental.responseActionUploadEnabled: true`
- The Endpoint has not yet implemented support for `upload`. In order to test this locally, run the endpoint agent emulator dev. tool:

```bash
node x-pack/plugins/security_solution/scripts/endpoint/endpoint_agent_emulator.js --asSuperuser
```


_______

![olm-5368-upload-console-command](https://github.com/elastic/kibana/assets/56442535/e1794c3c-b3f2-4a15-b449-6d70239104ca)



### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
