### PR TITLE
[Cloud Security] Rename configurations tab to misconfigurations

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/findings.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/findings.tsx
@@ -76,8 +76,8 @@ export const Findings = () => {
           isSelected={location.pathname !== findingsNavigation.vulnerabilities.path}
         >
           <FormattedMessage
-            id="xpack.csp.findings.tabs.configurations"
-            defaultMessage="Configurations"
+            id="xpack.csp.findings.tabs.misconfigurations"
+            defaultMessage="Misconfigurations"
           />
         </EuiTab>
       </EuiTabs>


### PR DESCRIPTION
## Summary

<img width="470" alt="Screenshot 2023-05-09 at 15 56 43" src="https://github.com/elastic/kibana/assets/61654899/a1503a02-d6c1-47a7-8aa1-c5e4d4af77ca">


<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->