### PR TITLE
[8.8] Upgrade EUI to v77.1.3 for push flyout fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "@elastic/datemath": "5.0.3",
     "@elastic/elasticsearch": "npm:@elastic/elasticsearch-canary@8.6.0-canary.3",
     "@elastic/ems-client": "8.4.0",
-    "@elastic/eui": "77.1.2",
+    "@elastic/eui": "77.1.3",
     "@elastic/filesaver": "1.1.2",
     "@elastic/node-crypto": "1.2.1",
     "@elastic/numeral": "^2.5.1",

--- a/src/dev/license_checker/config.ts
+++ b/src/dev/license_checker/config.ts
@@ -85,6 +85,6 @@ export const LICENSE_OVERRIDES = {
   'jsts@1.6.2': ['Eclipse Distribution License - v 1.0'], // cf. https://github.com/bjornharrtell/jsts
   '@mapbox/jsonlint-lines-primitives@2.0.2': ['MIT'], // license in readme https://github.com/tmcw/jsonlint
   '@elastic/ems-client@8.4.0': ['Elastic License 2.0'],
-  '@elastic/eui@77.1.2': ['SSPL-1.0 OR Elastic License 2.0'],
+  '@elastic/eui@77.1.3': ['SSPL-1.0 OR Elastic License 2.0'],
   'language-subtag-registry@0.3.21': ['CC-BY-4.0'], // retired ODC‑By license https://github.com/mattcg/language-subtag-registry
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1543,10 +1543,10 @@
   resolved "https://registry.yarnpkg.com/@elastic/eslint-plugin-eui/-/eslint-plugin-eui-0.0.2.tgz#56b9ef03984a05cc213772ae3713ea8ef47b0314"
   integrity sha512-IoxURM5zraoQ7C8f+mJb9HYSENiZGgRVcG4tLQxE61yHNNRDXtGDWTZh8N1KIHcsqN1CEPETjuzBXkJYF/fDiQ==
 
-"@elastic/eui@77.1.2":
-  version "77.1.2"
-  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-77.1.2.tgz#85c20c682058ada1a9478af2894c290cc20c1678"
-  integrity sha512-cq7TI/rOomifh/KXU1V+wGirClomkMcQ166K9/7eMyqJb50AAuweu5JkjiDRNvB06uX1lDP6GjSb+oGvf8885A==
+"@elastic/eui@77.1.3":
+  version "77.1.3"
+  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-77.1.3.tgz#486451e1b323e12f710be9edf74945849ec859c1"
+  integrity sha512-pfxjCsSLnPIoXrS/rRRZLceB2RT4Fz8OfmKymokvXmR2OeVH7jDrMtUZiqPlkTKLbk9ozzkTBEuTQ1g5398ijw==
   dependencies:
     "@types/chroma-js" "^2.0.0"
     "@types/lodash" "^4.14.160"
@@ -29532,12 +29532,7 @@ write-file-atomic@^4.0.1:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.7"
 
-ws@8.13.0:
-  version "8.13.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.13.0.tgz#9a9fb92f93cf41512a0735c8f4dd09b8a1211cd0"
-  integrity sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==
-
-ws@>=8.13.0:
+ws@8.13.0, ws@>=8.13.0:
   version "8.13.0"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.13.0.tgz#9a9fb92f93cf41512a0735c8f4dd09b8a1211cd0"
   integrity sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==


### PR DESCRIPTION
This backport is required to fix a bug with push EUI flyouts before v8.8 release. fixes https://github.com/elastic/kibana/issues/157180

## [`77.1.3`](https://github.com/elastic/eui/tree/v77.1.3)

**Bug fixes**

- Fixed broken push `EuiFlyout` behavior ([#6764](https://github.com/elastic/eui/pull/6764))
