### PR TITLE
[Cloud Security] Increase max number of CSPM accounts / KSPM clusters in the Cloud Security dashboard

### DIFF
--- a/x-pack/plugins/cloud_security_posture/server/routes/compliance_dashboard/get_clusters.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/compliance_dashboard/get_clusters.ts
@@ -41,6 +41,8 @@ interface ClustersQueryResult {
 
 export type ClusterWithoutTrend = Omit<Cluster, 'trend'>;
 
+const MAX_CLUSTERS = 500;
+
 export const getClustersQuery = (
   query: QueryDslQueryContainer,
   pitId: string,
@@ -54,6 +56,7 @@ export const getClustersQuery = (
   aggs: {
     aggs_by_asset_identifier: {
       terms: {
+        size: MAX_CLUSTERS,
         field: 'asset_identifier',
       },
       aggs: {


### PR DESCRIPTION
## Summary

While testing https://github.com/elastic/kibana/issues/153524, was noticed that the max number of accounts shown in the dashboard was 10 while displaying the results for all 31 accounts. That's the default `aggs` size in the Elasticsearch query. This PR changes the default to a higher number (500), to support more CSPM accounts and more KSPM clusters.


### Screenshots

Before

![image](https://github.com/elastic/kibana/assets/19270322/8db8246f-8022-46a3-8405-10aae6169403)

After

![image](https://github.com/elastic/kibana/assets/19270322/f520a018-d152-46ea-b0f6-46f77b370c91)

