### PR TITLE
[Synthetics] adjust alert id for synthetics

### DIFF
--- a/x-pack/plugins/synthetics/server/alert_rules/status_rule/monitor_status_rule.ts
+++ b/x-pack/plugins/synthetics/server/alert_rules/status_rule/monitor_status_rule.ts
@@ -31,7 +31,6 @@ import {
   ALERT_DETAILS_URL,
   VIEW_IN_APP_URL,
 } from '../../legacy_uptime/lib/alerts/action_variables';
-import { getInstanceId } from '../../legacy_uptime/lib/alerts/status_check';
 import { UMServerLibs } from '../../legacy_uptime/uptime_server';
 import { SyntheticsMonitorClient } from '../../synthetics_service/synthetics_monitor/synthetics_monitor_client';
 import { UptimeRuleTypeAlertDefinition } from '../../legacy_uptime/lib/alerts/common';
@@ -92,7 +91,7 @@ export const registerSyntheticsStatusCheckRule = (
       Object.entries(downConfigs).forEach(([idWithLocation, { ping, configId }]) => {
         const locationId = statusRule.getLocationId(ping.observer?.geo?.name!) ?? '';
         const monitorSummary = getMonitorSummary(ping, DOWN_LABEL, locationId, configId);
-        const alertId = getInstanceId(ping, idWithLocation);
+        const alertId = idWithLocation;
         const alert = alertWithLifecycle({
           id: alertId,
           fields: getMonitorAlertDocument(monitorSummary),


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/152773

Uses the `idWithLocation` value as the unique id for a monitor alert.

Given that we use uuid's for monitor config ids, this id should be unique enough for any given monitor. 

## Release note

All monitor status alerts for the Synthetics app that are active at the time of upgrading will be resolved. A new alert will be created in its place. 

<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->