### PR TITLE
[8.8] Adds documentation to clarify kibana-keystore behaviour (#157146)

### DIFF
--- a/docs/setup/secure-settings.asciidoc
+++ b/docs/setup/secure-settings.asciidoc
@@ -36,6 +36,8 @@ bin/kibana-keystore list
 [[add-string-to-keystore]]
 === Add string settings
 
+NOTE: Your input will be JSON-parsed to allow for object/array input configurations. To enforce string values, use "double quotes" around your input.
+
 Sensitive string settings, like authentication credentials for Elasticsearch
 can be added using the `add` command:
 

--- a/src/cli_keystore/add.js
+++ b/src/cli_keystore/add.js
@@ -64,7 +64,9 @@ export async function add(keystore, key, options = {}) {
 export function addCli(program, keystore) {
   program
     .command('add <key>')
-    .description('Add a string setting to the keystore')
+    .description(
+      'Add a setting to the keystore. Note: The value will be JSON parsed. Use quotes to force string inputs.'
+    )
     .option('-f, --force', 'overwrite existing setting without prompting')
     .option('-x, --stdin', 'read setting value from stdin')
     .option('-s, --silent', 'prevent all logging')


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.8`:
 - [Adds documentation to clarify kibana-keystore behaviour (#157146)](https://github.com/elastic/kibana/pull/157146)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!-- BACKPORT [{"author":{"name":"Alex Szabo","email":"alex.szabo@elastic.co"},"sourceCommit":{"committedDate":"2023-05-09T16:02:45Z","message":"Adds documentation to clarify kibana-keystore behaviour (#157146)\n\n## Summary\r\nAddresses #155474 \r\n\r\nWe've discussed with the team, and decided that we'd retain current\r\nbehaviour, and adjust the docs and notes around the behaviour.\r\n\r\nfix(keystore): add warning note to explain that input is being JSON\r\nparsed\r\ndocs(keystore): add documentation to clarify behavior\r\n\r\n### Checklist\r\n\r\n- [x]\r\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\r\nwas added for features that require explanation or tutorials\r\n\r\n### For maintainers\r\n\r\n- [x] This was checked for breaking API changes and was [labeled\r\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"58650c55456fbcf418f7a75edf98de32238f6bea","branchLabelMapping":{"^v8.9.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Operations","release_note:skip","backport:all-open","v8.9.0","v7.17.11"],"number":157146,"url":"https://github.com/elastic/kibana/pull/157146","mergeCommit":{"message":"Adds documentation to clarify kibana-keystore behaviour (#157146)\n\n## Summary\r\nAddresses #155474 \r\n\r\nWe've discussed with the team, and decided that we'd retain current\r\nbehaviour, and adjust the docs and notes around the behaviour.\r\n\r\nfix(keystore): add warning note to explain that input is being JSON\r\nparsed\r\ndocs(keystore): add documentation to clarify behavior\r\n\r\n### Checklist\r\n\r\n- [x]\r\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\r\nwas added for features that require explanation or tutorials\r\n\r\n### For maintainers\r\n\r\n- [x] This was checked for breaking API changes and was [labeled\r\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"58650c55456fbcf418f7a75edf98de32238f6bea"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.9.0","labelRegex":"^v8.9.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/157146","number":157146,"mergeCommit":{"message":"Adds documentation to clarify kibana-keystore behaviour (#157146)\n\n## Summary\r\nAddresses #155474 \r\n\r\nWe've discussed with the team, and decided that we'd retain current\r\nbehaviour, and adjust the docs and notes around the behaviour.\r\n\r\nfix(keystore): add warning note to explain that input is being JSON\r\nparsed\r\ndocs(keystore): add documentation to clarify behavior\r\n\r\n### Checklist\r\n\r\n- [x]\r\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\r\nwas added for features that require explanation or tutorials\r\n\r\n### For maintainers\r\n\r\n- [x] This was checked for breaking API changes and was [labeled\r\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"58650c55456fbcf418f7a75edf98de32238f6bea"}},{"branch":"7.17","label":"v7.17.11","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/157187","number":157187,"state":"MERGED","mergeCommit":{"sha":"13f1a94039ea0f3c89852eeb6e0c581f5e82f5c3","message":"[7.17] Adds documentation to clarify kibana-keystore behaviour (#157146) (#157187)\n\n# Backport\n\nThis will backport the following commits from `main` to `7.17`:\n- [Adds documentation to clarify kibana-keystore behaviour\n(#157146)](https://github.com/elastic/kibana/pull/157146)\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n<!--BACKPORT [{\"author\":{\"name\":\"Alex\nSzabo\",\"email\":\"alex.szabo@elastic.co\"},\"sourceCommit\":{\"committedDate\":\"2023-05-09T16:02:45Z\",\"message\":\"Adds\ndocumentation to clarify kibana-keystore behaviour (#157146)\\n\\n##\nSummary\\r\\nAddresses #155474 \\r\\n\\r\\nWe've discussed with the team, and\ndecided that we'd retain current\\r\\nbehaviour, and adjust the docs and\nnotes around the behaviour.\\r\\n\\r\\nfix(keystore): add warning note to\nexplain that input is being JSON\\r\\nparsed\\r\\ndocs(keystore): add\ndocumentation to clarify behavior\\r\\n\\r\\n### Checklist\\r\\n\\r\\n-\n[x]\\r\\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\\r\\nwas\nadded for features that require explanation or tutorials\\r\\n\\r\\n### For\nmaintainers\\r\\n\\r\\n- [x] This was checked for breaking API changes and\nwas\n[labeled\\r\\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\",\"sha\":\"58650c55456fbcf418f7a75edf98de32238f6bea\",\"branchLabelMapping\":{\"^v8.9.0$\":\"main\",\"^v(\\\\d+).(\\\\d+).\\\\d+$\":\"$1.$2\"}},\"sourcePullRequest\":{\"labels\":[\"Team:Operations\",\"release_note:skip\",\"backport:all-open\",\"v8.9.0\"],\"number\":157146,\"url\":\"https://github.com/elastic/kibana/pull/157146\",\"mergeCommit\":{\"message\":\"Adds\ndocumentation to clarify kibana-keystore behaviour (#157146)\\n\\n##\nSummary\\r\\nAddresses #155474 \\r\\n\\r\\nWe've discussed with the team, and\ndecided that we'd retain current\\r\\nbehaviour, and adjust the docs and\nnotes around the behaviour.\\r\\n\\r\\nfix(keystore): add warning note to\nexplain that input is being JSON\\r\\nparsed\\r\\ndocs(keystore): add\ndocumentation to clarify behavior\\r\\n\\r\\n### Checklist\\r\\n\\r\\n-\n[x]\\r\\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\\r\\nwas\nadded for features that require explanation or tutorials\\r\\n\\r\\n### For\nmaintainers\\r\\n\\r\\n- [x] This was checked for breaking API changes and\nwas\n[labeled\\r\\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\",\"sha\":\"58650c55456fbcf418f7a75edf98de32238f6bea\"}},\"sourceBranch\":\"main\",\"suggestedTargetBranches\":[],\"targetPullRequestStates\":[{\"branch\":\"main\",\"label\":\"v8.9.0\",\"labelRegex\":\"^v8.9.0$\",\"isSourceBranch\":true,\"state\":\"MERGED\",\"url\":\"https://github.com/elastic/kibana/pull/157146\",\"number\":157146,\"mergeCommit\":{\"message\":\"Adds\ndocumentation to clarify kibana-keystore behaviour (#157146)\\n\\n##\nSummary\\r\\nAddresses #155474 \\r\\n\\r\\nWe've discussed with the team, and\ndecided that we'd retain current\\r\\nbehaviour, and adjust the docs and\nnotes around the behaviour.\\r\\n\\r\\nfix(keystore): add warning note to\nexplain that input is being JSON\\r\\nparsed\\r\\ndocs(keystore): add\ndocumentation to clarify behavior\\r\\n\\r\\n### Checklist\\r\\n\\r\\n-\n[x]\\r\\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\\r\\nwas\nadded for features that require explanation or tutorials\\r\\n\\r\\n### For\nmaintainers\\r\\n\\r\\n- [x] This was checked for breaking API changes and\nwas\n[labeled\\r\\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\",\"sha\":\"58650c55456fbcf418f7a75edf98de32238f6bea\"}}]}]\nBACKPORT-->\n\nCo-authored-by: Alex Szabo <alex.szabo@elastic.co>"}}]}] BACKPORT-->