### PR TITLE
[Enterprise Search] [Behavioral Analytics] fix incorrect field name

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/analytics/components/analytics_collection_view/analytics_collection_explore_table_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/analytics/components/analytics_collection_view/analytics_collection_explore_table_logic.ts
@@ -237,7 +237,7 @@ const tablesParams: {
     requestParams: (
       dataView,
       { timeRange, sorting, pageIndex, pageSize, search },
-      aggregationFieldName = 'page.referrer'
+      aggregationFieldName = 'page.referrer.original'
     ) =>
       getBaseSearchTemplate(
         dataView,


### PR DESCRIPTION
With the url ingest processor changes, the aggregation field changed to original subfield. This changes corrects the field name  

<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->