### PR TITLE
[8.8] [Ingest Pipelines] Unskip functional and a11y tests (#157173)

### DIFF
--- a/x-pack/test/accessibility/apps/ingest_node_pipelines.ts
+++ b/x-pack/test/accessibility/apps/ingest_node_pipelines.ts
@@ -14,8 +14,7 @@ export default function ({ getService, getPageObjects }: any) {
   const log = getService('log');
   const a11y = getService('a11y'); /* this is the wrapping service around axe */
 
-  // Failing: See https://github.com/elastic/kibana/issues/155928
-  describe.skip('Ingest Pipelines Accessibility', async () => {
+  describe('Ingest Pipelines Accessibility', async () => {
     before(async () => {
       await putSamplePipeline(esClient);
       await common.navigateToApp('ingestPipelines');

--- a/x-pack/test/functional/apps/ingest_pipelines/ingest_pipelines.ts
+++ b/x-pack/test/functional/apps/ingest_pipelines/ingest_pipelines.ts
@@ -26,10 +26,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
   const es = getService('es');
   const security = getService('security');
 
-  // Failing: See https://github.com/elastic/kibana/issues/156014
-  // Failing: See https://github.com/elastic/kibana/issues/118593
-  // Failing: See https://github.com/elastic/kibana/issues/156015
-  describe.skip('Ingest Pipelines', function () {
+  describe('Ingest Pipelines', function () {
     this.tags('smoke');
     before(async () => {
       await security.testUser.setRoles(['ingest_pipelines_user']);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.8`:
 - [[Ingest Pipelines] Unskip functional and a11y tests (#157173)](https://github.com/elastic/kibana/pull/157173)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Yulia Čech","email":"6585477+yuliacech@users.noreply.github.com"},"sourceCommit":{"committedDate":"2023-05-09T16:08:15Z","message":"[Ingest Pipelines] Unskip functional and a11y tests (#157173)\n\n## Summary\r\nFixes https://github.com/elastic/kibana/issues/156015\r\nFixes https://github.com/elastic/kibana/issues/156014\r\nFixes https://github.com/elastic/kibana/issues/155924 \r\nFixes https://github.com/elastic/kibana/issues/155914\r\n\r\nThe Ingest Pipelines tests were broken because of a new pipeline\r\nintroduced in https://github.com/elastic/elasticsearch/pull/95198 but\r\nthere was a fix added in\r\nhttps://github.com/elastic/elasticsearch/pull/95621. The last PR fixes\r\nthe error where it was not possible to delete the pipeline in the tests.\r\nThis PR unskips the tests since they should now work as expected.","sha":"32bc5c77bbe5b17215715ea56c4a13593855323c","branchLabelMapping":{"^v8.9.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Deployment Management","release_note:skip","Feature:Ingest Node Pipelines","v8.8.0","v8.9.0"],"number":157173,"url":"https://github.com/elastic/kibana/pull/157173","mergeCommit":{"message":"[Ingest Pipelines] Unskip functional and a11y tests (#157173)\n\n## Summary\r\nFixes https://github.com/elastic/kibana/issues/156015\r\nFixes https://github.com/elastic/kibana/issues/156014\r\nFixes https://github.com/elastic/kibana/issues/155924 \r\nFixes https://github.com/elastic/kibana/issues/155914\r\n\r\nThe Ingest Pipelines tests were broken because of a new pipeline\r\nintroduced in https://github.com/elastic/elasticsearch/pull/95198 but\r\nthere was a fix added in\r\nhttps://github.com/elastic/elasticsearch/pull/95621. The last PR fixes\r\nthe error where it was not possible to delete the pipeline in the tests.\r\nThis PR unskips the tests since they should now work as expected.","sha":"32bc5c77bbe5b17215715ea56c4a13593855323c"}},"sourceBranch":"main","suggestedTargetBranches":["8.8"],"targetPullRequestStates":[{"branch":"8.8","label":"v8.8.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.9.0","labelRegex":"^v8.9.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/157173","number":157173,"mergeCommit":{"message":"[Ingest Pipelines] Unskip functional and a11y tests (#157173)\n\n## Summary\r\nFixes https://github.com/elastic/kibana/issues/156015\r\nFixes https://github.com/elastic/kibana/issues/156014\r\nFixes https://github.com/elastic/kibana/issues/155924 \r\nFixes https://github.com/elastic/kibana/issues/155914\r\n\r\nThe Ingest Pipelines tests were broken because of a new pipeline\r\nintroduced in https://github.com/elastic/elasticsearch/pull/95198 but\r\nthere was a fix added in\r\nhttps://github.com/elastic/elasticsearch/pull/95621. The last PR fixes\r\nthe error where it was not possible to delete the pipeline in the tests.\r\nThis PR unskips the tests since they should now work as expected.","sha":"32bc5c77bbe5b17215715ea56c4a13593855323c"}}]}] BACKPORT-->