### PR TITLE
[Enterprise Search] Enable default native config

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/native_connector_configuration/native_connector_configuration.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/native_connector_configuration/native_connector_configuration.tsx
@@ -24,6 +24,7 @@ import {
 import { i18n } from '@kbn/i18n';
 
 import { docLinks } from '../../../../../shared/doc_links';
+import { CONNECTOR_ICONS } from '../../../../../shared/icons/connector_icons';
 
 import { hasConfiguredConfiguration } from '../../../../utils/has_configured_configuration';
 import { isConnectorIndex } from '../../../../utils/indices';
@@ -45,11 +46,18 @@ export const NativeConnectorConfiguration: React.FC = () => {
 
   const nativeConnector = NATIVE_CONNECTORS.find(
     (connector) => connector.serviceType === index.connector.service_type
-  );
-
-  if (!nativeConnector) {
-    return <></>;
-  }
+  ) || {
+    docsUrl: '',
+    externalAuthDocsUrl: '',
+    externalDocsUrl: '',
+    icon: CONNECTOR_ICONS.custom,
+    iconPath: 'custom.svg',
+    isBeta: true,
+    isNative: true,
+    keywords: [],
+    name: index.connector.name,
+    serviceType: index.connector.service_type ?? '',
+  };
 
   const hasDescription = !!index.connector.description;
   const hasConfigured = hasConfiguredConfiguration(index.connector.configuration);
@@ -71,7 +79,7 @@ export const NativeConnectorConfiguration: React.FC = () => {
               )}
               <EuiFlexItem grow={false}>
                 <EuiTitle size="m">
-                  <h3>{nativeConnector.name}</h3>
+                  <h3>{nativeConnector?.name ?? index.connector.name}</h3>
                 </EuiTitle>
               </EuiFlexItem>
             </EuiFlexGroup>


### PR DESCRIPTION
## Summary

This enables a default native config, so that we don't show an empty page to connectors that have `is_native` set to true but don't have a known native configuration in Kibana. 

<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->