### PR TITLE
[Synthetics] Fix nav from tls certificate page for monitor details page

### DIFF
--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/hooks/use_selected_location.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/hooks/use_selected_location.tsx
@@ -7,12 +7,14 @@
 
 import { useEffect, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { useSelectedMonitor } from './use_selected_monitor';
 import { selectSelectedLocationId, setMonitorDetailsLocationAction } from '../../../state';
 import { useUrlParams, useLocations } from '../../../hooks';
 
 export const useSelectedLocation = (updateUrl = true) => {
   const [getUrlParams, updateUrlParams] = useUrlParams();
   const { locations } = useLocations();
+  const { monitor } = useSelectedMonitor();
   const selectedLocationId = useSelector(selectSelectedLocationId);
   const dispatch = useDispatch();
 
@@ -20,16 +22,24 @@ export const useSelectedLocation = (updateUrl = true) => {
 
   useEffect(() => {
     if (!urlLocationId) {
-      const firstLocationId = locations?.[0]?.id;
-      if (firstLocationId && updateUrl) {
-        updateUrlParams({ locationId: firstLocationId }, true);
+      const monitorLocationId = monitor?.locations?.[0]?.id;
+      if (monitorLocationId && updateUrl) {
+        updateUrlParams({ locationId: monitorLocationId }, true);
       }
     }
 
     if (urlLocationId && selectedLocationId !== urlLocationId) {
       dispatch(setMonitorDetailsLocationAction(urlLocationId));
     }
-  }, [dispatch, updateUrlParams, locations, urlLocationId, selectedLocationId, updateUrl]);
+  }, [
+    dispatch,
+    updateUrlParams,
+    locations,
+    urlLocationId,
+    selectedLocationId,
+    updateUrl,
+    monitor?.locations,
+  ]);
 
   return useMemo(
     () => locations.find((loc) => loc.id === urlLocationId) ?? null,


### PR DESCRIPTION
## Summary

When clicking monitor name from tls cert page, right location should be selected when landing on page !!

<img width="1790" alt="image" src="https://github.com/elastic/kibana/assets/3505601/1798ab2a-208c-44f0-b2cd-d7881bb1fb93">


<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->