### PR TITLE
[Enterprise Search][Behavioral Analytics] Add cors link to behavioral analytics

### DIFF
--- a/packages/kbn-doc-links/src/get_doc_links.ts
+++ b/packages/kbn-doc-links/src/get_doc_links.ts
@@ -125,6 +125,7 @@ export const getDocLinks = ({ kibanaBranch }: GetDocLinkOptions): DocLinks => {
     enterpriseSearch: {
       apiKeys: `${KIBANA_DOCS}api-keys.html`,
       behavioralAnalytics: `${ENTERPRISE_SEARCH_DOCS}analytics-overview.html`,
+      behavioralAnalyticsCORS: `${ENTERPRISE_SEARCH_DOCS}analytics-cors-proxy.html`,
       behavioralAnalyticsEvents: `${ENTERPRISE_SEARCH_DOCS}analytics-events.html`,
       buildConnector: `${ENTERPRISE_SEARCH_DOCS}build-connector.html`,
       bulkApi: `${ELASTICSEARCH_DOCS}docs-bulk.html`,

--- a/packages/kbn-doc-links/src/types.ts
+++ b/packages/kbn-doc-links/src/types.ts
@@ -110,6 +110,7 @@ export interface DocLinks {
   readonly enterpriseSearch: {
     readonly apiKeys: string;
     readonly behavioralAnalytics: string;
+    readonly behavioralAnalyticsCORS: string;
     readonly behavioralAnalyticsEvents: string;
     readonly buildConnector: string;
     readonly bulkApi: string;

--- a/x-pack/plugins/enterprise_search/public/applications/analytics/components/analytics_collection_view/analytics_collection_integrate/analytics_collection_integrate_view.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/analytics/components/analytics_collection_view/analytics_collection_integrate/analytics_collection_integrate_view.tsx
@@ -90,7 +90,7 @@ http.cors.allow-headers: X-Requested-With, X-Auth-Token, Content-Type, Content-L
             )}
           </p>
           <EuiLink
-            href={``}
+            href={docLinks.behavioralAnalyticsCORS}
             data-telemetry-id="entSearchContent-analytics-cors-learnMoreLink"
             external
             target="_blank"

--- a/x-pack/plugins/enterprise_search/public/applications/shared/doc_links/doc_links.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/doc_links/doc_links.ts
@@ -35,6 +35,7 @@ class DocLinks {
   public appSearchWebCrawlerEventLogs: string;
   public appSearchWebCrawlerReference: string;
   public behavioralAnalytics: string;
+  public behavioralAnalyticsCORS: string;
   public behavioralAnalyticsEvents: string;
   public buildConnector: string;
   public bulkApi: string;
@@ -169,6 +170,7 @@ class DocLinks {
     this.appSearchWebCrawlerEventLogs = '';
     this.appSearchWebCrawlerReference = '';
     this.behavioralAnalytics = '';
+    this.behavioralAnalyticsCORS = '';
     this.behavioralAnalyticsEvents = '';
     this.buildConnector = '';
     this.bulkApi = '';
@@ -305,6 +307,7 @@ class DocLinks {
     this.appSearchWebCrawlerEventLogs = docLinks.links.appSearch.webCrawlerEventLogs;
     this.appSearchWebCrawlerReference = docLinks.links.appSearch.webCrawlerReference;
     this.behavioralAnalytics = docLinks.links.enterpriseSearch.behavioralAnalytics;
+    this.behavioralAnalyticsCORS = docLinks.links.enterpriseSearch.behavioralAnalyticsCORS;
     this.behavioralAnalyticsEvents = docLinks.links.enterpriseSearch.behavioralAnalyticsEvents;
     this.buildConnector = docLinks.links.enterpriseSearch.buildConnector;
     this.bulkApi = docLinks.links.enterpriseSearch.bulkApi;


### PR DESCRIPTION
Updated the link to point to the following page:
https://www.elastic.co/guide/en/enterprise-search/master/analytics-cors-proxy.html

<img width="1637" alt="image" src="https://github.com/elastic/kibana/assets/17390745/e734763d-4f65-4a43-b457-2344820c8e4b">




<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->