### PR TITLE
[Enterprise Search] Fix connector configuration UI for migrated connectors

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_configuration_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_configuration_logic.ts
@@ -123,7 +123,7 @@ function sortAndFilterConnectorConfiguration(config: ConnectorConfiguration): Co
 
   return sortedConfig.filter(
     (configEntry) =>
-      configEntry.ui_restrictions.length <= 0 &&
+      (configEntry.ui_restrictions ?? []).length <= 0 &&
       dependenciesSatisfied(configEntry.depends_on, dependencyLookup)
   );
 }
@@ -197,6 +197,10 @@ export function dependenciesSatisfied(
   dependencies: Dependency[],
   dependencyLookup: DependencyLookup
 ): boolean {
+  if (!dependencies) {
+    return true;
+  }
+
   for (const dependency of dependencies) {
     if (dependency.value !== dependencyLookup[dependency.field]) {
       return false;


### PR DESCRIPTION
## Summary

When a connector is migrated from 8.7 they are missing some configurable fields. Connector UI should still run even if a field is missing. This PR adds a check to the filtering on the `ui_restrictions` field because the field may not exist.
