### PR TITLE
[Enterprise Search] Enable icons for global search

### DIFF
--- a/x-pack/plugins/global_search_bar/public/lib/result_to_option.tsx
+++ b/x-pack/plugins/global_search_bar/public/lib/result_to_option.tsx
@@ -21,7 +21,8 @@ export const resultToOption = (
   const { id, title, url, icon, type, meta = {} } = result;
   const { tagIds = [], categoryLabel = '' } = meta as { tagIds: string[]; categoryLabel: string };
   // only displaying icons for applications and integrations
-  const useIcon = type === 'application' || type === 'integration';
+  const useIcon =
+    type === 'application' || type === 'integration' || type.toLowerCase() === 'enterprise search';
   const option: EuiSelectableTemplateSitewideOption = {
     key: id,
     label: title,


### PR DESCRIPTION
## Summary

This makes sure the global search bar shows icons for Enterprise Search search results.



<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->