### PR TITLE
[Enterprise Search] Search Application schema conflict warnings

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/applications/components/engine/engine_connect/engine_connect.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/applications/components/engine/engine_connect/engine_connect.tsx
@@ -51,15 +51,15 @@ const getTabBreadCrumb = (tabId: string) => {
 };
 
 export const EngineConnect: React.FC = () => {
-  const { engineName, isLoadingEngine } = useValues(EngineViewLogic);
+  const { engineName, isLoadingEngine, hasSchemaConflicts } = useValues(EngineViewLogic);
   const { connectTabId = SearchApplicationConnectTabs.API } = useParams<{
     connectTabId?: string;
   }>();
   const onTabClick = (tab: SearchApplicationConnectTabs) => () => {
     KibanaLogic.values.navigateToUrl(
       generateEncodedPath(SEARCH_APPLICATION_CONTENT_PATH, {
-        engineName,
         connectTabId: tab,
+        engineName,
       })
     );
   };
@@ -76,6 +76,7 @@ export const EngineConnect: React.FC = () => {
           rightSideItems: [],
         }}
         engineName={engineName}
+        hasSchemaConflicts={hasSchemaConflicts}
       >
         <EngineError notFound />
       </EnterpriseSearchEnginesPageTemplate>
@@ -101,6 +102,7 @@ export const EngineConnect: React.FC = () => {
         ],
       }}
       engineName={engineName}
+      hasSchemaConflicts={hasSchemaConflicts}
     >
       {connectTabId === SearchApplicationConnectTabs.API && <SearchApplicationAPI />}
     </EnterpriseSearchEnginesPageTemplate>

--- a/x-pack/plugins/enterprise_search/public/applications/applications/components/engine/engine_schema.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/applications/components/engine/engine_schema.tsx
@@ -5,9 +5,9 @@
  * 2.0.
  */
 
-import React, { useEffect, useState, useCallback, useMemo } from 'react';
+import React, { useState, useCallback, useMemo } from 'react';
 
-import { useActions, useValues } from 'kea';
+import { useValues } from 'kea';
 
 import {
   EuiBadge,
@@ -44,8 +44,6 @@ import { docLinks } from '../../../shared/doc_links';
 import { generateEncodedPath } from '../../../shared/encode_path_params';
 import { KibanaLogic } from '../../../shared/kibana';
 import { EuiLinkTo } from '../../../shared/react_router_helpers';
-
-import { EngineIndicesLogic } from './engine_indices_logic';
 
 import { EngineViewLogic } from './engine_view_logic';
 
@@ -154,10 +152,8 @@ const SchemaFieldDetails: React.FC<{ schemaField: SchemaField }> = ({ schemaFiel
 };
 
 export const EngineSchema: React.FC = () => {
-  const { engineName } = useValues(EngineIndicesLogic);
   const [onlyShowConflicts, setOnlyShowConflicts] = useState<boolean>(false);
   const { isLoadingEngineSchema, schemaFields, hasSchemaConflicts } = useValues(EngineViewLogic);
-  const { fetchEngineSchema } = useActions(EngineViewLogic);
 
   const [isFilterByPopoverOpen, setIsFilterByPopoverOpen] = useState<boolean>(false);
   const [itemIdToExpandedRowMap, setItemIdToExpandedRowMap] = useState<Record<string, JSX.Element>>(
@@ -200,10 +196,6 @@ export const EngineSchema: React.FC = () => {
   const totalConflictsHiddenByTypeFilters = onlyShowConflicts
     ? schemaFieldsMaybeWithConflicts.length - filteredSchemaFields.length
     : 0;
-
-  useEffect(() => {
-    fetchEngineSchema({ engineName });
-  }, [engineName]);
 
   const toggleDetails = (schemaField: SchemaField) => {
     const newItemIdToExpandedRowMap = { ...itemIdToExpandedRowMap };

--- a/x-pack/plugins/enterprise_search/public/applications/applications/components/engine/engine_schema.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/applications/components/engine/engine_schema.tsx
@@ -145,6 +145,7 @@ const SchemaFieldDetails: React.FC<{ schemaField: SchemaField }> = ({ schemaFiel
           css={{ '& .euiTable': { backgroundColor: 'transparent' } }}
           columns={columns}
           items={schemaField.indices}
+          responsive={false}
         />
       </EuiFlexGroup>
     </EuiPanel>
@@ -216,7 +217,7 @@ export const EngineSchema: React.FC = () => {
         if (type !== 'conflict') return null;
         return <EuiIcon type="error" color="danger" />;
       },
-      width: '2%',
+      width: '24px',
     },
     {
       name: i18n.translate('xpack.enterpriseSearch.content.engine.schema.field_name.columnTitle', {
@@ -230,7 +231,6 @@ export const EngineSchema: React.FC = () => {
           </EuiText>
         </EuiFlexGroup>
       ),
-      width: '43%',
     },
     {
       name: i18n.translate('xpack.enterpriseSearch.content.engine.schema.field_type.columnTitle', {
@@ -259,7 +259,7 @@ export const EngineSchema: React.FC = () => {
           </EuiFlexGroup>
         );
       },
-      width: '30%',
+      width: '180px',
     },
     {
       name: i18n.translate(
@@ -288,15 +288,16 @@ export const EngineSchema: React.FC = () => {
           </EuiBadge>
         );
       },
-      width: '15%',
+      width: '110px',
     },
     {
+      isExpander: true,
       render: (schemaField: SchemaField) => {
         const { name, type, indices } = schemaField;
         if (type === 'conflict' || indices.some((i) => i.type === 'unmapped')) {
           const icon = itemIdToExpandedRowMap[name] ? 'arrowUp' : 'arrowDown';
           return (
-            <EuiFlexGroup gutterSize="s" alignItems="center">
+            <EuiFlexGroup gutterSize="s" alignItems="center" justifyContent="flexEnd">
               <EuiButtonEmpty
                 size="s"
                 color="primary"
@@ -316,7 +317,7 @@ export const EngineSchema: React.FC = () => {
         }
         return null;
       },
-      width: '10%',
+      width: '115px',
     },
   ];
   const filterButton = (
@@ -437,6 +438,7 @@ export const EngineSchema: React.FC = () => {
           itemId="name"
           itemIdToExpandedRowMap={itemIdToExpandedRowMap}
           isExpandable
+          responsive={false}
         />
         {totalConflictsHiddenByTypeFilters > 0 && (
           <EuiCallOut

--- a/x-pack/plugins/enterprise_search/public/applications/applications/components/engine/engine_schema.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/applications/components/engine/engine_schema.tsx
@@ -371,7 +371,7 @@ export const EngineSchema: React.FC = () => {
             )}
           </EuiCallOut>
         )}
-        <EuiFlexGroup>
+        <EuiFlexGroup alignItems="center" justifyContent="spaceBetween">
           <EuiSwitch
             label={i18n.translate(
               'xpack.enterpriseSearch.content.engine.schema.onlyShowConflicts',

--- a/x-pack/plugins/enterprise_search/public/applications/applications/components/engine/engine_schema.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/applications/components/engine/engine_schema.tsx
@@ -156,7 +156,7 @@ const SchemaFieldDetails: React.FC<{ schemaField: SchemaField }> = ({ schemaFiel
 export const EngineSchema: React.FC = () => {
   const { engineName } = useValues(EngineIndicesLogic);
   const [onlyShowConflicts, setOnlyShowConflicts] = useState<boolean>(false);
-  const { isLoadingEngineSchema, schemaFields } = useValues(EngineViewLogic);
+  const { isLoadingEngineSchema, schemaFields, hasSchemaConflicts } = useValues(EngineViewLogic);
   const { fetchEngineSchema } = useActions(EngineViewLogic);
 
   const [isFilterByPopoverOpen, setIsFilterByPopoverOpen] = useState<boolean>(false);
@@ -346,6 +346,31 @@ export const EngineSchema: React.FC = () => {
   return (
     <>
       <EuiFlexGroup direction="column" gutterSize="l">
+        {hasSchemaConflicts && (
+          <EuiCallOut
+            title={i18n.translate(
+              'xpack.enterpriseSearch.content.applications.schema.conflictsCallOut.title',
+              { defaultMessage: 'Potential field mapping issues found' }
+            )}
+            iconType="error"
+            color="danger"
+          >
+            <p>
+              <FormattedMessage
+                id="xpack.enterpriseSearch.content.applications.schema.conflictsCallOut.description"
+                defaultMessage="Schema field type conflicts can be resolved by navigating to the source index directly and updating the field type of the conflicting field(s) to match that of the other source indices."
+              />
+            </p>
+            {!onlyShowConflicts && (
+              <EuiButton color="danger" fill onClick={toggleOnlyShowConflicts}>
+                <FormattedMessage
+                  id="xpack.enterpriseSearch.content.applications.schema.conflictsCallOut.button"
+                  defaultMessage="View conflicts"
+                />
+              </EuiButton>
+            )}
+          </EuiCallOut>
+        )}
         <EuiFlexGroup>
           <EuiSwitch
             label={i18n.translate(

--- a/x-pack/plugins/enterprise_search/public/applications/applications/components/engine/engine_search_preview/engine_search_preview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/applications/components/engine/engine_search_preview/engine_search_preview.tsx
@@ -282,7 +282,7 @@ export const EngineSearchPreview: React.FC = () => {
   // const [showAPICallFlyout, setShowAPICallFlyout] = useState<boolean>(false);    Uncomment when view this API call is needed
   const [showConfigurationPopover, setShowConfigurationPopover] = useState<boolean>(false);
   // const [lastAPICall, setLastAPICall] = useState<null | APICallData>(null); Uncomment when view this API call is needed
-  const { engineName, isLoadingEngine } = useValues(EngineViewLogic);
+  const { engineName, isLoadingEngine, hasSchemaConflicts } = useValues(EngineViewLogic);
   const { resultFields, sortableFields } = useValues(EngineSearchPreviewLogic);
   const { engineData } = useValues(EngineIndicesLogic);
 
@@ -333,6 +333,7 @@ export const EngineSearchPreview: React.FC = () => {
         ],
       }}
       engineName={engineName}
+      hasSchemaConflicts={hasSchemaConflicts}
     >
       <DocumentProvider>
         <SearchProvider config={config}>

--- a/x-pack/plugins/enterprise_search/public/applications/applications/components/engine/engine_search_preview/engine_search_preview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/applications/components/engine/engine_search_preview/engine_search_preview.tsx
@@ -199,13 +199,13 @@ const ConfigurationPopover: React.FC<ConfigurationPopOverProps> = ({
           >
             <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
               <FormattedMessage
-                id="xpack.enterpriseSearch.content.engine.searchPreview.configuration.content.Schema"
+                id="xpack.enterpriseSearch.content.engine.searchPreview.configuration.content.schema"
                 defaultMessage="Schema"
               />
               {hasSchemaConflicts && (
-                <EuiText color="danger">
+                <EuiText size="s" color="danger">
                   <FormattedMessage
-                    id="xpack.enterpriseSearch.content.engine.searchPreview.configuration.content.SchemaConflict"
+                    id="xpack.enterpriseSearch.content.engine.searchPreview.configuration.content.schemaConflict"
                     defaultMessage="Conflict"
                   />
                 </EuiText>

--- a/x-pack/plugins/enterprise_search/public/applications/applications/components/engine/engine_search_preview/engine_search_preview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/applications/components/engine/engine_search_preview/engine_search_preview.tsx
@@ -21,6 +21,7 @@ import {
   EuiPanel,
   EuiPopover,
   EuiSpacer,
+  EuiText,
   EuiTextColor,
   EuiTitle,
 } from '@elastic/eui';
@@ -112,14 +113,16 @@ class InternalEngineTransporter implements Transporter {
 
 interface ConfigurationPopOverProps {
   engineName: string;
+  hasSchemaConflicts: boolean;
   setCloseConfiguration: () => void;
   showConfiguration: boolean;
 }
 
 const ConfigurationPopover: React.FC<ConfigurationPopOverProps> = ({
   engineName,
-  showConfiguration,
+  hasSchemaConflicts,
   setCloseConfiguration,
+  showConfiguration,
 }) => {
   const { navigateToUrl } = useValues(KibanaLogic);
   const { engineData } = useValues(EngineViewLogic);
@@ -184,7 +187,7 @@ const ConfigurationPopover: React.FC<ConfigurationPopOverProps> = ({
           </EuiContextMenuItem>
           <EuiContextMenuItem
             key="Schema"
-            icon="kqlField"
+            icon={hasSchemaConflicts ? <EuiIcon type="warning" color="danger" /> : 'kqlField'}
             onClick={() =>
               navigateToUrl(
                 generateEncodedPath(SEARCH_APPLICATION_CONTENT_PATH, {
@@ -194,12 +197,20 @@ const ConfigurationPopover: React.FC<ConfigurationPopOverProps> = ({
               )
             }
           >
-            {i18n.translate(
-              'xpack.enterpriseSearch.content.engine.searchPreview.configuration.content.Schema',
-              {
-                defaultMessage: 'Schema',
-              }
-            )}
+            <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
+              <FormattedMessage
+                id="xpack.enterpriseSearch.content.engine.searchPreview.configuration.content.Schema"
+                defaultMessage="Schema"
+              />
+              {hasSchemaConflicts && (
+                <EuiText color="danger">
+                  <FormattedMessage
+                    id="xpack.enterpriseSearch.content.engine.searchPreview.configuration.content.SchemaConflict"
+                    defaultMessage="Conflict"
+                  />
+                </EuiText>
+              )}
+            </EuiFlexGroup>
           </EuiContextMenuItem>
 
           <EuiPanel color="transparent" paddingSize="s">
@@ -326,6 +337,7 @@ export const EngineSearchPreview: React.FC = () => {
           <>
             <ConfigurationPopover
               engineName={engineName}
+              hasSchemaConflicts={hasSchemaConflicts}
               showConfiguration={showConfigurationPopover}
               setCloseConfiguration={() => setShowConfigurationPopover(!showConfigurationPopover)}
             />

--- a/x-pack/plugins/enterprise_search/public/applications/applications/components/engine/engine_view.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/applications/components/engine/engine_view.tsx
@@ -35,9 +35,14 @@ import { EngineHeaderDocsAction } from './header_docs_action';
 import { SearchApplicationContent } from './search_application_content';
 
 export const EngineView: React.FC = () => {
-  const { fetchEngine, closeDeleteEngineModal, hasSchemaConflicts } = useActions(EngineViewLogic);
-  const { engineName, fetchEngineApiError, fetchEngineApiStatus, isDeleteModalVisible } =
-    useValues(EngineViewLogic);
+  const { fetchEngine, closeDeleteEngineModal } = useActions(EngineViewLogic);
+  const {
+    engineName,
+    fetchEngineApiError,
+    fetchEngineApiStatus,
+    hasSchemaConflicts,
+    isDeleteModalVisible,
+  } = useValues(EngineViewLogic);
   const { tabId = EngineViewTabs.PREVIEW } = useParams<{
     tabId?: string;
   }>();

--- a/x-pack/plugins/enterprise_search/public/applications/applications/components/engine/engine_view.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/applications/components/engine/engine_view.tsx
@@ -35,7 +35,7 @@ import { EngineHeaderDocsAction } from './header_docs_action';
 import { SearchApplicationContent } from './search_application_content';
 
 export const EngineView: React.FC = () => {
-  const { fetchEngine, closeDeleteEngineModal } = useActions(EngineViewLogic);
+  const { fetchEngine, closeDeleteEngineModal, hasSchemaConflicts } = useActions(EngineViewLogic);
   const { engineName, fetchEngineApiError, fetchEngineApiStatus, isDeleteModalVisible } =
     useValues(EngineViewLogic);
   const { tabId = EngineViewTabs.PREVIEW } = useParams<{
@@ -61,6 +61,7 @@ export const EngineView: React.FC = () => {
         }}
         engineName={engineName}
         emptyState={<EngineError error={fetchEngineApiError} />}
+        hasSchemaConflicts={hasSchemaConflicts}
       />
     );
   }
@@ -97,6 +98,7 @@ export const EngineView: React.FC = () => {
               rightSideItems: [],
             }}
             engineName={engineName}
+            hasSchemaConflicts={hasSchemaConflicts}
           >
             <EngineError notFound />
           </EnterpriseSearchEnginesPageTemplate>

--- a/x-pack/plugins/enterprise_search/public/applications/applications/components/engine/engine_view_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/applications/components/engine/engine_view_logic.test.ts
@@ -19,13 +19,14 @@ import { EngineViewLogic, EngineViewValues } from './engine_view_logic';
 const DEFAULT_VALUES: EngineViewValues = {
   engineData: undefined,
   engineName: 'my-test-engine',
+  engineSchemaData: undefined,
   fetchEngineApiError: undefined,
   fetchEngineApiStatus: Status.IDLE,
-  isDeleteModalVisible: false,
-  isLoadingEngine: true,
-  engineSchemaData: undefined,
   fetchEngineSchemaApiError: undefined,
   fetchEngineSchemaApiStatus: Status.IDLE,
+  hasSchemaConflicts: false,
+  isDeleteModalVisible: false,
+  isLoadingEngine: true,
   isLoadingEngineSchema: true,
   schemaFields: [],
 };

--- a/x-pack/plugins/enterprise_search/public/applications/applications/components/engine/engine_view_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/applications/components/engine/engine_view_logic.ts
@@ -79,6 +79,9 @@ export const EngineViewLogic = kea<MakeLogicType<EngineViewValues, EngineViewAct
       actions.closeDeleteEngineModal();
       KibanaLogic.values.navigateToUrl(ENGINES_PATH);
     },
+    fetchEngine: ({ engineName }) => {
+      actions.fetchEngineSchema({ engineName });
+    },
   }),
   path: ['enterprise_search', 'content', 'engine_view_logic'],
   reducers: () => ({

--- a/x-pack/plugins/enterprise_search/public/applications/applications/components/engine/engine_view_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/applications/components/engine/engine_view_logic.ts
@@ -40,6 +40,7 @@ export interface EngineViewValues {
   fetchEngineApiStatus: typeof FetchEngineApiLogic.values.status;
   fetchEngineSchemaApiError?: typeof FetchEngineFieldCapabilitiesApiLogic.values.error;
   fetchEngineSchemaApiStatus: typeof FetchEngineFieldCapabilitiesApiLogic.values.status;
+  hasSchemaConflicts: boolean;
   isDeleteModalVisible: boolean;
   isLoadingEngine: boolean;
   isLoadingEngineSchema: boolean;
@@ -90,6 +91,10 @@ export const EngineViewLogic = kea<MakeLogicType<EngineViewValues, EngineViewAct
     ],
   }),
   selectors: ({ selectors }) => ({
+    hasSchemaConflicts: [
+      () => [selectors.schemaFields],
+      (data: EngineViewValues['schemaFields']) => data.some((f) => f.type === 'conflict'),
+    ],
     isLoadingEngine: [
       () => [selectors.fetchEngineApiStatus, selectors.engineData],
       (status: EngineViewValues['fetchEngineApiStatus'], data: EngineViewValues['engineData']) => {

--- a/x-pack/plugins/enterprise_search/public/applications/applications/components/engine/search_application_content.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/applications/components/engine/search_application_content.tsx
@@ -10,7 +10,7 @@ import { useParams } from 'react-router-dom';
 
 import { useActions, useValues } from 'kea';
 
-import { EuiButton, EuiIcon } from '@elastic/eui';
+import { EuiButton, EuiIcon, EuiFlexGroup } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
 import { generateEncodedPath } from '../../../shared/encode_path_params';
@@ -147,7 +147,12 @@ export const SearchApplicationContent = () => {
           },
           {
             isSelected: contentTabId === SearchApplicationContentTabs.SCHEMA,
-            label: SCHEMA_TAB_TITLE,
+            label: (
+              <EuiFlexGroup gutterSize="s" alignItems="center">
+                {hasSchemaConflicts && <EuiIcon type="warning" color="danger" />}
+                {SCHEMA_TAB_TITLE}
+              </EuiFlexGroup>
+            ),
             onClick: onTabClick(SearchApplicationContentTabs.SCHEMA),
           },
         ],

--- a/x-pack/plugins/enterprise_search/public/applications/applications/components/engine/search_application_content.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/applications/components/engine/search_application_content.tsx
@@ -65,7 +65,7 @@ const getTabBreadCrumb = (tabId: string) => {
 const ContentTabs: string[] = Object.values(SearchApplicationContentTabs);
 
 export const SearchApplicationContent = () => {
-  const { engineName, isLoadingEngine } = useValues(EngineViewLogic);
+  const { engineName, isLoadingEngine, hasSchemaConflicts } = useValues(EngineViewLogic);
   const { addIndicesFlyoutOpen } = useValues(EngineIndicesLogic);
   const { closeAddIndicesFlyout, openAddIndicesFlyout } = useActions(EngineIndicesLogic);
   const { contentTabId = SearchApplicationContentTabs.INDICES } = useParams<{
@@ -85,6 +85,7 @@ export const SearchApplicationContent = () => {
           rightSideItems: [],
         }}
         engineName={engineName}
+        hasSchemaConflicts={hasSchemaConflicts}
       >
         <EngineError notFound />
       </EnterpriseSearchEnginesPageTemplate>
@@ -152,6 +153,7 @@ export const SearchApplicationContent = () => {
         ],
       }}
       engineName={engineName}
+      hasSchemaConflicts={hasSchemaConflicts}
     >
       {contentTabId === SearchApplicationContentTabs.INDICES && <EngineIndices />}
       {contentTabId === SearchApplicationContentTabs.SCHEMA && <EngineSchema />}

--- a/x-pack/plugins/enterprise_search/public/applications/applications/components/layout/engines_page_template.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/applications/components/layout/engines_page_template.tsx
@@ -15,12 +15,24 @@ import { SendEnterpriseSearchTelemetry } from '../../../shared/telemetry';
 
 export type EnterpriseSearchEnginesPageTemplateProps = PageTemplateProps & {
   engineName?: string;
+  hasSchemaConflicts?: boolean;
 };
 
 export const EnterpriseSearchEnginesPageTemplate: React.FC<
   EnterpriseSearchEnginesPageTemplateProps
-> = ({ children, pageChrome, pageViewTelemetry, engineName, ...pageTemplateProps }) => {
-  const navItems = useEnterpriseSearchEngineNav(engineName, pageTemplateProps.isEmptyState);
+> = ({
+  children,
+  pageChrome,
+  pageViewTelemetry,
+  engineName,
+  hasSchemaConflicts,
+  ...pageTemplateProps
+}) => {
+  const navItems = useEnterpriseSearchEngineNav(
+    engineName,
+    pageTemplateProps.isEmptyState,
+    hasSchemaConflicts
+  );
   return (
     <EnterpriseSearchPageTemplateWrapper
       {...pageTemplateProps}

--- a/x-pack/plugins/enterprise_search/public/applications/shared/layout/nav.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/layout/nav.test.tsx
@@ -291,28 +291,38 @@ describe('useEnterpriseSearchEngineNav', () => {
 
     // @ts-ignore
     const engineItem: EuiSideNavItemType<unknown> = enginesItem!.items[0];
-    expect(engineItem).toEqual({
-      href: `/app/enterprise_search/applications/search_applications/${engineName}`,
-      id: 'engineId',
-      items: [
-        {
-          href: `/app/enterprise_search/applications/search_applications/${engineName}/preview`,
-          id: 'enterpriseSearchEnginePreview',
-          name: 'Search Preview',
-        },
-        {
-          href: `/app/enterprise_search/applications/search_applications/${engineName}/content`,
-          id: 'enterpriseSearchApplicationsContent',
-          name: 'Content',
-        },
-        {
-          href: `/app/enterprise_search/applications/search_applications/${engineName}/connect`,
-          id: 'enterpriseSearchApplicationConnect',
-          name: 'Connect',
-        },
-      ],
-      name: engineName,
-    });
+    expect(engineItem).toMatchInlineSnapshot(`
+      Object {
+        "href": "/app/enterprise_search/applications/search_applications/my-test-engine",
+        "id": "engineId",
+        "items": Array [
+          Object {
+            "href": "/app/enterprise_search/applications/search_applications/my-test-engine/preview",
+            "id": "enterpriseSearchEnginePreview",
+            "items": undefined,
+            "name": "Search Preview",
+          },
+          Object {
+            "href": "/app/enterprise_search/applications/search_applications/my-test-engine/content",
+            "id": "enterpriseSearchApplicationsContent",
+            "items": undefined,
+            "name": <EuiFlexGroup
+              alignItems="center"
+              justifyContent="spaceBetween"
+            >
+              Content
+            </EuiFlexGroup>,
+          },
+          Object {
+            "href": "/app/enterprise_search/applications/search_applications/my-test-engine/connect",
+            "id": "enterpriseSearchApplicationConnect",
+            "items": undefined,
+            "name": "Connect",
+          },
+        ],
+        "name": "my-test-engine",
+      }
+    `);
   });
 
   it('returns selected engine without tabs when isEmpty', () => {
@@ -342,6 +352,37 @@ describe('useEnterpriseSearchEngineNav', () => {
       id: 'engineId',
       name: engineName,
     });
+  });
+
+  it('returns selected engine with conflict warning when hasSchemaConflicts', () => {
+    const engineName = 'my-test-engine';
+    const navItems = useEnterpriseSearchEngineNav(engineName, false, true);
+
+    // @ts-ignore
+    const engineItem = navItems
+      .find((ni: EuiSideNavItemType<unknown>) => ni.id === 'applications')
+      .items.find((ni: EuiSideNavItemType<unknown>) => ni.id === 'searchApplications')
+      .items[0].items.find(
+        (ni: EuiSideNavItemType<unknown>) => ni.id === 'enterpriseSearchApplicationsContent'
+      );
+
+    expect(engineItem).toMatchInlineSnapshot(`
+      Object {
+        "href": "/app/enterprise_search/applications/search_applications/my-test-engine/content",
+        "id": "enterpriseSearchApplicationsContent",
+        "items": undefined,
+        "name": <EuiFlexGroup
+          alignItems="center"
+          justifyContent="spaceBetween"
+        >
+          Content
+          <EuiIcon
+            color="danger"
+            type="warning"
+          />
+        </EuiFlexGroup>,
+      }
+    `);
   });
 });
 

--- a/x-pack/plugins/enterprise_search/public/applications/shared/layout/nav.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/layout/nav.tsx
@@ -194,7 +194,7 @@ export const useEnterpriseSearchEngineNav = (
           name: engineName,
           ...generateNavLink({
             shouldNotCreateHref: true,
-            shouldShowActiveForSubroutes: true,
+            shouldShowActiveForSubroutes: false,
             to: enginePath,
           }),
           items: [

--- a/x-pack/plugins/enterprise_search/public/applications/shared/layout/nav.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/layout/nav.tsx
@@ -5,9 +5,11 @@
  * 2.0.
  */
 
+import React from 'react';
+
 import { useValues } from 'kea';
 
-import { EuiSideNavItemType } from '@elastic/eui';
+import { EuiFlexGroup, EuiIcon, EuiSideNavItemType } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
 import {
@@ -170,7 +172,11 @@ export const useEnterpriseSearchNav = () => {
   return navItems;
 };
 
-export const useEnterpriseSearchEngineNav = (engineName?: string, isEmptyState?: boolean) => {
+export const useEnterpriseSearchEngineNav = (
+  engineName?: string,
+  isEmptyState?: boolean,
+  hasSchemaConflicts?: boolean
+) => {
   const navItems = useEnterpriseSearchNav();
   if (!navItems) return undefined;
   if (!engineName) return navItems;
@@ -204,9 +210,14 @@ export const useEnterpriseSearchEngineNav = (engineName?: string, isEmptyState?:
             },
             {
               id: 'enterpriseSearchApplicationsContent',
-              name: i18n.translate('xpack.enterpriseSearch.nav.engine.contentTitle', {
-                defaultMessage: 'Content',
-              }),
+              name: (
+                <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
+                  {i18n.translate('xpack.enterpriseSearch.nav.engine.contentTitle', {
+                    defaultMessage: 'Content',
+                  })}
+                  {hasSchemaConflicts && <EuiIcon type="warning" color="danger" />}
+                </EuiFlexGroup>
+              ),
               ...generateNavLink({
                 shouldNotCreateHref: true,
                 shouldShowActiveForSubroutes: true,


### PR DESCRIPTION
## Summary

Adds warnings through the search applications UI when a search application has schema conflicts

<details>
<summary>🖼️ screenshots</summary>

![Screen Shot 2023-05-10 at 09 37 55](https://github.com/elastic/kibana/assets/1699281/452c7950-248a-4e3a-bfe3-631718d4d981)
![Screen Shot 2023-05-10 at 09 38 05](https://github.com/elastic/kibana/assets/1699281/be3b51e6-3830-45bc-877e-635ca3c8c938)
![Screen Shot 2023-05-10 at 09 38 09](https://github.com/elastic/kibana/assets/1699281/bfcf56d3-c2d5-49b0-b7e0-3081c2ad773e)
![Screen Shot 2023-05-10 at 09 38 12](https://github.com/elastic/kibana/assets/1699281/8515ba20-d888-4678-a1d0-b0e897c70602)
![Screen Shot 2023-05-10 at 09 38 18](https://github.com/elastic/kibana/assets/1699281/1695be43-5780-46bb-8a4e-114e09bc308b)

</details>

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)
