### PR TITLE
Update ftr services to handle occasional WebDriverError

### DIFF
--- a/test/functional/apps/visualize/replaced_vislib_chart_types/_area_chart.ts
+++ b/test/functional/apps/visualize/replaced_vislib_chart_types/_area_chart.ts
@@ -433,8 +433,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         expect(isFieldErrorMessageExists).to.be(false);
       });
 
-      // FLAKY: https://github.com/elastic/kibana/issues/156821
-      describe.skip('interval errors', () => {
+      describe('interval errors', () => {
         before(async () => {
           // to trigger displaying of error messages
           await testSubjects.clickWhenNotDisabledWithoutRetry('visualizeEditorRenderButton');

--- a/test/functional/services/combo_box.ts
+++ b/test/functional/services/combo_box.ts
@@ -117,7 +117,6 @@ export class ComboBoxService extends FtrService {
    * @param value option text
    */
   public async setCustom(comboBoxSelector: string, value: string): Promise<void> {
-    this.log.debug(`comboBox.setCustom, comboBoxSelector: ${comboBoxSelector}, value: ${value}`);
     const comboBoxElement = await this.testSubjects.find(comboBoxSelector);
     await this.setFilterValue(comboBoxElement, value);
     await this.common.pressEnterKey();

--- a/test/functional/services/common/find.ts
+++ b/test/functional/services/common/find.ts
@@ -195,7 +195,7 @@ export class FindService extends FtrService {
   ): Promise<WebElementWrapper[]> {
     this.log.debug(`Find.allDescendantDisplayedByTagName('${tagName}')`);
     const allElements = await this.wrapAll(
-      await parentElement._webElement.findElements(By.tagName(tagName))
+      await parentElement._webElement.findElements(By.css(tagName))
     );
     return await this.filterElementIsDisplayed(allElements);
   }
@@ -372,7 +372,7 @@ export class FindService extends FtrService {
     return await this.retry.tryForTime(timeout, async () => {
       // tslint:disable-next-line:variable-name
       const _element = element instanceof WebElementWrapper ? element._webElement : element;
-      const allButtons = this.wrapAll(await _element.findElements(By.tagName('button')));
+      const allButtons = this.wrapAll(await _element.findElements(By.css('button')));
       const buttonTexts = await Promise.all(
         allButtons.map(async (el) => {
           return el.getVisibleText();


### PR DESCRIPTION
## Summary

Starting with Chrome v113 we noticed that `_area_chart.ts` suite became flaky #156821 failing with
`WebDriverError: unknown error: unhandled inspector error: {"code":-32000,"message":"No node with given id found"}`
Updating chromedriver to v113 did not solve the issue and more tests started to fail with the same error.

It happens occasionally when driver returns unhandled error instead of StaleElementReferenceException. This PR adds the error to the `RETRY_ON_ERRORS` list, so that FTR can search for the element again and re-try the action on it:

```
           │ debg getVisibleText: elementId=29C3E81151C86107290DD8F020524333_element_290
           │ debg Chromedriver issue #4440, WebElementWrapper.getVisibleText: WebDriverError: unknown error: unhandled inspector error: {"code":-32000,"message":"No node with given id found"}
           │        (Session info: chrome=113.0.5672.63)
           │ debg current ElementID=29C3E81151C86107290DD8F020524333_element_290
           │ debg new ElementID=29C3E81151C86107290DD8F020524333_element_293
           │ debg Searching again for the element 'By(css selector, [data-test-subj="visEditorInterval"] + .euiFormErrorText)', 2 attempts left
           │ debg getVisibleText: elementId=29C3E81151C86107290DD8F020524333_element_293
           └- ✓ pass  (1.8s)
```

There is no need to use `Retry` service, `WebDriverWrapper.retryCall` should handle the issue.

Flaky test runner 100x for Vis Editor config: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2236
Flaky test runner 100x for Cases config: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2237

And 2 more 100x:
https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2239
https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2237

<!--ONMERGE {"backportTargets":["8.7","8.8"]} ONMERGE-->