### PR TITLE
[8.8] [Synthetics] Monitor add/edit form, don't save color (#156668)

### DIFF
--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/form/field_config.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/form/field_config.tsx
@@ -421,7 +421,12 @@ export const FIELD = (readOnly?: boolean): FieldMap => ({
         })),
         'data-test-subj': 'syntheticsMonitorConfigLocations',
         onChange: (updatedValues: FormLocation[]) => {
-          setValue(ConfigKey.LOCATIONS, updatedValues, {
+          const valuesToSave = updatedValues.map(({ id, label, isServiceManaged }) => ({
+            id,
+            label,
+            isServiceManaged,
+          }));
+          setValue(ConfigKey.LOCATIONS, valuesToSave, {
             shouldValidate: Boolean(formState.submitCount > 0),
           });
         },


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.8`:
 - [[Synthetics] Monitor add/edit form, don't save color (#156668)](https://github.com/elastic/kibana/pull/156668)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Shahzad","email":"shahzad31comp@gmail.com"},"sourceCommit":{"committedDate":"2023-05-10T15:10:43Z","message":"[Synthetics] Monitor add/edit form, don't save color (#156668)","sha":"f74adedab29a434ce154ba5da2f2e6ca48cb9ce0","branchLabelMapping":{"^v8.9.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:uptime","release_note:skip","v8.8.0","v8.9.0"],"number":156668,"url":"https://github.com/elastic/kibana/pull/156668","mergeCommit":{"message":"[Synthetics] Monitor add/edit form, don't save color (#156668)","sha":"f74adedab29a434ce154ba5da2f2e6ca48cb9ce0"}},"sourceBranch":"main","suggestedTargetBranches":["8.8"],"targetPullRequestStates":[{"branch":"8.8","label":"v8.8.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.9.0","labelRegex":"^v8.9.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/156668","number":156668,"mergeCommit":{"message":"[Synthetics] Monitor add/edit form, don't save color (#156668)","sha":"f74adedab29a434ce154ba5da2f2e6ca48cb9ce0"}}]}] BACKPORT-->