### PR TITLE
[8.8] [Enterprise Search] Fix connector configuration UI for migrated connectors (#157276)

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_configuration_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_configuration_logic.ts
@@ -123,7 +123,7 @@ function sortAndFilterConnectorConfiguration(config: ConnectorConfiguration): Co
 
   return sortedConfig.filter(
     (configEntry) =>
-      configEntry.ui_restrictions.length <= 0 &&
+      (configEntry.ui_restrictions ?? []).length <= 0 &&
       dependenciesSatisfied(configEntry.depends_on, dependencyLookup)
   );
 }
@@ -197,6 +197,10 @@ export function dependenciesSatisfied(
   dependencies: Dependency[],
   dependencyLookup: DependencyLookup
 ): boolean {
+  if (!dependencies) {
+    return true;
+  }
+
   for (const dependency of dependencies) {
     if (dependency.value !== dependencyLookup[dependency.field]) {
       return false;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.8`:
 - [[Enterprise Search] Fix connector configuration UI for migrated connectors (#157276)](https://github.com/elastic/kibana/pull/157276)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Navarone Feekery","email":"13634519+navarone-feekery@users.noreply.github.com"},"sourceCommit":{"committedDate":"2023-05-10T15:13:02Z","message":"[Enterprise Search] Fix connector configuration UI for migrated connectors (#157276)\n\nWhen a connector is migrated from 8.7 they are missing some configurable\r\nfields. Connector UI should still run even if a field is missing. This\r\nPR adds a check to the filtering on the `ui_restrictions` field because\r\nthe field may not exist.","sha":"ff089e72846bd631e67fa672909b0b8e5e653922","branchLabelMapping":{"^v8.9.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:EnterpriseSearch","v8.8.0","v8.9.0"],"number":157276,"url":"https://github.com/elastic/kibana/pull/157276","mergeCommit":{"message":"[Enterprise Search] Fix connector configuration UI for migrated connectors (#157276)\n\nWhen a connector is migrated from 8.7 they are missing some configurable\r\nfields. Connector UI should still run even if a field is missing. This\r\nPR adds a check to the filtering on the `ui_restrictions` field because\r\nthe field may not exist.","sha":"ff089e72846bd631e67fa672909b0b8e5e653922"}},"sourceBranch":"main","suggestedTargetBranches":["8.8"],"targetPullRequestStates":[{"branch":"8.8","label":"v8.8.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.9.0","labelRegex":"^v8.9.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/157276","number":157276,"mergeCommit":{"message":"[Enterprise Search] Fix connector configuration UI for migrated connectors (#157276)\n\nWhen a connector is migrated from 8.7 they are missing some configurable\r\nfields. Connector UI should still run even if a field is missing. This\r\nPR adds a check to the filtering on the `ui_restrictions` field because\r\nthe field may not exist.","sha":"ff089e72846bd631e67fa672909b0b8e5e653922"}}]}] BACKPORT-->