### PR TITLE
[8.7] Update ftr services to handle occasional WebDriverError (#157283)

### DIFF
--- a/test/functional/services/combo_box.ts
+++ b/test/functional/services/combo_box.ts
@@ -117,7 +117,6 @@ export class ComboBoxService extends FtrService {
    * @param value option text
    */
   public async setCustom(comboBoxSelector: string, value: string): Promise<void> {
-    this.log.debug(`comboBox.setCustom, comboBoxSelector: ${comboBoxSelector}, value: ${value}`);
     const comboBoxElement = await this.testSubjects.find(comboBoxSelector);
     await this.setFilterValue(comboBoxElement, value);
     await this.common.pressEnterKey();

--- a/test/functional/services/common/find.ts
+++ b/test/functional/services/common/find.ts
@@ -195,7 +195,7 @@ export class FindService extends FtrService {
   ): Promise<WebElementWrapper[]> {
     this.log.debug(`Find.allDescendantDisplayedByTagName('${tagName}')`);
     const allElements = await this.wrapAll(
-      await parentElement._webElement.findElements(By.tagName(tagName))
+      await parentElement._webElement.findElements(By.css(tagName))
     );
     return await this.filterElementIsDisplayed(allElements);
   }
@@ -372,7 +372,7 @@ export class FindService extends FtrService {
     return await this.retry.tryForTime(timeout, async () => {
       // tslint:disable-next-line:variable-name
       const _element = element instanceof WebElementWrapper ? element._webElement : element;
-      const allButtons = this.wrapAll(await _element.findElements(By.tagName('button')));
+      const allButtons = this.wrapAll(await _element.findElements(By.css('button')));
       const buttonTexts = await Promise.all(
         allButtons.map(async (el) => {
           return el.getVisibleText();


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.7`:
 - [Update ftr services to handle occasional WebDriverError (#157283)](https://github.com/elastic/kibana/pull/157283)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Dzmitry Lemechko","email":"dzmitry.lemechko@elastic.co"},"sourceCommit":{"committedDate":"2023-05-10T18:00:44Z","message":"Update ftr services to handle occasional WebDriverError (#157283)\n\n## Summary\r\n\r\nStarting with Chrome v113 we noticed that `_area_chart.ts` suite became\r\nflaky #156821 failing with\r\n`WebDriverError: unknown error: unhandled inspector error:\r\n{\"code\":-32000,\"message\":\"No node with given id found\"}`\r\nUpdating chromedriver to v113 did not solve the issue and more tests\r\nstarted to fail with the same error.\r\n\r\nIt happens occasionally when driver returns unhandled error instead of\r\nStaleElementReferenceException. This PR adds the error to the\r\n`RETRY_ON_ERRORS` list, so that FTR can search for the element again and\r\nre-try the action on it:\r\n\r\n```\r\n           │ debg getVisibleText: elementId=29C3E81151C86107290DD8F020524333_element_290\r\n           │ debg Chromedriver issue #4440, WebElementWrapper.getVisibleText: WebDriverError: unknown error: unhandled inspector error: {\"code\":-32000,\"message\":\"No node with given id found\"}\r\n           │        (Session info: chrome=113.0.5672.63)\r\n           │ debg current ElementID=29C3E81151C86107290DD8F020524333_element_290\r\n           │ debg new ElementID=29C3E81151C86107290DD8F020524333_element_293\r\n           │ debg Searching again for the element 'By(css selector, [data-test-subj=\"visEditorInterval\"] + .euiFormErrorText)', 2 attempts left\r\n           │ debg getVisibleText: elementId=29C3E81151C86107290DD8F020524333_element_293\r\n           └- ✓ pass  (1.8s)\r\n```\r\n\r\nThere is no need to use `Retry` service, `WebDriverWrapper.retryCall`\r\nshould handle the issue.\r\n\r\nFlaky test runner 100x for Vis Editor config:\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2236\r\nFlaky test runner 100x for Cases config:\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2237\r\n\r\nAnd 2 more 100x:\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2239\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2237","sha":"7f4ceb1d302cf24411c1b82030b882e87a8616dd","branchLabelMapping":{"^v8.9.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v8.7.2","v8.9.0","v8.8.1"],"number":157283,"url":"https://github.com/elastic/kibana/pull/157283","mergeCommit":{"message":"Update ftr services to handle occasional WebDriverError (#157283)\n\n## Summary\r\n\r\nStarting with Chrome v113 we noticed that `_area_chart.ts` suite became\r\nflaky #156821 failing with\r\n`WebDriverError: unknown error: unhandled inspector error:\r\n{\"code\":-32000,\"message\":\"No node with given id found\"}`\r\nUpdating chromedriver to v113 did not solve the issue and more tests\r\nstarted to fail with the same error.\r\n\r\nIt happens occasionally when driver returns unhandled error instead of\r\nStaleElementReferenceException. This PR adds the error to the\r\n`RETRY_ON_ERRORS` list, so that FTR can search for the element again and\r\nre-try the action on it:\r\n\r\n```\r\n           │ debg getVisibleText: elementId=29C3E81151C86107290DD8F020524333_element_290\r\n           │ debg Chromedriver issue #4440, WebElementWrapper.getVisibleText: WebDriverError: unknown error: unhandled inspector error: {\"code\":-32000,\"message\":\"No node with given id found\"}\r\n           │        (Session info: chrome=113.0.5672.63)\r\n           │ debg current ElementID=29C3E81151C86107290DD8F020524333_element_290\r\n           │ debg new ElementID=29C3E81151C86107290DD8F020524333_element_293\r\n           │ debg Searching again for the element 'By(css selector, [data-test-subj=\"visEditorInterval\"] + .euiFormErrorText)', 2 attempts left\r\n           │ debg getVisibleText: elementId=29C3E81151C86107290DD8F020524333_element_293\r\n           └- ✓ pass  (1.8s)\r\n```\r\n\r\nThere is no need to use `Retry` service, `WebDriverWrapper.retryCall`\r\nshould handle the issue.\r\n\r\nFlaky test runner 100x for Vis Editor config:\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2236\r\nFlaky test runner 100x for Cases config:\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2237\r\n\r\nAnd 2 more 100x:\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2239\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2237","sha":"7f4ceb1d302cf24411c1b82030b882e87a8616dd"}},"sourceBranch":"main","suggestedTargetBranches":["8.7"],"targetPullRequestStates":[{"branch":"8.7","label":"v8.7.2","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.9.0","labelRegex":"^v8.9.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/157283","number":157283,"mergeCommit":{"message":"Update ftr services to handle occasional WebDriverError (#157283)\n\n## Summary\r\n\r\nStarting with Chrome v113 we noticed that `_area_chart.ts` suite became\r\nflaky #156821 failing with\r\n`WebDriverError: unknown error: unhandled inspector error:\r\n{\"code\":-32000,\"message\":\"No node with given id found\"}`\r\nUpdating chromedriver to v113 did not solve the issue and more tests\r\nstarted to fail with the same error.\r\n\r\nIt happens occasionally when driver returns unhandled error instead of\r\nStaleElementReferenceException. This PR adds the error to the\r\n`RETRY_ON_ERRORS` list, so that FTR can search for the element again and\r\nre-try the action on it:\r\n\r\n```\r\n           │ debg getVisibleText: elementId=29C3E81151C86107290DD8F020524333_element_290\r\n           │ debg Chromedriver issue #4440, WebElementWrapper.getVisibleText: WebDriverError: unknown error: unhandled inspector error: {\"code\":-32000,\"message\":\"No node with given id found\"}\r\n           │        (Session info: chrome=113.0.5672.63)\r\n           │ debg current ElementID=29C3E81151C86107290DD8F020524333_element_290\r\n           │ debg new ElementID=29C3E81151C86107290DD8F020524333_element_293\r\n           │ debg Searching again for the element 'By(css selector, [data-test-subj=\"visEditorInterval\"] + .euiFormErrorText)', 2 attempts left\r\n           │ debg getVisibleText: elementId=29C3E81151C86107290DD8F020524333_element_293\r\n           └- ✓ pass  (1.8s)\r\n```\r\n\r\nThere is no need to use `Retry` service, `WebDriverWrapper.retryCall`\r\nshould handle the issue.\r\n\r\nFlaky test runner 100x for Vis Editor config:\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2236\r\nFlaky test runner 100x for Cases config:\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2237\r\n\r\nAnd 2 more 100x:\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2239\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2237","sha":"7f4ceb1d302cf24411c1b82030b882e87a8616dd"}},{"branch":"8.8","label":"v8.8.1","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/157326","number":157326,"state":"OPEN"}]}] BACKPORT-->