### PR TITLE
Add temporary test pipeline for KME test

### DIFF
--- a/.buildkite/pull_requests.json
+++ b/.buildkite/pull_requests.json
@@ -49,6 +49,57 @@
         "/__snapshots__/",
         "\\.test\\.(ts|tsx|js|jsx)"
       ]
+    },
+    {
+      "repoOwner": "elastic",
+      "repoName": "kibana",
+      "pipelineSlug": "kibana-kme-test",
+
+      "enabled": true,
+      "allow_org_users": true,
+      "allowed_repo_permissions": ["admin", "write"],
+      "allowed_list": ["barlowm", "renovate[bot]"],
+      "set_commit_status": true,
+      "commit_status_context": "kibana-ci",
+      "build_on_commit": true,
+      "build_on_comment": true,
+      "trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))",
+      "always_trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))",
+      "skip_ci_labels": [],
+      "labels": ["kme-test"],
+      "skip_target_branches": ["6.8", "7.11", "7.12"],
+      "enable_skippable_commits": true,
+      "skip_ci_on_only_changed": [
+        "^dev_docs/",
+        "^docs/",
+        "^rfcs/",
+        "^.ci/.+\\.yml$",
+        "^.ci/es-snapshots/",
+        "^.ci/pipeline-library/",
+        "^.ci/Jenkinsfile_[^/]+$",
+        "^\\.github/",
+        "\\.md$",
+        "\\.mdx$",
+        "^api_docs/.+\\.devdocs\\.json$",
+        "^\\.backportrc\\.json$",
+        "^nav-kibana-dev\\.docnav\\.json$",
+        "^src/dev/prs/kibana_qa_pr_list\\.json$",
+        "^\\.buildkite/pull_requests\\.json$"
+      ],
+      "always_require_ci_on_changed": [
+        "^docs/developer/plugin-list.asciidoc$",
+        "^\\.github/CODEOWNERS$",
+        "/plugins/[^/]+/readme\\.(md|asciidoc)$"
+      ],
+      "kibana_versions_check": true,
+      "kibana_build_reuse": true,
+      "kibana_build_reuse_pipeline_slugs": ["kibana-kme-test", "kibana-on-merge"],
+      "kibana_build_reuse_regexes": [
+        "^test/",
+        "^x-pack/test/",
+        "/__snapshots__/",
+        "\\.test\\.(ts|tsx|js|jsx)"
+      ]
     }
   ]
 }


### PR DESCRIPTION
The CI team is working on a lot of changes that will enable Kibana to eventually migrate pipelines to the Elastic-wide Buildkite system.

I have also been working on migrating Kibana's CI agent image to our new VM image building system, and would like to test out what I have so far. To do that, I need a separate pipeline that will run my PR that `gobld` is aware of.

This new pipeline should only be triggered when a PR has the label `kme-test`.

I will put `skip-ci` and `kme-test` on my PR, which should keep regular CI from running for it.