### PR TITLE
[7.17] [Unified Search] Fix "Edit as Query DSL" breaks when pasting in entire query DSL (#131906)

### DIFF
--- a/packages/kbn-es-query/src/es_query/migrate_filter.test.ts
+++ b/packages/kbn-es-query/src/es_query/migrate_filter.test.ts
@@ -9,6 +9,7 @@
 import { isEqual, cloneDeep } from 'lodash';
 import { migrateFilter, DeprecatedMatchPhraseFilter } from './migrate_filter';
 import { PhraseFilter, MatchAllFilter } from '../filters';
+import { Filter } from '../filters';
 
 describe('migrateFilter', function () {
   const oldMatchPhraseFilter = {
@@ -66,7 +67,23 @@ describe('migrateFilter', function () {
     } as MatchAllFilter;
     const migratedFilter = migrateFilter(originalFilter, undefined);
 
-    expect(migratedFilter).toBe(originalFilter);
-    expect(isEqual(migratedFilter, originalFilter)).toBe(true);
+    expect(migratedFilter).toEqual(originalFilter);
+  });
+
+  it('should handle the case where .query already exists and filter has other top level keys on there', function () {
+    const originalFilter = {
+      query: { match_all: {} },
+      meta: {},
+      size: 0,
+    } as Filter;
+
+    const filterAfterMigrate = {
+      query: { match_all: {} },
+      meta: {},
+    } as Filter;
+
+    const migratedFilter = migrateFilter(originalFilter, undefined);
+
+    expect(migratedFilter).toEqual(filterAfterMigrate);
   });
 });

--- a/packages/kbn-es-query/src/es_query/migrate_filter.ts
+++ b/packages/kbn-es-query/src/es_query/migrate_filter.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { get, omit } from 'lodash';
+import { get, omit, pick } from 'lodash';
 import { getConvertedValueForField } from '../filters';
 import { Filter } from '../filters';
 import { IndexPatternBase } from './types';
@@ -65,6 +65,9 @@ export function migrateFilter(filter: Filter, indexPattern?: IndexPatternBase) {
 
   if (!filter.query) {
     filter.query = {};
+  } else {
+    // handle the case where .query already exists and filter has other top level keys on there
+    filter = pick(filter, ['meta', 'query', '$state']);
   }
 
   // @ts-ignore


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [[Unified Search] Fix "Edit as Query DSL" breaks when pasting in entire query DSL (#131906)](https://github.com/elastic/kibana/pull/131906)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Nodir Latipov","email":"nodir.latypov@gmail.com"},"sourceCommit":{"committedDate":"2022-05-24T10:22:32Z","message":"[Unified Search] Fix \"Edit as Query DSL\" breaks when pasting in entire query DSL (#131906)\n\n* fix: added handle the case where .query already exists and filter has other top level keys on there\r\n\r\n* refact: handle the case where .query exists\r\n\r\n* fix: rollback refact handle the case where .query already exists\r\n\r\n* refact: replaced solution with pick lodash and added test\r\n\r\n* refact: remove the extra check in jest test","sha":"4557beb25bc0bc5844f0d3b7e85cfdb7f0588eaa","branchLabelMapping":{"^v8.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Visualizations","release_note:skip","backport:skip","Feature:Unified search","v8.3.0"],"number":131906,"url":"https://github.com/elastic/kibana/pull/131906","mergeCommit":{"message":"[Unified Search] Fix \"Edit as Query DSL\" breaks when pasting in entire query DSL (#131906)\n\n* fix: added handle the case where .query already exists and filter has other top level keys on there\r\n\r\n* refact: handle the case where .query exists\r\n\r\n* fix: rollback refact handle the case where .query already exists\r\n\r\n* refact: replaced solution with pick lodash and added test\r\n\r\n* refact: remove the extra check in jest test","sha":"4557beb25bc0bc5844f0d3b7e85cfdb7f0588eaa"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.3.0","labelRegex":"^v8.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/131906","number":131906,"mergeCommit":{"message":"[Unified Search] Fix \"Edit as Query DSL\" breaks when pasting in entire query DSL (#131906)\n\n* fix: added handle the case where .query already exists and filter has other top level keys on there\r\n\r\n* refact: handle the case where .query exists\r\n\r\n* fix: rollback refact handle the case where .query already exists\r\n\r\n* refact: replaced solution with pick lodash and added test\r\n\r\n* refact: remove the extra check in jest test","sha":"4557beb25bc0bc5844f0d3b7e85cfdb7f0588eaa"}}]}] BACKPORT-->