### PR TITLE
Make "Create an SLO burn rate alert rule" checkbox clickable when Editing SLO

### DIFF
--- a/x-pack/plugins/observability/public/pages/slo_edit/components/slo_edit_form.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/slo_edit_form.tsx
@@ -81,10 +81,10 @@ export function SloEditForm({ slo }: Props) {
   }
 
   useEffect(() => {
-    if (isEditMode && rules && rules[slo.id].length && isCreateRuleCheckboxChecked) {
+    if (isEditMode && rules && rules[slo.id].length) {
       setIsCreateRuleCheckboxChecked(false);
     }
-  }, [isCreateRuleCheckboxChecked, isEditMode, rules, slo]);
+  }, [isEditMode, rules, slo]);
 
   const methods = useForm({
     defaultValues: { ...SLO_EDIT_FORM_DEFAULT_VALUES, ...urlParams },


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/157352

## 📝 Summary

This allows the "Create an SLO burn rate alert rule checkbox" to be clickable when editing an existing SLO.

## ✅ Checklist
- The checkbox should be toggleable when creating a new SLO
- The checkbox should be toggleable when editing an existing SLO
- When opening the form, the checkbox should be checked when editing an existing SLO that does not have a rule set yet
- When opening the form, the checkbox should be unchecked when editing an existing SLO that has at least one rule set yet


<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->