### PR TITLE
[Enterprise Search] Add check for dependencies before checking length

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_configuration_form.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_configuration_form.tsx
@@ -76,7 +76,7 @@ export const ConnectorConfigurationForm = () => {
             </EuiToolTip>
           );
 
-        if (dependencies && dependencies.length > 0) {
+        if (dependencies?.length > 0) {
           // dynamic spacing without CSS
           const previousField = localConfigView[index - 1];
           const nextField = localConfigView[index + 1];

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_configuration_form.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_configuration_form.tsx
@@ -76,7 +76,7 @@ export const ConnectorConfigurationForm = () => {
             </EuiToolTip>
           );
 
-        if (dependencies.length > 0) {
+        if (dependencies && dependencies.length > 0) {
           // dynamic spacing without CSS
           const previousField = localConfigView[index - 1];
           const nextField = localConfigView[index + 1];

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_configuration_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_configuration_logic.ts
@@ -351,7 +351,7 @@ export const ConnectorConfigurationLogic = kea<
             type,
             ui_restrictions,
             validations: validations ?? [],
-            value: ensureCorrectTyping(type, value),
+            value: display ? ensureCorrectTyping(type, value) : value, // only check type if field had a specified eui element
           },
         }),
         setLocalConfigState: (_, { configState }) => configState,


### PR DESCRIPTION
## Summary

Add check to see if dependencies is undefined before checking length. Dependencies can be undefined if a user's connector was created before 8.8.

<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->