### PR TITLE
Only set timeslice properties when budgeting method is set to timeslices

### DIFF
--- a/x-pack/plugins/observability/public/pages/slo_edit/components/slo_edit_form_objective_section_timeslices.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/slo_edit_form_objective_section_timeslices.tsx
@@ -13,6 +13,7 @@ import type { CreateSLOInput } from '@kbn/slo-schema';
 
 export function SloEditFormObjectiveSectionTimeslices() {
   const { control, getFieldState } = useFormContext<CreateSLOInput>();
+
   return (
     <EuiFlexGrid columns={3}>
       <EuiFlexItem>
@@ -34,7 +35,6 @@ export function SloEditFormObjectiveSectionTimeslices() {
           }
         >
           <Controller
-            shouldUnregister
             name="objective.timesliceTarget"
             control={control}
             defaultValue={95}
@@ -78,7 +78,6 @@ export function SloEditFormObjectiveSectionTimeslices() {
           }
         >
           <Controller
-            shouldUnregister
             name="objective.timesliceWindow"
             defaultValue="1"
             control={control}

--- a/x-pack/plugins/observability/public/pages/slo_edit/helpers/process_slo_form_values.ts
+++ b/x-pack/plugins/observability/public/pages/slo_edit/helpers/process_slo_form_values.ts
@@ -19,12 +19,14 @@ export function transformSloResponseToCreateSloInput(
     ...omit(values, ['id', 'revision', 'createdAt', 'updatedAt', 'summary', 'enabled']),
     objective: {
       target: values.objective.target * 100,
-      ...(values.objective.timesliceTarget && {
-        timesliceTarget: values.objective.timesliceTarget * 100,
-      }),
-      ...(values.objective.timesliceWindow && {
-        timesliceWindow: String(toDuration(values.objective.timesliceWindow).value),
-      }),
+      ...(values.budgetingMethod === 'timeslices' &&
+        values.objective.timesliceTarget && {
+          timesliceTarget: values.objective.timesliceTarget * 100,
+        }),
+      ...(values.budgetingMethod === 'timeslices' &&
+        values.objective.timesliceWindow && {
+          timesliceWindow: String(toDuration(values.objective.timesliceWindow).value),
+        }),
     },
   };
 }
@@ -34,12 +36,14 @@ export function transformValuesToCreateSLOInput(values: CreateSLOInput): CreateS
     ...values,
     objective: {
       target: values.objective.target / 100,
-      ...(values.objective.timesliceTarget && {
-        timesliceTarget: values.objective.timesliceTarget / 100,
-      }),
-      ...(values.objective.timesliceWindow && {
-        timesliceWindow: `${values.objective.timesliceWindow}m`,
-      }),
+      ...(values.budgetingMethod === 'timeslices' &&
+        values.objective.timesliceTarget && {
+          timesliceTarget: values.objective.timesliceTarget / 100,
+        }),
+      ...(values.budgetingMethod === 'timeslices' &&
+        values.objective.timesliceWindow && {
+          timesliceWindow: `${values.objective.timesliceWindow}m`,
+        }),
     },
   };
 }
@@ -49,12 +53,14 @@ export function transformValuesToUpdateSLOInput(values: CreateSLOInput): UpdateS
     ...values,
     objective: {
       target: values.objective.target / 100,
-      ...(values.objective.timesliceTarget && {
-        timesliceTarget: values.objective.timesliceTarget / 100,
-      }),
-      ...(values.objective.timesliceWindow && {
-        timesliceWindow: `${values.objective.timesliceWindow}m`,
-      }),
+      ...(values.budgetingMethod === 'timeslices' &&
+        values.objective.timesliceTarget && {
+          timesliceTarget: values.objective.timesliceTarget / 100,
+        }),
+      ...(values.budgetingMethod === 'timeslices' &&
+        values.objective.timesliceWindow && {
+          timesliceWindow: `${values.objective.timesliceWindow}m`,
+        }),
     },
   };
 }


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/157368

## 📝 Summary

This removes the `shouldUnregister` prop from the timeslice form components, which fixes the switching of SLI type when changing the budgeting method.

Additionally, it reimplements the behavior from `shouldUnregister` in the pre- and postprocessing utilities for form values.


## ✅ Checklist
- When an Custom KQL SLO is toggled to APM Latency in the form, and then changing the budgeting method to a different value, the form should not switch back to Custom KQL
- The payload of the PUT operation when saving an SLO should no longer contain `objective.timesliceWindow` and `objective.timesliceTarget` when `budgetingMethod` is set to `occurences`.


<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->