### PR TITLE
[8.8] [Logs/APM] Get context menu items from triggers (#157131)

### DIFF
--- a/x-pack/plugins/apm/kibana.jsonc
+++ b/x-pack/plugins/apm/kibana.jsonc
@@ -26,7 +26,8 @@
       "advancedSettings",
       "unifiedFieldList",
       "lens",
-      "maps"
+      "maps",
+      "uiActions"
     ],
     "optionalPlugins": [
       "actions",

--- a/x-pack/plugins/apm/public/application/index.tsx
+++ b/x-pack/plugins/apm/public/application/index.tsx
@@ -54,6 +54,7 @@ export const renderApp = ({
     dataViews: pluginsStart.dataViews,
     unifiedSearch: pluginsStart.unifiedSearch,
     lens: pluginsStart.lens,
+    uiActions: pluginsStart.uiActions,
   };
 
   // render APM feedback link in global help menu

--- a/x-pack/plugins/apm/public/components/app/error_group_details/error_sampler/error_sample_detail.tsx
+++ b/x-pack/plugins/apm/public/components/app/error_group_details/error_sampler/error_sample_detail.tsx
@@ -6,26 +6,39 @@
  */
 
 import {
+  EuiBadge,
+  EuiEmptyPrompt,
   EuiFlexGroup,
   EuiFlexItem,
   EuiIcon,
   EuiLink,
+  EuiLoadingContent,
+  EuiPagination,
   EuiPanel,
   EuiSpacer,
   EuiTab,
   EuiTabs,
   EuiTitle,
   EuiToolTip,
-  EuiEmptyPrompt,
-  EuiPagination,
-  EuiLoadingContent,
-  EuiBadge,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import { euiStyled } from '@kbn/kibana-react-plugin/common';
+import { ObservabilityTriggerId } from '@kbn/observability-shared-plugin/common';
+import { getContextMenuItemsFromActions } from '@kbn/observability-shared-plugin/public';
 import { first } from 'lodash';
 import React, { useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
-import { euiStyled } from '@kbn/kibana-react-plugin/common';
+import useAsync from 'react-use/lib/useAsync';
+import { ERROR_GROUP_ID } from '../../../../../common/es_fields/apm';
+import { TraceSearchType } from '../../../../../common/trace_explorer';
+import { APMError } from '../../../../../typings/es_schemas/ui/apm_error';
+import { useApmPluginContext } from '../../../../context/apm_plugin/use_apm_plugin_context';
+import { useLegacyUrlParams } from '../../../../context/url_params_context/use_url_params';
+import { useApmParams } from '../../../../hooks/use_apm_params';
+import { useApmRouter } from '../../../../hooks/use_apm_router';
+import { FETCH_STATUS, isPending } from '../../../../hooks/use_fetcher';
+import { useTraceExplorerEnabledSetting } from '../../../../hooks/use_trace_explorer_enabled_setting';
+import { APIReturnType } from '../../../../services/rest/create_call_apm_api';
 import { TransactionDetailLink } from '../../../shared/links/apm/transaction_detail_link';
 import { DiscoverErrorLink } from '../../../shared/links/discover_links/discover_error_link';
 import { fromQuery, toQuery } from '../../../shared/links/url_helpers';
@@ -35,23 +48,15 @@ import { Summary } from '../../../shared/summary';
 import { HttpInfoSummaryItem } from '../../../shared/summary/http_info_summary_item';
 import { UserAgentSummaryItem } from '../../../shared/summary/user_agent_summary_item';
 import { TimestampTooltip } from '../../../shared/timestamp_tooltip';
+import { TransactionTab } from '../../transaction_details/waterfall_with_summary/transaction_tabs';
 import {
   ErrorTab,
   exceptionStacktraceTab,
   getTabs,
   logStacktraceTab,
 } from './error_tabs';
+import { ErrorUiActionsContextMenu } from './error_ui_actions_context_menu';
 import { ExceptionStacktrace } from './exception_stacktrace';
-import { useApmRouter } from '../../../../hooks/use_apm_router';
-import { useApmParams } from '../../../../hooks/use_apm_params';
-import { ERROR_GROUP_ID } from '../../../../../common/es_fields/apm';
-import { TraceSearchType } from '../../../../../common/trace_explorer';
-import { TransactionTab } from '../../transaction_details/waterfall_with_summary/transaction_tabs';
-import { useTraceExplorerEnabledSetting } from '../../../../hooks/use_trace_explorer_enabled_setting';
-import { FETCH_STATUS, isPending } from '../../../../hooks/use_fetcher';
-import { APMError } from '../../../../../typings/es_schemas/ui/apm_error';
-import { APIReturnType } from '../../../../services/rest/create_call_apm_api';
-import { useLegacyUrlParams } from '../../../../context/url_params_context/use_url_params';
 import { SampleSummary } from './sample_summary';
 
 const TransactionLinkName = euiStyled.div`
@@ -91,6 +96,8 @@ export function ErrorSampleDetails({
     urlParams: { detailTab, offset, comparisonEnabled },
   } = useLegacyUrlParams();
 
+  const { uiActions } = useApmPluginContext();
+
   const router = useApmRouter();
 
   const isTraceExplorerEnabled = useTraceExplorerEnabledSetting();
@@ -121,6 +128,17 @@ export function ErrorSampleDetails({
   };
 
   const { error, transaction } = errorData;
+
+  const externalContextMenuItems = useAsync(() => {
+    return getContextMenuItemsFromActions({
+      uiActions,
+      triggerId: ObservabilityTriggerId.ApmErrorContextMenu,
+      context: {
+        error,
+        transaction,
+      },
+    });
+  }, [error, transaction, uiActions]);
 
   if (!error && errorSampleIds?.length === 0 && isSucceded) {
     return (
@@ -207,6 +225,9 @@ export function ErrorSampleDetails({
             </EuiLink>
           </EuiFlexItem>
         )}
+        {externalContextMenuItems.value?.length ? (
+          <ErrorUiActionsContextMenu items={externalContextMenuItems.value} />
+        ) : undefined}
         <EuiFlexItem grow={false}>
           <DiscoverErrorLink error={error} kuery={kuery}>
             <EuiFlexGroup alignItems="center" gutterSize="s">

--- a/x-pack/plugins/apm/public/components/app/error_group_details/error_sampler/error_ui_actions_context_menu.tsx
+++ b/x-pack/plugins/apm/public/components/app/error_group_details/error_sampler/error_ui_actions_context_menu.tsx
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import {
+  EuiButton,
+  EuiContextMenu,
+  EuiContextMenuPanelItemDescriptor,
+  EuiPopover,
+} from '@elastic/eui';
+import React, { useState } from 'react';
+import { ObservabilityActionContextMenuItemProps } from '@kbn/observability-shared-plugin/public';
+import { i18n } from '@kbn/i18n';
+
+interface Props {
+  items: ObservabilityActionContextMenuItemProps[];
+}
+
+export function ErrorUiActionsContextMenu({ items }: Props) {
+  const [isContextMenuOpen, setIsContextMenuOpen] = useState(false);
+
+  return (
+    <EuiPopover
+      id="errorContextMenu"
+      button={
+        <EuiButton
+          data-test-subj="ErrorSampleDetailsButton"
+          onClick={() => setIsContextMenuOpen((isOpen) => !isOpen)}
+          iconType="arrowDown"
+          iconSide="right"
+        >
+          {i18n.translate('xpack.apm.errorSampleDetails.investigateMenu', {
+            defaultMessage: 'Investigate',
+          })}
+        </EuiButton>
+      }
+      isOpen={isContextMenuOpen}
+      closePopover={() => setIsContextMenuOpen(() => false)}
+      panelPaddingSize="none"
+      anchorPosition="downLeft"
+    >
+      <EuiContextMenu
+        initialPanelId="mainMenu"
+        panels={[
+          {
+            id: 'mainMenu',
+            items: items as EuiContextMenuPanelItemDescriptor[],
+          },
+        ]}
+      />
+    </EuiPopover>
+  );
+}

--- a/x-pack/plugins/apm/public/components/shared/transaction_action_menu/__snapshots__/transaction_action_menu.test.tsx.snap
+++ b/x-pack/plugins/apm/public/components/shared/transaction_action_menu/__snapshots__/transaction_action_menu.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`TransactionActionMenu component matches the snapshot 1`] = `
 <div>
   <div
-    class="euiPopover emotion-euiPopover"
+    class="euiPopover euiPopover-isOpen emotion-euiPopover"
     id="transactionActionMenu"
   >
     <div

--- a/x-pack/plugins/apm/public/components/shared/transaction_action_menu/sections_helper.ts
+++ b/x-pack/plugins/apm/public/components/shared/transaction_action_menu/sections_helper.ts
@@ -6,12 +6,13 @@
  */
 
 import { isEmpty } from 'lodash';
+import { MouseEvent } from 'react';
 
 export interface Action {
   key: string;
-  label: string;
+  label: React.ReactNode;
   href?: string;
-  onClick?: () => void;
+  onClick?: (event: MouseEvent) => void;
   condition: boolean;
 }
 

--- a/x-pack/plugins/apm/public/components/shared/transaction_action_menu/transaction_action_menu.test.tsx
+++ b/x-pack/plugins/apm/public/components/shared/transaction_action_menu/transaction_action_menu.test.tsx
@@ -66,7 +66,9 @@ const renderTransaction = async (transaction: Record<string, any>) => {
     }
   );
 
-  fireEvent.click(rendered.getByText('Investigate'));
+  await act(async () => {
+    fireEvent.click(rendered.getByText('Investigate'));
+  });
 
   return rendered;
 };
@@ -291,7 +293,7 @@ describe('TransactionActionMenu component', () => {
         { wrapper: Wrapper }
       );
     }
-    it('doesnt show custom links when license is not valid', () => {
+    it('doesnt show custom links when license is not valid', async () => {
       const license = new License({
         signature: 'test signature',
         license: {
@@ -303,12 +305,12 @@ describe('TransactionActionMenu component', () => {
         },
       });
       const component = renderTransactionActionMenuWithLicense(license);
-      act(() => {
+      await act(async () => {
         fireEvent.click(component.getByText('Investigate'));
       });
       expectTextsNotInDocument(component, ['Custom Links']);
     });
-    it('doesnt show custom links when basic license', () => {
+    it('doesnt show custom links when basic license', async () => {
       const license = new License({
         signature: 'test signature',
         license: {
@@ -328,12 +330,12 @@ describe('TransactionActionMenu component', () => {
         </LicenseContext.Provider>,
         { wrapper: Wrapper }
       );
-      act(() => {
+      await act(async () => {
         fireEvent.click(component.getByText('Investigate'));
       });
       expectTextsNotInDocument(component, ['Custom Links']);
     });
-    it('shows custom links when trial license', () => {
+    it('shows custom links when trial license', async () => {
       const license = new License({
         signature: 'test signature',
         license: {
@@ -345,12 +347,12 @@ describe('TransactionActionMenu component', () => {
         },
       });
       const component = renderTransactionActionMenuWithLicense(license);
-      act(() => {
+      await act(async () => {
         fireEvent.click(component.getByText('Investigate'));
       });
       expectTextsInDocument(component, ['Custom Links']);
     });
-    it('shows custom links when gold license', () => {
+    it('shows custom links when gold license', async () => {
       const license = new License({
         signature: 'test signature',
         license: {
@@ -362,12 +364,12 @@ describe('TransactionActionMenu component', () => {
         },
       });
       const component = renderTransactionActionMenuWithLicense(license);
-      act(() => {
+      await act(async () => {
         fireEvent.click(component.getByText('Investigate'));
       });
       expectTextsInDocument(component, ['Custom Links']);
     });
-    it('opens flyout with filters prefilled', () => {
+    it('opens flyout with filters prefilled', async () => {
       const license = new License({
         signature: 'test signature',
         license: {
@@ -379,11 +381,11 @@ describe('TransactionActionMenu component', () => {
         },
       });
       const component = renderTransactionActionMenuWithLicense(license);
-      act(() => {
+      await act(async () => {
         fireEvent.click(component.getByText('Investigate'));
       });
       expectTextsInDocument(component, ['Custom Links']);
-      act(() => {
+      await act(async () => {
         fireEvent.click(component.getByText('Create custom link'));
       });
       expectTextsInDocument(component, ['Create link']);

--- a/x-pack/plugins/apm/public/components/shared/transaction_action_menu/transaction_action_menu.tsx
+++ b/x-pack/plugins/apm/public/components/shared/transaction_action_menu/transaction_action_menu.tsx
@@ -7,8 +7,6 @@
 
 import { EuiButton } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import React, { useState } from 'react';
-import { useLocation } from 'react-router-dom';
 import {
   ActionMenu,
   ActionMenuDivider,
@@ -18,6 +16,11 @@ import {
   SectionSubtitle,
   SectionTitle,
 } from '@kbn/observability-plugin/public';
+import { ObservabilityTriggerId } from '@kbn/observability-shared-plugin/common';
+import { getContextMenuItemsFromActions } from '@kbn/observability-shared-plugin/public';
+import React, { useState } from 'react';
+import { useLocation } from 'react-router-dom';
+import useAsync from 'react-use/lib/useAsync';
 import { Transaction } from '../../../../typings/es_schemas/ui/transaction';
 import { useApmPluginContext } from '../../../context/apm_plugin/use_apm_plugin_context';
 import { useLicenseContext } from '../../../context/license/use_license_context';
@@ -84,7 +87,7 @@ export function TransactionActionMenu({ transaction, isLoading }: Props) {
 }
 
 function ActionMenuSections({ transaction }: { transaction?: Transaction }) {
-  const { core } = useApmPluginContext();
+  const { core, uiActions } = useApmPluginContext();
   const location = useLocation();
   const apmRouter = useApmRouter();
 
@@ -94,6 +97,33 @@ function ActionMenuSections({ transaction }: { transaction?: Transaction }) {
     location,
     apmRouter,
   });
+
+  const externalMenuItems = useAsync(() => {
+    return transaction
+      ? getContextMenuItemsFromActions({
+          uiActions,
+          triggerId: ObservabilityTriggerId.ApmTransactionContextMenu,
+          context: transaction,
+        })
+      : Promise.resolve([]);
+  }, [transaction, uiActions]);
+
+  if (externalMenuItems.value?.length) {
+    sections.push([
+      {
+        key: 'external',
+        actions: externalMenuItems.value.map((item, i) => {
+          return {
+            condition: true,
+            key: `external-${i}`,
+            label: item.children,
+            onClick: item.onClick,
+            href: item.href,
+          };
+        }),
+      },
+    ]);
+  }
 
   return (
     <div>
@@ -113,6 +143,7 @@ function ActionMenuSections({ transaction }: { transaction?: Transaction }) {
                       key={action.key}
                       label={action.label}
                       href={action.href}
+                      onClick={action.onClick}
                     />
                   ))}
                 </SectionLinks>

--- a/x-pack/plugins/apm/public/context/apm_plugin/apm_plugin_context.tsx
+++ b/x-pack/plugins/apm/public/context/apm_plugin/apm_plugin_context.tsx
@@ -14,6 +14,7 @@ import { Start as InspectorPluginStart } from '@kbn/inspector-plugin/public';
 import { DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
 import { UnifiedSearchPublicPluginStart } from '@kbn/unified-search-plugin/public';
 import { DataPublicPluginStart } from '@kbn/data-plugin/public';
+import { UiActionsStart } from '@kbn/ui-actions-plugin/public';
 import { ApmPluginSetupDeps } from '../../plugin';
 import { ConfigSchema } from '../..';
 
@@ -28,6 +29,7 @@ export interface ApmPluginContextValue {
   dataViews: DataViewsPublicPluginStart;
   data: DataPublicPluginStart;
   unifiedSearch: UnifiedSearchPublicPluginStart;
+  uiActions: UiActionsStart;
 }
 
 export const ApmPluginContext = createContext({} as ApmPluginContextValue);

--- a/x-pack/plugins/apm/public/context/apm_plugin/mock_apm_plugin_context.tsx
+++ b/x-pack/plugins/apm/public/context/apm_plugin/mock_apm_plugin_context.tsx
@@ -113,6 +113,9 @@ export const mockApmPluginContextValue = {
   corePlugins: mockCorePlugins,
   deps: {},
   unifiedSearch: mockUnifiedSearch,
+  uiActions: {
+    getTriggerCompatibleActions: () => Promise.resolve([]),
+  },
 };
 
 export function MockApmPluginContextWrapper({

--- a/x-pack/plugins/apm/public/plugin.ts
+++ b/x-pack/plugins/apm/public/plugin.ts
@@ -58,6 +58,8 @@ import { InfraClientStartExports } from '@kbn/infra-plugin/public';
 import { DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
 import { ChartsPluginStart } from '@kbn/charts-plugin/public';
 import { FieldFormatsStart } from '@kbn/field-formats-plugin/public';
+import { UiActionsStart, UiActionsSetup } from '@kbn/ui-actions-plugin/public';
+import { ObservabilityTriggerId } from '@kbn/observability-shared-plugin/common';
 import { registerApmRuleTypes } from './components/alerting/rule_types/register_apm_rule_types';
 import {
   getApmEnrollmentFlyoutData,
@@ -87,6 +89,7 @@ export interface ApmPluginSetupDeps {
   observabilityShared: ObservabilitySharedPluginSetup;
   triggersActionsUi: TriggersAndActionsUIPublicPluginSetup;
   share: SharePluginSetup;
+  uiActions: UiActionsSetup;
 }
 
 export interface ApmPluginStartDeps {
@@ -111,6 +114,7 @@ export interface ApmPluginStartDeps {
   unifiedSearch: UnifiedSearchPublicPluginStart;
   storage: IStorageWrapper;
   lens: LensPublicStart;
+  uiActions: UiActionsStart;
 }
 
 const servicesTitle = i18n.translate('xpack.apm.navigation.servicesTitle', {
@@ -266,6 +270,14 @@ export class ApmPlugin implements Plugin<ApmPluginSetup, ApmPluginStart> {
       'TutorialConfigAgentRumScript',
       () => import('./tutorial/config_agent/rum_script')
     );
+
+    pluginSetupDeps.uiActions.registerTrigger({
+      id: ObservabilityTriggerId.ApmTransactionContextMenu,
+    });
+
+    pluginSetupDeps.uiActions.registerTrigger({
+      id: ObservabilityTriggerId.ApmErrorContextMenu,
+    });
 
     plugins.observability.dashboard.register({
       appName: 'apm',

--- a/x-pack/plugins/apm/tsconfig.json
+++ b/x-pack/plugins/apm/tsconfig.json
@@ -85,6 +85,7 @@
     "@kbn/chart-icons",
     "@kbn/observability-shared-plugin",
     "@kbn/shared-ux-prompt-not-found",
+    "@kbn/ui-actions-plugin",
   ],
   "exclude": [
     "target/**/*",

--- a/x-pack/plugins/infra/kibana.jsonc
+++ b/x-pack/plugins/infra/kibana.jsonc
@@ -24,6 +24,7 @@
       "security",
       "share",
       "triggersActionsUi",
+      "uiActions",
       "unifiedSearch",
       "usageCollection",
       "visTypeTimeseries"

--- a/x-pack/plugins/infra/public/components/logging/log_text_stream/log_entry_context_menu.tsx
+++ b/x-pack/plugins/infra/public/components/logging/log_text_stream/log_entry_context_menu.tsx
@@ -13,6 +13,7 @@ import {
   EuiPopover,
   EuiContextMenuPanel,
   EuiContextMenuItem,
+  EuiContextMenuItemProps,
 } from '@elastic/eui';
 
 import { euiStyled } from '@kbn/kibana-react-plugin/common';
@@ -30,6 +31,7 @@ interface LogEntryContextMenuProps {
   onOpen: () => void;
   onClose: () => void;
   items: LogEntryContextMenuItem[];
+  externalItems?: EuiContextMenuItemProps[];
 }
 
 const DEFAULT_MENU_LABEL = i18n.translate(
@@ -45,12 +47,13 @@ export const LogEntryContextMenu: React.FC<LogEntryContextMenuProps> = ({
   onOpen,
   onClose,
   items,
+  externalItems,
 }) => {
   const closeMenuAndCall = useMemo(() => {
-    return (callback: LogEntryContextMenuItem['onClick']) => {
+    return (callback: LogEntryContextMenuItem['onClick'] | EuiContextMenuItemProps['onClick']) => {
       return (e: React.MouseEvent) => {
         onClose();
-        callback(e);
+        callback?.(e);
       };
     };
   }, [onClose]);
@@ -71,12 +74,22 @@ export const LogEntryContextMenu: React.FC<LogEntryContextMenuProps> = ({
   );
 
   const wrappedItems = useMemo(() => {
-    return items.map((item, i) => (
-      <EuiContextMenuItem key={i} onClick={closeMenuAndCall(item.onClick)} href={item.href}>
-        {item.label}
-      </EuiContextMenuItem>
-    ));
-  }, [items, closeMenuAndCall]);
+    return items
+      .map((item, i) => (
+        <EuiContextMenuItem key={i} onClick={closeMenuAndCall(item.onClick)} href={item.href}>
+          {item.label}
+        </EuiContextMenuItem>
+      ))
+      .concat(
+        (externalItems ?? []).map((item, i) => (
+          <EuiContextMenuItem
+            key={`external_${i}`}
+            {...item}
+            onClick={closeMenuAndCall(item.onClick)}
+          />
+        ))
+      );
+  }, [items, closeMenuAndCall, externalItems]);
 
   return (
     <LogEntryContextMenuContent>

--- a/x-pack/plugins/infra/public/plugin.ts
+++ b/x-pack/plugins/infra/public/plugin.ts
@@ -15,6 +15,7 @@ import {
 } from '@kbn/core/public';
 import { i18n } from '@kbn/i18n';
 import { enableInfrastructureHostsView } from '@kbn/observability-plugin/public';
+import { ObservabilityTriggerId } from '@kbn/observability-shared-plugin/common';
 import { BehaviorSubject, combineLatest, from } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { defaultLogViewsStaticConfig } from '../common/log_views';
@@ -64,6 +65,10 @@ export class Plugin implements InfraClientPluginClass {
     if (pluginsSetup.home) {
       registerFeatures(pluginsSetup.home);
     }
+
+    pluginsSetup.uiActions.registerTrigger({
+      id: ObservabilityTriggerId.LogEntryContextMenu,
+    });
 
     pluginsSetup.observability.observabilityRuleTypeRegistry.register(
       createInventoryMetricRuleType()

--- a/x-pack/plugins/infra/public/types.ts
+++ b/x-pack/plugins/infra/public/types.ts
@@ -38,6 +38,7 @@ import { LensPublicStart } from '@kbn/lens-plugin/public';
 import type { ChartsPluginStart } from '@kbn/charts-plugin/public';
 import { CasesUiStart } from '@kbn/cases-plugin/public';
 import { DiscoverStart } from '@kbn/discover-plugin/public';
+import { UiActionsSetup, UiActionsStart } from '@kbn/ui-actions-plugin/public';
 import type { UnwrapPromise } from '../common/utility_types';
 import type {
   SourceProviderProps,
@@ -70,6 +71,7 @@ export interface InfraClientSetupDeps {
   observability: ObservabilityPublicSetup;
   observabilityShared: ObservabilitySharedPluginSetup;
   triggersActionsUi: TriggersAndActionsUIPublicPluginSetup;
+  uiActions: UiActionsSetup;
   usageCollection: UsageCollectionSetup;
   ml: MlPluginSetup;
   embeddable: EmbeddableSetup;
@@ -93,6 +95,7 @@ export interface InfraClientStartDeps {
   spaces: SpacesPluginStart;
   storage: IStorageWrapper;
   triggersActionsUi: TriggersAndActionsUIPublicPluginStart;
+  uiActions: UiActionsStart;
   unifiedSearch: UnifiedSearchPublicPluginStart;
   usageCollection: UsageCollectionStart;
   telemetry: ITelemetryClient;

--- a/x-pack/plugins/observability_shared/common/index.ts
+++ b/x-pack/plugins/observability_shared/common/index.ts
@@ -122,3 +122,5 @@ export {
   PROFILE_INUSE_OBJECTS,
   PROFILE_INUSE_SPACE,
 } from './elasticsearch_fieldnames';
+
+export { ObservabilityTriggerId } from './trigger_ids';

--- a/x-pack/plugins/observability_shared/common/trigger_ids.ts
+++ b/x-pack/plugins/observability_shared/common/trigger_ids.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export enum ObservabilityTriggerId {
+  LogEntryContextMenu = 'logEntryContextMenu',
+  ApmTransactionContextMenu = 'apmTransactionContextMenu',
+  ApmErrorContextMenu = 'apmErrorContextMenu',
+}

--- a/x-pack/plugins/observability_shared/kibana.jsonc
+++ b/x-pack/plugins/observability_shared/kibana.jsonc
@@ -7,7 +7,7 @@
     "server": false,
     "browser": true,
     "configPath": ["xpack", "observability_shared"],
-    "requiredPlugins": ["cases", "guidedOnboarding"],
+    "requiredPlugins": ["cases", "guidedOnboarding", "uiActions"],
     "optionalPlugins": [],
     "requiredBundles": ["kibanaReact"],
     "extraPublicDirs": ["common"]

--- a/x-pack/plugins/observability_shared/public/index.ts
+++ b/x-pack/plugins/observability_shared/public/index.ts
@@ -19,6 +19,11 @@ export type {
 
 export type { NavigationEntry } from './components/page_template/page_template';
 
+export {
+  type ObservabilityActionContextMenuItemProps,
+  getContextMenuItemsFromActions,
+} from './services/get_context_menu_items_from_actions';
+
 export { useObservabilityTourContext } from './components/tour';
 
 export const plugin = () => {

--- a/x-pack/plugins/observability_shared/public/services/get_context_menu_items_from_actions.ts
+++ b/x-pack/plugins/observability_shared/public/services/get_context_menu_items_from_actions.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiContextMenuItemProps } from '@elastic/eui';
+import { buildContextMenuForActions, UiActionsStart } from '@kbn/ui-actions-plugin/public';
+import { ObservabilityTriggerId } from '../../common';
+
+export type ObservabilityActionContextMenuItemProps = EuiContextMenuItemProps & {
+  children: React.ReactElement;
+};
+
+export function getContextMenuItemsFromActions({
+  uiActions,
+  triggerId,
+  context,
+}: {
+  uiActions: UiActionsStart;
+  triggerId: ObservabilityTriggerId;
+  context: Record<string, any>;
+}): Promise<ObservabilityActionContextMenuItemProps[]> {
+  return uiActions
+    .getTriggerCompatibleActions(triggerId, context)
+    .then((actions) => {
+      return buildContextMenuForActions({
+        actions: actions.map((action) => ({
+          action,
+          trigger: {
+            id: triggerId,
+          },
+          context,
+        })),
+      });
+    })
+    .then((descriptors) => {
+      return descriptors
+        .flatMap((descriptor) => descriptor.items ?? [])
+        .map((item) => {
+          return {
+            ...item,
+            children: (item.children || item.name) as React.ReactNode,
+          } as ObservabilityActionContextMenuItemProps;
+        });
+    });
+}

--- a/x-pack/plugins/observability_shared/tsconfig.json
+++ b/x-pack/plugins/observability_shared/tsconfig.json
@@ -22,6 +22,7 @@
     "@kbn/shared-ux-page-kibana-template-mocks",
     "@kbn/analytics",
     "@kbn/usage-collection-plugin",
+    "@kbn/ui-actions-plugin",
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.8`:
 - [[Logs/APM] Get context menu items from triggers (#157131)](https://github.com/elastic/kibana/pull/157131)

<!--- Backport version: 7.3.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT {commits} BACKPORT-->