### PR TITLE
Return error from RQ useFetchList hook, have better error handling

### DIFF
--- a/x-pack/plugins/observability/public/pages/slos/slos.tsx
+++ b/x-pack/plugins/observability/public/pages/slos/slos.tsx
@@ -31,7 +31,7 @@ export function SlosPage() {
   const { hasWriteCapabilities } = useCapabilities();
   const { hasAtLeast } = useLicense();
 
-  const { isInitialLoading, isLoading, sloList } = useFetchSloList();
+  const { isInitialLoading, isLoading, isError, sloList } = useFetchSloList();
 
   const { total } = sloList || {};
 
@@ -46,6 +46,12 @@ export function SlosPage() {
     },
   ]);
 
+  useEffect(() => {
+    if ((!isLoading && total === 0) || hasAtLeast('platinum') === false || isError) {
+      navigateToUrl(basePath.prepend(paths.observability.slosWelcome));
+    }
+  }, [basePath, hasAtLeast, isError, isLoading, navigateToUrl, total]);
+
   const handleClickCreateSlo = () => {
     navigateToUrl(basePath.prepend(paths.observability.sloCreate));
   };
@@ -53,12 +59,6 @@ export function SlosPage() {
   const handleToggleAutoRefresh = () => {
     setIsAutoRefreshing(!isAutoRefreshing);
   };
-
-  useEffect(() => {
-    if ((!isLoading && total === 0) || hasAtLeast('platinum') === false) {
-      navigateToUrl(basePath.prepend(paths.observability.slosWelcome));
-    }
-  }, [basePath, hasAtLeast, isLoading, navigateToUrl, total]);
 
   if (isInitialLoading) {
     return null;


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/157316

## 📝 Summary

The `useFetchSloList` now returns an error when the API call fails. It also immediately stops retrying when the API returns a Forbidden error. In other cases, the hook will retry fetching 3 times before erroring out. 

## ✅ Checklist
- If user has no permissions, she should be redirected to the Welcome page without the screen flickering
- If the user has permissions but the API fails for another reason, the client should retry the API call 3 times before failing.


<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->