### PR TITLE
[SLO] Correctly wait for licensing promise to resolve on server

### DIFF
--- a/x-pack/plugins/observability/server/routes/slo/route.ts
+++ b/x-pack/plugins/observability/server/routes/slo/route.ts
@@ -48,7 +48,8 @@ const transformGenerators: Record<IndicatorTypes, TransformGenerator> = {
 };
 
 const isLicenseAtLeastPlatinum = async (context: ObservabilityRequestHandlerContext) => {
-  return (await context.licensing).license.hasAtLeast('platinum');
+  const licensing = await context.licensing;
+  return licensing.license.hasAtLeast('platinum');
 };
 
 const createSLORoute = createObservabilityServerRoute({
@@ -58,7 +59,9 @@ const createSLORoute = createObservabilityServerRoute({
   },
   params: createSLOParamsSchema,
   handler: async ({ context, params, logger }) => {
-    if (!isLicenseAtLeastPlatinum(context)) {
+    const hasCorrectLicense = await isLicenseAtLeastPlatinum(context);
+
+    if (!hasCorrectLicense) {
       throw badRequest('Platinum license or higher is needed to make use of this feature.');
     }
 
@@ -83,7 +86,9 @@ const updateSLORoute = createObservabilityServerRoute({
   },
   params: updateSLOParamsSchema,
   handler: async ({ context, params, logger }) => {
-    if (!isLicenseAtLeastPlatinum(context)) {
+    const hasCorrectLicense = await isLicenseAtLeastPlatinum(context);
+
+    if (!hasCorrectLicense) {
       throw badRequest('Platinum license or higher is needed to make use of this feature.');
     }
 
@@ -113,7 +118,9 @@ const deleteSLORoute = createObservabilityServerRoute({
     logger,
     dependencies: { getRulesClientWithRequest },
   }) => {
-    if (!isLicenseAtLeastPlatinum(context)) {
+    const hasCorrectLicense = await isLicenseAtLeastPlatinum(context);
+
+    if (!hasCorrectLicense) {
       throw badRequest('Platinum license or higher is needed to make use of this feature.');
     }
 
@@ -137,7 +144,9 @@ const getSLORoute = createObservabilityServerRoute({
   },
   params: getSLOParamsSchema,
   handler: async ({ context, params }) => {
-    if (!isLicenseAtLeastPlatinum(context)) {
+    const hasCorrectLicense = await isLicenseAtLeastPlatinum(context);
+
+    if (!hasCorrectLicense) {
       throw badRequest('Platinum license or higher is needed to make use of this feature.');
     }
 
@@ -160,7 +169,9 @@ const enableSLORoute = createObservabilityServerRoute({
   },
   params: manageSLOParamsSchema,
   handler: async ({ context, params, logger }) => {
-    if (!isLicenseAtLeastPlatinum(context)) {
+    const hasCorrectLicense = await isLicenseAtLeastPlatinum(context);
+
+    if (!hasCorrectLicense) {
       throw badRequest('Platinum license or higher is needed to make use of this feature.');
     }
 
@@ -184,7 +195,9 @@ const disableSLORoute = createObservabilityServerRoute({
   },
   params: manageSLOParamsSchema,
   handler: async ({ context, params, logger }) => {
-    if (!isLicenseAtLeastPlatinum(context)) {
+    const hasCorrectLicense = await isLicenseAtLeastPlatinum(context);
+
+    if (!hasCorrectLicense) {
       throw badRequest('Platinum license or higher is needed to make use of this feature.');
     }
 
@@ -208,7 +221,9 @@ const findSLORoute = createObservabilityServerRoute({
   },
   params: findSLOParamsSchema,
   handler: async ({ context, params }) => {
-    if (!isLicenseAtLeastPlatinum(context)) {
+    const hasCorrectLicense = await isLicenseAtLeastPlatinum(context);
+
+    if (!hasCorrectLicense) {
       throw badRequest('Platinum license or higher is needed to make use of this feature.');
     }
 
@@ -231,9 +246,12 @@ const fetchHistoricalSummary = createObservabilityServerRoute({
   },
   params: fetchHistoricalSummaryParamsSchema,
   handler: async ({ context, params }) => {
-    if (!isLicenseAtLeastPlatinum(context)) {
+    const hasCorrectLicense = await isLicenseAtLeastPlatinum(context);
+
+    if (!hasCorrectLicense) {
       throw badRequest('Platinum license or higher is needed to make use of this feature.');
     }
+
     const soClient = (await context.core).savedObjects.client;
     const esClient = (await context.core).elasticsearch.client.asCurrentUser;
     const repository = new KibanaSavedObjectsSLORepository(soClient);


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/157350

## 📝 Summary

This PR makes sure we correctly await the licensing function to determine whether the user has permission to access the SLO endpoints.

## ✅ Checklist
- When having a basic license, all CRUD SLO APIs (fetch SLO list, fetch SLO detail, create SLO, update SLO, delete SLO) should throw an error
- When having a platinum license, all CRUD SLO APIs should return data where appropriate 

<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->