### PR TITLE
[Fleet] update uninstall token index to ingest

### DIFF
--- a/x-pack/plugins/fleet/server/saved_objects/index.ts
+++ b/x-pack/plugins/fleet/server/saved_objects/index.ts
@@ -398,6 +398,7 @@ const getSavedObjectTypes = (): { [key: string]: SavedObjectsType } => ({
   },
   [UNINSTALL_TOKENS_SAVED_OBJECT_TYPE]: {
     name: UNINSTALL_TOKENS_SAVED_OBJECT_TYPE,
+    indexPattern: INGEST_SAVED_OBJECT_INDEX,
     hidden: true,
     namespaceType: 'agnostic',
     management: {


### PR DESCRIPTION
## Summary

moving uninstall token to `.kibana_ingest` index. see https://github.com/elastic/kibana/pull/154610#discussion_r1191319136.


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
