### PR TITLE
[DOCS] Removes coming tag from 8.8 release notes

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -45,8 +45,6 @@ Review important information about the {kib} 8.x releases.
 [[release-notes-8.8.0]]
 == {kib} 8.8.0
 
-coming::[8.8.0]
-
 Review the following information about the {kib} 8.8.0 release.
 
 [float]


### PR DESCRIPTION
## Summary

Removes `coming` tag from the 8.8 release notes.

<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->