### PR TITLE
[Synthetics] Indicate synthetics as new app in nav

### DIFF
--- a/x-pack/plugins/synthetics/public/plugin.ts
+++ b/x-pack/plugins/synthetics/public/plugin.ts
@@ -309,6 +309,7 @@ function registerUptimeRoutesWithNavigation(
                   path: OVERVIEW_ROUTE,
                   matchFullPath: false,
                   ignoreTrailingSlash: true,
+                  isNewFeature: true,
                 },
               ],
             },


### PR DESCRIPTION
## Summary

Indicate synthetics as new app in nav

<img width="1792" alt="image" src="https://github.com/elastic/kibana/assets/3505601/4b753288-ccb2-490a-970d-b6ce815daf0b">




<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->