### PR TITLE
[Serverless Search] Add API key creation

### DIFF
--- a/x-pack/plugins/serverless_search/common/doc_links.ts
+++ b/x-pack/plugins/serverless_search/common/doc_links.ts
@@ -17,6 +17,8 @@ class ESDocLinks {
   public jsBasicConfig: string = '';
   public jsClient: string = '';
   public logStash: string = '';
+  public metadata: string = '';
+  public roleDescriptors: string = '';
   public rubyAdvancedConfig: string = '';
   public rubyBasicConfig: string = '';
   public rubyClient: string = '';
@@ -31,6 +33,8 @@ class ESDocLinks {
     this.jsApiReference = newDocLinks.clients.jsApiReference;
     this.jsBasicConfig = newDocLinks.clients.jsBasicConfig;
     this.jsClient = newDocLinks.clients.jsIntro;
+    this.metadata = newDocLinks.security.mappingRoles;
+    this.roleDescriptors = newDocLinks.security.mappingRoles;
     this.rubyAdvancedConfig = newDocLinks.clients.rubyAdvancedConfig;
     this.rubyBasicConfig = newDocLinks.clients.rubyBasicConfig;
     this.rubyExamples = newDocLinks.clients.rubyExamples;

--- a/x-pack/plugins/serverless_search/common/i18n_string.ts
+++ b/x-pack/plugins/serverless_search/common/i18n_string.ts
@@ -10,3 +10,19 @@ import { i18n } from '@kbn/i18n';
 export const LEARN_MORE_LABEL = i18n.translate('xpack.serverlessSearch.learnMore', {
   defaultMessage: 'Learn more',
 });
+
+export const CANCEL_LABEL = i18n.translate('xpack.serverlessSearch.cancel', {
+  defaultMessage: 'Cancel',
+});
+
+export const BACK_LABEL = i18n.translate('xpack.serverlessSearch.back', {
+  defaultMessage: 'Back',
+});
+
+export const NEXT_LABEL = i18n.translate('xpack.serverlessSearch.next', {
+  defaultMessage: 'Next',
+});
+
+export const OPTIONAL_LABEL = i18n.translate('xpack.serverlessSearch.optional', {
+  defaultMessage: 'Optional',
+});

--- a/x-pack/plugins/serverless_search/kibana.jsonc
+++ b/x-pack/plugins/serverless_search/kibana.jsonc
@@ -14,8 +14,10 @@
     ],
     "requiredPlugins": [
       "serverless",
+      "cloud",
       "enterpriseSearch",
-      "management"
+      "management",
+      "security",
     ],
     "optionalPlugins": [],
     "requiredBundles": ["kibanaReact"]

--- a/x-pack/plugins/serverless_search/public/application/components/api_key/api_key.tsx
+++ b/x-pack/plugins/serverless_search/public/application/components/api_key/api_key.tsx
@@ -1,0 +1,195 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  EuiBadge,
+  EuiButton,
+  EuiCodeBlock,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiIcon,
+  EuiPanel,
+  EuiSpacer,
+  EuiSplitPanel,
+  EuiStep,
+  EuiText,
+  EuiThemeProvider,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { css } from '@emotion/react';
+import { ApiKey } from '@kbn/security-plugin/common';
+import { useQuery } from '@tanstack/react-query';
+import React, { useState } from 'react';
+import { useKibanaServices } from '../../hooks/use_kibana';
+import { CreateApiKeyFlyout } from './create_api_key_flyout';
+
+export const ApiKeyPanel: React.FC = () => {
+  const { cloud, http, userProfile } = useKibanaServices();
+  const [isFlyoutOpen, setIsFlyoutOpen] = useState(false);
+  const { data } = useQuery({
+    queryKey: ['apiKey'],
+    queryFn: () => http.fetch<{ apiKeys: ApiKey[] }>('/internal/serverless_search/api_keys'),
+  });
+  const [apiKey, setApiKey] = useState<ApiKey | undefined>(undefined);
+
+  return (
+    <>
+      {isFlyoutOpen && (
+        <CreateApiKeyFlyout
+          onClose={() => setIsFlyoutOpen(false)}
+          setApiKey={setApiKey}
+          username={userProfile.user.full_name || userProfile.user.username}
+        />
+      )}
+      {apiKey ? (
+        <EuiPanel color="success">
+          <EuiStep
+            css={css`
+              .euiStep__content {
+                padding-bottom: 0;
+              }
+            `}
+            status="complete"
+            headingElement="h3"
+            title={i18n.translate('xpack.serverlessSearch.apiKey.apiKeyStepTitle', {
+              defaultMessage: 'Store this API key',
+            })}
+            titleSize="xs"
+          >
+            <EuiText>
+              {i18n.translate('xpack.serverlessSearch.apiKey.apiKeyStepDescription', {
+                defaultMessage:
+                  "You'll only see this key once, so save it somewhere safe. We don't store your API keys, so if you lose a key you'll need to generate a replacement.",
+              })}
+            </EuiText>
+            <EuiSpacer size="s" />
+            <EuiCodeBlock isCopyable>{JSON.stringify(apiKey, undefined, 2)}</EuiCodeBlock>
+          </EuiStep>
+        </EuiPanel>
+      ) : (
+        <EuiPanel>
+          <EuiStep
+            css={css`
+              .euiStep__content {
+                padding-bottom: 0;
+              }
+            `}
+            status="incomplete"
+            headingElement="h3"
+            title={i18n.translate('xpack.serverlessSearch.apiKey.stepOneTitle', {
+              defaultMessage: 'Generate and store your API key',
+            })}
+            titleSize="xs"
+          >
+            <EuiText size="s">
+              {i18n.translate('xpack.serverlessSearch.apiKey.stepOneDescription', {
+                defaultMessage: 'Unique identifier for authentication and authorization. ',
+              })}
+            </EuiText>
+            <EuiSpacer size="l" />
+            <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
+              <EuiFlexItem>
+                <EuiFlexGroup>
+                  <EuiFlexItem>
+                    <span>
+                      <EuiButton
+                        iconType="plusInCircleFilled"
+                        size="s"
+                        fill
+                        onClick={() => setIsFlyoutOpen(true)}
+                      >
+                        <EuiText size="s">
+                          {i18n.translate('xpack.serverlessSearch.apiKey.newButtonLabel', {
+                            defaultMessage: 'New',
+                          })}
+                        </EuiText>
+                      </EuiButton>
+                    </span>
+                  </EuiFlexItem>
+                  <EuiFlexItem>
+                    <span>
+                      <EuiButton iconType="popout" size="s">
+                        {i18n.translate('xpack.serverlessSearch.apiKey.manageLabel', {
+                          defaultMessage: 'Manage',
+                        })}
+                      </EuiButton>
+                    </span>
+                  </EuiFlexItem>
+                </EuiFlexGroup>
+              </EuiFlexItem>
+              <EuiFlexItem>
+                {!!data?.apiKeys && (
+                  <EuiFlexGroup gutterSize="s" justifyContent="flexEnd" alignItems="center">
+                    <EuiFlexItem grow={false}>
+                      <EuiIcon size="s" type="iInCircle" color="subdued" />
+                    </EuiFlexItem>
+                    <EuiFlexItem grow={false}>
+                      <EuiText size="xs" color="subdued">
+                        <FormattedMessage
+                          id="xpack.serverlessSearch.apiKey.manageLabel"
+                          defaultMessage="You have {number} active keys."
+                          values={{
+                            number: (
+                              <EuiBadge color={data.apiKeys.length > 0 ? 'success' : 'warning'}>
+                                {data.apiKeys.length}
+                              </EuiBadge>
+                            ),
+                          }}
+                        />
+                      </EuiText>
+                    </EuiFlexItem>
+                  </EuiFlexGroup>
+                )}
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiStep>
+        </EuiPanel>
+      )}
+      <EuiSpacer />
+      <EuiSplitPanel.Outer>
+        <EuiSplitPanel.Inner>
+          <EuiStep
+            css={css`
+              .euiStep__content {
+                padding-bottom: 0;
+              }
+            `}
+            headingElement="h3"
+            step={2}
+            status="incomplete"
+            title={i18n.translate('xpack.serverlessSearch.apiKey.stepTwoTitle', {
+              defaultMessage: 'Store your unique Cloud ID',
+            })}
+            titleSize="xs"
+          >
+            <EuiText>
+              {i18n.translate('xpack.serverlessSearch.apiKey.stepTwoDescription', {
+                defaultMessage: 'Unique identifier for specific project. ',
+              })}
+            </EuiText>
+          </EuiStep>
+        </EuiSplitPanel.Inner>
+        <EuiThemeProvider colorMode="dark">
+          <EuiSplitPanel.Inner paddingSize="none">
+            <EuiCodeBlock
+              isCopyable
+              fontSize="m"
+              // Code block isn't respecting overflow in only this situation
+              css={css`
+                overflow-wrap: anywhere;
+              `}
+            >
+              {cloud.cloudId ||
+                'ProjectXDHS:dXMtd2VzdDIuZ2NwLmVsYXN0aWMtY2xvdWQuY29tJDEwMDYxN2IwMzM3ODRiYWJhODc5NzZiOTA0MTA3NGYwJDQ5ZWM'}
+            </EuiCodeBlock>
+          </EuiSplitPanel.Inner>
+        </EuiThemeProvider>
+      </EuiSplitPanel.Outer>
+    </>
+  );
+};

--- a/x-pack/plugins/serverless_search/public/application/components/api_key/basic_setup_form.tsx
+++ b/x-pack/plugins/serverless_search/public/application/components/api_key/basic_setup_form.tsx
@@ -1,0 +1,78 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiForm, EuiFieldText, EuiFormRow } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import React from 'react';
+
+interface BasicSetupFormProps {
+  isLoading: boolean;
+  name: string;
+  user: string;
+  expires: string;
+  onChangeName: (name: string) => void;
+  onChangeExpires: (expires: string) => void;
+}
+
+export const BasicSetupForm: React.FC<BasicSetupFormProps> = ({
+  isLoading,
+  name,
+  user,
+  expires,
+  onChangeName,
+  onChangeExpires,
+}) => {
+  return (
+    <EuiForm>
+      <EuiFormRow
+        isInvalid={!name}
+        helpText={i18n.translate('xpack.serverlessSearch.apiKey.nameFieldHelpText', {
+          defaultMessage: 'A good name makes it clear what your API key does.',
+        })}
+        label={i18n.translate('xpack.serverlessSearch.apiKey.nameFieldLabel', {
+          defaultMessage: 'Name',
+        })}
+      >
+        <EuiFieldText
+          isLoading={isLoading}
+          value={name}
+          onChange={(e) => onChangeName(e.currentTarget.value)}
+        />
+      </EuiFormRow>
+      <EuiFormRow
+        helpText={i18n.translate('xpack.serverlessSearch.apiKey.userFieldHelpText', {
+          defaultMessage: 'ID of the user creating the API key.',
+        })}
+        label={i18n.translate('xpack.serverlessSearch.apiKey.userFieldLabel', {
+          defaultMessage: 'User',
+        })}
+      >
+        <EuiFieldText
+          disabled={true}
+          placeholder="3058000678"
+          value={user}
+          onChange={(e) => onChangeName(e.currentTarget.value)}
+        />
+      </EuiFormRow>
+      <EuiFormRow
+        helpText={i18n.translate('xpack.serverlessSearch.apiKey.expiresFieldHelpText', {
+          defaultMessage: 'API keys should be rotated regularly.',
+        })}
+        label={i18n.translate('xpack.serverlessSearch.apiKey.expiresFieldLabel', {
+          defaultMessage: 'Expires',
+        })}
+      >
+        <EuiFieldText
+          disabled={isLoading}
+          placeholder="1d"
+          value={expires}
+          onChange={(e) => onChangeExpires(e.currentTarget.value)}
+        />
+      </EuiFormRow>
+    </EuiForm>
+  );
+};

--- a/x-pack/plugins/serverless_search/public/application/components/api_key/create_api_key_flyout.tsx
+++ b/x-pack/plugins/serverless_search/public/application/components/api_key/create_api_key_flyout.tsx
@@ -1,0 +1,235 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  EuiButton,
+  EuiButtonEmpty,
+  EuiCallOut,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFlyout,
+  EuiFlyoutBody,
+  EuiFlyoutFooter,
+  EuiFlyoutHeader,
+  EuiStepsHorizontal,
+  EuiTitle,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { ApiKey } from '@kbn/security-plugin/common';
+import { useMutation } from '@tanstack/react-query';
+import React, { useState } from 'react';
+import { BACK_LABEL, CANCEL_LABEL, NEXT_LABEL } from '../../../../common/i18n_string';
+import { useKibanaServices } from '../../hooks/use_kibana';
+import { BasicSetupForm } from './basic_setup_form';
+import { MetadataForm } from './metadata_form';
+import { SecurityPrivilegesForm } from './security_privileges_form';
+
+interface CreateApiKeyFlyoutProps {
+  onClose: () => void;
+  setApiKey: (apiKey: ApiKey) => void;
+  username: string;
+}
+
+enum Steps {
+  BASIC_SETUP,
+  PRIVILEGES,
+  METADATA,
+}
+
+function getNextStep(currentStep: Steps): Steps {
+  switch (currentStep) {
+    case Steps.BASIC_SETUP:
+      return Steps.PRIVILEGES;
+    case Steps.PRIVILEGES:
+      return Steps.METADATA;
+    case Steps.METADATA:
+      return Steps.METADATA;
+  }
+}
+
+function getPreviousStep(currentStep: Steps): Steps {
+  switch (currentStep) {
+    case Steps.BASIC_SETUP:
+      return Steps.BASIC_SETUP;
+    case Steps.PRIVILEGES:
+      return Steps.BASIC_SETUP;
+    case Steps.METADATA:
+      return Steps.PRIVILEGES;
+  }
+}
+
+const DEFAULT_ROLE_DESCRIPTORS = `{
+  "serverless_search": {
+    "indices": [{
+      "names": ["*"],
+      "privileges": [
+        "all"
+      ]
+    }]
+  }
+}`;
+const DEFAULT_METADATA = `{
+  "application": "myapp"
+}`;
+
+export const CreateApiKeyFlyout: React.FC<CreateApiKeyFlyoutProps> = ({
+  onClose,
+  username,
+  setApiKey,
+}) => {
+  const { http } = useKibanaServices();
+  const [currentStep, setCurrentStep] = useState<Steps>(Steps.BASIC_SETUP);
+  const [name, setName] = useState('');
+  const [expires, setExpires] = useState('60d');
+  const [roleDescriptors, setRoleDescriptors] = useState(DEFAULT_ROLE_DESCRIPTORS);
+  const [metadata, setMetadata] = useState(DEFAULT_METADATA);
+
+  const { isLoading, isError, error, data, mutate } = useMutation({
+    mutationFn: async (input: {
+      expiration: string;
+      name: string;
+      role_descriptors: string;
+      metadata: string;
+    }) => {
+      const result = await http.post<{ apiKey: ApiKey }>('/internal/serverless_search/api_keys', {
+        body: JSON.stringify(input),
+      });
+      return result;
+    },
+    onSuccess: ({ apiKey }) => {
+      setApiKey(apiKey);
+      onClose();
+    },
+  });
+  return (
+    <EuiFlyout onClose={onClose}>
+      <EuiFlyoutHeader hasBorder={true}>
+        <EuiTitle size="m">
+          <h2>
+            {i18n.translate('xpack.serverlessSearch.apiKey.flyoutTitle', {
+              defaultMessage: 'Create an API key',
+            })}
+          </h2>
+        </EuiTitle>
+      </EuiFlyoutHeader>
+      <EuiFlyoutBody>
+        {isError && (
+          <EuiCallOut
+            color="danger"
+            iconType="warning"
+            title={i18n.translate('xpack.serverlessSearch.apiKey.flyoutTitle', {
+              defaultMessage: 'Error creating API key',
+            })}
+          >
+            {JSON.stringify(error)}
+          </EuiCallOut>
+        )}
+        <EuiStepsHorizontal
+          steps={[
+            {
+              title: i18n.translate('xpack.serverlessSearch.apiKey.basicSetupLabel', {
+                defaultMessage: 'Basic Setup',
+              }),
+              status: currentStep === Steps.BASIC_SETUP ? 'current' : 'complete',
+              onClick: () => setCurrentStep(Steps.BASIC_SETUP),
+            },
+            {
+              title: i18n.translate('xpack.serverlessSearch.apiKey.privilegesLabel', {
+                defaultMessage: 'Privileges',
+              }),
+              status:
+                currentStep === Steps.PRIVILEGES
+                  ? 'current'
+                  : currentStep === Steps.METADATA
+                  ? 'complete'
+                  : 'incomplete',
+              onClick: () => setCurrentStep(Steps.PRIVILEGES),
+            },
+            {
+              title: i18n.translate('xpack.serverlessSearch.apiKey.metadataLabel', {
+                defaultMessage: 'Metadata',
+              }),
+              status: currentStep === Steps.METADATA ? 'current' : 'incomplete',
+              onClick: () => setCurrentStep(Steps.METADATA),
+            },
+          ]}
+        />
+        {currentStep === Steps.BASIC_SETUP && (
+          <BasicSetupForm
+            isLoading={isLoading}
+            name={name}
+            user={username}
+            expires={expires}
+            onChangeName={(newName: string) => setName(newName)}
+            onChangeExpires={(newExpires: string) => setExpires(newExpires)}
+          />
+        )}
+        {currentStep === Steps.PRIVILEGES && (
+          <SecurityPrivilegesForm
+            roleDescriptors={roleDescriptors}
+            onChangeRoleDescriptors={setRoleDescriptors}
+          />
+        )}
+        {currentStep === Steps.METADATA && (
+          <MetadataForm metadata={metadata} onChangeMetadata={setMetadata} />
+        )}
+      </EuiFlyoutBody>
+      <EuiFlyoutFooter>
+        <EuiFlexGroup justifyContent="spaceBetween">
+          <EuiFlexItem grow={false}>
+            <EuiButtonEmpty isDisabled={isLoading} onClick={onClose}>
+              {CANCEL_LABEL}
+            </EuiButtonEmpty>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiFlexGroup justifyContent="flexEnd">
+              {currentStep !== Steps.BASIC_SETUP && (
+                <EuiFlexItem>
+                  <EuiButtonEmpty
+                    iconType="sortLeft"
+                    isDisabled={isLoading}
+                    onClick={() => setCurrentStep(getPreviousStep(currentStep))}
+                  >
+                    {BACK_LABEL}
+                  </EuiButtonEmpty>
+                </EuiFlexItem>
+              )}
+              <EuiFlexItem>
+                {currentStep === Steps.METADATA ? (
+                  <EuiButton
+                    fill
+                    isLoading={isLoading}
+                    onClick={() =>
+                      mutate({
+                        expiration: expires,
+                        name,
+                        role_descriptors: roleDescriptors,
+                        metadata,
+                      })
+                    }
+                  >
+                    {i18n.translate('xpack.serverlessSearch.apiKey.flyOutCreateLabel', {
+                      defaultMessage: 'Create API Key',
+                    })}
+                  </EuiButton>
+                ) : (
+                  <EuiButton
+                    fill
+                    disabled={!name || !roleDescriptors}
+                    onClick={() => setCurrentStep(getNextStep(currentStep))}
+                  >
+                    {NEXT_LABEL}
+                  </EuiButton>
+                )}
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlyoutFooter>
+    </EuiFlyout>
+  );
+};

--- a/x-pack/plugins/serverless_search/public/application/components/api_key/metadata_form.tsx
+++ b/x-pack/plugins/serverless_search/public/application/components/api_key/metadata_form.tsx
@@ -1,0 +1,69 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  EuiBadge,
+  EuiTitle,
+  EuiFlexItem,
+  EuiFlexGroup,
+  EuiText,
+  EuiLink,
+  EuiSpacer,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { CodeEditorField } from '@kbn/kibana-react-plugin/public';
+import React from 'react';
+import { docLinks } from '../../../../common/doc_links';
+import { OPTIONAL_LABEL } from '../../../../common/i18n_string';
+
+interface MetadataFormProps {
+  metadata: string;
+  onChangeMetadata: (metadata: string) => void;
+}
+
+export const MetadataForm: React.FC<MetadataFormProps> = ({ metadata, onChangeMetadata }) => {
+  return (
+    <>
+      <EuiFlexGroup>
+        <EuiFlexItem grow={false}>
+          <EuiTitle size="xs">
+            <h3>
+              {i18n.translate('xpack.serverlessSearch.apiKey.metadataTitle', {
+                defaultMessage: 'Add Metadata',
+              })}
+            </h3>
+          </EuiTitle>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiBadge>{OPTIONAL_LABEL}</EuiBadge>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+      <EuiSpacer />
+      <EuiText>
+        {i18n.translate('xpack.serverlessSearch.apiKey.metadataDescription', {
+          defaultMessage:
+            'Use configurable key-value pairs to add information about the API key or customize Elasticsearch resource access.',
+        })}
+      </EuiText>
+      <EuiSpacer />
+      <EuiLink href={docLinks.metadata} target="_blank">
+        {i18n.translate('xpack.serverlessSearch.apiKey.metadataLinkLabel', {
+          defaultMessage: 'Learn how to structure role metadata',
+        })}
+      </EuiLink>
+      <EuiSpacer />
+      <CodeEditorField
+        allowFullScreen
+        height="600px"
+        languageId="json"
+        isCopyable
+        onChange={(e) => onChangeMetadata(e)}
+        value={metadata}
+      />
+    </>
+  );
+};

--- a/x-pack/plugins/serverless_search/public/application/components/api_key/security_privileges_form.tsx
+++ b/x-pack/plugins/serverless_search/public/application/components/api_key/security_privileges_form.tsx
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  EuiBadge,
+  EuiTitle,
+  EuiFlexItem,
+  EuiFlexGroup,
+  EuiText,
+  EuiLink,
+  EuiSpacer,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { CodeEditorField } from '@kbn/kibana-react-plugin/public';
+import React from 'react';
+import { docLinks } from '../../../../common/doc_links';
+import { OPTIONAL_LABEL } from '../../../../common/i18n_string';
+
+interface SecurityPrivilegesFormProps {
+  roleDescriptors: string;
+  onChangeRoleDescriptors: (roleDescriptors: string) => void;
+}
+
+export const SecurityPrivilegesForm: React.FC<SecurityPrivilegesFormProps> = ({
+  roleDescriptors,
+  onChangeRoleDescriptors,
+}) => {
+  return (
+    <>
+      <EuiFlexGroup>
+        <EuiFlexItem grow={false}>
+          <EuiTitle size="xs">
+            <h3>
+              {i18n.translate('xpack.serverlessSearch.apiKey.privilegesTitle', {
+                defaultMessage: 'Set up security privileges',
+              })}
+            </h3>
+          </EuiTitle>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiBadge>{OPTIONAL_LABEL}</EuiBadge>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+      <EuiSpacer />
+      <EuiText>
+        {i18n.translate('xpack.serverlessSearch.apiKey.privilegesDescription', {
+          defaultMessage:
+            'Control access to specific Elasticsearch APIs and resources using predefined roles or custom privileges per API key.',
+        })}
+      </EuiText>
+      <EuiSpacer />
+      <EuiLink href={docLinks.roleDescriptors} target="_blank">
+        {i18n.translate('xpack.serverlessSearch.apiKey.roleDescriptorsLinkLabel', {
+          defaultMessage: 'Learn how to structure role descriptors',
+        })}
+      </EuiLink>
+      <EuiSpacer />
+      <CodeEditorField
+        allowFullScreen
+        height="600px"
+        languageId="json"
+        isCopyable
+        onChange={(e) => onChangeRoleDescriptors(e)}
+        value={roleDescriptors}
+      />
+    </>
+  );
+};

--- a/x-pack/plugins/serverless_search/public/application/components/overview.scss
+++ b/x-pack/plugins/serverless_search/public/application/components/overview.scss
@@ -1,10 +1,5 @@
-.serverlessSearchHeaderTitle {
-  color: $euiColorEmptyShade;
-}
-
 .serverlessSearchHeaderSection {
   background-color: $euiColorPrimary;
-  color: $euiColorEmptyShade;
 }
 
 .serverlessSearchHeaderSection > div {

--- a/x-pack/plugins/serverless_search/public/application/components/overview.tsx
+++ b/x-pack/plugins/serverless_search/public/application/components/overview.tsx
@@ -16,6 +16,7 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React, { useState } from 'react';
+import { docLinks } from '../../../common/doc_links';
 import { PLUGIN_ID } from '../../../common';
 import { useKibanaServices } from '../hooks/use_kibana';
 import { CodeBox } from './code_box';
@@ -26,50 +27,83 @@ import { InstallClientPanel } from './overview_panels/install_client';
 import { OverviewPanel } from './overview_panels/overview_panel';
 import './overview.scss';
 import { IngestData } from './overview_panels/ingest_data';
+import { ApiKeyPanel } from './api_key/api_key';
 
 export const ElasticsearchOverview = () => {
   const [selectedLanguage, setSelectedLanguage] =
     useState<LanguageDefinition>(javascriptDefinition);
-  const { http } = useKibanaServices();
+  const { http, userProfile } = useKibanaServices();
 
   return (
     <EuiPageTemplate offset={0} grow restrictWidth>
       <EuiPageTemplate.Section alignment="top" className="serverlessSearchHeaderSection">
-        <EuiFlexGroup justifyContent="spaceBetween">
-          <EuiFlexItem grow={false}>
-            <EuiFlexGroup justifyContent="flexEnd" direction="column" gutterSize="l">
-              <EuiFlexItem grow={false}>
-                <EuiTitle className="serverlessSearchHeaderTitle" size="l">
-                  <h1>
-                    {i18n.translate('xpack.serverlessSearch.header.title', {
-                      defaultMessage: 'Get started with Elasticsearch',
-                    })}
-                  </h1>
-                </EuiTitle>
-              </EuiFlexItem>
-              <EuiFlexItem grow={false}>
-                <EuiText>
-                  {i18n.translate('xpack.serverlessSearch.header.description', {
-                    defaultMessage:
-                      "Set up your programming language client, ingest some data, and you'll be ready to start searching within minutes.",
-                  })}
-                </EuiText>
-                <EuiSpacer size="xxl" />
-              </EuiFlexItem>
-            </EuiFlexGroup>
-          </EuiFlexItem>
+        <EuiText color="ghost">
+          <EuiFlexGroup justifyContent="spaceBetween">
+            <EuiFlexItem grow={false}>
+              {/* Reversing column direction here so screenreaders keep h1 as the first element */}
+              <EuiFlexGroup justifyContent="flexStart" direction="columnReverse" gutterSize="s">
+                <EuiFlexItem grow={false}>
+                  <EuiTitle className="serverlessSearchHeaderTitle" size="s">
+                    <h1>
+                      {i18n.translate('xpack.serverlessSearch.header.title', {
+                        defaultMessage: 'Get started with Elasticsearch',
+                      })}
+                    </h1>
+                  </EuiTitle>
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                  <EuiTitle size="xxxs">
+                    <h2>
+                      {i18n.translate('xpack.serverlessSearch.header.title', {
+                        defaultMessage: 'Hi {name}!',
+                        values: { name: userProfile.user.full_name || userProfile.user.username },
+                      })}
+                    </h2>
+                  </EuiTitle>
+                </EuiFlexItem>
+              </EuiFlexGroup>
+              <EuiSpacer />
+              <EuiText>
+                {i18n.translate('xpack.serverlessSearch.header.description', {
+                  defaultMessage:
+                    "Set up your programming language client, ingest some data, and you'll be ready to start searching within minutes.",
+                })}
+              </EuiText>
+              <EuiSpacer size="xxl" />
+            </EuiFlexItem>
 
-          <EuiFlexItem grow={false}>
-            <EuiImage
-              alt=""
-              src={http.basePath.prepend(`/plugins/${PLUGIN_ID}/assets/serverless_header.png`)}
-              size="554px"
-            />
-          </EuiFlexItem>
-        </EuiFlexGroup>
+            <EuiFlexItem grow={false}>
+              <EuiImage
+                alt=""
+                src={http.basePath.prepend(`/plugins/${PLUGIN_ID}/assets/serverless_header.png`)}
+                size="554px"
+              />
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiText>
       </EuiPageTemplate.Section>
       <EuiPageTemplate.Section color="subdued" bottomBorder="extended">
         <InstallClientPanel language={selectedLanguage} setSelectedLanguage={setSelectedLanguage} />
+      </EuiPageTemplate.Section>
+      <EuiPageTemplate.Section color="subdued" bottomBorder="extended">
+        <OverviewPanel
+          description={i18n.translate('xpack.serverlessSearch.apiKey.description', {
+            defaultMessage:
+              "You'll need these unique identifiers to securely connect to your Elasticsearch project.",
+          })}
+          leftPanelContent={<ApiKeyPanel />}
+          links={[
+            {
+              href: docLinks.securityApis,
+              label: i18n.translate('xpack.serverlessSearch.configureClient.basicConfigLabel', {
+                defaultMessage: 'Basic configuration',
+              }),
+            },
+          ]}
+          title={i18n.translate('xpack.serverlessSearch.apiKey.title', {
+            defaultMessage: 'Store your API key and Cloud ID',
+          })}
+        />
       </EuiPageTemplate.Section>
       <EuiPageTemplate.Section color="subdued" bottomBorder="extended">
         <OverviewPanel

--- a/x-pack/plugins/serverless_search/public/application/components/overview_panels/overview_panel.tsx
+++ b/x-pack/plugins/serverless_search/public/application/components/overview_panels/overview_panel.tsx
@@ -35,8 +35,8 @@ export const OverviewPanel: React.FC<OverviewPanelProps> = ({
     <>
       <EuiSpacer size="xxl" />
       <EuiFlexGroup alignItems="center">
-        <EuiFlexItem grow={3}>{leftPanelContent}</EuiFlexItem>
-        <EuiFlexItem grow={2}>
+        <EuiFlexItem grow={6}>{leftPanelContent}</EuiFlexItem>
+        <EuiFlexItem grow={4}>
           <EuiPanel color="subdued">
             <EuiTitle>
               <h2>{title}</h2>

--- a/x-pack/plugins/serverless_search/public/application/context.ts
+++ b/x-pack/plugins/serverless_search/public/application/context.ts
@@ -4,9 +4,12 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+import { HttpStart } from '@kbn/core-http-browser';
 import React, { useContext } from 'react';
 
-export const ServerlessSearchContext = React.createContext<{} | undefined>(undefined);
+export const ServerlessSearchContext = React.createContext<{ http: HttpStart } | undefined>(
+  undefined
+);
 
 export const useServerlessSearchContext = () => {
   return useContext(ServerlessSearchContext);

--- a/x-pack/plugins/serverless_search/public/application/hooks/use_kibana.tsx
+++ b/x-pack/plugins/serverless_search/public/application/hooks/use_kibana.tsx
@@ -5,9 +5,16 @@
  * 2.0.
  */
 
+import { CloudStart } from '@kbn/cloud-plugin/public';
 import type { CoreStart } from '@kbn/core/public';
 import { useKibana as useKibanaBase } from '@kbn/kibana-react-plugin/public';
+import { GetUserProfileResponse, UserProfileData } from '@kbn/security-plugin/common';
 
-type ServerlessSearchKibanaContext = CoreStart;
+export interface ServerlessSearchContext {
+  cloud: CloudStart;
+  userProfile: GetUserProfileResponse<UserProfileData>;
+}
+
+type ServerlessSearchKibanaContext = CoreStart & ServerlessSearchContext;
 
 export const useKibanaServices = () => useKibanaBase<ServerlessSearchKibanaContext>().services;

--- a/x-pack/plugins/serverless_search/public/application/index.tsx
+++ b/x-pack/plugins/serverless_search/public/application/index.tsx
@@ -10,15 +10,26 @@ import ReactDOM from 'react-dom';
 import { CoreStart } from '@kbn/core/public';
 import { KibanaContextProvider, KibanaThemeProvider } from '@kbn/kibana-react-plugin/public';
 import { I18nProvider } from '@kbn/i18n-react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import { ServerlessSearchContext } from './hooks/use_kibana';
 
-export async function renderApp(element: HTMLElement, core: CoreStart) {
+export async function renderApp(
+  element: HTMLElement,
+  core: CoreStart,
+  { cloud, userProfile }: ServerlessSearchContext
+) {
   const { ElasticsearchOverview } = await import('./components/overview');
+  const queryClient = new QueryClient();
   ReactDOM.render(
     <KibanaThemeProvider theme$={core.theme.theme$}>
-      <KibanaContextProvider services={core}>
-        <I18nProvider>
-          <ElasticsearchOverview />
-        </I18nProvider>
+      <KibanaContextProvider services={{ ...core, cloud, userProfile }}>
+        <QueryClientProvider client={queryClient}>
+          <ReactQueryDevtools initialIsOpen={false} />
+          <I18nProvider>
+            <ElasticsearchOverview />
+          </I18nProvider>
+        </QueryClientProvider>
       </KibanaContextProvider>
     </KibanaThemeProvider>,
     element

--- a/x-pack/plugins/serverless_search/public/plugin.ts
+++ b/x-pack/plugins/serverless_search/public/plugin.ts
@@ -16,10 +16,16 @@ import {
 } from './types';
 
 export class ServerlessSearchPlugin
-  implements Plugin<ServerlessSearchPluginSetup, ServerlessSearchPluginStart>
+  implements
+    Plugin<
+      ServerlessSearchPluginSetup,
+      ServerlessSearchPluginStart,
+      ServerlessSearchPluginSetupDependencies,
+      ServerlessSearchPluginStartDependencies
+    >
 {
   public setup(
-    core: CoreSetup,
+    core: CoreSetup<ServerlessSearchPluginStartDependencies, ServerlessSearchPluginStart>,
     _setupDeps: ServerlessSearchPluginSetupDependencies
   ): ServerlessSearchPluginSetup {
     core.application.register({
@@ -28,10 +34,12 @@ export class ServerlessSearchPlugin
       appRoute: '/app/elasticsearch',
       async mount({ element }: AppMountParameters) {
         const { renderApp } = await import('./application');
-        const [coreStart] = await core.getStartServices();
+        const [coreStart, { cloud, security }] = await core.getStartServices();
         docLinks.setDocLinks(coreStart.docLinks.links);
 
-        return await renderApp(element, coreStart);
+        const userProfile = await security.userProfiles.getCurrent();
+
+        return await renderApp(element, coreStart, { cloud, userProfile });
       },
     });
     return {};

--- a/x-pack/plugins/serverless_search/public/types.ts
+++ b/x-pack/plugins/serverless_search/public/types.ts
@@ -10,6 +10,8 @@ import {
   EnterpriseSearchPublicSetup,
   EnterpriseSearchPublicStart,
 } from '@kbn/enterprise-search-plugin/public';
+import { CloudSetup, CloudStart } from '@kbn/cloud-plugin/public';
+import { SecurityPluginStart } from '@kbn/security-plugin/public';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface ServerlessSearchPluginSetup {}
@@ -18,11 +20,14 @@ export interface ServerlessSearchPluginSetup {}
 export interface ServerlessSearchPluginStart {}
 
 export interface ServerlessSearchPluginSetupDependencies {
+  cloud: CloudSetup;
   enterpriseSearch: EnterpriseSearchPublicSetup;
   management: ManagementSetup;
 }
 
 export interface ServerlessSearchPluginStartDependencies {
+  cloud: CloudStart;
   enterpriseSearch: EnterpriseSearchPublicStart;
   management: ManagementStart;
+  security: SecurityPluginStart;
 }

--- a/x-pack/plugins/serverless_search/server/plugin.ts
+++ b/x-pack/plugins/serverless_search/server/plugin.ts
@@ -5,16 +5,41 @@
  * 2.0.
  */
 
-import { PluginInitializerContext, Plugin } from '@kbn/core/server';
+import { IRouter, Logger, PluginInitializerContext, Plugin, CoreSetup } from '@kbn/core/server';
+import { SecurityPluginStart } from '@kbn/security-plugin/server';
+import { registerApiKeyRoutes } from './routes/api_key_routes';
 
 import { ServerlessSearchPluginSetup, ServerlessSearchPluginStart } from './types';
+
+interface StartDependencies {
+  security: SecurityPluginStart;
+}
+export interface RouteDependencies {
+  logger: Logger;
+  router: IRouter;
+  security: SecurityPluginStart;
+}
 
 export class ServerlessSearchPlugin
   implements Plugin<ServerlessSearchPluginSetup, ServerlessSearchPluginStart>
 {
-  constructor(_initializerContext: PluginInitializerContext) {}
+  private readonly config: {};
+  private readonly logger: Logger;
+  private security?: SecurityPluginStart;
 
-  public setup() {
+  constructor(initializerContext: PluginInitializerContext) {
+    this.config = initializerContext.config.get<{}>();
+    this.logger = initializerContext.logger.get();
+  }
+
+  public setup({ getStartServices, http }: CoreSetup<StartDependencies>) {
+    const router = http.createRouter();
+    getStartServices().then(([, { security }]) => {
+      this.security = security;
+      const dependencies = { logger: this.logger, router, security: this.security };
+
+      registerApiKeyRoutes(dependencies);
+    });
     return {};
   }
 

--- a/x-pack/plugins/serverless_search/server/routes/api_key_routes.ts
+++ b/x-pack/plugins/serverless_search/server/routes/api_key_routes.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+import { RouteDependencies } from '../plugin';
+
+export const registerApiKeyRoutes = ({ logger, router, security }: RouteDependencies) => {
+  router.get(
+    {
+      path: '/internal/serverless_search/api_keys',
+      validate: {},
+    },
+    async (context, request, response) => {
+      const { client } = (await context.core).elasticsearch;
+      const user = security.authc.getCurrentUser(request);
+      if (user) {
+        const apiKeys = await client.asCurrentUser.security.getApiKey({ username: user.username });
+        return response.ok({ body: { apiKeys: apiKeys.api_keys } });
+      }
+      return response.customError({
+        statusCode: 502,
+        body: 'Could not retrieve current user, security plugin is not ready',
+      });
+    }
+  );
+  router.post(
+    {
+      path: '/internal/serverless_search/api_keys',
+      validate: {
+        body: schema.object({
+          expiration: schema.maybe(schema.string()),
+          metadata: schema.maybe(schema.recordOf(schema.string(), schema.any())),
+          name: schema.string(),
+          role_descriptors: schema.recordOf(schema.string(), schema.any()),
+        }),
+      },
+    },
+    async (context, request, response) => {
+      const { client } = (await context.core).elasticsearch;
+      const { name, expiration, role_descriptors: roleDescriptors, metadata } = request.body;
+      const apiKey = await client.asCurrentUser.security.createApiKey({
+        expiration,
+        name,
+        role_descriptors: roleDescriptors,
+        metadata,
+      });
+      return response.ok({ body: { apiKey } });
+    }
+  );
+};

--- a/x-pack/plugins/serverless_search/tsconfig.json
+++ b/x-pack/plugins/serverless_search/tsconfig.json
@@ -24,5 +24,8 @@
     "@kbn/i18n",
     "@kbn/kibana-react-plugin",
     "@kbn/i18n-react",
+    "@kbn/security-plugin",
+    "@kbn/core-http-browser",
+    "@kbn/cloud-plugin",
   ]
 }


### PR DESCRIPTION
## Summary

This adds the API key creation flow to the Serverless Search plugin. 




https://github.com/elastic/kibana/assets/94373878/f174c5ba-ddf4-48eb-9036-22fc2371d25c

Still TODO:

- Minor styling improvements
- Error message (we're not catching errors or returning them nicely, so any Elasticsearch-side errors just disappear--including info about why your role descriptor was invalid). 
- Form invalidation