### PR TITLE
[Serverless Search] update codeowner for serverless-search

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -578,7 +578,7 @@ packages/kbn-server-route-repository @elastic/apm-ui
 x-pack/plugins/serverless @elastic/appex-sharedux
 x-pack/plugins/serverless_observability @elastic/appex-sharedux
 packages/serverless/project_switcher @elastic/appex-sharedux
-x-pack/plugins/serverless_search @elastic/appex-sharedux
+x-pack/plugins/serverless_search @elastic/enterprise-search-frontend
 x-pack/plugins/serverless_security @elastic/security-solution
 packages/serverless/storybook/config @elastic/appex-sharedux
 packages/serverless/types @elastic/appex-sharedux

--- a/x-pack/plugins/serverless_search/kibana.jsonc
+++ b/x-pack/plugins/serverless_search/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "plugin",
   "id": "@kbn/serverless-search",
-  "owner": "@elastic/appex-sharedux",
+  "owner": "@elastic/enterprise-search-frontend",
   "description": "Serverless customizations for search.",
   "plugin": {
     "id": "serverlessSearch",


### PR DESCRIPTION
## Summary

Updated the code owner entry for `x-pack/plugins/serverless_search` from `@elastic/appex-sharedux` to `@elastic/enterprise-search-frontend`

The Enterprise Search team will be owning the development of the serverless search solution and we will need to be the ones reviewing PRs within the team.