### PR TITLE
[TIP] refactor and improve Cypress tests

### DIFF
--- a/x-pack/plugins/threat_intelligence/cypress/e2e/block_list.cy.ts
+++ b/x-pack/plugins/threat_intelligence/cypress/e2e/block_list.cy.ts
@@ -6,42 +6,38 @@
  */
 
 import {
-  BLOCK_LIST_ADD_BUTTON,
-  BLOCK_LIST_DESCRIPTION,
-  BLOCK_LIST_FLYOUT_CLOSE_BUTTON,
-  BLOCK_LIST_NAME,
-  BLOCK_LIST_TOAST_LIST,
-  BLOCK_LIST_VALUE_INPUT,
-  FLYOUT_ADD_TO_BLOCK_LIST_ITEM,
-  FLYOUT_TAKE_ACTION_BUTTON,
-  INDICATORS_TABLE_ADD_TO_BLOCK_LIST_BUTTON_ICON,
-  INDICATORS_TABLE_MORE_ACTION_BUTTON_ICON,
-  TOGGLE_FLYOUT_BUTTON,
-} from '../screens/indicators';
+  closeFlyout,
+  openFlyout,
+  openFlyoutTakeAction,
+  openIndicatorsTableMoreActions,
+} from '../tasks/common';
+import {
+  deleteBlocklistEntry,
+  fillBlocklistForm,
+  openAddToBlockListFlyoutFromTable,
+  openAddToBlocklistFromFlyout,
+} from '../tasks/blocklist';
+import { navigateToBlocklist, navigateToThreatIntelligence } from '../tasks/common';
 import { login } from '../tasks/login';
 import { esArchiverLoad, esArchiverUnload } from '../tasks/es_archiver';
 import { selectRange } from '../tasks/select_range';
+import {
+  BLOCK_LIST_VALUE_INPUT,
+  FLYOUT_ADD_TO_BLOCK_LIST_ITEM,
+  INDICATORS_TABLE_ADD_TO_BLOCK_LIST_BUTTON_ICON,
+  SAVED_BLOCK_LIST_DESCRIPTION,
+  SAVED_BLOCK_LIST_NAME,
+} from '../screens/blocklist';
 
 const THREAT_INTELLIGENCE = '/app/security/threat_intelligence/indicators';
 
 const BLOCK_LIST_NEW_NAME = 'new blocklist entry';
+const BLOCK_LIST_NEW_DESCRIPTION = 'the best description';
 
-const fillBlocklistForm = () => {
-  cy.get(BLOCK_LIST_NAME).type(BLOCK_LIST_NEW_NAME);
-  cy.get(BLOCK_LIST_DESCRIPTION).type('the best description');
-  cy.get(BLOCK_LIST_ADD_BUTTON).last().click();
-
-  const text: string = `"${BLOCK_LIST_NEW_NAME}" has been added`;
-  cy.get(BLOCK_LIST_TOAST_LIST).should('exist').and('contain.text', text);
-};
-
-describe('Block list with invalid indicators', () => {
+describe('Block list with invalid indicators', { testIsolation: false }, () => {
   before(() => {
     esArchiverLoad('threat_intelligence/invalid_indicators_data');
     login();
-  });
-
-  beforeEach(() => {
     cy.visit(THREAT_INTELLIGENCE);
     selectRange();
   });
@@ -51,24 +47,21 @@ describe('Block list with invalid indicators', () => {
   });
 
   it('should disabled the indicators table context menu item if invalid indicator', () => {
-    cy.get(INDICATORS_TABLE_MORE_ACTION_BUTTON_ICON).eq(3).click();
+    openIndicatorsTableMoreActions(3);
     cy.get(INDICATORS_TABLE_ADD_TO_BLOCK_LIST_BUTTON_ICON).should('be.disabled');
   });
 
   it('should disable the flyout context menu items if invalid indicator', () => {
-    cy.get(TOGGLE_FLYOUT_BUTTON).eq(3).click({ force: true });
-    cy.get(FLYOUT_TAKE_ACTION_BUTTON).first().click();
+    openFlyout(3);
+    openFlyoutTakeAction();
     cy.get(FLYOUT_ADD_TO_BLOCK_LIST_ITEM).should('be.disabled');
   });
 });
 
-describe('Block list interactions', () => {
+describe('Block list interactions', { testIsolation: false }, () => {
   before(() => {
     esArchiverLoad('threat_intelligence/indicators_data');
     login();
-  });
-
-  beforeEach(() => {
     cy.visit(THREAT_INTELLIGENCE);
     selectRange();
   });
@@ -78,34 +71,47 @@ describe('Block list interactions', () => {
   });
 
   it('should add to block list from the indicators table', () => {
-    cy.get(INDICATORS_TABLE_MORE_ACTION_BUTTON_ICON).first().click();
-    cy.get(INDICATORS_TABLE_ADD_TO_BLOCK_LIST_BUTTON_ICON).first().click();
+    openIndicatorsTableMoreActions(0);
+    openAddToBlockListFlyoutFromTable();
+    fillBlocklistForm(BLOCK_LIST_NEW_NAME, BLOCK_LIST_NEW_DESCRIPTION);
+    navigateToBlocklist();
 
-    fillBlocklistForm();
+    cy.get(SAVED_BLOCK_LIST_NAME).should('have.text', BLOCK_LIST_NEW_NAME);
+    cy.get(SAVED_BLOCK_LIST_DESCRIPTION).should('have.text', BLOCK_LIST_NEW_DESCRIPTION);
+
+    deleteBlocklistEntry();
+    navigateToThreatIntelligence();
   });
 
   it('should add to block list from the indicator flyout', () => {
-    cy.get(TOGGLE_FLYOUT_BUTTON).first().click({ force: true });
-    cy.get(FLYOUT_TAKE_ACTION_BUTTON).first().click();
-    cy.get(FLYOUT_ADD_TO_BLOCK_LIST_ITEM).first().click();
+    openFlyout(0);
+    openFlyoutTakeAction();
+    openAddToBlocklistFromFlyout();
+    fillBlocklistForm(BLOCK_LIST_NEW_NAME, BLOCK_LIST_NEW_DESCRIPTION);
+    closeFlyout();
+    navigateToBlocklist();
 
-    fillBlocklistForm();
+    cy.get(SAVED_BLOCK_LIST_NAME).should('have.text', BLOCK_LIST_NEW_NAME);
+    cy.get(SAVED_BLOCK_LIST_DESCRIPTION).should('have.text', BLOCK_LIST_NEW_DESCRIPTION);
+
+    deleteBlocklistEntry();
+    navigateToThreatIntelligence();
   });
 
   it('add to blocklist flyout should have the correct IoC id', () => {
     // first indicator is a valid indicator for add to blocklist feature
     const firstIndicatorId = 'd86e656455f985357df3063dff6637f7f3b95bb27d1769a6b88c7adecaf7763f';
-    cy.get(INDICATORS_TABLE_MORE_ACTION_BUTTON_ICON).first().click();
-    cy.get(INDICATORS_TABLE_ADD_TO_BLOCK_LIST_BUTTON_ICON).first().click();
+    openIndicatorsTableMoreActions(0);
+    openAddToBlockListFlyoutFromTable();
 
     cy.get(BLOCK_LIST_VALUE_INPUT(firstIndicatorId)).should('exist');
 
-    cy.get(BLOCK_LIST_FLYOUT_CLOSE_BUTTON).click();
+    closeFlyout();
 
     // second indicator is a valid indicator for add to blocklist feature
     const secondIndicatorId = 'd3e2cf87eabf84ef929aaf8dad1431b3387f5a26de8ffb7a0c3c2a13f973c0ab';
-    cy.get(INDICATORS_TABLE_MORE_ACTION_BUTTON_ICON).eq(1).click();
-    cy.get(INDICATORS_TABLE_ADD_TO_BLOCK_LIST_BUTTON_ICON).first().click();
+    openIndicatorsTableMoreActions(1);
+    openAddToBlockListFlyoutFromTable();
 
     cy.get(BLOCK_LIST_VALUE_INPUT(secondIndicatorId)).should('exist');
   });

--- a/x-pack/plugins/threat_intelligence/cypress/e2e/cases.cy.ts
+++ b/x-pack/plugins/threat_intelligence/cypress/e2e/cases.cy.ts
@@ -6,74 +6,40 @@
  */
 
 import {
-  CASE_ACTION_WRAPPER,
+  navigateToCases,
+  navigateToThreatIntelligence,
+  openFlyout,
+  openFlyoutTakeAction,
+  openIndicatorsTableMoreActions,
+} from '../tasks/common';
+import {
+  createNewCaseFromCases,
+  createNewCaseFromTI,
+  deleteCase,
+  navigateToCaseViaToaster,
+  openAddToExistingCaseFlyoutFromTable,
+  openAddToExistingCaseFromFlyout,
+  openAddToNewCaseFlyoutFromTable,
+  openAddToNewCaseFromFlyout,
+  selectExistingCase,
+} from '../tasks/cases';
+import {
   CASE_COMMENT_EXTERNAL_REFERENCE,
-  CASE_ELLIPSE_BUTTON,
-  CASE_ELLIPSE_DELETE_CASE_CONFIRMATION_BUTTON,
-  CASE_ELLIPSE_DELETE_CASE_OPTION,
-  CREAT_CASE_BUTTON,
   FLYOUT_ADD_TO_EXISTING_CASE_ITEM,
   FLYOUT_ADD_TO_NEW_CASE_ITEM,
-  FLYOUT_TAKE_ACTION_BUTTON,
   INDICATORS_TABLE_ADD_TO_EXISTING_CASE_BUTTON_ICON,
   INDICATORS_TABLE_ADD_TO_NEW_CASE_BUTTON_ICON,
-  INDICATORS_TABLE_MORE_ACTION_BUTTON_ICON,
-  NEW_CASE_CREATE_BUTTON,
-  NEW_CASE_DESCRIPTION_INPUT,
-  NEW_CASE_NAME_INPUT,
-  SELECT_EXISTING_CASE,
-  TOGGLE_FLYOUT_BUTTON,
-  VIEW_CASE_TOASTER_LINK,
-} from '../screens/indicators';
+} from '../screens/cases';
 import { login } from '../tasks/login';
 import { esArchiverLoad, esArchiverUnload } from '../tasks/es_archiver';
 import { selectRange } from '../tasks/select_range';
 
 const THREAT_INTELLIGENCE = '/app/security/threat_intelligence/indicators';
-const CASES = 'app/security/cases';
 
-const createNewCaseFromCases = () => {
-  cy.visit(CASES);
-  cy.get(CREAT_CASE_BUTTON).click();
-  cy.get(NEW_CASE_NAME_INPUT).click().type('case');
-  cy.get(NEW_CASE_DESCRIPTION_INPUT).click().type('case description');
-  cy.get(NEW_CASE_CREATE_BUTTON).click();
-};
-
-const createNewCaseFromTI = () => {
-  cy.get(NEW_CASE_NAME_INPUT).type('case');
-  cy.get(NEW_CASE_DESCRIPTION_INPUT).type('case description');
-  cy.get(NEW_CASE_CREATE_BUTTON).click();
-};
-
-const selectExistingCase = () => {
-  cy.wait(1000); // TODO find a better way to wait for the table to render
-  cy.get(SELECT_EXISTING_CASE).should('exist').contains('Select').click();
-};
-
-const navigateToNewCaseAndCheckAddedComment = () => {
-  cy.get(VIEW_CASE_TOASTER_LINK).click();
-  cy.get(CASE_COMMENT_EXTERNAL_REFERENCE)
-    .should('exist')
-    .and('contain.text', 'added an indicator of compromise')
-    .and('contain.text', 'Indicator name')
-    .and('contain.text', 'Indicator type')
-    .and('contain.text', 'Feed name');
-};
-
-const deleteCase = () => {
-  cy.get(CASE_ACTION_WRAPPER).find(CASE_ELLIPSE_BUTTON).click();
-  cy.get(CASE_ELLIPSE_DELETE_CASE_OPTION).click();
-  cy.get(CASE_ELLIPSE_DELETE_CASE_CONFIRMATION_BUTTON).click();
-};
-
-describe('Cases with invalid indicators', () => {
+describe('Cases with invalid indicators', { testIsolation: false }, () => {
   before(() => {
     esArchiverLoad('threat_intelligence/invalid_indicators_data');
     login();
-  });
-
-  beforeEach(() => {
     cy.visit(THREAT_INTELLIGENCE);
     selectRange();
   });
@@ -84,28 +50,28 @@ describe('Cases with invalid indicators', () => {
 
   it('should disable the indicators table context menu items if invalid indicator', () => {
     const documentsNumber = 22;
-    cy.get(INDICATORS_TABLE_MORE_ACTION_BUTTON_ICON)
-      .eq(documentsNumber - 1)
-      .click();
+    openIndicatorsTableMoreActions(documentsNumber - 1);
+
     cy.get(INDICATORS_TABLE_ADD_TO_EXISTING_CASE_BUTTON_ICON).should('be.disabled');
     cy.get(INDICATORS_TABLE_ADD_TO_NEW_CASE_BUTTON_ICON).should('be.disabled');
   });
 
   it('should disable the flyout context menu items if invalid indicator', () => {
     const documentsNumber = 22;
-    cy.get(TOGGLE_FLYOUT_BUTTON)
-      .eq(documentsNumber - 1)
-      .click({ force: true });
-    cy.get(FLYOUT_TAKE_ACTION_BUTTON).first().click();
+    openFlyout(documentsNumber - 1);
+    openFlyoutTakeAction();
+
     cy.get(FLYOUT_ADD_TO_EXISTING_CASE_ITEM).should('be.disabled');
     cy.get(FLYOUT_ADD_TO_NEW_CASE_ITEM).should('be.disabled');
   });
 });
 
-describe('Cases interactions', () => {
+describe('Cases interactions', { testIsolation: false }, () => {
   before(() => {
     esArchiverLoad('threat_intelligence/indicators_data');
     login();
+    cy.visit(THREAT_INTELLIGENCE);
+    selectRange();
   });
 
   after(() => {
@@ -113,56 +79,82 @@ describe('Cases interactions', () => {
   });
 
   it('should add to existing case when clicking on the button in the indicators table', () => {
+    navigateToCases();
     createNewCaseFromCases();
 
     cy.visit(THREAT_INTELLIGENCE);
     selectRange();
-
-    cy.get(INDICATORS_TABLE_MORE_ACTION_BUTTON_ICON).first().click();
-    cy.get(INDICATORS_TABLE_ADD_TO_EXISTING_CASE_BUTTON_ICON).first().click();
-
+    openIndicatorsTableMoreActions(0);
+    openAddToExistingCaseFlyoutFromTable();
     selectExistingCase();
-    navigateToNewCaseAndCheckAddedComment();
+    navigateToCaseViaToaster();
+
+    cy.get(CASE_COMMENT_EXTERNAL_REFERENCE)
+      .should('exist')
+      .and('contain.text', 'added an indicator of compromise')
+      .and('contain.text', 'Indicator name')
+      .and('contain.text', 'Indicator type')
+      .and('contain.text', 'Feed name');
+
     deleteCase();
+    navigateToThreatIntelligence();
   });
 
   it('should add to new case when clicking on the button in the indicators table', () => {
-    cy.visit(THREAT_INTELLIGENCE);
-    selectRange();
-
-    cy.get(INDICATORS_TABLE_MORE_ACTION_BUTTON_ICON).first().click();
-    cy.get(INDICATORS_TABLE_ADD_TO_NEW_CASE_BUTTON_ICON).first().click();
+    openIndicatorsTableMoreActions(0);
+    openAddToNewCaseFlyoutFromTable();
     createNewCaseFromTI();
 
-    navigateToNewCaseAndCheckAddedComment();
+    navigateToCaseViaToaster();
+    cy.get(CASE_COMMENT_EXTERNAL_REFERENCE)
+      .should('exist')
+      .and('contain.text', 'added an indicator of compromise')
+      .and('contain.text', 'Indicator name')
+      .and('contain.text', 'Indicator type')
+      .and('contain.text', 'Feed name');
+
     deleteCase();
+    navigateToThreatIntelligence();
   });
 
   it('should add to existing case when clicking on the button in the indicators flyout', () => {
+    navigateToCases();
     createNewCaseFromCases();
 
     cy.visit(THREAT_INTELLIGENCE);
     selectRange();
-
-    cy.get(TOGGLE_FLYOUT_BUTTON).first().click({ force: true });
-    cy.get(FLYOUT_TAKE_ACTION_BUTTON).first().click();
-    cy.get(FLYOUT_ADD_TO_EXISTING_CASE_ITEM).first().click();
-
+    openFlyout(0);
+    openFlyoutTakeAction();
+    openAddToExistingCaseFromFlyout();
     selectExistingCase();
-    navigateToNewCaseAndCheckAddedComment();
+
+    navigateToCaseViaToaster();
+    cy.get(CASE_COMMENT_EXTERNAL_REFERENCE)
+      .should('exist')
+      .and('contain.text', 'added an indicator of compromise')
+      .and('contain.text', 'Indicator name')
+      .and('contain.text', 'Indicator type')
+      .and('contain.text', 'Feed name');
+
     deleteCase();
+    navigateToThreatIntelligence();
   });
 
   it('should add to new case when clicking on the button in the indicators flyout', () => {
-    cy.visit(THREAT_INTELLIGENCE);
-    selectRange();
-
-    cy.get(TOGGLE_FLYOUT_BUTTON).first().click({ force: true });
-    cy.get(FLYOUT_TAKE_ACTION_BUTTON).first().click();
-    cy.get(FLYOUT_ADD_TO_NEW_CASE_ITEM).first().click();
+    openFlyout(0);
+    openFlyoutTakeAction();
+    openAddToNewCaseFromFlyout();
     createNewCaseFromTI();
 
-    navigateToNewCaseAndCheckAddedComment();
+    navigateToCaseViaToaster();
+    cy.get(CASE_COMMENT_EXTERNAL_REFERENCE)
+      .should('exist')
+      .and('contain.text', 'added an indicator of compromise')
+      .and('contain.text', 'Indicator name')
+      .and('contain.text', 'Indicator type')
+      .and('contain.text', 'Feed name');
+
     deleteCase();
+    navigateToThreatIntelligence();
   });
 });

--- a/x-pack/plugins/threat_intelligence/cypress/e2e/empty_page.cy.ts
+++ b/x-pack/plugins/threat_intelligence/cypress/e2e/empty_page.cy.ts
@@ -14,12 +14,9 @@ import {
 
 const THREAT_INTEL_PATH = '/app/security/threat_intelligence/';
 
-describe('Empty Page', () => {
+describe('Empty Page', { testIsolation: false }, () => {
   before(() => {
     login();
-  });
-
-  beforeEach(() => {
     cy.visit(THREAT_INTEL_PATH);
   });
 

--- a/x-pack/plugins/threat_intelligence/cypress/e2e/query_bar.cy.ts
+++ b/x-pack/plugins/threat_intelligence/cypress/e2e/query_bar.cy.ts
@@ -6,154 +6,177 @@
  */
 
 import {
-  BARCHART_FILTER_IN_BUTTON,
-  BARCHART_FILTER_OUT_BUTTON,
-  BARCHART_POPOVER_BUTTON,
-  FLYOUT_CLOSE_BUTTON,
-  FLYOUT_OVERVIEW_TAB_BLOCKS_FILTER_IN_BUTTON,
-  FLYOUT_OVERVIEW_TAB_BLOCKS_FILTER_OUT_BUTTON,
-  FLYOUT_OVERVIEW_TAB_BLOCKS_ITEM,
-  FLYOUT_OVERVIEW_TAB_TABLE_ROW_FILTER_IN_BUTTON,
-  FLYOUT_OVERVIEW_TAB_TABLE_ROW_FILTER_OUT_BUTTON,
-  FLYOUT_TABLE_TAB_ROW_FILTER_IN_BUTTON,
-  FLYOUT_TABLE_TAB_ROW_FILTER_OUT_BUTTON,
-  FLYOUT_TABS,
-  INDICATOR_TYPE_CELL,
-  INDICATORS_TABLE_CELL_FILTER_IN_BUTTON,
-  INDICATORS_TABLE_CELL_FILTER_OUT_BUTTON,
-  KQL_FILTER,
-  TOGGLE_FLYOUT_BUTTON,
-} from '../screens/indicators';
+  closeFlyout,
+  navigateToFlyoutTableTab,
+  openBarchartPopoverMenu,
+  openFlyout,
+  waitForViewToBeUpdated,
+} from '../tasks/common';
+import {
+  clearKQLBar,
+  filterInFromBarChartLegend,
+  filterInFromFlyoutBlockItem,
+  filterInFromFlyoutOverviewTable,
+  filterInFromFlyoutTableTab,
+  filterInFromTableCell,
+  filterOutFromBarChartLegend,
+  filterOutFromFlyoutBlockItem,
+  filterOutFromFlyoutOverviewTable,
+  filterOutFromFlyoutTableTab,
+  filterOutFromTableCell,
+} from '../tasks/query_bar';
+import { INDICATOR_TYPE_CELL } from '../screens/indicators';
+import { KQL_FILTER } from '../screens/query_bar';
 import { selectRange } from '../tasks/select_range';
 import { login } from '../tasks/login';
 import { esArchiverLoad, esArchiverUnload } from '../tasks/es_archiver';
 
 const THREAT_INTELLIGENCE = '/app/security/threat_intelligence/indicators';
 
-describe('Indicators', () => {
+describe('Indicators query bar interaction', { testIsolation: false }, () => {
   before(() => {
     esArchiverLoad('threat_intelligence/indicators_data');
     login();
+    cy.visit(THREAT_INTELLIGENCE);
+    selectRange();
   });
   after(() => {
     esArchiverUnload('threat_intelligence/indicators_data');
   });
 
-  describe('Indicators query bar interaction', () => {
-    beforeEach(() => {
-      cy.visit(THREAT_INTELLIGENCE);
+  it('should add filter to kql and filter in values when clicking in the barchart legend', () => {
+    waitForViewToBeUpdated();
+    cy.get(INDICATOR_TYPE_CELL).its('length').should('be.gte', 0);
 
-      selectRange();
-    });
+    openBarchartPopoverMenu();
+    filterInFromBarChartLegend();
 
-    it('should add filter to kql and filter in values when clicking in the barchart legend', () => {
-      cy.get(INDICATOR_TYPE_CELL).its('length').should('be.gte', 0);
-      cy.get(BARCHART_POPOVER_BUTTON).should('exist').first().click();
-      cy.get(BARCHART_FILTER_IN_BUTTON).should('exist').click();
-      cy.get(KQL_FILTER).should('exist');
-      cy.get(INDICATOR_TYPE_CELL).its('length').should('be.gte', 0);
-    });
+    cy.get(KQL_FILTER).should('exist');
+    cy.get(INDICATOR_TYPE_CELL).its('length').should('be.gte', 0);
 
-    it('should add negated filter to kql and filter out values when clicking in the barchart legend', () => {
-      cy.get(INDICATOR_TYPE_CELL).its('length').should('be.gte', 0);
-      cy.get(BARCHART_POPOVER_BUTTON).should('exist').first().click();
-      cy.get(BARCHART_FILTER_OUT_BUTTON).should('exist').click();
-      cy.get(KQL_FILTER).should('exist');
-      cy.get(INDICATOR_TYPE_CELL).its('length').should('be.gte', 0);
-    });
+    clearKQLBar();
+  });
 
-    it('should add filter to kql and filter in and out values when clicking in an indicators table cell', () => {
-      cy.get(INDICATOR_TYPE_CELL).its('length').should('be.gte', 0);
+  it('should add negated filter to kql and filter out values when clicking in the barchart legend', () => {
+    waitForViewToBeUpdated();
+    cy.get(INDICATOR_TYPE_CELL).its('length').should('be.gte', 0);
 
-      cy.get(INDICATOR_TYPE_CELL)
-        .first()
-        .should('be.visible')
-        .trigger('mouseover')
-        .within((_cell) => {
-          cy.get(INDICATORS_TABLE_CELL_FILTER_IN_BUTTON).should('exist').click({
-            force: true,
-          });
-        });
+    openBarchartPopoverMenu();
+    filterOutFromBarChartLegend();
 
-      cy.get(KQL_FILTER).should('exist');
-      cy.get(INDICATOR_TYPE_CELL).its('length').should('be.gte', 0);
-    });
+    cy.get(KQL_FILTER).should('exist');
+    cy.get(INDICATOR_TYPE_CELL).its('length').should('be.gte', 0);
 
-    it('should add negated filter and filter out and out values when clicking in an indicators table cell', () => {
-      cy.get(INDICATOR_TYPE_CELL).its('length').should('be.gte', 0);
-      cy.get(INDICATOR_TYPE_CELL)
-        .first()
-        .trigger('mouseover')
-        .within((_cell) => {
-          cy.get(INDICATORS_TABLE_CELL_FILTER_OUT_BUTTON).should('exist').click({ force: true });
-        });
+    clearKQLBar();
+  });
 
-      cy.get(KQL_FILTER).should('exist');
-      cy.get(INDICATOR_TYPE_CELL).its('length').should('be.gte', 0);
-    });
+  it('should add filter to kql and filter in and out values when clicking in an indicators table cell', () => {
+    waitForViewToBeUpdated();
+    cy.get(INDICATOR_TYPE_CELL).its('length').should('be.gte', 0);
 
-    it('should add filter to kql and filter in values when clicking in an indicators flyout overview tab block', () => {
-      cy.get(INDICATOR_TYPE_CELL).its('length').should('be.gte', 0);
-      cy.get(TOGGLE_FLYOUT_BUTTON).first().click({ force: true });
-      cy.get(FLYOUT_OVERVIEW_TAB_BLOCKS_ITEM).first().trigger('mouseover');
-      cy.get(FLYOUT_OVERVIEW_TAB_BLOCKS_FILTER_IN_BUTTON)
-        .should('exist')
-        .first()
-        .click({ force: true });
-      cy.get(FLYOUT_CLOSE_BUTTON).should('exist').click();
-      cy.get(KQL_FILTER).should('exist');
-      cy.get(INDICATOR_TYPE_CELL).its('length').should('be.gte', 0);
-    });
+    filterInFromTableCell();
 
-    it('should add negated filter to kql filter out values when clicking in an indicators flyout overview block', () => {
-      cy.get(INDICATOR_TYPE_CELL).its('length').should('be.gte', 0);
-      cy.get(TOGGLE_FLYOUT_BUTTON).first().click({ force: true });
-      cy.get(FLYOUT_OVERVIEW_TAB_BLOCKS_ITEM).first().trigger('mouseover');
-      cy.get(FLYOUT_OVERVIEW_TAB_BLOCKS_FILTER_OUT_BUTTON)
-        .should('exist')
-        .first()
-        .click({ force: true });
-      cy.get(FLYOUT_CLOSE_BUTTON).should('exist').click();
-      cy.get(KQL_FILTER).should('exist');
-      cy.get(INDICATOR_TYPE_CELL).its('length').should('be.gte', 0);
-    });
+    cy.get(KQL_FILTER).should('exist');
+    cy.get(INDICATOR_TYPE_CELL).its('length').should('be.gte', 0);
 
-    it('should add filter to kql and filter in values when clicking in an indicators flyout overview tab table row', () => {
-      cy.get(INDICATOR_TYPE_CELL).its('length').should('be.gte', 0);
-      cy.get(TOGGLE_FLYOUT_BUTTON).first().click({ force: true });
-      cy.get(FLYOUT_OVERVIEW_TAB_TABLE_ROW_FILTER_IN_BUTTON).should('exist').first().click();
-      cy.get(FLYOUT_CLOSE_BUTTON).should('exist').click();
-      cy.get(KQL_FILTER).should('exist');
-      cy.get(INDICATOR_TYPE_CELL).its('length').should('be.gte', 0);
-    });
+    clearKQLBar();
+  });
 
-    it('should add negated filter to kql filter out values when clicking in an indicators flyout overview tab row', () => {
-      cy.get(INDICATOR_TYPE_CELL).its('length').should('be.gte', 0);
-      cy.get(TOGGLE_FLYOUT_BUTTON).first().click({ force: true });
-      cy.get(FLYOUT_OVERVIEW_TAB_TABLE_ROW_FILTER_OUT_BUTTON).should('exist').first().click();
-      cy.get(FLYOUT_CLOSE_BUTTON).should('exist').click();
-      cy.get(KQL_FILTER).should('exist');
-      cy.get(INDICATOR_TYPE_CELL).its('length').should('be.gte', 0);
-    });
+  it('should add negated filter and filter out and out values when clicking in an indicators table cell', () => {
+    waitForViewToBeUpdated();
+    cy.get(INDICATOR_TYPE_CELL).its('length').should('be.gte', 0);
 
-    it('should add filter to kql and filter in values when clicking in an indicators flyout table tab action column', () => {
-      cy.get(INDICATOR_TYPE_CELL).its('length').should('be.gte', 0);
-      cy.get(TOGGLE_FLYOUT_BUTTON).first().click({ force: true });
-      cy.get(`${FLYOUT_TABS} button:nth-child(2)`).click();
-      cy.get(FLYOUT_TABLE_TAB_ROW_FILTER_IN_BUTTON).should('exist').first().click();
-      cy.get(FLYOUT_CLOSE_BUTTON).should('exist').click();
-      cy.get(KQL_FILTER).should('exist');
-      cy.get(INDICATOR_TYPE_CELL).its('length').should('be.gte', 0);
-    });
+    filterOutFromTableCell();
 
-    it('should add negated filter to kql filter out values when clicking in an indicators flyout table tab action column', () => {
-      cy.get(INDICATOR_TYPE_CELL).its('length').should('be.gte', 0);
-      cy.get(TOGGLE_FLYOUT_BUTTON).first().click({ force: true });
-      cy.get(`${FLYOUT_TABS} button:nth-child(2)`).click();
-      cy.get(FLYOUT_TABLE_TAB_ROW_FILTER_OUT_BUTTON).should('exist').first().click();
-      cy.get(FLYOUT_CLOSE_BUTTON).should('exist').click();
-      cy.get(KQL_FILTER).should('exist');
-      cy.get(INDICATOR_TYPE_CELL).its('length').should('be.gte', 0);
-    });
+    cy.get(KQL_FILTER).should('exist');
+    cy.get(INDICATOR_TYPE_CELL).its('length').should('be.gte', 0);
+
+    clearKQLBar();
+  });
+
+  it('should add filter to kql and filter in values when clicking in an indicators flyout overview tab block', () => {
+    waitForViewToBeUpdated();
+    cy.get(INDICATOR_TYPE_CELL).its('length').should('be.gte', 0);
+
+    openFlyout(0);
+    filterInFromFlyoutBlockItem();
+    closeFlyout();
+
+    cy.get(KQL_FILTER).should('exist');
+    cy.get(INDICATOR_TYPE_CELL).its('length').should('be.gte', 0);
+
+    clearKQLBar();
+  });
+
+  it('should add negated filter to kql filter out values when clicking in an indicators flyout overview block', () => {
+    waitForViewToBeUpdated();
+    cy.get(INDICATOR_TYPE_CELL).its('length').should('be.gte', 0);
+
+    openFlyout(0);
+    filterOutFromFlyoutBlockItem();
+    closeFlyout();
+
+    cy.get(KQL_FILTER).should('exist');
+    cy.get(INDICATOR_TYPE_CELL).its('length').should('be.gte', 0);
+
+    clearKQLBar();
+  });
+
+  it('should add filter to kql and filter in values when clicking in an indicators flyout overview tab table row', () => {
+    waitForViewToBeUpdated();
+    cy.get(INDICATOR_TYPE_CELL).its('length').should('be.gte', 0);
+
+    openFlyout(0);
+    filterInFromFlyoutOverviewTable();
+    closeFlyout();
+
+    cy.get(KQL_FILTER).should('exist');
+    cy.get(INDICATOR_TYPE_CELL).its('length').should('be.gte', 0);
+
+    clearKQLBar();
+  });
+
+  it('should add negated filter to kql filter out values when clicking in an indicators flyout overview tab row', () => {
+    waitForViewToBeUpdated();
+    cy.get(INDICATOR_TYPE_CELL).its('length').should('be.gte', 0);
+
+    openFlyout(0);
+    filterOutFromFlyoutOverviewTable();
+    closeFlyout();
+
+    cy.get(KQL_FILTER).should('exist');
+    cy.get(INDICATOR_TYPE_CELL).its('length').should('be.gte', 0);
+
+    clearKQLBar();
+  });
+
+  it('should add filter to kql and filter in values when clicking in an indicators flyout table tab action column', () => {
+    waitForViewToBeUpdated();
+    cy.get(INDICATOR_TYPE_CELL).its('length').should('be.gte', 0);
+
+    openFlyout(0);
+    navigateToFlyoutTableTab();
+    filterInFromFlyoutTableTab();
+    closeFlyout();
+
+    cy.get(KQL_FILTER).should('exist');
+    cy.get(INDICATOR_TYPE_CELL).its('length').should('be.gte', 0);
+
+    clearKQLBar();
+  });
+
+  it('should add negated filter to kql filter out values when clicking in an indicators flyout table tab action column', () => {
+    waitForViewToBeUpdated();
+    cy.get(INDICATOR_TYPE_CELL).its('length').should('be.gte', 0);
+
+    openFlyout(0);
+    navigateToFlyoutTableTab();
+    filterOutFromFlyoutTableTab();
+    closeFlyout();
+
+    cy.get(KQL_FILTER).should('exist');
+    cy.get(INDICATOR_TYPE_CELL).its('length').should('be.gte', 0);
+
+    clearKQLBar();
   });
 });

--- a/x-pack/plugins/threat_intelligence/cypress/e2e/timeline.cy.ts
+++ b/x-pack/plugins/threat_intelligence/cypress/e2e/timeline.cy.ts
@@ -6,89 +6,96 @@
  */
 
 import {
-  BARCHART_POPOVER_BUTTON,
-  BARCHART_TIMELINE_BUTTON,
-  FLYOUT_CLOSE_BUTTON,
-  FLYOUT_OVERVIEW_TAB_BLOCKS_TIMELINE_BUTTON,
-  FLYOUT_OVERVIEW_TAB_TABLE_ROW_TIMELINE_BUTTON,
-  INDICATOR_TYPE_CELL,
-  INDICATORS_TABLE_CELL_TIMELINE_BUTTON,
-  INDICATORS_TABLE_INVESTIGATE_IN_TIMELINE_BUTTON_ICON,
-  TIMELINE_DRAGGABLE_ITEM,
-  TOGGLE_FLYOUT_BUTTON,
-  UNTITLED_TIMELINE_BUTTON,
-  FLYOUT_TABLE_MORE_ACTIONS_BUTTON,
-  FLYOUT_BLOCK_MORE_ACTIONS_BUTTON,
-  FLYOUT_TAKE_ACTION_BUTTON,
-  FLYOUT_INVESTIGATE_IN_TIMELINE_ITEM,
-} from '../screens/indicators';
+  addToTimelineFromBarchartLegend,
+  addToTimelineFromFlyoutOverviewTabBlock,
+  addToTimelineFromFlyoutOverviewTabTable,
+  addToTimelineFromTableCell,
+  closeTimeline,
+  investigateInTimelineFromFlyout,
+  investigateInTimelineFromTable,
+  openTimeline,
+} from '../tasks/timeline';
+import {
+  closeFlyout,
+  openBarchartPopoverMenu,
+  openFlyout,
+  openFlyoutTakeAction,
+} from '../tasks/common';
+import { TIMELINE_DRAGGABLE_ITEM } from '../screens/timeline';
 import { esArchiverLoad, esArchiverUnload } from '../tasks/es_archiver';
 import { login } from '../tasks/login';
 import { selectRange } from '../tasks/select_range';
 
 const THREAT_INTELLIGENCE = '/app/security/threat_intelligence/indicators';
 
-describe.skip('Indicators', () => {
+describe('Timeline', { testIsolation: false }, () => {
   before(() => {
     esArchiverLoad('threat_intelligence/indicators_data');
     login();
+    cy.visit(THREAT_INTELLIGENCE);
+    selectRange();
   });
 
   after(() => {
     esArchiverUnload('threat_intelligence/indicators_data');
   });
 
-  describe('Indicators timeline interactions', () => {
-    beforeEach(() => {
-      cy.visit(THREAT_INTELLIGENCE);
+  it('should add entry in timeline when clicking in the barchart legend', () => {
+    openBarchartPopoverMenu();
+    addToTimelineFromBarchartLegend();
+    openTimeline();
 
-      selectRange();
-    });
+    cy.get(TIMELINE_DRAGGABLE_ITEM).should('exist');
 
-    it('should add entry in timeline when clicking in the barchart legend', () => {
-      cy.get(BARCHART_POPOVER_BUTTON).should('exist').first().click();
-      cy.get(BARCHART_TIMELINE_BUTTON).should('exist').first().click();
-      cy.get(UNTITLED_TIMELINE_BUTTON).should('exist').first().click();
-      cy.get(TIMELINE_DRAGGABLE_ITEM).should('exist');
-    });
+    closeTimeline();
+  });
 
-    it('should add entry in timeline when clicking in an indicator table cell', () => {
-      cy.get(INDICATOR_TYPE_CELL).first().trigger('mouseover');
-      cy.get(INDICATORS_TABLE_CELL_TIMELINE_BUTTON).should('exist').first().click({ force: true });
-      cy.get(UNTITLED_TIMELINE_BUTTON).should('exist').first().click();
-      cy.get(TIMELINE_DRAGGABLE_ITEM).should('exist');
-    });
+  it('should add entry in timeline when clicking in an indicator table cell', () => {
+    addToTimelineFromTableCell();
+    openTimeline();
 
-    it('should add entry in timeline when clicking in an indicator flyout overview tab table row', () => {
-      cy.get(TOGGLE_FLYOUT_BUTTON).first().click({ force: true });
-      cy.get(FLYOUT_TABLE_MORE_ACTIONS_BUTTON).first().click({ force: true });
-      cy.get(FLYOUT_OVERVIEW_TAB_TABLE_ROW_TIMELINE_BUTTON).should('exist').first().click();
-      cy.get(FLYOUT_CLOSE_BUTTON).should('exist').click();
-      cy.get(UNTITLED_TIMELINE_BUTTON).should('exist').first().click();
-      cy.get(TIMELINE_DRAGGABLE_ITEM).should('exist');
-    });
+    cy.get(TIMELINE_DRAGGABLE_ITEM).should('exist');
 
-    it('should add entry in timeline when clicking in an indicator flyout overview block', () => {
-      cy.get(TOGGLE_FLYOUT_BUTTON).first().click({ force: true });
-      cy.get(FLYOUT_BLOCK_MORE_ACTIONS_BUTTON).first().click({ force: true });
-      cy.get(FLYOUT_OVERVIEW_TAB_BLOCKS_TIMELINE_BUTTON).should('exist').first().click();
-      cy.get(FLYOUT_CLOSE_BUTTON).should('exist').click();
-      cy.get(UNTITLED_TIMELINE_BUTTON).should('exist').first().click();
-      cy.get(TIMELINE_DRAGGABLE_ITEM).should('exist');
-    });
+    closeTimeline();
+  });
 
-    it('should investigate in timeline when clicking in an indicator table action row', () => {
-      cy.get(INDICATORS_TABLE_INVESTIGATE_IN_TIMELINE_BUTTON_ICON).should('exist').first().click();
-      cy.get(UNTITLED_TIMELINE_BUTTON).should('exist').first().click();
-      cy.get(TIMELINE_DRAGGABLE_ITEM).should('exist');
-    });
+  it('should add entry in timeline when clicking in an indicator flyout overview tab table row', () => {
+    openFlyout(0);
+    addToTimelineFromFlyoutOverviewTabTable();
+    closeFlyout();
+    openTimeline();
 
-    it('should investigate in timeline when clicking in an indicator flyout', () => {
-      cy.get(TOGGLE_FLYOUT_BUTTON).first().click({ force: true });
-      cy.get(FLYOUT_TAKE_ACTION_BUTTON).first().click();
-      cy.get(FLYOUT_INVESTIGATE_IN_TIMELINE_ITEM).should('exist').first().click();
-      cy.get(UNTITLED_TIMELINE_BUTTON).should('exist').first().click();
-      cy.get(TIMELINE_DRAGGABLE_ITEM).should('exist');
-    });
+    cy.get(TIMELINE_DRAGGABLE_ITEM).should('exist');
+
+    closeTimeline();
+  });
+
+  it('should add entry in timeline when clicking in an indicator flyout overview block', () => {
+    openFlyout(0);
+    addToTimelineFromFlyoutOverviewTabBlock();
+    closeFlyout();
+    openTimeline();
+
+    cy.get(TIMELINE_DRAGGABLE_ITEM).should('exist');
+
+    closeTimeline();
+  });
+
+  it('should investigate in timeline when clicking in an indicator table action row', () => {
+    investigateInTimelineFromTable();
+
+    cy.get(TIMELINE_DRAGGABLE_ITEM).should('exist');
+
+    closeTimeline();
+  });
+
+  it('should investigate in timeline when clicking in an indicator flyout', () => {
+    openFlyout(0);
+    openFlyoutTakeAction();
+    investigateInTimelineFromFlyout();
+
+    cy.get(TIMELINE_DRAGGABLE_ITEM).should('exist');
+
+    closeTimeline();
   });
 });

--- a/x-pack/plugins/threat_intelligence/cypress/screens/blocklist.ts
+++ b/x-pack/plugins/threat_intelligence/cypress/screens/blocklist.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ADD_TO_BLOCK_LIST_TEST_ID as INDICATOR_FLYOUT_TAKE_ACTION_ADD_TO_BLOCK_LIST_TEST_ID } from '../../public/modules/indicators/components/flyout/test_ids';
+import { ADD_TO_BLOCK_LIST_TEST_ID as INDICATORS_TABLE_ADD_TO_BLOCK_LIST_TEST_ID } from '../../public/modules/indicators/components/table/test_ids';
+
+export const INDICATORS_TABLE_ADD_TO_BLOCK_LIST_BUTTON_ICON = `[data-test-subj="${INDICATORS_TABLE_ADD_TO_BLOCK_LIST_TEST_ID}"]`;
+export const FLYOUT_ADD_TO_BLOCK_LIST_ITEM = `[data-test-subj="${INDICATOR_FLYOUT_TAKE_ACTION_ADD_TO_BLOCK_LIST_TEST_ID}"]`;
+export const BLOCK_LIST_NAME = `[data-test-subj="blocklist-form-name-input"]`;
+export const BLOCK_LIST_DESCRIPTION = `[data-test-subj="blocklist-form-description-input"]`;
+export const BLOCK_LIST_ADD_BUTTON = `[class="eui-textTruncate"]`;
+export const BLOCK_LIST_TOAST_LIST = `[data-test-subj="globalToastList"]`;
+export const BLOCK_LIST_VALUE_INPUT = (iocId: string) =>
+  `[data-test-subj="blocklist-form-values-input-${iocId}"]`;
+export const SAVED_BLOCK_LIST_NAME = `[data-test-subj="blocklistPage-card-header-title"]`;
+export const SAVED_BLOCK_LIST_DESCRIPTION = `[data-test-subj="blocklistPage-card-description"]`;
+export const SAVED_BLOCK_LIST_ACTION_MENU = `[data-test-subj="blocklistPage-card-header-actions-button"]`;
+export const SAVED_BLOCK_LIST_DELETE_BUTTON = `[data-test-subj="blocklistPage-card-cardDeleteAction"]`;
+export const SAVED_BLOCK_LIST_CONFIRM_DELETE_BUTTON = `[data-test-subj="blocklistPage-deleteModal-submitButton"]`;

--- a/x-pack/plugins/threat_intelligence/cypress/screens/cases.ts
+++ b/x-pack/plugins/threat_intelligence/cypress/screens/cases.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  ADD_TO_EXISTING_CASE_TEST_ID as INDICATOR_FLYOUT_TAKE_ACTION_ADD_TO_EXISTING_CASE_TEST_ID,
+  ADD_TO_NEW_CASE_TEST_ID as INDICATOR_FLYOUT_TAKE_ACTION_ADD_TO_NEW_CASE_TEST_ID,
+} from '../../public/modules/indicators/components/flyout/test_ids';
+import {
+  ADD_TO_EXISTING_TEST_ID as INDICATORS_TABLE_ADD_TO_EXISTING_TEST_ID,
+  ADD_TO_NEW_CASE_TEST_ID as INDICATORS_TABLE_ADD_TO_NEW_CASE_TEST_ID,
+} from '../../public/modules/indicators/components/table/test_ids';
+
+export const INDICATORS_TABLE_ADD_TO_NEW_CASE_BUTTON_ICON = `[data-test-subj="${INDICATORS_TABLE_ADD_TO_NEW_CASE_TEST_ID}"]`;
+export const INDICATORS_TABLE_ADD_TO_EXISTING_CASE_BUTTON_ICON = `[data-test-subj="${INDICATORS_TABLE_ADD_TO_EXISTING_TEST_ID}"]`;
+export const FLYOUT_ADD_TO_EXISTING_CASE_ITEM = `[data-test-subj="${INDICATOR_FLYOUT_TAKE_ACTION_ADD_TO_EXISTING_CASE_TEST_ID}"]`;
+export const FLYOUT_ADD_TO_NEW_CASE_ITEM = `[data-test-subj="${INDICATOR_FLYOUT_TAKE_ACTION_ADD_TO_NEW_CASE_TEST_ID}"]`;
+export const CREATE_CASE_BUTTON = `[data-test-subj="createNewCaseBtn"]`;
+export const SELECT_EXISTING_CASE = `[class="eui-textTruncate"]`;
+export const VIEW_CASE_TOASTER_LINK = `[data-test-subj="toaster-content-case-view-link"]`;
+export const CASE_COMMENT_EXTERNAL_REFERENCE = `[data-test-subj="comment-externalReference-indicator"]`;
+export const CASE_ACTION_WRAPPER = `[data-test-subj="case-action-bar-wrapper"]`;
+export const CASE_ELLIPSE_BUTTON = `[data-test-subj="property-actions-case-ellipses"]`;
+export const CASE_ELLIPSE_DELETE_CASE_OPTION = `[data-test-subj="property-actions-case-trash"]`;
+export const CASE_ELLIPSE_DELETE_CASE_CONFIRMATION_BUTTON = `[data-test-subj="confirmModalConfirmButton"]`;
+export const NEW_CASE_NAME_INPUT = `[data-test-subj="input"][aria-describedby="caseTitle"]`;
+export const NEW_CASE_DESCRIPTION_INPUT = `[data-test-subj="euiMarkdownEditorTextArea"]`;
+export const NEW_CASE_CREATE_BUTTON = `[data-test-subj="create-case-submit"]`;
+export const SELECT_CASE_TABLE_ROW = `.euiTableRow`;
+export const SELECT_EXISTING_CASES_MODAL = `[data-test-subj="all-cases-modal"]`;

--- a/x-pack/plugins/threat_intelligence/cypress/screens/common.ts
+++ b/x-pack/plugins/threat_intelligence/cypress/screens/common.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const UPDATE_STATUS = `[data-test-subj="updateStatus"]`;
+export const SECURITY_SOLUTION_NAVBAR_MANAGE_ITEM = `[data-test-subj="solutionSideNavItemLink-administration"]`;
+export const SECURITY_SOLUTION_NAVBAR_THREAT_INTELLIGENCE_ITEM = `[data-test-subj="solutionSideNavItemLink-threat_intelligence-indicators"]`;
+export const SECURITY_SOLUTION_NAVBAR_CASES_ITEM = `[data-test-subj="solutionSideNavItemLink-cases"]`;
+export const MANAGE_NAVIGATION_ITEMS = `.euiLink`;

--- a/x-pack/plugins/threat_intelligence/cypress/screens/empty_page.ts
+++ b/x-pack/plugins/threat_intelligence/cypress/screens/empty_page.ts
@@ -6,7 +6,5 @@
  */
 
 export const EMPTY_PAGE_BODY = '[data-test-subj="tiEmptyPage"]';
-
 export const EMPTY_PAGE_DOCS_LINK = '[data-test-subj="tiEmptyPageDocsLink"]';
-
 export const EMPTY_PAGE_INTEGRATIONS_LINK = '[data-test-subj="tiEmptyPageIntegrationsPageLink"]';

--- a/x-pack/plugins/threat_intelligence/cypress/screens/indicators.ts
+++ b/x-pack/plugins/threat_intelligence/cypress/screens/indicators.ts
@@ -7,8 +7,8 @@
 
 /* Breadcrumbs */
 
-import { INSPECT_BUTTON_TEST_ID } from '../../public/modules/indicators/hooks/test_ids';
 import { PANEL_TEST_ID, TITLE_TEST_ID } from '../../public/components/test_ids';
+import { INSPECT_BUTTON_TEST_ID } from '../../public/modules/indicators/hooks/test_ids';
 import {
   DROPDOWN_TEST_ID,
   FILTER_IN_BUTTON_TEST_ID as LEGEND_FILTER_IN_BUTTON_TEST_ID,
@@ -17,10 +17,6 @@ import {
   TIMELINE_BUTTON_TEST_ID as LEGEND_TIMELINE_BUTTON_TEST_ID,
 } from '../../public/modules/indicators/components/barchart/test_ids';
 import {
-  ADD_TO_BLOCK_LIST_TEST_ID as INDICATOR_FLYOUT_TAKE_ACTION_ADD_TO_BLOCK_LIST_TEST_ID,
-  ADD_TO_EXISTING_CASE_TEST_ID as INDICATOR_FLYOUT_TAKE_ACTION_ADD_TO_EXISTING_CASE_TEST_ID,
-  ADD_TO_NEW_CASE_TEST_ID as INDICATOR_FLYOUT_TAKE_ACTION_ADD_TO_NEW_CASE_TEST_ID,
-  INVESTIGATE_IN_TIMELINE_TEST_ID as INDICATOR_FLYOUT_TAKE_ACTION_INVESTIGATE_IN_TIMELINE_TEST_ID,
   TAKE_ACTION_BUTTON_TEST_ID as INDICATOR_FLYOUT_TAKE_ACTION_TAKE_ACTION_BUTTON_TEST_ID,
   INDICATORS_FLYOUT_OVERVIEW_HIGH_LEVEL_BLOCKS,
   INDICATORS_FLYOUT_OVERVIEW_TABLE,
@@ -28,207 +24,84 @@ import {
   FLYOUT_TABLE_TEST_ID,
   INDICATORS_FLYOUT_TABS_TEST_ID,
   INDICATORS_FLYOUT_TITLE_TEST_ID,
-  TIMELINE_BUTTON_TEST_ID as VALUE_ACTION_TIMELINE_BUTTON_TEST_ID,
   FILTER_IN_BUTTON_TEST_ID as VALUE_ACTION_FILTER_IN_BUTTON_TEST_ID,
   FILTER_OUT_BUTTON_TEST_ID as VALUE_ACTION_FILTER_OUT_BUTTON_TEST_ID,
   POPOVER_BUTTON_TEST_ID as VALUE_ACTION_POPOVER_BUTTON_TEST_ID,
 } from '../../public/modules/indicators/components/flyout/test_ids';
 import {
-  ADD_TO_BLOCK_LIST_TEST_ID as INDICATORS_TABLE_ADD_TO_BLOCK_LIST_TEST_ID,
-  ADD_TO_EXISTING_TEST_ID as INDICATORS_TABLE_ADD_TO_EXISTING_TEST_ID,
-  ADD_TO_NEW_CASE_TEST_ID as INDICATORS_TABLE_ADD_TO_NEW_CASE_TEST_ID,
   MORE_ACTIONS_TEST_ID as INDICATORS_TABLE_MORE_ACTIONS_TEST_ID,
   BUTTON_TEST_ID,
   FILTER_IN_BUTTON_TEST_ID as CELL_FILTER_IN_BUTTON_TEST_ID,
   FILTER_OUT_BUTTON_TEST_ID as CELL_FILTER_OUT_BUTTON_TEST_ID,
-  TIMELINE_BUTTON_TEST_ID as CELL_TIMELINE_BUTTON_TEST_ID,
-  INVESTIGATE_IN_TIMELINE_TEST_ID as CELL_INVESTIGATE_IN_TIMELINE_TEST_ID,
   TABLE_TEST_ID,
 } from '../../public/modules/indicators/components/table/test_ids';
-
-export const BREADCRUMBS = `[data-test-subj="breadcrumbs"]`;
-
-export const LEADING_BREADCRUMB = `[data-test-subj="breadcrumb first"]`;
-
-export const ENDING_BREADCRUMB = `[data-test-subj="breadcrumb last"]`;
-
-/* Title */
-
-export const DEFAULT_LAYOUT_TITLE = `[data-test-subj="${TITLE_TEST_ID}"]`;
 
 /* Indicators Table */
 
 export const INDICATORS_TABLE = `[data-test-subj="${TABLE_TEST_ID}"]`;
-
 export const INDICATORS_TABLE_ROW_CELL = `[data-test-subj="dataGridRowCell"]`;
-
 export const INDICATORS_TABLE_INDICATOR_NAME_CELL = `[data-gridcell-column-id="threat.indicator.name"]`;
-
 export const INDICATORS_TABLE_INDICATOR_TYPE_CELL = `[data-gridcell-column-id="threat.indicator.type"]`;
-
 export const INDICATORS_TABLE_INDICATOR_NAME_COLUMN_HEADER = `[data-test-subj="dataGridHeaderCell-threat.indicator.name"]`;
-
 export const INDICATORS_TABLE_INDICATOR_TYPE_COLUMN_HEADER = `[data-test-subj="dataGridHeaderCell-threat.indicator.type"]`;
-
 export const INDICATORS_TABLE_FEED_NAME_COLUMN_HEADER = `[data-test-subj="dataGridHeaderCell-threat.feed.name"]`;
-
 export const INDICATORS_TABLE_FIRST_SEEN_COLUMN_HEADER = `[data-test-subj="dataGridHeaderCell-threat.indicator.first_seen"]`;
-
 export const INDICATORS_TABLE_LAST_SEEN_COLUMN_HEADER = `[data-test-subj="dataGridHeaderCell-threat.indicator.last_seen"]`;
-
 export const TABLE_CONTROLS = `[data-test-subj="dataGridControls"]`;
-
 export const INDICATOR_TYPE_CELL = `[role="gridcell"][data-gridcell-column-id="threat.indicator.type"]`;
-
-export const INDICATORS_TABLE_CELL_TIMELINE_BUTTON = `[data-test-subj="${CELL_TIMELINE_BUTTON_TEST_ID}"] button`;
-
 export const INDICATORS_TABLE_CELL_FILTER_IN_BUTTON = `[data-test-subj="${CELL_FILTER_IN_BUTTON_TEST_ID}"] button`;
-
 export const INDICATORS_TABLE_CELL_FILTER_OUT_BUTTON = `[data-test-subj="${CELL_FILTER_OUT_BUTTON_TEST_ID}"] button`;
-
-export const INDICATORS_TABLE_INVESTIGATE_IN_TIMELINE_BUTTON_ICON = `[data-test-subj="${CELL_INVESTIGATE_IN_TIMELINE_TEST_ID}"]`;
-
 export const INDICATORS_TABLE_MORE_ACTION_BUTTON_ICON = `[data-test-subj="${INDICATORS_TABLE_MORE_ACTIONS_TEST_ID}"]`;
-
-export const INDICATORS_TABLE_ADD_TO_NEW_CASE_BUTTON_ICON = `[data-test-subj="${INDICATORS_TABLE_ADD_TO_NEW_CASE_TEST_ID}"]`;
-
-export const INDICATORS_TABLE_ADD_TO_EXISTING_CASE_BUTTON_ICON = `[data-test-subj="${INDICATORS_TABLE_ADD_TO_EXISTING_TEST_ID}"]`;
-
-export const INDICATORS_TABLE_ADD_TO_BLOCK_LIST_BUTTON_ICON = `[data-test-subj="${INDICATORS_TABLE_ADD_TO_BLOCK_LIST_TEST_ID}"]`;
 
 /* Flyout */
 
 export const TOGGLE_FLYOUT_BUTTON = `[data-test-subj="${BUTTON_TEST_ID}"]`;
-
 export const FLYOUT_CLOSE_BUTTON = `[data-test-subj="euiFlyoutCloseButton"]`;
-
 export const FLYOUT_TITLE = `[data-test-subj="${INDICATORS_FLYOUT_TITLE_TEST_ID}"]`;
-
 export const FLYOUT_TABS = `[data-test-subj="${INDICATORS_FLYOUT_TABS_TEST_ID}"]`;
-
 export const FLYOUT_TABLE = `[data-test-subj="${FLYOUT_TABLE_TEST_ID}"]`;
-
 export const FLYOUT_JSON = `[data-test-subj="${CODE_BLOCK_TEST_ID}"]`;
-
-export const FLYOUT_OVERVIEW_TAB_TABLE_ROW_TIMELINE_BUTTON = `[data-test-subj="${INDICATORS_FLYOUT_OVERVIEW_TABLE}${VALUE_ACTION_TIMELINE_BUTTON_TEST_ID}"]`;
-
 export const FLYOUT_OVERVIEW_TAB_TABLE_ROW_FILTER_IN_BUTTON = `[data-test-subj="${INDICATORS_FLYOUT_OVERVIEW_TABLE}${VALUE_ACTION_FILTER_IN_BUTTON_TEST_ID}"]`;
-
 export const FLYOUT_OVERVIEW_TAB_TABLE_ROW_FILTER_OUT_BUTTON = `[data-test-subj="${INDICATORS_FLYOUT_OVERVIEW_TABLE}${VALUE_ACTION_FILTER_OUT_BUTTON_TEST_ID}"]`;
-
 export const FLYOUT_OVERVIEW_TAB_BLOCKS_ITEM = `[data-test-subj="${INDICATORS_FLYOUT_OVERVIEW_HIGH_LEVEL_BLOCKS}Item"]`;
-
-export const FLYOUT_OVERVIEW_TAB_BLOCKS_TIMELINE_BUTTON = `[data-test-subj="${INDICATORS_FLYOUT_OVERVIEW_HIGH_LEVEL_BLOCKS}${VALUE_ACTION_TIMELINE_BUTTON_TEST_ID}"]`;
-
 export const FLYOUT_OVERVIEW_TAB_BLOCKS_FILTER_IN_BUTTON = `[data-test-subj="${INDICATORS_FLYOUT_OVERVIEW_HIGH_LEVEL_BLOCKS}${VALUE_ACTION_FILTER_IN_BUTTON_TEST_ID}"]`;
-
 export const FLYOUT_OVERVIEW_TAB_BLOCKS_FILTER_OUT_BUTTON = `[data-test-subj="${INDICATORS_FLYOUT_OVERVIEW_HIGH_LEVEL_BLOCKS}${VALUE_ACTION_FILTER_OUT_BUTTON_TEST_ID}"]`;
-
 export const FLYOUT_TABLE_MORE_ACTIONS_BUTTON = `[data-test-subj="${INDICATORS_FLYOUT_OVERVIEW_TABLE}${VALUE_ACTION_POPOVER_BUTTON_TEST_ID}"] button`;
-
 export const FLYOUT_BLOCK_MORE_ACTIONS_BUTTON = `[data-test-subj="${INDICATORS_FLYOUT_OVERVIEW_HIGH_LEVEL_BLOCKS}${VALUE_ACTION_POPOVER_BUTTON_TEST_ID}"] button`;
-
-export const FLYOUT_TABLE_TAB_ROW_TIMELINE_BUTTON = `[data-test-subj="${FLYOUT_TABLE_TEST_ID}${VALUE_ACTION_TIMELINE_BUTTON_TEST_ID}"]`;
-
 export const FLYOUT_TABLE_TAB_ROW_FILTER_IN_BUTTON = `[data-test-subj="${FLYOUT_TABLE_TEST_ID}${VALUE_ACTION_FILTER_IN_BUTTON_TEST_ID}"]`;
-
 export const FLYOUT_TABLE_TAB_ROW_FILTER_OUT_BUTTON = `[data-test-subj="${FLYOUT_TABLE_TEST_ID}${VALUE_ACTION_FILTER_OUT_BUTTON_TEST_ID}"]`;
-
 export const FLYOUT_TAKE_ACTION_BUTTON = `[data-test-subj="${INDICATOR_FLYOUT_TAKE_ACTION_TAKE_ACTION_BUTTON_TEST_ID}"]`;
-
-export const FLYOUT_ADD_TO_EXISTING_CASE_ITEM = `[data-test-subj="${INDICATOR_FLYOUT_TAKE_ACTION_ADD_TO_EXISTING_CASE_TEST_ID}"]`;
-
-export const FLYOUT_ADD_TO_NEW_CASE_ITEM = `[data-test-subj="${INDICATOR_FLYOUT_TAKE_ACTION_ADD_TO_NEW_CASE_TEST_ID}"]`;
-
-export const FLYOUT_INVESTIGATE_IN_TIMELINE_ITEM = `[data-test-subj="${INDICATOR_FLYOUT_TAKE_ACTION_INVESTIGATE_IN_TIMELINE_TEST_ID}"]`;
-
-export const FLYOUT_ADD_TO_BLOCK_LIST_ITEM = `[data-test-subj="${INDICATOR_FLYOUT_TAKE_ACTION_ADD_TO_BLOCK_LIST_TEST_ID}"]`;
 
 /* Field selector */
 
 export const FIELD_SELECTOR = `[data-test-subj="${DROPDOWN_TEST_ID}"]`;
-
 export const FIELD_SELECTOR_INPUT = `[data-test-subj="comboBoxInput"]`;
-
 export const FIELD_SELECTOR_TOGGLE_BUTTON = `[data-test-subj="comboBoxToggleListButton"]`;
-
 export const FIELD_SELECTOR_LIST = `[data-test-subj="comboBoxOptionsList ${DROPDOWN_TEST_ID}-optionsList"]`;
 
 /* Field browser */
 
 export const FIELD_BROWSER = `[data-test-subj="show-field-browser"]`;
-
 export const FIELD_BROWSER_MODAL = `[data-test-subj="fields-browser-container"]`;
 
 /* Barchart */
 
 export const BARCHART_POPOVER_BUTTON = `[data-test-subj="${LEGEND_POPOVER_BUTTON_TEST_ID}"]`;
-
 export const BARCHART_TIMELINE_BUTTON = `[data-test-subj="${LEGEND_TIMELINE_BUTTON_TEST_ID}"]`;
-
 export const BARCHART_FILTER_IN_BUTTON = `[data-test-subj="${LEGEND_FILTER_IN_BUTTON_TEST_ID}"]`;
-
 export const BARCHART_FILTER_OUT_BUTTON = `[data-test-subj="${LEGEND_FILTER_OUT_BUTTON_TEST_ID}"]`;
 
-/* Cases */
+/* Miscenalleous */
 
-export const CREAT_CASE_BUTTON = `[data-test-subj="createNewCaseBtn"]`;
-
-export const SELECT_EXISTING_CASE = `[class="eui-textTruncate"]`;
-
-export const VIEW_CASE_TOASTER_LINK = `[data-test-subj="toaster-content-case-view-link"]`;
-
-export const CASE_COMMENT_EXTERNAL_REFERENCE = `[data-test-subj="comment-externalReference-indicator"]`;
-
-export const CASE_ACTION_WRAPPER = `[data-test-subj="case-action-bar-wrapper"]`;
-
-export const CASE_ELLIPSE_BUTTON = `[data-test-subj="property-actions-case-ellipses"]`;
-
-export const CASE_ELLIPSE_DELETE_CASE_OPTION = `[data-test-subj="property-actions-case-trash"]`;
-
-export const CASE_ELLIPSE_DELETE_CASE_CONFIRMATION_BUTTON = `[data-test-subj="confirmModalConfirmButton"]`;
-
-export const NEW_CASE_NAME_INPUT = `[data-test-subj="input"][aria-describedby="caseTitle"]`;
-
-export const NEW_CASE_DESCRIPTION_INPUT = `[data-test-subj="euiMarkdownEditorTextArea"]`;
-
-export const NEW_CASE_CREATE_BUTTON = `[data-test-subj="create-case-submit"]`;
-
-/* Block list */
-
-export const BLOCK_LIST_NAME = `[data-test-subj="blocklist-form-name-input"]`;
-
-export const BLOCK_LIST_DESCRIPTION = `[data-test-subj="blocklist-form-description-input"]`;
-
-export const BLOCK_LIST_ADD_BUTTON = `[class="eui-textTruncate"]`;
-
-export const BLOCK_LIST_FLYOUT_CLOSE_BUTTON = `[data-test-subj="euiFlyoutCloseButton"]`;
-
-export const BLOCK_LIST_TOAST_LIST = `[data-test-subj="globalToastList"]`;
-
-export const BLOCK_LIST_VALUE_INPUT = (iocId: string) =>
-  `[data-test-subj="blocklist-form-values-input-${iocId}"]`;
-
-/* Miscellaneous */
-
-export const UNTITLED_TIMELINE_BUTTON = `[data-test-subj="flyoutOverlay"]`;
-
-export const TIMELINE_DRAGGABLE_ITEM = `[data-test-subj="providerContainer"]`;
-
-export const KQL_FILTER = `[id="popoverFor_filter0"]`;
-
+export const DEFAULT_LAYOUT_TITLE = `[data-test-subj="${TITLE_TEST_ID}"]`;
+export const BREADCRUMBS = `[data-test-subj="breadcrumbs"]`;
+export const LEADING_BREADCRUMB = `[data-test-subj="breadcrumb first"]`;
+export const ENDING_BREADCRUMB = `[data-test-subj="breadcrumb last"]`;
 export const FILTERS_GLOBAL_CONTAINER = `[data-test-subj="filters-global-container"]`;
-
 export const TIME_RANGE_PICKER = `[data-test-subj="superDatePickerToggleQuickMenuButton"]`;
-
 export const QUERY_INPUT = `[data-test-subj="queryInput"]`;
-
 export const EMPTY_STATE = `[data-test-subj="${PANEL_TEST_ID}"]`;
-
 export const INSPECTOR_BUTTON = `[data-test-subj="${INSPECT_BUTTON_TEST_ID}"]`;
-
 export const INSPECTOR_PANEL = `[data-test-subj="inspectorPanel"]`;
-
 export const ADD_INTEGRATIONS_BUTTON = `[data-test-subj="add-data"]`;
-
 export const REFRESH_BUTTON = `[data-test-subj="querySubmitButton"]`;

--- a/x-pack/plugins/threat_intelligence/cypress/screens/query_bar.ts
+++ b/x-pack/plugins/threat_intelligence/cypress/screens/query_bar.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const QUERY_BAR = '[data-test-subj="globalDatePicker"]';
+export const QUERY_BAR_MENU = '[data-test-subj="showQueryBarMenu"]';
+export const QUERY_BAR_MENU_REMOVE_ALL_FILTERS_BUTTON =
+  '[data-test-subj="filter-sets-removeAllFilters"]';
+export const KQL_FILTER = `[id="popoverFor_filter0"]`;

--- a/x-pack/plugins/threat_intelligence/cypress/screens/timeline.ts
+++ b/x-pack/plugins/threat_intelligence/cypress/screens/timeline.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  FLYOUT_TABLE_TEST_ID,
+  INDICATORS_FLYOUT_OVERVIEW_HIGH_LEVEL_BLOCKS,
+  INDICATORS_FLYOUT_OVERVIEW_TABLE,
+  INVESTIGATE_IN_TIMELINE_TEST_ID as INDICATOR_FLYOUT_TAKE_ACTION_INVESTIGATE_IN_TIMELINE_TEST_ID,
+  TIMELINE_BUTTON_TEST_ID as VALUE_ACTION_TIMELINE_BUTTON_TEST_ID,
+} from '../../public/modules/indicators/components/flyout/test_ids';
+import {
+  INVESTIGATE_IN_TIMELINE_TEST_ID as CELL_INVESTIGATE_IN_TIMELINE_TEST_ID,
+  TIMELINE_BUTTON_TEST_ID as CELL_TIMELINE_BUTTON_TEST_ID,
+} from '../../public/modules/indicators/components/table/test_ids';
+
+export const INDICATORS_TABLE_INVESTIGATE_IN_TIMELINE_BUTTON_ICON = `[data-test-subj="${CELL_INVESTIGATE_IN_TIMELINE_TEST_ID}"]`;
+export const UNTITLED_TIMELINE_BUTTON = `[data-test-subj="flyoutOverlay"]`;
+export const INDICATORS_TABLE_CELL_TIMELINE_BUTTON = `[data-test-subj="${CELL_TIMELINE_BUTTON_TEST_ID}"] button`;
+export const TIMELINE_DRAGGABLE_ITEM = `[data-test-subj="providerContainer"]`;
+export const CLOSE_TIMELINE_BTN = '[data-test-subj="close-timeline"]';
+export const QUERY_TAB_BUTTON = '[data-test-subj="timelineTabs-query"]';
+export const FLYOUT_OVERVIEW_TAB_TABLE_ROW_TIMELINE_BUTTON = `[data-test-subj="${INDICATORS_FLYOUT_OVERVIEW_TABLE}${VALUE_ACTION_TIMELINE_BUTTON_TEST_ID}"]`;
+export const FLYOUT_OVERVIEW_TAB_BLOCKS_TIMELINE_BUTTON = `[data-test-subj="${INDICATORS_FLYOUT_OVERVIEW_HIGH_LEVEL_BLOCKS}${VALUE_ACTION_TIMELINE_BUTTON_TEST_ID}"]`;
+export const FLYOUT_TABLE_TAB_ROW_TIMELINE_BUTTON = `[data-test-subj="${FLYOUT_TABLE_TEST_ID}${VALUE_ACTION_TIMELINE_BUTTON_TEST_ID}"]`;
+export const FLYOUT_INVESTIGATE_IN_TIMELINE_ITEM = `[data-test-subj="${INDICATOR_FLYOUT_TAKE_ACTION_INVESTIGATE_IN_TIMELINE_TEST_ID}"]`;

--- a/x-pack/plugins/threat_intelligence/cypress/tasks/blocklist.ts
+++ b/x-pack/plugins/threat_intelligence/cypress/tasks/blocklist.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  BLOCK_LIST_ADD_BUTTON,
+  BLOCK_LIST_DESCRIPTION,
+  BLOCK_LIST_NAME,
+  SAVED_BLOCK_LIST_ACTION_MENU,
+  BLOCK_LIST_TOAST_LIST,
+  SAVED_BLOCK_LIST_CONFIRM_DELETE_BUTTON,
+  SAVED_BLOCK_LIST_DELETE_BUTTON,
+  FLYOUT_ADD_TO_BLOCK_LIST_ITEM,
+  INDICATORS_TABLE_ADD_TO_BLOCK_LIST_BUTTON_ICON,
+} from '../screens/blocklist';
+
+/**
+ * Open the blocklist form from the indicators table more actions menu
+ */
+export const openAddToBlockListFlyoutFromTable = () => {
+  cy.get(INDICATORS_TABLE_ADD_TO_BLOCK_LIST_BUTTON_ICON).first().click();
+};
+
+/**
+ * Open the blocklist form from the indicators flyout take action menu
+ */
+export const openAddToBlocklistFromFlyout = () => {
+  cy.get(FLYOUT_ADD_TO_BLOCK_LIST_ITEM).first().click();
+};
+
+/**
+ * Fill out blocklist form with title and description
+ */
+export const fillBlocklistForm = (title: string, description: string) => {
+  cy.get(BLOCK_LIST_NAME).type(title);
+  cy.get(BLOCK_LIST_DESCRIPTION).type(description);
+  cy.get(BLOCK_LIST_ADD_BUTTON).last().click();
+
+  const text: string = `"${title}" has been added`;
+  cy.get(BLOCK_LIST_TOAST_LIST).should('exist').and('contain.text', text);
+};
+
+/**
+ * Remove the blocklist entry
+ */
+export const deleteBlocklistEntry = () => {
+  cy.get(SAVED_BLOCK_LIST_ACTION_MENU).click();
+  cy.get(SAVED_BLOCK_LIST_DELETE_BUTTON).click();
+  cy.get(SAVED_BLOCK_LIST_CONFIRM_DELETE_BUTTON).click();
+};

--- a/x-pack/plugins/threat_intelligence/cypress/tasks/cases.ts
+++ b/x-pack/plugins/threat_intelligence/cypress/tasks/cases.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  FLYOUT_ADD_TO_EXISTING_CASE_ITEM,
+  FLYOUT_ADD_TO_NEW_CASE_ITEM,
+  INDICATORS_TABLE_ADD_TO_EXISTING_CASE_BUTTON_ICON,
+  INDICATORS_TABLE_ADD_TO_NEW_CASE_BUTTON_ICON,
+  CASE_ACTION_WRAPPER,
+  CASE_ELLIPSE_BUTTON,
+  CASE_ELLIPSE_DELETE_CASE_CONFIRMATION_BUTTON,
+  CASE_ELLIPSE_DELETE_CASE_OPTION,
+  CREATE_CASE_BUTTON,
+  NEW_CASE_CREATE_BUTTON,
+  NEW_CASE_DESCRIPTION_INPUT,
+  NEW_CASE_NAME_INPUT,
+  SELECT_CASE_TABLE_ROW,
+  SELECT_EXISTING_CASE,
+  SELECT_EXISTING_CASES_MODAL,
+  VIEW_CASE_TOASTER_LINK,
+} from '../screens/cases';
+
+/**
+ * Open the add to new case flyout from the indicators table more actions menu
+ */
+export const openAddToNewCaseFlyoutFromTable = () => {
+  cy.get(INDICATORS_TABLE_ADD_TO_NEW_CASE_BUTTON_ICON).first().click();
+};
+
+/**
+ * Open the add to existing case flyout from the indicators table more actions menu
+ */
+export const openAddToExistingCaseFlyoutFromTable = () => {
+  cy.get(INDICATORS_TABLE_ADD_TO_EXISTING_CASE_BUTTON_ICON).first().click();
+};
+
+/**
+ * Open the new case flyout from the indicators flyout take action menu
+ */
+export const openAddToNewCaseFromFlyout = () => {
+  cy.get(FLYOUT_ADD_TO_NEW_CASE_ITEM).first().click();
+};
+
+/**
+ * Open the new existing flyout from the indicators flyout take action menu
+ */
+export const openAddToExistingCaseFromFlyout = () => {
+  cy.get(FLYOUT_ADD_TO_EXISTING_CASE_ITEM).first().click();
+};
+
+/**
+ * Create a new case by filling out the form from the Cases page
+ */
+export const createNewCaseFromCases = () => {
+  cy.get(CREATE_CASE_BUTTON).click();
+  cy.get(NEW_CASE_NAME_INPUT).click().type('case');
+  cy.get(NEW_CASE_DESCRIPTION_INPUT).click().type('case description');
+  cy.get(NEW_CASE_CREATE_BUTTON).click();
+};
+
+/**
+ * Create a new case from the Threat Intelligence page
+ */
+export const createNewCaseFromTI = () => {
+  cy.get(NEW_CASE_NAME_INPUT).type('case');
+  cy.get(NEW_CASE_DESCRIPTION_INPUT).type('case description');
+  cy.get(NEW_CASE_CREATE_BUTTON).click();
+};
+
+/**
+ * Click on the toaster to navigate to case and verified created case
+ */
+export const navigateToCaseViaToaster = () => {
+  cy.get(VIEW_CASE_TOASTER_LINK).click();
+};
+
+/**
+ * Delete case from the Cases page
+ */
+export const deleteCase = () => {
+  cy.get(CASE_ACTION_WRAPPER).find(CASE_ELLIPSE_BUTTON).click();
+  cy.get(CASE_ELLIPSE_DELETE_CASE_OPTION).click();
+  cy.get(CASE_ELLIPSE_DELETE_CASE_CONFIRMATION_BUTTON).click();
+};
+
+/**
+ * Select existing case from cases modal
+ */
+export const selectExistingCase = () => {
+  cy.get(SELECT_EXISTING_CASES_MODAL).within(() => {
+    cy.get(SELECT_CASE_TABLE_ROW).its('length').should('be.gte', 0);
+    cy.get(SELECT_EXISTING_CASE).should('exist').contains('Select').click();
+  });
+};

--- a/x-pack/plugins/threat_intelligence/cypress/tasks/common.ts
+++ b/x-pack/plugins/threat_intelligence/cypress/tasks/common.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  MANAGE_NAVIGATION_ITEMS,
+  SECURITY_SOLUTION_NAVBAR_CASES_ITEM,
+  SECURITY_SOLUTION_NAVBAR_MANAGE_ITEM,
+  SECURITY_SOLUTION_NAVBAR_THREAT_INTELLIGENCE_ITEM,
+  UPDATE_STATUS,
+} from '../screens/common';
+
+import {
+  BARCHART_POPOVER_BUTTON,
+  FLYOUT_CLOSE_BUTTON,
+  FLYOUT_TABS,
+  FLYOUT_TAKE_ACTION_BUTTON,
+  INDICATORS_TABLE_MORE_ACTION_BUTTON_ICON,
+  TOGGLE_FLYOUT_BUTTON,
+} from '../screens/indicators';
+
+/**
+ * Navigate to Blocklist screen via the Security Solution navbar and Manage menu item
+ */
+export const navigateToBlocklist = () => {
+  cy.get(SECURITY_SOLUTION_NAVBAR_MANAGE_ITEM).scrollIntoView().click();
+  cy.get(MANAGE_NAVIGATION_ITEMS).contains('Blocklist').click();
+};
+
+/**
+ * Navigate to Threat Intelligence screen via the Security Solution navbar
+ */
+export const navigateToThreatIntelligence = () => {
+  cy.get(SECURITY_SOLUTION_NAVBAR_THREAT_INTELLIGENCE_ITEM).click();
+};
+
+/**
+ * Navigate to Cases screen via the Security Solution navbar
+ */
+export const navigateToCases = () => {
+  cy.get(SECURITY_SOLUTION_NAVBAR_CASES_ITEM).click();
+};
+
+/**
+ * Close the opened flyout
+ */
+export const closeFlyout = () => {
+  cy.get(FLYOUT_CLOSE_BUTTON).click();
+};
+
+/**
+ * Open the indicators table more actions menu
+ */
+export const openIndicatorsTableMoreActions = (index: number) => {
+  cy.get(INDICATORS_TABLE_MORE_ACTION_BUTTON_ICON).eq(index).click();
+};
+
+/**
+ * Open the indicator flyout from indicators table
+ */
+export const openFlyout = (index: number) => {
+  cy.get(TOGGLE_FLYOUT_BUTTON).eq(index).click({ force: true });
+};
+
+/**
+ * Open the take action button within indicator flyout
+ */
+export const openFlyoutTakeAction = () => {
+  cy.get(FLYOUT_TAKE_ACTION_BUTTON).first().click();
+};
+
+/**
+ * Navigate to Table tab in indicators flyout
+ */
+export const navigateToFlyoutTableTab = () => {
+  cy.get(`${FLYOUT_TABS} button:nth-child(2)`).click();
+};
+
+/**
+ * Navigate to Json tab in indicators flyout
+ */
+export const navigateToFlyoutJsonTab = () => {
+  cy.get(`${FLYOUT_TABS} button:nth-child(3)`).click();
+};
+
+export const waitForViewToBeUpdated = () => {
+  cy.get(UPDATE_STATUS).scrollIntoView().should('contain.text', 'Updated');
+};
+
+/**
+ * Open barchart 3-dot popover menu
+ */
+export const openBarchartPopoverMenu = () => {
+  cy.get(BARCHART_POPOVER_BUTTON).should('exist').first().click();
+};

--- a/x-pack/plugins/threat_intelligence/cypress/tasks/indicators.ts
+++ b/x-pack/plugins/threat_intelligence/cypress/tasks/indicators.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { QUERY_INPUT } from '../screens/indicators';
+
+/**
+ * Nvigate to specific page in indicators table
+ */
+export const navigateToIndicatorsTablePage = (index: number) => {
+  cy.get(`[data-test-subj="pagination-button-${index}"]`).click();
+};
+
+/**
+ * Clears text in KQL bar
+ */
+export const enterQuery = (text: string) => {
+  cy.get(QUERY_INPUT).should('exist').focus().type(text);
+};
+
+/**
+ * Clears text in KQL bar
+ */
+export const clearQuery = () => {
+  cy.get(QUERY_INPUT).should('exist').focus().clear();
+};

--- a/x-pack/plugins/threat_intelligence/cypress/tasks/query_bar.ts
+++ b/x-pack/plugins/threat_intelligence/cypress/tasks/query_bar.ts
@@ -1,0 +1,125 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  QUERY_BAR,
+  QUERY_BAR_MENU_REMOVE_ALL_FILTERS_BUTTON,
+  QUERY_BAR_MENU,
+} from '../screens/query_bar';
+import {
+  BARCHART_FILTER_IN_BUTTON,
+  BARCHART_FILTER_OUT_BUTTON,
+  INDICATORS_TABLE_CELL_FILTER_IN_BUTTON,
+  INDICATORS_TABLE_CELL_FILTER_OUT_BUTTON,
+  INDICATOR_TYPE_CELL,
+  FLYOUT_OVERVIEW_TAB_BLOCKS_ITEM,
+  FLYOUT_OVERVIEW_TAB_BLOCKS_FILTER_IN_BUTTON,
+  FLYOUT_OVERVIEW_TAB_BLOCKS_FILTER_OUT_BUTTON,
+  FLYOUT_OVERVIEW_TAB_TABLE_ROW_FILTER_IN_BUTTON,
+  FLYOUT_OVERVIEW_TAB_TABLE_ROW_FILTER_OUT_BUTTON,
+  FLYOUT_TABLE_TAB_ROW_FILTER_IN_BUTTON,
+  FLYOUT_TABLE_TAB_ROW_FILTER_OUT_BUTTON,
+} from '../screens/indicators';
+
+/**
+ * Filter in value by clicking on the menu item within barchart popover
+ */
+export const filterInFromBarChartLegend = () => {
+  cy.get(BARCHART_FILTER_IN_BUTTON).should('exist').click();
+};
+
+/**
+ * Filter out value by clicking on the menu item within barchart popover
+ */
+export const filterOutFromBarChartLegend = () => {
+  cy.get(BARCHART_FILTER_OUT_BUTTON).should('exist').click();
+};
+
+/**
+ * Filter in value by clicking on the menu item within an indicators table cell
+ */
+export const filterInFromTableCell = () => {
+  cy.get(INDICATOR_TYPE_CELL)
+    .first()
+    .should('be.visible')
+    .trigger('mouseover')
+    .within((_cell) => {
+      cy.get(INDICATORS_TABLE_CELL_FILTER_IN_BUTTON).should('exist').click({
+        force: true,
+      });
+    });
+};
+
+/**
+ * Filter out value by clicking on the menu item within an indicators table cell
+ */
+export const filterOutFromTableCell = () => {
+  cy.get(INDICATOR_TYPE_CELL)
+    .first()
+    .trigger('mouseover')
+    .within((_cell) => {
+      cy.get(INDICATORS_TABLE_CELL_FILTER_OUT_BUTTON).should('exist').click({ force: true });
+    });
+};
+
+/**
+ * Clears all filters within KQL bar
+ */
+export const clearKQLBar = () => {
+  cy.get(QUERY_BAR).within(() => cy.get(QUERY_BAR_MENU).click());
+  cy.get(QUERY_BAR_MENU_REMOVE_ALL_FILTERS_BUTTON).click();
+};
+
+/**
+ * Filter in value from indicators flyout block item
+ */
+export const filterInFromFlyoutBlockItem = () => {
+  cy.get(FLYOUT_OVERVIEW_TAB_BLOCKS_ITEM).first().trigger('mouseover');
+  cy.get(FLYOUT_OVERVIEW_TAB_BLOCKS_FILTER_IN_BUTTON)
+    .should('exist')
+    .first()
+    .click({ force: true });
+};
+
+/**
+ * Filter out value from indicators flyout block item
+ */
+export const filterOutFromFlyoutBlockItem = () => {
+  cy.get(FLYOUT_OVERVIEW_TAB_BLOCKS_ITEM).first().trigger('mouseover');
+  cy.get(FLYOUT_OVERVIEW_TAB_BLOCKS_FILTER_OUT_BUTTON)
+    .should('exist')
+    .first()
+    .click({ force: true });
+};
+
+/**
+ * Filter in value from indicators flyout overview tab table
+ */
+export const filterInFromFlyoutOverviewTable = () => {
+  cy.get(FLYOUT_OVERVIEW_TAB_TABLE_ROW_FILTER_IN_BUTTON).should('exist').first().click();
+};
+
+/**
+ * Filter out value from indicators flyout overview tab table
+ */
+export const filterOutFromFlyoutOverviewTable = () => {
+  cy.get(FLYOUT_OVERVIEW_TAB_TABLE_ROW_FILTER_OUT_BUTTON).should('exist').first().click();
+};
+
+/**
+ * Filter in value from indicators flyout overview tab table
+ */
+export const filterInFromFlyoutTableTab = () => {
+  cy.get(FLYOUT_TABLE_TAB_ROW_FILTER_IN_BUTTON).should('exist').first().click();
+};
+
+/**
+ * Filter out value from indicators flyout overview tab table
+ */
+export const filterOutFromFlyoutTableTab = () => {
+  cy.get(FLYOUT_TABLE_TAB_ROW_FILTER_OUT_BUTTON).should('exist').first().click();
+};

--- a/x-pack/plugins/threat_intelligence/cypress/tasks/timeline.ts
+++ b/x-pack/plugins/threat_intelligence/cypress/tasks/timeline.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  CLOSE_TIMELINE_BTN,
+  FLYOUT_INVESTIGATE_IN_TIMELINE_ITEM,
+  FLYOUT_OVERVIEW_TAB_BLOCKS_TIMELINE_BUTTON,
+  FLYOUT_OVERVIEW_TAB_TABLE_ROW_TIMELINE_BUTTON,
+  INDICATORS_TABLE_CELL_TIMELINE_BUTTON,
+  INDICATORS_TABLE_INVESTIGATE_IN_TIMELINE_BUTTON_ICON,
+  UNTITLED_TIMELINE_BUTTON,
+} from '../screens/timeline';
+import {
+  BARCHART_TIMELINE_BUTTON,
+  FLYOUT_BLOCK_MORE_ACTIONS_BUTTON,
+  FLYOUT_TABLE_MORE_ACTIONS_BUTTON,
+  INDICATOR_TYPE_CELL,
+} from '../screens/indicators';
+
+/**
+ * Add data to timeline from barchart legend menu item
+ */
+export const addToTimelineFromBarchartLegend = () => {
+  cy.get(BARCHART_TIMELINE_BUTTON).should('exist').first().click();
+};
+/**
+ * Add data to timeline from indicators table cell menu
+ */
+export const addToTimelineFromTableCell = () => {
+  cy.get(INDICATOR_TYPE_CELL).first().trigger('mouseover');
+  cy.get(INDICATORS_TABLE_CELL_TIMELINE_BUTTON).should('exist').first().click({ force: true });
+};
+
+/**
+ * Open untitled timeline from button in footerx
+ */
+export const openTimeline = () => {
+  cy.get(UNTITLED_TIMELINE_BUTTON).should('exist').first().click({ force: true });
+};
+
+/**
+ * Close flyout button in top right corner
+ */
+export const closeTimeline = () => {
+  cy.get(CLOSE_TIMELINE_BTN).should('be.visible').click();
+};
+
+/**
+ * Add data to timeline from flyout overview tab table
+ */
+export const addToTimelineFromFlyoutOverviewTabTable = () => {
+  cy.get(FLYOUT_TABLE_MORE_ACTIONS_BUTTON).first().click({ force: true });
+  cy.get(FLYOUT_OVERVIEW_TAB_TABLE_ROW_TIMELINE_BUTTON).should('exist').first().click();
+};
+
+/**
+ * Add data to timeline from flyout overview tab block
+ */
+export const addToTimelineFromFlyoutOverviewTabBlock = () => {
+  cy.get(FLYOUT_BLOCK_MORE_ACTIONS_BUTTON).first().click({ force: true });
+  cy.get(FLYOUT_OVERVIEW_TAB_BLOCKS_TIMELINE_BUTTON).should('exist').first().click();
+};
+
+/**
+ * Investigate data to timeline from indicators table row
+ */
+export const investigateInTimelineFromTable = () => {
+  cy.get(INDICATORS_TABLE_INVESTIGATE_IN_TIMELINE_BUTTON_ICON).should('exist').first().click();
+};
+
+/**
+ * Investigate data to timeline from flyout take action button
+ */
+export const investigateInTimelineFromFlyout = () => {
+  cy.get(FLYOUT_INVESTIGATE_IN_TIMELINE_ITEM).should('exist').first().click();
+};


### PR DESCRIPTION
## Summary

This PR is the last one of the Threat Intelligence plugin refactor work.

It focuses on improving the performance of our Cypress tests by leveraging the use of `{ testIsolation: false }`.
It also separates the variables under the `screens` folder in multiple files (one per test file).
It also extracts the tasks into multiple files within the `tasks` folder (one per test file as well).

Finally it fixes the flakiness of the `timeline` tests and re-enables them.

https://github.com/elastic/security-team/issues/6062