### PR TITLE
fix(slo): keep service name list

### DIFF
--- a/x-pack/plugins/observability/public/hooks/slo/use_fetch_apm_suggestions.ts
+++ b/x-pack/plugins/observability/public/hooks/slo/use_fetch_apm_suggestions.ts
@@ -48,7 +48,7 @@ export function useFetchApmSuggestions({
             start: moment().subtract(2, 'days').toISOString(),
             end: moment().toISOString(),
             fieldValue: search,
-            ...(!!serviceName && { serviceName }),
+            ...(!!serviceName && fieldName !== 'service.name' && { serviceName }),
           },
           signal,
         });
@@ -59,6 +59,7 @@ export function useFetchApmSuggestions({
       }
     },
     refetchOnWindowFocus: false,
+    keepPreviousData: true,
   });
 
   return {

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/apm_common/field_selector.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/apm_common/field_selector.tsx
@@ -11,6 +11,7 @@ import { Controller, FieldPath, useFormContext } from 'react-hook-form';
 import { CreateSLOInput } from '@kbn/slo-schema';
 import { i18n } from '@kbn/i18n';
 
+import { debounce } from 'lodash';
 import {
   Suggestion,
   useFetchApmSuggestions,
@@ -48,6 +49,8 @@ export function FieldSelector({
     search,
     serviceName,
   });
+
+  const debouncedSearch = debounce((value) => setSearch(value), 200);
 
   const options = (
     allowAllOption
@@ -99,9 +102,7 @@ export function FieldSelector({
 
                 field.onChange('');
               }}
-              onSearchChange={(value: string) => {
-                setSearch(value);
-              }}
+              onSearchChange={(value: string) => debouncedSearch(value)}
               options={options}
               placeholder={placeholder}
               selectedOptions={


### PR DESCRIPTION
resolves https://github.com/elastic/kibana/issues/157455

## 📝 Summary

This PR keeps the list of service name after selecting one. I've also added a debounced search on it to avoid querying the server too much while typing for a service name.


| Screenshot |
|--------|
|  <img width="458" alt="image" src="https://github.com/elastic/kibana/assets/1376800/9a7106a5-e761-4ae1-a7b1-729a6acb0d98"> | 

<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->