### PR TITLE
Add SloGlobalDiagnosis check to SLO List and SLO Create pages

### DIFF
--- a/x-pack/plugins/observability/public/hooks/slo/helpers/convert_error_for_use_in_toast.ts
+++ b/x-pack/plugins/observability/public/hooks/slo/helpers/convert_error_for_use_in_toast.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export function convertErrorForUseInToast(error: Error) {
+  const newError = {
+    ...error,
+    message: Object(error).body.message,
+  };
+
+  return newError;
+}

--- a/x-pack/plugins/observability/public/hooks/slo/use_fetch_global_diagnosis.ts
+++ b/x-pack/plugins/observability/public/hooks/slo/use_fetch_global_diagnosis.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  QueryObserverResult,
+  RefetchOptions,
+  RefetchQueryFilters,
+  useQuery,
+} from '@tanstack/react-query';
+import { i18n } from '@kbn/i18n';
+import type { PublicLicenseJSON } from '@kbn/licensing-plugin/public';
+import type { SecurityGetUserPrivilegesResponse } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import { useKibana } from '../../utils/kibana_react';
+import { convertErrorForUseInToast } from './helpers/convert_error_for_use_in_toast';
+
+interface SloGlobalDiagnosisResponse {
+  licenseAndFeatures: PublicLicenseJSON;
+  userPrivileges: SecurityGetUserPrivilegesResponse;
+  sloResources: {
+    [x: string]: string;
+  };
+}
+
+export interface UseFetchSloGlobalDiagnoseResponse {
+  isInitialLoading: boolean;
+  isLoading: boolean;
+  isRefetching: boolean;
+  isSuccess: boolean;
+  isError: boolean;
+  globalSloDiagnosis: SloGlobalDiagnosisResponse | undefined;
+  refetch: <TPageData>(
+    options?: (RefetchOptions & RefetchQueryFilters<TPageData>) | undefined
+  ) => Promise<QueryObserverResult<SloGlobalDiagnosisResponse | undefined, unknown>>;
+}
+
+export function useFetchSloGlobalDiagnosis(): UseFetchSloGlobalDiagnoseResponse {
+  const {
+    http,
+    notifications: { toasts },
+  } = useKibana().services;
+
+  const { isInitialLoading, isLoading, isError, isSuccess, isRefetching, data, refetch } = useQuery(
+    {
+      queryKey: ['fetchSloGlobalDiagnosis'],
+      queryFn: async ({ signal }) => {
+        try {
+          const response = await http.get<SloGlobalDiagnosisResponse>(
+            '/internal/observability/slos/_diagnosis',
+            {
+              query: {},
+              signal,
+            }
+          );
+
+          return response;
+        } catch (error) {
+          throw convertErrorForUseInToast(error);
+        }
+      },
+      keepPreviousData: true,
+      refetchOnWindowFocus: false,
+      retry: false,
+      onError: (error: Error) => {
+        toasts.addError(error, {
+          title: i18n.translate('xpack.observability.slo.globalDiagnosis.errorNotification', {
+            defaultMessage: 'You do not have the right permissions to use this feature.',
+          }),
+        });
+      },
+    }
+  );
+
+  return {
+    globalSloDiagnosis: data,
+    isLoading,
+    isInitialLoading,
+    isRefetching,
+    isSuccess,
+    isError,
+    refetch,
+  };
+}

--- a/x-pack/plugins/observability/public/hooks/slo/use_fetch_global_diagnosis.ts
+++ b/x-pack/plugins/observability/public/hooks/slo/use_fetch_global_diagnosis.ts
@@ -21,7 +21,7 @@ interface SloGlobalDiagnosisResponse {
   licenseAndFeatures: PublicLicenseJSON;
   userPrivileges: SecurityGetUserPrivilegesResponse;
   sloResources: {
-    [x: string]: string;
+    [x: string]: "OK" | "NOT_OK";
   };
 }
 

--- a/x-pack/plugins/observability/public/hooks/slo/use_fetch_global_diagnosis.ts
+++ b/x-pack/plugins/observability/public/hooks/slo/use_fetch_global_diagnosis.ts
@@ -21,7 +21,7 @@ interface SloGlobalDiagnosisResponse {
   licenseAndFeatures: PublicLicenseJSON;
   userPrivileges: SecurityGetUserPrivilegesResponse;
   sloResources: {
-    [x: string]: "OK" | "NOT_OK";
+    [x: string]: 'OK' | 'NOT_OK';
   };
 }
 

--- a/x-pack/plugins/observability/public/pages/slo_edit/slo_edit.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/slo_edit.tsx
@@ -15,9 +15,10 @@ import { usePluginContext } from '../../hooks/use_plugin_context';
 import { useBreadcrumbs } from '../../hooks/use_breadcrumbs';
 import { useFetchSloDetails } from '../../hooks/slo/use_fetch_slo_details';
 import { useLicense } from '../../hooks/use_license';
-import { SloEditForm } from './components/slo_edit_form';
-import { FeedbackButton } from '../../components/slo/feedback_button/feedback_button';
 import { useCapabilities } from '../../hooks/slo/use_capabilities';
+import { useFetchSloGlobalDiagnosis } from '../../hooks/slo/use_fetch_global_diagnosis';
+import { FeedbackButton } from '../../components/slo/feedback_button/feedback_button';
+import { SloEditForm } from './components/slo_edit_form';
 
 export function SloEditPage() {
   const {
@@ -25,6 +26,7 @@ export function SloEditPage() {
     http: { basePath },
   } = useKibana().services;
   const { hasWriteCapabilities } = useCapabilities();
+  const { isError: hasErrorInGlobalDiagnosis } = useFetchSloGlobalDiagnosis();
   const { ObservabilityPageTemplate } = usePluginContext();
 
   const { sloId } = useParams<{ sloId: string | undefined }>();
@@ -43,7 +45,7 @@ export function SloEditPage() {
 
   const { slo, isInitialLoading } = useFetchSloDetails({ sloId });
 
-  if (hasRightLicense === false || !hasWriteCapabilities) {
+  if (hasRightLicense === false || !hasWriteCapabilities || hasErrorInGlobalDiagnosis) {
     navigateToUrl(basePath.prepend(paths.observability.slos));
   }
 

--- a/x-pack/plugins/observability/public/pages/slos_welcome/slos_welcome.test.tsx
+++ b/x-pack/plugins/observability/public/pages/slos_welcome/slos_welcome.test.tsx
@@ -11,6 +11,7 @@ import { screen, waitFor } from '@testing-library/react';
 import { render } from '../../utils/test_helper';
 import { useKibana } from '../../utils/kibana_react';
 import { useFetchSloList } from '../../hooks/slo/use_fetch_slo_list';
+import { useFetchSloGlobalDiagnosis } from '../../hooks/slo/use_fetch_global_diagnosis';
 import { useLicense } from '../../hooks/use_license';
 import { SlosWelcomePage } from './slos_welcome';
 import { emptySloList, sloList } from '../../data/slo/slo';
@@ -22,11 +23,13 @@ jest.mock('../../hooks/use_breadcrumbs');
 jest.mock('../../hooks/use_license');
 jest.mock('../../hooks/slo/use_fetch_slo_list');
 jest.mock('../../hooks/slo/use_capabilities');
+jest.mock('../../hooks/slo/use_fetch_global_diagnosis');
 
 const useKibanaMock = useKibana as jest.Mock;
 const useLicenseMock = useLicense as jest.Mock;
 const useFetchSloListMock = useFetchSloList as jest.Mock;
 const useCapabilitiesMock = useCapabilities as jest.Mock;
+const useGlobalDiagnosisMock = useFetchSloGlobalDiagnosis as jest.Mock;
 
 const mockNavigate = jest.fn();
 
@@ -54,6 +57,9 @@ describe('SLOs Welcome Page', () => {
     it('renders the welcome message with subscription buttons', async () => {
       useFetchSloListMock.mockReturnValue({ isLoading: false, sloList: emptySloList });
       useLicenseMock.mockReturnValue({ hasAtLeast: () => false });
+      useGlobalDiagnosisMock.mockReturnValue({
+        isError: false,
+      });
 
       render(<SlosWelcomePage />);
 
@@ -66,6 +72,9 @@ describe('SLOs Welcome Page', () => {
   describe('when the correct license is found', () => {
     beforeEach(() => {
       useLicenseMock.mockReturnValue({ hasAtLeast: () => true });
+      useGlobalDiagnosisMock.mockReturnValue({
+        isError: false,
+      });
     });
 
     describe('when loading is done and no results are found', () => {
@@ -80,6 +89,24 @@ describe('SLOs Welcome Page', () => {
         });
 
         render(<SlosWelcomePage />);
+
+        expect(screen.queryByTestId('slosPageWelcomePrompt')).toBeTruthy();
+
+        const createNewSloButton = screen.queryByTestId('o11ySloListWelcomePromptCreateSloButton');
+
+        expect(createNewSloButton).toBeDisabled();
+      });
+
+      it('disables the create slo button when no cluster permissions capabilities', async () => {
+        useCapabilitiesMock.mockReturnValue({
+          hasWriteCapabilities: true,
+          hasReadCapabilities: true,
+        });
+        useGlobalDiagnosisMock.mockReturnValue({
+          isError: true,
+        });
+
+        render(<SlosWelcomePage />);
         expect(screen.queryByTestId('slosPageWelcomePrompt')).toBeTruthy();
 
         const createNewSloButton = screen.queryByTestId('o11ySloListWelcomePromptCreateSloButton');
@@ -87,6 +114,10 @@ describe('SLOs Welcome Page', () => {
       });
 
       it('should display the welcome message with a Create new SLO button which should navigate to the SLO Creation page', async () => {
+        useGlobalDiagnosisMock.mockReturnValue({
+          isError: false,
+        });
+
         render(<SlosWelcomePage />);
         expect(screen.queryByTestId('slosPageWelcomePrompt')).toBeTruthy();
 
@@ -103,6 +134,9 @@ describe('SLOs Welcome Page', () => {
     describe('when loading is done and results are found', () => {
       beforeEach(() => {
         useFetchSloListMock.mockReturnValue({ isLoading: false, sloList });
+        useGlobalDiagnosisMock.mockReturnValue({
+          isError: false,
+        });
       });
 
       it('should navigate to the SLO List page', async () => {

--- a/x-pack/plugins/observability/public/pages/slos_welcome/slos_welcome.tsx
+++ b/x-pack/plugins/observability/public/pages/slos_welcome/slos_welcome.tsx
@@ -21,10 +21,11 @@ import { i18n } from '@kbn/i18n';
 import { useKibana } from '../../utils/kibana_react';
 import { useLicense } from '../../hooks/use_license';
 import { usePluginContext } from '../../hooks/use_plugin_context';
+import { useCapabilities } from '../../hooks/slo/use_capabilities';
 import { useFetchSloList } from '../../hooks/slo/use_fetch_slo_list';
 import { paths } from '../../config/paths';
 import illustration from './assets/illustration.svg';
-import { useCapabilities } from '../../hooks/slo/use_capabilities';
+import { useFetchSloGlobalDiagnosis } from '../../hooks/slo/use_fetch_global_diagnosis';
 
 export function SlosWelcomePage() {
   const {
@@ -32,6 +33,7 @@ export function SlosWelcomePage() {
     http: { basePath },
   } = useKibana().services;
   const { hasWriteCapabilities } = useCapabilities();
+  const { isError: hasErrorInGlobalDiagnosis } = useFetchSloGlobalDiagnosis();
   const { ObservabilityPageTemplate } = usePluginContext();
 
   const { hasAtLeast } = useLicense();
@@ -44,7 +46,8 @@ export function SlosWelcomePage() {
     navigateToUrl(basePath.prepend(paths.observability.sloCreate));
   };
 
-  const hasSlosAndHasPermissions = total > 0 && hasAtLeast('platinum') === true;
+  const hasSlosAndHasPermissions =
+    total > 0 && hasAtLeast('platinum') === true && !hasErrorInGlobalDiagnosis;
 
   useEffect(() => {
     if (hasSlosAndHasPermissions) {
@@ -110,7 +113,7 @@ export function SlosWelcomePage() {
                       fill
                       color="primary"
                       onClick={handleClickCreateSlo}
-                      disabled={!hasWriteCapabilities}
+                      disabled={!hasWriteCapabilities || hasErrorInGlobalDiagnosis}
                     >
                       {i18n.translate('xpack.observability.slo.sloList.welcomePrompt.buttonLabel', {
                         defaultMessage: 'Create SLO',

--- a/x-pack/plugins/observability/server/routes/slo/route.ts
+++ b/x-pack/plugins/observability/server/routes/slo/route.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { badRequest } from '@hapi/boom';
+import { badRequest, forbidden, failedDependency } from '@hapi/boom';
 import {
   createSLOParamsSchema,
   deleteSLOParamsSchema,
@@ -275,7 +275,15 @@ const getDiagnosisRoute = createObservabilityServerRoute({
     const esClient = (await context.core).elasticsearch.client.asCurrentUser;
     const licensing = await context.licensing;
 
-    return getGlobalDiagnosis(esClient, licensing);
+    try {
+      const response = await getGlobalDiagnosis(esClient, licensing);
+      return response;
+    } catch (error) {
+      if (error.cause.statusCode === 403) {
+        throw forbidden('Insufficient Elasticsearch cluster permissions to access feature.');
+      }
+      throw failedDependency(error);
+    }
   },
 });
 


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/157317

## 📝 Summary

This adds the usage of the SLO Global Diagnosis endpoint in the SLO app on the SLO Welcome and SLO Create pages.

If the endpoint returns an error, the user will receive a toast with more detailed information as to what is the cause of the issue.

On the Welcome page the Create SLO button will be disabled. When the user visits the Create page via URL she will be navigated back to the Welcome page.

<img width="1624" alt="Screenshot 2023-05-12 at 14 41 35" src="https://github.com/elastic/kibana/assets/535564/3b628a66-56fc-45a6-95f6-6a7bb29db51a">

## ✅ Checklist
- If a user has required cluster permissions, the user should be able to click the Create SLO button on the welcome page
- If a user has required cluster permissions, the user should be able to navigate to the Create SLO page
- If a user does not have required cluster permissions, the user should not be able to click the Create SLO button on the welcome page
- If a user does not have required cluster permissions, the user should be navigated to the Welcome page when the user attempts to visit the Create SLO page
- If a user does not have required cluster permissions, the user should receive a helpful error message.


<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->