### PR TITLE
fix(slo): remove good status codes from apm availability

### DIFF
--- a/packages/kbn-slo-schema/src/schema/indicators.ts
+++ b/packages/kbn-slo-schema/src/schema/indicators.ts
@@ -39,9 +39,6 @@ const apmTransactionErrorRateIndicatorSchema = t.type({
       index: t.string,
     }),
     t.partial({
-      goodStatusCodes: t.array(
-        t.union([t.literal('2xx'), t.literal('3xx'), t.literal('4xx'), t.literal('5xx')])
-      ),
       filter: t.string,
     }),
   ]),

--- a/x-pack/plugins/observability/dev_docs/slo.md
+++ b/x-pack/plugins/observability/dev_docs/slo.md
@@ -10,7 +10,7 @@ We currently support the following SLI:
 - APM Transaction Duration, known as APM Latency
 - Custom KQL
 
-For the APM SLIs, customer can provide the service, environment, transaction name and type to configure them. For the **APM Latency** SLI, a threshold in milliseconds needs to be provided to discriminate the good and bad responses (events). For the **APM Availability** SLI, a list of good status codes needs to be provided to discriminate the good and bad responses (events). The API supports an optional kql filter to further filter the apm data.
+For the APM SLIs, customer can provide the service, environment, transaction name and type to configure them. For the **APM Latency** SLI, a threshold in milliseconds needs to be provided to discriminate the good and bad responses (events). For the **APM Availability** SLI, we use the `event.outcome` as a way to discriminate the good and the bad responses(events). The API supports an optional kql filter to further filter the apm data.
 
 The **custom KQL** SLI requires an index pattern, an optional filter query, a numerator query, and denominator query. A custom 'timestampField' can be provided to override the default @timestamp field.
 
@@ -69,7 +69,6 @@ curl --request POST \
 			"service": "o11y-app",
 			"transactionType": "request",
 			"transactionName": "GET /api",
-			"goodStatusCodes": ["2xx", "3xx", "4xx"],
 			"index": "metrics-apm*"
 		}
 	},
@@ -105,7 +104,6 @@ curl --request POST \
 			"service": "o11y-app",
 			"transactionType": "request",
 			"transactionName": "GET /api",
-			"goodStatusCodes": ["2xx", "3xx", "4xx"],
 			"index": "metrics-apm*"
 		}
 	},
@@ -143,7 +141,6 @@ curl --request POST \
 			"service": "o11y-app",
 			"transactionType": "request",
 			"transactionName": "GET /api",
-			"goodStatusCodes": ["2xx", "3xx", "4xx"],
 			"index": "metrics-apm*"
 		}
 	},

--- a/x-pack/plugins/observability/docs/openapi/slo/bundled.yaml
+++ b/x-pack/plugins/observability/docs/openapi/slo/bundled.yaml
@@ -424,15 +424,6 @@ components:
               description: The APM transaction name or "*"
               type: string
               example: GET /my/api
-            goodStatusCodes:
-              description: The status codes considered as good events. Default to 2xx, 3xx and 4xx
-              type: array
-              items:
-                type: string
-              example:
-                - 2xx
-                - 3xx
-                - 4xx
             filter:
               description: KQL query used for filtering the data
               type: string

--- a/x-pack/plugins/observability/docs/openapi/slo/components/schemas/indicator_properties_apm_availability.yaml
+++ b/x-pack/plugins/observability/docs/openapi/slo/components/schemas/indicator_properties_apm_availability.yaml
@@ -32,15 +32,6 @@ properties:
         description: The APM transaction name or "*"
         type: string
         example: GET /my/api
-      goodStatusCodes:
-        description: The status codes considered as good events. Default to 2xx, 3xx and 4xx
-        type: array
-        items:
-          type: string
-        example: 
-          - "2xx"
-          - "3xx"
-          - "4xx"
       filter:
         description: KQL query used for filtering the data
         type: string

--- a/x-pack/plugins/observability/public/data/slo/indicator.ts
+++ b/x-pack/plugins/observability/public/data/slo/indicator.ts
@@ -17,7 +17,6 @@ export const buildApmAvailabilityIndicator = (
       service: 'o11y-app',
       transactionType: 'request',
       transactionName: 'GET /flaky',
-      goodStatusCodes: ['2xx', '3xx', '4xx'],
       index: 'metrics-apm*',
       ...params,
     },

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/apm_availability/apm_availability_indicator_type_form.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/apm_availability/apm_availability_indicator_type_form.tsx
@@ -6,15 +6,8 @@
  */
 
 import React, { useEffect } from 'react';
-import {
-  EuiComboBox,
-  EuiComboBoxOptionOption,
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiFormRow,
-  EuiIconTip,
-} from '@elastic/eui';
-import { Controller, useFormContext } from 'react-hook-form';
+import { EuiFlexGroup, EuiFlexItem, EuiIconTip } from '@elastic/eui';
+import { useFormContext } from 'react-hook-form';
 import { i18n } from '@kbn/i18n';
 import type { CreateSLOInput } from '@kbn/slo-schema';
 
@@ -23,7 +16,7 @@ import { FieldSelector } from '../apm_common/field_selector';
 import { QueryBuilder } from '../common/query_builder';
 
 export function ApmAvailabilityIndicatorTypeForm() {
-  const { control, setValue, watch, getFieldState } = useFormContext<CreateSLOInput>();
+  const { control, setValue, watch } = useFormContext<CreateSLOInput>();
   const { data: apmIndex } = useFetchApmIndex();
   useEffect(() => {
     setValue('indicator.params.index', apmIndex);
@@ -105,65 +98,6 @@ export function ApmAvailabilityIndicatorTypeForm() {
 
       <EuiFlexGroup direction="row" gutterSize="l">
         <EuiFlexItem>
-          <EuiFormRow
-            label={
-              <span>
-                {i18n.translate('xpack.observability.slo.sloEdit.apmAvailability.goodStatusCodes', {
-                  defaultMessage: 'Good status codes',
-                })}{' '}
-                <EuiIconTip
-                  content={i18n.translate(
-                    'xpack.observability.slo.sloEdit.apmAvailability.goodStatusCodes.tooltip',
-                    {
-                      defaultMessage:
-                        'Configure the HTTP status codes defining the "good" or "successful" requests for the SLO.',
-                    }
-                  )}
-                  position="top"
-                />
-              </span>
-            }
-            isInvalid={getFieldState('indicator.params.goodStatusCodes').invalid}
-          >
-            <Controller
-              shouldUnregister
-              name="indicator.params.goodStatusCodes"
-              control={control}
-              defaultValue={['2xx', '3xx', '4xx']}
-              rules={{ required: true }}
-              render={({ field: { ref, ...field }, fieldState }) => (
-                <EuiComboBox
-                  {...field}
-                  aria-label={i18n.translate(
-                    'xpack.observability.slo.sloEdit.apmAvailability.goodStatusCodes.placeholder',
-                    {
-                      defaultMessage: 'Select the good status codes',
-                    }
-                  )}
-                  placeholder={i18n.translate(
-                    'xpack.observability.slo.sloEdit.apmAvailability.goodStatusCodes.placeholder',
-                    {
-                      defaultMessage: 'Select the good status codes',
-                    }
-                  )}
-                  isInvalid={fieldState.invalid}
-                  options={generateStatusCodeOptions(['2xx', '3xx', '4xx', '5xx'])}
-                  selectedOptions={generateStatusCodeOptions(field.value)}
-                  onChange={(selected: EuiComboBoxOptionOption[]) => {
-                    if (selected.length) {
-                      return field.onChange(selected.map((opts) => opts.value));
-                    }
-
-                    field.onChange([]);
-                  }}
-                  isClearable
-                  data-test-subj="sloEditApmAvailabilityGoodStatusCodesSelector"
-                />
-              )}
-            />
-          </EuiFormRow>
-        </EuiFlexItem>
-        <EuiFlexItem>
           <QueryBuilder
             control={control}
             dataTestSubj="apmLatencyFilterInput"
@@ -192,12 +126,4 @@ export function ApmAvailabilityIndicatorTypeForm() {
       </EuiFlexGroup>
     </EuiFlexGroup>
   );
-}
-
-function generateStatusCodeOptions(codes: string[] = []) {
-  return codes.map((code) => ({
-    label: code,
-    value: code,
-    'data-test-subj': `${code}Option`,
-  }));
 }

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/slo_edit_form_description_section.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/slo_edit_form_description_section.tsx
@@ -154,7 +154,7 @@ export function SloEditFormDescriptionSection() {
                     }
                   }}
                   isClearable
-                  data-test-subj="sloEditApmAvailabilityGoodStatusCodesSelector"
+                  data-test-subj="sloEditTagsSelector"
                 />
               )}
             />

--- a/x-pack/plugins/observability/public/pages/slo_edit/helpers/use_section_form_validation.ts
+++ b/x-pack/plugins/observability/public/pages/slo_edit/helpers/use_section_form_validation.ts
@@ -57,7 +57,7 @@ export function useSectionFormValidation({ getFieldState, getValues, formState, 
             'indicator.params.transactionName',
           ] as const
         ).every((field) => !getFieldState(field, formState).invalid && getValues(field) !== '') &&
-        (['indicator.params.index', 'indicator.params.goodStatusCodes'] as const).every(
+        (['indicator.params.index'] as const).every(
           (field) => !getFieldState(field, formState).invalid
         );
       break;

--- a/x-pack/plugins/observability/server/services/slo/fixtures/slo.ts
+++ b/x-pack/plugins/observability/server/services/slo/fixtures/slo.ts
@@ -34,7 +34,6 @@ export const createAPMTransactionErrorRateIndicator = (
     service: 'irrelevant',
     transactionName: 'irrelevant',
     transactionType: 'irrelevant',
-    goodStatusCodes: ['2xx', '3xx', '4xx'],
     index: 'metrics-apm*',
     ...params,
   },

--- a/x-pack/plugins/observability/server/services/slo/get_slo.test.ts
+++ b/x-pack/plugins/observability/server/services/slo/get_slo.test.ts
@@ -53,7 +53,6 @@ describe('GetSLO', () => {
             service: 'irrelevant',
             transactionName: 'irrelevant',
             transactionType: 'irrelevant',
-            goodStatusCodes: ['2xx', '3xx', '4xx'],
             index: 'metrics-apm*',
           },
           type: 'sli.apm.transactionErrorRate',

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/apm_transaction_error_rate.test.ts.snap
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/apm_transaction_error_rate.test.ts.snap
@@ -181,23 +181,11 @@ Object {
       "slo.numerator": Object {
         "filter": Object {
           "bool": Object {
-            "should": Array [
-              Object {
-                "match": Object {
-                  "transaction.result": "HTTP 2xx",
-                },
+            "should": Object {
+              "match": Object {
+                "event.outcome": "success",
               },
-              Object {
-                "match": Object {
-                  "transaction.result": "HTTP 3xx",
-                },
-              },
-              Object {
-                "match": Object {
-                  "transaction.result": "HTTP 4xx",
-                },
-              },
-            ],
+            },
           },
         },
       },
@@ -329,23 +317,11 @@ Object {
       "slo.numerator": Object {
         "filter": Object {
           "bool": Object {
-            "should": Array [
-              Object {
-                "match": Object {
-                  "transaction.result": "HTTP 2xx",
-                },
+            "should": Object {
+              "match": Object {
+                "event.outcome": "success",
               },
-              Object {
-                "match": Object {
-                  "transaction.result": "HTTP 3xx",
-                },
-              },
-              Object {
-                "match": Object {
-                  "transaction.result": "HTTP 4xx",
-                },
-              },
-            ],
+            },
           },
         },
       },
@@ -451,38 +427,5 @@ Object {
     },
   },
   "transform_id": Any<String>,
-}
-`;
-
-exports[`APM Transaction Error Rate Transform Generator uses default values when 'good_status_codes' is not specified 1`] = `
-Object {
-  "slo.denominator": Object {
-    "value_count": Object {
-      "field": "transaction.duration.histogram",
-    },
-  },
-  "slo.numerator": Object {
-    "filter": Object {
-      "bool": Object {
-        "should": Array [
-          Object {
-            "match": Object {
-              "transaction.result": "HTTP 2xx",
-            },
-          },
-          Object {
-            "match": Object {
-              "transaction.result": "HTTP 3xx",
-            },
-          },
-          Object {
-            "match": Object {
-              "transaction.result": "HTTP 4xx",
-            },
-          },
-        ],
-      },
-    },
-  },
 }
 `;

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/apm_transaction_error_rate.test.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/apm_transaction_error_rate.test.ts
@@ -44,15 +44,6 @@ describe('APM Transaction Error Rate Transform Generator', () => {
     });
   });
 
-  it("uses default values when 'good_status_codes' is not specified", async () => {
-    const anSLO = createSLO({
-      indicator: createAPMTransactionErrorRateIndicator({ goodStatusCodes: [] }),
-    });
-    const transform = generator.getTransformParams(anSLO);
-
-    expect(transform.pivot?.aggregations).toMatchSnapshot();
-  });
-
   it("does not include the query filter when params are '*'", async () => {
     const anSLO = createSLO({
       indicator: createAPMTransactionErrorRateIndicator({


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/157495

## 📝 Summary

This PR removes the ability to select the status codes on the APM availability indicator type. Instead, we rely on the normalized `event.outcome` field. 

This allow for a better experience between APM (what they show as successful request) and an SLO upon the same service.


| Screenshot |
|--------|
| ![image](https://github.com/elastic/kibana/assets/1376800/1e825ac1-3ad9-4341-8fd1-e23394444c42) | 

<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->