### PR TITLE
[Security Solution][Response Ops] Alert Table column metadata does not have the columns data type

### DIFF
--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/hooks/use_columns/use_columns.ts
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/hooks/use_columns/use_columns.ts
@@ -165,10 +165,14 @@ export const useColumns = ({
     // if defaultColumns have changed, populate again
     if (didDefaultColumnChange) {
       defaultColumnsRef.current = defaultColumns;
-      setColumns(storageAlertsTable.current.columns);
+      let cols = storageAlertsTable.current.columns;
+      if (initialBrowserFields) {
+        cols = populateColumns(cols, initialBrowserFields, defaultColumns);
+      }
+      setColumns(cols);
       return;
     }
-  }, [didDefaultColumnChange, storageAlertsTable, defaultColumns]);
+  }, [initialBrowserFields, didDefaultColumnChange, storageAlertsTable, defaultColumns]);
 
   useEffect(() => {
     if (isBrowserFieldDataLoading !== false || isColumnsPopulated) return;

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/hooks/use_columns/use_columns.ts
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/hooks/use_columns/use_columns.ts
@@ -159,6 +159,7 @@ export const useColumns = ({
     }
     return cols;
   });
+
   const [isColumnsPopulated, setColumnsPopulated] = useState<boolean>(false);
 
   const defaultColumnsRef = useRef<typeof defaultColumns>(defaultColumns);
@@ -169,13 +170,19 @@ export const useColumns = ({
   );
 
   useEffect(() => {
-    // if defaultColumns have changed, populate again
+    // if defaultColumns have changed,
+    // get the latest columns provided by client and
     if (didDefaultColumnChange) {
       defaultColumnsRef.current = defaultColumns;
-      setColumns(storageAlertsTable.current.columns);
+      let cols = storageAlertsTable.current.columns;
+      // before restoring from storage, enrich the column data
+      if (initialBrowserFields && defaultColumns) {
+        cols = populateColumns(cols, initialBrowserFields, defaultColumns);
+      }
+      setColumns(cols);
       return;
     }
-  }, [didDefaultColumnChange, storageAlertsTable, defaultColumns]);
+  }, [didDefaultColumnChange, storageAlertsTable, defaultColumns, initialBrowserFields]);
 
   useEffect(() => {
     if (isBrowserFieldDataLoading !== false || isColumnsPopulated) return;

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/hooks/use_columns/use_columns.ts
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/hooks/use_columns/use_columns.ts
@@ -10,7 +10,7 @@ import { IStorageWrapper } from '@kbn/kibana-utils-plugin/public';
 import { BrowserField, BrowserFields } from '@kbn/rule-registry-plugin/common';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { AlertConsumers } from '@kbn/rule-data-utils';
-import { isEqual } from 'lodash';
+import { isEmpty, isEqual } from 'lodash';
 import { AlertsTableStorage } from '../../alerts_table_state';
 import { toggleColumn } from './toggle_column';
 import { useFetchBrowserFieldCapabilities } from '../use_fetch_browser_fields_capabilities';
@@ -174,18 +174,14 @@ export const useColumns = ({
     // get the latest columns provided by client and
     if (didDefaultColumnChange) {
       defaultColumnsRef.current = defaultColumns;
-      let cols = storageAlertsTable.current.columns;
-      // before restoring from storage, enrich the column data
-      if (initialBrowserFields && defaultColumns) {
-        cols = populateColumns(cols, initialBrowserFields, defaultColumns);
-      }
-      setColumns(cols);
+      setColumnsPopulated(false);
+      setColumns(storageAlertsTable.current.columns);
       return;
     }
-  }, [didDefaultColumnChange, storageAlertsTable, defaultColumns, initialBrowserFields]);
+  }, [didDefaultColumnChange, storageAlertsTable, defaultColumns]);
 
   useEffect(() => {
-    if (isBrowserFieldDataLoading !== false || isColumnsPopulated) return;
+    if (isEmpty(browserFields) || isColumnsPopulated) return;
 
     const populatedColumns = populateColumns(columns, browserFields, defaultColumns);
 

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/hooks/use_columns/use_columns.ts
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/hooks/use_columns/use_columns.ts
@@ -151,7 +151,14 @@ export const useColumns = ({
     initialBrowserFields,
   });
 
-  const [columns, setColumns] = useState<EuiDataGridColumn[]>(storageAlertsTable.current.columns);
+  const [columns, setColumns] = useState<EuiDataGridColumn[]>(() => {
+    let cols = storageAlertsTable.current.columns;
+    // before restoring from storage, enrich the column data
+    if (initialBrowserFields && defaultColumns) {
+      cols = populateColumns(cols, initialBrowserFields, defaultColumns);
+    }
+    return cols;
+  });
   const [isColumnsPopulated, setColumnsPopulated] = useState<boolean>(false);
 
   const defaultColumnsRef = useRef<typeof defaultColumns>(defaultColumns);
@@ -165,14 +172,10 @@ export const useColumns = ({
     // if defaultColumns have changed, populate again
     if (didDefaultColumnChange) {
       defaultColumnsRef.current = defaultColumns;
-      let cols = storageAlertsTable.current.columns;
-      if (initialBrowserFields) {
-        cols = populateColumns(cols, initialBrowserFields, defaultColumns);
-      }
-      setColumns(cols);
+      setColumns(storageAlertsTable.current.columns);
       return;
     }
-  }, [initialBrowserFields, didDefaultColumnChange, storageAlertsTable, defaultColumns]);
+  }, [didDefaultColumnChange, storageAlertsTable, defaultColumns]);
 
   useEffect(() => {
     if (isBrowserFieldDataLoading !== false || isColumnsPopulated) return;


### PR DESCRIPTION
## Summary

Handles : #157463 

 - `@timestamp` Sorting is working functionally instead of `A-Z` it should be `Old - New`

|Before|After|
|---|---|
|![image](https://github.com/elastic/kibana/assets/59917825/6c5a4c64-cd74-4421-af16-f6172bfc7fc5)|<video src="https://github.com/elastic/kibana/assets/7485038/15ac8a52-eece-4892-8c32-09f19e18e870" />|

Image-After
<img width="611" alt="image" src="https://github.com/elastic/kibana/assets/7485038/b9f62366-3067-4a74-b7be-74fb8f94d2b8">
















<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->