### PR TITLE
[APM] Fix manual refresh on Unified Search

### DIFF
--- a/x-pack/plugins/apm/public/components/shared/unified_search_bar/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/unified_search_bar/index.tsx
@@ -6,7 +6,6 @@
  */
 import React, { useCallback, useEffect, useState } from 'react';
 import { i18n } from '@kbn/i18n';
-import { isEqual } from 'lodash';
 import {
   Filter,
   fromKueryExpression,
@@ -192,7 +191,10 @@ export function UnifiedSearchBar({
     clearCache();
     incrementTimeRangeId();
   };
-  const handleSubmit = (payload: { dateRange: TimeRange; query?: Query }) => {
+  const handleSubmit = (
+    payload: { dateRange: TimeRange; query?: Query },
+    isUpdate?: boolean
+  ) => {
     if (dataView == null) {
       return;
     }
@@ -221,15 +223,13 @@ export function UnifiedSearchBar({
         kuery: query?.query,
       };
 
-      const isRefresh = isEqual(existingQueryParams, newSearchParams);
-
-      if (isRefresh) {
-        onRefresh();
-      } else {
+      if (isUpdate) {
         history.push({
           ...location,
           search: fromQuery(newSearchParams),
         });
+      } else {
+        onRefresh();
       }
     } catch (e) {
       console.log('Invalid kuery syntax'); // eslint-disable-line no-console


### PR DESCRIPTION
Fixes - https://github.com/elastic/kibana/issues/156363

Depends on - https://github.com/elastic/kibana/pull/157468
## Summary

The PR fixes the issues
1. Where when manually Refresh button on the Unified Search Bar is clicked, the refresh would do nothing.