### PR TITLE
[Security Solution] Rename the Rules Area team to Rule Management in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1098,38 +1098,38 @@ x-pack/test/observability_functional @elastic/actionable-observability
 /x-pack/plugins/security_solution/server/lib/detection_engine/routes/index @elastic/security-detections-response-alerts
 /x-pack/plugins/security_solution/server/lib/detection_engine/routes/signals @elastic/security-detections-response-alerts
 
-## Security Solution sub teams - Detections and Response Rules
-/x-pack/plugins/security_solution/common/detection_engine/fleet_integrations @elastic/security-detections-response-rules
-/x-pack/plugins/security_solution/common/detection_engine/prebuilt_rules @elastic/security-detections-response-rules
-/x-pack/plugins/security_solution/common/detection_engine/rule_management @elastic/security-detections-response-rules
-/x-pack/plugins/security_solution/common/detection_engine/rule_monitoring @elastic/security-detections-response-rules
-/x-pack/plugins/security_solution/common/detection_engine/rule_schema @elastic/security-detections-response-rules @elastic/security-detections-response-alerts
+## Security Solution sub teams - Detection Rule Management
+/x-pack/plugins/security_solution/common/detection_engine/fleet_integrations @elastic/security-detection-rule-management
+/x-pack/plugins/security_solution/common/detection_engine/prebuilt_rules @elastic/security-detection-rule-management
+/x-pack/plugins/security_solution/common/detection_engine/rule_management @elastic/security-detection-rule-management
+/x-pack/plugins/security_solution/common/detection_engine/rule_monitoring @elastic/security-detection-rule-management
+/x-pack/plugins/security_solution/common/detection_engine/rule_schema @elastic/security-detection-rule-management @elastic/security-detections-response-alerts
 
-/x-pack/plugins/security_solution/public/common/components/health_truncate_text @elastic/security-detections-response-rules
-/x-pack/plugins/security_solution/public/common/components/links_to_docs @elastic/security-detections-response-rules
-/x-pack/plugins/security_solution/public/common/components/ml_popover @elastic/security-detections-response-rules
-/x-pack/plugins/security_solution/public/common/components/popover_items @elastic/security-detections-response-rules
-/x-pack/plugins/security_solution/public/detection_engine/fleet_integrations @elastic/security-detections-response-rules
-/x-pack/plugins/security_solution/public/detection_engine/rule_details_ui @elastic/security-detections-response-rules
-/x-pack/plugins/security_solution/public/detection_engine/rule_management @elastic/security-detections-response-rules
-/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui @elastic/security-detections-response-rules
-/x-pack/plugins/security_solution/public/detection_engine/rule_monitoring @elastic/security-detections-response-rules
-/x-pack/plugins/security_solution/public/detections/components/callouts @elastic/security-detections-response-rules
-/x-pack/plugins/security_solution/public/detections/components/modals/ml_job_upgrade_modal @elastic/security-detections-response-rules
-/x-pack/plugins/security_solution/public/detections/components/rules @elastic/security-detections-response-rules
+/x-pack/plugins/security_solution/public/common/components/health_truncate_text @elastic/security-detection-rule-management
+/x-pack/plugins/security_solution/public/common/components/links_to_docs @elastic/security-detection-rule-management
+/x-pack/plugins/security_solution/public/common/components/ml_popover @elastic/security-detection-rule-management
+/x-pack/plugins/security_solution/public/common/components/popover_items @elastic/security-detection-rule-management
+/x-pack/plugins/security_solution/public/detection_engine/fleet_integrations @elastic/security-detection-rule-management
+/x-pack/plugins/security_solution/public/detection_engine/rule_details_ui @elastic/security-detection-rule-management
+/x-pack/plugins/security_solution/public/detection_engine/rule_management @elastic/security-detection-rule-management
+/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui @elastic/security-detection-rule-management
+/x-pack/plugins/security_solution/public/detection_engine/rule_monitoring @elastic/security-detection-rule-management
+/x-pack/plugins/security_solution/public/detections/components/callouts @elastic/security-detection-rule-management
+/x-pack/plugins/security_solution/public/detections/components/modals/ml_job_upgrade_modal @elastic/security-detection-rule-management
+/x-pack/plugins/security_solution/public/detections/components/rules @elastic/security-detection-rule-management
 /x-pack/plugins/security_solution/public/detections/components/rules/rule_preview @elastic/security-detections-response-alerts
-/x-pack/plugins/security_solution/public/detections/containers/detection_engine/rules @elastic/security-detections-response-rules
-/x-pack/plugins/security_solution/public/detections/mitre @elastic/security-detections-response-rules
-/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules @elastic/security-detections-response-rules
-/x-pack/plugins/security_solution/public/rules @elastic/security-detections-response-rules
+/x-pack/plugins/security_solution/public/detections/containers/detection_engine/rules @elastic/security-detection-rule-management
+/x-pack/plugins/security_solution/public/detections/mitre @elastic/security-detection-rule-management
+/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules @elastic/security-detection-rule-management
+/x-pack/plugins/security_solution/public/rules @elastic/security-detection-rule-management
 
-/x-pack/plugins/security_solution/server/lib/detection_engine/fleet_integrations @elastic/security-detections-response-rules
-/x-pack/plugins/security_solution/server/lib/detection_engine/prebuilt_rules @elastic/security-detections-response-rules
-/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management @elastic/security-detections-response-rules
-/x-pack/plugins/security_solution/server/lib/detection_engine/rule_monitoring @elastic/security-detections-response-rules
-/x-pack/plugins/security_solution/server/lib/detection_engine/rule_schema @elastic/security-detections-response-rules @elastic/security-detections-response-alerts
+/x-pack/plugins/security_solution/server/lib/detection_engine/fleet_integrations @elastic/security-detection-rule-management
+/x-pack/plugins/security_solution/server/lib/detection_engine/prebuilt_rules @elastic/security-detection-rule-management
+/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management @elastic/security-detection-rule-management
+/x-pack/plugins/security_solution/server/lib/detection_engine/rule_monitoring @elastic/security-detection-rule-management
+/x-pack/plugins/security_solution/server/lib/detection_engine/rule_schema @elastic/security-detection-rule-management @elastic/security-detections-response-alerts
 
-/x-pack/plugins/security_solution/server/utils @elastic/security-detections-response-rules
+/x-pack/plugins/security_solution/server/utils @elastic/security-detection-rule-management
 
 ## Security Solution sub teams - Security Platform
 
@@ -1156,7 +1156,7 @@ x-pack/test/observability_functional @elastic/actionable-observability
 ## Security Solution cross teams ownership
 /x-pack/plugins/security_solution/cypress/fixtures @elastic/security-detections-response @elastic/security-threat-hunting
 /x-pack/plugins/security_solution/cypress/helpers @elastic/security-detections-response @elastic/security-threat-hunting
-/x-pack/plugins/security_solution/cypress/e2e/detection_rules @elastic/security-detections-response-rules @elastic/security-detections-response-alerts
+/x-pack/plugins/security_solution/cypress/e2e/detection_rules @elastic/security-detection-rule-management @elastic/security-detections-response-alerts
 /x-pack/plugins/security_solution/cypress/objects @elastic/security-detections-response @elastic/security-threat-hunting
 /x-pack/plugins/security_solution/cypress/plugins @elastic/security-detections-response @elastic/security-threat-hunting
 /x-pack/plugins/security_solution/cypress/screens/common @elastic/security-detections-response @elastic/security-threat-hunting
@@ -1164,12 +1164,12 @@ x-pack/test/observability_functional @elastic/actionable-observability
 /x-pack/plugins/security_solution/cypress/urls @elastic/security-threat-hunting-investigations @elastic/security-solution-platform
 
 /x-pack/plugins/security_solution/common/ecs @elastic/security-threat-hunting-investigations
-/x-pack/plugins/security_solution/common/test @elastic/security-detections-response-rules @elastic/security-detections-response-alerts
+/x-pack/plugins/security_solution/common/test @elastic/security-detection-rule-management @elastic/security-detections-response-alerts
 
 /x-pack/plugins/security_solution/public/common/components/callouts @elastic/security-detections-response
 /x-pack/plugins/security_solution/public/common/components/hover_actions @elastic/security-threat-hunting-explore @elastic/security-threat-hunting-investigations
 
-/x-pack/plugins/security_solution/server/lib/detection_engine/rule_actions @elastic/security-solution-platform @elastic/security-detections-response-rules
+/x-pack/plugins/security_solution/server/lib/detection_engine/rule_actions @elastic/security-solution-platform @elastic/security-detection-rule-management
 /x-pack/plugins/security_solution/server/routes @elastic/security-detections-response @elastic/security-threat-hunting
 
 ## Security Solution sub teams - security-defend-workflows


### PR DESCRIPTION
## Summary

Renaming the `@elastic/security-detections-response-rules` team to `@elastic/security-detection-rule-management` in the CODEOWNERS file according to the recent org restructure.

https://github.com/orgs/elastic/teams/security-detection-rule-management
