### PR TITLE
[8.8] [Defend workflows] Osquery license check + display errors (#156738)

### DIFF
--- a/x-pack/plugins/security_solution/public/management/cypress/tasks/response_actions.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/tasks/response_actions.ts
@@ -49,7 +49,17 @@ export const fillUpNewRule = (name = 'Test', description = 'Test') => {
 };
 export const visitRuleActions = (ruleId: string) => {
   cy.visit(`app/security/rules/id/${ruleId}/edit`);
-  cy.getByTestSubj('edit-rule-actions-tab').wait(500).click();
+  cy.getByTestSubj('edit-rule-actions-tab').should('exist');
+  // strange rerendering behaviour. the following make sure the test doesn't fail
+  cy.get('body').then(($body) => {
+    if ($body.find('[data-test-subj="globalLoadingIndicator"]').length) {
+      cy.getByTestSubj('globalLoadingIndicator').should('exist');
+      cy.getByTestSubj('globalLoadingIndicator').should('not.exist');
+    }
+    cy.getByTestSubj('globalLoadingIndicator').should('not.exist');
+  });
+
+  cy.getByTestSubj('edit-rule-actions-tab').click();
 };
 export const tryAddingDisabledResponseAction = (itemNumber = 0) => {
   cy.getByTestSubj('response-actions-wrapper').within(() => {


### PR DESCRIPTION
# Backport

**This PR just backports one helper for e2e tests, instead of the whole functionality.** 

This will backport the following commits from `main` to `8.8`:
 - [[Defend workflows] Osquery license check + display errors (#156738)](https://github.com/elastic/kibana/pull/156738)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Tomasz Ciecierski","email":"tomasz.ciecierski@elastic.co"},"sourceCommit":{"committedDate":"2023-05-08T17:32:43Z","message":"[Defend workflows] Osquery license check + display errors (#156738)","sha":"952489fa71f101ecb83e7cb8cea4581f8a57fb52","branchLabelMapping":{"^v8.9.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","Team:Defend Workflows","Feature:Osquery","v8.9.0"],"number":156738,"url":"https://github.com/elastic/kibana/pull/156738","mergeCommit":{"message":"[Defend workflows] Osquery license check + display errors (#156738)","sha":"952489fa71f101ecb83e7cb8cea4581f8a57fb52"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.9.0","labelRegex":"^v8.9.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/156738","number":156738,"mergeCommit":{"message":"[Defend workflows] Osquery license check + display errors (#156738)","sha":"952489fa71f101ecb83e7cb8cea4581f8a57fb52"}}]}] BACKPORT-->