### PR TITLE
[ML] Use auto layout for anomalies table columns

### DIFF
--- a/x-pack/plugins/ml/public/application/components/anomalies_table/anomalies_table.js
+++ b/x-pack/plugins/ml/public/application/components/anomalies_table/anomalies_table.js
@@ -205,6 +205,10 @@ export class AnomaliesTableInternal extends Component {
       this.props.sourceIndicesWithGeoFields
     );
 
+    // Use auto table layout, unless any columns (categorization examples) have truncateText
+    // set to true which only works with a fixed layout.
+    const tableLayout = columns.some((column) => column.truncateText === true) ? 'fixed' : 'auto';
+
     const sorting = {
       sort: {
         field: tableState.sortField,
@@ -237,6 +241,7 @@ export class AnomaliesTableInternal extends Component {
           className="ml-anomalies-table eui-textBreakWord"
           items={tableData.anomalies}
           columns={columns}
+          tableLayout={tableLayout}
           pagination={pagination}
           sorting={sorting}
           itemId="rowId"

--- a/x-pack/plugins/ml/public/application/components/anomalies_table/anomalies_table_columns.js
+++ b/x-pack/plugins/ml/public/application/components/anomalies_table/anomalies_table_columns.js
@@ -219,6 +219,7 @@ export function getColumns(
         return formatValue(item.actual, item.source.function, fieldFormat, item.source);
       },
       sortable: true,
+      className: 'eui-textBreakNormal',
     });
   }
 
@@ -248,6 +249,7 @@ export function getColumns(
         return formatValue(item.typical, item.source.function, fieldFormat, item.source);
       },
       sortable: true,
+      className: 'eui-textBreakNormal',
     });
 
     // Assume that if we are showing typical, there will be an actual too,


### PR DESCRIPTION
## Summary

Switches the layout of the anomalies table, as used in the Anomaly Explorer and Single Metric Viewer, to use an `auto` layout rather than the default `fixed` layout, so that the column widths better adapt to the length of content in the columns.

### Before - narrow widths of `Found for` and `Influenced by` columns

<img width="1030" alt="anomalies_table_fixed_layout" src="https://github.com/elastic/kibana/assets/7405507/bf4a4cbb-8150-44d8-b2e5-87e2bd529d23">

### After - auto layout

<img width="1036" alt="anomalies_table_auto_layout" src="https://github.com/elastic/kibana/assets/7405507/6e83f19f-6e51-4179-9957-6852b21cfd2a">

Note that the `fixed` layout is retained where the table is showing categorization examples, as columns which have `truncateText` set to `true` do not work with the EUI table `fixed` layout. e.g. if layout was set to `auto` the examples column could be very wide and result in the Action column going off-screen:

<img width="1048" alt="anomalies_table_auto_layout_category" src="https://github.com/elastic/kibana/assets/7405507/456f95bf-2bbd-4c21-807a-5a0c2c39b032">

### Checklist

- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

Closes #134227