### PR TITLE
[Fleet] Fix expiration timeout

### DIFF
--- a/x-pack/plugins/fleet/server/services/agents/request_diagnostics.ts
+++ b/x-pack/plugins/fleet/server/services/agents/request_diagnostics.ts
@@ -18,7 +18,7 @@ import {
   requestDiagnosticsBatch,
 } from './request_diagnostics_action_runner';
 
-const REQUEST_DIAGNOSTICS_TIMEOUT_MS = 1000; // 3 hours;
+const REQUEST_DIAGNOSTICS_TIMEOUT_MS = 3 * 60 * 1000; // 3 hours;
 
 export async function requestDiagnostics(
   esClient: ElasticsearchClient,


### PR DESCRIPTION
## Summary

It seems I did not push one commit on my latest PR to improve expiration for request diagnostics that PR should fix it

Fix request diagnostics expiration timeout https://github.com/elastic/kibana/issues/157695



<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->