### PR TITLE
[ResponseOps] es query rule params not compatible between 8.6 and 8.7

### DIFF
--- a/x-pack/plugins/stack_alerts/server/rule_types/es_query/rule_type_params.test.ts
+++ b/x-pack/plugins/stack_alerts/server/rule_types/es_query/rule_type_params.test.ts
@@ -144,6 +144,28 @@ describe('ruleType Params validate()', () => {
     );
   });
 
+  it('uses default value "count" if aggType is undefined', async () => {
+    params.aggType = undefined;
+    expect(onValidate()).not.toThrow();
+  });
+
+  it('fails for invalid groupBy', async () => {
+    params.groupBy = 42;
+    expect(onValidate()).toThrowErrorMatchingInlineSnapshot(
+      `"[groupBy]: expected value of type [string] but got [number]"`
+    );
+
+    params.groupBy = '-not-a-valid-groupBy-';
+    expect(onValidate()).toThrowErrorMatchingInlineSnapshot(
+      `"[groupBy]: invalid groupBy: \\"-not-a-valid-groupBy-\\""`
+    );
+  });
+
+  it('uses default value "all" if groupBy is undefined', async () => {
+    params.groupBy = undefined;
+    expect(onValidate()).not.toThrow();
+  });
+
   it('fails for invalid aggField', async () => {
     params.aggField = 42;
     expect(onValidate()).toThrowErrorMatchingInlineSnapshot(

--- a/x-pack/plugins/stack_alerts/server/rule_types/es_query/rule_type_params.ts
+++ b/x-pack/plugins/stack_alerts/server/rule_types/es_query/rule_type_params.ts
@@ -41,11 +41,11 @@ const EsQueryRuleParamsSchemaProperties = {
   threshold: schema.arrayOf(schema.number(), { minSize: 1, maxSize: 2 }),
   thresholdComparator: getComparatorSchemaType(validateComparator),
   // aggregation type
-  aggType: schema.maybe(schema.string({ validate: validateAggType, defaultValue: 'count' })),
+  aggType: schema.string({ validate: validateAggType, defaultValue: 'count' }),
   // aggregation field
   aggField: schema.maybe(schema.string({ minLength: 1 })),
   // how to group
-  groupBy: schema.maybe(schema.string({ validate: validateGroupBy, defaultValue: 'all' })),
+  groupBy: schema.string({ validate: validateGroupBy, defaultValue: 'all' }),
   // field to group on (for groupBy: top)
   termField: schema.maybe(schema.string({ minLength: 1 })),
   // limit on number of groups returned

--- a/x-pack/plugins/stack_alerts/server/rule_types/es_query/rule_type_params.ts
+++ b/x-pack/plugins/stack_alerts/server/rule_types/es_query/rule_type_params.ts
@@ -41,11 +41,11 @@ const EsQueryRuleParamsSchemaProperties = {
   threshold: schema.arrayOf(schema.number(), { minSize: 1, maxSize: 2 }),
   thresholdComparator: getComparatorSchemaType(validateComparator),
   // aggregation type
-  aggType: schema.string({ validate: validateAggType }),
+  aggType: schema.maybe(schema.string({ validate: validateAggType, defaultValue: 'count' })),
   // aggregation field
   aggField: schema.maybe(schema.string({ minLength: 1 })),
   // how to group
-  groupBy: schema.string({ validate: validateGroupBy }),
+  groupBy: schema.maybe(schema.string({ validate: validateGroupBy, defaultValue: 'all' })),
   // field to group on (for groupBy: top)
   termField: schema.maybe(schema.string({ minLength: 1 })),
   // limit on number of groups returned

--- a/x-pack/plugins/triggers_actions_ui/server/data/lib/core_query_types.test.ts
+++ b/x-pack/plugins/triggers_actions_ui/server/data/lib/core_query_types.test.ts
@@ -109,6 +109,28 @@ export function runTests(schema: ObjectType, defaultTypeParams: Record<string, u
       );
     });
 
+    it('uses default value "count" if aggType is undefined', async () => {
+      params.aggType = undefined;
+      expect(onValidate()).not.toThrow();
+    });
+
+    it('fails for invalid groupBy', async () => {
+      params.groupBy = 42;
+      expect(onValidate()).toThrowErrorMatchingInlineSnapshot(
+        `"[groupBy]: expected value of type [string] but got [number]"`
+      );
+
+      params.groupBy = '-not-a-valid-groupBy-';
+      expect(onValidate()).toThrowErrorMatchingInlineSnapshot(
+        `"[groupBy]: invalid groupBy: \\"-not-a-valid-groupBy-\\""`
+      );
+    });
+
+    it('uses default value "all" if groupBy is undefined', async () => {
+      params.groupBy = undefined;
+      expect(onValidate()).not.toThrow();
+    });
+
     it('fails for invalid aggField', async () => {
       params.aggField = 42;
       expect(onValidate()).toThrowErrorMatchingInlineSnapshot(

--- a/x-pack/plugins/triggers_actions_ui/server/data/lib/core_query_types.ts
+++ b/x-pack/plugins/triggers_actions_ui/server/data/lib/core_query_types.ts
@@ -22,11 +22,11 @@ export const CoreQueryParamsSchemaProperties = {
   // field in index used for date/time
   timeField: schema.string({ minLength: 1 }),
   // aggregation type
-  aggType: schema.string({ validate: validateAggType }),
+  aggType: schema.maybe(schema.string({ validate: validateAggType, defaultValue: 'count' })),
   // aggregation field
   aggField: schema.maybe(schema.string({ minLength: 1 })),
   // how to group
-  groupBy: schema.string({ validate: validateGroupBy }),
+  groupBy: schema.maybe(schema.string({ validate: validateGroupBy, defaultValue: 'all' })),
   // field to group on (for groupBy: top)
   termField: schema.maybe(schema.string({ minLength: 1 })),
   // filter field

--- a/x-pack/plugins/triggers_actions_ui/server/data/lib/core_query_types.ts
+++ b/x-pack/plugins/triggers_actions_ui/server/data/lib/core_query_types.ts
@@ -22,11 +22,11 @@ export const CoreQueryParamsSchemaProperties = {
   // field in index used for date/time
   timeField: schema.string({ minLength: 1 }),
   // aggregation type
-  aggType: schema.maybe(schema.string({ validate: validateAggType, defaultValue: 'count' })),
+  aggType: schema.string({ validate: validateAggType, defaultValue: 'count' }),
   // aggregation field
   aggField: schema.maybe(schema.string({ minLength: 1 })),
   // how to group
-  groupBy: schema.maybe(schema.string({ validate: validateGroupBy, defaultValue: 'all' })),
+  groupBy: schema.string({ validate: validateGroupBy, defaultValue: 'all' }),
   // field to group on (for groupBy: top)
   termField: schema.maybe(schema.string({ minLength: 1 })),
   // filter field


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/156856

## Summary

Adds a default value to `aggType` and `groupBy` fields 


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->