### PR TITLE
[Cloud Posture]fix incorrect vuln_mgmt details in flyout

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/pages/vulnerabilities/vulnerabilities.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/vulnerabilities/vulnerabilities.tsx
@@ -116,7 +116,12 @@ const VulnerabilitiesContent = ({ dataView }: { dataView: DataView }) => {
   const slicedPage = usePageSlice(data?.page, pageIndex, pageSize);
 
   const invalidIndex = -1;
-  const selectedVulnerability = data?.page[urlQuery.vulnerabilityIndex];
+
+  const selectedVulnerability = useMemo(() => {
+    return slicedPage?.find(
+      (_vulnerabilityRecord: VulnerabilityRecord, i) => i === urlQuery.vulnerabilityIndex
+    );
+  }, [slicedPage, urlQuery.vulnerabilityIndex]);
 
   const onCloseFlyout = () => {
     setUrlQuery({

--- a/x-pack/plugins/cloud_security_posture/public/pages/vulnerabilities/vulnerabilities.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/vulnerabilities/vulnerabilities.tsx
@@ -118,9 +118,7 @@ const VulnerabilitiesContent = ({ dataView }: { dataView: DataView }) => {
   const invalidIndex = -1;
 
   const selectedVulnerability = useMemo(() => {
-    return slicedPage?.find(
-      (_vulnerabilityRecord: VulnerabilityRecord, i) => i === urlQuery.vulnerabilityIndex
-    );
+    return slicedPage[urlQuery.vulnerabilityIndex];
   }, [slicedPage, urlQuery.vulnerabilityIndex]);
 
   const onCloseFlyout = () => {


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.
Currently, after navigating any page after the first page and clicking on vulnerability, the flyout displays incorrect details.

Currently, we use the `data.page`, which lists the maximum amount of vulnerabilities(500 vulnerabilities). The `vulnerabilityIndex` is set each time, a user clicks to expand vulnerability. We were currently only selecting vulnerabilities from the first page.  

Solution:

Use `slicedPage`  to get the vulnerabilities on the current page and then select vulnerability by `vulnerabilityIndex`

https://github.com/elastic/kibana/assets/17135495/df682ecf-d024-45e4-84ca-d7df22a60ec4




<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->