### PR TITLE
[ResponseOps][Task Manager] stop spamming the logs on status changes

### DIFF
--- a/x-pack/plugins/task_manager/server/lib/calculate_health_status.ts
+++ b/x-pack/plugins/task_manager/server/lib/calculate_health_status.ts
@@ -38,14 +38,14 @@ export function calculateHealthStatus(
   if (shouldRunTasks) {
     if (hasExpiredHotTimestamps(summarizedStats, now, requiredHotStatsFreshness)) {
       const reason = 'setting HealthStatus.Error because of expired hot timestamps';
-      logger.warn(reason);
+      logger.debug(reason);
       return { status: HealthStatus.Error, reason };
     }
   }
 
   if (hasExpiredColdTimestamps(summarizedStats, now, requiredColdStatsFreshness)) {
     const reason = 'setting HealthStatus.Error because of expired cold timestamps';
-    logger.warn(reason);
+    logger.debug(reason);
     return { status: HealthStatus.Error, reason };
   }
 

--- a/x-pack/plugins/task_manager/server/monitoring/capacity_estimation.ts
+++ b/x-pack/plugins/task_manager/server/monitoring/capacity_estimation.ts
@@ -247,12 +247,12 @@ function getHealthStatus(
 
   if (assumedAverageRecurringRequiredThroughputPerMinutePerKibana < capacityPerMinutePerKibana) {
     const reason = `setting HealthStatus.Warning because assumedAverageRecurringRequiredThroughputPerMinutePerKibana (${assumedAverageRecurringRequiredThroughputPerMinutePerKibana}) < capacityPerMinutePerKibana (${capacityPerMinutePerKibana})`;
-    logger.warn(reason);
+    logger.debug(reason);
     return { status: HealthStatus.Warning, reason };
   }
 
   const reason = `setting HealthStatus.Error because assumedRequiredThroughputPerMinutePerKibana (${assumedRequiredThroughputPerMinutePerKibana}) >= capacityPerMinutePerKibana (${capacityPerMinutePerKibana}) AND assumedAverageRecurringRequiredThroughputPerMinutePerKibana (${assumedAverageRecurringRequiredThroughputPerMinutePerKibana}) >= capacityPerMinutePerKibana (${capacityPerMinutePerKibana})`;
-  logger.warn(reason);
+  logger.debug(reason);
   return { status: HealthStatus.Error, reason };
 }
 

--- a/x-pack/plugins/task_manager/server/monitoring/task_run_statistics.test.ts
+++ b/x-pack/plugins/task_manager/server/monitoring/task_run_statistics.test.ts
@@ -375,24 +375,24 @@ describe('Task Run Statistics', () => {
               { Success: 40, RetryScheduled: 40, Failed: 20, status: 'OK' },
             ]);
 
-            expect(logger.warn).toHaveBeenCalledTimes(5);
-            expect(logger.warn).toHaveBeenNthCalledWith(
+            expect(logger.debug).toHaveBeenCalledTimes(5);
+            expect(logger.debug).toHaveBeenNthCalledWith(
               1,
               'Health Status warn threshold has been exceeded, resultFrequencySummary.Failed (40) is greater than warn_threshold (39)'
             );
-            expect(logger.warn).toHaveBeenNthCalledWith(
+            expect(logger.debug).toHaveBeenNthCalledWith(
               2,
               'Health Status error threshold has been exceeded, resultFrequencySummary.Failed (60) is greater than error_threshold (59)'
             );
-            expect(logger.warn).toHaveBeenNthCalledWith(
+            expect(logger.debug).toHaveBeenNthCalledWith(
               3,
               'Health Status error threshold has been exceeded, resultFrequencySummary.Failed (60) is greater than error_threshold (59)'
             );
-            expect(logger.warn).toHaveBeenNthCalledWith(
+            expect(logger.debug).toHaveBeenNthCalledWith(
               4,
               'Health Status error threshold has been exceeded, resultFrequencySummary.Failed (60) is greater than error_threshold (59)'
             );
-            expect(logger.warn).toHaveBeenNthCalledWith(
+            expect(logger.debug).toHaveBeenNthCalledWith(
               5,
               'Health Status warn threshold has been exceeded, resultFrequencySummary.Failed (40) is greater than warn_threshold (39)'
             );

--- a/x-pack/plugins/task_manager/server/monitoring/task_run_statistics.ts
+++ b/x-pack/plugins/task_manager/server/monitoring/task_run_statistics.ts
@@ -433,11 +433,11 @@ function getHealthStatus(
 ): HealthStatus {
   if (resultFrequencySummary.Failed > executionErrorThreshold.warn_threshold) {
     if (resultFrequencySummary.Failed > executionErrorThreshold.error_threshold) {
-      logger.warn(
+      logger.debug(
         `Health Status error threshold has been exceeded, resultFrequencySummary.Failed (${resultFrequencySummary.Failed}) is greater than error_threshold (${executionErrorThreshold.error_threshold})`
       );
     } else {
-      logger.warn(
+      logger.debug(
         `Health Status warn threshold has been exceeded, resultFrequencySummary.Failed (${resultFrequencySummary.Failed}) is greater than warn_threshold (${executionErrorThreshold.warn_threshold})`
       );
     }

--- a/x-pack/plugins/task_manager/server/routes/health.test.ts
+++ b/x-pack/plugins/task_manager/server/routes/health.test.ts
@@ -488,7 +488,7 @@ describe('healthRoute', () => {
       summary:
         'Task Manager is unhealthy - Reason: setting HealthStatus.Error because of expired hot timestamps',
     });
-    const warnCalls = (logger as jest.Mocked<Logger>).warn.mock.calls as string[][];
+    const warnCalls = (logger as jest.Mocked<Logger>).debug.mock.calls as string[][];
     const warnMessage =
       /^setting HealthStatus.Warning because assumedAverageRecurringRequiredThroughputPerMinutePerKibana/;
     const found = warnCalls


### PR DESCRIPTION
resolves https://github.com/elastic/kibana/issues/156112

Change task manager logging on status errors from `warn` to `debug. Making this change as we recently changed from `debug` to `warn` in https://github.com/elastic/kibana/pull/154045 .  But this ended up too noisy, especially at Kibana startup.


<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->