### PR TITLE
[Lens] Undo/redo

### DIFF
--- a/package.json
+++ b/package.json
@@ -769,6 +769,7 @@
     "constate": "^3.3.2",
     "copy-to-clipboard": "^3.0.8",
     "core-js": "^3.29.0",
+    "cors": "^2.8.5",
     "cronstrue": "^1.51.0",
     "cuid": "^2.1.8",
     "cytoscape": "^3.10.0",

--- a/package.json
+++ b/package.json
@@ -794,6 +794,7 @@
     "expiry-js": "0.1.7",
     "extract-zip": "^2.0.1",
     "fast-deep-equal": "^3.1.1",
+    "fast-json-patch": "^3.1.1",
     "fflate": "^0.6.9",
     "file-saver": "^1.3.8",
     "font-awesome": "4.7.0",

--- a/src/plugins/navigation/public/top_nav_menu/top_nav_menu_item.tsx
+++ b/src/plugins/navigation/public/top_nav_menu/top_nav_menu_item.tsx
@@ -8,7 +8,7 @@
 
 import { upperFirst, isFunction } from 'lodash';
 import React, { MouseEvent } from 'react';
-import { EuiToolTip, EuiButton, EuiHeaderLink, EuiBetaBadge } from '@elastic/eui';
+import { EuiToolTip, EuiButton, EuiHeaderLink, EuiBetaBadge, EuiButtonIcon } from '@elastic/eui';
 import { TopNavMenuData } from './top_nav_menu_data';
 
 export function TopNavMenuItem(props: TopNavMenuData) {
@@ -61,6 +61,8 @@ export function TopNavMenuItem(props: TopNavMenuData) {
     <EuiButton size="s" {...commonButtonProps} fill>
       {getButtonContainer()}
     </EuiButton>
+  ) : !props.label && props.iconType ? (
+    <EuiButtonIcon size="s" {...commonButtonProps} iconType={props.iconType} />
   ) : (
     <EuiHeaderLink size="s" color="primary" {...commonButtonProps} {...overrideProps}>
       {getButtonContainer()}

--- a/src/plugins/navigation/public/top_nav_menu/top_nav_menu_item.tsx
+++ b/src/plugins/navigation/public/top_nav_menu/top_nav_menu_item.tsx
@@ -62,7 +62,7 @@ export function TopNavMenuItem(props: TopNavMenuData) {
       {getButtonContainer()}
     </EuiButton>
   ) : !props.label && props.iconType ? (
-    <EuiButtonIcon size="s" {...commonButtonProps} iconType={props.iconType} />
+    <EuiButtonIcon size="s" {...commonButtonProps} display="base" iconType={props.iconType} />
   ) : (
     <EuiHeaderLink size="s" color="primary" {...commonButtonProps} {...overrideProps}>
       {getButtonContainer()}

--- a/x-pack/plugins/lens/common/constants.ts
+++ b/x-pack/plugins/lens/common/constants.ts
@@ -16,6 +16,7 @@ export const LENS_EMBEDDABLE_TYPE = 'lens';
 export const DOC_TYPE = 'lens';
 export const NOT_INTERNATIONALIZED_PRODUCT_NAME = 'Lens Visualizations';
 export const BASE_API_URL = '/api/lens';
+export const STATE_PATCH_API_PATH = `${BASE_API_URL}/state_patch`;
 export const LENS_EDIT_BY_VALUE = 'edit_by_value';
 
 export const ENABLE_SQL = 'discover:enableSql';

--- a/x-pack/plugins/lens/common/constants.ts
+++ b/x-pack/plugins/lens/common/constants.ts
@@ -16,7 +16,7 @@ export const LENS_EMBEDDABLE_TYPE = 'lens';
 export const DOC_TYPE = 'lens';
 export const NOT_INTERNATIONALIZED_PRODUCT_NAME = 'Lens Visualizations';
 export const BASE_API_URL = '/api/lens';
-export const STATE_PATCH_API_PATH = `${BASE_API_URL}/state_patch`;
+export const STATE_PATCH_API_PATH = `${BASE_API_URL}/state_coordinator`;
 export const LENS_EDIT_BY_VALUE = 'edit_by_value';
 
 export const ENABLE_SQL = 'discover:enableSql';

--- a/x-pack/plugins/lens/common/types.ts
+++ b/x-pack/plugins/lens/common/types.ts
@@ -12,6 +12,7 @@ import type { CustomPaletteParams, PaletteOutput } from '@kbn/coloring';
 import type { IFieldFormat, SerializedFieldFormat } from '@kbn/field-formats-plugin/common';
 import type { ColorMode } from '@kbn/charts-plugin/common';
 import type { LegendSize } from '@kbn/visualizations-plugin/common';
+import type { Operation } from 'fast-json-patch';
 import { CategoryDisplay, LegendDisplay, NumberDisplay, PieChartTypes } from './constants';
 import { layerTypes } from './layer_types';
 import { CollapseFunction } from './expressions';
@@ -96,3 +97,5 @@ export interface LegacyMetricState {
   size?: string;
   textAlign?: 'left' | 'right' | 'center';
 }
+
+export type Patch = Operation[];

--- a/x-pack/plugins/lens/public/app_plugin/app.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/app.tsx
@@ -59,7 +59,7 @@ import {
   type IndexPatternServiceAPI,
   createIndexPatternService,
 } from '../data_views_service/service';
-import { replaceIndexpattern } from '../state_management/lens_slice';
+import { replaceIndexpattern, timeTravel } from '../state_management/lens_slice';
 import {
   filterAndSortUserMessages,
   getApplicationUserMessages,
@@ -748,6 +748,7 @@ const MemoizedEditorFrameWrapper = React.memo(function EditorFrameWrapper({
 });
 
 const RevisionHistoryFlyout = ({ onClose }: { onClose: () => void }) => {
+  const dispatch = useLensDispatch();
   const changes = useLensSelector(selectRevisionHistory);
 
   return (
@@ -758,10 +759,9 @@ const RevisionHistoryFlyout = ({ onClose }: { onClose: () => void }) => {
         </EuiTitle>
       </EuiFlyoutHeader>
       <EuiFlyoutBody>
-        {changes.map((change, index) => (
-          <>
+        {changes.map((change) => (
+          <div key={change.created}>
             <EuiCard
-              key={index}
               title={i18n.translate('xpack.lens.revisionCreated', {
                 defaultMessage: '{dateCreated, date, medium} @ {dateCreated, time, short}',
                 values: { dateCreated: new Date(change.created) },
@@ -770,10 +770,10 @@ const RevisionHistoryFlyout = ({ onClose }: { onClose: () => void }) => {
               display={change.active ? 'primary' : 'plain'}
               hasBorder
               layout="horizontal"
-              onClick={change.active ? undefined : () => {}}
+              onClick={change.active ? undefined : () => dispatch(timeTravel(change.created))}
             />
-            <EuiSpacer size="s" key={index} />
-          </>
+            <EuiSpacer size="s" />
+          </div>
         ))}
       </EuiFlyoutBody>
     </EuiFlyout>

--- a/x-pack/plugins/lens/public/app_plugin/app.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/app.tsx
@@ -32,6 +32,7 @@ import {
   updateDatasourceState,
   selectActiveDatasourceId,
   selectFrameDatasourceAPI,
+  applyPatches,
 } from '../state_management';
 import { SaveModalContainer, runSaveLensVisualization } from './save_modal_container';
 import { LensInspector } from '../lens_inspector_service';
@@ -46,6 +47,7 @@ import {
   filterAndSortUserMessages,
   getApplicationUserMessages,
 } from './get_application_user_messages';
+import { StateCoordinator } from '../state_management/state_coordinator';
 
 export type SaveProps = Omit<OnSaveProps, 'onTitleDuplicate' | 'newDescription'> & {
   returnToOrigin: boolean;
@@ -103,6 +105,13 @@ export function App({
     (state: Partial<LensAppState>) => dispatch(setState(state)),
     [dispatch]
   );
+
+  useEffect(() => {
+    StateCoordinator.registerPatchListener((patches) => {
+      console.log(patches);
+      dispatch(applyPatches({ patches }));
+    });
+  }, [dispatch]);
 
   const {
     persistedDoc,

--- a/x-pack/plugins/lens/public/app_plugin/app.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/app.tsx
@@ -17,7 +17,13 @@ import type { LensAppLocatorParams } from '../../common/locator/locator';
 import { LensAppProps, LensAppServices } from './types';
 import { LensTopNavMenu } from './lens_top_nav';
 import { LensByReferenceInput } from '../embeddable';
-import { AddUserMessages, EditorFrameInstance, UserMessage, UserMessagesGetter } from '../types';
+import {
+  AddUserMessages,
+  EditorFrameInstance,
+  ExtendedUndoableOperationService,
+  UserMessage,
+  UserMessagesGetter,
+} from '../types';
 import { Document } from '../persistence/saved_object_store';
 
 import {
@@ -32,6 +38,8 @@ import {
   updateDatasourceState,
   selectActiveDatasourceId,
   selectFrameDatasourceAPI,
+  beginReversibleOperation,
+  completeReversibleOperation,
 } from '../state_management';
 import { SaveModalContainer, runSaveLensVisualization } from './save_modal_container';
 import { LensInspector } from '../lens_inspector_service';
@@ -575,6 +583,14 @@ export function App({
     };
   };
 
+  const extendedUndoService: ExtendedUndoableOperationService = useMemo(
+    () => ({
+      begin: () => dispatch(beginReversibleOperation),
+      complete: () => dispatch(completeReversibleOperation),
+    }),
+    [dispatch]
+  );
+
   return (
     <>
       <div className="lnsApp" data-test-subj="lnsApp" role="main">
@@ -620,6 +636,7 @@ export function App({
             indexPatternService={indexPatternService}
             getUserMessages={getUserMessages}
             addUserMessages={addUserMessages}
+            extendedUndoService={extendedUndoService}
           />
         )}
       </div>
@@ -691,6 +708,7 @@ const MemoizedEditorFrameWrapper = React.memo(function EditorFrameWrapper({
   addUserMessages,
   lensInspector,
   indexPatternService,
+  extendedUndoService,
 }: {
   editorFrame: EditorFrameInstance;
   lensInspector: LensInspector;
@@ -698,6 +716,7 @@ const MemoizedEditorFrameWrapper = React.memo(function EditorFrameWrapper({
   getUserMessages: UserMessagesGetter;
   addUserMessages: AddUserMessages;
   indexPatternService: IndexPatternServiceAPI;
+  extendedUndoService: ExtendedUndoableOperationService;
 }) {
   const { EditorFrameContainer } = editorFrame;
   return (
@@ -707,6 +726,7 @@ const MemoizedEditorFrameWrapper = React.memo(function EditorFrameWrapper({
       addUserMessages={addUserMessages}
       lensInspector={lensInspector}
       indexPatternService={indexPatternService}
+      extendedUndoService={extendedUndoService}
     />
   );
 });

--- a/x-pack/plugins/lens/public/app_plugin/app.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/app.tsx
@@ -32,7 +32,6 @@ import {
   updateDatasourceState,
   selectActiveDatasourceId,
   selectFrameDatasourceAPI,
-  applyPatches,
 } from '../state_management';
 import { SaveModalContainer, runSaveLensVisualization } from './save_modal_container';
 import { LensInspector } from '../lens_inspector_service';
@@ -47,7 +46,6 @@ import {
   filterAndSortUserMessages,
   getApplicationUserMessages,
 } from './get_application_user_messages';
-import { StateCoordinator } from '../state_management/state_coordinator';
 
 export type SaveProps = Omit<OnSaveProps, 'onTitleDuplicate' | 'newDescription'> & {
   returnToOrigin: boolean;
@@ -105,13 +103,6 @@ export function App({
     (state: Partial<LensAppState>) => dispatch(setState(state)),
     [dispatch]
   );
-
-  useEffect(() => {
-    StateCoordinator.registerPatchListener((patches) => {
-      console.log(patches);
-      dispatch(applyPatches({ patches }));
-    });
-  }, [dispatch]);
 
   const {
     persistedDoc,

--- a/x-pack/plugins/lens/public/app_plugin/app.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/app.tsx
@@ -585,8 +585,8 @@ export function App({
 
   const extendedUndoService: ExtendedUndoableOperationService = useMemo(
     () => ({
-      begin: () => dispatch(beginReversibleOperation),
-      complete: () => dispatch(completeReversibleOperation),
+      begin: () => dispatch(beginReversibleOperation()),
+      complete: () => dispatch(completeReversibleOperation()),
     }),
     [dispatch]
   );

--- a/x-pack/plugins/lens/public/app_plugin/lens_top_nav.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/lens_top_nav.tsx
@@ -261,6 +261,16 @@ function getLensTopNavConfig(options: {
         defaultMessage: 'Redo last change',
       }),
       disableButton: !canRedo,
+    },
+    {
+      label: '',
+      iconType: 'timeRefresh',
+      run: actions.toggleHistory.execute,
+      testId: 'lnsApp_toggleHistory',
+      description: i18n.translate('xpack.lens.app.redoButtonAriaLabel', {
+        defaultMessage: 'Toggle revision history list',
+      }),
+      disableButton: !canUndo,
     }
   );
 
@@ -321,6 +331,7 @@ export const LensTopNavMenu = ({
   getUserMessages,
   shortUrlService,
   isCurrentStateDirty,
+  toggleShowRevisionHistory,
 }: LensTopNavMenuProps) => {
   const {
     data,
@@ -800,6 +811,10 @@ export const LensTopNavMenu = ({
             dispatch(redo());
           },
         },
+        toggleHistory: {
+          visible: true,
+          execute: () => toggleShowRevisionHistory(),
+        },
       },
     });
     return [...(additionalMenuEntries || []), ...baseMenuEntries];
@@ -850,6 +865,7 @@ export const LensTopNavMenu = ({
     lensStore,
     theme$,
     dispatch,
+    toggleShowRevisionHistory,
   ]);
 
   const onQuerySubmitWrapped = useCallback(

--- a/x-pack/plugins/lens/public/app_plugin/lens_top_nav.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/lens_top_nav.tsx
@@ -27,6 +27,7 @@ import {
   LensAppState,
   DispatchSetState,
   switchAndCleanDatasource,
+  selectDataViews,
 } from '../state_management';
 import {
   getIndexPatternsObjects,
@@ -310,8 +311,9 @@ export const LensTopNavMenu = ({
     datasourceStates,
     visualization,
     filters,
-    dataViews,
   } = useLensSelector((state) => state.lens);
+
+  const dataViews = useLensSelector(selectDataViews);
 
   const dispatch = useLensDispatch();
   const dispatchSetState: DispatchSetState = React.useCallback(

--- a/x-pack/plugins/lens/public/app_plugin/settings_menu.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/settings_menu.tsx
@@ -8,7 +8,7 @@
 import React, { useCallback } from 'react';
 import ReactDOM from 'react-dom';
 import type { CoreTheme } from '@kbn/core/public';
-import { EuiPopoverTitle, EuiSwitch, EuiWrappingPopover } from '@elastic/eui';
+import { EuiButton, EuiPopoverTitle, EuiSwitch, EuiWrappingPopover } from '@elastic/eui';
 import { Observable } from 'rxjs';
 import { FormattedMessage, I18nProvider } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
@@ -26,6 +26,7 @@ import {
 } from '../state_management';
 import { writeToStorage } from '../settings_storage';
 import { AUTO_APPLY_DISABLED_STORAGE_KEY } from '../editor_frame_service/editor_frame/workspace_panel/workspace_panel_wrapper';
+import { StateCoordinator } from '../state_management/state_coordinator';
 
 const container = document.createElement('div');
 let isMenuOpen = false;
@@ -65,6 +66,9 @@ export function SettingsMenu({
       <EuiPopoverTitle>
         <FormattedMessage id="xpack.lens.settings.title" defaultMessage="Lens settings" />
       </EuiPopoverTitle>
+      <EuiButton onClick={() => StateCoordinator.clearVisualizationPatches()}>
+        Clear current changes
+      </EuiButton>
       <EuiSwitch
         label={i18n.translate('xpack.lens.settings.autoApply', {
           defaultMessage: 'Auto-apply visualization changes',

--- a/x-pack/plugins/lens/public/app_plugin/settings_menu.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/settings_menu.tsx
@@ -16,6 +16,7 @@ import { Store } from 'redux';
 import { Provider } from 'react-redux';
 import { Storage } from '@kbn/kibana-utils-plugin/public';
 import { KibanaThemeProvider } from '@kbn/kibana-react-plugin/public';
+import { EuiFormRow } from '@elastic/eui';
 import {
   disableAutoApply,
   enableAutoApply,
@@ -66,17 +67,22 @@ export function SettingsMenu({
       <EuiPopoverTitle>
         <FormattedMessage id="xpack.lens.settings.title" defaultMessage="Lens settings" />
       </EuiPopoverTitle>
-      <EuiButton onClick={() => StateCoordinator.clearVisualizationPatches()}>
-        Clear current changes
-      </EuiButton>
-      <EuiSwitch
-        label={i18n.translate('xpack.lens.settings.autoApply', {
-          defaultMessage: 'Auto-apply visualization changes',
-        })}
-        checked={autoApplyEnabled}
-        onChange={() => toggleAutoApply()}
-        data-test-subj="lnsToggleAutoApply"
-      />
+      <EuiFormRow>
+        <EuiButton onClick={() => StateCoordinator.clearVisualizationPatches()}>
+          Clear current changes
+        </EuiButton>
+      </EuiFormRow>
+
+      <EuiFormRow>
+        <EuiSwitch
+          label={i18n.translate('xpack.lens.settings.autoApply', {
+            defaultMessage: 'Auto-apply visualization changes',
+          })}
+          checked={autoApplyEnabled}
+          onChange={() => toggleAutoApply()}
+          data-test-subj="lnsToggleAutoApply"
+        />
+      </EuiFormRow>
     </EuiWrappingPopover>
   );
 }

--- a/x-pack/plugins/lens/public/app_plugin/types.ts
+++ b/x-pack/plugins/lens/public/app_plugin/types.ts
@@ -188,5 +188,7 @@ type AvailableTopNavActions =
   | 'cancel'
   | 'share'
   | 'getUnderlyingDataUrl'
-  | 'openSettings';
+  | 'openSettings'
+  | 'undo'
+  | 'redo';
 export type LensTopNavActions = Record<AvailableTopNavActions, TopNavAction>;

--- a/x-pack/plugins/lens/public/app_plugin/types.ts
+++ b/x-pack/plugins/lens/public/app_plugin/types.ts
@@ -129,6 +129,7 @@ export interface LensTopNavMenuProps {
   getUserMessages: UserMessagesGetter;
   shortUrlService: (params: LensAppLocatorParams) => Promise<string>;
   isCurrentStateDirty: boolean;
+  toggleShowRevisionHistory: () => void;
 }
 
 export interface HistoryLocationState {
@@ -190,5 +191,6 @@ type AvailableTopNavActions =
   | 'getUnderlyingDataUrl'
   | 'openSettings'
   | 'undo'
+  | 'toggleHistory'
   | 'redo';
 export type LensTopNavActions = Record<AvailableTopNavActions, TopNavAction>;

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/config_panel.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/config_panel.tsx
@@ -118,6 +118,7 @@ export function LayerPanels(
         // which we don't want. The timeout lets user interaction have priority, then React updates.
 
         setTimeout(() => {
+          props.extendedUndoService.begin();
           dispatchLens(
             updateState({
               updater: (prevState) => {
@@ -148,9 +149,10 @@ export function LayerPanels(
               },
             })
           );
+          props.extendedUndoService.complete();
         }, 0);
       },
-    [dispatchLens]
+    [dispatchLens, props.extendedUndoService]
   );
 
   const toggleFullscreen = useMemo(

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/layer_panel.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/layer_panel.tsx
@@ -34,6 +34,7 @@ import {
   LayerAction,
   VisualizationDimensionGroupConfig,
   UserMessagesGetter,
+  ExtendedUndoableOperationService,
 } from '../../../types';
 import { LayerSettings } from './layer_settings';
 import { LayerPanelProps, ActiveDimensionState } from './types';
@@ -89,6 +90,7 @@ export function LayerPanel(
     }) => void;
     indexPatternService: IndexPatternServiceAPI;
     getUserMessages: UserMessagesGetter;
+    extendedUndoService: ExtendedUndoableOperationService;
   }
 ) {
   const [activeDimension, setActiveDimension] = useState<ActiveDimensionState>(
@@ -116,6 +118,7 @@ export function LayerPanel(
     visualizationState,
     onChangeIndexPattern,
     core,
+    extendedUndoService,
   } = props;
 
   const datasourceStates = useLensSelector(selectDatasourceStates);
@@ -189,6 +192,8 @@ export function LayerPanel(
         setNextFocusedButtonId(target.columnId);
       }
 
+      extendedUndoService.begin();
+
       let hasDropSucceeded = true;
       if (layerDatasource) {
         hasDropSucceeded = Boolean(
@@ -235,8 +240,11 @@ export function LayerPanel(
           });
         }
       }
+
+      extendedUndoService.complete();
     };
   }, [
+    extendedUndoService,
     layerDatasource,
     setNextFocusedButtonId,
     layerDatasourceState,

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/types.ts
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/types.ts
@@ -16,6 +16,7 @@ import {
   DatasourceMap,
   VisualizationMap,
   UserMessagesGetter,
+  ExtendedUndoableOperationService,
 } from '../../../types';
 
 export interface ConfigPanelWrapperProps {
@@ -26,6 +27,7 @@ export interface ConfigPanelWrapperProps {
   indexPatternService: IndexPatternServiceAPI;
   uiActions: UiActionsStart;
   getUserMessages: UserMessagesGetter;
+  extendedUndoService: ExtendedUndoableOperationService;
 }
 
 export interface LayerPanelProps {

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/editor_frame.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/editor_frame.tsx
@@ -17,6 +17,7 @@ import {
   Suggestion,
   UserMessagesGetter,
   AddUserMessages,
+  ExtendedUndoableOperationService,
 } from '../../types';
 import { DataPanelWrapper } from './data_panel_wrapper';
 import { BannerWrapper } from './banner_wrapper';
@@ -50,6 +51,7 @@ export interface EditorFrameProps {
   indexPatternService: IndexPatternServiceAPI;
   getUserMessages: UserMessagesGetter;
   addUserMessages: AddUserMessages;
+  extendedUndoService: ExtendedUndoableOperationService;
 }
 
 export function EditorFrame(props: EditorFrameProps) {
@@ -143,6 +145,7 @@ export function EditorFrame(props: EditorFrameProps) {
                 uiActions={props.plugins.uiActions}
                 indexPatternService={props.indexPatternService}
                 getUserMessages={props.getUserMessages}
+                extendedUndoService={props.extendedUndoService}
               />
             </ErrorBoundary>
           )

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel_wrapper.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel_wrapper.tsx
@@ -146,7 +146,7 @@ export function WorkspacePanelWrapper({
 
                 <EuiFlexItem grow={false}>
                   <EuiButton
-                    disabled={canUndo}
+                    disabled={!canUndo}
                     fill
                     className={
                       'lnsWorkspacePanelWrapper__applyButton ' +

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel_wrapper.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel_wrapper.tsx
@@ -31,7 +31,9 @@ import {
   applyChanges,
   selectAutoApplyEnabled,
   undo,
+  redo,
   selectCanUndo,
+  selectCanRedo,
 } from '../../../state_management';
 import { WorkspaceTitle } from './title';
 import { LensInspector } from '../../../lens_inspector_service';
@@ -66,6 +68,7 @@ export function WorkspacePanelWrapper({
   const changesApplied = useLensSelector(selectChangesApplied);
   const autoApplyEnabled = useLensSelector(selectAutoApplyEnabled);
   const canUndo = useLensSelector(selectCanUndo);
+  const canRedo = useLensSelector(selectCanRedo);
 
   const activeVisualization = visualizationId ? visualizationMap[visualizationId] : null;
   const setVisualizationState = useCallback(
@@ -159,6 +162,25 @@ export function WorkspacePanelWrapper({
                     <FormattedMessage
                       id="xpack.lens.editorFrame.applyChangesLabel"
                       defaultMessage="Undo"
+                    />
+                  </EuiButton>
+                </EuiFlexItem>
+
+                <EuiFlexItem grow={false}>
+                  <EuiButton
+                    disabled={!canRedo}
+                    fill
+                    className={
+                      'lnsWorkspacePanelWrapper__applyButton ' +
+                      DONT_CLOSE_DIMENSION_CONTAINER_ON_CLICK_CLASS
+                    }
+                    onClick={() => dispatchLens(redo())}
+                    size="m"
+                    minWidth="auto"
+                  >
+                    <FormattedMessage
+                      id="xpack.lens.editorFrame.applyChangesLabel"
+                      defaultMessage="Redo"
                     />
                   </EuiButton>
                 </EuiFlexItem>

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel_wrapper.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel_wrapper.tsx
@@ -30,10 +30,6 @@ import {
   selectChangesApplied,
   applyChanges,
   selectAutoApplyEnabled,
-  undo,
-  redo,
-  selectCanUndo,
-  selectCanRedo,
 } from '../../../state_management';
 import { WorkspaceTitle } from './title';
 import { LensInspector } from '../../../lens_inspector_service';
@@ -67,8 +63,6 @@ export function WorkspacePanelWrapper({
 
   const changesApplied = useLensSelector(selectChangesApplied);
   const autoApplyEnabled = useLensSelector(selectAutoApplyEnabled);
-  const canUndo = useLensSelector(selectCanUndo);
-  const canRedo = useLensSelector(selectCanRedo);
 
   const activeVisualization = visualizationId ? visualizationMap[visualizationId] : null;
   const setVisualizationState = useCallback(
@@ -146,44 +140,6 @@ export function WorkspacePanelWrapper({
                     <MessageList messages={userMessages} />
                   </EuiFlexItem>
                 ) : null}
-
-                <EuiFlexItem grow={false}>
-                  <EuiButton
-                    disabled={!canUndo}
-                    fill
-                    className={
-                      'lnsWorkspacePanelWrapper__applyButton ' +
-                      DONT_CLOSE_DIMENSION_CONTAINER_ON_CLICK_CLASS
-                    }
-                    onClick={() => dispatchLens(undo())}
-                    size="m"
-                    minWidth="auto"
-                  >
-                    <FormattedMessage
-                      id="xpack.lens.editorFrame.applyChangesLabel"
-                      defaultMessage="Undo"
-                    />
-                  </EuiButton>
-                </EuiFlexItem>
-
-                <EuiFlexItem grow={false}>
-                  <EuiButton
-                    disabled={!canRedo}
-                    fill
-                    className={
-                      'lnsWorkspacePanelWrapper__applyButton ' +
-                      DONT_CLOSE_DIMENSION_CONTAINER_ON_CLICK_CLASS
-                    }
-                    onClick={() => dispatchLens(redo())}
-                    size="m"
-                    minWidth="auto"
-                  >
-                    <FormattedMessage
-                      id="xpack.lens.editorFrame.applyChangesLabel"
-                      defaultMessage="Redo"
-                    />
-                  </EuiButton>
-                </EuiFlexItem>
 
                 {!autoApplyEnabled && (
                   <EuiFlexItem grow={false}>

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel_wrapper.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel_wrapper.tsx
@@ -31,6 +31,7 @@ import {
   applyChanges,
   selectAutoApplyEnabled,
   undo,
+  selectCanUndo,
 } from '../../../state_management';
 import { WorkspaceTitle } from './title';
 import { LensInspector } from '../../../lens_inspector_service';
@@ -64,6 +65,7 @@ export function WorkspacePanelWrapper({
 
   const changesApplied = useLensSelector(selectChangesApplied);
   const autoApplyEnabled = useLensSelector(selectAutoApplyEnabled);
+  const canUndo = useLensSelector(selectCanUndo);
 
   const activeVisualization = visualizationId ? visualizationMap[visualizationId] : null;
   const setVisualizationState = useCallback(
@@ -144,6 +146,7 @@ export function WorkspacePanelWrapper({
 
                 <EuiFlexItem grow={false}>
                   <EuiButton
+                    disabled={canUndo}
                     fill
                     className={
                       'lnsWorkspacePanelWrapper__applyButton ' +

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel_wrapper.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel_wrapper.tsx
@@ -30,6 +30,7 @@ import {
   selectChangesApplied,
   applyChanges,
   selectAutoApplyEnabled,
+  undo,
 } from '../../../state_management';
 import { WorkspaceTitle } from './title';
 import { LensInspector } from '../../../lens_inspector_service';
@@ -140,6 +141,24 @@ export function WorkspacePanelWrapper({
                     <MessageList messages={userMessages} />
                   </EuiFlexItem>
                 ) : null}
+
+                <EuiFlexItem grow={false}>
+                  <EuiButton
+                    fill
+                    className={
+                      'lnsWorkspacePanelWrapper__applyButton ' +
+                      DONT_CLOSE_DIMENSION_CONTAINER_ON_CLICK_CLASS
+                    }
+                    onClick={() => dispatchLens(undo())}
+                    size="m"
+                    minWidth="auto"
+                  >
+                    <FormattedMessage
+                      id="xpack.lens.editorFrame.applyChangesLabel"
+                      defaultMessage="Undo"
+                    />
+                  </EuiButton>
+                </EuiFlexItem>
 
                 {!autoApplyEnabled && (
                   <EuiFlexItem grow={false}>

--- a/x-pack/plugins/lens/public/editor_frame_service/service.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/service.tsx
@@ -124,6 +124,7 @@ export class EditorFrameService {
           indexPatternService,
           getUserMessages,
           addUserMessages,
+          extendedUndoService,
         }) => {
           return (
             <div className="lnsApp__frame">
@@ -139,6 +140,7 @@ export class EditorFrameService {
                 datasourceMap={resolvedDatasources}
                 visualizationMap={resolvedVisualizations}
                 ExpressionRenderer={plugins.expressions.ReactExpressionRenderer}
+                extendedUndoService={extendedUndoService}
               />
             </div>
           );

--- a/x-pack/plugins/lens/public/state_management/index.ts
+++ b/x-pack/plugins/lens/public/state_management/index.ts
@@ -8,6 +8,7 @@
 import { configureStore, getDefaultMiddleware, PreloadedState } from '@reduxjs/toolkit';
 import { createLogger } from 'redux-logger';
 import { useDispatch, useSelector, TypedUseSelectorHook } from 'react-redux';
+import { v4 } from 'uuid';
 import { makeLensReducer, lensActions } from './lens_slice';
 import { LensState, LensStoreDeps } from './types';
 import { initMiddleware } from './init_middleware';
@@ -15,6 +16,7 @@ import { optimizingMiddleware } from './optimizing_middleware';
 import { contextMiddleware } from './context_middleware';
 import { fullscreenMiddleware } from './fullscreen_middleware';
 import { stateHistoryMiddleware } from './state_history';
+import { StateCoordinator } from './state_coordinator';
 export * from './types';
 export * from './selectors';
 
@@ -71,6 +73,10 @@ export const makeConfigureStore = (
       })
     );
   }
+
+  StateCoordinator.setHTTP(storeDeps.lensServices.http);
+  StateCoordinator.setSessionId(v4());
+  StateCoordinator.runPoll();
 
   return configureStore({
     reducer: {

--- a/x-pack/plugins/lens/public/state_management/index.ts
+++ b/x-pack/plugins/lens/public/state_management/index.ts
@@ -49,6 +49,8 @@ export const {
   undo,
   redo,
   applyPatches,
+  beginReversibleOperation,
+  completeReversibleOperation,
 } = lensActions;
 
 export const makeConfigureStore = (

--- a/x-pack/plugins/lens/public/state_management/index.ts
+++ b/x-pack/plugins/lens/public/state_management/index.ts
@@ -49,6 +49,7 @@ export const {
   setLayerDefaultDimension,
   removeDimension,
   undo,
+  applyPatches,
 } = lensActions;
 
 export const makeConfigureStore = (

--- a/x-pack/plugins/lens/public/state_management/index.ts
+++ b/x-pack/plugins/lens/public/state_management/index.ts
@@ -8,7 +8,6 @@
 import { configureStore, getDefaultMiddleware, PreloadedState } from '@reduxjs/toolkit';
 import { createLogger } from 'redux-logger';
 import { useDispatch, useSelector, TypedUseSelectorHook } from 'react-redux';
-import { v4 } from 'uuid';
 import { makeLensReducer, lensActions } from './lens_slice';
 import { LensState, LensStoreDeps } from './types';
 import { initMiddleware } from './init_middleware';
@@ -16,7 +15,6 @@ import { optimizingMiddleware } from './optimizing_middleware';
 import { contextMiddleware } from './context_middleware';
 import { fullscreenMiddleware } from './fullscreen_middleware';
 import { stateHistoryMiddleware } from './state_history';
-import { StateCoordinator } from './state_coordinator';
 export * from './types';
 export * from './selectors';
 
@@ -74,10 +72,6 @@ export const makeConfigureStore = (
       })
     );
   }
-
-  StateCoordinator.setHTTP(storeDeps.lensServices.http);
-  StateCoordinator.setSessionId(v4());
-  StateCoordinator.runPoll();
 
   return configureStore({
     reducer: {

--- a/x-pack/plugins/lens/public/state_management/index.ts
+++ b/x-pack/plugins/lens/public/state_management/index.ts
@@ -47,6 +47,7 @@ export const {
   setLayerDefaultDimension,
   removeDimension,
   undo,
+  redo,
   applyPatches,
 } = lensActions;
 

--- a/x-pack/plugins/lens/public/state_management/index.ts
+++ b/x-pack/plugins/lens/public/state_management/index.ts
@@ -14,6 +14,7 @@ import { initMiddleware } from './init_middleware';
 import { optimizingMiddleware } from './optimizing_middleware';
 import { contextMiddleware } from './context_middleware';
 import { fullscreenMiddleware } from './fullscreen_middleware';
+import { stateHistoryMiddleware } from './state_history';
 export * from './types';
 export * from './selectors';
 
@@ -59,6 +60,7 @@ export const makeConfigureStore = (
     optimizingMiddleware(),
     contextMiddleware(storeDeps),
     fullscreenMiddleware(storeDeps),
+    stateHistoryMiddleware(),
   ];
   if (process.env.NODE_ENV === 'development') {
     middleware.push(

--- a/x-pack/plugins/lens/public/state_management/index.ts
+++ b/x-pack/plugins/lens/public/state_management/index.ts
@@ -46,6 +46,7 @@ export const {
   addLayer,
   setLayerDefaultDimension,
   removeDimension,
+  undo,
 } = lensActions;
 
 export const makeConfigureStore = (

--- a/x-pack/plugins/lens/public/state_management/init_middleware/load_initial.ts
+++ b/x-pack/plugins/lens/public/state_management/init_middleware/load_initial.ts
@@ -18,6 +18,7 @@ import { initializeSources } from '../../editor_frame_service/editor_frame';
 import { LensAppServices } from '../../app_plugin/types';
 import { getEditPath, getFullPath, LENS_EMBEDDABLE_TYPE } from '../../../common/constants';
 import { Document } from '../../persistence';
+import { StateCoordinator } from '../state_coordinator';
 
 export const getPersisted = async ({
   initialInput,
@@ -274,6 +275,11 @@ export function loadInitial(
               doc.title,
               initialInput.savedObjectId
             );
+          }
+
+          if (doc.savedObjectId) {
+            // TODO - this only works for by reference
+            StateCoordinator.setVisId(doc.savedObjectId);
           }
 
           const docDatasourceStates = Object.entries(doc.state.datasourceStates).reduce(

--- a/x-pack/plugins/lens/public/state_management/lens_slice.ts
+++ b/x-pack/plugins/lens/public/state_management/lens_slice.ts
@@ -292,23 +292,6 @@ export const lensActions = {
   applyPatches,
 };
 
-export const undoRedoActions = [
-  updateDatasourceState,
-  updateVisualizationState,
-  insertLayer,
-  switchVisualization,
-  rollbackSuggestion,
-  submitSuggestion,
-  switchDatasource,
-  switchAndCleanDatasource,
-  removeLayers,
-  removeOrClearLayer,
-  addLayer,
-  cloneLayer,
-  setLayerDefaultDimension,
-  removeDimension,
-];
-
 export const makeLensReducer = (storeDeps: LensStoreDeps) => {
   const { datasourceMap, visualizationMap } = storeDeps;
   return createReducer<LensAppState>(initialState, {
@@ -1251,6 +1234,7 @@ export const makeLensReducer = (storeDeps: LensStoreDeps) => {
       const currentState = current(_state);
       const history = currentState.changes;
       const change = history[history.length - 1];
+
       return change
         ? {
             ...applyPatch(currentState, change.backward, false, false).newDocument,
@@ -1263,6 +1247,7 @@ export const makeLensReducer = (storeDeps: LensStoreDeps) => {
       const currentState = current(_state);
       const history = currentState.reversedChanges;
       const change = history[history.length - 1];
+
       return change
         ? {
             ...applyPatch(currentState, change.forward, false, false).newDocument,

--- a/x-pack/plugins/lens/public/state_management/lens_slice.ts
+++ b/x-pack/plugins/lens/public/state_management/lens_slice.ts
@@ -10,7 +10,7 @@ import { VisualizeFieldContext } from '@kbn/ui-actions-plugin/public';
 import { mapValues, uniq } from 'lodash';
 import { Query } from '@kbn/es-query';
 import { History } from 'history';
-import { applyPatch, type Operation as JsonPatchOperation } from 'fast-json-patch';
+import { applyPatch } from 'fast-json-patch';
 import { LensEmbeddableInput } from '..';
 import { TableInspectorAdapter } from '../editor_frame_service/types';
 import type {
@@ -24,7 +24,7 @@ import { getInitialDatasourceId, getResolvedDateRange, getRemoveOperation } from
 import type { DataViewsState, LensAppState, LensStoreDeps, VisualizationState } from './types';
 import type { Datasource, Visualization } from '../types';
 import { generateId } from '../id_generator';
-import type { LayerType } from '../../common/types';
+import type { LayerType, Patch } from '../../common/types';
 import { getLayerType } from '../editor_frame_service/editor_frame/config_panel/add_layer';
 import { getVisualizeFieldSuggestions } from '../editor_frame_service/editor_frame/suggestion_helpers';
 import type { FramePublicAPI, LensEditContextMapping, LensEditEvent } from '../types';
@@ -241,7 +241,7 @@ export const removeDimension = createAction<{
   datasourceId?: string;
 }>('lens/removeDimension');
 export const recordUndoableStateChange = createAction<{
-  patch: JsonPatchOperation[];
+  patch: Patch;
 }>('lens/recordUndoableStateChange');
 export const undo = createAction('lens/undo');
 
@@ -1227,7 +1227,7 @@ export const makeLensReducer = (storeDeps: LensStoreDeps) => {
         payload: { patch },
       }: {
         payload: {
-          patch: JsonPatchOperation[];
+          patch: Patch;
         };
       }
     ) => {

--- a/x-pack/plugins/lens/public/state_management/lens_slice.ts
+++ b/x-pack/plugins/lens/public/state_management/lens_slice.ts
@@ -252,6 +252,8 @@ export const recordReversibleStateChange = createAction<{
 }>('lens/recordReversibleStateChange');
 export const undo = createAction('lens/undo');
 export const redo = createAction('lens/redo');
+export const beginReversibleOperation = createAction('lens/beginReversibleOperation');
+export const completeReversibleOperation = createAction('lens/completeReversibleOperation');
 export const applyPatches = createAction<{ patches: Patch[] }>('lens/applyPatches');
 
 export const lensActions = {
@@ -290,6 +292,8 @@ export const lensActions = {
   undo,
   redo,
   applyPatches,
+  beginReversibleOperation,
+  completeReversibleOperation,
 };
 
 export const makeLensReducer = (storeDeps: LensStoreDeps) => {

--- a/x-pack/plugins/lens/public/state_management/lens_slice.ts
+++ b/x-pack/plugins/lens/public/state_management/lens_slice.ts
@@ -1242,16 +1242,14 @@ export const makeLensReducer = (storeDeps: LensStoreDeps) => {
       const currentState = current(_state);
       return moveStateThroughHistory(
         currentState,
-        currentState.changes[currentState.changes.length - 1].created,
-        'backward'
+        currentState.changes[currentState.changes.length - 1].created
       );
     },
     [redo.type]: (_state) => {
       const currentState = current(_state);
       return moveStateThroughHistory(
         currentState,
-        currentState.reversedChanges[currentState.reversedChanges.length - 1].created,
-        'forward'
+        currentState.reversedChanges[currentState.reversedChanges.length - 1].created
       );
     },
     [applyPatches.type]: (_state, { payload: { patches } }: { payload: { patches: Patch[] } }) => {
@@ -1279,11 +1277,12 @@ function moveLastItemToAnotherReadonlyArray<T>(from: T[], to: T[]): [T[], T[], T
 const applyToLastElement = <T>(arr: T[], transform: (item: T) => T): T[] =>
   arr.map((item, index) => (index === arr.length - 1 ? transform(item) : item));
 
-function moveStateThroughHistory(
-  _state: LensAppState,
-  targetTimestamp: number,
-  direction: 'forward' | 'backward'
-) {
+function moveStateThroughHistory(_state: LensAppState, targetTimestamp: number) {
+  const currentTimestamp = _state.changes[_state.changes.length - 1]?.created as number | undefined;
+
+  const direction: 'backward' | 'forward' =
+    currentTimestamp && currentTimestamp >= targetTimestamp ? 'backward' : 'forward';
+
   const comparator =
     direction === 'backward'
       ? (source: number, target: number) => source >= target

--- a/x-pack/plugins/lens/public/state_management/lens_slice.ts
+++ b/x-pack/plugins/lens/public/state_management/lens_slice.ts
@@ -1239,11 +1239,16 @@ export const makeLensReducer = (storeDeps: LensStoreDeps) => {
       const history = currentState.changes;
       const change = history[history.length - 1];
 
+      const changes = history.slice(0, history.length - 1);
+      const reversedChanges = [...currentState.reversedChanges, change];
+
+      // console.log('changes', changes);
+      // console.log('reversedChanges', reversedChanges);
       return change
         ? {
             ...applyPatch(currentState, change.backward, false, false).newDocument,
-            changes: history.slice(0, history.length - 1),
-            reversedChanges: [...currentState.reversedChanges, change],
+            changes,
+            reversedChanges,
           }
         : currentState;
     },
@@ -1252,11 +1257,15 @@ export const makeLensReducer = (storeDeps: LensStoreDeps) => {
       const history = currentState.reversedChanges;
       const change = history[history.length - 1];
 
+      const reversedChanges = history.slice(0, history.length - 1);
+      const changes = [...currentState.changes, change];
+      // console.log('changes', changes);
+      // console.log('reversedChanges', reversedChanges);
       return change
         ? {
             ...applyPatch(currentState, change.forward, false, false).newDocument,
-            reversedChanges: history.slice(0, history.length - 1),
-            changes: [...currentState.reversedChanges, change],
+            changes,
+            reversedChanges,
           }
         : currentState;
     },

--- a/x-pack/plugins/lens/public/state_management/lens_slice.ts
+++ b/x-pack/plugins/lens/public/state_management/lens_slice.ts
@@ -244,6 +244,7 @@ export const recordUndoableStateChange = createAction<{
   patch: Patch;
 }>('lens/recordUndoableStateChange');
 export const undo = createAction('lens/undo');
+export const applyPatches = createAction<{ patches: Patch[] }>('lens/applyPatches');
 
 export const lensActions = {
   setState,
@@ -279,6 +280,7 @@ export const lensActions = {
   syncLinkedDimensions,
   recordUndoableStateChange,
   undo,
+  applyPatches,
 };
 export const undoRedoActions = [
   updateDatasourceState,
@@ -1243,6 +1245,13 @@ export const makeLensReducer = (storeDeps: LensStoreDeps) => {
             undoableOperationHistory: history.slice(0, history.length - 1),
           }
         : currentState;
+    },
+    [applyPatches.type]: (_state, { payload: { patches } }: { payload: { patches: Patch[] } }) => {
+      let newState = current(_state);
+      patches.forEach((patch) => {
+        newState = applyPatch(newState, patch, false, false).newDocument;
+      });
+      return newState;
     },
   });
 };

--- a/x-pack/plugins/lens/public/state_management/lens_slice.ts
+++ b/x-pack/plugins/lens/public/state_management/lens_slice.ts
@@ -891,7 +891,7 @@ export const makeLensReducer = (storeDeps: LensStoreDeps) => {
         datasourceStates: newState.datasourceStates,
         visualizationMap,
         visualizeTriggerFieldContext: payload.initialContext,
-        dataViews: newState.dataViews,
+        dataViews: selectDataViews({ lens: newState }),
       });
       if (suggestion) {
         return {

--- a/x-pack/plugins/lens/public/state_management/lens_slice.ts
+++ b/x-pack/plugins/lens/public/state_management/lens_slice.ts
@@ -272,6 +272,22 @@ export const lensActions = {
   removeDimension,
   syncLinkedDimensions,
 };
+export const undoRedoActions = [
+  updateDatasourceState,
+  updateVisualizationState,
+  insertLayer,
+  switchVisualization,
+  rollbackSuggestion,
+  submitSuggestion,
+  switchDatasource,
+  switchAndCleanDatasource,
+  removeLayers,
+  removeOrClearLayer,
+  addLayer,
+  cloneLayer,
+  setLayerDefaultDimension,
+  removeDimension,
+];
 
 export const makeLensReducer = (storeDeps: LensStoreDeps) => {
   const { datasourceMap, visualizationMap } = storeDeps;

--- a/x-pack/plugins/lens/public/state_management/selectors.ts
+++ b/x-pack/plugins/lens/public/state_management/selectors.ts
@@ -32,8 +32,8 @@ export const selectStagedActiveData = (state: LensState) =>
 export const selectAutoApplyEnabled = (state: LensState) => !state.lens.autoApplyDisabled;
 export const selectChangesApplied = (state: LensState) =>
   !state.lens.autoApplyDisabled || Boolean(state.lens.changesApplied);
-export const selectCanUndo = (state: LensState) => state.lens.changes.length;
-export const selectCanRedo = (state: LensState) => state.lens.reversedChanges.length;
+export const selectCanUndo = (state: LensState) => Boolean(state.lens.changes.length);
+export const selectCanRedo = (state: LensState) => Boolean(state.lens.reversedChanges.length);
 export const selectDatasourceStates = (state: LensState) => state.lens.datasourceStates;
 export const selectVisualizationState = (state: LensState) => state.lens.visualization;
 export const selectActiveDatasourceId = (state: LensState) => state.lens.activeDatasourceId;

--- a/x-pack/plugins/lens/public/state_management/selectors.ts
+++ b/x-pack/plugins/lens/public/state_management/selectors.ts
@@ -34,6 +34,10 @@ export const selectChangesApplied = (state: LensState) =>
   !state.lens.autoApplyDisabled || Boolean(state.lens.changesApplied);
 export const selectCanUndo = (state: LensState) => Boolean(state.lens.changes.length);
 export const selectCanRedo = (state: LensState) => Boolean(state.lens.reversedChanges.length);
+export const selectRevisionHistory = (state: LensState) =>
+  [...state.lens.changes, ...state.lens.reversedChanges].sort(
+    ({ created: a }, { created: b }) => b - a
+  );
 export const selectDatasourceStates = (state: LensState) => state.lens.datasourceStates;
 export const selectVisualizationState = (state: LensState) => state.lens.visualization;
 export const selectActiveDatasourceId = (state: LensState) => state.lens.activeDatasourceId;

--- a/x-pack/plugins/lens/public/state_management/selectors.ts
+++ b/x-pack/plugins/lens/public/state_management/selectors.ts
@@ -32,7 +32,8 @@ export const selectStagedActiveData = (state: LensState) =>
 export const selectAutoApplyEnabled = (state: LensState) => !state.lens.autoApplyDisabled;
 export const selectChangesApplied = (state: LensState) =>
   !state.lens.autoApplyDisabled || Boolean(state.lens.changesApplied);
-export const selectCanUndo = (state: LensState) => state.lens.changeHistory.length;
+export const selectCanUndo = (state: LensState) => state.lens.changes.length;
+export const selectCanRedo = (state: LensState) => state.lens.reversedChanges.length;
 export const selectDatasourceStates = (state: LensState) => state.lens.datasourceStates;
 export const selectVisualizationState = (state: LensState) => state.lens.visualization;
 export const selectActiveDatasourceId = (state: LensState) => state.lens.activeDatasourceId;

--- a/x-pack/plugins/lens/public/state_management/selectors.ts
+++ b/x-pack/plugins/lens/public/state_management/selectors.ts
@@ -32,7 +32,7 @@ export const selectStagedActiveData = (state: LensState) =>
 export const selectAutoApplyEnabled = (state: LensState) => !state.lens.autoApplyDisabled;
 export const selectChangesApplied = (state: LensState) =>
   !state.lens.autoApplyDisabled || Boolean(state.lens.changesApplied);
-export const selectCanUndo = (state: LensState) => !state.lens.undoableOperationHistory.length;
+export const selectCanUndo = (state: LensState) => state.lens.changeHistory.length;
 export const selectDatasourceStates = (state: LensState) => state.lens.datasourceStates;
 export const selectVisualizationState = (state: LensState) => state.lens.visualization;
 export const selectActiveDatasourceId = (state: LensState) => state.lens.activeDatasourceId;

--- a/x-pack/plugins/lens/public/state_management/selectors.ts
+++ b/x-pack/plugins/lens/public/state_management/selectors.ts
@@ -32,6 +32,7 @@ export const selectStagedActiveData = (state: LensState) =>
 export const selectAutoApplyEnabled = (state: LensState) => !state.lens.autoApplyDisabled;
 export const selectChangesApplied = (state: LensState) =>
   !state.lens.autoApplyDisabled || Boolean(state.lens.changesApplied);
+export const selectCanUndo = (state: LensState) => !state.lens.undoableOperationHistory.length;
 export const selectDatasourceStates = (state: LensState) => state.lens.datasourceStates;
 export const selectVisualizationState = (state: LensState) => state.lens.visualization;
 export const selectActiveDatasourceId = (state: LensState) => state.lens.activeDatasourceId;

--- a/x-pack/plugins/lens/public/state_management/state_coordinator/index.ts
+++ b/x-pack/plugins/lens/public/state_management/state_coordinator/index.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { HttpSetup } from '@kbn/core-http-browser';
+import { Patch } from '../../../common/types';
+import { STATE_PATCH_API_PATH } from '../../../common/constants';
+
+type Listener = (patches: Patch[]) => void;
+
+export class StateCoordinator {
+  private static _instance: StateCoordinator;
+  private static http?: HttpSetup;
+  private static visId?: string;
+  private static sessionId?: string;
+  private static POLLING_INTERVAL = 1000;
+
+  public static setHTTP(http: HttpSetup) {
+    this.http = http;
+  }
+
+  public static setVisId(id: string) {
+    this.visId = id;
+  }
+
+  public static setSessionId(id: string) {
+    this.sessionId = id;
+  }
+
+  public static async runPoll() {
+    const { http, visId, sessionId, POLLING_INTERVAL } = StateCoordinator;
+
+    let patches: Patch[] = [];
+    if (http && visId && sessionId) {
+      patches = (
+        await http.get<{ patches: Patch[] }>(STATE_PATCH_API_PATH, {
+          query: {
+            visId,
+            sessionId,
+          },
+        })
+      ).patches;
+    }
+
+    console.log(patches);
+
+    setTimeout(() => this.runPoll(), POLLING_INTERVAL);
+  }
+
+  private constructor() {}
+
+  public static get instance() {
+    if (!this._instance) {
+      this._instance = new StateCoordinator();
+    }
+
+    return this._instance;
+  }
+
+  registerPatchListener(listener: Listener) {
+    this.listeners.push(listener);
+  }
+
+  public sendPatch(patch: Patch) {
+    const { http, visId, sessionId } = StateCoordinator;
+    if (!http || !visId) return;
+
+    http.post(STATE_PATCH_API_PATH, {
+      method: 'POST',
+      cache: 'no-cache',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        patch,
+        visId,
+        sessionId,
+      }),
+    });
+  }
+}

--- a/x-pack/plugins/lens/public/state_management/state_coordinator/index.ts
+++ b/x-pack/plugins/lens/public/state_management/state_coordinator/index.ts
@@ -34,6 +34,7 @@ export class StateCoordinator {
   }
 
   public static async listen() {
+    return; // uncomment to enable state coordination
     const { visId, sessionId } = StateCoordinator;
     if (!visId || !sessionId) return;
     // let patches: Patch[] = [];

--- a/x-pack/plugins/lens/public/state_management/state_history.ts
+++ b/x-pack/plugins/lens/public/state_management/state_history.ts
@@ -20,7 +20,7 @@ export const stateHistoryMiddleware =
       const forwardPatch = compare(prevState, newState);
       const backwardPatch = compare(newState, prevState);
 
-      StateCoordinator.instance.sendPatch(forwardPatch);
+      StateCoordinator.sendPatch(forwardPatch);
 
       next(recordUndoableStateChange({ patch: backwardPatch }));
     } else {

--- a/x-pack/plugins/lens/public/state_management/state_history.ts
+++ b/x-pack/plugins/lens/public/state_management/state_history.ts
@@ -72,6 +72,7 @@ export const stateHistoryMiddleware = () => (store: MiddlewareAPI) => (next: Dis
 
     if (beginReversibleOperation.match(action)) {
       prevStateForExtendedOperation = store.getState().lens;
+      // console.log('BEGIN reversible operation');
     }
 
     if (prevStateForExtendedOperation) {
@@ -80,6 +81,7 @@ export const stateHistoryMiddleware = () => (store: MiddlewareAPI) => (next: Dis
       if (completeReversibleOperation.match(action)) {
         completeChange(prevStateForExtendedOperation);
         prevStateForExtendedOperation = undefined;
+        // console.log('COMPLETE reversible operation');
       }
     }
 

--- a/x-pack/plugins/lens/public/state_management/state_history.ts
+++ b/x-pack/plugins/lens/public/state_management/state_history.ts
@@ -15,7 +15,7 @@ import {
   recordReversibleStateChange,
 } from './lens_slice';
 import { StateCoordinator } from './state_coordinator';
-import { LensAppState, StateChangeOperation } from './types';
+import { LensAppState, StateRevision } from './types';
 import { initEmpty, redo, undo } from '.';
 
 const reversableStatePaths: Array<keyof LensAppState | string> = [
@@ -38,7 +38,9 @@ const createReversibleStateChange = (prev: LensAppState, next: LensAppState) => 
   const reversiblePrev = onlyReversiblePaths(prev);
   const reversibleNext = onlyReversiblePaths(next);
 
-  const change: StateChangeOperation = {
+  const change: StateRevision = {
+    active: true,
+    created: new Date().getTime(),
     forward: compare(reversiblePrev, reversibleNext),
     backward: compare(reversibleNext, reversiblePrev),
   };

--- a/x-pack/plugins/lens/public/state_management/state_history.ts
+++ b/x-pack/plugins/lens/public/state_management/state_history.ts
@@ -66,6 +66,7 @@ export const stateHistoryMiddleware = () => (store: MiddlewareAPI) => (next: Dis
         testAction.match(action)
       )
     ) {
+      // do nothing
       return next(action);
     }
 

--- a/x-pack/plugins/lens/public/state_management/state_history.ts
+++ b/x-pack/plugins/lens/public/state_management/state_history.ts
@@ -13,6 +13,7 @@ import {
   beginReversibleOperation,
   completeReversibleOperation,
   recordReversibleStateChange,
+  timeTravel,
 } from './lens_slice';
 import { StateCoordinator } from './state_coordinator';
 import { LensAppState, StateRevision } from './types';
@@ -64,7 +65,7 @@ export const stateHistoryMiddleware = () => (store: MiddlewareAPI) => (next: Dis
 
   return (action: Action) => {
     if (
-      [initEmpty, recordReversibleStateChange, undo, redo].some((testAction) =>
+      [initEmpty, recordReversibleStateChange, undo, redo, timeTravel].some((testAction) =>
         testAction.match(action)
       )
     ) {

--- a/x-pack/plugins/lens/public/state_management/state_history.ts
+++ b/x-pack/plugins/lens/public/state_management/state_history.ts
@@ -6,8 +6,8 @@
  */
 
 import { Dispatch, MiddlewareAPI, Action } from '@reduxjs/toolkit';
-import { compare } from 'fast-json-patch';
-import { undoRedoActions } from './lens_slice';
+import { diff } from 'jsondiffpatch';
+import { recordUndoableStateChange, undoRedoActions } from './lens_slice';
 
 export const stateHistoryMiddleware = () => (store: MiddlewareAPI) => {
   return (next: Dispatch) => (action: Action) => {
@@ -15,7 +15,13 @@ export const stateHistoryMiddleware = () => (store: MiddlewareAPI) => {
       console.log(action.type);
       const prevState = store.getState();
       next(action);
-      console.log(compare(prevState, store.getState()));
+
+      const change = diff(prevState, store.getState());
+      console.log(change);
+
+      if (change) {
+        next(recordUndoableStateChange({ change }));
+      }
     } else {
       next(action);
     }

--- a/x-pack/plugins/lens/public/state_management/state_history.ts
+++ b/x-pack/plugins/lens/public/state_management/state_history.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { Dispatch, MiddlewareAPI, Action } from '@reduxjs/toolkit';
+import { compare } from 'fast-json-patch';
+import { undoRedoActions } from './lens_slice';
+
+export const stateHistoryMiddleware = () => (store: MiddlewareAPI) => {
+  return (next: Dispatch) => (action: Action) => {
+    if (undoRedoActions.some((testAction) => testAction.match(action))) {
+      console.log(action.type);
+      const prevState = store.getState();
+      next(action);
+      console.log(compare(prevState, store.getState()));
+    } else {
+      next(action);
+    }
+  };
+};

--- a/x-pack/plugins/lens/public/state_management/types.ts
+++ b/x-pack/plugins/lens/public/state_management/types.ts
@@ -9,12 +9,11 @@ import type { VisualizeFieldContext } from '@kbn/ui-actions-plugin/public';
 import type { EmbeddableEditorState } from '@kbn/embeddable-plugin/public';
 import type { Filter, Query } from '@kbn/es-query';
 import type { SavedQuery } from '@kbn/data-plugin/public';
-import type { Operation } from 'fast-json-patch';
 import type { MainHistoryLocationState } from '../../common/locator/locator';
 import type { Document } from '../persistence';
 
 import type { TableInspectorAdapter } from '../editor_frame_service/types';
-import type { DateRange } from '../../common/types';
+import type { DateRange, Patch } from '../../common/types';
 import type { LensAppServices } from '../app_plugin/types';
 import type {
   DatasourceMap,
@@ -72,7 +71,7 @@ export interface LensAppState extends EditorFrameState {
   // Dataview/Indexpattern management has moved in here from datasource
   dataViews: DataViewsStateInStateStore;
 
-  undoableOperationHistory: Operation[][];
+  undoableOperationHistory: Patch[];
 }
 
 export type DispatchSetState = (state: Partial<LensAppState>) => {

--- a/x-pack/plugins/lens/public/state_management/types.ts
+++ b/x-pack/plugins/lens/public/state_management/types.ts
@@ -77,7 +77,8 @@ export interface LensAppState extends EditorFrameState {
   // Dataview/Indexpattern management has moved in here from datasource
   dataViews: DataViewsStateInStateStore;
 
-  changeHistory: StateChangeOperation[];
+  changes: StateChangeOperation[];
+  reversedChanges: StateChangeOperation[];
 }
 
 export type DispatchSetState = (state: Partial<LensAppState>) => {

--- a/x-pack/plugins/lens/public/state_management/types.ts
+++ b/x-pack/plugins/lens/public/state_management/types.ts
@@ -55,7 +55,9 @@ export interface EditorFrameState extends PreviewState {
   isFullscreenDatasource?: boolean;
 }
 
-export interface StateChangeOperation {
+export interface StateRevision {
+  created: number;
+  active: boolean;
   forward: Patch;
   backward: Patch;
 }
@@ -77,8 +79,8 @@ export interface LensAppState extends EditorFrameState {
   // Dataview/Indexpattern management has moved in here from datasource
   dataViews: DataViewsStateInStateStore;
 
-  changes: StateChangeOperation[];
-  reversedChanges: StateChangeOperation[];
+  changes: StateRevision[];
+  reversedChanges: StateRevision[];
 }
 
 export type DispatchSetState = (state: Partial<LensAppState>) => {

--- a/x-pack/plugins/lens/public/state_management/types.ts
+++ b/x-pack/plugins/lens/public/state_management/types.ts
@@ -54,6 +54,12 @@ export interface EditorFrameState extends PreviewState {
   changesApplied?: boolean;
   isFullscreenDatasource?: boolean;
 }
+
+export interface StateChangeOperation {
+  forward: Patch;
+  backward: Patch;
+}
+
 export interface LensAppState extends EditorFrameState {
   persistedDoc?: Document;
 
@@ -71,7 +77,7 @@ export interface LensAppState extends EditorFrameState {
   // Dataview/Indexpattern management has moved in here from datasource
   dataViews: DataViewsStateInStateStore;
 
-  undoableOperationHistory: Patch[];
+  changeHistory: StateChangeOperation[];
 }
 
 export type DispatchSetState = (state: Partial<LensAppState>) => {

--- a/x-pack/plugins/lens/public/state_management/types.ts
+++ b/x-pack/plugins/lens/public/state_management/types.ts
@@ -23,6 +23,7 @@ import type {
   VisualizeEditorContext,
   IndexPattern,
   IndexPatternRef,
+  IndexPatternInStateStore,
 } from '../types';
 export interface VisualizationState {
   activeId: string | null;
@@ -32,6 +33,12 @@ export interface VisualizationState {
 export interface DataViewsState {
   indexPatternRefs: IndexPatternRef[];
   indexPatterns: Record<string, IndexPattern>;
+}
+
+// TODO - reconsider the naming of this interface
+export interface DataViewsStateInStateStore {
+  indexPatternRefs: IndexPatternRef[];
+  indexPatterns: Record<string, IndexPatternInStateStore>;
 }
 
 export type DatasourceStates = Record<string, { isLoading: boolean; state: unknown }>;
@@ -63,7 +70,7 @@ export interface LensAppState extends EditorFrameState {
   resolvedDateRange: DateRange;
   sharingSavedObjectProps?: Omit<SharingSavedObjectProps, 'sourceId'>;
   // Dataview/Indexpattern management has moved in here from datasource
-  dataViews: DataViewsState;
+  dataViews: DataViewsStateInStateStore;
 
   undoableOperationHistory: Delta[];
 }

--- a/x-pack/plugins/lens/public/state_management/types.ts
+++ b/x-pack/plugins/lens/public/state_management/types.ts
@@ -9,7 +9,7 @@ import type { VisualizeFieldContext } from '@kbn/ui-actions-plugin/public';
 import type { EmbeddableEditorState } from '@kbn/embeddable-plugin/public';
 import type { Filter, Query } from '@kbn/es-query';
 import type { SavedQuery } from '@kbn/data-plugin/public';
-import type { Delta } from 'jsondiffpatch';
+import type { Operation } from 'fast-json-patch';
 import type { MainHistoryLocationState } from '../../common/locator/locator';
 import type { Document } from '../persistence';
 
@@ -72,7 +72,7 @@ export interface LensAppState extends EditorFrameState {
   // Dataview/Indexpattern management has moved in here from datasource
   dataViews: DataViewsStateInStateStore;
 
-  undoableOperationHistory: Delta[];
+  undoableOperationHistory: Operation[][];
 }
 
 export type DispatchSetState = (state: Partial<LensAppState>) => {

--- a/x-pack/plugins/lens/public/state_management/types.ts
+++ b/x-pack/plugins/lens/public/state_management/types.ts
@@ -9,6 +9,7 @@ import type { VisualizeFieldContext } from '@kbn/ui-actions-plugin/public';
 import type { EmbeddableEditorState } from '@kbn/embeddable-plugin/public';
 import type { Filter, Query } from '@kbn/es-query';
 import type { SavedQuery } from '@kbn/data-plugin/public';
+import type { Delta } from 'jsondiffpatch';
 import type { MainHistoryLocationState } from '../../common/locator/locator';
 import type { Document } from '../persistence';
 
@@ -63,6 +64,8 @@ export interface LensAppState extends EditorFrameState {
   sharingSavedObjectProps?: Omit<SharingSavedObjectProps, 'sourceId'>;
   // Dataview/Indexpattern management has moved in here from datasource
   dataViews: DataViewsState;
+
+  undoableOperationHistory: Delta[];
 }
 
 export type DispatchSetState = (state: Partial<LensAppState>) => {

--- a/x-pack/plugins/lens/public/types.ts
+++ b/x-pack/plugins/lens/public/types.ts
@@ -116,6 +116,7 @@ export interface EditorFrameProps {
   showNoDataPopover: () => void;
   lensInspector: LensInspector;
   indexPatternService: IndexPatternServiceAPI;
+  extendedUndoService: ExtendedUndoableOperationService;
   getUserMessages: UserMessagesGetter;
   addUserMessages: AddUserMessages;
 }
@@ -668,7 +669,13 @@ export type DatasourceDimensionEditorProps<T = unknown> = DatasourceDimensionPro
   enableFormatSelector: boolean;
   dataSectionExtra?: React.ReactNode;
   formatSelectorOptions: FormatSelectorOptions | undefined;
+  extendedUndoService: ExtendedUndoableOperationService;
 };
+
+export interface ExtendedUndoableOperationService {
+  begin: () => void;
+  complete: () => void;
+}
 
 export type DatasourceDimensionTriggerProps<T> = DatasourceDimensionProps<T>;
 

--- a/x-pack/plugins/lens/public/types.ts
+++ b/x-pack/plugins/lens/public/types.ts
@@ -91,6 +91,8 @@ export interface IndexPattern {
   isPersisted: boolean;
 }
 
+export type IndexPatternInStateStore = Omit<IndexPattern, 'getFieldByName'>;
+
 export type IndexPatternField = FieldSpec & {
   displayName: string;
   aggregationRestrictions?: Partial<IndexPatternAggRestrictions>;

--- a/x-pack/plugins/lens/server/plugin.tsx
+++ b/x-pack/plugins/lens/server/plugin.tsx
@@ -30,6 +30,7 @@ import type { CustomVisualizationMigrations } from './migrations/types';
 import { LensAppLocatorDefinition } from '../common/locator/locator';
 import { CONTENT_ID, LATEST_VERSION } from '../common/content_management';
 import { LensStorage } from './content_management';
+import { defineRoutes } from './routes';
 
 export interface PluginSetupContract {
   taskManager?: TaskManagerSetupContract;
@@ -67,6 +68,8 @@ export class LensServerPlugin implements Plugin<LensServerPluginSetup, {}, {}, {
   constructor() {}
 
   setup(core: CoreSetup<PluginStartContract>, plugins: PluginSetupContract) {
+    defineRoutes(core.http);
+
     const getFilterMigrations = plugins.data.query.filterManager.getAllMigrations.bind(
       plugins.data.query.filterManager
     );

--- a/x-pack/plugins/lens/server/plugin.tsx
+++ b/x-pack/plugins/lens/server/plugin.tsx
@@ -30,7 +30,8 @@ import type { CustomVisualizationMigrations } from './migrations/types';
 import { LensAppLocatorDefinition } from '../common/locator/locator';
 import { CONTENT_ID, LATEST_VERSION } from '../common/content_management';
 import { LensStorage } from './content_management';
-import { defineRoutes } from './routes';
+// import { defineRoutes } from './routes';
+import { setupStateCoordinatorServer } from './routes/state_coordinator_with_server_side_events';
 
 export interface PluginSetupContract {
   taskManager?: TaskManagerSetupContract;
@@ -68,7 +69,8 @@ export class LensServerPlugin implements Plugin<LensServerPluginSetup, {}, {}, {
   constructor() {}
 
   setup(core: CoreSetup<PluginStartContract>, plugins: PluginSetupContract) {
-    defineRoutes(core.http);
+    // defineRoutes(core.http);
+    setupStateCoordinatorServer(); // had to cook my own server because of lack of server-sent event support in Core
 
     const getFilterMigrations = plugins.data.query.filterManager.getAllMigrations.bind(
       plugins.data.query.filterManager

--- a/x-pack/plugins/lens/server/routes/index.ts
+++ b/x-pack/plugins/lens/server/routes/index.ts
@@ -6,10 +6,10 @@
  */
 
 import { HttpServiceSetup } from '@kbn/core/server';
-import { statePatches } from './state_patches';
+import { stateCoordinator } from './state_coordinator';
 
 export function defineRoutes(http: HttpServiceSetup) {
   const router = http.createRouter();
 
-  statePatches(router);
+  stateCoordinator(router);
 }

--- a/x-pack/plugins/lens/server/routes/index.ts
+++ b/x-pack/plugins/lens/server/routes/index.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { HttpServiceSetup } from '@kbn/core/server';
+import { statePatches } from './state_patches';
+
+export function defineRoutes(http: HttpServiceSetup) {
+  const router = http.createRouter();
+
+  statePatches(router);
+}

--- a/x-pack/plugins/lens/server/routes/state_coordinator.ts
+++ b/x-pack/plugins/lens/server/routes/state_coordinator.ts
@@ -12,7 +12,7 @@ import { STATE_PATCH_API_PATH } from '../../common/constants';
 
 const patches: Record<string, Array<{ patch: Patch; sessionsReceived: Set<string> }>> = {};
 
-export async function statePatches(router: IRouter) {
+export async function stateCoordinator(router: IRouter) {
   router.post(
     {
       path: STATE_PATCH_API_PATH,

--- a/x-pack/plugins/lens/server/routes/state_coordinator_with_server_side_events.ts
+++ b/x-pack/plugins/lens/server/routes/state_coordinator_with_server_side_events.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import express from 'express';
+import bodyParser from 'body-parser';
+import cors from 'cors';
+import type { Response } from 'express';
+import { STATE_PATCH_API_PATH } from '../../common/constants';
+import { Patch } from '../../common/types';
+
+const patches: Record<string, Array<{ patch: Patch; clientsReceived: Set<string> }>> = {};
+
+interface Client {
+  id: string;
+  visId: string;
+  response: Response;
+}
+
+const getPatchesForClient = (client: Client) =>
+  patches[client.visId]
+    ? patches[client.visId]
+        .filter(({ clientsReceived }) => {
+          if (!clientsReceived.has(client.id)) {
+            clientsReceived.add(client.id);
+            return true;
+          }
+
+          return false;
+        })
+        .map(({ patch }) => patch)
+    : [];
+
+export const setupStateCoordinatorServer = () => {
+  const app = express();
+
+  app.use(cors());
+  app.use(bodyParser.json());
+  app.use(bodyParser.urlencoded({ extended: false }));
+
+  app.get('/status', (request, response) => response.json({ clients: clients.length }));
+
+  const PORT = 3000;
+
+  let clients: Client[] = [];
+
+  app.listen(PORT, () => {
+    console.log(`Facts Events service listening at http://localhost:${PORT}`);
+  });
+
+  app.get(STATE_PATCH_API_PATH, (request, response, _next) => {
+    const headers = {
+      'Content-Type': 'text/event-stream',
+      Connection: 'keep-alive',
+      'Cache-Control': 'no-cache',
+    };
+    response.writeHead(200, headers);
+
+    const clientId = request.query.sessionId as string;
+
+    const newClient = {
+      id: clientId,
+      visId: request.query.visId as string,
+      response,
+    };
+
+    clients.push(newClient);
+
+    const data = `data: ${JSON.stringify(getPatchesForClient(newClient))}\n\n`;
+
+    response.write(data);
+
+    request.on('close', () => {
+      console.log(`${clientId} Connection closed`);
+      clients = clients.filter((client) => client.id !== clientId);
+    });
+  });
+
+  function broadcastPatches() {
+    clients.forEach((client) =>
+      client.response.write(`data: ${JSON.stringify(getPatchesForClient(client))}\n\n`)
+    );
+  }
+
+  app.post(STATE_PATCH_API_PATH, (request, response, next) => {
+    const patch: Patch = request.body.patch;
+    if (!patches[request.body.visId]) {
+      patches[request.body.visId] = [];
+    }
+
+    const patchRecord = {
+      patch,
+      clientsReceived: new Set([request.body.sessionId]),
+    };
+    patches[request.body.visId].push(patchRecord);
+
+    response.status(200);
+    return broadcastPatches();
+  });
+
+  app.delete(STATE_PATCH_API_PATH, async (req, res) => {
+    delete patches[req.query.visId as string];
+
+    return res.status(200);
+  });
+};

--- a/x-pack/plugins/lens/server/routes/state_coordinator_with_server_side_events.ts
+++ b/x-pack/plugins/lens/server/routes/state_coordinator_with_server_side_events.ts
@@ -80,9 +80,12 @@ export const setupStateCoordinatorServer = () => {
   });
 
   function broadcastPatches() {
-    clients.forEach((client) =>
-      client.response.write(`data: ${JSON.stringify(getPatchesForClient(client))}\n\n`)
-    );
+    clients.forEach((client) => {
+      const patchesForClient = getPatchesForClient(client);
+      if (patchesForClient.length) {
+        client.response.write(`data: ${JSON.stringify(patchesForClient)}\n\n`);
+      }
+    });
   }
 
   app.post(STATE_PATCH_API_PATH, (request, response, next) => {

--- a/x-pack/plugins/lens/server/routes/state_patches.ts
+++ b/x-pack/plugins/lens/server/routes/state_patches.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+import type { IRouter } from '@kbn/core-http-server';
+import type { Patch } from '../../common/types';
+import { STATE_PATCH_API_PATH } from '../../common/constants';
+
+const patches: Record<string, Array<{ patch: Patch; sessionsReceived: Set<string> }>> = {};
+
+export async function statePatches(router: IRouter) {
+  router.post(
+    {
+      path: STATE_PATCH_API_PATH,
+      validate: {
+        body: schema.object({
+          visId: schema.string(),
+          sessionId: schema.string(),
+          patch: schema.arrayOf(schema.any()),
+        }),
+      },
+    },
+    async (context, req, res) => {
+      const patch: Patch = req.body.patch;
+      if (!patches[req.body.visId]) {
+        patches[req.body.visId] = [];
+      }
+
+      patches[req.body.visId].push({ patch, sessionsReceived: new Set([req.body.sessionId]) });
+
+      return res.ok();
+    }
+  );
+
+  router.get(
+    {
+      path: STATE_PATCH_API_PATH,
+      validate: {
+        query: schema.object({
+          visId: schema.string(),
+          sessionId: schema.string(),
+        }),
+      },
+    },
+    async (context, req, res) => {
+      const patchesToReturn = patches[req.query.visId]
+        ? patches[req.query.visId]
+            .filter(({ sessionsReceived }) => {
+              if (!sessionsReceived.has(req.query.sessionId)) {
+                sessionsReceived.add(req.query.sessionId);
+                return true;
+              }
+
+              return false;
+            })
+            .map(({ patch }) => patch)
+        : [];
+
+      return res.ok({
+        body: { patches: patchesToReturn },
+      });
+    }
+  );
+}

--- a/x-pack/plugins/lens/server/routes/state_patches.ts
+++ b/x-pack/plugins/lens/server/routes/state_patches.ts
@@ -65,4 +65,20 @@ export async function statePatches(router: IRouter) {
       });
     }
   );
+
+  router.delete(
+    {
+      path: STATE_PATCH_API_PATH,
+      validate: {
+        query: schema.object({
+          visId: schema.string(),
+        }),
+      },
+    },
+    async (context, req, res) => {
+      delete patches[req.query.visId];
+
+      return res.ok();
+    }
+  );
 }

--- a/x-pack/plugins/lens/tsconfig.json
+++ b/x-pack/plugins/lens/tsconfig.json
@@ -71,6 +71,8 @@
     "@kbn/core-saved-objects-api-server",
     "@kbn/object-versioning",
     "@kbn/config-schema",
+    "@kbn/core-http-browser",
+    "@kbn/core-http-server",
   ],
   "exclude": [
     "target/**/*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12667,6 +12667,14 @@ core-util-is@1.0.2, core-util-is@^1.0.2, core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
+cors@^2.8.5:
+  version "2.8.5"
+  resolved "https://registry.yarnpkg.com/cors/-/cors-2.8.5.tgz#eac11da51592dd86b9f06f6e7ac293b3df875d29"
+  integrity sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==
+  dependencies:
+    object-assign "^4"
+    vary "^1"
+
 cosmiconfig@8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-8.0.0.tgz#e9feae014eab580f858f8a0288f38997a7bebe97"
@@ -22010,7 +22018,7 @@ nyc@15.1.0, nyc@^15.1.0:
     test-exclude "^6.0.0"
     yargs "^15.0.2"
 
-object-assign@4.X, object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
+object-assign@4.X, object-assign@^4, object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
@@ -28479,7 +28487,7 @@ variable-diff@1.1.0:
     chalk "^1.1.1"
     object-assign "^4.0.1"
 
-vary@~1.1.2:
+vary@^1, vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=

--- a/yarn.lock
+++ b/yarn.lock
@@ -15691,6 +15691,11 @@ fast-json-parse@^1.0.3:
   resolved "https://registry.yarnpkg.com/fast-json-parse/-/fast-json-parse-1.0.3.tgz#43e5c61ee4efa9265633046b770fb682a7577c4d"
   integrity sha512-FRWsaZRWEJ1ESVNbDWmsAlqDk96gPQezzLghafp5J4GUKjbCz3OkAHuZs5TuPEtkbVQERysLp9xv6c24fBm8Aw==
 
+fast-json-patch@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/fast-json-patch/-/fast-json-patch-3.1.1.tgz#85064ea1b1ebf97a3f7ad01e23f9337e72c66947"
+  integrity sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ==
+
 fast-json-stable-stringify@^2.0.0, fast-json-stable-stringify@^2.1.0, fast-json-stable-stringify@~2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"


### PR DESCRIPTION
## Summary

PoC for https://github.com/elastic/kibana/issues/54971

This PR introduces support for undo/redo in Lens. It also includes some experiments around broadcasting state changes to other clients for a more collaborative editing experience.

### Undo/redo/history


https://github.com/elastic/kibana/assets/315764/909bd725-4c2b-4dc4-9e30-b9c26e8575f5


### Broadcasting changes


https://github.com/elastic/kibana/assets/315764/b1accbce-d471-4261-be60-e7a43a69662e




### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
