### PR TITLE
[8.7] fix(NA): chromium installation on distribution

### DIFF
--- a/src/dev/build/tasks/install_chromium.ts
+++ b/src/dev/build/tasks/install_chromium.ts
@@ -41,7 +41,10 @@ export const InstallChromium: Task = {
         log: log.write.bind(log),
       };
 
-      const path = build.resolvePathForPlatform(platform, 'x-pack/plugins/screenshotting/chromium');
+      const path = build.resolvePathForPlatform(
+        platform,
+        'node_modules/@kbn/screenshotting-plugin/chromium'
+      );
       await install(logger as unknown as Logger, pkg, path);
     }
   },


### PR DESCRIPTION
With the recent puppeteer and chromium upgrades the installation path on distribution is not correct and in sync anymore with the package system. 

This PR fixes the problem and the underlying pipeline tests currently failing.