### PR TITLE
[Security Solution] Fix grouping rows per page bug

### DIFF
--- a/packages/kbn-securitysolution-grouping/src/components/grouping.tsx
+++ b/packages/kbn-securitysolution-grouping/src/components/grouping.tsx
@@ -221,7 +221,7 @@ const GroupingComponent = <T,>({
           <EuiProgress data-test-subj="is-loading-grouping-table" size="xs" color="accent" />
         )}
         {groupCount > 0 ? (
-          <>
+          <span data-test-subj={`grouping-level-${groupingLevel}`}>
             {groupPanels}
             {groupCount > 0 && (
               <>
@@ -246,7 +246,7 @@ const GroupingComponent = <T,>({
                 />
               </>
             )}
-          </>
+          </span>
         ) : (
           <EmptyGroupingComponent />
         )}

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/alerts_grouping.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/alerts_grouping.tsx
@@ -149,6 +149,12 @@ const GroupedAlertsTableComponent: React.FC<AlertsTableComponentProps> = (props)
           setStoragePageSize(newArr);
           return newArr;
         });
+        // set page index to 0 when page size is changed
+        setPageIndex((currentIndex) => {
+          const newArr = [...currentIndex];
+          newArr[groupingLevel] = 0;
+          return newArr;
+        });
       }
     },
     [setStoragePageSize]


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/156515

We were not reseting the active page to 0 when rows per page changed. If we had 100 groups with rows per page set to 10, and navigate to page 10. Then set rows per page to 100. Because we are still on page 10, it is querying for results 900-1000 which do not exist. It shows an empty page. We need to reset to page 1 to make sure data still exists for the page we are loading.

<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->