### PR TITLE
Unskip interactive setup functional tests

### DIFF
--- a/test/interactive_setup_functional/tests/manual_configuration.ts
+++ b/test/interactive_setup_functional/tests/manual_configuration.ts
@@ -18,8 +18,7 @@ export default function ({ getService }: FtrProviderContext) {
   const retry = getService('retry');
   const log = getService('log');
 
-  // FAILING ES PROMOTION: https://github.com/elastic/kibana/issues/157017
-  describe.skip('Interactive Setup Functional Tests (Manual configuration)', function () {
+  describe('Interactive Setup Functional Tests (Manual configuration)', function () {
     this.tags('skipCloud');
 
     let verificationCode: string;

--- a/test/interactive_setup_functional/tests/manual_configuration_without_tls.ts
+++ b/test/interactive_setup_functional/tests/manual_configuration_without_tls.ts
@@ -18,8 +18,7 @@ export default function ({ getService }: FtrProviderContext) {
   const retry = getService('retry');
   const log = getService('log');
 
-  // FAILING ES PROMOTION: https://github.com/elastic/kibana/issues/157018
-  describe.skip('Interactive Setup Functional Tests (Manual configuration without TLS)', function () {
+  describe('Interactive Setup Functional Tests (Manual configuration without TLS)', function () {
     this.tags('skipCloud');
 
     let verificationCode: string;


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/157017
Resolves https://github.com/elastic/kibana/issues/157018

Unskips our Interactive Setup functional tests, which started failing after a recent ES snapshot promotion. This was caused by a regression in Elasticsearch, which was resolved via https://github.com/elastic/elasticsearch/pull/96061.

I will not be running a flaky test suite here, as these tests were consistently failing, as opposed to flaky.