### PR TITLE
[Profiling] Update imports of hooks and components from Observability to Observability Shared

### DIFF
--- a/x-pack/plugins/profiling/public/app.tsx
+++ b/x-pack/plugins/profiling/public/app.tsx
@@ -12,7 +12,7 @@ import { RedirectAppLinks } from '@kbn/shared-ux-link-redirect-app';
 import { RouteRenderer, RouterProvider } from '@kbn/typed-react-router-config';
 import React, { useMemo } from 'react';
 import ReactDOM from 'react-dom';
-import { HeaderMenuPortal } from '@kbn/observability-plugin/public';
+import { HeaderMenuPortal } from '@kbn/observability-shared-plugin/public';
 import { CheckSetup } from './components/check_setup';
 import { ProfilingDependenciesContextProvider } from './components/contexts/profiling_dependencies/profiling_dependencies_context';
 import { RouteBreadcrumbsContextProvider } from './components/contexts/route_breadcrumbs_context';

--- a/x-pack/plugins/profiling/public/components/contexts/route_breadcrumbs_context/index.tsx
+++ b/x-pack/plugins/profiling/public/components/contexts/route_breadcrumbs_context/index.tsx
@@ -8,7 +8,7 @@ import { Route, RouteMatch, useMatchRoutes } from '@kbn/typed-react-router-confi
 import { ChromeBreadcrumb } from '@kbn/core/public';
 import { compact, isEqual } from 'lodash';
 import React, { createContext, useMemo, useState } from 'react';
-import { useBreadcrumbs } from '@kbn/observability-plugin/public';
+import { useBreadcrumbs } from '@kbn/observability-shared-plugin/public';
 
 export interface Breadcrumb {
   title: string;

--- a/x-pack/plugins/profiling/public/plugin.tsx
+++ b/x-pack/plugins/profiling/public/plugin.tsx
@@ -13,7 +13,7 @@ import {
   Plugin,
 } from '@kbn/core/public';
 import { i18n } from '@kbn/i18n';
-import type { NavigationSection } from '@kbn/observability-plugin/public';
+import type { NavigationSection } from '@kbn/observability-shared-plugin/public';
 import { Location } from 'history';
 import { BehaviorSubject, combineLatest, from, map } from 'rxjs';
 import { getServices } from './services';


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/157855

## 📝 Summary

This PR updates imports of hooks and components from Observability to Observability Shared. 

It builds on the preparation work done in https://github.com/elastic/kibana/issues/157848.

More information on the progress in [the epic](https://github.com/elastic/kibana/issues/152783).

## ✅ Acceptance criteria
- Everything should work as before.