### PR TITLE
[8.7] [ResponseOps] es query rule params not compatible between 8.6 and 8.7 (#157710)

### DIFF
--- a/x-pack/plugins/stack_alerts/server/rule_types/es_query/rule_type_params.test.ts
+++ b/x-pack/plugins/stack_alerts/server/rule_types/es_query/rule_type_params.test.ts
@@ -144,6 +144,28 @@ describe('ruleType Params validate()', () => {
     );
   });
 
+  it('uses default value "count" if aggType is undefined', async () => {
+    params.aggType = undefined;
+    expect(onValidate()).not.toThrow();
+  });
+
+  it('fails for invalid groupBy', async () => {
+    params.groupBy = 42;
+    expect(onValidate()).toThrowErrorMatchingInlineSnapshot(
+      `"[groupBy]: expected value of type [string] but got [number]"`
+    );
+
+    params.groupBy = '-not-a-valid-groupBy-';
+    expect(onValidate()).toThrowErrorMatchingInlineSnapshot(
+      `"[groupBy]: invalid groupBy: \\"-not-a-valid-groupBy-\\""`
+    );
+  });
+
+  it('uses default value "all" if groupBy is undefined', async () => {
+    params.groupBy = undefined;
+    expect(onValidate()).not.toThrow();
+  });
+
   it('fails for invalid aggField', async () => {
     params.aggField = 42;
     expect(onValidate()).toThrowErrorMatchingInlineSnapshot(

--- a/x-pack/plugins/stack_alerts/server/rule_types/es_query/rule_type_params.ts
+++ b/x-pack/plugins/stack_alerts/server/rule_types/es_query/rule_type_params.ts
@@ -41,11 +41,11 @@ const EsQueryRuleParamsSchemaProperties = {
   threshold: schema.arrayOf(schema.number(), { minSize: 1, maxSize: 2 }),
   thresholdComparator: getComparatorSchemaType(validateComparator),
   // aggregation type
-  aggType: schema.string({ validate: validateAggType }),
+  aggType: schema.string({ validate: validateAggType, defaultValue: 'count' }),
   // aggregation field
   aggField: schema.maybe(schema.string({ minLength: 1 })),
   // how to group
-  groupBy: schema.string({ validate: validateGroupBy }),
+  groupBy: schema.string({ validate: validateGroupBy, defaultValue: 'all' }),
   // field to group on (for groupBy: top)
   termField: schema.maybe(schema.string({ minLength: 1 })),
   // limit on number of groups returned

--- a/x-pack/plugins/triggers_actions_ui/server/data/lib/core_query_types.test.ts
+++ b/x-pack/plugins/triggers_actions_ui/server/data/lib/core_query_types.test.ts
@@ -109,6 +109,28 @@ export function runTests(schema: ObjectType, defaultTypeParams: Record<string, u
       );
     });
 
+    it('uses default value "count" if aggType is undefined', async () => {
+      params.aggType = undefined;
+      expect(onValidate()).not.toThrow();
+    });
+
+    it('fails for invalid groupBy', async () => {
+      params.groupBy = 42;
+      expect(onValidate()).toThrowErrorMatchingInlineSnapshot(
+        `"[groupBy]: expected value of type [string] but got [number]"`
+      );
+
+      params.groupBy = '-not-a-valid-groupBy-';
+      expect(onValidate()).toThrowErrorMatchingInlineSnapshot(
+        `"[groupBy]: invalid groupBy: \\"-not-a-valid-groupBy-\\""`
+      );
+    });
+
+    it('uses default value "all" if groupBy is undefined', async () => {
+      params.groupBy = undefined;
+      expect(onValidate()).not.toThrow();
+    });
+
     it('fails for invalid aggField', async () => {
       params.aggField = 42;
       expect(onValidate()).toThrowErrorMatchingInlineSnapshot(

--- a/x-pack/plugins/triggers_actions_ui/server/data/lib/core_query_types.ts
+++ b/x-pack/plugins/triggers_actions_ui/server/data/lib/core_query_types.ts
@@ -22,11 +22,11 @@ export const CoreQueryParamsSchemaProperties = {
   // field in index used for date/time
   timeField: schema.string({ minLength: 1 }),
   // aggregation type
-  aggType: schema.string({ validate: validateAggType }),
+  aggType: schema.string({ validate: validateAggType, defaultValue: 'count' }),
   // aggregation field
   aggField: schema.maybe(schema.string({ minLength: 1 })),
   // how to group
-  groupBy: schema.string({ validate: validateGroupBy }),
+  groupBy: schema.string({ validate: validateGroupBy, defaultValue: 'all' }),
   // field to group on (for groupBy: top)
   termField: schema.maybe(schema.string({ minLength: 1 })),
   // filter field


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.7`:
 - [[ResponseOps] es query rule params not compatible between 8.6 and 8.7 (#157710)](https://github.com/elastic/kibana/pull/157710)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Alexi Doak","email":"109488926+doakalexi@users.noreply.github.com"},"sourceCommit":{"committedDate":"2023-05-15T17:08:30Z","message":"[ResponseOps] es query rule params not compatible between 8.6 and 8.7 (#157710)\n\nResolves https://github.com/elastic/kibana/issues/156856\r\n\r\n## Summary\r\n\r\nAdds a default value to `aggType` and `groupBy` fields \r\n\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"8ecd2d67a02f9de2a0e4f8778dcca3781dceaa90","branchLabelMapping":{"^v8.9.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","Team:ResponseOps","v8.7.0","v8.8.0","v8.9.0"],"number":157710,"url":"https://github.com/elastic/kibana/pull/157710","mergeCommit":{"message":"[ResponseOps] es query rule params not compatible between 8.6 and 8.7 (#157710)\n\nResolves https://github.com/elastic/kibana/issues/156856\r\n\r\n## Summary\r\n\r\nAdds a default value to `aggType` and `groupBy` fields \r\n\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"8ecd2d67a02f9de2a0e4f8778dcca3781dceaa90"}},"sourceBranch":"main","suggestedTargetBranches":["8.7"],"targetPullRequestStates":[{"branch":"8.7","label":"v8.7.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.8","label":"v8.8.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/157775","number":157775,"state":"MERGED","mergeCommit":{"sha":"f61bbf30093491919b757d54c2a520b0cb91e8f6","message":"[8.8] [ResponseOps] es query rule params not compatible between 8.6 and 8.7 (#157710) (#157775)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.8`:\n- [[ResponseOps] es query rule params not compatible between 8.6 and 8.7\n(#157710)](https://github.com/elastic/kibana/pull/157710)\n\n<!--- Backport version: 8.9.7 -->\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n<!--BACKPORT [{\"author\":{\"name\":\"Alexi\nDoak\",\"email\":\"109488926+doakalexi@users.noreply.github.com\"},\"sourceCommit\":{\"committedDate\":\"2023-05-15T17:08:30Z\",\"message\":\"[ResponseOps]\nes query rule params not compatible between 8.6 and 8.7\n(#157710)\\n\\nResolves\nhttps://github.com/elastic/kibana/issues/156856\\r\\n\\r\\n##\nSummary\\r\\n\\r\\nAdds a default value to `aggType` and `groupBy` fields\n\\r\\n\\r\\n\\r\\n### Checklist\\r\\n\\r\\n- [x] [Unit or\nfunctional\\r\\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\\r\\nwere\nupdated or added to match the most common\nscenarios\",\"sha\":\"8ecd2d67a02f9de2a0e4f8778dcca3781dceaa90\",\"branchLabelMapping\":{\"^v8.9.0$\":\"main\",\"^v(\\\\d+).(\\\\d+).\\\\d+$\":\"$1.$2\"}},\"sourcePullRequest\":{\"labels\":[\"bug\",\"release_note:skip\",\"Team:ResponseOps\",\"v8.8.0\",\"v8.9.0\"],\"number\":157710,\"url\":\"https://github.com/elastic/kibana/pull/157710\",\"mergeCommit\":{\"message\":\"[ResponseOps]\nes query rule params not compatible between 8.6 and 8.7\n(#157710)\\n\\nResolves\nhttps://github.com/elastic/kibana/issues/156856\\r\\n\\r\\n##\nSummary\\r\\n\\r\\nAdds a default value to `aggType` and `groupBy` fields\n\\r\\n\\r\\n\\r\\n### Checklist\\r\\n\\r\\n- [x] [Unit or\nfunctional\\r\\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\\r\\nwere\nupdated or added to match the most common\nscenarios\",\"sha\":\"8ecd2d67a02f9de2a0e4f8778dcca3781dceaa90\"}},\"sourceBranch\":\"main\",\"suggestedTargetBranches\":[\"8.8\"],\"targetPullRequestStates\":[{\"branch\":\"8.8\",\"label\":\"v8.8.0\",\"labelRegex\":\"^v(\\\\d+).(\\\\d+).\\\\d+$\",\"isSourceBranch\":false,\"state\":\"NOT_CREATED\"},{\"branch\":\"main\",\"label\":\"v8.9.0\",\"labelRegex\":\"^v8.9.0$\",\"isSourceBranch\":true,\"state\":\"MERGED\",\"url\":\"https://github.com/elastic/kibana/pull/157710\",\"number\":157710,\"mergeCommit\":{\"message\":\"[ResponseOps]\nes query rule params not compatible between 8.6 and 8.7\n(#157710)\\n\\nResolves\nhttps://github.com/elastic/kibana/issues/156856\\r\\n\\r\\n##\nSummary\\r\\n\\r\\nAdds a default value to `aggType` and `groupBy` fields\n\\r\\n\\r\\n\\r\\n### Checklist\\r\\n\\r\\n- [x] [Unit or\nfunctional\\r\\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\\r\\nwere\nupdated or added to match the most common\nscenarios\",\"sha\":\"8ecd2d67a02f9de2a0e4f8778dcca3781dceaa90\"}}]}]\nBACKPORT-->\n\nCo-authored-by: Alexi Doak <109488926+doakalexi@users.noreply.github.com>"}},{"branch":"main","label":"v8.9.0","labelRegex":"^v8.9.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/157710","number":157710,"mergeCommit":{"message":"[ResponseOps] es query rule params not compatible between 8.6 and 8.7 (#157710)\n\nResolves https://github.com/elastic/kibana/issues/156856\r\n\r\n## Summary\r\n\r\nAdds a default value to `aggType` and `groupBy` fields \r\n\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"8ecd2d67a02f9de2a0e4f8778dcca3781dceaa90"}}]}] BACKPORT-->