### PR TITLE
[HTTP] Fix how versioned route opts are mapped to IRouter registrar opts

### DIFF
--- a/packages/core/http/core-http-router-server-internal/src/versioned_router/core_versioned_route.ts
+++ b/packages/core/http/core-http-router-server-internal/src/versioned_router/core_versioned_route.ts
@@ -17,6 +17,7 @@ import type {
   VersionedRoute,
   VersionedRouteConfig,
   IKibanaResponse,
+  RouteConfigOptions,
 } from '@kbn/core-http-server';
 import type { Mutable } from 'utility-types';
 import type { Method } from './types';
@@ -72,10 +73,17 @@ export class CoreVersionedRoute implements VersionedRoute {
       {
         path: this.path,
         validate: passThroughValidation,
-        options: this.options,
+        options: this.getRouteConfigOptions(),
       },
       this.requestHandler
     );
+  }
+
+  private getRouteConfigOptions(): RouteConfigOptions<Method> {
+    return {
+      access: this.options.access,
+      ...this.options.options,
+    };
   }
 
   /** This method assumes that one or more versions handlers are registered  */


### PR DESCRIPTION
## Summary

The versioned router internally uses the IRouter and currently incorrectly passes through options. TS was not complaining due to structural type checking seeing this as valid. Added a test to ensure all options are being passed through as expected.


Note: auto merge is on so only approve if happy for it to be merged.



### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
