### PR TITLE
[Serverless] Disable Migrate plugin

### DIFF
--- a/config/serverless.yml
+++ b/config/serverless.yml
@@ -17,6 +17,7 @@ xpack.license_management.enabled: false
 # Other disabled plugins
 #xpack.canvas.enabled: false #only disabable in dev-mode
 xpack.reporting.enabled: false
+xpack.cloud_integrations.data_migration.enabled: false
 
 # Enforce restring access to internal APIs see https://github.com/elastic/kibana/issues/151940
 # server.restrictInternalApis: true

--- a/x-pack/plugins/cloud_integrations/cloud_data_migration/server/config.ts
+++ b/x-pack/plugins/cloud_integrations/cloud_data_migration/server/config.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema, TypeOf } from '@kbn/config-schema';
+import { PluginConfigDescriptor } from '@kbn/core-plugins-server';
+
+const configSchema = schema.object({
+  enabled: schema.boolean({ defaultValue: true }),
+});
+
+export type CloudDataMigrationConfig = TypeOf<typeof configSchema>;
+
+export const config: PluginConfigDescriptor<CloudDataMigrationConfig> = {
+  schema: configSchema,
+};

--- a/x-pack/plugins/cloud_integrations/cloud_data_migration/server/index.ts
+++ b/x-pack/plugins/cloud_integrations/cloud_data_migration/server/index.ts
@@ -7,4 +7,6 @@
 
 import { CloudDataMigrationPlugin } from './plugin';
 
+export { config } from './config';
+
 export const plugin = () => new CloudDataMigrationPlugin();

--- a/x-pack/plugins/cloud_integrations/cloud_data_migration/tsconfig.json
+++ b/x-pack/plugins/cloud_integrations/cloud_data_migration/tsconfig.json
@@ -19,6 +19,8 @@
     "@kbn/kibana-react-plugin",
     "@kbn/i18n",
     "@kbn/i18n-react",
+    "@kbn/config-schema",
+    "@kbn/core-plugins-server",
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
## Summary

This PR makes the Migrate plugin disable-able for serverless.

Partially addresses https://github.com/elastic/kibana/issues/157756

**How to test:**

1. Start Elasticsearch with `yarn es snapshot` and Kibana with yarn `serverless-{mode}` where `{mode}` can be `es`, `security`, or `oblt`.
2. Verify that the Migrate plugin doesn't show up in the nav bar and its path (`management/data/migrate_data`) leads to the Stack Management landing page.
