### PR TITLE
Unskip report tests

### DIFF
--- a/x-pack/test/examples/screenshotting/index.ts
+++ b/x-pack/test/examples/screenshotting/index.ts
@@ -20,8 +20,7 @@ export default function ({
   const testSubjects = getService('testSubjects');
   const PageObjects = getPageObjects(['common']);
 
-  // FLAKY: https://github.com/elastic/kibana/issues/156106
-  describe.skip('Screenshotting Example', function () {
+  describe('Screenshotting Example', function () {
     before(async () => {
       await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/logstash_functional');
       await kibanaServer.importExport.load('test/functional/fixtures/kbn_archiver/visualize.json');

--- a/x-pack/test/functional/apps/reporting_management/report_listing.ts
+++ b/x-pack/test/functional/apps/reporting_management/report_listing.ts
@@ -19,7 +19,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
   const esArchiver = getService('esArchiver');
 
   // FAILING ES PROMOTION: https://github.com/elastic/kibana/issues/156901
-  describe.skip('Listing of Reports', function () {
+  describe('Listing of Reports', function () {
     before(async () => {
       await security.testUser.setRoles([
         'kibana_admin', // to access stack management

--- a/x-pack/test/functional/apps/reporting_management/report_listing.ts
+++ b/x-pack/test/functional/apps/reporting_management/report_listing.ts
@@ -18,7 +18,6 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
   const testSubjects = getService('testSubjects');
   const esArchiver = getService('esArchiver');
 
-  // FAILING ES PROMOTION: https://github.com/elastic/kibana/issues/156901
   describe('Listing of Reports', function () {
     before(async () => {
       await security.testUser.setRoles([

--- a/x-pack/test/reporting_api_integration/reporting_and_security/error_codes.ts
+++ b/x-pack/test/reporting_api_integration/reporting_and_security/error_codes.ts
@@ -15,8 +15,7 @@ export default function ({ getService }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');
   const supertest = getService('supertestWithoutAuth');
 
-  // FAILING ES PROMOTION: https://github.com/elastic/kibana/issues/156902
-  describe.skip('Reporting error codes', () => {
+  describe('Reporting error codes', () => {
     it('places error_code in report output', async () => {
       await reportingAPI.initEcommerce();
 


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/156901, https://github.com/elastic/kibana/issues/156902, and https://github.com/elastic/kibana/issues/156106

As Tim discovered and mentioned in 156901 - these suite of tests were skipped because of a new limit that was reverted in es https://github.com/elastic/elasticsearch/pull/96031

Tests pass without any problems now.
