### PR TITLE
[ML] Fix the file upload telemetry 

### DIFF
--- a/x-pack/plugins/file_upload/server/telemetry/usage_collector.ts
+++ b/x-pack/plugins/file_upload/server/telemetry/usage_collector.ts
@@ -10,7 +10,7 @@ import { CoreSetup } from '@kbn/core/server';
 import { UsageCollectionSetup } from '@kbn/usage-collection-plugin/server';
 import { getTelemetry, initTelemetry, Telemetry } from './telemetry';
 import { telemetryMappingsType } from './mappings';
-import { setInternalRepository } from './internal_repository';
+import { getInternalRepository, setInternalRepository } from './internal_repository';
 
 export function initFileUploadTelemetry(
   coreSetup: CoreSetup,
@@ -33,7 +33,7 @@ function registerUsageCollector(usageCollectionSetup: UsageCollectionSetup): voi
       },
     },
     fetch: async () => {
-      const mlUsage = await getTelemetry();
+      const mlUsage = await getTelemetry(getInternalRepository()!);
       if (!mlUsage) {
         return initTelemetry();
       }


### PR DESCRIPTION
## Summary

Fixes the usage collector for the file upload plugin. According to the git history it hasn't been working since https://github.com/elastic/kibana/pull/60418. 

The saved objects repository required for retrieving telemetry data wasn't provided, causing telemetry to fall back to `index_creation_count: 0` after each check. 


### How to test 

Execute the following request in the Dev Console.

```
POST kbn:/api/telemetry/v2/clusters/_stats
{ "unencrypted": true }
```

[`mlUsage`](https://github.com/elastic/kibana/blob/9047d69d574225212996ea9dbcd15dddc607d11e/x-pack/plugins/file_upload/server/telemetry/usage_collector.ts#L36) shouldn't be `null`.



<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->