### PR TITLE
[UnifiedFieldList] Move routes to internal

### DIFF
--- a/src/plugins/unified_field_list/README.md
+++ b/src/plugins/unified_field_list/README.md
@@ -141,9 +141,9 @@ const hasData = hasFieldData(currentDataViewId, fieldName) // returns a boolean
 
 ## Server APIs
 
-* `/api/unified_field_list/field_stats` - returns the loaded field stats (except for Ad-hoc data views)
+* `/internal/unified_field_list/field_stats` - returns the loaded field stats (except for Ad-hoc data views)
 
-* `/api/unified_field_list/existing_fields/{dataViewId}` - returns the loaded existing fields (except for Ad-hoc data views)
+* `/internal/unified_field_list/existing_fields/{dataViewId}` - returns the loaded existing fields (except for Ad-hoc data views)
 
 ## Development
 

--- a/src/plugins/unified_field_list/common/constants.ts
+++ b/src/plugins/unified_field_list/common/constants.ts
@@ -6,6 +6,6 @@
  * Side Public License, v 1.
  */
 
-export const BASE_API_PATH = '/api/unified_field_list';
+export const BASE_API_PATH = '/internal/unified_field_list';
 export const FIELD_STATS_API_PATH = `${BASE_API_PATH}/field_stats`;
 export const FIELD_EXISTING_API_PATH = `${BASE_API_PATH}/existing_fields/{dataViewId}`;

--- a/src/plugins/unified_field_list/server/routes/index.ts
+++ b/src/plugins/unified_field_list/server/routes/index.ts
@@ -11,6 +11,9 @@ import { PluginStart } from '../types';
 import { existingFieldsRoute } from './existing_fields';
 import { initFieldStatsRoute } from './field_stats';
 
+// These routes are defined only for running integration tests under
+// test/api_integration/apis/unified_field_list
+// UnifiedFieldList does not call these API - it uses only the client code.
 export function defineRoutes(setup: CoreSetup<PluginStart>, logger: Logger) {
   initFieldStatsRoute(setup);
   existingFieldsRoute(setup, logger);

--- a/test/api_integration/apis/unified_field_list/existing_fields.ts
+++ b/test/api_integration/apis/unified_field_list/existing_fields.ts
@@ -31,7 +31,7 @@ export default ({ getService }: FtrProviderContext) => {
   const supertest = getService('supertest');
   const kibanaServer = getService('kibanaServer');
   const dataViewId = 'existence_index';
-  const API_PATH = `/api/unified_field_list/existing_fields/${dataViewId}`;
+  const API_PATH = `/internal/unified_field_list/existing_fields/${dataViewId}`;
 
   describe('existing_fields apis', () => {
     before(async () => {

--- a/test/api_integration/apis/unified_field_list/field_stats.ts
+++ b/test/api_integration/apis/unified_field_list/field_stats.ts
@@ -20,7 +20,7 @@ export default ({ getService }: FtrProviderContext) => {
   const esArchiver = getService('esArchiver');
   const kibanaServer = getService('kibanaServer');
   const supertest = getService('supertest');
-  const API_PATH = '/api/unified_field_list/field_stats';
+  const API_PATH = '/internal/unified_field_list/field_stats';
 
   describe('field stats apis', () => {
     before(async () => {


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/157081

## Summary

Moving routes to `internal` namespace.


