### PR TITLE
[Security Solution][Endpoint][Response Actions] Fix expand details tray

### DIFF
--- a/x-pack/plugins/security_solution/public/management/hooks/response_actions/use_get_endpoint_action_list.ts
+++ b/x-pack/plugins/security_solution/public/management/hooks/response_actions/use_get_endpoint_action_list.ts
@@ -40,6 +40,7 @@ export const useGetEndpointActionList = (
   return useQuery<ActionListApiResponse, IHttpFetchError<ErrorType>>({
     queryKey: ['get-action-list', query],
     ...options,
+    keepPreviousData: true,
     queryFn: async () => {
       return http.get<ActionListApiResponse>(path, {
         query: {


### PR DESCRIPTION
## Summary

Fixes the bug when sometimes the expanding tray breaks the page on the response actions history page/flyout

It doesn't fix the other issues where when a tray is expanded and paging is used the page breaks.
That is being worked on in elastic/kibana/pull/157777

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->