### PR TITLE
Skip migrations in the ES version compatibility tests

### DIFF
--- a/src/core/server/integration_tests/elasticsearch/version_compatibility.test.ts
+++ b/src/core/server/integration_tests/elasticsearch/version_compatibility.test.ts
@@ -72,6 +72,8 @@ describe('Version Compatibility', () => {
           elasticsearch: {
             ignoreVersionMismatch,
           },
+          // Skipping migrations because we are setting a customKibanaVersion and that makes new registered migrations fail.
+          migrations: { skip: true },
         },
       },
     });


### PR DESCRIPTION
## Summary

Fixing the test error https://github.com/elastic/kibana/pull/157699#issuecomment-1549917825 cc @stratoula 

Since we are setting the previous version of Kibana in some of the version-compatibility tests, new migrations fail. We should skip them.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
