### PR TITLE
[Security Solution] use event to use current user and not kibana system

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/index.tsx
@@ -315,7 +315,7 @@ export const AlertsTableComponent: FC<DetectionEngineAlertTableProps> = ({
   });
 
   const { DetailsPanel, SessionView } = useSessionView({
-    entityType: 'alerts',
+    entityType: 'events',
     scopeId: tableId,
   });
 


### PR DESCRIPTION
FIX https://github.com/elastic/kibana/issues/157882

Security solution user needs to use the current user instead of using kibana system user to fetch alert.

@michaelolo24 will push a follow up PR to write unit test so nobody can change this value anymore!!!

<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->