### PR TITLE
[Controls] Add query settings to ES query

### DIFF
--- a/src/plugins/controls/public/services/options_list/options_list_service.ts
+++ b/src/plugins/controls/public/services/options_list/options_list_service.ts
@@ -9,6 +9,8 @@
 import { memoize } from 'lodash';
 
 import dateMath from '@kbn/datemath';
+import { CoreStart } from '@kbn/core/public';
+import { getEsQueryConfig } from '@kbn/data-plugin/common';
 import { buildEsQuery, type TimeRange } from '@kbn/es-query';
 import { KibanaPluginServiceFactory } from '@kbn/presentation-util-plugin/public';
 
@@ -24,10 +26,12 @@ import { ControlsPluginStartDeps } from '../../types';
 import { ControlsOptionsListService } from './types';
 
 class OptionsListService implements ControlsOptionsListService {
+  private core: CoreStart;
   private data: ControlsDataService;
   private http: ControlsHTTPService;
 
-  constructor(requiredServices: OptionsListServiceRequiredServices) {
+  constructor(core: CoreStart, requiredServices: OptionsListServiceRequiredServices) {
+    this.core = core;
     ({ data: this.data, http: this.http } = requiredServices);
   }
 
@@ -85,7 +89,8 @@ class OptionsListService implements ControlsOptionsListService {
     const { query, filters, dataView, timeRange, field, ...passThroughProps } = request;
     const timeFilter = timeRange ? timeService.createFilter(dataView, timeRange) : undefined;
     const filtersToUse = [...(filters ?? []), ...(timeFilter ? [timeFilter] : [])];
-    const esFilters = [buildEsQuery(dataView, query ?? [], filtersToUse ?? [])];
+    const config = getEsQueryConfig(this.core.uiSettings);
+    const esFilters = [buildEsQuery(dataView, query ?? [], filtersToUse ?? [], config)];
 
     return {
       ...passThroughProps,
@@ -145,5 +150,5 @@ export type OptionsListServiceFactory = KibanaPluginServiceFactory<
 >;
 
 export const optionsListServiceFactory: OptionsListServiceFactory = (core, requiredServices) => {
-  return new OptionsListService(requiredServices);
+  return new OptionsListService(core.coreStart, requiredServices);
 };


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/157411

## Summary

This PR sends the Kibana query settings to the controls ES query so that things like leading wildcard queries in the query bar no longer break them.

**Before:**

![Screenshot 2023-05-17 at 12 25 20 PM](https://github.com/elastic/kibana/assets/8698078/d451f901-bd24-4acb-a753-553d54a86aab)

**After:**

![image](https://github.com/elastic/kibana/assets/8698078/9deca883-6251-49f4-954b-7ffd7e418255)

As a follow up, we need to address https://github.com/elastic/kibana/issues/156430 so that, if a user has the wrong query setting and ends up in an error state from something like a leading wildcard query, they can recover without hard refreshing the page.

### Checklist

- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->