### PR TITLE
[Fleet] Fix agent logs detail

### DIFF
--- a/x-pack/plugins/fleet/kibana.jsonc
+++ b/x-pack/plugins/fleet/kibana.jsonc
@@ -22,7 +22,8 @@
       "savedObjectsTagging",
       "taskManager",
       "guidedOnboarding",
-      "files"
+      "files",
+      "uiActions"
     ],
     "optionalPlugins": [
       "features",


### PR DESCRIPTION
## Summary

Resolve https://github.com/elastic/kibana/issues/157846

Looks like https://github.com/elastic/kibana/pull/157131 introduced a dependency to `uiActions`, that PR fix the missing dependency for Fleet

## Test

How to test? check that the agent logs details are visible.
We should probably as a followup add some cypress test to check we have logs visible. (it seems not coverable by a unit test)
 



<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->