### PR TITLE
[Security Solution] Fix incorrectly applied emotion styles

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_about_rule_details/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_about_rule_details/index.tsx
@@ -20,7 +20,7 @@ import { isEmpty } from 'lodash';
 import type { PropsWithChildren } from 'react';
 import React, { memo, useCallback, useMemo, useState } from 'react';
 
-import { css } from '@emotion/react';
+import { css } from '@emotion/css';
 import { HeaderSection } from '../../../../common/components/header_section';
 import { MarkdownRenderer } from '../../../../common/components/markdown_editor';
 import type {
@@ -81,8 +81,8 @@ const StepAboutRuleToggleDetailsComponent: React.FC<StepPanelProps> = ({
   return (
     <EuiPanel
       hasBorder
-      css={css`
-        position: 'relative';
+      className={css`
+        position: relative;
       `}
     >
       {loading && (
@@ -92,7 +92,7 @@ const StepAboutRuleToggleDetailsComponent: React.FC<StepPanelProps> = ({
         </>
       )}
       {stepData != null && stepDataDetails != null && (
-        <EuiFlexGroup gutterSize="xs" direction="column" css={fullHeight}>
+        <EuiFlexGroup gutterSize="xs" direction="column" className={fullHeight}>
           <EuiFlexItem grow={false} key="header">
             <HeaderSection title={i18n.ABOUT_TEXT}>
               {toggleOptions.length > 0 && (
@@ -112,7 +112,7 @@ const StepAboutRuleToggleDetailsComponent: React.FC<StepPanelProps> = ({
             {selectedToggleOption === 'details' && (
               <EuiResizeObserver data-test-subj="stepAboutDetailsContent" onResize={onResize}>
                 {(resizeRef) => (
-                  <div ref={resizeRef} css={fullHeight}>
+                  <div ref={resizeRef} className={fullHeight}>
                     <VerticalOverflowContainer maxHeight={120}>
                       <VerticalOverflowContent maxHeight={120}>
                         <EuiText
@@ -175,10 +175,10 @@ function VerticalOverflowContainer({
 }: PropsWithChildren<VerticalOverflowContainerProps>): JSX.Element {
   return (
     <div
-      css={css`
-        max-height: ${maxHeight};
-        overflow-y: 'hidden';
-        word-break: 'break-word';
+      className={css`
+        max-height: ${maxHeight}px;
+        overflow-y: hidden;
+        word-break: break-word;
       `}
       data-test-subj={dataTestSubject}
     >
@@ -193,15 +193,13 @@ interface VerticalOverflowContentProps {
 
 function VerticalOverflowContent({
   maxHeight,
-
   children,
 }: PropsWithChildren<VerticalOverflowContentProps>): JSX.Element {
   return (
     <div
-      className="eui-yScroll"
-      css={css`
-        max-height: ${maxHeight};
-      `}
+      className={`eui-yScroll ${css`
+        max-height: ${maxHeight}px;
+      `}`}
     >
       {children}
     </div>

--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_about_rule_details/styles.ts
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_about_rule_details/styles.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { css } from '@emotion/react';
+import { css } from '@emotion/css';
 
 export const fullHeight = css`
   height: 100%;


### PR DESCRIPTION
**Resolves:** https://github.com/elastic/kibana/issues/156820

## Summary

This PR fixes improperly applied styles via emotion on the rule details page.

*Before:*

<img width="2267" alt="image" src="https://user-images.githubusercontent.com/92328789/236432092-1a102af4-e746-4c32-ba17-6d17f76df6d2.png">

<img width="2236" alt="image" src="https://user-images.githubusercontent.com/92328789/236432072-da6efa55-0953-4abc-a5b5-c27be2b103ee.png">

*After:*

<img width="2267" alt="image" src="https://github.com/elastic/kibana/assets/3775283/4431eda1-0a69-403a-ad93-51658d0dbeff">

<img width="2236" alt="image" src="https://github.com/elastic/kibana/assets/3775283/06647825-9b1f-4cd8-a60a-2c8988acbd9b">


## Details

Recent investigation has revealed emotion css styles aren't applied correctly on production while the problem isn't noticeable locally. This is caused by simultaneously using **styled-components** and **emotion** in Security Solution plugin. Further research lead to a way to fix it

1. import `css` utility function from `@emotion/css` instead of  `@emotion/react`
2. apply styles using `className` instead of `css`

Like in the code below

```ts
import { css } from '@emotion/css';

...

<div className={css`
  padding-left: 200px;
`}>
  TEST
</div>

...
```


<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->