### PR TITLE
Serverless Search: update enterpriseSearch config to run without ent-search node

### DIFF
--- a/config/serverless.es.yml
+++ b/config/serverless.es.yml
@@ -5,6 +5,13 @@ xpack.apm.enabled: false
 xpack.uptime.enabled: false
 enterpriseSearch.enabled: true
 
+## Configure Enterprise Search plugin to run without ent-search node
+enterpriseSearch.canDeployEntSearch: false
+enterpriseSearch.hasConnectors: false
+enterpriseSearch.hasDefaultIngestPipeline: false
+enterpriseSearch.hasNativeConnectors: false
+enterpriseSearch.hasWebCrawler: false
+
 ## Enable the Serverless Search plugin
 xpack.serverless.search.enabled: true
 


### PR DESCRIPTION
## Summary

Updated the `serverless.es.yml` kibana config to configure the enterprise-search plugin to run without an ent-search node in the a serverless environment.