### PR TITLE
[Expressions] Unskip test

### DIFF
--- a/test/examples/expressions_explorer/expressions.ts
+++ b/test/examples/expressions_explorer/expressions.ts
@@ -53,7 +53,7 @@ export default function ({ getService }: PluginFunctionalProviderContext) {
       await find.clickByCssSelector(selector);
       await retry.try(async () => {
         const text = await browser.getCurrentUrl();
-        expect(text).to.be('https://www.google.com/');
+        expect(text).to.contain('https://www.google.com/');
       });
     });
   });

--- a/test/examples/expressions_explorer/expressions.ts
+++ b/test/examples/expressions_explorer/expressions.ts
@@ -17,8 +17,7 @@ export default function ({ getService }: PluginFunctionalProviderContext) {
   const find = getService('find');
   const browser = getService('browser');
 
-  // failing test: https://github.com/elastic/kibana/issues/156780
-  describe.skip('', () => {
+  describe('', () => {
     it('runs expression', async () => {
       await retry.try(async () => {
         const text = await testSubjects.getVisibleText('expressionResult');
@@ -54,7 +53,7 @@ export default function ({ getService }: PluginFunctionalProviderContext) {
       await find.clickByCssSelector(selector);
       await retry.try(async () => {
         const text = await browser.getCurrentUrl();
-        expect(text).to.be('https://www.google.com/?gws_rd=ssl');
+        expect(text).to.be('https://www.google.com/');
       });
     });
   });


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/156780

I think that something changed on the chromedriver and now the ssl parameter is not  always added on the google url. I changed it to use contain instead and unskipped the test


Flaky test runner https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2265