### PR TITLE
[HTTP] Keep validation error message the same for versioned validator

### DIFF
--- a/packages/core/http/core-http-router-server-internal/src/versioned_router/validate.ts
+++ b/packages/core/http/core-http-router-server-internal/src/versioned_router/validate.ts
@@ -18,8 +18,8 @@ export function validate(
 ): { body: unknown; params: unknown; query: unknown } {
   const validator = RouteValidator.from(runtimeSchema);
   return {
-    body: validator.getBody(data.body, `get ${version} body`),
-    params: validator.getParams(data.params, `get ${version} params`),
-    query: validator.getQuery(data.query, `get ${version} query`),
+    params: validator.getParams(data.params, 'request params'),
+    query: validator.getQuery(data.query, 'request query'),
+    body: validator.getBody(data.body, 'request body'),
   };
 }


### PR DESCRIPTION
## Summary

Validation error messages from the versioned route validator currently return messages of the form:

```
get <version> <path>
```

E.g.

```
get 1 body.my.cool.path
```

This is not very useful for readers of the error message and may cause tests to be somewhat needlessly be updated. This PR keeps the error message the same as the `Router`'s validation error messages:

[https://github.com/elastic/kibana/blob/81bcd4a3bad1e6e057addecf29c5f8d7bdec0aae/pa[…]kages/core/http/core-http-router-server-internal/src/request.ts](https://github.com/elastic/kibana/blob/81bcd4a3bad1e6e057addecf29c5f8d7bdec0aae/packages/core/http/core-http-router-server-internal/src/request.ts#L89)