### PR TITLE
moving visualizations team owned paths to /internal

### DIFF
--- a/src/plugins/vis_types/timelion/public/components/timelion_expression_input.tsx
+++ b/src/plugins/vis_types/timelion/public/components/timelion_expression_input.tsx
@@ -86,7 +86,9 @@ function TimelionExpressionInput({ value, setValue }: TimelionExpressionInputPro
     const abortController = new AbortController();
     if (kibana.services.http) {
       kibana.services.http
-        .get<ITimelionFunction[]>('../api/timelion/functions', { signal: abortController.signal })
+        .get<ITimelionFunction[]>('../internal/timelion/functions', {
+          signal: abortController.signal,
+        })
         .then((data) => {
           functionList.current = data;
         });

--- a/src/plugins/vis_types/timelion/public/helpers/timelion_request_handler.ts
+++ b/src/plugins/vis_types/timelion/public/helpers/timelion_request_handler.ts
@@ -105,7 +105,7 @@ export function getTimelionRequestHandler({
     const doSearch = async (
       searchOptions: ReturnType<typeof dataSearch.session.getSearchOptions>
     ): Promise<TimelionSuccessResponse> => {
-      return await http.post('/api/timelion/run', {
+      return await http.post('/internal/timelion/run', {
         body: JSON.stringify({
           sheet: [expression],
           extended: {

--- a/src/plugins/vis_types/timelion/server/routes/functions.ts
+++ b/src/plugins/vis_types/timelion/server/routes/functions.ts
@@ -13,7 +13,7 @@ import { LoadFunctions } from '../lib/load_functions';
 export function functionsRoute(router: IRouter, { functions }: { functions: LoadFunctions }) {
   router.get(
     {
-      path: '/api/timelion/functions',
+      path: '/internal/timelion/functions',
       validate: false,
     },
     async (context, request, response) => {

--- a/src/plugins/vis_types/timelion/server/routes/run.ts
+++ b/src/plugins/vis_types/timelion/server/routes/run.ts
@@ -37,7 +37,7 @@ export function runRoute(
 ) {
   router.post(
     {
-      path: '/api/timelion/run',
+      path: '/internal/timelion/run',
       validate: {
         body: schema.object({
           sheet: schema.arrayOf(schema.string()),

--- a/x-pack/plugins/canvas/public/functions/timelion.ts
+++ b/x-pack/plugins/canvas/public/functions/timelion.ts
@@ -132,7 +132,7 @@ export function timelionFunctionFactory(initialize: InitializeArguments): () => 
         let result: any;
 
         try {
-          result = await fetch(initialize.prependBasePath(`/api/timelion/run`), {
+          result = await fetch(initialize.prependBasePath(`/internal/timelion/run`), {
             method: 'POST',
             responseType: 'json',
             data: body,

--- a/x-pack/plugins/graph/public/helpers/use_graph_loader.ts
+++ b/x-pack/plugins/graph/public/helpers/use_graph_loader.ts
@@ -101,7 +101,7 @@ export const useGraphLoader = ({ toastNotifications, coreStart }: UseGraphLoader
       inspectRequest.json(dsl);
 
       return coreStart.http
-        .post<{ resp: estypes.GraphExploreResponse }>('../api/graph/graphExplore', request)
+        .post<{ resp: estypes.GraphExploreResponse }>('../internal/graph/graphExplore', request)
         .then(function (data) {
           const response = data.resp;
 
@@ -136,7 +136,7 @@ export const useGraphLoader = ({ toastNotifications, coreStart }: UseGraphLoader
       inspectRequest.json(dsl);
 
       coreStart.http
-        .post<{ resp: estypes.GraphExploreResponse }>('../api/graph/searchProxy', request)
+        .post<{ resp: estypes.GraphExploreResponse }>('../internal/graph/searchProxy', request)
         .then(function (data) {
           const response = data.resp;
           inspectRequest.stats({}).ok({ json: response });

--- a/x-pack/plugins/graph/public/services/fetch_top_nodes.test.ts
+++ b/x-pack/plugins/graph/public/services/fetch_top_nodes.test.ts
@@ -33,7 +33,7 @@ describe('fetch_top_nodes', () => {
         aggregatable: true,
       },
     ]);
-    expect(postMock).toHaveBeenCalledWith('../api/graph/searchProxy', {
+    expect(postMock).toHaveBeenCalledWith('../internal/graph/searchProxy', {
       body: JSON.stringify({
         index: 'test',
         body: {

--- a/x-pack/plugins/graph/public/services/fetch_top_nodes.ts
+++ b/x-pack/plugins/graph/public/services/fetch_top_nodes.ts
@@ -97,7 +97,7 @@ export async function fetchTopNodes(
   const body = createSamplerSearchBody(aggs);
 
   const response = (
-    await post<{ resp: TopTermsAggResponse }>('../api/graph/searchProxy', {
+    await post<{ resp: TopTermsAggResponse }>('../internal/graph/searchProxy', {
       body: JSON.stringify({ index, body }),
     })
   ).resp;

--- a/x-pack/plugins/graph/server/routes/explore.ts
+++ b/x-pack/plugins/graph/server/routes/explore.ts
@@ -26,7 +26,7 @@ export function registerExploreRoute({
 }) {
   router.post(
     {
-      path: '/api/graph/graphExplore',
+      path: '/internal/graph/graphExplore',
       validate: {
         body: schema.object({
           index: schema.string(),

--- a/x-pack/plugins/graph/server/routes/search.ts
+++ b/x-pack/plugins/graph/server/routes/search.ts
@@ -19,7 +19,7 @@ export function registerSearchRoute({
 }) {
   router.post(
     {
-      path: '/api/graph/searchProxy',
+      path: '/internal/graph/searchProxy',
       validate: {
         body: schema.object({
           index: schema.string(),


### PR DESCRIPTION
## Summary

moves paths that are internal to /internal/ prefix

resolves https://github.com/elastic/kibana/issues/157080
resolves https://github.com/elastic/kibana/issues/157081
resolves https://github.com/elastic/kibana/issues/157082

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
