### PR TITLE
Security tech debt cleanup

### DIFF
--- a/x-pack/plugins/features/common/feature_elasticsearch_privileges.ts
+++ b/x-pack/plugins/features/common/feature_elasticsearch_privileges.ts
@@ -40,6 +40,17 @@ export interface FeatureElasticsearchPrivileges {
   };
 
   /**
+   * A set of Elasticsearch roles which are required for this feature to be enabled.
+   *
+   * @deprecated do not rely on hard-coded role names.
+   * @removeBy 8.8.0
+   *
+   * This is relied on by the reporting feature, and should be removed once reporting
+   * migrates to using the Kibana Privilege model: https://github.com/elastic/kibana/issues/19914
+   */
+  requiredRoles?: string[];
+
+  /**
    * A list of UI Capabilities that should be granted to users with this privilege.
    * These capabilities will automatically be namespaces within your feature id.
    *

--- a/x-pack/plugins/features/common/feature_elasticsearch_privileges.ts
+++ b/x-pack/plugins/features/common/feature_elasticsearch_privileges.ts
@@ -40,17 +40,6 @@ export interface FeatureElasticsearchPrivileges {
   };
 
   /**
-   * A set of Elasticsearch roles which are required for this feature to be enabled.
-   *
-   * @deprecated do not rely on hard-coded role names.
-   * @removeBy 8.8.0
-   *
-   * This is relied on by the reporting feature, and should be removed once reporting
-   * migrates to using the Kibana Privilege model: https://github.com/elastic/kibana/issues/19914
-   */
-  requiredRoles?: string[];
-
-  /**
    * A list of UI Capabilities that should be granted to users with this privilege.
    * These capabilities will automatically be namespaces within your feature id.
    *

--- a/x-pack/plugins/features/common/feature_kibana_privileges.ts
+++ b/x-pack/plugins/features/common/feature_kibana_privileges.ts
@@ -22,8 +22,6 @@ export interface FeatureKibanaPrivileges {
 
   /**
    * Whether or not this privilege should be hidden in the roles UI and disallowed on the API. Defaults to `false`.
-   * @deprecated
-   * @removeBy 8.8.0
    */
   disabled?: boolean;
 

--- a/x-pack/plugins/features/server/feature_registry.test.ts
+++ b/x-pack/plugins/features/server/feature_registry.test.ts
@@ -1964,16 +1964,8 @@ describe('FeatureRegistry', () => {
             ui: ['ui_a'],
           },
           {
-            requiredClusterPrivileges: ['monitor', 'manage'],
-            ui: ['ui_a'],
-          },
-          {
             requiredClusterPrivileges: [],
-            requiredIndexPrivileges: {
-              foo: ['read'],
-              bar: ['all'],
-              baz: ['view_index_metadata'],
-            },
+            requiredRoles: ['some_role'],
             ui: ['ui_b'],
           },
         ],

--- a/x-pack/plugins/features/server/feature_registry.test.ts
+++ b/x-pack/plugins/features/server/feature_registry.test.ts
@@ -1964,8 +1964,16 @@ describe('FeatureRegistry', () => {
             ui: ['ui_a'],
           },
           {
+            requiredClusterPrivileges: ['monitor', 'manage'],
+            ui: ['ui_a'],
+          },
+          {
             requiredClusterPrivileges: [],
-            requiredRoles: ['some_role'],
+            requiredIndexPrivileges: {
+              foo: ['read'],
+              bar: ['all'],
+              baz: ['view_index_metadata'],
+            },
             ui: ['ui_b'],
           },
         ],

--- a/x-pack/plugins/features/server/feature_schema.ts
+++ b/x-pack/plugins/features/server/feature_schema.ts
@@ -490,17 +490,9 @@ export function validateElasticsearchFeature(feature: ElasticsearchFeatureConfig
   // the following validation can't be enforced by the Joi schema without a very convoluted and verbose definition
   const { privileges } = feature;
   privileges.forEach((privilege, index) => {
-    const {
-      requiredClusterPrivileges = [],
-      requiredIndexPrivileges = [],
-      requiredRoles = [],
-    } = privilege;
+    const { requiredClusterPrivileges = [], requiredIndexPrivileges = [] } = privilege;
 
-    if (
-      requiredClusterPrivileges.length === 0 &&
-      requiredIndexPrivileges.length === 0 &&
-      requiredRoles.length === 0
-    ) {
+    if (requiredClusterPrivileges.length === 0 && requiredIndexPrivileges.length === 0) {
       throw new Error(
         `Feature ${feature.id} has a privilege definition at index ${index} without any privileges defined.`
       );

--- a/x-pack/plugins/features/server/feature_schema.ts
+++ b/x-pack/plugins/features/server/feature_schema.ts
@@ -490,9 +490,17 @@ export function validateElasticsearchFeature(feature: ElasticsearchFeatureConfig
   // the following validation can't be enforced by the Joi schema without a very convoluted and verbose definition
   const { privileges } = feature;
   privileges.forEach((privilege, index) => {
-    const { requiredClusterPrivileges = [], requiredIndexPrivileges = [] } = privilege;
+    const {
+      requiredClusterPrivileges = [],
+      requiredIndexPrivileges = [],
+      requiredRoles = [],
+    } = privilege;
 
-    if (requiredClusterPrivileges.length === 0 && requiredIndexPrivileges.length === 0) {
+    if (
+      requiredClusterPrivileges.length === 0 &&
+      requiredIndexPrivileges.length === 0 &&
+      requiredRoles.length === 0
+    ) {
       throw new Error(
         `Feature ${feature.id} has a privilege definition at index ${index} without any privileges defined.`
       );

--- a/x-pack/plugins/security/server/authorization/disable_ui_capabilities.ts
+++ b/x-pack/plugins/security/server/authorization/disable_ui_capabilities.ts
@@ -346,5 +346,9 @@ function isGrantedElasticsearchPrivilege(
     }
   );
 
-  return hasRequiredClusterPrivileges && hasRequiredIndexPrivileges;
+  const hasRequiredRoles = (privilege.requiredRoles ?? []).every(
+    (requiredRole) => user?.roles.includes(requiredRole) ?? false
+  );
+
+  return hasRequiredClusterPrivileges && hasRequiredIndexPrivileges && hasRequiredRoles;
 }

--- a/x-pack/plugins/security/server/authorization/disable_ui_capabilities.ts
+++ b/x-pack/plugins/security/server/authorization/disable_ui_capabilities.ts
@@ -346,9 +346,5 @@ function isGrantedElasticsearchPrivilege(
     }
   );
 
-  const hasRequiredRoles = (privilege.requiredRoles ?? []).every(
-    (requiredRole) => user?.roles.includes(requiredRole) ?? false
-  );
-
-  return hasRequiredClusterPrivileges && hasRequiredIndexPrivileges && hasRequiredRoles;
+  return hasRequiredClusterPrivileges && hasRequiredIndexPrivileges;
 }


### PR DESCRIPTION
## Summary

This PR cleans up some outstanding tech debt.

### 1. Remove deprecation warning for `disabled` prop

This property was marked as deprecated the moment it was introduced (See https://github.com/elastic/kibana/pull/118001/files#r753124740). However it has been adopted by Fleet and Guided Onboarding plugins so I don't think there's value in keeping this deprecation warning in place. 

As an alternative we could also bump the `@removeBy` version if people think we should still remove this property. 


### ~~2. Remove deprecated property `requiredRoles`~~

~~This property has been deprecated and marked for removal for 8.8. The property isn't being used anywhere in our codebase and we have reached feature freeze for 8.8 so looks safe to be removed now.~~

Turns out this property is still used and can't be removed without breaking existing functionality so reverting that commit.

<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->