### PR TITLE
[Serverless Search] M0 Navigation

### DIFF
--- a/config/serverless.es.yml
+++ b/config/serverless.es.yml
@@ -3,7 +3,7 @@
 ## Disable APM and Uptime, enable Enterprise Search
 xpack.apm.enabled: false
 xpack.uptime.enabled: false
-enterpriseSearch.enabled: true
+enterpriseSearch.enabled: false
 
 ## Enable the Serverless Search plugin
 xpack.serverless.search.enabled: true

--- a/packages/kbn-optimizer/limits.yml
+++ b/packages/kbn-optimizer/limits.yml
@@ -117,7 +117,7 @@ pageLoadAssetSize:
   securitySolution: 66738
   serverless: 16573
   serverlessObservability: 30000
-  serverlessSearch: 25600
+  serverlessSearch: 26000
   serverlessSecurity: 41807
   sessionView: 77750
   share: 71239

--- a/x-pack/plugins/serverless_search/kibana.jsonc
+++ b/x-pack/plugins/serverless_search/kibana.jsonc
@@ -14,7 +14,6 @@
     ],
     "requiredPlugins": [
       "serverless",
-      "enterpriseSearch",
       "management"
     ],
     "optionalPlugins": [],

--- a/x-pack/plugins/serverless_search/public/layout/nav.tsx
+++ b/x-pack/plugins/serverless_search/public/layout/nav.tsx
@@ -12,20 +12,114 @@ import {
   NavigationKibanaProvider,
 } from '@kbn/shared-ux-chrome-navigation';
 import React from 'react';
+import { i18n } from '@kbn/i18n';
+
+const NAVIGATION_PLATFORM_CONFIG = {
+  analytics: { enabled: false },
+  ml: { enabled: false },
+  devTools: { enabled: false },
+  management: { enabled: false },
+};
 
 const navItems: ChromeNavigationNodeViewModel[] = [
   {
-    title: '',
-    id: 'root',
+    id: 'search_getting_started',
+    title: i18n.translate('xpack.serverlessSearch.nav.gettingStarted', {
+      defaultMessage: 'Getting started',
+    }),
+    href: '/app/elasticsearch',
+  },
+  {
+    id: 'dev_tools',
+    title: i18n.translate('xpack.serverlessSearch.nav.devTools', { defaultMessage: 'Dev Tools' }),
     items: [
-      { id: 'overview', title: 'Overview', href: '/app/enterprise_search/overview' },
-      { id: 'indices', title: 'Indices', href: '/app/enterprise_search/content/search_indices' },
-      { id: 'engines', title: 'Engines', href: '/app/enterprise_search/content/engines' },
-      { id: 'api_keys', title: 'API keys', href: '/app/management/security/api_keys' },
       {
-        id: 'ingest_pipelines',
-        title: 'Ingest pipelines',
-        href: '/app/management/ingest/ingest_pipelines',
+        id: 'dev_tools_console',
+        title: i18n.translate('xpack.serverlessSearch.nav.devTools.console', {
+          defaultMessage: 'Console',
+        }),
+        href: '/app/dev_tools#/console',
+      },
+      {
+        id: 'dev_tools_profiler',
+        title: i18n.translate('xpack.serverlessSearch.nav.devTools.searchProfiler', {
+          defaultMessage: 'Search Profiler',
+        }),
+        href: '/app/dev_tools#/searchprofiler',
+      },
+      {
+        id: 'dev_tools_grok_debugger',
+        title: i18n.translate('xpack.serverlessSearch.nav.devTools.grokDebugger', {
+          defaultMessage: 'Grok debugger',
+        }),
+        href: '/app/dev_tools#/grokdebugger',
+      },
+      {
+        id: 'dev_tools_painless_lab',
+        title: i18n.translate('xpack.serverlessSearch.nav.devTools.painlessLab', {
+          defaultMessage: 'Painless Lab',
+        }),
+        href: '/app/dev_tools#/painless_lab',
+      },
+    ],
+  },
+  {
+    id: 'explore',
+    title: i18n.translate('xpack.serverlessSearch.nav.explore', { defaultMessage: 'Explore' }),
+    items: [
+      {
+        id: 'explore_discover',
+        title: i18n.translate('xpack.serverlessSearch.nav.explore.discover', {
+          defaultMessage: 'Discover',
+        }),
+        href: '/app/discover',
+      },
+      {
+        id: 'explore_dashboard',
+        title: i18n.translate('xpack.serverlessSearch.nav.explore.dashboard', {
+          defaultMessage: 'Dashboard',
+        }),
+        href: '/app/dashboards',
+      },
+      {
+        id: 'explore_visualize_library',
+        title: i18n.translate('xpack.serverlessSearch.nav.explore.visualizeLibrary', {
+          defaultMessage: 'Visualize Library',
+        }),
+        href: '/app/visualize',
+      },
+    ],
+  },
+  {
+    id: 'content',
+    title: i18n.translate('xpack.serverlessSearch.nav.content', { defaultMessage: 'Content' }),
+    items: [
+      {
+        id: 'content_indices',
+        title: i18n.translate('xpack.serverlessSearch.nav.content.indices', {
+          defaultMessage: 'Indices',
+        }),
+        href: '/app/management/data/index_management/indices',
+      },
+      {
+        id: 'content_transforms',
+        title: i18n.translate('xpack.serverlessSearch.nav.content.transforms', {
+          defaultMessage: 'Transforms',
+        }),
+        href: '/app/management/data/transform',
+      },
+    ],
+  },
+  {
+    id: 'security',
+    title: i18n.translate('xpack.serverlessSearch.nav.security', { defaultMessage: 'Security' }),
+    items: [
+      {
+        id: 'security_api_keys',
+        title: i18n.translate('xpack.serverlessSearch.nav.security.apiKeys', {
+          defaultMessage: 'API Keys',
+        }),
+        href: '/app/management/security/api_keys',
       },
     ],
   },
@@ -34,21 +128,22 @@ const navItems: ChromeNavigationNodeViewModel[] = [
 export const createServerlessSearchSideNavComponent = (core: CoreStart) => () => {
   // Currently, this allows the "Search" section of the side nav to render as pre-expanded.
   // This will soon be powered from state received from core.chrome
-  const activeNavItemId = 'search_project_nav.root';
+  const activeNavItemId = 'search_project_nav.search_getting_started';
 
   return (
     <NavigationKibanaProvider core={core}>
       <Navigation
+        platformConfig={NAVIGATION_PLATFORM_CONFIG}
         navigationTree={[
           {
             id: 'search_project_nav',
             items: navItems,
-            title: 'Search',
-            icon: 'logoEnterpriseSearch',
+            title: 'Elasticsearch',
+            icon: 'logoElasticsearch',
           },
         ]}
         activeNavItemId={activeNavItemId}
-        homeHref="/app/enterprise_search/content/setup_guide"
+        homeHref="/app/elasticsearch"
         linkToCloud="projects"
       />
     </NavigationKibanaProvider>

--- a/x-pack/plugins/serverless_search/public/types.ts
+++ b/x-pack/plugins/serverless_search/public/types.ts
@@ -5,10 +5,6 @@
  * 2.0.
  */
 
-import {
-  EnterpriseSearchPublicSetup,
-  EnterpriseSearchPublicStart,
-} from '@kbn/enterprise-search-plugin/public';
 import { ManagementSetup, ManagementStart } from '@kbn/management-plugin/public';
 import { ServerlessPluginSetup, ServerlessPluginStart } from '@kbn/serverless/public';
 
@@ -19,13 +15,11 @@ export interface ServerlessSearchPluginSetup {}
 export interface ServerlessSearchPluginStart {}
 
 export interface ServerlessSearchPluginSetupDependencies {
-  enterpriseSearch: EnterpriseSearchPublicSetup;
   management: ManagementSetup;
   serverless: ServerlessPluginSetup;
 }
 
 export interface ServerlessSearchPluginStartDependencies {
-  enterpriseSearch: EnterpriseSearchPublicStart;
   management: ManagementStart;
   serverless: ServerlessPluginStart;
 }

--- a/x-pack/plugins/serverless_search/tsconfig.json
+++ b/x-pack/plugins/serverless_search/tsconfig.json
@@ -17,7 +17,6 @@
   "kbn_references": [
     "@kbn/core",
     "@kbn/config-schema",
-    "@kbn/enterprise-search-plugin",
     "@kbn/management-plugin",
     "@kbn/shared-ux-chrome-navigation",
     "@kbn/doc-links",


### PR DESCRIPTION
## Summary

- Updates the project navigation to match latest design with a single combined left nav
- Disables & removes `enterprise_search` plugin usage as we are not linking to any ent-search pages for this milestone

*Note: the "Getting started" nav item will always show as active until the Navigation component is updated to determine the selected nav item, which will be done with other upcoming work.

## Screenshots
![image](https://github.com/elastic/kibana/assets/1972968/fc54e4c3-a264-493c-bf1e-e5ae45126aeb)