### PR TITLE
[Serverless/sidenav] Hide collapsed sidebar on smaller screen, move nav button to the header

### DIFF
--- a/packages/core/chrome/core-chrome-browser-internal/src/ui/project/navigation.tsx
+++ b/packages/core/chrome/core-chrome-browser-internal/src/ui/project/navigation.tsx
@@ -6,67 +6,52 @@
  * Side Public License, v 1.
  */
 
-import React, { useCallback } from 'react';
-import useLocalStorage from 'react-use/lib/useLocalStorage';
+import React from 'react';
 import { css } from '@emotion/react';
+import { EuiCollapsibleNav, EuiCollapsibleNavProps, useIsWithinMinBreakpoint } from '@elastic/eui';
 
-import { i18n } from '@kbn/i18n';
-import { EuiButtonIcon, EuiCollapsibleNav } from '@elastic/eui';
+const SIZE_EXPANDED = 248;
+const SIZE_COLLAPSED = 48;
 
-const LOCAL_STORAGE_IS_OPEN_KEY = 'PROJECT_NAVIGATION_OPEN' as const;
-const SIZE_OPEN = 248;
-const SIZE_CLOSED = 40;
+export interface ProjectNavigationProps {
+  isOpen: boolean;
+  closeNav: () => void;
+  button: EuiCollapsibleNavProps['button'];
+}
 
-const buttonCSS = css`
-  margin-left: -32px;
-  margin-top: 12px;
-  position: fixed;
-  z-index: 1000;
-`;
-
-const openAriaLabel = i18n.translate('core.ui.chrome.projectNav.collapsibleNavOpenAriaLabel', {
-  defaultMessage: 'Close navigation',
-});
-
-const closedAriaLabel = i18n.translate('core.ui.chrome.projectNav.collapsibleNavClosedAriaLabel', {
-  defaultMessage: 'Open navigation',
-});
-
-export const ProjectNavigation: React.FC = ({ children }) => {
-  const [isOpen, setIsOpen] = useLocalStorage(LOCAL_STORAGE_IS_OPEN_KEY, true);
-
-  const toggleOpen = useCallback(() => {
-    setIsOpen(!isOpen);
-  }, [isOpen, setIsOpen]);
-
+export const ProjectNavigation: React.FC<ProjectNavigationProps> = ({
+  children,
+  isOpen,
+  closeNav,
+  button,
+}) => {
   const collabsibleNavCSS = css`
     border-inline-end-width: 1,
     display: flex,
     flex-direction: row,
   `;
 
+  // on small screen isOpen hides the nav,
+  // on larger screen isOpen makes it smaller
+  const DOCKED_BREAKPOINT = 'xs' as const;
+  const isCollapsible = useIsWithinMinBreakpoint(DOCKED_BREAKPOINT);
+  const isVisible = isCollapsible ? true : isOpen;
+  const isCollapsed = isCollapsible ? !isOpen : false;
+
   return (
     <EuiCollapsibleNav
       css={collabsibleNavCSS}
-      isOpen={true}
+      isOpen={isVisible}
       showButtonIfDocked={true}
-      onClose={toggleOpen}
+      onClose={closeNav}
       isDocked={true}
-      size={isOpen ? SIZE_OPEN : SIZE_CLOSED}
+      size={isCollapsed ? SIZE_COLLAPSED : SIZE_EXPANDED}
       hideCloseButton={false}
+      dockedBreakpoint={DOCKED_BREAKPOINT}
       ownFocus={false}
-      button={
-        <span css={buttonCSS}>
-          <EuiButtonIcon
-            iconType={isOpen ? 'menuLeft' : 'menuRight'}
-            aria-label={isOpen ? openAriaLabel : closedAriaLabel}
-            color={isOpen ? 'ghost' : 'text'}
-            onClick={toggleOpen}
-          />
-        </span>
-      }
+      button={button}
     >
-      {isOpen && children}
+      {!isCollapsed && children}
     </EuiCollapsibleNav>
   );
 };

--- a/packages/core/chrome/core-chrome-browser-internal/src/ui/project/navigation.tsx
+++ b/packages/core/chrome/core-chrome-browser-internal/src/ui/project/navigation.tsx
@@ -33,7 +33,7 @@ export const ProjectNavigation: React.FC<ProjectNavigationProps> = ({
 
   // on small screen isOpen hides the nav,
   // on larger screen isOpen makes it smaller
-  const DOCKED_BREAKPOINT = 'xs' as const;
+  const DOCKED_BREAKPOINT = 's' as const;
   const isCollapsible = useIsWithinMinBreakpoint(DOCKED_BREAKPOINT);
   const isVisible = isCollapsible ? true : isOpen;
   const isCollapsed = isCollapsible ? !isOpen : false;


### PR DESCRIPTION
## Summary

Partially addresses https://github.com/elastic/kibana/issues/157819, https://github.com/elastic/kibana/issues/157032

To address https://github.com/elastic/kibana/issues/157032 I've hidden the collapsed side nav on a smaller screen. Since there is no more side nav on smaller screen, I had to move the expand/collapse button to the header. But it was also proposed to have that button in the header constantly [here](https://github.com/elastic/kibana/issues/157819#issuecomment-1551023516), so I decided to just leave it there both for smaller and larger screens. This makes us closer to the recent version (17/05) that @MichaelMarcialis proposed _(Not sure if we it was already decide to go that route?)_ 



https://github.com/elastic/kibana/assets/7784120/7a163572-ee0a-41d1-89df-2882b786be94

