### PR TITLE
Harden security response headers for serverless offering

### DIFF
--- a/config/serverless.yml
+++ b/config/serverless.yml
@@ -23,3 +23,9 @@ xpack.reporting.enabled: false
 # Telemetry enabled by default and not disableable via UI
 telemetry.optIn: true
 telemetry.allowChangingOptInStatus: false
+
+# Harden security response headers, see https://github.com/elastic/kibana/issues/150884
+# The browser should remember that a site, including subdomains, is only to be accessed using HTTPS for 1 year
+server.securityResponseHeaders.strictTransportSecurity: max-age=31536000; includeSubDomains
+# Disable embedding for serverless MVP
+server.securityResponseHeaders.disableEmbedding: true

--- a/config/serverless.yml
+++ b/config/serverless.yml
@@ -26,6 +26,7 @@ telemetry.allowChangingOptInStatus: false
 
 # Harden security response headers, see https://github.com/elastic/kibana/issues/150884
 # The browser should remember that a site, including subdomains, is only to be accessed using HTTPS for 1 year
+# Can override this setting in kibana.dev.yml, e.g. server.securityResponseHeaders.strictTransportSecurity: null
 server.securityResponseHeaders.strictTransportSecurity: max-age=31536000; includeSubDomains
 # Disable embedding for serverless MVP
 server.securityResponseHeaders.disableEmbedding: true


### PR DESCRIPTION
Closes #150884

## Summary

Adds both strictTransportSecurity and disableEmbedding to the serverless.yml config file, which sets the defaults for Kibana running in a serverless configuration. Note that the disabling of embedding is for the serverless MVP, with a plan to more strategically and explicitly allow embedding of specific resources in future releases.

- `server.securityResponseHeaders.strictTransportSecurity: max-age=31536000; includeSubDomains`: Adds the `strict-transport-security` response header. The browser should remember that a site, including subdomains, is only to be accessed using HTTPS for 1 year.
- `server.securityResponseHeaders.disableEmbedding`: true adds the `X-Frame-Options` response header with a avalue of `SAMEORIGIN` and adds `frame-ancestors 'self'` to the `content-security-policy` response header.

Note: if you are running without TLS enabled locally, you can disable the `strict-transport-security` response header by overriding the setting in kibana.dev.yml (see Testing step 8 below).

### Testing (locally)
1. Start Elasticearch
3. Start Kibana with `yarn start --serverless`
4. Sign into Kibana and open your browser's dev tools
5. In the network tab, inspect one of the requests for localhost
6. In the Headers tab, verify the above defined headers and values are present
7. Stop Kibana, and restart normally with `yarn start`
8. Repeat the process in steps 4-6 and verify that the above defined headers and values are not present
9. Stop Kibana, edit the Kibana.dev.yml file by adding `server.securityResponseHeaders.strictTransportSecurity: null`
10. Start Kibana with `yarn start --serverless`
11. Repeat the process in steps 4-6 and verify that the headers and values associated with disableEmbedding are present while the `strict-transport-security` response header is not present.