### PR TITLE
[DOCS] Adds canonical URLs to 8.2 Kibana Guide

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -27,8 +27,7 @@ Review important information about the {kib} 8.x releases.
 //* <<release-notes-8.0.0-alpha1>>
 
 --
-
-[[release-notes-8.2.3]]
+[id="release-notes-8.2.3",canonical-url="https://www.elastic.co/guide/en/kibana/current/release-notes.html"]
 == {kib} 8.2.3
 
 Review the following information about the {kib} 8.2.3 release.
@@ -65,7 +64,7 @@ Fixes an issue where `node.options` was reset between upgrades in deb and rpm pa
 Platform::
 defaultIndex attribute was migrated for config saved object {kibana-pull}133339[#133339]
 
-[[release-notes-8.2.2]]
+[id="release-notes-8.2.2",canonical-url="https://www.elastic.co/guide/en/kibana/current/release-notes.html"]
 == {kib} 8.2.2
 
 Review the following information about the {kib} 8.2.2 release.
@@ -89,7 +88,7 @@ To review the breaking changes in previous versions, refer to the following:
 Machine Learning::
 Fixes width of icon column in Messages table {kibana-pull}132444[#132444]
 
-[[release-notes-8.2.1]]
+[id="release-notes-8.2.1",canonical-url="https://www.elastic.co/guide/en/kibana/current/release-notes.html"]
 == {kib} 8.2.1
 
 Review the following information about the {kib} 8.2.1 release.
@@ -146,7 +145,7 @@ Platform::
 * Fixes resetting image values {kibana-pull}131610[#131610]
 * Fixes a bug causing the newsfeed to not be properly displayed in locales other than english {kibana-pull}131315[#131315]
 
-[[release-notes-8.2.0]]
+[id="release-notes-8.2.0",canonical-url="https://www.elastic.co/guide/en/kibana/current/release-notes.html"]
 == {kib} 8.2.0
 
 Review the following information about the {kib} 8.2.0 release.

--- a/docs/discover/document-explorer.asciidoc
+++ b/docs/discover/document-explorer.asciidoc
@@ -1,4 +1,4 @@
-[[document-explorer]]
+[id="document-explorer",canonical-url="https://www.elastic.co/guide/en/kibana/current/document-explorer.html"]
 == Explore your documents
 
 

--- a/docs/discover/field-statistics.asciidoc
+++ b/docs/discover/field-statistics.asciidoc
@@ -1,4 +1,4 @@
-[[show-field-statistics]]
+[id="show-field-statistics",canonical-url="https://www.elastic.co/guide/en/kibana/current/show-field-statistics.html"]
 == View field statistics
 
 beta::[]

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,4 +1,4 @@
-[[kibana-guide]]
+[id="kibana-guide",canonical-url="https://www.elastic.co/guide/en/kibana/current/index.html"]
 = Kibana Guide
 
 :include-xpack:  true

--- a/docs/management/connectors/action-types/xmatters.asciidoc
+++ b/docs/management/connectors/action-types/xmatters.asciidoc
@@ -1,4 +1,4 @@
-[[xmatters-action-type]]
+[id="xmatters-action-type",canonical-url="https://www.elastic.co/guide/en/kibana/current/xmatters-action-type.html"]
 === xMatters connector and action
 ++++
 <titleabbrev>xMatters</titleabbrev>

--- a/docs/settings/i18n-settings.asciidoc
+++ b/docs/settings/i18n-settings.asciidoc
@@ -1,5 +1,5 @@
 [role="xpack"]
-[[i18n-settings-kb]]
+[id="i18n-settings-kb",canonical-url="https://www.elastic.co/guide/en/kibana/current/i18n-settings-kb.html"]
 === i18n settings in {kib}
 ++++
 <titleabbrev>i18n settings</titleabbrev>

--- a/docs/setup/docker.asciidoc
+++ b/docs/setup/docker.asciidoc
@@ -1,4 +1,4 @@
-[[docker]]
+[id="docker",canonical-url="https://www.elastic.co/guide/en/kibana/current/docker.html"]
 === Install {kib} with Docker
 ++++
 <titleabbrev>Install with Docker</titleabbrev>

--- a/docs/user/discover.asciidoc
+++ b/docs/user/discover.asciidoc
@@ -1,4 +1,4 @@
-[[discover]]
+[id="discover",canonical-url="https://www.elastic.co/guide/en/kibana/current/discover.html"]
 = Discover
 
 [partintro]

--- a/docs/user/whats-new.asciidoc
+++ b/docs/user/whats-new.asciidoc
@@ -1,4 +1,4 @@
-[[whats-new]]
+[id="whats-new",canonical-url="https://www.elastic.co/guide/en/kibana/current/whats-new.html"]
 == What's new in {minor-version}
 
 Here are the highlights of what's new and improved in {minor-version}.


### PR DESCRIPTION
## Summary

Adds [canonical URL](https://developers.google.com/search/docs/advanced/crawling/consolidate-duplicate-urls) to pages in the 8.2.0 Kibana Guide that have similar or duplicate content in the current Kibana Guide.