### PR TITLE
[DOCS] Adds canonical URLs to 8.1 Kibana Guide

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -58,7 +58,7 @@ To review the breaking changes in previous versions, refer to the following:
 Discover::
 * Fixes toggle table column for classic table {kibana-pull}128603[#128603]
 
-[[release-notes-8.1.2]]
+[id="release-notes-8.1.2",canonical-url="https://www.elastic.co/guide/en/kibana/current/release-notes.html"]
 == {kib} 8.1.2
 
 Review the following information about the {kib} 8.1.2 release.
@@ -101,7 +101,7 @@ Rename "APM & Fleet Server" to "Integrations Server" {kibana-pull}128574[#128574
 Platform::
 Fixes KQL typeahead missing description and improve display for long field names {kibana-pull}128480[#128480]
 
-[[release-notes-8.1.1]]
+[id="release-notes-8.1.1",canonical-url="https://www.elastic.co/guide/en/kibana/current/release-notes.html"]
 == {kib} 8.1.1
 
 Review the following information about the {kib} 8.1.1 release.
@@ -144,7 +144,7 @@ Fleet::
 * Makes input IDs unique in agent policy yaml {kibana-pull}127343[#127343]
 * Fixes links to Agent logs for APM, Endpoint, Synthetics, and OSQuery {kibana-pull}127480[#127480]
 
-[[release-notes-8.1.0]]
+[id="release-notes-8.1.0",canonical-url="https://www.elastic.co/guide/en/kibana/current/release-notes.html"]
 == {kib} 8.1.0
 
 Review the following information about the {kib} 8.1.0 release.

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,4 +1,4 @@
-[[kibana-guide]]
+[id="kibana-guide",canonical-url="https://www.elastic.co/guide/en/kibana/current/index.html"]
 = Kibana Guide
 
 :include-xpack:  true

--- a/docs/maps/import-geospatial-data.asciidoc
+++ b/docs/maps/import-geospatial-data.asciidoc
@@ -1,5 +1,5 @@
 [role="xpack"]
-[[import-geospatial-data]]
+[id="import-geospatial-data",canonical-url="https://www.elastic.co/guide/en/kibana/current/import-geospatial-data.html"]
 == Import geospatial data
 
 To import geospatical data into the Elastic Stack, the data must be indexed as {ref}/geo-point.html[geo_point] or {ref}/geo-shape.html[geo_shape].

--- a/docs/setup/docker.asciidoc
+++ b/docs/setup/docker.asciidoc
@@ -1,4 +1,4 @@
-[[docker]]
+[id="docker",canonical-url="https://www.elastic.co/guide/en/kibana/current/docker.html"]
 === Install {kib} with Docker
 ++++
 <titleabbrev>Install with Docker</titleabbrev>

--- a/docs/user/whats-new.asciidoc
+++ b/docs/user/whats-new.asciidoc
@@ -1,4 +1,4 @@
-[[whats-new]]
+[id="whats-new",canonical-url="https://www.elastic.co/guide/en/kibana/current/whats-new.html"]
 == What's new in {minor-version}
 
 Here are the highlights of what's new and improved in {minor-version}.


### PR DESCRIPTION
## Summary

Adds [canonical URL](https://developers.google.com/search/docs/advanced/crawling/consolidate-duplicate-urls) to pages in the 8.1.0 Kibana Guide that have similar or duplicate content in the current Kibana Guide.