### PR TITLE
[8.7] [build] Fix config argument order (#151052)

### DIFF
--- a/src/dev/build/lib/config.test.ts
+++ b/src/dev/build/lib/config.test.ts
@@ -25,9 +25,12 @@ const versionInfo = jest.requireMock('./version_info').getVersionInfo();
 
 expect.addSnapshotSerializer(createAbsolutePathSerializer());
 
-const setup = async ({ targetAllPlatforms = true }: { targetAllPlatforms?: boolean } = {}) => {
+const setup = async ({
+  targetAllPlatforms = true,
+  isRelease = true,
+}: { targetAllPlatforms?: boolean; isRelease?: boolean } = {}) => {
   return await Config.create({
-    isRelease: true,
+    isRelease,
     targetAllPlatforms,
     dockerContextUseLocalArtifact: false,
     dockerCrossCompile: false,
@@ -189,6 +192,17 @@ describe('#getBuildSha()', () => {
   it('returns the sha from the build info', async () => {
     const config = await setup();
     expect(config.getBuildSha()).toBe(versionInfo.buildSha);
+  });
+});
+
+describe('#isRelease()', () => {
+  it('returns true when marked as a release', async () => {
+    const config = await setup({ isRelease: true });
+    expect(config.isRelease).toBe(true);
+  });
+  it('returns false when not marked as a release', async () => {
+    const config = await setup({ isRelease: false });
+    expect(config.isRelease).toBe(false);
   });
 });
 

--- a/src/dev/build/lib/config.ts
+++ b/src/dev/build/lib/config.ts
@@ -82,8 +82,8 @@ export class Config {
     private readonly dockerTag: string | null,
     private readonly dockerTagQualifier: string | null,
     private readonly dockerPush: boolean,
-    public readonly downloadFreshNode: boolean,
     public readonly isRelease: boolean,
+    public readonly downloadFreshNode: boolean,
     public readonly pluginSelector: PluginSelector
   ) {
     this.pluginFilter = getPluginPackagesFilter(this.pluginSelector);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.7`:
 - [[build] Fix config argument order (#151052)](https://github.com/elastic/kibana/pull/151052)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Jon","email":"jon@elastic.co"},"sourceCommit":{"committedDate":"2023-02-13T21:48:28Z","message":"[build] Fix config argument order (#151052)\n\nSnapshot builds are currently being marked as release builds in the\r\nconfig service. This impacts the release property in package.json\r\nsnapshot builds and pull request deployments.\r\n\r\nThis was introduced in\r\nhttps://github.com/elastic/kibana/commit/1b8581540295fde746dae6b4a09d74fb5821bfef#diff-dbea24da2a777429d025c1da037dd966d65bff2c97a7b78b82a33532f3ad06d9R63","sha":"17855ba5a240ce2cd60f318b49f0040d0cfabbbd","branchLabelMapping":{"^v8.8.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Operations","release_note:skip","backport:skip","ci:cloud-deploy","v8.8.0"],"number":151052,"url":"https://github.com/elastic/kibana/pull/151052","mergeCommit":{"message":"[build] Fix config argument order (#151052)\n\nSnapshot builds are currently being marked as release builds in the\r\nconfig service. This impacts the release property in package.json\r\nsnapshot builds and pull request deployments.\r\n\r\nThis was introduced in\r\nhttps://github.com/elastic/kibana/commit/1b8581540295fde746dae6b4a09d74fb5821bfef#diff-dbea24da2a777429d025c1da037dd966d65bff2c97a7b78b82a33532f3ad06d9R63","sha":"17855ba5a240ce2cd60f318b49f0040d0cfabbbd"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.8.0","labelRegex":"^v8.8.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/151052","number":151052,"mergeCommit":{"message":"[build] Fix config argument order (#151052)\n\nSnapshot builds are currently being marked as release builds in the\r\nconfig service. This impacts the release property in package.json\r\nsnapshot builds and pull request deployments.\r\n\r\nThis was introduced in\r\nhttps://github.com/elastic/kibana/commit/1b8581540295fde746dae6b4a09d74fb5821bfef#diff-dbea24da2a777429d025c1da037dd966d65bff2c97a7b78b82a33532f3ad06d9R63","sha":"17855ba5a240ce2cd60f318b49f0040d0cfabbbd"}}]}] BACKPORT-->