### PR TITLE
[DOCS] Adds canonical URLs to 7.9 Kibana Guide

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -44,7 +44,7 @@ This section summarizes the changes in each release.
 
 --
 
-[[release-notes-7.9.3]]
+[id="release-notes-7.9.3",canonical-url="https://www.elastic.co/guide/en/kibana/current/release-notes.html"]
 == {kib} 7.9.3
 
 For breaking changes, refer to <<breaking-changes-7.9,breaking changes in 7.9>>.
@@ -77,7 +77,7 @@ Security::
 * Adds `xpack.security.sameSiteCookies` to docker allow list {kibana-pull}78192[#78192]
 * Updates user table after user is deleted {kibana-pull}79491[#79491]
 
-[[release-notes-7.9.2]]
+[id="release-notes-7.9.2",canonical-url="https://www.elastic.co/guide/en/kibana/current/release-notes.html"]
 == {kib} 7.9.2
 
 See also <<breaking-changes-7.9,breaking changes in 7.9>>.
@@ -123,7 +123,7 @@ Security::
 Uptime::
 * Fixes alerting false positives {kibana-pull}75577[#75577]
 
-[[release-notes-7.9.1]]
+[id="release-notes-7.9.1",canonical-url="https://www.elastic.co/guide/en/kibana/current/release-notes.html"]
 == {kib} 7.9.1
 
 See also <<breaking-changes-7.9,breaking changes in 7.9>>.
@@ -1832,7 +1832,7 @@ image::images/rn_7.5.2.png[]
 == {kib} 7.5.1
 
 [float]
-[[breaking-7.5.1]]
+ 7.5.1]]
 === Breaking changes
 
 See <<breaking-changes-7.5, breaking changes in 7.5>>.

--- a/docs/apm/index.asciidoc
+++ b/docs/apm/index.asciidoc
@@ -6,7 +6,7 @@ ifeval::[{branch} == 7.x]
 endif::[]
 
 [role="xpack"]
-[[xpack-apm]]
+[id="xpack-apm",canonical-url="https://www.elastic.co/guide/en/apm/guide/current/apm-overview.html"]
 = APM
 
 [partintro]

--- a/docs/apm/traces.asciidoc
+++ b/docs/apm/traces.asciidoc
@@ -1,5 +1,5 @@
 [role="xpack"]
-[[traces]]
+[id="traces",canonical-url="https://www.elastic.co/guide/en/apm/guide/current/apm-distributed-tracing.html"]
 === Traces overview
 
 TIP: Traces link together related transactions to show an end-to-end performance of how a request was served

--- a/docs/dev-tools/grokdebugger/index.asciidoc
+++ b/docs/dev-tools/grokdebugger/index.asciidoc
@@ -1,5 +1,5 @@
 [role="xpack"]
-[[xpack-grokdebugger]]
+[id="xpack-grokdebugger",canonical-url="https://www.elastic.co/guide/en/kibana/current/xpack-grokdebugger.html"]
 == Debugging grok expressions
 
 You can build and debug grok patterns in the {kib} *Grok Debugger*

--- a/docs/discover/kuery.asciidoc
+++ b/docs/discover/kuery.asciidoc
@@ -1,4 +1,4 @@
-[[kuery-query]]
+[id="kuery-query",canonical-url="https://www.elastic.co/guide/en/kibana/current/kuery-query.html"]
 === Kibana Query Language
 
 The Kibana Query Language (KQL) makes it easy to find

--- a/docs/getting-started/tutorial-full-experience.asciidoc
+++ b/docs/getting-started/tutorial-full-experience.asciidoc
@@ -1,4 +1,4 @@
-[[tutorial-build-dashboard]]
+[id="tutorial-build-dashboard",canonical-url="https://www.elastic.co/guide/en/kibana/current/get-started.html"]
 == Build your own dashboard
 
 Want to load some data into Kibana and build a dashboard? This tutorial shows you how to:

--- a/docs/getting-started/tutorial-sample-data.asciidoc
+++ b/docs/getting-started/tutorial-sample-data.asciidoc
@@ -1,4 +1,4 @@
-[[tutorial-sample-data]]
+[id="tutorial-sample-data",canonical-url="https://www.elastic.co/guide/en/kibana/current/get-started.html"]
 == Explore {kib} using sample data
 
 Ready to get some hands-on experience with Kibana?

--- a/docs/getting-started/tutorial-visualizing.asciidoc
+++ b/docs/getting-started/tutorial-visualizing.asciidoc
@@ -1,4 +1,4 @@
-[[tutorial-visualizing]]
+[id="tutorial-visualizing",canonical-url="https://www.elastic.co/guide/en/kibana/current/get-started.html"]
 === Visualize your data
 
 In *Visualize*, you can shape your data using a variety

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,4 +1,4 @@
-[[kibana-guide]]
+[id="kibana-guide",canonical-url="https://www.elastic.co/guide/en/kibana/current/index.html"]
 = Kibana Guide
 
 :include-xpack:  true

--- a/docs/infrastructure/index.asciidoc
+++ b/docs/infrastructure/index.asciidoc
@@ -1,6 +1,6 @@
 [chapter]
 [role="xpack"]
-[[xpack-infra]]
+[id="xpack-infra",canonical-url="https://www.elastic.co/guide/en/observability/current/analyze-metrics.html"]
 = Metrics
 
 The {metrics-app} in {kib} enables you to monitor your infrastructure metrics and identify problems in real time.

--- a/docs/logs/index.asciidoc
+++ b/docs/logs/index.asciidoc
@@ -1,6 +1,6 @@
 [chapter]
 [role="xpack"]
-[[xpack-logs]]
+[id="xpack-logs",canonical-url="https://www.elastic.co/guide/en/observability/current/monitor-logs.html"]
 = Logs
 
 The Logs app in Kibana enables you to explore logs for common servers, containers, and services.

--- a/docs/management/advanced-options.asciidoc
+++ b/docs/management/advanced-options.asciidoc
@@ -1,4 +1,4 @@
-[[advanced-options]]
+[id="advanced-options",canonical-url="https://www.elastic.co/guide/en/kibana/current/advanced-options.html"]
 == Advanced Settings
 
 The *Advanced Settings* UI enables you to edit settings that control the

--- a/docs/management/index-lifecycle-policies/intro-to-lifecycle-policies.asciidoc
+++ b/docs/management/index-lifecycle-policies/intro-to-lifecycle-policies.asciidoc
@@ -1,5 +1,5 @@
 [role="xpack"]
-[[index-lifecycle-policies]]
+[id="index-lifecycle-policies",canonical-url="https://www.elastic.co/guide/en/elasticsearch/reference/current/index-lifecycle-management.html"]
 == Index Lifecycle Policies
 
 If you're working with time series data, you don't want to continually dump

--- a/docs/management/ingest-pipelines/ingest-pipelines.asciidoc
+++ b/docs/management/ingest-pipelines/ingest-pipelines.asciidoc
@@ -1,5 +1,5 @@
 [role="xpack"]
-[[ingest-node-pipelines]]
+[id="ingest-node-pipelines",canonical-url="https://www.elastic.co/guide/en/elasticsearch/reference/current/ingest.html"]
 == Ingest Node Pipelines
 
 *Ingest Node Pipelines* enables you to create and manage {es}

--- a/docs/management/managing-licenses.asciidoc
+++ b/docs/management/managing-licenses.asciidoc
@@ -1,4 +1,4 @@
-[[managing-licenses]]
+[id="managing-licenses",canonical-url="https://www.elastic.co/guide/en/kibana/current/managing-licenses.html"]
 == License Management
 
 When you install the default distribution of {kib}, you receive free features

--- a/docs/migration/migrate_7_9.asciidoc
+++ b/docs/migration/migrate_7_9.asciidoc
@@ -1,4 +1,4 @@
-[[breaking-changes-7.9]]
+[id="breaking-changes-7.9",canonical-url="https://www.elastic.co/guide/en/kibana/current/release-notes.html"]
 == Breaking changes in 7.9
 ++++
 <titleabbrev>7.9</titleabbrev>

--- a/docs/settings/infrastructure-ui-settings.asciidoc
+++ b/docs/settings/infrastructure-ui-settings.asciidoc
@@ -1,5 +1,5 @@
 [role="xpack"]
-[[infrastructure-ui-settings-kb]]
+[id="infrastructure-ui-settings-kb",canonical-url="https://www.elastic.co/guide/en/kibana/current/infrastructure-ui-settings-kb.html"]
 === Metrics settings in {kib}
 ++++
 <titleabbrev>Metrics settings</titleabbrev>

--- a/docs/settings/logs-ui-settings.asciidoc
+++ b/docs/settings/logs-ui-settings.asciidoc
@@ -1,5 +1,5 @@
 [role="xpack"]
-[[logs-ui-settings-kb]]
+[id="logs-ui-settings-kb",canonical-url="https://www.elastic.co/guide/en/kibana/current/logs-ui-settings-kb.html"]
 === Logs settings in {kib}
 ++++
 <titleabbrev>Logs settings</titleabbrev>

--- a/docs/setup/connect-to-elasticsearch.asciidoc
+++ b/docs/setup/connect-to-elasticsearch.asciidoc
@@ -1,4 +1,4 @@
-[[connect-to-elasticsearch]]
+[id="connect-to-elasticsearch",canonical-url="https://www.elastic.co/guide/en/kibana/current/connect-to-elasticsearch.html"]
 == Add data to {kib}
 
 To start working with your data in {kib}, you can:

--- a/docs/setup/docker.asciidoc
+++ b/docs/setup/docker.asciidoc
@@ -1,4 +1,4 @@
-[[docker]]
+[id="docker",canonical-url="https://www.elastic.co/guide/en/kibana/current/docker.html"]
 === Install {kib} with Docker
 ++++
 <titleabbrev>Install with Docker </titleabbrev>

--- a/docs/setup/settings.asciidoc
+++ b/docs/setup/settings.asciidoc
@@ -1,4 +1,4 @@
-[[settings]]
+[id="settings",canonical-url="https://www.elastic.co/guide/en/kibana/current/settings.html"]
 == Configure {kib}
 
 The {kib} server reads properties from the `kibana.yml` file on startup. The

--- a/docs/siem/index.asciidoc
+++ b/docs/siem/index.asciidoc
@@ -1,5 +1,5 @@
 [role="xpack"]
-[[xpack-siem]]
+[id="xpack-siem",canonical-url="https://www.elastic.co/guide/en/siem/guide/current/siem-overview.html"]
 = Elastic Security
 
 [partintro]

--- a/docs/spaces/index.asciidoc
+++ b/docs/spaces/index.asciidoc
@@ -1,5 +1,5 @@
 [role="xpack"]
-[[xpack-spaces]]
+[id="xpack-spaces",canonical-url="https://www.elastic.co/guide/en/kibana/current/xpack-spaces.html"]
 == Spaces
 
 Spaces enable you to organize your dashboards and other saved

--- a/docs/uptime/index.asciidoc
+++ b/docs/uptime/index.asciidoc
@@ -1,6 +1,6 @@
 [chapter]
 [role="xpack"]
-[[xpack-uptime]]
+[id="xpack-uptime",canonical-url="https://www.elastic.co/guide/en/observability/current/uptime-intro.html"]
 = Uptime
 
 The Uptime app in {kib} enables you to monitor the status of network endpoints via HTTP/S, TCP, and ICMP.

--- a/docs/user/alerting/alerting-getting-started.asciidoc
+++ b/docs/user/alerting/alerting-getting-started.asciidoc
@@ -1,5 +1,5 @@
 [role="xpack"]
-[[alerting-getting-started]]
+[id="alerting-getting-started",canonical-url="https://www.elastic.co/guide/en/kibana/current/alerting-getting-started.html"]
 = Alerting and Actions
 
 beta[]

--- a/docs/user/alerting/defining-alerts.asciidoc
+++ b/docs/user/alerting/defining-alerts.asciidoc
@@ -1,5 +1,5 @@
 [role="xpack"]
-[[defining-alerts]]
+[id="defining-alerts",canonical-url="https://www.elastic.co/guide/en/kibana/current/alerting-getting-started.html"]
 == Defining alerts
 
 {kib} alerts can be created in a variety of apps including <<xpack-apm,*APM*>>, <<xpack-infra,*Metrics*>>, <<xpack-siem,*SIEM*>>, <<xpack-uptime,*Uptime*>> and from <<management,*Management*>> UI. While alerting details may differ from app to app, they share a common interface for defining and configuring alerts that this section describes in more detail.

--- a/docs/user/dashboard.asciidoc
+++ b/docs/user/dashboard.asciidoc
@@ -1,4 +1,4 @@
-[[dashboard]]
+[id="dashboard",canonical-url="https://www.elastic.co/guide/en/kibana/current/dashboard.html"]
 = Dashboard
 
 [partintro]

--- a/docs/user/management.asciidoc
+++ b/docs/user/management.asciidoc
@@ -1,4 +1,4 @@
-[[management]]
+[id="management",canonical-url="https://www.elastic.co/guide/en/kibana/current/management.html"]
 = Stack Management
 
 [partintro]

--- a/docs/user/ml/index.asciidoc
+++ b/docs/user/ml/index.asciidoc
@@ -1,5 +1,5 @@
 [role="xpack"]
-[[xpack-ml]]
+[id="xpack-ml",canonical-url="https://www.elastic.co/guide/en/kibana/current/xpack-ml.html"]
 = {ml-cap}
 
 [partintro]
@@ -30,7 +30,7 @@ NOTE: There are limitations in {ml-features} that affect {kib}. For more informa
 
 --
 
-[[xpack-ml-anomalies]]
+[id="xpack-ml-anomalies",canonical-url="https://www.elastic.co/guide/en/kibana/current/xpack-ml-anomalies.html"]
 == {anomaly-detect-cap}
 
 The Elastic {ml} {anomaly-detect} feature automatically models the normal

--- a/docs/user/monitoring/viewing-metrics.asciidoc
+++ b/docs/user/monitoring/viewing-metrics.asciidoc
@@ -1,5 +1,5 @@
 [role="xpack"]
-[[monitoring-data]]
+[id="monitoring-data",canonical-url="https://www.elastic.co/guide/en/kibana/current/monitoring-data.html"]
 = View monitoring data in {kib}
 ++++
 <titleabbrev>View monitoring data</titleabbrev>

--- a/docs/user/monitoring/xpack-monitoring.asciidoc
+++ b/docs/user/monitoring/xpack-monitoring.asciidoc
@@ -1,5 +1,5 @@
 [role="xpack"]
-[[xpack-monitoring]]
+[id="xpack-monitoring",canonical-url="https://www.elastic.co/guide/en/kibana/current/xpack-monitoring.html"]
 = Stack Monitoring
 
 [partintro]

--- a/docs/user/security/authorization/index.asciidoc
+++ b/docs/user/security/authorization/index.asciidoc
@@ -1,7 +1,7 @@
 [role="xpack"]
-[[xpack-security-authorization]]
-
+[id="xpack-security-authorization",canonical-url="https://www.elastic.co/guide/en/kibana/current/xpack-security-authorization.html"]
 === Granting access to {kib}
+
 The Elastic Stack comes with the `kibana_admin` {ref}/built-in-roles.html[built-in role], which you can use to grant access to all Kibana features in all spaces. To grant users access to a subset of spaces or features, you can create a custom role that grants the desired Kibana privileges.
 
 When you assign a user multiple roles, the user receives a union of the roles’ privileges. Therefore, assigning the `kibana_admin` role in addition to a custom role that grants Kibana privileges is ineffective because `kibana_admin` has access to all the features in all spaces.

--- a/docs/user/whats-new.asciidoc
+++ b/docs/user/whats-new.asciidoc
@@ -1,4 +1,4 @@
-[[whats-new]]
+[id="whats-new",canonical-url="https://www.elastic.co/guide/en/kibana/current/whats-new.html"]
 == What's new in {minor-version}
 ++++
 <titleabbrev>What's new in {minor-version}</titleabbrev>

--- a/docs/visualize/tsvb.asciidoc
+++ b/docs/visualize/tsvb.asciidoc
@@ -1,4 +1,4 @@
-[[TSVB]]
+[id="TSVB",canonical-url="https://www.elastic.co/guide/en/kibana/current/tsvb.html"]
 == TSVB
 
 TSVB is a time series data visualizer that allows you to use the full power of the


### PR DESCRIPTION
## Summary

Adds [canonical URL](https://developers.google.com/search/docs/advanced/crawling/consolidate-duplicate-urls) to pages in the 7.9.0 Kibana Guide that have similar or duplicate content in the current Kibana Guide.