### PR TITLE
[8.8] [RAM] Fix snooze scheduler timezone handling (#157338)

### DIFF
--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/rules_list/components/rule_snooze/scheduler.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/rules_list/components/rule_snooze/scheduler.tsx
@@ -146,9 +146,21 @@ const RuleSnoozeSchedulerPanel: React.FunctionComponent<PanelOpts> = ({
           ...(initialSchedule.rRule.until ? { until: moment(initialSchedule.rRule.until) } : {}),
         } as RecurrenceSchedule);
 
+    // Ensure intitial datetimes are displayed in the initial timezone
+    const startMoment = moment(initialSchedule.rRule.dtstart).tz(initialSchedule.rRule.tzid);
+    const dtstartOffsetToKibanaTz = moment()
+      .tz(defaultTz)
+      .year(startMoment.year())
+      .month(startMoment.month())
+      .date(startMoment.date())
+      .hour(startMoment.hour())
+      .minute(startMoment.minute())
+      .second(startMoment.second())
+      .millisecond(startMoment.millisecond())
+      .toISOString();
     return {
-      startDT: moment(initialSchedule.rRule.dtstart),
-      endDT: moment(initialSchedule.rRule.dtstart).add(initialSchedule.duration, 'ms'),
+      startDT: moment(dtstartOffsetToKibanaTz),
+      endDT: moment(dtstartOffsetToKibanaTz).add(initialSchedule.duration, 'ms'),
       isRecurring,
       recurrenceSchedule,
       selectedTimezone: [{ label: initialSchedule.rRule.tzid }],
@@ -218,6 +230,19 @@ const RuleSnoozeSchedulerPanel: React.FunctionComponent<PanelOpts> = ({
 
   const onClickSaveSchedule = useCallback(() => {
     if (!startDT || !endDT) return;
+
+    const tzid = selectedTimezone[0].label ?? defaultTz;
+    // Convert the dtstart from Kibana timezone to the selected timezone
+    const dtstart = moment()
+      .tz(tzid)
+      .year(startDT.year())
+      .month(startDT.month())
+      .date(startDT.date())
+      .hour(startDT.hour())
+      .minute(startDT.minute())
+      .second(startDT.second())
+      .toISOString();
+
     const recurrence =
       isRecurring && recurrenceSchedule
         ? recurrenceSchedule
@@ -227,8 +252,8 @@ const RuleSnoozeSchedulerPanel: React.FunctionComponent<PanelOpts> = ({
     onSaveSchedule({
       id: initialSchedule?.id ?? uuidv4(),
       rRule: {
-        dtstart: startDT.toISOString(),
-        tzid: selectedTimezone[0].label ?? defaultTz,
+        dtstart,
+        tzid,
         ...recurrence,
       },
       duration: endDT.valueOf() - startDT.valueOf(),


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.8`:
 - [[RAM] Fix snooze scheduler timezone handling (#157338)](https://github.com/elastic/kibana/pull/157338)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Zacqary Adam Xeper","email":"Zacqary@users.noreply.github.com"},"sourceCommit":{"committedDate":"2023-05-17T16:41:04Z","message":"[RAM] Fix snooze scheduler timezone handling (#157338)\n\n## Summary\r\n\r\nCloses #156535 \r\n\r\nThe Snooze Scheduler was failing to properly save and load snoozes if\r\nthe user selected a timezone other than the Kibana default. This is\r\nbecause the datepicker only converts timestamp values between UTC and\r\nthe default Kibana timezone.\r\n\r\nThis PR fixes the issue by offsetting all dates that come in and out of\r\nthe scheduler UI relative to local time.\r\n\r\nTo test, create a snooze like this on `main` and make sure you select\r\ntimezone America/Los_Angeles. (If your local timezone is equivalent to\r\nAmerica/Los_Angeles, select a different timezone)\r\n\r\n<img width=\"426\" alt=\"Screenshot 2023-05-10 at 3 58 57 PM\"\r\nsrc=\"https://github.com/elastic/kibana/assets/1445834/ab95c47c-30a0-44d5-bd9d-45fdb929193d\">\r\n\r\nOn `main`, editing the snooze will (erroneously) display the wrong\r\ntimes:\r\n\r\n<img width=\"423\" alt=\"Screenshot 2023-05-10 at 4 03 24 PM\"\r\nsrc=\"https://github.com/elastic/kibana/assets/1445834/ff28ccdd-f491-43ce-87cd-d606c8d71c64\">\r\n\r\nRepeating this process on this PR's branch will save a snooze with the\r\ncorrect `dtstart` and consequently load the correct snooze time.","sha":"213a69739f89bde0fefab284618968a77d1798b8","branchLabelMapping":{"^v8.9.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:ResponseOps","Feature:Alerting/RulesManagement","v8.8.0","v8.9.0"],"number":157338,"url":"https://github.com/elastic/kibana/pull/157338","mergeCommit":{"message":"[RAM] Fix snooze scheduler timezone handling (#157338)\n\n## Summary\r\n\r\nCloses #156535 \r\n\r\nThe Snooze Scheduler was failing to properly save and load snoozes if\r\nthe user selected a timezone other than the Kibana default. This is\r\nbecause the datepicker only converts timestamp values between UTC and\r\nthe default Kibana timezone.\r\n\r\nThis PR fixes the issue by offsetting all dates that come in and out of\r\nthe scheduler UI relative to local time.\r\n\r\nTo test, create a snooze like this on `main` and make sure you select\r\ntimezone America/Los_Angeles. (If your local timezone is equivalent to\r\nAmerica/Los_Angeles, select a different timezone)\r\n\r\n<img width=\"426\" alt=\"Screenshot 2023-05-10 at 3 58 57 PM\"\r\nsrc=\"https://github.com/elastic/kibana/assets/1445834/ab95c47c-30a0-44d5-bd9d-45fdb929193d\">\r\n\r\nOn `main`, editing the snooze will (erroneously) display the wrong\r\ntimes:\r\n\r\n<img width=\"423\" alt=\"Screenshot 2023-05-10 at 4 03 24 PM\"\r\nsrc=\"https://github.com/elastic/kibana/assets/1445834/ff28ccdd-f491-43ce-87cd-d606c8d71c64\">\r\n\r\nRepeating this process on this PR's branch will save a snooze with the\r\ncorrect `dtstart` and consequently load the correct snooze time.","sha":"213a69739f89bde0fefab284618968a77d1798b8"}},"sourceBranch":"main","suggestedTargetBranches":["8.8"],"targetPullRequestStates":[{"branch":"8.8","label":"v8.8.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.9.0","labelRegex":"^v8.9.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/157338","number":157338,"mergeCommit":{"message":"[RAM] Fix snooze scheduler timezone handling (#157338)\n\n## Summary\r\n\r\nCloses #156535 \r\n\r\nThe Snooze Scheduler was failing to properly save and load snoozes if\r\nthe user selected a timezone other than the Kibana default. This is\r\nbecause the datepicker only converts timestamp values between UTC and\r\nthe default Kibana timezone.\r\n\r\nThis PR fixes the issue by offsetting all dates that come in and out of\r\nthe scheduler UI relative to local time.\r\n\r\nTo test, create a snooze like this on `main` and make sure you select\r\ntimezone America/Los_Angeles. (If your local timezone is equivalent to\r\nAmerica/Los_Angeles, select a different timezone)\r\n\r\n<img width=\"426\" alt=\"Screenshot 2023-05-10 at 3 58 57 PM\"\r\nsrc=\"https://github.com/elastic/kibana/assets/1445834/ab95c47c-30a0-44d5-bd9d-45fdb929193d\">\r\n\r\nOn `main`, editing the snooze will (erroneously) display the wrong\r\ntimes:\r\n\r\n<img width=\"423\" alt=\"Screenshot 2023-05-10 at 4 03 24 PM\"\r\nsrc=\"https://github.com/elastic/kibana/assets/1445834/ff28ccdd-f491-43ce-87cd-d606c8d71c64\">\r\n\r\nRepeating this process on this PR's branch will save a snooze with the\r\ncorrect `dtstart` and consequently load the correct snooze time.","sha":"213a69739f89bde0fefab284618968a77d1798b8"}}]}] BACKPORT-->