### PR TITLE
[RAM] Fix updates also updating createdAt/createdBy for maintenance window and rules settings

### DIFF
--- a/x-pack/plugins/alerting/server/maintenance_window_client/methods/archive.test.ts
+++ b/x-pack/plugins/alerting/server/maintenance_window_client/methods/archive.test.ts
@@ -85,7 +85,8 @@ describe('MaintenanceWindowClient - archive', () => {
           { gte: '2023-03-05T00:00:00.000Z', lte: '2023-03-05T01:00:00.000Z' },
         ],
         expirationDate: new Date().toISOString(),
-        ...updatedMetadata,
+        updatedAt: updatedMetadata.updatedAt,
+        updatedBy: updatedMetadata.updatedBy,
       },
       { version: '123' }
     );
@@ -132,7 +133,8 @@ describe('MaintenanceWindowClient - archive', () => {
           { gte: '2023-03-05T00:00:00.000Z', lte: '2023-03-05T01:00:00.000Z' },
         ],
         expirationDate: moment.utc().add(1, 'year').toISOString(),
-        ...updatedMetadata,
+        updatedAt: updatedMetadata.updatedAt,
+        updatedBy: updatedMetadata.updatedBy,
       },
       { version: '123' }
     );
@@ -182,7 +184,8 @@ describe('MaintenanceWindowClient - archive', () => {
         ...mockMaintenanceWindow,
         events: modifiedEvents.slice(0, 4),
         expirationDate: new Date().toISOString(),
-        ...updatedMetadata,
+        updatedAt: updatedMetadata.updatedAt,
+        updatedBy: updatedMetadata.updatedBy,
       },
       { version: '123' }
     );

--- a/x-pack/plugins/alerting/server/maintenance_window_client/methods/archive.ts
+++ b/x-pack/plugins/alerting/server/maintenance_window_client/methods/archive.ts
@@ -77,7 +77,8 @@ async function archiveWithOCC(
         ...attributes,
         events,
         expirationDate,
-        ...modificationMetadata,
+        updatedAt: modificationMetadata.updatedAt,
+        updatedBy: modificationMetadata.updatedBy,
       },
       {
         version,

--- a/x-pack/plugins/alerting/server/maintenance_window_client/methods/finish.ts
+++ b/x-pack/plugins/alerting/server/maintenance_window_client/methods/finish.ts
@@ -105,7 +105,8 @@ async function finishWithOCC(
       {
         events: eventsWithFinishedEvent,
         expirationDate: expirationDate.toISOString(),
-        ...modificationMetadata,
+        updatedAt: modificationMetadata.updatedAt,
+        updatedBy: modificationMetadata.updatedBy,
       },
       {
         version,

--- a/x-pack/plugins/alerting/server/maintenance_window_client/methods/update.test.ts
+++ b/x-pack/plugins/alerting/server/maintenance_window_client/methods/update.test.ts
@@ -48,7 +48,7 @@ const mockContext: jest.Mocked<MaintenanceWindowClientContext> = {
 
 describe('MaintenanceWindowClient - update', () => {
   beforeEach(() => {
-    mockContext.getModificationMetadata.mockResolvedValueOnce(updatedMetadata);
+    mockContext.getModificationMetadata.mockResolvedValue(updatedMetadata);
   });
 
   afterEach(() => {
@@ -101,7 +101,10 @@ describe('MaintenanceWindowClient - update', () => {
           { gte: '2023-04-01T23:00:00.000Z', lte: '2023-04-02T01:00:00.000Z' }, // Daylight savings
         ],
         expirationDate: moment(new Date(secondTimestamp)).tz('UTC').add(1, 'year').toISOString(),
-        ...updatedMetadata,
+        createdAt: '2023-02-26T00:00:00.000Z',
+        createdBy: 'test-user',
+        updatedAt: updatedMetadata.updatedAt,
+        updatedBy: updatedMetadata.updatedBy,
       },
       { id: 'test-id' }
     );

--- a/x-pack/plugins/alerting/server/maintenance_window_client/methods/update.ts
+++ b/x-pack/plugins/alerting/server/maintenance_window_client/methods/update.ts
@@ -84,7 +84,8 @@ async function updateWithOCC(
       ...(typeof enabled === 'boolean' ? { enabled } : {}),
       expirationDate,
       events,
-      ...modificationMetadata,
+      updatedBy: modificationMetadata.updatedBy,
+      updatedAt: modificationMetadata.updatedAt,
     };
 
     // We are deleting and then creating rather than updating because SO.update

--- a/x-pack/plugins/alerting/server/rules_settings_client/flapping/rules_settings_flapping_client.test.ts
+++ b/x-pack/plugins/alerting/server/rules_settings_client/flapping/rules_settings_flapping_client.test.ts
@@ -29,9 +29,9 @@ const getMockRulesSettings = (): RulesSettings => {
       lookBackWindow: DEFAULT_FLAPPING_SETTINGS.lookBackWindow,
       statusChangeThreshold: DEFAULT_FLAPPING_SETTINGS.statusChangeThreshold,
       createdBy: 'test name',
+      createdAt: '2023-03-24T00:00:00.000Z',
       updatedBy: 'test name',
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
+      updatedAt: '2023-03-24T00:00:00.000Z',
     },
   };
 };
@@ -50,7 +50,17 @@ const rulesSettingsFlappingClientParams: jest.Mocked<RulesSettingsFlappingClient
     savedObjectsClient,
   };
 
+const updatedMetadata = {
+  createdAt: '2023-03-26T00:00:00.000Z',
+  updatedAt: '2023-03-26T00:00:00.000Z',
+  createdBy: 'updated-user',
+  updatedBy: 'updated-user',
+};
+
 describe('RulesSettingsFlappingClient', () => {
+  beforeEach(() =>
+    rulesSettingsFlappingClientParams.getModificationMetadata.mockResolvedValue(updatedMetadata)
+  );
   beforeAll(() => {
     jest.useFakeTimers();
     jest.setSystemTime(new Date(mockDateString));
@@ -115,10 +125,10 @@ describe('RulesSettingsFlappingClient', () => {
           enabled: false,
           lookBackWindow: 19,
           statusChangeThreshold: 3,
+          updatedAt: '2023-03-26T00:00:00.000Z',
+          updatedBy: 'updated-user',
           createdBy: 'test name',
-          updatedBy: 'test name',
-          createdAt: expect.any(String),
-          updatedAt: expect.any(String),
+          createdAt: '2023-03-24T00:00:00.000Z',
         }),
       },
       { version: '123' }

--- a/x-pack/plugins/alerting/server/rules_settings_client/flapping/rules_settings_flapping_client.ts
+++ b/x-pack/plugins/alerting/server/rules_settings_client/flapping/rules_settings_flapping_client.ts
@@ -92,7 +92,8 @@ export class RulesSettingsFlappingClient {
           flapping: {
             ...attributes.flapping,
             ...newFlappingProperties,
-            ...modificationMetadata,
+            updatedAt: modificationMetadata.updatedAt,
+            updatedBy: modificationMetadata.updatedBy,
           },
         },
         {

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/get_flapping_settings.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/get_flapping_settings.ts
@@ -57,7 +57,6 @@ export default function getFlappingSettingsTests({ getService }: FtrProviderCont
               expect(response.body.status_change_threshold).to.eql(
                 DEFAULT_FLAPPING_SETTINGS.statusChangeThreshold
               );
-              expect(response.body.created_by).to.be.a('string');
               expect(response.body.updated_by).to.be.a('string');
               expect(Date.parse(response.body.created_at)).to.be.greaterThan(0);
               expect(Date.parse(response.body.updated_at)).to.be.greaterThan(0);

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/update_flapping_settings.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/update_flapping_settings.ts
@@ -53,7 +53,6 @@ export default function updateFlappingSettingsTest({ getService }: FtrProviderCo
               expect(response.body.enabled).to.eql(false);
               expect(response.body.look_back_window).to.eql(20);
               expect(response.body.status_change_threshold).to.eql(20);
-              expect(response.body.created_by).to.eql(user.username);
               expect(response.body.updated_by).to.eql(user.username);
               expect(Date.parse(response.body.created_at)).to.be.greaterThan(0);
               expect(Date.parse(response.body.updated_at)).to.be.greaterThan(0);


### PR DESCRIPTION
## Summary

Fix a small bug where our update functions were also updating the `createdBy/createdAt` fields for some of our saved objects, we should just be updating the `updatedBy/updatedAt` fields

### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->