### PR TITLE
Disable User Profile theme button group when DarkMode config is set

### DIFF
--- a/src/plugins/kibana_react/public/code_editor/index.tsx
+++ b/src/plugins/kibana_react/public/code_editor/index.tsx
@@ -9,8 +9,6 @@
 import React from 'react';
 import { EuiDelayRender, EuiErrorBoundary, EuiSkeletonText } from '@elastic/eui';
 
-import useObservable from 'react-use/lib/useObservable';
-import { useKibana } from '..';
 import { useUiSetting } from '../ui_settings';
 import type { Props } from './code_editor';
 
@@ -56,9 +54,7 @@ export const CodeEditor: React.FunctionComponent<Props> = (props) => {
  * Renders a Monaco code editor in the same style as other EUI form fields.
  */
 export const CodeEditorField: React.FunctionComponent<Props> = (props) => {
-  const { services } = useKibana();
-  const darkMode = services.theme?.theme$ ? useObservable(services.theme?.theme$)?.darkMode : false;
-
+  const darkMode = useUiSetting<boolean>('theme:darkMode');
   return (
     <EuiErrorBoundary>
       <React.Suspense fallback={<Fallback height={props.height} />}>

--- a/src/plugins/kibana_react/public/code_editor/index.tsx
+++ b/src/plugins/kibana_react/public/code_editor/index.tsx
@@ -9,6 +9,8 @@
 import React from 'react';
 import { EuiDelayRender, EuiErrorBoundary, EuiSkeletonText } from '@elastic/eui';
 
+import useObservable from 'react-use/lib/useObservable';
+import { useKibana } from '..';
 import { useUiSetting } from '../ui_settings';
 import type { Props } from './code_editor';
 
@@ -54,7 +56,9 @@ export const CodeEditor: React.FunctionComponent<Props> = (props) => {
  * Renders a Monaco code editor in the same style as other EUI form fields.
  */
 export const CodeEditorField: React.FunctionComponent<Props> = (props) => {
-  const darkMode = useUiSetting<boolean>('theme:darkMode');
+  const { services } = useKibana();
+  const darkMode = services.theme?.theme$ ? useObservable(services.theme?.theme$)?.darkMode : false;
+
   return (
     <EuiErrorBoundary>
       <React.Suspense fallback={<Fallback height={props.height} />}>

--- a/x-pack/plugins/security/public/account_management/user_profile/user_profile.test.tsx
+++ b/x-pack/plugins/security/public/account_management/user_profile/user_profile.test.tsx
@@ -58,6 +58,8 @@ describe('useUserProfileForm', () => {
     coreStart.http.post.mockReset().mockResolvedValue(undefined);
     coreStart.notifications.toasts.addDanger.mockReset();
     coreStart.notifications.toasts.addSuccess.mockReset();
+    coreStart.settings.client.get.mockReset();
+    coreStart.settings.client.isOverridden.mockReset();
   });
 
   it('should initialise form with values from user profile', () => {
@@ -254,8 +256,9 @@ describe('useUserProfileForm', () => {
           <UserProfile user={nonCloudUser} data={data} />
         </Providers>
       );
-
-      expect(testWrapper.exists('[data-test-subj="darkModeButton"]')).toBeTruthy();
+      const darkModeButton = testWrapper.find('EuiButtonGroup[data-test-subj="darkModeButton"]');
+      expect(darkModeButton).toBeTruthy();
+      expect(darkModeButton.getDOMNode()).not.toBeDisabled();
     });
 
     it('should not display if the User is a cloud user', () => {
@@ -278,7 +281,7 @@ describe('useUserProfileForm', () => {
         </Providers>
       );
 
-      expect(testWrapper.exists('[data-test-subj="darkModeButton"]')).toBeFalsy();
+      expect(testWrapper.exists('EuiButtonGroup[data-test-subj="darkModeButton"]')).toBeFalsy();
     });
 
     it('should add special toast after submitting form successfully since darkMode requires a refresh', async () => {
@@ -305,6 +308,33 @@ describe('useUserProfileForm', () => {
         expect.objectContaining({ title: 'Profile updated' }),
         expect.objectContaining({ toastLifeTimeMs: 300000 })
       );
+    });
+
+    it('should be disabled if the theme has been set in the config', () => {
+      const data: UserProfileData = {};
+
+      const nonCloudUser = mockAuthenticatedUser({ elastic_cloud_user: false });
+      coreStart.settings.client.get.mockReturnValueOnce(true);
+      coreStart.settings.client.isOverridden.mockReturnValueOnce(true);
+
+      const testWrapper = mount(
+        <Providers
+          services={coreStart}
+          theme$={theme$}
+          history={history}
+          authc={authc}
+          securityApiClients={{
+            userProfiles: new UserProfileAPIClient(coreStart.http),
+            users: new UserAPIClient(coreStart.http),
+          }}
+        >
+          <UserProfile user={nonCloudUser} data={data} />
+        </Providers>
+      );
+
+      const darkModeButton = testWrapper.find('EuiButtonGroup[data-test-subj="darkModeButton"]');
+      expect(darkModeButton).toBeTruthy();
+      expect(darkModeButton.getDOMNode()).toHaveProperty('disabled');
     });
   });
 });

--- a/x-pack/plugins/security/public/account_management/user_profile/user_profile.tsx
+++ b/x-pack/plugins/security/public/account_management/user_profile/user_profile.tsx
@@ -29,7 +29,7 @@ import type { FunctionComponent } from 'react';
 import React, { useRef, useState } from 'react';
 import useUpdateEffect from 'react-use/lib/useUpdateEffect';
 
-import type { CoreStart, ToastInput, ToastOptions } from '@kbn/core/public';
+import type { CoreStart, IUiSettingsClient, ToastInput, ToastOptions } from '@kbn/core/public';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { toMountPoint, useKibana } from '@kbn/kibana-react-plugin/public';
@@ -546,10 +546,7 @@ export const UserProfile: FunctionComponent<UserProfileProps> = ({ user, data })
 
   const isCloudUser = user.elastic_cloud_user;
 
-  const settingsService = services.settings;
-  const uiSettings = settingsService.client;
-  const isThemeOverridden = uiSettings.isOverridden('theme:darkMode');
-  const isOverriddenThemeDarkMode = uiSettings.get<boolean>('theme:darkMode');
+  const isDarkModeOverride = determineIfDarkModeOverride(services.settings.client);
 
   const rightSideItems = [
     {
@@ -678,13 +675,7 @@ export const UserProfile: FunctionComponent<UserProfileProps> = ({ user, data })
                   onShowPasswordForm={() => setShowChangePasswordForm(true)}
                 />
                 {isCloudUser ? null : (
-                  <UserSettingsEditor
-                    formik={formik}
-                    isDarkModeOverride={determineIfDarkModeOverride(
-                      isThemeOverridden,
-                      isOverriddenThemeDarkMode
-                    )}
-                  />
+                  <UserSettingsEditor formik={formik} isDarkModeOverride={isDarkModeOverride} />
                 )}
               </Form>
             </EuiPageTemplate>
@@ -919,9 +910,9 @@ function renderHelpText(isOverridden: boolean) {
   }
 }
 
-function determineIfDarkModeOverride(
-  isThemeOverridden: boolean,
-  isOverriddenThemeDarkMode: boolean
-) {
+function determineIfDarkModeOverride(settingsClient: IUiSettingsClient) {
+  const isThemeOverridden = settingsClient.isOverridden('theme:darkMode');
+  const isOverriddenThemeDarkMode = settingsClient.get<boolean>('theme:darkMode');
+
   return isThemeOverridden && isOverriddenThemeDarkMode;
 }


### PR DESCRIPTION

## Summary

Closes [#156424](https://github.com/elastic/kibana/issues/156424)

When `uiSettings.overrides.theme:darkMode: true` is set in the `kibana.yml` it should take precedence over all other theme selectors.

The User Profile theme selector was still interactive while `uiSettings.overrides.theme:darkMode: true` was set in the config, causing a confusing UX.

## Screenshots

<img width="930" alt="Screenshot 2023-05-17 at 5 22 58 PM" src="https://github.com/elastic/kibana/assets/21210601/7539df59-9f7d-4ec4-9d11-9b47a8e0a6fc">

<img width="937" alt="Screenshot 2023-05-17 at 5 23 22 PM" src="https://github.com/elastic/kibana/assets/21210601/f20b8a20-d2f2-4669-8621-9e0998af4e4c">

## Testing

*When `uiSettings.overrides.theme:darkMode` is `true` the theme is overridden to 'Dark', but if it is set to `false`, it DOES NOT override the theme to 'Light'.*

1) In `kibana.yml`, set `uiSettings.overrides.theme:darkMode: true`
2) Navigate to User Profiles and see that the Theme control is disabled/set to 'Dark' and that there is help text
3) set `uiSettings.overrides.theme:darkMode: false` / remove the configuration line
4) Navigate to User Profiles and see that the Theme control is enabled and set to 'Light'

<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->