### PR TITLE
chore(NA): add no cache headers for axios requests when downloading cloud dependencies

### DIFF
--- a/src/dev/build/tasks/download_cloud_dependencies.ts
+++ b/src/dev/build/tasks/download_cloud_dependencies.ts
@@ -61,8 +61,8 @@ export const DownloadCloudDependencies: Task = {
     const axiosConfigWithNoCacheHeaders = {
       headers: {
         'Cache-Control': 'no-cache',
-        'Pragma': 'no-cache',
-        'Expires': '0',
+        Pragma: 'no-cache',
+        Expires: '0',
       },
     };
     try {

--- a/src/dev/build/tasks/download_cloud_dependencies.ts
+++ b/src/dev/build/tasks/download_cloud_dependencies.ts
@@ -58,11 +58,18 @@ export const DownloadCloudDependencies: Task = {
     let manifestUrl = '';
     let manifestJSON = null;
     const buildUrl = `https://${subdomain}.elastic.co/beats/latest/${config.getBuildVersion()}.json`;
+    const axiosConfigWithNoCacheHeaders = {
+      headers: {
+        'Cache-Control': 'no-cache',
+        'Pragma': 'no-cache',
+        'Expires': '0',
+      },
+    };
     try {
-      const latest = await Axios.get(buildUrl);
+      const latest = await Axios.get(buildUrl, axiosConfigWithNoCacheHeaders);
       buildId = latest.data.build_id;
       manifestUrl = latest.data.manifest_url;
-      manifestJSON = (await Axios.get(manifestUrl)).data;
+      manifestJSON = (await Axios.get(manifestUrl, axiosConfigWithNoCacheHeaders)).data;
       if (!(manifestUrl && manifestJSON)) throw new Error('Missing manifest.');
     } catch (e) {
       log.error(`Unable to find Beats artifacts for ${config.getBuildVersion()} at ${buildUrl}.`);


### PR DESCRIPTION
There are times when our DRA artifact jobs bundle a previous version of the dependencies (for example beats) even though a new one is already available. 

I'm not 100% this will fix the problem but I think we should try to use no cache headers on the requests that get the manifest contents for the latest versions.

<!--ONMERGE {"backportTargets":["7.17","8.8"]} ONMERGE-->