### PR TITLE
[docs] [kql] Update KQL docs to include info about errors with multiple field types

### DIFF
--- a/docs/concepts/kuery.asciidoc
+++ b/docs/concepts/kuery.asciidoc
@@ -185,7 +185,7 @@ documents where any sub-field of `datastream` contains “logs”, use the follo
 datastream.*: logs
 -------------------
 
-NOTE: When using wildcards to query multiple fields, errors may occur if the fields are of
+NOTE: When using wildcards to query multiple fields, errors might occur if the fields are of
 different types. For example, if `datastream.*` matches both numeric and string fields, the
 above query will result in an error since numeric fields cannot be queried for string values.
 

--- a/docs/concepts/kuery.asciidoc
+++ b/docs/concepts/kuery.asciidoc
@@ -178,12 +178,16 @@ http.request.method: (GET OR POST OR DELETE)
 === Matching multiple fields
 
 Wildcards can also be used to query multiple fields. For example, to search for
-documents where any sub-field of `http.response` contains “error”, use the following:
+documents where any sub-field of `datastream` contains “logs”, use the following:
 
 [source,yaml]
 -------------------
-http.response.*: error
+datastream.*: logs
 -------------------
+
+NOTE: When using wildcards to query multiple fields, errors may occur if the fields are of
+different types. For example, if `datastream.*` matches both numeric and string fields, the
+above query will result in an error since numeric fields cannot be queried for string values.
 
 [discrete]
 === Querying nested fields

--- a/docs/concepts/kuery.asciidoc
+++ b/docs/concepts/kuery.asciidoc
@@ -187,7 +187,7 @@ datastream.*: logs
 
 NOTE: When using wildcards to query multiple fields, errors might occur if the fields are of
 different types. For example, if `datastream.*` matches both numeric and string fields, the
-above query will result in an error since numeric fields cannot be queried for string values.
+above query will result in an error because numeric fields cannot be queried for string values.
 
 [discrete]
 === Querying nested fields


### PR DESCRIPTION
## Summary

We received feedback that the given example would result in errors, since it targets both [string](https://www.elastic.co/guide/en/ecs/current/ecs-http.html#field-http-response-body-content) and [numeric](https://www.elastic.co/guide/en/ecs/current/ecs-http.html#field-http-response-bytes) fields, so we've updated the example with something that won't result in an error, and updated the docs with a note that explains when/why these errors may occur.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["7.17","8.0","8.1","8.2","8.3","8.4","8.5","8.6","8.7","8.8"]} ONMERGE-->