### PR TITLE
[Fleet] update uninstall token length

### DIFF
--- a/x-pack/plugins/fleet/server/services/security/uninstall_token_service/index.ts
+++ b/x-pack/plugins/fleet/server/services/security/uninstall_token_service/index.ts
@@ -374,7 +374,7 @@ export class UninstallTokenService implements UninstallTokenServiceInterface {
   }
 
   private generateToken(): string {
-    return randomBytes(32).toString('hex');
+    return randomBytes(16).toString('hex');
   }
 
   private hashToken(token: string): string {


### PR DESCRIPTION
## Summary

Reduce uninstall token length. From some offline discussions, the token was a bit long to use with an uninstall command and we settled on 16 byte to hex.


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
