### PR TITLE
[Synthetics] remove public SO usage from delete params flow

### DIFF
--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/settings/global_params/delete_param.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/settings/global_params/delete_param.tsx
@@ -12,10 +12,9 @@ import { toMountPoint, useKibana } from '@kbn/kibana-react-plugin/public';
 import { i18n } from '@kbn/i18n';
 
 import { useDispatch } from 'react-redux';
-import { getGlobalParamAction } from '../../../state/global_params';
+import { getGlobalParamAction, deleteGlobalParams } from '../../../state/global_params';
 import { syncGlobalParamsAction } from '../../../state/settings';
 import { kibanaService } from '../../../../../utils/kibana_service';
-import { syntheticsParamType } from '../../../../../../common/types/saved_objects';
 import { NO_LABEL, YES_LABEL } from '../../monitors_page/management/monitor_list_table/labels';
 import { ListParamItem } from './params_list';
 
@@ -38,10 +37,7 @@ export const DeleteParam = ({
 
   const { status } = useFetcher(() => {
     if (isDeleting && savedObjects) {
-      return savedObjects.client.bulkDelete(
-        items.map(({ id }) => ({ type: syntheticsParamType, id })),
-        { force: true }
-      );
+      return deleteGlobalParams({ ids: items.map(({ id }) => id) });
     }
   }, [items, isDeleting]);
 

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/global_params/api.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/global_params/api.ts
@@ -35,3 +35,13 @@ export const editGlobalParam = async ({
     ...paramRequest,
   });
 };
+
+export const deleteGlobalParams = async ({
+  ids,
+}: {
+  ids: string[];
+}): Promise<SyntheticsParamSO> => {
+  return apiService.delete(SYNTHETICS_API_URLS.PARAMS, {
+    ids: JSON.stringify(ids),
+  });
+};

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/global_params/index.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/global_params/index.ts
@@ -69,3 +69,4 @@ export const globalParamsReducer = createReducer(initialState, (builder) => {
 export * from './actions';
 export * from './effects';
 export * from './selectors';
+export * from './api';

--- a/x-pack/plugins/synthetics/public/utils/api_service/api_service.ts
+++ b/x-pack/plugins/synthetics/public/utils/api_service/api_service.ts
@@ -115,8 +115,9 @@ class ApiService {
     return response;
   }
 
-  public async delete<T>(apiUrl: string) {
-    const response = await this._http!.delete<T>(apiUrl);
+  public async delete<T>(apiUrl: string, params?: HttpFetchQuery) {
+    const response = await this._http!.delete<T>({ path: apiUrl, query: params });
+
     if (response instanceof Error) {
       throw response;
     }

--- a/x-pack/plugins/synthetics/server/routes/index.ts
+++ b/x-pack/plugins/synthetics/server/routes/index.ts
@@ -45,6 +45,7 @@ import {
 } from '../legacy_uptime/routes';
 import { getHasIntegrationMonitorsRoute } from './fleet/get_has_integration_monitors';
 import { addSyntheticsParamsRoute } from './settings/add_param';
+import { deleteSyntheticsParamsRoute } from './settings/delete_param';
 import { enableDefaultAlertingRoute } from './default_alerts/enable_default_alert';
 import { getDefaultAlertingRoute } from './default_alerts/get_default_alert';
 import { createNetworkEventsRoute } from './network_events';
@@ -78,6 +79,7 @@ export const syntheticsAppRestApiRoutes: SyntheticsRestApiRouteFactory[] = [
   getSyntheticsParamsRoute,
   editSyntheticsParamsRoute,
   addSyntheticsParamsRoute,
+  deleteSyntheticsParamsRoute,
   syncParamsSyntheticsParamsRoute,
   enableDefaultAlertingRoute,
   getDefaultAlertingRoute,

--- a/x-pack/plugins/synthetics/server/routes/settings/delete_param.ts
+++ b/x-pack/plugins/synthetics/server/routes/settings/delete_param.ts
@@ -14,16 +14,17 @@ export const deleteSyntheticsParamsRoute: SyntheticsRestApiRouteFactory = () => 
   method: 'DELETE',
   path: SYNTHETICS_API_URLS.PARAMS,
   validate: {
-    body: schema.object({
-      ids: schema.arrayOf(schema.string()),
+    query: schema.object({
+      ids: schema.string(),
     }),
   },
   writeAccess: true,
-  handler: async ({ savedObjectsClient, request, server }): Promise<any> => {
-    const { ids } = request.body as { ids: string[] };
+  handler: async ({ savedObjectsClient, request }): Promise<any> => {
+    const { ids } = request.query as { ids: string };
+    const parsedIds = JSON.parse(ids) as string[];
 
     const result = await savedObjectsClient.bulkDelete(
-      ids.map((id) => ({ type: syntheticsParamType, id })),
+      parsedIds.map((id) => ({ type: syntheticsParamType, id })),
       { force: true }
     );
 


### PR DESCRIPTION
## Summary

Relates to https://github.com/elastic/kibana/issues/153399

Removes public SO client usage for the delete params workflow by directly calling the `DELETE` params api.

Addresses the following task from the related issue
- [ ] https://github.com/elastic/kibana/blob/main/x-pack/plugins/synthetics/public/apps/synthetics/components/settings/global_params/delete_param.tsx#L42

### Testing
1. Navigate to Synthetics global params
2. Create a param
3. Delete that param
4. Create two more params
5. Using bulk actions, select both params and delete both params
