### PR TITLE
[Security Solution] Add support for multiple values in cell actions

### DIFF
--- a/packages/kbn-cell-actions/src/actions/copy_to_clipboard/copy_to_clipboard.test.ts
+++ b/packages/kbn-cell-actions/src/actions/copy_to_clipboard/copy_to_clipboard.test.ts
@@ -48,5 +48,25 @@ describe('Default createCopyToClipboardActionFactory', () => {
       expect(mockCopy).toHaveBeenCalledWith('user.name: "the value"');
       expect(mockSuccessToast).toHaveBeenCalled();
     });
+
+    it('should escape value', async () => {
+      await copyToClipboardAction.execute({
+        ...context,
+        field: { ...context.field, value: 'the "value"' },
+      });
+      expect(mockCopy).toHaveBeenCalledWith('user.name: "the \\"value\\""');
+      expect(mockSuccessToast).toHaveBeenCalled();
+    });
+
+    it('should suport multiple values', async () => {
+      await copyToClipboardAction.execute({
+        ...context,
+        field: { ...context.field, value: ['the "value"', 'another value', 'last value'] },
+      });
+      expect(mockCopy).toHaveBeenCalledWith(
+        'user.name: "the \\"value\\"" AND "another value" AND "last value"'
+      );
+      expect(mockSuccessToast).toHaveBeenCalled();
+    });
   });
 });

--- a/packages/kbn-cell-actions/src/actions/copy_to_clipboard/copy_to_clipboard.ts
+++ b/packages/kbn-cell-actions/src/actions/copy_to_clipboard/copy_to_clipboard.ts
@@ -23,6 +23,8 @@ const COPY_TO_CLIPBOARD_SUCCESS = i18n.translate(
   }
 );
 
+const escapeValue = (value: string) => value.replace(/"/g, '\\"');
+
 export const createCopyToClipboardActionFactory = createCellActionFactory(
   ({ notifications }: { notifications: NotificationsStart }) => ({
     type: COPY_CELL_ACTION_TYPE,
@@ -34,8 +36,8 @@ export const createCopyToClipboardActionFactory = createCellActionFactory(
       let textValue: undefined | string;
       if (field.value != null) {
         textValue = Array.isArray(field.value)
-          ? field.value.map((value) => `"${value}"`).join(', ')
-          : `"${field.value}"`;
+          ? field.value.map((value) => `"${escapeValue(value)}"`).join(' AND ')
+          : `"${escapeValue(field.value)}"`;
       }
       const text = textValue ? `${field.name}: ${textValue}` : field.name;
       const isSuccess = copy(text, { debug: true });

--- a/packages/kbn-cell-actions/src/actions/filter/create_filter.test.ts
+++ b/packages/kbn-cell-actions/src/actions/filter/create_filter.test.ts
@@ -64,7 +64,6 @@ describe('createFilter', () => {
   ])('should return combined filter with multiple $caseName values', ({ negate }) => {
     const value2 = 'the-value2';
     expect(createFilter({ key: field, value: [value, value2], negate })).toEqual({
-      $state: expect.any(Object),
       meta: {
         type: 'combined',
         relation: 'AND',

--- a/packages/kbn-cell-actions/src/actions/filter/create_filter.test.ts
+++ b/packages/kbn-cell-actions/src/actions/filter/create_filter.test.ts
@@ -18,21 +18,17 @@ describe('createFilter', () => {
   ])('should return filter with $caseName value', ({ caseValue }) => {
     expect(createFilter({ key: field, value: caseValue, negate: false })).toEqual({
       meta: {
-        alias: null,
-        disabled: false,
         type: 'phrase',
         key: field,
         negate: false,
-        value,
         params: {
           query: value,
         },
       },
       query: {
-        match: {
+        match_phrase: {
           [field]: {
             query: value,
-            type: 'phrase',
           },
         },
       },
@@ -45,23 +41,45 @@ describe('createFilter', () => {
   ])('should return negate filter with $caseName value', ({ caseValue }) => {
     expect(createFilter({ key: field, value: caseValue, negate: true })).toEqual({
       meta: {
-        alias: null,
-        disabled: false,
         type: 'phrase',
         key: field,
         negate: true,
-        value,
         params: {
           query: value,
         },
       },
       query: {
-        match: {
+        match_phrase: {
           [field]: {
             query: value,
-            type: 'phrase',
           },
         },
+      },
+    });
+  });
+
+  it.each([
+    { caseName: 'non-negated', negate: false },
+    { caseName: 'negated', negate: true },
+  ])('should return combined filter with multiple $caseName values', ({ negate }) => {
+    const value2 = 'the-value2';
+    expect(createFilter({ key: field, value: [value, value2], negate })).toEqual({
+      $state: expect.any(Object),
+      meta: {
+        type: 'combined',
+        relation: 'AND',
+        key: field,
+        negate,
+        params: [
+          {
+            meta: { type: 'phrase', key: field, params: { query: value } },
+            query: { match_phrase: { [field]: { query: value } } },
+          },
+          {
+            meta: { type: 'phrase', key: field, params: { query: value2 } },
+            query: { match_phrase: { [field]: { query: value2 } } },
+          },
+        ],
       },
     });
   });
@@ -79,8 +97,6 @@ describe('createFilter', () => {
         },
       },
       meta: {
-        alias: null,
-        disabled: false,
         key: field,
         negate: false,
         type: 'exists',
@@ -102,8 +118,6 @@ describe('createFilter', () => {
         },
       },
       meta: {
-        alias: null,
-        disabled: false,
         key: field,
         negate: true,
         type: 'exists',

--- a/packages/kbn-cell-actions/src/actions/filter/create_filter.ts
+++ b/packages/kbn-cell-actions/src/actions/filter/create_filter.ts
@@ -12,7 +12,6 @@ import {
   type ExistsFilter,
   type PhraseFilter,
   type Filter,
-  FilterStateStore,
 } from '@kbn/es-query';
 
 export const isEmptyFilterValue = (
@@ -33,7 +32,7 @@ const createPhraseFilter = ({
   key: string;
   negate?: boolean;
 }): PhraseFilter => ({
-  meta: { key, negate, type: FILTERS.PHRASE, value: undefined, params: { query: value } },
+  meta: { key, negate, type: FILTERS.PHRASE, params: { query: value } },
   query: { match_phrase: { [key]: { query: value } } },
 });
 
@@ -46,13 +45,9 @@ const createCombinedFilter = ({
   key: string;
   negate: boolean;
 }): CombinedFilter => ({
-  $state: {
-    store: FilterStateStore.APP_STATE,
-  },
   meta: {
     key,
     negate,
-    value: undefined,
     type: FILTERS.COMBINED,
     relation: BooleanRelation.AND,
     params: values.map((value) => createPhraseFilter({ key, value })),

--- a/packages/kbn-cell-actions/src/actions/filter/create_filter.ts
+++ b/packages/kbn-cell-actions/src/actions/filter/create_filter.ts
@@ -5,10 +5,59 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
-import type { Filter } from '@kbn/es-query';
+import {
+  BooleanRelation,
+  FILTERS,
+  type CombinedFilter,
+  type ExistsFilter,
+  type PhraseFilter,
+  type Filter,
+  FilterStateStore,
+} from '@kbn/es-query';
 
-export const isEmptyFilterValue = (value: string[] | string | null | undefined) =>
-  value == null || value.length === 0;
+export const isEmptyFilterValue = (
+  value: string[] | string | null | undefined
+): value is null | undefined | never[] => value == null || value.length === 0;
+
+const createExistsFilter = ({ key, negate }: { key: string; negate: boolean }): ExistsFilter => ({
+  meta: { key, negate, type: FILTERS.EXISTS, value: 'exists' },
+  query: { exists: { field: key } },
+});
+
+const createPhraseFilter = ({
+  key,
+  negate,
+  value,
+}: {
+  value: string;
+  key: string;
+  negate?: boolean;
+}): PhraseFilter => ({
+  meta: { key, negate, type: FILTERS.PHRASE, value: undefined, params: { query: value } },
+  query: { match_phrase: { [key]: { query: value } } },
+});
+
+const createCombinedFilter = ({
+  values,
+  key,
+  negate,
+}: {
+  values: string[];
+  key: string;
+  negate: boolean;
+}): CombinedFilter => ({
+  $state: {
+    store: FilterStateStore.APP_STATE,
+  },
+  meta: {
+    key,
+    negate,
+    value: undefined,
+    type: FILTERS.COMBINED,
+    relation: BooleanRelation.AND,
+    params: values.map((value) => createPhraseFilter({ key, value })),
+  },
+});
 
 export const createFilter = ({
   key,
@@ -19,39 +68,15 @@ export const createFilter = ({
   value: string[] | string | null | undefined;
   negate: boolean;
 }): Filter => {
-  const queryValue = !isEmptyFilterValue(value) ? (Array.isArray(value) ? value[0] : value) : null;
-  const meta = { alias: null, disabled: false, key, negate };
-
-  if (queryValue == null) {
-    return {
-      query: {
-        exists: {
-          field: key,
-        },
-      },
-      meta: {
-        ...meta,
-        type: 'exists',
-        value: 'exists',
-      },
-    };
+  if (isEmptyFilterValue(value)) {
+    return createExistsFilter({ key, negate });
   }
-  return {
-    meta: {
-      ...meta,
-      type: 'phrase',
-      value: queryValue,
-      params: {
-        query: queryValue,
-      },
-    },
-    query: {
-      match: {
-        [key]: {
-          query: queryValue,
-          type: 'phrase',
-        },
-      },
-    },
-  };
+  if (Array.isArray(value)) {
+    if (value.length > 1) {
+      return createCombinedFilter({ key, negate, values: value });
+    } else {
+      return createPhraseFilter({ key, negate, value: value[0] });
+    }
+  }
+  return createPhraseFilter({ key, negate, value });
 };

--- a/x-pack/plugins/security_solution/public/common/components/event_details/overview/overview_card.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/overview/overview_card.tsx
@@ -94,7 +94,7 @@ export const OverviewCardWithActions: React.FC<OverviewCardWithActionsProps> = (
         <SecurityCellActions
           field={{
             name: enrichedFieldInfo.data.field,
-            value: enrichedFieldInfo?.values ? enrichedFieldInfo?.values[0] : '',
+            value: enrichedFieldInfo?.values,
             type: enrichedFieldInfo.data.type,
             aggregatable: enrichedFieldInfo.fieldFromBrowserField?.aggregatable,
           }}

--- a/x-pack/plugins/security_solution/public/common/components/event_details/table/summary_value_cell.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/table/summary_value_cell.tsx
@@ -47,7 +47,7 @@ export const SummaryValueCell: React.FC<AlertSummaryRow['description']> = ({
         <SecurityCellActions
           field={{
             name: data.field,
-            value: values && values.length > 0 ? values[0] : '',
+            value: values,
             type: data.type,
             aggregatable: fieldFromBrowserField?.aggregatable,
           }}


### PR DESCRIPTION
## Summary

fixes: https://github.com/elastic/kibana/issues/157237
closes: https://github.com/elastic/kibana/issues/157887 

Enables cell actions package to support multi-valuated cells. Actions affected:
- Filter In
- Filter Out
- Add To Timeline
- Copy To Clipboard

### Recording

https://github.com/elastic/kibana/assets/17747913/a192173d-5fca-4b33-91a7-664ecd71550b

#### Caveat
The `FilterManager` does not recognize the duplicated filter when using the new `Combined` filters (the ones that allow AND/OR operations), so when adding two opposite combined filters, it does not remove the first one and both are applied at the same time:

![combined_filters_problem](https://github.com/elastic/kibana/assets/17747913/dc2f60db-28e7-4656-aaa2-d8550e8ef128)




<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->