### PR TITLE
[Logs UI] Decouple log view HTTP API schema from saved object schema

### DIFF
--- a/x-pack/plugins/infra/server/saved_objects/log_view/types.ts
+++ b/x-pack/plugins/infra/server/saved_objects/log_view/types.ts
@@ -7,13 +7,61 @@
 
 import { isoToEpochRt } from '@kbn/io-ts-utils';
 import * as rt from 'io-ts';
-import { logViewAttributesRT } from '../../../common/log_views';
 import { savedObjectReferenceRT } from '../references';
+
+export const logDataViewSavedObjectReferenceRT = rt.type({
+  type: rt.literal('data_view'),
+  dataViewId: rt.string,
+});
+
+export const logIndexNameSavedObjectReferenceRT = rt.type({
+  type: rt.literal('index_name'),
+  indexName: rt.string,
+});
+
+export const logIndexSavedObjectReferenceRT = rt.union([
+  logDataViewSavedObjectReferenceRT,
+  logIndexNameSavedObjectReferenceRT,
+]);
+
+const logViewSavedObjectCommonColumnConfigurationRT = rt.strict({
+  id: rt.string,
+});
+
+const logViewSavedObjectTimestampColumnConfigurationRT = rt.strict({
+  timestampColumn: logViewSavedObjectCommonColumnConfigurationRT,
+});
+
+const logViewSavedObjectMessageColumnConfigurationRT = rt.strict({
+  messageColumn: logViewSavedObjectCommonColumnConfigurationRT,
+});
+
+export const logViewSavedObjectFieldColumnConfigurationRT = rt.strict({
+  fieldColumn: rt.intersection([
+    logViewSavedObjectCommonColumnConfigurationRT,
+    rt.strict({
+      field: rt.string,
+    }),
+  ]),
+});
+
+export const logViewSavedObjectColumnConfigurationRT = rt.union([
+  logViewSavedObjectTimestampColumnConfigurationRT,
+  logViewSavedObjectMessageColumnConfigurationRT,
+  logViewSavedObjectFieldColumnConfigurationRT,
+]);
+
+export const logViewSavedObjectAttributesRT = rt.strict({
+  name: rt.string,
+  description: rt.string,
+  logIndices: logIndexSavedObjectReferenceRT,
+  logColumns: rt.array(logViewSavedObjectColumnConfigurationRT),
+});
 
 export const logViewSavedObjectRT = rt.intersection([
   rt.type({
     id: rt.string,
-    attributes: logViewAttributesRT,
+    attributes: logViewSavedObjectAttributesRT,
     references: rt.array(savedObjectReferenceRT),
   }),
   rt.partial({


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/152278.

Separates out the type for saved object `infrastructure-monitoring-log-view` so the HTTP API no longer references the same type. 