### PR TITLE
[ML][Discover] Prototype: create embeddable Explain Log Rate Spikes view in Discover

### DIFF
--- a/src/plugins/discover/public/application/main/components/analysis_tab/analysis_tab.tsx
+++ b/src/plugins/discover/public/application/main/components/analysis_tab/analysis_tab.tsx
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React, { FC, memo } from 'react';
+import { useQuerySubscriber } from '@kbn/unified-field-list-plugin/public';
+import { useSavedSearch } from '../../services/discover_state_provider';
+import type { FieldStatisticsTableProps } from '../field_stats_table';
+import { ExplainLogRateSpikesView } from './explain_log_rate_spikes_view';
+import { useDiscoverServices } from '../../../../hooks/use_discover_services';
+
+export const AnalysisTab: FC<Omit<FieldStatisticsTableProps, 'query' | 'filters'>> = memo(
+  (props) => {
+    const services = useDiscoverServices();
+    const querySubscriberResult = useQuerySubscriber({
+      data: services.data,
+    });
+    const savedSearch = useSavedSearch();
+
+    return (
+      <ExplainLogRateSpikesView
+        {...props}
+        savedSearch={savedSearch}
+        query={querySubscriberResult.query}
+        filters={querySubscriberResult.filters}
+      />
+    );
+  }
+);

--- a/src/plugins/discover/public/application/main/components/analysis_tab/explain_log_rate_spikes_view.tsx
+++ b/src/plugins/discover/public/application/main/components/analysis_tab/explain_log_rate_spikes_view.tsx
@@ -1,0 +1,189 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React, { useEffect, useRef, useState } from 'react';
+import { css } from '@emotion/react';
+import type { SavedSearch } from '@kbn/saved-search-plugin/public';
+import type { Filter, Query, AggregateQuery } from '@kbn/es-query';
+import { UiCounterMetricType } from '@kbn/analytics';
+import type { DataViewField, DataView } from '@kbn/data-views-plugin/public';
+import { EuiFlexItem } from '@elastic/eui';
+import {
+  EmbeddableInput,
+  EmbeddableOutput,
+  ErrorEmbeddable,
+  IEmbeddable,
+  // isErrorEmbeddable,
+} from '@kbn/embeddable-plugin/public';
+import type { DiscoverStateContainer } from '../../services/discover_state';
+import { useDiscoverServices } from '../../../../hooks/use_discover_services';
+export interface ExplainLogRateSpikesInput {
+  dataView: DataView;
+  savedSearch?: SavedSearch | null;
+  query?: Query;
+  visibleFieldNames?: string[];
+  filters?: Filter[];
+  showPreviewByDefault?: boolean;
+  allowEditDataView?: boolean;
+  id?: string;
+  /**
+   * Callback to add a filter to filter bar
+   */
+  onAddFilter?: (field: DataViewField | string, value: string, type: '+' | '-') => void;
+  sessionId?: string;
+  fieldsToFetch?: string[];
+  totalDocuments?: number;
+  // samplingOption?: SamplingOption;
+}
+export type ExplainLogRateSpikesEmbeddableInput = EmbeddableInput & ExplainLogRateSpikesInput;
+export type ExplainLogRateSpikesEmbeddableOutput = EmbeddableOutput;
+
+export interface ExplainLogRateSpikesViewProps {
+  /**
+   * Determines which columns are displayed
+   */
+  columns: string[];
+  /**
+   * The used data view
+   */
+  dataView: DataView;
+  /**
+   * Saved search description
+   */
+  searchDescription?: string;
+  /**
+   * Saved search title
+   */
+  searchTitle?: string;
+  /**
+   * Optional saved search
+   */
+  savedSearch?: SavedSearch;
+  /**
+   * Optional query to update the table content
+   */
+  query?: Query | AggregateQuery;
+  /**
+   * Filters query to update the table content
+   */
+  filters?: Filter[];
+  /**
+   * State container with persisted settings
+   */
+  stateContainer?: DiscoverStateContainer;
+  /**
+   * Callback to add a filter to filter bar
+   */
+  onAddFilter?: (field: DataViewField | string, value: string, type: '+' | '-') => void;
+  /**
+   * Metric tracking function
+   * @param metricType
+   * @param eventName
+   */
+  trackUiMetric?: (metricType: UiCounterMetricType, eventName: string | string[]) => void;
+  searchSessionId?: string;
+}
+
+export const ExplainLogRateSpikesView = (props: ExplainLogRateSpikesViewProps) => {
+  const {
+    dataView,
+    savedSearch,
+    query,
+    filters,
+    // stateContainer,
+    onAddFilter,
+    trackUiMetric,
+    // searchSessionId,
+  } = props;
+
+  const services = useDiscoverServices();
+  const [embeddable, setEmbeddable] = useState<
+    | ErrorEmbeddable
+    | IEmbeddable<ExplainLogRateSpikesEmbeddableInput, ExplainLogRateSpikesEmbeddableOutput>
+    | undefined
+  >();
+  const embeddableRoot: React.RefObject<HTMLDivElement> = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    let unmounted = false;
+    const loadEmbeddable = async () => {
+      if (services.embeddable) {
+        const factory = services.embeddable.getEmbeddableFactory<EmbeddableInput, EmbeddableOutput>(
+          'explain_log_rate_spikes_view'
+        );
+        if (factory) {
+          // Initialize embeddable with information available at mount
+          const initializedEmbeddable = await factory.create({
+            id: 'discover_explain_log_rate_spikes_view',
+            dataView,
+            filters,
+            savedSearch,
+            query,
+            showPreviewByDefault: false,
+            onAddFilter,
+          });
+          if (!unmounted) {
+            setEmbeddable(initializedEmbeddable);
+          }
+        }
+      }
+    };
+    loadEmbeddable();
+    return () => {
+      unmounted = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [services.embeddable]);
+
+  // We can only render after embeddable has already initialized
+  useEffect(() => {
+    if (embeddableRoot.current && embeddable) {
+      embeddable.render(embeddableRoot.current);
+
+      // trackUiMetric?.(METRIC_TYPE.LOADED, FIELD_STATISTICS_LOADED);
+    }
+
+    return () => {
+      // Clean up embeddable upon unmounting
+      embeddable?.destroy();
+    };
+  }, [embeddable, embeddableRoot, trackUiMetric]);
+
+  useEffect(
+    function syncIntoEmbeddable() {
+      if (embeddable) {
+        embeddable.updateInput({
+          dataView,
+          savedSearch,
+          query,
+          filters,
+        });
+      }
+    },
+    [embeddable, filters, query, dataView, savedSearch]
+  );
+
+  const elrsViewCss = css`
+    overflow-y: auto;
+
+    .kbnDocTableWrapper {
+      overflow-x: hidden;
+    }
+  `;
+
+  return (
+    <EuiFlexItem css={elrsViewCss}>
+      <div
+        data-test-subj="dscExplainLogRateSpikesEmbeddedContent"
+        ref={embeddableRoot}
+        // Match the scroll bar of the Discover doc table
+        className="kbnDocTableWrapper"
+      />
+    </EuiFlexItem>
+  );
+};

--- a/src/plugins/discover/public/application/main/components/analysis_tab/index.ts
+++ b/src/plugins/discover/public/application/main/components/analysis_tab/index.ts
@@ -6,10 +6,4 @@
  * Side Public License, v 1.
  */
 
-export const DEFAULT_ROWS_PER_PAGE = 100;
-export const ROWS_PER_PAGE_OPTIONS = [10, 25, 50, DEFAULT_ROWS_PER_PAGE, 250, 500];
-export enum VIEW_MODE {
-  DOCUMENT_LEVEL = 'documents',
-  AGGREGATED_LEVEL = 'aggregated',
-  ANALYSIS_LEVEL = 'analysis',
-}
+export { AnalysisTab } from './analysis_tab';

--- a/src/plugins/discover/public/application/main/components/field_stats_table/constants.ts
+++ b/src/plugins/discover/public/application/main/components/field_stats_table/constants.ts
@@ -10,3 +10,4 @@
 export const FIELD_STATISTICS_LOADED = 'field_statistics_loaded';
 export const FIELD_STATISTICS_VIEW_CLICK = 'field_statistics_view_click';
 export const DOCUMENTS_VIEW_CLICK = 'documents_view_click';
+export const ANALYSIS_VIEW_CLICK = 'analysis_view_click';

--- a/src/plugins/discover/public/application/main/components/layout/discover_main_content.tsx
+++ b/src/plugins/discover/public/application/main/components/layout/discover_main_content.tsx
@@ -18,8 +18,13 @@ import { DocumentViewModeToggle } from '../../../../components/view_mode_toggle'
 import { DocViewFilterFn } from '../../../../services/doc_views/doc_views_types';
 import { DiscoverStateContainer } from '../../services/discover_state';
 import { FieldStatisticsTab } from '../field_stats_table';
+import { AnalysisTab } from '../analysis_tab';
 import { DiscoverDocuments } from './discover_documents';
-import { DOCUMENTS_VIEW_CLICK, FIELD_STATISTICS_VIEW_CLICK } from '../field_stats_table/constants';
+import {
+  ANALYSIS_VIEW_CLICK,
+  DOCUMENTS_VIEW_CLICK,
+  FIELD_STATISTICS_VIEW_CLICK,
+} from '../field_stats_table/constants';
 import { ErrorCallout } from '../../../../components/common/error_callout';
 import { useDataState } from '../../hooks/use_data_state';
 
@@ -66,8 +71,10 @@ export const DiscoverMainContent = ({
       if (trackUiMetric) {
         if (mode === VIEW_MODE.AGGREGATED_LEVEL) {
           trackUiMetric(METRIC_TYPE.CLICK, FIELD_STATISTICS_VIEW_CLICK);
-        } else {
+        } else if (mode === VIEW_MODE.DOCUMENT_LEVEL) {
           trackUiMetric(METRIC_TYPE.CLICK, DOCUMENTS_VIEW_CLICK);
+        } else {
+          trackUiMetric(METRIC_TYPE.CLICK, ANALYSIS_VIEW_CLICK);
         }
       }
     },
@@ -99,6 +106,7 @@ export const DiscoverMainContent = ({
               <DocumentViewModeToggle
                 viewMode={viewMode}
                 setDiscoverViewMode={setDiscoverViewMode}
+                isTimeBasedDataView={dataView.isTimeBased()}
               />
             )}
           </EuiFlexItem>
@@ -120,7 +128,8 @@ export const DiscoverMainContent = ({
               stateContainer={stateContainer}
               onFieldEdited={!isPlainRecord ? onFieldEdited : undefined}
             />
-          ) : (
+          ) : null}
+          {viewMode === VIEW_MODE.AGGREGATED_LEVEL ? (
             <FieldStatisticsTab
               dataView={dataView}
               columns={columns}
@@ -128,7 +137,16 @@ export const DiscoverMainContent = ({
               onAddFilter={!isPlainRecord ? onAddFilter : undefined}
               trackUiMetric={trackUiMetric}
             />
-          )}
+          ) : null}
+          {viewMode === VIEW_MODE.ANALYSIS_LEVEL && dataView.isTimeBased() ? (
+            <AnalysisTab
+              dataView={dataView}
+              columns={columns}
+              stateContainer={stateContainer}
+              onAddFilter={!isPlainRecord ? onAddFilter : undefined}
+              trackUiMetric={trackUiMetric}
+            />
+          ) : null}
         </EuiFlexGroup>
       </DropOverlayWrapper>
     </DragDrop>

--- a/src/plugins/discover/public/components/view_mode_toggle/view_mode_toggle.test.tsx
+++ b/src/plugins/discover/public/components/view_mode_toggle/view_mode_toggle.test.tsx
@@ -27,7 +27,11 @@ describe('Document view mode toggle component', () => {
 
     return mountWithIntl(
       <KibanaContextProvider services={serivces}>
-        <DocumentViewModeToggle viewMode={viewMode} setDiscoverViewMode={setDiscoverViewMode} />
+        <DocumentViewModeToggle
+          viewMode={viewMode}
+          setDiscoverViewMode={setDiscoverViewMode}
+          isTimeBasedDataView={true}
+        />
       </KibanaContextProvider>
     );
   };

--- a/src/plugins/discover/public/components/view_mode_toggle/view_mode_toggle.tsx
+++ b/src/plugins/discover/public/components/view_mode_toggle/view_mode_toggle.tsx
@@ -18,9 +18,11 @@ import { useDiscoverServices } from '../../hooks/use_discover_services';
 export const DocumentViewModeToggle = ({
   viewMode,
   setDiscoverViewMode,
+  isTimeBasedDataView,
 }: {
   viewMode: VIEW_MODE;
   setDiscoverViewMode: (viewMode: VIEW_MODE) => void;
+  isTimeBasedDataView: boolean;
 }) => {
   const { uiSettings } = useDiscoverServices();
 
@@ -56,6 +58,16 @@ export const DocumentViewModeToggle = ({
           defaultMessage="Field statistics"
         />
       </EuiTab>
+      {isTimeBasedDataView ? (
+        <EuiTab
+          isSelected={viewMode === VIEW_MODE.ANALYSIS_LEVEL}
+          onClick={() => setDiscoverViewMode(VIEW_MODE.ANALYSIS_LEVEL)}
+          className="dscViewModeToggle__tab"
+          data-test-subj="dscViewModeAnalysisButton"
+        >
+          <FormattedMessage id="discover.viewModes.analysis.label" defaultMessage="Analysis" />
+        </EuiTab>
+      ) : null}
     </EuiTabs>
   );
 };

--- a/src/plugins/saved_search/common/index.ts
+++ b/src/plugins/saved_search/common/index.ts
@@ -19,4 +19,5 @@ export type {
 export enum VIEW_MODE {
   DOCUMENT_LEVEL = 'documents',
   AGGREGATED_LEVEL = 'aggregated',
+  ANALYSIS_LEVEL = 'analysis',
 }

--- a/x-pack/plugins/aiops/kibana.jsonc
+++ b/x-pack/plugins/aiops/kibana.jsonc
@@ -10,6 +10,9 @@
     "requiredPlugins": [
       "charts",
       "data",
+      "discover",
+      "embeddable",
+      "fieldFormats",
       "lens",
       "licensing",
       "uiActions",

--- a/x-pack/plugins/aiops/public/components/document_count_content/document_count_chart/document_count_chart.tsx
+++ b/x-pack/plugins/aiops/public/components/document_count_content/document_count_chart/document_count_chart.tsx
@@ -108,6 +108,7 @@ export const DocumentCountChart: FC<DocumentCountChartProps> = ({
   const chartBaseTheme = charts.theme.useChartsBaseTheme();
 
   const xAxisFormatter = fieldFormats.deserialize({ id: 'date' });
+
   const useLegacyTimeAxis = uiSettings.get('visualization:useLegacyTimeAxis', false);
 
   const overallSeriesName = i18n.translate(

--- a/x-pack/plugins/aiops/public/components/document_count_content/document_count_content/document_count_content.tsx
+++ b/x-pack/plugins/aiops/public/components/document_count_content/document_count_content/document_count_content.tsx
@@ -30,8 +30,9 @@ export interface DocumentCountContentProps {
   documentCountStats?: DocumentCountStats;
   documentCountStatsSplit?: DocumentCountStats;
   documentCountStatsSplitLabel?: string;
-  totalCount: number;
   sampleProbability: number;
+  showTotalCount?: boolean;
+  totalCount: number;
   windowParameters?: WindowParameters;
 }
 
@@ -41,8 +42,9 @@ export const DocumentCountContent: FC<DocumentCountContentProps> = ({
   documentCountStats,
   documentCountStatsSplit,
   documentCountStatsSplitLabel = '',
-  totalCount,
   sampleProbability,
+  showTotalCount = true,
+  totalCount,
   windowParameters,
 }) => {
   const [isBrushCleared, setIsBrushCleared] = useState(true);
@@ -101,9 +103,11 @@ export const DocumentCountContent: FC<DocumentCountContentProps> = ({
   return (
     <>
       <EuiFlexGroup gutterSize="xs">
-        <EuiFlexItem>
-          <TotalCountHeader totalCount={totalCount} sampleProbability={sampleProbability} />
-        </EuiFlexItem>
+        {showTotalCount ? (
+          <EuiFlexItem>
+            <TotalCountHeader totalCount={totalCount} sampleProbability={sampleProbability} />
+          </EuiFlexItem>
+        ) : null}
         {!isBrushCleared && (
           <EuiFlexItem grow={false}>
             <EuiButtonEmpty

--- a/x-pack/plugins/aiops/public/components/explain_log_rate_spikes/embeddables/explain_log_rate_spikes_view_embeddable/constants.ts
+++ b/x-pack/plugins/aiops/public/components/explain_log_rate_spikes/embeddables/explain_log_rate_spikes_view_embeddable/constants.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const EXPLAIN_LOG_RATE_SPIKES_EMBEDDABLE_TYPE = 'explain_log_rate_spikes_view';

--- a/x-pack/plugins/aiops/public/components/explain_log_rate_spikes/embeddables/explain_log_rate_spikes_view_embeddable/embeddable_loading_fallback.tsx
+++ b/x-pack/plugins/aiops/public/components/explain_log_rate_spikes/embeddables/explain_log_rate_spikes_view_embeddable/embeddable_loading_fallback.tsx
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { EuiLoadingSpinner, EuiSpacer, EuiText } from '@elastic/eui';
+
+export const EmbeddableLoading = () => {
+  return (
+    <EuiText textAlign="center">
+      <EuiSpacer size="l" />
+      <EuiLoadingSpinner size="l" />
+      <EuiSpacer size="l" />
+    </EuiText>
+  );
+};

--- a/x-pack/plugins/aiops/public/components/explain_log_rate_spikes/embeddables/explain_log_rate_spikes_view_embeddable/explain_log_rate_spikes_view_embeddable.tsx
+++ b/x-pack/plugins/aiops/public/components/explain_log_rate_spikes/embeddables/explain_log_rate_spikes_view_embeddable/explain_log_rate_spikes_view_embeddable.tsx
@@ -1,0 +1,203 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { pick } from 'lodash';
+import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import { Observable, Subject } from 'rxjs';
+import { CoreStart } from '@kbn/core/public';
+import ReactDOM from 'react-dom';
+import React, { useState, Suspense } from 'react';
+import useObservable from 'react-use/lib/useObservable';
+import { EuiEmptyPrompt } from '@elastic/eui';
+import { Filter } from '@kbn/es-query';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { fromKueryExpression, toElasticsearchQuery } from '@kbn/es-query';
+import {
+  Embeddable,
+  EmbeddableInput,
+  EmbeddableOutput,
+  IContainer,
+} from '@kbn/embeddable-plugin/public';
+import { UI_SETTINGS } from '@kbn/data-plugin/common';
+import { toMountPoint, wrapWithTheme } from '@kbn/kibana-react-plugin/public';
+import { KibanaContextProvider, KibanaThemeProvider } from '@kbn/kibana-react-plugin/public';
+import type { Query } from '@kbn/es-query';
+import { DataView, DataViewField } from '@kbn/data-views-plugin/public';
+import { DatePickerContextProvider } from '@kbn/ml-date-picker';
+import type { SavedSearch } from '@kbn/discover-plugin/public';
+import { EXPLAIN_LOG_RATE_SPIKES_EMBEDDABLE_TYPE } from './constants';
+import { EmbeddableLoading } from './embeddable_loading_fallback';
+import { AiopsPluginStartDeps } from '../../../../types';
+import { ExplainLogRateSpikesContent } from '../../explain_log_rate_spikes_content';
+
+import { SpikeAnalysisTableRowStateProvider } from '../../../spike_analysis_table/spike_analysis_table_row_provider';
+import { AiopsAppContext } from '../../../../hooks/use_aiops_app_context';
+import { SEARCH_QUERY_LANGUAGE } from '../../../../application/utils/search_utils';
+
+export type ExplainLogRateSpikesEmbeddableServices = [CoreStart, AiopsPluginStartDeps];
+export interface ExplainLogRateSpikesInput {
+  dataView: DataView;
+  savedSearch?: SavedSearch | null;
+  query?: Query;
+  visibleFieldNames?: string[];
+  filters?: Filter[];
+  showPreviewByDefault?: boolean;
+  allowEditDataView?: boolean;
+  id?: string;
+  /**
+   * Callback to add a filter to filter bar
+   */
+  onAddFilter?: (field: DataViewField | string, value: string, type: '+' | '-') => void;
+  sessionId?: string;
+  fieldsToFetch?: string[];
+  totalDocuments?: number;
+  // samplingOption?: SamplingOption;
+}
+export type ExplainLogRateSpikesEmbeddableInput = EmbeddableInput & ExplainLogRateSpikesInput;
+export type ExplainLogRateSpikesEmbeddableOutput = EmbeddableOutput;
+
+export type IExplainLogRateSpikesEmbeddable = typeof ExplainLogRateSpikesEmbeddable;
+
+export const EmbeddableWrapper = ({
+  input,
+  onOutputChange,
+}: {
+  input: ExplainLogRateSpikesEmbeddableInput;
+  onOutputChange?: (ouput: any) => void;
+}) => {
+  // Force component to re-render when time range changes
+  const [_, setCurrentTimeSelection] = useState({});
+  const convertedQuery: estypes.QueryDslQueryContainer = toElasticsearchQuery(
+    fromKueryExpression(input.query?.query ?? ''),
+    input.dataView
+  );
+
+  const aiopsListState = {
+    searchString: input.query?.query ?? '',
+    searchQueryLanguage: input.query?.language ?? SEARCH_QUERY_LANGUAGE.KUERY,
+    searchQuery: convertedQuery,
+    filters: input.filters,
+  };
+
+  return (
+    <ExplainLogRateSpikesContent
+      dataView={input.dataView}
+      selectedSavedSearch={input.savedSearch ?? null}
+      setGlobalState={setCurrentTimeSelection}
+      aiopsListState={aiopsListState}
+    />
+  );
+};
+
+export const ExplainLogRateSpikesViewWrapper = (props: {
+  id: string;
+  embeddableContext: InstanceType<IExplainLogRateSpikesEmbeddable>;
+  embeddableInput: Readonly<Observable<ExplainLogRateSpikesEmbeddableInput>>;
+  onOutputChange?: (output: any) => void;
+}) => {
+  const { embeddableInput, onOutputChange } = props;
+
+  const input = useObservable(embeddableInput);
+  if (input && input.dataView) {
+    return <EmbeddableWrapper input={input} onOutputChange={onOutputChange} />;
+  } else {
+    return (
+      <EuiEmptyPrompt
+        iconType="warning"
+        iconColor="danger"
+        title={
+          <h2>
+            <FormattedMessage
+              id="xpack.dataVisualizer.index.embeddableErrorTitle"
+              defaultMessage="Error loading embeddable"
+            />
+          </h2>
+        }
+        body={
+          <p>
+            <FormattedMessage
+              id="xpack.dataVisualizer.index.embeddableErrorDescription"
+              defaultMessage="There was an error loading the embeddable. Please check if all the required input is valid."
+            />
+          </p>
+        }
+      />
+    );
+  }
+};
+
+export class ExplainLogRateSpikesEmbeddable extends Embeddable<
+  ExplainLogRateSpikesEmbeddableInput,
+  ExplainLogRateSpikesEmbeddableOutput
+> {
+  private node?: HTMLElement;
+  private reload$ = new Subject<void>();
+  public readonly type: string = EXPLAIN_LOG_RATE_SPIKES_EMBEDDABLE_TYPE;
+
+  constructor(
+    initialInput: ExplainLogRateSpikesEmbeddableInput,
+    public services: ExplainLogRateSpikesEmbeddableServices,
+    parent?: IContainer
+  ) {
+    super(initialInput, {}, parent);
+  }
+
+  public render(node: HTMLElement) {
+    super.render(node);
+    this.node = node;
+
+    const I18nContext = this.services[0].i18n.Context;
+
+    const services = { ...this.services[0], ...this.services[1] };
+
+    const datePickerDeps = {
+      ...pick(services, ['data', 'http', 'notifications', 'theme', 'uiSettings']),
+      toMountPoint,
+      wrapWithTheme,
+      uiSettingsKeys: UI_SETTINGS,
+    };
+
+    ReactDOM.render(
+      <I18nContext>
+        <KibanaThemeProvider theme$={this.services[0].theme.theme$}>
+          <KibanaContextProvider services={services}>
+            <AiopsAppContext.Provider value={services}>
+              <SpikeAnalysisTableRowStateProvider>
+                <DatePickerContextProvider {...datePickerDeps}>
+                  <Suspense fallback={<EmbeddableLoading />}>
+                    <ExplainLogRateSpikesViewWrapper
+                      id={this.input.id}
+                      embeddableContext={this}
+                      embeddableInput={this.getInput$()}
+                      onOutputChange={(output) => this.updateOutput(output)}
+                    />
+                  </Suspense>
+                </DatePickerContextProvider>
+              </SpikeAnalysisTableRowStateProvider>
+            </AiopsAppContext.Provider>
+          </KibanaContextProvider>
+        </KibanaThemeProvider>
+      </I18nContext>,
+      node
+    );
+  }
+
+  public destroy() {
+    super.destroy();
+    if (this.node) {
+      ReactDOM.unmountComponentAtNode(this.node);
+    }
+  }
+
+  public reload() {
+    this.reload$.next();
+  }
+
+  public supportedTriggers() {
+    return [];
+  }
+}

--- a/x-pack/plugins/aiops/public/components/explain_log_rate_spikes/embeddables/explain_log_rate_spikes_view_embeddable/explain_log_rate_spikes_view_embeddable_factory.tsx
+++ b/x-pack/plugins/aiops/public/components/explain_log_rate_spikes/embeddables/explain_log_rate_spikes_view_embeddable/explain_log_rate_spikes_view_embeddable_factory.tsx
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+import { StartServicesAccessor } from '@kbn/core/public';
+import { EmbeddableFactoryDefinition, IContainer } from '@kbn/embeddable-plugin/public';
+import { EXPLAIN_LOG_RATE_SPIKES_EMBEDDABLE_TYPE } from './constants';
+import {
+  ExplainLogRateSpikesEmbeddableInput,
+  ExplainLogRateSpikesEmbeddableServices,
+} from './explain_log_rate_spikes_view_embeddable';
+import { AiopsPluginStart, AiopsPluginStartDeps } from '../../../../types';
+
+export class ExplainLogRateSpikesViewEmbeddableFactory
+  implements EmbeddableFactoryDefinition<ExplainLogRateSpikesEmbeddableInput>
+{
+  public readonly type = EXPLAIN_LOG_RATE_SPIKES_EMBEDDABLE_TYPE;
+
+  public readonly grouping = [
+    {
+      id: 'explain_log_rate_spikes_view',
+      getDisplayName: () => 'Explain Log Rate Spikes View',
+    },
+  ];
+
+  constructor(
+    private getStartServices: StartServicesAccessor<AiopsPluginStartDeps, AiopsPluginStart>
+  ) {}
+
+  public async isEditable() {
+    return false;
+  }
+
+  public canCreateNew() {
+    return false;
+  }
+
+  public getDisplayName() {
+    return i18n.translate('xpack.explainLogRateSpikesView.displayName', {
+      defaultMessage: 'Explain log rate spikes view',
+    });
+  }
+
+  public getDescription() {
+    return i18n.translate('xpack.explainLogRateSpikesView.description', {
+      defaultMessage: 'Analyzes log rate spikes in Elasticsearch indices.',
+    });
+  }
+
+  private async getServices(): Promise<ExplainLogRateSpikesEmbeddableServices> {
+    const [coreStart, pluginsStart] = await this.getStartServices();
+    return [coreStart, pluginsStart];
+  }
+
+  public async create(initialInput: ExplainLogRateSpikesEmbeddableInput, parent?: IContainer) {
+    const [coreStart, pluginsStart] = await this.getServices();
+    const { ExplainLogRateSpikesEmbeddable } = await import(
+      './explain_log_rate_spikes_view_embeddable'
+    );
+    return new ExplainLogRateSpikesEmbeddable(initialInput, [coreStart, pluginsStart], parent);
+  }
+}

--- a/x-pack/plugins/aiops/public/components/explain_log_rate_spikes/embeddables/index.ts
+++ b/x-pack/plugins/aiops/public/components/explain_log_rate_spikes/embeddables/index.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { CoreSetup } from '@kbn/core/public';
+import { EmbeddableSetup } from '@kbn/embeddable-plugin/public';
+import { ExplainLogRateSpikesViewEmbeddableFactory } from './explain_log_rate_spikes_view_embeddable/explain_log_rate_spikes_view_embeddable_factory';
+import { AiopsPluginStart, AiopsPluginStartDeps } from '../../../types';
+
+export function registerEmbeddables(
+  embeddable: EmbeddableSetup,
+  core: CoreSetup<AiopsPluginStartDeps, AiopsPluginStart>
+) {
+  const dataVisualizerGridEmbeddableFactory = new ExplainLogRateSpikesViewEmbeddableFactory(
+    core.getStartServices
+  );
+  embeddable.registerEmbeddableFactory(
+    dataVisualizerGridEmbeddableFactory.type,
+    dataVisualizerGridEmbeddableFactory
+  );
+}

--- a/x-pack/plugins/aiops/public/components/explain_log_rate_spikes/explain_log_rate_spikes_content.tsx
+++ b/x-pack/plugins/aiops/public/components/explain_log_rate_spikes/explain_log_rate_spikes_content.tsx
@@ -1,0 +1,172 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useState, FC } from 'react';
+import {
+  EuiEmptyPrompt,
+  EuiFlexItem,
+  EuiHorizontalRule,
+  EuiResizableContainer,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
+
+import type { DataView } from '@kbn/data-views-plugin/public';
+import type { SavedSearch } from '@kbn/saved-search-plugin/public';
+import type { Dictionary } from '@kbn/ml-url-state';
+import type { WindowParameters } from '@kbn/aiops-utils';
+import type { SignificantTerm } from '@kbn/ml-agg-utils';
+
+import { useData } from '../../hooks/use_data';
+import { DocumentCountContent } from '../document_count_content/document_count_content';
+import { ExplainLogRateSpikesAnalysis } from './explain_log_rate_spikes_analysis';
+import type { GroupTableItem } from '../spike_analysis_table/types';
+import { useSpikeAnalysisTableRowContext } from '../spike_analysis_table/spike_analysis_table_row_provider';
+import type { AiOpsIndexBasedAppState } from '../../application/utils/url_state';
+
+export function getDocumentCountStatsSplitLabel(
+  significantTerm?: SignificantTerm,
+  group?: GroupTableItem
+) {
+  if (significantTerm) {
+    return `${significantTerm?.fieldName}:${significantTerm?.fieldValue}`;
+  } else if (group) {
+    return i18n.translate('xpack.aiops.spikeAnalysisPage.documentCountStatsSplitGroupLabel', {
+      defaultMessage: 'Selected group',
+    });
+  }
+}
+
+interface Props {
+  dataView: DataView;
+  selectedSavedSearch: SavedSearch | null;
+  aiopsListState: AiOpsIndexBasedAppState;
+  setGlobalState?: (params: Dictionary<unknown>) => void;
+  showTotalCount?: boolean;
+}
+
+export const ExplainLogRateSpikesContent: FC<Props> = ({
+  dataView,
+  selectedSavedSearch,
+  aiopsListState,
+  setGlobalState,
+  showTotalCount = true,
+}) => {
+  const [windowParameters, setWindowParameters] = useState<WindowParameters | undefined>();
+
+  const {
+    currentSelectedSignificantTerm,
+    currentSelectedGroup,
+    setPinnedSignificantTerm,
+    setPinnedGroup,
+    setSelectedSignificantTerm,
+    setSelectedGroup,
+  } = useSpikeAnalysisTableRowContext();
+
+  const { documentStats, earliest, latest, searchQuery } = useData(
+    { selectedDataView: dataView, selectedSavedSearch },
+    'explain_log_rage_spikes',
+    aiopsListState,
+    setGlobalState,
+    currentSelectedSignificantTerm,
+    currentSelectedGroup
+  );
+
+  const { sampleProbability, totalCount, documentCountStats, documentCountStatsCompare } =
+    documentStats;
+
+  function clearSelection() {
+    setWindowParameters(undefined);
+    setPinnedSignificantTerm(null);
+    setPinnedGroup(null);
+    setSelectedSignificantTerm(null);
+    setSelectedGroup(null);
+  }
+
+  return (
+    <EuiResizableContainer style={{ height: '400px' }} direction="vertical">
+      {(EuiResizablePanel, EuiResizableButton) => (
+        <>
+          <EuiResizablePanel
+            mode={'collapsible'}
+            initialSize={60}
+            minSize="40%"
+            tabIndex={0}
+            paddingSize="s"
+          >
+            {documentCountStats !== undefined && (
+              <EuiFlexItem>
+                <DocumentCountContent
+                  brushSelectionUpdateHandler={setWindowParameters}
+                  clearSelectionHandler={clearSelection}
+                  documentCountStats={documentCountStats}
+                  documentCountStatsSplit={documentCountStatsCompare}
+                  documentCountStatsSplitLabel={getDocumentCountStatsSplitLabel(
+                    currentSelectedSignificantTerm,
+                    currentSelectedGroup
+                  )}
+                  showTotalCount={showTotalCount}
+                  totalCount={totalCount}
+                  sampleProbability={sampleProbability}
+                  windowParameters={windowParameters}
+                />
+              </EuiFlexItem>
+            )}
+            <EuiHorizontalRule />
+          </EuiResizablePanel>
+          {/* <EuiResizableButton /> */}
+          <EuiResizablePanel
+            paddingSize="s"
+            mode={'main'}
+            initialSize={80}
+            minSize="10%"
+            tabIndex={0}
+          >
+            <EuiFlexItem>
+              {earliest !== undefined && latest !== undefined && windowParameters !== undefined && (
+                <ExplainLogRateSpikesAnalysis
+                  dataView={dataView}
+                  earliest={earliest}
+                  latest={latest}
+                  windowParameters={windowParameters}
+                  searchQuery={searchQuery}
+                  sampleProbability={sampleProbability}
+                />
+              )}
+              {windowParameters === undefined && (
+                <EuiEmptyPrompt
+                  color="subdued"
+                  hasShadow={false}
+                  hasBorder={false}
+                  css={{ minWidth: '100%' }}
+                  title={
+                    <h2>
+                      <FormattedMessage
+                        id="xpack.aiops.explainLogRateSpikesPage.emptyPromptTitle"
+                        defaultMessage="Click a spike in the histogram chart to start the analysis."
+                      />
+                    </h2>
+                  }
+                  titleSize="xs"
+                  body={
+                    <p>
+                      <FormattedMessage
+                        id="xpack.aiops.explainLogRateSpikesPage.emptyPromptBody"
+                        defaultMessage="The explain log rate spikes feature identifies statistically significant field/value combinations that contribute to a log rate spike."
+                      />
+                    </p>
+                  }
+                  data-test-subj="aiopsNoWindowParametersEmptyPrompt"
+                />
+              )}
+            </EuiFlexItem>
+          </EuiResizablePanel>
+        </>
+      )}
+    </EuiResizableContainer>
+  );
+};

--- a/x-pack/plugins/aiops/public/components/explain_log_rate_spikes/explain_log_rate_spikes_page.tsx
+++ b/x-pack/plugins/aiops/public/components/explain_log_rate_spikes/explain_log_rate_spikes_page.tsx
@@ -8,21 +8,9 @@
 import React, { useCallback, useEffect, useState, FC } from 'react';
 
 import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
-import {
-  EuiEmptyPrompt,
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiPageBody,
-  EuiPageSection,
-  EuiPanel,
-  EuiSpacer,
-} from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiPageBody, EuiPageSection, EuiSpacer } from '@elastic/eui';
 
-import { i18n } from '@kbn/i18n';
-import type { WindowParameters } from '@kbn/aiops-utils';
-import type { SignificantTerm } from '@kbn/ml-agg-utils';
 import { Filter, FilterStateStore, Query } from '@kbn/es-query';
-import { FormattedMessage } from '@kbn/i18n-react';
 import { useUrlState, usePageUrlState } from '@kbn/ml-url-state';
 
 import { useDataSource } from '../../hooks/use_data_source';
@@ -34,26 +22,11 @@ import {
   type AiOpsPageUrlState,
 } from '../../application/utils/url_state';
 
-import { DocumentCountContent } from '../document_count_content/document_count_content';
 import { SearchPanel } from '../search_panel';
-import type { GroupTableItem } from '../spike_analysis_table/types';
 import { useSpikeAnalysisTableRowContext } from '../spike_analysis_table/spike_analysis_table_row_provider';
 import { PageHeader } from '../page_header';
 
-import { ExplainLogRateSpikesAnalysis } from './explain_log_rate_spikes_analysis';
-
-function getDocumentCountStatsSplitLabel(
-  significantTerm?: SignificantTerm,
-  group?: GroupTableItem
-) {
-  if (significantTerm) {
-    return `${significantTerm?.fieldName}:${significantTerm?.fieldValue}`;
-  } else if (group) {
-    return i18n.translate('xpack.aiops.spikeAnalysisPage.documentCountStatsSplitGroupLabel', {
-      defaultMessage: 'Selected group',
-    });
-  }
-}
+import { ExplainLogRateSpikesContent } from './explain_log_rate_spikes_content';
 
 export const ExplainLogRateSpikesPage: FC = () => {
   const { data: dataService } = useAiopsAppContext();
@@ -62,10 +35,10 @@ export const ExplainLogRateSpikesPage: FC = () => {
   const {
     currentSelectedSignificantTerm,
     currentSelectedGroup,
-    setPinnedSignificantTerm,
-    setPinnedGroup,
-    setSelectedSignificantTerm,
-    setSelectedGroup,
+    // setPinnedSignificantTerm,
+    // setPinnedGroup,
+    // setSelectedSignificantTerm,
+    // setSelectedGroup,
   } = useSpikeAnalysisTableRowContext();
 
   const [aiopsListState, setAiopsListState] = usePageUrlState<AiOpsPageUrlState>(
@@ -107,10 +80,10 @@ export const ExplainLogRateSpikesPage: FC = () => {
   );
 
   const {
-    documentStats,
+    // documentStats,
     timefilter,
-    earliest,
-    latest,
+    // earliest,
+    // latest,
     searchQueryLanguage,
     searchString,
     searchQuery,
@@ -122,9 +95,6 @@ export const ExplainLogRateSpikesPage: FC = () => {
     currentSelectedSignificantTerm,
     currentSelectedGroup
   );
-
-  const { sampleProbability, totalCount, documentCountStats, documentCountStatsCompare } =
-    documentStats;
 
   useEffect(
     // TODO: Consolidate this hook/function with with Data visualizer's
@@ -140,8 +110,6 @@ export const ExplainLogRateSpikesPage: FC = () => {
     },
     [dataService.query.filterManager]
   );
-
-  const [windowParameters, setWindowParameters] = useState<WindowParameters | undefined>();
 
   useEffect(() => {
     if (globalState?.time !== undefined) {
@@ -168,14 +136,6 @@ export const ExplainLogRateSpikesPage: FC = () => {
     });
   }, [dataService, searchQueryLanguage, searchString]);
 
-  function clearSelection() {
-    setWindowParameters(undefined);
-    setPinnedSignificantTerm(null);
-    setPinnedGroup(null);
-    setSelectedSignificantTerm(null);
-    setSelectedGroup(null);
-  }
-
   return (
     <EuiPageBody data-test-subj="aiopsExplainLogRateSpikesPage" paddingSize="none" panelled={false}>
       <PageHeader />
@@ -191,61 +151,12 @@ export const ExplainLogRateSpikesPage: FC = () => {
               setSearchParams={setSearchParams}
             />
           </EuiFlexItem>
-          {documentCountStats !== undefined && (
-            <EuiFlexItem>
-              <EuiPanel paddingSize="m">
-                <DocumentCountContent
-                  brushSelectionUpdateHandler={setWindowParameters}
-                  clearSelectionHandler={clearSelection}
-                  documentCountStats={documentCountStats}
-                  documentCountStatsSplit={documentCountStatsCompare}
-                  documentCountStatsSplitLabel={getDocumentCountStatsSplitLabel(
-                    currentSelectedSignificantTerm,
-                    currentSelectedGroup
-                  )}
-                  totalCount={totalCount}
-                  sampleProbability={sampleProbability}
-                  windowParameters={windowParameters}
-                />
-              </EuiPanel>
-            </EuiFlexItem>
-          )}
-          <EuiFlexItem>
-            <EuiPanel paddingSize="m">
-              {earliest !== undefined && latest !== undefined && windowParameters !== undefined && (
-                <ExplainLogRateSpikesAnalysis
-                  dataView={dataView}
-                  earliest={earliest}
-                  latest={latest}
-                  windowParameters={windowParameters}
-                  searchQuery={searchQuery}
-                  sampleProbability={sampleProbability}
-                />
-              )}
-              {windowParameters === undefined && (
-                <EuiEmptyPrompt
-                  title={
-                    <h2>
-                      <FormattedMessage
-                        id="xpack.aiops.explainLogRateSpikesPage.emptyPromptTitle"
-                        defaultMessage="Click a spike in the histogram chart to start the analysis."
-                      />
-                    </h2>
-                  }
-                  titleSize="xs"
-                  body={
-                    <p>
-                      <FormattedMessage
-                        id="xpack.aiops.explainLogRateSpikesPage.emptyPromptBody"
-                        defaultMessage="The explain log rate spikes feature identifies statistically significant field/value combinations that contribute to a log rate spike."
-                      />
-                    </p>
-                  }
-                  data-test-subj="aiopsNoWindowParametersEmptyPrompt"
-                />
-              )}
-            </EuiPanel>
-          </EuiFlexItem>
+          <ExplainLogRateSpikesContent
+            dataView={dataView}
+            selectedSavedSearch={selectedSavedSearch}
+            aiopsListState={aiopsListState}
+            setGlobalState={setGlobalState}
+          />
         </EuiFlexGroup>
       </EuiPageSection>
     </EuiPageBody>

--- a/x-pack/plugins/aiops/public/components/spike_analysis_table/spike_analysis_table.tsx
+++ b/x-pack/plugins/aiops/public/components/spike_analysis_table/spike_analysis_table.tsx
@@ -240,7 +240,11 @@ export const SpikeAnalysisTable: FC<SpikeAnalysisTableProps> = ({
       name: i18n.translate('xpack.aiops.spikeAnalysisTable.actionsColumnName', {
         defaultMessage: 'Actions',
       }),
-      actions: [viewInDiscoverAction, viewInLogPatternAnalysisAction, copyToClipBoardAction],
+      actions: [
+        ...(viewInDiscoverAction ? [viewInDiscoverAction] : []),
+        ...(viewInLogPatternAnalysisAction ? [viewInLogPatternAnalysisAction] : []),
+        copyToClipBoardAction,
+      ],
       width: ACTIONS_COLUMN_WIDTH,
       valign: 'middle',
     },

--- a/x-pack/plugins/aiops/public/components/spike_analysis_table/spike_analysis_table_groups.tsx
+++ b/x-pack/plugins/aiops/public/components/spike_analysis_table/spike_analysis_table_groups.tsx
@@ -59,6 +59,7 @@ interface SpikeAnalysisTableProps {
   searchQuery: estypes.QueryDslQueryContainer;
   timeRangeMs: TimeRangeMs;
   dataView: DataView;
+  showActionsColumn?: boolean;
 }
 
 export const SpikeAnalysisGroupsTable: FC<SpikeAnalysisTableProps> = ({
@@ -68,6 +69,7 @@ export const SpikeAnalysisGroupsTable: FC<SpikeAnalysisTableProps> = ({
   dataView,
   timeRangeMs,
   searchQuery,
+  showActionsColumn,
 }) => {
   const [pageIndex, setPageIndex] = useState(0);
   const [pageSize, setPageSize] = useState(10);
@@ -350,10 +352,14 @@ export const SpikeAnalysisGroupsTable: FC<SpikeAnalysisTableProps> = ({
     },
     {
       'data-test-subj': 'aiOpsSpikeAnalysisTableColumnAction',
-      name: i18n.translate('xpack.aiops.spikeAnalysisTable.actionsColumnName', {
+      name: i18n.translate('xpack.aiops.aiopsSpikeAnalysisGroupsTable.actionsColumnName', {
         defaultMessage: 'Actions',
       }),
-      actions: [viewInDiscoverAction, viewInLogPatternAnalysisAction, copyToClipBoardAction],
+      actions: [
+        ...(viewInDiscoverAction ? [viewInDiscoverAction] : []),
+        ...(viewInLogPatternAnalysisAction ? [viewInLogPatternAnalysisAction] : []),
+        copyToClipBoardAction,
+      ],
       width: ACTIONS_COLUMN_WIDTH,
       valign: 'top',
     },

--- a/x-pack/plugins/aiops/public/components/spike_analysis_table/use_view_in_discover_action.tsx
+++ b/x-pack/plugins/aiops/public/components/spike_analysis_table/use_view_in_discover_action.tsx
@@ -24,12 +24,12 @@ const viewInDiscoverMessage = i18n.translate(
   }
 );
 
-export const useViewInDiscoverAction = (dataViewId?: string): TableItemAction => {
+export const useViewInDiscoverAction = (dataViewId?: string): TableItemAction | undefined => {
   const { application, share, data } = useAiopsAppContext();
 
   const discoverLocator = useMemo(
-    () => share.url.locators.get('DISCOVER_APP_LOCATOR'),
-    [share.url.locators]
+    () => share?.url?.locators.get('DISCOVER_APP_LOCATOR'),
+    [share?.url?.locators]
   );
 
   const discoverUrlError = useMemo(() => {

--- a/x-pack/plugins/aiops/public/components/spike_analysis_table/use_view_in_log_pattern_analysis_action.tsx
+++ b/x-pack/plugins/aiops/public/components/spike_analysis_table/use_view_in_log_pattern_analysis_action.tsx
@@ -29,7 +29,10 @@ const viewInLogPatternAnalysisMessage = i18n.translate(
 export const useViewInLogPatternAnalysisAction = (dataViewId?: string): TableItemAction => {
   const { application, share, data } = useAiopsAppContext();
 
-  const mlLocator = useMemo(() => share.url.locators.get('ML_APP_LOCATOR'), [share.url.locators]);
+  const mlLocator = useMemo(
+    () => share?.url?.locators.get('ML_APP_LOCATOR'),
+    [share?.url?.locators]
+  );
 
   const generateLogPatternAnalysisUrl = async (
     groupTableItem: GroupTableItem | SignificantTerm

--- a/x-pack/plugins/aiops/public/plugin.ts
+++ b/x-pack/plugins/aiops/public/plugin.ts
@@ -5,8 +5,9 @@
  * 2.0.
  */
 
-import type { CoreStart, Plugin } from '@kbn/core/public';
+import type { CoreSetup, CoreStart, Plugin } from '@kbn/core/public';
 import { firstValueFrom } from 'rxjs';
+import { registerEmbeddables } from './components/explain_log_rate_spikes/embeddables';
 
 import {
   AiopsPluginSetup,
@@ -18,8 +19,11 @@ import {
 export class AiopsPlugin
   implements Plugin<AiopsPluginSetup, AiopsPluginStart, AiopsPluginSetupDeps, AiopsPluginStartDeps>
 {
-  public setup() {
-    return {};
+  public setup(
+    core: CoreSetup<AiopsPluginStartDeps, AiopsPluginStart>,
+    plugins: AiopsPluginSetupDeps
+  ) {
+    registerEmbeddables(plugins.embeddable, core);
   }
 
   public start(core: CoreStart, plugins: AiopsPluginStartDeps) {

--- a/x-pack/plugins/aiops/public/types.ts
+++ b/x-pack/plugins/aiops/public/types.ts
@@ -12,24 +12,31 @@ import type { FieldFormatsStart } from '@kbn/field-formats-plugin/public';
 import type { IStorageWrapper } from '@kbn/kibana-utils-plugin/public';
 import type { LensPublicStart } from '@kbn/lens-plugin/public';
 import type { LicensingPluginStart } from '@kbn/licensing-plugin/public';
-import type { SharePluginStart } from '@kbn/share-plugin/public';
+import type { SharePluginStart, SharePluginSetup } from '@kbn/share-plugin/public';
 import type { UiActionsStart } from '@kbn/ui-actions-plugin/public';
 import type { UnifiedSearchPublicPluginStart } from '@kbn/unified-search-plugin/public';
+import type { EmbeddableSetup, EmbeddableStart } from '@kbn/embeddable-plugin/public';
+import type { DiscoverSetup, DiscoverStart } from '@kbn/discover-plugin/public';
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface AiopsPluginSetupDeps {}
+export interface AiopsPluginSetupDeps {
+  embeddable: EmbeddableSetup;
+  share: SharePluginSetup;
+  discover: DiscoverSetup;
+}
 
 export interface AiopsPluginStartDeps {
-  data: DataPublicPluginStart;
   charts: ChartsPluginStart;
-  uiActions: UiActionsStart;
+  data: DataPublicPluginStart;
+  discover: DiscoverStart;
+  embeddable: EmbeddableStart;
+  executionContext: ExecutionContextStart;
   fieldFormats: FieldFormatsStart;
   lens: LensPublicStart;
-  share: SharePluginStart;
-  unifiedSearch: UnifiedSearchPublicPluginStart;
-  storage: IStorageWrapper;
   licensing: LicensingPluginStart;
-  executionContext: ExecutionContextStart;
+  share: SharePluginStart;
+  storage: IStorageWrapper;
+  uiActions: UiActionsStart;
+  unifiedSearch: UnifiedSearchPublicPluginStart;
 }
 
 /**

--- a/x-pack/plugins/aiops/tsconfig.json
+++ b/x-pack/plugins/aiops/tsconfig.json
@@ -54,6 +54,7 @@
     "@kbn/unified-field-list-plugin",
     "@kbn/unified-search-plugin",
     "@kbn/utility-types",
+    "@kbn/embeddable-plugin",
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
## Summary

This PR creates a separate component encompassing just the histogram and analysis parts of the UI and creates an embeddable with that component to be used in Discover

<img width="1323" alt="image" src="https://github.com/elastic/kibana/assets/6446462/2165dcd1-4027-4862-87be-dd0f1c69eef1">



### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)
