### PR TITLE
[DOCS] Replace description attributes with frontmatter for migration

### DIFF
--- a/docs/management/maintenance-windows/maintenance-windows.asciidoc
+++ b/docs/management/maintenance-windows/maintenance-windows.asciidoc
@@ -1,9 +1,10 @@
 [[maintenance-windows]]
 == Maintenance windows
-:description: Maintenance windows enable you to suppress rule notifications.
-:tags-products: [kibana, alerting] 
-:tags-content-type: [overview] 
-:tags-user-goals: [manage]
+
+:frontmatter-description: Maintenance windows enable you to suppress rule notifications.
+:frontmatter-tags-products: [kibana, alerting] 
+:frontmatter-tags-content-type: [overview] 
+:frontmatter-tags-user-goals: [manage]
 
 preview::[]
 

--- a/docs/management/manage-data-views.asciidoc
+++ b/docs/management/manage-data-views.asciidoc
@@ -1,7 +1,8 @@
 [[managing-data-views]]
 == Manage data views
-:keywords: administrator, data view, data views, management, runtime fields, runtime fields in Kibana, scripted fields, field formatters, data fields, index pattern, index patterns
-:description: Conceptual and step-by-step procedures for using runtime fields, scripted fields, and field formatters.
+
+:frontmatter-description: Conceptual and step-by-step procedures for using runtime fields, scripted fields, and field formatters.
+:frontmatter-tags-products: [kibana]
 
 To customize the data fields in your data view,
 you can add runtime fields to the existing documents,

--- a/docs/settings/alert-action-settings.asciidoc
+++ b/docs/settings/alert-action-settings.asciidoc
@@ -4,10 +4,10 @@
 <titleabbrev>Alerting and action settings</titleabbrev>
 ++++
 
-:description: Learn about the settings that affect {kib} {alert-features}.
-:tags-products: [kibana, alerting]
-:tags-content-type: [reference]
-:tags-user-goals: [configure]
+:frontmatter-description: Learn about the settings that affect {kib} {alert-features}.
+:frontmatter-tags-products: [kibana, alerting] 
+:frontmatter-tags-content-type: [reference] 
+:frontmatter-tags-user-goals: [configure]
 
 Alerting and actions are enabled by default in {kib}, but require you to configure the following:
 

--- a/docs/settings/reporting-settings.asciidoc
+++ b/docs/settings/reporting-settings.asciidoc
@@ -4,8 +4,11 @@
 ++++
 <titleabbrev>Reporting settings</titleabbrev>
 ++++
-:keywords: administrator, reference, setup, reporting
-:description: A reference of the reporting settings administrators configure in kibana.yml.
+
+:frontmatter-description: A reference of the reporting settings administrators configure in kibana.yml.
+:frontmatter-tags-products: [kibana] 
+:frontmatter-tags-content-type: [reference] 
+:frontmatter-tags-user-goals: [configure]
 
 You can configure `xpack.reporting` settings in your `kibana.yml` to:
 

--- a/docs/user/dashboard/make-dashboards-interactive.asciidoc
+++ b/docs/user/dashboard/make-dashboards-interactive.asciidoc
@@ -2,10 +2,10 @@
 [[drilldowns]]
 == Make dashboards interactive
 
-:keywords: administrator, analyst, concept, task, analyze, dashboard, controls, range slider, options list, author, drilldowns
-:description: Add interactive capabilities to your dashboard, such as controls that allow \
-you to apply dashboard-level filters, and drilldowns that allow you to navigate to other \
-dashboards and external websites.
+:frontmatter-description: Add interactive filter and navigation capabilities to your dashboard.
+:frontmatter-tags-products: [kibana] 
+:frontmatter-tags-content-type: [how-to] 
+:frontmatter-tags-user-goals: [analyze, visualize]
 
 Add interactive capabilities to your dashboard, such as interactive filter controls, and drilldowns that allow you to navigate to *Discover*, other dashboards, and external websites. 
 

--- a/docs/user/production-considerations/reporting-production-considerations.asciidoc
+++ b/docs/user/production-considerations/reporting-production-considerations.asciidoc
@@ -5,8 +5,9 @@
 ++++
 <titleabbrev>Reporting</titleabbrev>
 ++++
-:keywords: administrator, analyst, concept, setup, reporting
-:description: Consider the production components that are used to generate reports.
+
+:frontmatter-description: Consider the production components that are used to generate reports.
+:frontmatter-tags-products: [kibana]
 
 To generate reports, {kib} uses the Chromium web browser, which runs on the server in headless mode. Chromium is an open-source project not related to Elastic, and is embedded into {kib}. Chromium may require additional OS dependencies to run properly.
 

--- a/docs/user/production-considerations/security-production-considerations.asciidoc
+++ b/docs/user/production-considerations/security-production-considerations.asciidoc
@@ -5,8 +5,9 @@
 ++++
 <titleabbrev>Security</titleabbrev>
 ++++
-:keywords: administrator, analyst, concept, setup, security
-:description: Consider the production components for {kib} security.
+
+:frontmatter-description: Consider the production components for {kib} security.
+:frontmatter-tags-products: [kibana]
 
 To secure your {kib} installation in production, consider these high-priority topics to ensure
 that only authorized users can access {kib}.

--- a/docs/user/reporting/index.asciidoc
+++ b/docs/user/reporting/index.asciidoc
@@ -1,13 +1,11 @@
-[role="xpack"]
 [[reporting-getting-started]]
 = Reporting and sharing
 
 [partintro]
 
 --
-
-:keywords: analyst, concept, task, reporting
-:description: {kib} provides you with several options to share *Discover* saved searches, dashboards, *Visualize Library* visualizations, and *Canvas* workpads with others, or on a website.
+:frontmatter-description: {kib} provides you with several options to share *Discover* saved searches, dashboards, *Visualize Library* visualizations, and *Canvas* workpads with others, or on a website.
+:frontmatter-tags-products: [kibana]
 
 {kib} provides you with several options to share *Discover* saved searches, dashboards, *Visualize Library* visualizations, and *Canvas* workpads.
 

--- a/docs/user/security/authentication/index.asciidoc
+++ b/docs/user/security/authentication/index.asciidoc
@@ -1,11 +1,11 @@
-[role="xpack"]
 [[kibana-authentication]]
 === Authentication in {kib}
 ++++
 <titleabbrev>Authentication</titleabbrev>
 ++++
-:keywords: administrator, concept, security, authentication
-:description: A list of the supported authentication mechanisms in {kib}.
+
+:frontmatter-description: A list of the supported authentication mechanisms in {kib}.
+:frontmatter-tags-products: [kibana]
 
 {kib} supports the following authentication mechanisms:
 


### PR DESCRIPTION
## Summary

This PR updates pages that use `description` attributes to use `:frontmatter-description:` instead. It also adds the other frontmatter attributes if they seemed obvious.

<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->