### PR TITLE
[Security Solution] Options on `Create Control` flyout are shrunken to top left corner.

### DIFF
--- a/src/plugins/controls/public/control_group/editor/control_editor.tsx
+++ b/src/plugins/controls/public/control_group/editor/control_editor.tsx
@@ -172,7 +172,7 @@ export const ControlEditor = ({
         </EuiTitle>
       </EuiFlyoutHeader>
       <EuiFlyoutBody data-test-subj="control-editor-flyout">
-        <EuiForm>
+        <EuiForm fullWidth>
           {!editorConfig?.hideDataViewSelector && (
             <EuiFormRow label={ControlGroupStrings.manageControl.getDataViewTitle()}>
               <DataViewPicker


### PR DESCRIPTION
## What does this PR do?
* This PR fixes the width of the form on the `Create Control` flyout .

## Issue References
* https://github.com/elastic/kibana/issues/157864

## Video/Screenshot Demo 

###### BEFORE:
![image](https://github.com/GitStartHQ/client-kibana-oss/assets/50892465/095b1d90-4231-4909-a8b2-885efff8f8aa)

###### THEN:
![image](https://github.com/GitStartHQ/client-kibana-oss/assets/50892465/ea48f1db-64cf-4d17-b67b-0fa223b7193a)

---
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.

