### PR TITLE
[Security Solution] The "Create a New Case Modal" is currently being blocked by the "Top N Popup"

### DIFF
--- a/x-pack/plugins/security_solution/public/actions/show_top_n/show_top_n_component.tsx
+++ b/x-pack/plugins/security_solution/public/actions/show_top_n/show_top_n_component.tsx
@@ -44,6 +44,7 @@ export const TopNAction = ({
         repositionOnScroll
         ownFocus
         attachToAnchor={false}
+        zIndex={1000}
       >
         <StatefulTopN
           field={field.name}


### PR DESCRIPTION
## What does this PR do?
* The fix implemented in this PR is to modify the code so that the Create a New Case Modal is no longer obscured by the Top N Popup. This will allow users to access the Create a New Case feature seamlessly without any hindrance.

## Issue References
* https://github.com/elastic/kibana/issues/157732 

## Video/Screenshot Demo 

###### FIX:

https://github.com/GitStartHQ/client-kibana-oss/assets/57623705/89b2fa8a-4937-4fa3-a022-2ce45b5a7f07

---
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.

