### PR TITLE
docs(kibana): fix md syntax, first dev login details

### DIFF
--- a/dev_docs/getting_started/setting_up_a_development_env.mdx
+++ b/dev_docs/getting_started/setting_up_a_development_env.mdx
@@ -75,11 +75,13 @@ In another terminal tab/window you can start Kibana.
 yarn start
 ```
 
-Include developer examples](https://github.com/elastic/kibana/tree/main/examples) by adding an optional `--run-examples` flag. Read more about the advanced options for [Running Kibana](https://www.elastic.co/guide/en/kibana/current/running-kibana-advanced.html).
+Include developer [examples](https://github.com/elastic/kibana/tree/main/examples) by adding an optional `--run-examples` flag. Read more about the advanced options for [Running Kibana](https://www.elastic.co/guide/en/kibana/current/running-kibana-advanced.html).
+You will find the development server running on (http://localhost:5601) - and you can log in with the `elastic:changeme` credential pair.
 
 ## Code away!
 
-You are now ready to start developing. Changes to the source files should be picked up automatically and either cause the server to restart, or be served to the browser on the next page refresh.
+You are now ready to start developing. 
+Changes to the source files should be picked up automatically and either cause the server to restart, or be served to the browser on the next page refresh.
 
 ## Install pre-commit hook (optional)
 


### PR DESCRIPTION
## Summary
Fixing very minor issues in the Kibana dev docs that I found as I was getting bootstrapped:
 - fixing bad markdown syntax
 - adding first startup info (url + credentials)

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
