### PR TITLE
[Response Ops][Task Manager] Add `kibana.yml` setting for disabling authentication for background task utilization public API

### DIFF
--- a/x-pack/plugins/task_manager/server/config.test.ts
+++ b/x-pack/plugins/task_manager/server/config.test.ts
@@ -40,6 +40,7 @@ describe('config validation', () => {
         "poll_interval": 3000,
         "request_capacity": 1000,
         "unsafe": Object {
+          "authenticate_background_task_utilization": true,
           "exclude_task_types": Array [],
         },
         "version_conflict_threshold": 80,
@@ -91,6 +92,7 @@ describe('config validation', () => {
         "poll_interval": 3000,
         "request_capacity": 1000,
         "unsafe": Object {
+          "authenticate_background_task_utilization": true,
           "exclude_task_types": Array [],
         },
         "version_conflict_threshold": 80,
@@ -145,6 +147,7 @@ describe('config validation', () => {
         "poll_interval": 3000,
         "request_capacity": 1000,
         "unsafe": Object {
+          "authenticate_background_task_utilization": true,
           "exclude_task_types": Array [],
         },
         "version_conflict_threshold": 80,

--- a/x-pack/plugins/task_manager/server/config.ts
+++ b/x-pack/plugins/task_manager/server/config.ts
@@ -135,6 +135,7 @@ export const configSchema = schema.object(
     /* These are not designed to be used by most users. Please use caution when changing these */
     unsafe: schema.object({
       exclude_task_types: schema.arrayOf(schema.string(), { defaultValue: [] }),
+      authenticate_background_task_utilization: schema.boolean({ defaultValue: true }),
     }),
   },
   {

--- a/x-pack/plugins/task_manager/server/ephemeral_task_lifecycle.test.ts
+++ b/x-pack/plugins/task_manager/server/ephemeral_task_lifecycle.test.ts
@@ -71,6 +71,7 @@ describe('EphemeralTaskLifecycle', () => {
         },
         unsafe: {
           exclude_task_types: [],
+          authenticate_background_task_utilization: true,
         },
         event_loop_delay: {
           monitor: true,

--- a/x-pack/plugins/task_manager/server/integration_tests/managed_configuration.test.ts
+++ b/x-pack/plugins/task_manager/server/integration_tests/managed_configuration.test.ts
@@ -66,6 +66,7 @@ describe('managed configuration', () => {
       },
       unsafe: {
         exclude_task_types: [],
+        authenticate_background_task_utilization: true,
       },
       event_loop_delay: {
         monitor: true,

--- a/x-pack/plugins/task_manager/server/monitoring/configuration_statistics.test.ts
+++ b/x-pack/plugins/task_manager/server/monitoring/configuration_statistics.test.ts
@@ -39,6 +39,7 @@ describe('Configuration Statistics Aggregator', () => {
       },
       unsafe: {
         exclude_task_types: [],
+        authenticate_background_task_utilization: true,
       },
       event_loop_delay: {
         monitor: true,

--- a/x-pack/plugins/task_manager/server/monitoring/monitoring_stats_stream.test.ts
+++ b/x-pack/plugins/task_manager/server/monitoring/monitoring_stats_stream.test.ts
@@ -43,6 +43,7 @@ describe('createMonitoringStatsStream', () => {
     },
     unsafe: {
       exclude_task_types: [],
+      authenticate_background_task_utilization: true,
     },
     event_loop_delay: {
       monitor: true,

--- a/x-pack/plugins/task_manager/server/plugin.test.ts
+++ b/x-pack/plugins/task_manager/server/plugin.test.ts
@@ -64,6 +64,7 @@ const pluginInitializerContextParams = {
   },
   unsafe: {
     exclude_task_types: [],
+    authenticate_background_task_utilization: true,
   },
   event_loop_delay: {
     monitor: true,
@@ -101,6 +102,7 @@ describe('TaskManagerPlugin', () => {
         ...pluginInitializerContextParams,
         unsafe: {
           exclude_task_types: ['*'],
+          authenticate_background_task_utilization: true,
         },
       });
 
@@ -110,6 +112,24 @@ describe('TaskManagerPlugin', () => {
       expect((logger.warn as jest.Mock).mock.calls.length).toBe(1);
       expect((logger.warn as jest.Mock).mock.calls[0][0]).toBe(
         'Excluding task types from execution: *'
+      );
+    });
+
+    test('it logs a warning when the unsafe `authenticate_background_task_utilization` config is set to false', async () => {
+      const pluginInitializerContext = coreMock.createPluginInitializerContext<TaskManagerConfig>({
+        ...pluginInitializerContextParams,
+        unsafe: {
+          exclude_task_types: [],
+          authenticate_background_task_utilization: false,
+        },
+      });
+
+      const logger = pluginInitializerContext.logger.get();
+      const taskManagerPlugin = new TaskManagerPlugin(pluginInitializerContext);
+      taskManagerPlugin.setup(coreMock.createSetup(), { usageCollection: undefined });
+      expect((logger.warn as jest.Mock).mock.calls.length).toBe(1);
+      expect((logger.warn as jest.Mock).mock.calls[0][0]).toBe(
+        'Disabling authentication for background task utilization API'
       );
     });
   });

--- a/x-pack/plugins/task_manager/server/plugin.ts
+++ b/x-pack/plugins/task_manager/server/plugin.ts
@@ -180,6 +180,10 @@ export class TaskManagerPlugin
       );
     }
 
+    if (this.config.unsafe.authenticate_background_task_utilization === false) {
+      this.logger.warn(`Disabling authentication for background task utilization API`);
+    }
+
     return {
       index: TASK_MANAGER_INDEX,
       addMiddleware: (middleware: Middleware) => {

--- a/x-pack/plugins/task_manager/server/polling_lifecycle.test.ts
+++ b/x-pack/plugins/task_manager/server/polling_lifecycle.test.ts
@@ -69,6 +69,7 @@ describe('TaskPollingLifecycle', () => {
       },
       unsafe: {
         exclude_task_types: [],
+        authenticate_background_task_utilization: true,
       },
       event_loop_delay: {
         monitor: true,

--- a/x-pack/plugins/task_manager/server/routes/background_task_utilization.test.ts
+++ b/x-pack/plugins/task_manager/server/routes/background_task_utilization.test.ts
@@ -56,10 +56,42 @@ describe('backgroundTaskUtilizationRoute', () => {
     expect(config1.path).toMatchInlineSnapshot(
       `"/internal/task_manager/_background_task_utilization"`
     );
+    expect(config1.options?.authRequired).toEqual(true);
 
     const [config2] = router.get.mock.calls[1];
 
     expect(config2.path).toMatchInlineSnapshot(`"/api/task_manager/_background_task_utilization"`);
+    expect(config2.options?.authRequired).toEqual(true);
+  });
+
+  it(`sets "authRequired" to false when config.unsafe.authenticate_background_task_utilization is set to false`, async () => {
+    const router = httpServiceMock.createRouter();
+    backgroundTaskUtilizationRoute({
+      router,
+      monitoringStats$: of(),
+      logger,
+      taskManagerId: uuidv4(),
+      config: {
+        ...getTaskManagerConfig(),
+        unsafe: { exclude_task_types: [], authenticate_background_task_utilization: false },
+      },
+      kibanaVersion: '8.0',
+      kibanaIndexName: '.kibana',
+      getClusterClient: () => Promise.resolve(elasticsearchServiceMock.createClusterClient()),
+      usageCounter: mockUsageCounter,
+    });
+
+    const [config1] = router.get.mock.calls[0];
+
+    expect(config1.path).toMatchInlineSnapshot(
+      `"/internal/task_manager/_background_task_utilization"`
+    );
+    expect(config1.options?.authRequired).toEqual(true);
+
+    const [config2] = router.get.mock.calls[1];
+
+    expect(config2.path).toMatchInlineSnapshot(`"/api/task_manager/_background_task_utilization"`);
+    expect(config2.options?.authRequired).toEqual(false);
   });
 
   it('checks user privileges and increments usage counter when API is accessed', async () => {
@@ -169,6 +201,34 @@ describe('backgroundTaskUtilizationRoute', () => {
     await handler(context, req, res);
 
     expect(mockScopedClusterClient.asCurrentUser.security.hasPrivileges).not.toHaveBeenCalled();
+  });
+
+  it(`skips checking user privileges for public API if config.unsafe.authenticate_background_task_utilization is set to false`, async () => {
+    const { mockClusterClient, mockScopedClusterClient } = createMockClusterClient({
+      has_all_requested: false,
+    } as SecurityHasPrivilegesResponse);
+    const router = httpServiceMock.createRouter();
+    backgroundTaskUtilizationRoute({
+      router,
+      monitoringStats$: of(),
+      logger,
+      taskManagerId: uuidv4(),
+      config: {
+        ...getTaskManagerConfig(),
+        unsafe: { exclude_task_types: [], authenticate_background_task_utilization: false },
+      },
+      kibanaVersion: '8.0',
+      kibanaIndexName: 'foo',
+      getClusterClient: () => Promise.resolve(mockClusterClient),
+      usageCounter: mockUsageCounter,
+    });
+
+    const [, handler] = router.get.mock.calls[1];
+    const [context, req, res] = mockHandlerArguments({}, {}, ['ok']);
+    await handler(context, req, res);
+
+    expect(mockScopedClusterClient.asCurrentUser.security.hasPrivileges).not.toHaveBeenCalled();
+    expect(mockUsageCounter.incrementCounter).not.toHaveBeenCalled();
   });
 
   it(`logs an error if the utilization stats are null`, async () => {


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/158109

## Summary

Adds `xpack.task_manager.unsafe.authenticate_background_task_utilization` that will disable authentication on the public API for accessing background task utilization. 

## To Verify
- Run ES and Kibana, then access https://localhost:5601/api/task_manager/_background_task_utilization without logging into Kibana. Verify you get a `401` unauthorized error
- Set `xpack.task_manager.unsafe.authenticate_background_task_utilization: false` in your Kibana config and restart Kibana
- Verify you can access https://localhost:5601/api/task_manager/_background_task_utilization without logging in
- Verify that you still get a 401 unauthorized error for the internal API at https://localhost:5601/internal/task_manager/_background_task_utilization
