### PR TITLE
[Serverless] Disable UI of Users, Roles, and Role Mappings

### DIFF
--- a/config/serverless.yml
+++ b/config/serverless.yml
@@ -19,6 +19,11 @@ xpack.license_management.enabled: false
 xpack.reporting.enabled: false
 xpack.cloud_integrations.data_migration.enabled: false
 
+# Disabled plugin UIs
+xpack.security.ui.usersEnabled: false
+xpack.security.ui.rolesEnabled: false
+xpack.security.ui.roleMappingsEnabled: false
+
 # Enforce restring access to internal APIs see https://github.com/elastic/kibana/issues/151940
 # server.restrictInternalApis: true
 # Telemetry enabled by default and not disableable via UI

--- a/config/serverless.yml
+++ b/config/serverless.yml
@@ -19,11 +19,6 @@ xpack.license_management.enabled: false
 xpack.reporting.enabled: false
 xpack.cloud_integrations.data_migration.enabled: false
 
-# Disabled plugin UIs
-xpack.security.ui.usersEnabled: false
-xpack.security.ui.rolesEnabled: false
-xpack.security.ui.roleMappingsEnabled: false
-
 # Enforce restring access to internal APIs see https://github.com/elastic/kibana/issues/151940
 # server.restrictInternalApis: true
 # Telemetry enabled by default and not disableable via UI

--- a/src/plugins/management/public/index.ts
+++ b/src/plugins/management/public/index.ts
@@ -21,7 +21,6 @@ export type {
   ManagementSetup,
   ManagementStart,
   DefinedSections,
-  ClientConfigType,
 } from './types';
 
 export { MANAGEMENT_APP_ID } from '../common/contants';

--- a/src/plugins/management/public/index.ts
+++ b/src/plugins/management/public/index.ts
@@ -21,6 +21,7 @@ export type {
   ManagementSetup,
   ManagementStart,
   DefinedSections,
+  ClientConfigType,
 } from './types';
 
 export { MANAGEMENT_APP_ID } from '../common/contants';

--- a/src/plugins/management/public/types.ts
+++ b/src/plugins/management/public/types.ts
@@ -78,9 +78,3 @@ export interface CreateManagementItemArgs {
   capabilitiesId?: string; // overrides app id
   redirectFrom?: string; // redirects from an old app id to the current app id
 }
-
-export interface ClientConfigType {
-  usersEnabled: boolean;
-  rolesEnabled: boolean;
-  roleMappingsEnabled: boolean;
-}

--- a/src/plugins/management/public/types.ts
+++ b/src/plugins/management/public/types.ts
@@ -78,3 +78,9 @@ export interface CreateManagementItemArgs {
   capabilitiesId?: string; // overrides app id
   redirectFrom?: string; // redirects from an old app id to the current app id
 }
+
+export interface ClientConfigType {
+  usersEnabled: boolean;
+  rolesEnabled: boolean;
+  roleMappingsEnabled: boolean;
+}

--- a/test/plugin_functional/test_suites/core_plugins/rendering.ts
+++ b/test/plugin_functional/test_suites/core_plugins/rendering.ts
@@ -224,9 +224,7 @@ export default function ({ getService }: PluginFunctionalProviderContext) {
         'xpack.security.sameSiteCookies (alternatives)',
         'xpack.security.showInsecureClusterWarning (boolean)',
         'xpack.security.showNavLinks (boolean)',
-        'xpack.security.ui.roleMappingsEnabled (boolean)',
-        'xpack.security.ui.rolesEnabled (boolean)',
-        'xpack.security.ui.usersEnabled (boolean)',
+        'xpack.security.ui (any)',
         'xpack.securitySolution.enableExperimental (array)',
         'xpack.securitySolution.prebuiltRulesPackageVersion (string)',
         'xpack.snapshot_restore.slm_ui.enabled (boolean)',
@@ -275,9 +273,7 @@ export default function ({ getService }: PluginFunctionalProviderContext) {
         'xpack.security.sameSiteCookies (alternatives)',
         'xpack.security.showInsecureClusterWarning (boolean)',
         'xpack.security.showNavLinks (boolean)',
-        'xpack.security.ui.roleMappingsEnabled (boolean)',
-        'xpack.security.ui.rolesEnabled (boolean)',
-        'xpack.security.ui.usersEnabled (boolean)',
+        'xpack.security.ui (any)',
       ];
       // We don't assert that actualExposedConfigKeys and expectedExposedConfigKeys are equal, because test failure messages with large
       // arrays are hard to grok. Instead, we take the difference between the two arrays and assert them separately, that way it's

--- a/test/plugin_functional/test_suites/core_plugins/rendering.ts
+++ b/test/plugin_functional/test_suites/core_plugins/rendering.ts
@@ -224,6 +224,9 @@ export default function ({ getService }: PluginFunctionalProviderContext) {
         'xpack.security.sameSiteCookies (alternatives)',
         'xpack.security.showInsecureClusterWarning (boolean)',
         'xpack.security.showNavLinks (boolean)',
+        'xpack.security.ui.roleMappingsEnabled (boolean)',
+        'xpack.security.ui.rolesEnabled (boolean)',
+        'xpack.security.ui.usersEnabled (boolean)',
         'xpack.securitySolution.enableExperimental (array)',
         'xpack.securitySolution.prebuiltRulesPackageVersion (string)',
         'xpack.snapshot_restore.slm_ui.enabled (boolean)',
@@ -272,6 +275,9 @@ export default function ({ getService }: PluginFunctionalProviderContext) {
         'xpack.security.sameSiteCookies (alternatives)',
         'xpack.security.showInsecureClusterWarning (boolean)',
         'xpack.security.showNavLinks (boolean)',
+        'xpack.security.ui.roleMappingsEnabled (boolean)',
+        'xpack.security.ui.rolesEnabled (boolean)',
+        'xpack.security.ui.usersEnabled (boolean)',
       ];
       // We don't assert that actualExposedConfigKeys and expectedExposedConfigKeys are equal, because test failure messages with large
       // arrays are hard to grok. Instead, we take the difference between the two arrays and assert them separately, that way it's

--- a/x-pack/plugins/security/public/config.ts
+++ b/x-pack/plugins/security/public/config.ts
@@ -11,8 +11,8 @@ export interface ConfigType {
   sameSiteCookies: 'Strict' | 'Lax' | 'None' | undefined;
   showNavLinks: boolean;
   ui: {
-    usersEnabled: boolean;
-    rolesEnabled: boolean;
-    roleMappingsEnabled: boolean;
+    userManagementEnabled: boolean;
+    roleManagementEnabled: boolean;
+    roleMappingManagementEnabled: boolean;
   };
 }

--- a/x-pack/plugins/security/public/config.ts
+++ b/x-pack/plugins/security/public/config.ts
@@ -10,4 +10,9 @@ export interface ConfigType {
   showInsecureClusterWarning: boolean;
   sameSiteCookies: 'Strict' | 'Lax' | 'None' | undefined;
   showNavLinks: boolean;
+  ui: {
+    usersEnabled: boolean;
+    rolesEnabled: boolean;
+    roleMappingsEnabled: boolean;
+  };
 }

--- a/x-pack/plugins/security/public/management/management_service.test.ts
+++ b/x-pack/plugins/security/public/management/management_service.test.ts
@@ -9,6 +9,7 @@ import { BehaviorSubject } from 'rxjs';
 
 import { coreMock } from '@kbn/core/public/mocks';
 import type {
+  ClientConfigType,
   DefinedSections,
   ManagementApp,
   ManagementSetup,
@@ -43,6 +44,12 @@ describe('ManagementService', () => {
         locator: {} as any,
       };
 
+      const uiConfig: ClientConfigType = {
+        usersEnabled: true,
+        rolesEnabled: true,
+        roleMappingsEnabled: true,
+      };
+
       const service = new ManagementService();
       service.setup({
         getStartServices: getStartServices as any,
@@ -50,6 +57,7 @@ describe('ManagementService', () => {
         fatalErrors,
         authc,
         management: managementSetup,
+        uiConfig,
       });
 
       expect(mockSection.registerApp).toHaveBeenCalledTimes(4);
@@ -105,12 +113,19 @@ describe('ManagementService', () => {
         locator: {} as any,
       };
 
+      const uiConfig: ClientConfigType = {
+        usersEnabled: true,
+        rolesEnabled: true,
+        roleMappingsEnabled: true,
+      };
+
       service.setup({
         getStartServices: getStartServices as any,
         license,
         fatalErrors,
         authc: securityMock.createSetup().authc,
         management: managementSetup,
+        uiConfig,
       });
 
       const getMockedApp = (id: string) => {
@@ -150,6 +165,7 @@ describe('ManagementService', () => {
           navLinks: {},
           catalogue: {},
         },
+        uiConfig,
       });
 
       return {

--- a/x-pack/plugins/security/public/management/management_service.ts
+++ b/x-pack/plugins/security/public/management/management_service.ts
@@ -9,7 +9,6 @@ import type { Subscription } from 'rxjs';
 
 import type { Capabilities, FatalErrorsSetup, StartServicesAccessor } from '@kbn/core/public';
 import type {
-  ClientConfigType,
   ManagementApp,
   ManagementSection,
   ManagementSetup,
@@ -23,18 +22,24 @@ import { roleMappingsManagementApp } from './role_mappings';
 import { rolesManagementApp } from './roles';
 import { usersManagementApp } from './users';
 
+export interface ManagementAppConfigType {
+  userManagementEnabled: boolean;
+  roleManagementEnabled: boolean;
+  roleMappingManagementEnabled: boolean;
+}
+
 interface SetupParams {
   management: ManagementSetup;
   license: SecurityLicense;
   authc: AuthenticationServiceSetup;
   fatalErrors: FatalErrorsSetup;
   getStartServices: StartServicesAccessor<PluginStartDependencies>;
-  uiConfig: ClientConfigType;
+  uiConfig?: ManagementAppConfigType;
 }
 
 interface StartParams {
   capabilities: Capabilities;
-  uiConfig: ClientConfigType;
+  uiConfig?: ManagementAppConfigType;
 }
 
 export class ManagementService {
@@ -46,16 +51,16 @@ export class ManagementService {
     this.license = license;
     this.securitySection = management.sections.section.security;
 
-    if (uiConfig.usersEnabled) {
+    if (!uiConfig || uiConfig.userManagementEnabled) {
       this.securitySection.registerApp(usersManagementApp.create({ authc, getStartServices }));
     }
-    if (uiConfig.rolesEnabled) {
+    if (!uiConfig || uiConfig.roleManagementEnabled) {
       this.securitySection.registerApp(
         rolesManagementApp.create({ fatalErrors, license, getStartServices })
       );
     }
     this.securitySection.registerApp(apiKeysManagementApp.create({ authc, getStartServices }));
-    if (uiConfig.roleMappingsEnabled) {
+    if (!uiConfig || uiConfig.roleMappingManagementEnabled) {
       this.securitySection.registerApp(roleMappingsManagementApp.create({ getStartServices }));
     }
   }
@@ -68,21 +73,21 @@ export class ManagementService {
         [securitySection.getApp(apiKeysManagementApp.id)!, features.showLinks],
       ];
 
-      if (uiConfig.usersEnabled) {
+      if (!uiConfig || uiConfig.userManagementEnabled) {
         securityManagementAppsStatuses.push([
           securitySection.getApp(usersManagementApp.id)!,
           features.showLinks,
         ]);
       }
 
-      if (uiConfig.rolesEnabled) {
+      if (!uiConfig || uiConfig.roleManagementEnabled) {
         securityManagementAppsStatuses.push([
           securitySection.getApp(rolesManagementApp.id)!,
           features.showLinks,
         ]);
       }
 
-      if (uiConfig.roleMappingsEnabled) {
+      if (!uiConfig || uiConfig.roleMappingManagementEnabled) {
         securityManagementAppsStatuses.push([
           securitySection.getApp(roleMappingsManagementApp.id)!,
           features.showLinks && features.showRoleMappingsManagement,

--- a/x-pack/plugins/security/public/plugin.tsx
+++ b/x-pack/plugins/security/public/plugin.tsx
@@ -132,6 +132,7 @@ export class SecurityPlugin
         authc: this.authc,
         fatalErrors: core.fatalErrors,
         getStartServices: core.getStartServices,
+        uiConfig: this.config.ui,
       });
     }
 
@@ -180,7 +181,10 @@ export class SecurityPlugin
     this.securityCheckupService.start({ http, notifications, docLinks });
 
     if (management) {
-      this.managementService.start({ capabilities: application.capabilities });
+      this.managementService.start({
+        capabilities: application.capabilities,
+        uiConfig: this.config.ui,
+      });
     }
 
     if (share) {

--- a/x-pack/plugins/security/server/config.test.ts
+++ b/x-pack/plugins/security/server/config.test.ts
@@ -1412,6 +1412,44 @@ describe('config schema', () => {
     });
   });
 
+  describe('ui', () => {
+    it('should not allow xpack.security.ui.* to be configured outside of the serverless context', () => {
+      expect(() =>
+        ConfigSchema.validate(
+          {
+            ui: {
+              userManagementEnabled: false,
+              roleManagementEnabled: false,
+              roleMappingManagementEnabled: false,
+            },
+          },
+          { serverless: false }
+        )
+      ).toThrowErrorMatchingInlineSnapshot(`"[ui]: a value wasn't expected to be present"`);
+    });
+
+    it('should allow xpack.security.ui.* to be configured inside of the serverless context', () => {
+      expect(
+        ConfigSchema.validate(
+          {
+            ui: {
+              userManagementEnabled: false,
+              roleManagementEnabled: false,
+              roleMappingManagementEnabled: false,
+            },
+          },
+          { serverless: true }
+        ).ui
+      ).toMatchInlineSnapshot(`
+        Object {
+          "roleManagementEnabled": false,
+          "roleMappingManagementEnabled": false,
+          "userManagementEnabled": false,
+        }
+      `);
+    });
+  });
+
   describe('session', () => {
     it('should throw error if xpack.security.session.cleanupInterval is less than 10 seconds', () => {
       expect(() => ConfigSchema.validate({ session: { cleanupInterval: '9s' } })).toThrow(

--- a/x-pack/plugins/security/server/config.test.ts
+++ b/x-pack/plugins/security/server/config.test.ts
@@ -72,11 +72,6 @@ describe('config schema', () => {
         },
         "showInsecureClusterWarning": true,
         "showNavLinks": true,
-        "ui": Object {
-          "roleMappingsEnabled": true,
-          "rolesEnabled": true,
-          "usersEnabled": true,
-        },
       }
     `);
 
@@ -132,11 +127,6 @@ describe('config schema', () => {
         },
         "showInsecureClusterWarning": true,
         "showNavLinks": true,
-        "ui": Object {
-          "roleMappingsEnabled": true,
-          "rolesEnabled": true,
-          "usersEnabled": true,
-        },
       }
     `);
 
@@ -191,11 +181,6 @@ describe('config schema', () => {
         },
         "showInsecureClusterWarning": true,
         "showNavLinks": true,
-        "ui": Object {
-          "roleMappingsEnabled": true,
-          "rolesEnabled": true,
-          "usersEnabled": true,
-        },
       }
     `);
   });

--- a/x-pack/plugins/security/server/config.test.ts
+++ b/x-pack/plugins/security/server/config.test.ts
@@ -72,6 +72,11 @@ describe('config schema', () => {
         },
         "showInsecureClusterWarning": true,
         "showNavLinks": true,
+        "ui": Object {
+          "roleMappingsEnabled": true,
+          "rolesEnabled": true,
+          "usersEnabled": true,
+        },
       }
     `);
 
@@ -127,6 +132,11 @@ describe('config schema', () => {
         },
         "showInsecureClusterWarning": true,
         "showNavLinks": true,
+        "ui": Object {
+          "roleMappingsEnabled": true,
+          "rolesEnabled": true,
+          "usersEnabled": true,
+        },
       }
     `);
 
@@ -181,6 +191,11 @@ describe('config schema', () => {
         },
         "showInsecureClusterWarning": true,
         "showNavLinks": true,
+        "ui": Object {
+          "roleMappingsEnabled": true,
+          "rolesEnabled": true,
+          "usersEnabled": true,
+        },
       }
     `);
   });

--- a/x-pack/plugins/security/server/config.ts
+++ b/x-pack/plugins/security/server/config.ts
@@ -297,11 +297,18 @@ export const ConfigSchema = schema.object({
     ),
   }),
   enabled: schema.boolean({ defaultValue: true }),
-  ui: schema.object({
-    usersEnabled: schema.boolean({ defaultValue: true }),
-    rolesEnabled: schema.boolean({ defaultValue: true }),
-    roleMappingsEnabled: schema.boolean({ defaultValue: true }),
-  }),
+
+  // Setting only allowed in the Serverless offering
+  ui: schema.conditional(
+    schema.contextRef('serverless'),
+    true,
+    schema.object({
+      userManagementEnabled: schema.boolean({ defaultValue: false }),
+      roleManagementEnabled: schema.boolean({ defaultValue: false }),
+      roleMappingManagementEnabled: schema.boolean({ defaultValue: false }),
+    }),
+    schema.never()
+  ),
 });
 
 export function createConfig(

--- a/x-pack/plugins/security/server/config.ts
+++ b/x-pack/plugins/security/server/config.ts
@@ -297,6 +297,11 @@ export const ConfigSchema = schema.object({
     ),
   }),
   enabled: schema.boolean({ defaultValue: true }),
+  ui: schema.object({
+    usersEnabled: schema.boolean({ defaultValue: true }),
+    rolesEnabled: schema.boolean({ defaultValue: true }),
+    roleMappingsEnabled: schema.boolean({ defaultValue: true }),
+  }),
 });
 
 export function createConfig(

--- a/x-pack/plugins/security/server/index.ts
+++ b/x-pack/plugins/security/server/index.ts
@@ -53,6 +53,7 @@ export const config: PluginConfigDescriptor<TypeOf<typeof ConfigSchema>> = {
     showInsecureClusterWarning: true,
     sameSiteCookies: true,
     showNavLinks: true,
+    ui: true,
   },
 };
 export const plugin: PluginInitializer<


### PR DESCRIPTION
Partially addresses https://github.com/elastic/kibana/issues/157756

## Summary

This PR makes the UI of the following Security apps disable-able for serverless:
- Users
- Roles
- Role Mappings


**How to test:**

1. Start Elasticsearch with `yarn es snapshot` and Kibana with yarn `serverless-{mode}` where `{mode}` can be `es`, `security`, or `oblt`.
2. Verify that the Users app is not accessible and its path (`management/security/users`) leads to the Stack Management landing page.
3. Verify that the Roles app is not accessible and its path (`management/security/roles`) leads to the Stack Management landing page.
4. Verify that the Role Mappings app is not accessible and its path (`management/security/role_mappings`) leads to the Stack Management landing page.

Test the Security apps in regular (non-serverless) mode:
1. Start Elasticsearch with `yarn es snapshot` and Kibana with `yarn start`.
2. Verify that Users, Roles, and Role Mappings apps work as expected.
