### PR TITLE
[Profiling] Add support for inline frames

### DIFF
--- a/x-pack/plugins/profiling/common/__fixtures__/stacktraces.ts
+++ b/x-pack/plugins/profiling/common/__fixtures__/stacktraces.ts
@@ -143,6 +143,7 @@ const defaultStackFrame = {
   FunctionName: '',
   FunctionOffset: 0,
   LineNumber: 0,
+  Inline: false,
 };
 
 export const stackFrames = new Map([
@@ -153,9 +154,13 @@ export const stackFrames = new Map([
       FunctionName: 'java.lang.Runnable java.util.concurrent.ThreadPoolExecutor.getTask()',
       FunctionOffset: 26,
       LineNumber: 1061,
+      Inline: false,
     },
   ],
-  [frameID.B, { FileName: '', FunctionName: 'sock_sendmsg', FunctionOffset: 0, LineNumber: 0 }],
+  [
+    frameID.B,
+    { FileName: '', FunctionName: 'sock_sendmsg', FunctionOffset: 0, LineNumber: 0, Inline: false },
+  ],
   [frameID.C, defaultStackFrame],
   [frameID.D, defaultStackFrame],
   [frameID.E, defaultStackFrame],
@@ -165,7 +170,10 @@ export const stackFrames = new Map([
   [frameID.I, defaultStackFrame],
   [frameID.J, defaultStackFrame],
   [frameID.K, defaultStackFrame],
-  [frameID.L, { FileName: '', FunctionName: 'udp_sendmsg', FunctionOffset: 0, LineNumber: 0 }],
+  [
+    frameID.L,
+    { FileName: '', FunctionName: 'udp_sendmsg', FunctionOffset: 0, LineNumber: 0, Inline: false },
+  ],
   [frameID.M, defaultStackFrame],
   [frameID.N, defaultStackFrame],
   [frameID.O, defaultStackFrame],

--- a/x-pack/plugins/profiling/common/callee.ts
+++ b/x-pack/plugins/profiling/common/callee.ts
@@ -26,6 +26,7 @@ export interface CalleeTree {
 
   FileID: string[];
   FrameType: number[];
+  Inline: boolean[];
   ExeFilename: string[];
   AddressOrLine: number[];
   FunctionName: string[];
@@ -49,6 +50,7 @@ export function createCalleeTree(
     Edges: new Array(totalFrames),
     FileID: new Array(totalFrames),
     FrameType: new Array(totalFrames),
+    Inline: new Array(totalFrames),
     ExeFilename: new Array(totalFrames),
     AddressOrLine: new Array(totalFrames),
     FunctionName: new Array(totalFrames),
@@ -64,6 +66,7 @@ export function createCalleeTree(
 
   tree.FileID[0] = '';
   tree.FrameType[0] = 0;
+  tree.Inline[0] = false;
   tree.ExeFilename[0] = '';
   tree.AddressOrLine[0] = 0;
   tree.FunctionName[0] = '';
@@ -129,6 +132,7 @@ export function createCalleeTree(
         tree.FunctionOffset[node] = frame.FunctionOffset;
         tree.SourceLine[node] = frame.LineNumber;
         tree.SourceFilename[node] = frame.FileName;
+        tree.Inline[node] = frame.Inline;
         tree.CountInclusive[node] = samples;
         tree.CountExclusive[node] = 0;
 

--- a/x-pack/plugins/profiling/common/flamegraph.ts
+++ b/x-pack/plugins/profiling/common/flamegraph.ts
@@ -26,6 +26,7 @@ export interface BaseFlameGraph {
 
   FileID: string[];
   FrameType: number[];
+  Inline: boolean[];
   ExeFilename: string[];
   AddressOrLine: number[];
   FunctionName: string[];
@@ -47,6 +48,7 @@ export function createBaseFlameGraph(tree: CalleeTree, totalSeconds: number): Ba
 
     FileID: tree.FileID.slice(0, tree.Size),
     FrameType: tree.FrameType.slice(0, tree.Size),
+    Inline: tree.Inline.slice(0, tree.Size),
     ExeFilename: tree.ExeFilename.slice(0, tree.Size),
     AddressOrLine: tree.AddressOrLine.slice(0, tree.Size),
     FunctionName: tree.FunctionName.slice(0, tree.Size),
@@ -88,6 +90,7 @@ export function createFlameGraph(base: BaseFlameGraph): ElasticFlameGraph {
 
     FileID: base.FileID,
     FrameType: base.FrameType,
+    Inline: base.Inline,
     ExeFilename: base.ExeFilename,
     AddressOrLine: base.AddressOrLine,
     FunctionName: base.FunctionName,
@@ -137,6 +140,7 @@ export function createFlameGraph(base: BaseFlameGraph): ElasticFlameGraph {
     const metadata = createStackFrameMetadata({
       FileID: graph.FileID[i],
       FrameType: graph.FrameType[i],
+      Inline: graph.Inline[i],
       ExeFileName: graph.ExeFilename[i],
       AddressOrLine: graph.AddressOrLine[i],
       FunctionName: graph.FunctionName[i],

--- a/x-pack/plugins/profiling/common/functions.ts
+++ b/x-pack/plugins/profiling/common/functions.ts
@@ -87,6 +87,7 @@ export function createTopNFunctions(
           FileID: fileID,
           AddressOrLine: addressOrLine,
           FrameType: stackTrace.Types[i],
+          Inline: frame.Inline,
           FunctionName: frame.FunctionName,
           FunctionOffset: frame.FunctionOffset,
           SourceLine: frame.LineNumber,

--- a/x-pack/plugins/profiling/common/profiling.ts
+++ b/x-pack/plugins/profiling/common/profiling.ts
@@ -103,6 +103,7 @@ export interface StackFrame {
   FunctionName: string;
   FunctionOffset: number;
   LineNumber: number;
+  Inline: boolean;
 }
 
 export const emptyStackFrame: StackFrame = {
@@ -110,6 +111,7 @@ export const emptyStackFrame: StackFrame = {
   FunctionName: '',
   FunctionOffset: 0,
   LineNumber: 0,
+  Inline: false,
 };
 
 export interface Executable {

--- a/x-pack/plugins/profiling/common/profiling.ts
+++ b/x-pack/plugins/profiling/common/profiling.ts
@@ -129,6 +129,8 @@ export interface StackFrameMetadata {
   FileID: FileID;
   // StackTrace.Type
   FrameType: FrameType;
+  // StackFrame.Inline
+  Inline: boolean;
 
   // StackTrace.AddressOrLine
   AddressOrLine: number;
@@ -167,6 +169,7 @@ export function createStackFrameMetadata(
   metadata.FrameID = options.FrameID ?? '';
   metadata.FileID = options.FileID ?? '';
   metadata.FrameType = options.FrameType ?? 0;
+  metadata.Inline = options.Inline ?? false;
   metadata.AddressOrLine = options.AddressOrLine ?? 0;
   metadata.FunctionName = options.FunctionName ?? '';
   metadata.FunctionOffset = options.FunctionOffset ?? 0;
@@ -309,6 +312,7 @@ export function groupStackFrameMetadataByStackTrace(
         FileID: fileID,
         AddressOrLine: addressOrLine,
         FrameType: trace.Types[i],
+        Inline: frame.Inline,
         FunctionName: frame.FunctionName,
         FunctionOffset: frame.FunctionOffset,
         SourceLine: frame.LineNumber,

--- a/x-pack/plugins/profiling/common/stack_traces.ts
+++ b/x-pack/plugins/profiling/common/stack_traces.ts
@@ -11,7 +11,7 @@ interface ProfilingEvents {
   [key: string]: number;
 }
 
-interface ProfilingStackTrace {
+export interface ProfilingStackTrace {
   ['file_ids']: string[];
   ['frame_ids']: string[];
   ['address_or_lines']: number[];


### PR DESCRIPTION
This PR inserts inline frames into the StackFrames and StackTraces generated from the StackTraceResponse by `search_stacktraces.ts/searchStackTraces()`.

It includes a test for doing the inlining.

The inline frames are tagged as `Inline: true`, but I am currently not sure if this information is passed to the client. In a follow-up PR I'd like to mark or highlight inlined frames in the UI.
