### PR TITLE
[Lens][Example] Fix CodeEditor issue within Lens example

### DIFF
--- a/x-pack/examples/testing_embedded_lens/public/app.tsx
+++ b/x-pack/examples/testing_embedded_lens/public/app.tsx
@@ -492,7 +492,9 @@ export const App = (props: {
   const [overrides, setOverrides] = useState<AllOverrides | undefined>();
 
   return (
-    <KibanaContextProvider services={{ uiSettings: props.core.uiSettings }}>
+    <KibanaContextProvider
+      services={{ uiSettings: props.core.uiSettings, settings: props.core.settings }}
+    >
       <EuiPageTemplate fullHeight template="empty">
         <EuiFlexGroup
           className="eui-fullHeight"

--- a/x-pack/examples/testing_embedded_lens/public/plugin.ts
+++ b/x-pack/examples/testing_embedded_lens/public/plugin.ts
@@ -9,6 +9,7 @@ import { Plugin, CoreSetup, AppNavLinkStatus } from '@kbn/core/public';
 import { DataPublicPluginStart } from '@kbn/data-plugin/public';
 import { LensPublicStart } from '@kbn/lens-plugin/public';
 import { DeveloperExamplesSetup } from '@kbn/developer-examples-plugin/public';
+import { SettingsStart } from '@kbn/core-ui-settings-browser';
 import { mount } from './mount';
 import image from './image.png';
 
@@ -19,6 +20,7 @@ export interface SetupDependencies {
 export interface StartDependencies {
   data: DataPublicPluginStart;
   lens: LensPublicStart;
+  settings: SettingsStart;
 }
 
 export class TestingEmbeddedLensPlugin

--- a/x-pack/examples/testing_embedded_lens/tsconfig.json
+++ b/x-pack/examples/testing_embedded_lens/tsconfig.json
@@ -22,5 +22,6 @@
     "@kbn/data-views-plugin",
     "@kbn/ui-actions-plugin",
     "@kbn/kibana-react-plugin",
+    "@kbn/core-ui-settings-browser",
   ]
 }


### PR DESCRIPTION
## Summary

Fix #158193

#154710 changed a bit the context type to work with the Monaco CodeEditor and this example was not updated to use it. This PR should fix it. 


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
