### PR TITLE
[Search Application] Fix doc link in navigation toolbar

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/applications/components/engine/engine_view.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/applications/components/engine/engine_view.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useLayoutEffect } from 'react';
 import { useParams, Redirect, Switch } from 'react-router-dom';
 
 import { useValues, useActions } from 'kea';
@@ -48,9 +48,16 @@ export const EngineView: React.FC = () => {
   }>();
   const { renderHeaderActions } = useValues(KibanaLogic);
 
+  useLayoutEffect(() => {
+    renderHeaderActions(EngineHeaderDocsAction);
+
+    return () => {
+      renderHeaderActions();
+    };
+  }, []);
+
   useEffect(() => {
     fetchEngine({ engineName });
-    renderHeaderActions(EngineHeaderDocsAction);
   }, [engineName]);
 
   if (fetchEngineApiStatus === Status.ERROR) {

--- a/x-pack/plugins/enterprise_search/public/applications/index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/index.tsx
@@ -100,7 +100,9 @@ export const renderApp = (
     productAccess,
     productFeatures,
     renderHeaderActions: (HeaderActions) =>
-      params.setHeaderActionMenu((el) => renderHeaderActions(HeaderActions, store, el)),
+      params.setHeaderActionMenu(
+        HeaderActions ? renderHeaderActions.bind(null, HeaderActions, store) : undefined
+      ),
     security,
     setBreadcrumbs: chrome.setBreadcrumbs,
     setChromeIsVisible: chrome.setIsVisible,

--- a/x-pack/plugins/enterprise_search/public/applications/shared/kibana/kibana_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/kibana/kibana_logic.ts
@@ -45,7 +45,7 @@ interface KibanaLogicProps {
   navigateToUrl: RequiredFieldsOnly<ApplicationStart['navigateToUrl']>;
   productAccess: ProductAccess;
   productFeatures: ProductFeatures;
-  renderHeaderActions(HeaderActions: FC): void;
+  renderHeaderActions(HeaderActions?: FC): void;
   security: SecurityPluginStart;
   setBreadcrumbs(crumbs: ChromeBreadcrumb[]): void;
   setChromeIsVisible(isVisible: boolean): void;


### PR DESCRIPTION
- Fix the way of using setActionMenu. According their doc and source code we need to call it twice, for moun and unmount.
- Fix redirection issue and using reactDom in rendering of action items

<img width="926" alt="image" src="https://github.com/elastic/kibana/assets/17390745/1e531299-e055-4af1-8ec7-92511e1a6e81">


<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->