### PR TITLE
Try enabling cypress junit reporter

### DIFF
--- a/x-pack/plugins/security_solution/cypress/cypress.config.ts
+++ b/x-pack/plugins/security_solution/cypress/cypress.config.ts
@@ -22,6 +22,6 @@ export default defineCypressConfig({
   },
   reporter: 'junit',
   reporterOptions: {
-    mochaFile: 'target/junit/security-solution-cypress-[hash].xml'
-  }
+    mochaFile: 'target/junit/security-solution-cypress-[hash].xml',
+  },
 });

--- a/x-pack/plugins/security_solution/cypress/cypress.config.ts
+++ b/x-pack/plugins/security_solution/cypress/cypress.config.ts
@@ -20,4 +20,8 @@ export default defineCypressConfig({
   e2e: {
     baseUrl: 'http://localhost:5601',
   },
+  reporter: 'junit',
+  reporterOptions: {
+    mochaFile: 'target/junit/security-solution-cypress-[hash].xml'
+  }
 });


### PR DESCRIPTION
## Summary

The failed test reporter reads junit reports. Security Solution uses Cypress for e2e tests but failed tests aren't reported correctly. Cypress can output junit reports. This PR attempts to configure Cypress so that junit reports are generated. This should make it possible for the failed test reporter to pick up failed Cypress tests.


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
