### PR TITLE
[Security Solution][Endpoint] Un-skip test and add `waitFor` to assertion

### DIFF
--- a/x-pack/plugins/security_solution/public/management/components/endpoint_responder/hooks/use_console_action_submitter.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/endpoint_responder/hooks/use_console_action_submitter.test.tsx
@@ -22,8 +22,7 @@ import type { ActionDetails } from '../../../../../common/endpoint/types';
 import { act, waitFor } from '@testing-library/react';
 import { responseActionsHttpMocks } from '../../../mocks/response_actions_http_mocks';
 
-// FLAKY: https://github.com/elastic/kibana/issues/142584
-describe.skip('When using `useConsoleActionSubmitter()` hook', () => {
+describe('When using `useConsoleActionSubmitter()` hook', () => {
   let render: () => ReturnType<AppContextTestRender['render']>;
   let renderResult: ReturnType<AppContextTestRender['render']>;
   let renderArgs: UseConsoleActionSubmitterOptions;
@@ -245,7 +244,9 @@ describe.skip('When using `useConsoleActionSubmitter()` hook', () => {
       });
     });
 
-    expect(renderArgs.store.actionApiState?.actionDetailsError).toBe(error);
+    await waitFor(() => {
+      expect(renderArgs.store.actionApiState?.actionDetailsError).toBe(error);
+    });
 
     expect(renderResult.getByTestId('test-apiFailure').textContent).toEqual(
       'The following error was encountered:on oh. getting action details failed'


### PR DESCRIPTION
## Summary

- Un-skips unit test suite and add an additional `waitFor` around the the failing test

Fixes #142584 




