### PR TITLE
[CI] Drop duplicate lint check

### DIFF
--- a/.buildkite/scripts/steps/checks.sh
+++ b/.buildkite/scripts/steps/checks.sh
@@ -6,7 +6,6 @@ export DISABLE_BOOTSTRAP_VALIDATION=false
 .buildkite/scripts/bootstrap.sh
 
 .buildkite/scripts/steps/checks/precommit_hook.sh
-.buildkite/scripts/steps/checks/packages.sh
 .buildkite/scripts/steps/checks/ts_projects.sh
 .buildkite/scripts/steps/checks/packages.sh
 .buildkite/scripts/steps/checks/bazel_packages.sh


### PR DESCRIPTION
## Summary

Noticed a duplicate lint check in a [pr](https://buildkite.com/elastic/kibana-pull-request/builds/129550#01884877-20a5-4b7d-a395-9bd70bac3f75) I was working on.
Considering what this check does, we prolly really do not want to run it twice, unless this was not a mistake.

