### PR TITLE
Fleet: configure permissions for profiling collector

### DIFF
--- a/x-pack/plugins/fleet/common/constants/epm.ts
+++ b/x-pack/plugins/fleet/common/constants/epm.ts
@@ -17,6 +17,7 @@ export const FLEET_APM_PACKAGE = 'apm';
 export const FLEET_SYNTHETICS_PACKAGE = 'synthetics';
 export const FLEET_KUBERNETES_PACKAGE = 'kubernetes';
 export const FLEET_UNIVERSAL_PROFILING_SYMBOLIZER_PACKAGE = 'profiler_symbolizer';
+export const FLEET_UNIVERSAL_PROFILING_COLLECTOR_PACKAGE = 'profiler_collector';
 export const FLEET_CLOUD_SECURITY_POSTURE_PACKAGE = 'cloud_security_posture';
 export const FLEET_CLOUD_SECURITY_POSTURE_KSPM_POLICY_TEMPLATE = 'kspm';
 export const FLEET_CLOUD_SECURITY_POSTURE_CSPM_POLICY_TEMPLATE = 'cspm';

--- a/x-pack/plugins/fleet/server/services/agent_policies/package_policies_to_agent_permissions.test.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policies/package_policies_to_agent_permissions.test.ts
@@ -188,6 +188,56 @@ packageInfoCache.set('profiler_symbolizer-8.8.0-preview', {
     },
   },
 });
+packageInfoCache.set('profiler_collector-8.9.0-preview', {
+  format_version: '2.7.0',
+  name: 'profiler_collector',
+  title: 'Universal Profiling Collector',
+  version: '8.9.0-preview',
+  license: 'basic',
+  description:
+    'Fleet-wide, whole-system, continuous profiling with zero instrumentation. Collect profiling data.',
+  type: 'integration',
+  release: 'beta',
+  categories: ['monitoring', 'elastic_stack'],
+  icons: [
+    {
+      src: '/img/logo_profiling_symbolizer.svg',
+      title: 'logo symbolizer',
+      size: '32x32',
+      type: 'image/svg+xml',
+    },
+  ],
+  owner: { github: 'elastic/profiling' },
+  data_streams: [],
+  latestVersion: '8.9.0-preview',
+  notice: undefined,
+  status: 'not_installed',
+  assets: {
+    kibana: {
+      csp_rule_template: [],
+      dashboard: [],
+      visualization: [],
+      search: [],
+      index_pattern: [],
+      map: [],
+      lens: [],
+      security_rule: [],
+      ml_module: [],
+      tag: [],
+      osquery_pack_asset: [],
+      osquery_saved_query: [],
+    },
+    elasticsearch: {
+      component_template: [],
+      ingest_pipeline: [],
+      ilm_policy: [],
+      transform: [],
+      index_template: [],
+      data_stream_ilm_policy: [],
+      ml_model: [],
+    },
+  },
+});
 
 describe('storedPackagePoliciesToAgentPermissions()', () => {
   it('Returns `undefined` if there are no package policies', async () => {
@@ -426,6 +476,46 @@ describe('storedPackagePoliciesToAgentPermissions()', () => {
         inputs: [
           {
             type: 'pf-elastic-symbolizer',
+            enabled: true,
+            streams: [],
+          },
+        ],
+        created_at: '',
+        updated_at: '',
+        created_by: '',
+        updated_by: '',
+        revision: 1,
+        policy_id: '',
+      },
+    ];
+
+    const permissions = await storedPackagePoliciesToAgentPermissions(
+      packageInfoCache,
+      packagePolicies
+    );
+
+    expect(permissions).toMatchObject({
+      'package-policy-uuid-test-123': {
+        indices: [
+          {
+            names: ['profiling-*'],
+            privileges: UNIVERSAL_PROFILING_PERMISSIONS,
+          },
+        ],
+      },
+    });
+  });
+  it('Returns the Universal Profiling permissions for profiler_collector package', async () => {
+    const packagePolicies: PackagePolicy[] = [
+      {
+        id: 'package-policy-uuid-test-123',
+        name: 'test-policy',
+        namespace: '',
+        enabled: true,
+        package: { name: 'profiler_collector', version: '8.9.0-preview', title: 'Test Package' },
+        inputs: [
+          {
+            type: 'pf-elastic-collector',
             enabled: true,
             streams: [],
           },

--- a/x-pack/plugins/fleet/server/services/agent_policies/package_policies_to_agent_permissions.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policies/package_policies_to_agent_permissions.ts
@@ -5,7 +5,10 @@
  * 2.0.
  */
 
-import { FLEET_UNIVERSAL_PROFILING_SYMBOLIZER_PACKAGE } from '../../../common/constants';
+import {
+  FLEET_UNIVERSAL_PROFILING_COLLECTOR_PACKAGE,
+  FLEET_UNIVERSAL_PROFILING_SYMBOLIZER_PACKAGE,
+} from '../../../common/constants';
 
 import { getNormalizedDataStreams } from '../../../common/services';
 
@@ -56,7 +59,10 @@ export async function storedPackagePoliciesToAgentPermissions(
 
       // Special handling for Universal Profiling packages, as it does not use data streams _only_,
       // but also indices that do not adhere to the convention.
-      if (pkg.name === FLEET_UNIVERSAL_PROFILING_SYMBOLIZER_PACKAGE) {
+      if (
+        pkg.name === FLEET_UNIVERSAL_PROFILING_SYMBOLIZER_PACKAGE ||
+        pkg.name === FLEET_UNIVERSAL_PROFILING_COLLECTOR_PACKAGE
+      ) {
         return Promise.resolve(universalProfilingPermissions(packagePolicy.id));
       }
 


### PR DESCRIPTION
## Summary

Add support in Fleet to configure Universal Profiling collector using the new proposed package built in https://github.com/elastic/integrations/pull/6274.

### Checklist

Delete any items that are not applicable to this PR.

- [X] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [X] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
