### PR TITLE
serverless_search: update nav links

### DIFF
--- a/x-pack/plugins/serverless_search/public/layout/nav.tsx
+++ b/x-pack/plugins/serverless_search/public/layout/nav.tsx
@@ -99,6 +99,7 @@ const navItems: ChromeNavigationNodeViewModel[] = [
         title: i18n.translate('xpack.serverlessSearch.nav.content.indices', {
           defaultMessage: 'Indices',
         }),
+        // TODO: this will be updated to a new Indices page
         href: '/app/management/data/index_management/indices',
       },
       {
@@ -106,7 +107,16 @@ const navItems: ChromeNavigationNodeViewModel[] = [
         title: i18n.translate('xpack.serverlessSearch.nav.content.transforms', {
           defaultMessage: 'Transforms',
         }),
-        href: '/app/management/data/transform',
+        // TODO: this will be updated to a new Transforms page
+        href: '/app/management/ingest/ingest_pipelines',
+      },
+      {
+        id: 'content_indexing_api',
+        title: i18n.translate('xpack.serverlessSearch.nav.content.indexingApi', {
+          defaultMessage: 'Indexing API',
+        }),
+        // TODO: this page does not exist yet, linking to getting started for now
+        href: '/app/elasticsearch',
       },
     ],
   },


### PR DESCRIPTION
## Summary

- Updated the "Transforms" side navigation link to go to ingest pipelines stack management page. This link will eventually be updated to a new page in June, but this page is closer to whats needed for now.
- Add the Indexing API to the side nav as a placeholder, but it links to the getting started page for now, this will also be a new page in June.