### PR TITLE
[Security Solution] Add a feature flag for Protections/Detections Coverage Overview dashboard

### DIFF
--- a/x-pack/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/plugins/security_solution/common/experimental_features.ts
@@ -134,6 +134,15 @@ export const allowedExperimentalValues = Object.freeze({
    *
    **/
   newUserDetailsFlyout: false,
+
+  /**
+   * Enables Protections/Detections Coverage Overview page (Epic link https://github.com/elastic/security-team/issues/2905)
+   *
+   * This flag aims to facilitate the development process as the feature may not make it to 8.9 release.
+   *
+   * The flag doesn't have to be documented and has to be removed after the feature is ready to release.
+   */
+  detectionsCoverageOverview: false,
 });
 
 type ExperimentalConfigKeys = Array<keyof ExperimentalFeatures>;

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/register_routes.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/register_routes.ts
@@ -25,6 +25,7 @@ import { patchRuleRoute } from './rules/patch_rule/route';
 import { readRuleRoute } from './rules/read_rule/route';
 import { updateRuleRoute } from './rules/update_rule/route';
 import { readTagsRoute } from './tags/read_tags/route';
+import { getRulesDashboardDataRoute } from './rules/dashboard/route';
 
 export const registerRuleManagementRoutes = (
   router: SecuritySolutionPluginRouter,
@@ -60,4 +61,9 @@ export const registerRuleManagementRoutes = (
 
   // Rules filters
   getRuleManagementFilters(router);
+
+  // Rules dashboard
+  if (config.experimentalFeatures.detectionsCoverageOverview) {
+    getRulesDashboardDataRoute();
+  }
 };

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/dashboard/route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/dashboard/route.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export function getRulesDashboardDataRoute(): void {}


### PR DESCRIPTION
**Resolves:** https://github.com/elastic/kibana/issues/158200

## Summary

This PR adds a feature flag for Protections/Detections Coverage Overview dashboard to facilitate the development process until the MVP is ready. If it's not the case before the next release it will be safe to continue working on the feature in the next cycle.