### PR TITLE
[Synthetics] Remove public saved objects usage from `useLocationMonitors`

### DIFF
--- a/x-pack/plugins/synthetics/common/constants/synthetics/rest_api.ts
+++ b/x-pack/plugins/synthetics/common/constants/synthetics/rest_api.ts
@@ -13,6 +13,7 @@ export enum SYNTHETICS_API_URLS {
   INDEX_SIZE = `/internal/synthetics/index_size`,
   PARAMS = `/synthetics/params`,
   PRIVATE_LOCATIONS = `/synthetics/private_locations`,
+  PRIVATE_LOCATIONS_MONITORS = `/internal/synthetics/private_locations/monitors`,
   SYNC_GLOBAL_PARAMS = `/synthetics/sync_global_params`,
   ENABLE_DEFAULT_ALERTING = `/synthetics/enable_default_alerting`,
   JOURNEY = `/internal/synthetics/journey/{checkGroup}`,

--- a/x-pack/plugins/synthetics/common/runtime_types/dynamic_settings.ts
+++ b/x-pack/plugins/synthetics/common/runtime_types/dynamic_settings.ts
@@ -38,6 +38,27 @@ export const DynamicSettingsSaveType = t.intersection([
   }),
 ]);
 
+export const LocationMonitorsType = t.intersection([
+  t.partial({
+    payload: t.type({
+      aggregations: t.type({
+        locations: t.type({
+          buckets: t.array(
+            t.type({
+              key: t.string,
+              doc_count: t.number,
+            })
+          ),
+        }),
+      }),
+    }),
+  }),
+  t.type({
+    status: t.number,
+  }),
+]);
+
 export type DynamicSettings = t.TypeOf<typeof DynamicSettingsType>;
 export type DefaultEmail = t.TypeOf<typeof DefaultEmailType>;
 export type DynamicSettingsSaveResponse = t.TypeOf<typeof DynamicSettingsSaveType>;
+export type LocationMonitorsResponse = t.TypeOf<typeof LocationMonitorsType>;

--- a/x-pack/plugins/synthetics/common/runtime_types/dynamic_settings.ts
+++ b/x-pack/plugins/synthetics/common/runtime_types/dynamic_settings.ts
@@ -38,25 +38,15 @@ export const DynamicSettingsSaveType = t.intersection([
   }),
 ]);
 
-export const LocationMonitorsType = t.intersection([
-  t.partial({
-    payload: t.type({
-      aggregations: t.type({
-        locations: t.type({
-          buckets: t.array(
-            t.type({
-              key: t.string,
-              doc_count: t.number,
-            })
-          ),
-        }),
-      }),
-    }),
-  }),
-  t.type({
-    status: t.number,
-  }),
-]);
+export const LocationMonitorsType = t.type({
+  status: t.number,
+  payload: t.array(
+    t.type({
+      id: t.string,
+      count: t.number,
+    })
+  ),
+});
 
 export type DynamicSettings = t.TypeOf<typeof DynamicSettingsType>;
 export type DefaultEmail = t.TypeOf<typeof DefaultEmailType>;

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/settings/private_locations/hooks/use_location_monitors.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/settings/private_locations/hooks/use_location_monitors.ts
@@ -5,50 +5,17 @@
  * 2.0.
  */
 
-import { useMemo } from 'react';
-import { useFetcher } from '@kbn/observability-shared-plugin/public';
-import { useKibana } from '@kbn/kibana-react-plugin/public';
-import {
-  monitorAttributes,
-  syntheticsMonitorType,
-} from '../../../../../../../common/types/saved_objects';
-
-interface AggsResponse {
-  locations: {
-    buckets: Array<{
-      key: string;
-      doc_count: number;
-    }>;
-  };
-}
+import { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { getLocationMonitorsAction } from '../../../../state/settings/actions';
+import { selectLocationMonitors } from '../../../../state/settings';
 
 export const useLocationMonitors = () => {
-  const { savedObjects } = useKibana().services;
+  const dispatch = useDispatch();
 
-  const { data, loading } = useFetcher(() => {
-    const aggs = {
-      locations: {
-        terms: {
-          field: `${monitorAttributes}.locations.id`,
-          size: 10000,
-        },
-      },
-    };
-    return savedObjects?.client.find<unknown, typeof aggs>({
-      type: syntheticsMonitorType,
-      perPage: 0,
-      aggs,
-    });
-  }, []);
+  useEffect(() => {
+    dispatch(getLocationMonitorsAction.get());
+  }, [dispatch]);
 
-  return useMemo(() => {
-    if (data?.aggregations) {
-      const newValues = (data.aggregations as AggsResponse)?.locations.buckets.map(
-        ({ key, doc_count: count }) => ({ id: key, count })
-      );
-
-      return { locationMonitors: newValues, loading };
-    }
-    return { locationMonitors: [], loading };
-  }, [data, loading]);
+  return useSelector(selectLocationMonitors);
 };

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/root_effect.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/root_effect.ts
@@ -13,6 +13,7 @@ import { executeEsQueryEffect } from './elasticsearch';
 import {
   fetchAlertConnectorsEffect,
   fetchDynamicSettingsEffect,
+  fetchLocationMonitors,
   setDynamicSettingsEffect,
 } from './settings/effects';
 import { syncGlobalParamsEffect } from './settings';
@@ -47,6 +48,7 @@ export const rootEffect = function* root(): Generator {
     fork(fetchPingStatusesEffect),
     fork(fetchAgentPoliciesEffect),
     fork(fetchDynamicSettingsEffect),
+    fork(fetchLocationMonitors),
     fork(setDynamicSettingsEffect),
     fork(fetchAlertConnectorsEffect),
     fork(syncGlobalParamsEffect),

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/root_effect.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/root_effect.ts
@@ -13,7 +13,7 @@ import { executeEsQueryEffect } from './elasticsearch';
 import {
   fetchAlertConnectorsEffect,
   fetchDynamicSettingsEffect,
-  fetchLocationMonitors,
+  fetchLocationMonitorsEffect,
   setDynamicSettingsEffect,
 } from './settings/effects';
 import { syncGlobalParamsEffect } from './settings';
@@ -48,7 +48,7 @@ export const rootEffect = function* root(): Generator {
     fork(fetchPingStatusesEffect),
     fork(fetchAgentPoliciesEffect),
     fork(fetchDynamicSettingsEffect),
-    fork(fetchLocationMonitors),
+    fork(fetchLocationMonitorsEffect),
     fork(setDynamicSettingsEffect),
     fork(fetchAlertConnectorsEffect),
     fork(syncGlobalParamsEffect),

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/settings/actions.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/settings/actions.ts
@@ -18,3 +18,5 @@ export const setDynamicSettingsAction = createAsyncAction<DynamicSettings, Dynam
 export const getConnectorsAction = createAsyncAction<void, ActionConnector[]>('GET CONNECTORS');
 
 export const syncGlobalParamsAction = createAsyncAction<void, boolean>('SYNC GLOBAL PARAMS');
+
+export const getLocationMonitorsAction = createAsyncAction<void, any>('GET LOCATION MONITORS');

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/settings/api.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/settings/api.ts
@@ -38,18 +38,14 @@ export const setDynamicSettings = async ({
   return await apiService.post(apiPath, settings, DynamicSettingsSaveType);
 };
 
-export const getLocationMonitors = async (): Promise<LocationMonitor[]> => {
-  const response = await apiService.get<LocationMonitorsResponse>(
+export const fetchLocationMonitors = async (): Promise<LocationMonitor[]> => {
+  const { payload } = await apiService.get<LocationMonitorsResponse>(
     SYNTHETICS_API_URLS.PRIVATE_LOCATIONS_MONITORS,
     undefined,
     LocationMonitorsType
   );
-  return (
-    response.payload?.aggregations.locations.buckets.map(({ key: id, doc_count: count }) => ({
-      id,
-      count,
-    })) ?? []
-  );
+
+  return payload;
 };
 
 export type ActionConnector = Omit<RawActionConnector, 'secrets'>;

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/settings/api.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/settings/api.ts
@@ -20,6 +20,7 @@ import {
   LocationMonitorsType,
 } from '../../../../../common/runtime_types';
 import { API_URLS, SYNTHETICS_API_URLS } from '../../../../../common/constants';
+import { LocationMonitor } from '.';
 
 const apiPath = API_URLS.DYNAMIC_SETTINGS;
 
@@ -37,21 +38,18 @@ export const setDynamicSettings = async ({
   return await apiService.post(apiPath, settings, DynamicSettingsSaveType);
 };
 
-export const getLocationMonitors = async (): Promise<any> => {
+export const getLocationMonitors = async (): Promise<LocationMonitor[]> => {
   const response = await apiService.get<LocationMonitorsResponse>(
     SYNTHETICS_API_URLS.PRIVATE_LOCATIONS_MONITORS,
     undefined,
     LocationMonitorsType
   );
-  if (response.status === 200) {
-    return response.payload?.aggregations.locations.buckets.map(
-      ({ key: id, doc_count: count }) => ({
-        id,
-        count,
-      })
-    );
-  }
-  return [];
+  return (
+    response.payload?.aggregations.locations.buckets.map(({ key: id, doc_count: count }) => ({
+      id,
+      count,
+    })) ?? []
+  );
 };
 
 export type ActionConnector = Omit<RawActionConnector, 'secrets'>;

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/settings/api.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/settings/api.ts
@@ -16,6 +16,8 @@ import {
   DynamicSettingsSaveResponse,
   DynamicSettingsSaveType,
   DynamicSettingsType,
+  LocationMonitorsResponse,
+  LocationMonitorsType,
 } from '../../../../../common/runtime_types';
 import { API_URLS, SYNTHETICS_API_URLS } from '../../../../../common/constants';
 
@@ -33,6 +35,23 @@ export const setDynamicSettings = async ({
   settings,
 }: SaveApiRequest): Promise<DynamicSettingsSaveResponse> => {
   return await apiService.post(apiPath, settings, DynamicSettingsSaveType);
+};
+
+export const getLocationMonitors = async (): Promise<any> => {
+  const response = await apiService.get<LocationMonitorsResponse>(
+    SYNTHETICS_API_URLS.PRIVATE_LOCATIONS_MONITORS,
+    undefined,
+    LocationMonitorsType
+  );
+  if (response.status === 200) {
+    return response.payload?.aggregations.locations.buckets.map(
+      ({ key: id, doc_count: count }) => ({
+        id,
+        count,
+      })
+    );
+  }
+  return [];
 };
 
 export type ActionConnector = Omit<RawActionConnector, 'secrets'>;

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/settings/effects.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/settings/effects.ts
@@ -11,15 +11,21 @@ import { i18n } from '@kbn/i18n';
 import { updateDefaultAlertingAction } from '../alert_rules';
 import { DynamicSettings } from '../../../../../common/runtime_types';
 import { kibanaService } from '../../../../utils/kibana_service';
-import { getConnectorsAction, setDynamicSettingsAction, getDynamicSettingsAction } from './actions';
+import {
+  getConnectorsAction,
+  setDynamicSettingsAction,
+  getDynamicSettingsAction,
+  syncGlobalParamsAction,
+  getLocationMonitorsAction,
+} from './actions';
 import { fetchEffectFactory } from '../utils/fetch_effect';
 import {
   fetchConnectors,
   setDynamicSettings,
   syncGlobalParamsAPI,
   getDynamicSettings,
+  getLocationMonitors,
 } from './api';
-import { syncGlobalParamsAction } from './actions';
 
 export function* syncGlobalParamsEffect() {
   yield takeLeading(
@@ -30,6 +36,17 @@ export function* syncGlobalParamsEffect() {
       syncGlobalParamsAction.fail,
       successMessage,
       failureMessage
+    )
+  );
+}
+
+export function* fetchLocationMonitors() {
+  yield takeLeading(
+    String(getLocationMonitorsAction.get),
+    fetchEffectFactory(
+      getLocationMonitors,
+      getLocationMonitorsAction.success,
+      getLocationMonitorsAction.fail
     )
   );
 }

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/settings/effects.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/settings/effects.ts
@@ -24,7 +24,7 @@ import {
   setDynamicSettings,
   syncGlobalParamsAPI,
   getDynamicSettings,
-  getLocationMonitors,
+  fetchLocationMonitors,
 } from './api';
 
 export function* syncGlobalParamsEffect() {
@@ -40,11 +40,11 @@ export function* syncGlobalParamsEffect() {
   );
 }
 
-export function* fetchLocationMonitors() {
+export function* fetchLocationMonitorsEffect() {
   yield takeLeading(
     String(getLocationMonitorsAction.get),
     fetchEffectFactory(
-      getLocationMonitors,
+      fetchLocationMonitors,
       getLocationMonitorsAction.success,
       getLocationMonitorsAction.fail
     )

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/settings/index.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/settings/index.ts
@@ -17,6 +17,11 @@ import {
 import { ActionConnector } from './api';
 import { syncGlobalParamsAction } from './actions';
 
+export interface LocationMonitor {
+  id: string;
+  count: number;
+}
+
 export interface DynamicSettingsState {
   settings?: DynamicSettings;
   loadError?: IHttpSerializedFetchError;
@@ -24,7 +29,7 @@ export interface DynamicSettingsState {
   loading: boolean;
   connectors?: ActionConnector[];
   connectorsLoading?: boolean;
-  locationMonitors: Array<{ id: string; count: number }>;
+  locationMonitors: LocationMonitor[];
   locationMonitorsLoading?: boolean;
 }
 

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/settings/index.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/settings/index.ts
@@ -8,7 +8,12 @@
 import { createReducer } from '@reduxjs/toolkit';
 import { DynamicSettings } from '../../../../../common/runtime_types';
 import { IHttpSerializedFetchError } from '..';
-import { getConnectorsAction, getDynamicSettingsAction, setDynamicSettingsAction } from './actions';
+import {
+  getConnectorsAction,
+  getDynamicSettingsAction,
+  getLocationMonitorsAction,
+  setDynamicSettingsAction,
+} from './actions';
 import { ActionConnector } from './api';
 import { syncGlobalParamsAction } from './actions';
 
@@ -19,11 +24,14 @@ export interface DynamicSettingsState {
   loading: boolean;
   connectors?: ActionConnector[];
   connectorsLoading?: boolean;
+  locationMonitors: Array<{ id: string; count: number }>;
+  locationMonitorsLoading?: boolean;
 }
 
 const initialState: DynamicSettingsState = {
   loading: true,
   connectors: [],
+  locationMonitors: [],
 };
 
 export const dynamicSettingsReducer = createReducer(initialState, (builder) => {
@@ -57,8 +65,18 @@ export const dynamicSettingsReducer = createReducer(initialState, (builder) => {
       state.connectors = action.payload;
       state.connectorsLoading = false;
     })
-    .addCase(getConnectorsAction.fail, (state, action) => {
+    .addCase(getConnectorsAction.fail, (state, _action) => {
       state.connectorsLoading = false;
+    })
+    .addCase(getLocationMonitorsAction.get, (state) => {
+      state.locationMonitorsLoading = true;
+    })
+    .addCase(getLocationMonitorsAction.success, (state, action) => {
+      state.locationMonitors = action.payload;
+      state.locationMonitorsLoading = false;
+    })
+    .addCase(getLocationMonitorsAction.fail, (state) => {
+      state.locationMonitorsLoading = false;
     });
 });
 

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/settings/selectors.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/settings/selectors.ts
@@ -15,3 +15,8 @@ export const selectAgentPolicies = createSelector(getState, (state) => state);
 
 export const selectAddingNewPrivateLocation = (state: AppState) =>
   state.agentPolicies.isAddingNewPrivateLocation ?? false;
+
+export const selectLocationMonitors = (state: AppState) => ({
+  locationMonitors: state.dynamicSettings.locationMonitors,
+  loading: state.dynamicSettings.locationMonitorsLoading,
+});

--- a/x-pack/plugins/synthetics/public/apps/synthetics/utils/testing/__mocks__/synthetics_store.mock.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/utils/testing/__mocks__/synthetics_store.mock.ts
@@ -130,6 +130,7 @@ export const mockState: SyntheticsAppState = {
   },
   dynamicSettings: {
     loading: false,
+    locationMonitors: [],
   },
   defaultAlerting: {
     loading: false,

--- a/x-pack/plugins/synthetics/server/routes/index.ts
+++ b/x-pack/plugins/synthetics/server/routes/index.ts
@@ -53,7 +53,6 @@ import { addPrivateLocationRoute } from './settings/private_locations/add_privat
 import { deletePrivateLocationRoute } from './settings/private_locations/delete_private_location';
 import { getPrivateLocationsRoute } from './settings/private_locations/get_private_locations';
 import { getSyntheticsFilters } from './filters/filters';
-import { getAllSyntheticsMonitorRoute } from './monitor_cruds/get_monitors_list';
 import { getLocationMonitors } from './settings/private_locations/get_location_monitors';
 
 export const syntheticsAppRestApiRoutes: SyntheticsRestApiRouteFactory[] = [

--- a/x-pack/plugins/synthetics/server/routes/index.ts
+++ b/x-pack/plugins/synthetics/server/routes/index.ts
@@ -53,6 +53,8 @@ import { addPrivateLocationRoute } from './settings/private_locations/add_privat
 import { deletePrivateLocationRoute } from './settings/private_locations/delete_private_location';
 import { getPrivateLocationsRoute } from './settings/private_locations/get_private_locations';
 import { getSyntheticsFilters } from './filters/filters';
+import { getAllSyntheticsMonitorRoute } from './monitor_cruds/get_monitors_list';
+import { getLocationMonitors } from './settings/private_locations/get_location_monitors';
 
 export const syntheticsAppRestApiRoutes: SyntheticsRestApiRouteFactory[] = [
   addSyntheticsMonitorRoute,
@@ -94,6 +96,7 @@ export const syntheticsAppRestApiRoutes: SyntheticsRestApiRouteFactory[] = [
   deletePackagePolicyRoute,
   addPrivateLocationRoute,
   deletePrivateLocationRoute,
+  getLocationMonitors,
   getPrivateLocationsRoute,
   getSyntheticsFilters,
 ];

--- a/x-pack/plugins/synthetics/server/routes/monitor_cruds/get_monitor.ts
+++ b/x-pack/plugins/synthetics/server/routes/monitor_cruds/get_monitor.ts
@@ -6,7 +6,6 @@
  */
 import { schema } from '@kbn/config-schema';
 import { SavedObjectsErrorHelpers } from '@kbn/core/server';
-import { syntheticsMonitorType } from '../../../common/types/saved_objects';
 import { getAllMonitors } from '../../saved_objects/synthetics_monitor/get_all_monitors';
 import { isStatusEnabled } from '../../../common/runtime_types/monitor_management/alert_config';
 import {

--- a/x-pack/plugins/synthetics/server/routes/monitor_cruds/get_monitor.ts
+++ b/x-pack/plugins/synthetics/server/routes/monitor_cruds/get_monitor.ts
@@ -14,6 +14,7 @@ import {
   EncryptedSyntheticsMonitor,
   MonitorOverviewItem,
 } from '../../../common/runtime_types';
+import { syntheticsMonitorType } from '../../../common/types/saved_objects';
 import { UMServerLibs } from '../../legacy_uptime/lib/lib';
 import { SyntheticsRestApiRouteFactory } from '../../legacy_uptime/routes/types';
 import { API_URLS, SYNTHETICS_API_URLS } from '../../../common/constants';

--- a/x-pack/plugins/synthetics/server/routes/settings/private_locations/get_location_monitors.ts
+++ b/x-pack/plugins/synthetics/server/routes/settings/private_locations/get_location_monitors.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { IKibanaResponse } from '@kbn/core/server';
+import { SyntheticsRestApiRouteFactory } from '../../../legacy_uptime/routes';
+import { SYNTHETICS_API_URLS } from '../../../../common/constants';
+import { monitorAttributes, syntheticsMonitorType } from '../../../../common/types/saved_objects';
+
+const aggs = {
+  locations: {
+    terms: {
+      field: `${monitorAttributes}.locations.id`,
+      size: 10000,
+    },
+  },
+};
+
+export const getLocationMonitors: SyntheticsRestApiRouteFactory = () => ({
+  method: 'GET',
+  path: SYNTHETICS_API_URLS.PRIVATE_LOCATIONS_MONITORS,
+
+  validate: {},
+  handler: async ({
+    savedObjectsClient: _s,
+    uptimeEsClient: es,
+  }): Promise<IKibanaResponse<any>> => {
+    return {
+      options: {},
+      payload: await _s?.find<unknown, typeof aggs>({
+        type: syntheticsMonitorType,
+        perPage: 0,
+        aggs,
+      }),
+      status: 200,
+    };
+  },
+});

--- a/x-pack/plugins/synthetics/server/routes/settings/private_locations/get_location_monitors.ts
+++ b/x-pack/plugins/synthetics/server/routes/settings/private_locations/get_location_monitors.ts
@@ -38,11 +38,8 @@ export const getLocationMonitors: SyntheticsRestApiRouteFactory = () => ({
   path: SYNTHETICS_API_URLS.PRIVATE_LOCATIONS_MONITORS,
 
   validate: {},
-  handler: async ({
-    savedObjectsClient: _s,
-    uptimeEsClient: es,
-  }): Promise<IKibanaResponse<Payload>> => {
-    const locationMonitors = await _s?.find<unknown, ExpectedResponse>({
+  handler: async ({ savedObjectsClient: soClient }): Promise<IKibanaResponse<Payload>> => {
+    const locationMonitors = await soClient?.find<unknown, ExpectedResponse>({
       type: syntheticsMonitorType,
       perPage: 0,
       aggs,


### PR DESCRIPTION
## Summary

Related to #153399.

Creates a new route for fetching private location monitors and replaces the public saved object usages on the client.

Adds new redux state for these values and simplifies the public hook.

Updates unit tests.

## Testing instructions

1. Set up a private location (I used `elastic-package` + local Kibana but you can test this with oblt-cli or make a cloud deployment for this PR)
2. Create a monitor and add it to your private location.
3. Navigate to Synthetics > Settings > Private Locations
4. Verify the `Monitors` count is correct for your location
5. Add more monitors, double check that the count updates

Please ping me directly if you need help setting up a testing env.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
