### PR TITLE
Add Maps to the Serverless sidebar

### DIFF
--- a/x-pack/plugins/serverless_search/public/layout/nav.tsx
+++ b/x-pack/plugins/serverless_search/public/layout/nav.tsx
@@ -88,6 +88,13 @@ const navItems: ChromeNavigationNodeViewModel[] = [
         }),
         href: '/app/visualize',
       },
+      {
+        id: 'explore_maps',
+        title: i18n.translate('xpack.serverlessSearch.nav.explore.maps', {
+          defaultMessage: 'Maps',
+        }),
+        href: '/app/maps',
+      },
     ],
   },
   {


### PR DESCRIPTION
## Summary

Adds maps to the Elasticsearch project.

<img width="182" alt="image" src="https://github.com/elastic/kibana/assets/1833023/4a330659-7b62-419b-979b-1d277c0ecd86">

(fwiw - this is more to get clarity on how Maps should be accessible. Ie. should maps be accessed through Visualize Library menu, or should they be listed on the sidebar like today (?))


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios



### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
