### PR TITLE
[Lens] Handle properly partition chart empty slices

### DIFF
--- a/src/plugins/chart_expressions/expression_partition_vis/public/utils/layers/get_layers.test.ts
+++ b/src/plugins/chart_expressions/expression_partition_vis/public/utils/layers/get_layers.test.ts
@@ -111,4 +111,57 @@ describe('getLayers', () => {
       ]
     `);
   });
+
+  it('should handle empty slices with default label', () => {
+    const visData = createMockVisData();
+    const visDataWithNullValues = {
+      ...visData,
+      rows: [
+        {
+          'col-0-2': 'Null Airways',
+          'col-1-1': null,
+          'col-2-3': null,
+          'col-3-1': null,
+        },
+      ],
+    };
+
+    const columns: BucketColumns[] = [
+      {
+        id: 'col-0-0',
+        name: 'Normal column',
+        meta: { type: 'murmur3' },
+      },
+      {
+        id: 'col-0-0',
+        name: 'multi-metric column',
+        meta: {
+          type: 'number',
+          sourceParams: {
+            consolidatedMetricsColumn: true,
+          },
+        },
+      },
+    ];
+    const visParams = createMockPieParams();
+    const layers = getLayers(
+      ChartTypes.PIE,
+      columns,
+      visParams,
+      visDataWithNullValues,
+      {},
+      [],
+      getPaletteRegistry(),
+      {},
+      fieldFormatsMock,
+      false,
+      false
+    );
+
+    for (const layer of layers) {
+      expect(layer.groupByRollup(visDataWithNullValues.rows[0], 0)).toEqual('(empty)');
+      expect(layer.showAccessor?.(visDataWithNullValues.rows[0]['col-0-2'])).toEqual(true);
+      expect(layer.nodeLabel?.(visDataWithNullValues.rows[0]['col-0-2'])).toEqual('Null Airways');
+    }
+  });
 });

--- a/src/plugins/chart_expressions/expression_partition_vis/public/utils/layers/get_layers.ts
+++ b/src/plugins/chart_expressions/expression_partition_vis/public/utils/layers/get_layers.ts
@@ -18,6 +18,8 @@ import { sortPredicateByType, sortPredicateSaveSourceOrder } from './sort_predic
 import { byDataColorPaletteMap, getColor } from './get_color';
 import { getNodeLabel } from './get_node_labels';
 
+// This is particularly useful in case of a text based languages where
+// it's no possible to use a missingBucketLabel
 const emptySliceLabel = i18n.translate('expressionPartitionVis.emptySlice', {
   defaultMessage: '(empty)',
 });
@@ -63,7 +65,7 @@ export const getLayers = (
   return columns.map((col, layerIndex) => {
     return {
       groupByRollup: (d: Datum) => (col.id ? d[col.id] ?? emptySliceLabel : col.name),
-      showAccessor: (d: Datum) => d !== emptySliceLabel,
+      showAccessor: (d: Datum) => true,
       nodeLabel: (d: unknown) => getNodeLabel(d, col, formatters, formatter.deserialize),
       fillLabel:
         layerIndex === 0 && chartType === ChartTypes.MOSAIC

--- a/src/plugins/chart_expressions/expression_partition_vis/public/utils/layers/get_layers.ts
+++ b/src/plugins/chart_expressions/expression_partition_vis/public/utils/layers/get_layers.ts
@@ -8,6 +8,7 @@
 
 import { Datum, PartitionLayer } from '@elastic/charts';
 import type { PaletteRegistry } from '@kbn/coloring';
+import { i18n } from '@kbn/i18n';
 import { FieldFormat } from '@kbn/field-formats-plugin/common';
 import type { FieldFormatsStart } from '@kbn/field-formats-plugin/public';
 import type { Datatable, DatatableRow } from '@kbn/expressions-plugin/public';
@@ -17,7 +18,9 @@ import { sortPredicateByType, sortPredicateSaveSourceOrder } from './sort_predic
 import { byDataColorPaletteMap, getColor } from './get_color';
 import { getNodeLabel } from './get_node_labels';
 
-const EMPTY_SLICE = Symbol('empty_slice');
+const emptySliceLabel = i18n.translate('expressionPartitionVis.emptySlice', {
+  defaultMessage: '(empty)',
+});
 
 export const getLayers = (
   chartType: ChartTypes,
@@ -59,8 +62,8 @@ export const getLayers = (
 
   return columns.map((col, layerIndex) => {
     return {
-      groupByRollup: (d: Datum) => (col.id ? d[col.id] ?? EMPTY_SLICE : col.name),
-      showAccessor: (d: Datum) => d !== EMPTY_SLICE,
+      groupByRollup: (d: Datum) => (col.id ? d[col.id] ?? emptySliceLabel : col.name),
+      showAccessor: (d: Datum) => d !== emptySliceLabel,
       nodeLabel: (d: unknown) => getNodeLabel(d, col, formatters, formatter.deserialize),
       fillLabel:
         layerIndex === 0 && chartType === ChartTypes.MOSAIC


### PR DESCRIPTION
## Summary

Fix #157465

This PR replaces the Symbol empty slice with a string value.
Here's the result of the same scenario of the issue:

<img width="1402" alt="Screenshot 2023-05-24 at 09 20 34" src="https://github.com/elastic/kibana/assets/924948/b1b3db27-0e31-43be-8ae1-57dbcd645408">



### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
