### PR TITLE
[Serverless] Disable Search Sessions

### DIFF
--- a/config/serverless.yml
+++ b/config/serverless.yml
@@ -18,6 +18,7 @@ xpack.license_management.enabled: false
 #xpack.canvas.enabled: false #only disabable in dev-mode
 xpack.reporting.enabled: false
 xpack.cloud_integrations.data_migration.enabled: false
+data.search.sessions.enabled: false
 
 # Enforce restring access to internal APIs see https://github.com/elastic/kibana/issues/151940
 # server.restrictInternalApis: true


### PR DESCRIPTION
Partially addresses https://github.com/elastic/kibana/issues/157756

## Summary

This PR disables the Search Sessions plugin for serverless.

**How to test:**

1. Start Elasticsearch with `yarn es snapshot` and Kibana with yarn `serverless-{mode}` where `{mode}` can be `es`, `security`, or `oblt`.
2. Verify that the Search Sessions app is not accessible and its path (`app/management/kibana/search_sessions`) leads to the Stack Management landing page.
