### PR TITLE
[Cloud Security] Fixing evaluations colors mismatching

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/common/constants.ts
+++ b/x-pack/plugins/cloud_security_posture/public/common/constants.ts
@@ -29,7 +29,7 @@ import aksLogo from '../assets/icons/cis_aks_logo.svg';
 import gkeLogo from '../assets/icons/cis_gke_logo.svg';
 
 export const statusColors = {
-  passed: euiThemeVars.euiColorVis0,
+  passed: euiThemeVars.euiColorSuccess,
   failed: euiThemeVars.euiColorVis9,
 };
 

--- a/x-pack/plugins/cloud_security_posture/public/components/csp_evaluation_badge.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/csp_evaluation_badge.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 import { EuiBadge, type EuiBadgeProps } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { css } from '@emotion/react';
+import { statusColors } from '../common/constants';
 
 interface Props {
   type: 'passed' | 'failed';
@@ -19,8 +20,8 @@ interface Props {
 const BADGE_WIDTH = '46px';
 
 const getColor = (type: Props['type']): EuiBadgeProps['color'] => {
-  if (type === 'passed') return 'success';
-  if (type === 'failed') return 'danger';
+  if (type === 'passed') return statusColors.passed;
+  if (type === 'failed') return statusColors.failed;
   return 'default';
 };
 

--- a/x-pack/plugins/cloud_security_posture/public/pages/configurations/layout/findings_distribution_bar.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/configurations/layout/findings_distribution_bar.tsx
@@ -72,7 +72,7 @@ const PassedFailedCounters = ({ passed, failed }: Pick<Props, 'passed' | 'failed
         label={i18n.translate('xpack.csp.findings.distributionBar.totalPassedLabel', {
           defaultMessage: 'Passed Findings',
         })}
-        color={euiTheme.colors.success}
+        color={statusColors.passed}
         value={passed}
       />
       <Counter
@@ -123,7 +123,7 @@ const DistributionBar: React.FC<Omit<Props, 'pageEnd' | 'pageStart'>> = ({
     >
       <DistributionBarPart
         value={passed}
-        color={euiTheme.colors.success}
+        color={statusColors.passed}
         distributionOnClick={() => {
           distributionOnClick(RULE_PASSED);
         }}


### PR DESCRIPTION
## Summary

- [x] Confirmed all colors with @einatjacoby 
- [x] All colors are now matching in both findings and dashboard
- [x] Badge text color is now all black

![image](https://github.com/elastic/kibana/assets/51442161/7c681f0f-180a-4a1e-8609-0d6d86339bd1)

![image](https://github.com/elastic/kibana/assets/51442161/efb743d4-d97c-45cc-a161-b1ea2efe0483)

![image](https://github.com/elastic/kibana/assets/51442161/77551b61-29e7-4305-b8f6-4d71dc340f35)

![image](https://github.com/elastic/kibana/assets/51442161/038fb04e-a25a-4b67-a26f-ea42e0f8018e)

![image](https://github.com/elastic/kibana/assets/51442161/3df5c5dc-96e1-4398-bc98-4a9789c45b85)

![image](https://github.com/elastic/kibana/assets/51442161/cc36de68-a516-46eb-8038-58e70dfe62c0)
