### PR TITLE
[CI][Find Root Cause] Fix cant find ftr configs yaml fle

### DIFF
--- a/packages/kbn-test/src/functional_test_runner/lib/config/ftr_configs_manifest.ts
+++ b/packages/kbn-test/src/functional_test_runner/lib/config/ftr_configs_manifest.ts
@@ -8,7 +8,6 @@
 
 import Path from 'path';
 import Fs from 'fs';
-
 import { REPO_ROOT } from '@kbn/repo-info';
 import JsYaml from 'js-yaml';
 
@@ -25,10 +24,24 @@ interface FtrConfigsManifest {
   disabled: string[];
   enabled: Array<string | FtrConfigWithOptions>;
 }
+let ftrConfigsManifest: FtrConfigsManifest;
 
-const ftrConfigsManifest: FtrConfigsManifest = JsYaml.safeLoad(
-  Fs.readFileSync(Path.resolve(REPO_ROOT, FTR_CONFIGS_MANIFEST_REL), 'utf8')
-);
+const load = (x: string): FtrConfigsManifest => JsYaml.safeLoad(Fs.readFileSync(x, 'utf8'));
+try {
+  ftrConfigsManifest = load(Path.resolve(REPO_ROOT, FTR_CONFIGS_MANIFEST_REL));
+} catch (_) {
+  const abnormalPath = Path.resolve(REPO_ROOT, '../kibana', FTR_CONFIGS_MANIFEST_REL);
+  // eslint-disable-next-line no-console
+  console.error(`\n### Could not load ${FTR_CONFIGS_MANIFEST_REL} normally,
+(meaning we could not load it from ${REPO_ROOT}),
+Error: \n  ${_},
+Now we'll try to load it from ${abnormalPath}`);
+  try {
+    ftrConfigsManifest = load(abnormalPath);
+  } catch (e) {
+    throw new Error(`\n### Could not load ${abnormalPath} either, Error: \n  ${e}`);
+  }
+}
 
 export const FTR_CONFIGS_MANIFEST_PATHS = [
   Object.values(ftrConfigsManifest.enabled),


### PR DESCRIPTION
## Summary

This pr is meant to be a starting point for finding the root cause of the problem.

Born from: https://github.com/elastic/kibana/pull/158072

Resolves: https://github.com/elastic/kibana/issues/156861

### TLDR
For some reason, ci is trying to load `.buildkite/ftr_configs.yml` from `.../elastic/kibana-pull-request/kibana-build-xpack`

Not sure of the root cause, but this is a band-aid.
All the code does is try to load it normally, and if it fails, try to load it from one directory back.



### How I check my progress
Currently I've added a double try-catch block as an exception based flow control.
It will try to load path A and if it fails, it loads path B; complete with verbose
logging of what happenned.

To view this, you've to discover which ci group the the config in question ran within.
To do that, I download / view the ftr_run_order.json file, from the **Pick Test Group Run Order** panel.
Within the json file, I search for `x-pack/test/alerting_api_integration/security_and_spaces/group2/config_non_dedicated_task_runner` and the last time I did that, I saw the following stanza:
```
  "ftr_configs_54": {
    "title": "FTR Configs #55",
    "expectedDurationMin": 35.8,
    "names": [
      "x-pack/test/alerting_api_integration/security_and_spaces/group2/config_non_dedicated_task_runner.ts",
      "x-pack/test/api_integration/apis/kibana/config.ts"
    ]
  },
```
this means I now go look into the **FTR Configs 55** panel's terminal output for:
```
node scripts/functional_tests --bail --config x-pack/test/alerting_api_integration/security_and_spaces/group2/config_non_dedicated_task_runner.ts

within the output, I also look for `### `(my personal preference for log prefixing 😉).  

The last time I look I did not see it, meaning the "normal path" was used.
```
**Very Interesting**: _I did not see it this pr's terminal output, but I did see it in Patricks_
**Does that mean there is something in his PR???**

### Example of when the "Abnormal" execution path ran
The following thread shows this:
https://elastic.slack.com/archives/C5UDAFZQU/p1684926185982099?thread_ts=1683235279.695229&cid=C5UDAFZQU


> Note: This research first began by piggybacking onto Patrick Mueller's PR

> Patrick's PR: https://github.com/elastic/kibana/pull/156732

> My Piggy Back PR: https://github.com/elastic/kibana/pull/158072