### PR TITLE
[Cloud Posture] add correct eui theme colors for Vector score text

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/pages/vulnerabilities/vulnerabilities_finding_flyout/vulnerability_overview_tab.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/vulnerabilities/vulnerabilities_finding_flyout/vulnerability_overview_tab.tsx
@@ -109,7 +109,7 @@ const VectorScore = ({
       <EuiFlexGroup
         alignItems="center"
         css={css`
-          background: #f1f4fa;
+          background: ${euiThemeVars.euiColorLightestShade};
           padding: ${euiThemeVars.euiSizeXS} ${euiThemeVars.euiSizeS};
           border-radius: 6px;
         `}
@@ -118,6 +118,7 @@ const VectorScore = ({
           <EuiText
             css={css`
               font-size: ${euiThemeVars.euiFontSizeM};
+              color: ${euiThemeVars.euiColorFullShade};
             `}
           >
             {vector}{' '}


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.

Use the correct euiThemeColors so that Vector text is legible in light or dark themes.  This ticket is part of  [Quick Wins](https://github.com/elastic/security-team/issues/6646)
<img width="1016" alt="Screen Shot 2023-05-24 at 10 54 13 AM" src="https://github.com/elastic/kibana/assets/17135495/4707d5b2-3e74-4f87-b5c7-464c49615670">

<img width="1727" alt="Screen Shot 2023-05-24 at 10 52 05 AM" src="https://github.com/elastic/kibana/assets/17135495/be462a75-2854-44b3-a8bf-46447f2ec3e4">
