### PR TITLE
[Cloud Posture] fix end of line for json details

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/pages/vulnerabilities/vulnerabilities_finding_flyout/vulnerability_json_tab.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/vulnerabilities/vulnerabilities_finding_flyout/vulnerability_json_tab.tsx
@@ -14,10 +14,11 @@ interface VulnerabilityJsonTabProps {
   vulnerabilityRecord: VulnerabilityRecord;
 }
 export const VulnerabilityJsonTab = ({ vulnerabilityRecord }: VulnerabilityJsonTabProps) => {
-  const offsetHeight = 188;
+  const offsetTopHeight = 188;
+  const offsetBottomHeight = 60;
   return (
     <div
-      style={{ position: 'absolute', inset: 0, top: offsetHeight }}
+      style={{ position: 'absolute', inset: 0, top: offsetTopHeight, bottom: offsetBottomHeight }}
       data-test-subj={JSON_TAB_VULNERABILITY_FLYOUT}
     >
       <CodeEditor


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.
Added an offset bottom to json detail tab so pagination doesn't cut off json details

<img width="1708" alt="Screen Shot 2023-05-24 at 11 44 15 AM" src="https://github.com/elastic/kibana/assets/17135495/b04712d2-b377-4444-89a3-d00d66a6a794">
