### PR TITLE
[DOCS] Telemetry settings: improve phrasing

### DIFF
--- a/docs/settings/telemetry-settings.asciidoc
+++ b/docs/settings/telemetry-settings.asciidoc
@@ -4,32 +4,30 @@
 <titleabbrev>Telemetry settings</titleabbrev>
 ++++
 
-By default, Usage Collection (also known as Telemetry) is enabled. This
-helps us learn about the {kib} features that our users are most interested in, so we
-can focus our efforts on making them even better.
+Usage Collection (also known as Telemetry) is enabled by default. This allows us to learn what our users are most interested in, so we can improve our products and services.
+
+Refer to our https://www.elastic.co/legal/product-privacy-statement[Privacy Statement] to learn more.
 
 You can control whether this data is sent from the {kib} servers, or if it should be sent
 from the user's browser, in case a firewall is blocking the connections from the server. Additionally, you can decide to completely disable this feature either in the config file or in {kib} via *Management > Kibana > Advanced Settings > Usage Data*.
-
-Refer to our https://www.elastic.co/legal/product-privacy-statement[Privacy Statement] to learn more.
 
 [float]
 [[telemetry-general-settings]]
 ==== General telemetry settings
 
+[[telemetry-optIn]] `telemetry.optIn`::
+  Set to `false` to stop sending any telemetry data to Elastic. Reporting your
+cluster statistics helps us improve your user experience. *Default: `true`.*+
++
+This setting can be changed at any time in <<advanced-options, Advanced Settings>>.
+To prevent users from changing it,
+set <<telemetry-allowChangingOptInStatus, `telemetry.allowChangingOptInStatus`>> to `false`.
+
+`telemetry.allowChangingOptInStatus`::
+  Set to `false` to disallow overwriting the <<telemetry-optIn, `telemetry.optIn`>> setting via the <<advanced-options, Advanced Settings>> in {kib}. *Default: `true`.*
+
 `telemetry.sendUsageFrom`::
   Set to `'server'` to report the cluster statistics from the {kib} server.
   If the server fails to connect to our endpoint at https://telemetry.elastic.co/, it assumes
   it is behind a firewall and falls back to `'browser'` to send it from users' browsers
-  when they are navigating through {kib}. Defaults to `'server'`.
-
-[[telemetry-optIn]] `telemetry.optIn`::
-  Set to `true` to send cluster statistics to Elastic. Reporting your
-  cluster statistics helps us improve your user experience. Set to `false` to stop sending any telemetry data to Elastic. +
-+
-This setting can be changed at any time in <<advanced-options, Advanced Settings>>.
-To prevent users from changing it,
-set <<telemetry-allowChangingOptInStatus, `telemetry.allowChangingOptInStatus`>> to `false`. Defaults to `true`.
-
-`telemetry.allowChangingOptInStatus`::
-  Set to `true` to allow overwriting the <<telemetry-optIn, `telemetry.optIn`>> setting via the <<advanced-options, Advanced Settings>> in {kib}. Defaults to `true`.
+  when they are navigating through {kib}. *Default: `'server'`.*

--- a/docs/settings/telemetry-settings.asciidoc
+++ b/docs/settings/telemetry-settings.asciidoc
@@ -17,7 +17,7 @@ from the user's browser, in case a firewall is blocking the connections from the
 
 [[telemetry-optIn]] `telemetry.optIn`::
   Set to `false` to stop sending any telemetry data to Elastic. Reporting your
-cluster statistics helps us improve your user experience. *Default: `true`.*+
+cluster statistics helps us improve your user experience. *Default: `true`.* +
 +
 This setting can be changed at any time in <<advanced-options, Advanced Settings>>.
 To prevent users from changing it,

--- a/docs/setup/settings.asciidoc
+++ b/docs/setup/settings.asciidoc
@@ -556,14 +556,13 @@ setting this to `true` enables unauthenticated users to access the {kib}
 server status API and status page. *Default: `false`*
 
 [[telemetry-allowChangingOptInStatus]] `telemetry.allowChangingOptInStatus`::
-When `true`, users are able to change the telemetry setting at a later time in
-<<advanced-options, Advanced Settings>>.  When `false`, users cannot change the opt-in status through *Advanced Settings*, and
+When `false`, users cannot change the opt-in status through <<advanced-options, Advanced Settings>>, and
 {kib} only looks at the value of <<settings-telemetry-optIn, `telemetry.optIn`>> to determine whether to send telemetry data or not. *Default: `true`*.
 
 [[settings-telemetry-optIn]] `telemetry.optIn`::
+Set to `false` to stop sending any telemetry data to Elastic.
 Reporting your cluster statistics helps
 us improve your user experience.
-Set to `true` to allow telemetry data to be sent to Elastic.
 When `false`, the telemetry data is never sent to Elastic. +
 +
 This setting can be changed at any time in <<advanced-options, Advanced Settings>>.


### PR DESCRIPTION
## Summary

We want to improve our docs to make our telemetry collection clearer to our users.

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

Our intention is to backport this to as many versions as possible

<!--ONMERGE {"backportTargets":["7.17","8.0","8.1","8.2","8.3","8.4","8.5","8.6","8.7","8.8"]} ONMERGE-->