### PR TITLE
unskip tests for chrome, fix tags

### DIFF
--- a/test/functional/apps/visualize/group5/_tsvb_time_series.ts
+++ b/test/functional/apps/visualize/group5/_tsvb_time_series.ts
@@ -51,7 +51,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
         await visualBuilder.clickDataTab('timeSeries');
       });
 
-      describe('basics', () => {
+      describe('basics', function () {
         this.tags('includeFirefox');
 
         it('should render all necessary components', async () => {
@@ -237,7 +237,8 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
         });
       });
 
-      describe('Elastic charts', () => {
+      describe('Elastic charts', function () {
+        this.tags('skipFirefox');
         beforeEach(async () => {
           await visualBuilder.toggleNewChartsLibraryWithDebug(true);
           await visualBuilder.clickPanelOptions('timeSeries');
@@ -594,7 +595,8 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
         after(async () => await visualBuilder.toggleNewChartsLibraryWithDebug(false));
       });
 
-      describe('index pattern selection mode', () => {
+      describe('index pattern selection mode', function () {
+        this.tags('skipFirefox');
         it('should disable switch for Kibana index patterns mode by default', async () => {
           await visualBuilder.clickPanelOptions('timeSeries');
           const isEnabled = await visualBuilder.checkIndexPatternSelectionModeSwitchIsEnabled();

--- a/x-pack/test/functional/apps/infra/home_page.ts
+++ b/x-pack/test/functional/apps/infra/home_page.ts
@@ -21,9 +21,9 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
   const kibanaServer = getService('kibanaServer');
   const testSubjects = getService('testSubjects');
 
-  // Failing: See https://github.com/elastic/kibana/issues/157713
-  describe.skip('Home page', function () {
-    this.tags('includeFirefox');
+  describe('Home page', function () {
+    // Failing: See https://github.com/elastic/kibana/issues/157713
+    // this.tags('includeFirefox');
     before(async () => {
       await kibanaServer.savedObjects.cleanStandardList();
     });

--- a/x-pack/test/functional/apps/infra/home_page.ts
+++ b/x-pack/test/functional/apps/infra/home_page.ts
@@ -21,9 +21,10 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
   const kibanaServer = getService('kibanaServer');
   const testSubjects = getService('testSubjects');
 
-  describe('Home page', function () {
-    // Failing: See https://github.com/elastic/kibana/issues/157713
-    // this.tags('includeFirefox');
+  // Failing: See https://github.com/elastic/kibana/issues/157713
+  // Fails on both Chrome and Firefox
+  describe.skip('Home page', function () {
+    this.tags('includeFirefox');
     before(async () => {
       await kibanaServer.savedObjects.cleanStandardList();
     });

--- a/x-pack/test/functional/apps/infra/hosts_view.ts
+++ b/x-pack/test/functional/apps/infra/hosts_view.ts
@@ -148,10 +148,9 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
 
   const enableHostView = () => pageObjects.infraHostsView.clickEnableHostViewButton();
 
-  // Tests
-  // Failing: See https://github.com/elastic/kibana/issues/157718
-  describe.skip('Hosts View', function () {
-    this.tags('includeFirefox');
+  describe('Hosts View', function () {
+    // Failing: See https://github.com/elastic/kibana/issues/157718
+    // this.tags('includeFirefox');
 
     before(async () => {
       await Promise.all([

--- a/x-pack/test/functional/apps/infra/metrics_explorer.ts
+++ b/x-pack/test/functional/apps/infra/metrics_explorer.ts
@@ -100,8 +100,9 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
       });
     });
 
-    // FLAKY: https://github.com/elastic/kibana/issues/157738
-    describe.skip('Saved Views', () => {
+    describe('Saved Views', function () {
+      // FLAKY: https://github.com/elastic/kibana/issues/157738
+      this.tags('skipFirefox');
       before(async () => {
         await esArchiver.load('x-pack/test/functional/es_archives/infra/metrics_and_logs');
         await pageObjects.infraHome.goToMetricExplorer();

--- a/x-pack/test/functional/apps/security/security.ts
+++ b/x-pack/test/functional/apps/security/security.ts
@@ -16,9 +16,9 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const testSubjects = getService('testSubjects');
   const spaces = getService('spaces');
 
-  // FLAKY: https://github.com/elastic/kibana/issues/157722
-  describe.skip('Security', function () {
-    this.tags('includeFirefox');
+  describe('Security', function () {
+    // FLAKY: https://github.com/elastic/kibana/issues/157722
+    // this.tags('includeFirefox');
     describe('Login Page', () => {
       before(async () => {
         await kibanaServer.savedObjects.cleanStandardList();

--- a/x-pack/test/functional/apps/spaces/spaces_selection.ts
+++ b/x-pack/test/functional/apps/spaces/spaces_selection.ts
@@ -22,7 +22,6 @@ export default function spaceSelectorFunctionalTests({
   ]);
   const spacesService = getService('spaces');
 
-  // Failing: See https://github.com/elastic/kibana/issues/142155
   describe('Spaces', function () {
     const testSpacesIds = ['another-space', ...Array.from('123456789', (idx) => `space-${idx}`)];
     before(async () => {
@@ -95,7 +94,8 @@ export default function spaceSelectorFunctionalTests({
       });
     });
 
-    describe('Search spaces in popover', () => {
+    describe('Search spaces in popover', function () {
+      this.tags('skipFirefox');
       const spaceId = 'default';
       before(async () => {
         await PageObjects.security.forceLogout();
@@ -127,7 +127,8 @@ export default function spaceSelectorFunctionalTests({
       });
     });
 
-    describe('Spaces Data', () => {
+    describe('Spaces Data', function () {
+      this.tags('skipFirefox');
       const spaceId = 'another-space';
       const sampleDataHash = '/tutorial_directory/sampleData';
 

--- a/x-pack/test/functional/apps/watcher/index.js
+++ b/x-pack/test/functional/apps/watcher/index.js
@@ -6,9 +6,7 @@
  */
 
 export default function ({ loadTestFile }) {
-  describe('watcher app', function () {
-    this.tags('includeFirefox');
-
+  describe('watcher app', () => {
     loadTestFile(require.resolve('./watcher_test'));
   });
 }

--- a/x-pack/test/functional/apps/watcher/watcher_test.js
+++ b/x-pack/test/functional/apps/watcher/watcher_test.js
@@ -20,8 +20,9 @@ export default function ({ getService, getPageObjects }) {
   const esSupertest = getService('esSupertest');
   const PageObjects = getPageObjects(['security', 'common', 'header', 'settings', 'watcher']);
 
-  // FLAKY: https://github.com/elastic/kibana/issues/157723
-  describe.skip('watcher_test', function () {
+  describe('watcher_test', function () {
+    // FLAKY: https://github.com/elastic/kibana/issues/157723
+    // this.tags('includeFirefox');
     before('initialize tests', async () => {
       // There may be system watches if monitoring was previously enabled
       // These cannot be deleted via the UI, so we need to delete via the API

--- a/x-pack/test/functional/config.firefox.js
+++ b/x-pack/test/functional/config.firefox.js
@@ -16,7 +16,6 @@ export default async function ({ readConfigFile }) {
       require.resolve('./apps/infra'),
       require.resolve('./apps/security'),
       require.resolve('./apps/spaces'),
-      require.resolve('./apps/status_page'),
       require.resolve('./apps/watcher'),
     ],
 


### PR DESCRIPTION
## Summary

With Firefox update to v113 on our CI workers, we noticed that tests are run slower and more often fail with timeouts.
Unfortunately our auto-skip functionality skip the test suite completely, meaning it won't run on Chrome as well.

This PR unskips the firefox failed test to run on Chrome, I also fix the labels for some suites to run only sub set of tests for now. 

<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->