### PR TITLE
[Synthetics] - Fix broken sort behavior on overview page.

### DIFF
--- a/x-pack/plugins/synthetics/e2e/journeys/synthetics/overview_sorting.journey.ts
+++ b/x-pack/plugins/synthetics/e2e/journeys/synthetics/overview_sorting.journey.ts
@@ -35,6 +35,16 @@ journey('OverviewSorting', async ({ page, params }) => {
     await syntheticsApp.navigateToOverview(true, 15);
   });
 
+  step('sort should reload monitor cards', async () => {
+    await page.waitForSelector(`[data-test-subj="syntheticsOverviewGridItem"]`);
+    await page.click('[data-test-subj="syntheticsOverviewSortButton"]');
+    await page.click('button:has-text("Alphabetical")');
+    await page.waitForSelector(`[data-test-subj="syntheticsOverviewMonitorsLoading"]`);
+    await page.waitForSelector(`text=${testMonitor1}`);
+    await page.waitForSelector(`text=${testMonitor2}`);
+    await page.waitForSelector(`text=${testMonitor3}`);
+  });
+
   step('sort alphabetical asc', async () => {
     await page.waitForSelector(`[data-test-subj="syntheticsOverviewGridItem"]`);
     await page.click('[data-test-subj="syntheticsOverviewSortButton"]');

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/overview_pagination_info.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/overview_pagination_info.tsx
@@ -70,7 +70,7 @@ export const OverviewPaginationInfo = ({
       )}
     </EuiText>
   ) : (
-    <EuiText size="xs">
+    <EuiText size="xs" data-test-subj="syntheticsOverviewMonitorsLoading">
       <EuiFlexGroup alignItems="center" gutterSize="s">
         <EuiFlexItem grow={false}>
           <EuiLoadingSpinner size="m" />

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview_page.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview_page.tsx
@@ -72,11 +72,11 @@ export const OverviewPage: React.FC = () => {
 
   // fetch overview for all other page state changes
   useEffect(() => {
-    if (!monitorsLoaded) {
+    if (!overviewLoaded) {
       dispatch(fetchMonitorOverviewAction.get(pageState));
     }
     // change only needs to be triggered on pageState change
-  }, [dispatch, pageState, monitorsLoaded]);
+  }, [dispatch, pageState, overviewLoaded]);
 
   // fetch overview for refresh
   useEffect(() => {

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/overview/index.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/overview/index.ts
@@ -58,6 +58,7 @@ export const monitorOverviewReducer = createReducer(initialState, (builder) => {
         ...state.pageState,
         ...action.payload,
       };
+      state.loaded = false;
     })
     .addCase(setOverviewGroupByAction, (state, action) => {
       state.groupBy = {

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/overview/index.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/overview/index.ts
@@ -58,7 +58,6 @@ export const monitorOverviewReducer = createReducer(initialState, (builder) => {
         ...state.pageState,
         ...action.payload,
       };
-      state.loaded = false;
     })
     .addCase(setOverviewGroupByAction, (state, action) => {
       state.groupBy = {


### PR DESCRIPTION
## Summary

When sorting on Synthetics -> Overview page, cards keep loading until the next periodic update. This PR fixes this behavior.

### Testing
1. Setup monitors in sufficient numbers so that paging and sorting can be tested together.
2. Sort the monitors on Synthetics -> Overview page using by "Alphabetical" and "Last modified" and also by changing the order A -> Z, Z -> A and confirm that the it's behaving as expected.
3. Apply some filters and retest sorting.
4. Switch the tab to **Management** and change filters and confirm if everything is OK.
5. Switch back to **Overview** and retest sorting.
6. While keeping the sort active, test paging and grouping.

<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->