### PR TITLE
[7.17] Handles non-existing objects in _copy_saved_objects API call (#158036)

### DIFF
--- a/docs/api/spaces-management/copy_saved_objects.asciidoc
+++ b/docs/api/spaces-management/copy_saved_objects.asciidoc
@@ -63,6 +63,15 @@ NOTE: This cannot be used with the `overwrite` option.
 +
 NOTE: This cannot be used with the `createNewCopies` option.
 
+[[spaces-api-copy-saved-objects-response-codes]]
+==== Response codes
+
+`200`::
+    Indicates a successful call.
+
+`404`::
+    Indicates that the request failed because one or more of the objects specified could not be found. A list of the unresolved objects are included in the 404 response attributes.
+
 [role="child_attributes"]
 [[spaces-api-copy-saved-objects-response-body]]
 ==== {api-response-body-title}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [Handles non-existing objects in _copy_saved_objects API call (#158036)](https://github.com/elastic/kibana/pull/158036)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)