### PR TITLE
Fixes documentation of response codes for copy saved objects

### DIFF
--- a/docs/api/spaces-management/copy_saved_objects.asciidoc
+++ b/docs/api/spaces-management/copy_saved_objects.asciidoc
@@ -69,6 +69,15 @@ NOTE: This option cannot be used with the `createNewCopies` option.
 +
 NOTE: This option cannot be used with the `createNewCopies` option.
 
+[[spaces-api-copy-saved-objects-response-codes]]
+==== Response codes
+
+`200`::
+    Indicates a successful call.
+
+`404`::
+    Indicates that the request failed because one or more of the objects specified could not be found. A list of the unresolved objects are included in the 404 response attributes.
+
 [role="child_attributes"]
 [[spaces-api-copy-saved-objects-response-body]]
 ==== {api-response-body-title}

--- a/docs/api/spaces-management/update_objects_spaces.asciidoc
+++ b/docs/api/spaces-management/update_objects_spaces.asciidoc
@@ -36,15 +36,6 @@ Updates one or more saved objects to add and/or remove them from specified space
 `spacesToRemove`::
   (Required, string array) The IDs of the spaces the specified objects should be removed from.
 
-[[spaces-api-update-objects-spaces-response-codes]]
-==== Response codes
-
-`200`::
-    Indicates a successful call.
-
-`404`::
-    Indicates that the request failed because one or more of the objects specified could not be found. A list of the unresolved objects are included in the 404 response attributes.
-
 [role="child_attributes"]
 [[spaces-api-update-objects-spaces-response-body]]
 ==== {api-response-body-title}


### PR DESCRIPTION
## Summary

Moves the response codes documented for the copy saved object API to the correct document file.

Documentation was incorrectly located in https://github.com/elastic/kibana/pull/158036

<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->