### PR TITLE
Revert "[ci] Make container image tag update trigger async (#152970)"

### DIFF
--- a/.buildkite/scripts/steps/artifacts/docker_image.sh
+++ b/.buildkite/scripts/steps/artifacts/docker_image.sh
@@ -85,7 +85,6 @@ if [[ "$BUILDKITE_BRANCH" == "$KIBANA_BASE_BRANCH" ]]; then
   cat << EOF | buildkite-agent pipeline upload
 steps:
   - trigger: serverless-gitops-update-stack-image-tag
-    async: true
     label: ":argo: Update image tag for Kibana"
     branches: main
     build:


### PR DESCRIPTION
This reverts commit 3b20df420669aed27bb3427d394ae3748afdcca8.

This pipeline was made async to decrease the number of build failure alerts during a stabilization period.  This re-synchronizes the pipeline.

@afharo FYI.