### PR TITLE
[Synthetics] - Isolate `DynamicSettingsAttributes` from `DynamicSettings`

### DIFF
--- a/x-pack/plugins/synthetics/common/constants/settings_defaults.ts
+++ b/x-pack/plugins/synthetics/common/constants/settings_defaults.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { DynamicSettings } from '../runtime_types';
+import { DynamicSettings, DynamicSettingsAttributes } from '../runtime_types';
 
 export const DYNAMIC_SETTINGS_DEFAULTS: DynamicSettings = {
   heartbeatIndices: 'heartbeat-8*,heartbeat-7*,synthetics-*',
@@ -18,3 +18,8 @@ export const DYNAMIC_SETTINGS_DEFAULTS: DynamicSettings = {
     bcc: [],
   },
 };
+
+// `DYNAMIC_SETTINGS_DEFAULT_ATTRIBUTES` helps isolate the Saved Object attributes from `DynamicSettings`
+// which represents API response type. It may initially be a duplcate of `DYNAMIC_SETTINGS_DEFAULTS`
+export const DYNAMIC_SETTINGS_DEFAULT_ATTRIBUTES: DynamicSettingsAttributes =
+  DYNAMIC_SETTINGS_DEFAULTS;

--- a/x-pack/plugins/synthetics/common/runtime_types/dynamic_settings.ts
+++ b/x-pack/plugins/synthetics/common/runtime_types/dynamic_settings.ts
@@ -38,6 +38,14 @@ export const DynamicSettingsSaveType = t.intersection([
   }),
 ]);
 
+export type DynamicSettings = t.TypeOf<typeof DynamicSettingsType>;
+export type DefaultEmail = t.TypeOf<typeof DefaultEmailType>;
+export type DynamicSettingsSaveResponse = t.TypeOf<typeof DynamicSettingsSaveType>;
+
+// `DynamicSettingsAttributes` type helps isolate the Saved Object's attributes from API response object,
+// and it may likely be a duplicate of `DynamicSettings` initially.
+export type DynamicSettingsAttributes = t.TypeOf<typeof DynamicSettingsType>;
+
 export const LocationMonitorsType = t.type({
   status: t.number,
   payload: t.array(
@@ -48,7 +56,4 @@ export const LocationMonitorsType = t.type({
   ),
 });
 
-export type DynamicSettings = t.TypeOf<typeof DynamicSettingsType>;
-export type DefaultEmail = t.TypeOf<typeof DefaultEmailType>;
-export type DynamicSettingsSaveResponse = t.TypeOf<typeof DynamicSettingsSaveType>;
 export type LocationMonitorsResponse = t.TypeOf<typeof LocationMonitorsType>;

--- a/x-pack/plugins/synthetics/server/legacy_uptime/lib/saved_objects/migrations.test.ts
+++ b/x-pack/plugins/synthetics/server/legacy_uptime/lib/saved_objects/migrations.test.ts
@@ -6,12 +6,12 @@
  */
 import { add820Indices } from './migrations';
 import { SavedObject, SavedObjectMigrationContext } from '@kbn/core/server';
-import { DynamicSettings } from '../../../../common/runtime_types';
+import { DynamicSettingsAttributes } from '../../../../common/runtime_types';
 
 describe('add820Indices migration', () => {
   const context = { log: { warning: () => {} } } as unknown as SavedObjectMigrationContext;
 
-  const makeSettings = (heartbeatIndices: string): SavedObject<DynamicSettings> => {
+  const makeSettings = (heartbeatIndices: string): SavedObject<DynamicSettingsAttributes> => {
     return {
       id: '1',
       type: 't',

--- a/x-pack/plugins/synthetics/server/legacy_uptime/lib/saved_objects/migrations.ts
+++ b/x-pack/plugins/synthetics/server/legacy_uptime/lib/saved_objects/migrations.ts
@@ -6,9 +6,12 @@
  */
 
 import { SavedObjectMigrationFn } from '@kbn/core/server';
-import { DynamicSettings } from '../../../../common/runtime_types';
+import { DynamicSettingsAttributes } from '../../../../common/runtime_types';
 
-export const add820Indices: SavedObjectMigrationFn<DynamicSettings, DynamicSettings> = (doc) => {
+export const add820Indices: SavedObjectMigrationFn<
+  DynamicSettingsAttributes,
+  DynamicSettingsAttributes
+> = (doc) => {
   const heartbeatIndices = doc.attributes?.heartbeatIndices;
 
   const indicesArr = !heartbeatIndices ? [] : heartbeatIndices.split(',');

--- a/x-pack/plugins/synthetics/server/legacy_uptime/lib/saved_objects/saved_objects.ts
+++ b/x-pack/plugins/synthetics/server/legacy_uptime/lib/saved_objects/saved_objects.ts
@@ -71,7 +71,7 @@ export const savedObjectsAdapter: UMSavedObjectsAdapter = {
       throw getErr;
     }
   },
-  setUptimeDynamicSettings: async (client, settings: DynamicSettingsAttributes) => {
+  setUptimeDynamicSettings: async (client, settings: DynamicSettingsAttributes | undefined) => {
     await client.create(umDynamicSettings.name, settings, {
       id: settingsObjectId,
       overwrite: true,

--- a/x-pack/plugins/synthetics/server/legacy_uptime/routes/dynamic_settings.ts
+++ b/x-pack/plugins/synthetics/server/legacy_uptime/routes/dynamic_settings.ts
@@ -9,7 +9,11 @@ import { schema } from '@kbn/config-schema';
 import { isRight } from 'fp-ts/lib/Either';
 import { PathReporter } from 'io-ts/lib/PathReporter';
 import { UMServerLibs } from '../lib/lib';
-import { DynamicSettings, DynamicSettingsType } from '../../../common/runtime_types';
+import {
+  DynamicSettings,
+  DynamicSettingsAttributes,
+  DynamicSettingsType,
+} from '../../../common/runtime_types';
 import { UMRestApiRouteFactory } from '.';
 import { savedObjectsAdapter } from '../lib/saved_objects/saved_objects';
 import {
@@ -22,8 +26,10 @@ export const createGetDynamicSettingsRoute: UMRestApiRouteFactory = (_libs: UMSe
   method: 'GET',
   path: API_URLS.DYNAMIC_SETTINGS,
   validate: false,
-  handler: async ({ savedObjectsClient }): Promise<any> => {
-    return savedObjectsAdapter.getUptimeDynamicSettings(savedObjectsClient);
+  handler: async ({ savedObjectsClient }): Promise<DynamicSettings> => {
+    return savedObjectsAdapter.getUptimeDynamicSettings<DynamicSettingsAttributes>(
+      savedObjectsClient
+    );
   },
 });
 
@@ -71,7 +77,10 @@ export const createPostDynamicSettingsRoute: UMRestApiRouteFactory = (_libs: UMS
 
     if (isRight(decoded) && !certThresholdErrors) {
       const newSettings: DynamicSettings = decoded.right;
-      await savedObjectsAdapter.setUptimeDynamicSettings(savedObjectsClient, newSettings);
+      await savedObjectsAdapter.setUptimeDynamicSettings(
+        savedObjectsClient,
+        newSettings as DynamicSettingsAttributes
+      );
 
       return response.ok({
         body: {

--- a/x-pack/plugins/synthetics/server/legacy_uptime/routes/dynamic_settings.ts
+++ b/x-pack/plugins/synthetics/server/legacy_uptime/routes/dynamic_settings.ts
@@ -26,10 +26,8 @@ export const createGetDynamicSettingsRoute: UMRestApiRouteFactory = (_libs: UMSe
   method: 'GET',
   path: API_URLS.DYNAMIC_SETTINGS,
   validate: false,
-  handler: async ({ savedObjectsClient }): Promise<DynamicSettings> => {
-    return savedObjectsAdapter.getUptimeDynamicSettings<DynamicSettingsAttributes>(
-      savedObjectsClient
-    );
+  handler: async ({ savedObjectsClient }): Promise<any> => {
+    return savedObjectsAdapter.getUptimeDynamicSettings(savedObjectsClient);
   },
 });
 

--- a/x-pack/plugins/synthetics/server/routes/monitor_cruds/get_monitor.ts
+++ b/x-pack/plugins/synthetics/server/routes/monitor_cruds/get_monitor.ts
@@ -7,6 +7,7 @@
 import { schema } from '@kbn/config-schema';
 import { SavedObjectsErrorHelpers } from '@kbn/core/server';
 import { getAllMonitors } from '../../saved_objects/synthetics_monitor/get_all_monitors';
+import { syntheticsMonitorType } from '../../../common/types/saved_objects';
 import { isStatusEnabled } from '../../../common/runtime_types/monitor_management/alert_config';
 import {
   ConfigKey,

--- a/x-pack/plugins/synthetics/server/routes/monitor_cruds/get_monitor.ts
+++ b/x-pack/plugins/synthetics/server/routes/monitor_cruds/get_monitor.ts
@@ -14,7 +14,6 @@ import {
   EncryptedSyntheticsMonitor,
   MonitorOverviewItem,
 } from '../../../common/runtime_types';
-import { syntheticsMonitorType } from '../../../common/types/saved_objects';
 import { UMServerLibs } from '../../legacy_uptime/lib/lib';
 import { SyntheticsRestApiRouteFactory } from '../../legacy_uptime/routes/types';
 import { API_URLS, SYNTHETICS_API_URLS } from '../../../common/constants';


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/153496

## Summary

`DynamicSettings` was being used to represent both the SavedObject attributes and the API returned type. This PR isolates the two use cases in compliance with Serverless HTTP Versioning guidelines by introducing a separate type (`DynamicSettingsAttributes`) to represent the SavedObject attributes.