### PR TITLE
[DOCS] Allow users authenticated with API keys to manage alerting rules

### DIFF
--- a/docs/user/alerting/alerting-setup.asciidoc
+++ b/docs/user/alerting/alerting-setup.asciidoc
@@ -74,16 +74,16 @@ A rule or connector created in one space will not be visible in another.
 [[alerting-authorization]]
 === Authorization
 
-Rules are authorized using an <<api-keys,API key>> associated with the last user 
-to edit the rule. This API key captures a snapshot of the user's privileges at 
-the time of the edit. They are subsequently used to run all background tasks 
-associated with the rule, including condition checks like {es} queries and 
-triggered actions. The following rule actions will re-generate the API key:
+Rules are authorized using an API key.
+Its credentials are used to run all background tasks associated with the rule, including condition checks like {es} queries and triggered actions.
+
+You can create API keys and use them in the header of your API calls as described in <<api-keys>>.
+If you create or edit a rule in {kib}, an API key is created that captures a snapshot of your privileges at the time of the edit. The following actions regenerate the API key in {kib}:
 
 * Creating a rule
 * Updating a rule
 
-When you disable a rule, it retains the associated API key which is re-used when 
+When you disable a rule, it retains the associated API key which is reused when 
 the rule is enabled. If the API key is missing when you enable the rule (for 
 example, in the case of imported rules), it generates a new key that has your 
 security privileges.
@@ -94,10 +94,11 @@ You can update an API key manually in
 
 [IMPORTANT]
 ==============================================
-If a rule requires certain privileges, such as index privileges, to run, and a 
+If a rule requires certain privileges, such as index privileges, to run and a 
 user without those privileges updates the rule, the rule will no longer 
 function. Conversely, if a user with greater or administrator privileges 
 modifies the rule, it will begin running with increased privileges.
+The same behavior occurs when you change the API key in the header of your API calls.
 ==============================================
 
 [float]

--- a/docs/user/alerting/troubleshooting/alerting-common-issues.asciidoc
+++ b/docs/user/alerting/troubleshooting/alerting-common-issues.asciidoc
@@ -263,7 +263,7 @@ This error happens when the `xpack.encryptedSavedObjects.encryptionKey` value us
 | The other {kib} instance might be trying to run the rule using a different encryption key than what the rule was created with. Ensure the encryption keys among all the {kib} instances are the same, and setting <<xpack-encryptedSavedObjects-keyRotation-decryptionOnlyKeys, decryption only keys>> for previously used encryption keys.
 
 | If other scenarios don't apply.
-| Generate a new API key for the rule by disabling then enabling the rule.
+| Generate a new API key for the rule. For example, in *{stack-manage-app} > {rules-ui}, select *Update API key* from the action menu.
 
 |===
 

--- a/docs/user/alerting/troubleshooting/alerting-common-issues.asciidoc
+++ b/docs/user/alerting/troubleshooting/alerting-common-issues.asciidoc
@@ -263,7 +263,7 @@ This error happens when the `xpack.encryptedSavedObjects.encryptionKey` value us
 | The other {kib} instance might be trying to run the rule using a different encryption key than what the rule was created with. Ensure the encryption keys among all the {kib} instances are the same, and setting <<xpack-encryptedSavedObjects-keyRotation-decryptionOnlyKeys, decryption only keys>> for previously used encryption keys.
 
 | If other scenarios don't apply.
-| Generate a new API key for the rule. For example, in *{stack-manage-app} > {rules-ui}, select *Update API key* from the action menu.
+| Generate a new API key for the rule. For example, in *{stack-manage-app} > {rules-ui}*, select *Update API key* from the action menu.
 
 |===
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/154580



<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->