### PR TITLE
[Cloud Posture][Quick Wins] Hovering over filter in/out button on Vulnerability table now shows field name

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/pages/vulnerabilities/vulnerabilities.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/vulnerabilities/vulnerabilities.tsx
@@ -180,10 +180,25 @@ const VulnerabilitiesContent = ({ dataView }: { dataView: DataView }) => {
 
         if (!value) return null;
         return (
-          <EuiToolTip position="top" content={FILTER_IN}>
+          <EuiToolTip
+            position="top"
+            content={i18n.translate(
+              'xpack.csp.vulnerabilities.vulnerabilitiesTableCell.addFilterButtonTooltip',
+              {
+                defaultMessage: 'Add {columnId} filter',
+                values: { columnId },
+              }
+            )}
+          >
             <Component
               iconType="plusInCircle"
-              aria-label={FILTER_IN}
+              aria-label={i18n.translate(
+                'xpack.csp.vulnerabilities.vulnerabilitiesTableCell.addFilterButton',
+                {
+                  defaultMessage: 'Add {columnId} negated filter',
+                  values: { columnId },
+                }
+              )}
               onClick={() => {
                 setUrlQuery({
                   pageIndex: 0,
@@ -207,10 +222,25 @@ const VulnerabilitiesContent = ({ dataView }: { dataView: DataView }) => {
 
         if (!value) return null;
         return (
-          <EuiToolTip position="top" content={FILTER_OUT}>
+          <EuiToolTip
+            position="top"
+            content={i18n.translate(
+              'xpack.csp.vulnerabilities.vulnerabilitiesTableCell.addNegatedFilterButtonTooltip',
+              {
+                defaultMessage: 'Add {columnId} negated filter',
+                values: { columnId },
+              }
+            )}
+          >
             <Component
               iconType="minusInCircle"
-              aria-label={FILTER_OUT}
+              aria-label={i18n.translate(
+                'xpack.csp.vulnerabilities.vulnerabilitiesTableCell.addNegateFilterButton',
+                {
+                  defaultMessage: 'Add {columnId} negated filter',
+                  values: { columnId },
+                }
+              )}
               onClick={() => {
                 setUrlQuery({
                   pageIndex: 0,


### PR DESCRIPTION
## Summary
Hovering over the + / - filter button on Vulnerability tables now also show what field are being filtered
![field_name_filter](https://github.com/elastic/kibana/assets/8703149/81b88291-37b5-45fd-b9d4-c53347bb9299)
![field_name_filter_2](https://github.com/elastic/kibana/assets/8703149/db0bdeae-7088-4372-8eaf-27604f5384fc)



