### PR TITLE
[Cloud Posture]Re-added index timeout component for Vulnerability management

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/components/no_vulnerabilities_states.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/no_vulnerabilities_states.tsx
@@ -16,6 +16,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiImage,
+  EuiLink,
 } from '@elastic/eui';
 import { FormattedHTMLMessage, FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
@@ -108,6 +109,40 @@ const CnvmIntegrationNotInstalledEmptyPrompt = ({
     />
   );
 };
+
+const CnvmIndexTimeout = () => (
+  <EuiEmptyPrompt
+    data-test-subj={NO_VULNERABILITIES_STATUS_TEST_SUBJ.INDEX_TIMEOUT}
+    color="plain"
+    icon={<EuiLoadingLogo logo="logoSecurity" size="xl" />}
+    title={
+      <h2>
+        <FormattedMessage
+          id="xpack.csp.noVulnerabilitiesStates.indexTimeout.indexTimeoutTitle"
+          defaultMessage="Findings Delayed"
+        />
+      </h2>
+    }
+    body={
+      <p>
+        <FormattedMessage
+          id="xpack.csp.noVulnerabilitiesStates.indexTimeout.indexTimeoutDescription"
+          defaultMessage="Scanning workloads is taking longer than expected. Please check {docs}"
+          values={{
+            docs: (
+              <EuiLink href="https://ela.st/cnvm-faq" target="_blank">
+                <FormattedMessage
+                  id="xpack.csp.noVulnerabilitiesStates.indexTimeout.indexTimeoutDocLink"
+                  defaultMessage="CNVM FAQ"
+                />
+              </EuiLink>
+            ),
+          }}
+        />
+      </p>
+    }
+  />
+);
 
 const Unprivileged = ({ unprivilegedIndices }: { unprivilegedIndices: string[] }) => (
   <EuiEmptyPrompt
@@ -218,8 +253,9 @@ export const NoVulnerabilitiesStates = () => {
       .sort((a, b) => a.localeCompare(b));
 
   const render = () => {
-    if (status === 'indexing' || status === 'waiting_for_results' || status === 'index-timeout')
+    if (status === 'indexing' || status === 'waiting_for_results')
       return <ScanningVulnerabilitiesEmptyPrompt />; // integration installed, but no agents added// agent added, index timeout has passed
+    if (status === 'index-timeout') return <CnvmIndexTimeout />;
     if (status === 'not-installed')
       return (
         <CnvmIntegrationNotInstalledEmptyPrompt vulnMgmtIntegrationLink={vulnMgmtIntegrationLink} />

--- a/x-pack/plugins/cloud_security_posture/public/components/test_subjects.ts
+++ b/x-pack/plugins/cloud_security_posture/public/components/test_subjects.ts
@@ -27,6 +27,7 @@ export const NO_VULNERABILITIES_STATUS_TEST_SUBJ = {
   NOT_DEPLOYED: 'agent-not-deployed-vuln-mgmt',
   UNPRIVILEGED: 'status-api-vuln-mgmt-unprivileged',
   NO_VULNERABILITIES: 'no-vulnerabilities-vuln-mgmt-found',
+  INDEX_TIMEOUT: 'vulnerabilities-timeout',
 };
 
 export const VULNERABILITIES_CONTAINER_TEST_SUBJ = 'vulnerabilities_container';

--- a/x-pack/plugins/cloud_security_posture/public/pages/vulnerabilities/vulnerabilties.test.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/vulnerabilities/vulnerabilties.test.tsx
@@ -128,6 +128,29 @@ describe('<Vulnerabilities />', () => {
     });
   });
 
+  it('No vulnerabilities  state: index-timeout - shows IndexTimeout instead of vulnerabilities ', () => {
+    (useCspSetupStatusApi as jest.Mock).mockImplementation(() =>
+      createReactQueryResponse({
+        status: 'success',
+        data: {
+          [VULN_MGMT_POLICY_TEMPLATE]: { status: 'index-timeout' },
+          indicesDetails: [{ index: LATEST_VULNERABILITIES_INDEX_DEFAULT_NS, status: 'empty' }],
+        },
+      })
+    );
+    (useCspIntegrationLink as jest.Mock).mockImplementation(() => chance.url());
+    renderVulnerabilitiesPage();
+
+    expectIdsInDoc({
+      be: [NO_VULNERABILITIES_STATUS_TEST_SUBJ.INDEX_TIMEOUT],
+      notToBe: [
+        VULNERABILITIES_CONTAINER_TEST_SUBJ,
+        NO_VULNERABILITIES_STATUS_TEST_SUBJ.SCANNING_VULNERABILITIES,
+        NO_VULNERABILITIES_STATUS_TEST_SUBJ.UNPRIVILEGED,
+      ],
+    });
+  });
+
   it('No vulnerabilities  state: unprivileged - shows Unprivileged instead of vulnerabilities ', () => {
     (useCspSetupStatusApi as jest.Mock).mockImplementation(() =>
       createReactQueryResponse({

--- a/x-pack/plugins/cloud_security_posture/server/routes/status/status.test.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/status/status.test.ts
@@ -311,7 +311,7 @@ describe('calculateIntegrationStatus for vul_mgmt', () => {
       },
       mockInstallation,
       1,
-      61,
+      241,
       [VULN_MGMT_POLICY_TEMPLATE]
     );
 

--- a/x-pack/plugins/cloud_security_posture/server/routes/status/status.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/status/status.ts
@@ -45,7 +45,7 @@ import {
 import { checkIndexStatus } from '../../lib/check_index_status';
 
 export const INDEX_TIMEOUT_IN_MINUTES = 10;
-export const INDEX_TIMEOUT_IN_MINUTES_CNVM = 60;
+export const INDEX_TIMEOUT_IN_MINUTES_CNVM = 240;
 
 interface CspStatusDependencies {
   logger: Logger;


### PR DESCRIPTION
## Summary

- Re-added index timeout component for Vulnerability management + related test cases as well
- Timeout for CNVM is now set to 4 hours (previously it was 1 hour)
![vuln_delay](https://github.com/elastic/kibana/assets/8703149/16cad5b9-deaa-49f1-a7c9-d81f699dd7d4)




