### PR TITLE
[Serverless] Set observability onboarding as default page

### DIFF
--- a/config/serverless.oblt.yml
+++ b/config/serverless.oblt.yml
@@ -15,7 +15,7 @@ xpack.observability_onboarding.ui.enabled: true
 xpack.infra.logs.app_target: discover
 
 ## Set the home route
-uiSettings.overrides.defaultRoute: /app/observability/overview
+uiSettings.overrides.defaultRoute: /app/observabilityOnboarding
 
 ## Set the dev project switch current type
 xpack.serverless.plugin.developer.projectSwitcher.currentType: 'observability'


### PR DESCRIPTION
This PR set `observabilityOnboarding` as default page for serverless observability

https://github.com/elastic/kibana/assets/1313018/0ff9c462-0388-4ead-8e5e-7b67e26f6f93

