### PR TITLE
[Synthetisc] Unskip test get monitors

### DIFF
--- a/x-pack/test/api_integration/apis/synthetics/get_monitor.ts
+++ b/x-pack/test/api_integration/apis/synthetics/get_monitor.ts
@@ -13,8 +13,7 @@ import { FtrProviderContext } from '../../ftr_provider_context';
 import { getFixtureJson } from './helper/get_fixture_json';
 
 export default function ({ getService }: FtrProviderContext) {
-  // Failing: See https://github.com/elastic/kibana/issues/158394
-  describe.skip('getSyntheticsMonitors', function () {
+  describe('getSyntheticsMonitors', function () {
     this.tags('skipCloud');
 
     const supertest = getService('supertest');


### PR DESCRIPTION
## Summary

Test wasn't flaky , it was actually a case of bad merge, a race condition between two PR's broke types. Which has already been fixed.


fixes https://github.com/elastic/kibana/issues/158394