### PR TITLE
Add sync_cursor to connector index mapping

### DIFF
--- a/x-pack/plugins/enterprise_search/server/index_management/setup_indices.test.ts
+++ b/x-pack/plugins/enterprise_search/server/index_management/setup_indices.test.ts
@@ -150,6 +150,7 @@ describe('Setup Indices', () => {
       },
       service_type: { type: 'keyword' },
       status: { type: 'keyword' },
+      sync_cursor: { type: 'object' },
       sync_now: { type: 'boolean' },
     },
   };

--- a/x-pack/plugins/enterprise_search/server/index_management/setup_indices.ts
+++ b/x-pack/plugins/enterprise_search/server/index_management/setup_indices.ts
@@ -139,6 +139,7 @@ const connectorMappingsProperties: Record<string, MappingProperty> = {
   },
   service_type: { type: 'keyword' },
   status: { type: 'keyword' },
+  sync_cursor: { type: 'object' },
   sync_now: { type: 'boolean' },
 };
 


### PR DESCRIPTION
# Part of https://github.com/elastic/enterprise-search-team/issues/4626

## Summary

This PR adds a new field `sync_cursor` to index `.elastic-connectors`.


### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
