### PR TITLE
Serverless Search: Getting started cURL code snippets

### DIFF
--- a/x-pack/plugins/serverless_search/common/services/decode_cloud_id.test.ts
+++ b/x-pack/plugins/serverless_search/common/services/decode_cloud_id.test.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { decodeCloudId } from './decode_cloud_id';
+
+// Copied from Fleet's solution
+// x-pack/fleet/common/services/decode_cloud_id.test.ts
+describe('Enterprise Search - decodeCloudId', () => {
+  it('parses various CloudID formats', () => {
+    const tests = [
+      {
+        cloudID:
+          'staging:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyRjZWM2ZjI2MWE3NGJmMjRjZTMzYmI4ODExYjg0Mjk0ZiRjNmMyY2E2ZDA0MjI0OWFmMGNjN2Q3YTllOTYyNTc0Mw==',
+        expectedEsURL: 'https://cec6f261a74bf24ce33bb8811b84294f.us-east-1.aws.found.io:443',
+        expectedKibanaURL: 'https://c6c2ca6d042249af0cc7d7a9e9625743.us-east-1.aws.found.io:443',
+      },
+      {
+        cloudID:
+          'dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyRjZWM2ZjI2MWE3NGJmMjRjZTMzYmI4ODExYjg0Mjk0ZiRjNmMyY2E2ZDA0MjI0OWFmMGNjN2Q3YTllOTYyNTc0Mw==',
+        expectedEsURL: 'https://cec6f261a74bf24ce33bb8811b84294f.us-east-1.aws.found.io:443',
+        expectedKibanaURL: 'https://c6c2ca6d042249af0cc7d7a9e9625743.us-east-1.aws.found.io:443',
+      },
+      {
+        cloudID:
+          ':dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyRjZWM2ZjI2MWE3NGJmMjRjZTMzYmI4ODExYjg0Mjk0ZiRjNmMyY2E2ZDA0MjI0OWFmMGNjN2Q3YTllOTYyNTc0Mw==',
+        expectedEsURL: 'https://cec6f261a74bf24ce33bb8811b84294f.us-east-1.aws.found.io:443',
+        expectedKibanaURL: 'https://c6c2ca6d042249af0cc7d7a9e9625743.us-east-1.aws.found.io:443',
+      },
+      {
+        cloudID:
+          'gcp-cluster:dXMtY2VudHJhbDEuZ2NwLmNsb3VkLmVzLmlvJDhhMDI4M2FmMDQxZjE5NWY3NzI5YmMwNGM2NmEwZmNlJDBjZDVjZDU2OGVlYmU1M2M4OWViN2NhZTViYWM4YjM3',
+        expectedEsURL: 'https://8a0283af041f195f7729bc04c66a0fce.us-central1.gcp.cloud.es.io:443',
+        expectedKibanaURL:
+          'https://0cd5cd568eebe53c89eb7cae5bac8b37.us-central1.gcp.cloud.es.io:443',
+      },
+      {
+        cloudID:
+          'custom-port:dXMtY2VudHJhbDEuZ2NwLmNsb3VkLmVzLmlvOjkyNDMkYWMzMWViYjkwMjQxNzczMTU3MDQzYzM0ZmQyNmZkNDYkYTRjMDYyMzBlNDhjOGZjZTdiZTg4YTA3NGEzYmIzZTA=',
+        expectedEsURL: 'https://ac31ebb90241773157043c34fd26fd46.us-central1.gcp.cloud.es.io:9243',
+        expectedKibanaURL:
+          'https://a4c06230e48c8fce7be88a074a3bb3e0.us-central1.gcp.cloud.es.io:9243',
+      },
+      {
+        cloudID:
+          'different-es-kb-port:dXMtY2VudHJhbDEuZ2NwLmNsb3VkLmVzLmlvJGFjMzFlYmI5MDI0MTc3MzE1NzA0M2MzNGZkMjZmZDQ2OjkyNDMkYTRjMDYyMzBlNDhjOGZjZTdiZTg4YTA3NGEzYmIzZTA6OTI0NA==',
+        expectedEsURL: 'https://ac31ebb90241773157043c34fd26fd46.us-central1.gcp.cloud.es.io:9243',
+        expectedKibanaURL:
+          'https://a4c06230e48c8fce7be88a074a3bb3e0.us-central1.gcp.cloud.es.io:9244',
+      },
+      {
+        cloudID:
+          'only-kb-set:dXMtY2VudHJhbDEuZ2NwLmNsb3VkLmVzLmlvJGFjMzFlYmI5MDI0MTc3MzE1NzA0M2MzNGZkMjZmZDQ2JGE0YzA2MjMwZTQ4YzhmY2U3YmU4OGEwNzRhM2JiM2UwOjkyNDQ=',
+        expectedEsURL: 'https://ac31ebb90241773157043c34fd26fd46.us-central1.gcp.cloud.es.io:443',
+        expectedKibanaURL:
+          'https://a4c06230e48c8fce7be88a074a3bb3e0.us-central1.gcp.cloud.es.io:9244',
+      },
+      {
+        cloudID:
+          'host-and-kb-set:dXMtY2VudHJhbDEuZ2NwLmNsb3VkLmVzLmlvOjkyNDMkYWMzMWViYjkwMjQxNzczMTU3MDQzYzM0ZmQyNmZkNDYkYTRjMDYyMzBlNDhjOGZjZTdiZTg4YTA3NGEzYmIzZTA6OTI0NA==',
+        expectedEsURL: 'https://ac31ebb90241773157043c34fd26fd46.us-central1.gcp.cloud.es.io:9243',
+        expectedKibanaURL:
+          'https://a4c06230e48c8fce7be88a074a3bb3e0.us-central1.gcp.cloud.es.io:9244',
+      },
+      {
+        cloudID:
+          'extra-items:dXMtY2VudHJhbDEuZ2NwLmNsb3VkLmVzLmlvJGFjMzFlYmI5MDI0MTc3MzE1NzA0M2MzNGZkMjZmZDQ2JGE0YzA2MjMwZTQ4YzhmY2U3YmU4OGEwNzRhM2JiM2UwJGFub3RoZXJpZCRhbmRhbm90aGVy',
+        expectedEsURL: 'https://ac31ebb90241773157043c34fd26fd46.us-central1.gcp.cloud.es.io:443',
+        expectedKibanaURL:
+          'https://a4c06230e48c8fce7be88a074a3bb3e0.us-central1.gcp.cloud.es.io:443',
+      },
+    ];
+
+    for (const test of tests) {
+      const decoded = decodeCloudId(test.cloudID);
+      expect(decoded).toBeTruthy();
+      expect(decoded?.elasticsearchUrl === test.expectedEsURL).toBe(true);
+      expect(decoded?.kibanaUrl === test.expectedKibanaURL).toBe(true);
+    }
+  });
+
+  it('returns undefined for invalid formats', () => {
+    const tests = [
+      {
+        cloudID:
+          'staging:garbagedXMtZWFzdC0xLmF3cy5mb3VuZC5pbyRjZWM2ZjI2MWE3NGJmMjRjZTMzYmI4ODExYjg0Mjk0ZiRjNmMyY2E2ZDA0MjI0OWFmMGNjN2Q3YTllOTYyNTc0Mw==',
+        errorMsg: 'base64 decoding failed',
+      },
+      {
+        cloudID: 'dXMtY2VudHJhbDEuZ2NwLmNsb3VkLmVzLmlvJDhhMDI4M2FmMDQxZjE5NWY3NzI5YmMwNGM2NmEwZg==',
+        errorMsg: 'Expected at least 3 parts',
+      },
+    ];
+
+    for (const test of tests) {
+      const decoded = decodeCloudId(test.cloudID);
+      expect(decoded).toBe(undefined);
+      // decodeCloudId currently only logs; not throws errors
+    }
+  });
+});

--- a/x-pack/plugins/serverless_search/common/services/decode_cloud_id.ts
+++ b/x-pack/plugins/serverless_search/common/services/decode_cloud_id.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+// copied this solution from fleet due to time constraints
+// x-pack/fleet/common/services/decode_cloud_id.ts
+// decodeCloudId decodes the c.id into c.esURL and c.kibURL
+export function decodeCloudId(cid: string):
+  | {
+      defaultPort: string;
+      elasticsearchUrl: string;
+      host: string;
+      kibanaUrl: string;
+    }
+  | undefined {
+  // 1. Ignore anything before `:`.
+  const id = cid.split(':').pop();
+  if (!id) {
+    // throw new Error(`Unable to decode ${id}`);
+    // eslint-disable-next-line no-console
+    console.debug(`Unable to decode ${id}`);
+    return;
+  }
+
+  // 2. base64 decode
+  let decoded: string | undefined;
+  try {
+    decoded = Buffer.from(id, 'base64').toString('utf8');
+  } catch {
+    // throw new Error(`base64 decoding failed on ${id}`);
+    // eslint-disable-next-line no-console
+    console.debug(`base64 decoding failed on ${id}`);
+    return;
+  }
+
+  // 3. separate based on `$`
+  const words = decoded.split('$');
+  if (words.length < 3) {
+    // throw new Error(`Expected at least 3 parts in ${decoded}`);
+    // eslint-disable-next-line no-console
+    console.debug(`Expected at least 3 parts in ${decoded}`);
+    return;
+  }
+  // 4. extract port from the ES and Kibana host
+  const [host, defaultPort] = extractPortFromName(words[0]);
+  const [esId, esPort] = extractPortFromName(words[1], defaultPort);
+  const [kbId, kbPort] = extractPortFromName(words[2], defaultPort);
+  // 5. form the URLs
+  const esUrl = `https://${esId}.${host}:${esPort}`;
+  const kbUrl = `https://${kbId}.${host}:${kbPort}`;
+  return {
+    defaultPort,
+    elasticsearchUrl: esUrl,
+    host,
+    kibanaUrl: kbUrl,
+  };
+}
+// extractPortFromName takes a string in the form `id:port` and returns the
+// Id and the port. If there's no `:`, the default port is returned
+function extractPortFromName(word: string, defaultPort = '443') {
+  const [host, port = defaultPort] = word.split(':');
+  return [host, port];
+}

--- a/x-pack/plugins/serverless_search/jest.config.js
+++ b/x-pack/plugins/serverless_search/jest.config.js
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+module.exports = {
+  preset: '@kbn/test',
+  rootDir: '../../..',
+  roots: ['<rootDir>/x-pack/plugins/serverless_search'],
+  coverageDirectory: '<rootDir>/target/kibana-coverage/jest/x-pack/plugins/serverless_search',
+  coverageReporters: ['text', 'html'],
+  collectCoverageFrom: [
+    '<rootDir>/x-pack/plugins/serverless_search/{common,public,server}/**/*.{ts,tsx}',
+  ],
+};

--- a/x-pack/plugins/serverless_search/public/application/components/api_key/api_key.tsx
+++ b/x-pack/plugins/serverless_search/public/application/components/api_key/api_key.tsx
@@ -28,22 +28,27 @@ import React, { useState } from 'react';
 import { useKibanaServices } from '../../hooks/use_kibana';
 import { MANAGEMENT_API_KEYS } from '../../routes';
 import { CreateApiKeyFlyout } from './create_api_key_flyout';
+import { CreateApiKeyResponse } from './types';
 
-export const ApiKeyPanel: React.FC = () => {
+export const ApiKeyPanel = ({ setClientApiKey }: { setClientApiKey: (value: string) => void }) => {
   const { cloud, http, userProfile } = useKibanaServices();
   const [isFlyoutOpen, setIsFlyoutOpen] = useState(false);
   const { data } = useQuery({
     queryKey: ['apiKey'],
     queryFn: () => http.fetch<{ apiKeys: ApiKey[] }>('/internal/serverless_search/api_keys'),
   });
-  const [apiKey, setApiKey] = useState<ApiKey | undefined>(undefined);
+  const [apiKey, setApiKey] = useState<CreateApiKeyResponse | undefined>(undefined);
+  const saveApiKey = (value: CreateApiKeyResponse) => {
+    setApiKey(value);
+    if (value.encoded) setClientApiKey(value.encoded);
+  };
 
   return (
     <>
       {isFlyoutOpen && (
         <CreateApiKeyFlyout
           onClose={() => setIsFlyoutOpen(false)}
-          setApiKey={setApiKey}
+          setApiKey={saveApiKey}
           username={userProfile.user.full_name || userProfile.user.username}
         />
       )}

--- a/x-pack/plugins/serverless_search/public/application/components/api_key/create_api_key_flyout.tsx
+++ b/x-pack/plugins/serverless_search/public/application/components/api_key/create_api_key_flyout.tsx
@@ -19,7 +19,6 @@ import {
   EuiTitle,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { ApiKey } from '@kbn/security-plugin/common';
 import { useMutation } from '@tanstack/react-query';
 import React, { useState } from 'react';
 import {
@@ -35,10 +34,11 @@ import { isApiError } from '../../../utils/api';
 import { BasicSetupForm, DEFAULT_EXPIRES_VALUE } from './basic_setup_form';
 import { MetadataForm } from './metadata_form';
 import { SecurityPrivilegesForm } from './security_privileges_form';
+import { CreateApiKeyResponse } from './types';
 
 interface CreateApiKeyFlyoutProps {
   onClose: () => void;
-  setApiKey: (apiKey: ApiKey) => void;
+  setApiKey: (apiKey: CreateApiKeyResponse) => void;
   username: string;
 }
 
@@ -126,7 +126,7 @@ export const CreateApiKeyFlyout: React.FC<CreateApiKeyFlyoutProps> = ({
 
   const { isLoading, isError, error, mutate } = useMutation({
     mutationFn: async (input: CreateAPIKeyArgs) => {
-      const result = await http.post<ApiKey>(CREATE_API_KEY_PATH, {
+      const result = await http.post<CreateApiKeyResponse>(CREATE_API_KEY_PATH, {
         body: JSON.stringify(input),
       });
       return result;

--- a/x-pack/plugins/serverless_search/public/application/components/api_key/types.ts
+++ b/x-pack/plugins/serverless_search/public/application/components/api_key/types.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export interface CreateApiKeyResponse {
+  id: string;
+  name: string;
+  expiration?: number;
+  api_key: string;
+  encoded?: string;
+}

--- a/x-pack/plugins/serverless_search/public/application/components/code_box.tsx
+++ b/x-pack/plugins/serverless_search/public/application/components/code_box.tsx
@@ -22,20 +22,33 @@ import { i18n } from '@kbn/i18n';
 import React, { useState } from 'react';
 import { PLUGIN_ID } from '../../../common';
 import { useKibanaServices } from '../hooks/use_kibana';
-import { LanguageDefinition } from './languages/types';
+import { LanguageDefinition, LanguageDefinitionSnippetArguments } from './languages/types';
 import './code_box.scss';
 
 interface CodeBoxProps {
   languages: LanguageDefinition[];
   code: keyof LanguageDefinition;
+  codeArgs: LanguageDefinitionSnippetArguments;
   // overrides the language type for syntax highlighting
   languageType?: string;
   selectedLanguage: LanguageDefinition;
   setSelectedLanguage: (language: LanguageDefinition) => void;
 }
 
+const getCodeSnippet = (
+  language: LanguageDefinition,
+  key: keyof LanguageDefinition,
+  args: LanguageDefinitionSnippetArguments
+): string => {
+  const snippetVal = language[key];
+  if (snippetVal === undefined) return '';
+  if (typeof snippetVal === 'string') return snippetVal;
+  return snippetVal(args);
+};
+
 export const CodeBox: React.FC<CodeBoxProps> = ({
   code,
+  codeArgs,
   languages,
   languageType,
   selectedLanguage,
@@ -71,6 +84,7 @@ export const CodeBox: React.FC<CodeBoxProps> = ({
       </EuiButtonEmpty>
     </EuiThemeProvider>
   );
+  const codeSnippet = getCodeSnippet(selectedLanguage, code, codeArgs);
 
   return (
     <EuiThemeProvider colorMode="dark">
@@ -90,7 +104,7 @@ export const CodeBox: React.FC<CodeBoxProps> = ({
             </EuiThemeProvider>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiCopy textToCopy={selectedLanguage[code] ?? ''}>
+            <EuiCopy textToCopy={codeSnippet}>
               {(copy) => (
                 <EuiButtonEmpty color="text" iconType="copy" size="s" onClick={copy}>
                   {i18n.translate('xpack.serverlessSearch.codeBox.copyButtonLabel', {
@@ -107,7 +121,7 @@ export const CodeBox: React.FC<CodeBoxProps> = ({
           fontSize="m"
           language={languageType || selectedLanguage.languageStyling || selectedLanguage.id}
         >
-          {selectedLanguage[code]}
+          {codeSnippet}
         </EuiCodeBlock>
       </EuiPanel>
     </EuiThemeProvider>

--- a/x-pack/plugins/serverless_search/public/application/components/languages/curl.ts
+++ b/x-pack/plugins/serverless_search/public/application/components/languages/curl.ts
@@ -11,7 +11,7 @@ import { LanguageDefinition, Languages } from './types';
 
 export const curlDefinition: LanguageDefinition = {
   buildSearchQuery: `TBD`,
-  configureClient: `TBD`,
+  configureClient: () => `TBD`,
   docLink: docLinks.apiIntro,
   iconType: 'cURL.svg',
   id: Languages.CURL,

--- a/x-pack/plugins/serverless_search/public/application/components/languages/curl.ts
+++ b/x-pack/plugins/serverless_search/public/application/components/languages/curl.ts
@@ -10,7 +10,7 @@ import { docLinks } from '../../../../common/doc_links';
 import { LanguageDefinition, Languages } from './types';
 
 export const curlDefinition: LanguageDefinition = {
-  buildSearchQuery: `curl -X GET "\$\{ES_URL\}/books/_search?pretty" \\
+  buildSearchQuery: `curl -X POST "\$\{ES_URL\}/books/_search?pretty" \\
   -H "Authorization: ApiKey "\$\{API_KEY\}"" \\
   -H "Content-Type: application/json" \\
   -d'

--- a/x-pack/plugins/serverless_search/public/application/components/languages/curl.ts
+++ b/x-pack/plugins/serverless_search/public/application/components/languages/curl.ts
@@ -10,16 +10,49 @@ import { docLinks } from '../../../../common/doc_links';
 import { LanguageDefinition, Languages } from './types';
 
 export const curlDefinition: LanguageDefinition = {
-  buildSearchQuery: `TBD`,
-  configureClient: () => `TBD`,
+  buildSearchQuery: `curl -X GET "\$\{ES_URL\}/books/_search?pretty" \\
+  -H "Authorization: ApiKey "\$\{API_KEY\}"" \\
+  -H "Content-Type: application/json" \\
+  -d'
+{
+  "query": {
+    "query_string": {
+      "query": "snow"
+    }
+  }
+}'`,
+  configureClient: ({ apiKey, url }) => `export ES_URL="${url}"
+export API_KEY="${apiKey}"`,
   docLink: docLinks.apiIntro,
   iconType: 'cURL.svg',
   id: Languages.CURL,
-  ingestData: `TBD`,
-  installClient: `TBD`,
+  ingestData: `curl -X POST "\$\{ES_URL\}/_bulk?pretty" \\
+  -H "Authorization: ApiKey "\$\{API_KEY\}"" \\
+  -H "Content-Type: application/json" \\
+  -d'
+{ "index" : { "_index" : "books" } }
+{"name": "Snow Crash", "author": "Neal Stephenson", "release_date": "1992-06-01", "page_count": 470}
+{ "index" : { "_index" : "books" } }
+{"name": "Revelation Space", "author": "Alastair Reynolds", "release_date": "2000-03-15", "page_count": 585}
+{ "index" : { "_index" : "books" } }
+{"name": "1984", "author": "George Orwell", "release_date": "1985-06-01", "page_count": 328}
+{ "index" : { "_index" : "books" } }
+{"name": "Fahrenheit 451", "author": "Ray Bradbury", "release_date": "1953-10-15", "page_count": 227}
+{ "index" : { "_index" : "books" } }
+{"name": "Brave New World", "author": "Aldous Huxley", "release_date": "1932-06-01", "page_count": 268}
+{ "index" : { "_index" : "books" } }
+{"name": "The Handmaid'"'"'s Tale", "author": "Margaret Atwood", "release_date": "1985-06-01", "page_count": 311}
+'`,
+  installClient: `# if cURL is not already installed on your system
+# then install it with the package manager of your choice
+
+# example
+brew install curl`,
   name: i18n.translate('xpack.serverlessSearch.languages.cURL', {
     defaultMessage: 'cURL',
   }),
   languageStyling: 'shell',
-  testConnection: `TBD`,
+  testConnection: `curl "\$\{ES_URL\}" \\
+  -H "Authorization: ApiKey "\$\{API_KEY\}"" \\
+  -H "Content-Type: application/json"`,
 };

--- a/x-pack/plugins/serverless_search/public/application/components/languages/javascript.ts
+++ b/x-pack/plugins/serverless_search/public/application/components/languages/javascript.ts
@@ -41,11 +41,11 @@ bytes: 293,
 aborted: false
 }
 */`,
-  configureClient: `const { Client } = require('@elastic/elasticsearch');
+  configureClient: ({ url, apiKey }) => `const { Client } = require('@elastic/elasticsearch');
 const client = Client({
-node: 'https://my-deployment-url',
+node: '${url}',
 auth: {
-    apiKey: 'your_api_key'
+    apiKey: '${apiKey}'
 }
 });`,
   docLink: docLinks.jsClient,

--- a/x-pack/plugins/serverless_search/public/application/components/languages/javascript.ts
+++ b/x-pack/plugins/serverless_search/public/application/components/languages/javascript.ts
@@ -13,36 +13,16 @@ export const javascriptDefinition: LanguageDefinition = {
   advancedConfig: docLinks.jsAdvancedConfig,
   apiReference: docLinks.jsApiReference,
   basicConfig: docLinks.jsBasicConfig,
-  buildSearchQuery: `// Sample flight data
-const dataset = [
-{'flight': '9HY9SWR', 'price': 841.2656419677076, 'delayed': false},
-{'flight': 'X98CCZO', 'price': 882.9826615595518, 'delayed': false},
-{'flight': 'UFK2WIZ', 'price': 190.6369038508356, 'delayed': true},
-];
-
-// Index with the bulk helper
-const result = await client.helpers.bulk({
-datasource: dataset,
-onDocument (doc) {
-  return { index: { _index: 'my-index-name' }};
-}
+  buildSearchQuery: `// Let's search!
+const searchResult = await client.search({
+  index: 'my-index-name',
+  q: '9HY9SWR'
 });
 
-console.log(result);
-/**
-{
-total: 3,
-failed: 0,
-retry: 0,
-successful: 3,
-noop: 0,
-time: 421,
-bytes: 293,
-aborted: false
-}
-*/`,
+console.log(searchResult.hits.hits)
+`,
   configureClient: ({ url, apiKey }) => `const { Client } = require('@elastic/elasticsearch');
-const client = Client({
+const client = new Client({
 node: '${url}',
 auth: {
     apiKey: '${apiKey}'

--- a/x-pack/plugins/serverless_search/public/application/components/languages/ruby.ts
+++ b/x-pack/plugins/serverless_search/public/application/components/languages/ruby.ts
@@ -13,9 +13,9 @@ export const rubyDefinition: LanguageDefinition = {
   advancedConfig: docLinks.rubyAdvancedConfig,
   apiReference: docLinks.rubyExamples,
   buildSearchQuery: `client.search(index: 'books', q: 'snow')`,
-  configureClient: `client = ElasticsearchServerless::Client.new(
-  api_key: 'your_api_key',
-  url: 'https://my-deployment-url'
+  configureClient: ({ url, apiKey }) => `client = ElasticsearchServerless::Client.new(
+  api_key: '${apiKey}',
+  url: '${url}'
 )
 `,
   basicConfig: docLinks.rubyBasicConfig,
@@ -38,5 +38,5 @@ $ gem install elasticsearch-serverless-x.x.x.gem`,
   name: i18n.translate('xpack.serverlessSearch.languages.ruby', {
     defaultMessage: 'Ruby',
   }),
-  testConnection: `TBD`,
+  testConnection: `client.info`,
 };

--- a/x-pack/plugins/serverless_search/public/application/components/languages/types.ts
+++ b/x-pack/plugins/serverless_search/public/application/components/languages/types.ts
@@ -18,18 +18,24 @@ export enum Languages {
   CURL = 'curl',
 }
 
+export interface LanguageDefinitionSnippetArguments {
+  url: string;
+  apiKey: string;
+}
+
+type CodeSnippet = string | ((args: LanguageDefinitionSnippetArguments) => string);
 export interface LanguageDefinition {
   advancedConfig?: string;
   apiReference?: string;
   basicConfig?: string;
-  configureClient: string;
+  configureClient: CodeSnippet;
   docLink: string;
   iconType: string;
   id: Languages;
-  ingestData: string;
+  ingestData: CodeSnippet;
   installClient: string;
   languageStyling?: string;
   name: string;
-  buildSearchQuery: string;
-  testConnection: string;
+  buildSearchQuery: CodeSnippet;
+  testConnection: CodeSnippet;
 }

--- a/x-pack/plugins/serverless_search/public/application/components/overview.tsx
+++ b/x-pack/plugins/serverless_search/public/application/components/overview.tsx
@@ -19,14 +19,15 @@ import {
   EuiTitle,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { docLinks } from '../../../common/doc_links';
 import { PLUGIN_ID } from '../../../common';
+import { decodeCloudId } from '../../../common/services/decode_cloud_id';
 import { useKibanaServices } from '../hooks/use_kibana';
 import { CodeBox } from './code_box';
 import { javascriptDefinition } from './languages/javascript';
 import { languageDefinitions } from './languages/languages';
-import { LanguageDefinition } from './languages/types';
+import { LanguageDefinition, LanguageDefinitionSnippetArguments } from './languages/types';
 import { InstallClientPanel } from './overview_panels/install_client';
 import { OverviewPanel } from './overview_panels/overview_panel';
 import './overview.scss';
@@ -35,15 +36,31 @@ import { SelectClientPanel } from './overview_panels/select_client';
 import { ApiKeyPanel } from './api_key/api_key';
 import { LanguageClientPanel } from './overview_panels/language_client_panel';
 
+const ELASTICSEARCH_URL_PLACEHOLDER = 'https://your_deployment_url';
+const API_KEY_PLACEHOLDER = 'your_api_key';
+
 export const ElasticsearchOverview = () => {
   const [selectedLanguage, setSelectedLanguage] =
     useState<LanguageDefinition>(javascriptDefinition);
+  const [clientApiKey, setClientApiKey] = useState<string>(API_KEY_PLACEHOLDER);
   const {
+    cloud,
     http,
     userProfile,
     application: { navigateToApp },
   } = useKibanaServices();
+  const cloudId = cloud.cloudId ?? '';
+  const elasticsearchURL = useMemo(() => {
+    if (cloudId.length === 0) return ELASTICSEARCH_URL_PLACEHOLDER;
+    const decodedCloudId = decodeCloudId(cloudId);
+    return decodedCloudId?.elasticsearchUrl ?? ELASTICSEARCH_URL_PLACEHOLDER;
+  }, [cloudId]);
   const assetBasePath = http.basePath.prepend(`/plugins/${PLUGIN_ID}/assets/`);
+
+  const codeSnippetArguments: LanguageDefinitionSnippetArguments = {
+    url: elasticsearchURL,
+    apiKey: clientApiKey,
+  };
 
   return (
     <EuiPageTemplate offset={0} grow restrictWidth data-test-subj="svlSearchOverviewPage">
@@ -104,7 +121,11 @@ export const ElasticsearchOverview = () => {
       </EuiPageTemplate.Section>
 
       <EuiPageTemplate.Section color="subdued" bottomBorder="extended">
-        <InstallClientPanel language={selectedLanguage} setSelectedLanguage={setSelectedLanguage} />
+        <InstallClientPanel
+          codeArguments={codeSnippetArguments}
+          language={selectedLanguage}
+          setSelectedLanguage={setSelectedLanguage}
+        />
       </EuiPageTemplate.Section>
       <EuiPageTemplate.Section color="subdued" bottomBorder="extended">
         <OverviewPanel
@@ -112,7 +133,7 @@ export const ElasticsearchOverview = () => {
             defaultMessage:
               "You'll need these unique identifiers to securely connect to your Elasticsearch project.",
           })}
-          leftPanelContent={<ApiKeyPanel />}
+          leftPanelContent={<ApiKeyPanel setClientApiKey={setClientApiKey} />}
           links={[
             {
               href: docLinks.securityApis,
@@ -134,6 +155,7 @@ export const ElasticsearchOverview = () => {
           leftPanelContent={
             <CodeBox
               code="configureClient"
+              codeArgs={codeSnippetArguments}
               languages={languageDefinitions}
               selectedLanguage={selectedLanguage}
               setSelectedLanguage={setSelectedLanguage}
@@ -181,6 +203,7 @@ export const ElasticsearchOverview = () => {
           leftPanelContent={
             <CodeBox
               code="testConnection"
+              codeArgs={codeSnippetArguments}
               languages={languageDefinitions}
               selectedLanguage={selectedLanguage}
               setSelectedLanguage={setSelectedLanguage}
@@ -193,7 +216,11 @@ export const ElasticsearchOverview = () => {
         />
       </EuiPageTemplate.Section>
       <EuiPageTemplate.Section color="subdued" bottomBorder="extended">
-        <IngestData selectedLanguage={selectedLanguage} setSelectedLanguage={setSelectedLanguage} />
+        <IngestData
+          codeArguments={codeSnippetArguments}
+          selectedLanguage={selectedLanguage}
+          setSelectedLanguage={setSelectedLanguage}
+        />
       </EuiPageTemplate.Section>
       <EuiPageTemplate.Section color="subdued" bottomBorder="extended">
         <OverviewPanel
@@ -204,6 +231,7 @@ export const ElasticsearchOverview = () => {
           leftPanelContent={
             <CodeBox
               code="buildSearchQuery"
+              codeArgs={codeSnippetArguments}
               languages={languageDefinitions}
               selectedLanguage={selectedLanguage}
               setSelectedLanguage={setSelectedLanguage}

--- a/x-pack/plugins/serverless_search/public/application/components/overview_panels/ingest_data.tsx
+++ b/x-pack/plugins/serverless_search/public/application/components/overview_panels/ingest_data.tsx
@@ -11,16 +11,18 @@ import React, { useState } from 'react';
 import { docLinks } from '../../../../common/doc_links';
 import { CodeBox } from '../code_box';
 import { languageDefinitions } from '../languages/languages';
-import { LanguageDefinition } from '../languages/types';
+import { LanguageDefinition, LanguageDefinitionSnippetArguments } from '../languages/types';
 import { OverviewPanel } from './overview_panel';
 import { IntegrationsPanel } from './integrations_panel';
 
 interface IngestDataProps {
+  codeArguments: LanguageDefinitionSnippetArguments;
   selectedLanguage: LanguageDefinition;
   setSelectedLanguage: (language: LanguageDefinition) => void;
 }
 
 export const IngestData: React.FC<IngestDataProps> = ({
+  codeArguments,
   selectedLanguage,
   setSelectedLanguage,
 }) => {
@@ -37,6 +39,7 @@ export const IngestData: React.FC<IngestDataProps> = ({
         selectedIngestMethod === 'ingestViaApi' ? (
           <CodeBox
             code="ingestData"
+            codeArgs={codeArguments}
             languages={languageDefinitions}
             selectedLanguage={selectedLanguage}
             setSelectedLanguage={setSelectedLanguage}

--- a/x-pack/plugins/serverless_search/public/application/components/overview_panels/install_client.tsx
+++ b/x-pack/plugins/serverless_search/public/application/components/overview_panels/install_client.tsx
@@ -11,10 +11,15 @@ import React from 'react';
 import { CodeBox } from '../code_box';
 import { languageDefinitions } from '../languages/languages';
 import { OverviewPanel } from './overview_panel';
-import { LanguageDefinition, Languages } from '../languages/types';
+import {
+  LanguageDefinition,
+  Languages,
+  LanguageDefinitionSnippetArguments,
+} from '../languages/types';
 import { GithubLink } from '../shared/github_link';
 
 interface InstallClientProps {
+  codeArguments: LanguageDefinitionSnippetArguments;
   language: LanguageDefinition;
   setSelectedLanguage: (language: LanguageDefinition) => void;
 }
@@ -53,6 +58,7 @@ const Link: React.FC<{ language: Languages }> = ({ language }) => {
 };
 
 export const InstallClientPanel: React.FC<InstallClientProps> = ({
+  codeArguments,
   language,
   setSelectedLanguage,
 }) => {
@@ -78,6 +84,7 @@ export const InstallClientPanel: React.FC<InstallClientProps> = ({
         <>
           <CodeBox
             code="installClient"
+            codeArgs={codeArguments}
             languageType="shell"
             languages={languageDefinitions}
             selectedLanguage={language}


### PR DESCRIPTION
## Summary

- Updated the getting started code examples to use the deployment elasticsearch url instead of a placeholder and the user created api key if its available
- Added cURL examples
- added a test connection example for Ruby
- fixed JS examples

### Screenshots
<img width="1900" alt="image" src="https://github.com/elastic/kibana/assets/1972968/a536d35a-a860-4a20-bc33-a2bb5fdea547">
