### PR TITLE
[Security solution] Fix risk score cypress tests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1030,6 +1030,7 @@ x-pack/plugins/cloud_integrations/cloud_full_story/server/config.ts @elastic/kib
 /x-pack/plugins/security_solution/common/search_strategy/security_solution/user @elastic/security-threat-hunting-explore
 
 /x-pack/plugins/security_solution/cypress/e2e/cases @elastic/security-threat-hunting-explore
+/x-pack/plugins/security_solution/cypress/e2e/dashboards @elastic/security-threat-hunting-explore
 /x-pack/plugins/security_solution/cypress/e2e/filters @elastic/security-threat-hunting-explore
 /x-pack/plugins/security_solution/cypress/e2e/host_details @elastic/security-threat-hunting-explore
 /x-pack/plugins/security_solution/cypress/e2e/hosts @elastic/security-threat-hunting-explore

--- a/x-pack/plugins/security_solution/cypress/urls/risk_score.ts
+++ b/x-pack/plugins/security_solution/cypress/urls/risk_score.ts
@@ -8,7 +8,7 @@
 export const RISK_SCORE_URL = `/internal/risk_score` as const;
 export const INDICES_URL = `/internal/risk_score/indices` as const;
 export const INGEST_PIPELINES_URL = `/api/ingest_pipelines` as const;
-export const TRANSFORMS_URL = `/api/transform` as const;
+export const TRANSFORMS_URL = `/internal/transform` as const;
 export const STORED_SCRIPTS_URL = `/internal/risk_score/stored_scripts` as const;
 export const RISK_SCORE_SAVED_OBJECTS_URL =
   `/internal/risk_score/prebuilt_content/saved_objects` as const;

--- a/x-pack/plugins/security_solution/public/explore/containers/risk_score/onboarding/api/transforms.test.ts
+++ b/x-pack/plugins/security_solution/public/explore/containers/risk_score/onboarding/api/transforms.test.ts
@@ -48,7 +48,7 @@ describe('createTransform', () => {
     jest.clearAllMocks();
   });
   it('create transform', () => {
-    expect(mockRequest.mock.calls[0][0]).toEqual(`/api/transform/transforms/test`);
+    expect(mockRequest.mock.calls[0][0]).toEqual(`/internal/transform/transforms/test`);
   });
 
   it('handles error', () => {
@@ -74,7 +74,7 @@ describe('getTransformState', () => {
     jest.clearAllMocks();
   });
   it('get transform state', () => {
-    expect(mockRequest.mock.calls[0][0]).toEqual(`/api/transform/transforms/test/_stats`);
+    expect(mockRequest.mock.calls[0][0]).toEqual(`/internal/transform/transforms/test/_stats`);
   });
 
   it('handles error', () => {
@@ -100,7 +100,7 @@ describe('startTransforms', () => {
     jest.clearAllMocks();
   });
   it('get transform state', () => {
-    expect(mockRequest.mock.calls[0][0]).toEqual(`/api/transform/transforms/test/_stats`);
+    expect(mockRequest.mock.calls[0][0]).toEqual(`/internal/transform/transforms/test/_stats`);
   });
 
   it('handles error', () => {
@@ -140,11 +140,11 @@ describe('stopTransforms', () => {
     jest.clearAllMocks();
   });
   it('get transform state', () => {
-    expect(mockRequest.mock.calls[0][0]).toEqual(`/api/transform/transforms/test/_stats`);
+    expect(mockRequest.mock.calls[0][0]).toEqual(`/internal/transform/transforms/test/_stats`);
   });
 
   it('stop transform', () => {
-    expect(mockRequest.mock.calls[1][0]).toEqual(`/api/transform/stop_transforms`);
+    expect(mockRequest.mock.calls[1][0]).toEqual(`/internal/transform/stop_transforms`);
   });
 
   it('handles error', () => {
@@ -200,15 +200,15 @@ describe('deleteTransforms', () => {
     jest.clearAllMocks();
   });
   it('get transform state', () => {
-    expect(mockRequest.mock.calls[0][0]).toEqual(`/api/transform/transforms/test/_stats`);
+    expect(mockRequest.mock.calls[0][0]).toEqual(`/internal/transform/transforms/test/_stats`);
   });
 
   it('stop transform', () => {
-    expect(mockRequest.mock.calls[1][0]).toEqual(`/api/transform/stop_transforms`);
+    expect(mockRequest.mock.calls[1][0]).toEqual(`/internal/transform/stop_transforms`);
   });
 
   it('delete transform', () => {
-    expect(mockRequest.mock.calls[2][0]).toEqual(`/api/transform/delete_transforms`);
+    expect(mockRequest.mock.calls[2][0]).toEqual(`/internal/transform/delete_transforms`);
   });
 
   it('handles error', () => {

--- a/x-pack/plugins/security_solution/public/explore/containers/risk_score/onboarding/api/transforms.ts
+++ b/x-pack/plugins/security_solution/public/explore/containers/risk_score/onboarding/api/transforms.ts
@@ -26,7 +26,7 @@ import type {
   StopTransformsResult,
 } from './types';
 
-const TRANSFORM_API_BASE_PATH = `/api/transform`;
+const TRANSFORM_API_BASE_PATH = `/internal/transform`;
 const toastLifeTimeMs = 600000;
 
 const getErrorToastMessage = ({


### PR DESCRIPTION
## Summary

It seems the endpoint for transforms has changed from `api` to `internal`. This change broke our cypress tests. Sad. Updating the url fixes the tests 🪄 

I also added dashboards dir to codeowners for explore team

Resolves #158492 

