### PR TITLE
Add job_type to sync job index mapping

### DIFF
--- a/x-pack/plugins/enterprise_search/server/index_management/setup_indices.test.ts
+++ b/x-pack/plugins/enterprise_search/server/index_management/setup_indices.test.ts
@@ -215,6 +215,7 @@ describe('Setup Indices', () => {
       error: { type: 'keyword' },
       indexed_document_count: { type: 'integer' },
       indexed_document_volume: { type: 'integer' },
+      job_type: { type: 'keyword' },
       last_seen: { type: 'date' },
       metadata: { type: 'object' },
       started_at: { type: 'date' },

--- a/x-pack/plugins/enterprise_search/server/index_management/setup_indices.ts
+++ b/x-pack/plugins/enterprise_search/server/index_management/setup_indices.ts
@@ -239,6 +239,7 @@ const indices: IndexDefinition[] = [
         error: { type: 'keyword' },
         indexed_document_count: { type: 'integer' },
         indexed_document_volume: { type: 'integer' },
+        job_type: { type: 'keyword' },
         last_seen: { type: 'date' },
         metadata: { type: 'object' },
         started_at: { type: 'date' },


### PR DESCRIPTION
# Part of https://github.com/elastic/enterprise-search-team/issues/4627

## Summary

This PR adds a new field `job_type` to index `.elastic-connectors-sync-jobs`.


### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
