### PR TITLE
[ML] Disable delete action for deployed models

### DIFF
--- a/x-pack/packages/ml/trained_models_utils/src/constants/trained_models.ts
+++ b/x-pack/packages/ml/trained_models_utils/src/constants/trained_models.ts
@@ -68,3 +68,5 @@ export const MODEL_STATE = {
     defaultMessage: 'downloaded',
   }),
 } as const;
+
+export type ModelState = typeof MODEL_STATE[keyof typeof MODEL_STATE];

--- a/x-pack/plugins/ml/public/application/model_management/model_actions.tsx
+++ b/x-pack/plugins/ml/public/application/model_management/model_actions.tsx
@@ -392,16 +392,24 @@ export function useModelActions({
       },
       {
         name: (model) => {
-          const enabled = !isPopulatedObject(model.pipelines);
+          const hasPipelines = isPopulatedObject(model.pipelines);
+          const hasDeployments = model.state === MODEL_STATE.STARTED;
           return (
             <EuiToolTip
               position="left"
               content={
-                enabled
-                  ? null
-                  : i18n.translate('xpack.ml.trainedModels.modelsList.deleteDisabledTooltip', {
+                hasPipelines
+                  ? i18n.translate('xpack.ml.trainedModels.modelsList.deleteDisabledTooltip', {
                       defaultMessage: 'Model has associated pipelines',
                     })
+                  : hasDeployments
+                  ? i18n.translate(
+                      'xpack.ml.trainedModels.modelsList.deleteDisabledWithDeploymentsTooltip',
+                      {
+                        defaultMessage: 'Model has started deployments',
+                      }
+                    )
+                  : null
               }
             >
               <>

--- a/x-pack/plugins/ml/public/application/model_management/model_actions.tsx
+++ b/x-pack/plugins/ml/public/application/model_management/model_actions.tsx
@@ -428,7 +428,7 @@ export function useModelActions({
         enabled: (item) => {
           // TODO check for permissions to delete ingest pipelines.
           // ATM undefined means pipelines fetch failed server-side.
-          return !isPopulatedObject(item.pipelines);
+          return item.state !== MODEL_STATE.STARTED && !isPopulatedObject(item.pipelines);
         },
       },
       {

--- a/x-pack/plugins/ml/public/application/model_management/models_list.tsx
+++ b/x-pack/plugins/ml/public/application/model_management/models_list.tsx
@@ -38,6 +38,7 @@ import {
   ELASTIC_MODEL_TAG,
   ELASTIC_MODEL_TYPE,
   MODEL_STATE,
+  ModelState,
 } from '@kbn/ml-trained-models-utils/src/constants/trained_models';
 import { TechnicalPreviewBadge } from '../components/technical_preview_badge';
 import { useModelActions } from './model_actions';
@@ -70,7 +71,7 @@ export type ModelItem = TrainedModelConfigResponse & {
   pipelines?: ModelPipelines['pipelines'] | null;
   deployment_ids: string[];
   putModelConfig?: object;
-  state: string;
+  state: ModelState;
 };
 
 export type ModelItemFull = Required<ModelItem>;

--- a/x-pack/test/functional/apps/ml/short_tests/model_management/model_list.ts
+++ b/x-pack/test/functional/apps/ml/short_tests/model_management/model_list.ts
@@ -210,10 +210,12 @@ export default function ({ getService }: FtrProviderContext) {
               numOfAllocations: 1,
               threadsPerAllocation: 2,
             });
+            await ml.trainedModelsTable.assertModelDeleteActionButtonEnabled(model.id, false);
           });
 
           it(`stops deployment of the imported model ${model.id}`, async () => {
             await ml.trainedModelsTable.stopDeployment(model.id);
+            await ml.trainedModelsTable.assertModelDeleteActionButtonEnabled(model.id, true);
           });
 
           it(`deletes the imported model ${model.id}`, async () => {

--- a/x-pack/test/functional/services/ml/trained_models_table.ts
+++ b/x-pack/test/functional/services/ml/trained_models_table.ts
@@ -163,7 +163,7 @@ export function TrainedModelsTableProvider(
     }
 
     public async assertModelCollapsedActionsButtonExists(modelId: string, expectedValue: boolean) {
-      const actionsExists = await this.isModelCollapsedActionsButtonExists(modelId);
+      const actionsExists = await this.doesModelCollapsedActionsButtonExist(modelId);
       expect(actionsExists).to.eql(
         expectedValue,
         `Expected row collapsed actions menu button for trained model '${modelId}' to be ${
@@ -172,7 +172,7 @@ export function TrainedModelsTableProvider(
       );
     }
 
-    public async isModelCollapsedActionsButtonExists(modelId: string) {
+    public async doesModelCollapsedActionsButtonExist(modelId: string): Promise<boolean> {
       return await testSubjects.exists(this.rowSelector(modelId, 'euiCollapsedItemActionsButton'));
     }
 
@@ -238,13 +238,11 @@ export function TrainedModelsTableProvider(
     }
 
     public async assertModelDeleteActionButtonEnabled(modelId: string, expectedValue: boolean) {
-      const isModelCollapsedActionsButtonExists = await this.isModelCollapsedActionsButtonExists(
-        modelId
-      );
+      const actionsButtonExists = await this.doesModelCollapsedActionsButtonExist(modelId);
 
       let isEnabled = null;
 
-      if (isModelCollapsedActionsButtonExists) {
+      if (actionsButtonExists) {
         await this.toggleActionsContextMenu(modelId, true);
         const panelElement = await find.byCssSelector('.euiContextMenuPanel');
         const actionButton = await panelElement.findByTestSubject('mlModelsTableRowDeleteAction');


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/157692.

Disables delete action for deployed models.

<img width="1506" alt="image" src="https://github.com/elastic/kibana/assets/5236598/8e44dcca-789e-41c3-9dca-87034f84390b">


### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios





<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->