### PR TITLE
[ML] Stabilize and reenable notifications tests

### DIFF
--- a/x-pack/test/functional/apps/ml/short_tests/notifications/notification_list.ts
+++ b/x-pack/test/functional/apps/ml/short_tests/notifications/notification_list.ts
@@ -15,22 +15,26 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');
   const ml = getService('ml');
   const browser = getService('browser');
+  const spacesService = getService('spaces');
+
+  const idSpace1 = 'space1';
 
   const configs = [
     { jobId: 'fq_001', spaceId: undefined },
-    { jobId: 'fq_002', spaceId: 'space1' },
+    { jobId: 'fq_002', spaceId: idSpace1 },
   ];
 
   const failConfig = { jobId: 'fq_fail', spaceId: undefined };
 
-  // Failing: See https://github.com/elastic/kibana/issues/154578
-  describe.skip('Notifications list', function () {
+  describe('Notifications list', function () {
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/farequote');
       await ml.testResources.createIndexPatternIfNeeded('ft_farequote', '@timestamp');
       await ml.testResources.setKibanaTimeZoneToUTC();
+      await ml.securityUI.loginAsMlPowerUser();
 
       // Prepare jobs to generate notifications
+      await spacesService.create({ id: idSpace1, name: 'space_one', disabledFeatures: [] });
       for (const config of configs) {
         await ml.api.createAnomalyDetectionJob(
           ml.commonConfig.getADFqSingleMetricJobConfig(config.jobId),
@@ -38,7 +42,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         );
       }
 
-      await ml.securityUI.loginAsMlPowerUser();
       await PageObjects.common.navigateToApp('ml', {
         basePath: '',
       });
@@ -48,6 +51,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       for (const { jobId } of [...configs, failConfig]) {
         await ml.api.deleteAnomalyDetectionJobES(jobId);
       }
+      await spacesService.delete(idSpace1);
       await ml.testResources.cleanMLSavedObjects();
       await ml.api.cleanMlIndices();
       await ml.testResources.deleteIndexPatternByTitle('ft_farequote');

--- a/x-pack/test/functional/services/ml/common_table_service.ts
+++ b/x-pack/test/functional/services/ml/common_table_service.ts
@@ -67,7 +67,12 @@ export function MlTableServiceProvider({ getPageObject, getService }: FtrProvide
 
     public async waitForTableToStartLoading() {
       await testSubjects.existOrFail(`~${this.tableTestSubj}`, { timeout: 60 * 1000 });
-      await testSubjects.existOrFail(`${this.tableTestSubj} loading`, { timeout: 30 * 1000 });
+
+      // After invoking an action that caused the table to start loading, the loading
+      // should start quickly after the table exists. Sometimes it is even so quick that
+      // the loading is already done when we try to check for it, so we're not failing
+      // in that case and just move on.
+      await testSubjects.exists(`${this.tableTestSubj} loading`, { timeout: 3 * 1000 });
     }
 
     public async waitForTableToLoad() {


### PR DESCRIPTION
## Summary

This PR stabilizes ML notifications tests by introducing leniency when checking for the notifications table in loading state. It also reenables the test suite.

### Other changes

After the test cleanup was done, we still had a left-over saved object. This was caused by the test creating a job for `space1` without actually creating that space. In order to fix this, we now let the test properly create and cleanup that space.

Closes #154578

<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->