### PR TITLE
[ML] Stabilize and reenable classification tests

### DIFF
--- a/x-pack/test/functional/apps/ml/data_frame_analytics/classification_creation.ts
+++ b/x-pack/test/functional/apps/ml/data_frame_analytics/classification_creation.ts
@@ -14,8 +14,7 @@ export default function ({ getService }: FtrProviderContext) {
   const ml = getService('ml');
   const editedDescription = 'Edited description';
 
-  // FAILING ES PROMOTION: https://github.com/elastic/kibana/issues/153798
-  describe.skip('classification creation', function () {
+  describe('classification creation', function () {
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/bm_classification');
       await ml.testResources.createIndexPatternIfNeeded('ft_bank_marketing');

--- a/x-pack/test/functional/services/ml/common_ui.ts
+++ b/x-pack/test/functional/services/ml/common_ui.ts
@@ -402,6 +402,14 @@ export function MachineLearningCommonUIProvider({
       });
     },
 
+    async ensureComboBoxClosed() {
+      await retry.tryForTime(5000, async () => {
+        await browser.pressKeys(browser.keys.ESCAPE);
+        const comboBoxOpen = await testSubjects.exists('~comboBoxOptionsList', { timeout: 50 });
+        expect(comboBoxOpen).to.eql(false, 'Combo box should be closed');
+      });
+    },
+
     async invokeTableRowAction(
       rowSelector: string,
       actionTestSubject: string,

--- a/x-pack/test/functional/services/ml/data_frame_analytics_creation.ts
+++ b/x-pack/test/functional/services/ml/data_frame_analytics_creation.ts
@@ -283,12 +283,8 @@ export function MachineLearningDataFrameAnalyticsCreationProvider(
       );
     },
 
-    async assertFieldStatTopValuesContent(
-      fieldName: string,
-      fieldType: 'keyword' | 'date' | 'number',
-      expectedContent: string[]
-    ) {
-      await mlCommonFieldStatsFlyout.assertTopValuesContent(fieldName, fieldType, expectedContent);
+    async assertFieldStatTopValuesContent(fieldName: string, expectedContent: string[]) {
+      await mlCommonFieldStatsFlyout.assertTopValuesContent(fieldName, expectedContent);
     },
 
     async assertDependentVariableInputMissing() {

--- a/x-pack/test/functional/services/ml/index.ts
+++ b/x-pack/test/functional/services/ml/index.ts
@@ -68,7 +68,7 @@ export function MachineLearningProvider(context: FtrProviderContext) {
   const commonAPI = MachineLearningCommonAPIProvider(context);
   const commonUI = MachineLearningCommonUIProvider(context);
   const commonDataGrid = MachineLearningCommonDataGridProvider(context);
-  const commonFieldStatsFlyout = MachineLearningFieldStatsFlyoutProvider(context);
+  const commonFieldStatsFlyout = MachineLearningFieldStatsFlyoutProvider(context, commonUI);
 
   const anomaliesTable = MachineLearningAnomaliesTableProvider(context);
   const anomalyCharts = AnomalyChartsProvider(context);


### PR DESCRIPTION
## Summary

This PR stabilizes ML classification creation tests by closing the dependent variable combo box earlier. It also reenables the test suite.

### Other changes

- Remove the unused parameter `testSubj` from `assertFieldStatContentByType` in the field stats flyout service
- Remove the unused parameter `fieldType` from `assertTopValuesContent` in the field stats flyout service

Closes #153798


<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->