### PR TITLE
[Security Solution] Remove forced actions from detection rules Cypress tests

### DIFF
--- a/x-pack/plugins/security_solution/cypress/e2e/detection_rules/custom_query_rule.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_rules/custom_query_rule.cy.ts
@@ -153,15 +153,15 @@ describe('Custom query rules', () => {
       // expect define step to repopulate
       cy.get(DEFINE_EDIT_BUTTON).click();
       cy.get(CUSTOM_QUERY_INPUT).should('have.value', ruleFields.ruleQuery);
-      cy.get(DEFINE_CONTINUE_BUTTON).should('exist').click({ force: true });
+      cy.get(DEFINE_CONTINUE_BUTTON).should('exist').click();
       cy.get(DEFINE_CONTINUE_BUTTON).should('not.exist');
 
       // expect about step to populate
       cy.get(ABOUT_EDIT_BUTTON).click();
       cy.get(RULE_NAME_INPUT).invoke('val').should('eql', ruleFields.ruleName);
-      cy.get(ABOUT_CONTINUE_BTN).should('exist').click({ force: true });
+      cy.get(ABOUT_CONTINUE_BTN).should('exist').click();
       cy.get(ABOUT_CONTINUE_BTN).should('not.exist');
-      cy.get(SCHEDULE_CONTINUE_BUTTON).click({ force: true });
+      cy.get(SCHEDULE_CONTINUE_BUTTON).click();
 
       createAndEnableRule();
 
@@ -209,7 +209,7 @@ describe('Custom query rules', () => {
         'contain',
         `${ruleFields.threatSubtechnique.name} (${ruleFields.threatSubtechnique.id})`
       );
-      cy.get(INVESTIGATION_NOTES_TOGGLE).click({ force: true });
+      cy.get(INVESTIGATION_NOTES_TOGGLE).click();
       cy.get(ABOUT_INVESTIGATION_NOTES).should('have.text', INVESTIGATION_NOTES_MARKDOWN);
       cy.get(DEFINITION_DETAILS).within(() => {
         getDetails(INDEX_PATTERNS_DETAILS).should('have.text', 'auditbeat-*');
@@ -410,7 +410,7 @@ describe('Custom query rules', () => {
         cy.get(ACTIONS_NOTIFY_WHEN_BUTTON).should('have.text', 'Per rule run');
 
         goToAboutStepTab();
-        cy.get(TAGS_CLEAR_BUTTON).click({ force: true });
+        cy.get(TAGS_CLEAR_BUTTON).click();
         fillAboutRule(getEditedRule());
 
         cy.intercept('GET', '/api/detection_engine/rules?id*').as('getRule');
@@ -430,7 +430,7 @@ describe('Custom query rules', () => {
           getDetails(RISK_SCORE_DETAILS).should('have.text', `${getEditedRule().risk_score}`);
           getDetails(TAGS_DETAILS).should('have.text', expectedEditedtags);
         });
-        cy.get(INVESTIGATION_NOTES_TOGGLE).click({ force: true });
+        cy.get(INVESTIGATION_NOTES_TOGGLE).click();
         cy.get(ABOUT_INVESTIGATION_NOTES).should('have.text', getEditedRule().note);
         cy.get(DEFINITION_DETAILS).within(() => {
           getDetails(INDEX_PATTERNS_DETAILS).should(

--- a/x-pack/plugins/security_solution/cypress/e2e/detection_rules/custom_query_rule_data_view.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_rules/custom_query_rule_data_view.cy.ts
@@ -124,7 +124,7 @@ describe('Custom query rules', () => {
         });
         getDetails(TAGS_DETAILS).should('have.text', expectedTags);
       });
-      cy.get(INVESTIGATION_NOTES_TOGGLE).click({ force: true });
+      cy.get(INVESTIGATION_NOTES_TOGGLE).click();
       cy.get(ABOUT_INVESTIGATION_NOTES).should('have.text', INVESTIGATION_NOTES_MARKDOWN);
       cy.get(DEFINITION_DETAILS).within(() => {
         getDetails(DATA_VIEW_DETAILS).should('have.text', rule.data_view_id);
@@ -153,17 +153,17 @@ describe('Custom query rules', () => {
     it('Creates and edits a new rule with a data view', function () {
       visit(RULE_CREATION);
       fillDefineCustomRuleAndContinue(rule);
-      cy.get(RULE_NAME_INPUT).clear({ force: true }).type(rule.name, { force: true });
-      cy.get(RULE_DESCRIPTION_INPUT).clear({ force: true }).type(rule.description, { force: true });
+      cy.get(RULE_NAME_INPUT).clear().type(rule.name);
+      cy.get(RULE_DESCRIPTION_INPUT).clear().type(rule.description);
 
-      cy.get(ABOUT_CONTINUE_BTN).should('exist').click({ force: true });
+      cy.get(ABOUT_CONTINUE_BTN).should('exist').click();
 
       fillScheduleRuleAndContinue(rule);
       createRuleWithoutEnabling();
 
       goToRuleDetails();
 
-      cy.get(EDIT_RULE_SETTINGS_LINK).click({ force: true });
+      cy.get(EDIT_RULE_SETTINGS_LINK).click();
 
       cy.get(RULE_NAME_HEADER).should('contain', 'Edit rule settings');
     });

--- a/x-pack/plugins/security_solution/cypress/e2e/detection_rules/custom_saved_query_rule.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_rules/custom_saved_query_rule.cy.ts
@@ -74,7 +74,7 @@ describe('Custom saved_query rules', () => {
       getCustomQueryInput().should('have.value', savedQueryQuery).should('be.disabled');
       cy.get(QUERY_BAR).should('contain', savedQueryFilterKey);
 
-      cy.get(DEFINE_CONTINUE_BUTTON).should('exist').click({ force: true });
+      cy.get(DEFINE_CONTINUE_BUTTON).should('exist').click();
       cy.get(DEFINE_CONTINUE_BUTTON).should('not.exist');
 
       fillAboutRuleAndContinue(rule);

--- a/x-pack/plugins/security_solution/cypress/e2e/detection_rules/event_correlation_rule.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_rules/event_correlation_rule.cy.ts
@@ -111,7 +111,7 @@ describe('EQL rules', () => {
         });
         getDetails(TAGS_DETAILS).should('have.text', expectedTags);
       });
-      cy.get(INVESTIGATION_NOTES_TOGGLE).click({ force: true });
+      cy.get(INVESTIGATION_NOTES_TOGGLE).click();
       cy.get(ABOUT_INVESTIGATION_NOTES).should('have.text', INVESTIGATION_NOTES_MARKDOWN);
       cy.get(DEFINITION_DETAILS).within(() => {
         getDetails(INDEX_PATTERNS_DETAILS).should('have.text', getIndexPatterns().join(''));

--- a/x-pack/plugins/security_solution/cypress/e2e/detection_rules/indicator_match_rule.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_rules/indicator_match_rule.cy.ts
@@ -458,7 +458,7 @@ describe('indicator match', () => {
           });
           getDetails(TAGS_DETAILS).should('have.text', expectedTags);
         });
-        cy.get(INVESTIGATION_NOTES_TOGGLE).click({ force: true });
+        cy.get(INVESTIGATION_NOTES_TOGGLE).click();
         cy.get(ABOUT_INVESTIGATION_NOTES).should('have.text', INVESTIGATION_NOTES_MARKDOWN);
 
         cy.get(DEFINITION_DETAILS).within(() => {

--- a/x-pack/plugins/security_solution/cypress/e2e/detection_rules/new_terms_rule.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_rules/new_terms_rule.cy.ts
@@ -110,7 +110,7 @@ describe('New Terms rules', () => {
         });
         getDetails(TAGS_DETAILS).should('have.text', expectedTags);
       });
-      cy.get(INVESTIGATION_NOTES_TOGGLE).click({ force: true });
+      cy.get(INVESTIGATION_NOTES_TOGGLE).click();
       cy.get(ABOUT_INVESTIGATION_NOTES).should('have.text', INVESTIGATION_NOTES_MARKDOWN);
       cy.get(DEFINITION_DETAILS).within(() => {
         getDetails(INDEX_PATTERNS_DETAILS).should('have.text', getIndexPatterns().join(''));

--- a/x-pack/plugins/security_solution/cypress/e2e/detection_rules/override.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_rules/override.cy.ts
@@ -125,7 +125,7 @@ describe('Detection rules, override', () => {
           });
         });
     });
-    cy.get(INVESTIGATION_NOTES_TOGGLE).click({ force: true });
+    cy.get(INVESTIGATION_NOTES_TOGGLE).click();
     cy.get(ABOUT_INVESTIGATION_NOTES).should('have.text', INVESTIGATION_NOTES_MARKDOWN);
     cy.get(DEFINITION_DETAILS).within(() => {
       getDetails(INDEX_PATTERNS_DETAILS).should('have.text', getIndexPatterns().join(''));

--- a/x-pack/plugins/security_solution/cypress/e2e/detection_rules/threshold_rule.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_rules/threshold_rule.cy.ts
@@ -109,7 +109,7 @@ describe('Detection rules, threshold', () => {
       });
       getDetails(TAGS_DETAILS).should('have.text', expectedTags);
     });
-    cy.get(INVESTIGATION_NOTES_TOGGLE).click({ force: true });
+    cy.get(INVESTIGATION_NOTES_TOGGLE).click();
     cy.get(ABOUT_INVESTIGATION_NOTES).should('have.text', INVESTIGATION_NOTES_MARKDOWN);
     cy.get(DEFINITION_DETAILS).within(() => {
       getDetails(INDEX_PATTERNS_DETAILS).should('have.text', getIndexPatterns().join(''));

--- a/x-pack/plugins/security_solution/cypress/tasks/alerts_detection_rules.ts
+++ b/x-pack/plugins/security_solution/cypress/tasks/alerts_detection_rules.ts
@@ -77,19 +77,19 @@ import { goToRuleEditSettings } from './rule_details';
 import { goToActionsStepTab } from './create_new_rule';
 
 export const enableRule = (rulePosition: number) => {
-  cy.get(RULE_SWITCH).eq(rulePosition).click({ force: true });
+  cy.get(RULE_SWITCH).eq(rulePosition).click();
 };
 
 export const editFirstRule = () => {
   cy.get(COLLAPSED_ACTION_BTN).should('be.visible');
-  cy.get(COLLAPSED_ACTION_BTN).first().click({ force: true });
+  cy.get(COLLAPSED_ACTION_BTN).first().click();
   cy.get(EDIT_RULE_ACTION_BTN).should('be.visible');
   cy.get(EDIT_RULE_ACTION_BTN).click();
 };
 
 export const duplicateFirstRule = () => {
   cy.get(COLLAPSED_ACTION_BTN).should('be.visible');
-  cy.get(COLLAPSED_ACTION_BTN).first().click({ force: true });
+  cy.get(COLLAPSED_ACTION_BTN).first().click();
   cy.get(DUPLICATE_RULE_ACTION_BTN).should('be.visible');
   cy.get(DUPLICATE_RULE_ACTION_BTN).click();
   cy.get(CONFIRM_DUPLICATE_RULE).click();
@@ -102,7 +102,7 @@ export const duplicateFirstRule = () => {
  * flake.
  */
 export const duplicateRuleFromMenu = () => {
-  const click = ($el: Cypress.ObjectLike) => cy.wrap($el).click({ force: true });
+  const click = ($el: Cypress.ObjectLike) => cy.wrap($el).click();
   cy.get(LOADING_INDICATOR).should('not.exist');
   cy.get(ALL_ACTIONS).pipe(click);
   cy.get(DUPLICATE_RULE_MENU_PANEL_BTN).should('be.visible');
@@ -124,12 +124,12 @@ export const checkDuplicatedRule = () => {
 };
 
 export const deleteFirstRule = () => {
-  cy.get(COLLAPSED_ACTION_BTN).first().click({ force: true });
+  cy.get(COLLAPSED_ACTION_BTN).first().click();
   cy.get(DELETE_RULE_ACTION_BTN).click();
 };
 
 export const deleteSelectedRules = () => {
-  cy.get(BULK_ACTIONS_BTN).click({ force: true });
+  cy.get(BULK_ACTIONS_BTN).click();
   cy.get(DELETE_RULE_BULK_BTN).click();
 };
 
@@ -150,7 +150,7 @@ export const deleteRuleFromDetailsPage = () => {
 
 export const duplicateSelectedRulesWithoutExceptions = () => {
   cy.log('Duplicate selected rules');
-  cy.get(BULK_ACTIONS_BTN).click({ force: true });
+  cy.get(BULK_ACTIONS_BTN).click();
   cy.get(DUPLICATE_RULE_BULK_BTN).click();
   cy.get(DUPLICATE_WITHOUT_EXCEPTIONS_OPTION).click();
   cy.get(CONFIRM_DUPLICATE_RULE).click();
@@ -158,7 +158,7 @@ export const duplicateSelectedRulesWithoutExceptions = () => {
 
 export const duplicateSelectedRulesWithExceptions = () => {
   cy.log('Duplicate selected rules');
-  cy.get(BULK_ACTIONS_BTN).click({ force: true });
+  cy.get(BULK_ACTIONS_BTN).click();
   cy.get(DUPLICATE_RULE_BULK_BTN).click();
   cy.get(DUPLICATE_WITH_EXCEPTIONS_OPTION).click();
   cy.get(CONFIRM_DUPLICATE_RULE).click();
@@ -166,7 +166,7 @@ export const duplicateSelectedRulesWithExceptions = () => {
 
 export const duplicateSelectedRulesWithNonExpiredExceptions = () => {
   cy.log('Duplicate selected rules');
-  cy.get(BULK_ACTIONS_BTN).click({ force: true });
+  cy.get(BULK_ACTIONS_BTN).click();
   cy.get(DUPLICATE_RULE_BULK_BTN).click();
   cy.get(DUPLICATE_WITH_EXCEPTIONS_WITHOUT_EXPIRED_OPTION).click();
   cy.get(CONFIRM_DUPLICATE_RULE).click();
@@ -174,13 +174,13 @@ export const duplicateSelectedRulesWithNonExpiredExceptions = () => {
 
 export const enableSelectedRules = () => {
   cy.log('Enable selected rules');
-  cy.get(BULK_ACTIONS_BTN).click({ force: true });
+  cy.get(BULK_ACTIONS_BTN).click();
   cy.get(ENABLE_RULE_BULK_BTN).click();
 };
 
 export const disableSelectedRules = () => {
   cy.log('Disable selected rules');
-  cy.get(BULK_ACTIONS_BTN).click({ force: true });
+  cy.get(BULK_ACTIONS_BTN).click();
   cy.get(DISABLE_RULE_BULK_BTN).click();
 };
 
@@ -194,9 +194,7 @@ export const exportRule = (name: string) => {
 
 export const filterBySearchTerm = (term: string) => {
   cy.log(`Filter rules by search term: "${term}"`);
-  cy.get(RULE_SEARCH_FIELD)
-    .type(term, { force: true })
-    .trigger('search', { waitForAnimations: true });
+  cy.get(RULE_SEARCH_FIELD).type(term).trigger('search');
 };
 
 export const filterByTags = (tags: string[]) => {
@@ -226,23 +224,23 @@ export const filterByElasticRules = () => {
 };
 
 export const filterByCustomRules = () => {
-  cy.get(CUSTOM_RULES_BTN).click({ force: true });
+  cy.get(CUSTOM_RULES_BTN).click();
 };
 
 export const filterByEnabledRules = () => {
-  cy.get(ENABLED_RULES_BTN).click({ force: true });
+  cy.get(ENABLED_RULES_BTN).click();
 };
 
 export const filterByDisabledRules = () => {
-  cy.get(DISABLED_RULES_BTN).click({ force: true });
+  cy.get(DISABLED_RULES_BTN).click();
 };
 
 export const goToRuleDetails = () => {
-  cy.get(RULE_NAME).first().click({ force: true });
+  cy.get(RULE_NAME).first().click();
 };
 
 export const goToTheRuleDetailsOf = (ruleName: string) => {
-  cy.contains(RULE_NAME, ruleName).click({ force: true });
+  cy.contains(RULE_NAME, ruleName).click();
 };
 
 export const loadPrebuiltDetectionRules = () => {
@@ -268,7 +266,7 @@ export const openIntegrationsPopover = () => {
 };
 
 export const reloadDeletedRules = () => {
-  cy.get(LOAD_PREBUILT_RULES_ON_PAGE_HEADER_BTN).click({ force: true });
+  cy.get(LOAD_PREBUILT_RULES_ON_PAGE_HEADER_BTN).click();
 };
 
 /**
@@ -395,8 +393,8 @@ export const checkAutoRefresh = (ms: number, condition: string) => {
 export const importRules = (rulesFile: string) => {
   cy.get(RULE_IMPORT_MODAL).click();
   cy.get(INPUT_FILE).should('exist');
-  cy.get(INPUT_FILE).trigger('click', { force: true }).selectFile(rulesFile).trigger('change');
-  cy.get(RULE_IMPORT_MODAL_BUTTON).last().click({ force: true });
+  cy.get(INPUT_FILE).trigger('click').selectFile(rulesFile).trigger('change');
+  cy.get(RULE_IMPORT_MODAL_BUTTON).last().click();
   cy.get(INPUT_FILE).should('not.exist');
 };
 
@@ -513,11 +511,11 @@ const selectOverwriteConnectorsRulesImport = () => {
 export const importRulesWithOverwriteAll = (rulesFile: string) => {
   cy.get(RULE_IMPORT_MODAL).click();
   cy.get(INPUT_FILE).should('exist');
-  cy.get(INPUT_FILE).trigger('click', { force: true }).selectFile(rulesFile).trigger('change');
+  cy.get(INPUT_FILE).trigger('click').selectFile(rulesFile).trigger('change');
   selectOverwriteRulesImport();
   selectOverwriteExceptionsRulesImport();
   selectOverwriteConnectorsRulesImport();
-  cy.get(RULE_IMPORT_MODAL_BUTTON).last().click({ force: true });
+  cy.get(RULE_IMPORT_MODAL_BUTTON).last().click();
   cy.get(INPUT_FILE).should('not.exist');
 };
 


### PR DESCRIPTION
**Relates to:** https://github.com/elastic/kibana/issues/152344, https://github.com/elastic/kibana/issues/152470
**Depends on:** https://github.com/elastic/kibana/pull/158392

## Summary

Removes `force` option from Cypress actions like `type()`, `click()` and etc. It helps to catch UI quirks instead of silently ignoring them.

## Details

After merging back of https://github.com/elastic/kibana/pull/158392 it's possible to remove `force: true` flag from the Cypress actions used in Detection rules tests. Based on the discussion in https://github.com/elastic/kibana/issues/152470 it's bette to avoid forced actions and leave a comment if there is no other way than forcing an action.

