### PR TITLE
[APM] Enable Latency Rule on overview pages

### DIFF
--- a/x-pack/plugins/apm/public/components/routing/app_root/apm_header_action_menu/alerting_popover_flyout.tsx
+++ b/x-pack/plugins/apm/public/components/routing/app_root/apm_header_action_menu/alerting_popover_flyout.tsx
@@ -13,7 +13,6 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React, { useState } from 'react';
-import { IBasePath } from '@kbn/core/public';
 import { ApmRuleType } from '../../../../../common/rules/apm_rule_types';
 import { AlertingFlyout } from '../../../alerting/ui_components/alerting_flyout';
 import { useApmPluginContext } from '../../../../context/apm_plugin/use_apm_plugin_context';
@@ -44,19 +43,15 @@ const createAnomalyAlertAlertLabel = i18n.translate(
 const CREATE_THRESHOLD_PANEL_ID = 'create_threshold_panel';
 
 interface Props {
-  basePath: IBasePath;
   canReadAlerts: boolean;
   canSaveAlerts: boolean;
   canReadMlJobs: boolean;
-  includeTransactionDuration: boolean;
 }
 
 export function AlertingPopoverAndFlyout({
-  basePath,
   canSaveAlerts,
   canReadAlerts,
   canReadMlJobs,
-  includeTransactionDuration,
 }: Props) {
   const [popoverOpen, setPopoverOpen] = useState(false);
   const [ruleType, setRuleType] = useState<ApmRuleType | null>(null);
@@ -131,17 +126,13 @@ export function AlertingPopoverAndFlyout({
       title: createThresholdAlertLabel,
       items: [
         // Latency
-        ...(includeTransactionDuration
-          ? [
-              {
-                name: transactionDurationLabel,
-                onClick: () => {
-                  setRuleType(ApmRuleType.TransactionDuration);
-                  setPopoverOpen(false);
-                },
-              },
-            ]
-          : []),
+        {
+          name: transactionDurationLabel,
+          onClick: () => {
+            setRuleType(ApmRuleType.TransactionDuration);
+            setPopoverOpen(false);
+          },
+        },
         // Throughput *** TO BE ADDED ***
         // Failed transactions rate
         {

--- a/x-pack/plugins/apm/public/components/routing/app_root/apm_header_action_menu/index.tsx
+++ b/x-pack/plugins/apm/public/components/routing/app_root/apm_header_action_menu/index.tsx
@@ -19,7 +19,6 @@ import { getLegacyApmHref } from '../../../shared/links/apm/apm_link';
 import { useApmPluginContext } from '../../../../context/apm_plugin/use_apm_plugin_context';
 import { AlertingPopoverAndFlyout } from './alerting_popover_flyout';
 import { AnomalyDetectionSetupLink } from './anomaly_detection_setup_link';
-import { useServiceName } from '../../../../hooks/use_service_name';
 import { InspectorHeaderLink } from './inspector_header_link';
 import { Labs } from './labs';
 import { useApmFeatureFlag } from '../../../../hooks/use_apm_feature_flag';
@@ -27,7 +26,6 @@ import { ApmFeatureFlagName } from '../../../../../common/apm_feature_flags';
 
 export function ApmHeaderActionMenu() {
   const { core, plugins } = useApmPluginContext();
-  const serviceName = useServiceName();
   const { search } = window.location;
   const { application, http } = core;
   const { basePath } = http;
@@ -76,11 +74,9 @@ export function ApmHeaderActionMenu() {
       {canCreateMlJobs && <AnomalyDetectionSetupLink />}
       {isAlertingAvailable && (
         <AlertingPopoverAndFlyout
-          basePath={basePath}
           canReadAlerts={canReadAlerts}
           canSaveAlerts={canSaveApmAlerts}
           canReadMlJobs={canReadMlJobs}
-          includeTransactionDuration={serviceName !== undefined}
         />
       )}
       <EuiHeaderLink


### PR DESCRIPTION
In the past the latency threshold rule was service specific. We have since made it possible to create latency threshold rules for all services (still grouping by service). 

This PR makes the Latency Threshold rule visible in the menu again on the service inventory view.