### PR TITLE
[DOCS] Telemetry in advanced settings

### DIFF
--- a/docs/management/advanced-options.asciidoc
+++ b/docs/management/advanced-options.asciidoc
@@ -546,15 +546,6 @@ The maximum number of buckets a datasource can return. High numbers can have a n
 Disable this option if you prefer to use the new heatmap charts with improved performance, legend settings, and more..
 
 [float]
-[[kibana-telemetry-settings]]
-==== Usage Data
-
-[horizontal]
-[[telemetry-enabled-advanced-setting]]`telemetry:enabled`::
-When enabled, helps improve the Elastic Stack by providing usage statistics for
-basic features.
-
-[float]
 [[kibana-global-settings-reference]]
 === Change the global settings
 
@@ -586,8 +577,10 @@ The URL of a custom SVG image that appears on {kib} browser tabs. Images must be
 The URL of a custom PNG image that appears on {kib} browser tabs.
 
 [float]
-[[kibana-usage-data-settings]]
-==== Usage Data
+[[kibana-usage-collection-settings]]
+==== Usage Collection
 
 [[provide-usage-data]]`telemetry:enabled`::
-When enabled, helps manage and improve Elastic products and services by providing usage statistics.
+Enabling data usage collection (also known as Telemetry) allows us to learn
+what our users are most interested in, so we can improve our products and services.
+Refer to our https://www.elastic.co/legal/product-privacy-statement[Privacy Statement] for more details.

--- a/docs/management/advanced-options.asciidoc
+++ b/docs/management/advanced-options.asciidoc
@@ -578,7 +578,7 @@ The URL of a custom PNG image that appears on {kib} browser tabs.
 
 [float]
 [[kibana-usage-collection-settings]]
-==== Usage Collection
+==== Usage collection
 
 [[provide-usage-data]]`telemetry:enabled`::
 Enabling data usage collection (also known as Telemetry) allows us to learn


### PR DESCRIPTION
## Summary

This PR removes the duplicated section of `telemetry:enabled` in the Advanced Setting docs.


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
