### PR TITLE
[7.17] [Windows] Fix string comparison in bat scripts for default dir. (#158517)

### DIFF
--- a/src/dev/build/tasks/bin/scripts/kibana-encryption-keys.bat
+++ b/src/dev/build/tasks/bin/scripts/kibana-encryption-keys.bat
@@ -13,7 +13,7 @@ If Not Exist "%NODE%" (
 )
 
 set CONFIG_DIR=%KBN_PATH_CONF%
-If ["%KBN_PATH_CONF%"] == [] (
+If ["%KBN_PATH_CONF%"] == [""] (
   set "CONFIG_DIR=%DIR%\config"
 )
 

--- a/src/dev/build/tasks/bin/scripts/kibana-keystore.bat
+++ b/src/dev/build/tasks/bin/scripts/kibana-keystore.bat
@@ -13,7 +13,7 @@ If Not Exist "%NODE%" (
 )
 
 set CONFIG_DIR=%KBN_PATH_CONF%
-If ["%KBN_PATH_CONF%"] == [] (
+If ["%KBN_PATH_CONF%"] == [""] (
   set "CONFIG_DIR=%DIR%\config"
 )
 

--- a/src/dev/build/tasks/bin/scripts/kibana-plugin.bat
+++ b/src/dev/build/tasks/bin/scripts/kibana-plugin.bat
@@ -14,7 +14,7 @@ If Not Exist "%NODE%" (
 )
 
 set CONFIG_DIR=%KBN_PATH_CONF%
-If ["%KBN_PATH_CONF%"] == [] (
+If ["%KBN_PATH_CONF%"] == [""] (
   set "CONFIG_DIR=%DIR%\config"
 )
 

--- a/src/dev/build/tasks/bin/scripts/kibana.bat
+++ b/src/dev/build/tasks/bin/scripts/kibana.bat
@@ -15,7 +15,7 @@ If Not Exist "%NODE%" (
 )
 
 set CONFIG_DIR=%KBN_PATH_CONF%
-If ["%KBN_PATH_CONF%"] == [] (
+If ["%KBN_PATH_CONF%"] == [""] (
   set "CONFIG_DIR=%DIR%\config"
 )
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [[Windows] Fix string comparison in bat scripts for default dir. (#158517)](https://github.com/elastic/kibana/pull/158517)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Brad White","email":"Ikuni17@users.noreply.github.com"},"sourceCommit":{"committedDate":"2023-05-26T16:26:56Z","message":"[Windows] Fix string comparison in bat scripts for default dir. (#158517)\n\n## Summary\r\n \r\nFixes #137477\r\n\r\nThe `node.options` file was not being found if `KBN_PATH_CONF` was not\r\nset because the default directory fallback condition was failing.\r\n\r\n`kibana.bat` before fix, can see the flag I added in\r\n`config/node.options` is missing and default options are used:\r\n\r\n\r\n![broken](https://github.com/elastic/kibana/assets/14021797/178f75a5-f3ec-4785-bd7c-aa609e43b786)\r\n\r\n\r\nThe flag is correctly added after fix:\r\n\r\n\r\n![fixed](https://github.com/elastic/kibana/assets/14021797/f607a7b3-cc04-40ea-9608-db6466b0333f)\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"7655cb9e9e1c6da0266abec65f5c1399983bb252","branchLabelMapping":{"^v8.9.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Operations","release_note:skip","ci:build-all-platforms","backport:prev-MAJOR","v8.9.0"],"number":158517,"url":"https://github.com/elastic/kibana/pull/158517","mergeCommit":{"message":"[Windows] Fix string comparison in bat scripts for default dir. (#158517)\n\n## Summary\r\n \r\nFixes #137477\r\n\r\nThe `node.options` file was not being found if `KBN_PATH_CONF` was not\r\nset because the default directory fallback condition was failing.\r\n\r\n`kibana.bat` before fix, can see the flag I added in\r\n`config/node.options` is missing and default options are used:\r\n\r\n\r\n![broken](https://github.com/elastic/kibana/assets/14021797/178f75a5-f3ec-4785-bd7c-aa609e43b786)\r\n\r\n\r\nThe flag is correctly added after fix:\r\n\r\n\r\n![fixed](https://github.com/elastic/kibana/assets/14021797/f607a7b3-cc04-40ea-9608-db6466b0333f)\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"7655cb9e9e1c6da0266abec65f5c1399983bb252"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.9.0","labelRegex":"^v8.9.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/158517","number":158517,"mergeCommit":{"message":"[Windows] Fix string comparison in bat scripts for default dir. (#158517)\n\n## Summary\r\n \r\nFixes #137477\r\n\r\nThe `node.options` file was not being found if `KBN_PATH_CONF` was not\r\nset because the default directory fallback condition was failing.\r\n\r\n`kibana.bat` before fix, can see the flag I added in\r\n`config/node.options` is missing and default options are used:\r\n\r\n\r\n![broken](https://github.com/elastic/kibana/assets/14021797/178f75a5-f3ec-4785-bd7c-aa609e43b786)\r\n\r\n\r\nThe flag is correctly added after fix:\r\n\r\n\r\n![fixed](https://github.com/elastic/kibana/assets/14021797/f607a7b3-cc04-40ea-9608-db6466b0333f)\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"7655cb9e9e1c6da0266abec65f5c1399983bb252"}},{"url":"https://github.com/elastic/kibana/pull/158595","number":158595,"branch":"8.8","state":"OPEN"}]}] BACKPORT-->