### PR TITLE
[Security solution] Generative API connector, azure url fix

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1071,6 +1071,11 @@ x-pack/plugins/cloud_integrations/cloud_full_story/server/config.ts @elastic/kib
 /x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network @elastic/security-threat-hunting-explore
 /x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/users @elastic/security-threat-hunting-explore
 
+## Explore owner connectors
+/x-pack/plugins/stack_connectors/public/connector_types/gen_ai @elastic/security-threat-hunting-explore
+/x-pack/plugins/stack_connectors/server/connector_types/gen_ai @elastic/security-threat-hunting-explore
+/x-pack/plugins/stack_connectors/common/gen_ai @elastic/security-threat-hunting-explore
+
 ## Security Solution sub teams - Detection Rule Management
 /x-pack/plugins/security_solution/common/detection_engine/fleet_integrations @elastic/security-detection-rule-management
 /x-pack/plugins/security_solution/common/detection_engine/prebuilt_rules @elastic/security-detection-rule-management

--- a/x-pack/plugins/stack_connectors/public/connector_types/gen_ai/constants.ts
+++ b/x-pack/plugins/stack_connectors/public/connector_types/gen_ai/constants.ts
@@ -7,7 +7,7 @@
 
 export const DEFAULT_URL = 'https://api.openai.com/v1/chat/completions' as const;
 export const DEFAULT_URL_AZURE =
-  'https://{your-resource-name}.openai.azure.com/openai/deployments/{deployment-id}/completions?api-version={api-version}' as const;
+  'https://{your-resource-name}.openai.azure.com/openai/deployments/{deployment-id}/chat/completions?api-version={api-version}' as const;
 
 export const DEFAULT_BODY = `{
     "model":"gpt-3.5-turbo",


### PR DESCRIPTION
## Summary

The example url for the Azure OpenAI endpoint was using the `/completions` endpoint instead of the `/chat/completions` endpoint. Updated the string for a fast fix

Also added the `gen_ai/` dirs to the CODEOWNERS under threat hunting explore, as suggested [here](https://github.com/elastic/kibana/pull/158460#pullrequestreview-1444576238) by @pmuellr 