### PR TITLE
[AIOPS][Observability] Prototype - add Explain Log Rate Spikes UI to Alert details UI

### DIFF
--- a/x-pack/plugins/aiops/public/components/document_count_content/document_count_chart/document_count_chart.tsx
+++ b/x-pack/plugins/aiops/public/components/document_count_content/document_count_chart/document_count_chart.tsx
@@ -56,6 +56,8 @@ interface DocumentCountChartProps {
   interval: number;
   chartPointsSplitLabel: string;
   isBrushCleared: boolean;
+  /* Timestamp for start of initial analysis */
+  autoAnalysisStart?: number;
 }
 
 const SPEC_ID = 'document_count';
@@ -101,13 +103,15 @@ export const DocumentCountChart: FC<DocumentCountChartProps> = ({
   interval,
   chartPointsSplitLabel,
   isBrushCleared,
+  autoAnalysisStart,
 }) => {
   const { data, uiSettings, fieldFormats, charts } = useAiopsAppContext();
 
   const chartTheme = charts.theme.useChartsTheme();
   const chartBaseTheme = charts.theme.useChartsBaseTheme();
 
-  const xAxisFormatter = fieldFormats.deserialize({ id: 'date' });
+  // NOTE: temp removal as fieldFormats wasn't passed in correctly from the infra plugin
+  // const xAxisFormatter = fieldFormats.deserialize({ id: 'date' });
   const useLegacyTimeAxis = uiSettings.get('visualization:useLegacyTimeAxis', false);
 
   const overallSeriesName = i18n.translate(
@@ -201,39 +205,6 @@ export const DocumentCountChart: FC<DocumentCountChartProps> = ({
     timefilterUpdateHandler({ from, to });
   };
 
-  const onElementClick: ElementClickListener = ([elementData]) => {
-    if (brushSelectionUpdateHandler === undefined) {
-      return;
-    }
-    const startRange = (elementData as XYChartElementEvent)[0].x;
-
-    const range = {
-      from: startRange,
-      to: startRange + interval,
-    };
-
-    if (viewMode === VIEW_MODE.ZOOM) {
-      timefilterUpdateHandler(range);
-    } else {
-      if (
-        typeof startRange === 'number' &&
-        originalWindowParameters === undefined &&
-        windowParameters === undefined &&
-        adjustedChartPoints !== undefined
-      ) {
-        const wp = getWindowParameters(
-          startRange + interval / 2,
-          timeRangeEarliest,
-          timeRangeLatest + interval
-        );
-        const wpSnap = getSnappedWindowParameters(wp, snapTimestamps);
-        setOriginalWindowParameters(wpSnap);
-        setWindowParameters(wpSnap);
-        brushSelectionUpdateHandler(wpSnap, true);
-      }
-    }
-  };
-
   const timeZone = getTimezone(uiSettings);
 
   const [originalWindowParameters, setOriginalWindowParameters] = useState<
@@ -243,6 +214,69 @@ export const DocumentCountChart: FC<DocumentCountChartProps> = ({
   const [windowParametersAsPixels, setWindowParametersAsPixels] = useState<
     WindowParameters | undefined
   >();
+
+  const triggerAnalysis = useCallback(
+    (startRange: number) => {
+      const range = {
+        from: startRange,
+        to: startRange + interval,
+      };
+
+      if (viewMode === VIEW_MODE.ZOOM) {
+        timefilterUpdateHandler(range);
+      } else {
+        if (
+          typeof startRange === 'number' &&
+          originalWindowParameters === undefined &&
+          windowParameters === undefined &&
+          adjustedChartPoints !== undefined
+        ) {
+          const wp = getWindowParameters(
+            startRange + interval / 2,
+            timeRangeEarliest,
+            timeRangeLatest + interval
+          );
+          const wpSnap = getSnappedWindowParameters(wp, snapTimestamps);
+          setOriginalWindowParameters(wpSnap);
+          setWindowParameters(wpSnap);
+          if (brushSelectionUpdateHandler !== undefined) {
+            brushSelectionUpdateHandler(wpSnap, true);
+          }
+        }
+      }
+    },
+    [
+      interval,
+      timeRangeEarliest,
+      timeRangeLatest,
+      snapTimestamps,
+      originalWindowParameters,
+      setWindowParameters,
+      brushSelectionUpdateHandler,
+      adjustedChartPoints,
+      timefilterUpdateHandler,
+      viewMode,
+      windowParameters,
+    ]
+  );
+
+  const onElementClick: ElementClickListener = useCallback(
+    ([elementData]) => {
+      if (brushSelectionUpdateHandler === undefined) {
+        return;
+      }
+      const startRange = (elementData as XYChartElementEvent)[0].x;
+
+      triggerAnalysis(startRange);
+    },
+    [triggerAnalysis, brushSelectionUpdateHandler]
+  );
+
+  useEffect(() => {
+    if (autoAnalysisStart !== undefined) {
+      triggerAnalysis(autoAnalysisStart);
+    }
+  }, [triggerAnalysis, autoAnalysisStart]);
 
   useEffect(() => {
     if (isBrushCleared && originalWindowParameters !== undefined) {
@@ -350,7 +384,8 @@ export const DocumentCountChart: FC<DocumentCountChartProps> = ({
             id="aiops-histogram-bottom-axis"
             position={Position.Bottom}
             showOverlappingTicks={true}
-            tickFormat={(value) => xAxisFormatter.convert(value)}
+            tickFormat={(value) => value}
+            // tickFormat={(value) => xAxisFormatter.convert(value)}
             // temporary fix to reduce horizontal chart margin until fixed in Elastic Charts itself
             labelFormat={useLegacyTimeAxis ? undefined : () => ''}
             timeAxisLayerCount={useLegacyTimeAxis ? 0 : 2}

--- a/x-pack/plugins/aiops/public/components/document_count_content/document_count_content/document_count_content.tsx
+++ b/x-pack/plugins/aiops/public/components/document_count_content/document_count_content/document_count_content.tsx
@@ -33,6 +33,7 @@ export interface DocumentCountContentProps {
   totalCount: number;
   sampleProbability: number;
   windowParameters?: WindowParameters;
+  incomingInitialAnalysisStart?: number;
 }
 
 export const DocumentCountContent: FC<DocumentCountContentProps> = ({
@@ -44,8 +45,12 @@ export const DocumentCountContent: FC<DocumentCountContentProps> = ({
   totalCount,
   sampleProbability,
   windowParameters,
+  incomingInitialAnalysisStart,
 }) => {
   const [isBrushCleared, setIsBrushCleared] = useState(true);
+  const [initialAnalysisStart, setInitialAnalysisStart] = useState<number | undefined>(
+    incomingInitialAnalysisStart
+  );
 
   useEffect(() => {
     setIsBrushCleared(windowParameters === undefined);
@@ -95,6 +100,7 @@ export const DocumentCountContent: FC<DocumentCountContentProps> = ({
 
   function clearSelection() {
     setIsBrushCleared(true);
+    setInitialAnalysisStart(undefined);
     clearSelectionHandler();
   }
 
@@ -126,6 +132,7 @@ export const DocumentCountContent: FC<DocumentCountContentProps> = ({
           interval={documentCountStats.interval}
           chartPointsSplitLabel={documentCountStatsSplitLabel}
           isBrushCleared={isBrushCleared}
+          autoAnalysisStart={initialAnalysisStart}
         />
       )}
     </>

--- a/x-pack/plugins/aiops/public/components/explain_log_rate_spikes/explain_log_rate_spikes_content/explain_log_rate_spikes_content.tsx
+++ b/x-pack/plugins/aiops/public/components/explain_log_rate_spikes/explain_log_rate_spikes_content/explain_log_rate_spikes_content.tsx
@@ -12,7 +12,6 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 
 import type { DataView } from '@kbn/data-views-plugin/public';
-import type { SavedSearch } from '@kbn/saved-search-plugin/public';
 import type { Dictionary } from '@kbn/ml-url-state';
 import type { WindowParameters } from '@kbn/aiops-utils';
 import type { SignificantTerm } from '@kbn/ml-agg-utils';
@@ -23,7 +22,8 @@ import { DocumentCountContent } from '../../document_count_content/document_coun
 import { ExplainLogRateSpikesAnalysis } from '../explain_log_rate_spikes_analysis';
 import type { GroupTableItem } from '../../spike_analysis_table/types';
 import { useSpikeAnalysisTableRowContext } from '../../spike_analysis_table/spike_analysis_table_row_provider';
-import type { AiOpsIndexBasedAppState } from '../../../application/utils/url_state';
+
+const DEFAULT_SEARCH_QUERY = { match_all: {} };
 
 export function getDocumentCountStatsSplitLabel(
   significantTerm?: SignificantTerm,
@@ -41,9 +41,6 @@ export function getDocumentCountStatsSplitLabel(
 export interface ExplainLogRateSpikesContentProps {
   /** The data view to analyze. */
   dataView: DataView;
-  /** The saved search to analyze. */
-  selectedSavedSearch: SavedSearch | null;
-  aiopsListState: AiOpsIndexBasedAppState;
   setGlobalState?: (params: Dictionary<unknown>) => void;
   /** Timestamp for the start of the range for initial analysis */
   initialAnalysisStart?: number;
@@ -54,12 +51,10 @@ export interface ExplainLogRateSpikesContentProps {
 
 export const ExplainLogRateSpikesContent: FC<ExplainLogRateSpikesContentProps> = ({
   dataView,
-  selectedSavedSearch,
-  aiopsListState,
   setGlobalState,
   initialAnalysisStart,
   timeRange,
-  esSearchQuery,
+  esSearchQuery = DEFAULT_SEARCH_QUERY,
 }) => {
   const [windowParameters, setWindowParameters] = useState<WindowParameters | undefined>();
 
@@ -72,14 +67,13 @@ export const ExplainLogRateSpikesContent: FC<ExplainLogRateSpikesContentProps> =
     setSelectedGroup,
   } = useSpikeAnalysisTableRowContext();
 
-  const { documentStats, earliest, latest, searchQuery } = useData(
-    { selectedDataView: dataView, selectedSavedSearch },
+  const { documentStats, earliest, latest } = useData(
+    dataView,
     'explain_log_rage_spikes',
-    aiopsListState,
+    esSearchQuery,
     setGlobalState,
     currentSelectedSignificantTerm,
     currentSelectedGroup,
-    undefined,
     undefined,
     timeRange
   );
@@ -138,7 +132,7 @@ export const ExplainLogRateSpikesContent: FC<ExplainLogRateSpikesContentProps> =
                 earliest={earliest}
                 latest={latest}
                 windowParameters={windowParameters}
-                searchQuery={esSearchQuery ?? searchQuery}
+                searchQuery={esSearchQuery}
                 sampleProbability={sampleProbability}
               />
             )}

--- a/x-pack/plugins/aiops/public/components/explain_log_rate_spikes/explain_log_rate_spikes_content/explain_log_rate_spikes_content.tsx
+++ b/x-pack/plugins/aiops/public/components/explain_log_rate_spikes/explain_log_rate_spikes_content/explain_log_rate_spikes_content.tsx
@@ -1,0 +1,176 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useState, FC } from 'react';
+import { EuiEmptyPrompt, EuiHorizontalRule, EuiResizableContainer } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
+import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+
+import type { DataView } from '@kbn/data-views-plugin/public';
+import type { SavedSearch } from '@kbn/saved-search-plugin/public';
+import type { Dictionary } from '@kbn/ml-url-state';
+import type { WindowParameters } from '@kbn/aiops-utils';
+import type { SignificantTerm } from '@kbn/ml-agg-utils';
+
+import type { Moment } from 'moment';
+import { useData } from '../../../hooks/use_data';
+import { DocumentCountContent } from '../../document_count_content/document_count_content';
+import { ExplainLogRateSpikesAnalysis } from '../explain_log_rate_spikes_analysis';
+import type { GroupTableItem } from '../../spike_analysis_table/types';
+import { useSpikeAnalysisTableRowContext } from '../../spike_analysis_table/spike_analysis_table_row_provider';
+import type { AiOpsIndexBasedAppState } from '../../../application/utils/url_state';
+
+export function getDocumentCountStatsSplitLabel(
+  significantTerm?: SignificantTerm,
+  group?: GroupTableItem
+) {
+  if (significantTerm) {
+    return `${significantTerm?.fieldName}:${significantTerm?.fieldValue}`;
+  } else if (group) {
+    return i18n.translate('xpack.aiops.spikeAnalysisPage.documentCountStatsSplitGroupLabel', {
+      defaultMessage: 'Selected group',
+    });
+  }
+}
+
+export interface ExplainLogRateSpikesContentProps {
+  /** The data view to analyze. */
+  dataView: DataView;
+  /** The saved search to analyze. */
+  selectedSavedSearch: SavedSearch | null;
+  aiopsListState: AiOpsIndexBasedAppState;
+  setGlobalState?: (params: Dictionary<unknown>) => void;
+  /** Timestamp for the start of the range for initial analysis */
+  initialAnalysisStart?: number;
+  timeRange?: { min: Moment; max: Moment };
+  /** Elasticsearch query to pass to analysis endpoint */
+  esSearchQuery?: estypes.QueryDslQueryContainer;
+}
+
+export const ExplainLogRateSpikesContent: FC<ExplainLogRateSpikesContentProps> = ({
+  dataView,
+  selectedSavedSearch,
+  aiopsListState,
+  setGlobalState,
+  initialAnalysisStart,
+  timeRange,
+  esSearchQuery,
+}) => {
+  const [windowParameters, setWindowParameters] = useState<WindowParameters | undefined>();
+
+  const {
+    currentSelectedSignificantTerm,
+    currentSelectedGroup,
+    setPinnedSignificantTerm,
+    setPinnedGroup,
+    setSelectedSignificantTerm,
+    setSelectedGroup,
+  } = useSpikeAnalysisTableRowContext();
+
+  const { documentStats, earliest, latest, searchQuery } = useData(
+    { selectedDataView: dataView, selectedSavedSearch },
+    'explain_log_rage_spikes',
+    aiopsListState,
+    setGlobalState,
+    currentSelectedSignificantTerm,
+    currentSelectedGroup,
+    undefined,
+    undefined,
+    timeRange
+  );
+
+  const { sampleProbability, totalCount, documentCountStats, documentCountStatsCompare } =
+    documentStats;
+
+  function clearSelection() {
+    setWindowParameters(undefined);
+    setPinnedSignificantTerm(null);
+    setPinnedGroup(null);
+    setSelectedSignificantTerm(null);
+    setSelectedGroup(null);
+  }
+
+  return (
+    <EuiResizableContainer style={{ height: '400px' }} direction="vertical">
+      {(EuiResizablePanel, EuiResizableButton) => (
+        <>
+          <EuiResizablePanel
+            mode={'collapsible'}
+            initialSize={60}
+            minSize="40%"
+            tabIndex={0}
+            paddingSize="s"
+          >
+            {documentCountStats !== undefined && (
+              <DocumentCountContent
+                brushSelectionUpdateHandler={setWindowParameters}
+                clearSelectionHandler={clearSelection}
+                documentCountStats={documentCountStats}
+                documentCountStatsSplit={documentCountStatsCompare}
+                documentCountStatsSplitLabel={getDocumentCountStatsSplitLabel(
+                  currentSelectedSignificantTerm,
+                  currentSelectedGroup
+                )}
+                totalCount={totalCount}
+                sampleProbability={sampleProbability}
+                windowParameters={windowParameters}
+                incomingInitialAnalysisStart={initialAnalysisStart}
+              />
+            )}
+            <EuiHorizontalRule />
+          </EuiResizablePanel>
+          {/* <EuiResizableButton /> */}
+          <EuiResizablePanel
+            paddingSize="s"
+            mode={'main'}
+            initialSize={80}
+            minSize="50px"
+            tabIndex={0}
+          >
+            {earliest !== undefined && latest !== undefined && windowParameters !== undefined && (
+              <ExplainLogRateSpikesAnalysis
+                dataView={dataView}
+                earliest={earliest}
+                latest={latest}
+                windowParameters={windowParameters}
+                searchQuery={esSearchQuery ?? searchQuery}
+                sampleProbability={sampleProbability}
+              />
+            )}
+            {windowParameters === undefined && (
+              <EuiEmptyPrompt
+                color="subdued"
+                hasShadow={false}
+                hasBorder={false}
+                css={{ minWidth: '100%' }}
+                title={
+                  <h2>
+                    <FormattedMessage
+                      id="xpack.aiops.explainLogRateSpikesPage.emptyPromptTitle"
+                      defaultMessage="Click a spike in the histogram chart to start the analysis."
+                    />
+                  </h2>
+                }
+                titleSize="xs"
+                body={
+                  <p>
+                    <FormattedMessage
+                      id="xpack.aiops.explainLogRateSpikesPage.emptyPromptBody"
+                      defaultMessage="The explain log rate spikes feature identifies statistically significant field/value combinations that contribute to a log rate spike."
+                    />
+                  </p>
+                }
+                data-test-subj="aiopsNoWindowParametersEmptyPrompt"
+              />
+            )}
+          </EuiResizablePanel>
+        </>
+      )}
+    </EuiResizableContainer>
+  );
+};

--- a/x-pack/plugins/aiops/public/components/explain_log_rate_spikes/explain_log_rate_spikes_content/explain_log_rate_spikes_content_wrapper.tsx
+++ b/x-pack/plugins/aiops/public/components/explain_log_rate_spikes/explain_log_rate_spikes_content/explain_log_rate_spikes_content_wrapper.tsx
@@ -13,7 +13,6 @@ import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { EuiCallOut } from '@elastic/eui';
 
 import { i18n } from '@kbn/i18n';
-import type { SavedSearch } from '@kbn/discover-plugin/public';
 import type { DataView } from '@kbn/data-views-plugin/public';
 import { StorageContextProvider } from '@kbn/ml-local-storage';
 import { UrlStateProvider } from '@kbn/ml-url-state';
@@ -29,19 +28,14 @@ import { AIOPS_STORAGE_KEYS } from '../../../types/storage';
 import { SpikeAnalysisTableRowStateProvider } from '../../spike_analysis_table/spike_analysis_table_row_provider';
 
 import { ExplainLogRateSpikesContent } from './explain_log_rate_spikes_content';
-import type { AiOpsIndexBasedAppState } from '../../../application/utils/url_state';
 
 const localStorage = new Storage(window.localStorage);
 
 export interface ExplainLogRateSpikesContentWrapperProps {
   /** The data view to analyze. */
   dataView: DataView;
-  /** The saved search to analyze. */
-  savedSearch: SavedSearch | null;
   /** App dependencies */
   appDependencies: AiopsAppDependencies;
-  /** Active search query/filters */
-  aiopsListState: AiOpsIndexBasedAppState;
   /** On global timefilter update */
   setGlobalState?: any;
   /** Timestamp for start of initial analysis */
@@ -53,9 +47,7 @@ export interface ExplainLogRateSpikesContentWrapperProps {
 
 export const ExplainLogRateSpikesContentWrapper: FC<ExplainLogRateSpikesContentWrapperProps> = ({
   dataView,
-  savedSearch,
   appDependencies,
-  aiopsListState,
   setGlobalState,
   initialAnalysisStart,
   timeRange,
@@ -92,14 +84,12 @@ export const ExplainLogRateSpikesContentWrapper: FC<ExplainLogRateSpikesContentW
   return (
     <AiopsAppContext.Provider value={appDependencies}>
       <UrlStateProvider>
-        <DataSourceContext.Provider value={{ dataView, savedSearch }}>
+        <DataSourceContext.Provider value={{ dataView, savedSearch: null }}>
           <SpikeAnalysisTableRowStateProvider>
             <StorageContextProvider storage={localStorage} storageKeys={AIOPS_STORAGE_KEYS}>
               <DatePickerContextProvider {...datePickerDeps}>
                 <ExplainLogRateSpikesContent
                   dataView={dataView}
-                  selectedSavedSearch={savedSearch}
-                  aiopsListState={aiopsListState}
                   setGlobalState={setGlobalState}
                   initialAnalysisStart={initialAnalysisStart}
                   timeRange={timeRange}

--- a/x-pack/plugins/aiops/public/components/explain_log_rate_spikes/explain_log_rate_spikes_content/explain_log_rate_spikes_content_wrapper.tsx
+++ b/x-pack/plugins/aiops/public/components/explain_log_rate_spikes/explain_log_rate_spikes_content/explain_log_rate_spikes_content_wrapper.tsx
@@ -1,0 +1,115 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { FC } from 'react';
+import { pick } from 'lodash';
+import type { Moment } from 'moment';
+import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+
+import { EuiCallOut } from '@elastic/eui';
+
+import { i18n } from '@kbn/i18n';
+import type { SavedSearch } from '@kbn/discover-plugin/public';
+import type { DataView } from '@kbn/data-views-plugin/public';
+import { StorageContextProvider } from '@kbn/ml-local-storage';
+import { UrlStateProvider } from '@kbn/ml-url-state';
+import { Storage } from '@kbn/kibana-utils-plugin/public';
+import { DatePickerContextProvider } from '@kbn/ml-date-picker';
+import { UI_SETTINGS } from '@kbn/data-plugin/common';
+import { toMountPoint, wrapWithTheme } from '@kbn/kibana-react-plugin/public';
+
+import { AiopsAppContext, type AiopsAppDependencies } from '../../../hooks/use_aiops_app_context';
+import { DataSourceContext } from '../../../hooks/use_data_source';
+import { AIOPS_STORAGE_KEYS } from '../../../types/storage';
+
+import { SpikeAnalysisTableRowStateProvider } from '../../spike_analysis_table/spike_analysis_table_row_provider';
+
+import { ExplainLogRateSpikesContent } from './explain_log_rate_spikes_content';
+import type { AiOpsIndexBasedAppState } from '../../../application/utils/url_state';
+
+const localStorage = new Storage(window.localStorage);
+
+export interface ExplainLogRateSpikesContentWrapperProps {
+  /** The data view to analyze. */
+  dataView: DataView;
+  /** The saved search to analyze. */
+  savedSearch: SavedSearch | null;
+  /** App dependencies */
+  appDependencies: AiopsAppDependencies;
+  /** Active search query/filters */
+  aiopsListState: AiOpsIndexBasedAppState;
+  /** On global timefilter update */
+  setGlobalState?: any;
+  /** Timestamp for start of initial analysis */
+  initialAnalysisStart?: number;
+  timeRange?: { min: Moment; max: Moment };
+  /** Elasticsearch query to pass to analysis endpoint */
+  esSearchQuery?: estypes.QueryDslQueryContainer;
+}
+
+export const ExplainLogRateSpikesContentWrapper: FC<ExplainLogRateSpikesContentWrapperProps> = ({
+  dataView,
+  savedSearch,
+  appDependencies,
+  aiopsListState,
+  setGlobalState,
+  initialAnalysisStart,
+  timeRange,
+  esSearchQuery,
+}) => {
+  if (!dataView) return null;
+
+  if (!dataView.isTimeBased()) {
+    return (
+      <EuiCallOut
+        title={i18n.translate('xpack.aiops.index.dataViewNotBasedOnTimeSeriesNotificationTitle', {
+          defaultMessage: 'The data view "{dataViewTitle}" is not based on a time series.',
+          values: { dataViewTitle: dataView.getName() },
+        })}
+        color="danger"
+        iconType="warning"
+      >
+        <p>
+          {i18n.translate('xpack.aiops.index.dataViewNotBasedOnTimeSeriesNotificationDescription', {
+            defaultMessage: 'Log rate spike analysis only runs over time-based indices.',
+          })}
+        </p>
+      </EuiCallOut>
+    );
+  }
+
+  const datePickerDeps = {
+    ...pick(appDependencies, ['data', 'http', 'notifications', 'theme', 'uiSettings']),
+    toMountPoint,
+    wrapWithTheme,
+    uiSettingsKeys: UI_SETTINGS,
+  };
+
+  return (
+    <AiopsAppContext.Provider value={appDependencies}>
+      <UrlStateProvider>
+        <DataSourceContext.Provider value={{ dataView, savedSearch }}>
+          <SpikeAnalysisTableRowStateProvider>
+            <StorageContextProvider storage={localStorage} storageKeys={AIOPS_STORAGE_KEYS}>
+              <DatePickerContextProvider {...datePickerDeps}>
+                <ExplainLogRateSpikesContent
+                  dataView={dataView}
+                  selectedSavedSearch={savedSearch}
+                  aiopsListState={aiopsListState}
+                  setGlobalState={setGlobalState}
+                  initialAnalysisStart={initialAnalysisStart}
+                  timeRange={timeRange}
+                  esSearchQuery={esSearchQuery}
+                />
+              </DatePickerContextProvider>
+            </StorageContextProvider>
+          </SpikeAnalysisTableRowStateProvider>
+        </DataSourceContext.Provider>
+      </UrlStateProvider>
+    </AiopsAppContext.Provider>
+  );
+};

--- a/x-pack/plugins/aiops/public/components/explain_log_rate_spikes/explain_log_rate_spikes_content/index.ts
+++ b/x-pack/plugins/aiops/public/components/explain_log_rate_spikes/explain_log_rate_spikes_content/index.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ExplainLogRateSpikesContentWrapper } from './explain_log_rate_spikes_content_wrapper';
+
+// required for dynamic import using React.lazy()
+// eslint-disable-next-line import/no-default-export
+export default ExplainLogRateSpikesContentWrapper;

--- a/x-pack/plugins/aiops/public/components/explain_log_rate_spikes/explain_log_rate_spikes_page.tsx
+++ b/x-pack/plugins/aiops/public/components/explain_log_rate_spikes/explain_log_rate_spikes_page.tsx
@@ -8,21 +8,9 @@
 import React, { useCallback, useEffect, useState, FC } from 'react';
 
 import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
-import {
-  EuiEmptyPrompt,
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiPageBody,
-  EuiPageSection,
-  EuiPanel,
-  EuiSpacer,
-} from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiPageBody, EuiPageSection, EuiSpacer } from '@elastic/eui';
 
-import { i18n } from '@kbn/i18n';
-import type { WindowParameters } from '@kbn/aiops-utils';
-import type { SignificantTerm } from '@kbn/ml-agg-utils';
 import { Filter, FilterStateStore, Query } from '@kbn/es-query';
-import { FormattedMessage } from '@kbn/i18n-react';
 import { useUrlState, usePageUrlState } from '@kbn/ml-url-state';
 
 import { useDataSource } from '../../hooks/use_data_source';
@@ -34,26 +22,11 @@ import {
   type AiOpsPageUrlState,
 } from '../../application/utils/url_state';
 
-import { DocumentCountContent } from '../document_count_content/document_count_content';
 import { SearchPanel } from '../search_panel';
-import type { GroupTableItem } from '../spike_analysis_table/types';
 import { useSpikeAnalysisTableRowContext } from '../spike_analysis_table/spike_analysis_table_row_provider';
 import { PageHeader } from '../page_header';
 
-import { ExplainLogRateSpikesAnalysis } from './explain_log_rate_spikes_analysis';
-
-function getDocumentCountStatsSplitLabel(
-  significantTerm?: SignificantTerm,
-  group?: GroupTableItem
-) {
-  if (significantTerm) {
-    return `${significantTerm?.fieldName}:${significantTerm?.fieldValue}`;
-  } else if (group) {
-    return i18n.translate('xpack.aiops.spikeAnalysisPage.documentCountStatsSplitGroupLabel', {
-      defaultMessage: 'Selected group',
-    });
-  }
-}
+import { ExplainLogRateSpikesContent } from './explain_log_rate_spikes_content/explain_log_rate_spikes_content';
 
 export const ExplainLogRateSpikesPage: FC = () => {
   const { data: dataService } = useAiopsAppContext();
@@ -62,10 +35,10 @@ export const ExplainLogRateSpikesPage: FC = () => {
   const {
     currentSelectedSignificantTerm,
     currentSelectedGroup,
-    setPinnedSignificantTerm,
-    setPinnedGroup,
-    setSelectedSignificantTerm,
-    setSelectedGroup,
+    // setPinnedSignificantTerm,
+    // setPinnedGroup,
+    // setSelectedSignificantTerm,
+    // setSelectedGroup,
   } = useSpikeAnalysisTableRowContext();
 
   const [aiopsListState, setAiopsListState] = usePageUrlState<AiOpsPageUrlState>(
@@ -107,10 +80,11 @@ export const ExplainLogRateSpikesPage: FC = () => {
   );
 
   const {
-    documentStats,
-    timefilter,
-    earliest,
-    latest,
+    // documentStats,
+    timefilter, // only needs selectedDataView param
+    // earliest,
+    // latest,
+    // These bottom 3: from aiopsListState or savedSearch (aiopsListState only gets set by search panel)
     searchQueryLanguage,
     searchString,
     searchQuery,
@@ -122,9 +96,6 @@ export const ExplainLogRateSpikesPage: FC = () => {
     currentSelectedSignificantTerm,
     currentSelectedGroup
   );
-
-  const { sampleProbability, totalCount, documentCountStats, documentCountStatsCompare } =
-    documentStats;
 
   useEffect(
     // TODO: Consolidate this hook/function with with Data visualizer's
@@ -140,8 +111,6 @@ export const ExplainLogRateSpikesPage: FC = () => {
     },
     [dataService.query.filterManager]
   );
-
-  const [windowParameters, setWindowParameters] = useState<WindowParameters | undefined>();
 
   useEffect(() => {
     if (globalState?.time !== undefined) {
@@ -168,14 +137,6 @@ export const ExplainLogRateSpikesPage: FC = () => {
     });
   }, [dataService, searchQueryLanguage, searchString]);
 
-  function clearSelection() {
-    setWindowParameters(undefined);
-    setPinnedSignificantTerm(null);
-    setPinnedGroup(null);
-    setSelectedSignificantTerm(null);
-    setSelectedGroup(null);
-  }
-
   return (
     <EuiPageBody data-test-subj="aiopsExplainLogRateSpikesPage" paddingSize="none" panelled={false}>
       <PageHeader />
@@ -191,61 +152,12 @@ export const ExplainLogRateSpikesPage: FC = () => {
               setSearchParams={setSearchParams}
             />
           </EuiFlexItem>
-          {documentCountStats !== undefined && (
-            <EuiFlexItem>
-              <EuiPanel paddingSize="m">
-                <DocumentCountContent
-                  brushSelectionUpdateHandler={setWindowParameters}
-                  clearSelectionHandler={clearSelection}
-                  documentCountStats={documentCountStats}
-                  documentCountStatsSplit={documentCountStatsCompare}
-                  documentCountStatsSplitLabel={getDocumentCountStatsSplitLabel(
-                    currentSelectedSignificantTerm,
-                    currentSelectedGroup
-                  )}
-                  totalCount={totalCount}
-                  sampleProbability={sampleProbability}
-                  windowParameters={windowParameters}
-                />
-              </EuiPanel>
-            </EuiFlexItem>
-          )}
-          <EuiFlexItem>
-            <EuiPanel paddingSize="m">
-              {earliest !== undefined && latest !== undefined && windowParameters !== undefined && (
-                <ExplainLogRateSpikesAnalysis
-                  dataView={dataView}
-                  earliest={earliest}
-                  latest={latest}
-                  windowParameters={windowParameters}
-                  searchQuery={searchQuery}
-                  sampleProbability={sampleProbability}
-                />
-              )}
-              {windowParameters === undefined && (
-                <EuiEmptyPrompt
-                  title={
-                    <h2>
-                      <FormattedMessage
-                        id="xpack.aiops.explainLogRateSpikesPage.emptyPromptTitle"
-                        defaultMessage="Click a spike in the histogram chart to start the analysis."
-                      />
-                    </h2>
-                  }
-                  titleSize="xs"
-                  body={
-                    <p>
-                      <FormattedMessage
-                        id="xpack.aiops.explainLogRateSpikesPage.emptyPromptBody"
-                        defaultMessage="The explain log rate spikes feature identifies statistically significant field/value combinations that contribute to a log rate spike."
-                      />
-                    </p>
-                  }
-                  data-test-subj="aiopsNoWindowParametersEmptyPrompt"
-                />
-              )}
-            </EuiPanel>
-          </EuiFlexItem>
+          <ExplainLogRateSpikesContent
+            dataView={dataView}
+            selectedSavedSearch={selectedSavedSearch}
+            aiopsListState={aiopsListState}
+            setGlobalState={setGlobalState}
+          />
         </EuiFlexGroup>
       </EuiPageSection>
     </EuiPageBody>

--- a/x-pack/plugins/aiops/public/components/explain_log_rate_spikes/explain_log_rate_spikes_page.tsx
+++ b/x-pack/plugins/aiops/public/components/explain_log_rate_spikes/explain_log_rate_spikes_page.tsx
@@ -17,6 +17,7 @@ import { useDataSource } from '../../hooks/use_data_source';
 import { useAiopsAppContext } from '../../hooks/use_aiops_app_context';
 import { SearchQueryLanguage } from '../../application/utils/search_utils';
 import { useData } from '../../hooks/use_data';
+import { useSearch } from '../../hooks/use_search';
 import {
   getDefaultAiOpsListState,
   type AiOpsPageUrlState,
@@ -32,14 +33,8 @@ export const ExplainLogRateSpikesPage: FC = () => {
   const { data: dataService } = useAiopsAppContext();
   const { dataView, savedSearch } = useDataSource();
 
-  const {
-    currentSelectedSignificantTerm,
-    currentSelectedGroup,
-    // setPinnedSignificantTerm,
-    // setPinnedGroup,
-    // setSelectedSignificantTerm,
-    // setSelectedGroup,
-  } = useSpikeAnalysisTableRowContext();
+  const { currentSelectedSignificantTerm, currentSelectedGroup } =
+    useSpikeAnalysisTableRowContext();
 
   const [aiopsListState, setAiopsListState] = usePageUrlState<AiOpsPageUrlState>(
     'AIOPS_INDEX_VIEWER',
@@ -79,19 +74,15 @@ export const ExplainLogRateSpikesPage: FC = () => {
     [selectedSavedSearch, aiopsListState, setAiopsListState]
   );
 
-  const {
-    // documentStats,
-    timefilter, // only needs selectedDataView param
-    // earliest,
-    // latest,
-    // These bottom 3: from aiopsListState or savedSearch (aiopsListState only gets set by search panel)
-    searchQueryLanguage,
-    searchString,
-    searchQuery,
-  } = useData(
-    { selectedDataView: dataView, selectedSavedSearch },
+  const { searchQueryLanguage, searchString, searchQuery } = useSearch(
+    { dataView, savedSearch },
+    aiopsListState
+  );
+
+  const { timefilter } = useData(
+    dataView,
     'explain_log_rage_spikes',
-    aiopsListState,
+    searchQuery,
     setGlobalState,
     currentSelectedSignificantTerm,
     currentSelectedGroup
@@ -154,9 +145,8 @@ export const ExplainLogRateSpikesPage: FC = () => {
           </EuiFlexItem>
           <ExplainLogRateSpikesContent
             dataView={dataView}
-            selectedSavedSearch={selectedSavedSearch}
-            aiopsListState={aiopsListState}
             setGlobalState={setGlobalState}
+            esSearchQuery={searchQuery}
           />
         </EuiFlexGroup>
       </EuiPageSection>

--- a/x-pack/plugins/aiops/public/components/log_categorization/log_categorization_for_flyout.tsx
+++ b/x-pack/plugins/aiops/public/components/log_categorization/log_categorization_for_flyout.tsx
@@ -22,6 +22,7 @@ import { buildEmptyFilter, Filter } from '@kbn/es-query';
 
 import { usePageUrlState } from '@kbn/ml-url-state';
 import { useData } from '../../hooks/use_data';
+import { useSearch } from '../../hooks/use_search';
 import { useCategorizeRequest } from './use_categorize_request';
 import type { EventRate, Category, SparkLinesPerCategory } from './use_categorize_request';
 import { CategoryTable } from './category_table';
@@ -91,25 +92,20 @@ export const LogCategorizationFlyout: FC<LogCategorizationPageProps> = ({
     [cancelRequest, mounted]
   );
 
-  const {
-    documentStats,
-    timefilter,
-    earliest,
-    latest,
-    searchQueryLanguage,
-    searchString,
-    searchQuery,
-    intervalMs,
-    forceRefresh,
-  } = useData(
-    { selectedDataView: dataView, selectedSavedSearch },
-    'log_categorization',
+  const { searchQueryLanguage, searchString, searchQuery } = useSearch(
+    { dataView, savedSearch: selectedSavedSearch },
     aiopsListState,
-    undefined,
-    undefined,
-    undefined,
-    BAR_TARGET,
     true
+  );
+
+  const { documentStats, timefilter, earliest, latest, intervalMs, forceRefresh } = useData(
+    dataView,
+    'log_categorization',
+    searchQuery,
+    undefined,
+    undefined,
+    undefined,
+    BAR_TARGET
   );
 
   const loadCategories = useCallback(async () => {

--- a/x-pack/plugins/aiops/public/components/log_categorization/log_categorization_page.tsx
+++ b/x-pack/plugins/aiops/public/components/log_categorization/log_categorization_page.tsx
@@ -27,6 +27,7 @@ import { usePageUrlState, useUrlState } from '@kbn/ml-url-state';
 
 import { useDataSource } from '../../hooks/use_data_source';
 import { useData } from '../../hooks/use_data';
+import { useSearch } from '../../hooks/use_search';
 import type { SearchQueryLanguage } from '../../application/utils/search_utils';
 import { useAiopsAppContext } from '../../hooks/use_aiops_app_context';
 import {
@@ -110,19 +111,15 @@ export const LogCategorizationPage: FC = () => {
     [selectedSavedSearch, aiopsListState, setAiopsListState]
   );
 
-  const {
-    documentStats,
-    timefilter,
-    earliest,
-    latest,
-    searchQueryLanguage,
-    searchString,
-    searchQuery,
-    intervalMs,
-  } = useData(
-    { selectedDataView: dataView, selectedSavedSearch },
+  const { searchQueryLanguage, searchString, searchQuery } = useSearch(
+    { dataView, savedSearch: selectedSavedSearch },
+    aiopsListState
+  );
+
+  const { documentStats, timefilter, earliest, latest, intervalMs } = useData(
+    dataView,
     'log_categorization',
-    aiopsListState,
+    searchQuery,
     setGlobalState,
     undefined,
     undefined,

--- a/x-pack/plugins/aiops/public/components/spike_analysis_table/spike_analysis_table.tsx
+++ b/x-pack/plugins/aiops/public/components/spike_analysis_table/spike_analysis_table.tsx
@@ -240,7 +240,11 @@ export const SpikeAnalysisTable: FC<SpikeAnalysisTableProps> = ({
       name: i18n.translate('xpack.aiops.spikeAnalysisTable.actionsColumnName', {
         defaultMessage: 'Actions',
       }),
-      actions: [viewInDiscoverAction, viewInLogPatternAnalysisAction, copyToClipBoardAction],
+      actions: [
+        ...(viewInDiscoverAction ? [viewInDiscoverAction] : []),
+        ...(viewInLogPatternAnalysisAction ? [viewInLogPatternAnalysisAction] : []),
+        copyToClipBoardAction,
+      ],
       width: ACTIONS_COLUMN_WIDTH,
       valign: 'middle',
     },

--- a/x-pack/plugins/aiops/public/components/spike_analysis_table/spike_analysis_table_groups.tsx
+++ b/x-pack/plugins/aiops/public/components/spike_analysis_table/spike_analysis_table_groups.tsx
@@ -350,10 +350,14 @@ export const SpikeAnalysisGroupsTable: FC<SpikeAnalysisTableProps> = ({
     },
     {
       'data-test-subj': 'aiOpsSpikeAnalysisTableColumnAction',
-      name: i18n.translate('xpack.aiops.spikeAnalysisTable.actionsColumnName', {
+      name: i18n.translate('xpack.aiops.aiopsSpikeAnalysisGroupsTable.actionsColumnName', {
         defaultMessage: 'Actions',
       }),
-      actions: [viewInDiscoverAction, viewInLogPatternAnalysisAction, copyToClipBoardAction],
+      actions: [
+        ...(viewInDiscoverAction ? [viewInDiscoverAction] : []),
+        ...(viewInLogPatternAnalysisAction ? [viewInLogPatternAnalysisAction] : []),
+        copyToClipBoardAction,
+      ],
       width: ACTIONS_COLUMN_WIDTH,
       valign: 'top',
     },

--- a/x-pack/plugins/aiops/public/hooks/use_data.ts
+++ b/x-pack/plugins/aiops/public/hooks/use_data.ts
@@ -12,15 +12,13 @@ import type { Moment } from 'moment';
 import { useExecutionContext } from '@kbn/kibana-react-plugin/public';
 import type { DataView } from '@kbn/data-views-plugin/public';
 import type { SignificantTerm } from '@kbn/ml-agg-utils';
-import type { SavedSearch } from '@kbn/discover-plugin/public';
 import type { Dictionary } from '@kbn/ml-url-state';
 import { mlTimefilterRefresh$, useTimefilter } from '@kbn/ml-date-picker';
+import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 
 import { PLUGIN_ID } from '../../common';
 
 import type { DocumentStatsSearchStrategyParams } from '../get_document_stats';
-import type { AiOpsIndexBasedAppState } from '../application/utils/url_state';
-import { getEsQueryFromSavedSearch } from '../application/utils/search_utils';
 import type { GroupTableItem } from '../components/spike_analysis_table/types';
 
 import { useTimeBuckets } from './use_time_buckets';
@@ -31,26 +29,16 @@ import { useDocumentCountStats } from './use_document_count_stats';
 const DEFAULT_BAR_TARGET = 75;
 
 export const useData = (
-  {
-    selectedDataView,
-    selectedSavedSearch,
-  }: { selectedDataView: DataView; selectedSavedSearch: SavedSearch | null },
+  selectedDataView: DataView,
   contextId: string,
-  aiopsListState: AiOpsIndexBasedAppState,
+  searchQuery: estypes.QueryDslQueryContainer,
   onUpdate?: (params: Dictionary<unknown>) => void,
   selectedSignificantTerm?: SignificantTerm,
   selectedGroup: GroupTableItem | null = null,
   barTarget: number = DEFAULT_BAR_TARGET,
-  readOnly: boolean = false,
   timeRange?: { min: Moment; max: Moment }
 ) => {
-  const {
-    executionContext,
-    uiSettings,
-    data: {
-      query: { filterManager },
-    },
-  } = useAiopsAppContext();
+  const { executionContext } = useAiopsAppContext();
 
   useExecutionContext(executionContext, {
     name: PLUGIN_ID,
@@ -59,47 +47,6 @@ export const useData = (
   });
 
   const [lastRefresh, setLastRefresh] = useState(0);
-
-  /** Prepare required params to pass to search strategy **/
-  const { searchQueryLanguage, searchString, searchQuery } = useMemo(() => {
-    const searchData = getEsQueryFromSavedSearch({
-      dataView: selectedDataView,
-      uiSettings,
-      savedSearch: selectedSavedSearch,
-      filterManager,
-    });
-
-    if (searchData === undefined || (aiopsListState && aiopsListState.searchString !== '')) {
-      if (aiopsListState?.filters && readOnly === false) {
-        const globalFilters = filterManager?.getGlobalFilters();
-
-        if (filterManager) filterManager.setFilters(aiopsListState.filters);
-        if (globalFilters) filterManager?.addFilters(globalFilters);
-      }
-      return {
-        searchQuery: aiopsListState?.searchQuery,
-        searchString: aiopsListState?.searchString,
-        searchQueryLanguage: aiopsListState?.searchQueryLanguage,
-      };
-    } else {
-      return {
-        searchQuery: searchData.searchQuery,
-        searchString: searchData.searchString,
-        searchQueryLanguage: searchData.queryLanguage,
-      };
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    selectedSavedSearch?.id,
-    selectedDataView.id,
-    aiopsListState?.searchString,
-    aiopsListState?.searchQueryLanguage,
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    JSON.stringify({
-      searchQuery: aiopsListState?.searchQuery,
-    }),
-    lastRefresh,
-  ]);
 
   const _timeBuckets = useTimeBuckets();
   const timefilter = useTimefilter({
@@ -191,9 +138,6 @@ export const useData = (
     /** End timestamp filter */
     latest: fieldStatsRequest?.latest,
     intervalMs: fieldStatsRequest?.intervalMs,
-    searchQueryLanguage,
-    searchString,
-    searchQuery,
     forceRefresh: () => setLastRefresh(Date.now()),
   };
 };

--- a/x-pack/plugins/aiops/public/hooks/use_search.ts
+++ b/x-pack/plugins/aiops/public/hooks/use_search.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { DataView } from '@kbn/data-views-plugin/public';
+import type { SavedSearch } from '@kbn/discover-plugin/public';
+
+import { getEsQueryFromSavedSearch } from '../application/utils/search_utils';
+import type { AiOpsIndexBasedAppState } from '../application/utils/url_state';
+import { useAiopsAppContext } from './use_aiops_app_context';
+
+export const useSearch = (
+  { dataView, savedSearch }: { dataView: DataView; savedSearch: SavedSearch | null },
+  aiopsListState: AiOpsIndexBasedAppState,
+  readOnly: boolean = false
+) => {
+  const {
+    uiSettings,
+    data: {
+      query: { filterManager },
+    },
+  } = useAiopsAppContext();
+
+  const searchData = getEsQueryFromSavedSearch({
+    dataView,
+    uiSettings,
+    savedSearch,
+    filterManager,
+  });
+
+  if (searchData === undefined || (aiopsListState && aiopsListState.searchString !== '')) {
+    if (aiopsListState?.filters && readOnly === false) {
+      const globalFilters = filterManager?.getGlobalFilters();
+
+      if (filterManager) filterManager.setFilters(aiopsListState.filters);
+      if (globalFilters) filterManager?.addFilters(globalFilters);
+    }
+    return {
+      searchQuery: aiopsListState?.searchQuery,
+      searchString: aiopsListState?.searchString,
+      searchQueryLanguage: aiopsListState?.searchQueryLanguage,
+    };
+  } else {
+    return {
+      searchQuery: searchData.searchQuery,
+      searchString: searchData.searchString,
+      searchQueryLanguage: searchData.queryLanguage,
+    };
+  }
+};

--- a/x-pack/plugins/aiops/public/index.ts
+++ b/x-pack/plugins/aiops/public/index.ts
@@ -20,6 +20,7 @@ export type { ChangePointDetectionAppStateProps } from './components/change_poin
 
 export {
   ExplainLogRateSpikes,
+  ExplainLogRateSpikesContent,
   LogCategorization,
   ChangePointDetection,
 } from './shared_lazy_components';

--- a/x-pack/plugins/aiops/public/shared_lazy_components.tsx
+++ b/x-pack/plugins/aiops/public/shared_lazy_components.tsx
@@ -9,11 +9,16 @@ import React, { FC, Suspense } from 'react';
 
 import { EuiErrorBoundary, EuiSkeletonText } from '@elastic/eui';
 import type { ExplainLogRateSpikesAppStateProps } from './components/explain_log_rate_spikes';
+import type { ExplainLogRateSpikesContentWrapperProps } from './components/explain_log_rate_spikes/explain_log_rate_spikes_content/explain_log_rate_spikes_content_wrapper';
 import type { LogCategorizationAppStateProps } from './components/log_categorization';
 import type { ChangePointDetectionAppStateProps } from './components/change_point_detection';
 
 const ExplainLogRateSpikesAppStateLazy = React.lazy(
   () => import('./components/explain_log_rate_spikes')
+);
+
+const ExplainLogRateSpikesContentWrapperLazy = React.lazy(
+  () => import('./components/explain_log_rate_spikes/explain_log_rate_spikes_content')
 );
 
 const LazyWrapper: FC = ({ children }) => (
@@ -29,6 +34,16 @@ const LazyWrapper: FC = ({ children }) => (
 export const ExplainLogRateSpikes: FC<ExplainLogRateSpikesAppStateProps> = (props) => (
   <LazyWrapper>
     <ExplainLogRateSpikesAppStateLazy {...props} />
+  </LazyWrapper>
+);
+
+/**
+ * Lazy-wrapped ExplainLogRateSpikesContentWrapperReact component
+ * @param {ExplainLogRateSpikesContentWrapperProps}  props - properties specifying the data on which to run the analysis.
+ */
+export const ExplainLogRateSpikesContent: FC<ExplainLogRateSpikesContentWrapperProps> = (props) => (
+  <LazyWrapper>
+    <ExplainLogRateSpikesContentWrapperLazy {...props} />
   </LazyWrapper>
 );
 

--- a/x-pack/plugins/infra/kibana.jsonc
+++ b/x-pack/plugins/infra/kibana.jsonc
@@ -9,6 +9,7 @@
     "browser": true,
     "configPath": ["xpack", "infra"],
     "requiredPlugins": [
+      "aiops",
       "alerting",
       "cases",
       "charts",
@@ -17,6 +18,7 @@
       "discover",
       "embeddable",
       "features",
+      "fieldFormats",
       "lens",
       "observability",
       "observabilityShared",

--- a/x-pack/plugins/infra/public/alerting/log_threshold/components/alert_details_app_section/components/explain_log_rate_spikes.tsx
+++ b/x-pack/plugins/infra/public/alerting/log_threshold/components/alert_details_app_section/components/explain_log_rate_spikes.tsx
@@ -1,0 +1,105 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { FC, useEffect, useState } from 'react';
+import { pick } from 'lodash';
+import moment from 'moment';
+
+import { EuiFlexGroup, EuiFlexItem, EuiPanel, EuiTitle } from '@elastic/eui';
+
+import { FormattedMessage } from '@kbn/i18n-react';
+import { DataView } from '@kbn/data-views-plugin/common';
+import { ExplainLogRateSpikesContent } from '@kbn/aiops-plugin/public';
+
+import { Rule } from '@kbn/alerting-plugin/common';
+import { TopAlert } from '@kbn/observability-plugin/public';
+import { useKibanaContextForPlugin } from '../../../../../hooks/use_kibana';
+import { PartialRuleParams } from '../../../../../../common/alerting/logs/log_threshold';
+
+export interface AlertDetailsExplainLogRateSpikesSectionProps {
+  rule: Rule<PartialRuleParams>;
+  alert: TopAlert<Record<string, any>>;
+}
+
+export const ExplainLogRateSpikes: FC<AlertDetailsExplainLogRateSpikesSectionProps> = ({
+  rule,
+  alert,
+}) => {
+  // TODO: fieldFormats not included in services yet
+  const { services } = useKibanaContextForPlugin();
+  const { dataViews: dataViewsService } = services;
+
+  const [dataView, setDataView] = useState<DataView | undefined>();
+
+  const testQuery = {
+    match_all: {},
+    // bool: {
+    //   should: [
+    //     {
+    //       term: { 'response.keyword': '404' },
+    //     },
+    //   ],
+    // },
+  };
+
+  useEffect(() => {
+    const logViewId = rule.params.logView.logViewId;
+    const dataViewId = `log-view-${logViewId}`;
+
+    async function getDataView() {
+      const dv = await await dataViewsService.get(dataViewId);
+      setDataView(dv);
+    }
+
+    getDataView();
+  }, [rule, dataViewsService]);
+
+  // TODO: Replace with real time range from rule/alert
+  const timeRange = { min: moment(1684024742912), max: moment(1689284726749) };
+
+  return (
+    <EuiPanel hasBorder={true} data-test-subj="explainLogRateSpikesAlertDetails">
+      <EuiFlexGroup direction="column" gutterSize="none" responsive={false}>
+        <EuiFlexItem grow={false}>
+          <EuiTitle size="xs">
+            <h2>
+              <FormattedMessage
+                id="xpack.infra.logs.alertDetails.explainLogRateSpikes.sectionTitle"
+                defaultMessage="Explain Log Rate Spikes"
+              />
+            </h2>
+          </EuiTitle>
+        </EuiFlexItem>
+        <EuiFlexItem>
+          {dataView && (
+            <ExplainLogRateSpikesContent
+              dataView={dataView}
+              timeRange={timeRange}
+              esSearchQuery={testQuery}
+              initialAnalysisStart={alert.start}
+              appDependencies={pick(services, [
+                'application',
+                'data',
+                'executionContext',
+                'charts',
+                'fieldFormats',
+                'http',
+                'notifications',
+                'share',
+                'storage',
+                'uiSettings',
+                'unifiedSearch',
+                'theme',
+                'lens',
+              ])}
+            />
+          )}
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiPanel>
+  );
+};

--- a/x-pack/plugins/infra/public/alerting/log_threshold/components/alert_details_app_section/index.tsx
+++ b/x-pack/plugins/infra/public/alerting/log_threshold/components/alert_details_app_section/index.tsx
@@ -38,6 +38,7 @@ import { CriterionPreview } from '../expression_editor/criterion_preview_chart';
 import { AlertDetailsAppSectionProps } from './types';
 import { Threshold } from '../../../common/components/threshold';
 import LogsRatioChart from './components/logs_ratio_chart';
+import { ExplainLogRateSpikes } from './components/explain_log_rate_spikes';
 
 const LogsHistoryChart = React.lazy(() => import('./components/logs_history_chart'));
 const formatThreshold = (threshold: number) => String(threshold);
@@ -248,11 +249,16 @@ const AlertDetailsAppSection = ({
     );
   };
 
+  const getExplainLogRateSpikesSection = () => {
+    return <ExplainLogRateSpikes rule={rule} alert={alert} />;
+  };
+
   return (
     <EuiFlexGroup direction="column" data-test-subj="logsThresholdAlertDetailsPage">
       {getLogRatioChart()}
       {getLogCountChart()}
       {getLogsHistoryChart()}
+      {getExplainLogRateSpikesSection()}
     </EuiFlexGroup>
   );
 };

--- a/x-pack/plugins/infra/tsconfig.json
+++ b/x-pack/plugins/infra/tsconfig.json
@@ -64,6 +64,7 @@
     "@kbn/observability-shared-plugin",
     "@kbn/ui-theme",
     "@kbn/ml-anomaly-utils",
+    "@kbn/aiops-plugin",
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
## Summary

Related issues: 
- https://github.com/elastic/actionable-observability/issues/8
- https://github.com/elastic/ml-team/issues/954

This PR:
- exposes the `ExplainLogRateSpikesContent` shared component so that it can be used independently of the search bar/datepicker
   - The component accepts external settings for timerange and query to run the analysis against
- Adds set up code in the `infra` plugin showing how to use the new component (uses some dummy data for now)


Uploading AlertDetailsELRSExample.mp4…


NOTE:

This will remain a draft PR and is mostly for reference. I will be creating a separate PR with just the AIOPS changes after some cleanup.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)



