### PR TITLE
[Fleet] Disable requirement for Fleet server with standalone fleet server

### DIFF
--- a/config/serverless.yml
+++ b/config/serverless.yml
@@ -1,7 +1,7 @@
 newsfeed.enabled: false
 xpack.security.showNavLinks: false
 xpack.serverless.plugin.enabled: true
-xpack.fleet.enableExperimental: ['fleetServerStandalone']
+xpack.fleet.internal.fleetServerStandalone: true
 xpack.fleet.internal.disableILMPolicies: true
 
 # Management team plugins

--- a/test/plugin_functional/test_suites/core_plugins/rendering.ts
+++ b/test/plugin_functional/test_suites/core_plugins/rendering.ts
@@ -196,6 +196,7 @@ export default function ({ getService }: PluginFunctionalProviderContext) {
         'xpack.discoverEnhanced.actions.exploreDataInContextMenu.enabled (boolean)',
         'xpack.fleet.agents.enabled (boolean)',
         'xpack.fleet.enableExperimental (array)',
+        'xpack.fleet.internal.fleetServerStandalone (boolean)',
         'xpack.fleet.developer.maxAgentPoliciesWithInactivityTimeout (number)',
         'xpack.global_search.search_timeout (duration)',
         'xpack.graph.canEditDrillDownUrls (boolean)',

--- a/x-pack/plugins/fleet/common/experimental_features.ts
+++ b/x-pack/plugins/fleet/common/experimental_features.ts
@@ -21,7 +21,6 @@ export const allowedExperimentalValues = Object.freeze({
   showIntegrationsSubcategories: true,
   agentFqdnMode: true,
   showExperimentalShipperOptions: false,
-  fleetServerStandalone: false,
   agentTamperProtectionEnabled: false,
   secretsStorage: false,
 });

--- a/x-pack/plugins/fleet/common/types/index.ts
+++ b/x-pack/plugins/fleet/common/types/index.ts
@@ -47,6 +47,7 @@ export interface FleetConfigType {
   };
   internal?: {
     disableILMPolicies: boolean;
+    fleetServerStandalone: boolean;
   };
 }
 

--- a/x-pack/plugins/fleet/public/hooks/use_fleet_server_standalone.tsx
+++ b/x-pack/plugins/fleet/public/hooks/use_fleet_server_standalone.tsx
@@ -5,10 +5,11 @@
  * 2.0.
  */
 
-import { ExperimentalFeaturesService } from '../applications/fleet/services';
+import { useConfig } from './use_config';
 
 export function useFleetServerStandalone() {
-  const isFleetServerStandalone = ExperimentalFeaturesService.get().fleetServerStandalone;
+  const config = useConfig();
+  const isFleetServerStandalone = config.internal?.fleetServerStandalone ?? false;
 
   return { isFleetServerStandalone };
 }

--- a/x-pack/plugins/fleet/server/config.ts
+++ b/x-pack/plugins/fleet/server/config.ts
@@ -38,6 +38,9 @@ export const config: PluginConfigDescriptor = {
     developer: {
       maxAgentPoliciesWithInactivityTimeout: true,
     },
+    internal: {
+      fleetServerStandalone: true,
+    },
   },
   deprecations: ({ renameFromRoot, unused, unusedFromRoot }) => [
     // Unused settings before Fleet server exists
@@ -163,6 +166,9 @@ export const config: PluginConfigDescriptor = {
     internal: schema.maybe(
       schema.object({
         disableILMPolicies: schema.boolean({
+          defaultValue: false,
+        }),
+        fleetServerStandalone: schema.boolean({
           defaultValue: false,
         }),
       })

--- a/x-pack/plugins/fleet/server/routes/setup/handlers.ts
+++ b/x-pack/plugins/fleet/server/routes/setup/handlers.ts
@@ -19,10 +19,13 @@ export const getFleetStatusHandler: FleetRequestHandler = async (context, reques
       .getSecurity()
       .authc.apiKeys.areAPIKeysEnabled();
     const coreContext = await context.core;
-    const isFleetServerSetup = await hasFleetServers(
+    const isFleetServerMissing = !(await hasFleetServers(
       coreContext.elasticsearch.client.asInternalUser
-    );
+    ));
 
+    const isNotFleetServerStandalone = !(
+      appContextService.getConfig()?.internal?.fleetServerStandalone ?? false
+    );
     const missingRequirements: GetFleetStatusResponse['missing_requirements'] = [];
     const missingOptionalFeatures: GetFleetStatusResponse['missing_optional_features'] = [];
 
@@ -30,7 +33,7 @@ export const getFleetStatusHandler: FleetRequestHandler = async (context, reques
       missingRequirements.push('api_keys');
     }
 
-    if (!isFleetServerSetup) {
+    if (isNotFleetServerStandalone && isFleetServerMissing) {
       missingRequirements.push('fleet_server');
     }
 

--- a/x-pack/plugins/fleet/server/routes/setup/handlers.ts
+++ b/x-pack/plugins/fleet/server/routes/setup/handlers.ts
@@ -23,9 +23,8 @@ export const getFleetStatusHandler: FleetRequestHandler = async (context, reques
       coreContext.elasticsearch.client.asInternalUser
     ));
 
-    const isNotFleetServerStandalone = !(
-      appContextService.getConfig()?.internal?.fleetServerStandalone ?? false
-    );
+    const isFleetServerStandalone =
+      appContextService.getConfig()?.internal?.fleetServerStandalone ?? false;
     const missingRequirements: GetFleetStatusResponse['missing_requirements'] = [];
     const missingOptionalFeatures: GetFleetStatusResponse['missing_optional_features'] = [];
 
@@ -33,7 +32,7 @@ export const getFleetStatusHandler: FleetRequestHandler = async (context, reques
       missingRequirements.push('api_keys');
     }
 
-    if (isNotFleetServerStandalone && isFleetServerMissing) {
+    if (!isFleetServerStandalone && isFleetServerMissing) {
       missingRequirements.push('fleet_server');
     }
 

--- a/x-pack/plugins/fleet/server/services/epm/packages/_install_package.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/_install_package.test.ts
@@ -122,6 +122,7 @@ describe('_installPackage', () => {
       createAppContextStartContractMock({
         internal: {
           disableILMPolicies: true,
+          fleetServerStandalone: false,
         },
       })
     );
@@ -172,6 +173,7 @@ describe('_installPackage', () => {
       createAppContextStartContractMock({
         internal: {
           disableILMPolicies: false,
+          fleetServerStandalone: false,
         },
       })
     );


### PR DESCRIPTION
## Description 

Related to https://github.com/elastic/ingest-dev/issues/1530 

Disable requirement for Fleet server if the new flag `xpack.fleet.internal.fleetServerStandalone` is enabled

That PR allow testing serverless by disabling the requirement to add a fleet server if we use a standalone Fleet server

## UI Changes

<img width="1493" alt="Screenshot 2023-05-29 at 3 52 02 PM" src="https://github.com/elastic/kibana/assets/1336873/e9e50c81-de11-4bb3-b408-a309d18c832d">

