### PR TITLE
[APM] Fallback to the default space ID

### DIFF
--- a/config/serverless.oblt.yml
+++ b/config/serverless.oblt.yml
@@ -5,6 +5,8 @@ enterpriseSearch.enabled: false
 xpack.cloudSecurityPosture.enabled: false
 xpack.securitySolution.enabled: false
 
+xpack.spaces.enabled: false
+
 ## Enable the Serverless Obsersability plugin
 xpack.serverless.observability.enabled: true
 

--- a/config/serverless.oblt.yml
+++ b/config/serverless.oblt.yml
@@ -5,8 +5,6 @@ enterpriseSearch.enabled: false
 xpack.cloudSecurityPosture.enabled: false
 xpack.securitySolution.enabled: false
 
-xpack.spaces.enabled: false
-
 ## Enable the Serverless Obsersability plugin
 xpack.serverless.observability.enabled: true
 

--- a/x-pack/plugins/apm/server/routes/service_groups/route.ts
+++ b/x-pack/plugins/apm/server/routes/service_groups/route.ts
@@ -6,6 +6,7 @@
  */
 
 import * as t from 'io-ts';
+import { DEFAULT_SPACE_ID } from '@kbn/spaces-plugin/common';
 import Boom from '@hapi/boom';
 import datemath from '@kbn/datemath';
 import { apmServiceGroupMaxNumberOfServices } from '@kbn/observability-plugin/common';
@@ -186,7 +187,7 @@ const serviceGroupCountsRoute = createApmServerRoute({
         apmAlertsClient,
         context,
         logger,
-        spaceId: activeSpace?.id,
+        spaceId: activeSpace?.id ?? DEFAULT_SPACE_ID,
       }),
     ]);
     const serviceGroupCounts = serviceGroups.reduce<ServiceGroupCounts>(


### PR DESCRIPTION
closing https://github.com/elastic/kibana/issues/155329


<details>
  <summary>files using space id</summary>
  
```
apm • server/routes/alerts/rule_types/anomaly/register_anomaly_rule_type.ts:
   19  import { createLifecycleRuleTypeFactory } from '@kbn/rule-registry-plugin/server';
   20: import { addSpaceIdToPath } from '@kbn/spaces-plugin/common';
   21  import { compact } from 'lodash';

   89        isExportable: true,
   90:       executor: async ({ params, services, spaceId }) => {
   91          if (!ml) {

  278  
  279:           const viewInAppUrl = addSpaceIdToPath(
  280              basePath.publicBaseUrl,
  281:             spaceId,
  282              relativeViewInAppUrl

apm • server/routes/alerts/rule_types/error_count/register_error_count_rule_type.ts:
   19  import { termQuery } from '@kbn/observability-plugin/server';
   20: import { addSpaceIdToPath } from '@kbn/spaces-plugin/common';
   21  import { firstValueFrom } from 'rxjs';

   88        isExportable: true,
   89:       executor: async ({ params: ruleParams, services, spaceId }) => {
   90:         console.log('spaceId executor====', spaceId);
   91          const predefinedGroupby = [SERVICE_NAME, SERVICE_ENVIRONMENT];

  189  
  190:             const viewInAppUrl = addSpaceIdToPath(
  191                basePath.publicBaseUrl,
  192:               spaceId,
  193                relativeViewInAppUrl

apm • server/routes/alerts/rule_types/transaction_duration/register_transaction_duration_rule_type.ts:
   22  import { createLifecycleRuleTypeFactory } from '@kbn/rule-registry-plugin/server';
   23: import { addSpaceIdToPath } from '@kbn/spaces-plugin/common';
   24  import { firstValueFrom } from 'rxjs';

  104      isExportable: true,
  105:     executor: async ({ params: ruleParams, services, spaceId }) => {
  106        const predefinedGroupby = [

  257            basePath,
  258:           spaceId,
  259            alertUuid

  261  
  262:         const viewInAppUrl = addSpaceIdToPath(
  263            basePath.publicBaseUrl,
  264:           spaceId,
  265            getAlertUrlTransaction(

apm • server/routes/alerts/rule_types/transaction_error_rate/register_transaction_error_rate_rule_type.ts:
   20  import { createLifecycleRuleTypeFactory } from '@kbn/rule-registry-plugin/server';
   21: import { addSpaceIdToPath } from '@kbn/spaces-plugin/common';
   22  import { firstValueFrom } from 'rxjs';

   98        isExportable: true,
   99:       executor: async ({ services, spaceId, params: ruleParams }) => {
  100:         console.log('error rate executor space', spaceId);
  101          const predefinedGroupby = [

  251  
  252:           const viewInAppUrl = addSpaceIdToPath(
  253              basePath.publicBaseUrl,
  254:             spaceId,
  255              relativeViewInAppUrl

apm • server/routes/service_groups/get_service_group_alerts.ts:
  24    logger,
  25:   spaceId,
  26  }: {

  30    logger: Logger;
  31:   spaceId?: string;
  32  }) {
  33:   if (!spaceId || serviceGroups.length === 0) {
  34      return {};

apm • server/routes/service_groups/route.ts:
  189          logger,
  190:         spaceId: activeSpace?.id ?? DEFAULT_SPACE_ID,
  191        }),

apm • server/saved_objects/migrations/migrate_legacy_apm_indices_to_space_aware.ts:
  79          // Skip default space since it was already updated
  80:         .filter(({ id: spaceId }) => spaceId !== 'default')
  81:         .map(({ id: spaceId }) => ({
  82            id: APM_INDEX_SETTINGS_SAVED_OBJECT_ID,
  83            type: APM_INDEX_SETTINGS_SAVED_OBJECT_TYPE,
  84:           initialNamespaces: [spaceId],
  85            attributes: savedObjectAttributes,

apm • public/components/app/settings/apm_indices/index.tsx:
  105    const { data: space } = useFetcher(() => {
  106:     return services.spaces?.getActiveSpace();
  107    }, [services.spaces]);

apm • server/routes/service_groups/route.ts:
  174          getApmEventClient(resources),
  175:         await spacesPluginStart?.spacesService.getActiveSpace(request),
  176        ]);


  ```
</details>


### Notes 
it's a bit challenging to ensure the other plugins return the default space or have the plugin as optional. How do we want to handle these cases, if there are any? 

for example, alert returns default space when the plugin is disabled. 


Relate link PR
https://github.com/elastic/kibana/pull/149044