### PR TITLE
[Discover] Update single doc view locator to URL encode `rowId`

### DIFF
--- a/src/plugins/discover/public/application/doc/locator.test.ts
+++ b/src/plugins/discover/public/application/doc/locator.test.ts
@@ -31,4 +31,17 @@ describe('Discover single doc url generator', () => {
       `"#/doc/c367b774-a4c2-11ea-bb37-0242ac130002/mock-row-index?id=mock-row-id"`
     );
   });
+
+  it('should URL encode rowId', async () => {
+    const { locator } = setup();
+    const { path } = await locator.getLocation({
+      index: dataViewId,
+      rowId: 'id with special characters: &?#+',
+      rowIndex: 'mock-row-index',
+      referrer: 'mock-referrer',
+    });
+    expect(path).toMatchInlineSnapshot(
+      `"#/doc/c367b774-a4c2-11ea-bb37-0242ac130002/mock-row-index?id=id%20with%20special%20characters%3A%20%26%3F%23%2B"`
+    );
+  });
 });

--- a/src/plugins/discover/public/application/doc/locator.ts
+++ b/src/plugins/discover/public/application/doc/locator.ts
@@ -45,7 +45,7 @@ export class DiscoverSingleDocLocatorDefinition
       dataViewId = index;
     }
 
-    const path = `#/doc/${dataViewId}/${rowIndex}?id=${rowId}`;
+    const path = `#/doc/${dataViewId}/${rowIndex}?id=${encodeURIComponent(rowId)}`;
 
     return {
       app: 'discover',


### PR DESCRIPTION
## Summary

Fixes #158525.

### Checklist

- [ ] ~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)~
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] ~Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))~
- [ ] ~Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))~
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))~
- [ ] ~This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)~

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->