### PR TITLE
[ZDT] use range clause for outdated doc query

### DIFF
--- a/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/zdt/utils/outdated_documents_query.test.ts
+++ b/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/zdt/utils/outdated_documents_query.test.ts
@@ -52,11 +52,11 @@ describe('getOutdatedDocumentsQuery', () => {
                       "type": "foo",
                     },
                   },
-                ],
-                "must_not": Array [
                   Object {
-                    "term": Object {
-                      "typeMigrationVersion": "10.2.0",
+                    "range": Object {
+                      "typeMigrationVersion": Object {
+                        "lt": "10.2.0",
+                      },
                     },
                   },
                 ],
@@ -70,11 +70,11 @@ describe('getOutdatedDocumentsQuery', () => {
                       "type": "bar",
                     },
                   },
-                ],
-                "must_not": Array [
                   Object {
-                    "term": Object {
-                      "typeMigrationVersion": "10.3.0",
+                    "range": Object {
+                      "typeMigrationVersion": Object {
+                        "lt": "10.3.0",
+                      },
                     },
                   },
                 ],
@@ -118,11 +118,11 @@ describe('getOutdatedDocumentsQuery', () => {
                       "type": "foo",
                     },
                   },
-                ],
-                "must_not": Array [
                   Object {
-                    "term": Object {
-                      "typeMigrationVersion": "8.5.0",
+                    "range": Object {
+                      "typeMigrationVersion": Object {
+                        "lt": "8.5.0",
+                      },
                     },
                   },
                 ],
@@ -136,11 +136,11 @@ describe('getOutdatedDocumentsQuery', () => {
                       "type": "bar",
                     },
                   },
-                ],
-                "must_not": Array [
                   Object {
-                    "term": Object {
-                      "typeMigrationVersion": "8.7.2",
+                    "range": Object {
+                      "typeMigrationVersion": Object {
+                        "lt": "8.7.2",
+                      },
                     },
                   },
                 ],
@@ -189,11 +189,11 @@ describe('getOutdatedDocumentsQuery', () => {
                       "type": "foo",
                     },
                   },
-                ],
-                "must_not": Array [
                   Object {
-                    "term": Object {
-                      "typeMigrationVersion": "10.2.0",
+                    "range": Object {
+                      "typeMigrationVersion": Object {
+                        "lt": "10.2.0",
+                      },
                     },
                   },
                 ],
@@ -207,11 +207,11 @@ describe('getOutdatedDocumentsQuery', () => {
                       "type": "bar",
                     },
                   },
-                ],
-                "must_not": Array [
                   Object {
-                    "term": Object {
-                      "typeMigrationVersion": "8.7.2",
+                    "range": Object {
+                      "typeMigrationVersion": Object {
+                        "lt": "8.7.2",
+                      },
                     },
                   },
                 ],

--- a/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/zdt/utils/outdated_documents_query.ts
+++ b/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/zdt/utils/outdated_documents_query.ts
@@ -27,8 +27,10 @@ export const getOutdatedDocumentsQuery = ({
         const virtualVersion = virtualVersions[type.name];
         return {
           bool: {
-            must: [{ term: { type: type.name } }],
-            must_not: [{ term: { typeMigrationVersion: virtualVersion } }],
+            must: [
+              { term: { type: type.name } },
+              { range: { typeMigrationVersion: { lt: virtualVersion } } },
+            ],
           },
         };
       }),

--- a/src/core/server/integration_tests/saved_objects/migrations/zdt_2/outdated_doc_query.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/zdt_2/outdated_doc_query.test.ts
@@ -1,0 +1,135 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import Path from 'path';
+import fs from 'fs/promises';
+import { type TestElasticsearchUtils } from '@kbn/core-test-helpers-kbn-server';
+import '../jest_matchers';
+import { SavedObjectsModelVersionMap, SavedObject } from '@kbn/core-saved-objects-server';
+import { getKibanaMigratorTestKit, startElasticsearch } from '../kibana_migrator_test_kit';
+import { delay, createType } from '../test_utils';
+import { getBaseMigratorParams } from '../fixtures/zdt_base.fixtures';
+import {
+  SavedObjectsSerializer,
+  SavedObjectTypeRegistry,
+  modelVersionToVirtualVersion,
+} from '@kbn/core-saved-objects-base-server-internal';
+import { getOutdatedDocumentsQuery } from '@kbn/core-saved-objects-migration-server-internal/src/zdt/utils';
+
+export const logFilePath = Path.join(__dirname, 'outdated_doc_query.test.log');
+
+describe('getOutdatedDocumentsQuery', () => {
+  let esServer: TestElasticsearchUtils['es'];
+
+  const getTestType = ({ includeHigherVersions }: { includeHigherVersions: boolean }) => {
+    const modelVersions: SavedObjectsModelVersionMap = {
+      1: {
+        changes: [],
+      },
+      2: {
+        changes: [],
+      },
+      3: {
+        changes: [],
+      },
+    };
+    if (includeHigherVersions) {
+      Object.assign(modelVersions, {
+        4: {
+          changes: [],
+        },
+        5: {
+          changes: [],
+        },
+      });
+    }
+
+    return createType({
+      name: 'test-type',
+      switchToModelVersionAt: '8.0.0',
+      modelVersions,
+      mappings: {
+        dynamic: false,
+        properties: {
+          text: { type: 'text' },
+          bool: { type: 'boolean' },
+        },
+      },
+    });
+  };
+
+  const createBaseline = async () => {
+    const testTypeWithoutHigherVersion = getTestType({ includeHigherVersions: false });
+    const testTypeWithHigherVersion = getTestType({ includeHigherVersions: true });
+
+    const { runMigrations, client } = await getKibanaMigratorTestKit({
+      ...getBaseMigratorParams(),
+      logFilePath,
+      types: [testTypeWithoutHigherVersion],
+    });
+    await runMigrations();
+
+    const typeRegistry = new SavedObjectTypeRegistry();
+    typeRegistry.registerType(testTypeWithHigherVersion);
+    const serializer = new SavedObjectsSerializer(typeRegistry);
+
+    const bulkCreateParams: object[] = [];
+    for (let i = 1; i <= 5; i++) {
+      const so: SavedObject = {
+        type: 'test-type',
+        id: `doc-v${i}`,
+        attributes: {},
+        references: [],
+        typeMigrationVersion: modelVersionToVirtualVersion(i),
+      };
+      const raw = serializer.savedObjectToRaw(so);
+      bulkCreateParams.push(
+        {
+          create: {
+            _id: raw._id,
+            _index: '.kibana',
+          },
+        },
+        raw._source
+      );
+    }
+
+    await client.bulk({
+      refresh: 'true',
+      body: bulkCreateParams,
+    });
+
+    return { client };
+  };
+
+  beforeAll(async () => {
+    await fs.unlink(logFilePath).catch(() => {});
+    esServer = await startElasticsearch();
+  });
+
+  afterAll(async () => {
+    await esServer?.stop();
+    await delay(10);
+  });
+
+  it('creates a query returning the expected documents', async () => {
+    const { client } = await createBaseline();
+    const testTypeWithoutHigherVersion = getTestType({ includeHigherVersions: false });
+    const query = getOutdatedDocumentsQuery({ types: [testTypeWithoutHigherVersion] });
+
+    const response = await client.search({
+      index: '.kibana',
+      query,
+    });
+
+    const docs = response.hits.hits;
+
+    expect(docs).toHaveLength(2);
+    expect(docs.map((doc) => doc._id).sort()).toEqual(['test-type:doc-v1', 'test-type:doc-v2']);
+  });
+});


### PR DESCRIPTION
## Summary

Related to https://github.com/elastic/kibana/issues/150296

Use a `range` clause for version filtering for the ZDT outdated doc query, similar to what is already done for the `v2` algo, to avoid eventually trying to migrate documents from higher versions (which would result in a migration failure)