### PR TITLE
[Maps] Update asset tracking tutorial with production consideration for rule check interval

### DIFF
--- a/docs/maps/asset-tracking-tutorial.asciidoc
+++ b/docs/maps/asset-tracking-tutorial.asciidoc
@@ -440,7 +440,7 @@ image::maps/images/asset-tracking-tutorial/construction_zones.png[]
 [float]
 ==== Step 2. Configure an alert
 
-Create a new alert by defining a rule and a connector. The rule includes the conditions that will trigger the alert, and the connector defines what action takes place once the alert is triggered. In this case, each alert will log a message to the Kibana log.
+Create a new alert by defining a rule and a connector. The rule includes the conditions that will trigger the alert, and the connector defines what action takes place once the alert is triggered. In this case, each alert will log a message to the Kibana log. For this example, we will set the rule to check every 5 seconds. However, when running in production, consider setting a higher check interval (such as 1 minute) to avoid performance issues. Refer to <<alerting-production-considerations,Alerting production considerations>> for more information.
 
 . Open *{stack-manage-app}*, and then click *{rules-ui}*.
 . Click *Create rule*.

--- a/docs/maps/asset-tracking-tutorial.asciidoc
+++ b/docs/maps/asset-tracking-tutorial.asciidoc
@@ -442,7 +442,7 @@ image::maps/images/asset-tracking-tutorial/construction_zones.png[]
 
 Create a new alert by defining a rule and a connector. The rule includes the conditions that will trigger the alert, and the connector defines what action takes place once the alert is triggered. In this case, each alert will log a message to the Kibana log. 
 
-NOTE: For this example, we will set the rule to check every 5 seconds. However, when running in production, consider setting a higher check interval (such as 1 minute) to avoid performance issues. Refer to <<alerting-production-considerations,Alerting production considerations>> for more information.
+NOTE: For this example, you will set the rule to check every 5 seconds. However, when running in production, consider setting a higher check interval (such as 1 minute) to avoid performance issues. Refer to <<alerting-production-considerations,Alerting production considerations>> for more information.
 
 . Open *{stack-manage-app}*, and then click *{rules-ui}*.
 . Click *Create rule*.

--- a/docs/maps/asset-tracking-tutorial.asciidoc
+++ b/docs/maps/asset-tracking-tutorial.asciidoc
@@ -440,7 +440,7 @@ image::maps/images/asset-tracking-tutorial/construction_zones.png[]
 [float]
 ==== Step 2. Configure an alert
 
-Create a new alert by defining a rule and a connector. The rule includes the conditions that will trigger the alert, and the connector defines what action takes place once the alert is triggered. In this case, each alert will log a message to the Kibana log. 
+Create a new alert by defining a rule and a connector. The rule includes the conditions that will trigger the alert, and the connector defines what action takes place once the alert is triggered. In this case, each alert will log a message to the {kib} log. 
 
 NOTE: For this example, you will set the rule to check every 5 seconds. However, when running in production, consider setting a higher check interval (such as 1 minute) to avoid performance issues. Refer to <<alerting-production-considerations,Alerting production considerations>> for more information.
 

--- a/docs/maps/asset-tracking-tutorial.asciidoc
+++ b/docs/maps/asset-tracking-tutorial.asciidoc
@@ -440,7 +440,9 @@ image::maps/images/asset-tracking-tutorial/construction_zones.png[]
 [float]
 ==== Step 2. Configure an alert
 
-Create a new alert by defining a rule and a connector. The rule includes the conditions that will trigger the alert, and the connector defines what action takes place once the alert is triggered. In this case, each alert will log a message to the Kibana log. For this example, we will set the rule to check every 5 seconds. However, when running in production, consider setting a higher check interval (such as 1 minute) to avoid performance issues. Refer to <<alerting-production-considerations,Alerting production considerations>> for more information.
+Create a new alert by defining a rule and a connector. The rule includes the conditions that will trigger the alert, and the connector defines what action takes place once the alert is triggered. In this case, each alert will log a message to the Kibana log. 
+
+NOTE: For this example, we will set the rule to check every 5 seconds. However, when running in production, consider setting a higher check interval (such as 1 minute) to avoid performance issues. Refer to <<alerting-production-considerations,Alerting production considerations>> for more information.
 
 . Open *{stack-manage-app}*, and then click *{rules-ui}*.
 . Click *Create rule*.


### PR DESCRIPTION
Fixes #127289

## Summary

Updates the asset tracking tutorial docs with considerations for running in production.

For a better demo experience the tutorial uses a 5 second interval for rule checking, but a very low interval can be problematic for running in production. 

I'm suggesting backporting these doc changes to 8.3 which the first release to have a **Circuit breakers** section in https://www.elastic.co/guide/en/kibana/8.3/alerting-production-considerations.html that is most relevant to the added note in this PR.


<!--ONMERGE {"backportTargets":["8.3","8.4","8.5","8.6","8.7","8.8"]} ONMERGE-->