### PR TITLE
[ResponseOps] Throwing a mustache error when validating action message for warnings

### DIFF
--- a/x-pack/plugins/triggers_actions_ui/public/application/lib/validate_params_for_warnings.test.ts
+++ b/x-pack/plugins/triggers_actions_ui/public/application/lib/validate_params_for_warnings.test.ts
@@ -51,4 +51,8 @@ describe('validateParamsForWarnings', () => {
   test('does not returns warnings when publicUrl is not set and the value is not a string', () => {
     expect(validateParamsForWarnings(10, undefined, actionVariables)).toBeFalsy();
   });
+
+  test('does not throw an error when passing in invalid mustache', () => {
+    expect(() => validateParamsForWarnings('{{', undefined, actionVariables)).not.toThrowError();
+  });
 });

--- a/x-pack/plugins/triggers_actions_ui/public/application/lib/validate_params_for_warnings.ts
+++ b/x-pack/plugins/triggers_actions_ui/public/application/lib/validate_params_for_warnings.ts
@@ -31,14 +31,20 @@ export function validateParamsForWarnings(
       return acc;
     }, new Array<string>());
 
-    const variables = new Set(
-      (Mustache.parse(value) as Array<[string, string]>)
-        .filter(([type]) => type === 'name')
-        .map(([, v]) => v)
-    );
-    const hasUrlFields = some(publicUrlFields, (publicUrlField) => variables.has(publicUrlField));
-    if (hasUrlFields) {
-      return publicUrlWarning;
+    try {
+      const variables = new Set(
+        (Mustache.parse(value) as Array<[string, string]>)
+          .filter(([type]) => type === 'name')
+          .map(([, v]) => v)
+      );
+      const hasUrlFields = some(publicUrlFields, (publicUrlField) => variables.has(publicUrlField));
+      if (hasUrlFields) {
+        return publicUrlWarning;
+      }
+    } catch (e) {
+      /*
+       * do nothing, we don't care if the mustache is invalid
+       */
     }
   }
   return null;


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/158666

## Summary

Adds a try/catch around `mustache.parse` to catch and ignore any errors when validating the action message for warnings.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### To verify

- Create a rule and add a slack connector, and open dev tools console
- In the action message type `{{` - verify that an error is not thrown and that you can add the second open curly brace


<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->