### PR TITLE
[Search Applications] Add console autocomplete for search applications

### DIFF
--- a/src/plugins/console/server/lib/spec_definitions/json/generated/search_application.delete.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/search_application.delete.json
@@ -1,0 +1,11 @@
+{
+  "search_application.delete": {
+    "methods": [
+      "DELETE"
+    ],
+    "patterns": [
+      "_application/search_application/{name}"
+    ],
+    "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/master/put-search-application.html"
+  }
+}

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/search_application.delete_behavioral_analytics.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/search_application.delete_behavioral_analytics.json
@@ -1,0 +1,11 @@
+{
+  "search_application.delete_behavioral_analytics": {
+    "methods": [
+      "DELETE"
+    ],
+    "patterns": [
+      "_application/analytics/{name}"
+    ],
+    "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-analytics-collection.html"
+  }
+}

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/search_application.get.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/search_application.get.json
@@ -1,0 +1,11 @@
+{
+  "search_application.get": {
+    "methods": [
+      "GET"
+    ],
+    "patterns": [
+      "_application/search_application/{name}"
+    ],
+    "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/master/get-search-application.html"
+  }
+}

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/search_application.get_behavioral_analytics.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/search_application.get_behavioral_analytics.json
@@ -1,0 +1,12 @@
+{
+  "search_application.get_behavioral_analytics": {
+    "methods": [
+      "GET"
+    ],
+    "patterns": [
+      "_application/analytics",
+      "_application/analytics/{name}"
+    ],
+    "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/master/list-analytics-collection.html"
+  }
+}

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/search_application.list.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/search_application.list.json
@@ -1,0 +1,16 @@
+{
+  "search_application.list": {
+    "url_params": {
+      "q": "",
+      "from": 0,
+      "size": 0
+    },
+    "methods": [
+      "GET"
+    ],
+    "patterns": [
+      "_application/search_application"
+    ],
+    "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/master/list-search-applications.html"
+  }
+}

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/search_application.post_behavioral_analytics_event.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/search_application.post_behavioral_analytics_event.json
@@ -1,0 +1,14 @@
+{
+  "search_application.post_behavioral_analytics_event": {
+    "url_params": {
+      "debug": "__flag__"
+    },
+    "methods": [
+      "POST"
+    ],
+    "patterns": [
+      "_application/analytics/{collection_name}/event/{event_type}"
+    ],
+    "documentation": "http://todo.com/tbd"
+  }
+}

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/search_application.put.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/search_application.put.json
@@ -1,0 +1,14 @@
+{
+  "search_application.put": {
+    "url_params": {
+      "create": "__flag__"
+    },
+    "methods": [
+      "PUT"
+    ],
+    "patterns": [
+      "_application/search_application/{name}"
+    ],
+    "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/master/put-search-application.html"
+  }
+}

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/search_application.put_behavioral_analytics.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/search_application.put_behavioral_analytics.json
@@ -1,0 +1,11 @@
+{
+  "search_application.put_behavioral_analytics": {
+    "methods": [
+      "PUT"
+    ],
+    "patterns": [
+      "_application/analytics/{name}"
+    ],
+    "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/master/put-analytics-collection.html"
+  }
+}

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/search_application.render_query.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/search_application.render_query.json
@@ -1,0 +1,11 @@
+{
+  "search_application.render_query": {
+    "methods": [
+      "POST"
+    ],
+    "patterns": [
+      "_application/search_application/{name}/_render_query"
+    ],
+    "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-application-render-query.html"
+  }
+}

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/search_application.search.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/search_application.search.json
@@ -1,0 +1,12 @@
+{
+  "search_application.search": {
+    "methods": [
+      "GET",
+      "POST"
+    ],
+    "patterns": [
+      "_application/search_application/{name}/_search"
+    ],
+    "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-application-search.html"
+  }
+}

--- a/src/plugins/console/server/lib/spec_definitions/json/overrides/search_application.post_behavioral_analytics_event.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/overrides/search_application.post_behavioral_analytics_event.json
@@ -2,7 +2,6 @@
   "search_application.post_behavioral_analytics_event": {
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/master/post-analytics-collection-event.html",
     "patterns": [
-      "_application/analytics/{collection_name}/event/{event_type}",
       "_application/analytics/{collection_name}/event/click",
       "_application/analytics/{collection_name}/event/page_view",
       "_application/analytics/{collection_name}/event/search"

--- a/src/plugins/console/server/lib/spec_definitions/json/overrides/search_application.post_behavioral_analytics_event.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/overrides/search_application.post_behavioral_analytics_event.json
@@ -1,0 +1,45 @@
+{
+  "search_application.post_behavioral_analytics_event": {
+    "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/master/post-analytics-collection-event.html",
+    "patterns": [
+      "_application/analytics/{collection_name}/event/{event_type}",
+      "_application/analytics/{collection_name}/event/click",
+      "_application/analytics/{collection_name}/event/page_view",
+      "_application/analytics/{collection_name}/event/search"
+    ],
+    "data_autocomplete_rules": {
+      "document": {
+        "id": "",
+        "index": ""
+      },
+      "page": {
+        "referrer": "",
+        "url": "",
+        "title": ""
+      },
+      "search": {
+        "query": "",
+        "filters": [""],
+        "search_application": "",
+        "page": {
+          "current": 1,
+          "size": 1
+        },
+        "sort": [
+          {
+            "name": "",
+            "direction": { "__one_of": ["asc", "desc"] }
+          }
+        ],
+        "results": {
+          "items": [
+            { "document": { "index": "", "id": "" }, "page": { "url": "" } }
+          ],
+          "total_results": 0
+        }
+      },
+      "session": { "id": "" },
+      "user": { "id": "" }
+    }
+  }
+}

--- a/src/plugins/console/server/lib/spec_definitions/json/overrides/search_application.put.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/overrides/search_application.put.json
@@ -1,0 +1,29 @@
+{
+  "search_application.put": {
+    "data_autocomplete_rules": {
+      "__template": {
+        "indices": []
+      },
+      "indices": ["{index}"],
+      "template": {
+        "script": {
+          "__template": {
+            "source": {
+              "query": {
+                "query_string": {
+                  "query": "{{query_string}}",
+                  "default_field": "{{default_field}}"
+                }
+              }
+            },
+            "params": {
+              "query_string": "*",
+              "default_field": "*"
+            }
+          },
+          "__scope_link": "GLOBAL.script"
+        }
+      }
+    }
+  }
+}

--- a/src/plugins/console/server/lib/spec_definitions/json/overrides/search_application.search.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/overrides/search_application.search.json
@@ -1,0 +1,7 @@
+{
+  "search_application.search": {
+    "data_autocomplete_rules": {
+      "params": {}
+    }
+  }
+}


### PR DESCRIPTION
## Summary

adds specs for search application and analytics collections apis
- [`spec_to_console`](https://github.com/elastic/kibana/tree/main/packages/kbn-spec-to-console) for generated specs
- overrides for body params and some other overrides

https://github.com/elastic/kibana/assets/1699281/ddbdbe2d-0950-4aac-967e-cb376334b2a5

#### Release notes

> Dev Tools console now has autocomplete support for Search Application and Behavioral Analytics APIs
