### PR TITLE
[Security Solution][Endpoint] Improve dev tool so that incomplete agent downloads are deleted from disk cache

### DIFF
--- a/x-pack/plugins/security_solution/scripts/endpoint/common/agent_downloads_service.ts
+++ b/x-pack/plugins/security_solution/scripts/endpoint/common/agent_downloads_service.ts
@@ -148,14 +148,14 @@ const handleProcessInterruptions = async <T>(
 ): Promise<T> => {
   const eventNames = ['SIGINT', 'exit', 'uncaughtException', 'unhandledRejection'];
   const stopListeners = () => {
-    eventNames.forEach((eventName) => {
+    for (const eventName of eventNames) {
       process.off(eventName, cleanup);
-    });
+    }
   };
 
-  eventNames.forEach((eventName) => {
+  for (const eventName of eventNames) {
     process.on(eventName, cleanup);
-  });
+  }
 
   let runnerResponse: T | Promise<T>;
 

--- a/x-pack/plugins/security_solution/scripts/endpoint/common/agent_downloads_service.ts
+++ b/x-pack/plugins/security_solution/scripts/endpoint/common/agent_downloads_service.ts
@@ -85,9 +85,16 @@ class AgentDownloadStorage extends SettingsStorage<AgentDownloadStorageSettings>
 
     try {
       const outputStream = fs.createWriteStream(newDownloadInfo.fullFilePath);
-      const { body } = await nodeFetch(agentDownloadUrl);
 
-      await finished(body.pipe(outputStream));
+      await handleProcessInterruptions(
+        async () => {
+          const { body } = await nodeFetch(agentDownloadUrl);
+          await finished(body.pipe(outputStream));
+        },
+        () => {
+          fs.unlinkSync(newDownloadInfo.fullFilePath);
+        }
+      );
     } catch (e) {
       // Try to clean up download case it failed halfway through
       await unlink(newDownloadInfo.fullFilePath);
@@ -133,6 +140,42 @@ class AgentDownloadStorage extends SettingsStorage<AgentDownloadStorageSettings>
     return response;
   }
 }
+
+const handleProcessInterruptions = async <T>(
+  runFn: (() => T) | (() => Promise<T>),
+  /** The synchronous cleanup callback */
+  cleanup: () => void
+): Promise<T> => {
+  const eventNames = ['SIGINT', 'exit', 'uncaughtException', 'unhandledRejection'];
+  const stopListeners = () => {
+    eventNames.forEach((eventName) => {
+      process.off(eventName, cleanup);
+    });
+  };
+
+  eventNames.forEach((eventName) => {
+    process.on(eventName, cleanup);
+  });
+
+  let runnerResponse: T | Promise<T>;
+
+  try {
+    runnerResponse = runFn();
+  } catch (e) {
+    stopListeners();
+    throw e;
+  }
+
+  if ('finally' in runnerResponse) {
+    (runnerResponse as Promise<T>).finally(() => {
+      stopListeners();
+    });
+  } else {
+    stopListeners();
+  }
+
+  return runnerResponse;
+};
 
 const agentDownloadsClient = new AgentDownloadStorage();
 


### PR DESCRIPTION
## Summary

- Adds logic to the Agent Download services (part of dev scripts) so that if the process is interrupted (ex. `SIGNINT` signal from CLI), any download currently in flight will be deleted from disk, thus avoiding storing agent download files that are incomplete and invalid.

