### PR TITLE
Change kibana.alert.evaluation.threshold unit to microseconds

### DIFF
--- a/x-pack/plugins/apm/public/components/alerting/ui_components/alert_details_app_section/index.tsx
+++ b/x-pack/plugins/apm/public/components/alerting/ui_components/alert_details_app_section/index.tsx
@@ -21,7 +21,6 @@ import React, { useEffect, useMemo } from 'react';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { getPaddedAlertTimeRange } from '@kbn/observability-alert-details';
 import { EuiCallOut } from '@elastic/eui';
-import { toMicroseconds as toMicrosecondsUtil } from '../../../../../common/utils/formatters';
 import { SERVICE_ENVIRONMENT } from '../../../../../common/es_fields/apm';
 import { ChartPointerEventContextProvider } from '../../../../context/chart_pointer_event/chart_pointer_event_context';
 import { TimeRangeMetadataContextProvider } from '../../../../context/time_range_metadata/time_range_metadata_context';
@@ -36,9 +35,6 @@ import {
   SERVICE_NAME,
   TRANSACTION_TYPE,
 } from './types';
-
-const toMicroseconds = (value?: number) =>
-  value ? toMicrosecondsUtil(value, 'milliseconds') : value;
 
 export function AlertDetailsAppSection({
   rule,
@@ -69,7 +65,7 @@ export function AlertDetailsAppSection({
         ),
         value: formatAlertEvaluationValue(
           alert?.fields[ALERT_RULE_TYPE_ID],
-          toMicroseconds(alert?.fields[ALERT_EVALUATION_THRESHOLD])
+          alert?.fields[ALERT_EVALUATION_THRESHOLD]
         ),
       },
       {

--- a/x-pack/plugins/apm/server/routes/alerts/rule_types/transaction_duration/register_transaction_duration_rule_type.ts
+++ b/x-pack/plugins/apm/server/routes/alerts/rule_types/transaction_duration/register_transaction_duration_rule_type.ts
@@ -280,7 +280,7 @@ export function registerTransactionDurationRuleType({
               [TRANSACTION_NAME]: ruleParams.transactionName,
               [PROCESSOR_EVENT]: ProcessorEvent.transaction,
               [ALERT_EVALUATION_VALUE]: transactionDuration,
-              [ALERT_EVALUATION_THRESHOLD]: ruleParams.threshold,
+              [ALERT_EVALUATION_THRESHOLD]: thresholdMicroseconds,
               [ALERT_REASON]: reason,
               ...sourceFields,
               ...groupByFields,

--- a/x-pack/plugins/observability/public/components/alerts_flyout/alerts_flyout_body.tsx
+++ b/x-pack/plugins/observability/public/components/alerts_flyout/alerts_flyout_body.tsx
@@ -30,7 +30,7 @@ import { AlertLifecycleStatusBadge } from '@kbn/alerts-ui-shared';
 import moment from 'moment-timezone';
 import { useUiSetting } from '@kbn/kibana-react-plugin/public';
 import { useKibana } from '../../utils/kibana_react';
-import { asDuration, toMicroseconds } from '../../../common/utils/formatters';
+import { asDuration } from '../../../common/utils/formatters';
 import { paths } from '../../config/paths';
 import { translations } from '../../config/translations';
 import { formatAlertEvaluationValue } from '../../utils/format_alert_evaluation_value';
@@ -41,14 +41,6 @@ interface FlyoutProps {
   alert: TopAlert;
   id?: string;
 }
-
-// For APM Latency threshold rule, threshold is in ms but the duration formatter works with microseconds
-const normalizeUnit = (ruleTypeId: string, value?: number) => {
-  if (ruleTypeId === 'apm.transaction_duration' && value) {
-    return toMicroseconds(value, 'milliseconds');
-  }
-  return value;
-};
 
 export function AlertsFlyoutBody({ alert, id: pageId }: FlyoutProps) {
   const {
@@ -97,7 +89,7 @@ export function AlertsFlyoutBody({ alert, id: pageId }: FlyoutProps) {
       title: translations.alertsFlyout.expectedValueLabel,
       description: formatAlertEvaluationValue(
         alert.fields[ALERT_RULE_TYPE_ID],
-        normalizeUnit(alert.fields[ALERT_RULE_TYPE_ID], alert.fields[ALERT_EVALUATION_THRESHOLD])
+        alert.fields[ALERT_EVALUATION_THRESHOLD]
       ),
     },
     {


### PR DESCRIPTION
Resolves #156255
Fixes #158204
Partially reverts #154801

[RFC Document](https://docs.google.com/document/d/1-O6-nqOedrjtTF9mHawd_u-vUdXu06KGI8ic5qNeQPQ/edit?usp=sharing)

## Summary

This PR changes kibana.alert.evaluation.threshold unit to microseconds in AAD.

|Case|Screenshot|
|----|---|
|Saved value in AAD|![image](https://github.com/elastic/kibana/assets/12370520/9178031b-a187-4b3e-b6ed-6e67f4e708ce)|
|Should show correct information in flyout|![image](https://github.com/elastic/kibana/assets/12370520/75ec6664-8e2f-448d-b6d0-dacf01b22ac3)|
|Should show correct information on alert details page|![image](https://github.com/elastic/kibana/assets/12370520/4fb4b645-b450-48da-bec9-e7064b26258e)|
|Should show correct information in action message|![image](https://github.com/elastic/kibana/assets/12370520/c103266e-25ef-4c25-a0da-c6ecfd0e4c0a)|
|Same unit for value and threshold in the alert table|![image](https://github.com/elastic/kibana/assets/12370520/499814bc-9f41-4b94-9b03-18a75a50489f)|


## 🧪 How to test
- Generate an APM Latency threshold alert
- Check the threshold in
    - Alert's flyout
    - Alert's table
    - Alert details page (summary and chart)
    - Action generated by this alert

<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->