### PR TITLE
[EventLog] Use performance.now() rather than Date.now() to calculate elapsed time in tests

### DIFF
--- a/x-pack/plugins/event_log/server/es/context.mock.ts
+++ b/x-pack/plugins/event_log/server/es/context.mock.ts
@@ -25,7 +25,7 @@ const createContextMock = () => {
     waitTillReady: jest.fn(async () => true),
     esAdapter: clusterClientAdapterMock.create(),
     initialized: true,
-    retryDelay: MOCK_RETRY_DELAY,
+    retryDelay: MOCK_RETRY_DELAY - 1,
   };
   return mock;
 };

--- a/x-pack/plugins/event_log/server/es/context.mock.ts
+++ b/x-pack/plugins/event_log/server/es/context.mock.ts
@@ -25,7 +25,7 @@ const createContextMock = () => {
     waitTillReady: jest.fn(async () => true),
     esAdapter: clusterClientAdapterMock.create(),
     initialized: true,
-    retryDelay: MOCK_RETRY_DELAY - 1,
+    retryDelay: MOCK_RETRY_DELAY,
   };
   return mock;
 };

--- a/x-pack/plugins/event_log/server/es/init.test.ts
+++ b/x-pack/plugins/event_log/server/es/init.test.ts
@@ -455,8 +455,7 @@ describe('parseIndexAliases', () => {
   });
 });
 
-// FLAKY: https://github.com/elastic/kibana/issues/156061
-describe.skip('retries', () => {
+describe('retries', () => {
   let esContext = contextMock.create();
   // set up context APIs to return defaults indicating already created
   beforeEach(() => {
@@ -472,9 +471,9 @@ describe.skip('retries', () => {
   test('createIlmPolicyIfNotExists with 1 retry', async () => {
     esContext.esAdapter.doesIlmPolicyExist.mockRejectedValueOnce(new Error('retry 1'));
 
-    const timeStart = Date.now();
+    const timeStart = performance.now();
     await initializeEs(esContext);
-    const timeElapsed = Date.now() - timeStart;
+    const timeElapsed = performance.now() - timeStart;
 
     expect(timeElapsed).toBeGreaterThanOrEqual(MOCK_RETRY_DELAY);
 
@@ -492,9 +491,9 @@ describe.skip('retries', () => {
     esContext.esAdapter.doesIndexTemplateExist.mockRejectedValueOnce(new Error('retry 2a'));
     esContext.esAdapter.doesIndexTemplateExist.mockRejectedValueOnce(new Error('retry 2b'));
 
-    const timeStart = Date.now();
+    const timeStart = performance.now();
     await initializeEs(esContext);
-    const timeElapsed = Date.now() - timeStart;
+    const timeElapsed = performance.now() - timeStart;
 
     expect(timeElapsed).toBeGreaterThanOrEqual(MOCK_RETRY_DELAY * (1 + 2));
 
@@ -518,9 +517,9 @@ describe.skip('retries', () => {
     // make sure it only tries 5 times - this one should not be reported
     esContext.esAdapter.doesAliasExist.mockRejectedValueOnce(new Error('retry 5f'));
 
-    const timeStart = Date.now();
+    const timeStart = performance.now();
     await initializeEs(esContext);
-    const timeElapsed = Date.now() - timeStart;
+    const timeElapsed = performance.now() - timeStart;
 
     expect(timeElapsed).toBeGreaterThanOrEqual(MOCK_RETRY_DELAY * (1 + 2 + 4 + 8));
 

--- a/x-pack/plugins/event_log/server/es/init.ts
+++ b/x-pack/plugins/event_log/server/es/init.ts
@@ -52,7 +52,7 @@ function getRetryOptions(esContext: EsContext, operation: string) {
     maxTimeout: MAX_RETRY_DELAY,
     retries: 4,
     factor: 2,
-    randomize: false,
+    randomize: true,
     onFailedAttempt: (err: FailedAttemptError) => {
       const message = `eventLog initialization operation failed and will be retried: ${operation}; ${err.retriesLeft} more times; error: ${err.message}`;
       logger.warn(message);

--- a/x-pack/plugins/event_log/server/es/init.ts
+++ b/x-pack/plugins/event_log/server/es/init.ts
@@ -52,7 +52,7 @@ function getRetryOptions(esContext: EsContext, operation: string) {
     maxTimeout: MAX_RETRY_DELAY,
     retries: 4,
     factor: 2,
-    randomize: true,
+    randomize: false,
     onFailedAttempt: (err: FailedAttemptError) => {
       const message = `eventLog initialization operation failed and will be retried: ${operation}; ${err.retriesLeft} more times; error: ${err.message}`;
       logger.warn(message);


### PR DESCRIPTION
Resolves: #156061

Since all the failed CI results show actual elapsed time as `19` rather than `20` (expected), the issue seems like an inaccurate time calculation caused by `Date.now()` method.

Replacing `Date.now()` with the more precise `performance.now()` method may solve the problem.