### PR TITLE
[ML] Increases calendar events request limit

### DIFF
--- a/x-pack/plugins/ml/server/models/calendar/calendar_manager.ts
+++ b/x-pack/plugins/ml/server/models/calendar/calendar_manager.ts
@@ -47,7 +47,7 @@ export class CalendarManager {
   }
 
   async getAllCalendars() {
-    const body = await this._mlClient.getCalendars({ body: { page: { from: 0, size: 1000 } } });
+    const body = await this._mlClient.getCalendars({ body: { page: { from: 0, size: 10000 } } });
 
     const events: ScheduledEvent[] = await this._eventManager.getAllEvents();
     const calendars: Calendar[] = body.calendars as Calendar[];

--- a/x-pack/plugins/ml/server/models/calendar/event_manager.ts
+++ b/x-pack/plugins/ml/server/models/calendar/event_manager.ts
@@ -28,6 +28,7 @@ export class EventManager {
     const body = await this._mlClient.getCalendarEvents({
       calendar_id: calendarId,
       job_id: jobId,
+      size: 10000,
     });
 
     return body.events;


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/158712

Increasing the limit for getting all events, the default is `100`, which can easily be passed.
Also increasing the size for getting all calendars, for consistency. 

<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->