### PR TITLE
[RCS 2.0] Bypasses query for field list when configuring FLS against a remote cluster

### DIFF
--- a/x-pack/plugins/security/public/management/roles/edit_role/privileges/es/index_privilege_form.test.tsx
+++ b/x-pack/plugins/security/public/management/roles/edit_role/privileges/es/index_privilege_form.test.tsx
@@ -416,6 +416,26 @@ describe('field level security', () => {
     expect(testProps.indicesAPIClient.getFields).toHaveBeenCalledWith('newPattern');
   });
 
+  test('does not query availble fields for remote cluster indices', async () => {
+    const testProps = {
+      ...props,
+      indexType: 'remote_indices' as const,
+      indexPrivilege: {
+        ...props.indexPrivilege,
+        clusters: ['test-cluster'],
+        names: ['foo', 'bar-*'],
+      },
+      indicesAPIClient: indicesAPIClientMock.create(),
+      allowFieldLevelSecurity: true,
+    };
+
+    testProps.indicesAPIClient.getFields.mockResolvedValue(['a', 'b', 'c']);
+
+    mountWithIntl(<IndexPrivilegeForm {...testProps} />);
+    await nextTick();
+    expect(testProps.indicesAPIClient.getFields).not.toHaveBeenCalled();
+  });
+
   test('it displays a warning when no fields are granted', () => {
     const testProps = {
       ...props,

--- a/x-pack/plugins/security/public/management/roles/edit_role/privileges/es/index_privilege_form.tsx
+++ b/x-pack/plugins/security/public/management/roles/edit_role/privileges/es/index_privilege_form.tsx
@@ -227,7 +227,12 @@ export class IndexPrivilegeForm extends Component<Props, State> {
   };
 
   private loadFLSOptions = (indexNames: string[], force = false) => {
-    if (!force && (this.isFieldListLoading || indexNames.length === 0)) return;
+    if (
+      this.props.indexType === 'remote_indices' ||
+      (!force && (this.isFieldListLoading || indexNames.length === 0))
+    ) {
+      return;
+    }
 
     this.isFieldListLoading = true;
     this.setState({


### PR DESCRIPTION
Closes #158280

## Summary

This PR implements an index type (local vs remote) check within the index privilege form in order to bypass querying the field list from the index API client for remote cluster indices.


## Testing
- Augmented functional tests in `index_privilege_form.test.tsx` with '_does not query availble fields for remote cluster indices_' test case.