### PR TITLE
[Security Solution][Endpoint] Messages for `upload` response action return codes

### DIFF
--- a/x-pack/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/integration_tests/upload_action.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/endpoint_responder/command_render_components/integration_tests/upload_action.test.tsx
@@ -18,7 +18,11 @@ import {
   ConsoleManagerTestComponent,
   getConsoleManagerMockRenderResultQueriesAndActions,
 } from '../../../console/components/console_manager/mocks';
-import type { EndpointPrivileges } from '../../../../../../common/endpoint/types';
+import type {
+  EndpointPrivileges,
+  ResponseActionUploadOutputContent,
+  ActionDetailsApiResponse,
+} from '../../../../../../common/endpoint/types';
 import { getEndpointAuthzInitialStateMock } from '../../../../../../common/endpoint/service/authz/mocks';
 import { getEndpointConsoleCommands } from '../..';
 import React from 'react';
@@ -32,6 +36,7 @@ import {
   INSUFFICIENT_PRIVILEGES_FOR_COMMAND,
   UPGRADE_ENDPOINT_FOR_RESPONDER,
 } from '../../../../../common/translations';
+import { endpointActionResponseCodes } from '../../lib/endpoint_action_response_codes';
 
 describe('When using `upload` response action', () => {
   let render: (
@@ -197,6 +202,47 @@ describe('When using `upload` response action', () => {
     await waitFor(() => {
       expect(getByTestId('test-validationError-message').textContent).toEqual(
         UPGRADE_ENDPOINT_FOR_RESPONDER
+      );
+    });
+  });
+
+  it.each([
+    'ra_upload_error_failure',
+    'ra_upload_already-exists',
+    'ra_upload_error_not-found',
+    'ra_upload_error_not-permitted',
+    'ra_upload_error_too-big',
+    'ra_upload_error_queue-timeout',
+    'ra_upload_error_download-failed',
+  ])('should show detailed error if upload failure returned code: %s', async (outputCode) => {
+    const pendingDetailResponse = apiMocks.responseProvider.actionDetails({
+      path: '/api/endpoint/action/a.b.c',
+    }) as ActionDetailsApiResponse<ResponseActionUploadOutputContent>;
+    pendingDetailResponse.data.agents = ['a.b.c'];
+    pendingDetailResponse.data.wasSuccessful = false;
+    pendingDetailResponse.data.errors = ['not found'];
+    pendingDetailResponse.data.outputs = {
+      'a.b.c': {
+        type: 'json',
+        content: {
+          code: outputCode,
+        } as unknown as ResponseActionUploadOutputContent,
+      },
+    };
+    apiMocks.responseProvider.actionDetails.mockReturnValue(pendingDetailResponse);
+    await render();
+
+    console.enterCommand('upload --file', { inputOnly: true });
+    await waitFor(() => {
+      userEvent.upload(renderResult.getByTestId('console-arg-file-picker'), file);
+    });
+
+    console.submitCommand();
+
+    await waitFor(() => {
+      expect(renderResult.getByTestId('upload-actionFailure').textContent).toMatch(
+        // RegExp below taken from: https://github.com/sindresorhus/escape-string-regexp/blob/main/index.js
+        new RegExp(endpointActionResponseCodes[outputCode].replace(/[|\\{}()[\]^$+*?.]/g, '\\$&'))
       );
     });
   });

--- a/x-pack/plugins/security_solution/public/management/components/endpoint_responder/lib/endpoint_action_response_codes.ts
+++ b/x-pack/plugins/security_solution/public/management/components/endpoint_responder/lib/endpoint_action_response_codes.ts
@@ -214,6 +214,61 @@ const CODES = Object.freeze({
         'Failed to upload command execution output zip file. Timed out while queued waiting for Fleet Server',
     }
   ),
+
+  // -----------------------------------------------------------------
+  // UPLOAD CODES
+  // -----------------------------------------------------------------
+
+  // Dev:
+  // generic failure (rare corner case, software bug, etc)
+  ra_upload_error_failure: i18n.translate(
+    'xpack.securitySolution.endpointActionResponseCodes.upload.failure',
+    { defaultMessage: 'Upload failed' }
+  ),
+
+  // Dev:
+  // File with the given name already exists and overwrite was not allowed.
+  'ra_upload_already-exists': i18n.translate(
+    'xpack.securitySolution.endpointActionResponseCodes.upload.fileAlreadyExists',
+    {
+      defaultMessage:
+        'File with this name already exists. Use "--overwrite" argument if wanting to overwrite it',
+    }
+  ),
+
+  // Dev:
+  // HTTP 404 from fleet server when trying to download file
+  'ra_upload_error_not-found': i18n.translate(
+    'xpack.securitySolution.endpointActionResponseCodes.upload.fileNotFound',
+    { defaultMessage: 'Failed to retrieve file. File was not found (404)' }
+  ),
+
+  // Dev:
+  // HTTP 401, HTTP 403 from fleet server
+  'ra_upload_error_not-permitted': i18n.translate(
+    'xpack.securitySolution.endpointActionResponseCodes.upload.fileAccessForbidden',
+    { defaultMessage: 'Failed to retrieve file. Access is forbidden (403) or unauthorized (401)' }
+  ),
+
+  // Dev:
+  // file size exceeds hard coded limit (100MB)
+  'ra_upload_error_too-big': i18n.translate(
+    'xpack.securitySolution.endpointActionResponseCodes.upload.fileTooLarge',
+    { defaultMessage: 'Failed to save file. Size exceeds max allowed' }
+  ),
+
+  // Dev:
+  // Fleet file API could be busy, endpoint should periodically re-try (2 days = 192 x 15min, assuming that with 1Mbps 15min is enough to upload 100MB)
+  'ra_upload_error_queue-timeout': i18n.translate(
+    'xpack.securitySolution.endpointActionResponseCodes.upload.timeout',
+    { defaultMessage: 'Attempts to retrieve file failed due to timeout' }
+  ),
+
+  // Downloaded data was corrupted, SHA256 didn't match expected, or IO error when writing to disk happened.
+  'ra_upload_error_download-failed': i18n.translate(
+    'xpack.securitySolution.endpointActionResponseCodes.upload.fileCorruption',
+    { defaultMessage: 'Failed to save file to disk or validate its integrity' }
+  ),
 });
 
 /**


### PR DESCRIPTION
## Summary

- Adds the list of `upload` response action return codes and associated `i18n` messages


### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios



