### PR TITLE
[SecuritySolutions] Fix anomalies table pagination on EA page

### DIFF
--- a/x-pack/plugins/security_solution/public/overview/components/entity_analytics/anomalies/query/index.ts
+++ b/x-pack/plugins/security_solution/public/overview/components/entity_analytics/anomalies/query/index.ts
@@ -4,6 +4,8 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+// Maximum number of aggregation buckets allowed
+const MAX_BUCKET_SIZE = 10000;
 
 export const getAggregatedAnomaliesQuery = ({
   from,
@@ -52,6 +54,7 @@ export const getAggregatedAnomaliesQuery = ({
     number_of_anomalies: {
       terms: {
         field: 'job_id',
+        size: MAX_BUCKET_SIZE,
       },
       aggs: {
         entity: {


### PR DESCRIPTION
issue: https://github.com/elastic/kibana/issues/158809


## Summary

The anomalies table on the EA page only showed anomalies count data for the 10 first jobs. That happened because the default bucket limit for aggregations is 10. This bug started happening when we added more than 10 jobs to the table.

**Before**

![Jun-01-2023 10-41-01](https://github.com/elastic/kibana/assets/1490444/386cd69f-5531-40af-ab12-12476fababaa)

**After**
![Jun-01-2023 10-48-17](https://github.com/elastic/kibana/assets/1490444/afee4d3d-4e19-4dfe-aa84-787c4fab060d)




<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->