### PR TITLE
[Response Ops][Alerting] Adding null checks when iterating through index template list

### DIFF
--- a/x-pack/plugins/alerting/server/alerts_service/lib/create_or_update_component_template.ts
+++ b/x-pack/plugins/alerting/server/alerts_service/lib/create_or_update_component_template.ts
@@ -32,8 +32,16 @@ const getIndexTemplatesUsingComponentTemplate = async (
     { logger }
   );
   const indexTemplatesUsingComponentTemplate = (indexTemplates ?? []).filter(
-    (indexTemplate: IndicesGetIndexTemplateIndexTemplateItem) =>
-      indexTemplate.index_template.composed_of.includes(componentTemplateName)
+    (indexTemplate: IndicesGetIndexTemplateIndexTemplateItem) => {
+      if (
+        indexTemplate &&
+        indexTemplate.index_template &&
+        indexTemplate.index_template.composed_of
+      ) {
+        return indexTemplate.index_template.composed_of.includes(componentTemplateName);
+      }
+      return false;
+    }
   );
   await asyncForEach(
     indexTemplatesUsingComponentTemplate,


### PR DESCRIPTION
## Summary

When updating common component templates during AAD resource installation, we occassionally run into errors where the index templates using the common component template has a total field limit that is less than the new total number of fields with the updated component template. When this occurs, we query the ES index template API to get the list of index templates in order to check their `composed_of` field to see if they reference the specific component template and act accordingly. In theory, `composed_of` is (and is typed as) a required array. In practice, it seems that this field can be missing from the response. Since we're doing a `.includes` check on this array, this can lead to null dereference errors that can halt alerts as data resource installation.

This PR adds a check to make sure the `composed_of` field exists before using it.

## To Verify
1. Run Kibana 8.6 locally and create a metric threshold rule & detection rule that generates alerts. Make sure the alert index templates for these rule types have been created and the rule runs successfully.
2. Update to Kibana 8.7. Make sure the rules run successfully and generate alerts. Create a data view with no component templates. To do this, go to `Stack Management > Index Management > Index Templates` and click `Create template`. Fill in a name and index pattern (`test*` is fine) and make sure the `Create data stream` switch is checked. Click through all the remaining options without setting anything else. Use `GET /_index_template/<name>` to verify that this index template has no `composed_of` field
3. Update to this branch. All alert resources should be installed successfully and there should be no errors on startup.


<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->