### PR TITLE
[APM] Display size for hidden indices in storage explorer

### DIFF
--- a/x-pack/plugins/apm/server/routes/storage_explorer/get_storage_details_per_service.ts
+++ b/x-pack/plugins/apm/server/routes/storage_explorer/get_storage_details_per_service.ts
@@ -257,7 +257,7 @@ export async function getStorageDetailsPerIndex({
           ? indexInfo.settings?.index?.number_of_shards ?? 0
           : undefined,
         replica: indexInfo
-          ? indexInfo.settings?.number_of_replicas ?? 0
+          ? indexInfo.settings?.index?.number_of_replicas ?? 0
           : undefined,
         size,
         dataStream: indexInfo?.data_stream,

--- a/x-pack/plugins/apm/server/routes/storage_explorer/indices_stats_helpers.ts
+++ b/x-pack/plugins/apm/server/routes/storage_explorer/indices_stats_helpers.ts
@@ -18,7 +18,10 @@ export async function getTotalIndicesStats({
 }) {
   const index = getApmIndicesCombined(apmEventClient);
   const esClient = (await context.core).elasticsearch.client;
-  const totalStats = await esClient.asCurrentUser.indices.stats({ index });
+  const totalStats = await esClient.asCurrentUser.indices.stats({
+    index,
+    expand_wildcards: 'all',
+  });
   return totalStats;
 }
 


### PR DESCRIPTION
- Adds `expand_wildcards: 'all'` to the Index stats API call to fix an issue with missing statistics for hidden data streams in storage explorer
- Fixes an issue with number of replicas not being displayed

### Before
<img width="1452" alt="image" src="https://github.com/elastic/kibana/assets/5831975/680104e3-5a18-41f0-9185-438d1581f7d0">

### After
<img width="1448" alt="image" src="https://github.com/elastic/kibana/assets/5831975/9134d0ec-f8b7-42c0-a954-bb7741f24db2">

Closes https://github.com/elastic/kibana/issues/158743

<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->