### PR TITLE
fix(alerts-search-bar): Handle clearing query

### DIFF
--- a/x-pack/plugins/observability/public/components/alert_search_bar/alert_search_bar.tsx
+++ b/x-pack/plugins/observability/public/components/alert_search_bar/alert_search_bar.tsx
@@ -102,6 +102,12 @@ export function ObservabilityAlertSearchBar({
     ]
   );
 
+  const onSearchBarParamsCleared = (params: { query?: string }) => {
+    if (params.query === '') {
+      onKueryChange(params.query);
+    }
+  };
+
   return (
     <EuiFlexGroup direction="column" gutterSize="s">
       <EuiFlexItem>
@@ -112,6 +118,7 @@ export function ObservabilityAlertSearchBar({
           rangeTo={rangeTo}
           query={kuery}
           onQuerySubmit={onSearchBarParamsChange}
+          onQueryChange={onSearchBarParamsCleared}
         />
       </EuiFlexItem>
 


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/158400

## 📝  Summary

This PR fixes the clearing of the alert search query on the observability alerts search bar. We needed to handle the `onQueryChange` special case of an empty query, e.g. `""` for when the clear button is used. 

💀 FTR tests are failing when testing the date picker. If someone has an idea.

https://github.com/elastic/kibana/assets/1376800/dde87226-112e-4ac4-978a-33ee9fe2f0ae


