### PR TITLE
[Controls] Move controls routes to internal

### DIFF
--- a/src/plugins/controls/public/services/options_list/options_list_service.ts
+++ b/src/plugins/controls/public/services/options_list/options_list_service.ts
@@ -72,14 +72,12 @@ class OptionsListService implements ControlsOptionsListService {
     async (request: OptionsListRequest, abortSignal: AbortSignal) => {
       const index = request.dataView.title;
       const requestBody = this.getRequestBody(request);
-      return await this.http.fetch<OptionsListResponse>(
-        `/api/kibana/controls/optionsList/${index}`,
-        {
-          body: JSON.stringify(requestBody),
-          signal: abortSignal,
-          method: 'POST',
-        }
-      );
+      return await this.http.fetch<OptionsListResponse>(`/internal/controls/optionsList/${index}`, {
+        version: '1',
+        body: JSON.stringify(requestBody),
+        signal: abortSignal,
+        method: 'POST',
+      });
     },
     this.optionsListCacheResolver
   );
@@ -104,7 +102,9 @@ class OptionsListService implements ControlsOptionsListService {
   private cachedAllowExpensiveQueries = memoize(async () => {
     const { allowExpensiveQueries } = await this.http.get<{
       allowExpensiveQueries: boolean;
-    }>('/api/kibana/controls/optionsList/getExpensiveQueriesSetting');
+    }>('/internal/controls/optionsList/getExpensiveQueriesSetting', {
+      version: '1',
+    });
     return allowExpensiveQueries;
   });
 

--- a/src/plugins/controls/server/options_list/options_list_cluster_settings_route.ts
+++ b/src/plugins/controls/server/options_list/options_list_cluster_settings_route.ts
@@ -11,41 +11,46 @@ import { CoreSetup } from '@kbn/core/server';
 
 export const setupOptionsListClusterSettingsRoute = ({ http }: CoreSetup) => {
   const router = http.createRouter();
-  router.get(
-    {
-      path: '/api/kibana/controls/optionsList/getExpensiveQueriesSetting',
-      validate: false,
-    },
-    async (context, _, response) => {
-      try {
-        /**
-         *  using internal user here because in many cases the logged in user will not have the monitor permission required
-         * to check cluster settings. This endpoint does not take a query, params, or a body, so there is no chance of leaking info.
-         */
-        const esClient = (await context.core).elasticsearch.client.asInternalUser;
-        const settings = await esClient.cluster.getSettings({
-          include_defaults: true,
-          filter_path: '**.allow_expensive_queries',
-        });
+  router.versioned
+    .get({
+      access: 'internal',
+      path: '/internal/controls/optionsList/getExpensiveQueriesSetting',
+    })
+    .addVersion(
+      {
+        version: '1',
+        validate: false,
+      },
+      async (context, _, response) => {
+        try {
+          /**
+           *  using internal user here because in many cases the logged in user will not have the monitor permission required
+           * to check cluster settings. This endpoint does not take a query, params, or a body, so there is no chance of leaking info.
+           */
+          const esClient = (await context.core).elasticsearch.client.asInternalUser;
+          const settings = await esClient.cluster.getSettings({
+            include_defaults: true,
+            filter_path: '**.allow_expensive_queries',
+          });
 
-        // priority: transient -> persistent -> default
-        const allowExpensiveQueries: string =
-          settings.transient?.search?.allow_expensive_queries ??
-          settings.persistent?.search?.allow_expensive_queries ??
-          settings.defaults?.search?.allow_expensive_queries ??
-          // by default, the allowExpensiveQueries cluster setting is undefined; so, we need to treat this the same
-          // as `true` since that's the way other applications (such as the dashboard listing page) handle this.
-          'true';
+          // priority: transient -> persistent -> default
+          const allowExpensiveQueries: string =
+            settings.transient?.search?.allow_expensive_queries ??
+            settings.persistent?.search?.allow_expensive_queries ??
+            settings.defaults?.search?.allow_expensive_queries ??
+            // by default, the allowExpensiveQueries cluster setting is undefined; so, we need to treat this the same
+            // as `true` since that's the way other applications (such as the dashboard listing page) handle this.
+            'true';
 
-        return response.ok({
-          body: {
-            allowExpensiveQueries: allowExpensiveQueries === 'true',
-          },
-        });
-      } catch (e) {
-        const kbnErr = getKbnServerError(e);
-        return reportServerError(response, kbnErr);
+          return response.ok({
+            body: {
+              allowExpensiveQueries: allowExpensiveQueries === 'true',
+            },
+          });
+        } catch (e) {
+          const kbnErr = getKbnServerError(e);
+          return reportServerError(response, kbnErr);
+        }
       }
-    }
-  );
+    );
 };


### PR DESCRIPTION
Fixes #157084
Fixes #157103

## Summary

Moves Controls plugin routes to internal.

[More info on versioning HTTP APIs](https://docs.elastic.dev/kibana-dev-docs/versioning-http-apis)