### PR TITLE
[8.8] Upgrade EUI to v77.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "@elastic/datemath": "5.0.3",
     "@elastic/elasticsearch": "npm:@elastic/elasticsearch-canary@8.6.0-canary.3",
     "@elastic/ems-client": "8.4.0",
-    "@elastic/eui": "77.1.3",
+    "@elastic/eui": "77.1.4",
     "@elastic/filesaver": "1.1.2",
     "@elastic/node-crypto": "1.2.1",
     "@elastic/numeral": "^2.5.1",

--- a/src/dev/license_checker/config.ts
+++ b/src/dev/license_checker/config.ts
@@ -85,7 +85,7 @@ export const LICENSE_OVERRIDES = {
   'jsts@1.6.2': ['Eclipse Distribution License - v 1.0'], // cf. https://github.com/bjornharrtell/jsts
   '@mapbox/jsonlint-lines-primitives@2.0.2': ['MIT'], // license in readme https://github.com/tmcw/jsonlint
   '@elastic/ems-client@8.4.0': ['Elastic License 2.0'],
-  '@elastic/eui@77.1.3': ['SSPL-1.0 OR Elastic License 2.0'],
+  '@elastic/eui@77.1.4': ['SSPL-1.0 OR Elastic License 2.0'],
   'language-subtag-registry@0.3.21': ['CC-BY-4.0'], // retired ODC‑By license https://github.com/mattcg/language-subtag-registry
   'buffers@0.1.1': ['MIT'], // license in importing module https://www.npmjs.com/package/binary
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1543,10 +1543,10 @@
   resolved "https://registry.yarnpkg.com/@elastic/eslint-plugin-eui/-/eslint-plugin-eui-0.0.2.tgz#56b9ef03984a05cc213772ae3713ea8ef47b0314"
   integrity sha512-IoxURM5zraoQ7C8f+mJb9HYSENiZGgRVcG4tLQxE61yHNNRDXtGDWTZh8N1KIHcsqN1CEPETjuzBXkJYF/fDiQ==
 
-"@elastic/eui@77.1.3":
-  version "77.1.3"
-  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-77.1.3.tgz#486451e1b323e12f710be9edf74945849ec859c1"
-  integrity sha512-pfxjCsSLnPIoXrS/rRRZLceB2RT4Fz8OfmKymokvXmR2OeVH7jDrMtUZiqPlkTKLbk9ozzkTBEuTQ1g5398ijw==
+"@elastic/eui@77.1.4":
+  version "77.1.4"
+  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-77.1.4.tgz#c641f1f0e322f3a13c990c9f48c329134d74c540"
+  integrity sha512-UxlVbnCp+okcLoJX647meVwbY80wa0HsIVW6r7vj9X3552kSrLAeClZ9HEpultY0pSmuZZ6jkB60BizhQLRczw==
   dependencies:
     "@types/chroma-js" "^2.0.0"
     "@types/lodash" "^4.14.160"


### PR DESCRIPTION
This is a backport EUI upgrade to Kibana v8.8.1 containing an EuiDataGrid bugfix requested by the Discover team: https://github.com/elastic/eui/issues/6804#issuecomment-1564903858

## [`77.1.4`](https://github.com/elastic/eui/tree/v77.1.4)

- Updated `EuiDataGrid` to only render screen reader text announcing cell position if the cell is currently focused. This should improve the ability to copy and paste multiple cells without SR text. ([#6817](https://github.com/elastic/eui/pull/6817))