### PR TITLE
[Docs] Add new Fleet preconfiguration settings

### DIFF
--- a/docs/settings/fleet-settings.asciidoc
+++ b/docs/settings/fleet-settings.asciidoc
@@ -52,12 +52,11 @@ Hostnames used by {agent} for accessing {es}.
 `xpack.fleet.agents.elasticsearch.ca_sha256`::
 Hash pin used for certificate verification. The pin is a base64-encoded string of the SHA-256 fingerprint.
 
-
 [role="child_attributes"]
 ==== Preconfiguration settings (for advanced use cases)
 
-Use these settings to pre-define integrations and agent policies that you
-want {fleet} to load up by default.
+Use these settings to pre-define integrations, agent policies, and {fleet-server}
+hosts or proxies that you want {fleet} to load up by default.
 
 NOTE: These settings are not supported to pre-configure the Endpoint and Cloud
 Security integration.
@@ -134,39 +133,6 @@ List of agent policies that are configured when the {fleet} app starts.
     Array that overrides any default input settings for this integration. Follows the same schema as integration inputs, with the exception that any object in `vars` can be passed `frozen: true` in order to prevent that specific `var` from being edited by the user.
 =======
 =====
-
-`xpack.fleet.outputs`::
-List of outputs that are configured when the {fleet} app starts.
-+
-If configured in your `kibana.yml`, output settings are grayed out and
-unavailable in the {fleet} UI. To make these settings editable in the UI, do not
-configure them in the configuration file. 
-+
-NOTE: The `xpack.fleet.outputs` settings are intended for advanced configurations such as having multiple outputs. We recommend not enabling the `xpack.fleet.agents.elasticsearch.host` settings when using `xpack.fleet.outputs`.
-+
-.Required properties of `xpack.fleet.outputs`
-[%collapsible%open]
-=====
-  `id`::: 
-    Unique ID for this output. The ID should be a string.
-  `name`::: 
-    Output name.
-  `type`::: 
-    Type of Output. Currently we only support "elasticsearch".
-  `hosts`::: 
-    Array that contains the list of host for that output.
-  `config`::: 
-    Extra config for that output.
-=====
-+
-.Optional properties of `xpack.fleet.outputs`
-[%collapsible%open]
-=====
-  `is_default`::: 
-    If `true`, the output specified in `xpack.fleet.outputs` will be the one used to send agent data unless there is another one configured specifically for the agent policy.
-  `is_default_monitoring`::: 
-    If `true`, the output specified in `xpack.fleet.outputs` will be the one used to send agent monitoring data unless there is another one configured specifically for the agent policy.
-=====
 +
 Example configuration:
 +
@@ -202,5 +168,101 @@ xpack.fleet.agentPolicies:
             enabled: false
 ----
 
+
+`xpack.fleet.outputs`::
+List of outputs that are configured when the {fleet} app starts.
++
+If configured in your `kibana.yml`, output settings are grayed out and
+unavailable in the {fleet} UI. To make these settings editable in the UI, do not
+configure them in the configuration file. 
++
+NOTE: The `xpack.fleet.outputs` settings are intended for advanced configurations such as having multiple outputs. We recommend not enabling the `xpack.fleet.agents.elasticsearch.host` settings when using `xpack.fleet.outputs`.
++
+.Required properties of `xpack.fleet.outputs`
+[%collapsible%open]
+=====
+  `id`::: 
+    Unique ID for this output. The ID should be a string.
+  `name`::: 
+    Output name.
+  `type`::: 
+    Type of Output. Currently we only support "elasticsearch".
+  `hosts`::: 
+    Array that contains the list of host for that output.
+  `config`::: 
+    Extra config for that output.
+  `proxy_id`:::
+    Unique ID of a proxy to access the output.
+=====
++
+.Optional properties of `xpack.fleet.outputs`
+[%collapsible%open]
+=====
+  `is_default`::: 
+    If `true`, the output specified in `xpack.fleet.outputs` will be the one used to send agent data unless there is another one configured specifically for the agent policy.
+  `is_default_monitoring`::: 
+    If `true`, the output specified in `xpack.fleet.outputs` will be the one used to send agent monitoring data unless there is another one configured specifically for the agent policy.
+=====
+
+`xpack.fleet.fleetServerHosts`::
+List of {fleet-server} hosts that are configured when the {fleet} app starts.
++
+.Required properties of `xpack.fleet.fleetServerHosts`
+[%collapsible%open]
+=====
+  `id`:::
+    Unique ID for the host server.
+  `name`::: 
+    Name of the host server.
+  `host_urls`::: 
+    Array of one or more host URLs that {agents} will use to connect to {fleet-server}.
+=====
++
+.Optional properties of `xpack.fleet.fleetServerHosts`
+[%collapsible%open]
+=====
+  `is_default`:::
+    Whether or not this host should be the default to use for {fleet-server}.
+  `proxy_id`::: 
+    Unique ID of the proxy to access the {fleet-server} host.
+=====
+
+`xpack.fleet.proxy`::
+List of proxies to access {fleet-server} that are configured when the {fleet} app starts.
++
+.Required properties of `xpack.fleet.proxy`
+[%collapsible%open]
+=====
+  `id`:::
+    Unique ID of the proxy to access the {fleet-server} host.
+  `name`::: 
+    Name of the proxy to access the {fleet-server} host.
+  `url`::: 
+    URL that {agents} use to connect to the proxy to access {fleet-server}.
+=====
++
+.Optional properties of `xpack.fleet.proxy`
+[%collapsible%open]
+=====
+  `proxy_headers`:::
+    Map of headers to use with the proxy.
+.Properties of `proxy_headers`
+[%collapsible%open]
+=======
+  `key`:::: 
+    Key to use for the proxy header.
+  `value`:::: 
+    Value to use for the proxy header.
+=======
+  `certificate_authorities`::: 
+    Certificate authority (CA) used to issue the certificate.
+  `certificate`::: 
+    The name of the certificate to use to validate the proxy.
+  `certificate_key`::: 
+    Hash pin used for certificate verification. The pin is a base64-encoded string of the SHA-256 fingerprint.
+=====
+
 `xpack.fleet.enableExperimental`::
 List of experimental feature flag to enable in Fleet.
+
+

--- a/docs/settings/fleet-settings.asciidoc
+++ b/docs/settings/fleet-settings.asciidoc
@@ -257,9 +257,9 @@ List of proxies to access {fleet-server} that are configured when the {fleet} ap
   `certificate_authorities`::: 
     Certificate authority (CA) used to issue the certificate.
   `certificate`::: 
-    The name of the certificate to use to validate the proxy.
+    The name of the certificate used to authenticate the proxy.
   `certificate_key`::: 
-    Hash pin used for certificate verification. The pin is a base64-encoded string of the SHA-256 fingerprint.
+    The certificate key used to authenticate the proxy.
 =====
 
 `xpack.fleet.enableExperimental`::


### PR DESCRIPTION
This adds new Fleet preconfiguration settings to the Kibana [Fleet settings](https://www.elastic.co/guide/en/kibana/master/fleet-settings-kb.html) page. I also moved the "example configuration" to right below the `xpack.fleet.agentPolicies` setting, since that's what's shown in the example.

[Preview page](https://kibana_158771.docs-preview.app.elstc.co/guide/en/kibana/master/fleet-settings-kb.html)

Closes: https://github.com/elastic/ingest-docs/issues/191

<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->