### PR TITLE
Adding a temporary theme value to uiSettings for Code Editor usage

### DIFF
--- a/packages/core/rendering/core-rendering-server-internal/src/rendering_service.tsx
+++ b/packages/core/rendering/core-rendering-server-internal/src/rendering_service.tsx
@@ -175,6 +175,10 @@ export class RenderingService {
       darkMode = getSettingValue('theme:darkMode', settings, Boolean);
     }
 
+    settings.user['theme:codeEditors'] = {
+      userValue: darkMode,
+    };
+
     const themeVersion: ThemeVersion = 'v8';
 
     const stylesheetPaths = getStylesheetPaths({

--- a/src/plugins/kibana_react/public/code_editor/index.tsx
+++ b/src/plugins/kibana_react/public/code_editor/index.tsx
@@ -40,7 +40,7 @@ export type CodeEditorProps = Props;
  * @see CodeEditorField to render a code editor in the same style as other EUI form fields.
  */
 export const CodeEditor: React.FunctionComponent<Props> = (props) => {
-  const darkMode = useUiSetting<boolean>('theme:darkMode');
+  const darkMode = useUiSetting<boolean>('theme:codeEditors');
   return (
     <EuiErrorBoundary>
       <React.Suspense fallback={<Fallback height={props.height} />}>
@@ -54,7 +54,7 @@ export const CodeEditor: React.FunctionComponent<Props> = (props) => {
  * Renders a Monaco code editor in the same style as other EUI form fields.
  */
 export const CodeEditorField: React.FunctionComponent<Props> = (props) => {
-  const darkMode = useUiSetting<boolean>('theme:darkMode');
+  const darkMode = useUiSetting<boolean>('theme:codeEditors');
   return (
     <EuiErrorBoundary>
       <React.Suspense fallback={<Fallback height={props.height} />}>


### PR DESCRIPTION
## Summary

Adding a computed theme value to the uiSettings that will be used by Code Editors

The Code Editor fields, found [here](https://github.com/elastic/kibana/blob/648c669034bc2250323fc43e0a3571691ff192a1/src/plugins/kibana_react/public/code_editor/index.tsx#L42-L65), are currently relying on `uiSettings > 'theme:darkMode'` to be the source of truth for which theme they should be rendered in.

All callers of the Code Editor currently provide `uiSettings` in their context which is then accessed by Code Editor component.

After the introduction of Per User Dark Mode, the new source of truth for theme is the Core Theme Service. However, not all plugins currently provide the `theme` service in a consistent way (or even at all). All callers would need to be updated to provide the `theme` to their context in a similar fashion, or, pass the theme down to where the Code Editor component is being called and passed in as a prop (once the value is retrieved from the `theme$` observable).

Here is a list of callers for `CodeEditor`:
<img width="972" alt="Screenshot 2023-06-01 at 10 49 29 AM" src="https://github.com/elastic/kibana/assets/21210601/87476ad4-fc17-44ba-a330-cd77e9b4e8ae">

That is a lot of plugins to update/test/review by 8.8.1 FF, [I attempted to make the changes](https://github.com/elastic/kibana/pull/158837), but working on unfamiliar plugins is very challenging and risky. Some of the calls in the list above are wrappers around CodeEditor, which are then called many other places.

The changes in this PR are a 'hack' to take advantage of `uiSettings` already being provided in all necessary contexts, but now providing a correctly computed value (it is the same value that is being provided to `theme`).

I would like to put this in place temporarily, until either all plugins can make changes to provide `theme` (with more codeowner oversight) or take advantage of future functionality (such as this new [context feature](https://github.com/elastic/kibana/pull/158745))


