### PR TITLE
[FTR] Refactor soon to be deprecated

### DIFF
--- a/packages/kbn-dev-proc-runner/src/proc.ts
+++ b/packages/kbn-dev-proc-runner/src/proc.ts
@@ -19,7 +19,7 @@ import treeKill from 'tree-kill';
 import { ToolingLog } from '@kbn/tooling-log';
 import { observeLines } from '@kbn/stdio-dev-helpers';
 import { createFailError } from '@kbn/dev-cli-errors';
-
+import type { ChildProcess } from 'child_process';
 const treeKillAsync = promisify((...args: [number, string, any]) => treeKill(...args));
 
 const SECOND = 1000;
@@ -85,11 +85,13 @@ export function startProc(name: string, options: ProcOptions, log: ToolingLog) {
 
   let stopCalled = false;
 
+  type ChildProcessOnOff = Omit<ChildProcess, 'addListener' | 'removeListener'>;
+
   const outcome$: Rx.Observable<number | null> = Rx.race(
     // observe first exit event
-    Rx.fromEvent<[number]>(childProcess, 'exit').pipe(
+    Rx.fromEvent(childProcess as ChildProcessOnOff, 'exit').pipe(
       take(1),
-      map(([code]) => {
+      map(([code]: readonly number[]) => {
         if (stopCalled) {
           return null;
         }

--- a/packages/kbn-dev-proc-runner/src/proc.ts
+++ b/packages/kbn-dev-proc-runner/src/proc.ts
@@ -109,7 +109,9 @@ export function startProc(name: string, options: ProcOptions, log: ToolingLog) {
     // observe first error event
     Rx.fromEvent(childProcess, 'error').pipe(
       take(1),
-      mergeMap((err) => Rx.throwError(err))
+      mergeMap((err: any) => {
+        throw new Error(err);
+      })
     )
   ).pipe(share());
 


### PR DESCRIPTION
## Summary

RxJs is deprecating a few calls that we are using as apart of the FTR.
This pr updates those call sites.

1. [thowError()](https://github.com/ReactiveX/rxjs/blob/master/src/internal/observable/throwError.ts#L70)
1. [toPromise()](https://github.com/ReactiveX/rxjs/blob/master/docs_app/content/deprecations/to-promise.md)
1. [fromEvent<T>()](https://github.com/ReactiveX/rxjs/blob/master/src/internal/observable/fromEvent.ts#L81)