### PR TITLE
[8.8][AO] Change kibana.alert.evaluation.threshold unit to microseconds (#158703)

### DIFF
--- a/x-pack/plugins/apm/public/components/alerting/ui_components/alert_details_app_section/index.tsx
+++ b/x-pack/plugins/apm/public/components/alerting/ui_components/alert_details_app_section/index.tsx
@@ -19,7 +19,6 @@ import {
 import moment from 'moment';
 import React, { useEffect, useMemo } from 'react';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
-import { toMicroseconds as toMicrosecondsUtil } from '../../../../../common/utils/formatters';
 import { SERVICE_ENVIRONMENT } from '../../../../../common/es_fields/apm';
 import { ChartPointerEventContextProvider } from '../../../../context/chart_pointer_event/chart_pointer_event_context';
 import { TimeRangeMetadataContextProvider } from '../../../../context/time_range_metadata/time_range_metadata_context';
@@ -35,9 +34,6 @@ import {
   SERVICE_NAME,
   TRANSACTION_TYPE,
 } from './types';
-
-const toMicroseconds = (value?: number) =>
-  value ? toMicrosecondsUtil(value, 'milliseconds') : value;
 
 export function AlertDetailsAppSection({
   rule,
@@ -68,7 +64,7 @@ export function AlertDetailsAppSection({
         ),
         value: formatAlertEvaluationValue(
           alert?.fields[ALERT_RULE_TYPE_ID],
-          toMicroseconds(alert?.fields[ALERT_EVALUATION_THRESHOLD])
+          alert?.fields[ALERT_EVALUATION_THRESHOLD]
         ),
       },
       {

--- a/x-pack/plugins/apm/server/routes/alerts/rule_types/transaction_duration/register_transaction_duration_rule_type.ts
+++ b/x-pack/plugins/apm/server/routes/alerts/rule_types/transaction_duration/register_transaction_duration_rule_type.ts
@@ -280,7 +280,7 @@ export function registerTransactionDurationRuleType({
               [TRANSACTION_NAME]: ruleParams.transactionName,
               [PROCESSOR_EVENT]: ProcessorEvent.transaction,
               [ALERT_EVALUATION_VALUE]: transactionDuration,
-              [ALERT_EVALUATION_THRESHOLD]: ruleParams.threshold,
+              [ALERT_EVALUATION_THRESHOLD]: thresholdMicroseconds,
               [ALERT_REASON]: reason,
               ...sourceFields,
               ...groupByFields,

--- a/x-pack/plugins/observability/public/components/alerts_flyout_body.tsx
+++ b/x-pack/plugins/observability/public/components/alerts_flyout_body.tsx
@@ -30,7 +30,7 @@ import { AlertLifecycleStatusBadge } from '@kbn/alerts-ui-shared';
 import moment from 'moment-timezone';
 import { useUiSetting } from '@kbn/kibana-react-plugin/public';
 import { useKibana } from '../utils/kibana_react';
-import { asDuration, toMicroseconds } from '../../common/utils/formatters';
+import { asDuration } from '../../common/utils/formatters';
 import { paths } from '../config/paths';
 import { translations } from '../config/translations';
 import { formatAlertEvaluationValue } from '../utils/format_alert_evaluation_value';
@@ -41,14 +41,6 @@ interface FlyoutProps {
   alert: TopAlert;
   id?: string;
 }
-
-// For APM Latency threshold rule, threshold is in ms but the duration formatter works with microseconds
-const normalizeUnit = (ruleTypeId: string, value?: number) => {
-  if (ruleTypeId === 'apm.transaction_duration' && value) {
-    return toMicroseconds(value, 'milliseconds');
-  }
-  return value;
-};
 
 export function AlertsFlyoutBody({ alert, id: pageId }: FlyoutProps) {
   const {
@@ -97,7 +89,7 @@ export function AlertsFlyoutBody({ alert, id: pageId }: FlyoutProps) {
       title: translations.alertsFlyout.expectedValueLabel,
       description: formatAlertEvaluationValue(
         alert.fields[ALERT_RULE_TYPE_ID],
-        normalizeUnit(alert.fields[ALERT_RULE_TYPE_ID], alert.fields[ALERT_EVALUATION_THRESHOLD])
+        alert.fields[ALERT_EVALUATION_THRESHOLD]
       ),
     },
     {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.8`:
 - [Change kibana.alert.evaluation.threshold unit to microseconds (#158703)](https://github.com/elastic/kibana/pull/158703)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Maryam Saeidi","email":"maryam.saeidi@elastic.co"},"sourceCommit":{"committedDate":"2023-03-25T10:31:51Z","message":"[AO] Fix time range filter in alerts table (#153648)\n\nFixes #153284\r\n\r\n## Summary\r\n\r\nThis PR fixes the time range filter by using the `ALERT_TIME_RANGE`\r\ninstead of `TIMESTAMP`\r\ncc @tonyghiani \r\n\r\n\r\n\r\nhttps://user-images.githubusercontent.com/12370520/227532946-087c85c5-1390-47eb-bf0a-bd7319a000a7.mov","sha":"62827b1aabb7db6d5f8b7987b492c768169d291e","branchLabelMapping":{"^v8.8.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team: Actionable Observability","backport:prev-minor","v8.8.0"],"number":153648,"url":"https://github.com/elastic/kibana/pull/153648","mergeCommit":{"message":"[AO] Fix time range filter in alerts table (#153648)\n\nFixes #153284\r\n\r\n## Summary\r\n\r\nThis PR fixes the time range filter by using the `ALERT_TIME_RANGE`\r\ninstead of `TIMESTAMP`\r\ncc @tonyghiani \r\n\r\n\r\n\r\nhttps://user-images.githubusercontent.com/12370520/227532946-087c85c5-1390-47eb-bf0a-bd7319a000a7.mov","sha":"62827b1aabb7db6d5f8b7987b492c768169d291e"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.8.0","labelRegex":"^v8.8.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/153648","number":153648,"mergeCommit":{"message":"[AO] Fix time range filter in alerts table (#153648)\n\nFixes #153284\r\n\r\n## Summary\r\n\r\nThis PR fixes the time range filter by using the `ALERT_TIME_RANGE`\r\ninstead of `TIMESTAMP`\r\ncc @tonyghiani \r\n\r\n\r\n\r\nhttps://user-images.githubusercontent.com/12370520/227532946-087c85c5-1390-47eb-bf0a-bd7319a000a7.mov","sha":"62827b1aabb7db6d5f8b7987b492c768169d291e"}}]}] BACKPORT-->