### PR TITLE
[Guided onboarding] Fix Kibana crashing on Safari

### DIFF
--- a/src/plugins/guided_onboarding/public/components/get_step_location.ts
+++ b/src/plugins/guided_onboarding/public/components/get_step_location.ts
@@ -9,15 +9,21 @@
 import { PluginState } from '../../common';
 
 // regex matches everything between an opening and a closing curly braces
-// without matching the braces themselves
-const paramsBetweenCurlyBraces = /(?<=\{)[^\{\}]+(?=\})/g;
+// and the braces themselves
+const paramsWithBraces = /\{(.*?)\}/g;
+// regex matches both curly braces
+const curlyBraces = /[\{\}]/g;
 export const getStepLocationPath = (path: string, pluginState: PluginState): string | undefined => {
   if (pluginState.activeGuide?.params) {
     let dynamicPath = path;
-    const matchedParams = path.match(paramsBetweenCurlyBraces);
+    const matchedParams = path.match(paramsWithBraces);
     if (matchedParams) {
       for (const param of matchedParams) {
-        dynamicPath = dynamicPath.replace(`{${param}}`, pluginState.activeGuide?.params[param]);
+        const paramWithoutBraces = param.replace(curlyBraces, '');
+        dynamicPath = dynamicPath.replace(
+          `${param}`,
+          pluginState.activeGuide?.params[paramWithoutBraces]
+        );
       }
       return dynamicPath;
     }


### PR DESCRIPTION
## Summary
Fixes https://github.com/elastic/kibana/issues/158744

This PR refactors the code for step parameters introduced in https://github.com/elastic/kibana/pull/154572. The reason for this change is because the original code is using a lookbehind in a regular expression and this is not supported in Safari before version 16.4 (see this known [bug](https://bugs.webkit.org/show_bug.cgi?id=174931) in Webkit). 

How to test 
One needs an iOS simulator with version before 16.4 to test the fix.

Screenshot
![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2023-06-01 at 15 32 30](https://github.com/elastic/kibana/assets/6585477/c31f37e0-2bb4-4dfc-824b-71fa92582187)

### Release note
Fixes Kibana crashing on Safari versions prior to 8.4


<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->