### PR TITLE
[Telemetry] Log opt-in status at the INFO level

### DIFF
--- a/packages/kbn-doc-links/src/get_doc_links.ts
+++ b/packages/kbn-doc-links/src/get_doc_links.ts
@@ -767,5 +767,8 @@ export const getDocLinks = ({ kibanaBranch }: GetDocLinkOptions): DocLinks => {
     synthetics: {
       featureRoles: `${ELASTIC_WEBSITE_URL}guide/en/observability/${DOC_LINK_VERSION}/synthetics-feature-roles.html`,
     },
+    telemetry: {
+      settings: `${KIBANA_DOCS}telemetry-settings-kbn.html`,
+    },
   });
 };

--- a/packages/kbn-doc-links/src/types.ts
+++ b/packages/kbn-doc-links/src/types.ts
@@ -536,4 +536,7 @@ export interface DocLinks {
   readonly synthetics: {
     readonly featureRoles: string;
   };
+  readonly telemetry: {
+    readonly settings: string;
+  };
 }

--- a/src/plugins/telemetry/server/plugin.ts
+++ b/src/plugins/telemetry/server/plugin.ts
@@ -149,9 +149,16 @@ export class TelemetryPlugin implements Plugin<TelemetryPluginSetup, TelemetryPl
   }
 
   public setup(
-    { analytics, http, savedObjects }: CoreSetup,
+    { analytics, docLinks, http, savedObjects }: CoreSetup,
     { usageCollection, telemetryCollectionManager }: TelemetryPluginsDepsSetup
   ): TelemetryPluginSetup {
+    this.isOptedIn$.subscribe((optedIn) => {
+      const optInStatusMsg = optedIn ? 'enabled' : 'disabled';
+      this.logger.info(
+        `Telemetry collection is ${optInStatusMsg}. For more information on telemetry settings, refer to ${docLinks.links.telemetry.settings}.`
+      );
+    });
+
     if (this.isOptedIn !== undefined) {
       analytics.optIn({ global: { enabled: this.isOptedIn } });
     }


### PR DESCRIPTION
## Summary

In an effort to increase our transparency on the way we collect usage stats, this PR adds a log INFO entry every time the Opt-In status changes. This will let the users know if this feature is enabled/disabled even without opening the Kibana UI.

![image](https://github.com/elastic/kibana/assets/5469006/8e6c4800-01cc-4f30-ac64-29bb3e986868)

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->