### PR TITLE
[Enterprise Search] Optimize refresh usage

### DIFF
--- a/x-pack/plugins/enterprise_search/server/lib/connectors/add_connector.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/connectors/add_connector.test.ts
@@ -163,7 +163,7 @@ describe('addConnector lib function', () => {
         sync_now: false,
       },
       index: CONNECTORS_INDEX,
-      refresh: true,
+      refresh: 'wait_for',
     });
     expect(mockClient.asCurrentUser.indices.create).toHaveBeenCalledWith({
       index: 'index_name',
@@ -347,7 +347,7 @@ describe('addConnector lib function', () => {
         sync_now: false,
       },
       index: CONNECTORS_INDEX,
-      refresh: true,
+      refresh: 'wait_for',
     });
     expect(mockClient.asCurrentUser.indices.create).toHaveBeenCalledWith({
       index: 'index_name',
@@ -456,7 +456,7 @@ describe('addConnector lib function', () => {
         sync_now: false,
       },
       index: CONNECTORS_INDEX,
-      refresh: true,
+      refresh: 'wait_for',
     });
     expect(mockClient.asCurrentUser.indices.create).toHaveBeenCalledWith({
       index: 'search-index_name',

--- a/x-pack/plugins/enterprise_search/server/lib/connectors/add_connector.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/connectors/add_connector.ts
@@ -54,7 +54,7 @@ const createConnector = async (
   const result = await client.asCurrentUser.index({
     document,
     index: CONNECTORS_INDEX,
-    refresh: true,
+    refresh: 'wait_for',
   });
   await createIndex(client, document.index_name, language, false);
 

--- a/x-pack/plugins/enterprise_search/server/lib/connectors/fetch_connectors.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/connectors/fetch_connectors.test.ts
@@ -90,6 +90,9 @@ describe('fetchConnectors lib', () => {
       mockClient.asCurrentUser.search.mockImplementationOnce(() =>
         Promise.resolve({ hits: { hits: [{ _id: 'connectorId', _source: { source: 'source' } }] } })
       );
+      mockClient.asCurrentUser.get.mockImplementationOnce(() =>
+        Promise.resolve({ _id: 'connectorId', _source: { source: 'source' } })
+      );
       await expect(fetchConnectorByIndexName(mockClient as any, 'id')).resolves.toEqual({
         id: 'connectorId',
         source: 'source',

--- a/x-pack/plugins/enterprise_search/server/lib/connectors/fetch_connectors.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/connectors/fetch_connectors.ts
@@ -49,11 +49,10 @@ export const fetchConnectorByIndexName = async (
       index: CONNECTORS_INDEX,
       query: { term: { index_name: indexName } },
     });
+    // Because we cannot guarantee that the index has been refreshed and is giving us the most recent source
+    // we need to fetch the source with a direct get from the index, which will always be up to date
     const result = connectorResult.hits.hits[0]?._source
-      ? {
-          ...connectorResult.hits.hits[0]._source,
-          id: connectorResult.hits.hits[0]._id,
-        }
+      ? (await fetchConnectorById(client, connectorResult.hits.hits[0]._id))?.value
       : undefined;
     return result;
   } catch (error) {

--- a/x-pack/plugins/enterprise_search/server/lib/connectors/post_cancel_syncs.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/connectors/post_cancel_syncs.test.ts
@@ -88,7 +88,6 @@ ctx._source['cancelation_requested_at'] = '${new Date(Date.now()).toISOString()}
       doc: { last_sync_status: SyncStatus.CANCELED, sync_now: false },
       id: 'connectorId',
       index: CONNECTORS_INDEX,
-      refresh: 'wait_for',
     });
   });
 });

--- a/x-pack/plugins/enterprise_search/server/lib/connectors/post_cancel_syncs.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/connectors/post_cancel_syncs.ts
@@ -68,6 +68,5 @@ ctx._source['cancelation_requested_at'] = '${new Date(Date.now()).toISOString()}
     doc: { last_sync_status: SyncStatus.CANCELED, sync_now: false },
     id: connectorId,
     index: CONNECTORS_INDEX,
-    refresh: 'wait_for',
   });
 };

--- a/x-pack/plugins/enterprise_search/server/lib/connectors/put_update_filtering.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/connectors/put_update_filtering.ts
@@ -61,7 +61,6 @@ export const updateFiltering = async (
     if_primary_term: primaryTerm,
     if_seq_no: seqNo,
     index: CONNECTORS_INDEX,
-    refresh: true,
   });
 
   return result.result === 'updated' ? active : undefined;

--- a/x-pack/plugins/enterprise_search/server/lib/connectors/put_update_filtering_draft.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/connectors/put_update_filtering_draft.ts
@@ -61,7 +61,6 @@ export const updateFilteringDraft = async (
     if_primary_term: primaryTerm,
     if_seq_no: seqNo,
     index: CONNECTORS_INDEX,
-    refresh: true,
   });
 
   return result.result === 'updated' ? draft : undefined;

--- a/x-pack/plugins/enterprise_search/server/lib/connectors/update_connector_configuration.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/connectors/update_connector_configuration.test.ts
@@ -51,7 +51,6 @@ describe('updateConnectorConfiguration lib function', () => {
       if_primary_term: 0,
       if_seq_no: 3,
       index: CONNECTORS_INDEX,
-      refresh: 'wait_for',
     });
   });
 

--- a/x-pack/plugins/enterprise_search/server/lib/connectors/update_connector_configuration.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/connectors/update_connector_configuration.ts
@@ -53,7 +53,6 @@ export const updateConnectorConfiguration = async (
       if_primary_term: connectorResult?.primaryTerm,
       if_seq_no: connectorResult?.seqNo,
       index: CONNECTORS_INDEX,
-      refresh: 'wait_for',
     });
     return updatedConfig;
   } else {

--- a/x-pack/plugins/enterprise_search/server/lib/crawler/put_html_extraction.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/crawler/put_html_extraction.test.ts
@@ -45,7 +45,6 @@ describe('updateHtmlExtraction lib function', () => {
       },
       id: 'connectorId',
       index: CONNECTORS_INDEX,
-      refresh: 'wait_for',
     });
   });
 });

--- a/x-pack/plugins/enterprise_search/server/lib/crawler/put_html_extraction.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/crawler/put_html_extraction.ts
@@ -27,6 +27,5 @@ export async function updateHtmlExtraction(
     },
     id: connector.id,
     index: CONNECTORS_INDEX,
-    refresh: 'wait_for',
   });
 }


### PR DESCRIPTION
## Summary

This optimizes the usage of `refresh` across the Enterprise Search plugin. 
1) Removed most usages of refresh, where the document is not  expected to be accessed via search requests (or up-to-date-ness in the next search request is not essential).
2) Changed `refresh: true` to `refresh: 'wait_for'` for adding a connector document. We need to wait for this refresh to complete, or the redirect after adding a new connector will show a broken page.

