### PR TITLE
[Cases] Fix severity loading spinner visible while updating tags or assignees bug

### DIFF
--- a/x-pack/plugins/cases/public/components/case_view/components/case_view_activity.test.tsx
+++ b/x-pack/plugins/cases/public/components/case_view/components/case_view_activity.test.tsx
@@ -36,6 +36,7 @@ import { defaultInfiniteUseFindCaseUserActions, defaultUseFindCaseUserActions } 
 import { ActionTypes } from '../../../../common/api';
 import { useGetCaseUserActionsStats } from '../../../containers/use_get_case_user_actions_stats';
 import { useInfiniteFindCaseUserActions } from '../../../containers/use_infinite_find_case_user_actions';
+import { useOnUpdateField } from '../use_on_update_field';
 
 jest.mock('../../../containers/use_infinite_find_case_user_actions');
 jest.mock('../../../containers/use_find_case_user_actions');
@@ -51,6 +52,7 @@ jest.mock('../../../containers/use_get_tags');
 jest.mock('../../../containers/user_profiles/use_bulk_get_user_profiles');
 jest.mock('../../../containers/use_get_case_connectors');
 jest.mock('../../../containers/use_get_case_users');
+jest.mock('../use_on_update_field');
 
 (useGetTags as jest.Mock).mockReturnValue({ data: ['coke', 'pepsi'], refetch: jest.fn() });
 
@@ -118,11 +120,12 @@ const useGetConnectorsMock = useGetSupportedActionConnectors as jest.Mock;
 const usePostPushToServiceMock = usePostPushToService as jest.Mock;
 const useGetCaseConnectorsMock = useGetCaseConnectors as jest.Mock;
 const useGetCaseUsersMock = useGetCaseUsers as jest.Mock;
+const useOnUpdateFieldMock = useOnUpdateField as jest.Mock;
 
 // FLAKY: https://github.com/elastic/kibana/issues/151979
 // FLAKY: https://github.com/elastic/kibana/issues/151980
 // FLAKY: https://github.com/elastic/kibana/issues/151981
-describe.skip('Case View Page activity tab', () => {
+describe('Case View Page activity tab', () => {
   const caseConnectors = getCaseConnectorsMockResponse();
 
   beforeAll(() => {
@@ -137,6 +140,10 @@ describe.skip('Case View Page activity tab', () => {
     useGetCaseConnectorsMock.mockReturnValue({
       isLoading: false,
       data: caseConnectors,
+    });
+    useOnUpdateFieldMock.mockReturnValue({
+      isLoading: false,
+      useOnUpdateField: jest.fn,
     });
   });
   let appMockRender: AppMockRenderer;
@@ -226,6 +233,30 @@ describe.skip('Case View Page activity tab', () => {
     expect(result.getByTestId('case-view-loading-content')).toBeInTheDocument();
     expect(result.queryByTestId('case-view-activity')).not.toBeInTheDocument();
     expect(result.queryByTestId('user-actions-list')).not.toBeInTheDocument();
+  });
+
+  it('should show a loading when updating severity ', async () => {
+    useOnUpdateFieldMock.mockReturnValue({ isLoading: true, loadingKey: 'severity' });
+
+    const result = appMockRender.render(<CaseViewActivity {...caseProps} />);
+
+    expect(
+      result
+        .getByTestId('case-severity-selection')
+        .classList.contains('euiSuperSelectControl-isLoading')
+    ).toBeTruthy();
+  });
+
+  it('should not show a loading for severity when updating tags', async () => {
+    useOnUpdateFieldMock.mockReturnValue({ isLoading: true, loadingKey: 'tags' });
+
+    const result = appMockRender.render(<CaseViewActivity {...caseProps} />);
+
+    expect(
+      result
+        .getByTestId('case-severity-selection')
+        .classList.contains('euiSuperSelectControl-isLoading')
+    ).not.toBeTruthy();
   });
 
   it('should not render the assignees on basic license', () => {

--- a/x-pack/plugins/cases/public/components/case_view/components/case_view_activity.tsx
+++ b/x-pack/plugins/cases/public/components/case_view/components/case_view_activity.tsx
@@ -271,7 +271,7 @@ export const CaseViewActivity = ({
           ) : null}
           <SeveritySidebarSelector
             isDisabled={!permissions.update}
-            isLoading={isLoading}
+            isLoading={isLoading && loadingKey === 'severity'}
             selectedSeverity={caseData.severity}
             onSeverityChange={onUpdateSeverity}
           />


### PR DESCRIPTION
## Summary

This PR fixes https://github.com/elastic/kibana/issues/157364


https://github.com/elastic/kibana/assets/117571355/10ea3519-92cd-4b66-9d18-db38ab98f830

