### PR TITLE
[7.17] chore(NA): update caniuse-lite into v1.0.30001492 (#158791)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -9521,15 +9521,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001335, caniuse-lite@^1.0.30001358:
-  version "1.0.30001359"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001359.tgz#a1c1cbe1c2da9e689638813618b4219acbd4925e"
-  integrity sha512-Xln/BAsPzEuiVLgJ2/45IaqD9jShtk3Y33anKb4+yLwQzws3+v6odKfpgES/cDEaZMLzSChpIGdbOYtH9MyuHw==
-
-caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001400:
-  version "1.0.30001468"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001468.tgz#0101837c6a4e38e6331104c33dcfb3bdf367a4b7"
-  integrity sha512-zgAo8D5kbOyUcRAgSmgyuvBkjrGk5CGYG5TYgFdpQv+ywcyEpo1LOWoG8YmoflGnh+V+UsNuKYedsoYs0hzV5A==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001335, caniuse-lite@^1.0.30001358, caniuse-lite@^1.0.30001400:
+  version "1.0.30001492"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001492.tgz"
+  integrity sha512-2efF8SAZwgAX1FJr87KWhvuJxnGJKOnctQa8xLOskAXNXq8oiuqgl6u1kk3fFpsp3GgvzlRjiK1sl63hNtFADw==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [chore(NA): update caniuse-lite into v1.0.30001492 (#158791)](https://github.com/elastic/kibana/pull/158791)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Tiago Costa","email":"tiago.costa@elastic.co"},"sourceCommit":{"committedDate":"2023-06-01T23:42:53Z","message":"chore(NA): update caniuse-lite into v1.0.30001492 (#158791)\n\nSimple PR to bump version on this dependency that is throwing on older\r\nbranches.","sha":"f9f035fe9c1d59997c2b44534cb79a0c417e5a1d","branchLabelMapping":{"^v8.9.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["chore","Team:Operations","release_note:skip","backport:all-open","v8.9.0"],"number":158791,"url":"https://github.com/elastic/kibana/pull/158791","mergeCommit":{"message":"chore(NA): update caniuse-lite into v1.0.30001492 (#158791)\n\nSimple PR to bump version on this dependency that is throwing on older\r\nbranches.","sha":"f9f035fe9c1d59997c2b44534cb79a0c417e5a1d"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.9.0","labelRegex":"^v8.9.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/158791","number":158791,"mergeCommit":{"message":"chore(NA): update caniuse-lite into v1.0.30001492 (#158791)\n\nSimple PR to bump version on this dependency that is throwing on older\r\nbranches.","sha":"f9f035fe9c1d59997c2b44534cb79a0c417e5a1d"}},{"url":"https://github.com/elastic/kibana/pull/158889","number":158889,"branch":"8.8","state":"OPEN"}]}] BACKPORT-->