### PR TITLE
[Data Views] Fix data view field update paths in documentation

### DIFF
--- a/docs/api/data-views/update-fields.asciidoc
+++ b/docs/api/data-views/update-fields.asciidoc
@@ -49,7 +49,7 @@ Set popularity `count` for field `foo`:
 
 [source,sh]
 --------------------------------------------------
-$ curl -X POST api/data_views/data-view/my-view/fields
+$ curl -X POST api/data_views/data_view/my-view/fields
 {
     "fields": {
         "foo": {
@@ -64,7 +64,7 @@ Change a simple field format:
 
 [source,sh]
 --------------------------------------------------
-$ curl -X POST api/data_views/data-view/my-view/fields
+$ curl -X POST api/data_views/data_view/my-view/fields
 {
   "fields": {
     "foo": {
@@ -81,7 +81,7 @@ Change a complex field format:
 
 [source,sh]
 --------------------------------------------------
-$ curl -X POST api/data_views/data-view/my-view/fields
+$ curl -X POST api/data_views/data_view/my-view/fields
 {
   "fields": {
     "foo": {
@@ -111,7 +111,7 @@ Update multiple metadata fields in one request:
 
 [source,sh]
 --------------------------------------------------
-$ curl -X POST api/data_views/data-view/my-view/fields
+$ curl -X POST api/data_views/data_view/my-view/fields
 {
     "fields": {
         "foo": {
@@ -130,7 +130,7 @@ Use `null` value to delete metadata:
 
 [source,sh]
 --------------------------------------------------
-$ curl -X POST api/data_views/data-view/my-pattern/fields
+$ curl -X POST api/data_views/data_view/my-pattern/fields
 {
     "fields": {
         "foo": {


### PR DESCRIPTION
## Summary

Fixes #158792

This PR fixes the documentation for the "update data view fields" API which used an incorrect route in the provided examples (data-view instead of data_view)


### Checklist
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials


<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->