### PR TITLE
[8.8] [Security Solution][Response Ops] Alert Table column metadata does not have the columns data type (#157653)

### DIFF
--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/hooks/use_columns/use_columns.ts
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/hooks/use_columns/use_columns.ts
@@ -10,7 +10,7 @@ import { IStorageWrapper } from '@kbn/kibana-utils-plugin/public';
 import { BrowserField, BrowserFields } from '@kbn/rule-registry-plugin/common';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { AlertConsumers } from '@kbn/rule-data-utils';
-import { isEqual } from 'lodash';
+import { isEmpty, isEqual } from 'lodash';
 import { AlertsTableStorage } from '../../alerts_table_state';
 import { toggleColumn } from './toggle_column';
 import { useFetchBrowserFieldCapabilities } from '../use_fetch_browser_fields_capabilities';
@@ -151,7 +151,15 @@ export const useColumns = ({
     initialBrowserFields,
   });
 
-  const [columns, setColumns] = useState<EuiDataGridColumn[]>(storageAlertsTable.current.columns);
+  const [columns, setColumns] = useState<EuiDataGridColumn[]>(() => {
+    let cols = storageAlertsTable.current.columns;
+    // before restoring from storage, enrich the column data
+    if (initialBrowserFields && defaultColumns) {
+      cols = populateColumns(cols, initialBrowserFields, defaultColumns);
+    }
+    return cols;
+  });
+
   const [isColumnsPopulated, setColumnsPopulated] = useState<boolean>(false);
 
   const defaultColumnsRef = useRef<typeof defaultColumns>(defaultColumns);
@@ -162,16 +170,18 @@ export const useColumns = ({
   );
 
   useEffect(() => {
-    // if defaultColumns have changed, populate again
+    // if defaultColumns have changed,
+    // get the latest columns provided by client and
     if (didDefaultColumnChange) {
       defaultColumnsRef.current = defaultColumns;
+      setColumnsPopulated(false);
       setColumns(storageAlertsTable.current.columns);
       return;
     }
   }, [didDefaultColumnChange, storageAlertsTable, defaultColumns]);
 
   useEffect(() => {
-    if (isBrowserFieldDataLoading !== false || isColumnsPopulated) return;
+    if (isEmpty(browserFields) || isColumnsPopulated) return;
 
     const populatedColumns = populateColumns(columns, browserFields, defaultColumns);
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.8`:
 - [[Security Solution][Response Ops] Alert Table column metadata does not have the columns data type (#157653)](https://github.com/elastic/kibana/pull/157653)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Jatin Kathuria","email":"jatin.kathuria@elastic.co"},"sourceCommit":{"committedDate":"2023-05-15T09:59:57Z","message":"[Security Solution][Response Ops] Alert Table column metadata does not have the columns data type (#157653)\n\n## Summary\r\n\r\nHandles : #157463 \r\n\r\n- `@timestamp` Sorting is working functionally instead of `A-Z` it\r\nshould be `Old - New`\r\n\r\n|Before|After|\r\n|---|---|\r\n\r\n|![image](https://github.com/elastic/kibana/assets/59917825/6c5a4c64-cd74-4421-af16-f6172bfc7fc5)|<video\r\nsrc=\"https://github.com/elastic/kibana/assets/7485038/15ac8a52-eece-4892-8c32-09f19e18e870\"\r\n/>|\r\n\r\nImage-After\r\n<img width=\"611\" alt=\"image\"\r\nsrc=\"https://github.com/elastic/kibana/assets/7485038/b9f62366-3067-4a74-b7be-74fb8f94d2b8\">","sha":"1fd03ca9a80b85cc61ddd506e96eb316b8a9984f","branchLabelMapping":{"^v8.9.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:ResponseOps","Team:Threat Hunting:Investigations","v8.9.0","v8.8.1"],"number":157653,"url":"https://github.com/elastic/kibana/pull/157653","mergeCommit":{"message":"[Security Solution][Response Ops] Alert Table column metadata does not have the columns data type (#157653)\n\n## Summary\r\n\r\nHandles : #157463 \r\n\r\n- `@timestamp` Sorting is working functionally instead of `A-Z` it\r\nshould be `Old - New`\r\n\r\n|Before|After|\r\n|---|---|\r\n\r\n|![image](https://github.com/elastic/kibana/assets/59917825/6c5a4c64-cd74-4421-af16-f6172bfc7fc5)|<video\r\nsrc=\"https://github.com/elastic/kibana/assets/7485038/15ac8a52-eece-4892-8c32-09f19e18e870\"\r\n/>|\r\n\r\nImage-After\r\n<img width=\"611\" alt=\"image\"\r\nsrc=\"https://github.com/elastic/kibana/assets/7485038/b9f62366-3067-4a74-b7be-74fb8f94d2b8\">","sha":"1fd03ca9a80b85cc61ddd506e96eb316b8a9984f"}},"sourceBranch":"main","suggestedTargetBranches":["8.8"],"targetPullRequestStates":[{"branch":"main","label":"v8.9.0","labelRegex":"^v8.9.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/157653","number":157653,"mergeCommit":{"message":"[Security Solution][Response Ops] Alert Table column metadata does not have the columns data type (#157653)\n\n## Summary\r\n\r\nHandles : #157463 \r\n\r\n- `@timestamp` Sorting is working functionally instead of `A-Z` it\r\nshould be `Old - New`\r\n\r\n|Before|After|\r\n|---|---|\r\n\r\n|![image](https://github.com/elastic/kibana/assets/59917825/6c5a4c64-cd74-4421-af16-f6172bfc7fc5)|<video\r\nsrc=\"https://github.com/elastic/kibana/assets/7485038/15ac8a52-eece-4892-8c32-09f19e18e870\"\r\n/>|\r\n\r\nImage-After\r\n<img width=\"611\" alt=\"image\"\r\nsrc=\"https://github.com/elastic/kibana/assets/7485038/b9f62366-3067-4a74-b7be-74fb8f94d2b8\">","sha":"1fd03ca9a80b85cc61ddd506e96eb316b8a9984f"}},{"branch":"8.8","label":"v8.8.1","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->