### PR TITLE
[APM] Use transaction.duration.histogram for percentile aggs

### DIFF
--- a/x-pack/plugins/apm/server/routes/transactions/get_latency_charts/index.ts
+++ b/x-pack/plugins/apm/server/routes/transactions/get_latency_charts/index.ts
@@ -10,10 +10,14 @@ import {
   rangeQuery,
   termQuery,
 } from '@kbn/observability-plugin/server';
-import { ApmServiceTransactionDocumentType } from '../../../../common/document_type';
+import {
+  ApmDocumentType,
+  ApmServiceTransactionDocumentType,
+} from '../../../../common/document_type';
 import {
   FAAS_ID,
   SERVICE_NAME,
+  TRANSACTION_DURATION_HISTOGRAM,
   TRANSACTION_NAME,
   TRANSACTION_TYPE,
 } from '../../../../common/es_fields/apm';
@@ -72,7 +76,10 @@ function searchLatency({
   });
 
   const transactionDurationField =
-    getDurationFieldForTransactions(documentType);
+    documentType === ApmDocumentType.ServiceTransactionMetric &&
+    latencyAggregationType !== LatencyAggregationType.avg
+      ? TRANSACTION_DURATION_HISTOGRAM
+      : getDurationFieldForTransactions(documentType);
 
   const params = {
     apm: {

--- a/x-pack/test/apm_api_integration/tests/transactions/latency.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/transactions/latency.spec.ts
@@ -128,7 +128,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
       });
 
       describe('95th percentile latency type', () => {
-        it('returns average duration and timeseries', async () => {
+        it('returns p95 duration and timeseries', async () => {
           const response = await fetchLatencyCharts({
             query: { latencyAggregationType: LatencyAggregationType.p95 },
           });
@@ -143,10 +143,47 @@ export default function ApiTest({ getService }: FtrProviderContext) {
       });
 
       describe('99th percentile latency type', () => {
+        it('returns p99 duration and timeseries', async () => {
+          const response = await fetchLatencyCharts({
+            query: {
+              latencyAggregationType: LatencyAggregationType.p99,
+            },
+          });
+
+          expect(response.status).to.be(200);
+          const latencyChartReturn = response.body as LatencyChartReturnType;
+
+          expect(latencyChartReturn.currentPeriod.overallAvgDuration).to.be(
+            expectedLatencyAvgValueMs
+          );
+          expect(latencyChartReturn.currentPeriod.latencyTimeseries.length).to.be.eql(15);
+        });
+      });
+
+      describe('95th percentile latency type for service tx metrics', () => {
+        it('returns average duration and timeseries', async () => {
+          const response = await fetchLatencyCharts({
+            query: {
+              latencyAggregationType: LatencyAggregationType.p95,
+              documentType: ApmDocumentType.ServiceTransactionMetric,
+            },
+          });
+
+          expect(response.status).to.be(200);
+          const latencyChartReturn = response.body as LatencyChartReturnType;
+          expect(latencyChartReturn.currentPeriod.overallAvgDuration).to.be(
+            expectedLatencyAvgValueMs
+          );
+          expect(latencyChartReturn.currentPeriod.latencyTimeseries.length).to.be.eql(15);
+        });
+      });
+
+      describe('99th percentile latency type for service tx metrics', () => {
         it('returns average duration and timeseries', async () => {
           const response = await fetchLatencyCharts({
             query: {
               latencyAggregationType: LatencyAggregationType.p99,
+              documentType: ApmDocumentType.ServiceTransactionMetric,
             },
           });
 


### PR DESCRIPTION
Closes #158364.

Intentionally based on 8.8, as 8.9 includes some changes that will mean a very different fix. Still needs a review.