### PR TITLE
[XY] Fixes the threshold visibility

### DIFF
--- a/src/plugins/chart_expressions/expression_xy/common/expression_functions/reference_line.ts
+++ b/src/plugins/chart_expressions/expression_xy/common/expression_functions/reference_line.ts
@@ -108,7 +108,6 @@ export const referenceLineFunction: ReferenceLineFn = {
     forAccessor: {
       types: ['string'],
       help: '',
-      default: '',
     },
   },
   fn(table, args) {

--- a/src/plugins/chart_expressions/expression_xy/public/components/xy_chart.tsx
+++ b/src/plugins/chart_expressions/expression_xy/public/components/xy_chart.tsx
@@ -896,7 +896,7 @@ export function XYChart({
               tooltip: { visible: syncTooltips, placement: Placement.Right },
             }}
             legendColorPicker={uiState ? LegendColorPickerWrapper : undefined}
-            debugState={true}
+            debugState={window._echDebugStateFlag ?? false}
             showLegend={showLegend}
             legendPosition={legend?.isInside ? legendInsideParams : legend.position}
             legendSize={LegendSizeToPixels[legend.legendSize ?? DEFAULT_LEGEND_SIZE]}

--- a/src/plugins/chart_expressions/expression_xy/public/components/xy_chart.tsx
+++ b/src/plugins/chart_expressions/expression_xy/public/components/xy_chart.tsx
@@ -896,7 +896,7 @@ export function XYChart({
               tooltip: { visible: syncTooltips, placement: Placement.Right },
             }}
             legendColorPicker={uiState ? LegendColorPickerWrapper : undefined}
-            debugState={window._echDebugStateFlag ?? false}
+            debugState={true}
             showLegend={showLegend}
             legendPosition={legend?.isInside ? legendInsideParams : legend.position}
             legendSize={LegendSizeToPixels[legend.legendSize ?? DEFAULT_LEGEND_SIZE]}

--- a/test/functional/page_objects/visualize_chart_page.ts
+++ b/test/functional/page_objects/visualize_chart_page.ts
@@ -248,6 +248,12 @@ export class VisualizeChartPageObject extends FtrService {
     return items.map(({ name }) => name);
   }
 
+  public async getReferenceLine(selector: string) {
+    const items = (await this.getEsChartDebugState(selector))?.annotations;
+    const referenceLine = items?.filter(({ type }) => type === 'line');
+    return referenceLine;
+  }
+
   public async getLegendEntries() {
     const isVisTypePieChart = await this.isNewLibraryChart(partitionVisChartSelector);
     const isVisTypeHeatmapChart = await this.isNewLibraryChart(heatmapChartSelector);

--- a/x-pack/test/functional/apps/lens/open_in_lens/agg_based/xy.ts
+++ b/x-pack/test/functional/apps/lens/open_in_lens/agg_based/xy.ts
@@ -205,6 +205,8 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       await visEditor.clickOptionsTab();
       await visEditor.toggleShowThresholdLine();
       await visEditor.clickGo(isNewChartsLibraryEnabled);
+      const line = await visChart.getReferenceLine('xyVisChart');
+      expect(line?.length).to.be(1);
       await header.waitUntilLoadingHasFinished();
 
       await visualize.navigateToLensFromAnotherVisulization();


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/158343

Fixes the broken reference line in aggbased xy charts.

<img width="1715" alt="image" src="https://github.com/elastic/kibana/assets/17003240/ae48f0b8-475a-44e2-866a-c56e9da8e8b0">

The problem was the default here, apparently the expressions fail when the default is an empty string. The expression was failing and as a result the reference line was never rendered

### Checklist
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
