### PR TITLE
[Serverless] Disable plugin `interactiveSetup`

### DIFF
--- a/config/serverless.yml
+++ b/config/serverless.yml
@@ -1,3 +1,4 @@
+interactiveSetup.enabled: false
 newsfeed.enabled: false
 xpack.security.showNavLinks: false
 xpack.serverless.plugin.enabled: true


### PR DESCRIPTION
## Summary

We want to disable the Interactive Setup on Serverless because it shouldn't be necessary, and it's affecting our current health-checks.

Related to #158910.

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
