### PR TITLE
[Serverless Search] remove default cloud id from display

### DIFF
--- a/x-pack/plugins/serverless_search/public/application/components/api_key/api_key.tsx
+++ b/x-pack/plugins/serverless_search/public/application/components/api_key/api_key.tsx
@@ -195,8 +195,7 @@ export const ApiKeyPanel = ({ setClientApiKey }: { setClientApiKey: (value: stri
                 overflow-wrap: anywhere;
               `}
             >
-              {cloud.cloudId ||
-                'ProjectXDHS:dXMtd2VzdDIuZ2NwLmVsYXN0aWMtY2xvdWQuY29tJDEwMDYxN2IwMzM3ODRiYWJhODc5NzZiOTA0MTA3NGYwJDQ5ZWM'}
+              {cloud.cloudId}
             </EuiCodeBlock>
           </EuiSplitPanel.Inner>
         </EuiThemeProvider>


### PR DESCRIPTION
## Summary

Updated the API key panel for the getting started page to not render a fallback cloud id when its unavailable. In the future this cloud id should always be set for a serverless project, but defaulting to a cloud id was confusing in the QA environment since it was incorrect.

### Screenshots
with cloud id set in kibana config:
<img width="1418" alt="image" src="https://github.com/elastic/kibana/assets/1972968/649cc7f4-14a7-4038-98b2-2edad44130cb">
without cloud id set in kibana config:
<img width="1418" alt="image" src="https://github.com/elastic/kibana/assets/1972968/53ac94fe-5293-496b-88d8-3568b133d17c">

