### PR TITLE
[8.8] [SecuritySolutions] Fix recently installed jobs remains greyed out on EA page (#158821)

### DIFF
--- a/x-pack/plugins/security_solution/public/overview/components/entity_analytics/anomalies/columns.test.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/entity_analytics/anomalies/columns.test.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook } from '@testing-library/react-hooks';
+import { AnomalyEntity } from '../../../../common/components/ml/anomaly/use_anomalies_search';
+import type { SecurityJob } from '../../../../common/components/ml_popover/types';
+import { useAnomaliesColumns } from './columns';
+
+describe('useAnomaliesColumns', () => {
+  it('renders unstyled jobName when count is zero and job id is present on recentlyEnabledJobIds', () => {
+    const jobName = 'test-job-name';
+    const job = { id: 'test-id-1' } as SecurityJob;
+    const { result } = renderHook(() => useAnomaliesColumns(false, jest.fn(), [job.id]));
+
+    const nameColumn = result.current[0];
+    const renderedComponent = nameColumn.render?.(jobName, {
+      count: 0,
+      job,
+      name: jobName,
+      entity: AnomalyEntity.Host,
+    });
+
+    expect(renderedComponent).toEqual(jobName);
+  });
+
+  it("renders styled jobName when the count is zero and job hasn't started", () => {
+    const jobName = 'test-job-name';
+    const count = 0;
+    const job = {
+      id: 'test-id-1',
+      jobState: 'closed',
+      datafeedState: 'stopped',
+    } as SecurityJob;
+    const { result } = renderHook(() => useAnomaliesColumns(false, jest.fn(), []));
+
+    const nameColumn = result.current[0];
+    const renderedComponent = nameColumn.render?.(jobName, {
+      count,
+      job,
+      name: jobName,
+      entity: AnomalyEntity.Host,
+    });
+
+    expect(renderedComponent).toMatchInlineSnapshot(`
+      <styled.span>
+        test-job-name
+      </styled.span>
+    `);
+  });
+});

--- a/x-pack/plugins/security_solution/public/overview/components/entity_analytics/anomalies/columns.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/entity_analytics/anomalies/columns.tsx
@@ -6,7 +6,7 @@
  */
 import React, { useMemo } from 'react';
 import styled from 'styled-components';
-import type { EuiBasicTableColumn } from '@elastic/eui';
+import type { EuiTableFieldDataColumnType } from '@elastic/eui';
 import * as i18n from './translations';
 import type { SecurityJob } from '../../../../common/components/ml_popover/types';
 import { isJobStarted } from '../../../../../common/machine_learning/helpers';
@@ -14,7 +14,7 @@ import { isJobStarted } from '../../../../../common/machine_learning/helpers';
 import { TotalAnomalies } from './components/total_anomalies';
 import type { AnomaliesCount } from '../../../../common/components/ml/anomaly/use_anomalies_search';
 
-type AnomaliesColumns = Array<EuiBasicTableColumn<AnomaliesCount>>;
+type AnomaliesColumns = Array<EuiTableFieldDataColumnType<AnomaliesCount>>;
 
 const MediumShadeText = styled.span`
   color: ${({ theme }) => theme.eui.euiColorMediumShade};
@@ -33,8 +33,13 @@ export const useAnomaliesColumns = (
         truncateText: true,
         mobileOptions: { show: true },
         'data-test-subj': 'anomalies-table-column-name',
-        render: (jobName, { count, job }) => {
-          if (count > 0 || (job && isJobStarted(job.jobState, job.datafeedState))) {
+        render: (jobName: AnomaliesCount['name'], { count, job }) => {
+          if (
+            count > 0 ||
+            (job &&
+              (isJobStarted(job.jobState, job.datafeedState) ||
+                recentlyEnabledJobIds.includes(job.id)))
+          ) {
             return jobName;
           } else {
             return <MediumShadeText>{jobName}</MediumShadeText>;
@@ -60,7 +65,7 @@ export const useAnomaliesColumns = (
         mobileOptions: { show: true },
         width: '15%',
         'data-test-subj': 'anomalies-table-column-count',
-        render: (count, { entity, job }) => {
+        render: (count: AnomaliesCount['count'], { entity, job }) => {
           if (!job) return '';
           return (
             <TotalAnomalies


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.8`:
 - [[SecuritySolutions] Fix recently installed jobs remains greyed out on EA page (#158821)](https://github.com/elastic/kibana/pull/158821)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Pablo Machado","email":"pablo.nevesmachado@elastic.co"},"sourceCommit":{"committedDate":"2023-06-02T14:25:43Z","message":"[SecuritySolutions] Fix recently installed jobs remains greyed out on EA page (#158821)\n\nisse: https://github.com/elastic/kibana/issues/158370\r\n\r\n## Summary\r\n\r\nBug: When enabling a job the count shows up but the job name stays grey\r\ninstead of turning black like other enabled jobs.\r\n\r\n**Before**\r\n\r\n![Jun-01-2023\r\n14-27-13](https://github.com/elastic/kibana/assets/1490444/ef45ecf3-fc2b-4bfe-87fb-6e762d1e7fb2)\r\n\r\n**After**\r\n![Jun-01-2023\r\n14-23-45](https://github.com/elastic/kibana/assets/1490444/813e7f40-9c36-4d85-b3d7-1f51ebffd4be)\r\n\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"81d092695aa61606b31b7d38eb1ba395ea3b0c1d","branchLabelMapping":{"^v8.9.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:fix","Team:Threat Hunting","Team: SecuritySolution","Team:Threat Hunting:Explore","v8.9.0","v8.8.1"],"number":158821,"url":"https://github.com/elastic/kibana/pull/158821","mergeCommit":{"message":"[SecuritySolutions] Fix recently installed jobs remains greyed out on EA page (#158821)\n\nisse: https://github.com/elastic/kibana/issues/158370\r\n\r\n## Summary\r\n\r\nBug: When enabling a job the count shows up but the job name stays grey\r\ninstead of turning black like other enabled jobs.\r\n\r\n**Before**\r\n\r\n![Jun-01-2023\r\n14-27-13](https://github.com/elastic/kibana/assets/1490444/ef45ecf3-fc2b-4bfe-87fb-6e762d1e7fb2)\r\n\r\n**After**\r\n![Jun-01-2023\r\n14-23-45](https://github.com/elastic/kibana/assets/1490444/813e7f40-9c36-4d85-b3d7-1f51ebffd4be)\r\n\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"81d092695aa61606b31b7d38eb1ba395ea3b0c1d"}},"sourceBranch":"main","suggestedTargetBranches":["8.8"],"targetPullRequestStates":[{"branch":"main","label":"v8.9.0","labelRegex":"^v8.9.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/158821","number":158821,"mergeCommit":{"message":"[SecuritySolutions] Fix recently installed jobs remains greyed out on EA page (#158821)\n\nisse: https://github.com/elastic/kibana/issues/158370\r\n\r\n## Summary\r\n\r\nBug: When enabling a job the count shows up but the job name stays grey\r\ninstead of turning black like other enabled jobs.\r\n\r\n**Before**\r\n\r\n![Jun-01-2023\r\n14-27-13](https://github.com/elastic/kibana/assets/1490444/ef45ecf3-fc2b-4bfe-87fb-6e762d1e7fb2)\r\n\r\n**After**\r\n![Jun-01-2023\r\n14-23-45](https://github.com/elastic/kibana/assets/1490444/813e7f40-9c36-4d85-b3d7-1f51ebffd4be)\r\n\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"81d092695aa61606b31b7d38eb1ba395ea3b0c1d"}},{"branch":"8.8","label":"v8.8.1","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->