### PR TITLE
[Synthetics] Unskip alerting default test

### DIFF
--- a/x-pack/test/api_integration/apis/synthetics/enable_default_alerting.ts
+++ b/x-pack/test/api_integration/apis/synthetics/enable_default_alerting.ts
@@ -17,8 +17,7 @@ import { Spaces } from '../../../alerting_api_integration/spaces_only/scenarios'
 import { ObjectRemover } from '../../../alerting_api_integration/common/lib';
 
 export default function ({ getService }: FtrProviderContext) {
-  // FLAKY: https://github.com/elastic/kibana/issues/158408
-  describe.skip('EnableDefaultAlerting', function () {
+  describe('EnableDefaultAlerting', function () {
     this.tags('skipCloud');
 
     const supertest = getService('supertest');


### PR DESCRIPTION
## Summary

fixes https://github.com/elastic/kibana/issues/158408

This wasn't flaky actually, we had a bad merge due to PR race condition. So that's why test failed at that time.