### PR TITLE
Fix observability solution name

### DIFF
--- a/docs/setup/connect-to-elasticsearch.asciidoc
+++ b/docs/setup/connect-to-elasticsearch.asciidoc
@@ -31,7 +31,7 @@ Discover, extract, and index your web content into App Search engines using the
 Search across Google Drive, GitHub, Salesforce, and many other web services using
 {workplace-search-ref}/workplace-search-content-sources.html[Workplace Search content sources].
 
-* *Elastic APM.*
+* *Elastic Observability.*
 Get logs, metrics, traces, and uptime data into the Elastic Stack.
 Integrations are available for popular services and platforms,
 such as Nginx, AWS, and MongoDB,


### PR DESCRIPTION
Not sure if the original text was intentional. 

If APM needs to be more prominent here, you could say *Elastic Observability and APM* , but it's misleading to say that you can use Elastic APM for all of the use cases listed here.

Note that I didn't search the Kibana Guide for other instances of this problem; I just noticed this while doing something else and wanted to make sure it's fixed.

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)


<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->