### PR TITLE
[8.8] [Migrations] Update all aliases with a single updateAliases() when relocating SO documents #158940

### DIFF
--- a/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/actions/index.ts
+++ b/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/actions/index.ts
@@ -106,7 +106,8 @@ export {
 
 import type { UnknownDocsFound } from './check_for_unknown_docs';
 import type { IncompatibleClusterRoutingAllocation } from './initialize_action';
-import { ClusterShardLimitExceeded } from './create_index';
+import type { ClusterShardLimitExceeded } from './create_index';
+import type { SynchronizationFailed } from './synchronize_migrators';
 
 export type {
   CheckForUnknownDocsParams,
@@ -174,6 +175,7 @@ export interface ActionErrorTypeMap {
   index_not_yellow_timeout: IndexNotYellowTimeout;
   cluster_shard_limit_exceeded: ClusterShardLimitExceeded;
   es_response_too_large: EsResponseTooLargeError;
+  synchronization_failed: SynchronizationFailed;
 }
 
 /**

--- a/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/actions/synchronize_migrators.test.ts
+++ b/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/actions/synchronize_migrators.test.ts
@@ -6,38 +6,36 @@
  * Side Public License, v 1.
  */
 import { synchronizeMigrators } from './synchronize_migrators';
-import { type Defer, defer } from '../kibana_migrator_utils';
+import { type WaitGroup, waitGroup as createWaitGroup } from '../kibana_migrator_utils';
 
 describe('synchronizeMigrators', () => {
-  let defers: Array<Defer<void>>;
-  let allDefersPromise: Promise<any>;
-  let migratorsDefers: Array<Defer<void>>;
+  let waitGroups: Array<WaitGroup<void>>;
+  let allWaitGroupsPromise: Promise<any>;
+  let migratorsWaitGroups: Array<WaitGroup<void>>;
 
   beforeEach(() => {
     jest.clearAllMocks();
 
-    defers = ['.kibana_cases', '.kibana_task_manager', '.kibana'].map(defer);
-    allDefersPromise = Promise.all(defers.map(({ promise }) => promise));
+    waitGroups = ['.kibana_cases', '.kibana_task_manager', '.kibana'].map(createWaitGroup);
+    allWaitGroupsPromise = Promise.all(waitGroups.map(({ promise }) => promise));
 
-    migratorsDefers = defers.map(({ resolve, reject }) => ({
+    migratorsWaitGroups = waitGroups.map(({ resolve, reject }) => ({
       resolve: jest.fn(resolve),
       reject: jest.fn(reject),
-      promise: allDefersPromise,
+      promise: allWaitGroupsPromise,
     }));
   });
 
   describe('when all migrators reach the synchronization point with a correct state', () => {
     it('unblocks all migrators and resolves Right', async () => {
-      const tasks = migratorsDefers.map((migratorDefer) => synchronizeMigrators(migratorDefer));
+      const tasks = migratorsWaitGroups.map((waitGroup) => synchronizeMigrators({ waitGroup }));
 
       const res = await Promise.all(tasks.map((task) => task()));
 
-      migratorsDefers.forEach((migratorDefer) =>
-        expect(migratorDefer.resolve).toHaveBeenCalledTimes(1)
+      migratorsWaitGroups.forEach((waitGroup) =>
+        expect(waitGroup.resolve).toHaveBeenCalledTimes(1)
       );
-      migratorsDefers.forEach((migratorDefer) =>
-        expect(migratorDefer.reject).not.toHaveBeenCalled()
-      );
+      migratorsWaitGroups.forEach((waitGroup) => expect(waitGroup.reject).not.toHaveBeenCalled());
 
       expect(res).toEqual([
         { _tag: 'Right', right: 'synchronized_successfully' },
@@ -48,13 +46,11 @@ describe('synchronizeMigrators', () => {
 
     it('migrators are not unblocked until the last one reaches the synchronization point', async () => {
       let resolved: number = 0;
-      migratorsDefers.forEach((migratorDefer) => migratorDefer.promise.then(() => ++resolved));
-      const [casesDefer, ...otherMigratorsDefers] = migratorsDefers;
+      migratorsWaitGroups.forEach((waitGroup) => waitGroup.promise.then(() => ++resolved));
+      const [casesDefer, ...otherMigratorsDefers] = migratorsWaitGroups;
 
       // we simulate that only kibana_task_manager and kibana migrators get to the sync point
-      const tasks = otherMigratorsDefers.map((migratorDefer) =>
-        synchronizeMigrators(migratorDefer)
-      );
+      const tasks = otherMigratorsDefers.map((waitGroup) => synchronizeMigrators({ waitGroup }));
       // we don't await for them, or we would be locked forever
       Promise.all(tasks.map((task) => task()));
 
@@ -65,7 +61,7 @@ describe('synchronizeMigrators', () => {
       expect(resolved).toEqual(0);
 
       // finally, the last migrator gets to the synchronization point
-      await synchronizeMigrators(casesDefer)();
+      await synchronizeMigrators({ waitGroup: casesDefer })();
       expect(resolved).toEqual(3);
     });
   });
@@ -75,18 +71,16 @@ describe('synchronizeMigrators', () => {
       it('synchronizedMigrators resolves Left for the rest of migrators', async () => {
         let resolved: number = 0;
         let errors: number = 0;
-        migratorsDefers.forEach((migratorDefer) =>
-          migratorDefer.promise.then(() => ++resolved).catch(() => ++errors)
+        migratorsWaitGroups.forEach((waitGroup) =>
+          waitGroup.promise.then(() => ++resolved).catch(() => ++errors)
         );
-        const [casesDefer, ...otherMigratorsDefers] = migratorsDefers;
+        const [casesDefer, ...otherMigratorsDefers] = migratorsWaitGroups;
 
         // we first make one random migrator fail and not reach the sync point
         casesDefer.reject('Oops. The cases migrator failed unexpectedly.');
 
         // the other migrators then try to synchronize
-        const tasks = otherMigratorsDefers.map((migratorDefer) =>
-          synchronizeMigrators(migratorDefer)
-        );
+        const tasks = otherMigratorsDefers.map((waitGroup) => synchronizeMigrators({ waitGroup }));
 
         expect(Promise.all(tasks.map((task) => task()))).resolves.toEqual([
           {
@@ -116,15 +110,13 @@ describe('synchronizeMigrators', () => {
       it('synchronizedMigrators resolves Left for the rest of migrators', async () => {
         let resolved: number = 0;
         let errors: number = 0;
-        migratorsDefers.forEach((migratorDefer) =>
-          migratorDefer.promise.then(() => ++resolved).catch(() => ++errors)
+        migratorsWaitGroups.forEach((waitGroup) =>
+          waitGroup.promise.then(() => ++resolved).catch(() => ++errors)
         );
-        const [casesDefer, ...otherMigratorsDefers] = migratorsDefers;
+        const [casesDefer, ...otherMigratorsDefers] = migratorsWaitGroups;
 
         // some migrators try to synchronize
-        const tasks = otherMigratorsDefers.map((migratorDefer) =>
-          synchronizeMigrators(migratorDefer)
-        );
+        const tasks = otherMigratorsDefers.map((waitGroup) => synchronizeMigrators({ waitGroup }));
 
         // we then make one random migrator fail and not reach the sync point
         casesDefer.reject('Oops. The cases migrator failed unexpectedly.');

--- a/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/actions/synchronize_migrators.test.ts
+++ b/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/actions/synchronize_migrators.test.ts
@@ -86,14 +86,14 @@ describe('synchronizeMigrators', () => {
           {
             _tag: 'Left',
             left: {
-              type: 'sync_failed',
+              type: 'synchronization_failed',
               error: 'Oops. The cases migrator failed unexpectedly.',
             },
           },
           {
             _tag: 'Left',
             left: {
-              type: 'sync_failed',
+              type: 'synchronization_failed',
               error: 'Oops. The cases migrator failed unexpectedly.',
             },
           },
@@ -125,14 +125,14 @@ describe('synchronizeMigrators', () => {
           {
             _tag: 'Left',
             left: {
-              type: 'sync_failed',
+              type: 'synchronization_failed',
               error: 'Oops. The cases migrator failed unexpectedly.',
             },
           },
           {
             _tag: 'Left',
             left: {
-              type: 'sync_failed',
+              type: 'synchronization_failed',
               error: 'Oops. The cases migrator failed unexpectedly.',
             },
           },

--- a/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/actions/synchronize_migrators.ts
+++ b/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/actions/synchronize_migrators.ts
@@ -10,11 +10,13 @@ import * as Either from 'fp-ts/lib/Either';
 import * as TaskEither from 'fp-ts/lib/TaskEither';
 import type { WaitGroup } from '../kibana_migrator_utils';
 
-export interface SyncFailed {
-  type: 'sync_failed';
+/** @internal */
+export interface SynchronizationFailed {
+  type: 'synchronization_failed';
   error: Error;
 }
 
+/** @internal */
 export interface SynchronizeMigratorsParams<T, U> {
   waitGroup: WaitGroup<T>;
   thenHook?: (res: any) => Either.Right<U>;
@@ -28,11 +30,11 @@ export function synchronizeMigrators<T, U>({
     Either.right(
       'synchronized_successfully' as const
     ) as Either.Right<'synchronized_successfully'> as unknown as Either.Right<U>,
-}: SynchronizeMigratorsParams<T, U>): TaskEither.TaskEither<SyncFailed, U> {
+}: SynchronizeMigratorsParams<T, U>): TaskEither.TaskEither<SynchronizationFailed, U> {
   return () => {
     waitGroup.resolve(payload);
     return waitGroup.promise
       .then((res) => (thenHook ? thenHook(res) : res))
-      .catch((error) => Either.left({ type: 'sync_failed' as const, error }));
+      .catch((error) => Either.left({ type: 'synchronization_failed' as const, error }));
   };
 }

--- a/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/actions/update_aliases.ts
+++ b/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/actions/update_aliases.ts
@@ -37,13 +37,6 @@ export interface UpdateAliasesParams {
   aliasActions: AliasAction[];
   timeout?: string;
 }
-
-/** @internal */
-export type UpdateAliasesReturnType = TaskEither.TaskEither<
-  IndexNotFound | AliasNotFound | RemoveIndexNotAConcreteIndex | RetryableEsClientError,
-  'update_aliases_succeeded'
->;
-
 /**
  * Calls the Update index alias API `_alias` with the provided alias actions.
  */
@@ -52,9 +45,11 @@ export const updateAliases =
     client,
     aliasActions,
     timeout = DEFAULT_TIMEOUT,
-  }: UpdateAliasesParams): UpdateAliasesReturnType =>
+  }: UpdateAliasesParams): TaskEither.TaskEither<
+    IndexNotFound | AliasNotFound | RemoveIndexNotAConcreteIndex | RetryableEsClientError,
+    'update_aliases_succeeded'
+  > =>
   () => {
-    if (!aliasActions || !aliasActions.length) throw Error('updating NO aliases!');
     return client.indices
       .updateAliases({
         actions: aliasActions,

--- a/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/actions/update_aliases.ts
+++ b/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/actions/update_aliases.ts
@@ -37,6 +37,13 @@ export interface UpdateAliasesParams {
   aliasActions: AliasAction[];
   timeout?: string;
 }
+
+/** @internal */
+export type UpdateAliasesReturnType = TaskEither.TaskEither<
+  IndexNotFound | AliasNotFound | RemoveIndexNotAConcreteIndex | RetryableEsClientError,
+  'update_aliases_succeeded'
+>;
+
 /**
  * Calls the Update index alias API `_alias` with the provided alias actions.
  */
@@ -45,11 +52,9 @@ export const updateAliases =
     client,
     aliasActions,
     timeout = DEFAULT_TIMEOUT,
-  }: UpdateAliasesParams): TaskEither.TaskEither<
-    IndexNotFound | AliasNotFound | RemoveIndexNotAConcreteIndex | RetryableEsClientError,
-    'update_aliases_succeeded'
-  > =>
+  }: UpdateAliasesParams): UpdateAliasesReturnType =>
   () => {
+    if (!aliasActions || !aliasActions.length) throw Error('updating NO aliases!');
     return client.indices
       .updateAliases({
         actions: aliasActions,

--- a/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/kibana_migrator_utils.test.ts
+++ b/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/kibana_migrator_utils.test.ts
@@ -17,16 +17,16 @@ import { MAIN_SAVED_OBJECT_INDEX } from '@kbn/core-saved-objects-server';
 import { loggerMock } from '@kbn/logging-mocks';
 import {
   calculateTypeStatuses,
-  createMultiPromiseDefer,
+  createWaitGroupMap,
   getCurrentIndexTypesMap,
   getIndicesInvolvedInRelocation,
   indexMapToIndexTypesMap,
 } from './kibana_migrator_utils';
 import { INDEX_MAP_BEFORE_SPLIT } from './kibana_migrator_utils.fixtures';
 
-describe('createMultiPromiseDefer', () => {
+describe('createWaitGroupMap', () => {
   it('creates defer objects with the same Promise', () => {
-    const defers = createMultiPromiseDefer(['.kibana', '.kibana_cases']);
+    const defers = createWaitGroupMap(['.kibana', '.kibana_cases']);
     expect(Object.keys(defers)).toHaveLength(2);
     expect(defers['.kibana'].promise).toEqual(defers['.kibana_cases'].promise);
     expect(defers['.kibana'].resolve).not.toEqual(defers['.kibana_cases'].resolve);
@@ -34,7 +34,7 @@ describe('createMultiPromiseDefer', () => {
   });
 
   it('the common Promise resolves when all defers resolve', async () => {
-    const defers = createMultiPromiseDefer(['.kibana', '.kibana_cases']);
+    const defers = createWaitGroupMap(['.kibana', '.kibana_cases']);
     let resolved = 0;
     Object.values(defers).forEach((defer) => defer.promise.then(() => ++resolved));
     defers['.kibana'].resolve();

--- a/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/kibana_migrator_utils.ts
+++ b/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/kibana_migrator_utils.ts
@@ -101,7 +101,7 @@ export async function getIndicesInvolvedInRelocation({
   defaultIndexTypesMap: IndexTypesMap;
   logger: Logger;
 }): Promise<string[]> {
-  const indicesWithMovingTypesSet = new Set<string>();
+  const indicesWithRelocatingTypesSet = new Set<string>();
 
   const currentIndexTypesMap = await getCurrentIndexTypesMap({
     client,
@@ -120,11 +120,11 @@ export async function getIndicesInvolvedInRelocation({
   Object.values(typeIndexDistribution)
     .filter(({ status }) => status === TypeStatus.Moved)
     .forEach(({ currentIndex, targetIndex }) => {
-      indicesWithMovingTypesSet.add(currentIndex!);
-      indicesWithMovingTypesSet.add(targetIndex!);
+      indicesWithRelocatingTypesSet.add(currentIndex!);
+      indicesWithRelocatingTypesSet.add(targetIndex!);
     });
 
-  return Array.from(indicesWithMovingTypesSet);
+  return Array.from(indicesWithRelocatingTypesSet);
 }
 
 export function indexMapToIndexTypesMap(indexMap: IndexMap): IndexTypesMap {

--- a/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/model/helpers.ts
+++ b/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/model/helpers.ts
@@ -20,6 +20,9 @@ import type { BulkIndexOperationTuple } from './create_batches';
 import { OutdatedDocumentsSearchRead, ReindexSourceToTempRead } from '../state';
 
 /** @internal */
+export const REINDEX_TEMP_SUFFIX = '_reindex_temp';
+
+/** @internal */
 export type Aliases = Partial<Record<string, string>>;
 
 /**
@@ -309,7 +312,7 @@ export function getMigrationType({
  * @returns A temporary index name to reindex documents
  */
 export const getTempIndexName = (indexPrefix: string, kibanaVersion: string): string =>
-  `${indexPrefix}_${kibanaVersion}_reindex_temp`;
+  `${indexPrefix}_${kibanaVersion}${REINDEX_TEMP_SUFFIX}`;
 
 /** Increase batchSize by 20% until a maximum of maxBatchSize */
 export const increaseBatchSize = (

--- a/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/model/model.test.ts
+++ b/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/model/model.test.ts
@@ -1790,7 +1790,7 @@ describe('migrations v2 model', () => {
 
       test('READY_TO_REINDEX_SYNC -> FATAL if the synchronization between migrators fails', () => {
         const res: ResponseType<'READY_TO_REINDEX_SYNC'> = Either.left({
-          type: 'sync_failed',
+          type: 'synchronization_failed',
           error: new Error('Other migrators failed to reach the synchronization point'),
         });
         const newState = model(state, res);
@@ -2051,7 +2051,7 @@ describe('migrations v2 model', () => {
       });
       test('DONE_REINDEXING_SYNC -> FATAL if the synchronization between migrators fails', () => {
         const res: ResponseType<'DONE_REINDEXING_SYNC'> = Either.left({
-          type: 'sync_failed',
+          type: 'synchronization_failed',
           error: new Error('Other migrators failed to reach the synchronization point'),
         });
         const newState = model(state, res);

--- a/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/model/model.test.ts
+++ b/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/model/model.test.ts
@@ -2970,10 +2970,10 @@ describe('migrations v2 model', () => {
         sourceIndex: Option.none as Option.None,
         targetIndex: '.kibana_7.11.0_001',
       };
-      test('CREATE_NEW_TARGET -> MARK_VERSION_INDEX_READY', () => {
+      test('CREATE_NEW_TARGET -> CHECK_VERSION_INDEX_READY_ACTIONS', () => {
         const res: ResponseType<'CREATE_NEW_TARGET'> = Either.right('create_index_succeeded');
         const newState = model(createNewTargetState, res);
-        expect(newState.controlState).toEqual('MARK_VERSION_INDEX_READY');
+        expect(newState.controlState).toEqual('CHECK_VERSION_INDEX_READY_ACTIONS');
         expect(newState.retryCount).toEqual(0);
         expect(newState.retryDelay).toEqual(0);
       });
@@ -2987,7 +2987,7 @@ describe('migrations v2 model', () => {
         expect(newState.retryCount).toEqual(1);
         expect(newState.retryDelay).toEqual(2000);
       });
-      test('CREATE_NEW_TARGET -> MARK_VERSION_INDEX_READY resets the retry count and delay', () => {
+      test('CREATE_NEW_TARGET -> CHECK_VERSION_INDEX_READY_ACTIONS resets the retry count and delay', () => {
         const res: ResponseType<'CREATE_NEW_TARGET'> = Either.right('create_index_succeeded');
         const testState = {
           ...createNewTargetState,
@@ -2996,7 +2996,7 @@ describe('migrations v2 model', () => {
         };
 
         const newState = model(testState, res);
-        expect(newState.controlState).toEqual('MARK_VERSION_INDEX_READY');
+        expect(newState.controlState).toEqual('CHECK_VERSION_INDEX_READY_ACTIONS');
         expect(newState.retryCount).toEqual(0);
         expect(newState.retryDelay).toEqual(0);
       });

--- a/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/model/model.ts
+++ b/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/model/model.ts
@@ -46,6 +46,7 @@ import {
   increaseBatchSize,
   hasLaterVersionAlias,
   aliasVersion,
+  REINDEX_TEMP_SUFFIX,
 } from './helpers';
 import { buildTempIndexMap, createBatches } from './create_batches';
 import type { MigrationLog } from '../types';
@@ -1541,7 +1542,7 @@ export const model = (currentState: State, resW: ResponseType<AllActionStates>):
         // migration from the same source.
         return { ...stateP, controlState: 'MARK_VERSION_INDEX_READY_CONFLICT' };
       } else if (isTypeof(left, 'index_not_found_exception')) {
-        if (left.index === stateP.tempIndex) {
+        if (left.index.endsWith(REINDEX_TEMP_SUFFIX)) {
           // another instance has already completed the migration and deleted
           // the temporary index
           return { ...stateP, controlState: 'MARK_VERSION_INDEX_READY_CONFLICT' };

--- a/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/next.test.ts
+++ b/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/next.test.ts
@@ -7,7 +7,7 @@
  */
 
 import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
-import { defer } from './kibana_migrator_utils';
+import { waitGroup } from './kibana_migrator_utils';
 import { next } from './next';
 import type { State } from './state';
 
@@ -15,12 +15,24 @@ describe('migrations v2 next', () => {
   it.todo('when state.retryDelay > 0 delays execution of the next action');
   it('DONE returns null', () => {
     const state = { controlState: 'DONE' } as State;
-    const action = next({} as ElasticsearchClient, (() => {}) as any, defer(), defer())(state);
+    const action = next(
+      {} as ElasticsearchClient,
+      (() => {}) as any,
+      waitGroup(),
+      waitGroup(),
+      waitGroup()
+    )(state);
     expect(action).toEqual(null);
   });
   it('FATAL returns null', () => {
     const state = { controlState: 'FATAL', reason: '' } as State;
-    const action = next({} as ElasticsearchClient, (() => {}) as any, defer(), defer())(state);
+    const action = next(
+      {} as ElasticsearchClient,
+      (() => {}) as any,
+      waitGroup(),
+      waitGroup(),
+      waitGroup()
+    )(state);
     expect(action).toEqual(null);
   });
 });

--- a/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/next.ts
+++ b/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/next.ts
@@ -9,7 +9,7 @@
 import * as Option from 'fp-ts/lib/Option';
 import { omit } from 'lodash';
 import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
-import type { Defer } from './kibana_migrator_utils';
+import type { WaitGroup } from './kibana_migrator_utils';
 import type {
   AllActionStates,
   CalculateExcludeFiltersState,
@@ -72,8 +72,9 @@ export type ResponseType<ControlState extends AllActionStates> = Awaited<
 export const nextActionMap = (
   client: ElasticsearchClient,
   transformRawDocs: TransformRawDocs,
-  readyToReindex: Defer<void>,
-  doneReindexing: Defer<void>
+  readyToReindex: WaitGroup<void>,
+  doneReindexing: WaitGroup<void>,
+  updateRelocationAliases: WaitGroup<Actions.AliasAction[]>
 ) => {
   return {
     INIT: (state: InitState) =>
@@ -141,7 +142,10 @@ export const nextActionMap = (
         indexName: state.tempIndex,
         mappings: state.tempIndexMappings,
       }),
-    READY_TO_REINDEX_SYNC: () => Actions.synchronizeMigrators(readyToReindex),
+    READY_TO_REINDEX_SYNC: () =>
+      Actions.synchronizeMigrators({
+        waitGroup: readyToReindex,
+      }),
     REINDEX_SOURCE_TO_TEMP_OPEN_PIT: (state: ReindexSourceToTempOpenPit) =>
       Actions.openPit({ client, index: state.sourceIndex.value }),
     REINDEX_SOURCE_TO_TEMP_READ: (state: ReindexSourceToTempRead) =>
@@ -174,7 +178,10 @@ export const nextActionMap = (
          */
         refresh: false,
       }),
-    DONE_REINDEXING_SYNC: () => Actions.synchronizeMigrators(doneReindexing),
+    DONE_REINDEXING_SYNC: () =>
+      Actions.synchronizeMigrators({
+        waitGroup: doneReindexing,
+      }),
     SET_TEMP_WRITE_BLOCK: (state: SetTempWriteBlock) =>
       Actions.setWriteBlock({ client, index: state.tempIndex }),
     CLONE_TEMP_TO_TARGET: (state: CloneTempToTarget) =>
@@ -242,6 +249,12 @@ export const nextActionMap = (
       }),
     MARK_VERSION_INDEX_READY: (state: MarkVersionIndexReady) =>
       Actions.updateAliases({ client, aliasActions: state.versionIndexReadyActions.value }),
+    MARK_VERSION_INDEX_READY_SYNC: (state: MarkVersionIndexReady) =>
+      Actions.synchronizeMigrators({
+        waitGroup: updateRelocationAliases,
+        payload: state.versionIndexReadyActions.value,
+        thenHook: (res) => res,
+      }),
     MARK_VERSION_INDEX_READY_CONFLICT: (state: MarkVersionIndexReadyConflict) =>
       Actions.fetchIndices({ client, indices: [state.currentAlias, state.versionAlias] }),
     LEGACY_SET_WRITE_BLOCK: (state: LegacySetWriteBlockState) =>
@@ -272,10 +285,17 @@ export const nextActionMap = (
 export const next = (
   client: ElasticsearchClient,
   transformRawDocs: TransformRawDocs,
-  readyToReindex: Defer<void>,
-  doneReindexing: Defer<void>
+  readyToReindex: WaitGroup<void>,
+  doneReindexing: WaitGroup<void>,
+  updateRelocationAliases: WaitGroup<Actions.AliasAction[]>
 ) => {
-  const map = nextActionMap(client, transformRawDocs, readyToReindex, doneReindexing);
+  const map = nextActionMap(
+    client,
+    transformRawDocs,
+    readyToReindex,
+    doneReindexing,
+    updateRelocationAliases
+  );
   return (state: State) => {
     const delay = createDelayFn(state);
 

--- a/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/run_resilient_migrator.test.ts
+++ b/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/run_resilient_migrator.test.ts
@@ -13,7 +13,7 @@ import { elasticsearchClientMock } from '@kbn/core-elasticsearch-client-server-m
 import { loggingSystemMock } from '@kbn/core-logging-server-mocks';
 import type { MigrationResult } from '@kbn/core-saved-objects-base-server-internal';
 import { createInitialState } from './initial_state';
-import { Defer } from './kibana_migrator_utils';
+import { waitGroup } from './kibana_migrator_utils';
 import { migrationStateActionMachine } from './migrations_state_action_machine';
 import { next } from './next';
 import { runResilientMigrator, type RunResilientMigratorParams } from './run_resilient_migrator';
@@ -127,8 +127,9 @@ const mockOptions = (): RunResilientMigratorParams => {
         },
       },
     },
-    readyToReindex: new Defer(),
-    doneReindexing: new Defer(),
+    readyToReindex: waitGroup(),
+    doneReindexing: waitGroup(),
+    updateRelocationAliases: waitGroup(),
     logger,
     transformRawDocs: jest.fn(),
     preMigrationScript: "ctx._id = ctx._source.type + ':' + ctx._id",

--- a/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/run_resilient_migrator.ts
+++ b/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/run_resilient_migrator.ts
@@ -17,7 +17,7 @@ import type {
   MigrationResult,
   IndexTypesMap,
 } from '@kbn/core-saved-objects-base-server-internal';
-import type { Defer } from './kibana_migrator_utils';
+import type { WaitGroup } from './kibana_migrator_utils';
 import type { TransformRawDocs } from './types';
 import { next } from './next';
 import { model } from './model';
@@ -25,6 +25,7 @@ import { createInitialState } from './initial_state';
 import { migrationStateActionMachine } from './migrations_state_action_machine';
 import { cleanup } from './migrations_state_machine_cleanup';
 import type { State } from './state';
+import type { AliasAction } from './actions';
 
 /**
  * To avoid the Elasticsearch-js client aborting our requests before we
@@ -48,8 +49,9 @@ export interface RunResilientMigratorParams {
   indexTypesMap: IndexTypesMap;
   targetMappings: IndexMapping;
   preMigrationScript?: string;
-  readyToReindex: Defer<any>;
-  doneReindexing: Defer<any>;
+  readyToReindex: WaitGroup<void>;
+  doneReindexing: WaitGroup<void>;
+  updateRelocationAliases: WaitGroup<AliasAction[]>;
   logger: Logger;
   transformRawDocs: TransformRawDocs;
   migrationVersionPerType: SavedObjectsMigrationVersion;
@@ -75,6 +77,7 @@ export async function runResilientMigrator({
   preMigrationScript,
   readyToReindex,
   doneReindexing,
+  updateRelocationAliases,
   transformRawDocs,
   migrationVersionPerType,
   indexPrefix,
@@ -100,7 +103,13 @@ export async function runResilientMigrator({
   return migrationStateActionMachine({
     initialState,
     logger,
-    next: next(migrationClient, transformRawDocs, readyToReindex, doneReindexing),
+    next: next(
+      migrationClient,
+      transformRawDocs,
+      readyToReindex,
+      doneReindexing,
+      updateRelocationAliases
+    ),
     model,
     abort: async (state?: State) => {
       // At this point, we could reject this migrator's defers and unblock other migrators

--- a/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/run_v2_migration.test.ts
+++ b/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/run_v2_migration.test.ts
@@ -22,8 +22,8 @@ import { buildTypesMappings, createIndexMap } from './core';
 import {
   getIndicesInvolvedInRelocation,
   indexMapToIndexTypesMap,
-  createMultiPromiseDefer,
-  Defer,
+  createWaitGroupMap,
+  waitGroup,
 } from './kibana_migrator_utils';
 import { runResilientMigrator } from './run_resilient_migrator';
 import { indexTypesMapMock, savedObjectTypeRegistryMock } from './run_resilient_migrator.fixtures';
@@ -41,7 +41,7 @@ jest.mock('./kibana_migrator_utils', () => {
   return {
     ...actual,
     indexMapToIndexTypesMap: jest.fn(actual.indexMapToIndexTypesMap),
-    createMultiPromiseDefer: jest.fn(actual.createMultiPromiseDefer),
+    createWaitGroupMap: jest.fn(actual.createWaitGroupMap),
     getIndicesInvolvedInRelocation: jest.fn(() => Promise.resolve(['.my_index', '.other_index'])),
   };
 });
@@ -79,9 +79,7 @@ const mockCreateIndexMap = createIndexMap as jest.MockedFunction<typeof createIn
 const mockIndexMapToIndexTypesMap = indexMapToIndexTypesMap as jest.MockedFunction<
   typeof indexMapToIndexTypesMap
 >;
-const mockCreateMultiPromiseDefer = createMultiPromiseDefer as jest.MockedFunction<
-  typeof createMultiPromiseDefer
->;
+const mockCreateWaitGroupMap = createWaitGroupMap as jest.MockedFunction<typeof createWaitGroupMap>;
 const mockGetIndicesInvolvedInRelocation = getIndicesInvolvedInRelocation as jest.MockedFunction<
   typeof getIndicesInvolvedInRelocation
 >;
@@ -93,7 +91,7 @@ describe('runV2Migration', () => {
   beforeEach(() => {
     mockCreateIndexMap.mockClear();
     mockIndexMapToIndexTypesMap.mockClear();
-    mockCreateMultiPromiseDefer.mockClear();
+    mockCreateWaitGroupMap.mockClear();
     mockGetIndicesInvolvedInRelocation.mockClear();
     mockRunResilientMigrator.mockClear();
   });
@@ -143,9 +141,14 @@ describe('runV2Migration', () => {
     const options = mockOptions();
     options.documentMigrator.prepareMigrations();
     await runV2Migration(options);
-    expect(createMultiPromiseDefer).toBeCalledTimes(2);
-    expect(createMultiPromiseDefer).toHaveBeenNthCalledWith(1, ['.my_index', '.other_index']);
-    expect(createMultiPromiseDefer).toHaveBeenNthCalledWith(2, ['.my_index', '.other_index']);
+    expect(mockCreateWaitGroupMap).toBeCalledTimes(3);
+    expect(mockCreateWaitGroupMap).toHaveBeenNthCalledWith(1, ['.my_index', '.other_index']);
+    expect(mockCreateWaitGroupMap).toHaveBeenNthCalledWith(2, ['.my_index', '.other_index']);
+    expect(mockCreateWaitGroupMap).toHaveBeenNthCalledWith(
+      3,
+      ['.my_index', '.other_index'],
+      expect.any(Function) // we expect to receive a method to update all aliases in this hook
+    );
   });
 
   it('calls runResilientMigrator for each migrator it must spawn', async () => {
@@ -168,6 +171,7 @@ describe('runV2Migration', () => {
         mustRelocateDocuments: true,
         readyToReindex: expect.any(Object),
         doneReindexing: expect.any(Object),
+        updateRelocationAliases: expect.any(Object),
       })
     );
     expect(runResilientMigrator).toHaveBeenNthCalledWith(
@@ -178,6 +182,7 @@ describe('runV2Migration', () => {
         mustRelocateDocuments: true,
         readyToReindex: expect.any(Object),
         doneReindexing: expect.any(Object),
+        updateRelocationAliases: expect.any(Object),
       })
     );
     expect(runResilientMigrator).toHaveBeenNthCalledWith(
@@ -188,14 +193,15 @@ describe('runV2Migration', () => {
         mustRelocateDocuments: false,
         readyToReindex: undefined,
         doneReindexing: undefined,
+        updateRelocationAliases: undefined,
       })
     );
   });
 
   it('awaits on all runResilientMigrator promises, and resolves with the results of each of them', async () => {
-    const myIndexMigratorDefer = new Defer<MigrationResult>();
-    const otherIndexMigratorDefer = new Defer();
-    const taskIndexMigratorDefer = new Defer();
+    const myIndexMigratorDefer = waitGroup<MigrationResult>();
+    const otherIndexMigratorDefer = waitGroup();
+    const taskIndexMigratorDefer = waitGroup();
     let migrationResults: MigrationResult[] | undefined;
 
     mockRunResilientMigrator.mockReturnValueOnce(myIndexMigratorDefer.promise);

--- a/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/state.ts
+++ b/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/state.ts
@@ -453,6 +453,14 @@ export interface MarkVersionIndexReady extends PostInitState {
   readonly versionIndexReadyActions: Option.Some<AliasAction[]>;
 }
 
+export interface MarkVersionIndexReadySync extends PostInitState {
+  /** Single "client.indices.updateAliases" operation
+   * to update multiple indices' aliases simultaneously
+   * */
+  readonly controlState: 'MARK_VERSION_INDEX_READY_SYNC';
+  readonly versionIndexReadyActions: Option.Some<AliasAction[]>;
+}
+
 export interface MarkVersionIndexReadyConflict extends PostInitState {
   /**
    * If the MARK_VERSION_INDEX_READY step fails another instance was
@@ -535,6 +543,7 @@ export type State = Readonly<
   | LegacyReindexWaitForTaskState
   | LegacySetWriteBlockState
   | MarkVersionIndexReady
+  | MarkVersionIndexReadySync
   | MarkVersionIndexReadyConflict
   | OutdatedDocumentsRefresh
   | OutdatedDocumentsSearchClosePit

--- a/src/core/server/integration_tests/saved_objects/migrations/group3/actions/actions.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/group3/actions/actions.test.ts
@@ -1875,7 +1875,7 @@ describe('migration actions', () => {
         expect(res).toMatchInlineSnapshot(`
           Object {
             "_tag": "Right",
-            "right": "create_index_succeeded",
+            "right": "index_already_exists",
           }
         `);
       });

--- a/src/core/server/integration_tests/saved_objects/migrations/group3/dot_kibana_split.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/group3/dot_kibana_split.test.ts
@@ -435,8 +435,8 @@ describe('split .kibana index into multiple system indices', () => {
       }
 
       const testKits = await Promise.all(
-        new Array(PARALLEL_MIGRATORS)
-          .fill({
+        new Array(PARALLEL_MIGRATORS).fill(true).map((_, index) =>
+          getKibanaMigratorTestKit({
             settings: {
               migrations: {
                 discardUnknownObjects: currentVersion,
@@ -446,13 +446,9 @@ describe('split .kibana index into multiple system indices', () => {
             kibanaIndex: MAIN_SAVED_OBJECT_INDEX,
             types: typeRegistry.getAllTypes(),
             defaultIndexTypesMap: DEFAULT_INDEX_TYPES_MAP,
+            logFilePath: Path.join(__dirname, `dot_kibana_split_instance_${index}.log`),
           })
-          .map((config, index) =>
-            getKibanaMigratorTestKit({
-              ...config,
-              logFilePath: Path.join(__dirname, `dot_kibana_split_instance_${index}.log`),
-            })
-          )
+        )
       );
 
       const results = await Promise.all(testKits.map((testKit) => testKit.runMigrations()));
@@ -485,7 +481,7 @@ describe('split .kibana index into multiple system indices', () => {
           task: 5,
         },
       });
-    }, 600000);
+    }, 1200000);
 
     afterEach(async () => {
       await esServer?.stop();

--- a/src/core/server/integration_tests/saved_objects/migrations/group3/dot_kibana_split.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/group3/dot_kibana_split.test.ts
@@ -373,8 +373,8 @@ describe('split .kibana index into multiple system indices', () => {
             `[${index}] UPDATE_TARGET_MAPPINGS_PROPERTIES -> UPDATE_TARGET_MAPPINGS_PROPERTIES_WAIT_FOR_TASK.`,
             `[${index}] UPDATE_TARGET_MAPPINGS_PROPERTIES_WAIT_FOR_TASK -> UPDATE_TARGET_MAPPINGS_META.`,
             `[${index}] UPDATE_TARGET_MAPPINGS_META -> CHECK_VERSION_INDEX_READY_ACTIONS.`,
-            `[${index}] CHECK_VERSION_INDEX_READY_ACTIONS -> MARK_VERSION_INDEX_READY.`,
-            `[${index}] MARK_VERSION_INDEX_READY -> DONE.`,
+            `[${index}] CHECK_VERSION_INDEX_READY_ACTIONS -> MARK_VERSION_INDEX_READY_SYNC.`,
+            `[${index}] MARK_VERSION_INDEX_READY_SYNC -> DONE.`,
             `[${index}] Migration completed after`,
           ],
           { ordered: true }
@@ -392,7 +392,6 @@ describe('split .kibana index into multiple system indices', () => {
       const { runMigrations } = await migratorTestKitFactory();
       await clearLog(logFilePath);
       await runMigrations();
-
       const logs = await parseLogFile(logFilePath);
       expect(logs).not.toContainLogEntries(['REINDEX', 'CREATE', 'UPDATE_TARGET_MAPPINGS']);
     });

--- a/src/core/server/integration_tests/saved_objects/migrations/group3/incompatible_cluster_routing_allocation.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/group3/incompatible_cluster_routing_allocation.test.ts
@@ -161,7 +161,7 @@ describe('incompatible_cluster_routing_allocation', () => {
           .map((str) => JSON5.parse(str)) as LogRecord[];
 
         expect(
-          records.find((rec) => rec.message.includes('MARK_VERSION_INDEX_READY -> DONE'))
+          records.find((rec) => rec.message.includes('MARK_VERSION_INDEX_READY_SYNC -> DONE'))
         ).toBeDefined();
       },
       { retryAttempts: 100, retryDelayMs: 500 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.8`:
 - [[Migrations] Update all aliases with a single updateAliases() when relocating SO documents (#158940)](https://github.com/elastic/kibana/pull/158940)

<!--- Backport version: Manual! -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)