### PR TITLE
Fix bug with memoization

### DIFF
--- a/x-pack/plugins/cases/public/components/user_actions/comment/registered_attachments.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/comment/registered_attachments.tsx
@@ -48,29 +48,28 @@ type BuilderArgs<C, R> = Pick<
 };
 
 /**
- * Provides a render function for attachment type
+ * Provides a render function for attachment type.
+ * memoize uses the first argument as the caching key.
+ * The argument is intentionally declared and unused to
+ * be able for TS to warn us in case we forgot to provide one.
  */
-const getAttachmentRenderer = (cachingKey: string) =>
-  memoize(
-    () => {
-      let AttachmentElement: React.ReactElement;
+const getAttachmentRenderer = memoize((cachingKey: string) => {
+  let AttachmentElement: React.ReactElement;
 
-      const renderCallback = (attachmentViewObject: AttachmentViewObject, props: object) => {
-        if (!attachmentViewObject.children) return;
+  const renderCallback = (attachmentViewObject: AttachmentViewObject, props: object) => {
+    if (!attachmentViewObject.children) return;
 
-        if (!AttachmentElement) {
-          AttachmentElement = React.createElement(attachmentViewObject.children, props);
-        } else {
-          AttachmentElement = React.cloneElement(AttachmentElement, props);
-        }
+    if (!AttachmentElement) {
+      AttachmentElement = React.createElement(attachmentViewObject.children, props);
+    } else {
+      AttachmentElement = React.cloneElement(AttachmentElement, props);
+    }
 
-        return <Suspense fallback={<EuiLoadingSpinner />}>{AttachmentElement}</Suspense>;
-      };
+    return <Suspense fallback={<EuiLoadingSpinner />}>{AttachmentElement}</Suspense>;
+  };
 
-      return renderCallback;
-    },
-    () => cachingKey
-  );
+  return renderCallback;
+});
 
 export const createRegisteredAttachmentUserActionBuilder = <
   C extends Comment,
@@ -124,7 +123,7 @@ export const createRegisteredAttachmentUserActionBuilder = <
 
     const attachmentViewObject = attachmentType.getAttachmentViewObject(props);
 
-    const renderer = getAttachmentRenderer(userAction.id)();
+    const renderer = getAttachmentRenderer(userAction.id);
     const actions = attachmentViewObject.getActions?.(props) ?? [];
     const [primaryActions, nonPrimaryActions] = partition(actions, 'isPrimary');
     const visiblePrimaryActions = primaryActions.slice(0, 2);


### PR DESCRIPTION
## Summary

In https://github.com/elastic/kibana/pull/158441 we fix a bug with memoization of the react components of registered attachments in Cases. Though we fixed the bug, this change here https://github.com/elastic/kibana/pull/158441#discussion_r1206323660 broke the memorization. This PR fixes the memorization. 

## Testing instructions

1. Verify that you cannot reproduce https://github.com/elastic/kibana/issues/158447 
2. Verify that if you update the case (change the status for example), the components do not rerender again. If they rerender you should see loading spinners in the visualizations.

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->