### PR TITLE
Make Operations team codeowners of /src/cli/serve

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -904,6 +904,7 @@ x-pack/test/observability_functional @elastic/actionable-observability
 /src/dev/ @elastic/kibana-operations
 /src/setup_node_env/ @elastic/kibana-operations
 /src/cli/keystore/ @elastic/kibana-operations
+/src/cli/serve/ @elastic/kibana-operations
 /.ci/es-snapshots/ @elastic/kibana-operations
 /.github/workflows/ @elastic/kibana-operations
 /vars/ @elastic/kibana-operations
@@ -931,7 +932,6 @@ x-pack/test/observability_functional @elastic/actionable-observability
 # Core
 /config/kibana.yml @elastic/kibana-core
 /typings/ @elastic/kibana-core
-/src/cli/serve/ @elastic/kibana-core
 /test/analytics @elastic/kibana-core
 /x-pack/test/saved_objects_field_count/ @elastic/kibana-core
 #CC# /src/core/server/csp/ @elastic/kibana-core

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -931,8 +931,9 @@ x-pack/test/observability_functional @elastic/actionable-observability
 # Core
 /config/kibana.yml @elastic/kibana-core
 /typings/ @elastic/kibana-core
-/x-pack/test/saved_objects_field_count/ @elastic/kibana-core
+/src/cli/serve/ @elastic/kibana-core
 /test/analytics @elastic/kibana-core
+/x-pack/test/saved_objects_field_count/ @elastic/kibana-core
 #CC# /src/core/server/csp/ @elastic/kibana-core
 #CC# /src/plugins/saved_objects/ @elastic/kibana-core
 #CC# /x-pack/plugins/cloud/ @elastic/kibana-core


### PR DESCRIPTION
I'm pretty sure it's @elastic/kibana-core who owns the `src/cli/serve` directory, but I'm not 100% sure