### PR TITLE
[Versioned HTTP] Track adoption

### DIFF
--- a/packages/core/http/core-http-server/src/router/router.ts
+++ b/packages/core/http/core-http-server/src/router/router.ts
@@ -43,6 +43,8 @@ export interface IRouter<Context extends RequestHandlerContextBase = RequestHand
    * Register a route handler for `GET` request.
    * @param route {@link RouteConfig} - a route configuration.
    * @param handler {@link RequestHandler} - a function to call to respond to an incoming request
+   *
+   * @track-adoption
    */
   get: RouteRegistrar<'get', Context>;
 
@@ -50,6 +52,8 @@ export interface IRouter<Context extends RequestHandlerContextBase = RequestHand
    * Register a route handler for `POST` request.
    * @param route {@link RouteConfig} - a route configuration.
    * @param handler {@link RequestHandler} - a function to call to respond to an incoming request
+   *
+   * @track-adoption
    */
   post: RouteRegistrar<'post', Context>;
 
@@ -57,6 +61,8 @@ export interface IRouter<Context extends RequestHandlerContextBase = RequestHand
    * Register a route handler for `PUT` request.
    * @param route {@link RouteConfig} - a route configuration.
    * @param handler {@link RequestHandler} - a function to call to respond to an incoming request
+   *
+   * @track-adoption
    */
   put: RouteRegistrar<'put', Context>;
 
@@ -64,6 +70,8 @@ export interface IRouter<Context extends RequestHandlerContextBase = RequestHand
    * Register a route handler for `PATCH` request.
    * @param route {@link RouteConfig} - a route configuration.
    * @param handler {@link RequestHandler} - a function to call to respond to an incoming request
+   *
+   * @track-adoption
    */
   patch: RouteRegistrar<'patch', Context>;
 
@@ -71,6 +79,8 @@ export interface IRouter<Context extends RequestHandlerContextBase = RequestHand
    * Register a route handler for `DELETE` request.
    * @param route {@link RouteConfig} - a route configuration.
    * @param handler {@link RequestHandler} - a function to call to respond to an incoming request
+   *
+   * @track-adoption
    */
   delete: RouteRegistrar<'delete', Context>;
 

--- a/packages/core/http/core-http-server/src/versioning/types.ts
+++ b/packages/core/http/core-http-server/src/versioning/types.ts
@@ -140,15 +140,30 @@ export type VersionedRouteRegistrar<Method extends RouteMethod, Ctx extends RqCt
  * @experimental
  */
 export interface VersionedRouter<Ctx extends RqCtx = RqCtx> {
-  /** @experimental */
+  /**
+   * @experimental
+   * @track-adoption
+   */
   get: VersionedRouteRegistrar<'get', Ctx>;
-  /** @experimental */
+  /**
+   * @experimental
+   * @track-adoption
+   */
   put: VersionedRouteRegistrar<'put', Ctx>;
-  /** @experimental */
+  /**
+   * @experimental
+   * @track-adoption
+   */
   post: VersionedRouteRegistrar<'post', Ctx>;
-  /** @experimental */
+  /**
+   * @experimental
+   * @track-adoption
+   */
   patch: VersionedRouteRegistrar<'patch', Ctx>;
-  /** @experimental */
+  /**
+   * @experimental
+   * @track-adoption
+   */
   delete: VersionedRouteRegistrar<'delete', Ctx>;
 }
 


### PR DESCRIPTION
## Summary

Just adding `@track-adoption` to the versioned and non-versioned APIs so we can track how the adoption is evolving.

Here's the first set of metrics pushed to our API-Adoption dashboard:
<img width="2541" alt="image" src="https://github.com/elastic/kibana/assets/5469006/1653871c-d1dd-42b9-8961-15ef73c878e8">
[Link to dashboard](https://kibana-stats.elastic.dev/app/dashboards#/view/3bd81a70-7228-11ed-9daf-bd934924b770?_g=(filters%3A!()%2CrefreshInterval%3A(pause%3A!t%2Cvalue%3A0)%2Ctime%3A(from%3Anow-24h%2Fh%2Cto%3Anow)))

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
