### PR TITLE
[Failing Tests] Skips and comments tests failing with no_shard_available_action

### DIFF
--- a/x-pack/test/saved_object_api_integration/spaces_only/apis/import.ts
+++ b/x-pack/test/saved_object_api_integration/spaces_only/apis/import.ts
@@ -147,7 +147,10 @@ export default function ({ getService }: FtrProviderContext) {
     return tests.flat();
   };
 
-  describe('_import', () => {
+  // FLAKY: https://github.com/elastic/kibana/issues/158586
+  // Also, https://github.com/elastic/kibana/issues/158918
+  // esArchiver fails with no_shard_available_action_exception after deleting indexes
+  describe.skip('_import', () => {
     getTestScenarios([
       [false, false],
       [false, true],

--- a/x-pack/test/saved_object_api_integration/spaces_only/apis/resolve.ts
+++ b/x-pack/test/saved_object_api_integration/spaces_only/apis/resolve.ts
@@ -41,7 +41,9 @@ export default function ({ getService }: FtrProviderContext) {
     return createTestDefinitions(testCases, false, { spaceId });
   };
 
-  // FLAKY: https://github.com/elastic/kibana/issues/156998
+  // FLAKY: https://github.com/elastic/kibana/issues/156998, https://github.com/elastic/kibana/issues/156922, https://github.com/elastic/kibana/issues/156921
+  // Also, https://github.com/elastic/kibana/issues/158918
+  // esArchiver fails with no_shard_available_action_exception after deleting indexes
   describe.skip('_resolve', () => {
     getTestScenarios().spaces.forEach(({ spaceId }) => {
       const tests = createTests(spaceId);

--- a/x-pack/test/saved_object_api_integration/spaces_only/apis/resolve_import_errors.ts
+++ b/x-pack/test/saved_object_api_integration/spaces_only/apis/resolve_import_errors.ts
@@ -130,7 +130,9 @@ export default function ({ getService }: FtrProviderContext) {
     return createTestDefinitions(testCases, false, { overwrite, spaceId, singleRequest });
   };
 
-  // FLAKY: https://github.com/elastic/kibana/issues/155846
+  // FLAKY: https://github.com/elastic/kibana/issues/155846, https://github.com/elastic/kibana/issues/156045, https://github.com/elastic/kibana/issues/156041
+  // Also, https://github.com/elastic/kibana/issues/158918
+  // esArchiver fails with no_shard_available_action_exception after deleting indexes
   describe.skip('_resolve_import_errors', () => {
     getTestScenarios([
       [false, false],

--- a/x-pack/test/spaces_api_integration/spaces_only/apis/disable_legacy_url_aliases.ts
+++ b/x-pack/test/spaces_api_integration/spaces_only/apis/disable_legacy_url_aliases.ts
@@ -43,8 +43,5 @@ export default function ({ getService }: FtrProviderContext) {
 
   const testCases = createTestCases();
   const tests = createTestDefinitions(testCases, false);
-  // FLAKY: https://github.com/elastic/kibana/issues/158711, https://github.com/elastic/kibana/issues/158366
-  // Also, https://github.com/elastic/kibana/issues/158918
-  // esArchiver fails with no_shard_available_action_exception after deleting indexes
-  // addTests(`_disable_legacy_url_aliases`, { tests });
+  addTests(`_disable_legacy_url_aliases`, { tests });
 }

--- a/x-pack/test/spaces_api_integration/spaces_only/apis/disable_legacy_url_aliases.ts
+++ b/x-pack/test/spaces_api_integration/spaces_only/apis/disable_legacy_url_aliases.ts
@@ -43,5 +43,8 @@ export default function ({ getService }: FtrProviderContext) {
 
   const testCases = createTestCases();
   const tests = createTestDefinitions(testCases, false);
-  addTests(`_disable_legacy_url_aliases`, { tests });
+  // FLAKY: https://github.com/elastic/kibana/issues/158711, https://github.com/elastic/kibana/issues/158366
+  // Also, https://github.com/elastic/kibana/issues/158918
+  // esArchiver fails with no_shard_available_action_exception after deleting indexes
+  // addTests(`_disable_legacy_url_aliases`, { tests });
 }

--- a/x-pack/test/spaces_api_integration/spaces_only/apis/get.ts
+++ b/x-pack/test/spaces_api_integration/spaces_only/apis/get.ts
@@ -17,7 +17,9 @@ export default function getSpaceTestSuite({ getService }: FtrProviderContext) {
   const { getTest, createExpectResults, createExpectNotFoundResult, nonExistantSpaceId } =
     getTestSuiteFactory(esArchiver, supertestWithoutAuth);
 
-  // Failing: See https://github.com/elastic/kibana/issues/155723
+  // Failing: See https://github.com/elastic/kibana/issues/155723, https://github.com/elastic/kibana/issues/156422
+  // Also, https://github.com/elastic/kibana/issues/158918
+  // esArchiver fails with no_shard_available_action_exception after deleting indexes
   describe.skip('get', () => {
     // valid spaces
     [

--- a/x-pack/test/spaces_api_integration/spaces_only/apis/index.ts
+++ b/x-pack/test/spaces_api_integration/spaces_only/apis/index.ts
@@ -19,6 +19,9 @@ export default function spacesOnlyTestSuite({ loadTestFile }: FtrProviderContext
     loadTestFile(require.resolve('./get'));
     loadTestFile(require.resolve('./update'));
     loadTestFile(require.resolve('./update_objects_spaces'));
-    loadTestFile(require.resolve('./disable_legacy_url_aliases'));
+    // FLAKY: https://github.com/elastic/kibana/issues/158711, https://github.com/elastic/kibana/issues/158366
+    // Also, https://github.com/elastic/kibana/issues/158918
+    // esArchiver fails with no_shard_available_action_exception after deleting indexes
+    // loadTestFile(require.resolve('./disable_legacy_url_aliases'));
   });
 }

--- a/x-pack/test/spaces_api_integration/spaces_only/apis/update.ts
+++ b/x-pack/test/spaces_api_integration/spaces_only/apis/update.ts
@@ -17,7 +17,9 @@ export default function updateSpaceTestSuite({ getService }: FtrProviderContext)
   const { updateTest, expectAlreadyExistsResult, expectDefaultSpaceResult, expectNotFound } =
     updateTestSuiteFactory(esArchiver, supertestWithoutAuth);
 
-  // FLAKY: https://github.com/elastic/kibana/issues/156130
+  // FLAKY: https://github.com/elastic/kibana/issues/156130, https://github.com/elastic/kibana/issues/156074
+  // Also, https://github.com/elastic/kibana/issues/158918
+  // esArchiver fails with no_shard_available_action_exception after deleting indexes
   describe.skip('update', () => {
     [
       {

--- a/x-pack/test/spaces_api_integration/spaces_only/apis/update_objects_spaces.ts
+++ b/x-pack/test/spaces_api_integration/spaces_only/apis/update_objects_spaces.ts
@@ -183,7 +183,9 @@ export default function ({ getService }: FtrProviderContext) {
     return createTestDefinitions(testCases, false);
   };
 
-  // FLAKY: https://github.com/elastic/kibana/issues/156739
+  // FLAKY: https://github.com/elastic/kibana/issues/156739, https://github.com/elastic/kibana/issues/157673
+  // Also, https://github.com/elastic/kibana/issues/158918
+  // esArchiver fails with no_shard_available_action_exception after deleting indexes
   describe.skip('_update_objects_spaces', () => {
     getTestScenarios().spaces.forEach(({ spaceId }) => {
       const tests = createSinglePartTests(spaceId);


### PR DESCRIPTION
## Summary

Skips several tests failing with the `no_shard_available_action_exception`. Also adds comments noting the related test failure issues and the [master issue being tracked](https://github.com/elastic/kibana/issues/158918).

See issue #158918 and PR #159002.

<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->