### PR TITLE
[Console] Remove unused function

### DIFF
--- a/src/plugins/console/server/plugin.ts
+++ b/src/plugins/console/server/plugin.ts
@@ -83,9 +83,7 @@ export class ConsoleServerPlugin implements Plugin<ConsoleSetup, ConsoleStart> {
   }
 
   start() {
-    return {
-      ...this.specDefinitionsService.start(),
-    };
+    this.specDefinitionsService.start();
   }
 
   stop() {

--- a/src/plugins/console/server/services/spec_definitions_service.ts
+++ b/src/plugins/console/server/services/spec_definitions_service.ts
@@ -87,15 +87,6 @@ export class SpecDefinitionsService {
     this.extensionSpecFilePaths.push(path);
   }
 
-  public addProcessorDefinition(processor: unknown) {
-    if (!this.hasLoadedSpec) {
-      throw new Error(
-        'Cannot add a processor definition because spec definitions have not loaded!'
-      );
-    }
-    this.endpoints._processor!.data_autocomplete_rules.__one_of.push(processor);
-  }
-
   public setup() {
     return {
       addExtensionSpecFilePath: this.addExtensionSpecFilePath.bind(this),
@@ -107,9 +98,6 @@ export class SpecDefinitionsService {
       this.loadJsonSpec();
       this.loadJSSpec();
       this.hasLoadedSpec = true;
-      return {
-        addProcessorDefinition: this.addProcessorDefinition.bind(this),
-      };
     } else {
       throw new Error('Service has already started!');
     }


### PR DESCRIPTION
## Summary
While working on https://github.com/elastic/kibana/issues/159410, I noticed that there are some unused functions in the Console server side plugin contracts. This PR removes the function `addProcessorDefinition` from the `start` contract. I was not able to find any uses of this function in the Kibana code. I believe it might have been planned to be used for ingest processors but currently we use the `_processor` endpoint for that (see [here](https://github.com/elastic/kibana/blob/6f94e42a328a1fb3dc127ea823bbc8db3565a55e/src/plugins/console/server/lib/spec_definitions/js/ingest.ts#LL605C15-L605C37)). And since the tests also pass I think it's safe to remove this function. I'm using the label `release_note:breaking` because the plugin's contracts are public and theoretically it's possible that there are some external plugins that use that function. 

### Release note
The function `addProcessorDefinition` is removed from the Console plugin start contract (server side). 

