### PR TITLE
[SLO] Fix transformer bug with custom metric timeslices

### DIFF
--- a/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/metric_custom.test.ts.snap
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/metric_custom.test.ts.snap
@@ -87,8 +87,8 @@ Object {
       "slo.isGoodSlice": Object {
         "bucket_script": Object {
           "buckets_path": Object {
-            "goodEvents": "slo.numerator",
-            "totalEvents": "slo.denominator",
+            "goodEvents": "slo.numerator>value",
+            "totalEvents": "slo.denominator>value",
           },
           "script": "params.goodEvents / params.totalEvents >= 0.95 ? 1 : 0",
         },

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/metric_custom.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/metric_custom.ts
@@ -117,8 +117,8 @@ export class MetricCustomTransformGenerator extends TransformGenerator {
         'slo.isGoodSlice': {
           bucket_script: {
             buckets_path: {
-              goodEvents: 'slo.numerator',
-              totalEvents: 'slo.denominator',
+              goodEvents: 'slo.numerator>value',
+              totalEvents: 'slo.denominator>value',
             },
             script: `params.goodEvents / params.totalEvents >= ${slo.objective.timesliceTarget} ? 1 : 0`,
           },


### PR DESCRIPTION
## Summary

This PR fixes a bug with the transform code for custom metric when using timeslices. The bucket_path was missing `>value` suffix.