### PR TITLE
Upgrade EUI to v81.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "@elastic/datemath": "5.0.3",
     "@elastic/elasticsearch": "npm:@elastic/elasticsearch-canary@8.8.0-canary.2",
     "@elastic/ems-client": "8.4.0",
-    "@elastic/eui": "81.2.0",
+    "@elastic/eui": "81.3.0",
     "@elastic/filesaver": "1.1.2",
     "@elastic/node-crypto": "1.2.1",
     "@elastic/numeral": "^2.5.1",

--- a/src/dev/license_checker/config.ts
+++ b/src/dev/license_checker/config.ts
@@ -85,7 +85,7 @@ export const LICENSE_OVERRIDES = {
   'jsts@1.6.2': ['Eclipse Distribution License - v 1.0'], // cf. https://github.com/bjornharrtell/jsts
   '@mapbox/jsonlint-lines-primitives@2.0.2': ['MIT'], // license in readme https://github.com/tmcw/jsonlint
   '@elastic/ems-client@8.4.0': ['Elastic License 2.0'],
-  '@elastic/eui@81.2.0': ['SSPL-1.0 OR Elastic License 2.0'],
+  '@elastic/eui@81.3.0': ['SSPL-1.0 OR Elastic License 2.0'],
   'language-subtag-registry@0.3.21': ['CC-BY-4.0'], // retired ODC‑By license https://github.com/mattcg/language-subtag-registry
   'buffers@0.1.1': ['MIT'], // license in importing module https://www.npmjs.com/package/binary
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1552,10 +1552,10 @@
   resolved "https://registry.yarnpkg.com/@elastic/eslint-plugin-eui/-/eslint-plugin-eui-0.0.2.tgz#56b9ef03984a05cc213772ae3713ea8ef47b0314"
   integrity sha512-IoxURM5zraoQ7C8f+mJb9HYSENiZGgRVcG4tLQxE61yHNNRDXtGDWTZh8N1KIHcsqN1CEPETjuzBXkJYF/fDiQ==
 
-"@elastic/eui@81.2.0":
-  version "81.2.0"
-  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-81.2.0.tgz#cf48bb1437bd461ae48a347dcab5d232c988f085"
-  integrity sha512-JKp1NVoHWueWy704ierjD0ck+zAOH50aHuCnEMJWyVsixb0E89/9y/v1vn6VxIvrCs+6zo2OAMplG0RLQhvsFA==
+"@elastic/eui@81.3.0":
+  version "81.3.0"
+  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-81.3.0.tgz#dd1de5849d926c44a36eab2830d1a45415995352"
+  integrity sha512-IxZfBZ5ORpVrnFwfSJdY2brh/A4B4PEykL9D8e1S+BNKkRhU77IGBsGQ950/IBBMMrYed31IHhHUrwdGZV6UGA==
   dependencies:
     "@types/chroma-js" "^2.0.0"
     "@types/lodash" "^4.14.194"


### PR DESCRIPTION
## Summary

`eui@81.2.0` ⏩ `eui@81.3.0`

✨ Highlights:

- fixes https://github.com/elastic/kibana/issues/158644
- Adds a new Timeline icon for use within `EuiMarkdownEditor` (cc @kqualters-elastic)
- Expandable rows used within `EuiBasicTable` and `EuiInMemoryTable` now have a faster and snappier expand animation

___

## [`81.3.0`](https://github.com/elastic/eui/tree/v81.3.0)

- Added `timelineWithArrow` glyph to `EuiIcon` ([#6822](https://github.com/elastic/eui/pull/6822))

**Bug fixes**

- Fixed `EuiCodeBlock` potentially incorrectly ignoring lines ending with a question mark when using the Copy button. ([#6794](https://github.com/elastic/eui/pull/6794))
- Fixed `EuiCodeBlock` to not include line numbers when copying content ([#6824](https://github.com/elastic/eui/pull/6824))
- Fixed the expanded row animation on `EuiBasicTable` causing cross-browser Safari issues ([#6826](https://github.com/elastic/eui/pull/6826))