### PR TITLE
[maps] fix Map orphans sources on layer deletion

### DIFF
--- a/packages/kbn-mapbox-gl/index.ts
+++ b/packages/kbn-mapbox-gl/index.ts
@@ -13,6 +13,7 @@ import type {
   GeoJSONSource,
   VectorTileSource,
   RasterTileSource,
+  SourceSpecification,
   StyleSpecification,
   MapEvent,
   MapOptions,
@@ -45,6 +46,7 @@ export { maplibregl };
 export type {
   Map,
   LayerSpecification,
+  SourceSpecification,
   StyleSpecification,
   Source,
   GeoJSONSource,

--- a/x-pack/plugins/maps/public/connected_components/mb_map/mb_map.tsx
+++ b/x-pack/plugins/maps/public/connected_components/mb_map/mb_map.tsx
@@ -43,7 +43,7 @@ import {
 import { getCanAccessEmsFonts, getGlyphs, getKibanaFontsGlyphUrl } from './glyphs';
 import { syncLayerOrder } from './sort_layers';
 
-import { removeOrphanedSourcesAndLayers } from './utils';
+import { removeOrphanedSourcesAndLayers } from './remove_orphaned';
 import { RenderToolTipContent } from '../../classes/tooltips/tooltip_property';
 import { TileStatusTracker } from './tile_status_tracker';
 import { DrawFeatureControl } from './draw_control/draw_feature_control';

--- a/x-pack/plugins/maps/public/connected_components/mb_map/remove_orphaned.test.ts
+++ b/x-pack/plugins/maps/public/connected_components/mb_map/remove_orphaned.test.ts
@@ -7,7 +7,12 @@
 
 /* eslint-disable max-classes-per-file */
 
-import type { Map as MbMap, LayerSpecification, SourceSpecification, StyleSpecification } from '@kbn/mapbox-gl';
+import type {
+  Map as MbMap,
+  LayerSpecification,
+  SourceSpecification,
+  StyleSpecification,
+} from '@kbn/mapbox-gl';
 import { removeOrphanedSourcesAndLayers } from './remove_orphaned';
 import { SPATIAL_FILTERS_LAYER_ID } from '../../../common/constants';
 import _ from 'lodash';
@@ -39,9 +44,13 @@ class MockMbMap {
 class MockLayer {
   private readonly _layerId: string;
   private readonly _mbSourceIds: string[];
-  private readonly _mbLayerIdsToSource: { id: string, source: string }[];
+  private readonly _mbLayerIdsToSource: Array<{ id: string; source: string }>;
 
-  constructor(layerId: string, mbSourceIds: string[], mbLayerIdsToSource: { id: string, source: string }[]) {
+  constructor(
+    layerId: string,
+    mbSourceIds: string[],
+    mbLayerIdsToSource: Array<{ id: string; source: string }>
+  ) {
     this._mbSourceIds = mbSourceIds;
     this._mbLayerIdsToSource = mbLayerIdsToSource;
     this._layerId = layerId;
@@ -80,8 +89,8 @@ function getMockStyle(orderedMockLayerList: MockLayer[]) {
     });
     mockLayer.getMbLayersIdsToSource().forEach(({ id, source }) => {
       mockStyle.layers.push({
-        id: id,
-        source: source,
+        id,
+        source,
       } as unknown as LayerSpecification);
     });
   });
@@ -128,7 +137,11 @@ describe('removeOrphanedSourcesAndLayers', () => {
     const currentStyle = getMockStyle(currentLayerList);
     const mockMbMap = new MockMbMap(currentStyle);
 
-    removeOrphanedSourcesAndLayers(mockMbMap as unknown as MbMap, nextLayerList as unknown as ILayer[], spatialFilterLayer as unknown as ILayer);
+    removeOrphanedSourcesAndLayers(
+      mockMbMap as unknown as MbMap,
+      nextLayerList as unknown as ILayer[],
+      spatialFilterLayer as unknown as ILayer
+    );
     const removedStyle = mockMbMap.getStyle();
 
     const nextStyle = getMockStyle(nextLayerList);
@@ -146,7 +159,11 @@ describe('removeOrphanedSourcesAndLayers', () => {
     const currentStyle = getMockStyle(currentLayerList);
     const mockMbMap = new MockMbMap(currentStyle);
 
-    removeOrphanedSourcesAndLayers(mockMbMap as unknown as MbMap, nextLayerList as unknown as ILayer[], spatialFilterLayer as unknown as ILayer);
+    removeOrphanedSourcesAndLayers(
+      mockMbMap as unknown as MbMap,
+      nextLayerList as unknown as ILayer[],
+      spatialFilterLayer as unknown as ILayer
+    );
     const removedStyle = mockMbMap.getStyle();
 
     const nextStyle = getMockStyle(nextLayerList);
@@ -164,7 +181,11 @@ describe('removeOrphanedSourcesAndLayers', () => {
     const currentStyle = getMockStyle(currentLayerList);
     const mockMbMap = new MockMbMap(currentStyle);
 
-    removeOrphanedSourcesAndLayers(mockMbMap as unknown as MbMap, nextLayerList as unknown as ILayer[], spatialFilterLayer as unknown as ILayer);
+    removeOrphanedSourcesAndLayers(
+      mockMbMap as unknown as MbMap,
+      nextLayerList as unknown as ILayer[],
+      spatialFilterLayer as unknown as ILayer
+    );
     const removedStyle = mockMbMap.getStyle();
 
     const nextStyle = getMockStyle(nextLayerList);
@@ -175,7 +196,11 @@ describe('removeOrphanedSourcesAndLayers', () => {
     const styleWithSpatialFilters = getMockStyle([spatialFilterLayer]);
     const mockMbMap = new MockMbMap(styleWithSpatialFilters);
 
-    removeOrphanedSourcesAndLayers(mockMbMap as unknown as MbMap, [], spatialFilterLayer as unknown as ILayer);
+    removeOrphanedSourcesAndLayers(
+      mockMbMap as unknown as MbMap,
+      [],
+      spatialFilterLayer as unknown as ILayer
+    );
     expect(mockMbMap.getStyle()).toEqual(styleWithSpatialFilters);
   });
 
@@ -187,10 +212,17 @@ describe('removeOrphanedSourcesAndLayers', () => {
     const currentStyle = getMockStyle(currentLayerList);
     const mockMbMap = new MockMbMap(currentStyle);
 
-    removeOrphanedSourcesAndLayers(mockMbMap as unknown as MbMap, [], spatialFilterLayer as unknown as ILayer);
+    removeOrphanedSourcesAndLayers(
+      mockMbMap as unknown as MbMap,
+      [],
+      spatialFilterLayer as unknown as ILayer
+    );
     const removedStyle = mockMbMap.getStyle();
 
-    expect(Object.keys(removedStyle.sources)).toEqual(['SPATIAL_FILTERS_LAYER_ID_source1', 'SPATIAL_FILTERS_LAYER_ID_source2']);
+    expect(Object.keys(removedStyle.sources)).toEqual([
+      'SPATIAL_FILTERS_LAYER_ID_source1',
+      'SPATIAL_FILTERS_LAYER_ID_source2',
+    ]);
   });
 
   test('should not remove mapbox gl draw layers and sources', () => {
@@ -201,7 +233,11 @@ describe('removeOrphanedSourcesAndLayers', () => {
     currentStyle.layers.push({ id: 'gl-draw-points' } as unknown as LayerSpecification);
     const mockMbMap = new MockMbMap(currentStyle);
 
-    removeOrphanedSourcesAndLayers(mockMbMap as unknown as MbMap, layerList as unknown as ILayer[], spatialFilterLayer as unknown as ILayer);
+    removeOrphanedSourcesAndLayers(
+      mockMbMap as unknown as MbMap,
+      layerList as unknown as ILayer[],
+      spatialFilterLayer as unknown as ILayer
+    );
     expect(mockMbMap.getStyle()).toEqual(currentStyle);
   });
 });

--- a/x-pack/plugins/maps/public/connected_components/mb_map/remove_orphaned.test.ts
+++ b/x-pack/plugins/maps/public/connected_components/mb_map/remove_orphaned.test.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+/* eslint-disable max-classes-per-file */
+
 import type { Map as MbMap, LayerSpecification, SourceSpecification, StyleSpecification } from '@kbn/mapbox-gl';
 import { removeOrphanedSourcesAndLayers } from './remove_orphaned';
 import { SPATIAL_FILTERS_LAYER_ID } from '../../../common/constants';
@@ -20,21 +22,6 @@ class MockMbMap {
 
   getStyle() {
     return _.cloneDeep(this._style);
-  }
-
-  moveLayer(mbLayerId: string, nextMbLayerId: string) {
-    const indexOfLayerToMove = this._style.layers.findIndex((layer) => {
-      return layer.id === mbLayerId;
-    });
-
-    const layerToMove = this._style.layers[indexOfLayerToMove];
-    this._style.layers.splice(indexOfLayerToMove, 1);
-
-    const indexOfNextLayer = this._style.layers.findIndex((layer) => {
-      return layer.id === nextMbLayerId;
-    });
-
-    this._style.layers.splice(indexOfNextLayer, 0, layerToMove);
   }
 
   removeSource(sourceId: string) {

--- a/x-pack/plugins/maps/public/connected_components/mb_map/remove_orphaned.test.ts
+++ b/x-pack/plugins/maps/public/connected_components/mb_map/remove_orphaned.test.ts
@@ -5,12 +5,16 @@
  * 2.0.
  */
 
-import { removeOrphanedSourcesAndLayers } from './utils';
+import type { Map as MbMap, LayerSpecification, SourceSpecification, StyleSpecification } from '@kbn/mapbox-gl';
+import { removeOrphanedSourcesAndLayers } from './remove_orphaned';
 import { SPATIAL_FILTERS_LAYER_ID } from '../../../common/constants';
 import _ from 'lodash';
+import { ILayer } from '../../classes/layers/layer';
 
 class MockMbMap {
-  constructor(style) {
+  private _style: StyleSpecification;
+
+  constructor(style: StyleSpecification) {
     this._style = _.cloneDeep(style);
   }
 
@@ -18,7 +22,7 @@ class MockMbMap {
     return _.cloneDeep(this._style);
   }
 
-  moveLayer(mbLayerId, nextMbLayerId) {
+  moveLayer(mbLayerId: string, nextMbLayerId: string) {
     const indexOfLayerToMove = this._style.layers.findIndex((layer) => {
       return layer.id === mbLayerId;
     });
@@ -33,11 +37,11 @@ class MockMbMap {
     this._style.layers.splice(indexOfNextLayer, 0, layerToMove);
   }
 
-  removeSource(sourceId) {
+  removeSource(sourceId: string) {
     delete this._style.sources[sourceId];
   }
 
-  removeLayer(layerId) {
+  removeLayer(layerId: string) {
     const layerToRemove = this._style.layers.findIndex((layer) => {
       return layer.id === layerId;
     });
@@ -46,7 +50,11 @@ class MockMbMap {
 }
 
 class MockLayer {
-  constructor(layerId, mbSourceIds, mbLayerIdsToSource) {
+  private readonly _layerId: string;
+  private readonly _mbSourceIds: string[];
+  private readonly _mbLayerIdsToSource: { id: string, source: string }[];
+
+  constructor(layerId: string, mbSourceIds: string[], mbLayerIdsToSource: { id: string, source: string }[]) {
     this._mbSourceIds = mbSourceIds;
     this._mbLayerIdsToSource = mbLayerIdsToSource;
     this._layerId = layerId;
@@ -65,39 +73,40 @@ class MockLayer {
     return this._mbLayerIdsToSource.map(({ id }) => id);
   }
 
-  ownsMbLayerId(mbLayerId) {
+  ownsMbLayerId(mbLayerId: string) {
     return this._mbLayerIdsToSource.some((mbLayerToSource) => {
       return mbLayerToSource.id === mbLayerId;
     });
   }
 
-  ownsMbSourceId(mbSourceId) {
+  ownsMbSourceId(mbSourceId: string) {
     return this._mbSourceIds.some((id) => mbSourceId === id);
   }
 }
 
-function getMockStyle(orderedMockLayerList) {
+function getMockStyle(orderedMockLayerList: MockLayer[]) {
   const mockStyle = {
+    version: 8 as 8,
     sources: {},
     layers: [],
-  };
+  } as StyleSpecification;
 
   orderedMockLayerList.forEach((mockLayer) => {
     mockLayer.getMbSourceIds().forEach((mbSourceId) => {
-      mockStyle.sources[mbSourceId] = {};
+      mockStyle.sources[mbSourceId] = {} as unknown as SourceSpecification;
     });
     mockLayer.getMbLayersIdsToSource().forEach(({ id, source }) => {
       mockStyle.layers.push({
         id: id,
         source: source,
-      });
+      } as unknown as LayerSpecification);
     });
   });
 
   return mockStyle;
 }
 
-function makeSingleSourceMockLayer(layerId) {
+function makeSingleSourceMockLayer(layerId: string) {
   return new MockLayer(
     layerId,
     [layerId],
@@ -108,7 +117,7 @@ function makeSingleSourceMockLayer(layerId) {
   );
 }
 
-function makeMultiSourceMockLayer(layerId) {
+function makeMultiSourceMockLayer(layerId: string) {
   const source1 = layerId + '_source1';
   const source2 = layerId + '_source2';
   return new MockLayer(
@@ -136,14 +145,14 @@ describe('removeOrphanedSourcesAndLayers', () => {
     const currentStyle = getMockStyle(currentLayerList);
     const mockMbMap = new MockMbMap(currentStyle);
 
-    removeOrphanedSourcesAndLayers(mockMbMap, nextLayerList, spatialFilterLayer);
+    removeOrphanedSourcesAndLayers(mockMbMap as unknown as MbMap, nextLayerList as unknown as ILayer[], spatialFilterLayer as unknown as ILayer);
     const removedStyle = mockMbMap.getStyle();
 
     const nextStyle = getMockStyle(nextLayerList);
     expect(removedStyle).toEqual(nextStyle);
   });
 
-  test('should remove foo and bar layer (multisource)', async () => {
+  test('should remove foo and bar layer (multisource)', () => {
     const bazLayer = makeMultiSourceMockLayer('baz');
     const fooLayer = makeMultiSourceMockLayer('foo');
     const barLayer = makeMultiSourceMockLayer('bar');
@@ -154,14 +163,14 @@ describe('removeOrphanedSourcesAndLayers', () => {
     const currentStyle = getMockStyle(currentLayerList);
     const mockMbMap = new MockMbMap(currentStyle);
 
-    removeOrphanedSourcesAndLayers(mockMbMap, nextLayerList, spatialFilterLayer);
+    removeOrphanedSourcesAndLayers(mockMbMap as unknown as MbMap, nextLayerList as unknown as ILayer[], spatialFilterLayer as unknown as ILayer);
     const removedStyle = mockMbMap.getStyle();
 
     const nextStyle = getMockStyle(nextLayerList);
     expect(removedStyle).toEqual(nextStyle);
   });
 
-  test('should not remove anything', async () => {
+  test('should not remove anything', () => {
     const bazLayer = makeSingleSourceMockLayer('baz');
     const fooLayer = makeSingleSourceMockLayer('foo');
     const barLayer = makeSingleSourceMockLayer('bar');
@@ -172,30 +181,44 @@ describe('removeOrphanedSourcesAndLayers', () => {
     const currentStyle = getMockStyle(currentLayerList);
     const mockMbMap = new MockMbMap(currentStyle);
 
-    removeOrphanedSourcesAndLayers(mockMbMap, nextLayerList, spatialFilterLayer);
+    removeOrphanedSourcesAndLayers(mockMbMap as unknown as MbMap, nextLayerList as unknown as ILayer[], spatialFilterLayer as unknown as ILayer);
     const removedStyle = mockMbMap.getStyle();
 
     const nextStyle = getMockStyle(nextLayerList);
     expect(removedStyle).toEqual(nextStyle);
   });
 
-  test('should not remove spatial filter layer and sources when spatialFilterLayer is provided', async () => {
+  test('should not remove spatial filter layer and sources when spatialFilterLayer is provided', () => {
     const styleWithSpatialFilters = getMockStyle([spatialFilterLayer]);
     const mockMbMap = new MockMbMap(styleWithSpatialFilters);
 
-    removeOrphanedSourcesAndLayers(mockMbMap, [], spatialFilterLayer);
+    removeOrphanedSourcesAndLayers(mockMbMap as unknown as MbMap, [], spatialFilterLayer as unknown as ILayer);
     expect(mockMbMap.getStyle()).toEqual(styleWithSpatialFilters);
   });
 
-  test('should not remove mapbox gl draw layers and sources', async () => {
+  test('should remove sources after spatial filter layer', () => {
+    const barLayer = makeMultiSourceMockLayer('bar');
+
+    const currentLayerList = [spatialFilterLayer, barLayer];
+
+    const currentStyle = getMockStyle(currentLayerList);
+    const mockMbMap = new MockMbMap(currentStyle);
+
+    removeOrphanedSourcesAndLayers(mockMbMap as unknown as MbMap, [], spatialFilterLayer as unknown as ILayer);
+    const removedStyle = mockMbMap.getStyle();
+
+    expect(Object.keys(removedStyle.sources)).toEqual(['SPATIAL_FILTERS_LAYER_ID_source1', 'SPATIAL_FILTERS_LAYER_ID_source2']);
+  });
+
+  test('should not remove mapbox gl draw layers and sources', () => {
     const fooLayer = makeMultiSourceMockLayer('foo');
     const layerList = [fooLayer];
 
     const currentStyle = getMockStyle(layerList);
-    currentStyle.layers.push({ id: 'gl-draw-points' });
+    currentStyle.layers.push({ id: 'gl-draw-points' } as unknown as LayerSpecification);
     const mockMbMap = new MockMbMap(currentStyle);
 
-    removeOrphanedSourcesAndLayers(mockMbMap, layerList, spatialFilterLayer);
+    removeOrphanedSourcesAndLayers(mockMbMap as unknown as MbMap, layerList as unknown as ILayer[], spatialFilterLayer as unknown as ILayer);
     expect(mockMbMap.getStyle()).toEqual(currentStyle);
   });
 });

--- a/x-pack/plugins/maps/public/connected_components/mb_map/remove_orphaned.test.ts
+++ b/x-pack/plugins/maps/public/connected_components/mb_map/remove_orphaned.test.ts
@@ -46,9 +46,8 @@ class MockLayer {
     this._mbLayerIdsToSource = mbLayerIdsToSource;
     this._layerId = layerId;
   }
-  getId() {
-    return this._layerId;
-  }
+
+  // Custom interface used in getMockStyle for populating maplibre style with layers and sources
   getMbSourceIds() {
     return this._mbSourceIds;
   }
@@ -56,10 +55,7 @@ class MockLayer {
     return this._mbLayerIdsToSource;
   }
 
-  getMbLayerIds() {
-    return this._mbLayerIdsToSource.map(({ id }) => id);
-  }
-
+  // ILayer interface
   ownsMbLayerId(mbLayerId: string) {
     return this._mbLayerIdsToSource.some((mbLayerToSource) => {
       return mbLayerToSource.id === mbLayerId;

--- a/x-pack/plugins/maps/public/connected_components/mb_map/remove_orphaned.test.ts
+++ b/x-pack/plugins/maps/public/connected_components/mb_map/remove_orphaned.test.ts
@@ -45,10 +45,7 @@ class MockLayer {
   private readonly _mbSourceIds: string[];
   private readonly _mbLayerIdsToSource: Array<{ id: string; source: string }>;
 
-  constructor(
-    mbSourceIds: string[],
-    mbLayerIdsToSource: Array<{ id: string; source: string }>
-  ) {
+  constructor(mbSourceIds: string[], mbLayerIdsToSource: Array<{ id: string; source: string }>) {
     this._mbSourceIds = mbSourceIds;
     this._mbLayerIdsToSource = mbLayerIdsToSource;
   }

--- a/x-pack/plugins/maps/public/connected_components/mb_map/remove_orphaned.test.ts
+++ b/x-pack/plugins/maps/public/connected_components/mb_map/remove_orphaned.test.ts
@@ -42,18 +42,15 @@ class MockMbMap {
 }
 
 class MockLayer {
-  private readonly _layerId: string;
   private readonly _mbSourceIds: string[];
   private readonly _mbLayerIdsToSource: Array<{ id: string; source: string }>;
 
   constructor(
-    layerId: string,
     mbSourceIds: string[],
     mbLayerIdsToSource: Array<{ id: string; source: string }>
   ) {
     this._mbSourceIds = mbSourceIds;
     this._mbLayerIdsToSource = mbLayerIdsToSource;
-    this._layerId = layerId;
   }
 
   // Custom interface used in getMockStyle for populating maplibre style with layers and sources
@@ -99,12 +96,12 @@ function getMockStyle(orderedMockLayerList: MockLayer[]) {
 }
 
 function makeSingleSourceMockLayer(layerId: string) {
+  const source1 = layerId + '_source1';
   return new MockLayer(
-    layerId,
-    [layerId],
+    [source1],
     [
-      { id: layerId + '_fill', source: layerId },
-      { id: layerId + '_line', source: layerId },
+      { id: source1 + '_fill', source: source1 },
+      { id: source1 + '_line', source: source1 },
     ]
   );
 }
@@ -113,7 +110,6 @@ function makeMultiSourceMockLayer(layerId: string) {
   const source1 = layerId + '_source1';
   const source2 = layerId + '_source2';
   return new MockLayer(
-    layerId,
     [source1, source2],
     [
       { id: source1 + '_fill', source: source1 },

--- a/x-pack/plugins/maps/public/connected_components/mb_map/remove_orphaned.ts
+++ b/x-pack/plugins/maps/public/connected_components/mb_map/remove_orphaned.ts
@@ -19,7 +19,6 @@ export function removeOrphanedSourcesAndLayers(
     return;
   }
 
-  const mbLayerIdsToRemove: string[] = [];
   mbStyle.layers.forEach((mbLayer) => {
     // ignore mapbox layers from spatial filter layer
     if (spatialFilterLayer.ownsMbLayerId(mbLayer.id)) {
@@ -35,26 +34,23 @@ export function removeOrphanedSourcesAndLayers(
       return layer.ownsMbLayerId(mbLayer.id);
     });
     if (!targetLayer) {
-      mbLayerIdsToRemove.push(mbLayer.id);
+      mbMap.removeLayer(mbLayer.id)
     }
   });
-  mbLayerIdsToRemove.forEach((mbLayerId) => mbMap.removeLayer(mbLayerId));
 
-  const mbSourcesToRemove = [];
   for (const mbSourceId in mbStyle.sources) {
     if (mbStyle.sources.hasOwnProperty(mbSourceId)) {
       // ignore mapbox sources from spatial filter layer
       if (spatialFilterLayer.ownsMbSourceId(mbSourceId)) {
-        return;
+        continue;
       }
 
       const targetLayer = layerList.find((layer) => {
         return layer.ownsMbSourceId(mbSourceId);
       });
       if (!targetLayer) {
-        mbSourcesToRemove.push(mbSourceId);
+        mbMap.removeSource(mbSourceId);
       }
     }
   }
-  mbSourcesToRemove.forEach((mbSourceId) => mbMap.removeSource(mbSourceId));
 }

--- a/x-pack/plugins/maps/public/connected_components/mb_map/remove_orphaned.ts
+++ b/x-pack/plugins/maps/public/connected_components/mb_map/remove_orphaned.ts
@@ -34,7 +34,7 @@ export function removeOrphanedSourcesAndLayers(
       return layer.ownsMbLayerId(mbLayer.id);
     });
     if (!targetLayer) {
-      mbMap.removeLayer(mbLayer.id)
+      mbMap.removeLayer(mbLayer.id);
     }
   });
 


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/158133

Sources where not getting removed because `return` was used instead of `continue` in `for...in` loop. This caused the function to return instead of processing remaining sources.

<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->