### PR TITLE
[8.8] [SecuritySolutions] Fix anomalies table pagination on EA page (#158739)

### DIFF
--- a/x-pack/plugins/security_solution/public/overview/components/entity_analytics/anomalies/query/index.ts
+++ b/x-pack/plugins/security_solution/public/overview/components/entity_analytics/anomalies/query/index.ts
@@ -4,6 +4,8 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+// Maximum number of aggregation buckets allowed
+const MAX_BUCKET_SIZE = 10000;
 
 export const getAggregatedAnomaliesQuery = ({
   from,
@@ -52,6 +54,7 @@ export const getAggregatedAnomaliesQuery = ({
     number_of_anomalies: {
       terms: {
         field: 'job_id',
+        size: MAX_BUCKET_SIZE,
       },
       aggs: {
         entity: {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.8`:
 - [[SecuritySolutions] Fix anomalies table pagination on EA page (#158739)](https://github.com/elastic/kibana/pull/158739)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Pablo Machado","email":"pablo.nevesmachado@elastic.co"},"sourceCommit":{"committedDate":"2023-06-02T14:26:12Z","message":"[SecuritySolutions] Fix anomalies table pagination on EA page (#158739)\n\nissue: https://github.com/elastic/kibana/issues/158809\r\n\r\n\r\n## Summary\r\n\r\nThe anomalies table on the EA page only showed anomalies count data for\r\nthe 10 first jobs. That happened because the default bucket limit for\r\naggregations is 10. This bug started happening when we added more than\r\n10 jobs to the table.\r\n\r\n**Before**\r\n\r\n![Jun-01-2023\r\n10-41-01](https://github.com/elastic/kibana/assets/1490444/386cd69f-5531-40af-ab12-12476fababaa)\r\n\r\n**After**\r\n![Jun-01-2023\r\n10-48-17](https://github.com/elastic/kibana/assets/1490444/afee4d3d-4e19-4dfe-aa84-787c4fab060d)\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"11c4578db7fd56a83262b0caa16664eda8d906f7","branchLabelMapping":{"^v8.9.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:fix","backport:skip","Team:Threat Hunting","Team: SecuritySolution","Team:Threat Hunting:Explore","v8.9.0","v8.8.2"],"number":158739,"url":"https://github.com/elastic/kibana/pull/158739","mergeCommit":{"message":"[SecuritySolutions] Fix anomalies table pagination on EA page (#158739)\n\nissue: https://github.com/elastic/kibana/issues/158809\r\n\r\n\r\n## Summary\r\n\r\nThe anomalies table on the EA page only showed anomalies count data for\r\nthe 10 first jobs. That happened because the default bucket limit for\r\naggregations is 10. This bug started happening when we added more than\r\n10 jobs to the table.\r\n\r\n**Before**\r\n\r\n![Jun-01-2023\r\n10-41-01](https://github.com/elastic/kibana/assets/1490444/386cd69f-5531-40af-ab12-12476fababaa)\r\n\r\n**After**\r\n![Jun-01-2023\r\n10-48-17](https://github.com/elastic/kibana/assets/1490444/afee4d3d-4e19-4dfe-aa84-787c4fab060d)\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"11c4578db7fd56a83262b0caa16664eda8d906f7"}},"sourceBranch":"main","suggestedTargetBranches":["8.8"],"targetPullRequestStates":[{"branch":"main","label":"v8.9.0","labelRegex":"^v8.9.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/158739","number":158739,"mergeCommit":{"message":"[SecuritySolutions] Fix anomalies table pagination on EA page (#158739)\n\nissue: https://github.com/elastic/kibana/issues/158809\r\n\r\n\r\n## Summary\r\n\r\nThe anomalies table on the EA page only showed anomalies count data for\r\nthe 10 first jobs. That happened because the default bucket limit for\r\naggregations is 10. This bug started happening when we added more than\r\n10 jobs to the table.\r\n\r\n**Before**\r\n\r\n![Jun-01-2023\r\n10-41-01](https://github.com/elastic/kibana/assets/1490444/386cd69f-5531-40af-ab12-12476fababaa)\r\n\r\n**After**\r\n![Jun-01-2023\r\n10-48-17](https://github.com/elastic/kibana/assets/1490444/afee4d3d-4e19-4dfe-aa84-787c4fab060d)\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"11c4578db7fd56a83262b0caa16664eda8d906f7"}},{"branch":"8.8","label":"v8.8.2","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->