### PR TITLE
[ML] Explain Log Rate Spikes: Support `WindowParameters` for `autoAnalysisStart`.

### DIFF
--- a/x-pack/packages/ml/aiops_utils/src/get_window_parameters.ts
+++ b/x-pack/packages/ml/aiops_utils/src/get_window_parameters.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import { isPopulatedObject } from '@kbn/ml-is-populated-object';
+
 /**
  * Time range definition for baseline and deviation to be used by spike log analysis.
  *
@@ -34,6 +36,16 @@ export interface WindowParameters {
    */
   deviationMax: number;
 }
+
+/**
+ * Type guard for WindowParameters
+ *
+ * @param {unknown} arg - The argument to be checked.
+ * @returns {arg is WindowParameters}
+ */
+export const isWindowParameters = (arg: unknown): arg is WindowParameters =>
+  isPopulatedObject(arg, ['baselineMin', 'baselineMax', 'deviationMin', 'deviationMax']) &&
+  Object.values(arg).every((d) => typeof d === 'number');
 
 /**
  * Given a point in time (e.g. where a user clicks), use simple heuristics to compute:

--- a/x-pack/packages/ml/aiops_utils/tsconfig.json
+++ b/x-pack/packages/ml/aiops_utils/tsconfig.json
@@ -17,6 +17,7 @@
     "@kbn/logging",
     "@kbn/core-http-server",
     "@kbn/core-http-common",
+    "@kbn/ml-is-populated-object",
   ],
   "exclude": [
     "target/**/*",

--- a/x-pack/plugins/aiops/public/components/document_count_content/document_count_content/document_count_content.tsx
+++ b/x-pack/plugins/aiops/public/components/document_count_content/document_count_content/document_count_content.tsx
@@ -33,7 +33,7 @@ export interface DocumentCountContentProps {
   totalCount: number;
   sampleProbability: number;
   windowParameters?: WindowParameters;
-  incomingInitialAnalysisStart?: number;
+  incomingInitialAnalysisStart?: number | WindowParameters;
 }
 
 export const DocumentCountContent: FC<DocumentCountContentProps> = ({
@@ -48,9 +48,9 @@ export const DocumentCountContent: FC<DocumentCountContentProps> = ({
   incomingInitialAnalysisStart,
 }) => {
   const [isBrushCleared, setIsBrushCleared] = useState(true);
-  const [initialAnalysisStart, setInitialAnalysisStart] = useState<number | undefined>(
-    incomingInitialAnalysisStart
-  );
+  const [initialAnalysisStart, setInitialAnalysisStart] = useState<
+    number | WindowParameters | undefined
+  >(incomingInitialAnalysisStart);
 
   useEffect(() => {
     setIsBrushCleared(windowParameters === undefined);

--- a/x-pack/plugins/aiops/public/components/explain_log_rate_spikes/explain_log_rate_spikes_content/explain_log_rate_spikes_content.tsx
+++ b/x-pack/plugins/aiops/public/components/explain_log_rate_spikes/explain_log_rate_spikes_content/explain_log_rate_spikes_content.tsx
@@ -43,7 +43,7 @@ export interface ExplainLogRateSpikesContentProps {
   dataView: DataView;
   setGlobalState?: (params: Dictionary<unknown>) => void;
   /** Timestamp for the start of the range for initial analysis */
-  initialAnalysisStart?: number;
+  initialAnalysisStart?: number | WindowParameters;
   timeRange?: { min: Moment; max: Moment };
   /** Elasticsearch query to pass to analysis endpoint */
   esSearchQuery?: estypes.QueryDslQueryContainer;

--- a/x-pack/plugins/aiops/public/components/explain_log_rate_spikes/explain_log_rate_spikes_content/explain_log_rate_spikes_content_wrapper.tsx
+++ b/x-pack/plugins/aiops/public/components/explain_log_rate_spikes/explain_log_rate_spikes_content/explain_log_rate_spikes_content_wrapper.tsx
@@ -12,6 +12,7 @@ import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 
 import { EuiCallOut } from '@elastic/eui';
 
+import type { WindowParameters } from '@kbn/aiops-utils';
 import { i18n } from '@kbn/i18n';
 import type { DataView } from '@kbn/data-views-plugin/public';
 import { StorageContextProvider } from '@kbn/ml-local-storage';
@@ -39,7 +40,7 @@ export interface ExplainLogRateSpikesContentWrapperProps {
   /** On global timefilter update */
   setGlobalState?: any;
   /** Timestamp for start of initial analysis */
-  initialAnalysisStart?: number;
+  initialAnalysisStart?: number | WindowParameters;
   timeRange?: { min: Moment; max: Moment };
   /** Elasticsearch query to pass to analysis endpoint */
   esSearchQuery?: estypes.QueryDslQueryContainer;


### PR DESCRIPTION
## Summary

Related to #158960.

To allow for more fine grained control of the baseline and deviation time ranges for `autoAnalysisStart` this PR allows to pass in a `WindowParameters` object as an alternative to the plain timestamp. When more useful metadata is available this might lead to better selections then the default one provided by `getWindowParameters`.

### Checklist

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
