### PR TITLE
[Enterprise Search] Add service type to connector config code block

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_configuration.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_configuration.tsx
@@ -131,7 +131,7 @@ export const ConnectorConfiguration: React.FC = () => {
                       <EuiText size="s">
                         <FormattedMessage
                           id="xpack.enterpriseSearch.content.indices.configurationConnector.connectorPackage.description.thirdParagraph"
-                          defaultMessage="In this step, you will need to clone or fork the repository, and copy the generated API key and connector ID to the associated {link}. The connector ID will identify this connector to Enterprise Search."
+                          defaultMessage="In this step, you will need to clone or fork the repository, and copy the generated API key and connector ID to the associated {link}. The connector ID will identify this connector to Enterprise Search. The service type will determine which type of data source the connector is configured for."
                           values={{
                             link: (
                               <EuiLink
@@ -157,7 +157,8 @@ export const ConnectorConfiguration: React.FC = () => {
 `
                             : ''
                         }connector_id: "${index.connector.id}"
-            `}
+service_type: "${index.connector.service_type || 'changeme'}"
+`}
                       </EuiCodeBlock>
                       <EuiSpacer />
                       <EuiText size="s">


### PR DESCRIPTION
## Summary
This adds the necessary service type to the code block in the connector configuration screen. 

<img width="797" alt="Screenshot 2023-06-06 at 15 05 15" src="https://github.com/elastic/kibana/assets/94373878/9190e7bc-7960-45ef-b97d-f202a3f08ef8">

<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->