### PR TITLE
[Synthetics] Status alert fix index used for alerting query

### DIFF
--- a/x-pack/plugins/synthetics/server/alert_rules/status_rule/status_rule_executor.ts
+++ b/x-pack/plugins/synthetics/server/alert_rules/status_rule/status_rule_executor.ts
@@ -10,6 +10,7 @@ import {
   SavedObjectsFindResult,
 } from '@kbn/core-saved-objects-api-server';
 import { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
+import { SYNTHETICS_INDEX_PATTERN } from '../../../common/constants';
 import { getAllLocations } from '../../synthetics_service/get_all_locations';
 import {
   getAllMonitors,
@@ -61,7 +62,9 @@ export class StatusRuleExecutor {
     this.previousStartedAt = previousStartedAt;
     this.params = p;
     this.soClient = soClient;
-    this.esClient = new UptimeEsClient(this.soClient, scopedClient);
+    this.esClient = new UptimeEsClient(this.soClient, scopedClient, {
+      heartbeatIndices: SYNTHETICS_INDEX_PATTERN,
+    });
     this.server = server;
     this.syntheticsMonitorClient = syntheticsMonitorClient;
   }


### PR DESCRIPTION
## Summary

Monitor status alert is still using configured index pattern from uptime,

It needed to be hardcoded `synthetics-*`

<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->