### PR TITLE
[RAM] Fix flaky expiring snooze test

### DIFF
--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/snooze.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/snooze.ts
@@ -366,12 +366,14 @@ export default function createSnoozeRuleTests({ getService }: FtrProviderContext
         .get(`${getUrlPrefix(Spaces.space1.id)}/internal/alerting/rule/${createdRule.id}`)
         .set('kbn-xsrf', 'foo')
         .expect(200);
-      expect(updatedAlert.snooze_schedule).to.eql([
-        {
-          ...SNOOZE_SCHEDULE,
-          duration: 1000,
-        },
-      ]);
+      await retry.try(async () => {
+        expect(updatedAlert.snooze_schedule).to.eql([
+          {
+            ...SNOOZE_SCHEDULE,
+            duration: 1000,
+          },
+        ]);
+      });
       log.info('wait for snoozing to end');
       await retry.try(async () => {
         const { body: alertWithExpiredSnooze } = await supertestWithoutAuth


### PR DESCRIPTION
## Summary

Closes #159076 

Wraps a flaky bit of test in `retry.try`
