### PR TITLE
[8.8] [TaskManager] log health on interval with background_tasks only role (#158890)

### DIFF
--- a/x-pack/plugins/task_manager/server/lib/log_health_metrics.ts
+++ b/x-pack/plugins/task_manager/server/lib/log_health_metrics.ts
@@ -6,6 +6,7 @@
  */
 
 import { isEmpty } from 'lodash';
+import { Observable } from 'rxjs';
 import { Logger, DocLinksServiceSetup } from '@kbn/core/server';
 import { HealthStatus } from '../monitoring';
 import { TaskManagerConfig } from '../config';
@@ -23,6 +24,29 @@ let lastLogLevel: LogLevel | null = null;
 export function resetLastLogLevel() {
   lastLogLevel = null;
 }
+
+export function setupIntervalLogging(
+  monitoredHealth$: Observable<MonitoredHealth>,
+  logger: Logger,
+  minutes: number
+) {
+  let monitoredHealth: MonitoredHealth | undefined;
+  monitoredHealth$.subscribe((m) => {
+    monitoredHealth = m;
+  });
+
+  setInterval(onInterval, 1000 * 60 * minutes);
+
+  function onInterval() {
+    const meta = { tags: ['task-manager-background-node-health'] };
+    if (!monitoredHealth) {
+      return logger.warn('unable to log health metrics, not initialized yet', meta);
+    }
+
+    logger.info(`background node health: ${JSON.stringify(monitoredHealth)}`, meta);
+  }
+}
+
 export function logHealthMetrics(
   monitoredHealth: MonitoredHealth,
   logger: Logger,

--- a/x-pack/plugins/task_manager/server/plugin.ts
+++ b/x-pack/plugins/task_manager/server/plugin.ts
@@ -34,6 +34,7 @@ import { EphemeralTask, ConcreteTaskInstance } from './task';
 import { registerTaskManagerUsageCollector } from './usage';
 import { TASK_MANAGER_INDEX } from './constants';
 import { AdHocTaskCounter } from './lib/adhoc_task_counter';
+import { setupIntervalLogging } from './lib/log_health_metrics';
 
 export interface TaskManagerSetupContract {
   /**
@@ -66,6 +67,8 @@ export type TaskManagerStartContract = Pick<
     getRegisteredTypes: () => string[];
   };
 
+const LogHealthForBackgroundTasksOnlyMinutes = 60;
+
 export class TaskManagerPlugin
   implements Plugin<TaskManagerSetupContract, TaskManagerStartContract>
 {
@@ -82,6 +85,7 @@ export class TaskManagerPlugin
   private shouldRunBackgroundTasks: boolean;
   private readonly kibanaVersion: PluginInitializerContext['env']['packageInfo']['version'];
   private adHocTaskCounter: AdHocTaskCounter;
+  private nodeRoles: PluginInitializerContext['node']['roles'];
 
   constructor(private readonly initContext: PluginInitializerContext) {
     this.initContext = initContext;
@@ -89,8 +93,14 @@ export class TaskManagerPlugin
     this.config = initContext.config.get<TaskManagerConfig>();
     this.definitions = new TaskTypeDictionary(this.logger);
     this.kibanaVersion = initContext.env.packageInfo.version;
-    this.shouldRunBackgroundTasks = initContext.node.roles.backgroundTasks;
+    this.nodeRoles = initContext.node.roles;
+    this.shouldRunBackgroundTasks = this.nodeRoles.backgroundTasks;
     this.adHocTaskCounter = new AdHocTaskCounter();
+  }
+
+  isNodeBackgroundTasksOnly() {
+    const { backgroundTasks, migrator, ui } = this.nodeRoles;
+    return backgroundTasks && !migrator && !ui;
   }
 
   public setup(
@@ -178,6 +188,11 @@ export class TaskManagerPlugin
       this.logger.warn(
         `Excluding task types from execution: ${this.config.unsafe.exclude_task_types.join(', ')}`
       );
+    }
+
+    // for nodes with background_tasks mode only, log health metrics every hour
+    if (this.isNodeBackgroundTasksOnly()) {
+      setupIntervalLogging(monitoredHealth$, this.logger, LogHealthForBackgroundTasksOnlyMinutes);
     }
 
     return {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.8`:
 - [[TaskManager] log health on interval with background_tasks only role (#158890)](https://github.com/elastic/kibana/pull/158890)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Patrick Mueller","email":"patrick.mueller@elastic.co"},"sourceCommit":{"committedDate":"2023-06-06T12:42:40Z","message":"[TaskManager] log health on interval with background_tasks only role (#158890)\n\nresolves https://github.com/elastic/kibana/issues/158870\r\n\r\n## Summary\r\n\r\nFor Kibana servers that only have node role `background_tasks`, log the\r\ntask manager health report to the Kibana logs on an interval, currently\r\nevery hour.\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"837ef26fb0cced40214b25f0f1f22a8a0d610fb2","branchLabelMapping":{"^v8.9.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["enhancement","release_note:skip","Feature:Task Manager","Team:ResponseOps","backport:prev-minor","v8.9.0","v8.8.2"],"number":158890,"url":"https://github.com/elastic/kibana/pull/158890","mergeCommit":{"message":"[TaskManager] log health on interval with background_tasks only role (#158890)\n\nresolves https://github.com/elastic/kibana/issues/158870\r\n\r\n## Summary\r\n\r\nFor Kibana servers that only have node role `background_tasks`, log the\r\ntask manager health report to the Kibana logs on an interval, currently\r\nevery hour.\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"837ef26fb0cced40214b25f0f1f22a8a0d610fb2"}},"sourceBranch":"main","suggestedTargetBranches":["8.8"],"targetPullRequestStates":[{"branch":"main","label":"v8.9.0","labelRegex":"^v8.9.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/158890","number":158890,"mergeCommit":{"message":"[TaskManager] log health on interval with background_tasks only role (#158890)\n\nresolves https://github.com/elastic/kibana/issues/158870\r\n\r\n## Summary\r\n\r\nFor Kibana servers that only have node role `background_tasks`, log the\r\ntask manager health report to the Kibana logs on an interval, currently\r\nevery hour.\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"837ef26fb0cced40214b25f0f1f22a8a0d610fb2"}},{"branch":"8.8","label":"v8.8.2","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->