### PR TITLE
[Telemetry] Highlight status in notices

### DIFF
--- a/src/plugins/telemetry/public/components/opt_in_message.test.tsx
+++ b/src/plugins/telemetry/public/components/opt_in_message.test.tsx
@@ -37,7 +37,7 @@ describe('OptInMessage', () => {
     });
 
     it('claims that telemetry is enabled', () => {
-      expect(dom.text()).toContain('Usage collection (also known as Telemetry) is enabled.');
+      expect(dom.text()).toContain('Usage collection is enabled.');
     });
 
     it('offers the link to disable it', () => {
@@ -65,7 +65,7 @@ describe('OptInMessage', () => {
     });
 
     it('claims that telemetry is disabled', () => {
-      expect(dom.text()).toContain('Usage collection (also known as Telemetry) is disabled.');
+      expect(dom.text()).toContain('Usage collection is disabled.');
     });
 
     it('offers the link to enable it', () => {
@@ -93,7 +93,7 @@ describe('OptInMessage', () => {
     });
 
     it('claims that telemetry is disabled', () => {
-      expect(dom.text()).toContain('Usage collection (also known as Telemetry) is disabled.');
+      expect(dom.text()).toContain('Usage collection is disabled.');
     });
 
     it('offers the link to enable it', () => {

--- a/src/plugins/telemetry/public/components/opt_in_message.tsx
+++ b/src/plugins/telemetry/public/components/opt_in_message.tsx
@@ -30,18 +30,24 @@ export const OptInMessage: React.FC<OptInMessageProps> = ({
     <React.Fragment>
       <FormattedMessage
         id="telemetry.dataManagementDisclaimerPrivacy"
-        defaultMessage="Usage collection (also known as Telemetry) is {optInStatus}.
+        defaultMessage="{optInStatus}
           This allows us to learn what our users are most interested in, so we can improve our products and services.
           Refer to our {privacyStatementLink}."
         values={{
           optInStatus: (
-            <em>
+            <strong>
               {telemetryService.isOptedIn ? (
-                <FormattedMessage id="telemetry.enabledStatus" defaultMessage="enabled" />
+                <FormattedMessage
+                  id="telemetry.enabledStatus"
+                  defaultMessage="Usage collection is enabled."
+                />
               ) : (
-                <FormattedMessage id="telemetry.disabledStatus" defaultMessage="disabled" />
+                <FormattedMessage
+                  id="telemetry.disabledStatus"
+                  defaultMessage="Usage collection is disabled."
+                />
               )}
-            </em>
+            </strong>
           ),
           privacyStatementLink: (
             /* eslint-disable-next-line @elastic/eui/href-or-on-click */

--- a/src/plugins/telemetry_management_section/public/components/__snapshots__/telemetry_management_section.test.tsx.snap
+++ b/src/plugins/telemetry_management_section/public/components/__snapshots__/telemetry_management_section.test.tsx.snap
@@ -116,7 +116,7 @@ exports[`TelemetryManagementSectionComponent renders as expected 1`] = `
               "displayName": "Share usage with Elastic",
               "isCustom": true,
               "isOverridden": false,
-              "name": "telemetry:enabled",
+              "name": "Usage collection",
               "requiresPageReload": false,
               "type": "boolean",
               "value": true,

--- a/src/plugins/telemetry_management_section/public/components/__snapshots__/telemetry_management_section.test.tsx.snap
+++ b/src/plugins/telemetry_management_section/public/components/__snapshots__/telemetry_management_section.test.tsx.snap
@@ -63,7 +63,7 @@ exports[`TelemetryManagementSectionComponent renders as expected 1`] = `
               "description": <React.Fragment>
                 <p>
                   <FormattedMessage
-                    defaultMessage="Enabling usage collection (also known as Telemetry) allows us to learn what our users are most interested in, so we can improve our products and services. Refer to our {privacyStatementLink}."
+                    defaultMessage="Enabling usage collection allows us to learn what our users are most interested in, so we can improve our products and services. Refer to our {privacyStatementLink}."
                     id="telemetry.telemetryConfigAndLinkDescription"
                     values={
                       Object {

--- a/src/plugins/telemetry_management_section/public/components/telemetry_management_section.tsx
+++ b/src/plugins/telemetry_management_section/public/components/telemetry_management_section.tsx
@@ -221,7 +221,7 @@ export class TelemetryManagementSection extends Component<Props, State> {
         <p>
           <FormattedMessage
             id="telemetry.telemetryConfigAndLinkDescription"
-            defaultMessage="Enabling usage collection (also known as Telemetry) allows us to learn
+            defaultMessage="Enabling usage collection allows us to learn
             what our users are most interested in, so we can improve our products and services.
             Refer to our {privacyStatementLink}."
             values={{

--- a/src/plugins/telemetry_management_section/public/components/telemetry_management_section.tsx
+++ b/src/plugins/telemetry_management_section/public/components/telemetry_management_section.tsx
@@ -141,7 +141,7 @@ export class TelemetryManagementSection extends Component<Props, State> {
               <LazyField
                 setting={{
                   type: 'boolean',
-                  name: 'telemetry:enabled',
+                  name: 'Usage collection',
                   displayName: i18n.translate('telemetry.provideUsageDataTitle', {
                     defaultMessage: 'Share usage with Elastic',
                   }),


### PR DESCRIPTION
## Summary

Resolves #158841.

Sets the status in **bold** in the welcome notice and banner.
<img width="659" alt="image" src="https://github.com/elastic/kibana/assets/5469006/435640e7-316a-44ed-b08a-fa916ddf6c48">
<img width="1370" alt="image" src="https://github.com/elastic/kibana/assets/5469006/7010613f-b566-4f3d-a367-7c4bbb8bdf7e">

And changes `telemetry:enable` to `Usage collection`
![image](https://github.com/elastic/kibana/assets/5469006/33539c76-9cb5-4a79-aa35-02d5b7749d2d)

Also removed the `(also known as Telemetry)` from all descriptions.

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
