### PR TITLE
[Enterprise Search] Validate inference pipeline name on next

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/pipelines/fetch_pipeline.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/pipelines/fetch_pipeline.test.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { mockHttpValues } from '../../../__mocks__/kea_logic';
+
+import { nextTick } from '@kbn/test-jest-helpers';
+
+import { fetchPipeline } from './fetch_pipeline';
+
+describe('FetchPipelineApiLogic', () => {
+  const { http } = mockHttpValues;
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  describe('fetchIndex', () => {
+    it('calls correct api', async () => {
+      const response = {
+        'pipeline-name': {},
+      };
+      const promise = Promise.resolve(response);
+      http.get.mockReturnValue(promise);
+      const result = fetchPipeline({ pipelineName: 'pipeline-name' });
+      await nextTick();
+      expect(http.get).toHaveBeenCalledWith('/internal/enterprise_search/pipelines/pipeline-name');
+      await expect(result).resolves.toEqual(response);
+    });
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/pipelines/fetch_pipeline.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/pipelines/fetch_pipeline.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { MlInferencePipeline } from '../../../../../common/types/pipelines';
+import { Actions, createApiLogic } from '../../../shared/api_logic/create_api_logic';
+import { HttpLogic } from '../../../shared/http';
+
+export interface FetchPipelineArgs {
+  pipelineName: string;
+}
+export type FetchPipelineResponse = Record<string, MlInferencePipeline | undefined>;
+
+export const fetchPipeline = async ({ pipelineName }: FetchPipelineArgs) => {
+  const route = `/internal/enterprise_search/pipelines/${pipelineName}`;
+
+  return await HttpLogic.values.http.get<FetchPipelineResponse>(route);
+};
+
+export const FetchPipelineApiLogic = createApiLogic(['fetch_pipeline_api_logic'], fetchPipeline, {
+  showErrorFlash: false,
+});
+
+export type FetchPipelineApiLogicActions = Actions<FetchPipelineArgs, FetchPipelineResponse>;

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/add_inference_pipeline_flyout.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/add_inference_pipeline_flyout.test.tsx
@@ -136,10 +136,10 @@ describe('AddInferencePipelineFlyout', () => {
     const FIELDS_STEP_INDEX = 1;
     const TEST_STEP_INDEX = 2;
     const REVIEW_STEP_INDEX = 3;
-    const setAddInferencePipelineStep = jest.fn();
+    const onAddInferencePipelineStepChange = jest.fn();
     beforeEach(() => {
       setMockActions({
-        setAddInferencePipelineStep,
+        onAddInferencePipelineStepChange,
       });
     });
     it('renders EuiStepsHorizontal', () => {
@@ -228,7 +228,7 @@ describe('AddInferencePipelineFlyout', () => {
       const steps = wrapper.find(EuiStepsHorizontal);
       const configStep = steps.prop('steps')[CONFIGURE_STEP_INDEX];
       configStep.onClick({} as any);
-      expect(setAddInferencePipelineStep).toHaveBeenCalledWith(
+      expect(onAddInferencePipelineStepChange).toHaveBeenCalledWith(
         AddInferencePipelineSteps.Configuration
       );
     });
@@ -237,21 +237,25 @@ describe('AddInferencePipelineFlyout', () => {
       const steps = wrapper.find(EuiStepsHorizontal);
       const fieldsStep = steps.prop('steps')[FIELDS_STEP_INDEX];
       fieldsStep.onClick({} as any);
-      expect(setAddInferencePipelineStep).toHaveBeenCalledWith(AddInferencePipelineSteps.Fields);
+      expect(onAddInferencePipelineStepChange).toHaveBeenCalledWith(
+        AddInferencePipelineSteps.Fields
+      );
     });
     it('clicking test step updates step', () => {
       const wrapper = shallow(<AddInferencePipelineHorizontalSteps />);
       const steps = wrapper.find(EuiStepsHorizontal);
       const testStep = steps.prop('steps')[TEST_STEP_INDEX];
       testStep.onClick({} as any);
-      expect(setAddInferencePipelineStep).toHaveBeenCalledWith(AddInferencePipelineSteps.Test);
+      expect(onAddInferencePipelineStepChange).toHaveBeenCalledWith(AddInferencePipelineSteps.Test);
     });
     it('clicking review step updates step', () => {
       const wrapper = shallow(<AddInferencePipelineHorizontalSteps />);
       const steps = wrapper.find(EuiStepsHorizontal);
       const reviewStep = steps.prop('steps')[REVIEW_STEP_INDEX];
       reviewStep.onClick({} as any);
-      expect(setAddInferencePipelineStep).toHaveBeenCalledWith(AddInferencePipelineSteps.Review);
+      expect(onAddInferencePipelineStepChange).toHaveBeenCalledWith(
+        AddInferencePipelineSteps.Review
+      );
     });
     it('cannot click fields step when data is invalid', () => {
       setMockValues({
@@ -262,7 +266,7 @@ describe('AddInferencePipelineFlyout', () => {
       const steps = wrapper.find(EuiStepsHorizontal);
       const fieldsStep = steps.prop('steps')[FIELDS_STEP_INDEX];
       fieldsStep.onClick({} as any);
-      expect(setAddInferencePipelineStep).not.toHaveBeenCalled();
+      expect(onAddInferencePipelineStepChange).not.toHaveBeenCalled();
     });
     it('cannot click test step when data is invalid', () => {
       setMockValues({
@@ -273,7 +277,7 @@ describe('AddInferencePipelineFlyout', () => {
       const steps = wrapper.find(EuiStepsHorizontal);
       const testStep = steps.prop('steps')[TEST_STEP_INDEX];
       testStep.onClick({} as any);
-      expect(setAddInferencePipelineStep).not.toHaveBeenCalled();
+      expect(onAddInferencePipelineStepChange).not.toHaveBeenCalled();
     });
     it('cannot click review step when data is invalid', () => {
       setMockValues({
@@ -284,7 +288,7 @@ describe('AddInferencePipelineFlyout', () => {
       const steps = wrapper.find(EuiStepsHorizontal);
       const reviewStep = steps.prop('steps')[REVIEW_STEP_INDEX];
       reviewStep.onClick({} as any);
-      expect(setAddInferencePipelineStep).not.toHaveBeenCalled();
+      expect(onAddInferencePipelineStepChange).not.toHaveBeenCalled();
     });
   });
   describe('ModalFooter', () => {
@@ -292,7 +296,7 @@ describe('AddInferencePipelineFlyout', () => {
     const actions = {
       attachPipeline: jest.fn(),
       createPipeline: jest.fn(),
-      setAddInferencePipelineStep: jest.fn(),
+      onAddInferencePipelineStepChange: jest.fn(),
     };
     beforeEach(() => {
       setMockActions(actions);
@@ -373,7 +377,7 @@ describe('AddInferencePipelineFlyout', () => {
       const backBtn = wrapper.find(EuiButtonEmpty).at(1);
       expect(backBtn.prop('children')).toBe('Back');
       backBtn.prop('onClick')!({} as any);
-      expect(actions.setAddInferencePipelineStep).toHaveBeenCalledWith(
+      expect(actions.onAddInferencePipelineStepChange).toHaveBeenCalledWith(
         AddInferencePipelineSteps.Configuration
       );
     });
@@ -392,7 +396,7 @@ describe('AddInferencePipelineFlyout', () => {
       const backBtn = wrapper.find(EuiButtonEmpty).at(1);
       expect(backBtn.prop('children')).toBe('Back');
       backBtn.prop('onClick')!({} as any);
-      expect(actions.setAddInferencePipelineStep).toHaveBeenCalledWith(
+      expect(actions.onAddInferencePipelineStepChange).toHaveBeenCalledWith(
         AddInferencePipelineSteps.Fields
       );
     });
@@ -411,7 +415,7 @@ describe('AddInferencePipelineFlyout', () => {
       const backBtn = wrapper.find(EuiButtonEmpty).at(1);
       expect(backBtn.prop('children')).toBe('Back');
       backBtn.prop('onClick')!({} as any);
-      expect(actions.setAddInferencePipelineStep).toHaveBeenCalledWith(
+      expect(actions.onAddInferencePipelineStepChange).toHaveBeenCalledWith(
         AddInferencePipelineSteps.Test
       );
     });
@@ -424,7 +428,7 @@ describe('AddInferencePipelineFlyout', () => {
       expect(contBtn.prop('children')).toBe('Continue');
       expect(contBtn.prop('disabled')).toBe(false);
       contBtn.prop('onClick')!({} as any);
-      expect(actions.setAddInferencePipelineStep).toHaveBeenCalledWith(
+      expect(actions.onAddInferencePipelineStepChange).toHaveBeenCalledWith(
         AddInferencePipelineSteps.Fields
       );
     });
@@ -453,7 +457,7 @@ describe('AddInferencePipelineFlyout', () => {
       expect(contBtn.prop('children')).toBe('Continue');
       expect(contBtn.prop('disabled')).toBe(false);
       contBtn.prop('onClick')!({} as any);
-      expect(actions.setAddInferencePipelineStep).toHaveBeenCalledWith(
+      expect(actions.onAddInferencePipelineStepChange).toHaveBeenCalledWith(
         AddInferencePipelineSteps.Test
       );
     });
@@ -473,7 +477,7 @@ describe('AddInferencePipelineFlyout', () => {
       expect(contBtn.prop('children')).toBe('Continue');
       expect(contBtn.prop('disabled')).toBe(false);
       contBtn.prop('onClick')!({} as any);
-      expect(actions.setAddInferencePipelineStep).toHaveBeenCalledWith(
+      expect(actions.onAddInferencePipelineStepChange).toHaveBeenCalledWith(
         AddInferencePipelineSteps.Review
       );
     });

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/add_inference_pipeline_flyout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/add_inference_pipeline_flyout.tsx
@@ -146,11 +146,11 @@ export const AddInferencePipelineHorizontalSteps: React.FC = () => {
     isConfigureStepValid,
     isPipelineDataValid,
   } = useValues(MLInferenceLogic);
-  const { setAddInferencePipelineStep } = useActions(MLInferenceLogic);
+  const { onAddInferencePipelineStepChange } = useActions(MLInferenceLogic);
   const navSteps: EuiStepsHorizontalProps['steps'] = [
     {
       // Configure
-      onClick: () => setAddInferencePipelineStep(AddInferencePipelineSteps.Configuration),
+      onClick: () => onAddInferencePipelineStepChange(AddInferencePipelineSteps.Configuration),
       status: isConfigureStepValid ? 'complete' : 'disabled',
       title: i18n.translate(
         'xpack.enterpriseSearch.content.indices.transforms.addInferencePipelineModal.steps.configure.title',
@@ -163,7 +163,7 @@ export const AddInferencePipelineHorizontalSteps: React.FC = () => {
       // Fields
       onClick: () => {
         if (!isConfigureStepValid) return;
-        setAddInferencePipelineStep(AddInferencePipelineSteps.Fields);
+        onAddInferencePipelineStepChange(AddInferencePipelineSteps.Fields);
       },
       status: isConfigureStepValid ? (isPipelineDataValid ? 'complete' : 'incomplete') : 'disabled',
       title: i18n.translate(
@@ -177,7 +177,7 @@ export const AddInferencePipelineHorizontalSteps: React.FC = () => {
       // Test
       onClick: () => {
         if (!isPipelineDataValid) return;
-        setAddInferencePipelineStep(AddInferencePipelineSteps.Test);
+        onAddInferencePipelineStepChange(AddInferencePipelineSteps.Test);
       },
       status: isPipelineDataValid ? 'incomplete' : 'disabled',
       title: i18n.translate(
@@ -191,7 +191,7 @@ export const AddInferencePipelineHorizontalSteps: React.FC = () => {
       // Review
       onClick: () => {
         if (!isPipelineDataValid) return;
-        setAddInferencePipelineStep(AddInferencePipelineSteps.Review);
+        onAddInferencePipelineStepChange(AddInferencePipelineSteps.Review);
       },
       status: isPipelineDataValid ? 'incomplete' : 'disabled',
       title: i18n.translate(
@@ -227,7 +227,7 @@ export const AddInferencePipelineFooter: React.FC<
     isPipelineDataValid,
     isConfigureStepValid,
   } = useValues(MLInferenceLogic);
-  const { attachPipeline, createPipeline, setAddInferencePipelineStep } =
+  const { attachPipeline, createPipeline, onAddInferencePipelineStepChange } =
     useActions(MLInferenceLogic);
 
   const attachExistingPipeline = Boolean(modal.configuration.existingPipeline);
@@ -270,7 +270,9 @@ export const AddInferencePipelineFooter: React.FC<
           <EuiButtonEmpty
             flush="both"
             iconType="arrowLeft"
-            onClick={() => setAddInferencePipelineStep(previousStep as AddInferencePipelineSteps)}
+            onClick={() =>
+              onAddInferencePipelineStepChange(previousStep as AddInferencePipelineSteps)
+            }
           >
             {BACK_BUTTON_LABEL}
           </EuiButtonEmpty>
@@ -282,7 +284,7 @@ export const AddInferencePipelineFooter: React.FC<
             data-telemetry-id={`entSearchContent-${ingestionMethod}-pipelines-addMlInference-continue`}
             iconType="arrowRight"
             iconSide="right"
-            onClick={() => setAddInferencePipelineStep(nextStep as AddInferencePipelineSteps)}
+            onClick={() => onAddInferencePipelineStepChange(nextStep as AddInferencePipelineSteps)}
             disabled={!isContinueButtonEnabled}
             fill
           >

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/ml_inference_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/ml_inference_logic.test.ts
@@ -539,6 +539,55 @@ describe('MlInferenceLogic', () => {
         ]);
       });
     });
+    describe('formErrors', () => {
+      it('has errors when configuration is empty', () => {
+        expect(MLInferenceLogic.values.formErrors).toEqual({
+          modelID: 'Field is required.',
+          pipelineName: 'Field is required.',
+          sourceField: 'Field is required.',
+        });
+      });
+      it('has error for invalid pipeline names', () => {
+        MLInferenceLogic.actions.setInferencePipelineConfiguration({
+          ...MLInferenceLogic.values.addInferencePipelineModal.configuration,
+          modelID: 'unit-test-model',
+          existingPipeline: false,
+          sourceField: 'body',
+          pipelineName: 'Invalid Pipeline Name',
+        });
+        const expectedErrors = {
+          pipelineName: 'Name must only contain letters, numbers, underscores, and hyphens.',
+        };
+
+        expect(MLInferenceLogic.values.formErrors).toEqual(expectedErrors);
+        MLInferenceLogic.actions.setInferencePipelineConfiguration({
+          ...MLInferenceLogic.values.addInferencePipelineModal.configuration,
+          pipelineName: 'pipeline-name-$%^&',
+        });
+        expect(MLInferenceLogic.values.formErrors).toEqual(expectedErrors);
+        MLInferenceLogic.actions.setInferencePipelineConfiguration({
+          ...MLInferenceLogic.values.addInferencePipelineModal.configuration,
+          pipelineName: 'pipeline-name',
+        });
+        expect(MLInferenceLogic.values.formErrors).toEqual({});
+      });
+      it('has pipelineName error when existing pipeline returned from fetch', () => {
+        MLInferenceLogic.actions.setInferencePipelineConfiguration({
+          ...MLInferenceLogic.values.addInferencePipelineModal.configuration,
+          pipelineName: 'unit-test-pipeline',
+          modelID: 'unit-test-model',
+          existingPipeline: false,
+          sourceField: 'body',
+        });
+        MLInferenceLogic.actions.fetchPipelineSuccess({
+          'mock-pipeline': {},
+        });
+
+        expect(MLInferenceLogic.values.formErrors).toEqual({
+          pipelineName: 'Name already used by another pipeline.',
+        });
+      });
+    });
   });
 
   describe('listeners', () => {
@@ -641,6 +690,51 @@ describe('MlInferenceLogic', () => {
         });
 
         expect(MLInferenceLogic.actions.makeMLModelsRequest).toHaveBeenCalledWith(undefined);
+      });
+    });
+    describe('onAddInferencePipelineStepChange', () => {
+      it('calls setAddInferencePipelineStep with given step', () => {
+        jest.spyOn(MLInferenceLogic.actions, 'setAddInferencePipelineStep');
+        MLInferenceLogic.actions.onAddInferencePipelineStepChange(AddInferencePipelineSteps.Fields);
+        expect(MLInferenceLogic.actions.setAddInferencePipelineStep).toHaveBeenCalledWith(
+          AddInferencePipelineSteps.Fields
+        );
+      });
+      it('triggers pipeline fetch when moving from configuration step', () => {
+        MLInferenceLogic.actions.setInferencePipelineConfiguration({
+          ...MLInferenceLogic.values.addInferencePipelineModal.configuration,
+          pipelineName: 'unit-test-pipeline',
+          modelID: 'unit-test-model',
+          existingPipeline: false,
+        });
+        jest.spyOn(MLInferenceLogic.actions, 'fetchPipelineByName');
+        MLInferenceLogic.actions.onAddInferencePipelineStepChange(AddInferencePipelineSteps.Fields);
+        expect(MLInferenceLogic.actions.fetchPipelineByName).toHaveBeenCalledWith({
+          pipelineName: 'ml-inference-unit-test-pipeline',
+        });
+      });
+      it('does not trigger pipeline fetch existing pipeline is selected', () => {
+        MLInferenceLogic.actions.setInferencePipelineConfiguration({
+          ...MLInferenceLogic.values.addInferencePipelineModal.configuration,
+          pipelineName: 'unit-test-pipeline',
+          modelID: 'unit-test-model',
+          existingPipeline: true,
+        });
+        jest.spyOn(MLInferenceLogic.actions, 'fetchPipelineByName');
+        MLInferenceLogic.actions.onAddInferencePipelineStepChange(AddInferencePipelineSteps.Fields);
+        expect(MLInferenceLogic.actions.fetchPipelineByName).not.toHaveBeenCalled();
+      });
+    });
+    describe('fetchPipelineSuccess', () => {
+      it('goes back to configuration step when pipeline is found', () => {
+        jest.spyOn(MLInferenceLogic.actions, 'setAddInferencePipelineStep');
+
+        MLInferenceLogic.actions.fetchPipelineSuccess({
+          'mock-pipeline': {},
+        });
+        expect(MLInferenceLogic.actions.setAddInferencePipelineStep).toHaveBeenCalledWith(
+          AddInferencePipelineSteps.Configuration
+        );
       });
     });
   });

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/ml_inference_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/ml_inference_logic.test.ts
@@ -40,6 +40,7 @@ const DEFAULT_VALUES: MLInferenceProcessorsValues = {
     step: AddInferencePipelineSteps.Configuration,
   },
   createErrors: [],
+  existingPipeline: undefined,
   existingInferencePipelines: [],
   formErrors: {
     modelID: 'Field is required.',

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/ml_inference_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/ml_inference_logic.ts
@@ -62,6 +62,11 @@ import {
   FetchMlInferencePipelinesArgs,
   FetchMlInferencePipelinesResponse,
 } from '../../../../api/pipelines/fetch_ml_inference_pipelines';
+import {
+  FetchPipelineApiLogic,
+  FetchPipelineResponse,
+  FetchPipelineApiLogicActions,
+} from '../../../../api/pipelines/fetch_pipeline';
 
 import { isConnectorIndex } from '../../../../utils/indices';
 import {
@@ -82,6 +87,7 @@ import {
   getDisabledReason,
   validateInferencePipelineConfiguration,
   validateInferencePipelineFields,
+  validatePipelineNameIsAvailable,
 } from './utils';
 
 export const EMPTY_PIPELINE_CONFIGURATION: InferencePipelineConfiguration = {
@@ -119,6 +125,7 @@ interface MLInferenceProcessorsActions {
     AttachMlInferencePipelineResponse
   >['apiSuccess'];
   attachPipeline: () => void;
+  clearFetchedPipeline: FetchPipelineApiLogicActions['apiReset'];
   createApiError: Actions<
     CreateMlInferencePipelineApiLogicArgs,
     CreateMlInferencePipelineResponse
@@ -128,6 +135,8 @@ interface MLInferenceProcessorsActions {
     CreateMlInferencePipelineResponse
   >['apiSuccess'];
   createPipeline: () => void;
+  fetchPipelineByName: FetchPipelineApiLogicActions['makeRequest'];
+  fetchPipelineSuccess: FetchPipelineApiLogicActions['apiSuccess'];
   makeAttachPipelineRequest: Actions<
     AttachMlInferencePipelineApiLogicArgs,
     AttachMlInferencePipelineResponse
@@ -148,6 +157,9 @@ interface MLInferenceProcessorsActions {
     FetchMlInferencePipelinesResponse
   >['apiSuccess'];
   mlModelsApiError: TrainedModelsApiLogicActions['apiError'];
+  onAddInferencePipelineStepChange: (step: AddInferencePipelineSteps) => {
+    step: AddInferencePipelineSteps;
+  };
   removeFieldFromMapping: (fieldName: string) => { fieldName: string };
   selectExistingPipeline: (pipelineName: string) => {
     pipelineName: string;
@@ -173,6 +185,7 @@ export interface AddInferencePipelineModal {
 export interface MLInferenceProcessorsValues {
   addInferencePipelineModal: AddInferencePipelineModal;
   createErrors: string[];
+  existingPipeline: FetchPipelineResponse | undefined;
   existingInferencePipelines: MLInferencePipelineOption[];
   formErrors: AddInferencePipelineFormErrors;
   index: CachedFetchIndexApiLogicValues['indexData'];
@@ -200,6 +213,7 @@ export const MLInferenceLogic = kea<
     attachPipeline: true,
     clearFormErrors: true,
     createPipeline: true,
+    onAddInferencePipelineStepChange: (step: AddInferencePipelineSteps) => ({ step }),
     removeFieldFromMapping: (fieldName: string) => ({ fieldName }),
     selectExistingPipeline: (pipelineName: string) => ({ pipelineName }),
     selectFields: (fieldNames: string[]) => ({ fieldNames }),
@@ -237,6 +251,12 @@ export const MLInferenceLogic = kea<
       ['closeAddMlInferencePipelineModal as closeAddMlInferencePipelineModal'],
       StartTextExpansionModelApiLogic,
       ['apiSuccess as startTextExpansionModelSuccess'],
+      FetchPipelineApiLogic,
+      [
+        'apiReset as clearFetchedPipeline',
+        'makeRequest as fetchPipelineByName',
+        'apiSuccess as fetchPipelineSuccess',
+      ],
     ],
     values: [
       CachedFetchIndexApiLogic,
@@ -249,6 +269,8 @@ export const MLInferenceLogic = kea<
       ['data as mlModelsData', 'status as mlModelsStatus'],
       FetchMlInferencePipelineProcessorsApiLogic,
       ['data as mlInferencePipelineProcessors'],
+      FetchPipelineApiLogic,
+      ['data as existingPipeline'],
     ],
   },
   events: {},
@@ -326,6 +348,27 @@ export const MLInferenceLogic = kea<
     startTextExpansionModelSuccess: () => {
       // Refresh ML models list when the text expansion model is started
       actions.makeMLModelsRequest(undefined);
+    },
+    onAddInferencePipelineStepChange: ({ step }) => {
+      const {
+        addInferencePipelineModal: {
+          configuration: { pipelineName, existingPipeline },
+          step: currentStep,
+        },
+      } = values;
+      if (currentStep === AddInferencePipelineSteps.Configuration && !existingPipeline) {
+        // Validate name is not in use
+        actions.fetchPipelineByName({
+          pipelineName: `ml-inference-${formatPipelineName(pipelineName)}`,
+        });
+        // Continue to the next step so we don't have to save it to state, we will change
+        // back to the Configuration step if we find a pipeline with the same name
+      }
+      actions.setAddInferencePipelineStep(step);
+    },
+    fetchPipelineSuccess: () => {
+      // We found a pipeline with the name go back to configuration step
+      actions.setAddInferencePipelineStep(AddInferencePipelineSteps.Configuration);
     },
   }),
   path: ['enterprise_search', 'content', 'pipelines_add_ml_inference_pipeline'],
@@ -420,10 +463,14 @@ export const MLInferenceLogic = kea<
   },
   selectors: ({ selectors }) => ({
     formErrors: [
-      () => [selectors.addInferencePipelineModal],
-      (modal: AddInferencePipelineModal) => ({
+      () => [selectors.addInferencePipelineModal, selectors.existingPipeline],
+      (
+        modal: AddInferencePipelineModal,
+        existingPipeline: MLInferenceProcessorsValues['existingPipeline']
+      ) => ({
         ...validateInferencePipelineConfiguration(modal.configuration),
         ...validateInferencePipelineFields(modal.configuration),
+        ...validatePipelineNameIsAvailable(existingPipeline),
       }),
     ],
     isConfigureStepValid: [

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/utils.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/utils.ts
@@ -9,6 +9,8 @@ import { i18n } from '@kbn/i18n';
 
 import { SUPPORTED_PYTORCH_TASKS } from '@kbn/ml-trained-models-utils';
 
+import { FetchPipelineResponse } from '../../../../api/pipelines/fetch_pipeline';
+
 import { AddInferencePipelineFormErrors, InferencePipelineConfiguration } from './types';
 
 const VALID_PIPELINE_NAME_REGEX = /^[\w\-]+$/;
@@ -26,6 +28,12 @@ const FIELD_REQUIRED_ERROR = i18n.translate(
   'xpack.enterpriseSearch.content.indices.pipelines.addInferencePipelineModal.steps.configure.emptyValueError',
   {
     defaultMessage: 'Field is required.',
+  }
+);
+const PIPELINE_NAME_EXISTS_ERROR = i18n.translate(
+  'xpack.enterpriseSearch.content.indices.pipelines.addInferencePipelineModal.steps.configure.invalidPipelineName',
+  {
+    defaultMessage: 'Name already used by another pipeline.',
   }
 );
 
@@ -48,6 +56,16 @@ export const validateInferencePipelineConfiguration = (
     errors.modelID = FIELD_REQUIRED_ERROR;
   }
 
+  return errors;
+};
+
+export const validatePipelineNameIsAvailable = (
+  existingPipeline: FetchPipelineResponse | undefined
+) => {
+  const errors: AddInferencePipelineFormErrors = {};
+  if (existingPipeline !== undefined) {
+    errors.pipelineName = PIPELINE_NAME_EXISTS_ERROR;
+  }
   return errors;
 };
 

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/utils.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/utils.ts
@@ -31,7 +31,7 @@ const FIELD_REQUIRED_ERROR = i18n.translate(
   }
 );
 const PIPELINE_NAME_EXISTS_ERROR = i18n.translate(
-  'xpack.enterpriseSearch.content.indices.pipelines.addInferencePipelineModal.steps.configure.invalidPipelineName',
+  'xpack.enterpriseSearch.content.indices.pipelines.addInferencePipelineModal.steps.configure.pipelineNameExistsError',
   {
     defaultMessage: 'Name already used by another pipeline.',
   }

--- a/x-pack/plugins/enterprise_search/server/lib/pipelines/get_pipeline.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/pipelines/get_pipeline.ts
@@ -12,14 +12,9 @@ export const getPipeline = async (
   pipelineName: string,
   client: IScopedClusterClient
 ): Promise<IngestGetPipelineResponse> => {
-  try {
-    const pipelinesResponse = await client.asCurrentUser.ingest.getPipeline({
-      id: pipelineName,
-    });
+  const pipelinesResponse = await client.asCurrentUser.ingest.getPipeline({
+    id: pipelineName,
+  });
 
-    return pipelinesResponse;
-  } catch (error) {
-    // If we can't find anything, we return an empty object
-    return {};
-  }
+  return pipelinesResponse;
 };


### PR DESCRIPTION
## Summary

Updated the configuration step transition to check if the pipeline name is currently in use and add a form error if it is.

The UX trade-off I made here is to change the step and then take the user back if the name is unavailable, which results in a slight blip. This was preferable to having to store the state and disabling interaction while we make the API call IMO.

### Screenshots

https://github.com/elastic/kibana/assets/1972968/aa08da12-2e92-4e03-91ff-90fdfd9c422d


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->