### PR TITLE
[Maps][ML] Add hyperlink to anomaly explorer for job from anomaly layer in maps

### DIFF
--- a/x-pack/plugins/ml/public/maps/anomaly_source.tsx
+++ b/x-pack/plugins/ml/public/maps/anomaly_source.tsx
@@ -18,13 +18,13 @@ import {
 } from '@kbn/maps-plugin/common';
 import { AbstractSourceDescriptor, MapExtent } from '@kbn/maps-plugin/common/descriptor_types';
 import { ITooltipProperty, GEOJSON_FEATURE_ID_PROPERTY_NAME } from '@kbn/maps-plugin/public';
-import { SerializableRecord } from '@kbn/utility-types';
-import { LocatorPublic } from '@kbn/share-plugin/common';
+import type { SerializableRecord } from '@kbn/utility-types';
+import type { LocatorPublic } from '@kbn/share-plugin/common';
 import type { Adapters } from '@kbn/inspector-plugin/common/adapters';
 import type { GeoJsonWithMeta } from '@kbn/maps-plugin/public';
 import type { IField } from '@kbn/maps-plugin/public';
 import type { Attribution, ImmutableSourceProperty } from '@kbn/maps-plugin/public';
-import { TimefilterContract } from '@kbn/data-plugin/public';
+import type { TimefilterContract } from '@kbn/data-plugin/public';
 import type { SourceEditorArgs } from '@kbn/maps-plugin/public';
 import type { DataRequest } from '@kbn/maps-plugin/public';
 import type { GetFeatureActionsArgs, IVectorSource, SourceStatus } from '@kbn/maps-plugin/public';
@@ -47,9 +47,8 @@ export interface AnomalySourceDescriptor extends AbstractSourceDescriptor {
 
 export class AnomalySource implements IVectorSource {
   static mlResultsService: MlApiServices['results'];
-  static canGetJobs: boolean;
   static mlLocator?: LocatorPublic<SerializableRecord>;
-  static timefilter?: TimefilterContract;
+  static timefilter: TimefilterContract;
 
   static createDescriptor(descriptor: Partial<AnomalySourceDescriptor>) {
     if (typeof descriptor.jobId !== 'string') {

--- a/x-pack/plugins/ml/public/maps/anomaly_source_factory.ts
+++ b/x-pack/plugins/ml/public/maps/anomaly_source_factory.ts
@@ -7,9 +7,9 @@
 
 import type { StartServicesAccessor } from '@kbn/core/public';
 import { SOURCE_TYPES } from '@kbn/maps-plugin/common';
-import { LocatorPublic } from '@kbn/share-plugin/common';
-import { SerializableRecord } from '@kbn/utility-types';
-import { TimefilterContract } from '@kbn/data-plugin/public';
+import type { LocatorPublic } from '@kbn/share-plugin/common';
+import type { SerializableRecord } from '@kbn/utility-types';
+import type { TimefilterContract } from '@kbn/data-plugin/public';
 import { HttpService } from '../application/services/http_service';
 import type { MlPluginStart, MlStartDependencies } from '../plugin';
 import { ML_APP_LOCATOR } from '../../common/constants/locator';
@@ -19,16 +19,13 @@ export class AnomalySourceFactory {
   public readonly type = SOURCE_TYPES.ES_ML_ANOMALIES;
 
   constructor(
-    private getStartServices: StartServicesAccessor<MlStartDependencies, MlPluginStart>,
-    private canGetJobs: boolean
-  ) {
-    this.canGetJobs = canGetJobs;
-  }
+    private getStartServices: StartServicesAccessor<MlStartDependencies, MlPluginStart>
+  ) {}
 
   private async getServices(): Promise<{
     mlResultsService: MlApiServices['results'];
     mlLocator?: LocatorPublic<SerializableRecord>;
-    timefilter?: TimefilterContract;
+    timefilter: TimefilterContract;
   }> {
     const [coreStart, pluginStart] = await this.getStartServices();
     const { mlApiServicesProvider } = await import('../application/services/ml_api_service');
@@ -45,7 +42,6 @@ export class AnomalySourceFactory {
     const { mlResultsService, mlLocator, timefilter } = await this.getServices();
     const { AnomalySource } = await import('./anomaly_source');
     AnomalySource.mlResultsService = mlResultsService;
-    AnomalySource.canGetJobs = this.canGetJobs;
     AnomalySource.mlLocator = mlLocator;
     AnomalySource.timefilter = timefilter;
     return AnomalySource;


### PR DESCRIPTION
## Summary

Related issue: https://github.com/elastic/kibana/issues/148665

This PR adds a link to the anomaly explorer for the job corresponding to the anomalies layer in maps. The link is found under 'Source details' once the anomalies layer is created.

<img width="1291" alt="image" src="https://github.com/elastic/kibana/assets/6446462/f109ce21-1aec-40c4-8cf1-fc3dedaef199">


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))


