### PR TITLE
[Profiling] Fix incorrect status of single-click installation

### DIFF
--- a/x-pack/plugins/profiling/common/setup.test.ts
+++ b/x-pack/plugins/profiling/common/setup.test.ts
@@ -99,10 +99,10 @@ function createSettingsState(configured: boolean): PartialSetupState {
   };
 }
 
-describe('Merging partial states', () => {
+describe('Merging partial state operations', () => {
   const defaultSetupState = createDefaultSetupState();
 
-  test('0', () => {
+  test('partial states with missing key', () => {
     const mergedState = mergePartialSetupStates(defaultSetupState, [
       createCloudState(true),
       createDataState(true),
@@ -113,7 +113,7 @@ describe('Merging partial states', () => {
     expect(mergedState.data.available).toEqual(true);
   });
 
-  test('1', () => {
+  test('deeply nested partial states with overlap', () => {
     const mergedState = mergePartialSetupStates(defaultSetupState, [
       createApmPolicyState(true),
       createCollectorPolicyState(true),
@@ -125,7 +125,7 @@ describe('Merging partial states', () => {
     expect(mergedState.policies.symbolizer.installed).toEqual(true);
   });
 
-  test('2', () => {
+  test('check resource status with failed partial states', () => {
     const mergedState = mergePartialSetupStates(defaultSetupState, [
       createPackageState(false),
       createApmPolicyState(true),
@@ -139,7 +139,7 @@ describe('Merging partial states', () => {
     expect(areResourcesSetup(mergedState)).toEqual(false);
   });
 
-  test('3', () => {
+  test('check resource status with all successful partial states', () => {
     const mergedState = mergePartialSetupStates(defaultSetupState, [
       createPackageState(true),
       createApmPolicyState(true),

--- a/x-pack/plugins/profiling/common/setup.test.ts
+++ b/x-pack/plugins/profiling/common/setup.test.ts
@@ -1,0 +1,155 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  areResourcesSetup,
+  createDefaultSetupState,
+  mergePartialSetupStates,
+  PartialSetupState,
+} from './setup';
+
+function createCloudState(available: boolean): PartialSetupState {
+  return {
+    cloud: {
+      available,
+    },
+  };
+}
+
+function createDataState(available: boolean): PartialSetupState {
+  return {
+    data: {
+      available,
+    },
+  };
+}
+
+function createPackageState(installed: boolean): PartialSetupState {
+  return {
+    packages: {
+      installed,
+    },
+  };
+}
+
+function createPermissionState(configured: boolean): PartialSetupState {
+  return {
+    permissions: {
+      configured,
+    },
+  };
+}
+
+function createApmPolicyState(installed: boolean): PartialSetupState {
+  return {
+    policies: {
+      apm: {
+        installed,
+      },
+    },
+  };
+}
+
+function createCollectorPolicyState(installed: boolean): PartialSetupState {
+  return {
+    policies: {
+      collector: {
+        installed,
+      },
+    },
+  };
+}
+
+function createSymbolizerPolicyState(installed: boolean): PartialSetupState {
+  return {
+    policies: {
+      symbolizer: {
+        installed,
+      },
+    },
+  };
+}
+
+function createResourceState({
+  enabled,
+  created,
+}: {
+  enabled: boolean;
+  created: boolean;
+}): PartialSetupState {
+  return {
+    resource_management: {
+      enabled,
+    },
+    resources: {
+      created,
+    },
+  };
+}
+
+function createSettingsState(configured: boolean): PartialSetupState {
+  return {
+    settings: {
+      configured,
+    },
+  };
+}
+
+describe('Merging partial states', () => {
+  const defaultSetupState = createDefaultSetupState();
+
+  test('0', () => {
+    const mergedState = mergePartialSetupStates(defaultSetupState, [
+      createCloudState(true),
+      createDataState(true),
+    ]);
+
+    expect(mergedState.cloud.available).toEqual(true);
+    expect(mergedState.cloud.required).toEqual(true);
+    expect(mergedState.data.available).toEqual(true);
+  });
+
+  test('1', () => {
+    const mergedState = mergePartialSetupStates(defaultSetupState, [
+      createApmPolicyState(true),
+      createCollectorPolicyState(true),
+      createSymbolizerPolicyState(true),
+    ]);
+
+    expect(mergedState.policies.apm.installed).toEqual(true);
+    expect(mergedState.policies.collector.installed).toEqual(true);
+    expect(mergedState.policies.symbolizer.installed).toEqual(true);
+  });
+
+  test('2', () => {
+    const mergedState = mergePartialSetupStates(defaultSetupState, [
+      createPackageState(false),
+      createApmPolicyState(true),
+      createCollectorPolicyState(true),
+      createSymbolizerPolicyState(true),
+      createPermissionState(false),
+      createResourceState({ enabled: true, created: true }),
+      createSettingsState(true),
+    ]);
+
+    expect(areResourcesSetup(mergedState)).toEqual(false);
+  });
+
+  test('3', () => {
+    const mergedState = mergePartialSetupStates(defaultSetupState, [
+      createPackageState(true),
+      createApmPolicyState(true),
+      createCollectorPolicyState(true),
+      createSymbolizerPolicyState(true),
+      createPermissionState(true),
+      createResourceState({ enabled: true, created: true }),
+      createSettingsState(true),
+    ]);
+
+    expect(areResourcesSetup(mergedState)).toEqual(true);
+  });
+});

--- a/x-pack/plugins/profiling/common/setup.ts
+++ b/x-pack/plugins/profiling/common/setup.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { merge } from 'lodash';
 import { RecursivePartial } from '@kbn/apm-plugin/typings/common';
 
 export interface SetupState {
@@ -97,7 +98,7 @@ export function areResourcesSetup(state: SetupState): boolean {
 }
 
 function mergeRecursivePartial<T>(base: T, partial: RecursivePartial<T>): T {
-  return { ...base, ...partial };
+  return merge(base, partial);
 }
 
 export function mergePartialSetupStates(

--- a/x-pack/plugins/profiling/server/lib/setup/security_role.ts
+++ b/x-pack/plugins/profiling/server/lib/setup/security_role.ts
@@ -16,7 +16,7 @@ export async function validateSecurityRole({
   const esClient = client.getEsClient();
   const roles = await esClient.security.getRole();
   return {
-    settings: {
+    permissions: {
       configured: PROFILING_READER_ROLE_NAME in roles,
     },
   };


### PR DESCRIPTION
## Summary

This PR addresses two bugs discovered after https://github.com/elastic/kibana/pull/157949:

* when setting up security roles, the incorrect status was set
* when merging the statuses of all steps, the merged status could lose some statuses