### PR TITLE
[FTR - Common page] Better `subUrl` handling

### DIFF
--- a/test/functional/page_objects/common_page.ts
+++ b/test/functional/page_objects/common_page.ts
@@ -138,10 +138,12 @@ export class CommonPageObject extends FtrService {
       pathname: `${basePath}${this.config.get(['apps', appName]).pathname}`,
     };
 
-    if (shouldUseHashForSubUrl) {
-      appConfig.hash = useActualUrl ? subUrl : `/${appName}/${subUrl}`;
-    } else {
-      appConfig.pathname += `/${subUrl}`;
+    if (typeof subUrl === 'string') {
+      if (shouldUseHashForSubUrl) {
+        appConfig.hash = useActualUrl ? subUrl : `/${appName}/${subUrl}`;
+      } else {
+        appConfig.pathname += `/${subUrl}`;
+      }
     }
 
     await this.navigate({


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/158892

The flaky test is caused because it tries to navigate to `/app/home#/home/undefined`, and gets redirected to `/app/home#/`. The target URL doesn't match the current URL.

```
Error: retry.try timeout: Error: expected http://localhost:5620/app/home#/.includes(http://localhost:5620/app/home#/home/undefined)
```

FWIW, I don't think the `subUrl` (`undefined` in this test) should be appended in the first place. Hopefully fixing that won't break other tests.

✅ Flaky-test runner (x450): https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2356

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->