### PR TITLE
Update end of guide "Continue button" in modal view to be visible

### DIFF
--- a/src/plugins/guided_onboarding/public/components/guide_panel.styles.ts
+++ b/src/plugins/guided_onboarding/public/components/guide_panel.styles.ts
@@ -9,7 +9,7 @@
 import {
   euiCanAnimate,
   euiFlyoutSlideInRight,
-  euiYScrollWithShadows,
+  euiYScroll,
   logicalCSS,
   logicalCSSWithFallback,
 } from '@elastic/eui';
@@ -47,6 +47,9 @@ export const getGuidePanelStyles = ({
       animation: ${euiFlyoutSlideInRight} ${euiTheme.animation.normal}
         ${euiTheme.animation.resistance};
     }
+    @media (max-width: ${euiTheme.breakpoint.m}px) {
+      max-height: 85vh;
+    })
     @media (min-width: ${euiTheme.breakpoint.m}px) {
       right: calc(${euiTheme.size.s} + 128px); // Accounting for margin on button
     })
@@ -95,9 +98,7 @@ export const getGuidePanelStyles = ({
       flex-grow: 1;
       `,
       flyoutBody: css`
-        ${euiYScrollWithShadows(euiThemeContext, {
-          side: 'end',
-        })}
+        ${euiYScroll(euiThemeContext)}
         padding: 16px 10px 0 16px;
       `,
       flyoutBodyError: css`

--- a/src/plugins/guided_onboarding/public/components/guide_panel_flyout/guide_panel_flyout_body.tsx
+++ b/src/plugins/guided_onboarding/public/components/guide_panel_flyout/guide_panel_flyout_body.tsx
@@ -58,7 +58,7 @@ export const GuidePanelFlyoutBody = ({
 
     return (
       <>
-        <EuiSpacer size="l" />
+        <EuiSpacer size="m" />
         <EuiText size="m">
           <EuiLink external target="_blank" href={guideConfig.docs.url}>
             {guideConfig.docs.text}
@@ -109,7 +109,7 @@ export const GuidePanelFlyoutBody = ({
     return (
       <>
         <EuiImage
-          size="fullWidth"
+          size="l"
           src={isDarkTheme ? wellDoneAnimatedDarkGif : wellDoneAnimatedGif}
           alt={i18n.translate('guidedOnboarding.dropdownPanel.wellDoneAnimatedGif', {
             defaultMessage: `Guide completed animated gif`,
@@ -131,17 +131,9 @@ export const GuidePanelFlyoutBody = ({
 
         {docsLink()}
 
-        <GuideProgress
-          guideConfig={guideConfig}
-          styles={styles}
-          pluginState={pluginState}
-          isLoading={isLoading}
-          handleStepButtonClick={handleStepButtonClick}
-          isGuideReadyToComplete={isGuideReadyToComplete}
-          stepsCompleted={stepsCompleted}
-        />
+        <EuiSpacer />
 
-        <EuiFlexGroup justifyContent="flexEnd">
+        <EuiFlexGroup justifyContent="flexStart">
           <EuiFlexItem grow={false}>
             <EuiButton
               isLoading={isLoading}


### PR DESCRIPTION
Related to https://github.com/elastic/kibana/issues/155728

This PR updates the guide panel so that the "Continue to Elastic" button is visible as described in related issue.

### Screenshots
<img width="1149" alt="Screenshot 2023-06-07 at 12 42 17" src="https://github.com/elastic/kibana/assets/91763/eb7dbdba-00e3-4ef1-9033-b09c1fb8bb44">


### Mobile
<img width="381" alt="Screenshot 2023-06-07 at 12 44 28" src="https://github.com/elastic/kibana/assets/91763/3b883dc9-a0ce-4fc9-95d2-f359d7fdf718">


