### PR TITLE
[SecuritySolutions] Remove usages of refresh:true from tests

### DIFF
--- a/x-pack/plugins/security_solution/common/endpoint/data_loaders/index_alerts.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/data_loaders/index_alerts.ts
@@ -60,7 +60,7 @@ export async function indexAlerts({
       },
       []
     );
-    await client.bulk({ body, refresh: true });
+    await client.bulk({ body, refresh: 'wait_for' });
   }
 
   await client.indices.refresh({

--- a/x-pack/plugins/security_solution/scripts/endpoint/common/response_actions.ts
+++ b/x-pack/plugins/security_solution/scripts/endpoint/common/response_actions.ts
@@ -360,6 +360,6 @@ export function updateActionDoc<T = unknown>(esClient: Client, id: string, doc: 
     index: AGENT_ACTIONS_INDEX,
     id,
     doc,
-    refresh: true,
+    refresh: 'wait_for',
   });
 }


### PR DESCRIPTION
issue: https://github.com/elastic/security-team/issues/6561

## Summary

Remove usages of `refresh:true` from tests.


