### PR TITLE
[Infrastructure UI] Remove OS column from the hosts view table

### DIFF
--- a/x-pack/plugins/infra/public/pages/metrics/hosts/components/hosts_table.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/hosts/components/hosts_table.tsx
@@ -8,6 +8,7 @@
 import React from 'react';
 import { EuiBasicTable } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import { useIsWithinMaxBreakpoint } from '@elastic/eui';
 import { NoData } from '../../../../components/empty_states';
 import { HostNodeRow, useHostsTableContext } from '../hooks/use_hosts_table';
 import { useHostsViewContext } from '../hooks/use_hosts_view';
@@ -20,6 +21,7 @@ const PAGE_SIZE_OPTIONS = [5, 10, 20];
 export const HostsTable = () => {
   const { loading } = useHostsViewContext();
   const { onSubmit } = useUnifiedSearchContext();
+  const isFixedLayout = useIsWithinMaxBreakpoint('l');
 
   const {
     columns,
@@ -37,6 +39,7 @@ export const HostsTable = () => {
     <>
       <EuiBasicTable
         data-test-subj="hostsView-table"
+        tableLayout={isFixedLayout ? 'fixed' : 'auto'}
         pagination={{
           pageIndex: pagination.pageIndex ?? 0,
           pageSize: pagination.pageSize ?? DEFAULT_PAGE_SIZE,

--- a/x-pack/plugins/infra/public/pages/metrics/hosts/hooks/use_hosts_table.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/hosts/hooks/use_hosts_table.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useCallback, useMemo } from 'react';
-import { EuiBasicTableColumn, EuiText } from '@elastic/eui';
+import { EuiBasicTableColumn } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import createContainer from 'constate';
 import { isEqual } from 'lodash';
@@ -114,10 +114,6 @@ const sortTableData =
  */
 const titleLabel = i18n.translate('xpack.infra.hostsViewPage.table.nameColumnHeader', {
   defaultMessage: 'Name',
-});
-
-const osLabel = i18n.translate('xpack.infra.hostsViewPage.table.operatingSystemColumnHeader', {
-  defaultMessage: 'Operating System',
 });
 
 const averageCpuUsageLabel = i18n.translate(
@@ -259,13 +255,6 @@ export const useHostsTable = () => {
             onClick={() => reportHostEntryClick(title)}
           />
         ),
-      },
-      {
-        name: osLabel,
-        field: 'os',
-        sortable: true,
-        'data-test-subj': 'hostsView-tableRow-os',
-        render: (os: string) => <EuiText size="s">{os}</EuiText>,
       },
       {
         name: averageCpuUsageLabel,

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -18510,7 +18510,6 @@
     "xpack.infra.hostsViewPage.table.averageTxColumnHeader": "TX（平均值）",
     "xpack.infra.hostsViewPage.table.diskLatencyColumnHeader": "磁盘延迟（平均值）",
     "xpack.infra.hostsViewPage.table.nameColumnHeader": "名称",
-    "xpack.infra.hostsViewPage.table.operatingSystemColumnHeader": "操作系统",
     "xpack.infra.hostsViewPage.table.toggleDialogWithDetails": "切换具有详情的对话框",
     "xpack.infra.hostsViewPage.tabs.alerts.alertStatusFilter.active": "活动",
     "xpack.infra.hostsViewPage.tabs.alerts.alertStatusFilter.legend": "筛选依据",


### PR DESCRIPTION
closes [#1000](https://github.com/elastic/obs-infraobs-team/issues/1000)

## Summary

Removes OS column from the Hosts View table


<img width="1432" alt="image" src="https://github.com/elastic/kibana/assets/2767137/426f3a36-0565-4b99-a542-cf0ae3fa5a6d">


### How to test

- Start a local kibana
- Navigate to` Infrastructure > Hosts`
