### PR TITLE
[Search Applications] rename api tab, add safe search api callout

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/applications/components/engine/engine_connect/engine_connect.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/applications/components/engine/engine_connect/engine_connect.tsx
@@ -36,9 +36,9 @@ const pageTitle = i18n.translate(
   }
 );
 const API_TAB_TITLE = i18n.translate(
-  'xpack.enterpriseSearch.content.searchApplications.connect.apiTabTitle',
+  'xpack.enterpriseSearch.content.searchApplications.connect.safeSearchAPITabTitle',
   {
-    defaultMessage: 'API',
+    defaultMessage: 'Safe Search API',
   }
 );
 const DOCUMENTATION_TAB_TITLE = i18n.translate(

--- a/x-pack/plugins/enterprise_search/public/applications/applications/components/engine/engine_connect/search_application_api.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/applications/components/engine/engine_connect/search_application_api.tsx
@@ -11,6 +11,7 @@ import { useActions, useValues } from 'kea';
 
 import {
   EuiButton,
+  EuiCallOut,
   EuiCodeBlock,
   EuiFlexGroup,
   EuiFlexItem,
@@ -20,6 +21,7 @@ import {
   EuiText,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
 
 import { CloudDetails, useCloudDetails } from '../../../../shared/cloud_details/cloud_details';
 import { decodeCloudId } from '../../../../shared/decode_cloud_id/decode_cloud_id';
@@ -156,6 +158,21 @@ export const SearchApplicationAPI = () => {
       {isGenerateModalOpen ? (
         <GenerateEngineApiKeyModal engineName={engineName} onClose={closeGenerateModal} />
       ) : null}
+      <EuiCallOut
+        iconType="iInCircle"
+        title={
+          <FormattedMessage
+            id="xpack.enterpriseSearch.content.searchApplication.api.safeSearchCallout.title"
+            defaultMessage="What is Safe Search API?"
+          />
+        }
+      >
+        <FormattedMessage
+          id="xpack.enterpriseSearch.content.searchApplication.api.safeSearchCallout.body"
+          defaultMessage="The safe search API endpoint only allows queries with the parameters defined in the settings JSON, so you can create public-facing search endpoints for your Elasticsearch indices."
+        />
+      </EuiCallOut>
+      <EuiSpacer />
       <EuiSteps headingElement="h2" steps={steps} />
     </>
   );

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -13456,7 +13456,6 @@
     "xpack.enterpriseSearch.content.searchApplication.api.step2.copyEndpointDescription": "使用此 URL 访问您搜索应用程序的 API 终端。",
     "xpack.enterpriseSearch.content.searchApplication.api.step2.title": "复制搜索应用程序的终端",
     "xpack.enterpriseSearch.content.searchApplication.api.step3.title": "了解如何调用终端",
-    "xpack.enterpriseSearch.content.searchApplications.connect.apiTabTitle": "API",
     "xpack.enterpriseSearch.content.searchApplications.connect.pageTitle": "连接",
     "xpack.enterpriseSearch.content.searchApplications.content.indicesTabTitle": "索引",
     "xpack.enterpriseSearch.content.searchApplications.content.pageTitle": "内容",


### PR DESCRIPTION
## Summary

![Screen Shot 2023-06-07 at 10 23 52](https://github.com/elastic/kibana/assets/1699281/67a20908-fcc6-464c-8c09-3638fe5154f7)


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
