### PR TITLE
[Enterprise Search] Fix wrong config value in postgresql

### DIFF
--- a/x-pack/plugins/enterprise_search/common/connectors/native_connectors.ts
+++ b/x-pack/plugins/enterprise_search/common/connectors/native_connectors.ts
@@ -656,7 +656,7 @@ export const NATIVE_CONNECTOR_DEFINITIONS: Record<string, NativeConnector | unde
         validations: [],
         value: 9090,
       },
-      user: {
+      username: {
         default_value: '',
         depends_on: [],
         display: DisplayType.TEXTBOX,


### PR DESCRIPTION
## Summary

This fixes the PostgreSQL config being broken due to a mislabeled config key.

<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->