### PR TITLE
Increase cases bundle size limit

### DIFF
--- a/packages/kbn-optimizer/limits.yml
+++ b/packages/kbn-optimizer/limits.yml
@@ -7,7 +7,7 @@ pageLoadAssetSize:
   banners: 17946
   bfetch: 22837
   canvas: 1066647
-  cases: 180000
+  cases: 180037
   charts: 55000
   cloud: 21076
   cloudChat: 19894


### PR DESCRIPTION
Fixes CI, adds 37b to `cases`. Not sure what tripped it over the limit but this should get CI working again.