### PR TITLE
[ftr/test_serverless] Add junit reports

### DIFF
--- a/x-pack/test_serverless/api_integration/config.base.ts
+++ b/x-pack/test_serverless/api_integration/config.base.ts
@@ -26,6 +26,7 @@ export function createTestConfig(options: CreateTestConfigOptions) {
         ],
       },
       testFiles: options.testFiles,
+      junit: options.junit,
     };
   };
 }

--- a/x-pack/test_serverless/api_integration/test_suites/common/config.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/common/config.ts
@@ -10,4 +10,7 @@ import { createTestConfig } from '../../config.base';
 export default createTestConfig({
   serverlessProject: undefined,
   testFiles: [require.resolve('.')],
+  junit: {
+    reportName: 'Serverless Common API Integration Tests',
+  },
 });

--- a/x-pack/test_serverless/api_integration/test_suites/observability/config.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/observability/config.ts
@@ -10,4 +10,7 @@ import { createTestConfig } from '../../config.base';
 export default createTestConfig({
   serverlessProject: 'oblt',
   testFiles: [require.resolve('.')],
+  junit: {
+    reportName: 'Serverless Observability API Integration Tests',
+  },
 });

--- a/x-pack/test_serverless/api_integration/test_suites/search/config.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/search/config.ts
@@ -10,4 +10,7 @@ import { createTestConfig } from '../../config.base';
 export default createTestConfig({
   serverlessProject: 'es',
   testFiles: [require.resolve('.')],
+  junit: {
+    reportName: 'Serverless Search API Integration Tests',
+  },
 });

--- a/x-pack/test_serverless/api_integration/test_suites/security/config.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/security/config.ts
@@ -10,4 +10,7 @@ import { createTestConfig } from '../../config.base';
 export default createTestConfig({
   serverlessProject: 'security',
   testFiles: [require.resolve('.')],
+  junit: {
+    reportName: 'Serverless Security API Integration Tests',
+  },
 });

--- a/x-pack/test_serverless/functional/config.base.ts
+++ b/x-pack/test_serverless/functional/config.base.ts
@@ -57,6 +57,7 @@ export function createTestConfig(options: CreateTestConfigOptions) {
       screenshots: {
         directory: resolve(__dirname, 'screenshots'),
       },
+      junit: options.junit,
     };
   };
 }

--- a/x-pack/test_serverless/functional/test_suites/common/config.ts
+++ b/x-pack/test_serverless/functional/test_suites/common/config.ts
@@ -10,4 +10,7 @@ import { createTestConfig } from '../../config.base';
 export default createTestConfig({
   serverlessProject: undefined,
   testFiles: [require.resolve('.')],
+  junit: {
+    reportName: 'Serverless Common Functional Tests',
+  },
 });

--- a/x-pack/test_serverless/functional/test_suites/observability/config.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/config.ts
@@ -10,4 +10,7 @@ import { createTestConfig } from '../../config.base';
 export default createTestConfig({
   serverlessProject: 'oblt',
   testFiles: [require.resolve('.')],
+  junit: {
+    reportName: 'Serverless Observability Functional Tests',
+  },
 });

--- a/x-pack/test_serverless/functional/test_suites/search/config.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/config.ts
@@ -10,4 +10,7 @@ import { createTestConfig } from '../../config.base';
 export default createTestConfig({
   serverlessProject: 'es',
   testFiles: [require.resolve('.')],
+  junit: {
+    reportName: 'Serverless Search Functional Tests',
+  },
 });

--- a/x-pack/test_serverless/functional/test_suites/security/config.ts
+++ b/x-pack/test_serverless/functional/test_suites/security/config.ts
@@ -10,4 +10,7 @@ import { createTestConfig } from '../../config.base';
 export default createTestConfig({
   serverlessProject: 'security',
   testFiles: [require.resolve('.')],
+  junit: {
+    reportName: 'Serverless Security Functional Tests',
+  },
 });

--- a/x-pack/test_serverless/shared/types/index.ts
+++ b/x-pack/test_serverless/shared/types/index.ts
@@ -8,5 +8,5 @@
 export interface CreateTestConfigOptions {
   serverlessProject: 'es' | 'oblt' | 'security' | undefined;
   testFiles: string[];
-  junit: { reportName: string },
+  junit: { reportName: string };
 }

--- a/x-pack/test_serverless/shared/types/index.ts
+++ b/x-pack/test_serverless/shared/types/index.ts
@@ -8,4 +8,5 @@
 export interface CreateTestConfigOptions {
   serverlessProject: 'es' | 'oblt' | 'security' | undefined;
   testFiles: string[];
+  junit: { reportName: string },
 }


### PR DESCRIPTION
This will be used for issue tracking and metrics.  Reports will be output to the `target/junit` folder.
