### PR TITLE
[ftr/test_serverless] Pass repository config folder to kbnTestServer

### DIFF
--- a/x-pack/test_serverless/shared/config.base.ts
+++ b/x-pack/test_serverless/shared/config.base.ts
@@ -5,7 +5,10 @@
  * 2.0.
  */
 
+import { resolve } from 'path';
 import { format as formatUrl } from 'url';
+
+import { REPO_ROOT } from '@kbn/repo-info';
 
 import { esTestConfig, kbnTestConfig, kibanaServerTestUser } from '@kbn/test';
 
@@ -26,6 +29,9 @@ export default async () => {
 
     kbnTestServer: {
       buildArgs: [],
+      env: {
+        KBN_PATH_CONF: resolve(REPO_ROOT, 'config'),
+      },
       sourceArgs: ['--no-base-path', '--env.name=development'],
       serverArgs: [
         `--server.port=${kbnTestConfig.getPort()}`,

--- a/x-pack/test_serverless/tsconfig.json
+++ b/x-pack/test_serverless/tsconfig.json
@@ -20,5 +20,6 @@
     { "path": "../test/tsconfig.json" },
     "@kbn/expect",
     "@kbn/test",
+    "@kbn/repo-info",
   ]
 }


### PR DESCRIPTION
When running functional tests off a default distribution, serverless configuration files do not exist.  Instead of relying on the distribution config folder, this uses the development config folder.

This is intended as a stopgap until tests can run against the serverless image, which will have the full list of configuration files.

Testing

1) Create a kibana distribution, `node scripts/build`
2) Run a `x-pack/test_serverless` configuration using the
   `--kibana-install-dir` flag pointing to the distribution