### PR TITLE
[Security Solution][Endpoint] Remove use of `LRU` cache for endpoint artifact generation (no longer used)

### DIFF
--- a/x-pack/plugins/security_solution/server/endpoint/services/artifacts/manifest_manager/manifest_manager.mock.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/services/artifacts/manifest_manager/manifest_manager.mock.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import LRU from 'lru-cache';
 import { savedObjectsClientMock, loggingSystemMock } from '@kbn/core/server/mocks';
 import type { Logger } from '@kbn/core/server';
 import type { PackagePolicyClient } from '@kbn/fleet-plugin/server';
@@ -62,7 +61,6 @@ export enum ManifestManagerMockType {
 }
 
 export interface ManifestManagerMockOptions {
-  cache: LRU<string, Buffer>;
   exceptionListClient: ExceptionListClient;
   packagePolicyService: jest.Mocked<PackagePolicyClient>;
   savedObjectsClient: ReturnType<typeof savedObjectsClientMock.create>;
@@ -73,7 +71,6 @@ export const buildManifestManagerMockOptions = (
 ): ManifestManagerMockOptions => {
   const savedObjectMock = savedObjectsClientMock.create();
   return {
-    cache: new LRU<string, Buffer>({ max: 10, maxAge: 1000 * 60 * 60 }),
     exceptionListClient: listMock.getExceptionListClient(savedObjectMock),
     packagePolicyService: createPackagePolicyServiceMock(),
     savedObjectsClient: savedObjectMock,

--- a/x-pack/plugins/security_solution/server/endpoint/services/artifacts/manifest_manager/manifest_manager.test.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/services/artifacts/manifest_manager/manifest_manager.test.ts
@@ -616,7 +616,7 @@ describe('ManifestManager', () => {
   });
 
   describe('pushArtifacts', () => {
-    test('Successfully invokes artifactClient and stores in the cache', async () => {
+    test('Successfully invokes artifactClient', async () => {
       const context = buildManifestManagerContextMock({});
       const artifactClient = context.artifactClient as jest.Mocked<EndpointArtifactClientInterface>;
       const manifestManager = new ManifestManager(context);
@@ -637,12 +637,6 @@ describe('ManifestManager', () => {
           ...ARTIFACT_EXCEPTIONS_WINDOWS,
         },
       ]);
-      expect(
-        JSON.parse(context.cache.get(getArtifactId(ARTIFACT_EXCEPTIONS_MACOS))!.toString())
-      ).toStrictEqual(getArtifactObject(ARTIFACT_EXCEPTIONS_MACOS));
-      expect(
-        JSON.parse(context.cache.get(getArtifactId(ARTIFACT_EXCEPTIONS_WINDOWS))!.toString())
-      ).toStrictEqual(getArtifactObject(ARTIFACT_EXCEPTIONS_WINDOWS));
     });
 
     test('Returns errors for partial failures', async () => {
@@ -684,10 +678,6 @@ describe('ManifestManager', () => {
           ...ARTIFACT_EXCEPTIONS_WINDOWS,
         },
       ]);
-      expect(
-        JSON.parse(context.cache.get(getArtifactId(ARTIFACT_EXCEPTIONS_MACOS))!.toString())
-      ).toStrictEqual(getArtifactObject(ARTIFACT_EXCEPTIONS_MACOS));
-      expect(context.cache.get(getArtifactId(ARTIFACT_EXCEPTIONS_WINDOWS))).toBeUndefined();
     });
   });
 

--- a/x-pack/plugins/security_solution/server/plugin.ts
+++ b/x-pack/plugins/security_solution/server/plugin.ts
@@ -6,7 +6,6 @@
  */
 
 import type { Observable } from 'rxjs';
-import LRU from 'lru-cache';
 import { QUERY_RULE_TYPE_ID, SAVED_QUERY_RULE_TYPE_ID } from '@kbn/securitysolution-rules';
 import type { Logger } from '@kbn/core/server';
 import { SavedObjectsClient } from '@kbn/core/server';
@@ -111,7 +110,6 @@ export class Plugin implements ISecuritySolutionPlugin {
 
   private manifestTask: ManifestTask | undefined;
   private checkMetadataTransformsTask: CheckMetadataTransformsTask | undefined;
-  private artifactsCache: LRU<string, Buffer>;
   private telemetryUsageCounter?: UsageCounter;
   private endpointContext: EndpointAppContext;
 
@@ -124,8 +122,6 @@ export class Plugin implements ISecuritySolutionPlugin {
     this.appClientFactory = new AppClientFactory();
     this.appFeatures = new AppFeatures(this.logger, this.config.experimentalFeatures);
 
-    // Cache up to three artifacts with a max retention of 5 mins each
-    this.artifactsCache = new LRU<string, Buffer>({ max: 3, maxAge: 1000 * 60 * 5 });
     this.telemetryEventsSender = new TelemetryEventsSender(this.logger);
     this.telemetryReceiver = new TelemetryReceiver(this.logger);
 
@@ -430,7 +426,6 @@ export class Plugin implements ISecuritySolutionPlugin {
         exceptionListClient,
         packagePolicyService: plugins.fleet.packagePolicyService,
         logger,
-        cache: this.artifactsCache,
         experimentalFeatures: config.experimentalFeatures,
       });
 


### PR DESCRIPTION
## Summary

- Removes `artifactCache` from the server Plugin and `ManifestManager`
    - Background: This was used when artifact delivery to the endpoint was being done from Kibana. The delivery of artifacts has since moved to Fleet-Server and this was left over from the [PR that removed the download route](https://github.com/elastic/kibana/pull/97206).


