### PR TITLE
[ftr/test_serverless] Use serverless.yml instead of undefined project

### DIFF
--- a/x-pack/test_serverless/api_integration/config.base.ts
+++ b/x-pack/test_serverless/api_integration/config.base.ts
@@ -4,7 +4,9 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+import { resolve } from 'path';
 
+import { REPO_ROOT } from '@kbn/repo-info';
 import { FtrConfigProviderContext } from '@kbn/test';
 
 import { services } from './services';
@@ -13,6 +15,7 @@ import type { CreateTestConfigOptions } from '../shared/types';
 export function createTestConfig(options: CreateTestConfigOptions) {
   return async ({ readConfigFile }: FtrConfigProviderContext) => {
     const svlSharedConfig = await readConfigFile(require.resolve('../shared/config.base.ts'));
+    const svlBaseConfig = resolve(REPO_ROOT, 'config', 'serverless.yml');
 
     return {
       ...svlSharedConfig.getAll(),
@@ -22,7 +25,9 @@ export function createTestConfig(options: CreateTestConfigOptions) {
         ...svlSharedConfig.get('kbnTestServer'),
         serverArgs: [
           ...svlSharedConfig.get('kbnTestServer.serverArgs'),
-          `--serverless${options.serverlessProject ? `=${options.serverlessProject}` : ''}`,
+          options.serverlessProject
+            ? `--serverless=${options.serverlessProject}`
+            : `--config=${svlBaseConfig}`,
         ],
       },
       testFiles: options.testFiles,

--- a/x-pack/test_serverless/functional/config.base.ts
+++ b/x-pack/test_serverless/functional/config.base.ts
@@ -7,6 +7,7 @@
 
 import { resolve } from 'path';
 
+import { REPO_ROOT } from '@kbn/repo-info';
 import { FtrConfigProviderContext } from '@kbn/test';
 
 import { pageObjects } from './page_objects';
@@ -16,6 +17,7 @@ import type { CreateTestConfigOptions } from '../shared/types';
 export function createTestConfig(options: CreateTestConfigOptions) {
   return async ({ readConfigFile }: FtrConfigProviderContext) => {
     const svlSharedConfig = await readConfigFile(require.resolve('../shared/config.base.ts'));
+    const svlBaseConfig = resolve(REPO_ROOT, 'config', 'serverless.yml');
 
     return {
       ...svlSharedConfig.getAll(),
@@ -26,7 +28,9 @@ export function createTestConfig(options: CreateTestConfigOptions) {
         ...svlSharedConfig.get('kbnTestServer'),
         serverArgs: [
           ...svlSharedConfig.get('kbnTestServer.serverArgs'),
-          `--serverless${options.serverlessProject ? `=${options.serverlessProject}` : ''}`,
+          options.serverlessProject
+            ? `--serverless=${options.serverlessProject}`
+            : `--config=${svlBaseConfig}`,
         ],
       },
       testFiles: options.testFiles,

--- a/x-pack/test_serverless/tsconfig.json
+++ b/x-pack/test_serverless/tsconfig.json
@@ -20,5 +20,6 @@
     { "path": "../test/tsconfig.json" },
     "@kbn/expect",
     "@kbn/test",
+    "@kbn/repo-info",
   ]
 }


### PR DESCRIPTION
Currently the common configurations run with an undefined project.  In development, this will select the most recent project run via `serverless.recent.yml`, or default to `es`.  On distributions, a project must be selected.

This updates the test server arguments to run the base configuration instead, where all projects are disabled but the app switcher and home page is available.