### PR TITLE
ES cluster privileges for watcher removed in documentation 

### DIFF
--- a/docs/management/watcher-ui/index.asciidoc
+++ b/docs/management/watcher-ui/index.asciidoc
@@ -33,11 +33,7 @@ NOTE: There are limitations in *Watcher* that affect {kib}. For information, ref
 [[watcher-security]]
 === Watcher security
 
-If the {es} {security-features} are enabled, you must have the
-{ref}/security-privileges.html[`manage_watcher` or `monitor_watcher`]
-cluster privileges to use Watcher in {kib}.
-
-Alternately, you can have the built-in `kibana_admin` role
+you have the built-in `kibana_admin` role
 and either of these watcher roles:
 
 * `watcher_admin`. You can perform all Watcher actions, including create and edit watches.

--- a/docs/management/watcher-ui/index.asciidoc
+++ b/docs/management/watcher-ui/index.asciidoc
@@ -34,7 +34,7 @@ NOTE: There are limitations in *Watcher* that affect {kib}. For information, ref
 === Watcher security
 
 To use Watcher in {kib}, you must have the built-in `kibana_admin` role
-and either of these watcher roles:
+and either of these Watcher roles:
 
 * `watcher_admin`. You can perform all Watcher actions, including create and edit watches.
 * `watcher_user`. You can view watches, but not create or edit them.

--- a/docs/management/watcher-ui/index.asciidoc
+++ b/docs/management/watcher-ui/index.asciidoc
@@ -33,7 +33,7 @@ NOTE: There are limitations in *Watcher* that affect {kib}. For information, ref
 [[watcher-security]]
 === Watcher security
 
-you have the built-in `kibana_admin` role
+To use Watcher in {kib}, you must have the built-in `kibana_admin` role
 and either of these watcher roles:
 
 * `watcher_admin`. You can perform all Watcher actions, including create and edit watches.


### PR DESCRIPTION
The revised instructions for setting up user permission to activate the watcher plugin without using ES cluster privileges are included in this PR. https://github.com/elastic/kibana/issues/152909