### PR TITLE
[Fleet] Do not query cold/frozen indices when querying for agent metrics

### DIFF
--- a/x-pack/plugins/fleet/server/services/agents/agent_metrics.ts
+++ b/x-pack/plugins/fleet/server/services/agents/agent_metrics.ts
@@ -71,6 +71,11 @@ const aggregationQueryBuilder = (agentIds: string[]) => ({
     bool: {
       must: [
         {
+          terms: {
+            _tier: ['data_hot', 'data_warm'],
+          },
+        },
+        {
           range: {
             '@timestamp': {
               gte: 'now-5m',


### PR DESCRIPTION
## Summary

Resolve #159250

Do not query cold/frozen indices when querying for agent metrics, as this could have a significant performance impact.







<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->