### PR TITLE
[DOCS] Removes tag from 8.8.1 release notes

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -46,8 +46,6 @@ Review important information about the {kib} 8.x releases.
 [[release-notes-8.8.1]]
 == {kib} 8.8.1
 
-coming::[8.8.1]
-
 Review the following information about the {kib} 8.8.1 release.
 
 [float]


### PR DESCRIPTION
Removes the `coming` tag from the 8.8.1 release notes.

<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->