### PR TITLE
[PoC] Discover controls customization

### DIFF
--- a/examples/discover_customization_examples/kibana.jsonc
+++ b/examples/discover_customization_examples/kibana.jsonc
@@ -6,6 +6,6 @@
     "id": "discoverCustomizationExamples",
     "server": false,
     "browser": true,
-    "requiredPlugins": ["developerExamples", "discover"]
+    "requiredPlugins": ["controls", "developerExamples", "discover", "embeddable", "kibanaUtils"]
   }
 }

--- a/examples/discover_customization_examples/public/plugin.tsx
+++ b/examples/discover_customization_examples/public/plugin.tsx
@@ -251,6 +251,12 @@ export class DiscoverCustomizationExamplesPlugin implements Plugin {
               return;
             }
 
+            const stateSubscription = stateStorage
+              .change$<ControlsPanels>('controlPanels')
+              .subscribe((panels) => {
+                controlGroupAPI.updateInput({ panels: panels ?? undefined });
+              });
+
             const inputSubscription = controlGroupAPI.getInput$().subscribe((input) => {
               stateStorage.set('controlPanels', input.panels);
             });
@@ -263,13 +269,19 @@ export class DiscoverCustomizationExamplesPlugin implements Plugin {
             );
 
             return () => {
+              stateSubscription.unsubscribe();
               inputSubscription.unsubscribe();
               filterSubscription.unsubscribe();
             };
           }, [controlGroupAPI, stateStorage]);
 
+          if (dataView?.getIndexPattern() !== 'kibana_sample_data_logs') {
+            return null;
+          }
+
           return (
-            <div
+            <EuiFlexItem
+              grow={false}
               css={css`
                 .controlGroup {
                   min-height: unset;
@@ -319,7 +331,7 @@ export class DiscoverCustomizationExamplesPlugin implements Plugin {
                   };
                 }}
               />
-            </div>
+            </EuiFlexItem>
           );
         },
       });

--- a/examples/discover_customization_examples/tsconfig.json
+++ b/examples/discover_customization_examples/tsconfig.json
@@ -8,6 +8,9 @@
     "@kbn/core",
     "@kbn/discover-plugin",
     "@kbn/developer-examples-plugin",
+    "@kbn/controls-plugin",
+    "@kbn/embeddable-plugin",
+    "@kbn/kibana-utils-plugin",
   ],
   "exclude": ["target/**/*"]
 }

--- a/src/plugins/discover/public/application/main/components/layout/use_discover_histogram.ts
+++ b/src/plugins/discover/public/application/main/components/layout/use_discover_histogram.ts
@@ -215,6 +215,10 @@ export const useDiscoverHistogram = ({
    * Request params
    */
   const { query, filters } = useQuerySubscriber({ data: services.data });
+  const hiddenFilters = useObservable(
+    stateContainer.internalState.state$,
+    stateContainer.internalState.getState()
+  ).hiddenFilters;
   const timefilter = services.data.query.timefilter.timefilter;
   const timeRange = timefilter.getAbsoluteTime();
   const relativeTimeRange = useObservable(
@@ -305,7 +309,7 @@ export const useDiscoverHistogram = ({
     services: { ...services, uiActions: getUiActions() },
     dataView: isPlainRecord ? textBasedDataView : dataView,
     query: isPlainRecord ? textBasedQuery : query,
-    filters,
+    filters: [...(filters ?? []), ...hiddenFilters],
     timeRange,
     relativeTimeRange,
     columns,

--- a/src/plugins/discover/public/application/main/components/top_nav/discover_topnav.tsx
+++ b/src/plugins/discover/public/application/main/components/top_nav/discover_topnav.tsx
@@ -227,6 +227,11 @@ export const DiscoverTopNav = ({
         textBasedLanguageModeErrors ? [textBasedLanguageModeErrors] : undefined
       }
       onTextBasedSavedAndExit={onTextBasedSavedAndExit}
+      prependFilterBar={
+        searchBarCustomization?.PrependFilterBar ? (
+          <searchBarCustomization.PrependFilterBar />
+        ) : undefined
+      }
     />
   );
 };

--- a/src/plugins/discover/public/application/main/services/discover_data_state_container.ts
+++ b/src/plugins/discover/public/application/main/services/discover_data_state_container.ts
@@ -26,6 +26,7 @@ import { fetchAll } from '../utils/fetch_all';
 import { sendResetMsg } from '../hooks/use_saved_search_messages';
 import { getFetch$ } from '../utils/get_fetch_observable';
 import { DataTableRecord } from '../../../types';
+import type { InternalState } from './discover_internal_state_container';
 
 export interface SavedSearchData {
   main$: DataMain$;
@@ -131,12 +132,14 @@ export function getDataStateContainer({
   services,
   searchSessionManager,
   getAppState,
+  getInternalState,
   getSavedSearch,
   setDataView,
 }: {
   services: DiscoverServices;
   searchSessionManager: DiscoverSearchSessionManager;
   getAppState: () => DiscoverAppState;
+  getInternalState: () => InternalState;
   getSavedSearch: () => SavedSearch;
   setDataView: (dataView: DataView) => void;
 }): DiscoverDataStateContainer {
@@ -211,6 +214,7 @@ export function getDataStateContainer({
         searchSessionId,
         services,
         getAppState,
+        getInternalState,
         savedSearch: getSavedSearch(),
         useNewFieldsApi: !uiSettings.get(SEARCH_FIELDS_FROM_SOURCE),
       });

--- a/src/plugins/discover/public/application/main/services/discover_internal_state_container.ts
+++ b/src/plugins/discover/public/application/main/services/discover_internal_state_container.ts
@@ -12,6 +12,7 @@ import {
   ReduxLikeStateContainer,
 } from '@kbn/kibana-utils-plugin/common';
 import { DataView, DataViewListItem } from '@kbn/data-views-plugin/common';
+import type { Filter } from '@kbn/es-query';
 import { DataTableRecord } from '../../../types';
 
 export interface InternalState {
@@ -19,6 +20,7 @@ export interface InternalState {
   savedDataViews: DataViewListItem[];
   adHocDataViews: DataView[];
   expandedDoc: DataTableRecord | undefined;
+  hiddenFilters: Filter[];
 }
 
 interface InternalStateTransitions {
@@ -35,6 +37,7 @@ interface InternalStateTransitions {
   setExpandedDoc: (
     state: InternalState
   ) => (dataView: DataTableRecord | undefined) => InternalState;
+  setHiddenFilters: (state: InternalState) => (hiddenFilters: Filter[]) => InternalState;
 }
 
 export type DiscoverInternalStateContainer = ReduxLikeStateContainer<
@@ -52,6 +55,7 @@ export function getInternalStateContainer() {
       adHocDataViews: [],
       savedDataViews: [],
       expandedDoc: undefined,
+      hiddenFilters: [],
     },
     {
       setDataView: (prevState: InternalState) => (nextDataView: DataView) => ({
@@ -96,6 +100,10 @@ export function getInternalStateContainer() {
       setExpandedDoc: (prevState: InternalState) => (expandedDoc: DataTableRecord | undefined) => ({
         ...prevState,
         expandedDoc,
+      }),
+      setHiddenFilters: (prevState: InternalState) => (hiddenFilters: Filter[]) => ({
+        ...prevState,
+        hiddenFilters,
       }),
     },
     {},

--- a/src/plugins/discover/public/application/main/services/discover_state.ts
+++ b/src/plugins/discover/public/application/main/services/discover_state.ts
@@ -250,6 +250,7 @@ export function getDiscoverStateContainer({
     services,
     searchSessionManager,
     getAppState: appStateContainer.getState,
+    getInternalState: internalStateContainer.getState,
     getSavedSearch: savedSearchContainer.getState,
     setDataView,
   });

--- a/src/plugins/discover/public/application/main/utils/fetch_all.ts
+++ b/src/plugins/discover/public/application/main/utils/fetch_all.ts
@@ -24,10 +24,12 @@ import { FetchStatus } from '../../types';
 import { DataMsg, RecordRawType, SavedSearchData } from '../services/discover_data_state_container';
 import { DiscoverServices } from '../../../build_services';
 import { fetchSql } from './fetch_sql';
+import type { InternalState } from '../services/discover_internal_state_container';
 
 export interface FetchDeps {
   abortController: AbortController;
   getAppState: () => DiscoverAppState;
+  getInternalState: () => InternalState;
   initialFetchStatus: FetchStatus;
   inspectorAdapters: Adapters;
   savedSearch: SavedSearch;
@@ -48,7 +50,14 @@ export function fetchAll(
   reset = false,
   fetchDeps: FetchDeps
 ): Promise<void> {
-  const { initialFetchStatus, getAppState, services, inspectorAdapters, savedSearch } = fetchDeps;
+  const {
+    initialFetchStatus,
+    getAppState,
+    getInternalState,
+    services,
+    inspectorAdapters,
+    savedSearch,
+  } = fetchDeps;
   const { data } = services;
   const searchSource = savedSearch.searchSource.createChild();
 
@@ -67,6 +76,7 @@ export function fetchAll(
         dataView,
         services,
         sort: getAppState().sort as SortOrder[],
+        hiddenFilters: getInternalState().hiddenFilters,
       });
     }
 

--- a/src/plugins/discover/public/application/main/utils/update_search_source.ts
+++ b/src/plugins/discover/public/application/main/utils/update_search_source.ts
@@ -8,6 +8,7 @@
 
 import { ISearchSource } from '@kbn/data-plugin/public';
 import { DataViewType, DataView } from '@kbn/data-views-plugin/public';
+import type { Filter } from '@kbn/es-query';
 import type { SortOrder } from '@kbn/saved-search-plugin/public';
 import { SEARCH_FIELDS_FROM_SOURCE, SORT_DEFAULT_ORDER_SETTING } from '../../../../common';
 import { DiscoverServices } from '../../../build_services';
@@ -22,10 +23,12 @@ export function updateVolatileSearchSource(
     dataView,
     services,
     sort,
+    hiddenFilters,
   }: {
     dataView: DataView;
     services: DiscoverServices;
     sort?: SortOrder[];
+    hiddenFilters: Filter[];
   }
 ) {
   const { uiSettings, data } = services;
@@ -37,10 +40,15 @@ export function updateVolatileSearchSource(
   const useNewFieldsApi = !uiSettings.get(SEARCH_FIELDS_FROM_SOURCE);
   searchSource.setField('trackTotalHits', true).setField('sort', usedSort);
 
+  let filters = [...hiddenFilters];
+
   if (dataView.type !== DataViewType.ROLLUP) {
     // Set the date range filter fields from timeFilter using the absolute format. Search sessions requires that it be converted from a relative range
-    searchSource.setField('filter', data.query.timefilter.timefilter.createFilter(dataView));
+    const timeFilter = data.query.timefilter.timefilter.createFilter(dataView);
+    filters = timeFilter ? [...filters, timeFilter] : filters;
   }
+
+  searchSource.setField('filter', filters);
 
   if (useNewFieldsApi) {
     searchSource.removeField('fieldsFromSource');

--- a/src/plugins/discover/public/customizations/customization_types/search_bar_customization.ts
+++ b/src/plugins/discover/public/customizations/customization_types/search_bar_customization.ts
@@ -11,4 +11,5 @@ import type { ComponentType } from 'react';
 export interface SearchBarCustomization {
   id: 'search_bar';
   CustomDataViewPicker?: ComponentType;
+  PrependFilterBar?: ComponentType;
 }

--- a/src/plugins/unified_search/public/filter_bar/filter_bar.tsx
+++ b/src/plugins/unified_search/public/filter_bar/filter_bar.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { EuiFlexGroup, EuiFlexItem, useEuiTheme } from '@elastic/eui';
+import { EuiFlexGroup, useEuiTheme } from '@elastic/eui';
 import { InjectedIntl, injectI18n } from '@kbn/i18n-react';
 import type { Filter } from '@kbn/es-query';
 import React, { ReactNode, useRef } from 'react';
@@ -52,7 +52,7 @@ const FilterBarUI = React.memo(function FilterBarUI(props: Props) {
       alignItems="center"
       tabIndex={-1}
     >
-      {props.prepend && <EuiFlexItem grow={false}>{props.prepend}</EuiFlexItem>}
+      {props.prepend}
       <FilterItems
         filters={props.filters!}
         onFiltersUpdated={props.onFiltersUpdated}

--- a/src/plugins/unified_search/public/filter_bar/filter_bar.tsx
+++ b/src/plugins/unified_search/public/filter_bar/filter_bar.tsx
@@ -6,10 +6,10 @@
  * Side Public License, v 1.
  */
 
-import { EuiFlexGroup, useEuiTheme } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, useEuiTheme } from '@elastic/eui';
 import { InjectedIntl, injectI18n } from '@kbn/i18n-react';
 import type { Filter } from '@kbn/es-query';
-import React, { useRef } from 'react';
+import React, { ReactNode, useRef } from 'react';
 import { DataView } from '@kbn/data-views-plugin/public';
 import FilterItems, { type FilterItemsProps } from './filter_item/filter_items';
 
@@ -33,6 +33,8 @@ export interface Props {
    * Disable all interactive actions
    */
   isDisabled?: boolean;
+
+  prepend?: ReactNode;
 }
 
 const FilterBarUI = React.memo(function FilterBarUI(props: Props) {
@@ -50,6 +52,7 @@ const FilterBarUI = React.memo(function FilterBarUI(props: Props) {
       alignItems="center"
       tabIndex={-1}
     >
+      {props.prepend && <EuiFlexItem grow={false}>{props.prepend}</EuiFlexItem>}
       <FilterItems
         filters={props.filters!}
         onFiltersUpdated={props.onFiltersUpdated}

--- a/src/plugins/unified_search/public/search_bar/create_search_bar.tsx
+++ b/src/plugins/unified_search/public/search_bar/create_search_bar.tsx
@@ -252,6 +252,7 @@ export function createSearchBar({
             isScreenshotMode={isScreenshotMode}
             dataTestSubj={props.dataTestSubj}
             filtersForSuggestions={props.filtersForSuggestions}
+            prependFilterBar={props.prependFilterBar}
           />
         </core.i18n.Context>
       </KibanaContextProvider>

--- a/src/plugins/unified_search/public/search_bar/search_bar.tsx
+++ b/src/plugins/unified_search/public/search_bar/search_bar.tsx
@@ -57,6 +57,7 @@ export interface SearchBarOwnProps<QT extends AggregateQuery | Query = Query> {
   filters?: Filter[];
   filtersForSuggestions?: Filter[];
   hiddenFilterPanelOptions?: QueryBarMenuProps['hiddenPanelOptions'];
+  prependFilterBar?: React.ReactNode;
   // Date picker
   isRefreshPaused?: boolean;
   refreshInterval?: number;
@@ -541,6 +542,7 @@ class SearchBarUI<QT extends (Query | AggregateQuery) | Query = Query> extends C
           filtersForSuggestions={this.props.filtersForSuggestions}
           hiddenPanelOptions={this.props.hiddenFilterPanelOptions}
           isDisabled={this.props.isDisabled}
+          prepend={this.props.prependFilterBar}
           data-test-subj="unifiedFilterBar"
         />
       );


### PR DESCRIPTION
## Summary

PoC implementation of controls in Discover using the customization framework.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)