### PR TITLE
Reenable previously flaky snooze test

### DIFF
--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/snooze.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/snooze.ts
@@ -35,8 +35,7 @@ export default function createSnoozeRuleTests({ getService }: FtrProviderContext
   const log = getService('log');
   const retry = getService('retry');
 
-  // FLAKY: https://github.com/elastic/kibana/issues/159076
-  describe.skip('snooze', () => {
+  describe('snooze', () => {
     const objectRemover = new ObjectRemover(supertest);
 
     after(() => objectRemover.removeAll());


### PR DESCRIPTION
## Summary

Reverts https://github.com/elastic/kibana/commit/fd95b37c1073b6cd356903c4393763149cf1e36b

https://github.com/elastic/kibana/pull/159233 was opened before this skip commit was pushed, but it didn't trigger a merge conflict