### PR TITLE
ESQL in-product help update

### DIFF
--- a/packages/kbn-text-based-editor/src/esql_documentation_sections.tsx
+++ b/packages/kbn-text-based-editor/src/esql_documentation_sections.tsx
@@ -1034,7 +1034,7 @@ NOTE: The output type is always a double and the input type can be any number.
     },
     {
       label: i18n.translate(
-        'textBasedEditor.query.textBasedLanguagesEditor.documentation.mvJoinFunction',
+        'textBasedEditor.query.textBasedLanguagesEditor.documentation.mvConcatFunction',
         {
           defaultMessage: 'MV_CONCAT',
         }
@@ -1042,7 +1042,7 @@ NOTE: The output type is always a double and the input type can be any number.
       description: (
         <Markdown
           markdown={i18n.translate(
-            'textBasedEditor.query.textBasedLanguagesEditor.documentation.mvJoinFunction.markdown',
+            'textBasedEditor.query.textBasedLanguagesEditor.documentation.mvConcatFunction.markdown',
             {
               defaultMessage: `### MV_CONCAT
 Converts a multivalued string field into a single valued field containing the concatenation of all values separated by a delimiter:
@@ -1449,7 +1449,7 @@ FROM employees
     },
     {
       label: i18n.translate(
-        'textBasedEditor.query.textBasedLanguagesEditor.documentation.toStringFunction',
+        'textBasedEditor.query.textBasedLanguagesEditor.documentation.toBooleanFunction',
         {
           defaultMessage: 'TO_BOOLEAN',
         }
@@ -1457,7 +1457,7 @@ FROM employees
       description: (
         <Markdown
           markdown={i18n.translate(
-            'textBasedEditor.query.textBasedLanguagesEditor.documentation.toStringFunction.markdown',
+            'textBasedEditor.query.textBasedLanguagesEditor.documentation.toBooleanFunction.markdown',
             {
               defaultMessage: `### TO_BOOLEAN
 Converts an input value to a boolean value.
@@ -1490,7 +1490,7 @@ Alias: TO_BOOL
     },
     {
       label: i18n.translate(
-        'textBasedEditor.query.textBasedLanguagesEditor.documentation.toStringFunction',
+        'textBasedEditor.query.textBasedLanguagesEditor.documentation.toDatetimeFunction',
         {
           defaultMessage: 'TO_DATETIME',
         }
@@ -1498,7 +1498,7 @@ Alias: TO_BOOL
       description: (
         <Markdown
           markdown={i18n.translate(
-            'textBasedEditor.query.textBasedLanguagesEditor.documentation.toStringFunction.markdown',
+            'textBasedEditor.query.textBasedLanguagesEditor.documentation.toDatetimeFunction.markdown',
             {
               defaultMessage: `### TO_DATETIME
 Converts an input value to a date value.
@@ -1544,7 +1544,7 @@ Alias: TO_DT
     },
     {
       label: i18n.translate(
-        'textBasedEditor.query.textBasedLanguagesEditor.documentation.toStringFunction',
+        'textBasedEditor.query.textBasedLanguagesEditor.documentation.toDoubleFunction',
         {
           defaultMessage: 'TO_DOUBLE',
         }
@@ -1552,7 +1552,7 @@ Alias: TO_DT
       description: (
         <Markdown
           markdown={i18n.translate(
-            'textBasedEditor.query.textBasedLanguagesEditor.documentation.toStringFunction.markdown',
+            'textBasedEditor.query.textBasedLanguagesEditor.documentation.toDoubleFunction.markdown',
             {
               defaultMessage: `### TO_DOUBLE
 Converts an input value to a double value.
@@ -1589,7 +1589,7 @@ Alias: TO_DBL
     },
     {
       label: i18n.translate(
-        'textBasedEditor.query.textBasedLanguagesEditor.documentation.toStringFunction',
+        'textBasedEditor.query.textBasedLanguagesEditor.documentation.toIntegerFunction',
         {
           defaultMessage: 'TO_INTEGER',
         }
@@ -1597,7 +1597,7 @@ Alias: TO_DBL
       description: (
         <Markdown
           markdown={i18n.translate(
-            'textBasedEditor.query.textBasedLanguagesEditor.documentation.toStringFunction.markdown',
+            'textBasedEditor.query.textBasedLanguagesEditor.documentation.toIntegerFunction.markdown',
             {
               defaultMessage: `### TO_INTEGER
 Converts an input value to an integer value.
@@ -1634,7 +1634,7 @@ Alias: TO_INT
     },
     {
       label: i18n.translate(
-        'textBasedEditor.query.textBasedLanguagesEditor.documentation.toStringFunction',
+        'textBasedEditor.query.textBasedLanguagesEditor.documentation.toIpFunction',
         {
           defaultMessage: 'TO_IP',
         }
@@ -1642,7 +1642,7 @@ Alias: TO_INT
       description: (
         <Markdown
           markdown={i18n.translate(
-            'textBasedEditor.query.textBasedLanguagesEditor.documentation.toStringFunction.markdown',
+            'textBasedEditor.query.textBasedLanguagesEditor.documentation.toIpFunction.markdown',
             {
               defaultMessage: `### TO_IP
 Converts an input string to an IP value.
@@ -1674,7 +1674,7 @@ Note that in the example above the last conversion of the string isn’t possibl
     },
     {
       label: i18n.translate(
-        'textBasedEditor.query.textBasedLanguagesEditor.documentation.toStringFunction',
+        'textBasedEditor.query.textBasedLanguagesEditor.documentation.toLongFunction',
         {
           defaultMessage: 'TO_LONG',
         }
@@ -1682,7 +1682,7 @@ Note that in the example above the last conversion of the string isn’t possibl
       description: (
         <Markdown
           markdown={i18n.translate(
-            'textBasedEditor.query.textBasedLanguagesEditor.documentation.toStringFunction.markdown',
+            'textBasedEditor.query.textBasedLanguagesEditor.documentation.toLongFunction.markdown',
             {
               defaultMessage: `### TO_LONG
 Converts an input value to an long value.
@@ -1751,7 +1751,7 @@ ROW a=[10, 9, 8]
     },
     {
       label: i18n.translate(
-        'textBasedEditor.query.textBasedLanguagesEditor.documentation.toStringFunction',
+        'textBasedEditor.query.textBasedLanguagesEditor.documentation.toVersionFunction',
         {
           defaultMessage: 'TO_VERSION',
         }
@@ -1759,7 +1759,7 @@ ROW a=[10, 9, 8]
       description: (
         <Markdown
           markdown={i18n.translate(
-            'textBasedEditor.query.textBasedLanguagesEditor.documentation.toStringFunction.markdown',
+            'textBasedEditor.query.textBasedLanguagesEditor.documentation.toVersionFunction.markdown',
             {
               defaultMessage: `### TO_VERSION
 Converts an input string to a version value. For example:

--- a/packages/kbn-text-based-editor/src/esql_documentation_sections.tsx
+++ b/packages/kbn-text-based-editor/src/esql_documentation_sections.tsx
@@ -517,15 +517,21 @@ FROM employees
 \`\`\`
 
 #### Operators
-These comparison operators are supported:
+These binary comparison operators are supported:
 
 * equality: \`==\`
 * inequality: \`!=\`
-* comparison:
-  * less than: \`<\`
-  * less than or equal: \`<=\`
-  * larger than: \`>\`
-  * larger than or equal: \`>=\`
+* less than: \`<\`
+* less than or equal: \`<=\`
+* larger than: \`>\`
+* larger than or equal: \`>=\`
+
+The \`IN\` operator allows testing whether a field or expression equals an element in a list of literals, fields or expressions:
+
+\`\`\`
+ROW a = 1, b = 4, c = 3
+| WHERE c-a IN (3, b / 2, a)
+\`\`\`
 
 For string comparison using wildcards or regular expressions, use \`LIKE\` or \`RLIKE\`:
 
@@ -603,6 +609,81 @@ FROM employees
 | PROJECT first_name, last_name, height
 | EVAL abs_height = ABS(0.0 - height)
 \`\`\`
+              `,
+              description:
+                'Text is in markdown. Do not translate function names, special characters, or field names like sum(bytes)',
+            }
+          )}
+        />
+      ),
+    },
+    {
+      label: i18n.translate(
+        'textBasedEditor.query.textBasedLanguagesEditor.documentationESQL.absFunction',
+        {
+          defaultMessage: 'AUTO_BUCKET',
+        }
+      ),
+      description: (
+        <Markdown
+          markdown={i18n.translate(
+            'textBasedEditor.query.textBasedLanguagesEditor.documentationESQL.absFunction.markdown',
+            {
+              defaultMessage: `### AUTO_BUCKET
+Creates human-friendly buckets and returns a \`datetime\` value for each row that corresponds to the resulting bucket the row falls into. Combine \`AUTO_BUCKET\`with \`STATS ... BY\` to create a date histogram.
+
+You provide a target number of buckets, a start date, and an end date, and it picks an appropriate bucket size to generate the target number of buckets or fewer. For example, this asks for at most 20 buckets over a whole year, which picks monthly buckets:
+
+\`\`\`
+ROW date=TO_DATETIME("1985-07-09T00:00:00.000Z")
+| EVAL bucket=AUTO_BUCKET(date, 20, "1985-01-01T00:00:00Z", "1986-01-01T00:00:00Z")
+\`\`\`
+
+Returning:
+\`\`\`
+1985-07-09T00:00:00.000Z | 1985-07-01T00:00:00.000Z
+\`\`\`
+
+The goal isn't to provide *exactly* the target number of buckets, it's to pick a
+range that people are comfortable with that provides at most the target number of
+buckets.
+
+If you ask for more buckets then \`AUTO_BUCKET\` can pick a smaller range. For example,
+asking for at most 100 buckets in a year will get you week long buckets:
+
+\`\`\`
+ROW date=TO_DATETIME("1985-07-09T00:00:00.000Z")
+| EVAL bucket=AUTO_BUCKET(date, 100, "1985-01-01T00:00:00Z", "1986-01-01T00:00:00Z")
+\`\`\`
+
+Returning:
+\`\`\`
+1985-07-09T00:00:00.000Z | 1985-07-08T00:00:00.000Z
+\`\`\`
+
+\`AUTO_BUCKET\` does not filter any rows. It only uses the provided time range to pick a good bucket size. For rows with a date outside of the range, it returns a datetime that corresponds to a bucket outside the range. Combine \`AUTO_BUCKET\` with \`WHERE\` to filter rows.
+
+A more complete example might look like:
+
+\`\`\`
+FROM employees
+| WHERE hire_date >= "1985-01-01T00:00:00Z" AND hire_date < "1986-01-01T00:00:00Z"
+| EVAL bucket = AUTO_BUCKET(hire_date, 20, "1985-01-01T00:00:00Z", "1986-01-01T00:00:00Z")
+| STATS AVG(salary) BY bucket
+| SORT bucket
+\`\`\`
+
+Returning:
+\`\`\`
+46305.0 | 1985-02-01T00:00:00.000Z
+44817.0 | 1985-05-01T00:00:00.000Z
+62405.0 | 1985-07-01T00:00:00.000Z
+49095.0 | 1985-09-01T00:00:00.000Z
+51532.0 | 1985-10-01T00:00:00.000Z
+54539.75 | 1985-11-01T00:00:00.000
+\`\`\`
+
+NOTE: \`AUTO_BUCKET\` does not create buckets that don’t match any documents. That’s why the example above is missing 1985-02-01 and other dates.
               `,
               description:
                 'Text is in markdown. Do not translate function names, special characters, or field names like sum(bytes)',

--- a/packages/kbn-text-based-editor/src/esql_documentation_sections.tsx
+++ b/packages/kbn-text-based-editor/src/esql_documentation_sections.tsx
@@ -1451,6 +1451,274 @@ FROM employees
       label: i18n.translate(
         'textBasedEditor.query.textBasedLanguagesEditor.documentation.toStringFunction',
         {
+          defaultMessage: 'TO_BOOLEAN',
+        }
+      ),
+      description: (
+        <Markdown
+          markdown={i18n.translate(
+            'textBasedEditor.query.textBasedLanguagesEditor.documentation.toStringFunction.markdown',
+            {
+              defaultMessage: `### TO_BOOLEAN
+Converts an input value to a boolean value.
+
+The input can be a single- or multi-valued field or an expression. The input type must be of a string or numeric type.
+
+A string value of **"true"** will be case-insensitive converted to the Boolean **true**. For anything else, including the empty string, the function will return **false**. For example:
+
+\`\`\`
+ROW str = ["true", "TRuE", "false", "", "yes", "1"]
+| EVAL bool = TO_BOOLEAN(str)
+\`\`\`
+
+Returning:
+
+\`\`\`
+["true", "TRuE", "false", "", "yes", "1"] | [true, true, false, false, false, false]
+\`\`\`
+
+The numerical value of **0** will be converted to **false**, anything else will be converted to **true**.
+
+Alias: TO_BOOL
+              `,
+              description:
+                'Text is in markdown. Do not translate function names, special characters, or field names like sum(bytes)',
+            }
+          )}
+        />
+      ),
+    },
+    {
+      label: i18n.translate(
+        'textBasedEditor.query.textBasedLanguagesEditor.documentation.toStringFunction',
+        {
+          defaultMessage: 'TO_DATETIME',
+        }
+      ),
+      description: (
+        <Markdown
+          markdown={i18n.translate(
+            'textBasedEditor.query.textBasedLanguagesEditor.documentation.toStringFunction.markdown',
+            {
+              defaultMessage: `### TO_DATETIME
+Converts an input value to a date value.
+
+The input can be a single- or multi-valued field or an expression. The input type must be of a string or numeric type.
+
+A string will only be successfully converted if it’s respecting the format \`yyyy-MM-dd'T'HH:mm:ss.SSS'Z'\`. For example:
+
+\`\`\`
+ROW string = ["1953-09-02T00:00:00.000Z", "1964-06-02T00:00:00.000Z", "1964-06-02 00:00:00"]
+| EVAL datetime = TO_DATETIME(string)
+\`\`\`
+
+Returning:
+
+\`\`\`
+["1953-09-02T00:00:00.000Z", "1964-06-02T00:00:00.000Z", "1964-06-02 00:00:00"] | [1953-09-02T00:00:00.000Z, 1964-06-02T00:00:00.000Z]
+\`\`\`
+
+Note that in this example, the last value in the source multi-valued field has not been converted. The reason being that if the date format is not respected, the conversion will result in a **null** value.
+
+If the input parameter is of a numeric type, its value will be interpreted as milliseconds since the Unix epoch. For example:
+
+\`\`\`
+ROW int = [0, 1]
+| EVAL dt = TO_DATETIME(int)
+\`\`\`
+
+Returning:
+
+\`\`\`
+[0, 1] | [1970-01-01T00:00:00.000Z, 1970-01-01T00:00:00.001Z]
+\`\`\`
+
+Alias: TO_DT
+              `,
+              description:
+                'Text is in markdown. Do not translate function names, special characters, or field names like sum(bytes)',
+            }
+          )}
+        />
+      ),
+    },
+    {
+      label: i18n.translate(
+        'textBasedEditor.query.textBasedLanguagesEditor.documentation.toStringFunction',
+        {
+          defaultMessage: 'TO_DOUBLE',
+        }
+      ),
+      description: (
+        <Markdown
+          markdown={i18n.translate(
+            'textBasedEditor.query.textBasedLanguagesEditor.documentation.toStringFunction.markdown',
+            {
+              defaultMessage: `### TO_DOUBLE
+Converts an input value to a double value.
+
+The input can be a single- or multi-valued field or an expression. The input type must be of a boolean, date, string or numeric type.
+
+Example:
+
+\`\`\`
+ROW str1 = "5.20128E11", str2 = "foo"
+| EVAL dbl = TO_DOUBLE("520128000000"), dbl1 = TO_DOUBLE(str1), dbl2 = TO_DOUBLE(str2)
+\`\`\`
+
+Returning:
+
+\`\`\`
+5.20128E11 | foo | 5.20128E11 | 5.20128E11 | null
+\`\`\`
+
+Note that in this example, the last conversion of the string isn’t possible. When this happens, the result is a **null** value.
+
+If the input parameter is of a date type, its value will be interpreted as milliseconds since the Unix epoch, converted to double.
+
+Boolean **true** will be converted to double **1.0**, **false** to **0.0**.
+
+Alias: TO_DBL
+              `,
+              description:
+                'Text is in markdown. Do not translate function names, special characters, or field names like sum(bytes)',
+            }
+          )}
+        />
+      ),
+    },
+    {
+      label: i18n.translate(
+        'textBasedEditor.query.textBasedLanguagesEditor.documentation.toStringFunction',
+        {
+          defaultMessage: 'TO_INTEGER',
+        }
+      ),
+      description: (
+        <Markdown
+          markdown={i18n.translate(
+            'textBasedEditor.query.textBasedLanguagesEditor.documentation.toStringFunction.markdown',
+            {
+              defaultMessage: `### TO_INTEGER
+Converts an input value to an integer value.
+
+The input can be a single- or multi-valued field or an expression. The input type must be of a boolean, date, string or numeric type.
+
+Example:
+
+\`\`\`
+ROW long = [5013792, 2147483647, 501379200000]
+| EVAL int = TO_INTEGER(long)
+\`\`\`
+
+Returning:
+
+\`\`\`
+[5013792, 2147483647, 501379200000] | [5013792, 2147483647]
+\`\`\`
+
+Note that in this example, the last value of the multi-valued field cannot be converted as an integer. When this happens, the result is a **null** value.
+
+If the input parameter is of a date type, its value will be interpreted as milliseconds since the Unix epoch, converted to integer.
+
+Boolean **true** will be converted to integer **1**, **false** to **0**.
+
+Alias: TO_INT
+              `,
+              description:
+                'Text is in markdown. Do not translate function names, special characters, or field names like sum(bytes)',
+            }
+          )}
+        />
+      ),
+    },
+    {
+      label: i18n.translate(
+        'textBasedEditor.query.textBasedLanguagesEditor.documentation.toStringFunction',
+        {
+          defaultMessage: 'TO_IP',
+        }
+      ),
+      description: (
+        <Markdown
+          markdown={i18n.translate(
+            'textBasedEditor.query.textBasedLanguagesEditor.documentation.toStringFunction.markdown',
+            {
+              defaultMessage: `### TO_IP
+Converts an input string to an IP value.
+
+The input can be a single- or multi-valued field or an expression.
+
+Example:
+
+\`\`\`
+ROW str1 = "1.1.1.1", str2 = "foo"
+| EVAL ip1 = TO_IP(str1), ip2 = TO_IP(str2)
+| WHERE CIDR_MATCH(ip1, "1.0.0.0/8")
+\`\`\`
+
+Returning:
+
+\`\`\`
+1.1.1.1 | foo | 1.1.1.1 | null
+\`\`\`
+
+Note that in the example above the last conversion of the string isn’t possible. When this happens, the result is a **null** value.
+              `,
+              description:
+                'Text is in markdown. Do not translate function names, special characters, or field names like sum(bytes)',
+            }
+          )}
+        />
+      ),
+    },
+    {
+      label: i18n.translate(
+        'textBasedEditor.query.textBasedLanguagesEditor.documentation.toStringFunction',
+        {
+          defaultMessage: 'TO_LONG',
+        }
+      ),
+      description: (
+        <Markdown
+          markdown={i18n.translate(
+            'textBasedEditor.query.textBasedLanguagesEditor.documentation.toStringFunction.markdown',
+            {
+              defaultMessage: `### TO_LONG
+Converts an input value to an long value.
+
+The input can be a single- or multi-valued field or an expression. The input type must be of a boolean, date, string or numeric type.
+
+Example:
+
+\`\`\`
+ROW str1 = "2147483648", str2 = "2147483648.2", str3 = "foo"
+| EVAL long1 = TO_LONG(str1), long2 = TO_LONG(str2), long3 = TO_LONG(str3)
+\`\`\`
+
+Returning:
+
+\`\`\`
+2147483648 | 2147483648.2 | foo | 2147483648 | 2147483648 | null
+\`\`\`
+
+Note that in this example, the last conversion of the string isn’t possible. When this happens, the result is a **null** value. 
+
+If the input parameter is of a date type, its value will be interpreted as milliseconds since the Unix epoch, converted to integer.
+
+Boolean **true** will be converted to long **1**, **false** to **0**.
+              `,
+              description:
+                'Text is in markdown. Do not translate function names, special characters, or field names like sum(bytes)',
+            }
+          )}
+        />
+      ),
+    },
+    {
+      label: i18n.translate(
+        'textBasedEditor.query.textBasedLanguagesEditor.documentation.toStringFunction',
+        {
           defaultMessage: 'TO_STRING',
         }
       ),
@@ -1505,6 +1773,8 @@ Returning:
 \`\`\`
 1.2.3
 \`\`\`
+
+Alias: TO_VER
               `,
               description:
                 'Text is in markdown. Do not translate function names, special characters, or field names like sum(bytes)',

--- a/packages/kbn-text-based-editor/src/esql_documentation_sections.tsx
+++ b/packages/kbn-text-based-editor/src/esql_documentation_sections.tsx
@@ -683,7 +683,7 @@ Returning:
 54539.75 | 1985-11-01T00:00:00.000
 \`\`\`
 
-NOTE: \`AUTO_BUCKET\` does not create buckets that don’t match any documents. That’s why the example above is missing 1985-02-01 and other dates.
+NOTE: \`AUTO_BUCKET\` does not create buckets that don’t match any documents. That’s why the example above is missing 1985-03-01 and other dates.
               `,
               description:
                 'Text is in markdown. Do not translate function names, special characters, or field names like sum(bytes)',
@@ -1034,6 +1034,52 @@ NOTE: The output type is always a double and the input type can be any number.
     },
     {
       label: i18n.translate(
+        'textBasedEditor.query.textBasedLanguagesEditor.documentation.mvJoinFunction',
+        {
+          defaultMessage: 'MV_CONCAT',
+        }
+      ),
+      description: (
+        <Markdown
+          markdown={i18n.translate(
+            'textBasedEditor.query.textBasedLanguagesEditor.documentation.mvJoinFunction.markdown',
+            {
+              defaultMessage: `### MV_CONCAT
+Converts a multivalued string field into a single valued field containing the concatenation of all values separated by a delimiter:
+
+\`\`\`
+ROW a=["foo", "zoo", "bar"]
+| EVAL j = MV_CONCAT(a, ", ")
+\`\`\`
+
+Returning:
+
+\`\`\`
+["foo", "zoo", "bar"] | "foo, zoo, bar"
+\`\`\`
+
+If you want to join non-string fields call \`TO_STRING\` on them first:
+
+\`\`\`
+ROW a=[10, 9, 8]
+| EVAL j = MV_CONCAT(TO_STRING(a), ", ")
+\`\`\`
+
+Returning:
+
+\`\`\`
+[10, 9, 8] | "10, 9, 8"
+\`\`\`
+              `,
+              description:
+                'Text is in markdown. Do not translate function names, special characters, or field names like sum(bytes)',
+            }
+          )}
+        />
+      ),
+    },
+    {
+      label: i18n.translate(
         'textBasedEditor.query.textBasedLanguagesEditor.documentation.mvCountFunction',
         {
           defaultMessage: 'MV_COUNT',
@@ -1059,52 +1105,6 @@ Returning:
 \`\`\`
 
 NOTE: This function accepts all types and always returns an integer.
-              `,
-              description:
-                'Text is in markdown. Do not translate function names, special characters, or field names like sum(bytes)',
-            }
-          )}
-        />
-      ),
-    },
-    {
-      label: i18n.translate(
-        'textBasedEditor.query.textBasedLanguagesEditor.documentation.mvJoinFunction',
-        {
-          defaultMessage: 'MV_JOIN',
-        }
-      ),
-      description: (
-        <Markdown
-          markdown={i18n.translate(
-            'textBasedEditor.query.textBasedLanguagesEditor.documentation.mvJoinFunction.markdown',
-            {
-              defaultMessage: `### MV_JOIN
-Converts a multivalued string field into a single valued field containing the concatenation of all values separated by a delimiter:
-
-\`\`\`
-ROW a=["foo", "zoo", "bar"]
-| EVAL j = MV_JOIN(a, ", ")
-\`\`\`
-
-Returning:
-
-\`\`\`
-["foo", "zoo", "bar"] | "foo, zoo, bar"
-\`\`\`
-
-If you want to join non-string fields call \`TO_STRING\` on them first:
-
-\`\`\`
-ROW a=[10, 9, 8]
-| EVAL j = MV_JOIN(TO_STRING(a), ", ")
-\`\`\`
-
-Returning:
-
-\`\`\`
-[10, 9, 8] | "10, 9, 8"
-\`\`\`
               `,
               description:
                 'Text is in markdown. Do not translate function names, special characters, or field names like sum(bytes)',

--- a/packages/kbn-text-based-editor/src/esql_documentation_sections.tsx
+++ b/packages/kbn-text-based-editor/src/esql_documentation_sections.tsx
@@ -1481,5 +1481,37 @@ ROW a=[10, 9, 8]
         />
       ),
     },
+    {
+      label: i18n.translate(
+        'textBasedEditor.query.textBasedLanguagesEditor.documentation.toStringFunction',
+        {
+          defaultMessage: 'TO_VERSION',
+        }
+      ),
+      description: (
+        <Markdown
+          markdown={i18n.translate(
+            'textBasedEditor.query.textBasedLanguagesEditor.documentation.toStringFunction.markdown',
+            {
+              defaultMessage: `### TO_VERSION
+Converts an input string to a version value. For example:
+
+\`\`\`
+ROW v = TO_VERSION("1.2.3")
+\`\`\`
+
+Returning:
+
+\`\`\`
+1.2.3
+\`\`\`
+              `,
+              description:
+                'Text is in markdown. Do not translate function names, special characters, or field names like sum(bytes)',
+            }
+          )}
+        />
+      ),
+    },
   ],
 };

--- a/packages/kbn-text-based-editor/src/esql_documentation_sections.tsx
+++ b/packages/kbn-text-based-editor/src/esql_documentation_sections.tsx
@@ -619,7 +619,7 @@ FROM employees
     },
     {
       label: i18n.translate(
-        'textBasedEditor.query.textBasedLanguagesEditor.documentationESQL.absFunction',
+        'textBasedEditor.query.textBasedLanguagesEditor.documentationESQL.autoBucketFunction',
         {
           defaultMessage: 'AUTO_BUCKET',
         }
@@ -627,7 +627,7 @@ FROM employees
       description: (
         <Markdown
           markdown={i18n.translate(
-            'textBasedEditor.query.textBasedLanguagesEditor.documentationESQL.absFunction.markdown',
+            'textBasedEditor.query.textBasedLanguagesEditor.documentationESQL.autoBucketFunction.markdown',
             {
               defaultMessage: `### AUTO_BUCKET
 Creates human-friendly buckets and returns a \`datetime\` value for each row that corresponds to the resulting bucket the row falls into. Combine \`AUTO_BUCKET\`with \`STATS ... BY\` to create a date histogram.


### PR DESCRIPTION
This PR updates the in-product help for ESQL with the following:

- added the IN operator (under WHERE)
- added the AUTO_BUCKET, TO_BOOLEAN, TO_DATETIME, TO_DOUBLE, TO_INTEGER, TO_IP, TO_LONG, and TO_VERSION functions
- renamed the MV_JOIN function into MV_CONCAT
### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)