### PR TITLE
[Enterprise Search] Remove native connectors from cloud

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/method_connector/method_connector.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/method_connector/method_connector.tsx
@@ -47,7 +47,7 @@ export const MethodConnector: React.FC<MethodConnectorProps> = ({ serviceType })
 
   const isNative =
     Boolean(NATIVE_CONNECTORS.find((connector) => connector.serviceType === serviceType)) &&
-    (isCloud || hasPlatinumLicense);
+    isCloud;
   const isBeta = Boolean(
     BETA_CONNECTORS.find((connector) => connector.serviceType === serviceType)
   );

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/select_connector/connector_checkable.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/select_connector/connector_checkable.tsx
@@ -5,10 +5,11 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 
 import {
   EuiBadge,
+  EuiButtonIcon,
   EuiCheckableCard,
   EuiCheckableCardProps,
   EuiFlexGroup,
@@ -24,6 +25,7 @@ import { i18n } from '@kbn/i18n';
 import { BETA_LABEL, NATIVE_LABEL } from '../../../../shared/constants';
 
 import './connector_checkable.scss';
+import { PlatinumLicensePopover } from '../../shared/platinum_license_popover/platinum_license_popover';
 
 export type ConnectorCheckableProps = Omit<
   EuiCheckableCardProps,
@@ -39,6 +41,7 @@ export type ConnectorCheckableProps = Omit<
 };
 
 export const ConnectorCheckable: React.FC<ConnectorCheckableProps> = ({
+  disabled,
   documentationUrl,
   icon,
   isBeta,
@@ -48,9 +51,11 @@ export const ConnectorCheckable: React.FC<ConnectorCheckableProps> = ({
   serviceType,
   ...props
 }) => {
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   return (
     <EuiCheckableCard
       {...props}
+      disabled={disabled}
       id={`checkableCard-${serviceType}`}
       className="connectorCheckable"
       data-telemetry-id={`entSearchContent-connector-selectConnector-${serviceType}-select`}
@@ -62,10 +67,36 @@ export const ConnectorCheckable: React.FC<ConnectorCheckableProps> = ({
             </EuiFlexItem>
           )}
           <EuiFlexItem grow={false}>
-            <EuiTitle size="xs">
-              <h2>{name}</h2>
-            </EuiTitle>
+            {disabled ? (
+              <EuiText color="disabledText" size="xs">
+                <h3>{name}</h3>
+              </EuiText>
+            ) : (
+              <EuiTitle size="xs">
+                <h2>{name}</h2>
+              </EuiTitle>
+            )}
           </EuiFlexItem>
+          {disabled && (
+            <EuiFlexItem grow={false}>
+              <PlatinumLicensePopover
+                button={
+                  <EuiButtonIcon
+                    aria-label={i18n.translate(
+                      'xpack.enterpriseSearch.content.newIndex.selectConnector.openPopoverLabel',
+                      {
+                        defaultMessage: 'Open licensing popover',
+                      }
+                    )}
+                    iconType="questionInCircle"
+                    onClick={() => setIsPopoverOpen(!isPopoverOpen)}
+                  />
+                }
+                closePopover={() => setIsPopoverOpen(false)}
+                isPopoverOpen={isPopoverOpen}
+              />
+            </EuiFlexItem>
+          )}
         </EuiFlexGroup>
       }
       name={name}
@@ -93,21 +124,21 @@ export const ConnectorCheckable: React.FC<ConnectorCheckableProps> = ({
           >
             {showNativeBadge && (
               <EuiFlexItem grow={false}>
-                <EuiBadge color="hollow">
+                <EuiBadge color="hollow" isDisabled={disabled}>
                   <EuiText size="xs">{NATIVE_LABEL}</EuiText>
                 </EuiBadge>
               </EuiFlexItem>
             )}
             {isBeta && (
               <EuiFlexItem grow={false}>
-                <EuiBadge color="hollow">
+                <EuiBadge color="hollow" isDisabled={disabled}>
                   <EuiText size="xs">{BETA_LABEL}</EuiText>
                 </EuiBadge>
               </EuiFlexItem>
             )}
             {isTechPreview && (
               <EuiFlexItem grow={false}>
-                <EuiBadge color="hollow" iconType="beaker">
+                <EuiBadge color="hollow" iconType="beaker" isDisabled={disabled}>
                   <EuiText size="xs">
                     {i18n.translate(
                       'xpack.enterpriseSearch.content.indices.selectConnector.connectorCheckable.techPreviewLabel',

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/select_connector/select_connector.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/select_connector/select_connector.tsx
@@ -58,7 +58,7 @@ export const SelectConnector: React.FC = () => {
   const { isCloud } = useValues(KibanaLogic);
   const { hasPlatinumLicense } = useValues(LicensingLogic);
 
-  const hasNativeAccess = isCloud || hasPlatinumLicense;
+  const hasNativeAccess = isCloud;
 
   return (
     <EnterpriseSearchContentPageTemplate
@@ -150,6 +150,7 @@ export const SelectConnector: React.FC = () => {
             {CONNECTORS.map((connector) => (
               <EuiFlexItem key={connector.serviceType} grow>
                 <ConnectorCheckable
+                  disabled={connector.platinumOnly && !hasPlatinumLicense}
                   icon={connector.icon}
                   isBeta={connector.isBeta}
                   isTechPreview={Boolean(connector.isTechPreview)}

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/constants.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/constants.ts
@@ -91,6 +91,7 @@ export const CONNECTORS_DICT: Record<string, ConnectorClientSideDefinition> = {
     externalAuthDocsUrl: '',
     externalDocsUrl: '',
     icon: CONNECTOR_ICONS.sharepoint_online,
+    platinumOnly: true,
   },
 };
 

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/native_connector_configuration/convert_connector.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/native_connector_configuration/convert_connector.tsx
@@ -18,57 +18,24 @@ import {
   EuiText,
   EuiLink,
   EuiButton,
-  EuiConfirmModal,
 } from '@elastic/eui';
 
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 
-import { CANCEL_BUTTON_LABEL } from '../../../../../shared/constants';
-
 import { docLinks } from '../../../../../shared/doc_links';
+
+import { ConvertConnectorModal } from '../../../shared/convert_connector_modal/convert_connector_modal';
 
 import { ConvertConnectorLogic } from './convert_connector_logic';
 
 export const ConvertConnector: React.FC = () => {
-  const { convertConnector, hideModal, showModal } = useActions(ConvertConnectorLogic);
-  const { isLoading, isModalVisible } = useValues(ConvertConnectorLogic);
+  const { showModal } = useActions(ConvertConnectorLogic);
+  const { isModalVisible } = useValues(ConvertConnectorLogic);
 
   return (
     <>
-      {isModalVisible && (
-        <EuiConfirmModal
-          onCancel={() => hideModal()}
-          onConfirm={() => convertConnector()}
-          title={i18n.translate(
-            'xpack.enterpriseSearch.content.engine.indices.convertInfexConfirm.title',
-            { defaultMessage: 'Sure you want to convert your connector?' }
-          )}
-          buttonColor="danger"
-          cancelButtonText={CANCEL_BUTTON_LABEL}
-          confirmButtonText={i18n.translate(
-            'xpack.enterpriseSearch.content.engine.indices.convertIndexConfirm.text',
-            {
-              defaultMessage: 'Yes',
-            }
-          )}
-          isLoading={isLoading}
-          defaultFocusedButton="confirm"
-          maxWidth
-        >
-          <EuiText>
-            <p>
-              {i18n.translate(
-                'xpack.enterpriseSearch.content.engine.indices.convertIndexConfirm.description',
-                {
-                  defaultMessage:
-                    "Once you convert a native connector to a self-managed connector client this can't be undone.",
-                }
-              )}
-            </p>
-          </EuiText>
-        </EuiConfirmModal>
-      )}
+      {isModalVisible && <ConvertConnectorModal />}
       <EuiFlexGroup direction="row" alignItems="center" gutterSize="xs">
         <EuiFlexItem grow={false}>
           <EuiIcon type="wrench" />

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/types.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/types.ts
@@ -12,6 +12,7 @@ export interface ConnectorClientSideDefinition {
   externalAuthDocsUrl?: string;
   externalDocsUrl: string;
   icon: string;
+  platinumOnly?: boolean;
 }
 
 export type ConnectorDefinition = ConnectorClientSideDefinition & ConnectorServerSideDefinition;

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/overview.tsx
@@ -69,7 +69,7 @@ export const SearchIndexOverview: React.FC = () => {
             title={i18n.translate(
               'xpack.enterpriseSearch.content.searchIndex.nativeCloudCallout.title',
               {
-                defaultMessage: 'Native connectors are now only supported on Elastic Cloud',
+                defaultMessage: 'Native connectors are no longer supported outside Elastic Cloud',
               }
             )}
           >
@@ -78,7 +78,7 @@ export const SearchIndexOverview: React.FC = () => {
               <p>
                 <FormattedMessage
                   id="xpack.enterpriseSearch.content.searchIndex.nativeCloudCallout.content"
-                  defaultMessage="To continue using this connector, you'll need to convert  it to a {link}, that you'll self-manage on your own infrastructure."
+                  defaultMessage="Convert it to a {link}, to be self-managed on your own infrastructure. Native connectors are available only in your Elastic Cloud deployment."
                   values={{
                     link: (
                       <EuiLink href={docLinks.buildConnector} target="_blank">

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/overview.tsx
@@ -69,7 +69,7 @@ export const SearchIndexOverview: React.FC = () => {
             title={i18n.translate(
               'xpack.enterpriseSearch.content.searchIndex.nativeCloudCallout.title',
               {
-                defaultMessage: 'Native connectors are no longer supported outside Elastic Cloud',
+                defaultMessage: 'Native connectors are now only supported on Elastic Cloud',
               }
             )}
           >
@@ -78,7 +78,7 @@ export const SearchIndexOverview: React.FC = () => {
               <p>
                 <FormattedMessage
                   id="xpack.enterpriseSearch.content.searchIndex.nativeCloudCallout.title"
-                  defaultMessage="Convert this native connector to a {link}, to be self-managed on your own infrastructure."
+                  defaultMessage="To continue using this connector, you'll need to convert  it to a {link}, that you'll self-manage on your own infrastructure."
                   values={{
                     link: (
                       <EuiLink href={docLinks.buildConnector} target="_blank">

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/overview.tsx
@@ -77,7 +77,7 @@ export const SearchIndexOverview: React.FC = () => {
             <EuiText size="s">
               <p>
                 <FormattedMessage
-                  id="xpack.enterpriseSearch.content.searchIndex.nativeCloudCallout.title"
+                  id="xpack.enterpriseSearch.content.searchIndex.nativeCloudCallout.content"
                   defaultMessage="To continue using this connector, you'll need to convert  it to a {link}, that you'll self-manage on your own infrastructure."
                   values={{
                     link: (

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/overview.tsx
@@ -7,15 +7,22 @@
 
 import React from 'react';
 
-import { useValues } from 'kea';
+import { useActions, useValues } from 'kea';
 
-import { EuiCallOut, EuiSpacer, EuiText } from '@elastic/eui';
+import { EuiButton, EuiCallOut, EuiLink, EuiSpacer, EuiText } from '@elastic/eui';
 
 import { i18n } from '@kbn/i18n';
 
+import { FormattedMessage } from '@kbn/i18n-react';
+
+import { docLinks } from '../../../shared/doc_links';
+import { KibanaLogic } from '../../../shared/kibana';
 import { isApiIndex, isConnectorIndex, isCrawlerIndex } from '../../utils/indices';
 
+import { ConvertConnectorModal } from '../shared/convert_connector_modal/convert_connector_modal';
+
 import { ApiTotalStats } from './api_total_stats';
+import { ConvertConnectorLogic } from './connector/native_connector_configuration/convert_connector_logic';
 import { ConnectorTotalStats } from './connector_total_stats';
 import { CrawlDetailsFlyout } from './crawler/crawl_details_flyout/crawl_details_flyout';
 import { CrawlRequestsPanel } from './crawler/crawl_requests_panel/crawl_requests_panel';
@@ -28,6 +35,9 @@ import { SyncJobs } from './sync_jobs/sync_jobs';
 export const SearchIndexOverview: React.FC = () => {
   const { indexData } = useValues(OverviewLogic);
   const { error } = useValues(IndexViewLogic);
+  const { isCloud } = useValues(KibanaLogic);
+  const { showModal } = useActions(ConvertConnectorLogic);
+  const { isModalVisible } = useValues(ConvertConnectorLogic);
 
   return (
     <>
@@ -46,6 +56,49 @@ export const SearchIndexOverview: React.FC = () => {
           >
             <EuiSpacer size="s" />
             <EuiText size="s">{error}</EuiText>
+          </EuiCallOut>
+          <EuiSpacer />
+        </>
+      )}
+      {isConnectorIndex(indexData) && indexData.connector.is_native && !isCloud && (
+        <>
+          {isModalVisible && <ConvertConnectorModal />}
+          <EuiCallOut
+            iconType="warning"
+            color="warning"
+            title={i18n.translate(
+              'xpack.enterpriseSearch.content.searchIndex.nativeCloudCallout.title',
+              {
+                defaultMessage: 'Native connectors are no longer supported outside Elastic Cloud',
+              }
+            )}
+          >
+            <EuiSpacer size="s" />
+            <EuiText size="s">
+              <p>
+                <FormattedMessage
+                  id="xpack.enterpriseSearch.content.searchIndex.nativeCloudCallout.title"
+                  defaultMessage="Convert this native connector to a {link}, to be self-managed on your own infrastructure."
+                  values={{
+                    link: (
+                      <EuiLink href={docLinks.buildConnector} target="_blank">
+                        {i18n.translate(
+                          'xpack.enterpriseSearch.content.searchIndex.nativeCloudCallout.connectorClient',
+                          { defaultMessage: 'connector client' }
+                        )}
+                      </EuiLink>
+                    ),
+                  }}
+                />
+              </p>
+            </EuiText>
+            <EuiSpacer size="s" />
+            <EuiButton color="warning" fill onClick={() => showModal()}>
+              {i18n.translate(
+                'xpack.enterpriseSearch.content.indices.searchIndex.convertConnector.buttonLabel',
+                { defaultMessage: 'Convert connector' }
+              )}
+            </EuiButton>
           </EuiCallOut>
           <EuiSpacer />
         </>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/shared/convert_connector_modal/convert_connector_modal.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/shared/convert_connector_modal/convert_connector_modal.tsx
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { useActions, useValues } from 'kea';
+
+import { EuiConfirmModal, EuiText } from '@elastic/eui';
+
+import { i18n } from '@kbn/i18n';
+
+import { CANCEL_BUTTON_LABEL } from '../../../../shared/constants';
+
+import { ConvertConnectorLogic } from '../../search_index/connector/native_connector_configuration/convert_connector_logic';
+
+export const ConvertConnectorModal: React.FC = () => {
+  const { convertConnector, hideModal } = useActions(ConvertConnectorLogic);
+  const { isLoading } = useValues(ConvertConnectorLogic);
+  return (
+    <EuiConfirmModal
+      onCancel={() => hideModal()}
+      onConfirm={() => convertConnector()}
+      title={i18n.translate(
+        'xpack.enterpriseSearch.content.engine.indices.convertInfexConfirm.title',
+        { defaultMessage: 'Sure you want to convert your connector?' }
+      )}
+      buttonColor="danger"
+      cancelButtonText={CANCEL_BUTTON_LABEL}
+      confirmButtonText={i18n.translate(
+        'xpack.enterpriseSearch.content.engine.indices.convertIndexConfirm.text',
+        {
+          defaultMessage: 'Yes',
+        }
+      )}
+      isLoading={isLoading}
+      defaultFocusedButton="confirm"
+      maxWidth
+    >
+      <EuiText>
+        <p>
+          {i18n.translate(
+            'xpack.enterpriseSearch.content.engine.indices.convertIndexConfirm.description',
+            {
+              defaultMessage:
+                "Once you convert a native connector to a self-managed connector client this can't be undone.",
+            }
+          )}
+        </p>
+      </EuiText>
+    </EuiConfirmModal>
+  );
+};

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/shared/platinum_license_popover/platinum_license_popover.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/shared/platinum_license_popover/platinum_license_popover.tsx
@@ -1,0 +1,99 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { css } from '@emotion/react';
+
+import {
+  EuiPopover,
+  EuiPopoverTitle,
+  EuiText,
+  EuiPopoverFooter,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiButton,
+  EuiPopoverProps,
+  useEuiTheme,
+} from '@elastic/eui';
+
+import { i18n } from '@kbn/i18n';
+
+import { docLinks } from '../../../../shared/doc_links';
+import { KibanaLogic } from '../../../../shared/kibana';
+
+interface PlatinumLicensePopoverProps {
+  button: EuiPopoverProps['button'];
+  closePopover: () => void;
+  isPopoverOpen: boolean;
+}
+
+export const PlatinumLicensePopover: React.FC<PlatinumLicensePopoverProps> = ({
+  button,
+  isPopoverOpen,
+  closePopover,
+}) => {
+  const { euiTheme } = useEuiTheme();
+  return (
+    <EuiPopover button={button} isOpen={isPopoverOpen} closePopover={closePopover}>
+      <EuiPopoverTitle>
+        {i18n.translate('xpack.enterpriseSearch.content.newIndex.selectConnector.upgradeTitle', {
+          defaultMessage: 'Upgrade to Elastic Platinum',
+        })}
+      </EuiPopoverTitle>
+      <EuiText
+        grow={false}
+        size="s"
+        css={css`
+          max-width: calc(${euiTheme.size.xl} * 10);
+        `}
+      >
+        <p>
+          {i18n.translate(
+            'xpack.enterpriseSearch.content.newIndex.selectConnector.upgradeContent',
+            {
+              defaultMessage:
+                'To use this connector, you must update your license to Platinum or start a 30-day free trial.',
+            }
+          )}
+        </p>
+      </EuiText>
+      <EuiPopoverFooter>
+        <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
+          <EuiFlexItem grow={false}>
+            <EuiButton iconType="popout" target="_blank" href={docLinks.licenseManagement}>
+              {i18n.translate(
+                'xpack.enterpriseSearch.content.newIndex.selectConnector.subscriptionButtonLabel',
+                {
+                  defaultMessage: 'Subscription plans',
+                }
+              )}
+            </EuiButton>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiButton
+              iconType="wrench"
+              iconSide="right"
+              onClick={() =>
+                KibanaLogic.values.navigateToUrl('/app/management/stack/license_management', {
+                  shouldNotCreateHref: true,
+                })
+              }
+            >
+              {i18n.translate(
+                'xpack.enterpriseSearch.content.newIndex.selectConnector.manageLicenseButtonLabel',
+                {
+                  defaultMessage: 'Manage license',
+                }
+              )}
+            </EuiButton>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiPopoverFooter>
+    </EuiPopover>
+  );
+};


### PR DESCRIPTION
## Summary

This blocks users from creating new native connectors if they're not on cloud, gates the SharePoint Online connector to be platinum only, and adds a callout to convert non-cloud native connectors. 

<img width="1276" alt="Screenshot 2023-06-08 at 17 59 06" src="https://github.com/elastic/kibana/assets/94373878/50030ed8-e224-4ec4-b424-e1eb5d65e066">
<img width="509" alt="Screenshot 2023-06-08 at 17 56 06" src="https://github.com/elastic/kibana/assets/94373878/7e9128db-e459-4342-9bcb-202cb6e4a998">
