### PR TITLE
Add asset source switching config

### DIFF
--- a/x-pack/plugins/asset_manager/server/index.ts
+++ b/x-pack/plugins/asset_manager/server/index.ts
@@ -6,8 +6,9 @@
  */
 
 import { PluginInitializerContext } from '@kbn/core-plugins-server';
-import { AssetManagerServerPlugin, config, AssetManagerConfig } from './plugin';
+import { AssetManagerServerPlugin, config } from './plugin';
 import type { WriteSamplesPostBody } from './routes/sample_assets';
+import { AssetManagerConfig } from './types';
 
 export type { AssetManagerConfig, WriteSamplesPostBody };
 export { config };

--- a/x-pack/plugins/asset_manager/server/lib/implicit_collection/collector_runner.test.ts
+++ b/x-pack/plugins/asset_manager/server/lib/implicit_collection/collector_runner.test.ts
@@ -10,6 +10,7 @@ import { ElasticsearchClient, Logger } from '@kbn/core/server';
 import { CollectorRunner } from './collector_runner';
 import { CollectorOptions } from './collectors';
 import { Asset } from '../../../common/types_api';
+import { INDEX_DEFAULTS } from '../../types';
 
 const getMockClient = () => ({
   bulk: jest.fn().mockResolvedValue({ errors: false }),
@@ -28,6 +29,7 @@ describe(__filename, () => {
       outputClient: getMockClient() as unknown as ElasticsearchClient,
       logger: getMockLogger(),
       intervalMs: 1,
+      sourceIndices: INDEX_DEFAULTS,
     });
 
     const collector1 = jest.fn(async (opts: CollectorOptions) => {
@@ -52,6 +54,7 @@ describe(__filename, () => {
       inputClient: getMockClient() as unknown as ElasticsearchClient,
       logger: getMockLogger(),
       intervalMs: 1,
+      sourceIndices: INDEX_DEFAULTS,
     });
 
     const collector1 = jest.fn(async (opts: CollectorOptions) => {
@@ -77,6 +80,7 @@ describe(__filename, () => {
       inputClient: getMockClient() as unknown as ElasticsearchClient,
       logger: getMockLogger(),
       intervalMs: 1,
+      sourceIndices: INDEX_DEFAULTS,
     });
 
     const collector = jest.fn(async (opts: CollectorOptions) => {

--- a/x-pack/plugins/asset_manager/server/lib/implicit_collection/collector_runner.ts
+++ b/x-pack/plugins/asset_manager/server/lib/implicit_collection/collector_runner.ts
@@ -35,6 +35,7 @@ export class CollectorRunner {
         from: now - this.options.intervalMs,
         client: this.options.inputClient,
         transaction,
+        sourceIndices: this.options.sourceIndices,
       };
 
       const assets = await collector(collectorOptions)

--- a/x-pack/plugins/asset_manager/server/lib/implicit_collection/collectors/containers.ts
+++ b/x-pack/plugins/asset_manager/server/lib/implicit_collection/collectors/containers.ts
@@ -5,14 +5,19 @@
  * 2.0.
  */
 
-import { APM_INDICES, LOGS_INDICES, METRICS_INDICES } from '../../../constants';
 import { Asset } from '../../../../common/types_api';
 import { CollectorOptions, QUERY_MAX_SIZE } from '.';
 import { withSpan } from './helpers';
 
-export async function collectContainers({ client, from, transaction }: CollectorOptions) {
+export async function collectContainers({
+  client,
+  from,
+  transaction,
+  sourceIndices,
+}: CollectorOptions) {
+  const { metrics, logs, traces } = sourceIndices;
   const dsl = {
-    index: [APM_INDICES, LOGS_INDICES, METRICS_INDICES],
+    index: [traces, logs, metrics],
     size: QUERY_MAX_SIZE,
     collapse: {
       field: 'container.id',

--- a/x-pack/plugins/asset_manager/server/lib/implicit_collection/collectors/hosts.ts
+++ b/x-pack/plugins/asset_manager/server/lib/implicit_collection/collectors/hosts.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import { APM_INDICES, METRICS_INDICES, LOGS_INDICES } from '../../../constants';
 import { Asset } from '../../../../common/types_api';
 import { CollectorOptions, QUERY_MAX_SIZE } from '.';
 import { withSpan } from './helpers';
@@ -14,9 +13,11 @@ export async function collectHosts({
   client,
   from,
   transaction,
+  sourceIndices,
 }: CollectorOptions): Promise<Asset[]> {
+  const { metrics, logs, traces } = sourceIndices;
   const dsl = {
-    index: [APM_INDICES, LOGS_INDICES, METRICS_INDICES],
+    index: [metrics, logs, traces],
     size: QUERY_MAX_SIZE,
     collapse: { field: 'host.hostname' },
     sort: [{ _score: 'desc' }, { '@timestamp': 'desc' }],

--- a/x-pack/plugins/asset_manager/server/lib/implicit_collection/collectors/index.ts
+++ b/x-pack/plugins/asset_manager/server/lib/implicit_collection/collectors/index.ts
@@ -7,6 +7,7 @@
 
 import { Transaction } from 'elastic-apm-node';
 import { ElasticsearchClient } from '@kbn/core/server';
+import { AssetManagerConfig } from '../../../types';
 import { Asset } from '../../../../common/types_api';
 
 export const QUERY_MAX_SIZE = 1000;
@@ -15,6 +16,7 @@ export interface CollectorOptions {
   client: ElasticsearchClient;
   from: number;
   transaction: Transaction | null;
+  sourceIndices: AssetManagerConfig['sourceIndices'];
 }
 
 export type Collector = (opts: CollectorOptions) => Promise<Asset[]>;

--- a/x-pack/plugins/asset_manager/server/lib/implicit_collection/collectors/pods.ts
+++ b/x-pack/plugins/asset_manager/server/lib/implicit_collection/collectors/pods.ts
@@ -5,14 +5,14 @@
  * 2.0.
  */
 
-import { APM_INDICES, LOGS_INDICES, METRICS_INDICES } from '../../../constants';
 import { Asset } from '../../../../common/types_api';
 import { CollectorOptions, QUERY_MAX_SIZE } from '.';
 import { withSpan } from './helpers';
 
-export async function collectPods({ client, from, transaction }: CollectorOptions) {
+export async function collectPods({ client, from, transaction, sourceIndices }: CollectorOptions) {
+  const { metrics, logs, traces } = sourceIndices;
   const dsl = {
-    index: [APM_INDICES, LOGS_INDICES, METRICS_INDICES],
+    index: [metrics, logs, traces],
     size: QUERY_MAX_SIZE,
     collapse: {
       field: 'kubernetes.pod.uid',

--- a/x-pack/plugins/asset_manager/server/lib/implicit_collection/collectors/services.ts
+++ b/x-pack/plugins/asset_manager/server/lib/implicit_collection/collectors/services.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import { APM_INDICES } from '../../../constants';
 import { Asset } from '../../../../common/types_api';
 import { CollectorOptions, QUERY_MAX_SIZE } from '.';
 import { withSpan } from './helpers';
@@ -16,9 +15,11 @@ export async function collectServices({
   client,
   from,
   transaction,
+  sourceIndices,
 }: CollectorOptions): Promise<Asset[]> {
+  const { traces, serviceMetrics, serviceLogs } = sourceIndices;
   const dsl = {
-    index: APM_INDICES,
+    index: [traces, serviceMetrics, serviceLogs],
     size: 0,
     sort: [
       {

--- a/x-pack/plugins/asset_manager/server/lib/implicit_collection/index.ts
+++ b/x-pack/plugins/asset_manager/server/lib/implicit_collection/index.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 import { ElasticsearchClient, Logger } from '@kbn/core/server';
+import { AssetManagerConfig } from '../../types';
 
 import { collectContainers, collectHosts, collectPods, collectServices } from './collectors';
 import { CollectorRunner } from './collector_runner';
@@ -14,6 +15,7 @@ export interface ImplicitCollectionOptions {
   outputClient: ElasticsearchClient;
   intervalMs: number;
   logger: Logger;
+  sourceIndices: AssetManagerConfig['sourceIndices'];
 }
 
 export function startImplicitCollection(options: ImplicitCollectionOptions): () => void {

--- a/x-pack/plugins/asset_manager/server/plugin.ts
+++ b/x-pack/plugins/asset_manager/server/plugin.ts
@@ -26,6 +26,10 @@ export type AssetManagerServerPluginSetup = ReturnType<AssetManagerServerPlugin[
 
 const configSchema = schema.object({
   alphaEnabled: schema.maybe(schema.boolean()),
+  // Designate where various types of data live.
+  // NOTE: this should be handled in a centralized way for observability, so
+  // that when a user configures these differently from the known defaults,
+  // that value is propagated everywhere. For now, we duplicate the value here.
   sourceIndices: schema.maybe(
     schema.object({
       metrics: schema.string({ defaultValue: 'metricbeat-*,metrics-*' }),
@@ -34,6 +38,11 @@ const configSchema = schema.object({
       serviceMetrics: schema.string({ defaultValue: 'metrics-apm*' }),
     })
   ),
+  // Choose an explicit source for asset queries.
+  // NOTE: This will eventually need to be able to cleverly switch
+  // between these values based on the availability of data in the
+  // indices, and possibly for each asset kind/type value.
+  // For now, we set this explicitly.
   lockedSource: schema.oneOf([schema.literal('assets'), schema.literal('signals')], {
     defaultValue: 'signals',
   }),

--- a/x-pack/plugins/asset_manager/server/plugin.ts
+++ b/x-pack/plugins/asset_manager/server/plugin.ts
@@ -26,6 +26,17 @@ export type AssetManagerServerPluginSetup = ReturnType<AssetManagerServerPlugin[
 
 const configSchema = schema.object({
   alphaEnabled: schema.maybe(schema.boolean()),
+  sourceIndices: schema.maybe(
+    schema.object({
+      metrics: schema.string({ defaultValue: 'metricbeat-*,metrics-*' }),
+      logs: schema.string({ defaultValue: 'filebeat-*,logs-*' }),
+      traces: schema.string({ defaultValue: 'traces-*' }),
+      serviceMetrics: schema.string({ defaultValue: 'metrics-apm*' }),
+    })
+  ),
+  lockedSource: schema.oneOf([schema.literal('assets'), schema.literal('signals')], {
+    defaultValue: 'signals',
+  }),
   implicitCollection: schema.maybe(
     schema.object({
       enabled: schema.boolean({ defaultValue: true }),

--- a/x-pack/plugins/asset_manager/server/types.ts
+++ b/x-pack/plugins/asset_manager/server/types.ts
@@ -5,8 +5,65 @@
  * 2.0.
  */
 
+import { schema, TypeOf } from '@kbn/config-schema';
 import { ElasticsearchClient } from '@kbn/core/server';
 
 export interface ElasticsearchAccessorOptions {
   esClient: ElasticsearchClient;
 }
+
+export const INDEX_DEFAULTS = {
+  metrics: 'metricbeat-*,metrics-*',
+  logs: 'filebeat-*,logs-*',
+  traces: 'traces-*',
+  serviceMetrics: 'metrics-apm*',
+  serviceLogs: 'logs-apm*',
+};
+
+export const configSchema = schema.object({
+  alphaEnabled: schema.maybe(schema.boolean()),
+  // Designate where various types of data live.
+  // NOTE: this should be handled in a centralized way for observability, so
+  // that when a user configures these differently from the known defaults,
+  // that value is propagated everywhere. For now, we duplicate the value here.
+  sourceIndices: schema.object(
+    {
+      metrics: schema.string({ defaultValue: INDEX_DEFAULTS.metrics }),
+      logs: schema.string({ defaultValue: INDEX_DEFAULTS.logs }),
+      traces: schema.string({ defaultValue: INDEX_DEFAULTS.traces }),
+      serviceMetrics: schema.string({ defaultValue: INDEX_DEFAULTS.serviceMetrics }),
+      serviceLogs: schema.string({ defaultValue: INDEX_DEFAULTS.serviceLogs }),
+    },
+    { defaultValue: INDEX_DEFAULTS }
+  ),
+  // Choose an explicit source for asset queries.
+  // NOTE: This will eventually need to be able to cleverly switch
+  // between these values based on the availability of data in the
+  // indices, and possibly for each asset kind/type value.
+  // For now, we set this explicitly.
+  lockedSource: schema.oneOf([schema.literal('assets'), schema.literal('signals')], {
+    defaultValue: 'signals',
+  }),
+  implicitCollection: schema.maybe(
+    schema.object({
+      enabled: schema.boolean({ defaultValue: true }),
+      interval: schema.duration({ defaultValue: '5m' }),
+      input: schema.maybe(
+        schema.object({
+          hosts: schema.string(),
+          username: schema.string(),
+          password: schema.string(),
+        })
+      ),
+      output: schema.maybe(
+        schema.object({
+          hosts: schema.string(),
+          username: schema.string(),
+          password: schema.string(),
+        })
+      ),
+    })
+  ),
+});
+
+export type AssetManagerConfig = TypeOf<typeof configSchema>;


### PR DESCRIPTION
## Summary

Closes #158858 

This PR introduces a few new config values to allow the asset manager to read from signals indices. These config values are explained in comments in the PR.

This PR _also_ changes implicit collection logic to use these configuration values (and their associated defaults) for querying the signals in the implicit collection flow.