### PR TITLE
[Security] Skip "actions tab adds an action to a snoozed rule" test.

### DIFF
--- a/x-pack/plugins/security_solution/cypress/e2e/detection_rules/rule_snoozing.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_rules/rule_snoozing.cy.ts
@@ -165,7 +165,8 @@ describe('rule snoozing', () => {
     });
   });
 
-  describe('Rule editing page / actions tab', () => {
+  // SKIPPED: https://github.com/elastic/kibana/issues/159349
+  describe.skip('Rule editing page / actions tab', () => {
     beforeEach(() => {
       deleteConnectors();
     });


### PR DESCRIPTION
## Summary
Skip `Security Solution Tests #2 / rule snoozing Rule editing page / actions tab adds an action to a snoozed rule`

[This test failed on `main` as soon as it was merged.](https://buildkite.com/elastic/kibana-on-merge-unsupported-ftrs/builds/2952)


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
