### PR TITLE
[Profiling] Use secondary authentication if available

### DIFF
--- a/x-pack/plugins/profiling/common/setup.ts
+++ b/x-pack/plugins/profiling/common/setup.ts
@@ -7,6 +7,7 @@
 
 import { merge } from 'lodash';
 import { RecursivePartial } from '@kbn/apm-plugin/typings/common';
+import type { Logger } from '@kbn/core/server';
 
 export interface SetupState {
   cloud: {
@@ -82,6 +83,20 @@ export function createDefaultSetupState(): SetupState {
       configured: false,
     },
   };
+}
+
+export function logSetupState(logger: Logger, state: SetupState) {
+  logger.info(`cloud.available = ${state.cloud.available}`);
+  logger.info(`cloud.required = ${state.cloud.required}`);
+  logger.info(`data.available = ${state.data.available}`);
+  logger.info(`packages.installed = ${state.packages.installed}`);
+  logger.info(`permissions.configured = ${state.permissions.configured}`);
+  logger.info(`policies.apm.installed = ${state.policies.apm.installed}`);
+  logger.info(`policies.collector.installed = ${state.policies.collector.installed}`);
+  logger.info(`policies.symbolizer.installed = ${state.policies.symbolizer.installed}`);
+  logger.info(`resource_management.enabled = ${state.resource_management.enabled}`);
+  logger.info(`resources.created = ${state.resources.created}`);
+  logger.info(`settings.configured = ${state.settings.configured}`);
 }
 
 export function areResourcesSetup(state: SetupState): boolean {

--- a/x-pack/plugins/profiling/server/routes/setup.ts
+++ b/x-pack/plugins/profiling/server/routes/setup.ts
@@ -51,13 +51,12 @@ export function registerSetupRoute({
       try {
         const esClient = await getClient(context);
         const core = await context.core;
-        const clientWithDefaultAuth = createProfilingEsClient({
+        const client = createProfilingEsClient({
           esClient,
           request,
-          useDefaultAuth: true,
         });
         const setupOptions: ProfilingSetupOptions = {
-          client: clientWithDefaultAuth,
+          client,
           logger,
           packagePolicyClient: dependencies.start.fleet.packagePolicyService,
           soClient: core.savedObjects.client,
@@ -116,13 +115,12 @@ export function registerSetupRoute({
       try {
         const esClient = await getClient(context);
         const core = await context.core;
-        const clientWithDefaultAuth = createProfilingEsClient({
+        const client = createProfilingEsClient({
           esClient,
           request,
-          useDefaultAuth: true,
         });
         const setupOptions: ProfilingSetupOptions = {
-          client: clientWithDefaultAuth,
+          client,
           logger,
           packagePolicyClient: dependencies.start.fleet.packagePolicyService,
           soClient: core.savedObjects.client,

--- a/x-pack/plugins/profiling/server/routes/setup.ts
+++ b/x-pack/plugins/profiling/server/routes/setup.ts
@@ -31,6 +31,7 @@ import { getRoutePaths } from '../../common';
 import {
   areResourcesSetup,
   createDefaultSetupState,
+  logSetupState,
   mergePartialSetupStates,
 } from '../../common/setup';
 
@@ -94,6 +95,8 @@ export function registerSetupRoute({
         const partialStates = await Promise.all(verifyFunctions.map((fn) => fn(setupOptions)));
         const mergedState = mergePartialSetupStates(state, partialStates);
 
+        logSetupState(logger, mergedState);
+
         return response.ok({
           body: {
             has_setup: areResourcesSetup(mergedState),
@@ -156,6 +159,8 @@ export function registerSetupRoute({
         ];
         const partialStates = await Promise.all(verifyFunctions.map((fn) => fn(setupOptions)));
         const mergedState = mergePartialSetupStates(state, partialStates);
+
+        logSetupState(logger, mergedState);
 
         if (areResourcesSetup(mergedState)) {
           return response.ok();


### PR DESCRIPTION
This PR fixes a bug in which the secondary Elasticsearch authentication was not used if it was available.

The value of the setup state is also logged.