### PR TITLE
[Unified search] Fixes the wrap problem on the filter selection modal

### DIFF
--- a/src/plugins/unified_search/public/apply_filters/apply_filter_popover_content.tsx
+++ b/src/plugins/unified_search/public/apply_filters/apply_filter_popover_content.tsx
@@ -18,6 +18,7 @@ import {
   EuiCheckbox,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { css } from '@emotion/react';
 import React, { Component } from 'react';
 import {
   getDisplayValueFromFilter,
@@ -77,6 +78,9 @@ export default class ApplyFiltersPopoverContent extends Component<Props, State> 
               label={this.getLabel(filter)}
               checked={this.isFilterSelected(i)}
               onChange={() => this.toggleFilterSelected(i)}
+              css={css`
+                word-break: break-word;
+              `}
             />
           </EuiFormRow>
         ))}


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/158232

Fixes the wrap problem in filter selection modal when the text field/value is very long

<img width="956" alt="image" src="https://github.com/elastic/kibana/assets/17003240/beda8e16-6302-4d7e-aa84-0b6884891ccc">
