### PR TITLE
[Enterprise Search] Add access control index selector for document and mapping pages

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/components/access_control_index_selector/access_control_index_selector.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/components/access_control_index_selector/access_control_index_selector.tsx
@@ -1,0 +1,87 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { EuiFlexGrid, EuiFlexItem, EuiSuperSelect, EuiText, EuiTitle } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+
+export interface AccessControlSelectorOption {
+  description: string;
+  title: string;
+  value: 'content-index' | 'access-control-index';
+}
+
+const indexSelectorOptions: AccessControlSelectorOption[] = [
+  {
+    description: i18n.translate(
+      'xpack.enterpriseSearch.content.searchIndex.documents.selector.contentIndex.description',
+      {
+        defaultMessage: 'Browse content fields',
+      }
+    ),
+    title: i18n.translate(
+      'xpack.enterpriseSearch.content.searchIndex.documents.selector.contentIndex.title',
+      {
+        defaultMessage: 'Content index',
+      }
+    ),
+    value: 'content-index',
+  },
+  {
+    description: i18n.translate(
+      'xpack.enterpriseSearch.content.searchIndex.documents.selector.accessControl.description',
+      {
+        defaultMessage: 'Browse document level security fields',
+      }
+    ),
+    title: i18n.translate(
+      'xpack.enterpriseSearch.content.searchIndex.documents.selector.accessControl.title',
+      {
+        defaultMessage: 'Access control index',
+      }
+    ),
+    value: 'access-control-index',
+  },
+];
+
+interface IndexSelectorProps {
+  onChange(value: AccessControlSelectorOption['value']): void;
+  valueOfSelected?: AccessControlSelectorOption['value'];
+}
+
+export const AccessControlIndexSelector: React.FC<IndexSelectorProps> = ({
+  valueOfSelected,
+  onChange,
+}) => {
+  return (
+    <EuiSuperSelect
+      valueOfSelected={valueOfSelected}
+      onChange={onChange}
+      options={indexSelectorOptions.map((option) => {
+        return {
+          dropdownDisplay: (
+            <EuiFlexGrid gutterSize="none">
+              <EuiFlexItem>
+                <EuiTitle size="xs">
+                  <h4>{option.title}</h4>
+                </EuiTitle>
+              </EuiFlexItem>
+              <EuiFlexItem>
+                <EuiText size="xs">
+                  <p>{option.description}</p>
+                </EuiText>
+              </EuiFlexItem>
+            </EuiFlexGrid>
+          ),
+          inputDisplay: option.title,
+          value: option.value,
+        };
+      })}
+    />
+  );
+};

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/documents.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/documents.tsx
@@ -44,7 +44,7 @@ export const SearchIndexDocuments: React.FC = () => {
   const indexToShow =
     selectedIndexType === 'content-index'
       ? indexName
-      : indexName.replace('search-', 'access-control-');
+      : indexName.replace('search-', '.search-acl-filter-');
 
   const shouldShowAccessControlSwitcher =
     hasDocumentLevelSecurityFeature && productFeatures.hasDocumentLevelSecurityEnabled;

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/documents.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/documents.tsx
@@ -42,7 +42,9 @@ export const SearchIndexDocuments: React.FC = () => {
   const [selectedIndexType, setSelectedIndexType] =
     useState<AccessControlSelectorOption['value']>('content-index');
   const indexToShow =
-    selectedIndexType === 'content-index' ? indexName : 'TODO-access-control-index';
+    selectedIndexType === 'content-index'
+      ? indexName
+      : indexName.replace('search-', 'access-control-');
 
   const shouldShowAccessControlSwitcher =
     hasDocumentLevelSecurityFeature && productFeatures.hasDocumentLevelSecurityEnabled;

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/documents.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/documents.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useEffect, ChangeEvent } from 'react';
+import React, { useEffect, useState, ChangeEvent } from 'react';
 
 import { useActions, useValues } from 'kea';
 
@@ -20,28 +20,41 @@ import {
 
 import { i18n } from '@kbn/i18n';
 
+import { KibanaLogic } from '../../../shared/kibana';
+
+import {
+  AccessControlIndexSelector,
+  AccessControlSelectorOption,
+} from './components/access_control_index_selector/access_control_index_selector';
 import { DocumentList } from './components/document_list/document_list';
 import { DocumentsLogic, DEFAULT_PAGINATION } from './documents_logic';
-
 import { IndexNameLogic } from './index_name_logic';
-
-import './documents.scss';
 import { IndexViewLogic } from './index_view_logic';
+import './documents.scss';
 
 export const SearchIndexDocuments: React.FC = () => {
   const { indexName } = useValues(IndexNameLogic);
-  const { ingestionMethod } = useValues(IndexViewLogic);
+  const { ingestionMethod, hasDocumentLevelSecurityFeature } = useValues(IndexViewLogic);
   const { simplifiedMapping } = useValues(DocumentsLogic);
   const { makeRequest, makeMappingRequest, setSearchQuery } = useActions(DocumentsLogic);
+  const { productFeatures } = useValues(KibanaLogic);
+
+  const [selectedIndexType, setSelectedIndexType] =
+    useState<AccessControlSelectorOption['value']>('content-index');
+  const indexToShow =
+    selectedIndexType === 'content-index' ? indexName : 'TODO-access-control-index';
+
+  const shouldShowAccessControlSwitcher =
+    hasDocumentLevelSecurityFeature && productFeatures.hasDocumentLevelSecurityEnabled;
 
   useEffect(() => {
     makeRequest({
-      indexName,
+      indexName: indexToShow,
       pagination: DEFAULT_PAGINATION,
       query: '',
     });
-    makeMappingRequest({ indexName });
-  }, [indexName]);
+    makeMappingRequest({ indexName: indexToShow });
+  }, [indexToShow, indexName]);
 
   return (
     <EuiPanel hasBorder={false} hasShadow={false} paddingSize="none">
@@ -58,6 +71,14 @@ export const SearchIndexDocuments: React.FC = () => {
                 </h2>
               </EuiTitle>
             </EuiFlexItem>
+            {shouldShowAccessControlSwitcher && (
+              <EuiFlexItem grow={false}>
+                <AccessControlIndexSelector
+                  onChange={setSelectedIndexType}
+                  valueOfSelected={selectedIndexType}
+                />
+              </EuiFlexItem>
+            )}
             <EuiFlexItem>
               <EuiFieldSearch
                 data-telemetry-id={`entSearchContent-${ingestionMethod}-documents-searchDocuments`}

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/index_mappings.scss
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/index_mappings.scss
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+.enterpriseSearchMappingsSelector {
+  max-width: $euiSizeXXL * 6;
+}

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/index_mappings.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/index_mappings.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { useActions, useValues } from 'kea';
 
@@ -27,26 +27,56 @@ import { FormattedMessage } from '@kbn/i18n-react';
 
 import { docLinks } from '../../../shared/doc_links';
 
+import { KibanaLogic } from '../../../shared/kibana';
+
+import {
+  AccessControlIndexSelector,
+  AccessControlSelectorOption,
+} from './components/access_control_index_selector/access_control_index_selector';
 import { DocumentsLogic } from './documents_logic';
 import { IndexNameLogic } from './index_name_logic';
+import { IndexViewLogic } from './index_view_logic';
+
+import './index_mappings.scss';
 
 export const SearchIndexIndexMappings: React.FC = () => {
   const { indexName } = useValues(IndexNameLogic);
   const { makeMappingRequest } = useActions(DocumentsLogic);
   const { mappingData } = useValues(DocumentsLogic);
+  const { hasDocumentLevelSecurityFeature } = useValues(IndexViewLogic);
+  const { productFeatures } = useValues(KibanaLogic);
 
+  const [selectedIndexType, setSelectedIndexType] =
+    useState<AccessControlSelectorOption['value']>('content-index');
+  const indexToShow =
+    selectedIndexType === 'content-index' ? indexName : 'TODO-access-control-index';
+
+  const shouldShowAccessControlSwitch =
+    hasDocumentLevelSecurityFeature && productFeatures.hasDocumentLevelSecurityEnabled;
   useEffect(() => {
-    makeMappingRequest({ indexName });
-  }, [indexName]);
+    makeMappingRequest({ indexName: indexToShow });
+  }, [indexToShow, indexName]);
 
   return (
     <>
       <EuiSpacer />
       <EuiFlexGroup>
         <EuiFlexItem grow={2}>
-          <EuiCodeBlock language="json" isCopyable>
-            {JSON.stringify(mappingData, null, 2)}
-          </EuiCodeBlock>
+          <EuiFlexGroup direction="column" gutterSize="s">
+            {shouldShowAccessControlSwitch && (
+              <EuiFlexItem grow={false} className="enterpriseSearchMappingsSelector">
+                <AccessControlIndexSelector
+                  onChange={setSelectedIndexType}
+                  valueOfSelected={selectedIndexType}
+                />
+              </EuiFlexItem>
+            )}
+            <EuiFlexItem grow>
+              <EuiCodeBlock language="json" isCopyable>
+                {JSON.stringify(mappingData, null, 2)}
+              </EuiCodeBlock>
+            </EuiFlexItem>
+          </EuiFlexGroup>
         </EuiFlexItem>
         <EuiFlexItem grow={1}>
           <EuiPanel grow={false} hasShadow={false} hasBorder>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/index_mappings.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/index_mappings.tsx
@@ -51,7 +51,7 @@ export const SearchIndexIndexMappings: React.FC = () => {
   const indexToShow =
     selectedIndexType === 'content-index'
       ? indexName
-      : indexName.replace('search-', 'access-control-');
+      : indexName.replace('search-', '.search-acl-filter-');
 
   const shouldShowAccessControlSwitch =
     hasDocumentLevelSecurityFeature && productFeatures.hasDocumentLevelSecurityEnabled;

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/index_mappings.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/index_mappings.tsx
@@ -49,7 +49,9 @@ export const SearchIndexIndexMappings: React.FC = () => {
   const [selectedIndexType, setSelectedIndexType] =
     useState<AccessControlSelectorOption['value']>('content-index');
   const indexToShow =
-    selectedIndexType === 'content-index' ? indexName : 'TODO-access-control-index';
+    selectedIndexType === 'content-index'
+      ? indexName
+      : indexName.replace('search-', 'access-control-');
 
   const shouldShowAccessControlSwitch =
     hasDocumentLevelSecurityFeature && productFeatures.hasDocumentLevelSecurityEnabled;


### PR DESCRIPTION
## Summary

![Screenshot 2023-06-09 at 14 57 17](https://github.com/elastic/kibana/assets/1410658/9b6f74b0-f627-4d85-8042-2fd924af2573)
![Screenshot 2023-06-09 at 14 58 00](https://github.com/elastic/kibana/assets/1410658/df7c241f-b2f6-40be-9ef9-34be3063d9f6)

- Add selector to switch in between content index and related permission index for documents page.
- Add selector to switch in between content index and permission index for mappings page.


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
