### PR TITLE
[Dashboard] [Controls] Fix dashboard reset when initial state has no controls

### DIFF
--- a/src/plugins/dashboard/public/dashboard_container/embeddable/dashboard_container.tsx
+++ b/src/plugins/dashboard/public/dashboard_container/embeddable/dashboard_container.tsx
@@ -327,17 +327,11 @@ export class DashboardContainer extends Container<InheritedChildInput, Dashboard
       },
     } = this.getState();
 
-    if (this.controlGroup) {
-      if (!lastSavedControlGroupInput) {
-        this.controlGroup.updateInput(getDefaultControlGroupInput());
-      } else if (
-        !persistableControlGroupInputIsEqual(
-          this.controlGroup.getInput(),
-          lastSavedControlGroupInput
-        )
-      ) {
-        this.controlGroup.updateInput(lastSavedControlGroupInput);
-      }
+    if (
+      this.controlGroup &&
+      !persistableControlGroupInputIsEqual(this.controlGroup.getInput(), lastSavedControlGroupInput)
+    ) {
+      this.controlGroup.updateInput(lastSavedControlGroupInput ?? getDefaultControlGroupInput());
     }
 
     // if we are using the unified search integration, we need to force reset the time picker.

--- a/src/plugins/dashboard/public/dashboard_container/embeddable/dashboard_container.tsx
+++ b/src/plugins/dashboard/public/dashboard_container/embeddable/dashboard_container.tsx
@@ -28,7 +28,10 @@ import { reportPerformanceMetricEvent } from '@kbn/ebt-tools';
 import { KibanaThemeProvider } from '@kbn/kibana-react-plugin/public';
 import type { ControlGroupContainer } from '@kbn/controls-plugin/public';
 import type { KibanaExecutionContext, OverlayRef } from '@kbn/core/public';
-import { persistableControlGroupInputIsEqual } from '@kbn/controls-plugin/common';
+import {
+  getDefaultControlGroupInput,
+  persistableControlGroupInputIsEqual,
+} from '@kbn/controls-plugin/common';
 import { ExitFullScreenButtonKibanaProvider } from '@kbn/shared-ux-button-exit-full-screen';
 
 import {
@@ -324,12 +327,17 @@ export class DashboardContainer extends Container<InheritedChildInput, Dashboard
       },
     } = this.getState();
 
-    if (
-      this.controlGroup &&
-      lastSavedControlGroupInput &&
-      !persistableControlGroupInputIsEqual(this.controlGroup.getInput(), lastSavedControlGroupInput)
-    ) {
-      this.controlGroup.updateInput(lastSavedControlGroupInput);
+    if (this.controlGroup) {
+      if (!lastSavedControlGroupInput) {
+        this.controlGroup.updateInput(getDefaultControlGroupInput());
+      } else if (
+        !persistableControlGroupInputIsEqual(
+          this.controlGroup.getInput(),
+          lastSavedControlGroupInput
+        )
+      ) {
+        this.controlGroup.updateInput(lastSavedControlGroupInput);
+      }
     }
 
     // if we are using the unified search integration, we need to force reset the time picker.


### PR DESCRIPTION
## Summary

Consider taking the following steps:

1. Create a new dashboard and save it
2. Add a control and, without saving,
3. Reset the changes to the dashboard

### Before 
Before this PR, we were not updating the control group input if the `lastSavedControlGroupInput` was `undefined` (which only happens when a dashboard has **never** been saved with any controls and/or edits to the control group settings) - this caused a problem when trying to reset a dashboard from having controls back to the state where `lastSavedControlGroupInput` was `undefined` because the **dashboard's** input would get updated as expected (i.e. the dashboard would think it no longer has any controls), but the control group's input wouldn't get updated (i.e. the control group would think it **still has** controls).

Because of this discrepancy, the control would stick around until you refreshed the dashboard:

https://github.com/elastic/kibana/assets/8698078/c9da58dc-3373-493d-9bba-5d2540c19560

### After
Now, after this PR, I fixed this by resetting back to the default control group input if `lastSavedControlGroupInput` is `undefined` on reset:

https://github.com/elastic/kibana/assets/8698078/e41838e6-6dbe-47a1-bea7-28f20eddcf80


### Checklist

- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
