### PR TITLE
[Search Applications] Link to dev tools console from connect page

### DIFF
--- a/x-pack/plugins/enterprise_search/common/types/kibana_deps.ts
+++ b/x-pack/plugins/enterprise_search/common/types/kibana_deps.ts
@@ -14,6 +14,7 @@ import type { GuidedOnboardingPluginStart } from '@kbn/guided-onboarding-plugin/
 import type { InfraClientStartExports } from '@kbn/infra-plugin/public';
 import type { LicensingPluginStart } from '@kbn/licensing-plugin/public';
 import type { SecurityPluginStart } from '@kbn/security-plugin/public';
+import type { SharePluginStart } from '@kbn/share-plugin/public';
 import type { SpacesPluginStart } from '@kbn/spaces-plugin/public';
 
 export interface KibanaDeps {
@@ -26,5 +27,6 @@ export interface KibanaDeps {
   infra: InfraClientStartExports;
   licensing: LicensingPluginStart;
   security: SecurityPluginStart;
+  share: SharePluginStart;
   spaces: SpacesPluginStart;
 }

--- a/x-pack/plugins/enterprise_search/common/types/search_applications.ts
+++ b/x-pack/plugins/enterprise_search/common/types/search_applications.ts
@@ -22,6 +22,13 @@ export interface EnterpriseSearchApplication {
 export interface EnterpriseSearchApplicationDetails {
   indices: EnterpriseSearchApplicationIndex[];
   name: string;
+  template: {
+    script: {
+      lang: string;
+      params: unknown;
+      source: string;
+    };
+  };
   updated_at_millis: number;
 }
 

--- a/x-pack/plugins/enterprise_search/kibana.jsonc
+++ b/x-pack/plugins/enterprise_search/kibana.jsonc
@@ -23,6 +23,7 @@
       "guidedOnboarding",
       "lens",
       "embeddable",
+      "share"
     ],
     "optionalPlugins": [
       "customIntegrations",

--- a/x-pack/plugins/enterprise_search/public/applications/__mocks__/kea_logic/kibana_logic.mock.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/__mocks__/kea_logic/kibana_logic.mock.ts
@@ -14,6 +14,7 @@ import { dataPluginMock } from '@kbn/data-plugin/public/mocks';
 
 import { LensPublicStart } from '@kbn/lens-plugin/public';
 import { securityMock } from '@kbn/security-plugin/public/mocks';
+import { sharePluginMock } from '@kbn/share-plugin/public/mocks';
 
 import { mockHistory } from '../react_router/state.mock';
 
@@ -58,6 +59,7 @@ export const mockKibanaValues = {
   setBreadcrumbs: jest.fn(),
   setChromeIsVisible: jest.fn(),
   setDocTitle: jest.fn(),
+  share: sharePluginMock.createStartContract(),
   uiSettings: uiSettingsServiceMock.createStartContract(),
 };
 

--- a/x-pack/plugins/enterprise_search/public/applications/applications/components/engine/engine_connect/engine_api_integration.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/applications/components/engine/engine_connect/engine_api_integration.tsx
@@ -8,11 +8,22 @@
 import React from 'react';
 
 import { useValues } from 'kea';
+import { compressToEncodedURIComponent } from 'lz-string';
 
-import { EuiCodeBlock, EuiSpacer, EuiText, EuiTabs, EuiTab } from '@elastic/eui';
+import {
+  EuiCodeBlock,
+  EuiFlexGroup,
+  EuiLink,
+  EuiSpacer,
+  EuiTab,
+  EuiTabs,
+  EuiText,
+} from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
 
 import { useCloudDetails } from '../../../../shared/cloud_details/cloud_details';
+import { KibanaLogic } from '../../../../shared/kibana';
 import { EngineViewLogic } from '../engine_view_logic';
 
 import { EngineApiLogic } from './engine_api_logic';
@@ -28,32 +39,66 @@ const connector = new EnginesAPIConnector({
   apiKey: "${apiKey || '<YOUR_API_KEY>'}"
 });`;
 
-const cURLSnippet = (esUrl: string, engineName: string, apiKey: string) => `
-curl --location --request GET '${esUrl}/${engineName}/_search' \\
+const cURLSnippet = (esUrl: string, engineName: string, apiKey: string, params: unknown) => `
+curl --location --request POST '${esUrl}/_application/search_application/${engineName}/_search' \\
 --header 'Authorization: apiKey ${apiKey || '<YOUR_API_KEY>'}' \\
 --header 'Content-Type: application/json' \\
---data-raw '{
-  "query": {
-    "match_all": {}
-  }
-}'`;
+--data-raw '${JSON.stringify({ params }, null, 2)}'`;
 
-type TabId = 'curl' | 'searchui';
+const apiRequestSnippet = (
+  esUrl: string,
+  searchApplicationName: string,
+  apiKey: string,
+  params: unknown
+) => {
+  const body = JSON.stringify({ params }, null, 2);
+  return `
+POST /_application/search_application/${searchApplicationName}/_search HTTP/1.1
+Accept: application/json
+Authorization: apiKey ${apiKey || '<YOUR_API_KEY>'}
+Content-Length: ${body.length}
+Content-Type: application/json
+Host: ${new URL(esUrl).host}
+${body}
+`;
+};
+
+const consoleRequest = (searchApplicationName: string, params: unknown) =>
+  `POST /_application/search_application/${searchApplicationName}/_search
+${JSON.stringify({ params }, null, 2)}`;
+
+type TabId = 'curl' | 'searchui' | 'apirequest';
 interface Tab {
   code: string;
+  copy: boolean;
   language: string;
   title: string;
 }
 
 export const EngineApiIntegrationStage: React.FC = () => {
-  const [selectedTab, setSelectedTab] = React.useState<TabId>('curl');
-  const { engineName } = useValues(EngineViewLogic);
+  const {
+    application,
+    share: { url },
+  } = useValues(KibanaLogic);
+  const [selectedTab, setSelectedTab] = React.useState<TabId>('apirequest');
+  const { engineName, engineData } = useValues(EngineViewLogic);
   const { apiKey } = useValues(EngineApiLogic);
   const cloudContext = useCloudDetails();
 
+  const params = engineData?.template.script.params ?? {};
+
   const Tabs: Record<TabId, Tab> = {
+    apirequest: {
+      code: apiRequestSnippet(elasticsearchUrl(cloudContext), engineName, apiKey, params),
+      copy: false,
+      language: 'http',
+      title: i18n.translate('xpack.enterpriseSearch.content.engine.api.step3.apiRequestTitle', {
+        defaultMessage: 'API Request',
+      }),
+    },
     curl: {
-      code: cURLSnippet(elasticsearchUrl(cloudContext), engineName, apiKey),
+      code: cURLSnippet(elasticsearchUrl(cloudContext), engineName, apiKey, params),
+      copy: true,
       language: 'bash',
       title: i18n.translate('xpack.enterpriseSearch.content.engine.api.step3.curlTitle', {
         defaultMessage: 'cURL',
@@ -61,12 +106,26 @@ export const EngineApiIntegrationStage: React.FC = () => {
     },
     searchui: {
       code: SearchUISnippet(elasticsearchUrl(cloudContext), engineName, apiKey),
+      copy: true,
       language: 'javascript',
       title: i18n.translate('xpack.enterpriseSearch.content.engine.api.step3.searchUITitle', {
         defaultMessage: 'Search UI',
       }),
     },
   };
+
+  const canShowDevtools = !!application?.capabilities?.dev_tools?.show;
+  const consolePreviewLink = canShowDevtools
+    ? url.locators.get('CONSOLE_APP_LOCATOR')?.useUrl(
+        {
+          loadFrom: `data:text/plain,${compressToEncodedURIComponent(
+            consoleRequest(engineName, params)
+          )}`,
+        },
+        undefined,
+        []
+      )
+    : null;
 
   return (
     <>
@@ -92,9 +151,22 @@ export const EngineApiIntegrationStage: React.FC = () => {
         ))}
       </EuiTabs>
       <EuiSpacer size="l" />
-      <EuiCodeBlock isCopyable lang={Tabs[selectedTab].language}>
+      <EuiCodeBlock isCopyable={Tabs[selectedTab].copy} language={Tabs[selectedTab].language}>
         {Tabs[selectedTab].code}
       </EuiCodeBlock>
+      {selectedTab === 'apirequest' && consolePreviewLink && (
+        <>
+          <EuiSpacer size="s" />
+          <EuiFlexGroup direction="column" alignItems="flexEnd">
+            <EuiLink href={consolePreviewLink} target="_blank">
+              <FormattedMessage
+                id="xpack.enterpriseSearch.content.engine.api.step3.apiRequestConsoleButton"
+                defaultMessage="Try in console"
+              />
+            </EuiLink>
+          </EuiFlexGroup>
+        </>
+      )}
     </>
   );
 };

--- a/x-pack/plugins/enterprise_search/public/applications/applications/components/engine/engine_connect/search_application_api.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/applications/components/engine/engine_connect/search_application_api.tsx
@@ -34,7 +34,7 @@ import { EngineApiLogic } from './engine_api_logic';
 import { GenerateEngineApiKeyModal } from './generate_engine_api_key_modal/generate_engine_api_key_modal';
 
 export const elasticsearchUrl = (cloudContext: CloudDetails): string => {
-  const defaultUrl = 'https://localhost:9200';
+  const defaultUrl = 'http://localhost:9200';
   const url = cloudContext.elasticsearchUrl || defaultUrl;
   return url;
 };
@@ -47,9 +47,6 @@ export const SearchApplicationAPI = () => {
 
   const steps = [
     {
-      title: i18n.translate('xpack.enterpriseSearch.content.searchApplication.api.step1.title', {
-        defaultMessage: 'Generate and save API key',
-      }),
       children: (
         <>
           <EuiText>
@@ -115,11 +112,11 @@ export const SearchApplicationAPI = () => {
           </EuiFlexGroup>
         </>
       ),
+      title: i18n.translate('xpack.enterpriseSearch.content.searchApplication.api.step1.title', {
+        defaultMessage: 'Generate and save API key',
+      }),
     },
     {
-      title: i18n.translate('xpack.enterpriseSearch.content.searchApplication.api.step2.title', {
-        defaultMessage: "Copy your search application's endpoint",
-      }),
       children: (
         <>
           <EuiText>
@@ -142,12 +139,15 @@ export const SearchApplicationAPI = () => {
           </EuiFlexGroup>
         </>
       ),
+      title: i18n.translate('xpack.enterpriseSearch.content.searchApplication.api.step2.title', {
+        defaultMessage: "Copy your search application's endpoint",
+      }),
     },
     {
+      children: <EngineApiIntegrationStage />,
       title: i18n.translate('xpack.enterpriseSearch.content.searchApplication.api.step3.title', {
         defaultMessage: 'Learn how to call your endpoints',
       }),
-      children: <EngineApiIntegrationStage />,
     },
   ];
 

--- a/x-pack/plugins/enterprise_search/public/applications/applications/components/engine/engine_indices_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/applications/components/engine/engine_indices_logic.test.ts
@@ -33,6 +33,13 @@ const mockEngineData: EnterpriseSearchApplicationDetails = {
     },
   ],
   name: DEFAULT_VALUES.engineName,
+  template: {
+    script: {
+      lang: 'mustache',
+      params: { query_string: '*' },
+      source: '',
+    },
+  },
   updated_at_millis: 1679501369566,
 };
 

--- a/x-pack/plugins/enterprise_search/public/applications/applications/components/engines/engines_list_flyout_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/applications/components/engines/engines_list_flyout_logic.test.ts
@@ -37,6 +37,13 @@ const mockEngineData: EnterpriseSearchApplicationDetails = {
     },
   ],
   name: 'my-test-engine',
+  template: {
+    script: {
+      lang: 'mustache',
+      params: { query_string: '*' },
+      source: '',
+    },
+  },
   updated_at_millis: 1679337823167,
 };
 

--- a/x-pack/plugins/enterprise_search/public/applications/index.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/index.test.tsx
@@ -17,6 +17,7 @@ import { guidedOnboardingMock } from '@kbn/guided-onboarding-plugin/public/mocks
 import { lensPluginMock } from '@kbn/lens-plugin/public/mocks';
 import { licensingMock } from '@kbn/licensing-plugin/public/mocks';
 import { securityMock } from '@kbn/security-plugin/public/mocks';
+import { sharePluginMock } from '@kbn/share-plugin/public/mocks';
 
 import { AppSearch } from './app_search';
 import { EnterpriseSearchOverview } from './enterprise_search_overview';
@@ -36,6 +37,7 @@ describe('renderApp', () => {
       lens: lensPluginMock.createStartContract(),
       licensing: licensingMock.createStart(),
       security: securityMock.createStart(),
+      share: sharePluginMock.createStartContract(),
     },
   } as any;
   const pluginData = {

--- a/x-pack/plugins/enterprise_search/public/applications/index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/index.tsx
@@ -66,7 +66,7 @@ export const renderApp = (
   const { history } = params;
   const { application, chrome, http, uiSettings } = core;
   const { capabilities, navigateToUrl } = application;
-  const { charts, cloud, guidedOnboarding, lens, security } = plugins;
+  const { charts, cloud, guidedOnboarding, lens, security, share } = plugins;
 
   const entCloudHost = getCloudEnterpriseSearchHost(plugins.cloud);
   externalUrl.enterpriseSearchUrl = publicUrl || entCloudHost || config.host || '';
@@ -107,6 +107,7 @@ export const renderApp = (
     setBreadcrumbs: chrome.setBreadcrumbs,
     setChromeIsVisible: chrome.setIsVisible,
     setDocTitle: chrome.docTitle.change,
+    share,
     uiSettings,
   });
   const unmountLicensingLogic = mountLicensingLogic({

--- a/x-pack/plugins/enterprise_search/public/applications/shared/kibana/kibana_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/kibana/kibana_logic.ts
@@ -22,6 +22,7 @@ import { DataPublicPluginStart } from '@kbn/data-plugin/public';
 import { GuidedOnboardingPluginStart } from '@kbn/guided-onboarding-plugin/public';
 import { LensPublicStart } from '@kbn/lens-plugin/public';
 import { SecurityPluginStart } from '@kbn/security-plugin/public';
+import { SharePluginStart } from '@kbn/share-plugin/public';
 
 import { ClientConfigType, ProductAccess, ProductFeatures } from '../../../../common/types';
 
@@ -50,6 +51,7 @@ interface KibanaLogicProps {
   setBreadcrumbs(crumbs: ChromeBreadcrumb[]): void;
   setChromeIsVisible(isVisible: boolean): void;
   setDocTitle(title: string): void;
+  share: SharePluginStart;
   uiSettings: IUiSettingsClient;
 }
 
@@ -89,6 +91,7 @@ export const KibanaLogic = kea<MakeLogicType<KibanaValues>>({
     setBreadcrumbs: [props.setBreadcrumbs, {}],
     setChromeIsVisible: [props.setChromeIsVisible, {}],
     setDocTitle: [props.setDocTitle, {}],
+    share: [props.share, {}],
     uiSettings: [props.uiSettings, {}],
   }),
   selectors: ({ selectors }) => ({

--- a/x-pack/plugins/enterprise_search/public/plugin.ts
+++ b/x-pack/plugins/enterprise_search/public/plugin.ts
@@ -23,6 +23,7 @@ import type { HomePublicPluginSetup } from '@kbn/home-plugin/public';
 import { LensPublicStart } from '@kbn/lens-plugin/public';
 import { LicensingPluginStart } from '@kbn/licensing-plugin/public';
 import { SecurityPluginSetup, SecurityPluginStart } from '@kbn/security-plugin/public';
+import { SharePluginStart } from '@kbn/share-plugin/public';
 
 import {
   ANALYTICS_PLUGIN,
@@ -60,6 +61,7 @@ export interface PluginsStart {
   lens: LensPublicStart;
   licensing: LicensingPluginStart;
   security: SecurityPluginStart;
+  share: SharePluginStart;
 }
 
 export class EnterpriseSearchPlugin implements Plugin {
@@ -167,9 +169,6 @@ export class EnterpriseSearchPlugin implements Plugin {
       category: DEFAULT_APP_CATEGORIES.enterpriseSearch,
       euiIconType: APPLICATIONS_PLUGIN.LOGO,
       id: APPLICATIONS_PLUGIN.ID,
-      navLinkStatus: AppNavLinkStatus.default,
-      searchable: true,
-      title: APPLICATIONS_PLUGIN.NAV_TITLE,
       mount: async (params: AppMountParameters) => {
         const kibanaDeps = await this.getKibanaDeps(core, params, cloud);
         const { chrome, http } = kibanaDeps.core;
@@ -183,6 +182,9 @@ export class EnterpriseSearchPlugin implements Plugin {
 
         return renderApp(Applications, kibanaDeps, pluginData);
       },
+      navLinkStatus: AppNavLinkStatus.default,
+      searchable: true,
+      title: APPLICATIONS_PLUGIN.NAV_TITLE,
     });
 
     core.application.register({

--- a/x-pack/plugins/enterprise_search/tsconfig.json
+++ b/x-pack/plugins/enterprise_search/tsconfig.json
@@ -60,5 +60,6 @@
     "@kbn/core-elasticsearch-server-mocks",
     "@kbn/shared-ux-link-redirect-app",
     "@kbn/global-search-plugin",
+    "@kbn/share-plugin",
   ]
 }


### PR DESCRIPTION
## Summary

- updates curl example code to fetch from correct endpoint
- adds api request tab that shows an HTTP request to perform a search
- uses the default params from the search application's template to populate the request (as query dsl is no longer valid for the endpoint)
- adds link for api request tab to populate the example request in dev tools console in a new tab

https://github.com/elastic/kibana/assets/1699281/cccee236-cd45-4f19-89c7-f2c77ff4b4e9

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
