### PR TITLE
feat(composite-slo): add feature flag

### DIFF
--- a/packages/kbn-check-mappings-update-cli/current_mappings.json
+++ b/packages/kbn-check-mappings-update-cli/current_mappings.json
@@ -2137,36 +2137,6 @@
       }
     }
   },
-  "composite-slo": {
-    "dynamic": false,
-    "properties": {
-      "id": {
-        "type": "keyword"
-      },
-      "name": {
-        "type": "text"
-      },
-      "budgetingMethod": {
-        "type": "keyword"
-      },
-      "compositeMethod": {
-        "type": "keyword"
-      },
-      "sources": {
-        "properties": {
-          "id": {
-            "type": "keyword"
-          },
-          "revision": {
-            "type": "integer"
-          }
-        }
-      },
-      "tags": {
-        "type": "keyword"
-      }
-    }
-  },
   "threshold-explorer-view": {
     "dynamic": false,
     "properties": {}

--- a/src/core/server/integration_tests/saved_objects/migrations/group2/check_registered_types.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/group2/check_registered_types.test.ts
@@ -75,7 +75,6 @@ describe('checking migration metadata changes on all registered SO types', () =>
         "cases-connector-mappings": "f9d1ac57e484e69506c36a8051e4d61f4a8cfd25",
         "cases-telemetry": "f219eb7e26772884342487fc9602cfea07b3cedc",
         "cases-user-actions": "483f10db9b3bd1617948d7032a98b7791bf87414",
-        "composite-slo": "d771c24af50d7ca5667a046b63ed024a4bfd819d",
         "config": "179b3e2bc672626aafce3cf92093a113f456af38",
         "config-global": "8e8a134a2952df700d7d4ec51abb794bbd4cf6da",
         "connector_token": "5a9ac29fe9c740eb114e9c40517245c71706b005",

--- a/src/core/server/integration_tests/saved_objects/migrations/group3/dot_kibana_split.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/group3/dot_kibana_split.test.ts
@@ -196,7 +196,6 @@ describe('split .kibana index into multiple system indices', () => {
             "cases-connector-mappings",
             "cases-telemetry",
             "cases-user-actions",
-            "composite-slo",
             "config",
             "config-global",
             "connector_token",

--- a/src/core/server/integration_tests/saved_objects/migrations/group3/type_registrations.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/group3/type_registrations.test.ts
@@ -38,7 +38,6 @@ const previouslyRegisteredTypes = [
   'config',
   'config-global',
   'connector_token',
-  'composite-slo',
   'core-usage-stats',
   'csp-rule-template',
   'csp_rule',

--- a/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker
+++ b/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker
@@ -308,6 +308,7 @@ kibana_vars=(
     xpack.observability.unsafe.alertDetails.logs.enabled
     xpack.observability.unsafe.alertDetails.uptime.enabled
     xpack.observability.unsafe.thresholdRule.enabled
+    xpack.observability.compositeSlo.enabled
     xpack.reporting.capture.browser.autoDownload
     xpack.reporting.capture.browser.chromium.disableSandbox
     xpack.reporting.capture.browser.chromium.inspect

--- a/x-pack/plugins/observability/public/pages/overview/overview.stories.tsx
+++ b/x-pack/plugins/observability/public/pages/overview/overview.stories.tsx
@@ -87,6 +87,7 @@ const withCore = makeDecorator({
         },
         thresholdRule: { enabled: false },
       },
+      compositeSlo: { enabled: false },
       coPilot: {
         enabled: false,
       },

--- a/x-pack/plugins/observability/public/pages/rules/rules.test.tsx
+++ b/x-pack/plugins/observability/public/pages/rules/rules.test.tsx
@@ -43,6 +43,9 @@ jest.spyOn(pluginContext, 'usePluginContext').mockImplementation(() => ({
       },
       thresholdRule: { enabled: false },
     },
+    compositeSlo: {
+      enabled: false,
+    },
     coPilot: {
       enabled: false,
     },

--- a/x-pack/plugins/observability/public/plugin.ts
+++ b/x-pack/plugins/observability/public/plugin.ts
@@ -80,6 +80,7 @@ export interface ConfigSchema {
       enabled: boolean;
     };
   };
+  compositeSlo: { enabled: boolean };
   coPilot?: {
     enabled?: boolean;
   };

--- a/x-pack/plugins/observability/public/utils/kibana_react.storybook_decorator.tsx
+++ b/x-pack/plugins/observability/public/utils/kibana_react.storybook_decorator.tsx
@@ -34,6 +34,7 @@ export function KibanaReactStorybookDecorator(Story: ComponentType) {
       },
       thresholdRule: { enabled: false },
     },
+    compositeSlo: { enabled: false },
     coPilot: {
       enabled: false,
     },

--- a/x-pack/plugins/observability/public/utils/test_helper.tsx
+++ b/x-pack/plugins/observability/public/utils/test_helper.tsx
@@ -38,6 +38,7 @@ const defaultConfig: ConfigSchema = {
     },
     thresholdRule: { enabled: false },
   },
+  compositeSlo: { enabled: false },
   coPilot: {
     enabled: false,
   },

--- a/x-pack/plugins/observability/server/index.ts
+++ b/x-pack/plugins/observability/server/index.ts
@@ -50,6 +50,9 @@ const configSchema = schema.object({
   }),
   enabled: schema.boolean({ defaultValue: true }),
   coPilot: schema.maybe(observabilityCoPilotConfig),
+  compositeSlo: schema.object({
+    enabled: schema.boolean({ defaultValue: false }),
+  }),
 });
 
 export const config: PluginConfigDescriptor = {

--- a/x-pack/plugins/observability/server/plugin.ts
+++ b/x-pack/plugins/observability/server/plugin.ts
@@ -173,6 +173,9 @@ export class ObservabilityPlugin implements Plugin<ObservabilityPluginSetup> {
 
     const { ruleDataService } = plugins.ruleRegistry;
 
+    const savedObjectTypes = config.compositeSlo.enabled
+      ? [SO_SLO_TYPE, SO_COMPOSITE_SLO_TYPE]
+      : [SO_SLO_TYPE];
     plugins.features.registerKibanaFeature({
       id: sloFeatureId,
       name: i18n.translate('xpack.observability.featureRegistry.linkSloTitle', {
@@ -189,7 +192,7 @@ export class ObservabilityPlugin implements Plugin<ObservabilityPluginSetup> {
           catalogue: [sloFeatureId, 'observability'],
           api: ['slo_write', 'slo_read', 'rac'],
           savedObject: {
-            all: [SO_SLO_TYPE, SO_COMPOSITE_SLO_TYPE],
+            all: savedObjectTypes,
             read: [],
           },
           alerting: {
@@ -208,7 +211,7 @@ export class ObservabilityPlugin implements Plugin<ObservabilityPluginSetup> {
           api: ['slo_read', 'rac'],
           savedObject: {
             all: [],
-            read: [SO_SLO_TYPE, SO_COMPOSITE_SLO_TYPE],
+            read: savedObjectTypes,
           },
           alerting: {
             rule: {
@@ -224,7 +227,9 @@ export class ObservabilityPlugin implements Plugin<ObservabilityPluginSetup> {
     });
 
     core.savedObjects.registerType(slo);
-    core.savedObjects.registerType(compositeSlo);
+    if (config.compositeSlo.enabled) {
+      core.savedObjects.registerType(compositeSlo);
+    }
     core.savedObjects.registerType(threshold);
 
     registerRuleTypes(
@@ -248,7 +253,7 @@ export class ObservabilityPlugin implements Plugin<ObservabilityPluginSetup> {
           getOpenAIClient: () => openAIService?.client,
         },
         logger: this.logger,
-        repository: getObservabilityServerRouteRepository(),
+        repository: getObservabilityServerRouteRepository(config),
       });
     });
 

--- a/x-pack/plugins/observability/server/routes/get_global_observability_server_route_repository.ts
+++ b/x-pack/plugins/observability/server/routes/get_global_observability_server_route_repository.ts
@@ -5,16 +5,19 @@
  * 2.0.
  */
 
+import { ObservabilityConfig } from '..';
 import { compositeSloRouteRepository } from './composite_slo/route';
 import { observabilityCoPilotRouteRepository } from './copilot/route';
 import { rulesRouteRepository } from './rules/route';
 import { sloRouteRepository } from './slo/route';
 
-export function getObservabilityServerRouteRepository() {
+export function getObservabilityServerRouteRepository(config: ObservabilityConfig) {
+  const isCompositeSloFeatureEnabled = config.compositeSlo.enabled;
+
   const repository = {
     ...rulesRouteRepository,
     ...sloRouteRepository,
-    ...compositeSloRouteRepository,
+    ...(isCompositeSloFeatureEnabled ? compositeSloRouteRepository : {}),
     ...observabilityCoPilotRouteRepository,
   };
   return repository;

--- a/x-pack/test/observability_api_integration/apis/composite_slo/create.ts
+++ b/x-pack/test/observability_api_integration/apis/composite_slo/create.ts
@@ -13,7 +13,7 @@ export default function ({ getService }: FtrProviderContext) {
   const supertest = getService('supertest');
   const kibanaServer = getService('kibanaServer');
 
-  describe('create >', () => {
+  describe.skip('create >', () => {
     const security = getService('security');
 
     before(async () => {

--- a/x-pack/test/observability_api_integration/apis/composite_slo/delete.ts
+++ b/x-pack/test/observability_api_integration/apis/composite_slo/delete.ts
@@ -12,7 +12,7 @@ export default function ({ getService }: FtrProviderContext) {
   const supertest = getService('supertest');
   const kibanaServer = getService('kibanaServer');
 
-  describe('delete >', () => {
+  describe.skip('delete >', () => {
     const security = getService('security');
 
     before(async () => {

--- a/x-pack/test/observability_api_integration/apis/composite_slo/update.ts
+++ b/x-pack/test/observability_api_integration/apis/composite_slo/update.ts
@@ -13,7 +13,7 @@ export default function ({ getService }: FtrProviderContext) {
   const supertest = getService('supertest');
   const kibanaServer = getService('kibanaServer');
 
-  describe('update >', () => {
+  describe.skip('update >', () => {
     const security = getService('security');
 
     before(async () => {


### PR DESCRIPTION
## Summary

This PR adds a feature flag in front of the composite slo routes and saved objects registration.

For the context, we have decided to not release composite SLO has it is now until we further validate the use case it solves for SRE and iterate on the solution. We might have to change a few things later regarding the SO.

