### PR TITLE
[docs] improve external plugin documentation

### DIFF
--- a/docs/developer/plugin/plugin-tooling.asciidoc
+++ b/docs/developer/plugin/plugin-tooling.asciidoc
@@ -31,7 +31,7 @@ WARNING: {kib} distributable is not shipped with `@kbn/optimizer` anymore. You n
 
 You can leverage {kib-repo}blob/{branch}/packages/kbn-plugin-helpers[@kbn/plugin-helpers] to build a distributable archive for your plugin.
 The package transpiles the plugin code, adds polyfills, and links necessary js modules in the runtime.
-You don't need to install the `plugin-helpers` dependency, as the `package.json` is already pre-configured if you created your plugin with `node scripts/generate_plugin` script.
+You don't need to install the `plugin-helpers` dependency. If you created the plugin using `node scripts/generate_plugin` script, `package.json` is already pre-configured.
 To build your plugin run within your plugin folder:
 ["source","shell"]
 -----------

--- a/docs/developer/plugin/plugin-tooling.asciidoc
+++ b/docs/developer/plugin/plugin-tooling.asciidoc
@@ -31,7 +31,7 @@ WARNING: {kib} distributable is not shipped with `@kbn/optimizer` anymore. You n
 
 You can leverage {kib-repo}blob/{branch}/packages/kbn-plugin-helpers[@kbn/plugin-helpers] to build a distributable archive for your plugin.
 The package transpiles the plugin code, adds polyfills, and links necessary js modules in the runtime.
-You don't need to install the `plugin-helpers`: the `package.json` is already pre-configured if you created your plugin with `node scripts/generate_plugin` script.
+You don't need to install the `plugin-helpers` dependency, as the `package.json` is already pre-configured if you created your plugin with `node scripts/generate_plugin` script.
 To build your plugin run within your plugin folder:
 ["source","shell"]
 -----------


### PR DESCRIPTION
Just cleaning up the wording and punctuation a little bit so it's easier to read

<!--ONMERGE {"backportTargets":["7.17","8.0","8.1","8.2","8.3","8.4","8.5","8.6","8.7","8.8"]} ONMERGE-->