### PR TITLE
[docs] remove invalid arg from scripts/generate_plugin example

### DIFF
--- a/docs/developer/plugin/plugin-tooling.asciidoc
+++ b/docs/developer/plugin/plugin-tooling.asciidoc
@@ -9,7 +9,7 @@ We recommend that you kick-start your plugin by generating it with the {kib-repo
 
 ["source","shell"]
 -----------
-node scripts/generate_plugin my_plugin_name # replace "my_plugin_name" with your desired plugin name
+node scripts/generate_plugin
 -----------
 
 [discrete]


### PR DESCRIPTION
Since version 8.0.0 of Kibana it's not been possible to supply the plugin name directly on the command line like it's described in the docs. You instead need to use the `--name` flag. However, this is now optional, so you could just leave out the name entirely and the CLI will ask you for it.

In this PR I've opted to remove the name from the command instead of using the `--name` flag as there are so many other options you could provide, so highlighting `--name` specifically isn't really warranted IMO. It also makes the "code-block" easier to read as we can remove the trailing comment.

<!--ONMERGE {"backportTargets":["8.0","8.1","8.2","8.3","8.4","8.5","8.6","8.7","8.8"]} ONMERGE-->