### PR TITLE
[Profiling] Use collector and symbolizer integrations in the add data page

### DIFF
--- a/x-pack/plugins/profiling/public/views/no_data_view/index.tsx
+++ b/x-pack/plugins/profiling/public/views/no_data_view/index.tsx
@@ -41,9 +41,9 @@ export function NoDataView({ subTitle }: { subTitle: string }) {
     [setupDataCollectionInstructions]
   );
 
-  const secretToken = data?.variables.secretToken;
-  const collectionAgentHostPort = data?.variables.apmServerUrl.replace('https://', '');
-  const symbolUrl = data?.variables.apmServerUrl.replace(/\.apm\./, '.symbols.');
+  const secretToken = data?.variables.collector.secretToken;
+  const collectionAgentHost = data?.variables.collector.host.replace('https://', '');
+  const symbolUrl = data?.variables.symbolizer.host.replace('https://', '');
   const hostAgentVersion = 'v3';
 
   const tabs = [
@@ -71,7 +71,7 @@ export function NoDataView({ subTitle }: { subTitle: string }) {
             <EuiCodeBlock paddingSize="s" isCopyable>
               {`helm install --create-namespace -n=universal-profiling universal-profiling-agent \\
 --set "projectID=1,secretToken=${secretToken}" \\
---set "collectionAgentHostPort=${collectionAgentHostPort}" \\
+--set "collectionAgentHostPort=${collectionAgentHost}" \\
 --set "version=${hostAgentVersion}" \\
 optimyze/pf-host-agent`}
             </EuiCodeBlock>
@@ -112,7 +112,7 @@ optimyze/pf-host-agent`}
 -v /var/run/docker.sock:/var/run/docker.sock -v /sys/kernel/debug:/sys/kernel/debug:ro \\
 docker.elastic.co/observability/profiling-agent:${hostAgentVersion} /root/pf-host-agent \\
 -project-id=1 -secret-token=${secretToken} \\
--collection-agent=${collectionAgentHostPort}`}
+-collection-agent=${collectionAgentHost}`}
             </EuiCodeBlock>
           ),
         },
@@ -150,7 +150,7 @@ docker.elastic.co/observability/profiling-agent:${hostAgentVersion} /root/pf-hos
           }),
           content: (
             <EuiCodeBlock paddingSize="s" isCopyable>
-              {`sudo pf-host-agent/pf-host-agent -project-id=1 -secret-token=${secretToken} -collection-agent=${collectionAgentHostPort}`}
+              {`sudo pf-host-agent/pf-host-agent -project-id=1 -secret-token=${secretToken} -collection-agent=${collectionAgentHost}`}
             </EuiCodeBlock>
           ),
         },
@@ -192,7 +192,7 @@ docker.elastic.co/observability/profiling-agent:${hostAgentVersion} /root/pf-hos
           }),
           content: (
             <EuiCodeBlock paddingSize="s" isCopyable>
-              {`echo -e "project-id 1\nsecret-token ${secretToken}\ncollection-agent ${collectionAgentHostPort}" | sudo tee -a /etc/prodfiler/prodfiler.conf`}
+              {`echo -e "project-id 1\nsecret-token ${secretToken}\ncollection-agent ${collectionAgentHost}" | sudo tee -a /etc/prodfiler/prodfiler.conf`}
             </EuiCodeBlock>
           ),
         },
@@ -245,7 +245,7 @@ docker.elastic.co/observability/profiling-agent:${hostAgentVersion} /root/pf-hos
           }),
           content: (
             <EuiCodeBlock paddingSize="s" isCopyable>
-              {`echo -e "project-id 1\nsecret-token ${secretToken}\ncollection-agent ${collectionAgentHostPort}" | sudo tee -a /etc/prodfiler/prodfiler.conf`}
+              {`echo -e "project-id 1\nsecret-token ${secretToken}\ncollection-agent ${collectionAgentHost}" | sudo tee -a /etc/prodfiler/prodfiler.conf`}
             </EuiCodeBlock>
           ),
         },
@@ -258,6 +258,64 @@ docker.elastic.co/observability/profiling-agent:${hostAgentVersion} /root/pf-hos
             <EuiCodeBlock paddingSize="s" isCopyable>
               {`sudo systemctl enable pf-host-agent && sudo systemctl restart pf-host-agent`}
             </EuiCodeBlock>
+          ),
+        },
+      ],
+    },
+    {
+      key: 'elasticAgentIntegration',
+      title: i18n.translate('xpack.profiling.tabs.elasticAgentIntegrarion.title', {
+        defaultMessage: 'Elastic Agent Integration',
+      }),
+      steps: [
+        {
+          title: i18n.translate('xpack.profiling.tabs.elasticAgentIntegrarion.step1', {
+            defaultMessage: 'Copy credentials',
+          }),
+          content: (
+            <>
+              <EuiText>
+                {i18n.translate('xpack.profiling.tabs.elasticAgentIntegrarion.step1.hint', {
+                  defaultMessage:
+                    "You'll need these credentials to set up Universal Profiling. Please save them in a secure location, as they will be required in the subsequent step.",
+                })}
+              </EuiText>
+              <EuiSpacer />
+              <EuiCodeBlock paddingSize="s" isCopyable>
+                {i18n.translate('xpack.profiling.tabs.elasticAgentIntegrarion.step1.secretToken', {
+                  defaultMessage: 'Secret token: {secretToken}',
+                  values: { secretToken },
+                })}
+              </EuiCodeBlock>
+              <EuiSpacer size="s" />
+              <EuiCodeBlock paddingSize="s" isCopyable>
+                {i18n.translate(
+                  'xpack.profiling.tabs.elasticAgentIntegrarion.step1.collectionAgentUrl',
+                  {
+                    defaultMessage: 'Universal Profiling Collector url: {collectionAgentHost}',
+                    values: { collectionAgentHost },
+                  }
+                )}
+              </EuiCodeBlock>
+            </>
+          ),
+        },
+        {
+          title: i18n.translate('xpack.profiling.tabs.elasticAgentIntegrarion.step2', {
+            defaultMessage: 'Fleet',
+          }),
+          content: (
+            <EuiButton
+              iconType="gear"
+              fill
+              href={`${core.http.basePath.prepend(
+                '/app/integrations/detail/profiler_agent-8.8.0-preview/overview'
+              )}`}
+            >
+              {i18n.translate('xpack.profiling.tabs.elasticAgentIntegrarion.step2.button', {
+                defaultMessage: 'Manage Universal Profiling agent in Fleet',
+              })}
+            </EuiButton>
           ),
         },
       ],
@@ -345,61 +403,6 @@ docker.elastic.co/observability/profiling-agent:${hostAgentVersion} /root/pf-hos
                 />
               </EuiText>
             </div>
-          ),
-        },
-      ],
-    },
-    {
-      key: 'elasticAgentIntegration',
-      title: i18n.translate('xpack.profiling.tabs.elasticAgentIntegrarion.title', {
-        defaultMessage: 'Elastic Agent Integration',
-      }),
-      steps: [
-        {
-          title: i18n.translate('xpack.profiling.tabs.elasticAgentIntegrarion.step1', {
-            defaultMessage: 'Copy credentials',
-          }),
-          content: (
-            <>
-              <EuiText>
-                {i18n.translate('xpack.profiling.tabs.elasticAgentIntegrarion.step1.hint', {
-                  defaultMessage:
-                    "You'll need these credentials to set up Universal Profiling. Please save them in a secure location, as they will be required in the subsequent step.",
-                })}
-              </EuiText>
-              <EuiSpacer />
-              <EuiCodeBlock paddingSize="s" isCopyable>
-                {i18n.translate('xpack.profiling.tabs.elasticAgentIntegrarion.step1.secretToken', {
-                  defaultMessage: 'Secret token: {secretToken}',
-                  values: { secretToken },
-                })}
-              </EuiCodeBlock>
-              <EuiSpacer size="s" />
-              <EuiCodeBlock paddingSize="s" isCopyable>
-                {i18n.translate('xpack.profiling.tabs.elasticAgentIntegrarion.step1.apmServerUrl', {
-                  defaultMessage: 'APM server url: {apmServerUrl}',
-                  values: { apmServerUrl: collectionAgentHostPort },
-                })}
-              </EuiCodeBlock>
-            </>
-          ),
-        },
-        {
-          title: i18n.translate('xpack.profiling.tabs.elasticAgentIntegrarion.step2', {
-            defaultMessage: 'Fleet',
-          }),
-          content: (
-            <EuiButton
-              iconType="gear"
-              fill
-              href={`${core.http.basePath.prepend(
-                '/app/integrations/detail/profiler_agent-8.8.0-preview/overview'
-              )}`}
-            >
-              {i18n.translate('xpack.profiling.tabs.elasticAgentIntegrarion.step2.button', {
-                defaultMessage: 'Manage Universal Profiling agent in Fleet',
-              })}
-            </EuiButton>
           ),
         },
       ],

--- a/x-pack/plugins/profiling/server/lib/setup/fleet_policies.ts
+++ b/x-pack/plugins/profiling/server/lib/setup/fleet_policies.ts
@@ -8,6 +8,8 @@
 import { merge } from 'lodash';
 import { ElasticsearchClient } from '@kbn/core/server';
 import { fetchFindLatestPackageOrThrow } from '@kbn/fleet-plugin/server/services/epm/registry';
+import { SavedObjectsClientContract } from '@kbn/core/server';
+import { PackagePolicyClient } from '@kbn/fleet-plugin/server';
 import { getApmPolicy } from './get_apm_policy';
 import { ProfilingSetupOptions } from './types';
 import { PartialSetupState } from '../../../common/setup';
@@ -112,18 +114,39 @@ const CLOUD_AGENT_POLICY_ID = 'policy-elastic-agent-on-cloud';
 const COLLECTOR_PACKAGE_POLICY_NAME = 'elastic-universal-profiling-collector';
 const SYMBOLIZER_PACKAGE_POLICY_NAME = 'elastic-universal-profiling-symbolizer';
 
+async function getPackagePolicy({
+  soClient,
+  packagePolicyClient,
+  packageName,
+}: {
+  packagePolicyClient: PackagePolicyClient;
+  soClient: SavedObjectsClientContract;
+  packageName: string;
+}) {
+  const packagePolicies = await packagePolicyClient.list(soClient, {});
+  return packagePolicies.items.find((pkg) => pkg.name === packageName);
+}
+
+export async function getCollectorPolicy({
+  soClient,
+  packagePolicyClient,
+}: {
+  packagePolicyClient: PackagePolicyClient;
+  soClient: SavedObjectsClientContract;
+}) {
+  return getPackagePolicy({
+    soClient,
+    packagePolicyClient,
+    packageName: COLLECTOR_PACKAGE_POLICY_NAME,
+  });
+}
+
 export async function validateCollectorPackagePolicy({
   soClient,
   packagePolicyClient,
 }: ProfilingSetupOptions): Promise<PartialSetupState> {
-  const packagePolicies = await packagePolicyClient.list(soClient, {});
-  return {
-    policies: {
-      collector: {
-        installed: packagePolicies.items.some((pkg) => pkg.name === COLLECTOR_PACKAGE_POLICY_NAME),
-      },
-    },
-  };
+  const collectorPolicy = await getCollectorPolicy({ soClient, packagePolicyClient });
+  return { policies: { collector: { installed: !!collectorPolicy } } };
 }
 
 export function generateSecretToken() {
@@ -198,18 +221,26 @@ export async function createCollectorPackagePolicy({
   });
 }
 
+export async function getSymbolizerPolicy({
+  soClient,
+  packagePolicyClient,
+}: {
+  packagePolicyClient: PackagePolicyClient;
+  soClient: SavedObjectsClientContract;
+}) {
+  return getPackagePolicy({
+    soClient,
+    packagePolicyClient,
+    packageName: SYMBOLIZER_PACKAGE_POLICY_NAME,
+  });
+}
+
 export async function validateSymbolizerPackagePolicy({
   soClient,
   packagePolicyClient,
 }: ProfilingSetupOptions): Promise<PartialSetupState> {
-  const packagePolicies = await packagePolicyClient.list(soClient, {});
-  return {
-    policies: {
-      symbolizer: {
-        installed: packagePolicies.items.some((pkg) => pkg.name === SYMBOLIZER_PACKAGE_POLICY_NAME),
-      },
-    },
-  };
+  const symbolizerPackagePolicy = await getSymbolizerPolicy({ soClient, packagePolicyClient });
+  return { policies: { symbolizer: { installed: !!symbolizerPackagePolicy } } };
 }
 
 export async function createSymbolizerPackagePolicy({

--- a/x-pack/plugins/profiling/server/lib/setup/get_setup_instructions.ts
+++ b/x-pack/plugins/profiling/server/lib/setup/get_setup_instructions.ts
@@ -7,12 +7,17 @@
 
 import { SavedObjectsClientContract } from '@kbn/core/server';
 import { PackagePolicyClient } from '@kbn/fleet-plugin/server';
-import { getApmPolicy } from './get_apm_policy';
+import { getCollectorPolicy, getSymbolizerPolicy } from './fleet_policies';
 
 export interface SetupDataCollectionInstructions {
   variables: {
-    apmServerUrl: string;
-    secretToken: string;
+    collector: {
+      secretToken: string;
+      host: string;
+    };
+    symbolizer: {
+      host: string;
+    };
   };
 }
 
@@ -23,18 +28,31 @@ export async function getSetupInstructions({
   packagePolicyClient: PackagePolicyClient;
   soClient: SavedObjectsClientContract;
 }): Promise<SetupDataCollectionInstructions> {
-  const apmPolicy = await getApmPolicy({ packagePolicyClient, soClient });
+  const [collectorPolicy, symbolizerPolicy] = await Promise.all([
+    getCollectorPolicy({ packagePolicyClient, soClient }),
+    getSymbolizerPolicy({ packagePolicyClient, soClient }),
+  ]);
 
-  if (!apmPolicy) {
-    throw new Error('Could not find APM policy');
+  if (!collectorPolicy) {
+    throw new Error('Could not find Collector policy');
   }
 
-  const apmServerVars = apmPolicy.inputs[0].vars;
+  if (!symbolizerPolicy) {
+    throw new Error('Could not find Symbolizer policy');
+  }
+
+  const collectorVars = collectorPolicy.inputs[0].vars;
+  const symbolizerVars = symbolizerPolicy.inputs[0].vars;
 
   return {
     variables: {
-      apmServerUrl: apmServerVars!.url.value!,
-      secretToken: apmServerVars!.secret_token.value!,
+      collector: {
+        secretToken: collectorVars!.secret_token.value!,
+        host: collectorVars!.host.value,
+      },
+      symbolizer: {
+        host: symbolizerVars!.host.value,
+      },
     },
   };
 }


### PR DESCRIPTION
In this PR:

- Removed the apm server information from add data page.
- Fetches Collector host and secret token instead to apm.
- Fetches Symbolizer host to be used in the `Upload symbols` tab.
- Replace apm server URL for collector host.
- Swap `Elastic agent integration` and `Upload symbols` tabs.

<img width="1435" alt="Screenshot 2023-06-12 at 2 18 06 PM" src="https://github.com/elastic/kibana/assets/55978943/a32dfac3-7ab1-4a03-94d1-a9756927e3eb">
<img width="1469" alt="Screenshot 2023-06-12 at 2 18 13 PM" src="https://github.com/elastic/kibana/assets/55978943/63139e6b-71a5-4d94-a3ea-b51c126a2d19">
<img width="1486" alt="Screenshot 2023-06-12 at 2 18 21 PM" src="https://github.com/elastic/kibana/assets/55978943/b2811018-337f-46dd-8ad4-43a8f9986bbd">

