### PR TITLE
[8.8] [Security Solution][Testing] Improve policy related endpoint regression test coverage (#157412)

### DIFF
--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/endpoint/isolate.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/endpoint/isolate.cy.ts
@@ -7,7 +7,7 @@
 
 import type { Agent } from '@kbn/fleet-plugin/common';
 import { APP_CASES_PATH, APP_ENDPOINTS_PATH } from '../../../../../common/constants';
-import { closeAllToasts } from '../../tasks/close_all_toasts';
+import { closeAllToasts } from '../../tasks/toasts';
 import {
   checkEndpointListForOnlyIsolatedHosts,
   checkEndpointListForOnlyUnIsolatedHosts,

--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/mocked_data/artifact_tabs_in_policy_details.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/mocked_data/artifact_tabs_in_policy_details.cy.ts
@@ -7,6 +7,7 @@
 
 import { getEndpointSecurityPolicyManager } from '../../../../../scripts/endpoint/common/roles_users/endpoint_security_policy_manager';
 import { getArtifactsListTestsData } from '../../fixtures/artifacts_page';
+import { visitPolicyDetailsPage } from '../../screens/policy_details';
 import {
   createPerPolicyArtifact,
   createArtifactList,
@@ -60,13 +61,6 @@ const getRoleWithoutArtifactPrivilege = (privilegePrefix: string) => {
 const visitArtifactTab = (tabId: string) => {
   visitPolicyDetailsPage();
   cy.get(`#${tabId}`).click();
-};
-
-const visitPolicyDetailsPage = () => {
-  cy.visit('/app/security/administration/policy');
-  cy.getByTestSubj('policyNameCellLink').eq(0).click({ force: true });
-  cy.getByTestSubj('policyDetailsPage').should('exist');
-  cy.get('#settings').should('exist'); // waiting for Policy Settings tab
 };
 
 describe('Artifact tabs in Policy Details page', () => {

--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/mocked_data/endpoint_role_rbac.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/mocked_data/endpoint_role_rbac.cy.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { closeAllToasts } from '../../tasks/close_all_toasts';
+import { closeAllToasts } from '../../tasks/toasts';
 import { login } from '../../tasks/login';
 
 describe('When defining a kibana role for Endpoint security access', () => {

--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/mocked_data/isolate.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/mocked_data/isolate.cy.ts
@@ -19,7 +19,7 @@ import {
   waitForReleaseOption,
 } from '../../tasks/isolate';
 import type { ActionDetails } from '../../../../../common/endpoint/types';
-import { closeAllToasts } from '../../tasks/close_all_toasts';
+import { closeAllToasts } from '../../tasks/toasts';
 import type { ReturnTypeFromChainable } from '../../types';
 import { addAlertsToCase } from '../../tasks/add_alerts_to_case';
 import { APP_ALERTS_PATH, APP_CASES_PATH, APP_PATH } from '../../../../../common/constants';

--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/mocked_data/policy_details.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/mocked_data/policy_details.cy.ts
@@ -1,0 +1,199 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ProtectionModes } from '../../../../../common/endpoint/types';
+import {
+  PackagePolicyBackupHelper,
+  savePolicyForm,
+  visitPolicyDetailsPage,
+  yieldPolicyConfig,
+} from '../../screens/policy_details';
+import type { CyIndexEndpointHosts } from '../../tasks/index_endpoint_hosts';
+import { indexEndpointHosts } from '../../tasks/index_endpoint_hosts';
+import { login } from '../../tasks/login';
+
+describe('Policy Details', () => {
+  const packagePolicyBackupHelper = new PackagePolicyBackupHelper();
+  let indexedHostsData: CyIndexEndpointHosts;
+
+  before(() => {
+    login();
+    indexEndpointHosts().then((results) => {
+      indexedHostsData = results;
+    });
+    packagePolicyBackupHelper.backup();
+  });
+
+  beforeEach(() => {
+    login();
+    visitPolicyDetailsPage();
+  });
+
+  afterEach(() => {
+    packagePolicyBackupHelper.restore();
+  });
+
+  after(() => {
+    indexedHostsData.cleanup();
+  });
+
+  describe('Malware Protection card', () => {
+    it('user should be able to see related rules', () => {
+      cy.getByTestSubj('malwareProtectionsForm').contains('related detection rules').click();
+
+      cy.url().should('contain', 'app/security/rules/management');
+    });
+
+    it('changing protection level should enable or disable user notification', () => {
+      cy.getByTestSubj('malwareProtectionSwitch').click();
+      cy.getByTestSubj('malwareProtectionSwitch').should('have.attr', 'aria-checked', 'true');
+
+      // Default: Prevent + Notify user enabled
+      cy.getByTestSubj('malwareProtectionMode_prevent').find('input').should('be.checked');
+      cy.getByTestSubj('malwareUserNotificationCheckbox').should('be.checked');
+
+      // Changing to Detect -> Notify user disabled
+      cy.getByTestSubj('malwareProtectionMode_detect').find('label').click();
+      cy.getByTestSubj('malwareUserNotificationCheckbox').should('not.be.checked');
+
+      // Changing back to Prevent -> Notify user enabled
+      cy.getByTestSubj('malwareProtectionMode_prevent').find('label').click();
+      cy.getByTestSubj('malwareUserNotificationCheckbox').should('be.checked');
+    });
+
+    it('disabling protection should disable notification in yaml for every OS', () => {
+      // Enable malware protection and user notification
+      cy.getByTestSubj('malwareProtectionSwitch').click();
+      cy.getByTestSubj('malwareProtectionSwitch').should('have.attr', 'aria-checked', 'true');
+      savePolicyForm();
+
+      yieldPolicyConfig().then((policyConfig) => {
+        expect(policyConfig.mac.popup.malware.enabled).to.equal(true);
+        expect(policyConfig.windows.popup.malware.enabled).to.equal(true);
+        expect(policyConfig.linux.popup.malware.enabled).to.equal(true);
+      });
+
+      // disable malware protection
+      cy.getByTestSubj('malwareProtectionSwitch').click();
+      cy.getByTestSubj('malwareProtectionSwitch').should('have.attr', 'aria-checked', 'false');
+      savePolicyForm();
+
+      yieldPolicyConfig().then((policyConfig) => {
+        expect(policyConfig.mac.popup.malware.enabled).to.equal(false);
+        expect(policyConfig.windows.popup.malware.enabled).to.equal(false);
+        expect(policyConfig.linux.popup.malware.enabled).to.equal(false);
+      });
+    });
+
+    it('user should be able to enable Malware protection for every OS in yaml', () => {
+      yieldPolicyConfig().then((policyConfig) => {
+        expect(policyConfig.linux.malware.mode).to.equal(ProtectionModes.off);
+        expect(policyConfig.mac.malware.mode).to.equal(ProtectionModes.off);
+        expect(policyConfig.windows.malware.mode).to.equal(ProtectionModes.off);
+      });
+
+      cy.getByTestSubj('malwareProtectionsForm').should('contain.text', 'Linux');
+      cy.getByTestSubj('malwareProtectionsForm').should('contain.text', 'Windows');
+      cy.getByTestSubj('malwareProtectionsForm').should('contain.text', 'Mac');
+
+      cy.getByTestSubj('malwareProtectionSwitch').click();
+      savePolicyForm();
+
+      yieldPolicyConfig().then((policyConfig) => {
+        expect(policyConfig.linux.malware.mode).to.equal(ProtectionModes.prevent);
+        expect(policyConfig.mac.malware.mode).to.equal(ProtectionModes.prevent);
+        expect(policyConfig.windows.malware.mode).to.equal(ProtectionModes.prevent);
+      });
+    });
+  });
+
+  describe('Ransomware Protection card', () => {
+    it('user should be able to see related rules', () => {
+      cy.getByTestSubj('ransomwareProtectionsForm').contains('related detection rules').click();
+
+      cy.url().should('contain', 'app/security/rules/management');
+    });
+
+    it('changing protection level should enable or disable user notification', () => {
+      cy.getByTestSubj('ransomwareProtectionSwitch').click();
+      cy.getByTestSubj('ransomwareProtectionSwitch').should('have.attr', 'aria-checked', 'true');
+
+      // Default: Prevent + Notify user enabled
+      cy.getByTestSubj('ransomwareProtectionMode_prevent').find('input').should('be.checked');
+      cy.getByTestSubj('ransomwareUserNotificationCheckbox').should('be.checked');
+
+      // Changing to Detect -> Notify user disabled
+      cy.getByTestSubj('ransomwareProtectionMode_detect').find('label').click();
+      cy.getByTestSubj('ransomwareUserNotificationCheckbox').should('not.be.checked');
+
+      // Changing back to Prevent -> Notify user enabled
+      cy.getByTestSubj('ransomwareProtectionMode_prevent').find('label').click();
+      cy.getByTestSubj('ransomwareUserNotificationCheckbox').should('be.checked');
+    });
+  });
+
+  describe('Advanced settings', () => {
+    it('should show empty text inputs except for some settings', () => {
+      const settingsWithDefaultValues = [
+        'mac.advanced.capture_env_vars',
+        'linux.advanced.capture_env_vars',
+      ];
+
+      cy.getByTestSubj('advancedPolicyButton').click();
+
+      cy.getByTestSubj('advancedPolicyPanel')
+        .children()
+        .each(($child) => {
+          const settingName = $child.find('label').text();
+
+          if (settingsWithDefaultValues.includes(settingName)) {
+            cy.wrap($child).find('input').should('not.have.value', '');
+          } else {
+            cy.wrap($child).find('input').should('have.value', '');
+          }
+        });
+    });
+
+    it('should add advanced settings to policy yaml only when they are set', () => {
+      // Initially config should only contain the two default entries
+      yieldPolicyConfig().then((policyConfig) => {
+        expect(policyConfig.linux.advanced).to.have.keys(['capture_env_vars']);
+        expect(policyConfig.mac.advanced).to.have.keys(['capture_env_vars']);
+        expect(policyConfig.windows.advanced).to.equal(undefined);
+      });
+
+      // Set agent.connection_delay entry for every OS
+      cy.getByTestSubj('advancedPolicyButton').click();
+      cy.getByTestSubj('advancedPolicyPanel')
+        .children()
+        .each(($child) => {
+          const settingName = $child.find('label').text();
+
+          if (settingName.includes('.agent.connection_delay')) {
+            cy.wrap($child).find('input').type('66');
+          }
+        });
+      savePolicyForm();
+
+      // Validate yaml
+      yieldPolicyConfig().then((policyConfig) => {
+        expect(policyConfig.linux.advanced).to.have.keys(['capture_env_vars', 'agent']);
+        expect(policyConfig.linux.advanced).to.have.deep.property('agent', {
+          connection_delay: '66',
+        });
+        expect(policyConfig.mac.advanced).to.have.keys(['capture_env_vars', 'agent']);
+        expect(policyConfig.mac.advanced).to.have.deep.property('agent', {
+          connection_delay: '66',
+        });
+        expect(policyConfig.windows.advanced).to.have.keys(['agent']);
+        expect(policyConfig.windows.advanced).to.have.deep.property('agent', {
+          connection_delay: '66',
+        });
+      });
+    });
+  });
+});

--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/mocked_data/responder.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/mocked_data/responder.cy.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { closeAllToasts } from '../../tasks/close_all_toasts';
+import { closeAllToasts } from '../../tasks/toasts';
 import type { ReturnTypeFromChainable } from '../../types';
 import { addAlertsToCase } from '../../tasks/add_alerts_to_case';
 import { APP_CASES_PATH } from '../../../../../common/constants';

--- a/x-pack/plugins/security_solution/public/management/cypress/screens/policy_details.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/screens/policy_details.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type {
+  GetOnePackagePolicyResponse,
+  GetPackagePoliciesResponse,
+  PackagePolicy,
+  UpdatePackagePolicy,
+  UpdatePackagePolicyResponse,
+} from '@kbn/fleet-plugin/common';
+import { packagePolicyRouteService } from '@kbn/fleet-plugin/common';
+import { APP_POLICIES_PATH } from '../../../../common/constants';
+import type { PolicyConfig } from '../../../../common/endpoint/types';
+import { request } from '../tasks/common';
+import { expectAndCloseSuccessToast } from '../tasks/toasts';
+
+export const visitPolicyDetailsPage = () => {
+  cy.visit(APP_POLICIES_PATH);
+
+  cy.getByTestSubj('policyNameCellLink').eq(0).click({ force: true });
+  cy.getByTestSubj('policyDetailsPage').should('exist');
+  cy.get('#settings').should('exist'); // waiting for Policy Settings tab
+};
+
+export const savePolicyForm = () => {
+  cy.getByTestSubj('policyDetailsSaveButton').click();
+  cy.getByTestSubj('confirmModalConfirmButton').click();
+  expectAndCloseSuccessToast();
+};
+
+export const yieldPolicyConfig = (): Cypress.Chainable<PolicyConfig> => {
+  return cy
+    .url()
+    .then((url) => {
+      const policyId = url.match(/security\/administration\/policy\/([a-z0-9-]+)/)?.[1];
+      expect(policyId).to.not.equal(undefined);
+
+      return policyId;
+    })
+    .then((policyId: string) => {
+      return request<GetOnePackagePolicyResponse>({
+        url: `/api/fleet/package_policies/${policyId}`,
+      });
+    })
+    .then((res) => {
+      const firstPackagePolicyConfig = res.body.item.inputs[0].config;
+      expect(firstPackagePolicyConfig).to.not.equal(undefined);
+
+      const policyConfig: PolicyConfig = firstPackagePolicyConfig?.policy.value;
+
+      return policyConfig;
+    });
+};
+
+export class PackagePolicyBackupHelper {
+  originalPackagePolicy!: PackagePolicy;
+
+  backup() {
+    request<GetPackagePoliciesResponse>({
+      url: packagePolicyRouteService.getListPath(),
+      qs: {
+        kuery: 'ingest-package-policies.package.name: endpoint',
+      },
+    }).then((res) => {
+      this.originalPackagePolicy = res.body.items[0];
+    });
+  }
+
+  restore() {
+    const body: UpdatePackagePolicy = {
+      name: this.originalPackagePolicy.name,
+      namespace: this.originalPackagePolicy.namespace,
+      enabled: this.originalPackagePolicy.enabled,
+      inputs: this.originalPackagePolicy.inputs,
+      policy_id: this.originalPackagePolicy.policy_id,
+    };
+
+    request<UpdatePackagePolicyResponse>({
+      method: 'PUT',
+      url: packagePolicyRouteService.getUpdatePath(this.originalPackagePolicy.id),
+      body,
+    });
+  }
+}

--- a/x-pack/plugins/security_solution/public/management/cypress/tasks/response_console.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/tasks/response_console.ts
@@ -6,7 +6,7 @@
  */
 
 import type { ConsoleResponseActionCommands } from '../../../../common/endpoint/service/response_actions/constants';
-import { closeAllToasts } from './close_all_toasts';
+import { closeAllToasts } from './toasts';
 import { APP_ENDPOINTS_PATH } from '../../../../common/constants';
 import Chainable = Cypress.Chainable;
 

--- a/x-pack/plugins/security_solution/public/management/cypress/tasks/toasts.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/tasks/toasts.ts
@@ -40,3 +40,9 @@ export const closeAllToasts = (): Cypress.Chainable<JQuery<HTMLBodyElement>> => 
       });
   });
 };
+
+export const expectAndCloseSuccessToast = () => {
+  cy.contains('Success');
+  cy.getByTestSubj('toastCloseButton').click();
+  cy.contains('Success').should('not.exist');
+};

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/components/antivirus_registration_form/index.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/components/antivirus_registration_form/index.tsx
@@ -58,6 +58,7 @@ export const AntivirusRegistrationForm = memo(() => {
     <ConfigForm
       type={TRANSLATIONS.title}
       supportedOss={[OperatingSystem.WINDOWS]}
+      dataTestSubj="antivirusRegistrationForm"
       osRestriction={i18n.translate(
         'xpack.securitySolution.endpoint.policy.details.av.windowsServerNotSupported',
         {

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/policy_advanced.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/policy_advanced.tsx
@@ -98,7 +98,12 @@ const warningMessage = i18n.translate(
 export const AdvancedPolicyForms = React.memo(({ isPlatinumPlus }: { isPlatinumPlus: boolean }) => {
   return (
     <>
-      <EuiCallOut title={calloutTitle} color="warning" iconType="warning">
+      <EuiCallOut
+        title={calloutTitle}
+        color="warning"
+        iconType="warning"
+        data-test-subj="policyAdvancedSettingsWarning"
+      >
         <p>{warningMessage}</p>
       </EuiCallOut>
       <EuiSpacer />

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/policy_forms/components/policy_form_layout.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/policy_forms/components/policy_form_layout.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import type { ReactWrapper } from 'enzyme';
 import { mount } from 'enzyme';
 
 import { PolicyFormLayout } from './policy_form_layout';
@@ -63,7 +64,7 @@ describe('Policy Form Layout', () => {
   describe('when displayed with valid id', () => {
     let asyncActions: Promise<unknown> = Promise.resolve();
 
-    beforeEach(() => {
+    beforeEach(async () => {
       policyPackagePolicy = generator.generatePolicyPackagePolicy();
       policyPackagePolicy.id = '1';
 
@@ -102,6 +103,9 @@ describe('Policy Form Layout', () => {
       });
       history.push(policyDetailsPathUrl);
       policyFormLayoutView = render(<PolicyFormLayout />);
+
+      await asyncActions;
+      policyFormLayoutView.update();
     });
 
     it('should NOT display timeline', async () => {
@@ -109,8 +113,6 @@ describe('Policy Form Layout', () => {
     });
 
     it('should display cancel button', async () => {
-      await asyncActions;
-      policyFormLayoutView.update();
       const cancelbutton = policyFormLayoutView.find(
         'EuiButtonEmpty[data-test-subj="policyDetailsCancelButton"]'
       );
@@ -118,8 +120,6 @@ describe('Policy Form Layout', () => {
       expect(cancelbutton.text()).toEqual('Cancel');
     });
     it('should redirect to policy list when cancel button is clicked', async () => {
-      await asyncActions;
-      policyFormLayoutView.update();
       const cancelbutton = policyFormLayoutView.find(
         'EuiButtonEmpty[data-test-subj="policyDetailsCancelButton"]'
       );
@@ -132,8 +132,6 @@ describe('Policy Form Layout', () => {
       ]);
     });
     it('should display save button', async () => {
-      await asyncActions;
-      policyFormLayoutView.update();
       const saveButton = policyFormLayoutView.find(
         'EuiButton[data-test-subj="policyDetailsSaveButton"]'
       );
@@ -141,11 +139,96 @@ describe('Policy Form Layout', () => {
       expect(saveButton.text()).toEqual('Save');
     });
     it('should display beta badge', async () => {
-      await asyncActions;
-      policyFormLayoutView.update();
       const saveButton = policyFormLayoutView.find('EuiBetaBadge');
       expect(saveButton).toHaveLength(1);
       expect(saveButton.text()).toEqual('beta');
+    });
+
+    it('should display minimum Agent version number for User Notification', async () => {
+      const minVersionsMap = [
+        ['malware', '7.11'],
+        ['ransomware', '7.12'],
+        ['behavior', '7.15'],
+        ['memory', '7.15'],
+      ];
+
+      for (const [protection, minVersion] of minVersionsMap) {
+        expect(
+          policyFormLayoutView
+            .find(`EuiPanel[data-test-subj="${protection}ProtectionsForm"]`)
+            .find('EuiText[data-test-subj="policySupportedVersions"]')
+            .text()
+        ).toEqual(`Agent version ${minVersion}+`);
+      }
+    });
+
+    it('"Register as antivirus" should be only available for Windows', () => {
+      const antivirusRegistrationFormTextContent = policyFormLayoutView
+        .find('EuiPanel[data-test-subj="antivirusRegistrationForm"]')
+        .text();
+
+      expect(antivirusRegistrationFormTextContent).toContain('Windows');
+      expect(antivirusRegistrationFormTextContent).not.toContain('Linux');
+      expect(antivirusRegistrationFormTextContent).not.toContain('Mac');
+
+      expect(antivirusRegistrationFormTextContent).toContain(
+        'Toggle on to register Elastic as an official Antivirus solution for Windows OS. This will also disable Windows Defender.'
+      );
+    });
+
+    describe('Advanced settings', () => {
+      let showHideAdvancedSettingsButton: ReactWrapper;
+
+      beforeEach(() => {
+        showHideAdvancedSettingsButton = policyFormLayoutView.find(
+          'EuiButtonEmpty[data-test-subj="advancedPolicyButton"]'
+        );
+      });
+
+      it('should display "Show advanced settings" button, and hide advanced options on default', () => {
+        expect(showHideAdvancedSettingsButton.text()).toEqual('Show advanced settings');
+        expect(
+          policyFormLayoutView.find('EuiPanel[data-test-subj="advancedPolicyPanel"]').length
+        ).toEqual(0);
+      });
+
+      it('clicking on "Show/Hide advanced settings" should show/hide advanced settings', () => {
+        showHideAdvancedSettingsButton.simulate('click');
+
+        expect(showHideAdvancedSettingsButton.text()).toEqual('Hide advanced settings');
+        expect(
+          policyFormLayoutView.find('EuiPanel[data-test-subj="advancedPolicyPanel"]').length
+        ).toEqual(1);
+
+        showHideAdvancedSettingsButton.simulate('click');
+
+        expect(
+          policyFormLayoutView.find('EuiPanel[data-test-subj="advancedPolicyPanel"]').length
+        ).toEqual(0);
+      });
+
+      it('should display a warning message', () => {
+        showHideAdvancedSettingsButton.simulate('click');
+
+        expect(
+          policyFormLayoutView.find('div[data-test-subj="policyAdvancedSettingsWarning"]').text()
+        ).toContain(
+          `This section contains policy values that support advanced use cases. If not configured
+    properly, these values can cause unpredictable behavior. Please consult documentation
+    carefully or contact support before editing these values.`
+        );
+      });
+
+      it('every row should contain a tooltip', () => {
+        showHideAdvancedSettingsButton.simulate('click');
+
+        policyFormLayoutView
+          .find('EuiPanel[data-test-subj="advancedPolicyPanel"]')
+          .find('EuiFormRow')
+          .forEach((row) => {
+            expect(row.find('EuiIconTip').length).toEqual(1);
+          });
+      });
     });
 
     describe('when the save button is clicked', () => {

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/policy_forms/components/protection_radio.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/policy_forms/components/protection_radio.tsx
@@ -89,6 +89,7 @@ export const ProtectionRadio = React.memo(
         checked={selected === protectionMode}
         onChange={handleRadioChange}
         disabled={!showEditableFormFields || selected === ProtectionModes.off}
+        data-test-subj={`${protection}ProtectionMode_${protectionMode}`}
       />
     );
   }

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/policy_forms/components/protection_switch.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/policy_forms/components/protection_switch.tsx
@@ -125,6 +125,7 @@ export const ProtectionSwitch = React.memo(
         checked={selected !== ProtectionModes.off}
         onChange={handleSwitchChange}
         disabled={!showEditableFormFields}
+        data-test-subj={`${protection}ProtectionSwitch`}
       />
     );
   }

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/policy_forms/components/user_notification.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/policy_forms/components/user_notification.tsx
@@ -159,7 +159,7 @@ export const UserNotification = React.memo(
                   </h4>
                 </EuiText>
               </EuiFlexItem>
-              <EuiFlexItem grow={false}>
+              <EuiFlexItem grow={false} data-test-subj={`${protection}TooltipIcon`}>
                 <EuiIconTip
                   position="right"
                   data-test-subj={`${protection}Tooltip`}

--- a/x-pack/plugins/security_solution/scripts/endpoint/common/endpoint_metadata_services.ts
+++ b/x-pack/plugins/security_solution/scripts/endpoint/common/endpoint_metadata_services.ts
@@ -152,7 +152,7 @@ export const waitForEndpointToStreamData = async (
   let found: HostInfo | undefined;
 
   while (!found && !hasTimedOut()) {
-    found = await fetchEndpointMetadata(kbnClient, 'invalid-id-test').catch((error) => {
+    found = await fetchEndpointMetadata(kbnClient, endpointAgentId).catch((error) => {
       // Ignore `not found` (404) responses. Endpoint could be new and thus documents might not have
       // been streamed yet.
       if (error?.response?.status === 404) {

--- a/x-pack/test/security_solution_endpoint/apps/endpoint/policy_details.ts
+++ b/x-pack/test/security_solution_endpoint/apps/endpoint/policy_details.ts
@@ -81,47 +81,79 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       });
     });
 
-    describe('on the Malware protections section', () => {
-      let policyInfo: PolicyTestResourceInfo;
+    ['malware', 'ransomware'].forEach((protection) => {
+      describe(`on the ${protection} protections section`, () => {
+        let policyInfo: PolicyTestResourceInfo;
 
-      beforeEach(async () => {
-        policyInfo = await policyTestResources.createPolicy();
-        await pageObjects.policy.navigateToPolicyDetails(policyInfo.packagePolicy.id);
-        await testSubjects.existOrFail('malwareProtectionsForm');
-      });
+        beforeEach(async () => {
+          policyInfo = await policyTestResources.createPolicy();
+          await pageObjects.policy.navigateToPolicyDetails(policyInfo.packagePolicy.id);
+          await testSubjects.existOrFail(`${protection}ProtectionsForm`);
+        });
 
-      afterEach(async () => {
-        if (policyInfo) {
-          await policyInfo.cleanup();
-        }
-      });
+        afterEach(async () => {
+          if (policyInfo) {
+            await policyInfo.cleanup();
+          }
+        });
 
-      it('should show the supported Endpoint version', async () => {
-        expect(await testSubjects.getVisibleText('policySupportedVersions')).to.equal(
-          'Agent version ' + popupVersionsMap.get('malware')
-        );
-      });
+        it('should show the supported Endpoint version', async () => {
+          const supportedVersionElement = await testSubjects.findDescendant(
+            'policySupportedVersions',
+            await testSubjects.find(`${protection}ProtectionsForm`)
+          );
 
-      it('should show the custom message text area when the Notify User checkbox is checked', async () => {
-        expect(await testSubjects.isChecked('malwareUserNotificationCheckbox')).to.be(true);
-        await testSubjects.existOrFail('malwareUserNotificationCustomMessage');
-      });
+          expect(await supportedVersionElement.getVisibleText()).to.equal(
+            'Agent version ' + popupVersionsMap.get(protection)
+          );
+        });
 
-      it('should not show the custom message text area when the Notify User checkbox is unchecked', async () => {
-        await pageObjects.endpointPageUtils.clickOnEuiCheckbox('malwareUserNotificationCheckbox');
-        expect(await testSubjects.isChecked('malwareUserNotificationCheckbox')).to.be(false);
-        await testSubjects.missingOrFail('malwareUserNotificationCustomMessage');
-      });
+        it('should show the custom message text area when the Notify User checkbox is checked', async () => {
+          expect(await testSubjects.isChecked(`${protection}UserNotificationCheckbox`)).to.be(true);
+          await testSubjects.existOrFail(`${protection}UserNotificationCustomMessage`);
+        });
 
-      it('should preserve a custom notification message upon saving', async () => {
-        const customMessage = await testSubjects.find('malwareUserNotificationCustomMessage');
-        await customMessage.clearValue();
-        await customMessage.type('a custom malware notification message');
-        await pageObjects.policy.confirmAndSave();
-        await testSubjects.existOrFail('policyDetailsSuccessMessage');
-        expect(await testSubjects.getVisibleText('malwareUserNotificationCustomMessage')).to.equal(
-          'a custom malware notification message'
-        );
+        it('should not show the custom message text area when the Notify User checkbox is unchecked', async () => {
+          await pageObjects.endpointPageUtils.clickOnEuiCheckbox(
+            `${protection}UserNotificationCheckbox`
+          );
+          expect(await testSubjects.isChecked(`${protection}UserNotificationCheckbox`)).to.be(
+            false
+          );
+          await testSubjects.missingOrFail(`${protection}UserNotificationCustomMessage`);
+        });
+
+        it('should show a sample custom message', async () => {
+          const customMessageBox = await testSubjects.find(
+            `${protection}UserNotificationCustomMessage`
+          );
+          expect(await customMessageBox.getVisibleText()).equal(
+            'Elastic Security {action} {filename}'
+          );
+        });
+
+        it('should show a tooltip ', async () => {
+          const malwareTooltipIcon = await testSubjects.find(`${protection}TooltipIcon`);
+          await malwareTooltipIcon.moveMouseTo();
+
+          const malwareTooltip = await testSubjects.find(`${protection}Tooltip`);
+          expect(await malwareTooltip.getVisibleText()).equal(
+            `Selecting the user notification option will display a notification to the host user when ${protection} is prevented or detected.\nThe user notification can be customized in the text box below. Bracketed tags can be used to dynamically populate the applicable action (such as prevented or detected) and the filename.`
+          );
+        });
+
+        it('should preserve a custom notification message upon saving', async () => {
+          const customMessageBox = await testSubjects.find(
+            `${protection}UserNotificationCustomMessage`
+          );
+          await customMessageBox.clearValue();
+          await customMessageBox.type('a custom notification message @$% 123');
+          await pageObjects.policy.confirmAndSave();
+          await testSubjects.existOrFail('policyDetailsSuccessMessage');
+          expect(
+            await testSubjects.getVisibleText(`${protection}UserNotificationCustomMessage`)
+          ).to.equal('a custom notification message @$% 123');
+        });
       });
     });
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.8`:
 - [[Security Solution][Testing] Improve policy related endpoint regression test coverage (#157412)](https://github.com/elastic/kibana/pull/157412)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Gergő Ábrahám","email":"gergo.abraham@elastic.co"},"sourceCommit":{"committedDate":"2023-05-30T09:21:14Z","message":"[Security Solution][Testing] Improve policy related endpoint regression test coverage (#157412)\n\n## Summary\r\n\r\n- Adds automated test coverage for Policy Detail page related manual\r\ntests. See linked issue for test cases.\r\n- fixes e2e alerts tests\r\n\r\n~Note: 3 more e2e test cases are coming soon.~\r\nUpdate: ready to review, the 3 e2e test cases will be added in a\r\nseparate PR.","sha":"771c8790d7f05bfde308506c4eb4174540057d11","branchLabelMapping":{"^v8.9.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","Team:Defend Workflows","v8.9.0"],"number":157412,"url":"https://github.com/elastic/kibana/pull/157412","mergeCommit":{"message":"[Security Solution][Testing] Improve policy related endpoint regression test coverage (#157412)\n\n## Summary\r\n\r\n- Adds automated test coverage for Policy Detail page related manual\r\ntests. See linked issue for test cases.\r\n- fixes e2e alerts tests\r\n\r\n~Note: 3 more e2e test cases are coming soon.~\r\nUpdate: ready to review, the 3 e2e test cases will be added in a\r\nseparate PR.","sha":"771c8790d7f05bfde308506c4eb4174540057d11"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.9.0","labelRegex":"^v8.9.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/157412","number":157412,"mergeCommit":{"message":"[Security Solution][Testing] Improve policy related endpoint regression test coverage (#157412)\n\n## Summary\r\n\r\n- Adds automated test coverage for Policy Detail page related manual\r\ntests. See linked issue for test cases.\r\n- fixes e2e alerts tests\r\n\r\n~Note: 3 more e2e test cases are coming soon.~\r\nUpdate: ready to review, the 3 e2e test cases will be added in a\r\nseparate PR.","sha":"771c8790d7f05bfde308506c4eb4174540057d11"}}]}] BACKPORT-->