### PR TITLE
[Security Solution] Unskip Endpoint API tests after package fix

### DIFF
--- a/x-pack/test/security_solution_endpoint/apps/endpoint/index.ts
+++ b/x-pack/test/security_solution_endpoint/apps/endpoint/index.ts
@@ -15,8 +15,7 @@ import {
 export default function (providerContext: FtrProviderContext) {
   const { loadTestFile, getService } = providerContext;
 
-  // FAILING: https://github.com/elastic/kibana/issues/72874
-  describe.skip('endpoint', function () {
+  describe('endpoint', function () {
     const ingestManager = getService('ingestManager');
     const log = getService('log');
     const endpointTestResources = getService('endpointTestResources');

--- a/x-pack/test/security_solution_endpoint/apps/integrations/index.ts
+++ b/x-pack/test/security_solution_endpoint/apps/integrations/index.ts
@@ -15,8 +15,7 @@ import {
 export default function (providerContext: FtrProviderContext) {
   const { loadTestFile, getService } = providerContext;
 
-  // FAILING: https://github.com/elastic/kibana/issues/159450
-  describe.skip('endpoint', function () {
+  describe('endpoint', function () {
     const ingestManager = getService('ingestManager');
     const log = getService('log');
     const endpointTestResources = getService('endpointTestResources');

--- a/x-pack/test/security_solution_endpoint_api_int/apis/endpoint_authz.ts
+++ b/x-pack/test/security_solution_endpoint_api_int/apis/endpoint_authz.ts
@@ -38,8 +38,7 @@ export default function ({ getService }: FtrProviderContext) {
     body: Record<string, unknown> | undefined;
   }
 
-  // Failing: See https://github.com/elastic/kibana/issues/147640
-  describe.skip('When attempting to call an endpoint api', () => {
+  describe('When attempting to call an endpoint api', () => {
     let indexedData: IndexedHostsAndAlertsResponse;
     let actionId = '';
     let agentId = '';


### PR DESCRIPTION
## Summary

Unskip Endpoint API tests after package fix: https://github.com/elastic/endpoint-package/pull/373

Flaky runner to check that tests are passing: https://ci-stats.kibana.dev/trigger_flaky_test_runner/3

resolves:
https://github.com/elastic/kibana/issues/72874
https://github.com/elastic/kibana/issues/159450
https://github.com/elastic/kibana/issues/147640

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
