### PR TITLE
Fixes a regression in the usage of the portable dashboards

### DIFF
--- a/x-pack/plugins/apm/public/components/app/metrics/static_dashboard/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/metrics/static_dashboard/index.tsx
@@ -10,6 +10,7 @@ import React, { useState, useEffect } from 'react';
 import { ViewMode } from '@kbn/embeddable-plugin/public';
 import {
   AwaitingDashboardAPI,
+  DashboardCreationOptions,
   DashboardRenderer,
 } from '@kbn/dashboard-plugin/public';
 import { DataView } from '@kbn/data-views-plugin/common';
@@ -74,7 +75,7 @@ export function JsonMetricsDashboard(dashboardProps: MetricsDashboardProps) {
 async function getCreationOptions(
   dashboardProps: MetricsDashboardProps,
   notifications: NotificationsStart
-) {
+): Promise<DashboardCreationOptions> {
   try {
     const builder = controlGroupInputBuilder;
     const controlGroupInput = getDefaultControlGroupInput();
@@ -94,11 +95,11 @@ async function getCreationOptions(
 
     return {
       useControlGroupIntegration: true,
-      initialInput: {
+      getInitialInput: () => ({
         viewMode: ViewMode.VIEW,
         panels,
         controlGroupInput,
-      },
+      }),
     };
   } catch (error) {
     notifications.toasts.addDanger(


### PR DESCRIPTION
Fixes a regression in the usage of the portable dashboards for the APM runtime metrics.

There has been a change in the API for using the portable dashboards that broke the loading of runtime metrics.

This PR fixes that regression. 