### PR TITLE
Removed kibana-design approval on SCSS changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1220,10 +1220,6 @@ x-pack/test/threat_intelligence_cypress @elastic/protections-experience
 /x-pack/plugins/security_solution/public/common/components/guided_onboarding @elastic/security-threat-hunting-explore
 /x-pack/plugins/security_solution/cypress/e2e/guided_onboarding @elastic/security-threat-hunting-explore
 
-# Kibana design
-# scss overrides should be below this line for specificity
-**/*.scss @elastic/kibana-design
-
 # Observability design
 /x-pack/plugins/apm/**/*.scss @elastic/observability-design
 /x-pack/plugins/infra/**/*.scss @elastic/observability-design


### PR DESCRIPTION
We are of the opinion that the mandatory design reviews for all SCSS changes might no longer serve their intended purpose. This pull request proposes the elimination of kibana-design from the list of code owners for SCSS files.

With the expansion of the codebase, it has become less efficient to enforce this requirement. Furthermore, as styles transition to CSS-in-JS, this rule no longer captures all style overrides as it once did.

While design reviews remain crucial for delivering features to Kibana, we believe they should occur through a collaborative partnership between development teams and their design counterparts, rather than being mandatory at the code level.