### PR TITLE
[Serverless] Adding config to disable authentication on task manager background worker utilization API

### DIFF
--- a/config/serverless.yml
+++ b/config/serverless.yml
@@ -39,3 +39,6 @@ server.securityResponseHeaders.disableEmbedding: true
 
 # Enforce single "default" space
 xpack.spaces.maxSpaces: 1
+
+# Allow unauthenticated access to task manager utilization API for auto-scaling
+xpack.task_manager.unsafe.authenticate_background_task_utilization: false


### PR DESCRIPTION
## Summary

Until [this issue](https://github.com/elastic/kibana/issues/153720) is resolved, this config flag allows us to access the task manager background worker utilization API in serverless to support autoscaling of background task deployments

## To Verify

Run es: `yarn es snapshot`
Run serverless on this branch: `yarn serverless-es`

Verify you see the following warning in the logs:
```
[2023-06-12T12:47:19.641-04:00][WARN ][plugins.taskManager] Disabling authentication for background task utilization API
```

and you can access `/api/task_manager/_background_task_utilization` without logging in
