### PR TITLE
[Synthetics] adjust alert timing

### DIFF
--- a/x-pack/plugins/synthetics/server/alert_rules/status_rule/status_rule_executor.ts
+++ b/x-pack/plugins/synthetics/server/alert_rules/status_rule/status_rule_executor.ts
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-
+import moment from 'moment';
 import {
   SavedObjectsClientContract,
   SavedObjectsFindResult,
@@ -131,6 +131,9 @@ export class StatusRuleExecutor {
       projectMonitorsCount,
       monitorQueryIdToConfigIdMap,
     } = await this.getMonitors();
+    const from = this.previousStartedAt
+      ? moment(this.previousStartedAt).subtract(1, 'minute').toISOString()
+      : 'now-2m';
 
     if (enabledMonitorQueryIds.length > 0) {
       const currentStatus = await queryMonitorStatus(
@@ -138,7 +141,7 @@ export class StatusRuleExecutor {
         listOfLocations,
         {
           to: 'now',
-          from: this.previousStartedAt?.toISOString() ?? 'now-1m',
+          from,
         },
         enabledMonitorQueryIds,
         monitorLocationMap,


### PR DESCRIPTION
### Release note

Resolves https://github.com/elastic/kibana/issues/158172

Fixes an issue where alerting on Synthetics monitors could sometimes become delayed. 
 
## Summary
Adjust alerting timing to account for alerting framework delays.

Alert executors do not fire perfectly on the specified interval (in our case, every 1 minute). They are typically delayed a few seconds, be can especially delayed if the customer does not have their alerting settings configured to scale and there is no CPU available to take on the scheduled task.

This PR accounts for small delays in the alerting framework, by subtracting an additional 1 minute from the `from` value for our current status query.


<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->