### PR TITLE
[cli] Re-add --serverless support on distributions

### DIFF
--- a/src/cli/serve/serve.js
+++ b/src/cli/serve/serve.js
@@ -205,17 +205,17 @@ export default function (program) {
   }
 
   command.action(async function (opts) {
+    const unknownOptions = this.getUnknownOptions();
     const configs = compileConfigStack({
       configOverrides: opts.config,
       devConfig: opts.devConfig,
       dev: opts.dev,
-      serverless: opts.serverless,
+      serverless: opts.serverless || unknownOptions.serverless,
     });
 
     const configsEvaluted = getConfigFromFiles(configs);
-    const isServerlessMode = !!(configsEvaluted.serverless || opts.serverless);
+    const isServerlessMode = !!(configsEvaluted.serverless || opts.serverless || unknownOptions.serverless);
 
-    const unknownOptions = this.getUnknownOptions();
     const cliArgs = {
       dev: !!opts.dev,
       envName: unknownOptions.env ? unknownOptions.env.name : undefined,

--- a/src/cli/serve/serve.js
+++ b/src/cli/serve/serve.js
@@ -214,7 +214,11 @@ export default function (program) {
     });
 
     const configsEvaluted = getConfigFromFiles(configs);
-    const isServerlessMode = !!(configsEvaluted.serverless || opts.serverless || unknownOptions.serverless);
+    const isServerlessMode = !!(
+      configsEvaluted.serverless ||
+      opts.serverless ||
+      unknownOptions.serverless
+    );
 
     const cliArgs = {
       dev: !!opts.dev,


### PR DESCRIPTION
Prior to https://github.com/elastic/kibana/pull/158750, `bin/kibana --serverless=<project>` was able to load project specific configurations on Kibana distributions.  

This was used in functional tests [here](https://github.com/elastic/kibana/blob/main/x-pack/test_serverless/functional/config.base.ts#L31), but admittedly may not be the correct way to start the Kibana server.

Opening this up for discussion

1) Do we want to support `bin/kibana --serverless`?
2) What's the recommended way to run a distribution in serverless mode?