### PR TITLE
[Security Solution] Increase timeout for indexing hosts

### DIFF
--- a/x-pack/plugins/security_solution/public/management/cypress/tasks/index_endpoint_hosts.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/tasks/index_endpoint_hosts.ts
@@ -19,7 +19,7 @@ export interface CyIndexEndpointHosts {
 export const indexEndpointHosts = (
   options: IndexEndpointHostsCyTaskOptions = {}
 ): Cypress.Chainable<CyIndexEndpointHosts> => {
-  return cy.task('indexEndpointHosts', options, { timeout: 120000 }).then((indexHosts) => {
+  return cy.task('indexEndpointHosts', options, { timeout: 240000 }).then((indexHosts) => {
     return {
       data: indexHosts,
       cleanup: () => {


### PR DESCRIPTION
## Summary

Increase the timeout for the `indexEndpointHosts` task that was timing out on many Defend Workflows cypress tests.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

