### PR TITLE
[Enterprise Search][Search application]Fix Create Api key url

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/generate_engine_api_key/generate_engine_api_key_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/generate_engine_api_key/generate_engine_api_key_logic.test.ts
@@ -34,7 +34,7 @@ describe('GenerateEngineApiKeyLogic', () => {
       });
       await nextTick();
       expect(http.post).toHaveBeenCalledWith(
-        '/internal/enterprise_search/engines/puggles/api_key',
+        '/internal/enterprise_search/search_applications/puggles/api_key',
         {
           body: JSON.stringify({
             keyName: 'puggles read only key',

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/generate_engine_api_key/generate_engine_api_key_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/generate_engine_api_key/generate_engine_api_key_logic.ts
@@ -24,7 +24,7 @@ export const generateEngineApiKey = async ({
   engineName: string;
   keyName: string;
 }) => {
-  const route = `/internal/enterprise_search/engines/${engineName}/api_key`;
+  const route = `/internal/enterprise_search/search_applications/${engineName}/api_key`;
 
   return await HttpLogic.values.http.post<APIKeyResponse>(route, {
     body: JSON.stringify({


### PR DESCRIPTION
## Summary

Fixes regression issue, probably created when `engines` were renamed to `Search applications` in backend. The Create api key `POST` request  was redirecting to incorrect url. Replaced with correct url in this PR. 




