### PR TITLE
[8.8] [maps] fix geo line source not loaded unless maps application is opened (#159432)

### DIFF
--- a/x-pack/plugins/maps/public/actions/layer_actions.test.ts
+++ b/x-pack/plugins/maps/public/actions/layer_actions.test.ts
@@ -14,6 +14,13 @@ jest.mock('../kibana_services', () => {
     getMapsCapabilities() {
       return { save: true };
     },
+    getEMSSettings() {
+      return {
+        isEMSUrlSet() {
+          return false;
+        },
+      };
+    },
   };
 });
 

--- a/x-pack/plugins/maps/public/actions/tooltip_actions.test.ts
+++ b/x-pack/plugins/maps/public/actions/tooltip_actions.test.ts
@@ -5,6 +5,16 @@
  * 2.0.
  */
 
+jest.mock('../kibana_services', () => ({
+  getEMSSettings() {
+    return {
+      isEMSUrlSet() {
+        return false;
+      },
+    };
+  },
+}));
+
 import { TooltipState } from '../../common/descriptor_types';
 import { openOnClickTooltip } from './tooltip_actions';
 import { MapStoreState } from '../reducers/store';

--- a/x-pack/plugins/maps/public/classes/layers/wizards/choropleth_layer_wizard/create_choropleth_layer_descriptor.ts
+++ b/x-pack/plugins/maps/public/classes/layers/wizards/choropleth_layer_wizard/create_choropleth_layer_descriptor.ts
@@ -28,7 +28,6 @@ import {
 import { VectorStyle } from '../../../styles/vector/vector_style';
 import { GeoJsonVectorLayer, MvtVectorLayer } from '../../vector_layer';
 import { EMSFileSource } from '../../../sources/ems_file_source';
-// @ts-ignore
 import { ESSearchSource } from '../../../sources/es_search_source';
 import { getDefaultDynamicProperties } from '../../../styles/vector/vector_style_defaults';
 

--- a/x-pack/plugins/maps/public/classes/sources/create_source_instance.ts
+++ b/x-pack/plugins/maps/public/classes/sources/create_source_instance.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { AbstractSourceDescriptor } from '../../../common/descriptor_types';
+import { ISource } from './source';
+import { getSourceByType } from './source_registry';
+import { setupSources } from './setup_sources';
+
+setupSources();
+
+export function createSourceInstance(sourceDescriptor: AbstractSourceDescriptor | null): ISource {
+  if (sourceDescriptor === null) {
+    throw new Error('Source-descriptor should be initialized');
+  }
+  const source = getSourceByType(sourceDescriptor.type);
+  if (!source) {
+    throw new Error(`Unrecognized sourceType ${sourceDescriptor.type}`);
+  }
+  return new source.ConstructorFunction(sourceDescriptor);
+}

--- a/x-pack/plugins/maps/public/classes/sources/ems_file_source/ems_file_source.tsx
+++ b/x-pack/plugins/maps/public/classes/sources/ems_file_source/ems_file_source.tsx
@@ -16,7 +16,6 @@ import { getEmsFileLayers } from '../../../util';
 import { getDataSourceLabel } from '../../../../common/i18n_getters';
 import { UpdateSourceEditor } from './update_source_editor';
 import { EMSFileField } from '../../fields/ems_file_field';
-import { registerSource } from '../source_registry';
 import { IField } from '../../fields/field';
 import { EMSFileSourceDescriptor } from '../../../../common/descriptor_types';
 import { ITooltipProperty } from '../../tooltips/tooltip_property';
@@ -218,8 +217,3 @@ export class EMSFileSource extends AbstractVectorSource implements IEmsFileSourc
     return emsSettings.isEMSUrlSet() ? [LICENSED_FEATURES.ON_PREM_EMS] : [];
   }
 }
-
-registerSource({
-  ConstructorFunction: EMSFileSource,
-  type: SOURCE_TYPES.EMS_FILE,
-});

--- a/x-pack/plugins/maps/public/classes/sources/ems_tms_source/ems_tms_source.tsx
+++ b/x-pack/plugins/maps/public/classes/sources/ems_tms_source/ems_tms_source.tsx
@@ -15,7 +15,6 @@ import { getDataSourceLabel } from '../../../../common/i18n_getters';
 import { SOURCE_TYPES } from '../../../../common/constants';
 import { EMSTMSSourceDescriptor } from '../../../../common/descriptor_types';
 import { getEmsTileLayerId, getIsDarkMode, getEMSSettings } from '../../../kibana_services';
-import { registerSource } from '../source_registry';
 import { getEmsUnavailableMessage } from '../../../components/ems_unavailable_message';
 import { LICENSED_FEATURES } from '../../../licensed_features';
 
@@ -169,8 +168,3 @@ export class EMSTMSSource extends AbstractSource implements ITMSSource {
     return emsSettings.isEMSUrlSet() ? [LICENSED_FEATURES.ON_PREM_EMS] : [];
   }
 }
-
-registerSource({
-  ConstructorFunction: EMSTMSSource,
-  type: SOURCE_TYPES.EMS_TMS,
-});

--- a/x-pack/plugins/maps/public/classes/sources/es_geo_grid_source/es_geo_grid_source.tsx
+++ b/x-pack/plugins/maps/public/classes/sources/es_geo_grid_source/es_geo_grid_source.tsx
@@ -37,7 +37,6 @@ import { getDataSourceLabel, getDataViewLabel } from '../../../../common/i18n_ge
 import { buildGeoGridFilter } from '../../../../common/elasticsearch_util';
 import { AbstractESAggSource } from '../es_agg_source';
 import { DataRequestAbortError } from '../../util/data_request';
-import { registerSource } from '../source_registry';
 import { LICENSED_FEATURES } from '../../../licensed_features';
 
 import { getHttp } from '../../../kibana_services';
@@ -627,8 +626,3 @@ export class ESGeoGridSource extends AbstractESAggSource implements IMvtVectorSo
     ];
   }
 }
-
-registerSource({
-  ConstructorFunction: ESGeoGridSource,
-  type: SOURCE_TYPES.ES_GEO_GRID,
-});

--- a/x-pack/plugins/maps/public/classes/sources/es_geo_line_source/es_geo_line_source.tsx
+++ b/x-pack/plugins/maps/public/classes/sources/es_geo_line_source/es_geo_line_source.tsx
@@ -27,7 +27,6 @@ import {
 import { getDataSourceLabel, getDataViewLabel } from '../../../../common/i18n_getters';
 import { AbstractESAggSource } from '../es_agg_source';
 import { DataRequest } from '../../util/data_request';
-import { registerSource } from '../source_registry';
 import { convertToGeoJson } from './convert_to_geojson';
 import { ESDocField } from '../../fields/es_doc_field';
 import { UpdateSourceEditor } from './update_source_editor';
@@ -404,8 +403,3 @@ export class ESGeoLineSource extends AbstractESAggSource {
     return [LICENSED_FEATURES.GEO_LINE_AGG];
   }
 }
-
-registerSource({
-  ConstructorFunction: ESGeoLineSource,
-  type: SOURCE_TYPES.ES_GEO_LINE,
-});

--- a/x-pack/plugins/maps/public/classes/sources/es_pew_pew_source/es_pew_pew_source.tsx
+++ b/x-pack/plugins/maps/public/classes/sources/es_pew_pew_source/es_pew_pew_source.tsx
@@ -23,7 +23,6 @@ import { SOURCE_TYPES, VECTOR_SHAPE_TYPE } from '../../../../common/constants';
 import { getDataSourceLabel, getDataViewLabel } from '../../../../common/i18n_getters';
 import { convertToLines } from './convert_to_lines';
 import { AbstractESAggSource } from '../es_agg_source';
-import { registerSource } from '../source_registry';
 import { turfBboxToBounds } from '../../../../common/elasticsearch_util';
 import { DataRequestAbortError } from '../../util/data_request';
 import { mergeExecutionContext } from '../execution_context_utils';
@@ -295,8 +294,3 @@ export class ESPewPewSource extends AbstractESAggSource {
     return true;
   }
 }
-
-registerSource({
-  ConstructorFunction: ESPewPewSource,
-  type: SOURCE_TYPES.ES_PEW_PEW,
-});

--- a/x-pack/plugins/maps/public/classes/sources/es_search_source/es_search_source.tsx
+++ b/x-pack/plugins/maps/public/classes/sources/es_search_source/es_search_source.tsx
@@ -48,7 +48,6 @@ import { getSourceFields } from '../../../index_pattern_util';
 import { loadIndexSettings } from './util/load_index_settings';
 import { DEFAULT_FILTER_BY_MAP_BOUNDS } from './constants';
 import { ESDocField } from '../../fields/es_doc_field';
-import { registerSource } from '../source_registry';
 import {
   DataRequestMeta,
   ESSearchSourceDescriptor,
@@ -1009,8 +1008,3 @@ export class ESSearchSource extends AbstractESSource implements IMvtVectorSource
       : [];
   }
 }
-
-registerSource({
-  ConstructorFunction: ESSearchSource,
-  type: SOURCE_TYPES.ES_SEARCH,
-});

--- a/x-pack/plugins/maps/public/classes/sources/geojson_file_source/geojson_file_source.ts
+++ b/x-pack/plugins/maps/public/classes/sources/geojson_file_source/geojson_file_source.ts
@@ -13,7 +13,6 @@ import {
   GeojsonFileSourceDescriptor,
   MapExtent,
 } from '../../../../common/descriptor_types';
-import { registerSource } from '../source_registry';
 import { IField } from '../../fields/field';
 import { getFeatureCollectionBounds } from '../../util/get_feature_collection_bounds';
 import { InlineField } from '../../fields/inline_field';
@@ -135,8 +134,3 @@ export class GeoJsonFileSource extends AbstractVectorSource {
     return (this._descriptor as GeojsonFileSourceDescriptor).__featureCollection;
   }
 }
-
-registerSource({
-  ConstructorFunction: GeoJsonFileSource,
-  type: SOURCE_TYPES.GEOJSON_FILE,
-});

--- a/x-pack/plugins/maps/public/classes/sources/kibana_tilemap_source/kibana_tilemap_source.js
+++ b/x-pack/plugins/maps/public/classes/sources/kibana_tilemap_source/kibana_tilemap_source.js
@@ -11,7 +11,6 @@ import { i18n } from '@kbn/i18n';
 import { getDataSourceLabel } from '../../../../common/i18n_getters';
 import _ from 'lodash';
 import { SOURCE_TYPES } from '../../../../common/constants';
-import { registerSource } from '../source_registry';
 import { extractAttributions } from './extract_attributions';
 
 export const sourceTitle = i18n.translate('xpack.maps.source.kbnTMSTitle', {
@@ -87,8 +86,3 @@ export class KibanaTilemapSource extends AbstractSource {
     }
   }
 }
-
-registerSource({
-  ConstructorFunction: KibanaTilemapSource,
-  type: SOURCE_TYPES.KIBANA_TILEMAP,
-});

--- a/x-pack/plugins/maps/public/classes/sources/mvt_single_layer_vector_source/mvt_single_layer_vector_source.tsx
+++ b/x-pack/plugins/maps/public/classes/sources/mvt_single_layer_vector_source/mvt_single_layer_vector_source.tsx
@@ -23,7 +23,6 @@ import {
   SOURCE_TYPES,
   VECTOR_SHAPE_TYPE,
 } from '../../../../common/constants';
-import { registerSource } from '../source_registry';
 import { getDataSourceLabel, getUrlLabel } from '../../../../common/i18n_getters';
 import {
   MapExtent,
@@ -250,8 +249,3 @@ export class MVTSingleLayerVectorSource extends AbstractSource implements IMvtVe
     return [];
   }
 }
-
-registerSource({
-  ConstructorFunction: MVTSingleLayerVectorSource,
-  type: SOURCE_TYPES.MVT_SINGLE_LAYER,
-});

--- a/x-pack/plugins/maps/public/classes/sources/setup_sources.test.ts
+++ b/x-pack/plugins/maps/public/classes/sources/setup_sources.test.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+jest.mock('../../kibana_services', () => {
+  return {
+    getEMSSettings() {
+      return {
+        isEMSUrlSet() {
+          return false;
+        },
+      };
+    },
+  };
+});
+
+import { setupSources } from './setup_sources';
+import { SOURCE_TYPES } from '../../../common/constants';
+import { getSourceByType } from './source_registry';
+
+const EXPECTED_UNREGISTERED_SOURCE_TYPES = [
+  SOURCE_TYPES.ES_ML_ANOMALIES, // registered in ML plugin
+  // join sources are not contained in source registry
+  SOURCE_TYPES.ES_DISTANCE_SOURCE,
+  SOURCE_TYPES.ES_TERM_SOURCE,
+  SOURCE_TYPES.TABLE_SOURCE,
+];
+
+test('should register all Elastic Maps sources', () => {
+  setupSources();
+
+  Object.values(SOURCE_TYPES)
+    .filter((sourceType) => {
+      return !EXPECTED_UNREGISTERED_SOURCE_TYPES.includes(sourceType);
+    })
+    .forEach((sourceType) => {
+      const entry = getSourceByType(sourceType);
+      if (!entry) {
+        throw new Error(`Required source type "${sourceType}" not registered.`);
+      }
+    });
+});

--- a/x-pack/plugins/maps/public/classes/sources/setup_sources.test.ts
+++ b/x-pack/plugins/maps/public/classes/sources/setup_sources.test.ts
@@ -24,7 +24,6 @@ import { getSourceByType } from './source_registry';
 const EXPECTED_UNREGISTERED_SOURCE_TYPES = [
   SOURCE_TYPES.ES_ML_ANOMALIES, // registered in ML plugin
   // join sources are not contained in source registry
-  SOURCE_TYPES.ES_DISTANCE_SOURCE,
   SOURCE_TYPES.ES_TERM_SOURCE,
   SOURCE_TYPES.TABLE_SOURCE,
 ];

--- a/x-pack/plugins/maps/public/classes/sources/setup_sources.ts
+++ b/x-pack/plugins/maps/public/classes/sources/setup_sources.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { SOURCE_TYPES } from '../../../common/constants';
+import { registerSource } from './source_registry';
+import { EMSFileSource } from './ems_file_source';
+import { EMSTMSSource } from './ems_tms_source';
+import { ESGeoGridSource } from './es_geo_grid_source';
+import { ESGeoLineSource } from './es_geo_line_source';
+import { ESPewPewSource } from './es_pew_pew_source';
+import { ESSearchSource } from './es_search_source';
+import { GeoJsonFileSource } from './geojson_file_source';
+import { KibanaTilemapSource } from './kibana_tilemap_source';
+import { MVTSingleLayerVectorSource } from './mvt_single_layer_vector_source';
+import { WMSSource } from './wms_source';
+import { XYZTMSSource } from './xyz_tms_source';
+
+let registered = false;
+
+export function setupSources() {
+  if (registered) {
+    return;
+  }
+
+  registerSource({
+    ConstructorFunction: EMSFileSource,
+    type: SOURCE_TYPES.EMS_FILE,
+  });
+
+  registerSource({
+    ConstructorFunction: EMSTMSSource,
+    type: SOURCE_TYPES.EMS_TMS,
+  });
+
+  registerSource({
+    ConstructorFunction: ESGeoGridSource,
+    type: SOURCE_TYPES.ES_GEO_GRID,
+  });
+
+  registerSource({
+    ConstructorFunction: ESGeoLineSource,
+    type: SOURCE_TYPES.ES_GEO_LINE,
+  });
+
+  registerSource({
+    ConstructorFunction: ESPewPewSource,
+    type: SOURCE_TYPES.ES_PEW_PEW,
+  });
+
+  registerSource({
+    ConstructorFunction: ESSearchSource,
+    type: SOURCE_TYPES.ES_SEARCH,
+  });
+
+  registerSource({
+    ConstructorFunction: GeoJsonFileSource,
+    type: SOURCE_TYPES.GEOJSON_FILE,
+  });
+
+  registerSource({
+    ConstructorFunction: KibanaTilemapSource,
+    type: SOURCE_TYPES.KIBANA_TILEMAP,
+  });
+
+  registerSource({
+    ConstructorFunction: MVTSingleLayerVectorSource,
+    type: SOURCE_TYPES.MVT_SINGLE_LAYER,
+  });
+
+  registerSource({
+    ConstructorFunction: WMSSource,
+    type: SOURCE_TYPES.WMS,
+  });
+
+  registerSource({
+    ConstructorFunction: XYZTMSSource,
+    type: SOURCE_TYPES.EMS_XYZ,
+  });
+
+  registered = true;
+}

--- a/x-pack/plugins/maps/public/classes/sources/wms_source/wms_source.tsx
+++ b/x-pack/plugins/maps/public/classes/sources/wms_source/wms_source.tsx
@@ -13,7 +13,6 @@ import { getDataSourceLabel, getUrlLabel } from '../../../../common/i18n_getters
 // @ts-ignore
 import { WmsClient } from './wms_client';
 import { SOURCE_TYPES } from '../../../../common/constants';
-import { registerSource } from '../source_registry';
 import { IRasterSource, RasterTileSourceData } from '../raster_source';
 import { WMSSourceDescriptor } from '../../../../common/descriptor_types';
 export const sourceTitle = i18n.translate('xpack.maps.source.wmsTitle', {
@@ -80,8 +79,3 @@ export class WMSSource extends AbstractSource implements IRasterSource {
     return client.getUrlTemplate(this._descriptor.layers, this._descriptor.styles || '');
   }
 }
-
-registerSource({
-  ConstructorFunction: WMSSource,
-  type: SOURCE_TYPES.WMS,
-});

--- a/x-pack/plugins/maps/public/classes/sources/xyz_tms_source/xyz_tms_source.tsx
+++ b/x-pack/plugins/maps/public/classes/sources/xyz_tms_source/xyz_tms_source.tsx
@@ -10,7 +10,6 @@ import { ReactElement } from 'react';
 import { RasterTileSource } from 'maplibre-gl';
 import { getDataSourceLabel, getUrlLabel } from '../../../../common/i18n_getters';
 import { SOURCE_TYPES } from '../../../../common/constants';
-import { registerSource } from '../source_registry';
 import {
   XYZTMSSourceDescriptor,
   DataRequestMeta,
@@ -89,8 +88,3 @@ export class XYZTMSSource extends AbstractSource implements IRasterSource {
     return canSkip;
   }
 }
-
-registerSource({
-  ConstructorFunction: XYZTMSSource,
-  type: SOURCE_TYPES.EMS_XYZ,
-});

--- a/x-pack/plugins/maps/public/connected_components/edit_layer_panel/edit_layer_panel.test.tsx
+++ b/x-pack/plugins/maps/public/connected_components/edit_layer_panel/edit_layer_panel.test.tsx
@@ -43,6 +43,13 @@ jest.mock('../../kibana_services', () => {
     getCore() {
       return {};
     },
+    getEMSSettings() {
+      return {
+        isEMSUrlSet() {
+          return false;
+        },
+      };
+    },
   };
 });
 

--- a/x-pack/plugins/maps/public/connected_components/right_side_controls/layer_control/layer_toc/toc_entry/toc_entry.test.tsx
+++ b/x-pack/plugins/maps/public/connected_components/right_side_controls/layer_control/layer_toc/toc_entry/toc_entry.test.tsx
@@ -14,6 +14,13 @@ jest.mock('../../../../../kibana_services', () => {
     getMapsCapabilities() {
       return { save: true };
     },
+    getEMSSettings() {
+      return {
+        isEMSUrlSet() {
+          return false;
+        },
+      };
+    },
   };
 });
 

--- a/x-pack/plugins/maps/public/connected_components/right_side_controls/layer_control/layer_toc/toc_entry/toc_entry_actions_popover/toc_entry_actions_popover.test.tsx
+++ b/x-pack/plugins/maps/public/connected_components/right_side_controls/layer_control/layer_toc/toc_entry/toc_entry_actions_popover/toc_entry_actions_popover.test.tsx
@@ -7,6 +7,16 @@
 
 /* eslint-disable max-classes-per-file */
 
+jest.mock('../../../../../../kibana_services', () => ({
+  getEMSSettings() {
+    return {
+      isEMSUrlSet() {
+        return false;
+      },
+    };
+  },
+}));
+
 import React from 'react';
 import { shallow } from 'enzyme';
 import { AbstractLayer, ILayer } from '../../../../../../classes/layers/layer';

--- a/x-pack/plugins/maps/public/connected_components/toolbar_overlay/toolbar_overlay.test.tsx
+++ b/x-pack/plugins/maps/public/connected_components/toolbar_overlay/toolbar_overlay.test.tsx
@@ -14,6 +14,13 @@ jest.mock('../../kibana_services', () => {
     getMapsCapabilities() {
       return { save: true };
     },
+    getEMSSettings() {
+      return {
+        isEMSUrlSet() {
+          return false;
+        },
+      };
+    },
   };
 });
 

--- a/x-pack/plugins/maps/public/embeddable/map_embeddable.test.tsx
+++ b/x-pack/plugins/maps/public/embeddable/map_embeddable.test.tsx
@@ -51,6 +51,13 @@ jest.mock('../kibana_services', () => {
         },
       };
     },
+    getEMSSettings() {
+      return {
+        isEMSUrlSet() {
+          return false;
+        },
+      };
+    },
   };
 });
 

--- a/x-pack/plugins/maps/public/routes/map_page/saved_map/get_initial_layers_from_url_param.ts
+++ b/x-pack/plugins/maps/public/routes/map_page/saved_map/get_initial_layers_from_url_param.ts
@@ -7,12 +7,6 @@
 
 import rison from '@kbn/rison';
 import { i18n } from '@kbn/i18n';
-import '../../../classes/sources/wms_source';
-import '../../../classes/sources/ems_file_source';
-import '../../../classes/sources/es_search_source';
-import '../../../classes/sources/es_pew_pew_source';
-import '../../../classes/sources/es_geo_grid_source';
-import '../../../classes/sources/xyz_tms_source';
 import { LayerDescriptor } from '../../../../common';
 import { getToasts } from '../../../kibana_services';
 import { INITIAL_LAYERS_KEY } from '../../../../common/constants';

--- a/x-pack/plugins/maps/public/selectors/map_selectors.test.ts
+++ b/x-pack/plugins/maps/public/selectors/map_selectors.test.ts
@@ -25,6 +25,13 @@ jest.mock('../kibana_services', () => ({
   getIsDarkMode() {
     return false;
   },
+  getEMSSettings() {
+    return {
+      isEMSUrlSet() {
+        return false;
+      },
+    };
+  },
 }));
 
 import { DEFAULT_MAP_STORE_STATE } from '../reducers/store';

--- a/x-pack/plugins/maps/public/selectors/map_selectors.ts
+++ b/x-pack/plugins/maps/public/selectors/map_selectors.ts
@@ -27,7 +27,7 @@ import { getTimeFilter } from '../kibana_services';
 import { getChartsPaletteServiceGetColor } from '../reducers/non_serializable_instances';
 import { copyPersistentState, TRACKED_LAYER_DESCRIPTOR } from '../reducers/copy_persistent_state';
 import { InnerJoin } from '../classes/joins/inner_join';
-import { getSourceByType } from '../classes/sources/source_registry';
+import { createSourceInstance } from '../classes/sources/create_source_instance';
 import { GeoJsonFileSource } from '../classes/sources/geojson_file_source';
 import {
   LAYER_TYPE,
@@ -40,7 +40,6 @@ import {
 import { extractFeaturesFromFilters } from '../../common/elasticsearch_util';
 import { MapStoreState } from '../reducers/store';
 import {
-  AbstractSourceDescriptor,
   DataRequestDescriptor,
   CustomIcon,
   DrawState,
@@ -126,17 +125,6 @@ export function createLayerInstance(
     default:
       throw new Error(`Unrecognized layerType ${layerDescriptor.type}`);
   }
-}
-
-function createSourceInstance(sourceDescriptor: AbstractSourceDescriptor | null): ISource {
-  if (sourceDescriptor === null) {
-    throw new Error('Source-descriptor should be initialized');
-  }
-  const source = getSourceByType(sourceDescriptor.type);
-  if (!source) {
-    throw new Error(`Unrecognized sourceType ${sourceDescriptor.type}`);
-  }
-  return new source.ConstructorFunction(sourceDescriptor);
 }
 
 export const getMapSettings = ({ map }: MapStoreState): MapSettings => map.settings;


### PR DESCRIPTION
Manual backport of https://github.com/elastic/kibana/pull/159432

Needed to remove ES_DISTANCE_SOURCE reference since ES_DISTANCE_SOURCE does not exist on 8.8 branch