### PR TITLE
[Fleet] feature flag uninstall token generation

### DIFF
--- a/x-pack/plugins/fleet/server/mocks/index.ts
+++ b/x-pack/plugins/fleet/server/mocks/index.ts
@@ -68,7 +68,10 @@ export const createAppContextStartContractMock = (
     securitySetup: securityMock.createSetup(),
     securityStart: securityMock.createStart(),
     logger: loggingSystemMock.create().get(),
-    experimentalFeatures: { diagnosticFileUploadEnabled: true } as ExperimentalFeatures,
+    experimentalFeatures: {
+      agentTamperProtectionEnabled: true,
+      diagnosticFileUploadEnabled: true,
+    } as ExperimentalFeatures,
     isProductionMode: true,
     configInitialValue: {
       agents: { enabled: true, elasticsearch: {} },

--- a/x-pack/plugins/fleet/server/services/security/uninstall_token_service/index.test.ts
+++ b/x-pack/plugins/fleet/server/services/security/uninstall_token_service/index.test.ts
@@ -438,6 +438,19 @@ describe('UninstallTokenService', () => {
           ]);
         });
       });
+
+      describe('agentTamperProtectionEnabled false', () => {
+        beforeAll(() => {
+          // @ts-ignore
+          mockContext.experimentalFeatures.agentTamperProtectionEnabled = false;
+        });
+
+        it('should not generate token if agentTamperProtectionEnabled: false', async () => {
+          const so = getDefaultSO();
+          await uninstallTokenService.generateTokensForPolicyIds([so.attributes.policy_id]);
+          expect(soClientMock.bulkCreate).not.toBeCalled();
+        });
+      });
     });
   });
 });

--- a/x-pack/plugins/fleet/server/services/security/uninstall_token_service/index.test.ts
+++ b/x-pack/plugins/fleet/server/services/security/uninstall_token_service/index.test.ts
@@ -445,9 +445,20 @@ describe('UninstallTokenService', () => {
           mockContext.experimentalFeatures.agentTamperProtectionEnabled = false;
         });
 
-        it('should not generate token if agentTamperProtectionEnabled: false', async () => {
+        it('generateTokensForPolicyIds should not generate token if agentTamperProtectionEnabled: false', async () => {
           const so = getDefaultSO();
           await uninstallTokenService.generateTokensForPolicyIds([so.attributes.policy_id]);
+          expect(soClientMock.bulkCreate).not.toBeCalled();
+        });
+
+        it('generateTokensForAllPolicies should not generate token if agentTamperProtectionEnabled: false', async () => {
+          await uninstallTokenService.generateTokensForAllPolicies();
+          expect(soClientMock.bulkCreate).not.toBeCalled();
+        });
+
+        it('generateTokenForPolicyId should not generate token if agentTamperProtectionEnabled: false', async () => {
+          const so = getDefaultSO();
+          await uninstallTokenService.generateTokenForPolicyId(so.attributes.policy_id);
           expect(soClientMock.bulkCreate).not.toBeCalled();
         });
       });

--- a/x-pack/plugins/fleet/server/services/security/uninstall_token_service/index.ts
+++ b/x-pack/plugins/fleet/server/services/security/uninstall_token_service/index.ts
@@ -290,7 +290,9 @@ export class UninstallTokenService implements UninstallTokenServiceInterface {
     policyIds: string[],
     force: boolean = false
   ): Promise<Record<string, string>> {
-    if (!policyIds.length) {
+    const { agentTamperProtectionEnabled } = appContextService.getExperimentalFeatures();
+
+    if (!agentTamperProtectionEnabled || !policyIds.length) {
       return {};
     }
 


### PR DESCRIPTION
## Summary

gate uninstall token generation behind `agentTamperProtectionEnabled` feature flag.

Implements: https://github.com/elastic/security-team/issues/6819


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
