### PR TITLE
[8.8] [Failing Tests] Skips and comments tests failing with no_shard_available_action (#159039)

### DIFF
--- a/x-pack/test/saved_object_api_integration/spaces_only/apis/import.ts
+++ b/x-pack/test/saved_object_api_integration/spaces_only/apis/import.ts
@@ -147,7 +147,10 @@ export default function ({ getService }: FtrProviderContext) {
     return tests.flat();
   };
 
-  describe('_import', () => {
+  // FLAKY: https://github.com/elastic/kibana/issues/158586
+  // Also, https://github.com/elastic/kibana/issues/158918
+  // esArchiver fails with no_shard_available_action_exception after deleting indexes
+  describe.skip('_import', () => {
     getTestScenarios([
       [false, false],
       [false, true],

--- a/x-pack/test/saved_object_api_integration/spaces_only/apis/resolve.ts
+++ b/x-pack/test/saved_object_api_integration/spaces_only/apis/resolve.ts
@@ -41,7 +41,9 @@ export default function ({ getService }: FtrProviderContext) {
     return createTestDefinitions(testCases, false, { spaceId });
   };
 
-  // FLAKY: https://github.com/elastic/kibana/issues/156998
+  // FLAKY: https://github.com/elastic/kibana/issues/156998, https://github.com/elastic/kibana/issues/156922, https://github.com/elastic/kibana/issues/156921
+  // Also, https://github.com/elastic/kibana/issues/158918
+  // esArchiver fails with no_shard_available_action_exception after deleting indexes
   describe.skip('_resolve', () => {
     getTestScenarios().spaces.forEach(({ spaceId }) => {
       const tests = createTests(spaceId);

--- a/x-pack/test/saved_object_api_integration/spaces_only/apis/resolve_import_errors.ts
+++ b/x-pack/test/saved_object_api_integration/spaces_only/apis/resolve_import_errors.ts
@@ -130,7 +130,10 @@ export default function ({ getService }: FtrProviderContext) {
     return createTestDefinitions(testCases, false, { overwrite, spaceId, singleRequest });
   };
 
-  describe('_resolve_import_errors', () => {
+  // FLAKY: https://github.com/elastic/kibana/issues/155846, https://github.com/elastic/kibana/issues/156045, https://github.com/elastic/kibana/issues/156041
+  // Also, https://github.com/elastic/kibana/issues/158918
+  // esArchiver fails with no_shard_available_action_exception after deleting indexes
+  describe.skip('_resolve_import_errors', () => {
     getTestScenarios([
       [false, false],
       [false, true],

--- a/x-pack/test/spaces_api_integration/spaces_only/apis/get.ts
+++ b/x-pack/test/spaces_api_integration/spaces_only/apis/get.ts
@@ -17,7 +17,10 @@ export default function getSpaceTestSuite({ getService }: FtrProviderContext) {
   const { getTest, createExpectResults, createExpectNotFoundResult, nonExistantSpaceId } =
     getTestSuiteFactory(esArchiver, supertestWithoutAuth);
 
-  describe('get', () => {
+  // Failing: See https://github.com/elastic/kibana/issues/155723, https://github.com/elastic/kibana/issues/156422
+  // Also, https://github.com/elastic/kibana/issues/158918
+  // esArchiver fails with no_shard_available_action_exception after deleting indexes
+  describe.skip('get', () => {
     // valid spaces
     [
       {

--- a/x-pack/test/spaces_api_integration/spaces_only/apis/index.ts
+++ b/x-pack/test/spaces_api_integration/spaces_only/apis/index.ts
@@ -19,6 +19,9 @@ export default function spacesOnlyTestSuite({ loadTestFile }: FtrProviderContext
     loadTestFile(require.resolve('./get'));
     loadTestFile(require.resolve('./update'));
     loadTestFile(require.resolve('./update_objects_spaces'));
-    loadTestFile(require.resolve('./disable_legacy_url_aliases'));
+    // FLAKY: https://github.com/elastic/kibana/issues/158711, https://github.com/elastic/kibana/issues/158366
+    // Also, https://github.com/elastic/kibana/issues/158918
+    // esArchiver fails with no_shard_available_action_exception after deleting indexes
+    // loadTestFile(require.resolve('./disable_legacy_url_aliases'));
   });
 }

--- a/x-pack/test/spaces_api_integration/spaces_only/apis/update.ts
+++ b/x-pack/test/spaces_api_integration/spaces_only/apis/update.ts
@@ -17,8 +17,9 @@ export default function updateSpaceTestSuite({ getService }: FtrProviderContext)
   const { updateTest, expectAlreadyExistsResult, expectDefaultSpaceResult, expectNotFound } =
     updateTestSuiteFactory(esArchiver, supertestWithoutAuth);
 
-  // FLAKY: https://github.com/elastic/kibana/issues/156151
-  // FLAKY: https://github.com/elastic/kibana/issues/156130
+  // FLAKY: https://github.com/elastic/kibana/issues/156130, https://github.com/elastic/kibana/issues/156074
+  // Also, https://github.com/elastic/kibana/issues/158918
+  // esArchiver fails with no_shard_available_action_exception after deleting indexes
   describe.skip('update', () => {
     [
       {

--- a/x-pack/test/spaces_api_integration/spaces_only/apis/update_objects_spaces.ts
+++ b/x-pack/test/spaces_api_integration/spaces_only/apis/update_objects_spaces.ts
@@ -183,7 +183,9 @@ export default function ({ getService }: FtrProviderContext) {
     return createTestDefinitions(testCases, false);
   };
 
-  // FLAKY: https://github.com/elastic/kibana/issues/156739
+  // FLAKY: https://github.com/elastic/kibana/issues/156739, https://github.com/elastic/kibana/issues/157673
+  // Also, https://github.com/elastic/kibana/issues/158918
+  // esArchiver fails with no_shard_available_action_exception after deleting indexes
   describe.skip('_update_objects_spaces', () => {
     getTestScenarios().spaces.forEach(({ spaceId }) => {
       const tests = createSinglePartTests(spaceId);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.8`:
 - [[Failing Tests] Skips and comments tests failing with no_shard_available_action (#159039)](https://github.com/elastic/kibana/pull/159039)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Jeramy Soucy","email":"jeramy.soucy@elastic.co"},"sourceCommit":{"committedDate":"2023-06-06T07:11:22Z","message":"[Failing Tests] Skips and comments tests failing with no_shard_available_action (#159039)\n\n## Summary\r\n\r\nSkips several tests failing with the\r\n`no_shard_available_action_exception`. Also adds comments noting the\r\nrelated test failure issues and the [master issue being\r\ntracked](https://github.com/elastic/kibana/issues/158918).\r\n\r\nSee issue #158918 and PR #159002.","sha":"63bd0ba9f9cec244cac38affc2bc572ad5f6a6aa","branchLabelMapping":{"^v8.9.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Saved Objects","Feature:Security/Spaces","skipped-test","release_note:skip","backport:prev-minor","v8.9.0"],"number":159039,"url":"https://github.com/elastic/kibana/pull/159039","mergeCommit":{"message":"[Failing Tests] Skips and comments tests failing with no_shard_available_action (#159039)\n\n## Summary\r\n\r\nSkips several tests failing with the\r\n`no_shard_available_action_exception`. Also adds comments noting the\r\nrelated test failure issues and the [master issue being\r\ntracked](https://github.com/elastic/kibana/issues/158918).\r\n\r\nSee issue #158918 and PR #159002.","sha":"63bd0ba9f9cec244cac38affc2bc572ad5f6a6aa"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.9.0","labelRegex":"^v8.9.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/159039","number":159039,"mergeCommit":{"message":"[Failing Tests] Skips and comments tests failing with no_shard_available_action (#159039)\n\n## Summary\r\n\r\nSkips several tests failing with the\r\n`no_shard_available_action_exception`. Also adds comments noting the\r\nrelated test failure issues and the [master issue being\r\ntracked](https://github.com/elastic/kibana/issues/158918).\r\n\r\nSee issue #158918 and PR #159002.","sha":"63bd0ba9f9cec244cac38affc2bc572ad5f6a6aa"}}]}] BACKPORT-->