### PR TITLE
[ML] Explain Log Rate Spikes: Expose analysis results via optional callback.

### DIFF
--- a/x-pack/plugins/aiops/public/components/explain_log_rate_spikes/explain_log_rate_spikes_analysis.tsx
+++ b/x-pack/plugins/aiops/public/components/explain_log_rate_spikes/explain_log_rate_spikes_analysis.tsx
@@ -27,6 +27,7 @@ import { useFetchStream } from '@kbn/aiops-utils';
 import type { WindowParameters } from '@kbn/aiops-utils';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
+import type { SignificantTerm, SignificantTermGroup } from '@kbn/ml-agg-utils';
 
 import { useAiopsAppContext } from '../../hooks/use_aiops_app_context';
 import { initialState, streamReducer } from '../../../common/api/stream_reducer';
@@ -69,6 +70,11 @@ const groupResultsOnMessage = i18n.translate(
 const resultsGroupedOffId = 'aiopsExplainLogRateSpikesGroupingOff';
 const resultsGroupedOnId = 'aiopsExplainLogRateSpikesGroupingOn';
 
+export interface ExplainLogRateSpikesAnalysisResults {
+  significantTerms: SignificantTerm[];
+  significantTermsGroups: SignificantTermGroup[];
+}
+
 /**
  * ExplainLogRateSpikes props require a data view.
  */
@@ -85,6 +91,8 @@ interface ExplainLogRateSpikesAnalysisProps {
   searchQuery: estypes.QueryDslQueryContainer;
   /** Sample probability to be applied to random sampler aggregations */
   sampleProbability: number;
+  /** Optional callback that exposes data of the completed analysis */
+  onAnalysisCompleted?: (d: ExplainLogRateSpikesAnalysisResults) => void;
 }
 
 export const ExplainLogRateSpikesAnalysis: FC<ExplainLogRateSpikesAnalysisProps> = ({
@@ -94,6 +102,7 @@ export const ExplainLogRateSpikesAnalysis: FC<ExplainLogRateSpikesAnalysisProps>
   windowParameters,
   searchQuery,
   sampleProbability,
+  onAnalysisCompleted,
 }) => {
   const { http } = useAiopsAppContext();
   const basePath = http.basePath.get() ?? '';
@@ -174,6 +183,12 @@ export const ExplainLogRateSpikesAnalysis: FC<ExplainLogRateSpikesAnalysisProps>
         setOverrides({ loaded, remainingFieldCandidates, significantTerms: data.significantTerms });
       } else {
         setOverrides(undefined);
+        if (onAnalysisCompleted) {
+          onAnalysisCompleted({
+            significantTerms: data.significantTerms,
+            significantTermsGroups: data.significantTermsGroups,
+          });
+        }
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/x-pack/plugins/aiops/public/components/explain_log_rate_spikes/explain_log_rate_spikes_content/explain_log_rate_spikes_content.tsx
+++ b/x-pack/plugins/aiops/public/components/explain_log_rate_spikes/explain_log_rate_spikes_content/explain_log_rate_spikes_content.tsx
@@ -19,7 +19,10 @@ import type { SignificantTerm } from '@kbn/ml-agg-utils';
 import type { Moment } from 'moment';
 import { useData } from '../../../hooks/use_data';
 import { DocumentCountContent } from '../../document_count_content/document_count_content';
-import { ExplainLogRateSpikesAnalysis } from '../explain_log_rate_spikes_analysis';
+import {
+  ExplainLogRateSpikesAnalysis,
+  type ExplainLogRateSpikesAnalysisResults,
+} from '../explain_log_rate_spikes_analysis';
 import type { GroupTableItem } from '../../spike_analysis_table/types';
 import { useSpikeAnalysisTableRowContext } from '../../spike_analysis_table/spike_analysis_table_row_provider';
 
@@ -47,6 +50,8 @@ export interface ExplainLogRateSpikesContentProps {
   timeRange?: { min: Moment; max: Moment };
   /** Elasticsearch query to pass to analysis endpoint */
   esSearchQuery?: estypes.QueryDslQueryContainer;
+  /** Optional callback that exposes data of the completed analysis */
+  onAnalysisCompleted?: (d: ExplainLogRateSpikesAnalysisResults) => void;
 }
 
 export const ExplainLogRateSpikesContent: FC<ExplainLogRateSpikesContentProps> = ({
@@ -55,6 +60,7 @@ export const ExplainLogRateSpikesContent: FC<ExplainLogRateSpikesContentProps> =
   initialAnalysisStart,
   timeRange,
   esSearchQuery = DEFAULT_SEARCH_QUERY,
+  onAnalysisCompleted,
 }) => {
   const [windowParameters, setWindowParameters] = useState<WindowParameters | undefined>();
 
@@ -134,6 +140,7 @@ export const ExplainLogRateSpikesContent: FC<ExplainLogRateSpikesContentProps> =
                 windowParameters={windowParameters}
                 searchQuery={esSearchQuery}
                 sampleProbability={sampleProbability}
+                onAnalysisCompleted={onAnalysisCompleted}
               />
             )}
             {windowParameters === undefined && (

--- a/x-pack/plugins/aiops/public/components/explain_log_rate_spikes/explain_log_rate_spikes_content/explain_log_rate_spikes_content_wrapper.tsx
+++ b/x-pack/plugins/aiops/public/components/explain_log_rate_spikes/explain_log_rate_spikes_content/explain_log_rate_spikes_content_wrapper.tsx
@@ -28,10 +28,9 @@ import { AIOPS_STORAGE_KEYS } from '../../../types/storage';
 
 import { SpikeAnalysisTableRowStateProvider } from '../../spike_analysis_table/spike_analysis_table_row_provider';
 
-import {
-  ExplainLogRateSpikesContent,
-  type ExplainLogRateSpikesAnalysisResults,
-} from './explain_log_rate_spikes_content';
+import type { ExplainLogRateSpikesAnalysisResults } from '../explain_log_rate_spikes_analysis';
+
+import { ExplainLogRateSpikesContent } from './explain_log_rate_spikes_content';
 
 const localStorage = new Storage(window.localStorage);
 

--- a/x-pack/plugins/aiops/public/components/explain_log_rate_spikes/explain_log_rate_spikes_content/explain_log_rate_spikes_content_wrapper.tsx
+++ b/x-pack/plugins/aiops/public/components/explain_log_rate_spikes/explain_log_rate_spikes_content/explain_log_rate_spikes_content_wrapper.tsx
@@ -28,7 +28,10 @@ import { AIOPS_STORAGE_KEYS } from '../../../types/storage';
 
 import { SpikeAnalysisTableRowStateProvider } from '../../spike_analysis_table/spike_analysis_table_row_provider';
 
-import { ExplainLogRateSpikesContent } from './explain_log_rate_spikes_content';
+import {
+  ExplainLogRateSpikesContent,
+  type ExplainLogRateSpikesAnalysisResults,
+} from './explain_log_rate_spikes_content';
 
 const localStorage = new Storage(window.localStorage);
 
@@ -44,6 +47,8 @@ export interface ExplainLogRateSpikesContentWrapperProps {
   timeRange?: { min: Moment; max: Moment };
   /** Elasticsearch query to pass to analysis endpoint */
   esSearchQuery?: estypes.QueryDslQueryContainer;
+  /** Optional callback that exposes data of the completed analysis */
+  onAnalysisCompleted?: (d: ExplainLogRateSpikesAnalysisResults) => void;
 }
 
 export const ExplainLogRateSpikesContentWrapper: FC<ExplainLogRateSpikesContentWrapperProps> = ({
@@ -53,6 +58,7 @@ export const ExplainLogRateSpikesContentWrapper: FC<ExplainLogRateSpikesContentW
   initialAnalysisStart,
   timeRange,
   esSearchQuery,
+  onAnalysisCompleted,
 }) => {
   if (!dataView) return null;
 
@@ -95,6 +101,7 @@ export const ExplainLogRateSpikesContentWrapper: FC<ExplainLogRateSpikesContentW
                   initialAnalysisStart={initialAnalysisStart}
                   timeRange={timeRange}
                   esSearchQuery={esSearchQuery}
+                  onAnalysisCompleted={onAnalysisCompleted}
                 />
               </DatePickerContextProvider>
             </StorageContextProvider>

--- a/x-pack/plugins/aiops/public/index.ts
+++ b/x-pack/plugins/aiops/public/index.ts
@@ -17,6 +17,7 @@ export type { AiopsAppDependencies } from './hooks/use_aiops_app_context';
 export type { ExplainLogRateSpikesAppStateProps } from './components/explain_log_rate_spikes';
 export type { LogCategorizationAppStateProps } from './components/log_categorization';
 export type { ChangePointDetectionAppStateProps } from './components/change_point_detection';
+export type { ExplainLogRateSpikesAnalysisResults } from './components/explain_log_rate_spikes/explain_log_rate_spikes_analysis';
 
 export {
   ExplainLogRateSpikes,


### PR DESCRIPTION
## Summary

Related to https://github.com/elastic/kibana/pull/158960.

Adds an optional `onAnalysisCompleted` callback to able to act on the final analysis results.

### Checklist

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
