### PR TITLE
[Lens] fix missing key warning and IntlProvider warning

### DIFF
--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/layer_actions/layer_actions.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/layer_actions/layer_actions.tsx
@@ -129,6 +129,7 @@ const InContextMenuActions = (props: LayerActionsProps) => {
           size="s"
           items={props.actions.map((i) => (
             <EuiContextMenuItem
+              key={i.displayName}
               icon={<EuiIcon type={i.icon} title={i.displayName} color={i.color} />}
               data-test-subj={i['data-test-subj']}
               aria-label={i.displayName}

--- a/x-pack/plugins/lens/public/visualizations/xy/annotations/actions/save_action.tsx
+++ b/x-pack/plugins/lens/public/visualizations/xy/annotations/actions/save_action.tsx
@@ -11,7 +11,7 @@ import { render, unmountComponentAtNode } from 'react-dom';
 import { EventAnnotationServiceType } from '@kbn/event-annotation-plugin/public';
 import { ToastsStart } from '@kbn/core-notifications-browser';
 import { MountPoint } from '@kbn/core-mount-utils-browser';
-import { FormattedMessage } from '@kbn/i18n-react';
+import { FormattedMessage, I18nProvider } from '@kbn/i18n-react';
 import {
   OnSaveProps as SavedObjectOnSaveProps,
   SavedObjectSaveModal,
@@ -49,46 +49,48 @@ export const SaveModal = ({
   const closeModal = () => unmountComponentAtNode(domElement);
 
   return (
-    <SavedObjectSaveModal
-      onSave={async (props) => onSave({ ...props, closeModal, newTags: selectedTags })}
-      onClose={closeModal}
-      title={title}
-      description={description}
-      showCopyOnSave={showCopyOnSave}
-      objectType={i18n.translate(
-        'xpack.lens.xyChart.annotations.saveAnnotationGroupToLibrary.objectType',
-        { defaultMessage: 'group' }
-      )}
-      customModalTitle={i18n.translate(
-        'xpack.lens.xyChart.annotations.saveAnnotationGroupToLibrary.modalTitle',
-        {
-          defaultMessage: 'Save annotation group to library',
+    <I18nProvider>
+      <SavedObjectSaveModal
+        onSave={async (props) => onSave({ ...props, closeModal, newTags: selectedTags })}
+        onClose={closeModal}
+        title={title}
+        description={description}
+        showCopyOnSave={showCopyOnSave}
+        objectType={i18n.translate(
+          'xpack.lens.xyChart.annotations.saveAnnotationGroupToLibrary.objectType',
+          { defaultMessage: 'group' }
+        )}
+        customModalTitle={i18n.translate(
+          'xpack.lens.xyChart.annotations.saveAnnotationGroupToLibrary.modalTitle',
+          {
+            defaultMessage: 'Save annotation group to library',
+          }
+        )}
+        showDescription={true}
+        confirmButtonLabel={
+          <>
+            <div>
+              <EuiIcon type="save" />
+            </div>
+            <div>
+              {i18n.translate(
+                'xpack.lens.xyChart.annotations.saveAnnotationGroupToLibrary.confirmButton',
+                { defaultMessage: 'Save group' }
+              )}
+            </div>
+          </>
         }
-      )}
-      showDescription={true}
-      confirmButtonLabel={
-        <>
-          <div>
-            <EuiIcon type="save" />
-          </div>
-          <div>
-            {i18n.translate(
-              'xpack.lens.xyChart.annotations.saveAnnotationGroupToLibrary.confirmButton',
-              { defaultMessage: 'Save group' }
-            )}
-          </div>
-        </>
-      }
-      options={
-        savedObjectsTagging ? (
-          <savedObjectsTagging.ui.components.SavedObjectSaveModalTagSelector
-            initialSelection={selectedTags}
-            onTagsSelected={setSelectedTags}
-            markOptional
-          />
-        ) : undefined
-      }
-    />
+        options={
+          savedObjectsTagging ? (
+            <savedObjectsTagging.ui.components.SavedObjectSaveModalTagSelector
+              initialSelection={selectedTags}
+              onTagsSelected={setSelectedTags}
+              markOptional
+            />
+          ) : undefined
+        }
+      />
+    </I18nProvider>
   );
 };
 


### PR DESCRIPTION
## Summary

Fixes: 

1. When opening layer actions, React complains about missing key for `map`.
2. When opening saving modal for annotation group, the warning about missing <IntlProvider/> appears

Let's merge it after Drew's PR so he doesn't have to deal with conflicts right before vacations :) 

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
