### PR TITLE
[Logs onboarding] Add service name to logs setup

### DIFF
--- a/x-pack/plugins/observability_onboarding/public/components/app/custom_logs/wizard/configure_logs.tsx
+++ b/x-pack/plugins/observability_onboarding/public/components/app/custom_logs/wizard/configure_logs.tsx
@@ -227,7 +227,7 @@ export function ConfigureLogs() {
             />
           </EuiFormRow>
           <EuiSpacer size="m" />
-          <EuiFormRow
+          <OptionalFormRow
             label={i18n.translate(
               'xpack.observability_onboarding.configureLogs.serviceName',
               {
@@ -251,7 +251,7 @@ export function ConfigureLogs() {
               value={serviceName}
               onChange={(event) => setServiceName(event.target.value)}
             />
-          </EuiFormRow>
+          </OptionalFormRow>
           <EuiHorizontalRule margin="m" />
           <EuiFlexGroup
             alignItems="flexStart"

--- a/x-pack/plugins/observability_onboarding/public/components/app/custom_logs/wizard/configure_logs.tsx
+++ b/x-pack/plugins/observability_onboarding/public/components/app/custom_logs/wizard/configure_logs.tsx
@@ -42,6 +42,7 @@ export function ConfigureLogs() {
   const { goToStep, goBack, getState, setState } = useWizard();
   const wizardState = getState();
   const [datasetName, setDatasetName] = useState(wizardState.datasetName);
+  const [serviceName, setServiceName] = useState(wizardState.serviceName);
   const [logFilePaths, setLogFilePaths] = useState(wizardState.logFilePaths);
   const [namespace, setNamespace] = useState(wizardState.namespace);
   const [customConfigurations, setCustomConfigurations] = useState(
@@ -58,6 +59,7 @@ export function ConfigureLogs() {
     setState({
       ...getState(),
       datasetName,
+      serviceName,
       logFilePaths: logFilePaths.filter((filepath) => !!filepath),
       namespace,
       customConfigurations,
@@ -194,7 +196,68 @@ export function ConfigureLogs() {
                 )}
               </EuiButtonEmpty>
             </EuiFlexItem>
-            <EuiHorizontalRule margin="m" />
+          </EuiFlexGroup>
+          <EuiSpacer size="s" />
+          <EuiFormRow
+            label={i18n.translate(
+              'xpack.observability_onboarding.configureLogs.dataset.name',
+              {
+                defaultMessage: 'Dataset name',
+              }
+            )}
+            helpText={i18n.translate(
+              'xpack.observability_onboarding.configureLogs.dataset.helper',
+              {
+                defaultMessage:
+                  "Pick a name for your logs. All lowercase, max 100 chars, special characters will be replaced with '_'.",
+              }
+            )}
+          >
+            <EuiFieldText
+              placeholder={i18n.translate(
+                'xpack.observability_onboarding.configureLogs.dataset.placeholder',
+                {
+                  defaultMessage: 'Dataset name',
+                }
+              )}
+              value={datasetName}
+              onChange={(event) =>
+                setDatasetName(replaceSpecialChars(event.target.value))
+              }
+            />
+          </EuiFormRow>
+          <EuiSpacer size="m" />
+          <EuiFormRow
+            label={i18n.translate(
+              'xpack.observability_onboarding.configureLogs.serviceName',
+              {
+                defaultMessage: 'Service name',
+              }
+            )}
+            helpText={
+              <FormattedMessage
+                id="xpack.observability_onboarding.configureLogs.serviceName.helper"
+                defaultMessage="Name the service your data is collected from."
+              />
+            }
+          >
+            <EuiFieldText
+              placeholder={i18n.translate(
+                'xpack.observability_onboarding.configureLogs.serviceName.placeholder',
+                {
+                  defaultMessage: 'Give a name to your service',
+                }
+              )}
+              value={serviceName}
+              onChange={(event) => setServiceName(event.target.value)}
+            />
+          </EuiFormRow>
+          <EuiHorizontalRule margin="m" />
+          <EuiFlexGroup
+            alignItems="flexStart"
+            direction="column"
+            gutterSize="xs"
+          >
             <EuiFlexItem grow={false}>
               <EuiAccordion
                 id="advancedSettingsAccordion"
@@ -216,35 +279,6 @@ export function ConfigureLogs() {
                   }
                 )}
               >
-                <EuiSpacer size="l" />
-                <EuiFormRow
-                  label={i18n.translate(
-                    'xpack.observability_onboarding.configureLogs.dataset.name',
-                    {
-                      defaultMessage: 'Dataset name',
-                    }
-                  )}
-                  helpText={i18n.translate(
-                    'xpack.observability_onboarding.configureLogs.dataset.helper',
-                    {
-                      defaultMessage:
-                        "Pick a name for your logs. All lowercase, max 100 chars, special characters will be replaced with '_'.",
-                    }
-                  )}
-                >
-                  <EuiFieldText
-                    placeholder={i18n.translate(
-                      'xpack.observability_onboarding.configureLogs.dataset.placeholder',
-                      {
-                        defaultMessage: 'Dataset name',
-                      }
-                    )}
-                    value={datasetName}
-                    onChange={(event) =>
-                      setDatasetName(replaceSpecialChars(event.target.value))
-                    }
-                  />
-                </EuiFormRow>
                 <EuiSpacer size="l" />
                 <EuiFormRow
                   label={i18n.translate(

--- a/x-pack/plugins/observability_onboarding/public/components/app/custom_logs/wizard/index.tsx
+++ b/x-pack/plugins/observability_onboarding/public/components/app/custom_logs/wizard/index.tsx
@@ -13,6 +13,7 @@ import { Inspect } from './inspect';
 
 interface WizardState {
   datasetName: string;
+  serviceName: string;
   logFilePaths: string[];
   namespace: string;
   customConfigurations: string;
@@ -31,6 +32,7 @@ interface WizardState {
 
 const initialState: WizardState = {
   datasetName: '',
+  serviceName: '',
   logFilePaths: [''],
   namespace: 'default',
   customConfigurations: '',

--- a/x-pack/plugins/observability_onboarding/public/components/app/custom_logs/wizard/install_elastic_agent.tsx
+++ b/x-pack/plugins/observability_onboarding/public/components/app/custom_logs/wizard/install_elastic_agent.tsx
@@ -98,6 +98,7 @@ export function InstallElasticAgent() {
                 name: wizardState.datasetName,
                 state: {
                   datasetName: wizardState.datasetName,
+                  serviceName: wizardState.serviceName,
                   namespace: wizardState.namespace,
                   customConfigurations: wizardState.customConfigurations,
                   logFilePaths: wizardState.logFilePaths,

--- a/x-pack/plugins/observability_onboarding/server/routes/elastic_agent/generate_yml.ts
+++ b/x-pack/plugins/observability_onboarding/server/routes/elastic_agent/generate_yml.ts
@@ -9,6 +9,7 @@ import { dump, load } from 'js-yaml';
 
 export const generateYml = ({
   datasetName = '',
+  serviceName,
   namespace = '',
   customConfigurations,
   logFilePaths = [],
@@ -17,6 +18,7 @@ export const generateYml = ({
   logfileId,
 }: {
   datasetName?: string;
+  serviceName?: string;
   namespace?: string;
   customConfigurations?: string;
   logFilePaths?: string[];
@@ -25,6 +27,16 @@ export const generateYml = ({
   logfileId: string;
 }) => {
   const customConfigYaml = load(customConfigurations ?? '');
+  const processors = [
+    {
+      add_fields: {
+        target: 'service',
+        fields: {
+          name: serviceName,
+        },
+      },
+    },
+  ];
 
   return dump({
     ...{
@@ -49,6 +61,7 @@ export const generateYml = ({
                 dataset: datasetName,
               },
               paths: logFilePaths,
+              ...(serviceName ? { processors } : {}),
             },
           ],
         },

--- a/x-pack/plugins/observability_onboarding/server/routes/elastic_agent/route.ts
+++ b/x-pack/plugins/observability_onboarding/server/routes/elastic_agent/route.ts
@@ -42,6 +42,7 @@ const generateConfig = createObservabilityOnboardingServerRoute({
         : '$API_KEY',
       esHost: [elasticsearchUrl],
       logfileId: `custom-logs-${Date.now()}`,
+      serviceName: savedState?.state.serviceName,
     });
 
     return yaml;

--- a/x-pack/plugins/observability_onboarding/server/saved_objects/observability_onboarding_status.ts
+++ b/x-pack/plugins/observability_onboarding/server/saved_objects/observability_onboarding_status.ts
@@ -13,7 +13,8 @@ export const OBSERVABILITY_ONBOARDING_STATE_SAVED_OBJECT_TYPE =
 export interface ObservabilityOnboardingState {
   state: {
     datasetName: string;
-    customConfigurations: string;
+    serviceName?: string;
+    customConfigurations?: string;
     logFilePaths: string[];
     namespace: string;
   };


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/159492.

This PR adds a field to logs setup so users can define optionally the service name of the service generating logs.

### Changes
- New input for serviceName in setup step.
- ServiceName is added to SO.
- ServiceName is used in `generateYml`.

#### Demo

https://github.com/elastic/kibana/assets/1313018/15fe33ec-1c36-413a-809a-897b2c0a9042
