### PR TITLE
Placeholder and tooltip support

### DIFF
--- a/x-pack/plugins/enterprise_search/common/types/connectors.ts
+++ b/x-pack/plugins/enterprise_search/common/types/connectors.ts
@@ -46,6 +46,7 @@ export interface ConnectorConfigProperties {
   label: string;
   options: SelectOption[];
   order?: number | null;
+  placeholder?: string;
   required: boolean;
   sensitive: boolean;
   tooltip: string;

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_configuration_field.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_configuration_field.tsx
@@ -18,6 +18,9 @@ import {
   EuiSwitch,
   EuiTextArea,
   EuiToolTip,
+  EuiIcon,
+  EuiFlexGroup,
+  EuiFlexItem,
 } from '@elastic/eui';
 
 import { Status } from '../../../../../../common/types/api';
@@ -40,6 +43,25 @@ interface ConnectorConfigurationFieldProps {
 export const ConnectorConfigurationField: React.FC<ConnectorConfigurationFieldProps> = ({
   configEntry,
 }) => {
+  return configEntry.tooltip ? (
+    <EuiToolTip content={configEntry.tooltip}>
+      <EuiFlexGroup alignItems="center" gutterSize="xs">
+        <EuiFlexItem>
+          <ConnectorConfigurationFieldType configEntry={configEntry} />
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiIcon type="questionInCircle" />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiToolTip>
+  ) : (
+    <ConnectorConfigurationFieldType configEntry={configEntry} />
+  );
+};
+
+export const ConnectorConfigurationFieldType: React.FC<ConnectorConfigurationFieldProps> = ({
+  configEntry,
+}) => {
   const { status } = useValues(ConnectorConfigurationApiLogic);
   const { setLocalConfigEntry } = useActions(ConnectorConfigurationLogic);
 
@@ -50,6 +72,7 @@ export const ConnectorConfigurationField: React.FC<ConnectorConfigurationFieldPr
     label,
     options,
     required,
+    placeholder,
     sensitive,
     tooltip,
     value,
@@ -89,6 +112,7 @@ export const ConnectorConfigurationField: React.FC<ConnectorConfigurationFieldPr
           onChange={(event) => {
             setLocalConfigEntry({ ...configEntry, value: event.target.value });
           }}
+          placeholder={placeholder}
         />
       );
 
@@ -96,6 +120,7 @@ export const ConnectorConfigurationField: React.FC<ConnectorConfigurationFieldPr
       const textarea = (
         <EuiTextArea
           disabled={status === Status.LOADING}
+          placeholder={placeholder}
           required={required}
           value={ensureStringType(value)}
           onChange={(event) => {
@@ -155,6 +180,7 @@ export const ConnectorConfigurationField: React.FC<ConnectorConfigurationFieldPr
       ) : (
         <EuiFieldText
           disabled={status === Status.LOADING}
+          placeholder={placeholder}
           required={required}
           value={ensureStringType(value)}
           onChange={(event) => {


### PR DESCRIPTION
## Summary

This adds support for tooltips and placeholders to Kibana for connector configurations. 
<img width="673" alt="Screenshot 2023-06-13 at 14 40 49" src="https://github.com/elastic/kibana/assets/94373878/469d84e3-d8d6-4da9-ad6e-bff80c93ecfb">
<img width="894" alt="Screenshot 2023-06-13 at 14 37 30" src="https://github.com/elastic/kibana/assets/94373878/0b47471c-2d2c-4cfa-9b2b-4cb22aabbbc6">
