### PR TITLE
fix(slo): add missing version for index pattern api

### DIFF
--- a/x-pack/plugins/observability/public/hooks/slo/use_fetch_index_pattern_fields.ts
+++ b/x-pack/plugins/observability/public/hooks/slo/use_fetch_index_pattern_fields.ts
@@ -35,6 +35,9 @@ export function useFetchIndexPatternFields(
             query: {
               pattern: indexPattern,
             },
+            headers: {
+              'Elastic-Api-Version': 1,
+            },
             signal,
           }
         );


### PR DESCRIPTION
## Summary

While testing SLO, I've notice a change in the index pattern API handler was making the hook fails while fetching the timestamp fields of a kibana index. This PR adds the api version when calling the API.