### PR TITLE
[Serverless Snapshot Telemetry] Fallback ES version

### DIFF
--- a/src/plugins/telemetry/server/telemetry_collection/get_local_stats.test.ts
+++ b/src/plugins/telemetry/server/telemetry_collection/get_local_stats.test.ts
@@ -198,6 +198,19 @@ describe('get_local_stats', () => {
       expect(result.stack_stats).toEqual({ kibana: undefined, data: undefined });
     });
 
+    it('fallbacks to Kibana version if ES does not respond with it', () => {
+      const { version: _, ...clusterInfoWithoutVersion } = clusterInfo;
+      const result = handleLocalStats(
+        clusterInfoWithoutVersion as estypes.InfoResponse,
+        clusterStatsWithNodesUsage,
+        void 0,
+        void 0,
+        context
+      );
+
+      expect(result.version).toEqual('8.0.0');
+    });
+
     it('returns expected object with xpack', () => {
       const result = handleLocalStats(
         clusterInfo as estypes.InfoResponse,

--- a/src/plugins/telemetry/server/telemetry_collection/get_local_stats.test.ts
+++ b/src/plugins/telemetry/server/telemetry_collection/get_local_stats.test.ts
@@ -192,7 +192,7 @@ describe('get_local_stats', () => {
       expect(result.cluster_uuid).toStrictEqual(combinedStatsResult.cluster_uuid);
       expect(result.cluster_name).toStrictEqual(combinedStatsResult.cluster_name);
       expect(result.cluster_stats).toStrictEqual(combinedStatsResult.cluster_stats);
-      expect(result.version).toEqual('2.3.4');
+      expect(result.version).toEqual(version);
       expect(result.collection).toEqual('local');
       expect(Object.keys(result)).not.toContain('license');
       expect(result.stack_stats).toEqual({ kibana: undefined, data: undefined });
@@ -208,7 +208,7 @@ describe('get_local_stats', () => {
         context
       );
 
-      expect(result.version).toEqual('8.0.0');
+      expect(result.version).toEqual(context.version);
     });
 
     it('returns expected object with xpack', () => {
@@ -247,7 +247,7 @@ describe('get_local_stats', () => {
       expect(result.cluster_name).toEqual(combinedStatsResult.cluster_name);
       expect(result.cluster_stats).toEqual(combinedStatsResult.cluster_stats);
       expect(result.cluster_stats.nodes).toEqual(combinedStatsResult.cluster_stats.nodes);
-      expect(result.version).toBe('2.3.4');
+      expect(result.version).toBe(version);
       expect(result.collection).toBe('local');
       expect(Object.keys(result).indexOf('license')).toBeLessThan(0);
       expect(Object.keys(result.stack_stats).indexOf('xpack')).toBeLessThan(0);

--- a/src/plugins/telemetry/server/telemetry_collection/get_local_stats.ts
+++ b/src/plugins/telemetry/server/telemetry_collection/get_local_stats.ts
@@ -38,7 +38,7 @@ export function handleLocalStats<ClusterStats extends estypes.ClusterStatsRespon
     timestamp: new Date().toISOString(),
     cluster_uuid,
     cluster_name,
-    version: version.number,
+    version: version?.number || context.version,
     cluster_stats: clusterStats,
     collection: 'local',
     stack_stats: {


### PR DESCRIPTION
## Summary

Resolve #159238.

Serverless ES might not return the version. In order to keep BWC in our telemetry pipeline, let's fall back to Kibana's version to be ready for that breaking change.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
