### PR TITLE
[core router] Improve error message when version header is missing

### DIFF
--- a/packages/core/http/core-http-router-server-internal/src/versioned_router/core_versioned_route.ts
+++ b/packages/core/http/core-http-router-server-internal/src/versioned_router/core_versioned_route.ts
@@ -111,7 +111,7 @@ export class CoreVersionedRoute implements VersionedRoute {
 
     if (!this.hasVersion(req) && (this.isInternal || this.router.isDev)) {
       return res.badRequest({
-        body: `Please specify a version. Available versions: ${this.versionsToString()}`,
+        body: `Please specify a version via ${ELASTIC_HTTP_VERSION_HEADER} header. Available versions: ${this.versionsToString()}`,
       });
     }
 


### PR DESCRIPTION
## Summary

Across the kibana code base there are a number of http client wrappers, some of which have special handling of the version header and some don't. This can be quite confusing when you get an error message that says "Please specify a version." and you _are_ specifying a version header but you're not specifying _the_ version header. Now the error message will remind you where it expects to find the version. 

