### PR TITLE
Check lens support in editor comparisons table for  tag cloud and significant terms

### DIFF
--- a/docs/user/dashboard/create-panels-with-editors.asciidoc
+++ b/docs/user/dashboard/create-panels-with-editors.asciidoc
@@ -83,7 +83,7 @@
 |
 
 | Tag cloud
-|
+| &check;
 |
 | &check;
 | &check;
@@ -405,7 +405,7 @@ Bucket aggregations group, or bucket, documents based on the aggregation type. T
 | &check;
 
 | Significant terms
-|
+| &check;
 |
 | &check;
 | &check;


### PR DESCRIPTION
Update editor tables to reflect that tag cloud and significant terms aggregations are supported in lens