### PR TITLE
[data views] Move fields_for_wildcard to internal route

### DIFF
--- a/src/plugins/data_views/common/constants.ts
+++ b/src/plugins/data_views/common/constants.ts
@@ -51,3 +51,9 @@ export const DATA_VIEW_SAVED_OBJECT_TYPE = 'index-pattern';
  * @public
  */
 export const PLUGIN_NAME = 'DataViews';
+
+/**
+ * Fields for wildcard path.
+ * @public
+ */
+export const FIELDS_FOR_WILDCARD_PATH = '/internal/data_views/_fields_for_wildcard';

--- a/src/plugins/data_views/public/data_views/data_views_api_client.test.ts
+++ b/src/plugins/data_views/public/data_views/data_views_api_client.test.ts
@@ -8,6 +8,7 @@
 
 import { http } from './data_views_api_client.test.mock';
 import { DataViewsApiClient } from './data_views_api_client';
+import { FIELDS_FOR_WILDCARD_PATH as expectedPath } from '../../common/constants';
 
 describe('IndexPatternsApiClient', () => {
   let fetchSpy: jest.SpyInstance;
@@ -19,8 +20,6 @@ describe('IndexPatternsApiClient', () => {
   });
 
   test('uses the right URI to fetch fields for wildcard', async function () {
-    const expectedPath = '/api/index_patterns/_fields_for_wildcard';
-
     await indexPatternsApiClient.getFieldsForWildcard({ pattern: 'blah' });
 
     expect(fetchSpy).toHaveBeenCalledWith(expectedPath, expect.any(Object));

--- a/src/plugins/data_views/public/data_views/data_views_api_client.ts
+++ b/src/plugins/data_views/public/data_views/data_views_api_client.ts
@@ -61,7 +61,7 @@ export class DataViewsApiClient implements IDataViewsApiClient {
       fields,
     } = options;
     return this._request<FieldsForWildcardResponse>(
-      this._getUrl(['_fields_for_wildcard']),
+      '/internal/data_views/_fields_for_wildcard',
       {
         pattern,
         meta_fields: metaFields,

--- a/src/plugins/data_views/public/data_views/data_views_api_client.ts
+++ b/src/plugins/data_views/public/data_views/data_views_api_client.ts
@@ -10,6 +10,7 @@ import { HttpSetup } from '@kbn/core/public';
 import { DataViewMissingIndices } from '../../common/lib';
 import { GetFieldsOptions, IDataViewsApiClient } from '../../common';
 import { FieldsForWildcardResponse } from '../../common/types';
+import { FIELDS_FOR_WILDCARD_PATH } from '../../common/constants';
 
 const API_BASE_URL: string = `/api/index_patterns/`;
 const version = '1';
@@ -61,7 +62,7 @@ export class DataViewsApiClient implements IDataViewsApiClient {
       fields,
     } = options;
     return this._request<FieldsForWildcardResponse>(
-      '/internal/data_views/_fields_for_wildcard',
+      FIELDS_FOR_WILDCARD_PATH,
       {
         pattern,
         meta_fields: metaFields,

--- a/src/plugins/data_views/server/rest_api_routes/internal/fields_for.ts
+++ b/src/plugins/data_views/server/rest_api_routes/internal/fields_for.ts
@@ -17,6 +17,7 @@ import type {
   DataViewsServerPluginStartDependencies,
 } from '../../types';
 import type { FieldDescriptorRestResponse } from '../route_types';
+import { FIELDS_FOR_WILDCARD_PATH as path } from '../../../common/constants';
 
 /**
  * Accepts one of the following:
@@ -38,7 +39,6 @@ export const parseFields = (fields: string | string[]): string[] => {
   }
 };
 
-const path = '/internal/data_views/_fields_for_wildcard';
 const access = 'internal';
 
 type IBody = { index_filter?: estypes.QueryDslQueryContainer } | undefined;

--- a/src/plugins/data_views/server/rest_api_routes/internal/fields_for.ts
+++ b/src/plugins/data_views/server/rest_api_routes/internal/fields_for.ts
@@ -38,7 +38,7 @@ export const parseFields = (fields: string | string[]): string[] => {
   }
 };
 
-const path = '/api/index_patterns/_fields_for_wildcard';
+const path = '/internal/data_views/_fields_for_wildcard';
 const access = 'internal';
 
 type IBody = { index_filter?: estypes.QueryDslQueryContainer } | undefined;

--- a/test/api_integration/apis/data_views/fields_for_wildcard_route/conflicts.ts
+++ b/test/api_integration/apis/data_views/fields_for_wildcard_route/conflicts.ts
@@ -8,6 +8,7 @@
 
 import { ELASTIC_HTTP_VERSION_HEADER } from '@kbn/core-http-common';
 import { INITIAL_REST_VERSION_INTERNAL } from '@kbn/data-views-plugin/server/constants';
+import { FIELDS_FOR_WILDCARD_PATH } from '@kbn/data-views-plugin/common/constants';
 import expect from '@kbn/expect';
 import { FtrProviderContext } from '../../../ftr_provider_context';
 
@@ -25,7 +26,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     it('flags fields with mismatched types as conflicting', () =>
       supertest
-        .get('/api/index_patterns/_fields_for_wildcard')
+        .get(FIELDS_FOR_WILDCARD_PATH)
         .set(ELASTIC_HTTP_VERSION_HEADER, INITIAL_REST_VERSION_INTERNAL)
         .query({ pattern: 'logs-*' })
         .expect(200)

--- a/test/api_integration/apis/data_views/fields_for_wildcard_route/filter.ts
+++ b/test/api_integration/apis/data_views/fields_for_wildcard_route/filter.ts
@@ -8,6 +8,7 @@
 
 import { ELASTIC_HTTP_VERSION_HEADER } from '@kbn/core-http-common';
 import { INITIAL_REST_VERSION_INTERNAL } from '@kbn/data-views-plugin/server/constants';
+import { FIELDS_FOR_WILDCARD_PATH } from '@kbn/data-views-plugin/common/constants';
 import expect from '@kbn/expect';
 import { FtrProviderContext } from '../../../ftr_provider_context';
 
@@ -34,7 +35,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     it('can filter', async () => {
       const a = await supertest
-        .put('/api/index_patterns/_fields_for_wildcard')
+        .put(FIELDS_FOR_WILDCARD_PATH)
         .set(ELASTIC_HTTP_VERSION_HEADER, INITIAL_REST_VERSION_INTERNAL)
         .query({ pattern: 'helloworld*' })
         .send({ index_filter: { exists: { field: 'bye' } } });

--- a/test/api_integration/apis/data_views/fields_for_wildcard_route/params.ts
+++ b/test/api_integration/apis/data_views/fields_for_wildcard_route/params.ts
@@ -8,6 +8,7 @@
 
 import { ELASTIC_HTTP_VERSION_HEADER } from '@kbn/core-http-common';
 import { INITIAL_REST_VERSION_INTERNAL } from '@kbn/data-views-plugin/server/constants';
+import { FIELDS_FOR_WILDCARD_PATH } from '@kbn/data-views-plugin/common/constants';
 import { FtrProviderContext } from '../../../ftr_provider_context';
 
 export default function ({ getService }: FtrProviderContext) {
@@ -25,14 +26,14 @@ export default function ({ getService }: FtrProviderContext) {
 
     it('requires a pattern query param', () =>
       supertest
-        .get('/api/index_patterns/_fields_for_wildcard')
+        .get(FIELDS_FOR_WILDCARD_PATH)
         .set(ELASTIC_HTTP_VERSION_HEADER, INITIAL_REST_VERSION_INTERNAL)
         .query({})
         .expect(400));
 
     it('accepts include_unmapped param', () =>
       supertest
-        .get('/api/index_patterns/_fields_for_wildcard')
+        .get(FIELDS_FOR_WILDCARD_PATH)
         .set(ELASTIC_HTTP_VERSION_HEADER, INITIAL_REST_VERSION_INTERNAL)
         .query({
           pattern: '*',
@@ -42,7 +43,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     it('rejects unexpected query params', () =>
       supertest
-        .get('/api/index_patterns/_fields_for_wildcard')
+        .get(FIELDS_FOR_WILDCARD_PATH)
         .set(ELASTIC_HTTP_VERSION_HEADER, INITIAL_REST_VERSION_INTERNAL)
         .query({
           pattern: randomness.word(),
@@ -53,7 +54,7 @@ export default function ({ getService }: FtrProviderContext) {
     describe('fields', () => {
       it('accepts a JSON formatted fields query param', () =>
         supertest
-          .get('/api/index_patterns/_fields_for_wildcard')
+          .get(FIELDS_FOR_WILDCARD_PATH)
           .set(ELASTIC_HTTP_VERSION_HEADER, INITIAL_REST_VERSION_INTERNAL)
           .query({
             pattern: '*',
@@ -63,7 +64,7 @@ export default function ({ getService }: FtrProviderContext) {
 
       it('accepts meta_fields query param in string array', () =>
         supertest
-          .get('/api/index_patterns/_fields_for_wildcard')
+          .get(FIELDS_FOR_WILDCARD_PATH)
           .set(ELASTIC_HTTP_VERSION_HEADER, INITIAL_REST_VERSION_INTERNAL)
           .query({
             pattern: '*',
@@ -73,7 +74,7 @@ export default function ({ getService }: FtrProviderContext) {
 
       it('accepts single array fields query param', () =>
         supertest
-          .get('/api/index_patterns/_fields_for_wildcard')
+          .get(FIELDS_FOR_WILDCARD_PATH)
           .set(ELASTIC_HTTP_VERSION_HEADER, INITIAL_REST_VERSION_INTERNAL)
           .query({
             pattern: '*',
@@ -83,7 +84,7 @@ export default function ({ getService }: FtrProviderContext) {
 
       it('accepts single fields query param', () =>
         supertest
-          .get('/api/index_patterns/_fields_for_wildcard')
+          .get(FIELDS_FOR_WILDCARD_PATH)
           .set(ELASTIC_HTTP_VERSION_HEADER, INITIAL_REST_VERSION_INTERNAL)
           .query({
             pattern: '*',
@@ -93,7 +94,7 @@ export default function ({ getService }: FtrProviderContext) {
 
       it('rejects a comma-separated list of fields', () =>
         supertest
-          .get('/api/index_patterns/_fields_for_wildcard')
+          .get(FIELDS_FOR_WILDCARD_PATH)
           .set(ELASTIC_HTTP_VERSION_HEADER, INITIAL_REST_VERSION_INTERNAL)
           .query({
             pattern: '*',
@@ -105,7 +106,7 @@ export default function ({ getService }: FtrProviderContext) {
     describe('meta_fields', () => {
       it('accepts a JSON formatted meta_fields query param', () =>
         supertest
-          .get('/api/index_patterns/_fields_for_wildcard')
+          .get(FIELDS_FOR_WILDCARD_PATH)
           .set(ELASTIC_HTTP_VERSION_HEADER, INITIAL_REST_VERSION_INTERNAL)
           .query({
             pattern: '*',
@@ -115,7 +116,7 @@ export default function ({ getService }: FtrProviderContext) {
 
       it('accepts meta_fields query param in string array', () =>
         supertest
-          .get('/api/index_patterns/_fields_for_wildcard')
+          .get(FIELDS_FOR_WILDCARD_PATH)
           .set(ELASTIC_HTTP_VERSION_HEADER, INITIAL_REST_VERSION_INTERNAL)
           .query({
             pattern: '*',
@@ -125,7 +126,7 @@ export default function ({ getService }: FtrProviderContext) {
 
       it('accepts single meta_fields query param', () =>
         supertest
-          .get('/api/index_patterns/_fields_for_wildcard')
+          .get(FIELDS_FOR_WILDCARD_PATH)
           .set(ELASTIC_HTTP_VERSION_HEADER, INITIAL_REST_VERSION_INTERNAL)
           .query({
             pattern: '*',
@@ -135,7 +136,7 @@ export default function ({ getService }: FtrProviderContext) {
 
       it('rejects a comma-separated list of meta_fields', () =>
         supertest
-          .get('/api/index_patterns/_fields_for_wildcard')
+          .get(FIELDS_FOR_WILDCARD_PATH)
           .set(ELASTIC_HTTP_VERSION_HEADER, INITIAL_REST_VERSION_INTERNAL)
           .query({
             pattern: '*',

--- a/test/api_integration/apis/data_views/fields_for_wildcard_route/response.ts
+++ b/test/api_integration/apis/data_views/fields_for_wildcard_route/response.ts
@@ -8,6 +8,7 @@
 
 import { ELASTIC_HTTP_VERSION_HEADER } from '@kbn/core-http-common';
 import { INITIAL_REST_VERSION_INTERNAL } from '@kbn/data-views-plugin/server/constants';
+import { FIELDS_FOR_WILDCARD_PATH } from '@kbn/data-views-plugin/common/constants';
 import expect from '@kbn/expect';
 import { sortBy } from 'lodash';
 import { FtrProviderContext } from '../../../ftr_provider_context';
@@ -84,7 +85,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     it('returns a flattened version of the fields in es', async () => {
       await supertest
-        .get('/api/index_patterns/_fields_for_wildcard')
+        .get(FIELDS_FOR_WILDCARD_PATH)
         .set(ELASTIC_HTTP_VERSION_HEADER, INITIAL_REST_VERSION_INTERNAL)
         .query({ pattern: 'basic_index' })
         .expect(200, {
@@ -96,7 +97,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     it('returns a single field as requested', async () => {
       await supertest
-        .get('/api/index_patterns/_fields_for_wildcard')
+        .get(FIELDS_FOR_WILDCARD_PATH)
         .set(ELASTIC_HTTP_VERSION_HEADER, INITIAL_REST_VERSION_INTERNAL)
         .query({ pattern: 'basic_index', fields: JSON.stringify(['bar']) })
         .expect(200, {
@@ -107,7 +108,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     it('always returns a field for all passed meta fields', async () => {
       await supertest
-        .get('/api/index_patterns/_fields_for_wildcard')
+        .get(FIELDS_FOR_WILDCARD_PATH)
         .set(ELASTIC_HTTP_VERSION_HEADER, INITIAL_REST_VERSION_INTERNAL)
         .query({
           pattern: 'basic_index',
@@ -200,7 +201,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     it('returns fields when one pattern exists and the other does not', async () => {
       await supertest
-        .get('/api/index_patterns/_fields_for_wildcard')
+        .get(FIELDS_FOR_WILDCARD_PATH)
         .set(ELASTIC_HTTP_VERSION_HEADER, INITIAL_REST_VERSION_INTERNAL)
         .query({ pattern: 'bad_index,basic_index' })
         .expect(200, {
@@ -211,7 +212,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     it('returns 404 when neither exists', async () => {
       await supertest
-        .get('/api/index_patterns/_fields_for_wildcard')
+        .get(FIELDS_FOR_WILDCARD_PATH)
         .set(ELASTIC_HTTP_VERSION_HEADER, INITIAL_REST_VERSION_INTERNAL)
         .query({ pattern: 'bad_index,bad_index_2' })
         .expect(404);
@@ -219,7 +220,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     it('returns 404 when no patterns exist', async () => {
       await supertest
-        .get('/api/index_patterns/_fields_for_wildcard')
+        .get(FIELDS_FOR_WILDCARD_PATH)
         .set(ELASTIC_HTTP_VERSION_HEADER, INITIAL_REST_VERSION_INTERNAL)
         .query({
           pattern: 'bad_index',

--- a/x-pack/test/api_integration/apis/management/rollup/constants.js
+++ b/x-pack/test/api_integration/apis/management/rollup/constants.js
@@ -6,7 +6,6 @@
  */
 
 export const API_BASE_PATH = '/api/rollup';
-export const INDEX_PATTERNS_EXTENSION_BASE_PATH = '/api/index_patterns';
 export const ROLLUP_INDEX_NAME = 'rollup_index';
 export const INDEX_TO_ROLLUP_MAPPINGS = {
   properties: {

--- a/x-pack/test/api_integration/apis/management/rollup/index_patterns_extensions.js
+++ b/x-pack/test/api_integration/apis/management/rollup/index_patterns_extensions.js
@@ -7,10 +7,10 @@
 
 import { ELASTIC_HTTP_VERSION_HEADER } from '@kbn/core-http-common';
 import { INITIAL_REST_VERSION_INTERNAL } from '@kbn/data-views-plugin/server/constants';
+import { FIELDS_FOR_WILDCARD_PATH as BASE_URI } from '@kbn/data-views-plugin/common/constants';
 import expect from '@kbn/expect';
 import { stringify } from 'query-string';
 import { registerHelpers } from './rollup.test_helpers';
-import { INDEX_PATTERNS_EXTENSION_BASE_PATH } from './constants';
 import { getRandomString } from './lib';
 
 export default function ({ getService }) {
@@ -21,8 +21,6 @@ export default function ({ getService }) {
 
   describe('index patterns extension', () => {
     describe('Fields for wildcards', () => {
-      const BASE_URI = `${INDEX_PATTERNS_EXTENSION_BASE_PATH}/_fields_for_wildcard`;
-
       describe('query params validation', () => {
         let uri;
         let body;


### PR DESCRIPTION
## Summary

`/api/index_patterns/_fields_for_wildcard` => `/internal/data_views/_fields_for_wildcard`

Part of https://github.com/elastic/kibana/issues/159158