### PR TITLE
[Lens] small drag and drop visual fixes

### DIFF
--- a/packages/kbn-dom-drag-drop/src/constants.ts
+++ b/packages/kbn-dom-drag-drop/src/constants.ts
@@ -8,4 +8,4 @@
 
 export const DEFAULT_DATA_TEST_SUBJ = 'domDragDrop';
 export const REORDER_ITEM_HEIGHT = 32;
-export const REORDER_ITEM_MARGIN = 8;
+export const REORDER_ITEM_MARGIN = 16;

--- a/packages/kbn-dom-drag-drop/src/drag_drop.test.tsx
+++ b/packages/kbn-dom-drag-drop/src/drag_drop.test.tsx
@@ -1100,12 +1100,12 @@ describe('DragDrop', () => {
       expect(
         component.find('[data-test-subj="testDragDrop-translatableDrop"]').at(0).prop('style')
       ).toEqual({
-        transform: 'translateY(-4px)',
+        transform: 'translateY(-8px)',
       });
       expect(
         component.find('[data-test-subj="testDragDrop-translatableDrop"]').at(1).prop('style')
       ).toEqual({
-        transform: 'translateY(-4px)',
+        transform: 'translateY(-8px)',
       });
 
       component
@@ -1258,7 +1258,7 @@ describe('DragDrop', () => {
       expect(
         component.find('[data-test-subj="testDragDrop-reorderableDrag"]').at(0).prop('style')
       ).toEqual({
-        transform: 'translateY(+4px)',
+        transform: 'translateY(+8px)',
       });
       expect(
         component.find('[data-test-subj="testDragDrop-translatableDrop"]').at(0).prop('style')

--- a/packages/kbn-dom-drag-drop/src/sass/drag_drop.scss
+++ b/packages/kbn-dom-drag-drop/src/sass/drag_drop.scss
@@ -15,7 +15,7 @@
   width: 100%;
   left: 0;
   opacity: .9;
-  transform: translate(-$euiSizeS, -$euiSizeL);
+  transform: translate($euiSizeS, $euiSizeL);
   z-index: $domDragDropZLevel3;
   pointer-events: none;
   outline: $euiFocusRingSize solid currentColor; // Safari & Firefox

--- a/packages/kbn-dom-drag-drop/src/sass/drag_drop.scss
+++ b/packages/kbn-dom-drag-drop/src/sass/drag_drop.scss
@@ -15,7 +15,7 @@
   width: 100%;
   left: 0;
   opacity: .9;
-  transform: translate($euiSizeXS, $euiSizeXS);
+  transform: translate(-$euiSizeS, -$euiSizeL);
   z-index: $domDragDropZLevel3;
   pointer-events: none;
   outline: $euiFocusRingSize solid currentColor; // Safari & Firefox
@@ -138,6 +138,10 @@ $reorderItemMargin: $euiSizeS;
   }
 }
 
+.domDragDrop--isDragStarted {
+  opacity: .5;
+}
+
 // Draggable item when it is moving
 .domDragDrop-isHidden {
   opacity: 0;
@@ -147,10 +151,6 @@ $reorderItemMargin: $euiSizeS;
       animation: none;
     }
   }
-}
-
-.domDragDrop--isDragStarted {
-  opacity: .5;
 }
 
 .domDragDrop__extraDrops {


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/159572

1. The dimension element should be invisible when being moved - fixed by `.domDragDrop-isHidden` css below `.domDragDrop--isDragStarted` that was overwriting opacity.

before:
<img width="508" alt="Screenshot 2023-06-14 at 09 45 23" src="https://github.com/elastic/kibana/assets/4283304/96dcd98e-3b71-4675-8e0f-1617cfacbd2d">
after:
<img width="508" alt="Screenshot 2023-06-14 at 10 01 08" src="https://github.com/elastic/kibana/assets/4283304/f3b9de10-a2e5-4936-9695-245a57a9a8d4">



2. When navigating with keyboard, the margin of the element that was moving was slightly off - fixed by changing the constant `REORDER_ITEM_MARGIN` value to 16. Not sure if we use this package somewhere else and I should also test @jughosta? 

before:
<img width="436" alt="Screenshot 2023-06-14 at 09 45 38" src="https://github.com/elastic/kibana/assets/4283304/b6e3ad6e-fc6f-4c7f-850e-d3a4d8cf4775">
after: 
<img width="405" alt="Screenshot 2023-06-14 at 10 01 16" src="https://github.com/elastic/kibana/assets/4283304/4b850ca2-64d2-4c2a-a313-a7c10434674a">



3. When navigating with keyboard but not reordering, the ghost element was covering completely the element we would drop into. I fixed it by changing the translation values. I think that's not expected? Or is this intentional?
before:
<img width="410" alt="Screenshot 2023-06-14 at 09 45 47" src="https://github.com/elastic/kibana/assets/4283304/60296878-ca52-4d0c-bb49-5a84503d48ac">
after:
<img width="436" alt="Screenshot 2023-06-14 at 10 01 24" src="https://github.com/elastic/kibana/assets/4283304/c050fea1-10b2-4a72-95d3-fbfe920b9c96">


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->