### PR TITLE
[Security Solution] Introduce a folder for test plans

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1098,6 +1098,9 @@ x-pack/plugins/cloud_integrations/cloud_full_story/server/config.ts @elastic/kib
 /x-pack/plugins/security_solution/common/detection_engine/rule_monitoring @elastic/security-detection-rule-management
 /x-pack/plugins/security_solution/common/detection_engine/rule_schema @elastic/security-detection-rule-management @elastic/security-detection-engine
 
+/x-pack/plugins/security_solution/cypress/test_plans/detection_response/prebuilt_rules @elastic/security-detection-rule-management
+/x-pack/plugins/security_solution/cypress/test_plans/detection_response/rule_management @elastic/security-detection-rule-management
+
 /x-pack/plugins/security_solution/public/common/components/health_truncate_text @elastic/security-detection-rule-management
 /x-pack/plugins/security_solution/public/common/components/links_to_docs @elastic/security-detection-rule-management
 /x-pack/plugins/security_solution/public/common/components/ml_popover @elastic/security-detection-rule-management

--- a/x-pack/plugins/security_solution/cypress/test_plans/README.md
+++ b/x-pack/plugins/security_solution/cypress/test_plans/README.md
@@ -1,0 +1,33 @@
+# Test Plans
+
+This folder contains test plans for the features of Security Solution.
+
+## Folder Structure
+
+The folder is first split into major Security Solution domains:
+
+- `detection_response`
+- `threat_hunting`
+- etc
+
+And then each major domain is split into subdomains, for example:
+
+- `detection_response`
+  - `prebuilt_rules`
+  - `rule_exceptions`
+  - `rule_management`
+  - `rule_monitoring`
+  - etc
+- `threat_hunting`
+  - `explore`
+  - `timelines`
+  - etc
+
+Within each subdomain, you can organize test plans as you like, for example:
+
+- you might want to have a folder per feature, if your features are large and you have multiple test plans per feature
+- or you might want to have a plain list of test plans if features are relatively small
+
+## Ownership
+
+Each subdomain folder should be owned by a single GitHub team in the `.github/CODEOWNERS` file.

--- a/x-pack/plugins/security_solution/cypress/test_plans/detection_response/prebuilt_rules/todo
+++ b/x-pack/plugins/security_solution/cypress/test_plans/detection_response/prebuilt_rules/todo
@@ -1,0 +1,1 @@
+Add test plans.

--- a/x-pack/plugins/security_solution/cypress/test_plans/detection_response/rule_management/todo
+++ b/x-pack/plugins/security_solution/cypress/test_plans/detection_response/rule_management/todo
@@ -1,0 +1,1 @@
+Add test plans.


### PR DESCRIPTION
**Resolves: https://github.com/elastic/security-team/issues/6867** (internal)

## Summary

**TL;DR**: This PR introduces a folder for storing and working on test plans for Security Solution inside the Kibana repo.

Instead of using Google Docs for collaborating on test plans, @elastic/security-detection-rule-management folks have decided to leverage standard GitHub workflow. This should give us the following benefits:

- Right now it's hard to find the test plans you want to check. Most of them are stored in Google Drive and are not shared across the whole Elastic or Security orgs. Keeping them within the `security_solution` plugin in the open repo would make it much easier and straightforward to navigate the test plans.
- Additionally. we will start linking tickets and PRs to our test plans which will provide more context to them.
- With Google Docs it's often not clear who should review a test plan, who and when approved it, and whether it's done or still in progress. The GitHub workflow solves these and other issues, and eliminates the need to have a different workflow for test plans.
- GitHub's UX is superior to Google Docs UX when it comes to commenting.

See the ticket and the `README.md` in the PR's diff for more info.

### Checklist

- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
