### PR TITLE
[Asset Manager] query pagination

### DIFF
--- a/x-pack/plugins/asset_manager/common/types_api.ts
+++ b/x-pack/plugins/asset_manager/common/types_api.ts
@@ -141,8 +141,8 @@ export interface AssetFilters {
   kindLike?: string;
   eanLike?: string;
   collectionVersion?: number | 'latest' | 'all';
-  from?: string;
-  to?: string;
+  from?: string | number;
+  to?: string | number;
 }
 
 export const relationRT = rt.union([

--- a/x-pack/plugins/asset_manager/server/lib/accessors/hosts/get_hosts_by_signals.ts
+++ b/x-pack/plugins/asset_manager/server/lib/accessors/hosts/get_hosts_by_signals.ts
@@ -12,13 +12,13 @@ import { collectHosts } from '../../implicit_collection/collectors/hosts';
 export async function getHostsBySignals(
   options: GetHostsOptionsInjected
 ): Promise<{ hosts: Asset[] }> {
-  const hosts = await collectHosts({
+  const { assets } = await collectHosts({
     client: options.esClient,
     from: options.from,
-    // TODO: implement "to" for collectHosts
+    to: options.to,
     sourceIndices: options.sourceIndices,
   });
   return {
-    hosts,
+    hosts: assets,
   };
 }

--- a/x-pack/plugins/asset_manager/server/lib/accessors/hosts/index.ts
+++ b/x-pack/plugins/asset_manager/server/lib/accessors/hosts/index.ts
@@ -8,8 +8,8 @@
 import { AccessorOptions, OptionsWithInjectedValues } from '..';
 
 export interface GetHostsOptions extends AccessorOptions {
-  from: string;
-  to: string;
+  from: number;
+  to: number;
 }
 export type GetHostsOptionsInjected = OptionsWithInjectedValues<GetHostsOptions>;
 

--- a/x-pack/plugins/asset_manager/server/lib/get_assets.ts
+++ b/x-pack/plugins/asset_manager/server/lib/get_assets.ts
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { QueryDslQueryContainer, SearchRequest } from '@elastic/elasticsearch/lib/api/types';
+import { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
 import { debug } from '../../common/debug_log';
 import { Asset, AssetFilters } from '../../common/types_api';
 import { ASSETS_INDEX_PREFIX } from '../constants';
@@ -95,7 +95,7 @@ export async function getAssets({
     }
   }
 
-  const dsl: SearchRequest = {
+  const dsl = {
     index: ASSETS_INDEX_PREFIX + '*',
     size,
     query: {

--- a/x-pack/plugins/asset_manager/server/lib/implicit_collection/collector_runner.test.ts
+++ b/x-pack/plugins/asset_manager/server/lib/implicit_collection/collector_runner.test.ts
@@ -33,10 +33,10 @@ describe(__filename, () => {
     });
 
     const collector1 = jest.fn(async (opts: CollectorOptions) => {
-      return [];
+      return { assets: [] };
     });
     const collector2 = jest.fn(async (opts: CollectorOptions) => {
-      return [];
+      return { assets: [] };
     });
 
     runner.registerCollector('foo', collector1);
@@ -61,7 +61,7 @@ describe(__filename, () => {
       throw new Error('no');
     });
     const collector2 = jest.fn(async (opts: CollectorOptions) => {
-      return [];
+      return { assets: [] };
     });
 
     runner.registerCollector('foo', collector1);
@@ -84,10 +84,12 @@ describe(__filename, () => {
     });
 
     const collector = jest.fn(async (opts: CollectorOptions) => {
-      return [
-        { 'asset.kind': 'container', 'asset.ean': 'foo' },
-        { 'asset.kind': 'pod', 'asset.ean': 'bar' },
-      ] as Asset[];
+      return {
+        assets: [
+          { 'asset.kind': 'container', 'asset.ean': 'foo' },
+          { 'asset.kind': 'pod', 'asset.ean': 'bar' },
+        ] as Asset[],
+      };
     });
 
     runner.registerCollector('foo', collector);

--- a/x-pack/plugins/asset_manager/server/lib/implicit_collection/collector_runner.ts
+++ b/x-pack/plugins/asset_manager/server/lib/implicit_collection/collector_runner.ts
@@ -6,10 +6,10 @@
  */
 
 import apm from 'elastic-apm-node';
-
 import { ImplicitCollectionOptions } from '.';
-import { Collector, QUERY_MAX_SIZE } from './collectors';
+import { Collector, CollectorOptions, QUERY_MAX_SIZE } from './collectors';
 import { Asset } from '../../../common/types_api';
+import { withSpan } from './collectors/helpers';
 
 const TRANSACTION_TYPE = 'asset_manager-implicit_collection';
 const transactionName = (collectorName: string) => `asset_manager-collector_${collectorName}`;
@@ -24,56 +24,65 @@ export class CollectorRunner {
   }
 
   async run() {
-    const now = Date.now();
+    const to = Date.now();
+    const from = to - this.options.intervalMs;
 
     for (let i = 0; i < this.collectors.length; i++) {
       const { name, collector } = this.collectors[i];
       this.options.logger.info(`Collector '${name}' started`);
 
       const transaction = apm.startTransaction(transactionName(name), TRANSACTION_TYPE);
-      const collectorOptions = {
-        from: now - this.options.intervalMs,
+      const collectorOptions: CollectorOptions = {
+        from,
+        to,
         client: this.options.inputClient,
         transaction,
         sourceIndices: this.options.sourceIndices,
       };
 
-      const assets = await collector(collectorOptions)
-        .then((collectedAssets) => {
-          this.options.logger.info(`Collector '${name}' found ${collectedAssets.length} assets`);
-          return collectedAssets;
-        })
-        .catch((err) => {
-          this.options.logger.error(`Collector '${name}' execution failure: ${err}`);
-          return [];
-        });
+      let totalAssets = 0;
+      do {
+        const collectorResult = await withSpan({ name: 'read', transaction }, () =>
+          collector(collectorOptions as any as CollectorOptions).catch((err) => {
+            this.options.logger.error(`Collector '${name}' execution failure: ${err}`);
+            return { assets: [], afterKey: undefined };
+          })
+        );
+
+        collectorOptions.afterKey = collectorResult.afterKey;
+
+        if (collectorResult.assets.length) {
+          totalAssets += collectorResult.assets.length;
+          const bulkBody = collectorResult.assets.flatMap((asset: Asset) => {
+            return [{ create: { _index: `assets-${asset['asset.kind']}-default` } }, asset];
+          });
+
+          await withSpan({ name: 'write', transaction }, () =>
+            this.options.outputClient
+              .bulk({ body: bulkBody })
+              .then((res) => {
+                if (res.errors) {
+                  this.options.logger.error(
+                    `Failure writing assets documents from collector '${name}': ${JSON.stringify(
+                      res
+                    )}`
+                  );
+                }
+              })
+              .catch((err) => {
+                this.options.logger.error(
+                  `Failure writing assets documents from collector '${name}': ${err}`
+                );
+              })
+          );
+        }
+      } while (collectorOptions.afterKey);
 
       transaction?.addLabels({
-        assets_count: assets.length,
+        assets_count: totalAssets,
         interval_ms: this.options.intervalMs,
         page_size: QUERY_MAX_SIZE,
       });
-
-      if (assets.length) {
-        const bulkBody = assets.flatMap((asset: Asset) => {
-          return [{ create: { _index: `assets-${asset['asset.kind']}-default` } }, asset];
-        });
-
-        await this.options.outputClient
-          .bulk({ body: bulkBody })
-          .then((res) => {
-            if (res.errors) {
-              this.options.logger.error(
-                `Failure writing assets documents from collector '${name}': ${JSON.stringify(res)}`
-              );
-            }
-          })
-          .catch((err) => {
-            this.options.logger.error(
-              `Failure writing assets documents from collector '${name}': ${err}`
-            );
-          });
-      }
 
       transaction?.end();
     }

--- a/x-pack/plugins/asset_manager/server/lib/implicit_collection/collectors/containers.ts
+++ b/x-pack/plugins/asset_manager/server/lib/implicit_collection/collectors/containers.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { estypes } from '@elastic/elasticsearch';
 import { Asset } from '../../../../common/types_api';
 import { CollectorOptions, QUERY_MAX_SIZE } from '.';
 import { withSpan } from './helpers';
@@ -18,7 +19,7 @@ export async function collectContainers({
   afterKey,
 }: CollectorOptions) {
   const { metrics, logs, traces } = sourceIndices;
-  const dsl = {
+  const dsl: estypes.SearchRequest = {
     index: [traces, logs, metrics],
     size: QUERY_MAX_SIZE,
     collapse: {
@@ -56,7 +57,7 @@ export async function collectContainers({
   };
 
   if (afterKey) {
-    (dsl as any).search_after = afterKey;
+    dsl.search_after = afterKey;
   }
 
   const esResponse = await client.search(dsl);

--- a/x-pack/plugins/asset_manager/server/lib/implicit_collection/collectors/helpers.ts
+++ b/x-pack/plugins/asset_manager/server/lib/implicit_collection/collectors/helpers.ts
@@ -4,19 +4,17 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-
 import { Transaction } from 'elastic-apm-node';
-
-type CollectorSpan = 'processing_response';
+type CollectorSpan = 'processing_response' | 'read' | 'write';
 
 interface SpanOptions {
   name: CollectorSpan;
   transaction?: Transaction | null;
 }
 
-export function withSpan<T>(options: SpanOptions, fn: () => T) {
+export async function withSpan<T>(options: SpanOptions, fn: () => Promise<T>) {
   const span = options.transaction?.startSpan(options.name);
-  const result = fn();
+  const result = await fn();
   span?.end();
   return result;
 }

--- a/x-pack/plugins/asset_manager/server/lib/implicit_collection/collectors/hosts.ts
+++ b/x-pack/plugins/asset_manager/server/lib/implicit_collection/collectors/hosts.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { estypes } from '@elastic/elasticsearch';
 import { Asset } from '../../../../common/types_api';
 import { CollectorOptions, QUERY_MAX_SIZE } from '.';
 import { withSpan } from './helpers';
@@ -18,7 +19,7 @@ export async function collectHosts({
   afterKey,
 }: CollectorOptions) {
   const { metrics, logs, traces } = sourceIndices;
-  const dsl = {
+  const dsl: estypes.SearchRequest = {
     index: [metrics, logs, traces],
     size: QUERY_MAX_SIZE,
     collapse: { field: 'host.hostname' },
@@ -55,7 +56,7 @@ export async function collectHosts({
   };
 
   if (afterKey) {
-    (dsl as any).search_after = afterKey;
+    dsl.search_after = afterKey;
   }
 
   const esResponse = await client.search(dsl);

--- a/x-pack/plugins/asset_manager/server/lib/implicit_collection/collectors/hosts.ts
+++ b/x-pack/plugins/asset_manager/server/lib/implicit_collection/collectors/hosts.ts
@@ -12,15 +12,17 @@ import { withSpan } from './helpers';
 export async function collectHosts({
   client,
   from,
+  to,
   transaction,
   sourceIndices,
-}: CollectorOptions): Promise<Asset[]> {
+  afterKey,
+}: CollectorOptions) {
   const { metrics, logs, traces } = sourceIndices;
   const dsl = {
     index: [metrics, logs, traces],
     size: QUERY_MAX_SIZE,
     collapse: { field: 'host.hostname' },
-    sort: [{ _score: 'desc' }, { '@timestamp': 'desc' }],
+    sort: [{ 'host.hostname': 'asc' }],
     _source: false,
     fields: [
       '@timestamp',
@@ -37,6 +39,7 @@ export async function collectHosts({
             range: {
               '@timestamp': {
                 gte: from,
+                lte: to,
               },
             },
           },
@@ -51,10 +54,14 @@ export async function collectHosts({
     },
   };
 
+  if (afterKey) {
+    (dsl as any).search_after = afterKey;
+  }
+
   const esResponse = await client.search(dsl);
 
-  const hosts = withSpan({ transaction, name: 'processing_response' }, () => {
-    return esResponse.hits.hits.reduce<Asset[]>((acc: Asset[], hit: any) => {
+  const result = withSpan({ transaction, name: 'processing_response' }, async () => {
+    const assets = esResponse.hits.hits.reduce<Asset[]>((acc: Asset[], hit: any) => {
       const { fields = {} } = hit;
       const hostName = fields['host.hostname'];
       const k8sNode = fields['kubernetes.node.name'];
@@ -98,7 +105,11 @@ export async function collectHosts({
 
       return acc;
     }, []);
+
+    const hitsLen = esResponse.hits.hits.length;
+    const next = hitsLen === QUERY_MAX_SIZE ? esResponse.hits.hits[hitsLen - 1].sort : undefined;
+    return { assets, afterKey: next };
   });
 
-  return hosts;
+  return result;
 }

--- a/x-pack/plugins/asset_manager/server/lib/implicit_collection/collectors/index.ts
+++ b/x-pack/plugins/asset_manager/server/lib/implicit_collection/collectors/index.ts
@@ -6,28 +6,27 @@
  */
 
 import { Transaction } from 'elastic-apm-node';
+import { estypes } from '@elastic/elasticsearch';
 import { ElasticsearchClient } from '@kbn/core/server';
 import { AssetManagerConfig } from '../../../types';
 import { Asset } from '../../../../common/types_api';
 
 export const QUERY_MAX_SIZE = 10000;
 
-type AfterKey = string[] | { [key: string]: string };
-
 export type Collector = (opts: CollectorOptions) => Promise<CollectorResult>;
 
 export interface CollectorOptions {
   client: ElasticsearchClient;
-  from: string | number;
-  to: string | number;
+  from: number;
+  to: number;
   transaction?: Transaction | null;
   sourceIndices: AssetManagerConfig['sourceIndices'];
-  afterKey?: AfterKey;
+  afterKey?: estypes.SortResults;
 }
 
 export interface CollectorResult {
   assets: Asset[];
-  afterKey?: AfterKey;
+  afterKey?: estypes.SortResults;
 }
 
 export { collectContainers } from './containers';

--- a/x-pack/plugins/asset_manager/server/lib/implicit_collection/collectors/index.ts
+++ b/x-pack/plugins/asset_manager/server/lib/implicit_collection/collectors/index.ts
@@ -10,16 +10,25 @@ import { ElasticsearchClient } from '@kbn/core/server';
 import { AssetManagerConfig } from '../../../types';
 import { Asset } from '../../../../common/types_api';
 
-export const QUERY_MAX_SIZE = 1000;
+export const QUERY_MAX_SIZE = 10000;
+
+type AfterKey = string[] | { [key: string]: string };
+
+export type Collector = (opts: CollectorOptions) => Promise<CollectorResult>;
 
 export interface CollectorOptions {
   client: ElasticsearchClient;
   from: string | number;
+  to: string | number;
   transaction?: Transaction | null;
   sourceIndices: AssetManagerConfig['sourceIndices'];
+  afterKey?: AfterKey;
 }
 
-export type Collector = (opts: CollectorOptions) => Promise<Asset[]>;
+export interface CollectorResult {
+  assets: Asset[];
+  afterKey?: AfterKey;
+}
 
 export { collectContainers } from './containers';
 export { collectHosts } from './hosts';

--- a/x-pack/plugins/asset_manager/server/lib/implicit_collection/collectors/pods.ts
+++ b/x-pack/plugins/asset_manager/server/lib/implicit_collection/collectors/pods.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { estypes } from '@elastic/elasticsearch';
 import { Asset } from '../../../../common/types_api';
 import { CollectorOptions, QUERY_MAX_SIZE } from '.';
 import { withSpan } from './helpers';
@@ -18,7 +19,7 @@ export async function collectPods({
   afterKey,
 }: CollectorOptions) {
   const { metrics, logs, traces } = sourceIndices;
-  const dsl = {
+  const dsl: estypes.SearchRequest = {
     index: [metrics, logs, traces],
     size: QUERY_MAX_SIZE,
     collapse: {
@@ -54,7 +55,7 @@ export async function collectPods({
   };
 
   if (afterKey) {
-    (dsl as any).search_after = afterKey;
+    dsl.search_after = afterKey;
   }
 
   const esResponse = await client.search(dsl);

--- a/x-pack/plugins/asset_manager/server/lib/implicit_collection/collectors/services.ts
+++ b/x-pack/plugins/asset_manager/server/lib/implicit_collection/collectors/services.ts
@@ -9,23 +9,18 @@ import { Asset } from '../../../../common/types_api';
 import { CollectorOptions, QUERY_MAX_SIZE } from '.';
 import { withSpan } from './helpers';
 
-const MISSING_KEY = '__unknown__';
-
 export async function collectServices({
   client,
   from,
+  to,
   transaction,
   sourceIndices,
-}: CollectorOptions): Promise<Asset[]> {
+  afterKey,
+}: CollectorOptions) {
   const { traces, serviceMetrics, serviceLogs } = sourceIndices;
   const dsl = {
     index: [traces, serviceMetrics, serviceLogs],
     size: 0,
-    sort: [
-      {
-        '@timestamp': 'desc',
-      },
-    ],
     _source: false,
     query: {
       bool: {
@@ -34,6 +29,7 @@ export async function collectServices({
             range: {
               '@timestamp': {
                 gte: from,
+                lte: to,
               },
             },
           },
@@ -48,26 +44,36 @@ export async function collectServices({
       },
     },
     aggs: {
-      service_environment: {
-        multi_terms: {
+      services: {
+        composite: {
           size: QUERY_MAX_SIZE,
-          terms: [
+          sources: [
             {
-              field: 'service.name',
+              serviceName: {
+                terms: {
+                  field: 'service.name',
+                },
+              },
             },
             {
-              field: 'service.environment',
-              missing: MISSING_KEY,
+              serviceEnvironment: {
+                terms: {
+                  field: 'service.environment',
+                },
+              },
             },
           ],
         },
         aggs: {
-          container_host: {
+          container_and_hosts: {
             multi_terms: {
-              size: QUERY_MAX_SIZE,
               terms: [
-                { field: 'container.id', missing: MISSING_KEY },
-                { field: 'host.hostname', missing: MISSING_KEY },
+                {
+                  field: 'host.hostname',
+                },
+                {
+                  field: 'container.id',
+                },
               ],
             },
           },
@@ -76,14 +82,23 @@ export async function collectServices({
     },
   };
 
+  if (afterKey) {
+    (dsl.aggs.services.composite as any).after = afterKey;
+  }
+
   const esResponse = await client.search(dsl);
 
-  const services = withSpan({ transaction, name: 'processing_response' }, () => {
-    const serviceEnvironment = esResponse.aggregations?.service_environment as { buckets: any[] };
+  const result = withSpan({ transaction, name: 'processing_response' }, async () => {
+    const { after_key: nextKey, buckets = [] } = (esResponse.aggregations?.services || {}) as any;
+    const assets = buckets.reduce((acc: Asset[], bucket: any) => {
+      const {
+        key: { serviceName, serviceEnvironment },
+        container_and_hosts: containerHosts,
+      } = bucket;
 
-    return (serviceEnvironment?.buckets ?? []).reduce<Asset[]>((acc: Asset[], hit: any) => {
-      const [serviceName, environment] = hit.key;
-      const containerHosts = hit.container_host.buckets;
+      if (!serviceName) {
+        return acc;
+      }
 
       const service: Asset = {
         '@timestamp': new Date().toISOString(),
@@ -94,17 +109,17 @@ export async function collectServices({
         'asset.parents': [],
       };
 
-      if (environment !== MISSING_KEY) {
-        service['service.environment'] = environment;
+      if (serviceEnvironment) {
+        service['service.environment'] = serviceEnvironment;
       }
 
-      containerHosts.forEach((nestedHit: any) => {
-        const [containerId, hostname] = nestedHit.key;
-        if (containerId !== MISSING_KEY) {
+      containerHosts.buckets?.forEach((containerBucket: any) => {
+        const [containerId, hostname] = containerBucket.key;
+        if (containerId) {
           (service['asset.parents'] as string[]).push(`container:${containerId}`);
         }
 
-        if (hostname !== MISSING_KEY) {
+        if (hostname) {
           (service['asset.references'] as string[]).push(`host:${hostname}`);
         }
       });
@@ -113,7 +128,9 @@ export async function collectServices({
 
       return acc;
     }, []);
+
+    return { assets, afterKey: buckets.length === QUERY_MAX_SIZE ? nextKey : undefined };
   });
 
-  return services;
+  return result;
 }

--- a/x-pack/plugins/asset_manager/server/lib/implicit_collection/collectors/services.ts
+++ b/x-pack/plugins/asset_manager/server/lib/implicit_collection/collectors/services.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { estypes } from '@elastic/elasticsearch';
 import { Asset } from '../../../../common/types_api';
 import { CollectorOptions, QUERY_MAX_SIZE } from '.';
 import { withSpan } from './helpers';
@@ -18,7 +19,7 @@ export async function collectServices({
   afterKey,
 }: CollectorOptions) {
   const { traces, serviceMetrics, serviceLogs } = sourceIndices;
-  const dsl = {
+  const dsl: estypes.SearchRequest = {
     index: [traces, serviceMetrics, serviceLogs],
     size: 0,
     _source: false,
@@ -83,7 +84,7 @@ export async function collectServices({
   };
 
   if (afterKey) {
-    (dsl.aggs.services.composite as any).after = afterKey;
+    dsl.aggs!.services!.composite!.after = afterKey;
   }
 
   const esResponse = await client.search(dsl);

--- a/x-pack/plugins/asset_manager/server/routes/assets/hosts.ts
+++ b/x-pack/plugins/asset_manager/server/routes/assets/hosts.ts
@@ -6,6 +6,7 @@
  */
 
 import * as rt from 'io-ts';
+import datemath from '@kbn/datemath';
 import {
   dateRt,
   inRangeFromStringRt,
@@ -49,8 +50,8 @@ export function hostsRoutes<T extends RequestHandlerContext>({
 
       try {
         const response = await assetAccessor.getHosts({
-          from,
-          to,
+          from: datemath.parse(from)!.valueOf(),
+          to: datemath.parse(to)!.valueOf(),
           esClient,
         });
 

--- a/x-pack/plugins/asset_manager/tsconfig.json
+++ b/x-pack/plugins/asset_manager/tsconfig.json
@@ -20,5 +20,6 @@
     "@kbn/io-ts-utils",
     "@kbn/core-elasticsearch-server",
     "@kbn/core-http-request-handler-context-server",
+    "@kbn/datemath",
   ]
 }


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/157376

Adds pagination to implicit collector queries.
To get pagination collapse queries now sort results by the same field we collapse on. Instead of returning the `n` most recent results we'll now get the `n` first hosts by hostname when querying signals. Baring the limited sorting flexibility this sounds like a sane contract for an API if we send back the page cursor so that consumers (implicit collector or kibana UI) can loop through, but we may send incomplete results when UI consumers rely on sliding time ranges (ie last 15mn). If that is a concern we could have the API accumulating pages in a single call and return the entire dataset but are there use cases for that ? Alternatively UI consumer can also do it by locking the time range, similar to implicit collection

### Testing
- create a host dataset with `n` cardinality. [slingshot](https://github.com/elastic/slingshot) can help
- (optional) update [QUERY_MAX_SIZE](https://github.com/elastic/kibana/blob/feat/obs-asset-manager-demo/x-pack/plugins/asset_manager/server/lib/implicit_collection/collectors/index.ts#L13) to be less than `n`
- run host collector and verify that paginated queries are executed to retrieve the full set in a single run
