### PR TITLE
Update co-pilot prompt using analysis results in Logs alert details page

### DIFF
--- a/x-pack/plugins/infra/public/alerting/log_threshold/components/alert_details_app_section/components/explain_log_rate_spike.tsx
+++ b/x-pack/plugins/infra/public/alerting/log_threshold/components/alert_details_app_section/components/explain_log_rate_spike.tsx
@@ -54,7 +54,7 @@ export const ExplainLogRateSpikes: FC<AlertDetailsExplainLogRateSpikesSectionPro
   const { dataViews, logViews } = services;
   const [dataView, setDataView] = useState<DataView | undefined>();
   const [esSearchQuery, setEsSearchQuery] = useState<QueryDslQueryContainer | undefined>();
-  const [logSpikeParams, SetLogSpikeParams] = useState<
+  const [logSpikeParams, setLogSpikeParams] = useState<
     { significantFieldValues: FieldValuePair[] } | undefined
   >();
 

--- a/x-pack/plugins/infra/public/alerting/log_threshold/components/alert_details_app_section/components/explain_log_rate_spike.tsx
+++ b/x-pack/plugins/infra/public/alerting/log_threshold/components/alert_details_app_section/components/explain_log_rate_spike.tsx
@@ -125,7 +125,7 @@ export const ExplainLogRateSpikes: FC<AlertDetailsExplainLogRateSpikesSectionPro
       field: term.fieldName,
       value: term.fieldValue,
     }));
-    SetLogSpikeParams(
+    setLogSpikeParams(
       fieldValuePairs ? { significantFieldValues: fieldValuePairs?.slice(0, 2) } : undefined
     );
   };

--- a/x-pack/plugins/observability/common/co_pilot.ts
+++ b/x-pack/plugins/observability/common/co_pilot.ts
@@ -65,14 +65,12 @@ const logEntryRt = t.type({
   ),
 });
 
-const significantFieldValuesRt = t.type({
-  fields: t.array(
-    t.type({
-      field: t.string,
-      value: t.string,
-    })
-  ),
-});
+const significantFieldValuesRt = t.array(
+  t.type({
+    field: t.string,
+    value: t.union([t.string, t.number]),
+  })
+);
 
 export const coPilotPrompts = {
   [CoPilotPromptId.ProfilingOptimizeFunction]: prompt({
@@ -237,11 +235,9 @@ export const coPilotPrompts = {
     }),
     messages: ({ significantFieldValues }) => {
       const customMessageForPrompt =
-        significantFieldValues.fields.length === 1
-          ? `There has been an alert on spike of logs. The spike mainly consists of logs with field ${significantFieldValues.fields[0]?.field} with value "${significantFieldValues.fields[0]?.value}".`
-          : significantFieldValues.fields.length > 1
-          ? `There has been an alert on spike of logs. The spike mainly consists of logs with field ${significantFieldValues.fields[0]?.field} with value "${significantFieldValues.fields[0]?.value}" and field ${significantFieldValues.fields[1]?.field} with value "${significantFieldValues.fields[1]?.value}".`
-          : '';
+        significantFieldValues.length === 1
+          ? `There has been an alert on spike of logs. The spike mainly consists of logs with field ${significantFieldValues[0]?.field} with value "${significantFieldValues[0]?.value}".`
+          : `There has been an alert on spike of logs. The spike mainly consists of logs with field ${significantFieldValues[0]?.field} with value "${significantFieldValues[0]?.value}" and field ${significantFieldValues[1]?.field} with value "${significantFieldValues[1]?.value}".`;
       return [
         LOGS_SYSTEM_MESSAGE,
         {


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/159953

Updates co-pilot prompt using first two significant field names and values from the analysis results of the "Explain Log Spikes" in the Logs alert details page.


https://github.com/elastic/kibana/assets/69037875/f337225f-d079-4da9-aba0-7b66f62161ac

