### PR TITLE
[Security Solution] Fix timeline bug receiving dataProvider value as number

### DIFF
--- a/x-pack/plugins/security_solution/public/actions/add_to_timeline/cell_action/add_to_timeline.test.ts
+++ b/x-pack/plugins/security_solution/public/actions/add_to_timeline/cell_action/add_to_timeline.test.ts
@@ -87,6 +87,29 @@ describe('createAddToTimelineCellAction', () => {
       expect(mockWarningToast).not.toHaveBeenCalled();
     });
 
+    it('should execute with number value', async () => {
+      await addToTimelineAction.execute({
+        field: { name: 'process.parent.pid', value: 12345, type: 'number' },
+      } as unknown as CellActionExecutionContext); // TODO: remove `as unknown` when number value type is supported
+      expect(mockDispatch).toHaveBeenCalledWith(
+        set(
+          'payload.providers[0]',
+          {
+            ...defaultDataProvider,
+            id: 'event-field-default-timeline-1-process_parent_pid-0-12345',
+            name: 'process.parent.pid',
+            queryMatch: {
+              field: 'process.parent.pid',
+              value: '12345',
+              operator: ':',
+            },
+          },
+          defaultDataProviderAction
+        )
+      );
+      expect(mockWarningToast).not.toHaveBeenCalled();
+    });
+
     it('should execute with null value', async () => {
       await addToTimelineAction.execute({
         field: { name: 'user.name', value: null, type: 'text' },

--- a/x-pack/plugins/security_solution/public/actions/add_to_timeline/data_provider.ts
+++ b/x-pack/plugins/security_solution/public/actions/add_to_timeline/data_provider.ts
@@ -79,8 +79,9 @@ export const createDataProviders = ({
 
   const arrayValues = Array.isArray(values) ? (values.length > 0 ? values : [null]) : [values];
 
-  return arrayValues.reduce<DataProvider[]>((dataProviders, value, index) => {
+  return arrayValues.reduce<DataProvider[]>((dataProviders, rawValue, index) => {
     let id: string = '';
+    const value = rawValue != null ? rawValue.toString() : rawValue;
     const appendedUniqueId = `${contextId}${eventId ? `-${eventId}` : ''}-${field}-${index}${
       value ? `-${value}` : ''
     }`;


### PR DESCRIPTION
## Summary

issue: https://github.com/elastic/kibana/issues/159720
Timeline save request fails when the dataProvider value stored is a Number type.

Adding the dataProvider through timeline page itself does not cause the bug. it sets a string value even if the field type is `number`.

The bug only happens when using "add to timeline" CellAction on a field with type `number`

### Solution

Cast the dataProvider values to a `string` before adding them to the timeline.



<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->