### PR TITLE
[FullStory] Limit number of pageVars

### DIFF
--- a/packages/analytics/shippers/fullstory/src/fullstory_shipper.test.ts
+++ b/packages/analytics/shippers/fullstory/src/fullstory_shipper.test.ts
@@ -85,7 +85,6 @@ describe('FullStoryShipper', () => {
         expect(fullStoryApiMock.setVars).toHaveBeenCalledWith('page', {
           // eslint-disable-next-line @typescript-eslint/naming-convention
           cloudId_str: 'test-es-org-id',
-          org_id_str: 'test-es-org-id',
         });
       });
 
@@ -94,7 +93,6 @@ describe('FullStoryShipper', () => {
         expect(fullStoryApiMock.setVars).toHaveBeenCalledWith('page', {
           // eslint-disable-next-line @typescript-eslint/naming-convention
           cloudId_str: 'test-es-org-id',
-          org_id_str: 'test-es-org-id',
           version_str: '1.2.3',
           version_major_int: 1,
           version_minor_int: 2,
@@ -102,11 +100,12 @@ describe('FullStoryShipper', () => {
         });
       });
 
-      test('adds the rest of the context to `setVars`', () => {
+      test('adds the rest of the context to `setVars` (only if they match one of the valid keys)', () => {
         const context = {
           userId: 'test-user-id',
           version: '1.2.3',
           cloudId: 'test-es-org-id',
+          labels: { serverless: 'test' },
           foo: 'bar',
         };
         fullstoryShipper.extendContext(context);
@@ -117,8 +116,7 @@ describe('FullStoryShipper', () => {
           version_patch_int: 3,
           // eslint-disable-next-line @typescript-eslint/naming-convention
           cloudId_str: 'test-es-org-id',
-          org_id_str: 'test-es-org-id',
-          foo_str: 'bar',
+          labels: { serverless_str: 'test' },
         });
       });
     });

--- a/packages/analytics/shippers/fullstory/tsconfig.json
+++ b/packages/analytics/shippers/fullstory/tsconfig.json
@@ -12,7 +12,8 @@
   ],
   "kbn_references": [
     "@kbn/analytics-client",
-    "@kbn/logging-mocks"
+    "@kbn/logging-mocks",
+    "@kbn/safer-lodash-set"
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
## Summary

When testing https://github.com/elastic/kibana/pull/159549, we noticed that the new field was not coming through to FullStory.

The reason, FS's limit of reporting maximum 20 attributes per page.

@shahinakmal and I went through the list of currently reported context vars, and came up with the list that makes more sense to us right now.

Now we can filter the sessions by `serveless` project type 🎉 
<img width="1693" alt="image" src="https://github.com/elastic/kibana/assets/5469006/0e1ef952-d454-4592-8170-4ba523b5dda4">

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
