### PR TITLE
[Synthetics] http monitors - account for custom Content-Type headers

### DIFF
--- a/x-pack/plugins/synthetics/common/runtime_types/monitor_management/monitor_configs.ts
+++ b/x-pack/plugins/synthetics/common/runtime_types/monitor_management/monitor_configs.ts
@@ -140,3 +140,7 @@ export const ResponseCheckJSONCodec = t.interface({
   expression: t.string,
 });
 export type ResponseCheckJSON = t.TypeOf<typeof ResponseCheckJSONCodec>;
+
+export const RequestBodyCheckCodec = t.interface({ value: t.string, type: CodeEditorModeCodec });
+
+export type RequestBodyCheck = t.TypeOf<typeof RequestBodyCheckCodec>;

--- a/x-pack/plugins/synthetics/common/runtime_types/monitor_management/monitor_types.ts
+++ b/x-pack/plugins/synthetics/common/runtime_types/monitor_management/monitor_types.ts
@@ -11,7 +11,6 @@ import { secretKeys } from '../../constants/monitor_management';
 import { ConfigKey } from './config_key';
 import { MonitorServiceLocationCodec, ServiceLocationErrors } from './locations';
 import {
-  CodeEditorModeCodec,
   DataStream,
   DataStreamCodec,
   FormMonitorTypeCodec,
@@ -22,6 +21,7 @@ import {
   SourceTypeCodec,
   TLSVersionCodec,
   VerificationModeCodec,
+  RequestBodyCheckCodec,
 } from './monitor_configs';
 import { MetadataCodec } from './monitor_meta_data';
 import { PrivateLocationCodec } from './synthetics_private_locations';
@@ -195,7 +195,7 @@ export const HTTPSensitiveAdvancedFieldsCodec = t.intersection([
     [ConfigKey.RESPONSE_BODY_CHECK_NEGATIVE]: t.array(t.string),
     [ConfigKey.RESPONSE_BODY_CHECK_POSITIVE]: t.array(t.string),
     [ConfigKey.RESPONSE_HEADERS_CHECK]: t.record(t.string, t.string),
-    [ConfigKey.REQUEST_BODY_CHECK]: t.interface({ value: t.string, type: CodeEditorModeCodec }),
+    [ConfigKey.REQUEST_BODY_CHECK]: RequestBodyCheckCodec,
     [ConfigKey.REQUEST_HEADERS_CHECK]: t.record(t.string, t.string),
     [ConfigKey.USERNAME]: t.string,
   }),

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/fields/header_field.test.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/fields/header_field.test.tsx
@@ -106,4 +106,35 @@ describe('<HeaderField />', () => {
       });
     });
   });
+
+  it('shows custom Content-Type', async () => {
+    const contentMode: CodeEditorMode = CodeEditorMode.PLAINTEXT;
+    const { getByTestId } = render(
+      <HeaderField
+        defaultValue={{ ...defaultValue, 'Content-Type': 'custom' }}
+        onChange={onChange}
+        contentMode={contentMode}
+      />
+    );
+
+    const key = getByTestId('keyValuePairsKey0') as HTMLInputElement;
+    const value = getByTestId('keyValuePairsValue0') as HTMLInputElement;
+
+    expect(key.value).toBe('Content-Type');
+    expect(value.value).toBe('custom');
+  });
+
+  it('hides default Content-Type', async () => {
+    const contentMode: CodeEditorMode = CodeEditorMode.PLAINTEXT;
+    const { queryByTestId } = render(
+      <HeaderField
+        defaultValue={{ ...defaultValue, 'Content-Type': 'text/plain' }}
+        onChange={onChange}
+        contentMode={contentMode}
+      />
+    );
+
+    expect(queryByTestId('keyValuePairsKey0')).not.toBeInTheDocument();
+    expect(queryByTestId('keyValuePairsValue0')).not.toBeInTheDocument();
+  });
 });

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/fields/header_field.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/fields/header_field.tsx
@@ -28,7 +28,9 @@ export const HeaderField = ({
   'data-test-subj': dataTestSubj,
   readOnly,
 }: HeaderFieldProps) => {
-  const defaultValueKeys = Object.keys(defaultValue).filter((key) => key !== 'Content-Type'); // Content-Type is a secret header we hide from the user
+  const defaultValueKeys = Object.keys(defaultValue).filter(
+    filterContentType(defaultValue, contentTypes, contentMode)
+  );
   const formattedDefaultValues: Pair[] = [
     ...defaultValueKeys.map<Pair>((key) => {
       return [key || '', defaultValue[key] || '']; // key, value
@@ -71,6 +73,20 @@ export const HeaderField = ({
     />
   );
 };
+
+// We apply default `Content-Type` headers automatically, and hide these from the user when they apply custom values
+export const filterContentType =
+  (
+    defaultValue: Record<string, string>,
+    contentTypeMap: Record<CodeEditorMode, ContentType>,
+    contentMode?: CodeEditorMode
+  ) =>
+  (key: string) => {
+    return (
+      key !== 'Content-Type' ||
+      (key === 'Content-Type' && contentMode && defaultValue[key] !== contentTypeMap[contentMode])
+    );
+  };
 
 export const contentTypes: Record<CodeEditorMode, ContentType> = {
   [CodeEditorMode.JSON]: ContentType.JSON,

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/fields/header_field.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/fields/header_field.tsx
@@ -74,7 +74,9 @@ export const HeaderField = ({
   );
 };
 
-// We apply default `Content-Type` headers automatically, and hide these from the user when they apply custom values
+// We apply default `Content-Type` headers automatically depending on the request body mime type
+// We hide the default Content-Type headers from the user as an implementation detail
+// However, If the user applies a custom `Content-Type` header, it should be shown
 export const filterContentType =
   (
     defaultValue: Record<string, string>,

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/form/field_config.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/form/field_config.tsx
@@ -75,8 +75,8 @@ import {
   FormLocation,
   ResponseBodyIndexPolicy,
   ResponseCheckJSON,
-  RequestBodyCheck,
   ThrottlingConfig,
+  RequestBodyCheck,
 } from '../types';
 import { AlertConfigKey, ALLOWED_SCHEDULES_IN_MINUTES } from '../constants';
 import { getDefaultFormFields } from './defaults';
@@ -723,7 +723,10 @@ export const FIELD = (readOnly?: boolean): FieldMap => ({
     error: i18n.translate('xpack.synthetics.monitorConfig.requestHeaders.error', {
       defaultMessage: 'Header key must be a valid HTTP token.',
     }),
-    props: ({ dependencies }): HeaderFieldProps => {
+    // contentMode is optional for other implementations, but required for this implemention of this field
+    props: ({
+      dependencies,
+    }): HeaderFieldProps & { contentMode: HeaderFieldProps['contentMode'] } => {
       const [requestBody] = dependencies;
       return {
         readOnly,

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/form/field_config.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/form/field_config.tsx
@@ -75,6 +75,7 @@ import {
   FormLocation,
   ResponseBodyIndexPolicy,
   ResponseCheckJSON,
+  RequestBodyCheck,
   ThrottlingConfig,
 } from '../types';
 import { AlertConfigKey, ALLOWED_SCHEDULES_IN_MINUTES } from '../constants';
@@ -718,12 +719,17 @@ export const FIELD = (readOnly?: boolean): FieldMap => ({
     validation: () => ({
       validate: (headers) => !validateHeaders(headers),
     }),
+    dependencies: [ConfigKey.REQUEST_BODY_CHECK],
     error: i18n.translate('xpack.synthetics.monitorConfig.requestHeaders.error', {
       defaultMessage: 'Header key must be a valid HTTP token.',
     }),
-    props: (): HeaderFieldProps => ({
-      readOnly,
-    }),
+    props: ({ dependencies }): HeaderFieldProps => {
+      const [requestBody] = dependencies;
+      return {
+        readOnly,
+        contentMode: (requestBody as RequestBodyCheck).type,
+      };
+    },
   },
   [ConfigKey.REQUEST_BODY_CHECK]: {
     fieldKey: ConfigKey.REQUEST_BODY_CHECK,

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/types.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/types.ts
@@ -18,6 +18,7 @@ import {
   FormMonitorType,
   MonitorFields,
   ResponseCheckJSON,
+  RequestBodyCheck,
 } from '../../../../../common/runtime_types/monitor_management';
 import { AlertConfigKey } from './constants';
 
@@ -38,6 +39,7 @@ export interface FormLocation {
   isServiceManaged: boolean;
   label: string;
 }
+
 export type FormConfig = MonitorFields & {
   isTLSEnabled: boolean;
   ['schedule.number']: string;
@@ -57,6 +59,9 @@ export type FormConfig = MonitorFields & {
     supported_protocols: MonitorFields[ConfigKey.TLS_VERSION];
   };
   check: {
+    request: {
+      body: RequestBodyCheck;
+    };
     response: {
       json: ResponseCheckJSON[];
     };


### PR DESCRIPTION
## Release note
Ensures that users can configure custom `Content-Type` headers for HTTP monitors in the Synthetics app.

## Summary

This PR fixes two bugs identified by an SDH.

1. We are supposed to automatically add default `Content-Type` headers to the monitor payload based on the MIME type of the request body. We were doing so in Uptime, but have not been in the Synthetics app. This PR ensures the default `Content-Type` header is applied for UI monitors
2. When users attempted to use custom `Content-Type` headers, they were being removed on subsequent monitor edits. This PR ensures that they are preserved

### Testing

1. Create a basic HTTP monitor. Inspect the monitors configuration. Ensure that `check.request.headers` value is set to `Content-Type: 'text/plain`.
2. Create another basic HTTP monitor, but instead set the request body to JSON. Ensure the `check.request.headers` value is set to `Content-Type: 'application/json'`
3. Create another HTTP monitor, this time add a custom `Content-Type` in the request headers section. For example, you can just use `Content-Type: custom`. Make sure you set the request headers, not the response headers or proxy headers.
4. Inspect that monitor's configuration. Ensure the `Content-Type: custom` header is present in `check.request.headers`.
5. Attempt to edit that HTTP monitor, ensure that the custom `Content-Type` header remains in the UI edit flow. Save the monitor.
6. Inspect that monitor's configuration. Ensure the `Content-Type: custom` header still remains in `check.request.headers`. 

<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->