### PR TITLE
[Dashboard] Fix alias redirect & update error handling

### DIFF
--- a/src/plugins/dashboard/public/dashboard_container/embeddable/create/create_dashboard.ts
+++ b/src/plugins/dashboard/public/dashboard_container/embeddable/create/create_dashboard.ts
@@ -144,6 +144,7 @@ export const initializeDashboard = async ({
     validateLoadedSavedObject &&
     !validateLoadedSavedObject(loadDashboardReturn)
   ) {
+    // throw error to stop the rest of Dashboard loading and make the factory return an ErrorEmbeddable.
     throw new Error('Dashboard failed saved object result validation');
   }
 

--- a/src/plugins/dashboard/public/dashboard_container/embeddable/dashboard_container_factory.tsx
+++ b/src/plugins/dashboard/public/dashboard_container/embeddable/dashboard_container_factory.tsx
@@ -97,11 +97,14 @@ export class DashboardContainerFactoryDefinition
     const dashboardCreationStartTime = performance.now();
     const { createDashboard } = await import('./create/create_dashboard');
     try {
-      return Promise.resolve(
-        createDashboard(creationOptions, dashboardCreationStartTime, savedObjectId)
+      const dashboard = await createDashboard(
+        creationOptions,
+        dashboardCreationStartTime,
+        savedObjectId
       );
+      return dashboard;
     } catch (e) {
-      return new ErrorEmbeddable(e.text, { id: e.id });
+      return new ErrorEmbeddable(e, { id: e.id });
     }
   };
 }

--- a/src/plugins/dashboard/public/dashboard_container/external_api/dashboard_renderer.test.tsx
+++ b/src/plugins/dashboard/public/dashboard_container/external_api/dashboard_renderer.test.tsx
@@ -90,4 +90,76 @@ describe('dashboard renderer', () => {
       'saved_object_kibanakiwi'
     );
   });
+
+  test('renders and destroys an error embeddable when the dashboard factory create method throws an error', async () => {
+    const mockErrorEmbeddable = {
+      error: 'oh my goodness an error',
+      destroy: jest.fn(),
+      render: jest.fn(),
+    } as unknown as DashboardContainer;
+    mockDashboardFactory = {
+      create: jest.fn().mockReturnValue(mockErrorEmbeddable),
+    } as unknown as DashboardContainerFactory;
+    pluginServices.getServices().embeddable.getEmbeddableFactory = jest
+      .fn()
+      .mockReturnValue(mockDashboardFactory);
+
+    let wrapper: ReactWrapper;
+    await act(async () => {
+      wrapper = await mountWithIntl(<DashboardRenderer savedObjectId="saved_object_kibanana" />);
+    });
+
+    expect(mockErrorEmbeddable.render).toHaveBeenCalled();
+    wrapper!.unmount();
+    expect(mockErrorEmbeddable.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  test('creates a new dashboard container when the ID changes, and the first created dashboard resulted in an error', async () => {
+    // ensure that the first attempt at creating a dashboard results in an error embeddable
+    const mockErrorEmbeddable = {
+      error: 'oh my goodness an error',
+      destroy: jest.fn(),
+      render: jest.fn(),
+    } as unknown as DashboardContainer;
+    const mockErrorFactory = {
+      create: jest.fn().mockReturnValue(mockErrorEmbeddable),
+    } as unknown as DashboardContainerFactory;
+    pluginServices.getServices().embeddable.getEmbeddableFactory = jest
+      .fn()
+      .mockReturnValue(mockErrorFactory);
+
+    // render the dashboard - it should run into an error and render the error embeddable.
+    let wrapper: ReactWrapper;
+    await act(async () => {
+      wrapper = await mountWithIntl(<DashboardRenderer savedObjectId="saved_object_kibanana" />);
+    });
+    expect(mockErrorEmbeddable.render).toHaveBeenCalled();
+    expect(mockErrorFactory.create).toHaveBeenCalledTimes(1);
+
+    // ensure that the next attempt at creating a dashboard is successfull.
+    const mockSuccessEmbeddable = {
+      destroy: jest.fn(),
+      render: jest.fn(),
+      navigateToDashboard: jest.fn(),
+    } as unknown as DashboardContainer;
+    const mockSuccessFactory = {
+      create: jest.fn().mockReturnValue(mockSuccessEmbeddable),
+    } as unknown as DashboardContainerFactory;
+    pluginServices.getServices().embeddable.getEmbeddableFactory = jest
+      .fn()
+      .mockReturnValue(mockSuccessFactory);
+
+    // update the saved object id to trigger another dashboard load.
+    await act(async () => {
+      await wrapper.setProps({ savedObjectId: 'saved_object_kibanakiwi' });
+    });
+
+    expect(mockErrorEmbeddable.destroy).toHaveBeenCalled();
+
+    // because a new dashboard container has been created, we should not call navigate.
+    expect(mockSuccessEmbeddable.navigateToDashboard).not.toHaveBeenCalled();
+
+    // instead we should call create on the factory again.
+    expect(mockSuccessFactory.create).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/plugins/dashboard/public/dashboard_container/external_api/dashboard_renderer.tsx
+++ b/src/plugins/dashboard/public/dashboard_container/external_api/dashboard_renderer.tsx
@@ -142,12 +142,12 @@ export const DashboardRenderer = forwardRef<AwaitingDashboardAPI, DashboardRende
       <EuiLoadingElastic size="xxl" />
     );
 
-    return (
-      <div className={viewportClasses}>
-        {loading && loadingSpinner}
-        {fatalError && fatalError.render()}
-        {!fatalError && !loading && <div ref={dashboardRoot} />}
-      </div>
-    );
+    const renderDashboardContents = () => {
+      if (fatalError) return fatalError.render();
+      if (loading) return loadingSpinner;
+      return <div ref={dashboardRoot} />;
+    };
+
+    return <div className={viewportClasses}>{renderDashboardContents()}</div>;
   }
 );

--- a/src/plugins/dashboard/public/dashboard_container/external_api/dashboard_renderer.tsx
+++ b/src/plugins/dashboard/public/dashboard_container/external_api/dashboard_renderer.tsx
@@ -77,6 +77,7 @@ export const DashboardRenderer = forwardRef<AwaitingDashboardAPI, DashboardRende
 
         return;
       }
+      setLoading(true);
 
       let canceled = false;
       (async () => {
@@ -104,12 +105,13 @@ export const DashboardRenderer = forwardRef<AwaitingDashboardAPI, DashboardRende
           return;
         }
 
+        setLoading(false);
+
         if (isErrorEmbeddable(container)) {
           setFatalError(container);
           return;
         }
 
-        setLoading(false);
         if (dashboardRoot.current) {
           container.render(dashboardRoot.current);
         }
@@ -142,8 +144,9 @@ export const DashboardRenderer = forwardRef<AwaitingDashboardAPI, DashboardRende
 
     return (
       <div className={viewportClasses}>
-        {loading && !fatalError ? loadingSpinner : <div ref={dashboardRoot} />}
-        {fatalError ? fatalError.render() : null}
+        {loading && loadingSpinner}
+        {fatalError && fatalError.render()}
+        {!fatalError && !loading && <div ref={dashboardRoot} />}
       </div>
     );
   }


### PR DESCRIPTION
## Summary
This PR fixes a regression introduced in https://github.com/elastic/kibana/pull/150121 & https://github.com/elastic/kibana/pull/157437.

Basically what would happen is the following:

1. The Dashboard renderer would begin loading the dashboard container.
2. The validation would result in an alias match. 
3. This would update the URL, but also throw an error.
4. The new fast navigation would see that the url was updated, but it wouldn't redirect because the DashboardContainer was never completed.
5. The dashboard would infinite load 🔥

This PR fixes that with proper error handling on the dashboard container factory side, and the ability for the dashboard renderer to retry loading the dashboard container if the last load was unsuccessful.

### Before
https://github.com/elastic/kibana/assets/14276393/92ed349c-1a63-4b9b-b7e8-645e898dd923

### After
https://github.com/elastic/kibana/assets/14276393/2b5c90df-4343-4ce5-ac9e-6a7b4738f613

### Bonus
Additionally, this PR straightens out the error handling on Dashboard creation. If an error embeddable is returned from the dashboard container factory, the dashboard renderer will render it until the id changes. I got this screenshot by throwing an error in `create_dashboard.ts`.

<img width="1030" alt="Screen Shot 2023-06-14 at 1 53 55 PM" src="https://github.com/elastic/kibana/assets/14276393/32b4aa70-5c08-435e-8ba7-73032fcd8931">


### Checklist

Delete any items that are not applicable to this PR.
- [X] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->