### PR TITLE
[ResponseOps][Alerting] Flaky test x-pack/test/alerting_api_integration/spaces_only/tests/action_task_params/migrations·ts

### DIFF
--- a/x-pack/test/alerting_api_integration/spaces_only/tests/action_task_params/migrations.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/action_task_params/migrations.ts
@@ -16,8 +16,7 @@ export default function createGetTests({ getService }: FtrProviderContext) {
   const es = getService('es');
   const esArchiver = getService('esArchiver');
 
-  // FLAKY: https://github.com/elastic/kibana/issues/154358
-  describe.skip('migrations', () => {
+  describe('migrations', () => {
     before(async () => {
       await esArchiver.load('x-pack/test/functional/es_archives/action_task_params');
     });


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/154358

## Summary

This pr removes the skip on the flaky test. I couldn't replicate the failure, and it passed three runs through the flaky test runner.

1. Flaky test run 250x - https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2384
2. Flaky test run 250x - https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2383
3. Flaky test run 250x - https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2385
