### PR TITLE
Fix failing DW cypress test introduced by fields_for_wildcard URL path changes

### DIFF
--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/mocked_data/response_actions.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/mocked_data/response_actions.cy.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { FIELDS_FOR_WILDCARD_PATH } from '@kbn/data-views-plugin/common/constants';
 import {
   addEndpointResponseAction,
   fillUpNewRule,
@@ -155,7 +156,7 @@ describe('Response actions', () => {
     });
 
     it('All response action controls are disabled', () => {
-      cy.intercept('GET', 'api/index_patterns/_fields_for_wildcard*').as('getFieldsForWildcard');
+      cy.intercept('GET', `${FIELDS_FOR_WILDCARD_PATH}*`).as('getFieldsForWildcard');
       visitRuleActions(ruleId);
       cy.wait('@getFieldsForWildcard');
       cy.getByTestSubj('edit-rule-actions-tab').click();

--- a/x-pack/plugins/security_solution/public/management/cypress/tsconfig.json
+++ b/x-pack/plugins/security_solution/public/management/cypress/tsconfig.json
@@ -34,5 +34,6 @@
     "@kbn/cases-plugin",
     "@kbn/test",
     "@kbn/repo-info",
+    "@kbn/data-views-plugin",
   ]
 }


### PR DESCRIPTION
## Summary

The issue was introduced in https://github.com/elastic/kibana/pull/159637

One of the DW tests were relying on the old path and was not updated causing tests to fail.
