### PR TITLE
[SecuritySolution] Update checkIndicesExists logic

### DIFF
--- a/x-pack/plugins/security_solution/public/common/containers/sourcerer/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/containers/sourcerer/index.tsx
@@ -372,6 +372,7 @@ export const useSourcererDataView = (
     []
   );
   const {
+    defaultDataView,
     signalIndexName,
     selectedDataView,
     sourcererScope: { missingPatterns, selectedPatterns: scopeSelectedPatterns, loading },
@@ -383,6 +384,7 @@ export const useSourcererDataView = (
       sourcererScope,
     };
   });
+
   const selectedPatterns = useMemo(
     () => sortWithExcludesAtEnd(scopeSelectedPatterns),
     [scopeSelectedPatterns]
@@ -431,8 +433,17 @@ export const useSourcererDataView = (
             scopeId,
             signalIndexName,
             patternList: sourcererDataView.patternList,
+            isDefaultDataViewSelected: sourcererDataView.id === defaultDataView.id,
           }),
-    [loading, scopeId, signalIndexName, sourcererDataView.loading, sourcererDataView.patternList]
+    [
+      defaultDataView.id,
+      loading,
+      scopeId,
+      signalIndexName,
+      sourcererDataView.id,
+      sourcererDataView.loading,
+      sourcererDataView.patternList,
+    ]
   );
 
   const browserFields = useCallback(() => {

--- a/x-pack/plugins/security_solution/public/common/store/sourcerer/helpers.test.ts
+++ b/x-pack/plugins/security_solution/public/common/store/sourcerer/helpers.test.ts
@@ -7,7 +7,11 @@
 
 import { mockGlobalState, mockSourcererState } from '../../mock';
 import { SourcererScopeName } from './model';
-import { getScopePatternListSelection, validateSelectedPatterns } from './helpers';
+import {
+  checkIfIndicesExist,
+  getScopePatternListSelection,
+  validateSelectedPatterns,
+} from './helpers';
 import { sortWithExcludesAtEnd } from '../../../../common/utils/sourcerer';
 
 const signalIndexName = mockGlobalState.sourcerer.signalIndexName;
@@ -276,5 +280,95 @@ describe('sourcerer store helpers', () => {
         },
       });
     });
+  });
+});
+
+describe('checkIfIndicesExist', () => {
+  it('should return true when scopeId is "detections" and patternList includes signalIndexName', () => {
+    const result = checkIfIndicesExist({
+      patternList: ['index1', 'index2', 'signalIndex'],
+      scopeId: SourcererScopeName.detections,
+      signalIndexName: 'signalIndex',
+      isDefaultDataViewSelected: false,
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it('should return false when scopeId is "detections" and patternList does not include signalIndexName', () => {
+    const result = checkIfIndicesExist({
+      patternList: ['index1', 'index2'],
+      scopeId: SourcererScopeName.detections,
+      signalIndexName: 'signalIndex',
+      isDefaultDataViewSelected: false,
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it('should return true when scopeId is "default" and isDefaultDataViewSelected is true and patternList has elements other than signalIndexName', () => {
+    const result = checkIfIndicesExist({
+      patternList: ['index1', 'index2', 'index3'],
+      scopeId: SourcererScopeName.default,
+      signalIndexName: 'signalIndex',
+      isDefaultDataViewSelected: true,
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it('should return false when scopeId is "default" and isDefaultDataViewSelected is true and patternList only contains signalIndexName', () => {
+    const result = checkIfIndicesExist({
+      patternList: ['signalIndex'],
+      scopeId: SourcererScopeName.default,
+      signalIndexName: 'signalIndex',
+      isDefaultDataViewSelected: true,
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it('should return true when scopeId is "default" and isDefaultDataViewSelected is false and patternList has elements', () => {
+    const result = checkIfIndicesExist({
+      patternList: ['index1', 'index2'],
+      scopeId: SourcererScopeName.default,
+      signalIndexName: 'signalIndex',
+      isDefaultDataViewSelected: false,
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it('should return false when scopeId is "default" and isDefaultDataViewSelected is false and patternList is empty', () => {
+    const result = checkIfIndicesExist({
+      patternList: [],
+      scopeId: SourcererScopeName.default,
+      signalIndexName: 'signalIndex',
+      isDefaultDataViewSelected: false,
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it('should return true when scopeId is not "detections" or "default" and patternList has elements', () => {
+    const result = checkIfIndicesExist({
+      patternList: ['index1', 'index2'],
+      scopeId: 'other' as SourcererScopeName,
+      signalIndexName: 'signalIndex',
+      isDefaultDataViewSelected: false,
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it('should return false when scopeId is not "detections" or "default" and patternList is empty', () => {
+    const result = checkIfIndicesExist({
+      patternList: [],
+      scopeId: 'other' as SourcererScopeName,
+      signalIndexName: 'signalIndex',
+      isDefaultDataViewSelected: false,
+    });
+
+    expect(result).toBe(false);
   });
 });

--- a/x-pack/plugins/security_solution/public/common/store/sourcerer/helpers.ts
+++ b/x-pack/plugins/security_solution/public/common/store/sourcerer/helpers.ts
@@ -104,14 +104,18 @@ interface CheckIfIndicesExistParams {
   patternList: sourcererModel.SourcererDataView['patternList'];
   scopeId: sourcererModel.SourcererScopeName;
   signalIndexName: string | null;
+  isDefaultDataViewSelected: boolean;
 }
 export const checkIfIndicesExist = ({
   patternList,
   scopeId,
   signalIndexName,
+  isDefaultDataViewSelected,
 }: CheckIfIndicesExistParams) =>
   scopeId === SourcererScopeName.detections
     ? patternList.includes(`${signalIndexName}`)
     : scopeId === SourcererScopeName.default
-    ? patternList.filter((i) => i !== signalIndexName).length > 0
+    ? isDefaultDataViewSelected
+      ? patternList.filter((i) => i !== signalIndexName).length > 0
+      : patternList.length > 0
     : patternList.length > 0;


### PR DESCRIPTION
## Summary

issue: https://github.com/elastic/kibana/issues/159107



**Steps to verify:**

1. Generate some alerts and enable host or user risk score module.
2. Hard refresh the page, select the alerts data view. 

<img width="639" alt="Screenshot 2023-06-15 at 14 54 54" src="https://github.com/elastic/kibana/assets/6295984/412a2a9c-9125-4972-8c95-24dda90ad529">

3. Visit overview, host, network and users page. All should `Not` display the get started page.


https://github.com/elastic/kibana/assets/6295984/4b942604-f98f-40fe-bbca-9cfd11cdf275


### Checklist

Delete any items that are not applicable to this PR.


- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios



<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->