### PR TITLE
chore(slo): cleanup slo form

### DIFF
--- a/x-pack/plugins/observability/public/hooks/slo/use_fetch_active_alerts.ts
+++ b/x-pack/plugins/observability/public/hooks/slo/use_fetch_active_alerts.ts
@@ -62,7 +62,7 @@ export function useFetchActiveAlerts({ sloIds = [] }: Params): UseFetchActiveAle
                   {
                     range: {
                       '@timestamp': {
-                        gte: 'now-15m/m',
+                        gte: 'now-5m/m',
                       },
                     },
                   },

--- a/x-pack/plugins/observability/public/hooks/slo/use_fetch_index_pattern_fields.ts
+++ b/x-pack/plugins/observability/public/hooks/slo/use_fetch_index_pattern_fields.ts
@@ -23,29 +23,21 @@ export interface Field {
 export function useFetchIndexPatternFields(
   indexPattern?: string
 ): UseFetchIndexPatternFieldsResponse {
-  const { http } = useKibana().services;
+  const { dataViews } = useKibana().services;
 
   const { isLoading, isError, isSuccess, data } = useQuery({
     queryKey: ['fetchIndexPatternFields', indexPattern],
     queryFn: async ({ signal }) => {
+      if (!indexPattern) {
+        return [];
+      }
       try {
-        const response = await http.get<{ fields: Field[] }>(
-          `/api/index_patterns/_fields_for_wildcard`,
-          {
-            query: {
-              pattern: indexPattern,
-            },
-            headers: {
-              'Elastic-Api-Version': 1,
-            },
-            signal,
-          }
-        );
-        return response.fields;
+        return await dataViews.getFieldsForWildcard({ pattern: indexPattern });
       } catch (error) {
         throw new Error(`Something went wrong. Error: ${error}`);
       }
     },
+    retry: false,
     refetchOnWindowFocus: false,
     enabled: Boolean(indexPattern),
   });

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/apm_availability/apm_availability_indicator_type_form.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/apm_availability/apm_availability_indicator_type_form.tsx
@@ -16,7 +16,7 @@ import { FieldSelector } from '../apm_common/field_selector';
 import { QueryBuilder } from '../common/query_builder';
 
 export function ApmAvailabilityIndicatorTypeForm() {
-  const { control, setValue, watch } = useFormContext<CreateSLOInput>();
+  const { setValue, watch } = useFormContext<CreateSLOInput>();
   const { data: apmIndex } = useFetchApmIndex();
   useEffect(() => {
     setValue('indicator.params.index', apmIndex);

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/apm_availability/apm_availability_indicator_type_form.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/apm_availability/apm_availability_indicator_type_form.tsx
@@ -99,7 +99,6 @@ export function ApmAvailabilityIndicatorTypeForm() {
       <EuiFlexGroup direction="row" gutterSize="l">
         <EuiFlexItem>
           <QueryBuilder
-            control={control}
             dataTestSubj="apmLatencyFilterInput"
             indexPatternString={watch('indicator.params.index')}
             label={i18n.translate('xpack.observability.slo.sloEdit.apmLatency.filter', {

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/apm_latency/apm_latency_indicator_type_form.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/apm_latency/apm_latency_indicator_type_form.tsx
@@ -143,7 +143,6 @@ export function ApmLatencyIndicatorTypeForm() {
         </EuiFlexItem>
         <EuiFlexItem>
           <QueryBuilder
-            control={control}
             dataTestSubj="apmLatencyFilterInput"
             indexPatternString={watch('indicator.params.index')}
             label={i18n.translate('xpack.observability.slo.sloEdit.apmLatency.filter', {

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/common/query_builder.stories.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/common/query_builder.stories.tsx
@@ -23,7 +23,7 @@ const Template: ComponentStory<typeof Component> = (props: Props) => {
   const methods = useForm({ defaultValues: SLO_EDIT_FORM_DEFAULT_VALUES });
   return (
     <FormProvider {...methods}>
-      <Component {...props} control={methods.control} />
+      <Component {...props} />
     </FormProvider>
   );
 };

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/common/query_builder.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/common/query_builder.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { ReactNode } from 'react';
-import { Control, Controller, FieldPath, useFormContext } from 'react-hook-form';
+import { Controller, FieldPath, useFormContext } from 'react-hook-form';
 import { EuiFormRow } from '@elastic/eui';
 import { CreateSLOInput } from '@kbn/slo-schema';
 import { QueryStringInput } from '@kbn/unified-search-plugin/public';
@@ -14,7 +14,6 @@ import { useKibana } from '../../../../utils/kibana_react';
 import { useCreateDataView } from '../../../../hooks/use_create_data_view';
 
 export interface Props {
-  control: Control<CreateSLOInput>;
   dataTestSubj: string;
   indexPatternString: string | undefined;
   label: string;
@@ -25,7 +24,6 @@ export interface Props {
 }
 
 export function QueryBuilder({
-  control,
   dataTestSubj,
   indexPatternString,
   label,
@@ -37,7 +35,7 @@ export function QueryBuilder({
   const { data, dataViews, docLinks, http, notifications, storage, uiSettings, unifiedSearch } =
     useKibana().services;
 
-  const { getFieldState } = useFormContext();
+  const { control, getFieldState } = useFormContext<CreateSLOInput>();
 
   const { dataView } = useCreateDataView({ indexPatternString });
 

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/custom_kql/custom_kql_indicator_type_form.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/custom_kql/custom_kql_indicator_type_form.tsx
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import React from 'react';
 import {
   EuiComboBox,
   EuiComboBoxOptionOption,
@@ -15,15 +14,15 @@ import {
   EuiIconTip,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { Controller, useFormContext } from 'react-hook-form';
 import { CreateSLOInput } from '@kbn/slo-schema';
-
+import React from 'react';
+import { Controller, useFormContext } from 'react-hook-form';
 import {
   Field,
   useFetchIndexPatternFields,
 } from '../../../../hooks/slo/use_fetch_index_pattern_fields';
-import { IndexSelection } from '../custom_common/index_selection';
 import { QueryBuilder } from '../common/query_builder';
+import { IndexSelection } from '../custom_common/index_selection';
 
 interface Option {
   label: string;
@@ -91,7 +90,6 @@ export function CustomKqlIndicatorTypeForm() {
                           {
                             value: field.value,
                             label: field.value,
-                            'data-test-subj': `customKqlIndicatorFormTimestampFieldSelectedValue`,
                           },
                         ]
                       : []
@@ -106,7 +104,6 @@ export function CustomKqlIndicatorTypeForm() {
 
       <EuiFlexItem>
         <QueryBuilder
-          control={control}
           dataTestSubj="customKqlIndicatorFormQueryFilterInput"
           indexPatternString={watch('indicator.params.index')}
           label={i18n.translate('xpack.observability.slo.sloEdit.sliType.customKql.queryFilter', {
@@ -134,7 +131,6 @@ export function CustomKqlIndicatorTypeForm() {
 
       <EuiFlexItem>
         <QueryBuilder
-          control={control}
           dataTestSubj="customKqlIndicatorFormGoodQueryInput"
           indexPatternString={watch('indicator.params.index')}
           label={i18n.translate('xpack.observability.slo.sloEdit.sliType.customKql.goodQuery', {
@@ -165,7 +161,6 @@ export function CustomKqlIndicatorTypeForm() {
 
       <EuiFlexItem>
         <QueryBuilder
-          control={control}
           dataTestSubj="customKqlIndicatorFormTotalQueryInput"
           indexPatternString={watch('indicator.params.index')}
           label={i18n.translate('xpack.observability.slo.sloEdit.sliType.customKql.totalQuery', {

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/custom_metric/custom_metric_type_form.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/custom_metric/custom_metric_type_form.tsx
@@ -109,7 +109,6 @@ export function CustomMetricIndicatorTypeForm() {
 
       <EuiFlexItem>
         <QueryBuilder
-          control={control}
           dataTestSubj="customMetricIndicatorFormQueryFilterInput"
           indexPatternString={watch('indicator.params.index')}
           label={i18n.translate(


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/159832

## Summary

This PR uses the form context hook to retrieve the control on the QueryBuilder component, and changes the active alerts badge to fetch show only the active alerts from the past 5min instead of 15min.