### PR TITLE
[Enterprise Search] Search Application add tour in preview page 

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/applications/components/engine/engine_search_preview/engine_search_preview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/applications/components/engine/engine_search_preview/engine_search_preview.tsx
@@ -9,6 +9,8 @@ import React, { useState, useMemo } from 'react';
 
 import { useActions, useValues } from 'kea';
 
+import useLocalStorage from 'react-use/lib/useLocalStorage';
+
 import {
   EuiButtonEmpty,
   EuiContextMenuItem,
@@ -24,6 +26,7 @@ import {
   EuiText,
   EuiTextColor,
   EuiTitle,
+  EuiTourStep,
 } from '@elastic/eui';
 import {
   PagingInfo,
@@ -128,6 +131,11 @@ const ConfigurationPopover: React.FC<ConfigurationPopOverProps> = ({
   const { engineData } = useValues(EngineViewLogic);
   const { openDeleteEngineModal } = useActions(EngineViewLogic);
   const { sendEnterpriseSearchTelemetry } = useActions(TelemetryLogic);
+  const [isTourClosed, setTourClosed] = useLocalStorage<boolean>(
+    'search-application-tour-closed',
+    false
+  );
+
   return (
     <>
       <EuiPopover
@@ -137,20 +145,66 @@ const ConfigurationPopover: React.FC<ConfigurationPopOverProps> = ({
         closePopover={setCloseConfiguration}
         button={
           <EuiFlexGroup alignItems="center" gutterSize="xs">
-            {hasSchemaConflicts && <EuiIcon type="alert" color="danger" />}
-            <EuiButtonEmpty
-              color="primary"
-              iconType="arrowDown"
-              iconSide="right"
-              onClick={setCloseConfiguration}
-            >
-              {i18n.translate(
-                'xpack.enterpriseSearch.content.engine.searchPreview.configuration.buttonTitle',
-                {
-                  defaultMessage: 'Configuration',
+            {hasSchemaConflicts && (
+              <>
+                <EuiFlexItem>
+                  <EuiIcon type="alert" color="danger" />
+                </EuiFlexItem>
+                {!isTourClosed && <EuiSpacer size="xs" />}
+              </>
+            )}
+            <EuiFlexItem>
+              <EuiTourStep
+                display="block"
+                decoration="beacon"
+                content={
+                  <EuiText>
+                    <p>
+                      {i18n.translate(
+                        'xpack.enterpriseSearch.content.searchApplication.searchPreview.configuration.tourContent',
+                        {
+                          defaultMessage:
+                            'Create your API key, learn about using language clients and find more resources in Connect.',
+                        }
+                      )}
+                    </p>
+                  </EuiText>
                 }
-              )}
-            </EuiButtonEmpty>
+                isStepOpen={!isTourClosed}
+                maxWidth={360}
+                hasArrow
+                step={1}
+                onFinish={() => {
+                  setTourClosed(true);
+                }}
+                stepsTotal={1}
+                anchorPosition="downCenter"
+                title={i18n.translate(
+                  'xpack.enterpriseSearch.content.searchApplication.searchPreview.configuration.tourTitle',
+                  {
+                    defaultMessage: 'Review our API page to start using your search application',
+                  }
+                )}
+              >
+                <></>
+              </EuiTourStep>
+            </EuiFlexItem>
+
+            <EuiFlexItem>
+              <EuiButtonEmpty
+                color="primary"
+                iconType="arrowDown"
+                iconSide="right"
+                onClick={setCloseConfiguration}
+              >
+                {i18n.translate(
+                  'xpack.enterpriseSearch.content.engine.searchPreview.configuration.buttonTitle',
+                  {
+                    defaultMessage: 'Configuration',
+                  }
+                )}
+              </EuiButtonEmpty>
+            </EuiFlexItem>
           </EuiFlexGroup>
         }
       >


### PR DESCRIPTION
## Summary
* Adds tour near to configuration button when page loads
* Uses localStorage to save tour closed/open state
* Shows Tour, warning(if any), configuration button

### Screen Recording

https://github.com/elastic/kibana/assets/55930906/4acb6142-9822-41c4-b88a-1da2d3bf0b28

