### PR TITLE
[Cloud Posture] Installation stats telemetry

### DIFF
--- a/x-pack/plugins/cloud_security_posture/server/lib/telemetry/collectors/installation_stats_collector.ts
+++ b/x-pack/plugins/cloud_security_posture/server/lib/telemetry/collectors/installation_stats_collector.ts
@@ -4,6 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+import { agentPolicyService } from '@kbn/fleet-plugin/server/services';
 import type { CoreStart, Logger, SavedObjectsClientContract } from '@kbn/core/server';
 import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
 import {
@@ -11,11 +12,9 @@ import {
   PACKAGE_POLICY_SAVED_OBJECT_TYPE,
   SO_SEARCH_LIMIT,
 } from '@kbn/fleet-plugin/common';
-import type { CspServerPluginStart, CspServerPluginStartDeps } from '../../../types';
-
 import type { CloudSecurityInstallationStats } from './types';
+import type { CspServerPluginStart, CspServerPluginStartDeps } from '../../../types';
 import { CLOUD_SECURITY_POSTURE_PACKAGE_NAME } from '../../../../common/constants';
-import { agentPolicyService } from '@kbn/fleet-plugin/server/services';
 
 export const getInstallationStats = async (
   esClient: ElasticsearchClient,

--- a/x-pack/plugins/cloud_security_posture/server/lib/telemetry/collectors/installation_stats_collector.ts
+++ b/x-pack/plugins/cloud_security_posture/server/lib/telemetry/collectors/installation_stats_collector.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import type { CoreStart, Logger, SavedObjectsClientContract } from '@kbn/core/server';
+import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
+import {
+  PackagePolicy,
+  PACKAGE_POLICY_SAVED_OBJECT_TYPE,
+  SO_SEARCH_LIMIT,
+} from '@kbn/fleet-plugin/common';
+import type { CspServerPluginStart, CspServerPluginStartDeps } from '../../../types';
+
+import type { CloudSecurityInstallationStats } from './types';
+import { CLOUD_SECURITY_POSTURE_PACKAGE_NAME } from '../../../../common/constants';
+import { agentPolicyService } from '@kbn/fleet-plugin/server/services';
+
+export const getInstallationStats = async (
+  esClient: ElasticsearchClient,
+  soClient: SavedObjectsClientContract,
+  coreServices: Promise<[CoreStart, CspServerPluginStartDeps, CspServerPluginStart]>,
+  logger: Logger
+): Promise<CloudSecurityInstallationStats[]> => {
+  const [, cspServerPluginStartDeps] = await coreServices;
+
+  const cspContext = {
+    logger,
+    esClient,
+    soClient,
+    agentPolicyService: cspServerPluginStartDeps.fleet.agentPolicyService,
+    packagePolicyService: cspServerPluginStartDeps.fleet.packagePolicyService,
+    isPluginInitialized,
+  };
+
+  const packagePolicies = await cspContext.packagePolicyService.list(soClient, {
+    perPage: SO_SEARCH_LIMIT,
+    kuery: `${PACKAGE_POLICY_SAVED_OBJECT_TYPE}.package.name:"${CLOUD_SECURITY_POSTURE_PACKAGE_NAME}"`,
+  });
+
+  if (!packagePolicies?.items) return [];
+
+  const agentPolicies = await agentPolicyService.list(soClient, {
+    perPage: SO_SEARCH_LIMIT,
+    page: 1,
+    withAgentCount: true,
+    kuery: '',
+  });
+
+  const installationStats: CloudSecurityInstallationStats[] = packagePolicies.items.map(
+    (packagePolicy: PackagePolicy): CloudSecurityInstallationStats => {
+      const agentCounts = agentPolicies?.items.find(
+        (agentPolicy) => agentPolicy?.id === packagePolicy.policy_id
+      )?.agents;
+      return {
+        package_policy_id: packagePolicy.id,
+        feature: packagePolicy.vars?.posture?.value as string,
+        deployment_mode: packagePolicy.vars?.deployment?.value as string,
+        package_version: packagePolicy.package?.version as string,
+        created_at: packagePolicy.created_at,
+        created_by: packagePolicy.created_by,
+        agent_policy_id: packagePolicy.policy_id,
+        agent_count: agentCounts ?? 0,
+      };
+    }
+  );
+
+  return installationStats;
+};
+
+const isPluginInitialized = (): boolean => {
+  return true;
+};

--- a/x-pack/plugins/cloud_security_posture/server/lib/telemetry/collectors/installation_stats_collector.ts
+++ b/x-pack/plugins/cloud_security_posture/server/lib/telemetry/collectors/installation_stats_collector.ts
@@ -4,14 +4,15 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { agentPolicyService } from '@kbn/fleet-plugin/server/services';
 import type { CoreStart, Logger, SavedObjectsClientContract } from '@kbn/core/server';
 import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
 import {
+  AgentPolicy,
   PackagePolicy,
   PACKAGE_POLICY_SAVED_OBJECT_TYPE,
   SO_SEARCH_LIMIT,
 } from '@kbn/fleet-plugin/common';
+import { agentPolicyService } from '@kbn/fleet-plugin/server/services';
 import type { CloudSecurityInstallationStats } from './types';
 import type { CspServerPluginStart, CspServerPluginStartDeps } from '../../../types';
 import { CLOUD_SECURITY_POSTURE_PACKAGE_NAME } from '../../../../common/constants';
@@ -33,36 +34,47 @@ export const getInstallationStats = async (
     isPluginInitialized,
   };
 
+  const getInstalledPackagePolicies = async (
+    packagePolicies: PackagePolicy[],
+    agentPolicies: AgentPolicy[]
+  ) => {
+    const installationStats = await packagePolicies.map(
+      (packagePolicy: PackagePolicy): CloudSecurityInstallationStats => {
+        const agentCounts =
+          agentPolicies?.find((agentPolicy) => agentPolicy?.id === packagePolicy.policy_id)
+            ?.agents ?? 0;
+
+        return {
+          package_policy_id: packagePolicy.id,
+          feature: packagePolicy.vars?.posture?.value as string,
+          deployment_mode: packagePolicy.vars?.deployment?.value as string,
+          package_version: packagePolicy.package?.version as string,
+          created_at: packagePolicy.created_at,
+          created_by: packagePolicy.created_by,
+          agent_policy_id: packagePolicy.policy_id,
+          agent_count: agentCounts,
+        };
+      }
+    );
+    return installationStats;
+  };
+
   const packagePolicies = await cspContext.packagePolicyService.list(soClient, {
     perPage: SO_SEARCH_LIMIT,
     kuery: `${PACKAGE_POLICY_SAVED_OBJECT_TYPE}.package.name:"${CLOUD_SECURITY_POSTURE_PACKAGE_NAME}"`,
   });
 
-  if (!packagePolicies?.items) return [];
-
   const agentPolicies = await agentPolicyService.list(soClient, {
     perPage: SO_SEARCH_LIMIT,
-    page: 1,
-    withAgentCount: true,
     kuery: '',
+    esClient,
+    withAgentCount: true,
   });
+  if (!packagePolicies) return [];
 
-  const installationStats: CloudSecurityInstallationStats[] = packagePolicies.items.map(
-    (packagePolicy: PackagePolicy): CloudSecurityInstallationStats => {
-      const agentCounts = agentPolicies?.items.find(
-        (agentPolicy) => agentPolicy?.id === packagePolicy.policy_id
-      )?.agents;
-      return {
-        package_policy_id: packagePolicy.id,
-        feature: packagePolicy.vars?.posture?.value as string,
-        deployment_mode: packagePolicy.vars?.deployment?.value as string,
-        package_version: packagePolicy.package?.version as string,
-        created_at: packagePolicy.created_at,
-        created_by: packagePolicy.created_by,
-        agent_policy_id: packagePolicy.policy_id,
-        agent_count: agentCounts ?? 0,
-      };
-    }
+  const installationStats: CloudSecurityInstallationStats[] = await getInstalledPackagePolicies(
+    packagePolicies.items,
+    agentPolicies?.items || []
   );
 
   return installationStats;

--- a/x-pack/plugins/cloud_security_posture/server/lib/telemetry/collectors/register.ts
+++ b/x-pack/plugins/cloud_security_posture/server/lib/telemetry/collectors/register.ts
@@ -14,6 +14,7 @@ import { cspmUsageSchema } from './schema';
 import { CspmUsage } from './types';
 import { getAccountsStats } from './accounts_stats_collector';
 import { getRulesStats } from './rules_stats_collector';
+import { getInstallationStats } from './installation_stats_collector';
 
 export function registerCspmUsageCollector(
   logger: Logger,
@@ -33,23 +34,31 @@ export function registerCspmUsageCollector(
       return true;
     },
     fetch: async (collectorFetchContext: CollectorFetchContext) => {
-      const [indicesStats, accountsStats, resourcesStats, rulesStats] = await Promise.all([
-        getIndicesStats(
-          collectorFetchContext.esClient,
-          collectorFetchContext.soClient,
-          coreServices,
-          logger
-        ),
-        getAccountsStats(collectorFetchContext.esClient, logger),
-        getResourcesStats(collectorFetchContext.esClient, logger),
-        getRulesStats(collectorFetchContext.esClient, logger),
-      ]);
+      const [indicesStats, accountsStats, resourcesStats, rulesStats, installationStats] =
+        await Promise.all([
+          getIndicesStats(
+            collectorFetchContext.esClient,
+            collectorFetchContext.soClient,
+            coreServices,
+            logger
+          ),
+          getAccountsStats(collectorFetchContext.esClient, logger),
+          getResourcesStats(collectorFetchContext.esClient, logger),
+          getRulesStats(collectorFetchContext.esClient, logger),
+          getInstallationStats(
+            collectorFetchContext.esClient,
+            collectorFetchContext.soClient,
+            coreServices,
+            logger
+          ),
+        ]);
 
       return {
         indices: indicesStats,
         accounts_stats: accountsStats,
         resources_stats: resourcesStats,
         rules_stats: rulesStats,
+        installation_stats: installationStats,
       };
     },
     schema: cspmUsageSchema,

--- a/x-pack/plugins/cloud_security_posture/server/lib/telemetry/collectors/schema.ts
+++ b/x-pack/plugins/cloud_security_posture/server/lib/telemetry/collectors/schema.ts
@@ -143,4 +143,17 @@ export const cspmUsageSchema: MakeSchemaFrom<CspmUsage> = {
       failed_findings_count: { type: 'long' },
     },
   },
+  installation_stats: {
+    type: 'array',
+    items: {
+      package_policy_id: { type: 'keyword' },
+      feature: { type: 'keyword' },
+      package_version: { type: 'keyword' },
+      agent_policy_id: { type: 'keyword' },
+      deployment_mode: { type: 'keyword' },
+      created_at: { type: 'date' },
+      created_by: { type: 'keyword' },
+      agent_count: { type: 'long' },
+    },
+  },
 };

--- a/x-pack/plugins/cloud_security_posture/server/lib/telemetry/collectors/types.ts
+++ b/x-pack/plugins/cloud_security_posture/server/lib/telemetry/collectors/types.ts
@@ -12,6 +12,7 @@ export interface CspmUsage {
   resources_stats: CspmResourcesStats[];
   accounts_stats: CspmAccountsStats[];
   rules_stats: CspmRulesStats[];
+  installation_stats: CloudSecurityInstallationStats[];
 }
 
 export interface PackageSetupStatus {
@@ -75,4 +76,15 @@ export interface CspmRulesStats {
   benchmark_version: string;
   passed_findings_count: number;
   failed_findings_count: number;
+}
+
+export interface CloudSecurityInstallationStats {
+  package_policy_id: string;
+  feature: string;
+  package_version: string;
+  agent_policy_id: string;
+  deployment_mode: string;
+  created_at: string;
+  created_by: string;
+  agent_count: number;
 }

--- a/x-pack/plugins/telemetry_collection_xpack/schema/xpack_plugins.json
+++ b/x-pack/plugins/telemetry_collection_xpack/schema/xpack_plugins.json
@@ -5659,6 +5659,37 @@
               }
             }
           }
+        },
+        "installation_stats": {
+          "type": "array",
+          "items": {
+            "properties": {
+              "package_policy_id": {
+                "type": "keyword"
+              },
+              "feature": {
+                "type": "keyword"
+              },
+              "package_version": {
+                "type": "keyword"
+              },
+              "agent_policy_id": {
+                "type": "keyword"
+              },
+              "deployment_mode": {
+                "type": "keyword"
+              },
+              "created_at": {
+                "type": "date"
+              },
+              "created_by": {
+                "type": "keyword"
+              },
+              "agent_count": {
+                "type": "long"
+              }
+            }
+          }
         }
       }
     },


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.

 Add `installations_stats` collector which includes the following fields.

The installation stats collector telemetry we used for cloud security product adoption funnel. 
The `installation stats` collector will identify the following:
-  which cloud security integration is being installed ('cnvm', 'cspm, 'kspm') 
-  what deployment environment for cloud security integration( eks, aws, gcp, ake, self_managed)
-  how many agents deployed per integration installation

https://github.com/elastic/kibana/assets/17135495/1340eef2-7df3-46ee-8c6d-4e61af33289b



Here is the Telemetry Schema for Installation Stats

| Column             | Data Type    | Description                                               |
|--------------------|--------------|-----------------------------------------------------------|
| package_policy_id  | string | The ID of the package policy of integration installed                             |
| feature            | string | The feature integration(cnvm, cspm, kspm) associated with the package policy             |
| package_name       | string | The name of the package associated with the policy         |
| package_version    | string | The version of the package associated with the policy which is cloud_security_posture     |
| agent_policy_id    |string | The ID of the agent policy linked to the package policy    |
| deployment_mode    | string | The deployment mode for the kspm, cspm or cvnm(eks, gcp, aws, self-managed)                 |
| created_at         |  string   | The timestamp when the package policy was created          |
| created_by         | string | The username of the creator of the package policy          |
| agent_count        |number |  count of agents          |


