### PR TITLE
Add technical preview badge to alert detail pages of Infra rules

### DIFF
--- a/x-pack/plugins/observability/public/pages/alert_details/components/page_title.tsx
+++ b/x-pack/plugins/observability/public/pages/alert_details/components/page_title.tsx
@@ -52,7 +52,8 @@ export function PageTitle({ alert }: PageTitleProps) {
 
   const showExperimentalBadge =
     alert.fields[ALERT_RULE_CATEGORY] === 'Log threshold' ||
-    alert.fields[ALERT_RULE_CATEGORY] === 'Metric threshold';
+    alert.fields[ALERT_RULE_CATEGORY] === 'Metric threshold' ||
+    alert.fields[ALERT_RULE_CATEGORY] === 'Inventory';
 
   return (
     <div data-test-subj="page-title-container">

--- a/x-pack/plugins/observability/public/pages/alert_details/components/page_title.tsx
+++ b/x-pack/plugins/observability/public/pages/alert_details/components/page_title.tsx
@@ -29,6 +29,7 @@ import moment from 'moment';
 import { css } from '@emotion/react';
 import { asDuration } from '../../../../common/utils/formatters';
 import { TopAlert } from '../../../typings/alerts';
+import { ExperimentalBadge } from '../../../components/experimental_badge';
 
 export interface PageTitleProps {
   alert: TopAlert | null;
@@ -49,9 +50,16 @@ export function PageTitle({ alert }: PageTitleProps) {
 
   if (!alert) return <EuiLoadingSpinner />;
 
+  const showExperimentalBadge =
+    alert.fields[ALERT_RULE_CATEGORY] === 'Log threshold' ||
+    alert.fields[ALERT_RULE_CATEGORY] === 'Metric threshold';
+
   return (
     <div data-test-subj="page-title-container">
-      {pageTitleContent(alert.fields[ALERT_RULE_CATEGORY])}
+      <EuiFlexGroup direction="row" alignItems="center" gutterSize="s">
+        {pageTitleContent(alert.fields[ALERT_RULE_CATEGORY])}
+        {showExperimentalBadge && <ExperimentalBadge />}
+      </EuiFlexGroup>
       <EuiSpacer size="l" />
       <EuiFlexGroup direction="row" alignItems="center" gutterSize="xl">
         <EuiFlexItem grow={false}>


### PR DESCRIPTION
Adds technical preview badge to alert detail pages of Infra rules.

### Log threshold alert details page

<img width="1512" alt="Screenshot 2023-06-16 at 10 52 21" src="https://github.com/elastic/kibana/assets/69037875/f037c362-2a65-41ed-adce-70c53051981c">

<img width="1507" alt="Screenshot 2023-06-16 at 10 50 35" src="https://github.com/elastic/kibana/assets/69037875/ecef82a4-c3e8-4711-822e-5d9f57f5c883">

### Metric threshold alert details page

<img width="1522" alt="Screenshot 2023-06-16 at 10 50 54" src="https://github.com/elastic/kibana/assets/69037875/2fe96ebf-e969-4b2c-b537-0af520b2603a">

### Inventory threshold alert details page

<img width="1526" alt="Screenshot 2023-06-16 at 10 51 14" src="https://github.com/elastic/kibana/assets/69037875/d8721da4-cc5d-461f-9cfe-f3b14e0c5c89">
