### PR TITLE
[Security Solution] Filter by rule execution status (last response) on Rule Management page

### DIFF
--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/logic/types.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/logic/types.ts
@@ -33,6 +33,7 @@ import type { RuleSnoozeSettings } from '@kbn/triggers-actions-ui-plugin/public/
 import { PositiveInteger } from '@kbn/securitysolution-io-ts-types';
 import type { WarningSchema } from '../../../../common/detection_engine/schemas/response';
 import { RuleExecutionSummary } from '../../../../common/detection_engine/rule_monitoring';
+import type { RuleExecutionStatus } from '../../../../common/detection_engine/rule_monitoring';
 import {
   AlertSuppression,
   AlertsIndex,
@@ -250,6 +251,7 @@ export interface FilterOptions {
   tags: string[];
   excludeRuleTypes?: Type[];
   enabled?: boolean; // undefined is to display all the rules
+  ruleExecutionStatus?: RuleExecutionStatus; // undefined means "all"
 }
 
 export interface FetchRulesResponse {

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/logic/utils.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/logic/utils.ts
@@ -7,6 +7,7 @@
 
 import { escapeKuery } from '../../../common/lib/kuery';
 import type { FilterOptions } from './types';
+import { RuleExecutionStatus } from '../../../../common/detection_engine/rule_monitoring/model/execution_status';
 
 const SEARCHABLE_RULE_PARAMS = [
   'alert.attributes.name',
@@ -33,6 +34,7 @@ export const convertRulesFilterToKQL = ({
   tags,
   excludeRuleTypes = [],
   enabled,
+  ruleExecutionStatus,
 }: FilterOptions): string => {
   const filters: string[] = [];
 
@@ -68,6 +70,14 @@ export const convertRulesFilterToKQL = ({
         .map((ruleType) => `"${escapeKuery(ruleType)}"`)
         .join(' OR ')})`
     );
+  }
+
+  if (ruleExecutionStatus === RuleExecutionStatus.succeeded) {
+    filters.push(`alert.attributes.lastRun.outcome: "succeeded"`);
+  } else if (ruleExecutionStatus === RuleExecutionStatus['partial failure']) {
+    filters.push(`alert.attributes.lastRun.outcome: "partial failure"`);
+  } else if (ruleExecutionStatus === RuleExecutionStatus.failed) {
+    filters.push(`alert.attributes.lastRun.outcome: "failed"`);
   }
 
   return filters.join(' AND ');

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/logic/utils.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/logic/utils.ts
@@ -20,6 +20,12 @@ const SEARCHABLE_RULE_PARAMS = [
   'alert.attributes.params.threat.technique.subtechnique.name',
 ];
 
+const ENABLED_FIELD = 'alert.attributes.enabled';
+const TAGS_FIELD = 'alert.attributes.tags';
+const PARAMS_TYPE_FIELD = 'alert.attributes.params.type';
+const PARAMS_IMMUTABLE_FIELD = 'alert.attributes.params.immutable';
+const LAST_RUN_OUTCOME_FIELD = 'alert.attributes.lastRun.outcome';
+
 /**
  * Convert rules filter options object to KQL query
  *
@@ -41,19 +47,17 @@ export const convertRulesFilterToKQL = ({
   if (showCustomRules && showElasticRules) {
     // if both showCustomRules && showElasticRules selected we omit filter, as it includes all existing rules
   } else if (showElasticRules) {
-    filters.push('alert.attributes.params.immutable: true');
+    filters.push(`${PARAMS_IMMUTABLE_FIELD}: true`);
   } else if (showCustomRules) {
-    filters.push('alert.attributes.params.immutable: false');
+    filters.push(`${PARAMS_IMMUTABLE_FIELD}: false`);
   }
 
   if (enabled !== undefined) {
-    filters.push(`alert.attributes.enabled: ${enabled ? 'true' : 'false'}`);
+    filters.push(`${ENABLED_FIELD}: ${enabled ? 'true' : 'false'}`);
   }
 
   if (tags.length > 0) {
-    filters.push(
-      `alert.attributes.tags:(${tags.map((tag) => `"${escapeKuery(tag)}"`).join(' AND ')})`
-    );
+    filters.push(`${TAGS_FIELD}:(${tags.map((tag) => `"${escapeKuery(tag)}"`).join(' AND ')})`);
   }
 
   if (filter.length) {
@@ -66,18 +70,18 @@ export const convertRulesFilterToKQL = ({
 
   if (excludeRuleTypes.length) {
     filters.push(
-      `NOT alert.attributes.params.type: (${excludeRuleTypes
+      `NOT ${PARAMS_TYPE_FIELD}: (${excludeRuleTypes
         .map((ruleType) => `"${escapeKuery(ruleType)}"`)
         .join(' OR ')})`
     );
   }
 
   if (ruleExecutionStatus === RuleExecutionStatus.succeeded) {
-    filters.push(`alert.attributes.lastRun.outcome: "succeeded"`);
+    filters.push(`${LAST_RUN_OUTCOME_FIELD}: "succeeded"`);
   } else if (ruleExecutionStatus === RuleExecutionStatus['partial failure']) {
-    filters.push(`alert.attributes.lastRun.outcome: "warning"`);
+    filters.push(`${LAST_RUN_OUTCOME_FIELD}: "warning"`);
   } else if (ruleExecutionStatus === RuleExecutionStatus.failed) {
-    filters.push(`alert.attributes.lastRun.outcome: "failed"`);
+    filters.push(`${LAST_RUN_OUTCOME_FIELD}: "failed"`);
   }
 
   return filters.join(' AND ');

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/logic/utils.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/logic/utils.ts
@@ -75,7 +75,7 @@ export const convertRulesFilterToKQL = ({
   if (ruleExecutionStatus === RuleExecutionStatus.succeeded) {
     filters.push(`alert.attributes.lastRun.outcome: "succeeded"`);
   } else if (ruleExecutionStatus === RuleExecutionStatus['partial failure']) {
-    filters.push(`alert.attributes.lastRun.outcome: "partial failure"`);
+    filters.push(`alert.attributes.lastRun.outcome: "warning"`);
   } else if (ruleExecutionStatus === RuleExecutionStatus.failed) {
     filters.push(`alert.attributes.lastRun.outcome: "failed"`);
   }

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table/rules_table_context.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table/rules_table_context.tsx
@@ -206,7 +206,10 @@ export const RulesTableContextProvider = ({ children }: RulesTableContextProvide
     showElasticRules:
       savedFilter?.source === RuleSource.Prebuilt ?? DEFAULT_FILTER_OPTIONS.showElasticRules,
     enabled: savedFilter?.enabled,
+    ruleExecutionStatus:
+      savedFilter?.ruleExecutionStatus ?? DEFAULT_FILTER_OPTIONS.ruleExecutionStatus,
   });
+
   const [sortingOptions, setSortingOptions] = useState<SortingOptions>({
     field: savedSorting?.field ?? DEFAULT_SORTING_OPTIONS.field,
     order: savedSorting?.order ?? DEFAULT_SORTING_OPTIONS.order,
@@ -248,6 +251,7 @@ export const RulesTableContextProvider = ({ children }: RulesTableContextProvide
       showCustomRules: DEFAULT_FILTER_OPTIONS.showCustomRules,
       tags: DEFAULT_FILTER_OPTIONS.tags,
       enabled: undefined,
+      ruleExecutionStatus: DEFAULT_FILTER_OPTIONS.ruleExecutionStatus,
     });
     setSortingOptions({
       field: DEFAULT_SORTING_OPTIONS.field,

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table/rules_table_defaults.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table/rules_table_defaults.ts
@@ -13,6 +13,7 @@ export const DEFAULT_FILTER_OPTIONS: FilterOptions = {
   showCustomRules: false,
   showElasticRules: false,
   enabled: undefined,
+  ruleExecutionStatus: undefined,
 };
 export const DEFAULT_SORTING_OPTIONS: SortingOptions = {
   field: 'enabled',

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table/rules_table_saved_state.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table/rules_table_saved_state.ts
@@ -8,6 +8,7 @@
 import * as t from 'io-ts';
 import { enumeration } from '@kbn/securitysolution-io-ts-types';
 import { SortingOptions, PaginationOptions } from '../../../../rule_management/logic';
+import { TRuleExecutionStatus } from '../../../../../../common/detection_engine/rule_monitoring/model/execution_status';
 
 export enum RuleSource {
   Prebuilt = 'prebuilt',
@@ -20,6 +21,7 @@ export const RulesTableSavedFilter = t.partial({
   source: enumeration('RuleSource', RuleSource),
   tags: t.array(t.string),
   enabled: t.boolean,
+  ruleExecutionStatus: TRuleExecutionStatus,
 });
 
 export type RulesTableSavedSorting = t.TypeOf<typeof RulesTableSavedSorting>;

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table/use_rules_table_saved_state.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table/use_rules_table_saved_state.ts
@@ -67,6 +67,8 @@ function validateState(
     source: filterFromUrl?.source ?? filterFromStorage?.source,
     tags: filterFromUrl?.tags ?? filterFromStorage?.tags,
     enabled: filterFromUrl?.enabled ?? filterFromStorage?.enabled,
+    ruleExecutionStatus:
+      filterFromUrl?.ruleExecutionStatus ?? filterFromStorage?.ruleExecutionStatus,
   };
 
   const [sortingFromUrl] = validateNonExact(urlState, RulesTableSavedSorting);

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table/use_sync_rules_table_saved_state.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table/use_sync_rules_table_saved_state.ts
@@ -74,6 +74,11 @@ export function useSyncRulesTableSavedState(): void {
       storageStateToSave.perPage = state.pagination.perPage;
     }
 
+    if (state.filterOptions.ruleExecutionStatus !== undefined) {
+      urlStateToSave.ruleExecutionStatus = state.filterOptions.ruleExecutionStatus;
+      storageStateToSave.ruleExecutionStatus = state.filterOptions.ruleExecutionStatus;
+    }
+
     const hasUrlStateToSave = Object.keys(urlStateToSave).length > 0;
     const hasStorageStateToSave = Object.keys(storageStateToSave).length > 0;
 

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table_filters/rule_execution_status_popover.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table_filters/rule_execution_status_popover.tsx
@@ -12,8 +12,6 @@ import * as i18n from '../../../../../detections/pages/detection_engine/rules/tr
 import { RuleExecutionStatus } from '../../../../../../common/detection_engine/rule_monitoring/model/execution_status';
 import { getCapitalizedStatusText } from '../../../../../detections/components/rules/rule_execution_status/utils';
 
-const TAGS_POPOVER_WIDTH = 274;
-
 interface RuleExecutionStatusPopoverProps {
   selectedStatus?: RuleExecutionStatus;
   onSelectedStatusChanged: (newStatus?: RuleExecutionStatus) => void;
@@ -75,7 +73,6 @@ const RuleExecutionStatusPopoverComponent = ({
       isSelected={isExecutionStatusPopoverOpen}
       hasActiveFilters={selectedStatus !== undefined}
       numActiveFilters={selectedStatus !== undefined ? 1 : 0}
-      data-test-subj="tags-filter-popover-button"
     >
       {i18n.COLUMN_LAST_RESPONSE}
     </EuiFilterButton>
@@ -91,20 +88,19 @@ const RuleExecutionStatusPopoverComponent = ({
       }}
       panelPaddingSize="none"
       repositionOnScroll
-      panelProps={{
-        'data-test-subj': 'tags-filter-popover',
-      }}
     >
       <EuiSelectable
         aria-label={i18n.RULES_TAG_SEARCH}
         options={selectableOptions}
         onChange={handleSelectableOptionsChange}
-        emptyMessage={i18n.NO_TAGS_AVAILABLE}
-        noMatchesMessage={i18n.NO_TAGS_AVAILABLE}
         singleSelection
       >
         {(list, search) => (
-          <div style={{ width: TAGS_POPOVER_WIDTH }}>
+          <div
+            css={`
+              width: 200px;
+            `}
+          >
             <EuiPopoverTitle>{search}</EuiPopoverTitle>
             {list}
           </div>

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table_filters/rule_execution_status_popover.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table_filters/rule_execution_status_popover.tsx
@@ -11,6 +11,7 @@ import { EuiFilterButton, EuiPopover, EuiPopoverTitle, EuiSelectable } from '@el
 import * as i18n from '../../../../../detections/pages/detection_engine/rules/translations';
 import { RuleExecutionStatus } from '../../../../../../common/detection_engine/rule_monitoring/model/execution_status';
 import { getCapitalizedStatusText } from '../../../../../detections/components/rules/rule_execution_status/utils';
+
 const TAGS_POPOVER_WIDTH = 274;
 
 interface RuleExecutionStatusPopoverProps {

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table_filters/rule_execution_status_popover.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table_filters/rule_execution_status_popover.tsx
@@ -1,0 +1,120 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useState } from 'react';
+import type { EuiSelectableOption } from '@elastic/eui';
+import { EuiFilterButton, EuiPopover, EuiPopoverTitle, EuiSelectable } from '@elastic/eui';
+import * as i18n from '../../../../../detections/pages/detection_engine/rules/translations';
+import { RuleExecutionStatus } from '../../../../../../common/detection_engine/rule_monitoring/model/execution_status';
+import { getCapitalizedStatusText } from '../../../../../detections/components/rules/rule_execution_status/utils';
+const TAGS_POPOVER_WIDTH = 274;
+
+interface RuleExecutionStatusPopoverProps {
+  selectedStatus?: RuleExecutionStatus;
+  onSelectedStatusChanged: (newStatus?: RuleExecutionStatus) => void;
+}
+
+/**
+ * Popover for selecting last rule execution status to filter on
+ *
+ * @param selectedStatus Selected rule execution status
+ * @param onSelectedStatusChanged change listener to be notified when rule execution status selection changes
+ */
+const RuleExecutionStatusPopoverComponent = ({
+  selectedStatus,
+  onSelectedStatusChanged,
+}: RuleExecutionStatusPopoverProps) => {
+  const [isExecutionStatusPopoverOpen, setIsExecutionStatusPopoverOpen] = useState(false);
+
+  const [selectableOptions, setSelectableOptions] = useState<EuiSelectableOption[]>(() => [
+    {
+      label: getCapitalizedStatusText(RuleExecutionStatus.succeeded) as string,
+      data: { status: RuleExecutionStatus.succeeded },
+      checked: selectedStatus === RuleExecutionStatus.succeeded ? 'on' : undefined,
+    },
+    {
+      label: getCapitalizedStatusText(RuleExecutionStatus['partial failure']) as string,
+      data: { status: RuleExecutionStatus['partial failure'] },
+      checked: selectedStatus === RuleExecutionStatus['partial failure'] ? 'on' : undefined,
+    },
+    {
+      label: getCapitalizedStatusText(RuleExecutionStatus.failed) as string,
+      data: { status: RuleExecutionStatus.failed },
+      checked: selectedStatus === RuleExecutionStatus.failed ? 'on' : undefined,
+    },
+  ]);
+
+  const handleSelectableOptionsChange = (
+    newOptions: EuiSelectableOption[],
+    _: unknown,
+    changedOption: EuiSelectableOption
+  ) => {
+    setSelectableOptions(newOptions);
+    setIsExecutionStatusPopoverOpen(false);
+
+    if (changedOption.checked && changedOption?.data?.status) {
+      onSelectedStatusChanged(changedOption.data.status as RuleExecutionStatus);
+    } else if (!changedOption.checked) {
+      onSelectedStatusChanged();
+    }
+  };
+
+  const triggerButton = (
+    <EuiFilterButton
+      grow
+      iconType="arrowDown"
+      onClick={() => {
+        setIsExecutionStatusPopoverOpen(!isExecutionStatusPopoverOpen);
+      }}
+      numFilters={selectableOptions.length}
+      isSelected={isExecutionStatusPopoverOpen}
+      hasActiveFilters={selectedStatus !== undefined}
+      numActiveFilters={selectedStatus !== undefined ? 1 : 0}
+      data-test-subj="tags-filter-popover-button"
+    >
+      {i18n.COLUMN_LAST_RESPONSE}
+    </EuiFilterButton>
+  );
+
+  return (
+    <EuiPopover
+      ownFocus
+      button={triggerButton}
+      isOpen={isExecutionStatusPopoverOpen}
+      closePopover={() => {
+        setIsExecutionStatusPopoverOpen(!isExecutionStatusPopoverOpen);
+      }}
+      panelPaddingSize="none"
+      repositionOnScroll
+      panelProps={{
+        'data-test-subj': 'tags-filter-popover',
+      }}
+    >
+      <EuiSelectable
+        aria-label={i18n.RULES_TAG_SEARCH}
+        options={selectableOptions}
+        onChange={handleSelectableOptionsChange}
+        emptyMessage={i18n.NO_TAGS_AVAILABLE}
+        noMatchesMessage={i18n.NO_TAGS_AVAILABLE}
+        singleSelection
+      >
+        {(list, search) => (
+          <div style={{ width: TAGS_POPOVER_WIDTH }}>
+            <EuiPopoverTitle>{search}</EuiPopoverTitle>
+            {list}
+          </div>
+        )}
+      </EuiSelectable>
+    </EuiPopover>
+  );
+};
+
+RuleExecutionStatusPopoverComponent.displayName = 'RuleExecutionStatusPopoverComponent';
+
+export const RuleExecutionStatusPopover = React.memo(RuleExecutionStatusPopoverComponent);
+
+RuleExecutionStatusPopover.displayName = 'RuleExecutionStatusPopover';

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table_filters/rule_execution_status_selector.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table_filters/rule_execution_status_selector.tsx
@@ -10,7 +10,12 @@ import type { EuiSelectableOption } from '@elastic/eui';
 import { EuiFilterButton, EuiPopover, EuiSelectable } from '@elastic/eui';
 import * as i18n from '../../../../../detections/pages/detection_engine/rules/translations';
 import { RuleExecutionStatus } from '../../../../../../common/detection_engine/rule_monitoring/model/execution_status';
+import { getCapitalizedStatusText } from '../../../../../detections/components/rules/rule_execution_status/utils';
 import { RuleStatusBadge } from '../../../../../detections/components/rules/rule_execution_status/rule_status_badge';
+
+interface OptionData {
+  status: RuleExecutionStatus;
+}
 
 interface RuleExecutionStatusSelectorProps {
   selectedStatus?: RuleExecutionStatus;
@@ -31,17 +36,17 @@ const RuleExecutionStatusSelectorComponent = ({
 
   const selectableOptions = [
     {
-      label: RuleExecutionStatus.succeeded,
+      label: getCapitalizedStatusText(RuleExecutionStatus.succeeded),
       data: { status: RuleExecutionStatus.succeeded },
       checked: selectedStatus === RuleExecutionStatus.succeeded ? 'on' : undefined,
     },
     {
-      label: RuleExecutionStatus['partial failure'],
+      label: getCapitalizedStatusText(RuleExecutionStatus['partial failure']),
       data: { status: RuleExecutionStatus['partial failure'] },
       checked: selectedStatus === RuleExecutionStatus['partial failure'] ? 'on' : undefined,
     },
     {
-      label: RuleExecutionStatus.failed,
+      label: getCapitalizedStatusText(RuleExecutionStatus.failed),
       data: { status: RuleExecutionStatus.failed },
       checked: selectedStatus === RuleExecutionStatus.failed ? 'on' : undefined,
     },
@@ -93,10 +98,20 @@ const RuleExecutionStatusSelectorComponent = ({
         options={selectableOptions}
         onChange={handleSelectableOptionsChange}
         singleSelection
-        listProps={{ isVirtualized: false }}
+        listProps={{
+          isVirtualized: false,
+        }}
         renderOption={(option) => {
-          const status = option.label as RuleExecutionStatus;
-          return <RuleStatusBadge status={status} />;
+          const status = (option as EuiSelectableOption<OptionData>).status;
+          return (
+            <div
+              css={`
+                margin-top: 4px; // aligns the badge within the option
+              `}
+            >
+              <RuleStatusBadge status={status} showTooltip={false} />
+            </div>
+          );
         }}
       >
         {(list) => (

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table_filters/rule_execution_status_selector.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table_filters/rule_execution_status_selector.tsx
@@ -34,23 +34,23 @@ const RuleExecutionStatusSelectorComponent = ({
 }: RuleExecutionStatusSelectorProps) => {
   const [isExecutionStatusPopoverOpen, setIsExecutionStatusPopoverOpen] = useState(false);
 
-  const selectableOptions = [
+  const selectableOptions: EuiSelectableOption[] = [
     {
-      label: getCapitalizedStatusText(RuleExecutionStatus.succeeded),
+      label: getCapitalizedStatusText(RuleExecutionStatus.succeeded) || '',
       data: { status: RuleExecutionStatus.succeeded },
       checked: selectedStatus === RuleExecutionStatus.succeeded ? 'on' : undefined,
     },
     {
-      label: getCapitalizedStatusText(RuleExecutionStatus['partial failure']),
+      label: getCapitalizedStatusText(RuleExecutionStatus['partial failure']) || '',
       data: { status: RuleExecutionStatus['partial failure'] },
       checked: selectedStatus === RuleExecutionStatus['partial failure'] ? 'on' : undefined,
     },
     {
-      label: getCapitalizedStatusText(RuleExecutionStatus.failed),
+      label: getCapitalizedStatusText(RuleExecutionStatus.failed) || '',
       data: { status: RuleExecutionStatus.failed },
       checked: selectedStatus === RuleExecutionStatus.failed ? 'on' : undefined,
     },
-  ] as EuiSelectableOption[];
+  ];
 
   const handleSelectableOptionsChange = (
     newOptions: EuiSelectableOption[],

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table_filters/rule_execution_status_selector.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table_filters/rule_execution_status_selector.tsx
@@ -10,7 +10,7 @@ import type { EuiSelectableOption } from '@elastic/eui';
 import { EuiFilterButton, EuiPopover, EuiSelectable } from '@elastic/eui';
 import * as i18n from '../../../../../detections/pages/detection_engine/rules/translations';
 import { RuleExecutionStatus } from '../../../../../../common/detection_engine/rule_monitoring/model/execution_status';
-import { getCapitalizedStatusText } from '../../../../../detections/components/rules/rule_execution_status/utils';
+import { RuleStatusBadge } from '../../../../../detections/components/rules/rule_execution_status/rule_status_badge';
 
 interface RuleExecutionStatusSelectorProps {
   selectedStatus?: RuleExecutionStatus;
@@ -31,17 +31,17 @@ const RuleExecutionStatusSelectorComponent = ({
 
   const selectableOptions = [
     {
-      label: getCapitalizedStatusText(RuleExecutionStatus.succeeded),
+      label: RuleExecutionStatus.succeeded,
       data: { status: RuleExecutionStatus.succeeded },
       checked: selectedStatus === RuleExecutionStatus.succeeded ? 'on' : undefined,
     },
     {
-      label: getCapitalizedStatusText(RuleExecutionStatus['partial failure']),
+      label: RuleExecutionStatus['partial failure'],
       data: { status: RuleExecutionStatus['partial failure'] },
       checked: selectedStatus === RuleExecutionStatus['partial failure'] ? 'on' : undefined,
     },
     {
-      label: getCapitalizedStatusText(RuleExecutionStatus.failed),
+      label: RuleExecutionStatus.failed,
       data: { status: RuleExecutionStatus.failed },
       checked: selectedStatus === RuleExecutionStatus.failed ? 'on' : undefined,
     },
@@ -78,7 +78,7 @@ const RuleExecutionStatusSelectorComponent = ({
   );
 
   return (
-    <EuiPopover // has position: absolute
+    <EuiPopover
       ownFocus
       button={triggerButton}
       isOpen={isExecutionStatusPopoverOpen}
@@ -94,6 +94,10 @@ const RuleExecutionStatusSelectorComponent = ({
         onChange={handleSelectableOptionsChange}
         singleSelection
         listProps={{ isVirtualized: false }}
+        renderOption={(option) => {
+          const status = option.label as RuleExecutionStatus;
+          return <RuleStatusBadge status={status} />;
+        }}
       >
         {(list) => (
           <div

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table_filters/rule_execution_status_selector.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table_filters/rule_execution_status_selector.tsx
@@ -7,52 +7,51 @@
 
 import React, { useState } from 'react';
 import type { EuiSelectableOption } from '@elastic/eui';
-import { EuiFilterButton, EuiPopover, EuiPopoverTitle, EuiSelectable } from '@elastic/eui';
+import { EuiFilterButton, EuiPopover, EuiSelectable } from '@elastic/eui';
 import * as i18n from '../../../../../detections/pages/detection_engine/rules/translations';
 import { RuleExecutionStatus } from '../../../../../../common/detection_engine/rule_monitoring/model/execution_status';
 import { getCapitalizedStatusText } from '../../../../../detections/components/rules/rule_execution_status/utils';
 
-interface RuleExecutionStatusPopoverProps {
+interface RuleExecutionStatusSelectorProps {
   selectedStatus?: RuleExecutionStatus;
   onSelectedStatusChanged: (newStatus?: RuleExecutionStatus) => void;
 }
 
 /**
- * Popover for selecting last rule execution status to filter on
+ * Selector for selecting last rule execution status to filter on
  *
  * @param selectedStatus Selected rule execution status
  * @param onSelectedStatusChanged change listener to be notified when rule execution status selection changes
  */
-const RuleExecutionStatusPopoverComponent = ({
+const RuleExecutionStatusSelectorComponent = ({
   selectedStatus,
   onSelectedStatusChanged,
-}: RuleExecutionStatusPopoverProps) => {
+}: RuleExecutionStatusSelectorProps) => {
   const [isExecutionStatusPopoverOpen, setIsExecutionStatusPopoverOpen] = useState(false);
 
-  const [selectableOptions, setSelectableOptions] = useState<EuiSelectableOption[]>(() => [
+  const selectableOptions = [
     {
-      label: getCapitalizedStatusText(RuleExecutionStatus.succeeded) as string,
+      label: getCapitalizedStatusText(RuleExecutionStatus.succeeded),
       data: { status: RuleExecutionStatus.succeeded },
       checked: selectedStatus === RuleExecutionStatus.succeeded ? 'on' : undefined,
     },
     {
-      label: getCapitalizedStatusText(RuleExecutionStatus['partial failure']) as string,
+      label: getCapitalizedStatusText(RuleExecutionStatus['partial failure']),
       data: { status: RuleExecutionStatus['partial failure'] },
       checked: selectedStatus === RuleExecutionStatus['partial failure'] ? 'on' : undefined,
     },
     {
-      label: getCapitalizedStatusText(RuleExecutionStatus.failed) as string,
+      label: getCapitalizedStatusText(RuleExecutionStatus.failed),
       data: { status: RuleExecutionStatus.failed },
       checked: selectedStatus === RuleExecutionStatus.failed ? 'on' : undefined,
     },
-  ]);
+  ] as EuiSelectableOption[];
 
   const handleSelectableOptionsChange = (
     newOptions: EuiSelectableOption[],
     _: unknown,
     changedOption: EuiSelectableOption
   ) => {
-    setSelectableOptions(newOptions);
     setIsExecutionStatusPopoverOpen(false);
 
     if (changedOption.checked && changedOption?.data?.status) {
@@ -79,7 +78,7 @@ const RuleExecutionStatusPopoverComponent = ({
   );
 
   return (
-    <EuiPopover
+    <EuiPopover // has position: absolute
       ownFocus
       button={triggerButton}
       isOpen={isExecutionStatusPopoverOpen}
@@ -90,18 +89,18 @@ const RuleExecutionStatusPopoverComponent = ({
       repositionOnScroll
     >
       <EuiSelectable
-        aria-label={i18n.RULES_TAG_SEARCH}
+        aria-label={i18n.RULE_EXECTION_STATUS_FILTER}
         options={selectableOptions}
         onChange={handleSelectableOptionsChange}
         singleSelection
+        listProps={{ isVirtualized: false }}
       >
-        {(list, search) => (
+        {(list) => (
           <div
             css={`
               width: 200px;
             `}
           >
-            <EuiPopoverTitle>{search}</EuiPopoverTitle>
             {list}
           </div>
         )}
@@ -110,8 +109,8 @@ const RuleExecutionStatusPopoverComponent = ({
   );
 };
 
-RuleExecutionStatusPopoverComponent.displayName = 'RuleExecutionStatusPopoverComponent';
+RuleExecutionStatusSelectorComponent.displayName = 'RuleExecutionStatusSelectorComponent';
 
-export const RuleExecutionStatusPopover = React.memo(RuleExecutionStatusPopoverComponent);
+export const RuleExecutionStatusSelector = React.memo(RuleExecutionStatusSelectorComponent);
 
-RuleExecutionStatusPopover.displayName = 'RuleExecutionStatusPopover';
+RuleExecutionStatusSelector.displayName = 'RuleExecutionStatusSelector';

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table_filters/rules_table_filters.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table_filters/rules_table_filters.tsx
@@ -13,8 +13,10 @@ import { useRuleManagementFilters } from '../../../../rule_management/logic/use_
 import { RULES_TABLE_ACTIONS } from '../../../../../common/lib/apm/user_actions';
 import { useStartTransaction } from '../../../../../common/lib/apm/use_start_transaction';
 import * as i18n from '../../../../../detections/pages/detection_engine/rules/translations';
+import type { RuleExecutionStatus } from '../../../../../../common/detection_engine/rule_monitoring/model/execution_status';
 import { useRulesTableContext } from '../rules_table/rules_table_context';
 import { TagsFilterPopover } from './tags_filter_popover';
+import { RuleExecutionStatusPopover } from './rule_execution_status_popover';
 import { RuleSearchField } from './rule_search_field';
 
 const FilterWrapper = styled(EuiFlexGroup)`
@@ -36,7 +38,13 @@ const RulesTableFiltersComponent = () => {
   const rulesCustomCount = ruleManagementFields?.rules_summary.custom_count;
   const rulesPrebuiltInstalledCount = ruleManagementFields?.rules_summary.prebuilt_installed_count;
 
-  const { showCustomRules, showElasticRules, tags: selectedTags, enabled } = filterOptions;
+  const {
+    showCustomRules,
+    showElasticRules,
+    tags: selectedTags,
+    enabled,
+    ruleExecutionStatus: selectedRuleExecutionStatus,
+  } = filterOptions;
 
   const handleOnSearch = useCallback(
     (filterString) => {
@@ -76,6 +84,16 @@ const RulesTableFiltersComponent = () => {
     [selectedTags, setFilterOptions, startTransaction]
   );
 
+  const handleSelectedExecutionStatus = useCallback(
+    (newExecutionStatus?: RuleExecutionStatus) => {
+      if (newExecutionStatus !== selectedRuleExecutionStatus) {
+        startTransaction({ name: RULES_TABLE_ACTIONS.FILTER });
+        setFilterOptions({ ruleExecutionStatus: newExecutionStatus });
+      }
+    },
+    [selectedRuleExecutionStatus, setFilterOptions, startTransaction]
+  );
+
   return (
     <FilterWrapper gutterSize="m" justifyContent="flexEnd" wrap>
       <RuleSearchField initialValue={filterOptions.filter} onSearch={handleOnSearch} />
@@ -86,6 +104,15 @@ const RulesTableFiltersComponent = () => {
             selectedTags={selectedTags}
             tags={allTags}
             data-test-subj="allRulesTagPopover"
+          />
+        </EuiFilterGroup>
+      </EuiFlexItem>
+
+      <EuiFlexItem grow={false}>
+        <EuiFilterGroup>
+          <RuleExecutionStatusPopover
+            onSelectedStatusChanged={handleSelectedExecutionStatus}
+            selectedStatus={selectedRuleExecutionStatus}
           />
         </EuiFilterGroup>
       </EuiFlexItem>

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table_filters/rules_table_filters.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table_filters/rules_table_filters.tsx
@@ -16,7 +16,7 @@ import * as i18n from '../../../../../detections/pages/detection_engine/rules/tr
 import type { RuleExecutionStatus } from '../../../../../../common/detection_engine/rule_monitoring/model/execution_status';
 import { useRulesTableContext } from '../rules_table/rules_table_context';
 import { TagsFilterPopover } from './tags_filter_popover';
-import { RuleExecutionStatusPopover } from './rule_execution_status_popover';
+import { RuleExecutionStatusSelector } from './rule_execution_status_selector';
 import { RuleSearchField } from './rule_search_field';
 
 const FilterWrapper = styled(EuiFlexGroup)`
@@ -110,7 +110,7 @@ const RulesTableFiltersComponent = () => {
 
       <EuiFlexItem grow={false}>
         <EuiFilterGroup>
-          <RuleExecutionStatusPopover
+          <RuleExecutionStatusSelector
             onSelectedStatusChanged={handleSelectedExecutionStatus}
             selectedStatus={selectedRuleExecutionStatus}
           />

--- a/x-pack/plugins/security_solution/public/detections/components/rules/rule_execution_status/rule_status_badge.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/rule_execution_status/rule_status_badge.tsx
@@ -16,23 +16,32 @@ import { RuleExecutionStatus } from '../../../../../common/detection_engine/rule
 interface RuleStatusBadgeProps {
   status: RuleExecutionStatus | null | undefined;
   message?: string;
+  showTooltip?: boolean;
 }
 
 /**
  * Shows rule execution status
  * @param status - rule execution status
  */
-const RuleStatusBadgeComponent = ({ status, message }: RuleStatusBadgeProps) => {
+const RuleStatusBadgeComponent = ({
+  status,
+  message,
+  showTooltip = true,
+}: RuleStatusBadgeProps) => {
   const isFailedStatus =
     status === RuleExecutionStatus.failed || status === RuleExecutionStatus['partial failure'];
   const statusText = getCapitalizedStatusText(status);
+
   const statusTooltip = isFailedStatus && message ? message : statusText;
+  const tooltipContent = showTooltip
+    ? statusTooltip?.split('\n').map((line) => <p>{line}</p>)
+    : null;
+
   const statusColor = getStatusColor(status);
+
   return (
     <HealthTruncateText
-      tooltipContent={statusTooltip?.split('\n').map((line) => (
-        <p>{line}</p>
-      ))}
+      tooltipContent={tooltipContent}
       healthColor={statusColor}
       dataTestSubj="ruleExecutionStatus"
     >

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/translations.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/translations.ts
@@ -672,6 +672,13 @@ export const NO_TAGS_AVAILABLE = i18n.translate(
   }
 );
 
+export const RULE_EXECTION_STATUS_FILTER = i18n.translate(
+  'xpack.securitySolution.detectionEngine.rules.allRules.filters.ruleExecutionStatusFilter',
+  {
+    defaultMessage: 'Select rule execution status to filter by',
+  }
+);
+
 export const NO_RULES = i18n.translate(
   'xpack.securitySolution.detectionEngine.rules.allRules.filters.noRulesTitle',
   {


### PR DESCRIPTION
**Resolves**: https://github.com/elastic/kibana/issues/138903
**Docs ticket**: https://github.com/elastic/security-docs/issues/3486

## Summary

Adds a dropdown that allows you to filter rules by their rule execution status to the Rule Management page.

<img width="1583" alt="Screenshot 2023-06-16 at 16 34 23" src="https://github.com/elastic/kibana/assets/15949146/abc8234a-4c05-4195-bc15-86b76a108663">



### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

