### PR TITLE
[Security Solution] Reintroduce ML Jobs warning popover on rule upgrade

### DIFF
--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/upgrade_prebuilt_rules_table_buttons.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/upgrade_prebuilt_rules_table_buttons.tsx
@@ -8,12 +8,19 @@
 import { EuiButton, EuiFlexGroup, EuiFlexItem, EuiLoadingSpinner } from '@elastic/eui';
 import React from 'react';
 import * as i18n from './translations';
+import { MlJobUpgradeModal } from '../../../../../detections/components/modals/ml_job_upgrade_modal';
 import { useUpgradePrebuiltRulesTableContext } from './upgrade_prebuilt_rules_table_context';
 
 export const UpgradePrebuiltRulesTableButtons = () => {
   const {
-    state: { rules, selectedRules, loadingRules },
-    actions: { upgradeAllRules, upgradeSelectedRules },
+    state: { rules, selectedRules, loadingRules, isUpgradeModalVisible, legacyJobsInstalled },
+    actions: {
+      upgradeAllRules,
+      upgradeSelectedRules,
+      upgradeRulesWrapper,
+      mlJobUpgradeModalConfirm,
+      mlJobUpgradeModalCancel,
+    },
   } = useUpgradePrebuiltRulesTableContext();
 
   const isRulesAvailableForUpgrade = rules.length > 0;
@@ -23,28 +30,40 @@ export const UpgradePrebuiltRulesTableButtons = () => {
   const isRuleUpgrading = loadingRules.length > 0;
 
   return (
-    <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false} wrap={true}>
-      {shouldDisplayUpgradeSelectedRulesButton ? (
+    <>
+      <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false} wrap={true}>
+        {shouldDisplayUpgradeSelectedRulesButton ? (
+          <EuiFlexItem grow={false}>
+            <EuiButton
+              onClick={() => upgradeRulesWrapper('SPECIFIC_RULES', upgradeSelectedRules)}
+              disabled={isRuleUpgrading}
+            >
+              <>
+                {i18n.UPDATE_SELECTED_RULES(numberOfSelectedRules)}
+                {isRuleUpgrading ? <EuiLoadingSpinner size="s" /> : undefined}
+              </>
+            </EuiButton>
+          </EuiFlexItem>
+        ) : null}
         <EuiFlexItem grow={false}>
-          <EuiButton onClick={upgradeSelectedRules} disabled={isRuleUpgrading}>
-            <>
-              {i18n.UPDATE_SELECTED_RULES(numberOfSelectedRules)}
-              {isRuleUpgrading ? <EuiLoadingSpinner size="s" /> : undefined}
-            </>
+          <EuiButton
+            fill
+            iconType="plusInCircle"
+            onClick={() => upgradeRulesWrapper('ALL_RULES', upgradeAllRules)}
+            disabled={!isRulesAvailableForUpgrade || isRuleUpgrading}
+          >
+            {i18n.UPDATE_ALL}
+            {isRuleUpgrading ? <EuiLoadingSpinner size="s" /> : undefined}
           </EuiButton>
         </EuiFlexItem>
-      ) : null}
-      <EuiFlexItem grow={false}>
-        <EuiButton
-          fill
-          iconType="plusInCircle"
-          onClick={upgradeAllRules}
-          disabled={!isRulesAvailableForUpgrade || isRuleUpgrading}
-        >
-          {i18n.UPDATE_ALL}
-          {isRuleUpgrading ? <EuiLoadingSpinner size="s" /> : undefined}
-        </EuiButton>
-      </EuiFlexItem>
-    </EuiFlexGroup>
+      </EuiFlexGroup>
+      {isUpgradeModalVisible && (
+        <MlJobUpgradeModal
+          jobs={legacyJobsInstalled}
+          onCancel={mlJobUpgradeModalCancel}
+          onConfirm={mlJobUpgradeModalConfirm}
+        />
+      )}
+    </>
   );
 };

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/upgrade_prebuilt_rules_table_buttons.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/upgrade_prebuilt_rules_table_buttons.tsx
@@ -8,18 +8,12 @@
 import { EuiButton, EuiFlexGroup, EuiFlexItem, EuiLoadingSpinner } from '@elastic/eui';
 import React from 'react';
 import * as i18n from './translations';
-import { MlJobUpgradeModal } from '../../../../../detections/components/modals/ml_job_upgrade_modal';
 import { useUpgradePrebuiltRulesTableContext } from './upgrade_prebuilt_rules_table_context';
 
 export const UpgradePrebuiltRulesTableButtons = () => {
   const {
-    state: { rules, selectedRules, loadingRules, isUpgradeModalVisible, legacyJobsInstalled },
-    actions: {
-      upgradeSelectedRulesCTAClick: upgradeSelectedRules,
-      upgradeAllRulesCTAClick: upgradeAllRules,
-      mlJobUpgradeModalConfirm,
-      mlJobUpgradeModalCancel,
-    },
+    state: { rules, selectedRules, loadingRules },
+    actions: { upgradeSelectedRules, upgradeAllRules },
   } = useUpgradePrebuiltRulesTableContext();
 
   const isRulesAvailableForUpgrade = rules.length > 0;
@@ -53,13 +47,6 @@ export const UpgradePrebuiltRulesTableButtons = () => {
           </EuiButton>
         </EuiFlexItem>
       </EuiFlexGroup>
-      {isUpgradeModalVisible && (
-        <MlJobUpgradeModal
-          jobs={legacyJobsInstalled}
-          onCancel={mlJobUpgradeModalCancel}
-          onConfirm={mlJobUpgradeModalConfirm}
-        />
-      )}
     </>
   );
 };

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/upgrade_prebuilt_rules_table_buttons.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/upgrade_prebuilt_rules_table_buttons.tsx
@@ -15,9 +15,8 @@ export const UpgradePrebuiltRulesTableButtons = () => {
   const {
     state: { rules, selectedRules, loadingRules, isUpgradeModalVisible, legacyJobsInstalled },
     actions: {
-      upgradeAllRules,
-      upgradeSelectedRules,
-      upgradeRulesWrapper,
+      upgradeSelectedRulesCTAClick: upgradeSelectedRules,
+      upgradeAllRulesCTAClick: upgradeAllRules,
       mlJobUpgradeModalConfirm,
       mlJobUpgradeModalCancel,
     },
@@ -34,10 +33,7 @@ export const UpgradePrebuiltRulesTableButtons = () => {
       <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false} wrap={true}>
         {shouldDisplayUpgradeSelectedRulesButton ? (
           <EuiFlexItem grow={false}>
-            <EuiButton
-              onClick={() => upgradeRulesWrapper('SPECIFIC_RULES', upgradeSelectedRules)}
-              disabled={isRuleUpgrading}
-            >
+            <EuiButton onClick={upgradeSelectedRules} disabled={isRuleUpgrading}>
               <>
                 {i18n.UPDATE_SELECTED_RULES(numberOfSelectedRules)}
                 {isRuleUpgrading ? <EuiLoadingSpinner size="s" /> : undefined}
@@ -49,7 +45,7 @@ export const UpgradePrebuiltRulesTableButtons = () => {
           <EuiButton
             fill
             iconType="plusInCircle"
-            onClick={() => upgradeRulesWrapper('ALL_RULES', upgradeAllRules)}
+            onClick={upgradeAllRules}
             disabled={!isRulesAvailableForUpgrade || isRuleUpgrading}
           >
             {i18n.UPDATE_ALL}

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/upgrade_prebuilt_rules_table_buttons.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/upgrade_prebuilt_rules_table_buttons.tsx
@@ -13,7 +13,7 @@ import { useUpgradePrebuiltRulesTableContext } from './upgrade_prebuilt_rules_ta
 export const UpgradePrebuiltRulesTableButtons = () => {
   const {
     state: { rules, selectedRules, loadingRules },
-    actions: { upgradeSelectedRules, upgradeAllRules },
+    actions: { upgradeAllRules, upgradeSelectedRules },
   } = useUpgradePrebuiltRulesTableContext();
 
   const isRulesAvailableForUpgrade = rules.length > 0;
@@ -23,30 +23,28 @@ export const UpgradePrebuiltRulesTableButtons = () => {
   const isRuleUpgrading = loadingRules.length > 0;
 
   return (
-    <>
-      <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false} wrap={true}>
-        {shouldDisplayUpgradeSelectedRulesButton ? (
-          <EuiFlexItem grow={false}>
-            <EuiButton onClick={upgradeSelectedRules} disabled={isRuleUpgrading}>
-              <>
-                {i18n.UPDATE_SELECTED_RULES(numberOfSelectedRules)}
-                {isRuleUpgrading ? <EuiLoadingSpinner size="s" /> : undefined}
-              </>
-            </EuiButton>
-          </EuiFlexItem>
-        ) : null}
+    <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false} wrap={true}>
+      {shouldDisplayUpgradeSelectedRulesButton ? (
         <EuiFlexItem grow={false}>
-          <EuiButton
-            fill
-            iconType="plusInCircle"
-            onClick={upgradeAllRules}
-            disabled={!isRulesAvailableForUpgrade || isRuleUpgrading}
-          >
-            {i18n.UPDATE_ALL}
-            {isRuleUpgrading ? <EuiLoadingSpinner size="s" /> : undefined}
+          <EuiButton onClick={upgradeSelectedRules} disabled={isRuleUpgrading}>
+            <>
+              {i18n.UPDATE_SELECTED_RULES(numberOfSelectedRules)}
+              {isRuleUpgrading ? <EuiLoadingSpinner size="s" /> : undefined}
+            </>
           </EuiButton>
         </EuiFlexItem>
-      </EuiFlexGroup>
-    </>
+      ) : null}
+      <EuiFlexItem grow={false}>
+        <EuiButton
+          fill
+          iconType="plusInCircle"
+          onClick={upgradeAllRules}
+          disabled={!isRulesAvailableForUpgrade || isRuleUpgrading}
+        >
+          {i18n.UPDATE_ALL}
+          {isRuleUpgrading ? <EuiLoadingSpinner size="s" /> : undefined}
+        </EuiButton>
+      </EuiFlexItem>
+    </EuiFlexGroup>
   );
 };

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/upgrade_prebuilt_rules_table_context.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/upgrade_prebuilt_rules_table_context.tsx
@@ -86,18 +86,11 @@ export interface UpgradePrebuiltRulesTableState {
 
 export interface UpgradePrebuiltRulesTableActions {
   reFetchRules: () => void;
-  upgradeOneRule: (ruleId: string) => Promise<void>;
-  upgradeSelectedRules: () => Promise<void>;
-  upgradeAllRules: () => Promise<void>;
+  upgradeSingleRuleFromRowCTA: (ruleId: string) => void;
+  upgradeSelectedRulesCTAClick: () => void;
+  upgradeAllRulesCTAClick: () => void;
   selectRules: (rules: RuleUpgradeInfoForReview[]) => void;
   setFilterOptions: Dispatch<SetStateAction<UpgradePrebuiltRulesTableFilterOptions>>;
-  setModalConfirmationUpgradeMethod: Dispatch<SetStateAction<ModalConfirmationUpgradeMethod>>;
-  setRuleIdToUpgrade: Dispatch<SetStateAction<string>>;
-  upgradeRulesWrapper: (
-    upgradeMethod: ModalConfirmationUpgradeMethod,
-    upgradeRuleMethod: () => Promise<void>
-  ) => void;
-  upgradeSingleRuleFromRowCTA: (ruleId: string) => void;
   mlJobUpgradeModalConfirm: () => void;
   mlJobUpgradeModalCancel: () => void;
 }
@@ -202,16 +195,20 @@ export const UpgradePrebuiltRulesTableContextProvider = ({
 
   // Wrapper around upgrade rules methods to display ML Jobs warning modal when necessary
   const upgradeRulesWrapper = useCallback(
-    (upgradeMethod: ModalConfirmationUpgradeMethod, upgradeRuleMethod: () => Promise<void>) => {
-      if (legacyJobsInstalled.length > 0) {
-        showUpgradeModal();
-        setModalConfirmationUpgradeMethod(upgradeMethod);
-      } else {
-        upgradeRuleMethod();
-      }
-    },
+    (upgradeMethod: ModalConfirmationUpgradeMethod, upgradeRuleMethod: () => Promise<void>) =>
+      () => {
+        if (legacyJobsInstalled.length > 0) {
+          showUpgradeModal();
+          setModalConfirmationUpgradeMethod(upgradeMethod);
+        } else {
+          upgradeRuleMethod();
+        }
+      },
     [legacyJobsInstalled.length, showUpgradeModal]
   );
+
+  const upgradeSelectedRulesCTAClick = upgradeRulesWrapper('SPECIFIC_RULES', upgradeSelectedRules);
+  const upgradeAllRulesCTAClick = upgradeRulesWrapper('ALL_RULES', upgradeAllRules);
 
   // Wrapper around upgradeOneRule to display ML Jobs warning modal when necessary
   // when attempting to upgrade a single rule from each rule row CTA
@@ -260,25 +257,19 @@ export const UpgradePrebuiltRulesTableContextProvider = ({
   const actions = useMemo<UpgradePrebuiltRulesTableActions>(
     () => ({
       reFetchRules: refetch,
-      upgradeOneRule,
-      upgradeSelectedRules,
-      upgradeAllRules,
+      upgradeSingleRuleFromRowCTA,
+      upgradeSelectedRulesCTAClick,
+      upgradeAllRulesCTAClick,
       setFilterOptions,
       selectRules: setSelectedRules,
-      setModalConfirmationUpgradeMethod,
-      setRuleIdToUpgrade,
-      upgradeRulesWrapper,
-      upgradeSingleRuleFromRowCTA,
       mlJobUpgradeModalConfirm,
       mlJobUpgradeModalCancel,
     }),
     [
       refetch,
-      upgradeOneRule,
-      upgradeSelectedRules,
-      upgradeAllRules,
-      upgradeRulesWrapper,
       upgradeSingleRuleFromRowCTA,
+      upgradeSelectedRulesCTAClick,
+      upgradeAllRulesCTAClick,
       mlJobUpgradeModalConfirm,
       mlJobUpgradeModalCancel,
     ]

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/upgrade_prebuilt_rules_table_context.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/upgrade_prebuilt_rules_table_context.tsx
@@ -7,7 +7,6 @@
 
 import type { Dispatch, SetStateAction } from 'react';
 import React, { createContext, useCallback, useContext, useMemo, useState } from 'react';
-import type { MlSummaryJob } from '@kbn/ml-plugin/public';
 import { useInstalledSecurityJobs } from '../../../../../common/components/ml/hooks/use_installed_security_jobs';
 import { useBoolState } from '../../../../../common/hooks/use_bool_state';
 import { affectedJobIds } from '../../../../../detections/components/callouts/ml_job_compatibility_callout/affected_job_ids';
@@ -67,10 +66,6 @@ export interface UpgradePrebuiltRulesTableState {
    * Rule rows selected in EUI InMemory Table
    */
   selectedRules: RuleUpgradeInfoForReview[];
-  /**
-   * Legacy ML Jobs that cause modal to pop up before performing rule ugprades
-   */
-  legacyJobsInstalled: MlSummaryJob[];
 }
 
 export interface UpgradePrebuiltRulesTableActions {
@@ -78,8 +73,8 @@ export interface UpgradePrebuiltRulesTableActions {
   upgradeOneRule: (ruleId: string) => void;
   upgradeSelectedRules: () => void;
   upgradeAllRules: () => void;
-  selectRules: (rules: RuleUpgradeInfoForReview[]) => void;
   setFilterOptions: Dispatch<SetStateAction<UpgradePrebuiltRulesTableFilterOptions>>;
+  selectRules: (rules: RuleUpgradeInfoForReview[]) => void;
 }
 
 export interface UpgradePrebuiltRulesContextType {

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/use_upgrade_prebuilt_rules_table_columns.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/use_upgrade_prebuilt_rules_table_columns.tsx
@@ -82,7 +82,7 @@ const INTEGRATIONS_COLUMN: TableColumn = {
 };
 
 const createUpgradeButtonColumn = (
-  upgradeSingleRuleFromRowCTA: (ruleId: string) => void,
+  upgradeOneRule: (ruleId: string) => void,
   loadingRules: RuleSignatureId[]
 ): TableColumn => ({
   field: 'rule_id',
@@ -90,11 +90,7 @@ const createUpgradeButtonColumn = (
   render: (ruleId: RuleUpgradeInfoForReview['rule_id']) => {
     const isRuleUpgrading = loadingRules.includes(ruleId);
     return (
-      <EuiButtonEmpty
-        size="s"
-        disabled={isRuleUpgrading}
-        onClick={() => upgradeSingleRuleFromRowCTA(ruleId)}
-      >
+      <EuiButtonEmpty size="s" disabled={isRuleUpgrading} onClick={() => upgradeOneRule(ruleId)}>
         {isRuleUpgrading ? <EuiLoadingSpinner size="s" /> : i18n.UPDATE_RULE_BUTTON}
       </EuiButtonEmpty>
     );
@@ -109,7 +105,7 @@ export const useUpgradePrebuiltRulesTableColumns = (): TableColumn[] => {
   const [showRelatedIntegrations] = useUiSetting$<boolean>(SHOW_RELATED_INTEGRATIONS_SETTING);
   const {
     state: { loadingRules },
-    actions: { upgradeSingleRuleFromRowCTA },
+    actions: { upgradeOneRule },
   } = useUpgradePrebuiltRulesTableContext();
 
   return useMemo(
@@ -137,10 +133,8 @@ export const useUpgradePrebuiltRulesTableColumns = (): TableColumn[] => {
         truncateText: true,
         width: '12%',
       },
-      ...(hasCRUDPermissions
-        ? [createUpgradeButtonColumn(upgradeSingleRuleFromRowCTA, loadingRules)]
-        : []),
+      ...(hasCRUDPermissions ? [createUpgradeButtonColumn(upgradeOneRule, loadingRules)] : []),
     ],
-    [hasCRUDPermissions, loadingRules, showRelatedIntegrations, upgradeSingleRuleFromRowCTA]
+    [hasCRUDPermissions, loadingRules, showRelatedIntegrations, upgradeOneRule]
   );
 };

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/use_upgrade_prebuilt_rules_table_columns.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/use_upgrade_prebuilt_rules_table_columns.tsx
@@ -19,6 +19,7 @@ import { SeverityBadge } from '../../../../../detections/components/rules/severi
 import { useUserData } from '../../../../../detections/components/user_info';
 import * as i18n from '../../../../../detections/pages/detection_engine/rules/translations';
 import type { Rule } from '../../../../rule_management/logic';
+import type { UpgradePrebuiltRulesTableActions } from './upgrade_prebuilt_rules_table_context';
 import { useUpgradePrebuiltRulesTableContext } from './upgrade_prebuilt_rules_table_context';
 
 export type TableColumn = EuiBasicTableColumn<RuleUpgradeInfoForReview>;
@@ -82,7 +83,7 @@ const INTEGRATIONS_COLUMN: TableColumn = {
 };
 
 const createUpgradeButtonColumn = (
-  upgradeOneRule: (ruleId: string) => void,
+  upgradeOneRule: UpgradePrebuiltRulesTableActions['upgradeOneRule'],
   loadingRules: RuleSignatureId[]
 ): TableColumn => ({
   field: 'rule_id',

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/use_upgrade_prebuilt_rules_table_columns.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/use_upgrade_prebuilt_rules_table_columns.tsx
@@ -19,7 +19,6 @@ import { SeverityBadge } from '../../../../../detections/components/rules/severi
 import { useUserData } from '../../../../../detections/components/user_info';
 import * as i18n from '../../../../../detections/pages/detection_engine/rules/translations';
 import type { Rule } from '../../../../rule_management/logic';
-import type { UpgradePrebuiltRulesTableActions } from './upgrade_prebuilt_rules_table_context';
 import { useUpgradePrebuiltRulesTableContext } from './upgrade_prebuilt_rules_table_context';
 
 export type TableColumn = EuiBasicTableColumn<RuleUpgradeInfoForReview>;
@@ -83,7 +82,7 @@ const INTEGRATIONS_COLUMN: TableColumn = {
 };
 
 const createUpgradeButtonColumn = (
-  upgradeOneRule: UpgradePrebuiltRulesTableActions['upgradeOneRule'],
+  upgradeSingleRuleFromRowCTA: (ruleId: string) => void,
   loadingRules: RuleSignatureId[]
 ): TableColumn => ({
   field: 'rule_id',
@@ -91,7 +90,11 @@ const createUpgradeButtonColumn = (
   render: (ruleId: RuleUpgradeInfoForReview['rule_id']) => {
     const isRuleUpgrading = loadingRules.includes(ruleId);
     return (
-      <EuiButtonEmpty size="s" disabled={isRuleUpgrading} onClick={() => upgradeOneRule(ruleId)}>
+      <EuiButtonEmpty
+        size="s"
+        disabled={isRuleUpgrading}
+        onClick={() => upgradeSingleRuleFromRowCTA(ruleId)}
+      >
         {isRuleUpgrading ? <EuiLoadingSpinner size="s" /> : i18n.UPDATE_RULE_BUTTON}
       </EuiButtonEmpty>
     );
@@ -106,7 +109,7 @@ export const useUpgradePrebuiltRulesTableColumns = (): TableColumn[] => {
   const [showRelatedIntegrations] = useUiSetting$<boolean>(SHOW_RELATED_INTEGRATIONS_SETTING);
   const {
     state: { loadingRules },
-    actions: { upgradeOneRule },
+    actions: { upgradeSingleRuleFromRowCTA },
   } = useUpgradePrebuiltRulesTableContext();
 
   return useMemo(
@@ -134,8 +137,10 @@ export const useUpgradePrebuiltRulesTableColumns = (): TableColumn[] => {
         truncateText: true,
         width: '12%',
       },
-      ...(hasCRUDPermissions ? [createUpgradeButtonColumn(upgradeOneRule, loadingRules)] : []),
+      ...(hasCRUDPermissions
+        ? [createUpgradeButtonColumn(upgradeSingleRuleFromRowCTA, loadingRules)]
+        : []),
     ],
-    [hasCRUDPermissions, loadingRules, showRelatedIntegrations, upgradeOneRule]
+    [hasCRUDPermissions, loadingRules, showRelatedIntegrations, upgradeSingleRuleFromRowCTA]
   );
 };


### PR DESCRIPTION
## Summary

Reintroduces ML Jobs warning popover that was removed during [new install/upgrade initial implementation.](https://github.com/elastic/kibana/pull/158450)

ML Jobs warning popover that appears when user has legacy ML jobs installed, and the user attempts to update their prebuilt rules.

Modified behaviour so that the popover now appears in any of the three cases: upgrading **all rules**, upgrading **specific rules** and upgrading **a single rule**.

### Testing

In the `state` returned by `UpgradePrebuiltRulesTableContextProvider`, replace the value of `legacyJobsInstalled` for a mock value. See below:
```ts
    return {
      state: {
        rules,
        tags,
        isFetched,
        isLoading: isLoading && loadingJobs,
        isRefetching,
        selectedRules,
        loadingRules,
        lastUpdated: dataUpdatedAt,
        legacyJobsInstalled: [
          {
            id: 'rc-rare-process-windows-5',
            description:
              'Looks for rare and anomalous processes on a Windows host. Requires process execution events from Sysmon.',
            groups: ['host'],
            processed_record_count: 8577,
            memory_status: 'ok',
            jobState: 'closed',
            hasDatafeed: true,
            datafeedId: 'datafeed-rc-rare-process-windows-5',
            datafeedIndices: ['winlogbeat-*'],
            datafeedState: 'stopped',
            latestTimestampMs: 1561402325194,
            earliestTimestampMs: 1554327458406,
            isSingleMetricViewerJob: true,
            awaitingNodeAssignment: false,
            jobTags: {},
            bucketSpanSeconds: 900,
          },
          {
            id: 'siem-api-rare_process_linux_ecs',
            description: 'SIEM Auditbeat: Detect unusually rare processes on Linux (beta)',
            groups: ['siem'],
            processed_record_count: 582251,
            memory_status: 'hard_limit',
            jobState: 'closed',
            hasDatafeed: true,
            datafeedId: 'datafeed-siem-api-rare_process_linux_ecs',
            datafeedIndices: ['auditbeat-*'],
            datafeedState: 'stopped',
            latestTimestampMs: 1557434782207,
            earliestTimestampMs: 1557353420495,
            isSingleMetricViewerJob: true,
            awaitingNodeAssignment: false,
            jobTags: {},
            bucketSpanSeconds: 900,
          },
        ],
        isUpgradeModalVisible,
        ruleIdToUpgrade,
        modalConfirmationUpdateMethod,
      },
      actions,
    };
```

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)




### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
