### PR TITLE
Change the copy on save button on tags filter in dashboards/visualize listing table

### DIFF
--- a/packages/content-management/table_list_view_table/src/components/tag_filter_panel.tsx
+++ b/packages/content-management/table_list_view_table/src/components/tag_filter_panel.tsx
@@ -22,7 +22,6 @@ import {
   EuiLink,
   useEuiTheme,
   EuiPopoverFooter,
-  EuiButton,
 } from '@elastic/eui';
 import type { EuiSelectableProps, ExclusiveUnion } from '@elastic/eui';
 import { css } from '@emotion/react';
@@ -37,10 +36,6 @@ const modifierKeyPrefix = isMac ? '⌘' : '^';
 
 const clearSelectionBtnCSS = css`
   height: auto;
-`;
-
-const saveBtnWrapperCSS = css`
-  width: 100%;
 `;
 
 interface Props {
@@ -172,10 +167,6 @@ export const TagFilterPanel: FC<Props> = ({
                   )}
                 </EuiTextColor>
               </EuiText>
-            </EuiFlexItem>
-
-            <EuiFlexItem css={saveBtnWrapperCSS}>
-              <EuiButton onClick={closePopover}>Save</EuiButton>
             </EuiFlexItem>
 
             <EuiFlexItem>


### PR DESCRIPTION
## What does this PR do?
* It removes the button `Save` since the tags when is selected already auto-apply the filter.

## Issue References
* https://github.com/elastic/kibana/issues/157457

## Video/Screenshot Demo 

###### FIX:
![image](https://github.com/GitStartHQ/client-kibana-oss/assets/50892465/163bee5b-6bc4-4206-adf1-edf4a0611e99)


---
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.
