### PR TITLE
[APM] Circuit breaker and perf improvements for service map

### DIFF
--- a/packages/kbn-apm-synthtrace/src/scenarios/service_map_oom.ts
+++ b/packages/kbn-apm-synthtrace/src/scenarios/service_map_oom.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { ApmFields, httpExitSpan } from '@kbn/apm-synthtrace-client';
+import { service } from '@kbn/apm-synthtrace-client/src/lib/apm/service';
+import { Transaction } from '@kbn/apm-synthtrace-client/src/lib/apm/transaction';
+import { Scenario } from '../cli/scenario';
+import { RunOptions } from '../cli/utils/parse_run_cli_flags';
+import { getSynthtraceEnvironment } from '../lib/utils/get_synthtrace_environment';
+
+const environment = getSynthtraceEnvironment(__filename);
+
+const scenario: Scenario<ApmFields> = async (runOptions: RunOptions) => {
+  const connectionsPerService = 100;
+
+  const uniqueConnectionsPerService = 10;
+
+  const numServices = 500;
+
+  const tracesPerMinute = 10;
+
+  return {
+    generate: ({ range }) => {
+      const services = new Array(numServices)
+        .fill(undefined)
+        .map((_, idx) => {
+          return service(`service-${idx}`, 'prod', environment).instance('service-instance');
+        })
+        .reverse();
+
+      return range.ratePerMinute(tracesPerMinute).generator((timestamp) => {
+        const rootTransaction = services.reduce((prev, currentService) => {
+          const tx = currentService
+            .transaction(`GET /my/function`, 'request')
+            .timestamp(timestamp)
+            .duration(1000)
+            .children(
+              ...(prev
+                ? [
+                    currentService
+                      .span(
+                        httpExitSpan({
+                          spanName: `exit-span-${currentService.fields['service.name']}`,
+                          destinationUrl: `http://address-to-exit-span-${currentService.fields['service.name']}`,
+                        })
+                      )
+                      .timestamp(timestamp)
+                      .duration(1000)
+                      .children(prev),
+                  ]
+                : [])
+            );
+
+          return tx;
+        }, undefined as Transaction | undefined);
+
+        return rootTransaction!;
+      });
+    },
+  };
+};
+
+export default scenario;

--- a/packages/kbn-apm-synthtrace/src/scenarios/service_map_oom.ts
+++ b/packages/kbn-apm-synthtrace/src/scenarios/service_map_oom.ts
@@ -16,10 +16,6 @@ import { getSynthtraceEnvironment } from '../lib/utils/get_synthtrace_environmen
 const environment = getSynthtraceEnvironment(__filename);
 
 const scenario: Scenario<ApmFields> = async (runOptions: RunOptions) => {
-  const connectionsPerService = 100;
-
-  const uniqueConnectionsPerService = 10;
-
   const numServices = 500;
 
   const tracesPerMinute = 10;

--- a/x-pack/plugins/apm/server/index.ts
+++ b/x-pack/plugins/apm/server/index.ts
@@ -26,6 +26,8 @@ const configSchema = schema.object({
   serviceMapTraceIdBucketSize: schema.number({ defaultValue: 65 }),
   serviceMapTraceIdGlobalBucketSize: schema.number({ defaultValue: 6 }),
   serviceMapMaxTracesPerRequest: schema.number({ defaultValue: 50 }),
+  serviceMapTerminateAfter: schema.number({ defaultValue: 100_000 }),
+  serviceMapMaxTraces: schema.number({ defaultValue: 1000 }),
   ui: schema.object({
     enabled: schema.boolean({ defaultValue: true }),
     maxTraceItems: schema.number({ defaultValue: 5000 }),

--- a/x-pack/plugins/apm/server/routes/service_map/fetch_service_paths_from_trace_ids.ts
+++ b/x-pack/plugins/apm/server/routes/service_map/fetch_service_paths_from_trace_ids.ts
@@ -15,12 +15,19 @@ import {
 } from '../../../common/service_map';
 import { APMEventClient } from '../../lib/helpers/create_es_client/create_apm_event_client';
 
-export async function fetchServicePathsFromTraceIds(
-  apmEventClient: APMEventClient,
-  traceIds: string[],
-  start: number,
-  end: number
-) {
+export async function fetchServicePathsFromTraceIds({
+  apmEventClient,
+  traceIds,
+  start,
+  end,
+  terminateAfter,
+}: {
+  apmEventClient: APMEventClient;
+  traceIds: string[];
+  start: number;
+  end: number;
+  terminateAfter: number;
+}) {
   // make sure there's a range so ES can skip shards
   const dayInMs = 24 * 60 * 60 * 1000;
   const startRange = start - dayInMs;
@@ -30,6 +37,7 @@ export async function fetchServicePathsFromTraceIds(
     apm: {
       events: [ProcessorEvent.span, ProcessorEvent.transaction],
     },
+    terminate_after: terminateAfter,
     body: {
       track_total_hits: false,
       size: 0,

--- a/x-pack/plugins/apm/server/routes/service_map/get_service_map_from_trace_ids.test.ts
+++ b/x-pack/plugins/apm/server/routes/service_map/get_service_map_from_trace_ids.test.ts
@@ -11,9 +11,9 @@ import { Connection, ConnectionNode } from '../../../common/service_map';
 function getConnectionsPairs(connections: Connection[]) {
   return connections
     .map((conn) => {
-      const source = `${conn.source['service.name']}:${conn.source['service.environment']}`;
+      const source = conn.source['service.name'];
       const destination = conn.destination['service.name']
-        ? `${conn.destination['service.name']}:${conn.destination['service.environment']}`
+        ? conn.destination['service.name']
         : conn.destination['span.type'];
       return `${source} -> ${destination}`;
     })
@@ -21,139 +21,71 @@ function getConnectionsPairs(connections: Connection[]) {
 }
 
 describe('getConnections', () => {
-  describe('with environments defined', () => {
-    const paths = [
-      [
-        {
-          'service.environment': 'testing',
-          'service.name': 'opbeans-ruby',
-          'agent.name': 'ruby',
-        },
-        {
-          'service.environment': null,
-          'service.name': 'opbeans-node',
-          'agent.name': 'nodejs',
-        },
-        {
-          'service.environment': 'production',
-          'service.name': 'opbeans-go',
-          'agent.name': 'go',
-        },
-        {
-          'service.environment': 'production',
-          'service.name': 'opbeans-java',
-          'agent.name': 'java',
-        },
-        {
-          'span.subtype': 'http',
-          'span.destination.service.resource': '172.18.0.6:3000',
-          'span.type': 'external',
-        },
-      ],
-      [
-        {
-          'service.environment': 'testing',
-          'service.name': 'opbeans-ruby',
-          'agent.name': 'ruby',
-        },
-        {
-          'service.environment': 'testing',
-          'service.name': 'opbeans-python',
-          'agent.name': 'python',
-        },
-        {
-          'span.subtype': 'http',
-          'span.destination.service.resource': '172.18.0.6:3000',
-          'span.type': 'external',
-        },
-      ],
-    ] as ConnectionNode[][];
+  const paths = [
+    [
+      {
+        'service.name': 'opbeans-ruby',
+        'agent.name': 'ruby',
+      },
+      {
+        'service.name': 'opbeans-node',
+        'agent.name': 'nodejs',
+      },
+      {
+        'service.name': 'opbeans-go',
+        'agent.name': 'go',
+      },
+      {
+        'service.name': 'opbeans-java',
+        'agent.name': 'java',
+      },
+      {
+        'span.subtype': 'http',
+        'span.destination.service.resource': '172.18.0.6:3000',
+        'span.type': 'external',
+      },
+    ],
+    [
+      {
+        'service.name': 'opbeans-ruby',
+        'agent.name': 'ruby',
+      },
+      {
+        'service.name': 'opbeans-python',
+        'agent.name': 'python',
+      },
+      {
+        'span.subtype': 'http',
+        'span.destination.service.resource': '172.18.0.6:3000',
+        'span.type': 'external',
+      },
+    ],
+    [
+      {
+        'service.name': 'opbeans-go',
+        'agent.name': 'go',
+      },
+      {
+        'service.name': 'opbeans-node',
+        'agent.name': 'nodejs',
+      },
+    ],
+  ] as ConnectionNode[][];
 
-    it('includes all connections', () => {
-      const connections = getConnections({
-        paths,
-      });
-
-      const connectionsPairs = getConnectionsPairs(connections);
-      expect(connectionsPairs).toEqual([
-        'opbeans-ruby:testing -> opbeans-node:null',
-        'opbeans-node:null -> opbeans-go:production',
-        'opbeans-go:production -> opbeans-java:production',
-        'opbeans-java:production -> external',
-        'opbeans-ruby:testing -> opbeans-python:testing',
-        'opbeans-python:testing -> external',
-      ]);
+  it('includes all connections', () => {
+    const connections = getConnections({
+      paths,
     });
-  });
 
-  describe('environment is "not defined"', () => {
-    it('includes all connections', () => {
-      const environmentNotDefinedPaths = [
-        [
-          {
-            'service.environment': 'production',
-            'service.name': 'opbeans-go',
-            'agent.name': 'go',
-          },
-          {
-            'service.environment': 'production',
-            'service.name': 'opbeans-java',
-            'agent.name': 'java',
-          },
-          {
-            'span.subtype': 'http',
-            'span.destination.service.resource': '172.18.0.6:3000',
-            'span.type': 'external',
-          },
-        ],
-        [
-          {
-            'service.environment': null,
-            'service.name': 'opbeans-go',
-            'agent.name': 'go',
-          },
-          {
-            'service.environment': null,
-            'service.name': 'opbeans-java',
-            'agent.name': 'java',
-          },
-          {
-            'span.subtype': 'http',
-            'span.destination.service.resource': '172.18.0.6:3000',
-            'span.type': 'external',
-          },
-        ],
-        [
-          {
-            'service.environment': null,
-            'service.name': 'opbeans-python',
-            'agent.name': 'python',
-          },
-          {
-            'service.environment': null,
-            'service.name': 'opbeans-node',
-            'agent.name': 'nodejs',
-          },
-          {
-            'span.subtype': 'http',
-            'span.destination.service.resource': '172.18.0.6:3000',
-            'span.type': 'external',
-          },
-        ],
-      ] as ConnectionNode[][];
-      const connections = getConnections({
-        paths: environmentNotDefinedPaths,
-      });
-
-      const connectionsPairs = getConnectionsPairs(connections);
-      expect(connectionsPairs).toEqual([
-        'opbeans-go:production -> opbeans-java:production',
-        'opbeans-java:production -> external',
-        'opbeans-go:null -> opbeans-java:null',
-        'opbeans-java:null -> external',
-        'opbeans-python:null -> opbeans-node:null',
-        'opbeans-node:null -> external',
-      ]);
-    });
+    const connectionsPairs = getConnectionsPairs(connections);
+    expect(connectionsPairs).toEqual([
+      'opbeans-ruby -> opbeans-node',
+      'opbeans-node -> opbeans-go',
+      'opbeans-go -> opbeans-java',
+      'opbeans-java -> external',
+      'opbeans-ruby -> opbeans-python',
+      'opbeans-python -> external',
+      'opbeans-go -> opbeans-node',
+    ]);
   });
 });

--- a/x-pack/plugins/apm/server/routes/service_map/get_service_map_from_trace_ids.ts
+++ b/x-pack/plugins/apm/server/routes/service_map/get_service_map_from_trace_ids.ts
@@ -5,38 +5,43 @@
  * 2.0.
  */
 
-import { find, uniqBy } from 'lodash';
+import { Logger } from '@kbn/logging';
 import { Connection, ConnectionNode } from '../../../common/service_map';
 import { APMEventClient } from '../../lib/helpers/create_es_client/create_apm_event_client';
 import { fetchServicePathsFromTraceIds } from './fetch_service_paths_from_trace_ids';
+import { getConnectionId } from './transform_service_map_responses';
 
 export function getConnections({
   paths,
 }: {
   paths: ConnectionNode[][] | undefined;
-}) {
+}): Connection[] {
   if (!paths) {
     return [];
   }
 
-  const connectionsArr = paths.flatMap((path) => {
-    return path.reduce((conns, location, index) => {
-      const prev = path[index - 1];
+  const connectionsById: Map<string, Connection> = new Map();
+
+  paths.forEach((path) => {
+    path.forEach((location, i) => {
+      const prev = path[i - 1];
+
       if (prev) {
-        return conns.concat({
+        const connection = {
           source: prev,
           destination: location,
-        });
+        };
+
+        const id = getConnectionId(connection);
+
+        if (!connectionsById.has(id)) {
+          connectionsById.set(id, connection);
+        }
       }
-      return conns;
-    }, [] as Connection[]);
-  }, [] as Connection[]);
+    });
+  });
 
-  const connections = uniqBy(connectionsArr, (value) =>
-    find(connectionsArr, value)
-  );
-
-  return connections;
+  return Array.from(connectionsById.values());
 }
 
 export async function getServiceMapFromTraceIds({
@@ -44,14 +49,26 @@ export async function getServiceMapFromTraceIds({
   traceIds,
   start,
   end,
+  terminateAfter,
+  logger,
 }: {
   apmEventClient: APMEventClient;
   traceIds: string[];
   start: number;
   end: number;
+  terminateAfter: number;
+  logger: Logger;
 }) {
   const serviceMapFromTraceIdsScriptResponse =
-    await fetchServicePathsFromTraceIds(apmEventClient, traceIds, start, end);
+    await fetchServicePathsFromTraceIds({
+      apmEventClient,
+      traceIds,
+      start,
+      end,
+      terminateAfter,
+    });
+
+  logger.debug('Received scripted metric agg response');
 
   const serviceMapScriptedAggValue =
     serviceMapFromTraceIdsScriptResponse.aggregations?.service_map.value;

--- a/x-pack/plugins/apm/server/routes/service_map/get_trace_sample_ids.ts
+++ b/x-pack/plugins/apm/server/routes/service_map/get_trace_sample_ids.ts
@@ -26,8 +26,6 @@ import { environmentQuery } from '../../../common/utils/environment_query';
 import { APMEventClient } from '../../lib/helpers/create_es_client/create_apm_event_client';
 import { APMConfig } from '../..';
 
-const MAX_TRACES_TO_INSPECT = 1000;
-
 export async function getTraceSampleIds({
   serviceName,
   environment,
@@ -163,7 +161,7 @@ export async function getTraceSampleIds({
       uniq(
         sortBy(traceIdsWithPriority, 'priority').map(({ traceId }) => traceId)
       ),
-      MAX_TRACES_TO_INSPECT
+      config.serviceMapMaxTraces
     );
 
     return { traceIds };

--- a/x-pack/plugins/apm/server/routes/service_map/route.ts
+++ b/x-pack/plugins/apm/server/routes/service_map/route.ts
@@ -101,7 +101,7 @@ const serviceMapRoute = createApmServerRoute({
       serviceName,
       environment,
       searchAggregatedTransactions,
-      logger,
+      logger: logger.get('serviceMap'),
       start,
       end,
       maxNumberOfServices,

--- a/x-pack/plugins/apm/server/routes/service_map/transform_service_map_responses.ts
+++ b/x-pack/plugins/apm/server/routes/service_map/transform_service_map_responses.ts
@@ -35,7 +35,7 @@ function getConnectionNodeId(node: ConnectionNode): string {
   return node[SERVICE_NAME];
 }
 
-function getConnectionId(connection: Connection) {
+export function getConnectionId(connection: Connection) {
   return `${getConnectionNodeId(connection.source)}~${getConnectionNodeId(
     connection.destination
   )}`;


### PR DESCRIPTION
Closes #101920

This PR does three things:

- add a `terminate_after` parameter to the search request for the scripted metric agg. This is a configurable setting (`xpack.apm.serviceMapTerminateAfter`) and defaults to 100k. This is a shard-level parameter, so there's still the possibility of lots of shards individually returning 100k documents and the coordinating node running out of memory because it is collecting all these docs from individual shards. However, I suspect that there is already some protection in the reduce phase that will terminate the request with a stack_overflow_error without OOMing, I've reached out to the ES team to confirm whether this is the case.
- add `xpack.apm.serviceMapMaxTraces`: this tells the max traces to inspect in total, not just per search request. IE, if `xpack.apm.serviceMapMaxTracesPerRequest` is 1, we simply chunk the traces in n chunks, so it doesn't really help with memory management. `serviceMapMaxTraces` refers to the total amount of traces to inspect.
-  rewrite `getConnections` to use local mutation instead of immutability. I saw huge CPU usage (with admittedly a pathological scenario where there are 100s of services) in the `getConnections` function, because it uses a deduplication mechanism that is O(n²), so I rewrote it to O(n). Here's a before :

![image](https://github.com/elastic/kibana/assets/352732/6c24a7a2-3b48-4c95-9db2-563160a57aef)

and after:
![image](https://github.com/elastic/kibana/assets/352732/c00b8428-3026-4610-aa8b-c0046e8f0e08)

To reproduce an OOM, start ES with a much smaller amount of memory:
`$ ES_JAVA_OPTS='-Xms236m -Xmx236m' yarn es snapshot`

Then run the synthtrace Service Map OOM scenario:
`$ node scripts/synthtrace.js service_map_oom --from=now-15m --to=now --clean`

Finally, navigate to `service-100` in the UI, and click on Service Map. This should trigger an OOM.



<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->