### PR TITLE
[Visualizations] Unskips precalculater histogram FTs

### DIFF
--- a/x-pack/test/functional/apps/visualize/precalculated_histogram.ts
+++ b/x-pack/test/functional/apps/visualize/precalculated_histogram.ts
@@ -60,6 +60,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       it('with percentiles aggregation', async () => {
         const data = (await renderTableForAggregation('Percentiles')) as string[][];
         expect(data[0]).to.have.property('length', 7);
+        // Percentile values are not deterministic, so we can't check for the exact values here,
+        // but just check they are all within the given range
         expect(data[0].every((p: string) => Number(p) >= 0.3 && Number(p) <= 5)).to.be(true);
       });
 
@@ -76,7 +78,10 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       it('with median aggregation', async () => {
         const data = await renderTableForAggregation('Median');
         const value = Number(data[0][0]);
-        expect(value).to.be.eql(3.0);
+        // Percentile values are not deterministic, so we can't check for the exact values here,
+        // but just check they are all within the given range
+        expect(value).to.be.above(2.9);
+        expect(value).to.be.below(3.1);
       });
 
       it('with sum aggregation', async () => {

--- a/x-pack/test/functional/apps/visualize/precalculated_histogram.ts
+++ b/x-pack/test/functional/apps/visualize/precalculated_histogram.ts
@@ -40,8 +40,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       expect(rowData).to.contain('"values":[0.3,1,3,4.2,4.8]');
     });
 
-    // FAILING ES PROMOTION: https://github.com/elastic/kibana/issues/159615
-    describe.skip('works in visualizations', () => {
+    describe('works in visualizations', () => {
       before(async () => {
         await PageObjects.visualize.navigateToNewAggBasedVisualization();
         await PageObjects.visualize.clickDataTable();
@@ -61,9 +60,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       it('with percentiles aggregation', async () => {
         const data = (await renderTableForAggregation('Percentiles')) as string[][];
         expect(data[0]).to.have.property('length', 7);
-        // Percentile values are not deterministic, so we can't check for the exact values here,
-        // but just check they are all within the given range
-        // see https://github.com/elastic/elasticsearch/issues/49225
         expect(data[0].every((p: string) => Number(p) >= 0.3 && Number(p) <= 5)).to.be(true);
       });
 
@@ -78,13 +74,9 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       it('with median aggregation', async () => {
-        // Percentile values (which are used by median behind the scenes) are not deterministic,
-        // so we can't check for the exact values here, but just check they are all within the given range
-        // see https://github.com/elastic/elasticsearch/issues/49225
         const data = await renderTableForAggregation('Median');
         const value = Number(data[0][0]);
-        expect(value).to.be.above(3.0);
-        expect(value).to.be.below(3.3);
+        expect(value).to.be.eql(3.0);
       });
 
       it('with sum aggregation', async () => {


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/159615

This started faling most possibly because ES upgraded the TDigest library used for percentiles https://github.com/elastic/elasticsearch/pull/96086 and now we can have more accurate results.


Runner https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2397
