### PR TITLE
[AO] Handle buildEsQuery error (such as leading wildcard) in status change

### DIFF
--- a/x-pack/plugins/observability/public/components/alert_search_bar/alert_search_bar.test.tsx
+++ b/x-pack/plugins/observability/public/components/alert_search_bar/alert_search_bar.test.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import { waitFor } from '@testing-library/react';
 import { timefilterServiceMock } from '@kbn/data-plugin/public/query/timefilter/timefilter_service.mock';
-import { ObservabilityAlertSearchBarProps } from './types';
+import { ObservabilityAlertSearchBarProps, Services } from './types';
 import { ObservabilityAlertSearchBar } from './alert_search_bar';
 import { observabilityAlertFeatureIds } from '../../config/alert_feature_ids';
 import { render } from '../../utils/test_helper';
@@ -17,7 +17,10 @@ const getAlertsSearchBarMock = jest.fn();
 const ALERT_SEARCH_BAR_DATA_TEST_SUBJ = 'alerts-search-bar';
 
 describe('ObservabilityAlertSearchBar', () => {
-  const renderComponent = (props: Partial<ObservabilityAlertSearchBarProps> = {}) => {
+  const renderComponent = (
+    props: Partial<ObservabilityAlertSearchBarProps> = {},
+    services: Partial<Services> = {}
+  ) => {
     const observabilityAlertSearchBarProps: ObservabilityAlertSearchBarProps = {
       appName: 'testAppName',
       kuery: '',
@@ -35,6 +38,7 @@ describe('ObservabilityAlertSearchBar', () => {
           <div data-test-subj={ALERT_SEARCH_BAR_DATA_TEST_SUBJ} />
         ),
         useToasts: jest.fn(),
+        ...services,
       },
       ...props,
     };
@@ -151,5 +155,27 @@ describe('ObservabilityAlertSearchBar', () => {
         should: [],
       },
     });
+  });
+
+  it('should show error in a toast', async () => {
+    const error = new Error('something is wrong in esQueryChange');
+    const mockedOnEsQueryChange = jest.fn().mockImplementation(() => {
+      throw error;
+    });
+    const mockedAddError = jest.fn();
+    const mockedUseToast = jest.fn().mockImplementation(() => ({
+      addError: mockedAddError,
+    }));
+
+    renderComponent(
+      {
+        onEsQueryChange: mockedOnEsQueryChange,
+      },
+      {
+        useToasts: mockedUseToast,
+      }
+    );
+
+    expect(mockedAddError).toHaveBeenCalledWith(error, { title: 'Invalid query string' });
   });
 });


### PR DESCRIPTION
Fixes #159079

## Summary

In the case of providing a wildcard in the search query, an error might be generated depending on whether the related setting is enabled or not. This PR tries to handle this error on the Alerts page for a better user experience.

|Before|After|
|---|---|
|![image](https://github.com/elastic/kibana/assets/12370520/f38e4bc7-f900-4c73-8e6e-c1989eda57ad)|![image](https://github.com/elastic/kibana/assets/12370520/cf74577e-10ab-4543-8135-f498dcc7cabf)|

<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->