### PR TITLE
[Telemetry] Permanently hide the telemetry notice on dismissal

### DIFF
--- a/src/plugins/telemetry/server/routes/index.ts
+++ b/src/plugins/telemetry/server/routes/index.ts
@@ -35,6 +35,6 @@ export function registerRoutes(options: RegisterRoutesParams) {
   registerTelemetryConfigRoutes(options);
   registerTelemetryUsageStatsRoutes(router, telemetryCollectionManager, isDev, getSecurity);
   registerTelemetryOptInStatsRoutes(router, telemetryCollectionManager);
-  registerTelemetryUserHasSeenNotice(router);
+  registerTelemetryUserHasSeenNotice(router, options.currentKibanaVersion);
   registerTelemetryLastReported(router, savedObjectsInternalClient$);
 }

--- a/src/plugins/telemetry/server/routes/telemetry_user_has_seen_notice.ts
+++ b/src/plugins/telemetry/server/routes/telemetry_user_has_seen_notice.ts
@@ -15,7 +15,7 @@ import {
   updateTelemetrySavedObject,
 } from '../saved_objects';
 
-export function registerTelemetryUserHasSeenNotice(router: IRouter) {
+export function registerTelemetryUserHasSeenNotice(router: IRouter, currentKibanaVersion: string) {
   router.put(
     {
       path: '/api/telemetry/v2/userHasSeenNotice',
@@ -31,6 +31,9 @@ export function registerTelemetryUserHasSeenNotice(router: IRouter) {
       const updatedAttributes: TelemetrySavedObjectAttributes = {
         ...telemetrySavedObject,
         userHasSeenNotice: true,
+        // We need to store that the user was notified in this version.
+        // Otherwise, it'll continuously show the banner if previously opted-out.
+        lastVersionChecked: currentKibanaVersion,
       };
       await updateTelemetrySavedObject(soClient, updatedAttributes);
 


### PR DESCRIPTION
## Summary

Resolves #159870.

The reasoning for this bugfix is explained in [this comment](https://github.com/elastic/kibana/issues/159870#issuecomment-1596590351).

Note: I couldn't add a functional test to ensure this behavior is kept in the future because [the banner is explicitly disabled in them](https://github.com/elastic/kibana/blob/50444bbd598d8304eb2d99092266435266c744c5/test/common/config.js#L46) (I assume it'd increase the CI execution if we add a step to dismiss the banners). I've created https://github.com/elastic/kibana/issues/159892 to tackle the FTR creation appropriately without the FF pressure.

 

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->