### PR TITLE
[Lens] Use correct theme on save annotations modal

### DIFF
--- a/x-pack/plugins/lens/public/visualizations/xy/annotations/actions/index.ts
+++ b/x-pack/plugins/lens/public/visualizations/xy/annotations/actions/index.ts
@@ -8,6 +8,7 @@
 import type { CoreStart } from '@kbn/core/public';
 import { EventAnnotationServiceType } from '@kbn/event-annotation-plugin/public';
 import { SavedObjectTaggingPluginStart } from '@kbn/saved-objects-tagging-plugin/public';
+import type { ThemeServiceStart } from '@kbn/core/public';
 import { DataViewsContract } from '@kbn/data-views-plugin/public';
 import { VISUALIZE_APP_NAME } from '@kbn/visualizations-plugin/common/constants';
 import { ANNOTATIONS_LISTING_VIEW_ID } from '@kbn/event-annotation-plugin/common';
@@ -27,6 +28,7 @@ export const createAnnotationActions = ({
   eventAnnotationService,
   savedObjectsTagging,
   dataViews,
+  kibanaTheme,
 }: {
   state: XYState;
   layer: XYAnnotationLayerConfig;
@@ -36,6 +38,7 @@ export const createAnnotationActions = ({
   eventAnnotationService: EventAnnotationServiceType;
   savedObjectsTagging?: SavedObjectTaggingPluginStart;
   dataViews: DataViewsContract;
+  kibanaTheme: ThemeServiceStart;
 }): LayerAction[] => {
   const actions = [];
 
@@ -57,6 +60,7 @@ export const createAnnotationActions = ({
           core.application.navigateToApp(VISUALIZE_APP_NAME, {
             path: `#/${ANNOTATIONS_LISTING_VIEW_ID}`,
           }),
+        kibanaTheme,
       })
     );
   }

--- a/x-pack/plugins/lens/public/visualizations/xy/annotations/actions/save_action.tsx
+++ b/x-pack/plugins/lens/public/visualizations/xy/annotations/actions/save_action.tsx
@@ -8,6 +8,7 @@
 import React, { useState } from 'react';
 import { i18n } from '@kbn/i18n';
 import { render, unmountComponentAtNode } from 'react-dom';
+import type { ThemeServiceStart } from '@kbn/core/public';
 import { EventAnnotationServiceType } from '@kbn/event-annotation-plugin/public';
 import { ToastsStart } from '@kbn/core-notifications-browser';
 import { MountPoint } from '@kbn/core-mount-utils-browser';
@@ -16,6 +17,7 @@ import {
   OnSaveProps as SavedObjectOnSaveProps,
   SavedObjectSaveModal,
 } from '@kbn/saved-objects-plugin/public';
+import { KibanaThemeProvider } from '@kbn/kibana-react-plugin/public';
 import { EventAnnotationGroupConfig } from '@kbn/event-annotation-plugin/common';
 import { EuiIcon, EuiLink } from '@elastic/eui';
 import { type SavedObjectTaggingPluginStart } from '@kbn/saved-objects-tagging-plugin/public';
@@ -239,6 +241,7 @@ export const getSaveLayerAction = ({
   savedObjectsTagging,
   dataViews,
   goToAnnotationLibrary,
+  kibanaTheme,
 }: {
   state: XYState;
   layer: XYAnnotationLayerConfig;
@@ -248,6 +251,7 @@ export const getSaveLayerAction = ({
   savedObjectsTagging?: SavedObjectTaggingPluginStart;
   dataViews: DataViewsContract;
   goToAnnotationLibrary: () => Promise<void>;
+  kibanaTheme: ThemeServiceStart;
 }): LayerAction => {
   const neverSaved = !isByReferenceAnnotationsLayer(layer);
 
@@ -267,26 +271,28 @@ export const getSaveLayerAction = ({
     execute: async (domElement) => {
       if (domElement) {
         render(
-          <SaveModal
-            domElement={domElement}
-            savedObjectsTagging={savedObjectsTagging}
-            onSave={async (props) => {
-              await onSave({
-                state,
-                layer,
-                setState,
-                eventAnnotationService,
-                toasts,
-                modalOnSaveProps: props,
-                dataViews,
-                goToAnnotationLibrary,
-              });
-            }}
-            title={neverSaved ? '' : layer.__lastSaved.title}
-            description={neverSaved ? '' : layer.__lastSaved.description}
-            tags={neverSaved ? [] : layer.__lastSaved.tags}
-            showCopyOnSave={!neverSaved}
-          />,
+          <KibanaThemeProvider theme$={kibanaTheme.theme$}>
+            <SaveModal
+              domElement={domElement}
+              savedObjectsTagging={savedObjectsTagging}
+              onSave={async (props) => {
+                await onSave({
+                  state,
+                  layer,
+                  setState,
+                  eventAnnotationService,
+                  toasts,
+                  modalOnSaveProps: props,
+                  dataViews,
+                  goToAnnotationLibrary,
+                });
+              }}
+              title={neverSaved ? '' : layer.__lastSaved.title}
+              description={neverSaved ? '' : layer.__lastSaved.description}
+              tags={neverSaved ? [] : layer.__lastSaved.tags}
+              showCopyOnSave={!neverSaved}
+            />
+          </KibanaThemeProvider>,
           domElement
         );
       }

--- a/x-pack/plugins/lens/public/visualizations/xy/visualization.tsx
+++ b/x-pack/plugins/lens/public/visualizations/xy/visualization.tsx
@@ -297,6 +297,7 @@ export const getXyVisualization = ({
           eventAnnotationService,
           savedObjectsTagging,
           dataViews: data.dataViews,
+          kibanaTheme,
         })
       );
     }


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/159688

It passes the theme on the kibanaThemeProvider to fix the dark mode problem

<img width="972" alt="image" src="https://github.com/elastic/kibana/assets/17003240/df5a9fdc-9828-4f69-a712-4806f0a5455f">
