### PR TITLE
[Cases] Category backend validation

### DIFF
--- a/x-pack/plugins/cases/common/constants/index.ts
+++ b/x-pack/plugins/cases/common/constants/index.ts
@@ -110,6 +110,7 @@ export const MAX_BULK_GET_CASES = 1000 as const;
  */
 
 export const MAX_TITLE_LENGTH = 160 as const;
+export const MAX_CATEGORY_LENGTH = 50 as const;
 
 /**
  * Cases features

--- a/x-pack/plugins/cases/common/utils/validators.test.ts
+++ b/x-pack/plugins/cases/common/utils/validators.test.ts
@@ -5,8 +5,13 @@
  * 2.0.
  */
 
-import { MAX_ASSIGNEES_PER_CASE } from '../constants';
-import { isInvalidTag, areTotalAssigneesInvalid } from './validators';
+import { MAX_ASSIGNEES_PER_CASE, MAX_CATEGORY_LENGTH } from '../constants';
+import {
+  isInvalidTag,
+  areTotalAssigneesInvalid,
+  isCategoryFieldInvalidString,
+  isCategoryFieldTooLong,
+} from './validators';
 
 describe('validators', () => {
   describe('isInvalidTag', () => {
@@ -48,6 +53,44 @@ describe('validators', () => {
 
     it(`returns true if assignees are greater than ${MAX_ASSIGNEES_PER_CASE}`, () => {
       expect(areTotalAssigneesInvalid(generateAssignees(MAX_ASSIGNEES_PER_CASE + 1))).toBe(true);
+    });
+  });
+
+  describe('isCategoryFieldInvalidString', () => {
+    it('validates undefined categories correctly', () => {
+      expect(isCategoryFieldInvalidString()).toBe(false);
+    });
+
+    it('validates null categories correctly', () => {
+      expect(isCategoryFieldInvalidString(null)).toBe(false);
+    });
+
+    it('returns false if the category is a non-empty string', () => {
+      expect(isCategoryFieldInvalidString('foobar')).toBe(false);
+    });
+
+    it('returns true if the category is an empty string', () => {
+      expect(isCategoryFieldInvalidString('')).toBe(true);
+    });
+  });
+
+  describe('isCategoryFieldTooLong', () => {
+    it('validates undefined categories correctly', () => {
+      expect(isCategoryFieldTooLong()).toBe(false);
+    });
+
+    it('validates null categories correctly', () => {
+      expect(isCategoryFieldTooLong(null)).toBe(false);
+    });
+
+    it(`returns false if the category is smaller than ${MAX_CATEGORY_LENGTH}`, () => {
+      expect(isCategoryFieldTooLong('foobar')).toBe(false);
+    });
+
+    it(`returns true if the category is longer than ${MAX_CATEGORY_LENGTH}`, () => {
+      expect(isCategoryFieldTooLong('A very long category with more than fifty characters!')).toBe(
+        true
+      );
     });
   });
 });

--- a/x-pack/plugins/cases/common/utils/validators.ts
+++ b/x-pack/plugins/cases/common/utils/validators.ts
@@ -6,7 +6,7 @@
  */
 
 import type { CaseAssignees } from '../api';
-import { MAX_ASSIGNEES_PER_CASE } from '../constants';
+import { MAX_ASSIGNEES_PER_CASE, MAX_CATEGORY_LENGTH } from '../constants';
 
 export const isInvalidTag = (value: string) => value.trim() === '';
 
@@ -17,3 +17,8 @@ export const areTotalAssigneesInvalid = (assignees?: CaseAssignees): boolean => 
 
   return assignees.length > MAX_ASSIGNEES_PER_CASE;
 };
+
+export const isCategoryFieldInvalidString = (category?: string | null): boolean => category === '';
+
+export const isCategoryFieldTooLong = (category?: string | null): boolean =>
+  category !== undefined && category !== null && category.length > MAX_CATEGORY_LENGTH;

--- a/x-pack/plugins/cases/common/utils/validators.ts
+++ b/x-pack/plugins/cases/common/utils/validators.ts
@@ -18,7 +18,8 @@ export const areTotalAssigneesInvalid = (assignees?: CaseAssignees): boolean => 
   return assignees.length > MAX_ASSIGNEES_PER_CASE;
 };
 
-export const isCategoryFieldInvalidString = (category?: string | null): boolean => category === '';
+export const isCategoryFieldInvalidString = (category?: string | null): boolean =>
+  category?.trim().length === 0;
 
 export const isCategoryFieldTooLong = (category?: string | null): boolean =>
-  category !== undefined && category !== null && category.length > MAX_CATEGORY_LENGTH;
+  category != null && category.length > MAX_CATEGORY_LENGTH;

--- a/x-pack/plugins/cases/server/client/cases/create.test.ts
+++ b/x-pack/plugins/cases/server/client/cases/create.test.ts
@@ -109,5 +109,11 @@ describe('create', () => {
         'Failed to create case: Error: The category cannot be an empty string.'
       );
     });
+
+    it('should throw an error if the category is a string with empty characters', async () => {
+      await expect(create({ ...theCase, category: '   ' }, clientArgs)).rejects.toThrow(
+        'Failed to create case: Error: The category cannot be an empty string.'
+      );
+    });
   });
 });

--- a/x-pack/plugins/cases/server/client/cases/create.test.ts
+++ b/x-pack/plugins/cases/server/client/cases/create.test.ts
@@ -86,12 +86,27 @@ describe('create', () => {
       jest.clearAllMocks();
     });
 
-    it('should throw an error with an excess field exists', async () => {
+    it('should throw an error when an excess field exists', async () => {
       await expect(
         // @ts-expect-error foo is an invalid field
         create({ ...theCase, foo: 'bar' }, clientArgs)
       ).rejects.toThrowErrorMatchingInlineSnapshot(
         `"Failed to create case: Error: invalid keys \\"foo\\""`
+      );
+    });
+
+    it('should throw an error if the category length is too long', async () => {
+      await expect(
+        create(
+          { ...theCase, category: 'A very long category with more than fifty characters!' },
+          clientArgs
+        )
+      ).rejects.toThrow('Failed to create case: Error: The length of the category is too long.');
+    });
+
+    it('should throw an error if the category is an empty string', async () => {
+      await expect(create({ ...theCase, category: '' }, clientArgs)).rejects.toThrow(
+        'Failed to create case: Error: The category cannot be an empty string.'
       );
     });
   });

--- a/x-pack/plugins/cases/server/client/cases/create.ts
+++ b/x-pack/plugins/cases/server/client/cases/create.ts
@@ -17,7 +17,11 @@ import {
   CaseSeverity,
   decodeWithExcessOrThrow,
 } from '../../../common/api';
-import { MAX_ASSIGNEES_PER_CASE, MAX_TITLE_LENGTH } from '../../../common/constants';
+import {
+  MAX_ASSIGNEES_PER_CASE,
+  MAX_CATEGORY_LENGTH,
+  MAX_TITLE_LENGTH,
+} from '../../../common/constants';
 import {
   isInvalidTag,
   areTotalAssigneesInvalid,
@@ -32,13 +36,11 @@ import type { CasesClientArgs } from '..';
 import { LICENSING_CASE_ASSIGNMENT_FEATURE } from '../../common/constants';
 import { decodeOrThrow } from '../../../common/api/runtime_types';
 
-function validateCategory(category: string | null | undefined) {
-  if (category === undefined) {
-    return;
-  }
-
+function validateCategory(category?: string | null) {
   if (isCategoryFieldTooLong(category)) {
-    throw Boom.badRequest('The length of the category is too long.');
+    throw Boom.badRequest(
+      `The length of the category is too long. The maximum length is ${MAX_CATEGORY_LENGTH}`
+    );
   }
 
   if (isCategoryFieldInvalidString(category)) {

--- a/x-pack/plugins/cases/server/client/cases/update.test.ts
+++ b/x-pack/plugins/cases/server/client/cases/update.test.ts
@@ -271,4 +271,57 @@ describe('update', () => {
       );
     });
   });
+
+  describe('Category', () => {
+    const clientArgs = createCasesClientMockArgs();
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      clientArgs.services.caseService.getCases.mockResolvedValue({ saved_objects: mockCases });
+      clientArgs.services.caseService.getAllCaseComments.mockResolvedValue({
+        saved_objects: [],
+        total: 0,
+        per_page: 10,
+        page: 1,
+      });
+    });
+
+    it('does not update the category if the length is too long', async () => {
+      await expect(
+        update(
+          {
+            cases: [
+              {
+                id: mockCases[0].id,
+                version: mockCases[0].version ?? '',
+                category: 'A very long category with more than fifty characters!',
+              },
+            ],
+          },
+          clientArgs
+        )
+      ).rejects.toThrow(
+        'Failed to update case, ids: [{"id":"mock-id-1","version":"WzAsMV0="}]: Error: The length of the category is too long. The maximum length is 50, ids: [mock-id-1]'
+      );
+    });
+
+    it('does not update the category if it is just an empty string', async () => {
+      await expect(
+        update(
+          {
+            cases: [
+              {
+                id: mockCases[0].id,
+                version: mockCases[0].version ?? '',
+                category: '',
+              },
+            ],
+          },
+          clientArgs
+        )
+      ).rejects.toThrow(
+        'Failed to update case, ids: [{"id":"mock-id-1","version":"WzAsMV0="}]: Error: The category cannot be an empty string. Ids: [mock-id-1]'
+      );
+    });
+  });
 });

--- a/x-pack/plugins/cases/server/client/cases/update.test.ts
+++ b/x-pack/plugins/cases/server/client/cases/update.test.ts
@@ -323,5 +323,24 @@ describe('update', () => {
         'Failed to update case, ids: [{"id":"mock-id-1","version":"WzAsMV0="}]: Error: The category cannot be an empty string. Ids: [mock-id-1]'
       );
     });
+
+    it('does not update the category if it is a string with empty characters', async () => {
+      await expect(
+        update(
+          {
+            cases: [
+              {
+                id: mockCases[0].id,
+                version: mockCases[0].version ?? '',
+                category: '   ',
+              },
+            ],
+          },
+          clientArgs
+        )
+      ).rejects.toThrow(
+        'Failed to update case, ids: [{"id":"mock-id-1","version":"WzAsMV0="}]: Error: The category cannot be an empty string. Ids: [mock-id-1]'
+      );
+    });
   });
 });

--- a/x-pack/plugins/cases/server/client/cases/update.ts
+++ b/x-pack/plugins/cases/server/client/cases/update.ts
@@ -127,12 +127,12 @@ function throwIfUpdateAssigneesWithoutValidLicense(
  * the length is > MAX_CATEGORY_LENGTH.
  */
 function throwIfCategoryLengthIsInvalid(requests: UpdateRequestWithOriginalCase[]) {
-  const requestsInvalidTitle = requests.filter(({ updateReq }) =>
+  const requestsInvalidCategory = requests.filter(({ updateReq }) =>
     isCategoryFieldTooLong(updateReq.category)
   );
 
-  if (requestsInvalidTitle.length > 0) {
-    const ids = requestsInvalidTitle.map(({ updateReq }) => updateReq.id);
+  if (requestsInvalidCategory.length > 0) {
+    const ids = requestsInvalidCategory.map(({ updateReq }) => updateReq.id);
     throw Boom.badRequest(
       `The length of the category is too long. The maximum length is ${MAX_CATEGORY_LENGTH}, ids: [${ids.join(
         ', '
@@ -146,12 +146,12 @@ function throwIfCategoryLengthIsInvalid(requests: UpdateRequestWithOriginalCase[
  * the new value is an empty string.
  */
 function throwIfCategoryIsInvalidString(requests: UpdateRequestWithOriginalCase[]) {
-  const requestsInvalidTitle = requests.filter(({ updateReq }) =>
+  const requestsInvalidCategory = requests.filter(({ updateReq }) =>
     isCategoryFieldInvalidString(updateReq.category)
   );
 
-  if (requestsInvalidTitle.length > 0) {
-    const ids = requestsInvalidTitle.map(({ updateReq }) => updateReq.id);
+  if (requestsInvalidCategory.length > 0) {
+    const ids = requestsInvalidCategory.map(({ updateReq }) => updateReq.id);
     throw Boom.badRequest(`The category cannot be an empty string. Ids: [${ids.join(', ')}]`);
   }
 }

--- a/x-pack/plugins/cases/server/client/cases/update.ts
+++ b/x-pack/plugins/cases/server/client/cases/update.ts
@@ -17,7 +17,11 @@ import type {
 
 import { nodeBuilder } from '@kbn/es-query';
 
-import { areTotalAssigneesInvalid } from '../../../common/utils/validators';
+import {
+  areTotalAssigneesInvalid,
+  isCategoryFieldInvalidString,
+  isCategoryFieldTooLong,
+} from '../../../common/utils/validators';
 import type {
   CaseAssignees,
   CaseAttributes,
@@ -39,6 +43,7 @@ import {
   CASE_COMMENT_SAVED_OBJECT,
   CASE_SAVED_OBJECT,
   MAX_ASSIGNEES_PER_CASE,
+  MAX_CATEGORY_LENGTH,
   MAX_TITLE_LENGTH,
 } from '../../../common/constants';
 
@@ -114,6 +119,40 @@ function throwIfUpdateAssigneesWithoutValidLicense(
         ', '
       )}]`
     );
+  }
+}
+
+/**
+ * Throws an error if any of the requests tries to update the category and
+ * the length is > MAX_CATEGORY_LENGTH.
+ */
+function throwIfCategoryLengthIsInvalid(requests: UpdateRequestWithOriginalCase[]) {
+  const requestsInvalidTitle = requests.filter(({ updateReq }) =>
+    isCategoryFieldTooLong(updateReq.category)
+  );
+
+  if (requestsInvalidTitle.length > 0) {
+    const ids = requestsInvalidTitle.map(({ updateReq }) => updateReq.id);
+    throw Boom.badRequest(
+      `The length of the category is too long. The maximum length is ${MAX_CATEGORY_LENGTH}, ids: [${ids.join(
+        ', '
+      )}]`
+    );
+  }
+}
+
+/**
+ * Throws an error if any of the requests tries to update the category and
+ * the new value is an empty string.
+ */
+function throwIfCategoryIsInvalidString(requests: UpdateRequestWithOriginalCase[]) {
+  const requestsInvalidTitle = requests.filter(({ updateReq }) =>
+    isCategoryFieldInvalidString(updateReq.category)
+  );
+
+  if (requestsInvalidTitle.length > 0) {
+    const ids = requestsInvalidTitle.map(({ updateReq }) => updateReq.id);
+    throw Boom.badRequest(`The category cannot be an empty string. Ids: [${ids.join(', ')}]`);
   }
 }
 
@@ -386,6 +425,8 @@ export const update = async (
 
     throwIfUpdateOwner(casesToUpdate);
     throwIfTitleIsInvalid(casesToUpdate);
+    throwIfCategoryLengthIsInvalid(casesToUpdate);
+    throwIfCategoryIsInvalidString(casesToUpdate);
     throwIfUpdateAssigneesWithoutValidLicense(casesToUpdate, hasPlatinumLicense);
     throwIfTotalAssigneesAreInvalid(casesToUpdate);
 

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/patch_cases.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/patch_cases.ts
@@ -614,6 +614,23 @@ export default ({ getService }: FtrProviderContext): void => {
             expectedHttpCode: 400,
           });
         });
+
+        it('400s when a string with spaces category value is passed', async () => {
+          const postedCase = await createCase(supertest, postCaseReq);
+          await updateCase({
+            supertest,
+            params: {
+              cases: [
+                {
+                  id: postedCase.id,
+                  version: postedCase.version,
+                  category: '  ',
+                },
+              ],
+            },
+            expectedHttpCode: 400,
+          });
+        });
       });
     });
 

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/patch_cases.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/patch_cases.ts
@@ -579,6 +579,42 @@ export default ({ getService }: FtrProviderContext): void => {
           expectedHttpCode: 400,
         });
       });
+
+      describe('categories', async () => {
+        it('400s when a too long category value is passed', async () => {
+          const postedCase = await createCase(supertest, postCaseReq);
+          await updateCase({
+            supertest,
+            params: {
+              cases: [
+                {
+                  id: postedCase.id,
+                  version: postedCase.version,
+                  category: 'A very long category with more than fifty characters!',
+                },
+              ],
+            },
+            expectedHttpCode: 400,
+          });
+        });
+
+        it('400s when an empty string category value is passed', async () => {
+          const postedCase = await createCase(supertest, postCaseReq);
+          await updateCase({
+            supertest,
+            params: {
+              cases: [
+                {
+                  id: postedCase.id,
+                  version: postedCase.version,
+                  category: '',
+                },
+              ],
+            },
+            expectedHttpCode: 400,
+          });
+        });
+      });
     });
 
     describe('alerts', () => {

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/post_case.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/post_case.ts
@@ -278,6 +278,28 @@ export default ({ getService }: FtrProviderContext): void => {
           await createCase(supertest, getPostCaseRequest({ tags }), 400);
         });
       });
+
+      describe('categories', async () => {
+        it('400s when the category is too long', async () => {
+          await createCase(
+            supertest,
+            getPostCaseRequest({
+              category: 'A very long category with more than fifty characters!',
+            }),
+            400
+          );
+        });
+
+        it('400s when the category is an empty string', async () => {
+          await createCase(
+            supertest,
+            getPostCaseRequest({
+              category: '',
+            }),
+            400
+          );
+        });
+      });
     });
 
     describe('rbac', () => {

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/post_case.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/post_case.ts
@@ -299,6 +299,16 @@ export default ({ getService }: FtrProviderContext): void => {
             400
           );
         });
+
+        it('400s when the category is a string just with spaces', async () => {
+          await createCase(
+            supertest,
+            getPostCaseRequest({
+              category: '   ',
+            }),
+            400
+          );
+        });
       });
     });
 


### PR DESCRIPTION
### Summary

On this PR we are now validating the category field in the backend.

The category cannot be:
 - longer than 50 characters
 - an empty string