### PR TITLE
[Cloud Security] removing created by from telemetry

### DIFF
--- a/x-pack/plugins/cloud_security_posture/server/lib/telemetry/collectors/installation_stats_collector.ts
+++ b/x-pack/plugins/cloud_security_posture/server/lib/telemetry/collectors/installation_stats_collector.ts
@@ -50,7 +50,6 @@ export const getInstallationStats = async (
           deployment_mode: packagePolicy.vars?.deployment?.value as string,
           package_version: packagePolicy.package?.version as string,
           created_at: packagePolicy.created_at,
-          created_by: packagePolicy.created_by,
           agent_policy_id: packagePolicy.policy_id,
           agent_count: agentCounts,
         };

--- a/x-pack/plugins/cloud_security_posture/server/lib/telemetry/collectors/schema.ts
+++ b/x-pack/plugins/cloud_security_posture/server/lib/telemetry/collectors/schema.ts
@@ -152,7 +152,6 @@ export const cspmUsageSchema: MakeSchemaFrom<CspmUsage> = {
       agent_policy_id: { type: 'keyword' },
       deployment_mode: { type: 'keyword' },
       created_at: { type: 'date' },
-      created_by: { type: 'keyword' },
       agent_count: { type: 'long' },
     },
   },

--- a/x-pack/plugins/cloud_security_posture/server/lib/telemetry/collectors/types.ts
+++ b/x-pack/plugins/cloud_security_posture/server/lib/telemetry/collectors/types.ts
@@ -85,6 +85,5 @@ export interface CloudSecurityInstallationStats {
   agent_policy_id: string;
   deployment_mode: string;
   created_at: string;
-  created_by: string;
   agent_count: number;
 }

--- a/x-pack/plugins/telemetry_collection_xpack/schema/xpack_plugins.json
+++ b/x-pack/plugins/telemetry_collection_xpack/schema/xpack_plugins.json
@@ -5682,9 +5682,6 @@
               "created_at": {
                 "type": "date"
               },
-              "created_by": {
-                "type": "keyword"
-              },
               "agent_count": {
                 "type": "long"
               }


### PR DESCRIPTION
removing `created_by` field from telemetry