### PR TITLE
[AO] Set Feature flag of the Log threshold alert detail page to ON by default

### DIFF
--- a/x-pack/plugins/observability/server/index.ts
+++ b/x-pack/plugins/observability/server/index.ts
@@ -36,7 +36,7 @@ const configSchema = schema.object({
         enabled: schema.boolean({ defaultValue: false }),
       }),
       logs: schema.object({
-        // Enable it by defult: https://github.com/elastic/kibana/issues/159945
+        // Enable it by default: https://github.com/elastic/kibana/issues/159945
         enabled: schema.boolean({ defaultValue: true }),
       }),
       uptime: schema.object({

--- a/x-pack/plugins/observability/server/index.ts
+++ b/x-pack/plugins/observability/server/index.ts
@@ -19,6 +19,7 @@ import {
   WrappedElasticsearchClientError,
 } from '../common/utils/unwrap_es_response';
 import { observabilityCoPilotConfig } from './services/openai/config';
+
 export { rangeQuery, kqlQuery, termQuery, termsQuery } from './utils/queries';
 export { getInspectResponse } from '../common/utils/get_inspect_response';
 
@@ -35,7 +36,8 @@ const configSchema = schema.object({
         enabled: schema.boolean({ defaultValue: false }),
       }),
       logs: schema.object({
-        enabled: schema.boolean({ defaultValue: false }),
+        // Enable it by defult: https://github.com/elastic/kibana/issues/159945
+        enabled: schema.boolean({ defaultValue: true }),
       }),
       uptime: schema.object({
         enabled: schema.boolean({ defaultValue: false }),


### PR DESCRIPTION
## Summary

it fixes #159945


## Release note:
Introducing the Logs threshold alert detail page, which provides more information and context about the Logs threshold alert