### PR TITLE
[Lens] Don't preserve default filter by when moving away from last value

### DIFF
--- a/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/helpers.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/helpers.tsx
@@ -21,7 +21,7 @@ import {
   FormattedIndexPatternColumn,
   ReferenceBasedIndexPatternColumn,
 } from './column_types';
-import type { FormBasedLayer } from '../../types';
+import type { FormBasedLayer, LastValueIndexPatternColumn } from '../../types';
 import { hasField } from '../../pure_utils';
 
 export function getInvalidFieldMessage(
@@ -205,7 +205,8 @@ export function getFilter(
 ) {
   let filter = previousColumn?.filter;
   if (
-    previousColumn?.operationType === 'last_value' &&
+    previousColumn &&
+    isColumnOfType<LastValueIndexPatternColumn>('last_value', previousColumn) &&
     isEqual(filter, getExistsFilter((previousColumn as LastValueColumn)?.sourceField))
   ) {
     return;

--- a/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/helpers.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/helpers.tsx
@@ -8,6 +8,8 @@
 import { i18n } from '@kbn/i18n';
 import React, { Fragment } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { isEqual } from 'lodash';
+import { LastValueColumn } from '@kbn/visualizations-plugin/common';
 import type { IndexPattern, IndexPatternField } from '../../../../types';
 import {
   type FieldBasedOperationErrorMessage,
@@ -190,11 +192,24 @@ export function getFormatFromPreviousColumn(
     : undefined;
 }
 
+export function getExistsFilter(field: string) {
+  return {
+    query: `${field}: *`,
+    language: 'kuery',
+  };
+}
+
 export function getFilter(
   previousColumn: GenericIndexPatternColumn | undefined,
   columnParams: { kql?: string | undefined; lucene?: string | undefined } | undefined
 ) {
   let filter = previousColumn?.filter;
+  if (
+    previousColumn?.operationType === 'last_value' &&
+    isEqual(filter, getExistsFilter((previousColumn as LastValueColumn)?.sourceField))
+  ) {
+    return;
+  }
   if (columnParams) {
     if ('kql' in columnParams) {
       filter = { query: columnParams.kql ?? '', language: 'kuery' };

--- a/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/last_value.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/last_value.tsx
@@ -28,6 +28,7 @@ import {
   getInvalidFieldMessage,
   getSafeName,
   getFilter,
+  getExistsFilter,
 } from './helpers';
 import { adjustTimeScaleLabelSuffix } from '../time_scale_utils';
 import { isRuntimeField, isScriptedField } from './terms/helpers';
@@ -141,13 +142,6 @@ export interface LastValueIndexPatternColumn extends FieldBasedIndexPatternColum
     showArrayValues: boolean;
     // last value on numeric fields can be formatted
     format?: ValueFormatConfig;
-  };
-}
-
-function getExistsFilter(field: string) {
-  return {
-    query: `${field}: *`,
-    language: 'kuery',
   };
 }
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/159805


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
