### PR TITLE
[Fleet][Agent Tampering] Remove unused `created_at` field from uninstall token SO mapping

### DIFF
--- a/packages/kbn-check-mappings-update-cli/current_mappings.json
+++ b/packages/kbn-check-mappings-update-cli/current_mappings.json
@@ -931,17 +931,6 @@
       }
     }
   },
-  "event-annotation-group": {
-    "dynamic": false,
-    "properties": {
-      "title": {
-        "type": "text"
-      },
-      "description": {
-        "type": "text"
-      }
-    }
-  },
   "visualization": {
     "dynamic": false,
     "properties": {
@@ -956,6 +945,17 @@
       },
       "kibanaSavedObjectMeta": {
         "properties": {}
+      }
+    }
+  },
+  "event-annotation-group": {
+    "dynamic": false,
+    "properties": {
+      "title": {
+        "type": "text"
+      },
+      "description": {
+        "type": "text"
       }
     }
   },
@@ -1898,9 +1898,6 @@
   "fleet-uninstall-tokens": {
     "dynamic": false,
     "properties": {
-      "created_at": {
-        "type": "date"
-      },
       "policy_id": {
         "type": "keyword"
       },

--- a/src/core/server/integration_tests/saved_objects/migrations/group2/check_registered_types.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/group2/check_registered_types.test.ts
@@ -96,7 +96,7 @@ describe('checking migration metadata changes on all registered SO types', () =>
         "fleet-message-signing-keys": "93421f43fed2526b59092a4e3c65d64bc2266c0f",
         "fleet-preconfiguration-deletion-record": "c52ea1e13c919afe8a5e8e3adbb7080980ecc08e",
         "fleet-proxy": "6cb688f0d2dd856400c1dbc998b28704ff70363d",
-        "fleet-uninstall-tokens": "d25a8aedb522d2b839ab0950160777528122070f",
+        "fleet-uninstall-tokens": "ed8aa37e3cdd69e4360709e64944bb81cae0c025",
         "graph-workspace": "5cc6bb1455b078fd848c37324672163f09b5e376",
         "guided-onboarding-guide-state": "d338972ed887ac480c09a1a7fbf582d6a3827c91",
         "guided-onboarding-plugin-state": "bc109e5ef46ca594fdc179eda15f3095ca0a37a4",

--- a/x-pack/plugins/fleet/server/saved_objects/index.ts
+++ b/x-pack/plugins/fleet/server/saved_objects/index.ts
@@ -410,7 +410,6 @@ const getSavedObjectTypes = (): { [key: string]: SavedObjectsType } => ({
     mappings: {
       dynamic: false,
       properties: {
-        created_at: { type: 'date' },
         policy_id: { type: 'keyword' },
         token_plain: { type: 'keyword' },
       },

--- a/x-pack/plugins/fleet/server/services/security/uninstall_token_service/index.ts
+++ b/x-pack/plugins/fleet/server/services/security/uninstall_token_service/index.ts
@@ -152,7 +152,7 @@ export class UninstallTokenService implements UninstallTokenServiceInterface {
             latest: {
               top_hits: {
                 size: 1,
-                sort: [{ [`${UNINSTALL_TOKENS_SAVED_OBJECT_TYPE}.created_at`]: { order: 'desc' } }],
+                sort: [{ created_at: { order: 'desc' } }],
               },
             },
           },


### PR DESCRIPTION
## Summary

`created_at` field was added to the mapping for the uninstall token Saved Object, but it's not used and causes trouble.
~There is a discussion whether to remove it from the mapping or not, before the recently added mapping itself is released with v8.9.0, so I prepared this PR to merge in case we want to remove it.~ The discussion ended with the decision to remove the field, so the aim is to merge this PR.

