### PR TITLE
[Profiling] Internal APIs

### DIFF
--- a/x-pack/plugins/profiling/common/index.ts
+++ b/x-pack/plugins/profiling/common/index.ts
@@ -15,7 +15,7 @@ export const INDEX_TRACES = 'profiling-stacktraces';
 export const INDEX_FRAMES = 'profiling-stackframes';
 export const INDEX_EXECUTABLES = 'profiling-executables';
 
-const BASE_ROUTE_PATH = '/api/profiling/v1';
+const BASE_ROUTE_PATH = '/internal/profiling';
 
 export function getRoutePaths() {
   return {

--- a/x-pack/plugins/profiling/e2e/cypress/e2e/empty_state/home.cy.ts
+++ b/x-pack/plugins/profiling/e2e/cypress/e2e/empty_state/home.cy.ts
@@ -11,7 +11,7 @@ describe('Home page with empty state', () => {
   });
 
   it('shows the empty state when Profiling has not been set up', () => {
-    cy.intercept('GET', '/api/profiling/v1/setup/es_resources', {
+    cy.intercept('GET', '/internal/profiling/setup/es_resources', {
       fixture: 'es_resources_setup_false.json',
     }).as('getEsResources');
     cy.visitKibana('/app/profiling');
@@ -21,7 +21,7 @@ describe('Home page with empty state', () => {
   });
 
   it('shows the tutorial after Profiling has been set up', () => {
-    cy.intercept('GET', '/api/profiling/v1/setup/es_resources', {
+    cy.intercept('GET', '/internal/profiling/setup/es_resources', {
       fixture: 'es_resources_data_false.json',
     }).as('getEsResources');
     cy.visitKibana('/app/profiling');

--- a/x-pack/plugins/profiling/e2e/cypress_test_runner.ts
+++ b/x-pack/plugins/profiling/e2e/cypress_test_runner.ts
@@ -45,7 +45,7 @@ export async function cypressTestRunner({
   await axios.post(`${kibanaUrlWithAuth}/api/fleet/setup`, {}, { headers: { 'kbn-xsrf': true } });
 
   const profilingResources = await axios.get<{ has_setup: boolean; has_data: boolean }>(
-    `${kibanaUrlWithAuth}/api/profiling/v1/setup/es_resources`,
+    `${kibanaUrlWithAuth}/internal/profiling/setup/es_resources`,
     { headers: { 'kbn-xsrf': true } }
   );
 

--- a/x-pack/plugins/profiling/e2e/cypress_test_runner.ts
+++ b/x-pack/plugins/profiling/e2e/cypress_test_runner.ts
@@ -9,7 +9,6 @@ import axios from 'axios';
 import cypress from 'cypress';
 import path from 'path';
 import Url from 'url';
-import { getRoutePaths } from '../common';
 import { FtrProviderContext } from './ftr_provider_context';
 import { loadProfilingData } from './load_profiling_data';
 import { setupProfilingResources } from './setup_profiling_resources';
@@ -45,9 +44,8 @@ export async function cypressTestRunner({
   // Ensure Fleet setup is complete
   await axios.post(`${kibanaUrlWithAuth}/api/fleet/setup`, {}, { headers: { 'kbn-xsrf': true } });
 
-  const paths = getRoutePaths();
   const profilingResources = await axios.get<{ has_setup: boolean; has_data: boolean }>(
-    `${kibanaUrlWithAuth}/${paths.HasSetupESResources}`,
+    `${kibanaUrlWithAuth}/internal/profiling/setup/es_resources`,
     { headers: { 'kbn-xsrf': true } }
   );
 

--- a/x-pack/plugins/profiling/e2e/cypress_test_runner.ts
+++ b/x-pack/plugins/profiling/e2e/cypress_test_runner.ts
@@ -9,6 +9,7 @@ import axios from 'axios';
 import cypress from 'cypress';
 import path from 'path';
 import Url from 'url';
+import { getRoutePaths } from '../common';
 import { FtrProviderContext } from './ftr_provider_context';
 import { loadProfilingData } from './load_profiling_data';
 import { setupProfilingResources } from './setup_profiling_resources';
@@ -44,8 +45,9 @@ export async function cypressTestRunner({
   // Ensure Fleet setup is complete
   await axios.post(`${kibanaUrlWithAuth}/api/fleet/setup`, {}, { headers: { 'kbn-xsrf': true } });
 
+  const paths = getRoutePaths();
   const profilingResources = await axios.get<{ has_setup: boolean; has_data: boolean }>(
-    `${kibanaUrlWithAuth}/internal/profiling/setup/es_resources`,
+    `${kibanaUrlWithAuth}/${paths.HasSetupESResources}`,
     { headers: { 'kbn-xsrf': true } }
   );
 

--- a/x-pack/plugins/profiling/e2e/setup_profiling_resources.ts
+++ b/x-pack/plugins/profiling/e2e/setup_profiling_resources.ts
@@ -6,19 +6,16 @@
  */
 
 import axios from 'axios';
-import { getRoutePaths } from '../common';
 
 export async function setupProfilingResources({
   kibanaUrlWithAuth,
 }: {
   kibanaUrlWithAuth: string;
 }) {
-  const paths = getRoutePaths();
-
   // eslint-disable-next-line no-console
   console.log('Setting up Universal profiling resources...');
   await axios.post(
-    `${kibanaUrlWithAuth}/${paths.HasSetupESResources}`,
+    `${kibanaUrlWithAuth}/internal/profiling/setup/es_resources`,
     {},
     { headers: { 'kbn-xsrf': true } }
   );

--- a/x-pack/plugins/profiling/e2e/setup_profiling_resources.ts
+++ b/x-pack/plugins/profiling/e2e/setup_profiling_resources.ts
@@ -6,16 +6,19 @@
  */
 
 import axios from 'axios';
+import { getRoutePaths } from '../common';
 
 export async function setupProfilingResources({
   kibanaUrlWithAuth,
 }: {
   kibanaUrlWithAuth: string;
 }) {
+  const paths = getRoutePaths();
+
   // eslint-disable-next-line no-console
   console.log('Setting up Universal profiling resources...');
   await axios.post(
-    `${kibanaUrlWithAuth}/api/profiling/v1/setup/es_resources`,
+    `${kibanaUrlWithAuth}/${paths.HasSetupESResources}`,
     {},
     { headers: { 'kbn-xsrf': true } }
   );


### PR DESCRIPTION
As part of making the Universal Profiling plugin production ready, I'm tagging all our APIs as `internal`, as none of them is used by external resources. And because they are internal apis there's no need to add a version to it.

Before: `/api/profiling/v1/...`
After: `/internal/profiling/...`