### PR TITLE
[Enterprise Search] Prefix target index for access control syncs with "search-acl-filter-"

### DIFF
--- a/x-pack/plugins/enterprise_search/server/index.ts
+++ b/x-pack/plugins/enterprise_search/server/index.ts
@@ -52,3 +52,4 @@ export const CURRENT_CONNECTORS_INDEX = '.elastic-connectors-v1';
 export const CONNECTORS_JOBS_INDEX = '.elastic-connectors-sync-jobs';
 export const CONNECTORS_VERSION = 1;
 export const CRAWLERS_INDEX = '.ent-search-actastic-crawler2_configurations_v2';
+export const CONNECTORS_ACCESS_CONTROL_INDEX_PREFIX = 'search-acl-filter-';

--- a/x-pack/plugins/enterprise_search/server/lib/connectors/start_sync.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/connectors/start_sync.test.ts
@@ -7,7 +7,11 @@
 
 import { IScopedClusterClient } from '@kbn/core/server';
 
-import { CONNECTORS_INDEX, CONNECTORS_JOBS_INDEX } from '../..';
+import {
+  CONNECTORS_ACCESS_CONTROL_INDEX_PREFIX,
+  CONNECTORS_INDEX,
+  CONNECTORS_JOBS_INDEX,
+} from '../..';
 import { SyncJobType, SyncStatus, TriggerMethod } from '../../../common/types/connectors';
 
 import { ErrorCode } from '../../../common/types/error_codes';
@@ -345,7 +349,7 @@ describe('startSync lib function', () => {
           configuration: {},
           filtering: null,
           id: 'connectorId',
-          index_name: 'index_name',
+          index_name: `${CONNECTORS_ACCESS_CONTROL_INDEX_PREFIX}index_name`,
           language: null,
           pipeline: null,
           service_type: null,

--- a/x-pack/plugins/enterprise_search/server/lib/connectors/start_sync.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/connectors/start_sync.test.ts
@@ -315,7 +315,7 @@ describe('startSync lib function', () => {
           created_at: null,
           custom_scheduling: {},
           error: null,
-          index_name: 'index_name',
+          index_name: 'search-index_name',
           language: null,
           last_access_control_sync_status: null,
           last_seen: null,

--- a/x-pack/plugins/enterprise_search/server/lib/connectors/start_sync.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/connectors/start_sync.ts
@@ -67,9 +67,10 @@ export const startConnectorSync = async (
       });
     }
 
+    const indexNameWithoutSearchPrefix = index_name.replace('search-', '');
     const targetIndexName =
       jobType === SyncJobType.ACCESS_CONTROL
-        ? `${CONNECTORS_ACCESS_CONTROL_INDEX_PREFIX}index_name`
+        ? `${CONNECTORS_ACCESS_CONTROL_INDEX_PREFIX}${indexNameWithoutSearchPrefix}`
         : index_name;
 
     return await client.asCurrentUser.index<ConnectorSyncJobDocument>({

--- a/x-pack/plugins/enterprise_search/server/lib/connectors/start_sync.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/connectors/start_sync.ts
@@ -69,7 +69,7 @@ export const startConnectorSync = async (
 
     const targetIndexName =
       jobType === SyncJobType.ACCESS_CONTROL
-        ? CONNECTORS_ACCESS_CONTROL_INDEX_PREFIX + index_name
+        ? `${CONNECTORS_ACCESS_CONTROL_INDEX_PREFIX}index_name`
         : index_name;
 
     return await client.asCurrentUser.index<ConnectorSyncJobDocument>({


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/enterprise-search-team/issues/4979

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios