### PR TITLE
Fixes per-object audit logging for saved object resolve actions

### DIFF
--- a/config/kibana.yml
+++ b/config/kibana.yml
@@ -164,15 +164,3 @@
 # Maximum number of documents loaded by each shard to generate autocomplete suggestions.
 # This value must be a whole number greater than zero. Defaults to 100_000
 #unifiedSearch.autocomplete.valueSuggestions.terminateAfter: 100000
-xpack.security.audit.enabled: true
-xpack.security.audit.appender:
-  type: rolling-file
-  fileName: ./logs/audit.log
-  policy:
-    type: time-interval
-    interval: 24h
-  strategy:
-    type: numeric
-    max: 10
-  layout:
-    type: json

--- a/config/kibana.yml
+++ b/config/kibana.yml
@@ -164,3 +164,15 @@
 # Maximum number of documents loaded by each shard to generate autocomplete suggestions.
 # This value must be a whole number greater than zero. Defaults to 100_000
 #unifiedSearch.autocomplete.valueSuggestions.terminateAfter: 100000
+xpack.security.audit.enabled: true
+xpack.security.audit.appender:
+  type: rolling-file
+  fileName: ./logs/audit.log
+  policy:
+    type: time-interval
+    interval: 24h
+  strategy:
+    type: numeric
+    max: 10
+  layout:
+    type: json

--- a/x-pack/plugins/security/server/saved_objects/saved_objects_security_extension.ts
+++ b/x-pack/plugins/security/server/saved_objects/saved_objects_security_extension.ts
@@ -1212,7 +1212,7 @@ export class SavedObjectsSecurityExtension implements ISavedObjectsSecurityExten
       types: new Set(typesAndSpaces.keys()),
       spaces: spacesToAuthorize,
       enforceMap: typesAndSpaces,
-      auditOptions: { useSuccessOutcome: true },
+      auditOptions: { objects: auditableObjects, useSuccessOutcome: true },
     });
 
     return objects.map((result) => {


### PR DESCRIPTION
## Summary
It was noticed that audit logs for Saved Object 'resolve' actions were not getting generated. On investigation we found that this regression was introduced in #148165. During work on migrating saved object authorization and auditing logic into the saved object security extension, several abstracted functions were created for reuse. One of these is responsible for performing audit logging (`auditHelper`). In migration of the unit tests, inputs to the `auditHelper`, via `authorize` and `enforceAuthoriztion`, were not correctly validated for `authorizeAndRedactInternalBulkResolve`.

This PR corrects the regression by passing the saved object information through the call chain to `auditHelper`, and addresses the error in the unit tests by implementing checks to validate the input parameters at each level of the call chain.

This PR also corrects the unit test for auditObjectsForSpaceDeletion.

### Tests
See `x-pack/plugins/security/server/saved_objects/saved_objects_security_extension.test.ts` '#authorizeAndRedactInternalBulkResolve'

### Manual testing:
- Enable audit logging, example:

```yaml
xpack.security.audit.enabled: true
xpack.security.audit.appender:
  type: rolling-file
  fileName: ./logs/audit.log
  policy:
    type: time-interval
    interval: 24h
  strategy:
    type: numeric
    max: 10
  layout:
    type: json
```

- Create several dashboards (or add all sample data sets)
- Open each dashboard in the Kibana UI
- Check the audit logs and verify that there is a "saved_object_resolve" entry to describe each dashboard access event, and that each log contains the dashboard type and id, example:

> {"event":{"action":"saved_object_resolve","category":["database"],"type":["access"],"outcome":"success"},"kibana":{"space_id":"default","session_id":"HrDKOgZ6EiEV2bf8Io9bc/enfGsS+fTtbQ5g2ap21CU=","saved_object":{"type":"dashboard","id":"7adfa750-4c81-11e8-b3d7-01146121b73d"}},"user":{"id":"u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0","name":"elastic","roles":["superuser"]},"trace":{"id":"b11f0414-ca68-4e28-854a-249b19f88c36"},"client":{"ip":"127.0.0.1"},"http":{"request":{"headers":{"x-forwarded-for":"127.0.0.1"}}},"service":{"node":{"roles":["background_tasks","ui"]}},"ecs":{"version":"8.6.1"},"@timestamp":"2023-06-20T18:30:20.943+02:00","message":"User has resolved dashboard [id=7adfa750-4c81-11e8-b3d7-01146121b73d]","log":{"level":"INFO","logger":"plugins.security.audit.ecs"},"process":{"pid":15004},"transaction":{"id":"4917a352c3f68cd6"}}

## Release Note:
This PR fixes a regression where the "saved_object_resolve" audit action was not being logged per object.

<!--ONMERGE {"backportTargets":["8.8"]} ONMERGE-->