### PR TITLE
[Cases] Category fixes

### DIFF
--- a/x-pack/plugins/cases/common/api/cases/case.ts
+++ b/x-pack/plugins/cases/common/api/cases/case.ts
@@ -258,7 +258,6 @@ export const CasesFindRequestRt = rt.exact(
     /**
      * The field to use for sorting the found objects.
      *
-     * This only supports, `create_at`, `closed_at`, and `status`
      */
     sortField: rt.string,
     /**

--- a/x-pack/plugins/cases/common/utils/validators.test.ts
+++ b/x-pack/plugins/cases/common/utils/validators.test.ts
@@ -72,6 +72,10 @@ describe('validators', () => {
     it('returns true if the category is an empty string', () => {
       expect(isCategoryFieldInvalidString('')).toBe(true);
     });
+
+    it('returns true if the string contains only spaces', () => {
+      expect(isCategoryFieldInvalidString(' ')).toBe(true);
+    });
   });
 
   describe('isCategoryFieldTooLong', () => {

--- a/x-pack/plugins/cases/public/common/mock/test_providers.tsx
+++ b/x-pack/plugins/cases/public/common/mock/test_providers.tsx
@@ -13,7 +13,6 @@ import { ThemeProvider } from 'styled-components';
 
 import type { RenderOptions, RenderResult } from '@testing-library/react';
 import type { ILicense } from '@kbn/licensing-plugin/public';
-import type { FieldHook } from '@kbn/es-ui-shared-plugin/static/forms/hook_form_lib';
 import type { ScopedFilesClient } from '@kbn/files-plugin/public';
 
 import { euiDarkVars } from '@kbn/ui-theme';
@@ -220,27 +219,3 @@ export const createAppMockRenderer = ({
     getFilesClient,
   };
 };
-
-export const useFormFieldMock = <T,>(options?: Partial<FieldHook<T>>): FieldHook<T> => ({
-  path: 'path',
-  type: 'type',
-  value: 'mockedValue' as unknown as T,
-  isPristine: false,
-  isDirty: false,
-  isModified: false,
-  isValidating: false,
-  isValidated: false,
-  isChangingValue: false,
-  errors: [],
-  isValid: true,
-  getErrorsMessages: jest.fn(),
-  onChange: jest.fn(),
-  setValue: jest.fn(),
-  setErrors: jest.fn(),
-  clearErrors: jest.fn(),
-  validate: jest.fn(),
-  reset: jest.fn(),
-  __isIncludedInOutput: true,
-  __serializeValue: jest.fn(),
-  ...options,
-});

--- a/x-pack/plugins/cases/public/common/test_utils.tsx
+++ b/x-pack/plugins/cases/public/common/test_utils.tsx
@@ -5,9 +5,14 @@
  * 2.0.
  */
 
+/* eslint-disable react/display-name */
+
+import React from 'react';
 import type { ReactWrapper } from 'enzyme';
 import { act } from 'react-dom/test-utils';
 import type { MatcherFunction } from '@testing-library/react';
+import { useForm, Form } from '@kbn/es-ui-shared-plugin/static/forms/hook_form_lib';
+import { EuiButton } from '@elastic/eui';
 
 /**
  * Convenience utility to remove text appended to links by EUI
@@ -39,3 +44,23 @@ export const createQueryWithMarkup =
       );
       return hasText(node) && childrenDontHaveText;
     });
+
+interface FormTestComponentProps {
+  formDefaultValue?: Record<string, unknown>;
+  onSubmit?: jest.Mock;
+}
+
+export const FormTestComponent: React.FC<FormTestComponentProps> = ({
+  children,
+  onSubmit,
+  formDefaultValue,
+}) => {
+  const { form } = useForm({ onSubmit, defaultValue: formDefaultValue });
+
+  return (
+    <Form form={form}>
+      {children}
+      <EuiButton onClick={() => form.submit()}>{'Submit'}</EuiButton>
+    </Form>
+  );
+};

--- a/x-pack/plugins/cases/public/common/translations.ts
+++ b/x-pack/plugins/cases/public/common/translations.ts
@@ -235,7 +235,7 @@ export const ADD_CATEGORY = i18n.translate('xpack.cases.caseView.addCategory', {
   defaultMessage: 'added the category',
 });
 
-export const REMOVE_CATEGORY = i18n.translate('xpack.cases.caseView.removeCategory', {
+export const REMOVE_CATEGORY = i18n.translate('xpack.cases.caseView.userAction.removeCategory', {
   defaultMessage: 'removed the category',
 });
 

--- a/x-pack/plugins/cases/public/components/all_cases/all_cases_list.test.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/all_cases_list.test.tsx
@@ -38,7 +38,11 @@ import { useGetSupportedActionConnectors } from '../../containers/configure/use_
 import { useGetTags } from '../../containers/use_get_tags';
 import { useGetCategories } from '../../containers/use_get_categories';
 import { useUpdateCase } from '../../containers/use_update_case';
-import { useGetCases, DEFAULT_QUERY_PARAMS } from '../../containers/use_get_cases';
+import {
+  useGetCases,
+  DEFAULT_QUERY_PARAMS,
+  DEFAULT_FILTER_OPTIONS,
+} from '../../containers/use_get_cases';
 import { useGetCurrentUserProfile } from '../../containers/user_profiles/use_get_current_user_profile';
 import { userProfiles, userProfilesMap } from '../../containers/user_profiles/api.mock';
 import { useBulkGetUserProfiles } from '../../containers/user_profiles/use_bulk_get_user_profiles';
@@ -82,7 +86,6 @@ const mockKibana = () => {
 };
 
 describe('AllCasesListGeneric', () => {
-  const refetchCases = jest.fn();
   const onRowClick = jest.fn();
   const updateCaseProperty = jest.fn();
 
@@ -90,7 +93,6 @@ describe('AllCasesListGeneric', () => {
 
   const defaultGetCases = {
     ...useGetCasesMockState,
-    refetch: refetchCases,
   };
 
   const defaultColumnArgs = {
@@ -151,8 +153,8 @@ describe('AllCasesListGeneric', () => {
     jest.clearAllMocks();
     appMockRenderer = createAppMockRenderer();
     useGetCasesMock.mockReturnValue(defaultGetCases);
-    useGetTagsMock.mockReturnValue({ data: ['coke', 'pepsi'], refetch: jest.fn() });
-    useGetCategoriesMock.mockReturnValue({ data: ['twix', 'snickers'], refetch: jest.fn() });
+    useGetTagsMock.mockReturnValue({ data: ['coke', 'pepsi'], isLoading: false });
+    useGetCategoriesMock.mockReturnValue({ data: ['twix', 'snickers'], isLoading: false });
     useGetCurrentUserProfileMock.mockReturnValue({ data: userProfiles[0], isLoading: false });
     useBulkGetUserProfilesMock.mockReturnValue({ data: userProfilesMap });
     useGetConnectorsMock.mockImplementation(() => ({ data: connectorsMock, isLoading: false }));
@@ -294,34 +296,22 @@ describe('AllCasesListGeneric', () => {
     });
   });
 
-  it('renders the title column', async () => {
-    appMockRenderer.render(<AllCasesList />);
+  it('renders the columns correctly', async () => {
+    appMockRenderer.render(<AllCasesList isSelectorView={false} />);
 
-    expect(screen.getByTestId('tableHeaderCell_title_0')).toBeInTheDocument();
-  });
+    const casesTable = within(screen.getByTestId('cases-table'));
 
-  it('renders the category column', async () => {
-    appMockRenderer.render(<AllCasesList />);
-
-    expect(screen.getByTestId('tableHeaderCell_category_4')).toBeInTheDocument();
-  });
-
-  it('renders the updated on column', async () => {
-    appMockRenderer.render(<AllCasesList />);
-
-    expect(screen.getByTestId('tableHeaderCell_updatedAt_6')).toBeInTheDocument();
-  });
-
-  it('renders the status column', async () => {
-    appMockRenderer.render(<AllCasesList />);
-
-    expect(screen.getByTestId('tableHeaderCell_status_8')).toBeInTheDocument();
-  });
-
-  it('renders the severity column', async () => {
-    appMockRenderer.render(<AllCasesList />);
-
-    expect(screen.getByTestId('tableHeaderCell_severity_9')).toBeInTheDocument();
+    expect(casesTable.getByTitle('Name')).toBeInTheDocument();
+    expect(casesTable.getByTitle('Category')).toBeInTheDocument();
+    expect(casesTable.getByTitle('Created on')).toBeInTheDocument();
+    expect(casesTable.getByTitle('Updated on')).toBeInTheDocument();
+    expect(casesTable.getByTitle('Status')).toBeInTheDocument();
+    expect(casesTable.getByTitle('Severity')).toBeInTheDocument();
+    expect(casesTable.getByTitle('Tags')).toBeInTheDocument();
+    expect(casesTable.getByTitle('Alerts')).toBeInTheDocument();
+    expect(casesTable.getByTitle('Comments')).toBeInTheDocument();
+    expect(casesTable.getByTitle('External incident')).toBeInTheDocument();
+    expect(casesTable.getByTitle('Actions')).toBeInTheDocument();
   });
 
   it('should not render table utility bar when isSelectorView=true', async () => {
@@ -403,9 +393,7 @@ describe('AllCasesListGeneric', () => {
   it('should sort by status', async () => {
     appMockRenderer.render(<AllCasesList isSelectorView={false} />);
 
-    userEvent.click(
-      within(screen.getByTestId('tableHeaderCell_status_8')).getByTestId('tableHeaderSortButton')
-    );
+    userEvent.click(screen.getByTitle('Status'));
 
     await waitFor(() => {
       expect(useGetCasesMock).toHaveBeenLastCalledWith(
@@ -423,20 +411,17 @@ describe('AllCasesListGeneric', () => {
   it('should render Name, Category, CreatedOn and Severity columns when isSelectorView=true', async () => {
     appMockRenderer.render(<AllCasesList isSelectorView={true} />);
     await waitFor(() => {
-      expect(screen.getByTestId('tableHeaderCell_title_0')).toBeInTheDocument();
-      expect(screen.getByTestId('tableHeaderCell_category_1')).toBeInTheDocument();
-      expect(screen.getByTestId('tableHeaderCell_createdAt_2')).toBeInTheDocument();
-      expect(screen.getByTestId('tableHeaderCell_severity_3')).toBeInTheDocument();
-      expect(screen.queryByTestId('tableHeaderCell_assignees_1')).not.toBeInTheDocument();
+      expect(screen.getByTitle('Name')).toBeInTheDocument();
+      expect(screen.getByTitle('Category')).toBeInTheDocument();
+      expect(screen.getByTitle('Created on')).toBeInTheDocument();
+      expect(screen.getByTitle('Severity')).toBeInTheDocument();
     });
   });
 
   it('should sort by severity', async () => {
     appMockRenderer.render(<AllCasesList isSelectorView={false} />);
 
-    userEvent.click(
-      within(screen.getByTestId('tableHeaderCell_severity_9')).getByTestId('tableHeaderSortButton')
-    );
+    userEvent.click(screen.getByTitle('Severity'));
 
     await waitFor(() => {
       expect(useGetCasesMock).toHaveBeenLastCalledWith(
@@ -454,9 +439,7 @@ describe('AllCasesListGeneric', () => {
   it('should sort by title', async () => {
     appMockRenderer.render(<AllCasesList isSelectorView={false} />);
 
-    userEvent.click(
-      within(screen.getByTestId('tableHeaderCell_title_0')).getByTestId('tableHeaderSortButton')
-    );
+    userEvent.click(screen.getByTitle('Name'));
 
     await waitFor(() => {
       expect(useGetCasesMock).toHaveBeenLastCalledWith(
@@ -474,9 +457,7 @@ describe('AllCasesListGeneric', () => {
   it('should sort by updatedOn', async () => {
     appMockRenderer.render(<AllCasesList isSelectorView={false} />);
 
-    userEvent.click(
-      within(screen.getByTestId('tableHeaderCell_updatedAt_6')).getByTestId('tableHeaderSortButton')
-    );
+    userEvent.click(screen.getByTitle('Updated on'));
 
     await waitFor(() => {
       expect(useGetCasesMock).toHaveBeenLastCalledWith(
@@ -494,9 +475,7 @@ describe('AllCasesListGeneric', () => {
   it('should sort by category', async () => {
     appMockRenderer.render(<AllCasesList isSelectorView={false} />);
 
-    userEvent.click(
-      within(screen.getByTestId('tableHeaderCell_category_4')).getByTestId('tableHeaderSortButton')
-    );
+    userEvent.click(screen.getByTitle('Category'));
 
     await waitFor(() => {
       expect(useGetCasesMock).toHaveBeenLastCalledWith(
@@ -508,6 +487,26 @@ describe('AllCasesListGeneric', () => {
           },
         })
       );
+    });
+  });
+
+  it('should filter by category', async () => {
+    appMockRenderer.render(<AllCasesList isSelectorView={false} />);
+
+    userEvent.click(screen.getByTestId('options-filter-popover-button-Categories'));
+    await waitForEuiPopoverOpen();
+    userEvent.click(screen.getByTestId('options-filter-popover-item-twix'));
+
+    await waitFor(() => {
+      expect(useGetCasesMock).toHaveBeenLastCalledWith({
+        filterOptions: {
+          ...DEFAULT_FILTER_OPTIONS,
+          searchFields: [],
+          owner: ['securitySolution'],
+          category: ['twix'],
+        },
+        queryParams: DEFAULT_QUERY_PARAMS,
+      });
     });
   });
 

--- a/x-pack/plugins/cases/public/components/all_cases/table_filters.test.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/table_filters.test.tsx
@@ -32,7 +32,6 @@ jest.mock('../../containers/use_get_categories');
 jest.mock('../../containers/user_profiles/use_suggest_user_profiles');
 
 const onFilterChanged = jest.fn();
-const refetch = jest.fn();
 const setFilterRefetch = jest.fn();
 
 const props = {
@@ -53,8 +52,11 @@ describe('CasesTableFilters ', () => {
   beforeEach(() => {
     appMockRender = createAppMockRenderer();
     jest.clearAllMocks();
-    (useGetTags as jest.Mock).mockReturnValue({ data: ['coke', 'pepsi'], refetch });
-    (useGetCategories as jest.Mock).mockReturnValue({ data: ['twix', 'snickers'], refetch });
+    (useGetTags as jest.Mock).mockReturnValue({ data: ['coke', 'pepsi'], isLoading: false });
+    (useGetCategories as jest.Mock).mockReturnValue({
+      data: ['twix', 'snickers'],
+      isLoading: false,
+    });
     (useSuggestUserProfiles as jest.Mock).mockReturnValue({ data: userProfiles, isLoading: false });
   });
 

--- a/x-pack/plugins/cases/public/components/case_view/components/assign_users.test.tsx
+++ b/x-pack/plugins/cases/public/components/case_view/components/assign_users.test.tsx
@@ -188,10 +188,12 @@ describe('AssignUsers', () => {
     appMockRender.render(<AssignUsers {...props} />);
 
     fireEvent.mouseEnter(
-      screen.getByTestId(`user-profile-assigned-user-group-${userProfiles[0].user.username}`)
+      screen.getByTestId(`user-profile-assigned-user-${userProfiles[0].user.username}-remove-group`)
     );
     fireEvent.click(
-      screen.getByTestId(`user-profile-assigned-user-cross-${userProfiles[0].user.username}`)
+      screen.getByTestId(
+        `user-profile-assigned-user-${userProfiles[0].user.username}-remove-button`
+      )
     );
 
     await waitFor(() => expect(onAssigneesChanged).toBeCalledTimes(1));
@@ -268,8 +270,8 @@ describe('AssignUsers', () => {
     };
     appMockRender.render(<AssignUsers {...props} />);
 
-    fireEvent.mouseEnter(screen.getByTestId(`user-profile-assigned-user-group-unknownId1`));
-    fireEvent.click(screen.getByTestId(`user-profile-assigned-user-cross-unknownId1`));
+    fireEvent.mouseEnter(screen.getByTestId(`user-profile-assigned-user-unknownId1-remove-group`));
+    fireEvent.click(screen.getByTestId(`user-profile-assigned-user-unknownId1-remove-button`));
 
     await waitFor(() => expect(onAssigneesChanged).toBeCalledTimes(1));
 
@@ -291,8 +293,12 @@ describe('AssignUsers', () => {
     appMockRender.render(<AssignUsers {...props} />);
 
     expect(screen.getByText('Damaged Raccoon')).toBeInTheDocument();
-    expect(screen.getByTestId('user-profile-assigned-user-group-unknownId1')).toBeInTheDocument();
-    expect(screen.getByTestId('user-profile-assigned-user-group-unknownId2')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('user-profile-assigned-user-unknownId1-remove-group')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('user-profile-assigned-user-unknownId2-remove-group')
+    ).toBeInTheDocument();
   });
 
   it('calls onAssigneesChanged with both users with profiles and without', async () => {

--- a/x-pack/plugins/cases/public/components/case_view/components/edit_category.test.tsx
+++ b/x-pack/plugins/cases/public/components/case_view/components/edit_category.test.tsx
@@ -265,7 +265,7 @@ describe('EditCategory ', () => {
       expect(screen.getByText('My category')).toBeInTheDocument();
     });
 
-    userEvent.click(screen.getByTestId('remove-category-cross-button'));
+    userEvent.click(screen.getByTestId('category-remove-button'));
 
     await waitFor(() => expect(onSubmit).toBeCalledWith(null));
   });

--- a/x-pack/plugins/cases/public/components/case_view/components/edit_category.test.tsx
+++ b/x-pack/plugins/cases/public/components/case_view/components/edit_category.test.tsx
@@ -104,6 +104,11 @@ describe('EditCategory ', () => {
     });
 
     userEvent.type(screen.getByRole('combobox'), `${categories[0]}{enter}`);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('edit-category-submit')).not.toBeDisabled();
+    });
+
     userEvent.click(screen.getByTestId('edit-category-submit'));
 
     await waitFor(() => expect(onSubmit).toBeCalledWith(categories[0]));
@@ -119,6 +124,11 @@ describe('EditCategory ', () => {
     });
 
     userEvent.type(screen.getByRole('combobox'), 'new{enter}');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('edit-category-submit')).not.toBeDisabled();
+    });
+
     userEvent.click(screen.getByTestId('edit-category-submit'));
 
     await waitFor(() => expect(onSubmit).toBeCalledWith('new'));
@@ -159,9 +169,61 @@ describe('EditCategory ', () => {
     });
 
     userEvent.click(screen.getByTestId('comboBoxClearButton'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('edit-category-submit')).not.toBeDisabled();
+    });
+
     userEvent.click(screen.getByTestId('edit-category-submit'));
 
     await waitFor(() => expect(onSubmit).toBeCalledWith(null));
+  });
+
+  it('should disabled the save button on error', async () => {
+    const bigCategory = 'a'.repeat(51);
+
+    appMockRender.render(<EditCategory {...defaultProps} />);
+
+    userEvent.click(screen.getByTestId('category-edit-button'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('categories-list')).toBeInTheDocument();
+    });
+
+    userEvent.type(screen.getByRole('combobox'), `${bigCategory}{enter}`);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('The length of the category is too long. The maximum length is 50.')
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('edit-category-submit')).toBeDisabled();
+  });
+
+  it('should disabled the save button on empty state', async () => {
+    appMockRender.render(<EditCategory {...defaultProps} />);
+
+    userEvent.click(screen.getByTestId('category-edit-button'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('categories-list')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('edit-category-submit')).toBeDisabled();
+  });
+
+  it('should disabled the save button on when not changing category', async () => {
+    appMockRender.render(<EditCategory {...defaultProps} category={'My category'} />);
+
+    userEvent.click(screen.getByTestId('category-edit-button'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('categories-list')).toBeInTheDocument();
+      expect(screen.getByText('My category')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('edit-category-submit')).toBeDisabled();
   });
 
   it('does not show edit button when the user does not have update permissions', () => {

--- a/x-pack/plugins/cases/public/components/case_view/components/edit_category.test.tsx
+++ b/x-pack/plugins/cases/public/components/case_view/components/edit_category.test.tsx
@@ -233,4 +233,28 @@ describe('EditCategory ', () => {
 
     expect(screen.queryByTestId('category-edit-button')).not.toBeInTheDocument();
   });
+
+  it('should set the category correctly if it is updated', async () => {
+    const { rerender } = appMockRender.render(
+      <EditCategory {...defaultProps} category={'My category'} />
+    );
+
+    userEvent.click(screen.getByTestId('category-edit-button'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('categories-list')).toBeInTheDocument();
+      expect(screen.getByText('My category')).toBeInTheDocument();
+    });
+
+    userEvent.click(screen.getByTestId('edit-category-cancel'));
+
+    rerender(<EditCategory {...defaultProps} category="category from the API" />);
+
+    userEvent.click(screen.getByTestId('category-edit-button'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('categories-list')).toBeInTheDocument();
+      expect(screen.getByText('category from the API')).toBeInTheDocument();
+    });
+  });
 });

--- a/x-pack/plugins/cases/public/components/case_view/components/edit_category.test.tsx
+++ b/x-pack/plugins/cases/public/components/case_view/components/edit_category.test.tsx
@@ -213,7 +213,7 @@ describe('EditCategory ', () => {
     expect(screen.getByTestId('edit-category-submit')).toBeDisabled();
   });
 
-  it('should disabled the save button on when not changing category', async () => {
+  it('should disabled the save button when not changing category', async () => {
     appMockRender.render(<EditCategory {...defaultProps} category={'My category'} />);
 
     userEvent.click(screen.getByTestId('category-edit-button'));
@@ -256,5 +256,17 @@ describe('EditCategory ', () => {
       expect(screen.getByTestId('categories-list')).toBeInTheDocument();
       expect(screen.getByText('category from the API')).toBeInTheDocument();
     });
+  });
+
+  it('removes the category correctly using the cross button', async () => {
+    appMockRender.render(<EditCategory {...defaultProps} category="My category" />);
+
+    await waitFor(() => {
+      expect(screen.getByText('My category')).toBeInTheDocument();
+    });
+
+    userEvent.click(screen.getByTestId('remove-category-cross-button'));
+
+    await waitFor(() => expect(onSubmit).toBeCalledWith(null));
   });
 });

--- a/x-pack/plugins/cases/public/components/case_view/components/edit_category.tsx
+++ b/x-pack/plugins/cases/public/components/case_view/components/edit_category.tsx
@@ -25,8 +25,8 @@ import { CategoryFormField } from '../../category/category_form_field';
 
 export interface EditCategoryProps {
   isLoading: boolean;
-  onSubmit: (category: string | null | undefined) => void;
-  category: string | null | undefined;
+  onSubmit: (category?: string | null) => void;
+  category?: string | null;
 }
 
 export const EditCategory = React.memo(({ isLoading, onSubmit, category }: EditCategoryProps) => {

--- a/x-pack/plugins/cases/public/components/case_view/components/edit_category.tsx
+++ b/x-pack/plugins/cases/public/components/case_view/components/edit_category.tsx
@@ -15,7 +15,6 @@ import {
   EuiButtonEmpty,
   EuiButtonIcon,
   EuiLoadingSpinner,
-  EuiToolTip,
 } from '@elastic/eui';
 import type { FormHook } from '@kbn/es-ui-shared-plugin/static/forms/hook_form_lib';
 import { Form, useForm } from '@kbn/es-ui-shared-plugin/static/forms/hook_form_lib';
@@ -24,6 +23,7 @@ import * as i18n from '../../category/translations';
 import { CategoryViewer } from '../../category/category_viewer_component';
 import { useCasesContext } from '../../cases_context/use_cases_context';
 import { CategoryFormField } from '../../category/category_form_field';
+import { RemovableItem } from '../../removable_item/removable_item';
 
 export interface EditCategoryProps {
   isLoading: boolean;
@@ -72,7 +72,6 @@ export const EditCategory = React.memo(({ isLoading, onSubmit, category }: EditC
   const { permissions } = useCasesContext();
   const [isEditCategory, setIsEditCategory] = useState(false);
   const { data: categories = [], isLoading: isLoadingCategories } = useGetCategories();
-  const [isHovering, setIsHovering] = useState(false);
 
   const [formState, setFormState] = useState<CategoryFormState>({
     isValid: undefined,
@@ -91,9 +90,6 @@ export const EditCategory = React.memo(({ isLoading, onSubmit, category }: EditC
     onSubmit(null);
     setIsEditCategory(false);
   };
-
-  const onFocus = () => setIsHovering(true);
-  const onFocusLeave = () => setIsHovering(false);
 
   const onSubmitCategory = async () => {
     const { isValid, data } = await formState.submit();
@@ -139,38 +135,14 @@ export const EditCategory = React.memo(({ isLoading, onSubmit, category }: EditC
           {!isEditCategory && (
             <EuiFlexItem>
               {category ? (
-                <EuiFlexGroup
-                  alignItems="center"
-                  gutterSize="s"
-                  justifyContent="spaceBetween"
-                  onMouseEnter={onFocus}
-                  onMouseLeave={onFocusLeave}
+                <RemovableItem
+                  onRemoveItem={removeCategory}
+                  tooltipContent={i18n.REMOVE_CATEGORY}
+                  buttonAriaLabel={i18n.REMOVE_CATEGORY_ARIA_LABEL}
+                  dataTestSubjPrefix="category"
                 >
-                  <EuiFlexItem grow={false}>
-                    <CategoryViewer category={category} />
-                  </EuiFlexItem>
-                  <EuiFlexItem grow={false}>
-                    <EuiToolTip
-                      position="left"
-                      content={i18n.REMOVE_CATEGORY}
-                      data-test-subj="remove-category-cross-tooltip"
-                    >
-                      <EuiButtonIcon
-                        css={{
-                          opacity: isHovering ? 1 : 0,
-                        }}
-                        onFocus={onFocus}
-                        onBlur={onFocusLeave}
-                        data-test-subj="remove-category-cross-button"
-                        aria-label={i18n.REMOVE_CATEGORY_ARIA_LABEL}
-                        iconType="cross"
-                        color="danger"
-                        iconSize="m"
-                        onClick={removeCategory}
-                      />
-                    </EuiToolTip>
-                  </EuiFlexItem>
-                </EuiFlexGroup>
+                  <CategoryViewer category={category} />
+                </RemovableItem>
               ) : (
                 <EuiText size="xs" data-test-subj="no-categories">
                   {i18n.NO_CATEGORIES}

--- a/x-pack/plugins/cases/public/components/case_view/components/edit_category.tsx
+++ b/x-pack/plugins/cases/public/components/case_view/components/edit_category.tsx
@@ -60,6 +60,7 @@ export const EditCategory = React.memo(({ isLoading, onSubmit, category }: EditC
   };
 
   const isLoadingAll = isLoading || isLoadingCategories;
+  const isCategoryValid = form.isValid;
 
   return (
     <EuiFlexItem grow={false}>
@@ -113,6 +114,7 @@ export const EditCategory = React.memo(({ isLoading, onSubmit, category }: EditC
                       iconType="save"
                       onClick={onSubmitCategory}
                       size="s"
+                      disabled={!isCategoryValid || isLoadingAll}
                     >
                       {i18n.SAVE}
                     </EuiButton>

--- a/x-pack/plugins/cases/public/components/case_view/components/edit_category.tsx
+++ b/x-pack/plugins/cases/public/components/case_view/components/edit_category.tsx
@@ -15,6 +15,7 @@ import {
   EuiButtonEmpty,
   EuiButtonIcon,
   EuiLoadingSpinner,
+  EuiToolTip,
 } from '@elastic/eui';
 import type { FormHook } from '@kbn/es-ui-shared-plugin/static/forms/hook_form_lib';
 import { Form, useForm } from '@kbn/es-ui-shared-plugin/static/forms/hook_form_lib';
@@ -71,6 +72,7 @@ export const EditCategory = React.memo(({ isLoading, onSubmit, category }: EditC
   const { permissions } = useCasesContext();
   const [isEditCategory, setIsEditCategory] = useState(false);
   const { data: categories = [], isLoading: isLoadingCategories } = useGetCategories();
+  const [isHovering, setIsHovering] = useState(false);
 
   const [formState, setFormState] = useState<CategoryFormState>({
     isValid: undefined,
@@ -84,6 +86,14 @@ export const EditCategory = React.memo(({ isLoading, onSubmit, category }: EditC
   const onCancel = () => {
     setIsEditCategory(false);
   };
+
+  const removeCategory = () => {
+    onSubmit(null);
+    setIsEditCategory(false);
+  };
+
+  const onFocus = () => setIsHovering(true);
+  const onFocusLeave = () => setIsHovering(false);
 
   const onSubmitCategory = async () => {
     const { isValid, data } = await formState.submit();
@@ -129,7 +139,38 @@ export const EditCategory = React.memo(({ isLoading, onSubmit, category }: EditC
           {!isEditCategory && (
             <EuiFlexItem>
               {category ? (
-                <CategoryViewer category={category} />
+                <EuiFlexGroup
+                  alignItems="center"
+                  gutterSize="s"
+                  justifyContent="spaceBetween"
+                  onMouseEnter={onFocus}
+                  onMouseLeave={onFocusLeave}
+                >
+                  <EuiFlexItem grow={false}>
+                    <CategoryViewer category={category} />
+                  </EuiFlexItem>
+                  <EuiFlexItem grow={false}>
+                    <EuiToolTip
+                      position="left"
+                      content={i18n.REMOVE_CATEGORY}
+                      data-test-subj="remove-category-cross-tooltip"
+                    >
+                      <EuiButtonIcon
+                        css={{
+                          opacity: isHovering ? 1 : 0,
+                        }}
+                        onFocus={onFocus}
+                        onBlur={onFocusLeave}
+                        data-test-subj="remove-category-cross-button"
+                        aria-label={i18n.REMOVE_CATEGORY_ARIA_LABEL}
+                        iconType="cross"
+                        color="danger"
+                        iconSize="m"
+                        onClick={removeCategory}
+                      />
+                    </EuiToolTip>
+                  </EuiFlexItem>
+                </EuiFlexGroup>
               ) : (
                 <EuiText size="xs" data-test-subj="no-categories">
                   {i18n.NO_CATEGORIES}

--- a/x-pack/plugins/cases/public/components/category/category_component.test.tsx
+++ b/x-pack/plugins/cases/public/components/category/category_component.test.tsx
@@ -87,4 +87,20 @@ describe('Category ', () => {
       expect(screen.getByTestId('comboBoxInput')).toHaveTextContent('hi');
     });
   });
+
+  it('should add case sensitive text', async () => {
+    render(<CategoryComponent {...defaultProps} />);
+
+    userEvent.type(screen.getByRole('combobox'), 'hi{enter}');
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith('hi');
+    });
+
+    userEvent.type(screen.getByRole('combobox'), 'Hi{enter}');
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith('Hi');
+    });
+  });
 });

--- a/x-pack/plugins/cases/public/components/category/category_component.tsx
+++ b/x-pack/plugins/cases/public/components/category/category_component.tsx
@@ -65,6 +65,7 @@ export const CategoryComponent: React.FC<CategoryComponentProps> = React.memo(
         aria-label="categories-list"
         isClearable
         customOptionText={ADD_CATEGORY_CUSTOM_OPTION_LABEL_COMBO_BOX}
+        isCaseSensitive
       />
     );
   }

--- a/x-pack/plugins/cases/public/components/category/category_form_field.test.tsx
+++ b/x-pack/plugins/cases/public/components/category/category_form_field.test.tsx
@@ -9,30 +9,16 @@ import React from 'react';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import { useForm, Form } from '@kbn/es-ui-shared-plugin/static/forms/hook_form_lib';
 import type { AppMockRenderer } from '../../common/mock';
 import { createAppMockRenderer } from '../../common/mock';
 import { CategoryFormField } from './category_form_field';
 import { categories } from '../../containers/mock';
-import { EuiButton } from '@elastic/eui';
 import { MAX_CATEGORY_LENGTH } from '../../../common/constants';
+import { FormTestComponent } from '../../common/test_utils';
 
 describe('Category', () => {
   let appMockRender: AppMockRenderer;
   const onSubmit = jest.fn();
-
-  const FormComponent: React.FC<{ category?: string | null }> = ({ children, category }) => {
-    const defaultValue = category !== undefined ? { defaultValue: { category } } : {};
-
-    const { form } = useForm({ onSubmit, ...defaultValue });
-
-    return (
-      <Form form={form}>
-        {children}
-        <EuiButton onClick={() => form.submit()}>{'Submit'}</EuiButton>
-      </Form>
-    );
-  };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -41,9 +27,9 @@ describe('Category', () => {
 
   it('renders the category field correctly', () => {
     appMockRender.render(
-      <FormComponent>
+      <FormTestComponent onSubmit={onSubmit}>
         <CategoryFormField isLoading={false} availableCategories={categories} />
-      </FormComponent>
+      </FormTestComponent>
     );
 
     expect(screen.getByTestId('categories-list')).toBeInTheDocument();
@@ -51,9 +37,9 @@ describe('Category', () => {
 
   it('can submit without setting a category', async () => {
     appMockRender.render(
-      <FormComponent>
+      <FormTestComponent onSubmit={onSubmit}>
         <CategoryFormField isLoading={false} availableCategories={categories} />
-      </FormComponent>
+      </FormTestComponent>
     );
 
     expect(screen.getByTestId('categories-list')).toBeInTheDocument();
@@ -67,9 +53,9 @@ describe('Category', () => {
 
   it('can submit with category a string as default value', async () => {
     appMockRender.render(
-      <FormComponent category={categories[0]}>
+      <FormTestComponent formDefaultValue={{ category: categories[0] }} onSubmit={onSubmit}>
         <CategoryFormField isLoading={false} availableCategories={categories} />
-      </FormComponent>
+      </FormTestComponent>
     );
 
     expect(screen.getByTestId('categories-list')).toBeInTheDocument();
@@ -83,9 +69,9 @@ describe('Category', () => {
 
   it('can submit with category with null as default value', async () => {
     appMockRender.render(
-      <FormComponent category={null}>
+      <FormTestComponent formDefaultValue={{ category: null }} onSubmit={onSubmit}>
         <CategoryFormField isLoading={false} availableCategories={categories} />
-      </FormComponent>
+      </FormTestComponent>
     );
 
     expect(screen.getByTestId('categories-list')).toBeInTheDocument();
@@ -99,9 +85,9 @@ describe('Category', () => {
 
   it('cannot submit if the category is an empty string', async () => {
     appMockRender.render(
-      <FormComponent category={''}>
+      <FormTestComponent formDefaultValue={{ category: '' }} onSubmit={onSubmit}>
         <CategoryFormField isLoading={false} availableCategories={categories} />
-      </FormComponent>
+      </FormTestComponent>
     );
 
     expect(screen.getByTestId('categories-list')).toBeInTheDocument();
@@ -120,9 +106,9 @@ describe('Category', () => {
     const category = 'a'.repeat(MAX_CATEGORY_LENGTH + 1);
 
     appMockRender.render(
-      <FormComponent category={category}>
+      <FormTestComponent formDefaultValue={{ category }} onSubmit={onSubmit}>
         <CategoryFormField isLoading={false} availableCategories={categories} />
-      </FormComponent>
+      </FormTestComponent>
     );
 
     expect(screen.getByTestId('categories-list')).toBeInTheDocument();
@@ -139,9 +125,9 @@ describe('Category', () => {
 
   it('can set a category from existing ones', async () => {
     appMockRender.render(
-      <FormComponent>
+      <FormTestComponent onSubmit={onSubmit}>
         <CategoryFormField isLoading={false} availableCategories={categories} />
-      </FormComponent>
+      </FormTestComponent>
     );
 
     userEvent.type(screen.getByRole('combobox'), `${categories[1]}{enter}`);
@@ -155,9 +141,9 @@ describe('Category', () => {
 
   it('can set a new category', async () => {
     appMockRender.render(
-      <FormComponent>
+      <FormTestComponent onSubmit={onSubmit}>
         <CategoryFormField isLoading={false} availableCategories={categories} />
-      </FormComponent>
+      </FormTestComponent>
     );
 
     userEvent.type(screen.getByRole('combobox'), 'my new category{enter}');
@@ -171,9 +157,9 @@ describe('Category', () => {
 
   it('cannot set an empty category', async () => {
     appMockRender.render(
-      <FormComponent>
+      <FormTestComponent onSubmit={onSubmit}>
         <CategoryFormField isLoading={false} availableCategories={categories} />
-      </FormComponent>
+      </FormTestComponent>
     );
 
     userEvent.type(screen.getByRole('combobox'), ' {enter}');
@@ -188,9 +174,9 @@ describe('Category', () => {
 
   it('setting an empty category and clear it do not produce an error', async () => {
     appMockRender.render(
-      <FormComponent>
+      <FormTestComponent onSubmit={onSubmit}>
         <CategoryFormField isLoading={false} availableCategories={categories} />
-      </FormComponent>
+      </FormTestComponent>
     );
 
     userEvent.type(screen.getByRole('combobox'), ' {enter}');
@@ -212,9 +198,9 @@ describe('Category', () => {
 
   it('disables the component correctly when it is loading', () => {
     appMockRender.render(
-      <FormComponent>
+      <FormTestComponent onSubmit={onSubmit}>
         <CategoryFormField isLoading={true} availableCategories={categories} />
-      </FormComponent>
+      </FormTestComponent>
     );
 
     expect(screen.getByRole('combobox')).toBeDisabled();

--- a/x-pack/plugins/cases/public/components/category/category_form_field.test.tsx
+++ b/x-pack/plugins/cases/public/components/category/category_form_field.test.tsx
@@ -186,7 +186,7 @@ describe('Category', () => {
     });
   });
 
-  it('setting an empty and clear it do not produce an error', async () => {
+  it('setting an empty category and clear it do not produce an error', async () => {
     appMockRender.render(
       <FormComponent>
         <CategoryFormField isLoading={false} availableCategories={categories} />

--- a/x-pack/plugins/cases/public/components/category/category_viewer_component.test.tsx
+++ b/x-pack/plugins/cases/public/components/category/category_viewer_component.test.tsx
@@ -12,9 +12,6 @@ import { CategoryViewer } from './category_viewer_component';
 
 describe('Category viewer ', () => {
   const sampleCategory = 'foobar';
-  beforeEach(() => {
-    jest.resetAllMocks();
-  });
 
   it('renders category', () => {
     render(<CategoryViewer category={sampleCategory} />);

--- a/x-pack/plugins/cases/public/components/category/translations.ts
+++ b/x-pack/plugins/cases/public/components/category/translations.ts
@@ -25,7 +25,7 @@ export const REMOVE_CATEGORY = i18n.translate('xpack.cases.caseView.removeCatego
 });
 
 export const REMOVE_CATEGORY_ARIA_LABEL = i18n.translate(
-  'xpack.cases.userProfile.removeCategoryAriaLabel',
+  'xpack.cases.caseView.removeCategoryAriaLabel',
   {
     defaultMessage: 'click to remove category',
   }

--- a/x-pack/plugins/cases/public/components/category/translations.ts
+++ b/x-pack/plugins/cases/public/components/category/translations.ts
@@ -19,3 +19,14 @@ export const EMPTY_CATEGORY_VALIDATION_MSG = i18n.translate(
     defaultMessage: 'Empty category is not allowed',
   }
 );
+
+export const REMOVE_CATEGORY = i18n.translate('xpack.cases.caseView.removeCategory', {
+  defaultMessage: 'Remove category',
+});
+
+export const REMOVE_CATEGORY_ARIA_LABEL = i18n.translate(
+  'xpack.cases.userProfile.removeCategoryAriaLabel',
+  {
+    defaultMessage: 'click to remove category',
+  }
+);

--- a/x-pack/plugins/cases/public/components/removable_item/removable_item.test.tsx
+++ b/x-pack/plugins/cases/public/components/removable_item/removable_item.test.tsx
@@ -1,0 +1,105 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import type { AppMockRenderer } from '../../common/mock';
+import { noUpdateCasesPermissions, createAppMockRenderer } from '../../common/mock';
+import { fireEvent, screen } from '@testing-library/react';
+import { RemovableItem } from './removable_item';
+import userEvent from '@testing-library/user-event';
+
+const MockComponent = () => {
+  return <span>{'My component'}</span>;
+};
+
+describe('UserRepresentation', () => {
+  let appMockRender: AppMockRenderer;
+
+  const onRemoveItem = jest.fn();
+
+  const defaultProps = {
+    tooltipContent: 'Remove item',
+    buttonAriaLabel: 'Remove item',
+    onRemoveItem,
+  };
+
+  beforeEach(() => {
+    appMockRender = createAppMockRenderer();
+  });
+
+  it('does not show the cross button when the user is not hovering over the row', () => {
+    appMockRender.render(
+      <RemovableItem {...defaultProps}>
+        <MockComponent />
+      </RemovableItem>
+    );
+
+    expect(screen.queryByTestId('remove-button')).toHaveStyle('opacity: 0');
+  });
+
+  it('show the cross button when the user is hovering over the row', () => {
+    appMockRender.render(
+      <RemovableItem {...defaultProps}>
+        <MockComponent />
+      </RemovableItem>
+    );
+
+    fireEvent.mouseEnter(screen.getByTestId('remove-group'));
+
+    expect(screen.getByTestId('remove-button')).toHaveStyle('opacity: 1');
+  });
+
+  it('shows and then removes the cross button when the user hovers and removes the mouse from over the row', () => {
+    appMockRender.render(
+      <RemovableItem {...defaultProps}>
+        <MockComponent />
+      </RemovableItem>
+    );
+
+    fireEvent.mouseEnter(screen.getByTestId('remove-group'));
+    expect(screen.getByTestId('remove-button')).toHaveStyle('opacity: 1');
+
+    fireEvent.mouseLeave(screen.getByTestId('remove-group'));
+    expect(screen.queryByTestId('remove-button')).toHaveStyle('opacity: 0');
+  });
+
+  it('does not show the cross button when the user is hovering over the row and does not have update permissions', () => {
+    appMockRender = createAppMockRenderer({ permissions: noUpdateCasesPermissions() });
+    appMockRender.render(
+      <RemovableItem {...defaultProps}>
+        <MockComponent />
+      </RemovableItem>
+    );
+
+    fireEvent.mouseEnter(screen.getByTestId('remove-group'));
+
+    expect(screen.queryByTestId('remove-button')).not.toBeInTheDocument();
+  });
+
+  it('call onRemoveItem correctly', () => {
+    appMockRender.render(
+      <RemovableItem {...defaultProps}>
+        <MockComponent />
+      </RemovableItem>
+    );
+
+    userEvent.click(screen.getByTestId('remove-button'));
+
+    expect(onRemoveItem).toBeCalled();
+  });
+
+  it('sets the dataTestSubjPrefix correctly', () => {
+    appMockRender.render(
+      <RemovableItem {...defaultProps} dataTestSubjPrefix={'my-prefix'}>
+        <MockComponent />
+      </RemovableItem>
+    );
+
+    expect(screen.getByTestId('my-prefix-remove-group')).toBeInTheDocument();
+    expect(screen.getByTestId('my-prefix-remove-button')).toBeInTheDocument();
+  });
+});

--- a/x-pack/plugins/cases/public/components/removable_item/removable_item.tsx
+++ b/x-pack/plugins/cases/public/components/removable_item/removable_item.tsx
@@ -1,0 +1,74 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiFlexGroup, EuiFlexItem, EuiToolTip, EuiButtonIcon } from '@elastic/eui';
+import React, { useState } from 'react';
+import { useCasesContext } from '../cases_context/use_cases_context';
+
+interface Props {
+  tooltipContent: string;
+  buttonAriaLabel: string;
+  onRemoveItem: () => void;
+  children: React.ReactNode;
+  dataTestSubjPrefix?: string;
+}
+
+const RemovableItemComponent: React.FC<Props> = ({
+  children,
+  tooltipContent,
+  buttonAriaLabel,
+  onRemoveItem,
+  dataTestSubjPrefix = '',
+}) => {
+  const { permissions } = useCasesContext();
+  const [isHovering, setIsHovering] = useState(false);
+
+  const onFocus = () => setIsHovering(true);
+  const onFocusLeave = () => setIsHovering(false);
+
+  const dataTestSubj = dataTestSubjPrefix.length > 0 ? `${dataTestSubjPrefix}-remove-` : 'remove-';
+
+  return (
+    <EuiFlexGroup
+      alignItems="center"
+      gutterSize="s"
+      justifyContent="spaceBetween"
+      onMouseEnter={onFocus}
+      onMouseLeave={onFocusLeave}
+      data-test-subj={`${dataTestSubj}group`}
+    >
+      <EuiFlexItem grow={false}>{children}</EuiFlexItem>
+      {permissions.update && (
+        <EuiFlexItem grow={false}>
+          <EuiToolTip
+            position="left"
+            content={tooltipContent}
+            data-test-subj={`${dataTestSubj}tooltip`}
+          >
+            <EuiButtonIcon
+              css={{
+                opacity: isHovering ? 1 : 0,
+              }}
+              onFocus={onFocus}
+              onBlur={onFocusLeave}
+              data-test-subj={`${dataTestSubj}button`}
+              aria-label={buttonAriaLabel}
+              iconType="cross"
+              color="danger"
+              iconSize="m"
+              onClick={onRemoveItem}
+            />
+          </EuiToolTip>
+        </EuiFlexItem>
+      )}
+    </EuiFlexGroup>
+  );
+};
+
+RemovableItemComponent.displayName = 'RemovableItem';
+
+export const RemovableItem = React.memo(RemovableItemComponent);

--- a/x-pack/plugins/cases/public/components/user_actions/category.test.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/category.test.tsx
@@ -41,7 +41,7 @@ describe('createCategoryUserActionBuilder ', () => {
       </TestProviders>
     );
 
-    expect(screen.getByTestId('category-update-user-action')).toBeInTheDocument();
+    expect(screen.getByTestId('category-update-category-user-action-title')).toBeInTheDocument();
     expect(screen.getByText('added the category "fantasy"')).toBeInTheDocument();
   });
 
@@ -61,7 +61,7 @@ describe('createCategoryUserActionBuilder ', () => {
       </TestProviders>
     );
 
-    expect(screen.getByTestId('category-delete-user-action')).toBeInTheDocument();
+    expect(screen.getByTestId('category-delete-category-user-action-title')).toBeInTheDocument();
     expect(screen.getByText('removed the category')).toBeInTheDocument();
   });
 });

--- a/x-pack/plugins/cases/public/components/user_actions/category.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/category.tsx
@@ -21,7 +21,7 @@ const getLabelTitle = (userAction: UserActionResponse<CategoryUserAction>) => {
     <EuiFlexGroup
       gutterSize="s"
       alignItems="center"
-      data-test-subj={`${userAction.id}-user-action`}
+      data-test-subj={`${userAction.id}-category-user-action-title`}
       responsive={false}
     >
       {userAction.action === Actions.update ? (

--- a/x-pack/plugins/cases/public/components/user_profiles/removable_user.test.tsx
+++ b/x-pack/plugins/cases/public/components/user_profiles/removable_user.test.tsx
@@ -14,10 +14,10 @@ import type { AppMockRenderer } from '../../common/mock';
 import { createAppMockRenderer, noUpdateCasesPermissions } from '../../common/mock';
 
 describe('UserRepresentation', () => {
-  const dataTestSubjGroup = `user-profile-assigned-user-group-${userProfiles[0].user.username}`;
-  const dataTestSubjCross = `user-profile-assigned-user-cross-${userProfiles[0].user.username}`;
-  const dataTestSubjGroupUnknown = `user-profile-assigned-user-group-unknownId`;
-  const dataTestSubjCrossUnknown = `user-profile-assigned-user-cross-unknownId`;
+  const dataTestSubjGroup = `user-profile-assigned-user-${userProfiles[0].user.username}-remove-group`;
+  const dataTestSubjCross = `user-profile-assigned-user-${userProfiles[0].user.username}-remove-button`;
+  const dataTestSubjGroupUnknown = `user-profile-assigned-user-unknownId-remove-group`;
+  const dataTestSubjCrossUnknown = `user-profile-assigned-user-unknownId-remove-button`;
 
   let defaultProps: UserRepresentationProps;
   let appMockRender: AppMockRenderer;

--- a/x-pack/plugins/cases/public/components/user_profiles/removable_user.tsx
+++ b/x-pack/plugins/cases/public/components/user_profiles/removable_user.tsx
@@ -5,12 +5,11 @@
  * 2.0.
  */
 
-import React, { useCallback, useState } from 'react';
-import { EuiButtonIcon, EuiFlexGroup, EuiFlexItem, EuiToolTip } from '@elastic/eui';
+import React, { useCallback } from 'react';
 import * as i18n from './translations';
 import type { Assignee } from './types';
 import { HoverableUserWithAvatar } from './hoverable_user_with_avatar';
-import { useCasesContext } from '../cases_context/use_cases_context';
+import { RemovableItem } from '../removable_item/removable_item';
 
 export interface UserRepresentationProps {
   assignee: Assignee;
@@ -21,55 +20,22 @@ const RemovableUserComponent: React.FC<UserRepresentationProps> = ({
   assignee,
   onRemoveAssignee,
 }) => {
-  const { permissions } = useCasesContext();
-  const [isHovering, setIsHovering] = useState(false);
-
   const removeAssigneeCallback = useCallback(
     () => onRemoveAssignee(assignee.uid),
     [onRemoveAssignee, assignee.uid]
   );
 
-  const onFocus = useCallback(() => setIsHovering(true), []);
-  const onFocusLeave = useCallback(() => setIsHovering(false), []);
-
   const usernameDataTestSubj = assignee.profile?.user.username ?? assignee.uid;
 
   return (
-    <EuiFlexGroup
-      onMouseEnter={onFocus}
-      onMouseLeave={onFocusLeave}
-      alignItems="center"
-      gutterSize="s"
-      justifyContent="spaceBetween"
-      data-test-subj={`user-profile-assigned-user-group-${usernameDataTestSubj}`}
+    <RemovableItem
+      onRemoveItem={removeAssigneeCallback}
+      tooltipContent={i18n.REMOVE_ASSIGNEE}
+      buttonAriaLabel={i18n.REMOVE_ASSIGNEE_ARIA_LABEL}
+      dataTestSubjPrefix={`user-profile-assigned-user-${usernameDataTestSubj}`}
     >
-      <EuiFlexItem grow={false}>
-        <HoverableUserWithAvatar userInfo={assignee.profile} />
-      </EuiFlexItem>
-      {permissions.update && (
-        <EuiFlexItem grow={false}>
-          <EuiToolTip
-            position="left"
-            content={i18n.REMOVE_ASSIGNEE}
-            data-test-subj={`user-profile-assigned-user-cross-tooltip-${usernameDataTestSubj}`}
-          >
-            <EuiButtonIcon
-              css={{
-                opacity: isHovering ? 1 : 0,
-              }}
-              onFocus={onFocus}
-              onBlur={onFocusLeave}
-              data-test-subj={`user-profile-assigned-user-cross-${usernameDataTestSubj}`}
-              aria-label={i18n.REMOVE_ASSIGNEE_ARIA_LABEL}
-              iconType="cross"
-              color="danger"
-              iconSize="m"
-              onClick={removeAssigneeCallback}
-            />
-          </EuiToolTip>
-        </EuiFlexItem>
-      )}
-    </EuiFlexGroup>
+      <HoverableUserWithAvatar userInfo={assignee.profile} />
+    </RemovableItem>
   );
 };
 

--- a/x-pack/plugins/cases/public/containers/api.test.tsx
+++ b/x-pack/plugins/cases/public/containers/api.test.tsx
@@ -438,6 +438,26 @@ describe('Cases API', () => {
       });
       expect(resp).toEqual({ ...allCases });
     });
+
+    it('should not send the category field if it an empty array', async () => {
+      await getCases({
+        filterOptions: {
+          ...DEFAULT_FILTER_OPTIONS,
+          category: [],
+        },
+        queryParams: DEFAULT_QUERY_PARAMS,
+        signal: abortCtrl.signal,
+      });
+
+      expect(fetchMock).toHaveBeenCalledWith(`${CASES_URL}/_find`, {
+        method: 'GET',
+        query: {
+          ...DEFAULT_QUERY_PARAMS,
+          searchFields: DEFAULT_FILTER_OPTIONS.searchFields,
+        },
+        signal: abortCtrl.signal,
+      });
+    });
   });
 
   describe('getCasesStatus', () => {

--- a/x-pack/plugins/cases/public/containers/api.test.tsx
+++ b/x-pack/plugins/cases/public/containers/api.test.tsx
@@ -439,7 +439,7 @@ describe('Cases API', () => {
       expect(resp).toEqual({ ...allCases });
     });
 
-    it('should not send the category field if it an empty array', async () => {
+    it('should not send the category field if it is an empty array', async () => {
       await getCases({
         filterOptions: {
           ...DEFAULT_FILTER_OPTIONS,

--- a/x-pack/plugins/cases/public/containers/use_get_categories.tsx
+++ b/x-pack/plugins/cases/public/containers/use_get_categories.tsx
@@ -16,6 +16,7 @@ import * as i18n from './translations';
 export const useGetCategories = () => {
   const { showErrorToast } = useCasesToast();
   const { owner } = useCasesContext();
+
   return useQuery(
     casesQueriesKeys.categories(),
     () => {
@@ -24,11 +25,7 @@ export const useGetCategories = () => {
     },
     {
       onError: (error: ServerError) => {
-        if (error.name !== 'AbortError') {
-          showErrorToast(error.body && error.body.message ? new Error(error.body.message) : error, {
-            title: i18n.CATEGORIES_ERROR_TITLE,
-          });
-        }
+        showErrorToast(error, { title: i18n.CATEGORIES_ERROR_TITLE });
       },
       staleTime: 60 * 1000, // one minute
     }

--- a/x-pack/plugins/cases/server/client/utils.ts
+++ b/x-pack/plugins/cases/server/client/utils.ts
@@ -456,6 +456,15 @@ export const getCaseToUpdate = (
     { id: queryCase.id, version: queryCase.version }
   );
 
+/**
+ * TODO: Backend is not connected with the
+ * frontend in x-pack/plugins/cases/common/ui/types.ts.
+ * It is easy to forget to update a sort field.
+ * We should fix it and make it common.
+ * Also the sortField in x-pack/plugins/cases/common/api/cases/case.ts
+ * is set to string. We should narrow it to the
+ * acceptable values
+ */
 enum SortFieldCase {
   closedAt = 'closed_at',
   createdAt = 'created_at',
@@ -463,6 +472,7 @@ enum SortFieldCase {
   title = 'title.keyword',
   severity = 'severity',
   updatedAt = 'updated_at',
+  category = 'category',
 }
 
 export const convertSortField = (sortField: string | undefined): SortFieldCase => {
@@ -482,6 +492,8 @@ export const convertSortField = (sortField: string | undefined): SortFieldCase =
     case 'updatedAt':
     case 'updated_at':
       return SortFieldCase.updatedAt;
+    case 'category':
+      return SortFieldCase.category;
     default:
       return SortFieldCase.createdAt;
   }

--- a/x-pack/test/functional_with_es_ssl/apps/cases/group1/create_case_form.ts
+++ b/x-pack/test/functional_with_es_ssl/apps/cases/group1/create_case_form.ts
@@ -85,8 +85,8 @@ export default ({ getService, getPageObject }: FtrProviderContext) => {
 
         await header.waitUntilLoadingHasFinished();
         await testSubjects.existOrFail('case-view-title');
-        await testSubjects.existOrFail('user-profile-assigned-user-group-cases_all_user');
-        await testSubjects.existOrFail('user-profile-assigned-user-group-cases_all_user2');
+        await testSubjects.existOrFail('user-profile-assigned-user-cases_all_user-remove-group');
+        await testSubjects.existOrFail('user-profile-assigned-user-cases_all_user2-remove-group');
       });
     });
   });

--- a/x-pack/test/functional_with_es_ssl/apps/cases/group1/view_case.ts
+++ b/x-pack/test/functional_with_es_ssl/apps/cases/group1/view_case.ts
@@ -596,11 +596,11 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
         });
 
         it('shows the unknown assignee', async () => {
-          await testSubjects.existOrFail('user-profile-assigned-user-group-abc');
+          await testSubjects.existOrFail('user-profile-assigned-user-abc-remove-group');
         });
 
         it('removes the unknown assignee when selecting the remove all users in the popover', async () => {
-          await testSubjects.existOrFail('user-profile-assigned-user-group-abc');
+          await testSubjects.existOrFail('user-profile-assigned-user-abc-remove-group');
 
           await cases.singleCase.openAssigneesPopover();
           await cases.common.setSearchTextInAssigneesPopover('case');
@@ -608,7 +608,7 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
 
           await (await find.byButtonText('Remove all assignees')).click();
           await cases.singleCase.closeAssigneesPopover();
-          await testSubjects.missingOrFail('user-profile-assigned-user-group-abc');
+          await testSubjects.missingOrFail('user-profile-assigned-user-abc-remove-group');
         });
       });
 
@@ -627,7 +627,7 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
         it('assigns the case to the current user when clicking the assign to self link', async () => {
           await testSubjects.click('case-view-assign-yourself-link');
           await header.waitUntilLoadingHasFinished();
-          await testSubjects.existOrFail('user-profile-assigned-user-group-cases_all_user');
+          await testSubjects.existOrFail('user-profile-assigned-user-cases_all_user-remove-group');
         });
       });
 
@@ -652,7 +652,7 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
           await cases.common.selectFirstRowInAssigneesPopover();
           await cases.singleCase.closeAssigneesPopover();
           await header.waitUntilLoadingHasFinished();
-          await testSubjects.existOrFail('user-profile-assigned-user-group-cases_all_user');
+          await testSubjects.existOrFail('user-profile-assigned-user-cases_all_user-remove-group');
         });
 
         it('assigns multiple users', async () => {
@@ -662,8 +662,8 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
 
           await cases.singleCase.closeAssigneesPopover();
           await header.waitUntilLoadingHasFinished();
-          await testSubjects.existOrFail('user-profile-assigned-user-group-cases_all_user');
-          await testSubjects.existOrFail('user-profile-assigned-user-group-cases_all_user2');
+          await testSubjects.existOrFail('user-profile-assigned-user-cases_all_user-remove-group');
+          await testSubjects.existOrFail('user-profile-assigned-user-cases_all_user2-remove-group');
         });
       });
 
@@ -678,17 +678,17 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
           // navigate out of the modal
           await cases.singleCase.closeAssigneesPopover();
           await header.waitUntilLoadingHasFinished();
-          await testSubjects.existOrFail('user-profile-assigned-user-group-cases_all_user');
+          await testSubjects.existOrFail('user-profile-assigned-user-cases_all_user-remove-group');
 
           // hover over the assigned user
           await (
             await find.byCssSelector(
-              '[data-test-subj="user-profile-assigned-user-group-cases_all_user"]'
+              '[data-test-subj="user-profile-assigned-user-cases_all_user-remove-group"]'
             )
           ).moveMouseTo();
 
           // delete the user
-          await testSubjects.click('user-profile-assigned-user-cross-cases_all_user');
+          await testSubjects.click('user-profile-assigned-user-cases_all_user-remove-button');
 
           await testSubjects.existOrFail('case-view-assign-yourself-link');
         });


### PR DESCRIPTION
## Summary

This PR:

- Fixes a bug with the category sorting
- Fixes a bug where the save button is not disabled on error or no changes
- Fixes a bug where case-sensitive categories cannot be added
- Fixes a bug where if the category change from another user the form does not reflect the change
- Fixes a UX bug where it is difficult to understand how to remove a category
- Add more tests


### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
