### PR TITLE
Change service_type for Sharepoint Server connector

### DIFF
--- a/x-pack/plugins/enterprise_search/common/connectors/connectors.ts
+++ b/x-pack/plugins/enterprise_search/common/connectors/connectors.ts
@@ -137,7 +137,7 @@ export const CONNECTOR_DEFINITIONS: ConnectorServerSideDefinition[] = [
     name: i18n.translate('xpack.enterpriseSearch.content.nativeConnectors.sharepoint.name', {
       defaultMessage: 'Sharepoint Server',
     }),
-    serviceType: 'sharepoint',
+    serviceType: 'sharepoint_server',
   },
   {
     iconPath: 'sharepoint_online.svg',


### PR DESCRIPTION
## Summary

With changes from Crest team to move Sharepoint connector to be a Sharepoint Server connector, we need to update `service_type` for the service created by Kibana, see https://github.com/elastic/connectors-python/pull/1065.

This PR does it.
