### PR TITLE
[Enterprise Search] Add vector search and ESRE tiles to guides

### DIFF
--- a/packages/kbn-guided-onboarding/src/components/landing_page/__snapshots__/guide_cards.test.tsx.snap
+++ b/packages/kbn-guided-onboarding/src/components/landing_page/__snapshots__/guide_cards.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`guide cards snapshots should render all cards 1`] = `
             Object {
               "icon": "vector",
               "navigateTo": Object {
-                "appId": "enterpriseSearchVector",
+                "appId": "enterpriseSearchVectorSearch",
               },
               "order": 1,
               "solution": "search",

--- a/packages/kbn-guided-onboarding/src/components/landing_page/__snapshots__/guide_cards.test.tsx.snap
+++ b/packages/kbn-guided-onboarding/src/components/landing_page/__snapshots__/guide_cards.test.tsx.snap
@@ -18,9 +18,61 @@ exports[`guide cards snapshots should render all cards 1`] = `
           activeFilter="all"
           card={
             Object {
+              "icon": "vector",
+              "navigateTo": Object {
+                "appId": "enterpriseSearchVector",
+              },
+              "order": 1,
+              "solution": "search",
+              "telemetryId": "onboarding--search--vector",
+              "title": "Set up vector search",
+            }
+          }
+          guidesState={Array []}
+          navigateToApp={[MockFunction]}
+        />
+        <EuiSpacer
+          size="m"
+        />
+      </EuiFlexItem>
+      <EuiFlexItem
+        grow={false}
+        key="1"
+      >
+        <GuideCard
+          activateGuide={[MockFunction]}
+          activeFilter="all"
+          card={
+            Object {
+              "icon": "magnifyWithPlus",
+              "navigateTo": Object {
+                "appId": "enterpriseSearchEsre",
+              },
+              "order": 4,
+              "solution": "search",
+              "telemetryId": "onboarding--search--semantic",
+              "title": "Build a semantic search experience",
+            }
+          }
+          guidesState={Array []}
+          navigateToApp={[MockFunction]}
+        />
+        <EuiSpacer
+          size="m"
+        />
+      </EuiFlexItem>
+      <EuiFlexItem
+        grow={false}
+        key="2"
+      >
+        <GuideCard
+          activateGuide={[MockFunction]}
+          activeFilter="all"
+          card={
+            Object {
               "guideId": "appSearch",
               "icon": "wrench",
-              "order": 1,
+              "order": 7,
               "solution": "search",
               "telemetryId": "onboarding--search--application",
               "title": <FormattedMessage
@@ -43,7 +95,7 @@ exports[`guide cards snapshots should render all cards 1`] = `
       </EuiFlexItem>
       <EuiFlexItem
         grow={false}
-        key="1"
+        key="3"
       >
         <GuideCard
           activateGuide={[MockFunction]}
@@ -52,7 +104,7 @@ exports[`guide cards snapshots should render all cards 1`] = `
             Object {
               "guideId": "websiteSearch",
               "icon": "search",
-              "order": 4,
+              "order": 10,
               "solution": "search",
               "telemetryId": "onboarding--search--website",
               "title": "Add search to my website",
@@ -67,7 +119,7 @@ exports[`guide cards snapshots should render all cards 1`] = `
       </EuiFlexItem>
       <EuiFlexItem
         grow={false}
-        key="2"
+        key="4"
       >
         <GuideCard
           activateGuide={[MockFunction]}
@@ -76,7 +128,7 @@ exports[`guide cards snapshots should render all cards 1`] = `
             Object {
               "guideId": "databaseSearch",
               "icon": "database",
-              "order": 7,
+              "order": 13,
               "solution": "search",
               "telemetryId": "onboarding--search--database",
               "title": <FormattedMessage

--- a/packages/kbn-guided-onboarding/src/components/landing_page/guide_cards.constants.tsx
+++ b/packages/kbn-guided-onboarding/src/components/landing_page/guide_cards.constants.tsx
@@ -38,7 +38,7 @@ export const guideCards: GuideCardConstants[] = [
       defaultMessage: 'Set up vector search',
     }),
     navigateTo: {
-      appId: 'enterpriseSearch',
+      appId: 'enterpriseSearchVectorSearch',
     },
     telemetryId: 'onboarding--search--vector',
     order: 1,
@@ -46,7 +46,7 @@ export const guideCards: GuideCardConstants[] = [
   {
     solution: 'search',
     icon: 'magnifyWithPlus',
-    title: i18n.translate('guidedOnboardingPackage.gettingStarted.cards.vectorSearch.title', {
+    title: i18n.translate('guidedOnboardingPackage.gettingStarted.cards.esreSearch.title', {
       defaultMessage: 'Build a semantic search experience',
     }),
     navigateTo: {

--- a/packages/kbn-guided-onboarding/src/components/landing_page/guide_cards.constants.tsx
+++ b/packages/kbn-guided-onboarding/src/components/landing_page/guide_cards.constants.tsx
@@ -33,6 +33,30 @@ export interface GuideCardConstants {
 export const guideCards: GuideCardConstants[] = [
   {
     solution: 'search',
+    icon: 'vector',
+    title: i18n.translate('guidedOnboardingPackage.gettingStarted.cards.vectorSearch.title', {
+      defaultMessage: 'Set up vector search',
+    }),
+    navigateTo: {
+      appId: 'enterpriseSearch',
+    },
+    telemetryId: 'onboarding--search--vector',
+    order: 1,
+  },
+  {
+    solution: 'search',
+    icon: 'magnifyWithPlus',
+    title: i18n.translate('guidedOnboardingPackage.gettingStarted.cards.vectorSearch.title', {
+      defaultMessage: 'Build a semantic search experience',
+    }),
+    navigateTo: {
+      appId: 'enterpriseSearchEsre',
+    },
+    telemetryId: 'onboarding--search--semantic',
+    order: 4,
+  },
+  {
+    solution: 'search',
     icon: 'wrench',
     title: (
       <FormattedMessage
@@ -45,7 +69,7 @@ export const guideCards: GuideCardConstants[] = [
     ),
     guideId: 'appSearch',
     telemetryId: 'onboarding--search--application',
-    order: 1,
+    order: 7,
   },
   {
     solution: 'search',
@@ -55,7 +79,7 @@ export const guideCards: GuideCardConstants[] = [
     }),
     guideId: 'websiteSearch',
     telemetryId: 'onboarding--search--website',
-    order: 4,
+    order: 10,
   },
   {
     solution: 'search',
@@ -71,7 +95,7 @@ export const guideCards: GuideCardConstants[] = [
     ),
     guideId: 'databaseSearch',
     telemetryId: 'onboarding--search--database',
-    order: 7,
+    order: 13,
   },
   {
     solution: 'observability',


### PR DESCRIPTION
## Summary

This adds two guide tiles to the onboarding guides page. 
