### PR TITLE
[Dashboard] Fix flaky landing page test

### DIFF
--- a/test/functional/apps/dashboard/group4/dashboard_listing.ts
+++ b/test/functional/apps/dashboard/group4/dashboard_listing.ts
@@ -15,7 +15,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const browser = getService('browser');
   const listingTable = getService('listingTable');
 
-  describe('dashboard listing page', function describeIndexTests() {
+  describe.only('dashboard listing page', function describeIndexTests() {
     const dashboardName = 'Dashboard Listing Test';
 
     before(async function () {

--- a/test/functional/apps/dashboard/group4/dashboard_listing.ts
+++ b/test/functional/apps/dashboard/group4/dashboard_listing.ts
@@ -7,7 +7,6 @@
  */
 
 import expect from '@kbn/expect';
-import { Page } from '@kbn/share-plugin/public/url_service/redirect/components/page';
 
 import { FtrProviderContext } from '../../../ftr_provider_context';
 
@@ -16,12 +15,11 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const browser = getService('browser');
   const listingTable = getService('listingTable');
 
-  describe.only('dashboard listing page', function describeIndexTests() {
+  describe('dashboard listing page', function describeIndexTests() {
     const dashboardName = 'Dashboard Listing Test';
 
     before(async function () {
       await PageObjects.dashboard.initTests();
-      await PageObjects.common.sleep(600);
     });
 
     describe('create prompt', () => {

--- a/test/functional/apps/dashboard/group4/dashboard_listing.ts
+++ b/test/functional/apps/dashboard/group4/dashboard_listing.ts
@@ -7,6 +7,7 @@
  */
 
 import expect from '@kbn/expect';
+import { Page } from '@kbn/share-plugin/public/url_service/redirect/components/page';
 
 import { FtrProviderContext } from '../../../ftr_provider_context';
 
@@ -20,6 +21,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     before(async function () {
       await PageObjects.dashboard.initTests();
+      await PageObjects.common.sleep(600);
     });
 
     describe('create prompt', () => {
@@ -121,6 +123,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         const useTimeStamp = true;
         await browser.get(newUrl.toString(), useTimeStamp);
 
+        await PageObjects.header.awaitKibanaChrome();
+        await PageObjects.header.waitUntilLoadingHasFinished();
         const onDashboardLandingPage = await PageObjects.dashboard.onDashboardLandingPage();
         expect(onDashboardLandingPage).to.equal(false);
       });
@@ -133,6 +137,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         const useTimeStamp = true;
         await browser.get(newUrl.toString(), useTimeStamp);
 
+        await PageObjects.header.awaitKibanaChrome();
+        await PageObjects.header.waitUntilLoadingHasFinished();
         const onDashboardLandingPage = await PageObjects.dashboard.onDashboardLandingPage();
         expect(onDashboardLandingPage).to.equal(false);
       });
@@ -145,6 +151,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         const useTimeStamp = true;
         await browser.get(newUrl.toString(), useTimeStamp);
 
+        await PageObjects.header.awaitKibanaChrome();
         await PageObjects.header.waitUntilLoadingHasFinished();
         const onDashboardLandingPage = await PageObjects.dashboard.onDashboardLandingPage();
         expect(onDashboardLandingPage).to.equal(true);
@@ -165,6 +172,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         const useTimeStamp = true;
         await browser.get(newUrl.toString(), useTimeStamp);
 
+        await PageObjects.header.awaitKibanaChrome();
         await PageObjects.header.waitUntilLoadingHasFinished();
         const onDashboardLandingPage = await PageObjects.dashboard.onDashboardLandingPage();
         expect(onDashboardLandingPage).to.equal(true);
@@ -188,6 +196,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         const useTimeStamp = true;
         await browser.get(newUrl.toString(), useTimeStamp);
 
+        await PageObjects.header.awaitKibanaChrome();
         await PageObjects.header.waitUntilLoadingHasFinished();
         const onDashboardLandingPage = await PageObjects.dashboard.onDashboardLandingPage();
         expect(onDashboardLandingPage).to.equal(false);


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/160057

## Summary

It **seems** like the failure was a one-off or, at the very least, very rare - I [ran the test through the flaky test runner](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2423) without any changes and it passed 100 times. That being said, I was able to replicate the failure locally by switching to the preset "Slow 3G" network before running the test - this means, if the CI environment is running especially slow for any given reason, this test has the potential to fail again. 

So, to be safe, I added an extra `await` for the Kibana **chrome** to show up after every hard refresh - previously we were only waiting for the header loading state to go away, which doesn't work when Kibana itself is taking a little longer than expected to load and the Kibana chrome (where the header loading state is located) isn't yet visible. 

This **also** [passed the flaky test runner 100 times](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2425) but, as a bonus, the test **passed locally** when throttling the network using the same "Slow 3G" preset as before - hopefully this means that the test is less likely to fail even when the CI environment is running slow 👍 

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
