### PR TITLE
[Profiling] Check if data exists before validating setup

### DIFF
--- a/x-pack/plugins/profiling/server/lib/setup/has_profiling_data.ts
+++ b/x-pack/plugins/profiling/server/lib/setup/has_profiling_data.ts
@@ -6,20 +6,13 @@
  */
 
 import { ProfilingSetupOptions } from './types';
-import { PartialSetupState } from '../../../common/setup';
 
-export async function hasProfilingData({
-  client,
-}: ProfilingSetupOptions): Promise<PartialSetupState> {
+export async function hasProfilingData({ client }: ProfilingSetupOptions): Promise<boolean> {
   const hasProfilingDataResponse = await client.search('has_any_profiling_data', {
     index: 'profiling*',
     size: 0,
     track_total_hits: 1,
     terminate_after: 1,
   });
-  return {
-    data: {
-      available: hasProfilingDataResponse.hits.total.value > 0,
-    },
-  };
+  return hasProfilingDataResponse.hits.total.value > 0;
 }

--- a/x-pack/plugins/profiling/server/routes/setup.ts
+++ b/x-pack/plugins/profiling/server/routes/setup.ts
@@ -84,8 +84,17 @@ export function registerSetupRoute({
           });
         }
 
+        state.data.available = await hasProfilingData(setupOptions);
+        if (state.data.available) {
+          return response.ok({
+            body: {
+              has_setup: true,
+              has_data: state.data.available,
+            },
+          });
+        }
+
         const verifyFunctions = [
-          hasProfilingData,
           isApmPackageInstalled,
           validateApmPolicy,
           validateCollectorPackagePolicy,


### PR DESCRIPTION
This PR fixes a bug in which additional cluster admin privileges were needed after the initial resources are setup.

When opening Universal Profiling in Kibana, the `profiling/setup/es_resources` API throws this error:

```
Root causes:
 proc [kibana] 		security_exception: action [cluster:admin/xpack/security/role/get] is unauthorized for user [viewer] with effective roles [caue,profiling-reader,viewer], this action is granted by the cluster privileges [read_security,manage_security,all]
 proc [kibana]     at KibanaTransport.request (/Users/cauemarcondes/elastic/kibana/node_modules/@elastic/transport/src/Transport.ts:535:17)
 proc [kibana]     at runMicrotasks (<anonymous>)
 proc [kibana]     at processTicksAndRejections (node:internal/process/task_queues:96:5) {
```

The existence check for the profiling data was moved before the bulk of the validation checks in `GET profiling/setup/es_resources` so that we don't need the additional privilege.