### PR TITLE
[8.9] Add click telemetry to ESRE landing page components

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/esre/components/esre_guide/elser_panel.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/esre/components/esre_guide/elser_panel.tsx
@@ -37,7 +37,10 @@ const steps: EuiContainedStepProps[] = [
         to={generatePath(ENTERPRISE_SEARCH_CONTENT_PLUGIN.URL + NEW_INDEX_PATH)}
         shouldNotCreateHref
       >
-        <EuiButton iconType="plusInCircle">
+        <EuiButton
+          data-telemetry-id="entSearch-esre-semanticSearch-elserPanel-createIndexButton"
+          iconType="plusInCircle"
+        >
           {i18n.translate('xpack.enterpriseSearch.esre.elserPanel.step1.buttonLabel', {
             defaultMessage: 'Create an index',
           })}

--- a/x-pack/plugins/enterprise_search/public/applications/esre/components/esre_guide/esre_docs_section.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/esre/components/esre_guide/esre_docs_section.tsx
@@ -36,7 +36,12 @@ export const EsreDocsSection: React.FC = () => (
                 defaultMessage="To learn more about how to get started with ESRE, and test these tools with concrete examples, visit the {esreDocumentation}."
                 values={{
                   esreDocumentation: (
-                    <EuiLink target="_blank" href={docLinks.esre} external>
+                    <EuiLink
+                      data-telemetry-id="entSearch-esre-documentation-esreHomeLink"
+                      target="_blank"
+                      href={docLinks.esre}
+                      external
+                    >
                       {i18n.translate(
                         'xpack.enterpriseSearch.esre.esreDocsSection.description.esreLinkText',
                         {
@@ -75,7 +80,12 @@ export const EsreDocsSection: React.FC = () => (
                       defaultMessage="These are complex topics, so we've curated some {learningTopics} to help you get started."
                       values={{
                         learningTopics: (
-                          <EuiLink target="_blank" href={docLinks.esreLearn} external={false}>
+                          <EuiLink
+                            data-telemetry-id="entSearch-esre-documentation-esreLearnLink"
+                            target="_blank"
+                            href={docLinks.esreLearn}
+                            external={false}
+                          >
                             {i18n.translate(
                               'xpack.enterpriseSearch.esre.esreDocsSection.learn.learningTopicsLinkText',
                               {
@@ -113,7 +123,12 @@ export const EsreDocsSection: React.FC = () => (
                       defaultMessage="Learn what ESRE is (and isn't) from these {frequentlyAskedQuestions}."
                       values={{
                         frequentlyAskedQuestions: (
-                          <EuiLink target="_blank" href={docLinks.esreFaq} external={false}>
+                          <EuiLink
+                            data-telemetry-id="entSearch-esre-documentation-esreFaqLink"
+                            target="_blank"
+                            href={docLinks.esreFaq}
+                            external={false}
+                          >
                             {i18n.translate(
                               'xpack.enterpriseSearch.esre.esreDocsSection.learn.frequentlyAskedQuestionsLinkText',
                               {
@@ -151,7 +166,12 @@ export const EsreDocsSection: React.FC = () => (
                       defaultMessage="Need help? Check out the {discussForum}!"
                       values={{
                         discussForum: (
-                          <EuiLink target="_blank" href={docLinks.esreHelp} external={false}>
+                          <EuiLink
+                            data-telemetry-id="entSearch-esre-documentation-esreHelpLink"
+                            target="_blank"
+                            href={docLinks.esreHelp}
+                            external={false}
+                          >
                             {i18n.translate(
                               'xpack.enterpriseSearch.esre.esreDocsSection.learn.discussForumLinkText',
                               {

--- a/x-pack/plugins/enterprise_search/public/applications/esre/components/esre_guide/linear_combination_panel.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/esre/components/esre_guide/linear_combination_panel.tsx
@@ -32,7 +32,12 @@ const steps: EuiContainedStepProps[] = [
       defaultMessage: 'Discover how to use linear combination in _search queries',
     }),
     children: (
-      <EuiLink href={docLinks.knnSearchCombine} target="_blank" external>
+      <EuiLink
+        data-telemetry-id="entSearch-esre-rankAggregation-linearCombinationPanel-knnSearchCombineLink"
+        href={docLinks.knnSearchCombine}
+        target="_blank"
+        external
+      >
         {i18n.translate(
           'xpack.enterpriseSearch.esre.linearCombinationPanel.step1.knnSearchCombineLinkText',
           {
@@ -48,7 +53,11 @@ const steps: EuiContainedStepProps[] = [
       defaultMessage: 'Try it today in Console',
     }),
     children: (
-      <EuiLinkTo to={generatePath(DEV_TOOLS_CONSOLE_PATH)} shouldNotCreateHref>
+      <EuiLinkTo
+        data-telemetry-id="entSearch-esre-rankAggregation-linearCombinationPanel-devToolsConsoleButton"
+        to={generatePath(DEV_TOOLS_CONSOLE_PATH)}
+        shouldNotCreateHref
+      >
         <EuiButton>
           {i18n.translate('xpack.enterpriseSearch.esre.linearCombinationPanel.step2.buttonLabel', {
             defaultMessage: 'Open Console',

--- a/x-pack/plugins/enterprise_search/public/applications/esre/components/esre_guide/measure_performance_section.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/esre/components/esre_guide/measure_performance_section.tsx
@@ -36,7 +36,11 @@ const steps: EuiContainedStepProps[] = [
         defaultMessage="Visit {behavioralAnalytics} and create your first collection"
         values={{
           behavioralAnalytics: (
-            <EuiLinkTo to={generatePath(ANALYTICS_PLUGIN.URL)} shouldNotCreateHref>
+            <EuiLinkTo
+              data-telemetry-id="entSearch-esre-measurePerformance-behavioralAnalyticsLink"
+              to={generatePath(ANALYTICS_PLUGIN.URL)}
+              shouldNotCreateHref
+            >
               {i18n.translate(
                 'xpack.enterpriseSearch.esre.measurePerformanceSection.step1.behavioralAnalyticsLinkText',
                 {
@@ -98,7 +102,12 @@ export const MeasurePerformanceSection: React.FC = () => (
                 defaultMessage="Use {behavioralAnalytics} dashboards and tools to visualize user behavior and measure the impact of your changes."
                 values={{
                   behavioralAnalytics: (
-                    <EuiLink target="_blank" href={docLinks.behavioralAnalytics} external>
+                    <EuiLink
+                      data-telemetry-id="entSearch-esre-measurePerformance-behavioralAnalyticsDocsLink"
+                      target="_blank"
+                      href={docLinks.behavioralAnalytics}
+                      external
+                    >
                       {i18n.translate(
                         'xpack.enterpriseSearch.esre.measurePerformanceSection.behavioralAnalyticsLinkText',
                         {

--- a/x-pack/plugins/enterprise_search/public/applications/esre/components/esre_guide/nlp_enrichment_panel.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/esre/components/esre_guide/nlp_enrichment_panel.tsx
@@ -38,7 +38,12 @@ const steps: EuiContainedStepProps[] = [
     children: (
       <EuiFlexGroup direction="column">
         <EuiFlexItem>
-          <EuiLink href={docLinks.supportedNlpModels} target="_blank" external>
+          <EuiLink
+            data-telemetry-id="entSearch-esre-semanticSearch-nlpEnrichmentPanel-supportedNlpModelsLink"
+            href={docLinks.supportedNlpModels}
+            target="_blank"
+            external
+          >
             {i18n.translate(
               'xpack.enterpriseSearch.esre.nlpEnrichmentPanel.step1.supportedNlpModelsLinkText',
               { defaultMessage: 'Supported NLP models' }
@@ -46,7 +51,12 @@ const steps: EuiContainedStepProps[] = [
           </EuiLink>
         </EuiFlexItem>
         <EuiFlexItem>
-          <EuiLink href={docLinks.trainedModels} target="_blank" external>
+          <EuiLink
+            data-telemetry-id="entSearch-esre-semanticSearch-nlpEnrichmentPanel-trainedModelsLink"
+            href={docLinks.trainedModels}
+            target="_blank"
+            external
+          >
             {i18n.translate(
               'xpack.enterpriseSearch.esre.nlpEnrichmentPanel.step1.guideToTrainedModelsLinkText',
               { defaultMessage: 'Guide to trained models' }
@@ -54,7 +64,11 @@ const steps: EuiContainedStepProps[] = [
           </EuiLink>
         </EuiFlexItem>
         <EuiFlexItem>
-          <EuiLinkTo to={generatePath(ML_MANAGE_TRAINED_MODELS_PATH)} shouldNotCreateHref>
+          <EuiLinkTo
+            data-telemetry-id="entSearch-esre-semanticSearch-nlpEnrichmentPanel-trainedModelsButton"
+            to={generatePath(ML_MANAGE_TRAINED_MODELS_PATH)}
+            shouldNotCreateHref
+          >
             <EuiButton iconType="eye">
               {i18n.translate('xpack.enterpriseSearch.esre.nlpEnrichmentPanel.step1.buttonLabel', {
                 defaultMessage: 'View trained models',
@@ -72,6 +86,7 @@ const steps: EuiContainedStepProps[] = [
     }),
     children: (
       <EuiLinkTo
+        data-telemetry-id="entSearch-esre-semanticSearch-nlpEnrichmentPanel-createIndexButton"
         to={generatePath(ENTERPRISE_SEARCH_CONTENT_PLUGIN.URL + NEW_INDEX_PATH)}
         shouldNotCreateHref
       >
@@ -128,7 +143,12 @@ export const NlpEnrichmentPanel: React.FC = () => (
               defaultMessage="Use Natural Language Processing (NLP) tools like sentiment analysis, summarization, or Named Entity Recognition to enhance the relevance of your search results. NLP uses several {supportedMlModels} you can load to intelligently analyze and enrich documents with additional fields."
               values={{
                 supportedMlModels: (
-                  <EuiLink target="_blank" href={docLinks.supportedNlpModels} external={false}>
+                  <EuiLink
+                    data-telemetry-id="entSearch-esre-semanticSearch-nlpEnrichmentPanel-supportedMlModelsLink"
+                    target="_blank"
+                    href={docLinks.supportedNlpModels}
+                    external={false}
+                  >
                     {i18n.translate(
                       'xpack.enterpriseSearch.esre.nlpEnrichmentPanel.description.supportedMlModelsLinkText',
                       {

--- a/x-pack/plugins/enterprise_search/public/applications/esre/components/esre_guide/rank_aggregation_section.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/esre/components/esre_guide/rank_aggregation_section.tsx
@@ -49,6 +49,7 @@ export const RankAggregationSection: React.FC = () => (
         <EuiFlexItem grow={false}>
           <EsreGuideAccordion
             id="rrfRankingAccordion"
+            data-telemetry-id="entSearch-esre-rankAggregation-rrfRankingAccordion"
             icon={rrfRankingIllustration}
             title={i18n.translate('xpack.enterpriseSearch.esre.rrfRankingAccordion.title', {
               defaultMessage: 'RRF hybrid ranking',
@@ -66,6 +67,7 @@ export const RankAggregationSection: React.FC = () => (
         <EuiFlexItem grow={false}>
           <EsreGuideAccordion
             id="linearCombinationAccordion"
+            data-telemetry-id="entSearch-esre-rankAggregation-linearCombinationAccordion"
             icon={linearCombinationIllustration}
             title={i18n.translate('xpack.enterpriseSearch.esre.linearCombinationAccordion.title', {
               defaultMessage: 'Linear combination',

--- a/x-pack/plugins/enterprise_search/public/applications/esre/components/esre_guide/rrf_ranking_panel.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/esre/components/esre_guide/rrf_ranking_panel.tsx
@@ -32,7 +32,12 @@ const steps: EuiContainedStepProps[] = [
       defaultMessage: 'Discover examples of using RRF in _search queries',
     }),
     children: (
-      <EuiLink href={docLinks.rrf} target="_blank" external>
+      <EuiLink
+        data-telemetry-id="entSearch-esre-rankAggregation-rrfRankingPanel-rrfDocsLink"
+        href={docLinks.rrf}
+        target="_blank"
+        external
+      >
         {i18n.translate('xpack.enterpriseSearch.esre.rrfRankingPanel.step1.rrfDocsLinkText', {
           defaultMessage: 'Reciprocal Rank Fusion documentations',
         })}
@@ -45,7 +50,11 @@ const steps: EuiContainedStepProps[] = [
       defaultMessage: 'Try it today in Console',
     }),
     children: (
-      <EuiLinkTo to={generatePath(DEV_TOOLS_CONSOLE_PATH)} shouldNotCreateHref>
+      <EuiLinkTo
+        data-telemetry-id="entSearch-esre-rankAggregation-rrfRankingPanel-devToolsConsoleButton"
+        to={generatePath(DEV_TOOLS_CONSOLE_PATH)}
+        shouldNotCreateHref
+      >
         <EuiButton>
           {i18n.translate('xpack.enterpriseSearch.esre.rrfRankingPanel.step2.buttonLabel', {
             defaultMessage: 'Open Console',
@@ -66,6 +75,7 @@ export const RrfRankingPanel: React.FC = () => (
           <p>
             <FormattedMessage
               id="xpack.enterpriseSearch.esre.rrfRankingPanel.description"
+              data-telemetry-id="entSearch-esre-semanticSearch-rrfRankingPanel-rrfDocsLink"
               defaultMessage="Use {rrf} to combine rankings from multiple result sets with different relevance indicators, with no fine tuning required."
               values={{
                 rrf: (

--- a/x-pack/plugins/enterprise_search/public/applications/esre/components/esre_guide/semantic_search_section.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/esre/components/esre_guide/semantic_search_section.tsx
@@ -51,6 +51,7 @@ export const SemanticSearchSection: React.FC = () => (
         <EuiFlexItem grow={false}>
           <EsreGuideAccordion
             id="elserAccordion"
+            data-telemetry-id="entSearch-esre-semanticSearch-elserAccordion"
             initialIsOpen
             icon={elserIllustration}
             title={i18n.translate('xpack.enterpriseSearch.esre.elserAccordion.title', {
@@ -66,6 +67,7 @@ export const SemanticSearchSection: React.FC = () => (
         <EuiFlexItem grow={false}>
           <EsreGuideAccordion
             id="vectorSearchAccordion"
+            data-telemetry-id="entSearch-esre-semanticSearch-vectorSearchAccordion"
             icon={vectorSearchIllustration}
             title={i18n.translate('xpack.enterpriseSearch.esre.vectorSearchAccordion.title', {
               defaultMessage: 'Vector Search',
@@ -83,6 +85,7 @@ export const SemanticSearchSection: React.FC = () => (
         <EuiFlexItem grow={false}>
           <EsreGuideAccordion
             id="nlpEnrichmentAccordion"
+            data-telemetry-id="entSearch-esre-semanticSearch-nlpEnrichmentAccordion"
             icon={nlpEnrichmentIllustration}
             title={i18n.translate('xpack.enterpriseSearch.esre.nlpEnrichmentAccordion.title', {
               defaultMessage: 'NLP Enrichment',

--- a/x-pack/plugins/enterprise_search/public/applications/esre/components/esre_guide/vector_search_panel.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/esre/components/esre_guide/vector_search_panel.tsx
@@ -38,7 +38,12 @@ const steps: EuiContainedStepProps[] = [
     children: (
       <EuiFlexGroup direction="column">
         <EuiFlexItem>
-          <EuiLink href={docLinks.trainedModels} target="_blank" external>
+          <EuiLink
+            data-telemetry-id="entSearch-esre-semanticSearch-vectorSearchPanel-trainedModelsLink"
+            href={docLinks.trainedModels}
+            target="_blank"
+            external
+          >
             {i18n.translate(
               'xpack.enterpriseSearch.esre.vectorSearchPanel.step1.guideToTrainedModelsLinkText',
               { defaultMessage: 'Guide to trained models' }
@@ -46,7 +51,11 @@ const steps: EuiContainedStepProps[] = [
           </EuiLink>
         </EuiFlexItem>
         <EuiFlexItem>
-          <EuiLinkTo to={generatePath(ML_MANAGE_TRAINED_MODELS_PATH)} shouldNotCreateHref>
+          <EuiLinkTo
+            data-telemetry-id="entSearch-esre-semanticSearch-vectorSearchPanel-trainedModelsButton"
+            to={generatePath(ML_MANAGE_TRAINED_MODELS_PATH)}
+            shouldNotCreateHref
+          >
             <EuiButton iconType="eye">
               {i18n.translate('xpack.enterpriseSearch.esre.vectorSearchPanel.step1.buttonLabel', {
                 defaultMessage: 'View trained models',
@@ -67,7 +76,10 @@ const steps: EuiContainedStepProps[] = [
         to={generatePath(ENTERPRISE_SEARCH_CONTENT_PLUGIN.URL + NEW_INDEX_PATH)}
         shouldNotCreateHref
       >
-        <EuiButton iconType="plusInCircle">
+        <EuiButton
+          data-telemetry-id="entSearch-esre-semanticSearch-vectorSearchPanel-createIndexButton"
+          iconType="plusInCircle"
+        >
           {i18n.translate('xpack.enterpriseSearch.esre.vectorSearchPanel.step2.buttonLabel', {
             defaultMessage: 'Create an index',
           })}
@@ -120,7 +132,12 @@ export const VectorSearchPanel: React.FC = () => (
               defaultMessage="Use {vectorDbCapabilities} by adding embeddings from your ML models. Deploy trained models on Elastic ML nodes and set up inference pipelines to automatically add embeddings when you ingest documents, so you can use the kNN vector search method in _search."
               values={{
                 vectorDbCapabilities: (
-                  <EuiLink target="_blank" href={docLinks.knnSearch} external={false}>
+                  <EuiLink
+                    data-telemetry-id="entSearch-esre-semanticSearch-vectorSearchPanel-knnSearchLink"
+                    target="_blank"
+                    href={docLinks.knnSearch}
+                    external={false}
+                  >
                     {i18n.translate(
                       'xpack.enterpriseSearch.esre.vectorSearchPanel.description.vectorDbCapabilitiesLinkText',
                       {


### PR DESCRIPTION
## Summary

This PR adds click telemetry to the components of the ESRE landing page.