### PR TITLE
[Security solution] Fix broken rule preview when `tiebreakerField` is empty string

### DIFF
--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/search_super_select/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/search_super_select/index.tsx
@@ -16,32 +16,35 @@ import * as i18n from '../translations';
 import type { TimelineTypeLiteral } from '../../../../../common/types/timeline/api';
 import { TimelineType } from '../../../../../common/types/timeline/api';
 
-const StyledEuiFieldText = styled(EuiFieldText)`
-  padding-left: 12px;
-  padding-right: 40px;
+const StyledEuiInputPopover = styled(EuiInputPopover)`
+  .rightArrowIcon {
+    .euiFieldText {
+      padding-left: 12px;
+      padding-right: 40px;
 
-  &[readonly] {
-    cursor: pointer;
-    background-size: 0 100%;
-    background-repeat: no-repeat;
+      &[readonly] {
+        cursor: pointer;
+        background-size: 0 100%;
+        background-repeat: no-repeat;
 
-    // To match EuiFieldText focus state
-    &:focus {
-      background-color: ${({ theme }) => theme.eui.euiFormBackgroundColor};
-      background-image: linear-gradient(
-        to top,
-        ${({ theme }) => theme.eui.euiFocusRingColor},
-        ${({ theme }) => theme.eui.euiFocusRingColor} 2px,
-        transparent 2px,
-        transparent 100%
-      );
-      background-size: 100% 100%;
+        // To match EuiFieldText focus state
+        &:focus {
+          background-color: ${({ theme }) => theme.eui.euiFormBackgroundColor};
+          background-image: linear-gradient(
+            to top,
+            ${({ theme }) => theme.eui.euiFocusRingColor},
+            ${({ theme }) => theme.eui.euiFocusRingColor} 2px,
+            transparent 2px,
+            transparent 100%
+          );
+          background-size: 100% 100%;
+        }
+      }
     }
-  }
-
-  & + .euiFormControlLayoutIcons {
-    left: unset;
-    right: 12px;
+    .euiFormControlLayoutIcons {
+      left: unset;
+      right: 12px;
+    }
   }
 `;
 
@@ -87,7 +90,7 @@ const SearchTimelineSuperSelectComponent: React.FC<SearchTimelineSuperSelectProp
 
   const superSelect = useMemo(
     () => (
-      <StyledEuiFieldText
+      <EuiFieldText
         readOnly
         disabled={isDisabled}
         onFocus={handleOpenPopover}
@@ -125,11 +128,12 @@ const SearchTimelineSuperSelectComponent: React.FC<SearchTimelineSuperSelectProp
   );
 
   return (
-    <EuiInputPopover
+    <StyledEuiInputPopover
       id="searchTimelinePopover"
       input={superSelect}
       isOpen={isPopoverOpen}
       closePopover={handleClosePopover}
+      anchorClassName="rightArrowIcon"
     >
       <SelectableTimeline
         hideUntitled={hideUntitled}
@@ -139,7 +143,7 @@ const SearchTimelineSuperSelectComponent: React.FC<SearchTimelineSuperSelectProp
         timelineType={timelineType}
         placeholder={placeholder}
       />
-    </EuiInputPopover>
+    </StyledEuiInputPopover>
   );
 };
 

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/eql/build_eql_search_request.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/eql/build_eql_search_request.test.ts
@@ -318,7 +318,6 @@ describe('buildEqlSearchRequest', () => {
             "query": "process where true",
             "runtime_mappings": undefined,
             "size": 100,
-            "tiebreaker_field": undefined,
             "timestamp_field": undefined,
           },
           "index": Array [

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/eql/build_eql_search_request.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/eql/build_eql_search_request.test.ts
@@ -429,4 +429,42 @@ describe('buildEqlSearchRequest', () => {
       },
     });
   });
+
+  describe('handles the tiebreaker field', () => {
+    test('should pass a tiebreaker field with a valid value', async () => {
+      const request = buildEqlSearchRequest({
+        query: 'process where true',
+        index: ['testindex1', 'testindex2'],
+        from: 'now-5m',
+        to: 'now',
+        size: 100,
+        filters: undefined,
+        primaryTimestamp: '@timestamp',
+        secondaryTimestamp: undefined,
+        runtimeMappings: undefined,
+        tiebreakerField: 'host.name',
+        eventCategoryOverride: undefined,
+        exceptionFilter: undefined,
+      });
+      expect(request?.body?.tiebreaker_field).toEqual(`host.name`);
+    });
+
+    test('should not pass a tiebreaker field with a valid value', async () => {
+      const request = buildEqlSearchRequest({
+        query: 'process where true',
+        index: ['testindex1', 'testindex2'],
+        from: 'now-5m',
+        to: 'now',
+        size: 100,
+        filters: undefined,
+        primaryTimestamp: '@timestamp',
+        secondaryTimestamp: undefined,
+        runtimeMappings: undefined,
+        tiebreakerField: '',
+        eventCategoryOverride: undefined,
+        exceptionFilter: undefined,
+      });
+      expect(request?.body?.tiebreaker_field).toEqual(undefined);
+    });
+  });
 });

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/eql/build_eql_search_request.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/eql/build_eql_search_request.ts
@@ -7,6 +7,7 @@
 
 import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import type { Filter } from '@kbn/es-query';
+import { isEmpty } from 'lodash/fp';
 import type {
   RuleFilterArray,
   TimestampOverride,
@@ -89,7 +90,13 @@ export const buildEqlSearchRequest = ({
       runtime_mappings: runtimeMappings,
       timestamp_field: timestampField,
       event_category_field: eventCategoryOverride,
-      tiebreaker_field: tiebreakerField,
+      ...(!isEmpty(tiebreakerField)
+        ? {
+            tiebreaker_field: tiebreakerField,
+          }
+        : {
+            tiebreaker_field: undefined,
+          }),
       fields,
     },
   };

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/eql/build_eql_search_request.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/eql/build_eql_search_request.ts
@@ -94,9 +94,7 @@ export const buildEqlSearchRequest = ({
         ? {
             tiebreaker_field: tiebreakerField,
           }
-        : {
-            tiebreaker_field: undefined,
-          }),
+        : {}),
       fields,
     },
   };


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/153179

There are several places in the app where we use an empty string value for the EQL query `tiebreaker_field`. When this got piped through to the search itself, it resulted in the EQL query being broken as shown in [this issue](https://github.com/elastic/kibana/issues/153179) and below.
<img width="1380" alt="Screenshot 2023-06-20 at 2 39 47 PM" src="https://github.com/elastic/kibana/assets/6935300/34ae7fc6-27fb-496b-89e5-faea0ad8c4b3">


I updated the search request to check for an empty string and pass `undefined` in that case. I found this check being used [already here](https://github.com/elastic/kibana/blob/main/x-pack/plugins/timelines/server/search_strategy/timeline/eql/helpers.ts#L56-L60). This will prevent the issue from happening in old timelines where this data may be saved. Here is the same query from saved timeline pictured above, now working: 
<img width="1389" alt="Screenshot 2023-06-20 at 2 10 07 PM" src="https://github.com/elastic/kibana/assets/6935300/719eacca-0f8e-43b8-b0b0-abc304328da3">


### Unrelated CSS Fix
It seems an Eui update likely broken the arrow placement on our timeline template selector in create rule:
<img width="423" alt="Screenshot 2023-06-20 at 2 10 21 PM" src="https://github.com/elastic/kibana/assets/6935300/63f2cdba-9e73-4a8d-adda-36c892df6c8b">

Updating some CSS fixes this:
<img width="417" alt="Screenshot 2023-06-20 at 2 23 30 PM" src="https://github.com/elastic/kibana/assets/6935300/ba8bdfc8-59bb-4f0e-a3ce-9cdf3224f712">



