### PR TITLE
Unskips firefox for space selection and security tests

### DIFF
--- a/x-pack/test/functional/apps/security/security.ts
+++ b/x-pack/test/functional/apps/security/security.ts
@@ -17,8 +17,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const spaces = getService('spaces');
 
   describe('Security', function () {
-    // FLAKY: https://github.com/elastic/kibana/issues/157722
-    // this.tags('includeFirefox');
+    this.tags('includeFirefox');
     describe('Login Page', () => {
       before(async () => {
         await kibanaServer.savedObjects.cleanStandardList();

--- a/x-pack/test/functional/apps/spaces/spaces_selection.ts
+++ b/x-pack/test/functional/apps/spaces/spaces_selection.ts
@@ -35,11 +35,7 @@ export default function spaceSelectorFunctionalTests({
       }
     });
 
-    // FLAKY: https://github.com/elastic/kibana/issues/157760 (amongst others)
-    // Skipping only Firefox, as the flaky failures are caused by slow CI execution with new version of Firefox
-    // See also https://github.com/elastic/kibana/pull/158545
-    // Can un-comment line below when issue is resolved
-    // this.tags('includeFirefox');
+    this.tags('includeFirefox');
     describe('Login Space Selector', () => {
       before(async () => {
         await PageObjects.security.forceLogout();


### PR DESCRIPTION
## Summary

Some Firefox tests were skipped due to a known performance issue with Firefox 113.0.1. We're waiting on official confirmation that the issue is resolved.

Flaky test runner: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2430