### PR TITLE
[APM] Provide * to the params.environment field when environment_all

### DIFF
--- a/x-pack/plugins/apm/public/components/shared/slo_callout/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/slo_callout/index.tsx
@@ -17,6 +17,7 @@ import { encode } from '@kbn/rison';
 import React from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { useApmPluginContext } from '../../../context/apm_plugin/use_apm_plugin_context';
+import { ENVIRONMENT_ALL } from '../../../../common/environment_filter_values';
 
 interface Props {
   dismissCallout: () => void;
@@ -48,7 +49,7 @@ export function SloCallout({
       type: 'sli.apm.transactionErrorRate',
       params: {
         service: serviceName,
-        environment,
+        environment: environment === ENVIRONMENT_ALL.value ? '*' : environment,
         transactionName: transactionName ?? '',
         transactionType: transactionType ?? '',
       },


### PR DESCRIPTION
Bug fix for https://github.com/elastic/kibana/pull/159958#issuecomment-1599419095

### What was done

Provide * to the params.environment field when environment_all, actionable observability will handle it internally