### PR TITLE
Change infra alerting ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -822,6 +822,7 @@ packages/kbn-yarn-lock-validator @elastic/kibana-operations
 # Actionable observability
 x-pack/packages/observability/alert_details @elastic/actionable-observability
 x-pack/test/observability_functional @elastic/actionable-observability
+x-pack/plugins/infra/public/alerting @elastic/actionable-observability
 x-pack/plugins/infra/server/lib/alerting @elastic/actionable-observability
 
 # Observability robots

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -817,13 +817,12 @@ packages/kbn-yarn-lock-validator @elastic/kibana-operations
 #CC# /x-pack/plugins/reporting/ @elastic/appex-sharedux
 #CC# /x-pack/plugins/serverless_security/ @elastic/appex-sharedux
 
-### Observability packages
+### Observability Plugins
 
-# Observability App > Alert Details
+# Actionable observability
 x-pack/packages/observability/alert_details @elastic/actionable-observability
-
-# Observability App > Functional Tests
 x-pack/test/observability_functional @elastic/actionable-observability
+x-pack/plugins/infra/server/lib/alerting @elastic/actionable-observability
 
 # Observability robots
 /.github/workflows/deploy-my-kibana.yml @elastic/observablt-robots


### PR DESCRIPTION
## Summary

The actionable Observability team is taking over the ownership of rule types in the observability solution. This PR changes the ownership of alerting logic in the Infra plugin.