### PR TITLE
[Obsolete][8.8] [Security Solution] [Fix] [Performance] Alert Page Controls should query only from Alert Index. (#157286)

### DIFF
--- a/x-pack/plugins/security_solution/cypress/e2e/detection_alerts/detection_page_filters.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_alerts/detection_page_filters.cy.ts
@@ -10,12 +10,15 @@ import { getNewRule } from '../../objects/rule';
 import {
   CONTROL_FRAMES,
   CONTROL_FRAME_TITLE,
+  CONTROL_POPOVER,
   FILTER_GROUP_CHANGED_BANNER,
   FILTER_GROUP_EDIT_CONTROL_PANEL_ITEMS,
   FILTER_GROUP_SAVE_CHANGES_POPOVER,
+  OPTION_IGNORED,
   OPTION_LIST_LABELS,
   OPTION_LIST_VALUES,
   OPTION_SELECTABLE,
+  OPTION_SELECTABLE_COUNT,
   FILTER_GROUP_CONTROL_ACTION_EDIT,
 } from '../../screens/common/filter_group';
 import { createRule } from '../../tasks/api_calls/rules';
@@ -27,9 +30,11 @@ import { formatPageFilterSearchParam } from '../../../common/utils/format_page_f
 import {
   closePageFilterPopover,
   markAcknowledgedFirstAlert,
+  openFirstAlert,
   openPageFilterPopover,
   resetFilters,
   selectCountTable,
+  togglePageFilterPopover,
   visitAlertsPageWithCustomFilters,
   waitForAlerts,
   waitForPageFilters,
@@ -46,6 +51,9 @@ import {
   editFilterGroupControls,
   saveFilterGroupControls,
 } from '../../tasks/common/filter_group';
+import { TOASTER } from '../../screens/alerts_detection_rules';
+import { setEndDate, setStartDate } from '../../tasks/date_picker';
+import { fillAddFilterForm, openAddFilterPopover } from '../../tasks/search_bar';
 
 const customFilters = [
   {
@@ -231,13 +239,21 @@ describe('Detections : Page Filters', { testIsolation: false }, () => {
         markAcknowledgedFirstAlert();
         waitForAlerts();
         cy.get(OPTION_LIST_VALUES(0)).click();
-        cy.get(OPTION_SELECTABLE(0, 'acknowledged')).should('be.visible');
+        cy.get(OPTION_SELECTABLE(0, 'acknowledged')).should('be.visible').trigger('click');
         cy.get(ALERTS_COUNT)
           .invoke('text')
           .should((newAlertCount) => {
             expect(newAlertCount.split(' ')[0]).eq(String(parseInt(originalAlertCount, 10) - 1));
           });
       });
+
+    // cleanup
+    // revert the changes so that data does not change for further tests.
+    // It would make sure that tests can run in any order.
+    cy.get(OPTION_SELECTABLE(0, 'open')).trigger('click');
+    togglePageFilterPopover(0);
+    openFirstAlert();
+    waitForAlerts();
   });
 
   it(`URL is updated when filters are updated`, () => {
@@ -256,7 +272,7 @@ describe('Detections : Page Filters', { testIsolation: false }, () => {
 
     openPageFilterPopover(1);
     cy.get(OPTION_SELECTABLE(1, 'high')).should('be.visible');
-    cy.get(OPTION_SELECTABLE(1, 'high')).click({ force: true });
+    cy.get(OPTION_SELECTABLE(1, 'high')).click({});
     closePageFilterPopover(1);
   });
 
@@ -265,7 +281,7 @@ describe('Detections : Page Filters', { testIsolation: false }, () => {
     cy.visit(ALERTS_URL);
     cy.get(OPTION_LIST_VALUES(1)).click();
     cy.get(OPTION_SELECTABLE(1, 'high')).should('be.visible');
-    cy.get(OPTION_SELECTABLE(1, 'high')).click({ force: true });
+    cy.get(OPTION_SELECTABLE(1, 'high')).click({});
 
     // high should be scuccessfully selected.
     cy.get(OPTION_LIST_VALUES(1)).contains('high');
@@ -312,6 +328,57 @@ describe('Detections : Page Filters', { testIsolation: false }, () => {
     cy.get(FILTER_GROUP_CHANGED_BANNER).should('not.exist');
   });
 
+  context('Impact of inputs', () => {
+    afterEach(() => {
+      resetFilters();
+    });
+    it('should recover from invalide kql Query result', () => {
+      // do an invalid search
+      //
+      kqlSearch('\\');
+      cy.get(ALERTS_REFRESH_BTN).trigger('click');
+      waitForPageFilters();
+      cy.get(TOASTER).should('contain.text', 'KQLSyntaxError');
+      togglePageFilterPopover(0);
+      cy.get(OPTION_SELECTABLE(0, 'open')).should('be.visible');
+      cy.get(OPTION_SELECTABLE(0, 'open')).should('contain.text', 'open');
+      cy.get(OPTION_SELECTABLE(0, 'open')).get(OPTION_SELECTABLE_COUNT).should('have.text', 2);
+    });
+
+    it('should take kqlQuery into account', () => {
+      kqlSearch('kibana.alert.workflow_status: "nothing"');
+      cy.get(ALERTS_REFRESH_BTN).trigger('click');
+      waitForPageFilters();
+      togglePageFilterPopover(0);
+      cy.get(CONTROL_POPOVER(0)).should('contain.text', 'No options found');
+      cy.get(OPTION_IGNORED(0, 'open')).should('be.visible');
+    });
+
+    it('should take filters into account', () => {
+      openAddFilterPopover();
+      fillAddFilterForm({
+        key: 'kibana.alert.workflow_status',
+        value: 'invalid',
+      });
+      waitForPageFilters();
+      togglePageFilterPopover(0);
+      cy.get(CONTROL_POPOVER(0)).should('contain.text', 'No options found');
+      cy.get(OPTION_IGNORED(0, 'open')).should('be.visible');
+    });
+    it('should take timeRange into account', () => {
+      const startDateWithZeroAlerts = 'Jan 1, 2002 @ 00:00:00.000';
+      const endDateWithZeroAlerts = 'Jan 1, 2010 @ 00:00:00.000';
+
+      setStartDate(startDateWithZeroAlerts);
+      setEndDate(endDateWithZeroAlerts);
+
+      cy.get(ALERTS_REFRESH_BTN).trigger('click');
+      waitForPageFilters();
+      togglePageFilterPopover(0);
+      cy.get(CONTROL_POPOVER(0)).should('contain.text', 'No options found');
+      cy.get(OPTION_IGNORED(0, 'open')).should('be.visible');
+    });
+  });
   it('Number fields are not visible in field edit panel', () => {
     const idx = 3;
     const { FILTER_FIELD_TYPE, FIELD_TYPES } = FILTER_GROUP_EDIT_CONTROL_PANEL_ITEMS;

--- a/x-pack/plugins/security_solution/cypress/screens/common/filter_group.ts
+++ b/x-pack/plugins/security_solution/cypress/screens/common/filter_group.ts
@@ -36,6 +36,12 @@ export const OPTION_SELECTABLE = (popoverIndex: number, value: string) =>
 export const OPTION_IGNORED = (popoverIndex: number, value: string) =>
   `#control-popover-${popoverIndex} [data-test-subj="optionsList-control-ignored-selection-${value}"]`;
 
+export const OPTION_SELECTABLE_COUNT = getDataTestSubjectSelector(
+  'optionsList-document-count-badge'
+);
+
+export const CONTROL_POPOVER = (popoverIdx: number) => `#control-popover-${popoverIdx}`;
+
 export const DETECTION_PAGE_FILTER_GROUP_WRAPPER = '.filter-group__wrapper';
 
 export const DETECTION_PAGE_FILTERS_LOADING = '.securityPageWrapper .controlFrame--controlLoading';

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/detection_engine.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/detection_engine.tsx
@@ -153,7 +153,6 @@ const DetectionEnginePageComponent: React.FC<DetectionEngineComponentProps> = ({
   const {
     indexPattern,
     runtimeMappings,
-    dataViewId,
     loading: isLoadingIndexPattern,
   } = useSourcererDataView(SourcererScopeName.detections);
 
@@ -351,7 +350,6 @@ const DetectionEnginePageComponent: React.FC<DetectionEngineComponentProps> = ({
         </EuiFlexGroup>
       ) : (
         <DetectionPageFilterSet
-          dataViewId={dataViewId}
           onFilterChange={pageFiltersUpdateHandler}
           filters={topLevelFilters}
           query={query}
@@ -367,7 +365,6 @@ const DetectionEnginePageComponent: React.FC<DetectionEngineComponentProps> = ({
     [
       topLevelFilters,
       arePageFiltersEnabled,
-      dataViewId,
       statusFilter,
       onFilterGroupChangedCallback,
       pageFiltersUpdateHandler,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.8`:
 - [[Security Solution] [Fix] [Performance] Alert Page Controls should query only from Alert Index. (#157286)](https://github.com/elastic/kibana/pull/157286)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Jatin Kathuria","email":"jatin.kathuria@elastic.co"},"sourceCommit":{"committedDate":"2023-06-21T12:21:16Z","message":"[Security Solution] [Fix] [Performance] Alert Page Controls should query only from Alert Index. (#157286)\n\n## Summary\r\n\r\nHandles : #157217\r\n\r\n\r\n|Before|After|\r\n|---|---|\r\n| <video\r\nsrc=\"https://github.com/elastic/kibana/assets/7485038/aa892faf-8055-46e0-b23b-87061ecef67f\"\r\n/> | <video\r\nsrc=\"https://github.com/elastic/kibana/assets/7485038/2f392ea4-cfc5-4759-96c7-94561f60c3f4\"\r\n/> |","sha":"ac5207cca96db362ed31387e16e5b6849167f565","branchLabelMapping":{"^v8.9.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Threat Hunting:Investigations","backport:prev-MAJOR","v8.9.0"],"number":157286,"url":"https://github.com/elastic/kibana/pull/157286","mergeCommit":{"message":"[Security Solution] [Fix] [Performance] Alert Page Controls should query only from Alert Index. (#157286)\n\n## Summary\r\n\r\nHandles : #157217\r\n\r\n\r\n|Before|After|\r\n|---|---|\r\n| <video\r\nsrc=\"https://github.com/elastic/kibana/assets/7485038/aa892faf-8055-46e0-b23b-87061ecef67f\"\r\n/> | <video\r\nsrc=\"https://github.com/elastic/kibana/assets/7485038/2f392ea4-cfc5-4759-96c7-94561f60c3f4\"\r\n/> |","sha":"ac5207cca96db362ed31387e16e5b6849167f565"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.9.0","labelRegex":"^v8.9.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/157286","number":157286,"mergeCommit":{"message":"[Security Solution] [Fix] [Performance] Alert Page Controls should query only from Alert Index. (#157286)\n\n## Summary\r\n\r\nHandles : #157217\r\n\r\n\r\n|Before|After|\r\n|---|---|\r\n| <video\r\nsrc=\"https://github.com/elastic/kibana/assets/7485038/aa892faf-8055-46e0-b23b-87061ecef67f\"\r\n/> | <video\r\nsrc=\"https://github.com/elastic/kibana/assets/7485038/2f392ea4-cfc5-4759-96c7-94561f60c3f4\"\r\n/> |","sha":"ac5207cca96db362ed31387e16e5b6849167f565"}}]}] BACKPORT-->