### PR TITLE
[Synthetics] Copy updates follow-up

### DIFF
--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/common/components/monitor_inspect.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/common/components/monitor_inspect.tsx
@@ -201,5 +201,5 @@ export const INSPECT_MONITOR_LABEL = i18n.translate(
 );
 
 const HIDE_PARAMS = i18n.translate('xpack.synthetics.monitorInspect.hideParams', {
-  defaultMessage: 'Hide params values',
+  defaultMessage: 'Hide parameter values',
 });

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/settings/private_locations/view_location_monitors.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/settings/private_locations/view_location_monitors.tsx
@@ -31,7 +31,21 @@ export const ViewLocationMonitors = ({
 
   const history = useHistory();
 
-  const formattedLocationName = useMemo(() => <strong>{locationName}</strong>, [locationName]);
+  const { formattedLocationName, href } = useMemo(
+    () => ({
+      formattedLocationName: <strong>{locationName}</strong>,
+      href:
+        count > 0
+          ? history.createHref({
+              pathname: '/monitors',
+              search: `?locations=${JSON.stringify([locationName])}`,
+            })
+          : history.createHref({
+              pathname: '/add-monitor',
+            }),
+    }),
+    [count, history, locationName]
+  );
 
   return (
     <EuiPopover button={button} isOpen={isPopoverOpen} closePopover={closePopover}>
@@ -42,27 +56,18 @@ export const ViewLocationMonitors = ({
       )}
 
       <EuiSpacer size="s" />
-      {count > 0 ? (
-        <EuiButton
-          data-test-subj="syntheticsViewLocationMonitorsButton"
-          href={history.createHref({
-            pathname: '/monitors',
-            search: `?locations=${JSON.stringify([locationName])}`,
-          })}
-        >
-          {VIEW_LOCATION_MONITORS}
-        </EuiButton>
-      ) : (
-        <EuiButton
-          data-test-subj="syntheticsViewLocationMonitorsButton"
-          href={history.createHref({
-            pathname: '/add-monitor',
-          })}
-        >
-          {count > 0 ? VIEW_MESSAGE : CREATE_MONITOR}
-        </EuiButton>
-      )}
+      <ViewLocationMonitorsButton href={href}>
+        {count > 0 ? VIEW_LOCATION_MONITORS : CREATE_MONITOR}
+      </ViewLocationMonitorsButton>
     </EuiPopover>
+  );
+};
+
+const ViewLocationMonitorsButton: React.FC<{ href: string }> = ({ href, children }) => {
+  return (
+    <EuiButton data-test-subj="syntheticsViewLocationMonitorsButton" href={href}>
+      {children}
+    </EuiButton>
   );
 };
 

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/settings/private_locations/view_location_monitors.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/settings/private_locations/view_location_monitors.tsx
@@ -31,7 +31,7 @@ export const ViewLocationMonitors = ({
 
   const history = useHistory();
 
-  const { formattedLocationName, href } = useMemo(
+  const { formattedLocationName, href, viewMonitorsMessage } = useMemo(
     () => ({
       formattedLocationName: <strong>{locationName}</strong>,
       href:
@@ -43,6 +43,7 @@ export const ViewLocationMonitors = ({
           : history.createHref({
               pathname: '/add-monitor',
             }),
+      viewMonitorsMessage: count > 0 ? VIEW_LOCATION_MONITORS : CREATE_MONITOR,
     }),
     [count, history, locationName]
   );
@@ -56,9 +57,7 @@ export const ViewLocationMonitors = ({
       )}
 
       <EuiSpacer size="s" />
-      <ViewLocationMonitorsButton href={href}>
-        {count > 0 ? VIEW_LOCATION_MONITORS : CREATE_MONITOR}
-      </ViewLocationMonitorsButton>
+      <ViewLocationMonitorsButton href={href}>{viewMonitorsMessage}</ViewLocationMonitorsButton>
     </EuiPopover>
   );
 };
@@ -80,10 +79,6 @@ const VIEW_LOCATION_MONITORS = i18n.translate(
 
 const CREATE_MONITOR = i18n.translate('xpack.synthetics.monitorManagement.createLocationMonitors', {
   defaultMessage: 'Create monitor',
-});
-
-const VIEW_MESSAGE = i18n.translate('xpack.synthetics.monitorManagement.viewMessage', {
-  defaultMessage: 'View monitors',
 });
 
 const GreaterThanZeroMessage = ({ count, name }: { count: number; name: JSX.Element }) => (

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/settings/private_locations/view_location_monitors.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/settings/private_locations/view_location_monitors.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { EuiPopover, EuiButtonEmpty, EuiButton, EuiSpacer } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -31,13 +31,16 @@ export const ViewLocationMonitors = ({
 
   const history = useHistory();
 
+  const formattedLocationName = useMemo(() => <strong>{locationName}</strong>, [locationName]);
+
   return (
     <EuiPopover button={button} isOpen={isPopoverOpen} closePopover={closePopover}>
-      <FormattedMessage
-        id="xpack.synthetics.monitorManagement.viewMonitors"
-        defaultMessage="{name} is used in {count, number} {count, plural,one {monitor} other {monitors}}."
-        values={{ count, name: <strong>{locationName}</strong> }}
-      />
+      {count > 0 ? (
+        <GreaterThanZeroMessage count={count} name={formattedLocationName} />
+      ) : (
+        <ZeroMessage name={formattedLocationName} />
+      )}
+
       <EuiSpacer size="s" />
       {count > 0 ? (
         <EuiButton
@@ -56,7 +59,7 @@ export const ViewLocationMonitors = ({
             pathname: '/add-monitor',
           })}
         >
-          {CREATE_MONITOR}
+          {count > 0 ? VIEW_MESSAGE : CREATE_MONITOR}
         </EuiButton>
       )}
     </EuiPopover>
@@ -73,3 +76,23 @@ const VIEW_LOCATION_MONITORS = i18n.translate(
 const CREATE_MONITOR = i18n.translate('xpack.synthetics.monitorManagement.createLocationMonitors', {
   defaultMessage: 'Create monitor',
 });
+
+const VIEW_MESSAGE = i18n.translate('xpack.synthetics.monitorManagement.viewMessage', {
+  defaultMessage: 'View monitors',
+});
+
+const GreaterThanZeroMessage = ({ count, name }: { count: number; name: JSX.Element }) => (
+  <FormattedMessage
+    id="xpack.synthetics.monitorManagement.viewMonitors"
+    defaultMessage="{name} is used in {count, number} {count, plural,one {monitor} other {monitors}}."
+    values={{ count, name }}
+  />
+);
+
+const ZeroMessage = ({ name }: { name: JSX.Element }) => (
+  <FormattedMessage
+    id="xpack.synthetics.monitorManagement.viewZeroMonitors"
+    defaultMessage="{name} isn't used in any monitors yet."
+    values={{ name }}
+  />
+);


### PR DESCRIPTION
## Summary

In reviewing [a previous copy update PR](https://github.com/elastic/kibana/pull/159740), it [was noted](https://github.com/elastic/kibana/pull/159740#discussion_r1235303535) that we can further improve these changes for cases where there are 0 vs. non-0 monitor counts.

### Before

<img width="274" alt="image" src="https://github.com/elastic/kibana/assets/18429259/2b51e246-ee49-43a0-9b16-de3c83e28b69">

<img width="260" alt="image" src="https://github.com/elastic/kibana/assets/18429259/ecf9a565-986d-4900-ab2e-288c50478d17">


### After

<img width="315" alt="image" src="https://github.com/elastic/kibana/assets/18429259/1e79fc42-2777-4dd9-b9f6-f0def2a3062c">

<img width="249" alt="image" src="https://github.com/elastic/kibana/assets/18429259/50fb3a87-779e-4535-be08-9c00a6baf787">


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
