### PR TITLE
POC - Store AAD exclusions as metadata in encrypted objects to support ZDT upgrades

### DIFF
--- a/packages/kbn-check-mappings-update-cli/current_mappings.json
+++ b/packages/kbn-check-mappings-update-cli/current_mappings.json
@@ -475,6 +475,16 @@
       }
     }
   },
+  "versioned_enrcyption_definition": {
+    "properties": {
+      "type": {
+        "type": "keyword"
+      },
+      "version": {
+        "type": "keyword"
+      }
+    }
+  },
   "telemetry": {
     "dynamic": false,
     "properties": {}

--- a/src/core/server/integration_tests/saved_objects/migrations/group2/check_registered_types.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/group2/check_registered_types.test.ts
@@ -154,6 +154,7 @@ describe('checking migration metadata changes on all registered SO types', () =>
         "uptime-synthetics-api-key": "7ae976a461248f9dbd8442af14a179bdbc229eca",
         "url": "c923a4a5002a09c0080c9095e958f07d518e6704",
         "usage-counters": "48782b3bcb6b5a23ba6f2bfe3a380d835e68890a",
+        "versioned_enrcyption_definition": "ffed5d9f9a6a27e144ff7f8048ac888dc9d3d13a",
         "visualization": "93a3e73994ad836fe2b1dccbe208238f41f63da0",
         "workplace_search_telemetry": "52b32b47ee576f554ac77cb1d5896dfbcfe9a1fb",
       }

--- a/src/core/server/integration_tests/saved_objects/migrations/group3/dot_kibana_split.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/group3/dot_kibana_split.test.ts
@@ -267,6 +267,7 @@ describe('split .kibana index into multiple system indices', () => {
             "uptime-synthetics-api-key",
             "url",
             "usage-counters",
+            "versioned_enrcyption_definition",
             "workplace_search_telemetry",
           ],
           ".kibana_so_search": Array [

--- a/src/core/server/integration_tests/saved_objects/migrations/group3/type_registrations.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/group3/type_registrations.test.ts
@@ -132,6 +132,7 @@ const previouslyRegisteredTypes = [
   'uptime-synthetics-api-key',
   'url',
   'usage-counters',
+  'versioned_enrcyption_definition',
   'visualization',
   'workplace_search_telemetry',
 ].sort();

--- a/x-pack/plugins/encrypted_saved_objects/server/crypto/encrypted_saved_object_type_definition.ts
+++ b/x-pack/plugins/encrypted_saved_objects/server/crypto/encrypted_saved_object_type_definition.ts
@@ -16,6 +16,8 @@ export class EncryptedSavedObjectAttributesDefinition {
   public readonly attributesToEncrypt: ReadonlySet<string>;
   private readonly attributesToExcludeFromAAD: ReadonlySet<string> | undefined;
   private readonly attributesToStrip: ReadonlySet<string>;
+  public readonly type: string;
+  public readonly modelVersion?: string;
 
   constructor(typeRegistration: EncryptedSavedObjectTypeRegistration) {
     const attributesToEncrypt = new Set<string>();
@@ -35,6 +37,11 @@ export class EncryptedSavedObjectAttributesDefinition {
     this.attributesToEncrypt = attributesToEncrypt;
     this.attributesToStrip = attributesToStrip;
     this.attributesToExcludeFromAAD = typeRegistration.attributesToExcludeFromAAD;
+
+    // Embedding excluded AAD fields POC rev2
+    // Hold onto the type and version so we can write the hidden SO's
+    this.type = typeRegistration.type;
+    this.modelVersion = typeRegistration.modelVersion;
   }
 
   /**
@@ -51,17 +58,11 @@ export class EncryptedSavedObjectAttributesDefinition {
    * @param attributeName Name of the attribute.
    * @param excludedAttributesOverride override list of attributes to exclude. Embedding excluded AAD fields POC.
    */
-  public shouldBeExcludedFromAAD(attributeName: string, excludedAttributesOverride?: string[]) {
+  public shouldBeExcludedFromAAD(attributeName: string) {
     return (
       this.shouldBeEncrypted(attributeName) ||
-      (!!excludedAttributesOverride
-        ? excludedAttributesOverride?.includes(attributeName)
-        : this.attributesToExcludeFromAAD != null &&
-          this.attributesToExcludeFromAAD.has(attributeName))
-      // original logic below...
-      // this.shouldBeEncrypted(attributeName) ||
-      // (this.attributesToExcludeFromAAD != null &&
-      //   this.attributesToExcludeFromAAD.has(attributeName))
+      (this.attributesToExcludeFromAAD != null &&
+        this.attributesToExcludeFromAAD.has(attributeName))
     );
   }
 

--- a/x-pack/plugins/encrypted_saved_objects/server/crypto/encrypted_saved_object_type_definition.ts
+++ b/x-pack/plugins/encrypted_saved_objects/server/crypto/encrypted_saved_object_type_definition.ts
@@ -49,12 +49,19 @@ export class EncryptedSavedObjectAttributesDefinition {
   /**
    * Determines whether particular attribute should be excluded from AAD.
    * @param attributeName Name of the attribute.
+   * @param excludedAttributesOverride override list of attributes to exclude. Embedding excluded AAD fields POC.
    */
-  public shouldBeExcludedFromAAD(attributeName: string) {
+  public shouldBeExcludedFromAAD(attributeName: string, excludedAttributesOverride?: string[]) {
     return (
       this.shouldBeEncrypted(attributeName) ||
-      (this.attributesToExcludeFromAAD != null &&
-        this.attributesToExcludeFromAAD.has(attributeName))
+      (!!excludedAttributesOverride
+        ? excludedAttributesOverride?.includes(attributeName)
+        : this.attributesToExcludeFromAAD != null &&
+          this.attributesToExcludeFromAAD.has(attributeName))
+      // original logic below...
+      // this.shouldBeEncrypted(attributeName) ||
+      // (this.attributesToExcludeFromAAD != null &&
+      //   this.attributesToExcludeFromAAD.has(attributeName))
     );
   }
 
@@ -64,5 +71,10 @@ export class EncryptedSavedObjectAttributesDefinition {
    */
   public shouldBeStripped(attributeName: string) {
     return this.attributesToStrip.has(attributeName);
+  }
+
+  public getAttributesToExcludeFromAAD(): string[] {
+    if (!this.attributesToExcludeFromAAD) return [];
+    return [...this.attributesToExcludeFromAAD];
   }
 }

--- a/x-pack/plugins/encrypted_saved_objects/server/crypto/encrypted_saved_objects_service.test.ts
+++ b/x-pack/plugins/encrypted_saved_objects/server/crypto/encrypted_saved_objects_service.test.ts
@@ -84,7 +84,7 @@ function setup(types?: EncryptedSavedObjectTypeRegistration[]) {
   types?.forEach((esoType) => service.registerType(esoType));
 
   // simulate plugin start phase
-  if (!!types) {
+  if (types) {
     service.initializeVersionedMetadata(mockSavedObjects);
     expect(mockSavedObjects.createInternalRepository).toHaveBeenCalledTimes(1);
   }
@@ -2475,6 +2475,11 @@ describe('Embedding excluded AAD fields POC', () => {
         attributesToExcludeFromAAD: ['attrOne', 'attrFour'],
       },
     };
+    // SavedObjectsBulkResponse<T = unknown> {
+    //  /** array of saved objects */
+    //  saved_objects: Array<SavedObject<T>>;
+    // }
+    mockSavedObjectsRepo.bulkCreate.mockResolvedValue({ saved_objects: [] });
     expect(mockSavedObjectsRepo.bulkCreate).toHaveBeenCalledTimes(1);
     expect(mockSavedObjectsRepo.bulkCreate).toHaveBeenLastCalledWith([metadataSO], {
       overwrite: true,

--- a/x-pack/plugins/encrypted_saved_objects/server/crypto/encrypted_saved_objects_service.test.ts
+++ b/x-pack/plugins/encrypted_saved_objects/server/crypto/encrypted_saved_objects_service.test.ts
@@ -2478,6 +2478,7 @@ describe('Embedding excluded AAD fields POC', () => {
     expect(mockSavedObjectsRepo.bulkCreate).toHaveBeenCalledTimes(1);
     expect(mockSavedObjectsRepo.bulkCreate).toHaveBeenLastCalledWith([metadataSO], {
       overwrite: true,
+      managed: true,
     });
 
     // Encrypt type as Kibana V2 would encrypt it

--- a/x-pack/plugins/encrypted_saved_objects/server/crypto/encrypted_saved_objects_service.ts
+++ b/x-pack/plugins/encrypted_saved_objects/server/crypto/encrypted_saved_objects_service.ts
@@ -136,7 +136,7 @@ export function descriptorToArray(descriptor: SavedObjectDescriptor) {
 export class EncryptedSavedObjectsService {
   // Embedding excluded AAD fields POC rev2
   // We need an internal repo to write and read the versioned ESO descriptors
-  private internalSoRepository: ISavedObjectsRepository | undefined;
+  private internalSoRepository?: ISavedObjectsRepository;
 
   // Embedding excluded AAD fields POC rev2
   // Metadata is stored in an SO. Ehen we read one, we'll

--- a/x-pack/plugins/encrypted_saved_objects/server/crypto/encrypted_saved_objects_service.ts
+++ b/x-pack/plugins/encrypted_saved_objects/server/crypto/encrypted_saved_objects_service.ts
@@ -234,7 +234,7 @@ export class EncryptedSavedObjectsService {
     const versionedEsoMetadata = new Array<SavedObjectsBulkCreateObject>();
 
     this.typeDefinitions.forEach((versionedType) => {
-      if (!!versionedType.modelVersion) {
+      if (versionedType.modelVersion) {
         const attributes: EncryptedSavedObjectVersionedMetadata = {
           type: versionedType.type,
           modelVersion: versionedType.modelVersion,

--- a/x-pack/plugins/encrypted_saved_objects/server/crypto/encrypted_saved_objects_service.ts
+++ b/x-pack/plugins/encrypted_saved_objects/server/crypto/encrypted_saved_objects_service.ts
@@ -50,12 +50,12 @@ export interface EncryptedSavedObjectTypeRegistration {
  * Interface for writing/reading versioned ESO type metada
  * to/from hidden saved objects
  */
-interface EncryptedSavedObjectVersionedMetadata {
-  readonly type: string;
-  readonly modelVersion: string;
-  readonly attributesToEncrypt: string[];
-  readonly attributesToExcludeFromAAD: string[];
-}
+// interface EncryptedSavedObjectVersionedMetadata {
+//   readonly type: string;
+//   readonly modelVersion: string;
+//   readonly attributesToEncrypt: string[];
+//   readonly attributesToExcludeFromAAD: string[];
+// }
 
 /**
  * Uniquely identifies saved object.

--- a/x-pack/plugins/encrypted_saved_objects/server/crypto/encrypted_saved_objects_service.ts
+++ b/x-pack/plugins/encrypted_saved_objects/server/crypto/encrypted_saved_objects_service.ts
@@ -289,7 +289,7 @@ export class EncryptedSavedObjectsService {
         overwrite: true,
         managed: true,
       })
-      .catch((err) => {
+      ?.catch((err) => {
         this.options.logger.fatal(
           `Failed to create versioned encryption descriptors: ${err.message ?? err}`
         );

--- a/x-pack/plugins/encrypted_saved_objects/server/plugin.test.ts
+++ b/x-pack/plugins/encrypted_saved_objects/server/plugin.test.ts
@@ -59,7 +59,7 @@ describe('EncryptedSavedObjects Plugin', () => {
       );
       plugin.setup(coreMock.createSetup(), { security: securityMock.createSetup() });
 
-      const startContract = plugin.start();
+      const startContract = plugin.start(coreMock.createStart());
       expect(startContract).toMatchInlineSnapshot(`
               Object {
                 "getClient": [Function],

--- a/x-pack/plugins/encrypted_saved_objects/server/plugin.ts
+++ b/x-pack/plugins/encrypted_saved_objects/server/plugin.ts
@@ -138,11 +138,7 @@ export class EncryptedSavedObjectsPlugin
 
   public start({ savedObjects }: CoreStart) {
     this.logger.debug('Starting plugin');
-
-    this.esoService.initializeVersionedMetadata(savedObjects).catch((err) => {
-      this.logger.fatal(`Failed to ....: ${err.message ?? err}`);
-    });
-
+    this.esoService.initializeVersionedMetadata(savedObjects);
     return {
       isEncryptionError: (error: Error) => error instanceof EncryptionError,
       getClient: (options = {}) => this.savedObjectsSetup(options),

--- a/x-pack/plugins/encrypted_saved_objects/server/plugin.ts
+++ b/x-pack/plugins/encrypted_saved_objects/server/plugin.ts
@@ -138,9 +138,11 @@ export class EncryptedSavedObjectsPlugin
 
   public start({ savedObjects }: CoreStart) {
     this.logger.debug('Starting plugin');
-    // initializeVersionedMetadata contains an un-awaited async call to SO repo bulk save
-    // What is a more appropriate way of doing this?
-    this.esoService.initializeVersionedMetadata(savedObjects);
+
+    this.esoService.initializeVersionedMetadata(savedObjects).catch((err) => {
+      this.logger.fatal(`Failed to ....: ${err.message ?? err}`);
+    });
+
     return {
       isEncryptionError: (error: Error) => error instanceof EncryptionError,
       getClient: (options = {}) => this.savedObjectsSetup(options),

--- a/x-pack/plugins/encrypted_saved_objects/server/saved_objects/index.ts
+++ b/x-pack/plugins/encrypted_saved_objects/server/saved_objects/index.ts
@@ -117,7 +117,7 @@ export function setupSavedObjects({
       '8.10.0': schema.object({
         type: schema.string({ minLength: 1 }),
         version: schema.string({ minLength: 1 }),
-        attributesToEncrypt: schema.maybe(schema.arrayOf(schema.string())),
+        attributesToEncrypt: schema.arrayOf(schema.string()),
         attributesToExcludeFromAAD: schema.maybe(schema.arrayOf(schema.string())),
       }),
     },

--- a/x-pack/plugins/encrypted_saved_objects/tsconfig.json
+++ b/x-pack/plugins/encrypted_saved_objects/tsconfig.json
@@ -10,6 +10,7 @@
     "@kbn/core",
     "@kbn/utility-types",
     "@kbn/core-saved-objects-server",
+    "@kbn/core-saved-objects-api-server",
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
## Summary

This PR is a proof of concept only. It explores the idea of storing the attributes excluded from AAD (Additional Authenticated Data) to support encrypted saved objects during ZDT (zero downtime) upgrades. During ZDT upgrades, newer versions of encrypted objects may contain additional attributes which have been excluded from AAD. The older version of Kibana will not know about these additional attributes and thus will not be able to decrypt the objects. For more details please refer to #156023.

In this PR, ~~the saved object attributes excluded from AAD are written as a header in the object's encrypted data. During decryption, the header is stripped and used to generate the AAD to perform decryption. If the header is not found, the decryption process will defer to the encrypted object's registered data (current implementation).~~ the _versioned_ saved object encryption definitions are written to a hidden saved object. The mock "model version" is written as a header to the encrypted attributes of the objects - this is only to simulate access to the model version in the raw saved object document. During decryption, the model version is stripped and used to determine if the version of Kibana registered that model version or not. If so, the registered encryption definition is used to decrypt. If not, the type and model are used to read the hidden saved object containing the versioned definition, which is then used to decrypt.

### Where to store the data?
Storing the AAD exclusions in the encrypted attributes is not acceptable as a real solution because it will result in several copies of the metadata in every encrypted field of an object. Ideally, the metadata would get stored elsewhere in ~~the raw document only once, or could be stored once per saved object type per version in an internal index.~~ a hidden saved object.

~~Storing once per object could yield an addition overhead of 450 bytes per object in the worst case scenario that we've seen. Alternatively, if each version of Kibana writes this metadata for each registered encrypted object to a known internal index (one entry per ESO version), during ZDT upgrades the older version of Kibana would only need to read it once. I am not sure if this would make sense to implement, especially if the overhead per object is not problematic.~~

### What about the encrypted attributes?
~~If encrypted attributes can also be added or changed in an encrypted saved object when registering a new version, we would need to also store this as metadata.~~ By storing the encryption definition, both the attributes to encrypt and to exclude from AAD will be captured per version of the ESO type.

### Caveats
This solution requires the encrypted saved objects extension and saved object repository have access to the raw object documents prior to any conversions (see [forward compatibility schema of model versions](https://github.com/elastic/kibana/blob/53cc7414c430f83c1159e1fda2d4be1c7ce76dab/packages/core/saved-objects/core-saved-objects-server/model_versions.md#forwardcompatibility)). We would need to engage with the Core team to discuss this.

### Testing
See `x-pack/plugins/encrypted_saved_objects/server/crypto/encrypted_saved_objects_service.test.ts`