### PR TITLE
Fix theming for search sessions management

### DIFF
--- a/src/plugins/data/public/search/session/sessions_mgmt/components/main.tsx
+++ b/src/plugins/data/public/search/session/sessions_mgmt/components/main.tsx
@@ -10,6 +10,7 @@ import { EuiButtonEmpty, EuiPageHeader, EuiSpacer } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import type { CoreStart, HttpStart } from '@kbn/core/public';
 import React from 'react';
+import { KibanaThemeProvider } from '@kbn/kibana-react-plugin/public';
 import type { SearchSessionsMgmtAPI } from '../lib/api';
 import type { AsyncSearchIntroDocumentation } from '../lib/documentation';
 import { SearchSessionsMgmtTable } from './table';
@@ -29,7 +30,7 @@ interface Props {
 
 export function SearchSessionsMgmtMain({ documentation, ...tableProps }: Props) {
   return (
-    <>
+    <KibanaThemeProvider theme$={tableProps.core.theme.theme$}>
       <EuiPageHeader
         pageTitle={
           <FormattedMessage
@@ -60,6 +61,6 @@ export function SearchSessionsMgmtMain({ documentation, ...tableProps }: Props) 
 
       <EuiSpacer size="l" />
       <SearchSessionsMgmtTable data-test-subj="search-sessions-mgmt-table" {...tableProps} />
-    </>
+    </KibanaThemeProvider>
   );
 }


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/159155.
Fixes https://github.com/elastic/kibana/issues/159156.

Applies the current theme (dark/light) to the search sessions management table & its components.

Before:

![image](https://github.com/elastic/kibana/assets/1178348/ac58d9fe-0e54-43b3-af6e-87e44f3eee2a)

After:

![image](https://github.com/elastic/kibana/assets/1178348/86414f6a-dbd4-4d2d-b6a3-cccc125936c9)

<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->