### PR TITLE
[Dashboard] Unskip flaky "Add from library" flyout tests

### DIFF
--- a/test/functional/apps/dashboard/group1/embeddable_rendering.ts
+++ b/test/functional/apps/dashboard/group1/embeddable_rendering.ts
@@ -100,10 +100,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     await dashboardExpect.vegaTextsDoNotExist(['5,000']);
   };
 
-  // Failing: See https://github.com/elastic/kibana/issues/132865
-  // Failing: See https://github.com/elastic/kibana/issues/160070
-  // Failing: See https://github.com/elastic/kibana/issues/158529
-  describe.skip('dashboard embeddable rendering', function describeIndexTests() {
+  describe('dashboard embeddable rendering', function describeIndexTests() {
     before(async () => {
       await security.testUser.setRoles(['kibana_admin', 'animals', 'test_logstash_reader']);
       await kibanaServer.savedObjects.cleanStandardList();

--- a/test/functional/apps/dashboard/group2/dashboard_filtering.ts
+++ b/test/functional/apps/dashboard/group2/dashboard_filtering.ts
@@ -135,9 +135,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
     });
 
-    // FLAKY: https://github.com/elastic/kibana/issues/159931
-    // FLAKY: https://github.com/elastic/kibana/issues/159932
-    describe.skip('using a pinned filter that excludes all data', () => {
+    describe('using a pinned filter that excludes all data', () => {
       before(async () => {
         // Functional tests clear session storage after each suite, so it is important to repopulate unsaved panels
         await populateDashboard();
@@ -198,8 +196,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
     });
 
-    // FLAKY: https://github.com/elastic/kibana/issues/159933
-    describe.skip('disabling a filter unfilters the data on', function () {
+    describe('disabling a filter unfilters the data on', function () {
       before(async () => {
         // Functional tests clear session storage after each suite, so it is important to repopulate unsaved panels
         await populateDashboard();


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/158529
Closes https://github.com/elastic/kibana/issues/159931
Closes https://github.com/elastic/kibana/issues/159932

## Summary

Now that https://github.com/elastic/kibana/pull/159943 is [backported](https://github.com/elastic/kibana/pull/160186) to 8.8, these tests should no longer be flaky on 8.8. Unskipping the tests.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
