### PR TITLE
[8.8] [Fleet][BUG] Fix default output overwrite (#159894)

### DIFF
--- a/x-pack/plugins/fleet/server/services/output.test.ts
+++ b/x-pack/plugins/fleet/server/services/output.test.ts
@@ -82,6 +82,12 @@ function getMockedSoClient(
           type: 'elasticsearch',
         });
       }
+      case outputIdToUuid('existing-default-and-default-monitoring-output'): {
+        return mockOutputSO('existing-default-and-default-monitoring-output', {
+          is_default: true,
+          is_default_monitoring: true,
+        });
+      }
       case outputIdToUuid('existing-preconfigured-default-output'): {
         return mockOutputSO('existing-preconfigured-default-output', {
           is_default: true,
@@ -559,6 +565,46 @@ describe('Output Service', () => {
         expect.anything(),
         outputIdToUuid('existing-default-output'),
         { is_default: true, name: 'Test' }
+      );
+    });
+
+    it('should not set default output to false when the output is already the default one', async () => {
+      const soClient = getMockedSoClient({
+        defaultOutputId: 'existing-default-and-default-monitoring-output',
+      });
+
+      await expect(
+        outputService.update(
+          soClient,
+          esClientMock,
+          'existing-default-and-default-monitoring-output',
+          {
+            is_default: false,
+            name: 'Test',
+          }
+        )
+      ).rejects.toThrow(
+        `Default output existing-default-and-default-monitoring-output cannot be set to is_default=false or is_default_monitoring=false manually. Make another output the default first.`
+      );
+    });
+
+    it('should not set default monitoring output to false when the output is already the default one', async () => {
+      const soClient = getMockedSoClient({
+        defaultOutputId: 'existing-default-and-default-monitoring-output',
+      });
+
+      await expect(
+        outputService.update(
+          soClient,
+          esClientMock,
+          'existing-default-and-default-monitoring-output',
+          {
+            is_default_monitoring: false,
+            name: 'Test',
+          }
+        )
+      ).rejects.toThrow(
+        `Default output existing-default-and-default-monitoring-output cannot be set to is_default=false or is_default_monitoring=false manually. Make another output the default first.`
       );
     });
 

--- a/x-pack/plugins/fleet/server/services/output.ts
+++ b/x-pack/plugins/fleet/server/services/output.ts
@@ -8,27 +8,27 @@ import { v5 as uuidv5 } from 'uuid';
 import { omit } from 'lodash';
 import { safeLoad } from 'js-yaml';
 
-import { SavedObjectsUtils } from '@kbn/core/server';
 import type {
+  ElasticsearchClient,
   KibanaRequest,
   SavedObject,
   SavedObjectsClientContract,
-  ElasticsearchClient,
 } from '@kbn/core/server';
+import { SavedObjectsUtils } from '@kbn/core/server';
 
-import type { NewOutput, Output, OutputSOAttributes, AgentPolicy } from '../types';
+import type { AgentPolicy, NewOutput, Output, OutputSOAttributes } from '../types';
 import {
+  AGENT_POLICY_SAVED_OBJECT_TYPE,
   DEFAULT_OUTPUT,
   DEFAULT_OUTPUT_ID,
   OUTPUT_SAVED_OBJECT_TYPE,
-  AGENT_POLICY_SAVED_OBJECT_TYPE,
 } from '../constants';
-import { SO_SEARCH_LIMIT, outputType } from '../../common/constants';
+import { outputType, SO_SEARCH_LIMIT } from '../../common/constants';
 import { decodeCloudId, normalizeHostsForAgents } from '../../common/services';
 import {
-  OutputUnauthorizedError,
-  OutputInvalidError,
   FleetEncryptedSavedObjectEncryptionKeyRequired,
+  OutputInvalidError,
+  OutputUnauthorizedError,
 } from '../errors';
 
 import { agentPolicyService } from './agent_policy';
@@ -260,6 +260,59 @@ class OutputService {
     return outputs;
   }
 
+  private async _updateDefaultOutput(
+    soClient: SavedObjectsClientContract,
+    defaultDataOutputId: string,
+    updateData: { is_default: boolean } | { is_default_monitoring: boolean },
+    fromPreconfiguration: boolean
+  ) {
+    const originalOutput = await this.get(soClient, defaultDataOutputId);
+    this._validateFieldsAreEditable(
+      originalOutput,
+      updateData,
+      defaultDataOutputId,
+      fromPreconfiguration
+    );
+
+    auditLoggingService.writeCustomSoAuditLog({
+      action: 'update',
+      id: outputIdToUuid(defaultDataOutputId),
+      savedObjectType: OUTPUT_SAVED_OBJECT_TYPE,
+    });
+
+    return await this.encryptedSoClient.update<Nullable<OutputSOAttributes>>(
+      SAVED_OBJECT_TYPE,
+      outputIdToUuid(defaultDataOutputId),
+      updateData
+    );
+  }
+
+  private _validateFieldsAreEditable(
+    originalOutput: Output,
+    data: Partial<Output>,
+    id: string,
+    fromPreconfiguration: boolean
+  ) {
+    if (originalOutput.is_preconfigured) {
+      if (!fromPreconfiguration) {
+        const allowEditFields = originalOutput.allow_edit ?? [];
+
+        const allKeys = Array.from(new Set([...Object.keys(data)])) as Array<keyof Output>;
+        for (const key of allKeys) {
+          if (
+            (!!originalOutput[key] || !!data[key]) &&
+            !allowEditFields.includes(key) &&
+            !deepEqual(originalOutput[key], data[key])
+          ) {
+            throw new OutputUnauthorizedError(
+              `Preconfigured output ${id} ${key} cannot be updated outside of kibana config file.`
+            );
+          }
+        }
+      }
+    }
+  }
+
   public async ensureDefaultOutput(
     soClient: SavedObjectsClientContract,
     esClient: ElasticsearchClient
@@ -351,24 +404,22 @@ class OutputService {
     // ensure only default output exists
     if (data.is_default) {
       if (defaultDataOutputId) {
-        await this.update(
+        await this._updateDefaultOutput(
           soClient,
-          esClient,
           defaultDataOutputId,
           { is_default: false },
-          { fromPreconfiguration: options?.fromPreconfiguration ?? false }
+          options?.fromPreconfiguration ?? false
         );
       }
     }
     if (data.is_default_monitoring) {
       const defaultMonitoringOutputId = await this.getDefaultMonitoringOutputId(soClient);
       if (defaultMonitoringOutputId) {
-        await this.update(
+        await this._updateDefaultOutput(
           soClient,
-          esClient,
           defaultMonitoringOutputId,
           { is_default_monitoring: false },
-          { fromPreconfiguration: options?.fromPreconfiguration ?? false }
+          options?.fromPreconfiguration ?? false
         );
       }
     }
@@ -555,16 +606,19 @@ class OutputService {
   ) {
     const originalOutput = await this.get(soClient, id);
 
-    if (originalOutput.is_preconfigured && !fromPreconfiguration) {
+    this._validateFieldsAreEditable(originalOutput, data, id, fromPreconfiguration);
+    if (
+      (originalOutput.is_default && data.is_default === false) ||
+      (data.is_default_monitoring === false && originalOutput.is_default_monitoring)
+    ) {
       throw new OutputUnauthorizedError(
-        `Preconfigured output ${id} cannot be updated outside of kibana config file.`
+        `Default output ${id} cannot be set to is_default=false or is_default_monitoring=false manually. Make another output the default first.`
       );
     }
 
     const updateData: Nullable<Partial<OutputSOAttributes>> = { ...omit(data, 'ssl') };
     const mergedType = data.type ?? originalOutput.type;
     const defaultDataOutputId = await this.getDefaultDataOutputId(soClient);
-
     await validateTypeChanges(
       soClient,
       esClient,
@@ -597,12 +651,11 @@ class OutputService {
     // ensure only default output exists
     if (data.is_default) {
       if (defaultDataOutputId && defaultDataOutputId !== id) {
-        await this.update(
+        await this._updateDefaultOutput(
           soClient,
-          esClient,
           defaultDataOutputId,
           { is_default: false },
-          { fromPreconfiguration }
+          fromPreconfiguration
         );
       }
     }
@@ -610,12 +663,11 @@ class OutputService {
       const defaultMonitoringOutputId = await this.getDefaultMonitoringOutputId(soClient);
 
       if (defaultMonitoringOutputId && defaultMonitoringOutputId !== id) {
-        await this.update(
+        await this._updateDefaultOutput(
           soClient,
-          esClient,
           defaultMonitoringOutputId,
           { is_default_monitoring: false },
-          { fromPreconfiguration }
+          fromPreconfiguration
         );
       }
     }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.8`:
 - [[Fleet][BUG] Fix default output overwrite (#159894)](https://github.com/elastic/kibana/pull/159894)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Konrad Szwarc","email":"konrad.szwarc@elastic.co"},"sourceCommit":{"committedDate":"2023-06-21T14:54:31Z","message":"[Fleet][BUG] Fix default output overwrite (#159894)\n\nThis pull request resolves a bug in the fleet's API that permits setting\r\nthe default output to `is_default: false` and `is_default_monitoring:\r\nfalse`, resulting in the absence of a default output. This action is not\r\nallowed through the UI as the toggle is disabled. The objective is to\r\ndetermine whether the update method was called directly, fulfilling the\r\nAPI request, or if it was utilized as a helper by either the `create` or\r\n`update` methods themselves.","sha":"0c326673b984d5575c463e299c96bee486f42491","branchLabelMapping":{"^v8.9.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Fleet","backport:prev-minor","v8.9.0"],"number":159894,"url":"https://github.com/elastic/kibana/pull/159894","mergeCommit":{"message":"[Fleet][BUG] Fix default output overwrite (#159894)\n\nThis pull request resolves a bug in the fleet's API that permits setting\r\nthe default output to `is_default: false` and `is_default_monitoring:\r\nfalse`, resulting in the absence of a default output. This action is not\r\nallowed through the UI as the toggle is disabled. The objective is to\r\ndetermine whether the update method was called directly, fulfilling the\r\nAPI request, or if it was utilized as a helper by either the `create` or\r\n`update` methods themselves.","sha":"0c326673b984d5575c463e299c96bee486f42491"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.9.0","labelRegex":"^v8.9.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/159894","number":159894,"mergeCommit":{"message":"[Fleet][BUG] Fix default output overwrite (#159894)\n\nThis pull request resolves a bug in the fleet's API that permits setting\r\nthe default output to `is_default: false` and `is_default_monitoring:\r\nfalse`, resulting in the absence of a default output. This action is not\r\nallowed through the UI as the toggle is disabled. The objective is to\r\ndetermine whether the update method was called directly, fulfilling the\r\nAPI request, or if it was utilized as a helper by either the `create` or\r\n`update` methods themselves.","sha":"0c326673b984d5575c463e299c96bee486f42491"}}]}] BACKPORT-->