### PR TITLE
[Serverless Search] fix: remove $ from js install snippet

### DIFF
--- a/x-pack/plugins/serverless_search/public/application/components/languages/javascript.ts
+++ b/x-pack/plugins/serverless_search/public/application/components/languages/javascript.ts
@@ -59,7 +59,7 @@ bytes: 293,
 aborted: false
 }
 */`,
-  installClient: `$ npm install @elastic/elasticsearch@8`,
+  installClient: 'npm install @elastic/elasticsearch@8',
   name: i18n.translate('xpack.serverlessSearch.languages.javascript', {
     defaultMessage: 'JavaScript / Node.js',
   }),


### PR DESCRIPTION
## Summary

Removed the `$ ` from the start of the install code snippet for javascript

<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->