### PR TITLE
[RAM][Maintenance Windows][Bug] Show Maintenance Window Ids If Unable to Fetch Maintenance Windows

### DIFF
--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/maintenance_windows/cell.test.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/maintenance_windows/cell.test.tsx
@@ -19,7 +19,7 @@ const maintenanceWindowsMap = getMaintenanceWindowMockMap();
 const alert = {
   _id: 'alert-id',
   _index: 'alert-index',
-  [ALERT_MAINTENANCE_WINDOW_IDS]: ['test-mw-id-1'],
+  [ALERT_MAINTENANCE_WINDOW_IDS]: ['test-mw-id-1', 'test-mw-id-2'],
 } as Alert;
 
 const props: CellComponentProps = {
@@ -34,7 +34,7 @@ const props: CellComponentProps = {
 describe('MaintenanceWindowCell', () => {
   it('renders the maintenance window cell', async () => {
     render(<MaintenanceWindowCell {...props} />);
-    expect(screen.getByText('test-title')).toBeInTheDocument();
+    expect(screen.getByText('test-title,')).toBeInTheDocument();
   });
 
   it('renders the loading skeleton', async () => {
@@ -44,8 +44,16 @@ describe('MaintenanceWindowCell', () => {
 
   it('shows the tooltip', async () => {
     render(<MaintenanceWindowCell {...props} />);
-    expect(screen.getByText('test-title')).toBeInTheDocument();
-    userEvent.hover(screen.getByText('test-title'));
+    expect(screen.getByText('test-title,')).toBeInTheDocument();
+    userEvent.hover(screen.getByText('test-title,'));
     expect(await screen.findByTestId('maintenance-window-tooltip-content')).toBeInTheDocument();
+  });
+
+  it('renders the maintenance window IDs if the endpoint could not be fetched', async () => {
+    render(<MaintenanceWindowCell {...props} maintenanceWindows={new Map()} />);
+    expect(screen.queryByText('test-title,')).not.toBeInTheDocument();
+    expect(screen.queryByText('test-title-2')).not.toBeInTheDocument();
+    expect(screen.getByText('test-mw-id-1,')).toBeInTheDocument();
+    expect(screen.getByText('test-mw-id-2')).toBeInTheDocument();
   });
 });

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/rule_details/components/rule_alert_list.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/rule_details/components/rule_alert_list.tsx
@@ -72,10 +72,16 @@ const RuleAlertListMaintenanceWindowCell = (props: RuleAlertListMaintenanceWindo
       .filter(isMaintenanceWindowValid);
   }, [alert, maintenanceWindows]);
 
+  const idsWithoutMaintenanceWindow = useMemo(() => {
+    const maintenanceWindowIds = alert.maintenanceWindowIds || [];
+    return maintenanceWindowIds.filter((id) => !maintenanceWindows.get(id));
+  }, [alert, maintenanceWindows]);
+
   return (
     <MaintenanceWindowBaseCell
       timestamp={alert.start?.toISOString()}
       maintenanceWindows={validMaintenanceWindows}
+      maintenanceWindowIds={idsWithoutMaintenanceWindow}
       isLoading={isLoading}
     />
   );


### PR DESCRIPTION
## Summary
Resolves: https://github.com/elastic/kibana/issues/160202

We should show maintenance window IDs in the alert table columns if the user does not have the capability or license to fetch maintenance windows. Right now we will show nothing if the user can't fetch. 

## To Test:

1. Start trial, make sure you have a platinum license
2. Create a few maintenance windows (management -> Maintenance windows)
3. Create an O11y rule, trigger a few alerts
4. Go to the O11Y alerts table, ensuring the `Maintenance Windows` column is visible
5. Assert the MW names are displayed
6. Revert to a basic license
7. Go to the O11y alerts table again
8. Assert the MW ids are displayed
9. Repeat 1-8 for the rule details alerts page

### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->