### PR TITLE
[Discover] Encode context anchor ID

### DIFF
--- a/src/plugins/discover/public/application/context/services/locator.test.ts
+++ b/src/plugins/discover/public/application/context/services/locator.test.ts
@@ -113,4 +113,16 @@ describe('Discover context url generator', () => {
       `"#/context/c367b774-a4c2-11ea-bb37-0242ac130002/mock-row-id?_g=h@3a04046&_a=h@9ad8c77"`
     );
   });
+
+  it('should encode rowId', async () => {
+    const { locator } = await setup();
+    const { path } = await locator.getLocation({
+      index: dataViewId,
+      rowId: 'id with special characters: /&?#+=',
+      referrer: 'mock-referrer',
+    });
+    expect(path).toMatchInlineSnapshot(
+      `"#/context/c367b774-a4c2-11ea-bb37-0242ac130002/id%20with%20special%20characters%3A%20%2F%26%3F%23%2B%3D"`
+    );
+  });
 });

--- a/src/plugins/discover/public/application/context/services/locator.ts
+++ b/src/plugins/discover/public/application/context/services/locator.ts
@@ -71,7 +71,7 @@ export class DiscoverContextAppLocatorDefinition
       path = addProfile(path, params.profile);
     }
 
-    path = `${path}context/${dataViewId}/${rowId}`;
+    path = `${path}context/${dataViewId}/${encodeURIComponent(rowId)}`;
 
     if (Object.keys(queryState).length) {
       path = setStateToKbnUrl<GlobalQueryStateFromUrl>('_g', queryState, { useHash }, path);

--- a/src/plugins/discover/public/application/doc/locator.test.ts
+++ b/src/plugins/discover/public/application/doc/locator.test.ts
@@ -37,12 +37,12 @@ describe('Discover single doc url generator', () => {
     const { locator } = setup();
     const { path } = await locator.getLocation({
       index: dataViewId,
-      rowId: 'id with special characters: &?#+',
+      rowId: 'id with special characters: &?#+/=',
       rowIndex: 'mock-row-index',
       referrer: 'mock-referrer',
     });
     expect(path).toMatchInlineSnapshot(
-      `"#/doc/c367b774-a4c2-11ea-bb37-0242ac130002/mock-row-index?id=id%20with%20special%20characters%3A%20%26%3F%23%2B"`
+      `"#/doc/c367b774-a4c2-11ea-bb37-0242ac130002/mock-row-index?id=id%20with%20special%20characters%3A%20%26%3F%23%2B%2F%3D"`
     );
   });
 

--- a/test/functional/apps/discover/group2/_context_encoded_url_params.ts
+++ b/test/functional/apps/discover/group2/_context_encoded_url_params.ts
@@ -10,7 +10,7 @@ import expect from '@kbn/expect';
 import { FtrProviderContext } from '../ftr_provider_context';
 
 const customDataViewIdParam = 'context-enc:oded-param';
-const customDocIdParam = '1+1=2';
+const customDocIdParam = '1+1=2/&?#';
 
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const dataGrid = getService('dataGrid');
@@ -24,12 +24,12 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await security.testUser.setRoles(['kibana_admin', 'context_encoded_param']);
       await PageObjects.common.navigateToApp('settings');
       await es.transport.request({
-        path: `/context_encoded_param/_doc/${customDocIdParam}`,
+        path: `/_bulk`,
         method: 'PUT',
-        body: {
-          username: 'Dmitry',
-          '@timestamp': '2015-09-21T09:30:23',
-        },
+        bulkBody: [
+          { index: { _index: 'context_encoded_param', _id: customDocIdParam } },
+          { '@timestamp': '2015-09-21T09:30:23', name: 'Dmitry' },
+        ],
       });
       await PageObjects.settings.createIndexPattern(
         'context_encoded_param',
@@ -57,7 +57,9 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       const headerElement = await testSubjects.find('contextDocumentSurroundingHeader');
 
-      expect(await headerElement.getVisibleText()).to.be('Documents surrounding #1+1=2');
+      expect(await headerElement.getVisibleText()).to.be(
+        `Documents surrounding #${customDocIdParam}`
+      );
     });
   });
 }


### PR DESCRIPTION
- Closes https://github.com/elastic/kibana/issues/160212

## Summary

Added the missing encoding and updated tests.

## For testing

An id with special characters like `/` can be specified via `_bulk` API.
Example:

```
POST _bulk
{ "index" : { "_index" : "context-special", "_id" : "test&?#+/=" } }
{ "timestamp":"2023-06-20T20:00:00.123Z", "name": "test" }
```

<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->