### PR TITLE
[Profling][Fleet]Add a prerelease query param so who links to an integration can tell where the details must be read from 

### DIFF
--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/index.tsx
@@ -131,6 +131,7 @@ export function Detail() {
   const { pathname, search, hash } = useLocation();
   const queryParams = useMemo(() => new URLSearchParams(search), [search]);
   const integration = useMemo(() => queryParams.get('integration'), [queryParams]);
+  const prerelease = useMemo(() => Boolean(queryParams.get('prerelease')), [queryParams]);
 
   const canInstallPackages = useAuthz().integrations.installPackages;
   const canReadPackageSettings = useAuthz().integrations.readPackageSettings;
@@ -186,9 +187,9 @@ export function Detail() {
   const { data: settings } = useGetSettingsQuery();
 
   useEffect(() => {
-    const isEnabled = Boolean(settings?.item.prerelease_integrations_enabled);
+    const isEnabled = Boolean(settings?.item.prerelease_integrations_enabled) || prerelease;
     setPrereleaseIntegrationsEnabled(isEnabled);
-  }, [settings?.item.prerelease_integrations_enabled]);
+  }, [settings?.item.prerelease_integrations_enabled, prerelease]);
 
   const { pkgName, pkgVersion } = splitPkgKey(pkgkey);
   // Fetch package info

--- a/x-pack/plugins/profiling/public/views/no_data_view/index.tsx
+++ b/x-pack/plugins/profiling/public/views/no_data_view/index.tsx
@@ -309,7 +309,7 @@ docker.elastic.co/observability/profiling-agent:${hostAgentVersion} /root/pf-hos
               iconType="gear"
               fill
               href={`${core.http.basePath.prepend(
-                '/app/integrations/detail/profiler_agent-8.8.0-preview/overview'
+                '/app/integrations/detail/profiler_agent-8.8.0-preview/overview?prerelease=true'
               )}`}
             >
               {i18n.translate('xpack.profiling.tabs.elasticAgentIntegrarion.step2.button', {


### PR DESCRIPTION
Problem:
In the Profiler Add data page we show instructions on how to set up Universal Profiling. One of the options is from the Profiler integration. So we display a button that links to `/app/integrations/detail/profiler_agent-8.8.0-preview/overview`. The problem is this link, is that the profiler integration is still in `Beta`, and will be until `8.10`, and when I click on that link the error shown in the image below happens.
Before:
![Screenshot 2023-06-21 at 9 58 29 PM](https://github.com/elastic/kibana/assets/55978943/4800bdc3-df40-4579-9e57-d4b28e13be19)

Solution:
I added an optional query param `prerelase={true|false}` to the integration link. So now I changed the link to: `/app/integrations/detail/profiler_agent-8.8.0-preview/overview?prerelease=true`, this when true, overrides the `settings?.item.prerelease_integrations_enabled` which is false by default.

After:
<img width="1407" alt="Screenshot 2023-06-22 at 11 16 52 AM" src="https://github.com/elastic/kibana/assets/55978943/a0fd4ea5-b54b-45ea-9903-b43a24600e7e">
