### PR TITLE
Enterprise Search: Include field name in ingest pipeline inference error

### DIFF
--- a/x-pack/plugins/enterprise_search/common/ml_inference_pipeline/index.test.ts
+++ b/x-pack/plugins/enterprise_search/common/ml_inference_pipeline/index.test.ts
@@ -154,6 +154,7 @@ describe('generateMlInferencePipelineBody lib function', () => {
             {
               append: {
                 field: '_source._ingest.inference_errors',
+                allow_duplicates: false,
                 value: [
                   {
                     message:

--- a/x-pack/plugins/enterprise_search/common/ml_inference_pipeline/index.test.ts
+++ b/x-pack/plugins/enterprise_search/common/ml_inference_pipeline/index.test.ts
@@ -157,7 +157,7 @@ describe('generateMlInferencePipelineBody lib function', () => {
                 value: [
                   {
                     message:
-                      "Processor 'inference' in pipeline 'my-pipeline' failed with message '{{ _ingest.on_failure_message }}'",
+                      "Processor 'inference' in pipeline 'my-pipeline' failed for field 'my-source-field' with message '{{ _ingest.on_failure_message }}'",
                     pipeline: 'my-pipeline',
                     timestamp: '{{{ _ingest.timestamp }}}',
                   },

--- a/x-pack/plugins/enterprise_search/common/ml_inference_pipeline/index.ts
+++ b/x-pack/plugins/enterprise_search/common/ml_inference_pipeline/index.ts
@@ -135,7 +135,7 @@ export const getInferenceProcessor = (
           field: '_source._ingest.inference_errors',
           value: [
             {
-              message: `Processor 'inference' in pipeline '${pipelineName}' failed with message '{{ _ingest.on_failure_message }}'`,
+              message: `Processor 'inference' in pipeline '${pipelineName}' failed for field '${sourceField}' with message '{{ _ingest.on_failure_message }}'`,
               pipeline: pipelineName,
               timestamp: '{{{ _ingest.timestamp }}}',
             },

--- a/x-pack/plugins/enterprise_search/common/ml_inference_pipeline/index.ts
+++ b/x-pack/plugins/enterprise_search/common/ml_inference_pipeline/index.ts
@@ -133,6 +133,7 @@ export const getInferenceProcessor = (
       {
         append: {
           field: '_source._ingest.inference_errors',
+          allow_duplicates: false,
           value: [
             {
               message: `Processor 'inference' in pipeline '${pipelineName}' failed for field '${sourceField}' with message '{{ _ingest.on_failure_message }}'`,

--- a/x-pack/plugins/enterprise_search/server/lib/pipelines/create_pipeline_definitions.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/pipelines/create_pipeline_definitions.test.ts
@@ -62,6 +62,7 @@ describe('formatMlPipelineBody util function', () => {
             {
               append: {
                 field: '_source._ingest.inference_errors',
+                allow_duplicates: false,
                 value: [
                   {
                     pipeline: pipelineName,

--- a/x-pack/plugins/enterprise_search/server/lib/pipelines/create_pipeline_definitions.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/pipelines/create_pipeline_definitions.test.ts
@@ -65,7 +65,7 @@ describe('formatMlPipelineBody util function', () => {
                 value: [
                   {
                     pipeline: pipelineName,
-                    message: `Processor 'inference' in pipeline '${pipelineName}' failed with message '{{ _ingest.on_failure_message }}'`,
+                    message: `Processor 'inference' in pipeline '${pipelineName}' failed for field '${sourceField}' with message '{{ _ingest.on_failure_message }}'`,
                     timestamp: '{{{ _ingest.timestamp }}}',
                   },
                 ],


### PR DESCRIPTION
We can end up with with seemingly duplicate errors:

```
        "_source": {
          "_ingest": {
            "inference_errors": [
              {
                "message": "Processor 'inference' in pipeline 'test' failed with message 'Trained model deployment [.elser_model_1] is not allocated to any nodes'"
              },
              {
                "message": "Processor 'inference' in pipeline 'body-content' failed with message 'Trained model deployment [.elser_model_1] is not allocated to any nodes'"
              },
              {
                "message": "Processor 'inference' in pipeline 'body-content' failed with message 'Trained model deployment [.elser_model_1] is not allocated to any nodes'"
              }
            ]
          }
        }
      },
```

This adds the field name in the error message for easier differentiation.
It also includes `allow_duplicates: false` in the append processor, to make sure we are not adding duplicate error messages to `inference_errors`.


<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->