### PR TITLE
[shared ux] Remove usages of refresh: true

### DIFF
--- a/src/plugins/files/server/file_client/file_metadata_client/adapters/es_index.ts
+++ b/src/plugins/files/server/file_client/file_metadata_client/adapters/es_index.ts
@@ -76,7 +76,7 @@ export class EsIndexFilesMetadataClient<M = unknown> implements FileMetadataClie
       index: this.index,
       id,
       document: { file: metadata },
-      refresh: true,
+      refresh: 'wait_for',
     });
     return {
       id: result._id,
@@ -145,7 +145,12 @@ export class EsIndexFilesMetadataClient<M = unknown> implements FileMetadataClie
   }
 
   async update({ id, metadata }: UpdateArgs<M>): Promise<FileDescriptor<M>> {
-    await this.esClient.update({ index: this.index, id, doc: { file: metadata }, refresh: true });
+    await this.esClient.update({
+      index: this.index,
+      id,
+      doc: { file: metadata },
+      refresh: 'wait_for',
+    });
     return this.get({ id });
   }
 

--- a/src/plugins/share/server/url_service/short_urls/storage/saved_object_short_url_storage.ts
+++ b/src/plugins/share/server/url_service/short_urls/storage/saved_object_short_url_storage.ts
@@ -118,7 +118,7 @@ export class SavedObjectShortUrlStorage implements ShortUrlStorage {
     const attributes = createAttributes(data);
 
     const savedObject = await savedObjects.create(savedObjectType, attributes, {
-      refresh: true,
+      refresh: 'wait_for',
       references,
     });
 
@@ -134,7 +134,7 @@ export class SavedObjectShortUrlStorage implements ShortUrlStorage {
     const attributes = createAttributes(data);
 
     await savedObjects.update(savedObjectType, id, attributes, {
-      refresh: true,
+      refresh: 'wait_for',
       references,
     });
   }


### PR DESCRIPTION
Replace the usage of `refresh: true` with `refresh: 'wait_for'` in

* Files plugin
* Share plugin

Fixes https://github.com/elastic/kibana/issues/158138