### PR TITLE
fix: partial matching on suite name found incorrect group names

### DIFF
--- a/.buildkite/pipelines/flaky_tests/pipeline.ts
+++ b/.buildkite/pipelines/flaky_tests/pipeline.ts
@@ -153,18 +153,17 @@ for (const testSuite of testSuites) {
     continue;
   }
 
-  const keyParts = testSuite.key.split('/');
-  switch (keyParts[0]) {
+  const [category, suiteName] = testSuite.key.split('/');
+  switch (category) {
     case 'cypress':
-      const CYPRESS_SUITE = keyParts[1];
-      const group = groups.find((g) => g.key.includes(CYPRESS_SUITE));
+      const group = groups.find((g) => g.key === testSuite.key);
       if (!group) {
         throw new Error(
-          `Group configuration was not found in groups.json for the following cypress suite: {${CYPRESS_SUITE}}.`
+          `Group configuration was not found in groups.json for the following cypress suite: {${suiteName}}.`
         );
       }
       steps.push({
-        command: `.buildkite/scripts/steps/functional/${CYPRESS_SUITE}.sh`,
+        command: `.buildkite/scripts/steps/functional/${suiteName}.sh`,
         label: group.name,
         agents: { queue: 'n2-4-spot' },
         depends_on: 'build',


### PR DESCRIPTION
## Summary
Context: https://elastic.slack.com/archives/C0D8P2XK5/p1687424169737829
The flaky test runner was displaying incorrect name on the tasks on Buildkite.

The reason was a partial match (cypress/security_solution_investigations "includes" `security_solution`), now changed to a full match on the keys. 
