### PR TITLE
[ML] Hide `cache_miss_count` for pytorch models

### DIFF
--- a/x-pack/plugins/ml/common/types/common.ts
+++ b/x-pack/plugins/ml/common/types/common.ts
@@ -57,3 +57,8 @@ export type AwaitReturnType<T> = T extends PromiseLike<infer U> ? U : T;
  * Removes an optional modifier from a property in a type.
  */
 export type WithRequired<T, K extends keyof T> = T & { [P in K]-?: Exclude<T[P], null> };
+
+/**
+ * Makes requested properties in a type optional
+ */
+export type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;

--- a/x-pack/plugins/ml/public/application/model_management/expanded_row.tsx
+++ b/x-pack/plugins/ml/public/application/model_management/expanded_row.tsx
@@ -26,6 +26,7 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import { FIELD_FORMAT_IDS } from '@kbn/field-formats-plugin/common';
 import { isPopulatedObject } from '@kbn/ml-is-populated-object';
 import { isDefined } from '@kbn/ml-is-defined';
+import { TRAINED_MODEL_TYPE } from '@kbn/ml-trained-models-utils';
 import type { PartialBy } from '../../../common/types/common';
 import type { ModelItemFull } from './models_list';
 import { ModelPipelines } from './pipelines';
@@ -138,7 +139,7 @@ export const ExpandedRow: FC<ExpandedRowProps> = ({ item }) => {
       Exclude<TrainedModelStat['inference_stats'], undefined>,
       'cache_miss_count'
     >;
-    if (item.model_type === 'pytorch') {
+    if (item.model_type === TRAINED_MODEL_TYPE.PYTORCH) {
       delete result.cache_miss_count;
     }
     return result;


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/157385

<img width="1355" alt="image" src="https://github.com/elastic/kibana/assets/5236598/cb779fb5-f9d5-4222-af38-e636724867a3">

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->