### PR TITLE
[ML] Enable trained models tests 

### DIFF
--- a/x-pack/plugins/ml/server/routes/trained_models.ts
+++ b/x-pack/plugins/ml/server/routes/trained_models.ts
@@ -313,8 +313,12 @@ export function trainedModelsRoutes({ router, routeGuard }: RouteInitialization)
           const { with_pipelines: withPipelines, force } = request.query;
 
           if (withPipelines) {
-            // first we need to delete pipelines, otherwise ml api return an error
-            await modelsProvider(client).deleteModelPipelines(modelId.split(','));
+            try {
+              // first we need to delete pipelines, otherwise ml api return an error
+              await modelsProvider(client).deleteModelPipelines(modelId.split(','));
+            } catch (e) {
+              // temp fail silently
+            }
           }
 
           const body = await mlClient.deleteTrainedModel({

--- a/x-pack/plugins/ml/server/routes/trained_models.ts
+++ b/x-pack/plugins/ml/server/routes/trained_models.ts
@@ -313,12 +313,8 @@ export function trainedModelsRoutes({ router, routeGuard }: RouteInitialization)
           const { with_pipelines: withPipelines, force } = request.query;
 
           if (withPipelines) {
-            try {
-              // first we need to delete pipelines, otherwise ml api return an error
-              await modelsProvider(client).deleteModelPipelines(modelId.split(','));
-            } catch (e) {
-              // temp fail silently
-            }
+            // first we need to delete pipelines, otherwise ml api return an error
+            await modelsProvider(client).deleteModelPipelines(modelId.split(','));
           }
 
           const body = await mlClient.deleteTrainedModel({

--- a/x-pack/test/functional/apps/ml/short_tests/model_management/model_list.ts
+++ b/x-pack/test/functional/apps/ml/short_tests/model_management/model_list.ts
@@ -74,8 +74,7 @@ export default function ({ getService }: FtrProviderContext) {
       });
     });
 
-    // FLAKY: https://github.com/elastic/kibana/issues/159283
-    describe.skip('for ML power user', () => {
+    describe('for ML power user', () => {
       before(async () => {
         await ml.securityUI.loginAsMlPowerUser();
         await ml.navigation.navigateToTrainedModels();

--- a/x-pack/test/functional/apps/ml/short_tests/model_management/model_list.ts
+++ b/x-pack/test/functional/apps/ml/short_tests/model_management/model_list.ts
@@ -46,7 +46,7 @@ export default function ({ getService }: FtrProviderContext) {
       await ml.api.createTestTrainedModels('regression', 15);
 
       // Make sure the .ml-stats index is created in advance, see https://github.com/elastic/elasticsearch/issues/65846
-      await ml.api.assureMlStatsIndexToExist();
+      await ml.api.assureMlStatsIndexExists();
     });
 
     after(async () => {

--- a/x-pack/test/functional/apps/ml/short_tests/model_management/model_list.ts
+++ b/x-pack/test/functional/apps/ml/short_tests/model_management/model_list.ts
@@ -17,21 +17,6 @@ export default function ({ getService }: FtrProviderContext) {
   }));
 
   describe('trained models', function () {
-    before(async () => {
-      for (const model of trainedModels) {
-        await ml.api.importTrainedModel(model.id, model.name);
-      }
-
-      await ml.api.createTestTrainedModels('classification', 15, true);
-      await ml.api.createTestTrainedModels('regression', 15);
-    });
-
-    after(async () => {
-      await ml.api.stopAllTrainedModelDeploymentsES();
-      await ml.api.deleteAllTrainedModelsES();
-      await ml.api.cleanMlIndices();
-    });
-
     // 'Created at' will be different on each run,
     // so we will just assert that the value is in the expected timestamp format.
     const builtInModelData = {
@@ -51,6 +36,24 @@ export default function ({ getService }: FtrProviderContext) {
       description: '',
       modelTypes: ['regression', 'tree_ensemble'],
     };
+
+    before(async () => {
+      for (const model of trainedModels) {
+        await ml.api.importTrainedModel(model.id, model.name);
+      }
+
+      await ml.api.createTestTrainedModels('classification', 15, true);
+      await ml.api.createTestTrainedModels('regression', 15);
+
+      // Make sure the .ml-stats index is created in advance, see https://github.com/elastic/elasticsearch/issues/65846
+      await ml.api.assureMlStatsIndexToExist();
+    });
+
+    after(async () => {
+      await ml.api.stopAllTrainedModelDeploymentsES();
+      await ml.api.deleteAllTrainedModelsES();
+      await ml.api.cleanMlIndices();
+    });
 
     describe('for ML user with read-only access', () => {
       before(async () => {

--- a/x-pack/test/functional/services/ml/api.ts
+++ b/x-pack/test/functional/services/ml/api.ts
@@ -1497,10 +1497,10 @@ export function MachineLearningAPIProvider({ getService }: FtrProviderContext) {
       log.debug('> Ingest pipeline deleted');
     },
 
-    async assureMlStatsIndexToExist(timeout: number = 60 * 1000) {
+    async assureMlStatsIndexExists(timeout: number = 60 * 1000) {
       const params = {
         index: '.ml-stats-000001',
-        id: 'random-test-id',
+        id: 'noop_job_test_id',
         body: {
           type: 'analytics_memory_usage',
           job_id: 'noop_job',

--- a/x-pack/test/functional/services/ml/trained_models_table.ts
+++ b/x-pack/test/functional/services/ml/trained_models_table.ts
@@ -383,6 +383,7 @@ export function TrainedModelsTableProvider(
       await mlCommonUI.assertLastToastHeader(
         `Deployment for "${modelId}" has been started successfully.`
       );
+      await this.waitForModelsToLoad();
     }
 
     public async stopDeployment(modelId: string) {


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/159283

The tests were occasionally failing due to https://github.com/elastic/elasticsearch/issues/65846. The model deletion endpoint performs a search against the `.ml-stats*` index, and as this hidden index is created asynchronously, occasionally the test was failing either due to partial shards failure or failure to execute phase `[can_match]`.

This PR adds a manual doc indexing to the `.ml-stats` index and ensures the index health is green before the tests execution. 


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios