### PR TITLE
[RAM] Best practice for Alert tables

### DIFF
--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/alerts_table.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/alerts_table.tsx
@@ -207,7 +207,7 @@ const AlertsTable: React.FunctionComponent<AlertsTableProps> = (props: AlertsTab
   ])();
 
   const openFlyoutAlertIndex = useCallback(
-    (visibleRowIndex: number) => () => setFlyoutAlertIndex(visibleRowIndex),
+    (visibleRowIndex: number) => setFlyoutAlertIndex(visibleRowIndex),
     [setFlyoutAlertIndex]
   );
 
@@ -243,7 +243,7 @@ const AlertsTable: React.FunctionComponent<AlertsTableProps> = (props: AlertsTab
                         size="s"
                         iconType="expand"
                         color="primary"
-                        onClick={openFlyoutAlertIndex(visibleRowIndex)}
+                        onClick={openFlyoutAlertIndex.bind(this, visibleRowIndex)}
                         data-test-subj={`expandColumnCellOpenFlyoutButton-${visibleRowIndex}`}
                         aria-label={ALERTS_TABLE_CONTROL_COLUMNS_VIEW_DETAILS_LABEL}
                       />

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/bulk_actions/components/column_header.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/bulk_actions/components/column_header.tsx
@@ -6,7 +6,7 @@
  */
 
 import { EuiCheckbox } from '@elastic/eui';
-import React, { ChangeEvent, useContext } from 'react';
+import React, { ChangeEvent, useCallback, useContext } from 'react';
 import { BulkActionsVerbs } from '../../../../../types';
 import { BulkActionsContext } from '../context';
 import { COLUMN_HEADER_ARIA_LABEL } from '../translations';
@@ -15,18 +15,23 @@ const BulkActionsHeaderComponent: React.FunctionComponent = () => {
   const [{ isAllSelected, areAllVisibleRowsSelected }, updateSelectedRows] =
     useContext(BulkActionsContext);
 
+  const onChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      if (e.target.checked) {
+        updateSelectedRows({ action: BulkActionsVerbs.selectCurrentPage });
+      } else {
+        updateSelectedRows({ action: BulkActionsVerbs.clear });
+      }
+    },
+    [updateSelectedRows]
+  );
+
   return (
     <EuiCheckbox
       id="selection-toggle"
       aria-label={COLUMN_HEADER_ARIA_LABEL}
       checked={isAllSelected || areAllVisibleRowsSelected}
-      onChange={(e: ChangeEvent<HTMLInputElement>) => {
-        if (e.target.checked) {
-          updateSelectedRows({ action: BulkActionsVerbs.selectCurrentPage });
-        } else {
-          updateSelectedRows({ action: BulkActionsVerbs.clear });
-        }
-      }}
+      onChange={onChange}
       data-test-subj="bulk-actions-header"
     />
   );

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/bulk_actions/components/row_cell.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/bulk_actions/components/row_cell.tsx
@@ -6,7 +6,7 @@
  */
 
 import { EuiCheckbox, EuiLoadingSpinner } from '@elastic/eui';
-import React, { ChangeEvent } from 'react';
+import React, { ChangeEvent, useCallback } from 'react';
 import { useContext } from 'react';
 import { BulkActionsVerbs } from '../../../../../types';
 import { BulkActionsContext } from '../context';
@@ -16,6 +16,17 @@ const BulkActionsRowCellComponent = ({ rowIndex }: { rowIndex: number }) => {
   const isChecked = rowSelection.has(rowIndex);
   const isLoading = isChecked && rowSelection.get(rowIndex)?.isLoading;
 
+  const onChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      if (e.target.checked) {
+        updateSelectedRows({ action: BulkActionsVerbs.add, rowIndex });
+      } else {
+        updateSelectedRows({ action: BulkActionsVerbs.delete, rowIndex });
+      }
+    },
+    [rowIndex, updateSelectedRows]
+  );
+
   if (isLoading) {
     return <EuiLoadingSpinner size="m" data-test-subj="row-loader" />;
   }
@@ -24,13 +35,7 @@ const BulkActionsRowCellComponent = ({ rowIndex }: { rowIndex: number }) => {
     <EuiCheckbox
       id={rowIndex.toString()}
       checked={isChecked}
-      onChange={(e: ChangeEvent<HTMLInputElement>) => {
-        if (e.target.checked) {
-          updateSelectedRows({ action: BulkActionsVerbs.add, rowIndex });
-        } else {
-          updateSelectedRows({ action: BulkActionsVerbs.delete, rowIndex });
-        }
-      }}
+      onChange={onChange}
       data-test-subj="bulk-actions-row-cell"
     />
   );

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/bulk_actions/components/toolbar.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/bulk_actions/components/toolbar.tsx
@@ -87,6 +87,23 @@ const useBulkActionsToMenuPanelMapper = (
 ) => {
   const [{ isAllSelected, rowSelection }] = useContext(BulkActionsContext);
 
+  const itemOnClick = useCallback(
+    (item, selectedAlertItems) =>
+      item.onClick
+        ? () => {
+            closeIfPopoverIsOpen();
+            item.onClick?.(
+              selectedAlertItems,
+              isAllSelected,
+              setIsBulkActionsLoading,
+              clearSelection,
+              refresh
+            );
+          }
+        : undefined,
+    [clearSelection, closeIfPopoverIsOpen, isAllSelected, refresh, setIsBulkActionsLoading]
+  );
+
   const bulkActionsPanels = useMemo(() => {
     const bulkActionPanelsToReturn = [];
     for (const panel of panels) {
@@ -98,18 +115,7 @@ const useBulkActionsToMenuPanelMapper = (
             key: item.key,
             'data-test-subj': item['data-test-subj'],
             disabled: isDisabled,
-            onClick: item.onClick
-              ? () => {
-                  closeIfPopoverIsOpen();
-                  item.onClick?.(
-                    selectedAlertItems,
-                    isAllSelected,
-                    setIsBulkActionsLoading,
-                    clearSelection,
-                    refresh
-                  );
-                }
-              : undefined,
+            onClick: itemOnClick(item, selectedAlertItems),
             name: isDisabled && item.disabledLabel ? item.disabledLabel : item.label,
             panel: item.panel,
           };
@@ -129,13 +135,14 @@ const useBulkActionsToMenuPanelMapper = (
     }
     return bulkActionPanelsToReturn;
   }, [
-    alerts,
-    clearSelection,
-    isAllSelected,
     panels,
-    refresh,
+    alerts,
     rowSelection,
+    isAllSelected,
+    itemOnClick,
     setIsBulkActionsLoading,
+    clearSelection,
+    refresh,
     closeIfPopoverIsOpen,
   ]);
 

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/cases/cell.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/cases/cell.tsx
@@ -37,7 +37,7 @@ const CasesCellComponent: React.FC<CellComponentProps> = (props) => {
     .filter((theCase): theCase is Case => theCase != null);
 
   const onClick = useCallback(
-    (caseId: string) => () => navigateToCaseView({ caseId }),
+    (caseId: string) => navigateToCaseView({ caseId }),
     [navigateToCaseView]
   );
 
@@ -47,7 +47,7 @@ const CasesCellComponent: React.FC<CellComponentProps> = (props) => {
         ? validCases.map((theCase, index) => [
             index > 0 && index < validCases.length && ', ',
             <CaseTooltip loading={false} content={formatCase(theCase)} key={theCase.id}>
-              <EuiLink onClick={onClick(theCase.id)} data-test-subj="cases-cell-link">
+              <EuiLink onClick={onClick.bind(this, theCase.id)} data-test-subj="cases-cell-link">
                 {theCase.title}
               </EuiLink>
             </CaseTooltip>,

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/cases/cell.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/cases/cell.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { memo } from 'react';
+import React, { memo, useCallback } from 'react';
 import { EuiLink, EuiSkeletonText } from '@elastic/eui';
 import { Tooltip as CaseTooltip } from '@kbn/cases-components';
 import type { CaseTooltipContentProps } from '@kbn/cases-components';
@@ -36,16 +36,18 @@ const CasesCellComponent: React.FC<CellComponentProps> = (props) => {
     .map((id) => cases.get(id))
     .filter((theCase): theCase is Case => theCase != null);
 
+  const onClick = useCallback(
+    (caseId: string) => () => navigateToCaseView({ caseId }),
+    [navigateToCaseView]
+  );
+
   return (
     <EuiSkeletonText lines={1} isLoading={isLoading} size="s" data-test-subj="cases-cell-loading">
       {validCases.length !== 0
         ? validCases.map((theCase, index) => [
             index > 0 && index < validCases.length && ', ',
             <CaseTooltip loading={false} content={formatCase(theCase)} key={theCase.id}>
-              <EuiLink
-                onClick={() => navigateToCaseView({ caseId: theCase.id })}
-                data-test-subj="cases-cell-link"
-              >
+              <EuiLink onClick={onClick(theCase.id)} data-test-subj="cases-cell-link">
                 {theCase.title}
               </EuiLink>
             </CaseTooltip>,

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/empty_state.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/empty_state.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { useMemo } from 'react';
 import {
   EuiPanel,
   EuiFlexGroup,
@@ -29,6 +29,7 @@ const heights = {
 const panelStyle = {
   maxWidth: 500,
 };
+const EUI_IMG_STYLE = { width: 200, height: 148 };
 
 export const EmptyState: React.FC<{
   height?: keyof typeof heights;
@@ -36,6 +37,7 @@ export const EmptyState: React.FC<{
   getInspectQuery: GetInspectQuery;
   showInpectButton?: boolean;
 }> = ({ height = 'tall', controls, getInspectQuery, showInpectButton }) => {
+  const euiFlexGroupHeightStyle = useMemo(() => ({ height: heights[height] }), [height]);
   return (
     <EuiPanel color="subdued" data-test-subj="alertsStateTableEmptyState">
       <EuiFlexGroup alignItems="flexEnd" justifyContent="flexEnd">
@@ -46,7 +48,7 @@ export const EmptyState: React.FC<{
         )}
         {controls?.right && <EuiFlexItem grow={false}>{controls.right}</EuiFlexItem>}
       </EuiFlexGroup>
-      <EuiFlexGroup style={{ height: heights[height] }} alignItems="center" justifyContent="center">
+      <EuiFlexGroup style={euiFlexGroupHeightStyle} alignItems="center" justifyContent="center">
         <EuiFlexItem grow={false}>
           <EuiPanel hasBorder={true} style={panelStyle}>
             <EuiFlexGroup>
@@ -69,7 +71,7 @@ export const EmptyState: React.FC<{
                 </EuiText>
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
-                <EuiImage style={{ width: 200, height: 148 }} size="200" alt="" url={icon} />
+                <EuiImage style={EUI_IMG_STYLE} size="200" alt="" url={icon} />
               </EuiFlexItem>
             </EuiFlexGroup>
           </EuiPanel>

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/hooks/apis/bulk_get_maintenance_windows.ts
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/hooks/apis/bulk_get_maintenance_windows.ts
@@ -15,6 +15,7 @@ import { AsApiContract } from '@kbn/actions-plugin/common';
 export interface BulkGetMaintenanceWindowsParams {
   http: HttpStart;
   ids: string[];
+  signal?: AbortSignal;
 }
 
 export interface BulkGetMaintenanceWindowError {
@@ -76,11 +77,13 @@ const rewriteBodyRes = (
 export const bulkGetMaintenanceWindows = async ({
   http,
   ids,
+  signal,
 }: BulkGetMaintenanceWindowsParams): Promise<BulkGetMaintenanceWindowsResult> => {
   const res = await http.post<BulkGetMaintenanceWindowsResponse>(
     `${INTERNAL_ALERTING_API_MAINTENANCE_WINDOW_PATH}/_bulk_get`,
     {
       body: JSON.stringify({ ids }),
+      signal,
     }
   );
 

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/hooks/use_bulk_actions.ts
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/hooks/use_bulk_actions.ts
@@ -177,35 +177,49 @@ export function useBulkActions({
   const [bulkActionsState, updateBulkActionsState] = useContext(BulkActionsContext);
   const configBulkActionPanels = useBulkActionsConfig(query);
 
-  const clearSelection = () => {
+  const clearSelection = useCallback(() => {
     updateBulkActionsState({ action: BulkActionsVerbs.clear });
-  };
+  }, [updateBulkActionsState]);
   const caseBulkActions = useBulkAddToCaseActions({ casesConfig, refresh, clearSelection });
 
-  const bulkActions =
-    caseBulkActions.length !== 0
-      ? addItemsToInitialPanel({
-          panels: configBulkActionPanels,
-          items: caseBulkActions,
-        })
-      : configBulkActionPanels;
-
+  const bulkActions = useMemo(
+    () =>
+      caseBulkActions.length !== 0
+        ? addItemsToInitialPanel({
+            panels: configBulkActionPanels,
+            items: caseBulkActions,
+          })
+        : configBulkActionPanels,
+    [caseBulkActions, configBulkActionPanels]
+  );
   const isBulkActionsColumnActive = bulkActions.length !== 0;
 
   useEffect(() => {
     updateBulkActionsState({ action: BulkActionsVerbs.rowCountUpdate, rowCount: alerts.length });
   }, [alerts, updateBulkActionsState]);
 
-  const setIsBulkActionsLoading = (isLoading: boolean = true) => {
-    updateBulkActionsState({ action: BulkActionsVerbs.updateAllLoadingState, isLoading });
-  };
+  const setIsBulkActionsLoading = useCallback(
+    (isLoading: boolean = true) => {
+      updateBulkActionsState({ action: BulkActionsVerbs.updateAllLoadingState, isLoading });
+    },
+    [updateBulkActionsState]
+  );
 
-  return {
-    isBulkActionsColumnActive,
-    getBulkActionsLeadingControlColumn,
-    bulkActionsState,
-    bulkActions,
-    setIsBulkActionsLoading,
-    clearSelection,
-  };
+  return useMemo(
+    () => ({
+      isBulkActionsColumnActive,
+      getBulkActionsLeadingControlColumn,
+      bulkActionsState,
+      bulkActions,
+      setIsBulkActionsLoading,
+      clearSelection,
+    }),
+    [
+      bulkActions,
+      bulkActionsState,
+      clearSelection,
+      isBulkActionsColumnActive,
+      setIsBulkActionsLoading,
+    ]
+  );
 }

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/hooks/use_bulk_get_cases.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/hooks/use_bulk_get_cases.tsx
@@ -34,9 +34,8 @@ export const useBulkGetCases = (caseIds: string[], fetchCases: boolean) => {
 
   return useQuery(
     triggersActionsUiQueriesKeys.casesBulkGet(caseIds),
-    () => {
-      const abortCtrlRef = new AbortController();
-      return bulkGetCases(http, { ids: caseIds }, abortCtrlRef.signal);
+    ({ signal }) => {
+      return bulkGetCases(http, { ids: caseIds }, signal);
     },
     {
       enabled: caseIds.length > 0 && fetchCases,

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/hooks/use_fetch_alerts.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/hooks/use_fetch_alerts.tsx
@@ -354,7 +354,7 @@ const useFetchAlerts = ({
     [alertResponse, getInspectQuery, refetchGrid]
   );
 
-  return [loading, alertResponseMemo];
+  return useMemo(() => [loading, alertResponseMemo], [alertResponseMemo, loading]);
 };
 
 export { useFetchAlerts };

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/hooks/use_fetch_browser_fields_capabilities.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/hooks/use_fetch_browser_fields_capabilities.tsx
@@ -7,7 +7,7 @@
 
 import type { ValidFeatureId } from '@kbn/rule-data-utils';
 import { BASE_RAC_ALERTS_API_PATH, BrowserFields } from '@kbn/rule-registry-plugin/common';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { Alerts } from '../../../../types';
 import { useKibana } from '../../../../common/lib/kibana';
 import { ERROR_FETCH_BROWSER_FIELDS } from './translations';
@@ -76,5 +76,5 @@ export const useFetchBrowserFieldCapabilities = ({
     callApi();
   }, [getBrowserFieldInfo, isLoading, featureIds, initialBrowserFields]);
 
-  return [isLoading, browserFields];
+  return useMemo(() => [isLoading, browserFields], [browserFields, isLoading]);
 };

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/hooks/use_pagination.ts
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/hooks/use_pagination.ts
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { useCallback, useContext, useEffect, useState } from 'react';
+import { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { RuleRegistrySearchRequestPagination } from '@kbn/rule-registry-plugin/common';
 import { BulkActionsVerbs } from '../../../../types';
 import { BulkActionsContext } from '../bulk_actions/context';
@@ -94,12 +94,15 @@ export function usePagination({ onPageChange, pageIndex, pageSize }: PaginationP
     });
   }, [pageIndex, pageSize]);
 
-  return {
-    pagination,
-    onChangePageSize,
-    onChangePageIndex,
-    onPaginateFlyout,
-    flyoutAlertIndex,
-    setFlyoutAlertIndex,
-  };
+  return useMemo(
+    () => ({
+      pagination,
+      onChangePageSize,
+      onChangePageIndex,
+      onPaginateFlyout,
+      flyoutAlertIndex,
+      setFlyoutAlertIndex,
+    }),
+    [flyoutAlertIndex, onChangePageIndex, onChangePageSize, onPaginateFlyout, pagination]
+  );
 }

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/hooks/use_sorting.ts
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/hooks/use_sorting.ts
@@ -7,7 +7,7 @@
 
 import type { SortCombinations } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import type { EuiDataGridSorting } from '@elastic/eui';
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
 import { DefaultSort } from './constants';
 
@@ -43,5 +43,5 @@ export function useSorting(
     },
     [setSortingColumns, onSortChange]
   );
-  return { sortingColumns, onSort };
+  return useMemo(() => ({ sortingColumns, onSort }), [onSort, sortingColumns]);
 }

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/toolbar/toolbar_visibility.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/toolbar/toolbar_visibility.tsx
@@ -130,7 +130,7 @@ export const getToolbarVisibility = ({
   columnIds: string[];
   onToggleColumn: (columnId: string) => void;
   onResetColumns: () => void;
-  browserFields: any;
+  browserFields: BrowserFields;
   setIsBulkActionsLoading: (isLoading: boolean) => void;
   clearSelection: () => void;
   controls?: EuiDataGridToolBarAdditionalControlsOptions;

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/common/components/event_log/event_log_list_status_filter.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/common/components/event_log/event_log_list_status_filter.tsx
@@ -27,7 +27,7 @@ export const EventLogListStatusFilter = (props: EventLogListStatusFilterProps) =
   const [isPopoverOpen, setIsPopoverOpen] = useState<boolean>(false);
 
   const onFilterItemClick = useCallback(
-    (newOption: string) => () => {
+    (newOption: string) => {
       if (selectedOptions.includes(newOption)) {
         onChange(selectedOptions.filter((option) => option !== newOption));
         return;
@@ -68,7 +68,7 @@ export const EventLogListStatusFilter = (props: EventLogListStatusFilterProps) =
               <EuiFilterSelectItem
                 key={status}
                 data-test-subj={`eventLogStatusFilter-${status}`}
-                onClick={onFilterItemClick(status)}
+                onClick={onFilterItemClick.bind(this, status)}
                 checked={selectedOptions.includes(status) ? 'on' : undefined}
               >
                 <EventLogListStatus

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/rules_list/components/rule_last_run_outcome_filter.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/rules_list/components/rule_last_run_outcome_filter.tsx
@@ -34,7 +34,7 @@ export const RuleLastRunOutcomeFilter: React.FunctionComponent<RuleLastRunOutcom
   }, [setIsPopoverOpen]);
 
   const onFilterSelectItem = useCallback(
-    (filterItem: string) => () => {
+    (filterItem: string) => {
       const isPreviouslyChecked = selectedOutcomes.includes(filterItem);
       if (isPreviouslyChecked) {
         onChange?.(selectedOutcomes.filter((val) => val !== filterItem));
@@ -72,7 +72,7 @@ export const RuleLastRunOutcomeFilter: React.FunctionComponent<RuleLastRunOutcom
             <EuiFilterSelectItem
               key={item}
               style={{ textTransform: 'capitalize' }}
-              onClick={onFilterSelectItem(item)}
+              onClick={onFilterSelectItem.bind(this, item)}
               checked={selectedOutcomes.includes(item) ? 'on' : undefined}
               data-test-subj={`ruleLastRunOutcome${item}FilterOption`}
             >

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/rules_list/components/rule_snooze/panel/base_snooze_panel.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/rules_list/components/rule_snooze/panel/base_snooze_panel.tsx
@@ -130,7 +130,7 @@ export const BaseSnoozePanel: React.FunctionComponent<BaseSnoozePanelProps> = ({
 
   const onClickAddSchedule = useCallback(() => navigateToScheduler(), [navigateToScheduler]);
   const onClickEditScheduleFactory = useCallback(
-    (schedule: SnoozeSchedule) => () => navigateToScheduler(schedule),
+    (schedule: SnoozeSchedule) => navigateToScheduler(schedule),
     [navigateToScheduler]
   );
 
@@ -220,7 +220,7 @@ export const BaseSnoozePanel: React.FunctionComponent<BaseSnoozePanelProps> = ({
                           backgroundColor: isActive ? 'rgba(240,78,152,0.2)' : euiTheme.colors.body,
                         }}
                         className="euiButton euiPanel euiPanel--borderRadiusMedium euiPanel--noShadow euiPanel--noBorder"
-                        onClick={onClickEditScheduleFactory(schedule as SnoozeSchedule)}
+                        onClick={onClickEditScheduleFactory.bind(this, schedule as SnoozeSchedule)}
                       >
                         <EuiFlexGroup alignItems="center">
                           <EuiFlexItem grow={false}>

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/rules_list/components/rule_status_filter.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/rules_list/components/rule_status_filter.tsx
@@ -35,7 +35,7 @@ export const RuleStatusFilter = (props: RuleStatusFilterProps) => {
   const [isPopoverOpen, setIsPopoverOpen] = useState<boolean>(false);
 
   const onFilterItemClick = useCallback(
-    (newOption: RuleStatus) => () => {
+    (newOption: RuleStatus) => {
       if (selectedStatuses.includes(newOption)) {
         onChange(selectedStatuses.filter((option) => option !== newOption));
         return;
@@ -101,7 +101,7 @@ export const RuleStatusFilter = (props: RuleStatusFilterProps) => {
               <EuiSelectableListItem
                 key={status}
                 data-test-subj={optionDataTestSubj(status)}
-                onClick={onFilterItemClick(status)}
+                onClick={onFilterItemClick.bind(this, status)}
                 checked={selectedStatuses.includes(status) ? 'on' : undefined}
               >
                 {renderRuleStateOptions(status)}


### PR DESCRIPTION
## Summary
We used a new `eslint` rules on our alert table to determine if we were following best practices. We are not ready to get this new rules in the repo because we do have to check all our code first. However, we will go over gradually over these new rules  to clean up our plugin.


```ts
{
      // typescript only for back end
      files: [
        'x-pack/plugins/triggers_actions_ui/public/**/*.{ts,tsx}',
        'x-pack/plugins/triggers_actions_ui/common/**/*.{ts,tsx}',
      ],
      rules: {
        '@typescript-eslint/no-explicit-any': 'error',
        'react-perf/jsx-no-new-object-as-prop': 'error',
        'react-perf/jsx-no-new-array-as-prop': 'error',
        'react-perf/jsx-no-new-function-as-prop': 'error',
      },
    },
```

