### PR TITLE
[Fleet] Disable proxies feature in serverless

### DIFF
--- a/config/serverless.yml
+++ b/config/serverless.yml
@@ -4,6 +4,7 @@ xpack.security.showNavLinks: false
 xpack.serverless.plugin.enabled: true
 xpack.fleet.internal.fleetServerStandalone: true
 xpack.fleet.internal.disableILMPolicies: true
+xpack.fleet.internal.disableProxies: true
 
 # Ess plugins
 xpack.ess.security.enabled: false

--- a/test/plugin_functional/test_suites/core_plugins/rendering.ts
+++ b/test/plugin_functional/test_suites/core_plugins/rendering.ts
@@ -218,6 +218,7 @@ export default function ({ getService }: PluginFunctionalProviderContext) {
         'xpack.discoverEnhanced.actions.exploreDataInContextMenu.enabled (boolean)',
         'xpack.fleet.agents.enabled (boolean)',
         'xpack.fleet.enableExperimental (array)',
+        'xpack.fleet.internal.disableProxies (boolean)',
         'xpack.fleet.internal.fleetServerStandalone (boolean)',
         'xpack.fleet.developer.maxAgentPoliciesWithInactivityTimeout (number)',
         'xpack.global_search.search_timeout (duration)',

--- a/x-pack/plugins/fleet/common/types/index.ts
+++ b/x-pack/plugins/fleet/common/types/index.ts
@@ -47,6 +47,7 @@ export interface FleetConfigType {
   };
   internal?: {
     disableILMPolicies: boolean;
+    disableProxies: boolean;
     fleetServerStandalone: boolean;
   };
   createArtifactsBulkBatchSize?: number;

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/settings_page/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/settings_page/index.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 import { EuiSpacer } from '@elastic/eui';
 
 import type { Output, DownloadSource, FleetServerHost, FleetProxy } from '../../../../types';
+import { useConfig } from '../../../../hooks';
 
 import { FleetServerHostsSection } from './fleet_server_hosts_section';
 import { OutputSection } from './output_section';
@@ -36,6 +37,8 @@ export const SettingsPage: React.FunctionComponent<SettingsPageProps> = ({
   deleteDownloadSource,
   deleteFleetProxy,
 }) => {
+  const showProxySection = useConfig().internal?.disableProxies !== true;
+
   return (
     <>
       <EuiSpacer size="m" />
@@ -50,8 +53,12 @@ export const SettingsPage: React.FunctionComponent<SettingsPageProps> = ({
         downloadSources={downloadSources}
         deleteDownloadSource={deleteDownloadSource}
       />
-      <EuiSpacer size="m" />
-      <FleetProxiesSection proxies={proxies} deleteFleetProxy={deleteFleetProxy} />
+      {showProxySection && (
+        <>
+          <EuiSpacer size="m" />
+          <FleetProxiesSection proxies={proxies} deleteFleetProxy={deleteFleetProxy} />
+        </>
+      )}
     </>
   );
 };

--- a/x-pack/plugins/fleet/server/config.ts
+++ b/x-pack/plugins/fleet/server/config.ts
@@ -41,6 +41,7 @@ export const config: PluginConfigDescriptor = {
     },
     internal: {
       fleetServerStandalone: true,
+      disableProxies: true,
     },
   },
   deprecations: ({ renameFromRoot, unused, unusedFromRoot }) => [
@@ -167,6 +168,9 @@ export const config: PluginConfigDescriptor = {
     internal: schema.maybe(
       schema.object({
         disableILMPolicies: schema.boolean({
+          defaultValue: false,
+        }),
+        disableProxies: schema.boolean({
           defaultValue: false,
         }),
         fleetServerStandalone: schema.boolean({

--- a/x-pack/plugins/fleet/server/routes/fleet_proxies/handler.ts
+++ b/x-pack/plugins/fleet/server/routes/fleet_proxies/handler.ts
@@ -30,7 +30,7 @@ import type {
   FleetServerHost,
   Output,
 } from '../../types';
-import { agentPolicyService } from '../../services';
+import { agentPolicyService, appContextService } from '../../services';
 
 async function bumpRelatedPolicies(
   soClient: SavedObjectsClientContract,
@@ -66,6 +66,12 @@ async function bumpRelatedPolicies(
   }
 }
 
+function checkProxiesAvailable() {
+  if (appContextService.getConfig()?.internal?.disableProxies) {
+    throw new Error('Proxies are not available');
+  }
+}
+
 export const postFleetProxyHandler: RequestHandler<
   undefined,
   undefined,
@@ -74,6 +80,7 @@ export const postFleetProxyHandler: RequestHandler<
   const coreContext = await context.core;
   const soClient = coreContext.savedObjects.client;
   try {
+    checkProxiesAvailable();
     const { id, ...data } = request.body;
     const proxy = await createFleetProxy(soClient, { ...data, is_preconfigured: false }, { id });
 
@@ -93,6 +100,7 @@ export const putFleetProxyHandler: RequestHandler<
   TypeOf<typeof PutFleetProxyRequestSchema.body>
 > = async (context, request, response) => {
   try {
+    checkProxiesAvailable();
     const proxyId = request.params.itemId;
     const coreContext = await await context.core;
     const soClient = coreContext.savedObjects.client;
@@ -141,6 +149,7 @@ export const deleteFleetProxyHandler: RequestHandler<
   TypeOf<typeof GetOneFleetProxyRequestSchema.params>
 > = async (context, request, response) => {
   try {
+    checkProxiesAvailable();
     const proxyId = request.params.itemId;
     const coreContext = await context.core;
     const soClient = coreContext.savedObjects.client;

--- a/x-pack/plugins/fleet/server/services/epm/packages/_install_package.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/_install_package.test.ts
@@ -122,6 +122,7 @@ describe('_installPackage', () => {
       createAppContextStartContractMock({
         internal: {
           disableILMPolicies: true,
+          disableProxies: false,
           fleetServerStandalone: false,
         },
       })
@@ -172,6 +173,7 @@ describe('_installPackage', () => {
     appContextService.start(
       createAppContextStartContractMock({
         internal: {
+          disableProxies: false,
           disableILMPolicies: false,
           fleetServerStandalone: false,
         },


### PR DESCRIPTION
## Summary

Disable proxies in serverless, in the UI settings and in the APIs.


## UI Changes

Remove the proxy section
<img width="818" alt="Screenshot 2023-06-22 at 3 08 15 PM" src="https://github.com/elastic/kibana/assets/1336873/55750333-83b2-4d8b-9d25-abb195d65a3d">


