### PR TITLE
[Cases] Updating the audit log docs

### DIFF
--- a/docs/user/security/audit-logging.asciidoc
+++ b/docs/user/security/audit-logging.asciidoc
@@ -392,6 +392,10 @@ Refer to the corresponding {es} logs for potential write errors.
 | `success` | User has accessed a case comment as part of a search operation.
 | `failure` | User is not authorized to search for case comments.
 
+.2+| `case_categories_get`
+| `success` | User has accessed a case.
+| `failure` | User is not authorized to access a case.
+
 .2+| `case_tags_get`
 | `success` | User has accessed a case.
 | `failure` | User is not authorized to access a case.
@@ -415,6 +419,10 @@ Refer to the corresponding {es} logs for potential write errors.
 .2+| `case_user_action_get_metrics`
 | `success` | User has accessed metrics for the user activity of a case.
 | `failure` | User is not authorized to access metrics for the user activity of a case.
+
+.2+| `case_user_action_get_users`
+| `success` | User has accessed the users associated with a case.
+| `failure` | User is not authorized to access the users associated with a case.
 
 .2+| `case_connectors_get`
 | `success` | User has accessed the connectors of a case.


### PR DESCRIPTION
This PR updates the security audit logs with some cases values. We added a new operation for retrieving the `categories` of a case and the users associated with a case. 

<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->