### PR TITLE
[Fleet] Improve invalid package parsing error messages

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/archive/parse.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/archive/parse.test.ts
@@ -379,13 +379,17 @@ describe('parseAndVerifyArchive', () => {
     expect(() =>
       parseAndVerifyArchive(['input_only-0.1.0/manifest.yml', 'dummy/manifest.yml'], {})
     ).toThrowError(
-      new PackageInvalidArchiveError('Package contains more than one top-level directory.')
+      new PackageInvalidArchiveError(
+        'Package contains more than one top-level directory; top-level directory found: input_only-0.1.0; filePath: dummy/manifest.yml'
+      )
     );
   });
 
   it('should throw on missing manifest file', () => {
     expect(() => parseAndVerifyArchive(['input_only-0.1.0/test/manifest.yml'], {})).toThrowError(
-      new PackageInvalidArchiveError('Package must contain a top-level manifest.yml file.')
+      new PackageInvalidArchiveError(
+        'Package at top-level directory input_only-0.1.0 must contain a top-level manifest.yml file.'
+      )
     );
   });
 
@@ -396,7 +400,9 @@ describe('parseAndVerifyArchive', () => {
       parseAndVerifyArchive(['input_only-0.1.0/manifest.yml'], {
         'input_only-0.1.0/manifest.yml': buf,
       })
-    ).toThrowError('Could not parse top-level package manifest: YAMLException');
+    ).toThrowError(
+      'Could not parse top-level package manifest at top-level directory input_only-0.1.0: YAMLException'
+    );
   });
 
   it('should throw on missing required fields', () => {
@@ -416,7 +422,9 @@ version: 0.1.0
       parseAndVerifyArchive(['input_only-0.1.0/manifest.yml'], {
         'input_only-0.1.0/manifest.yml': buf,
       })
-    ).toThrowError('Invalid top-level package manifest: one or more fields missing of ');
+    ).toThrowError(
+      'Invalid top-level package manifest at top-level directory input_only-0.1.0 (package name: input_only): one or more fields missing of '
+    );
   });
 
   it('should throw on name or version mismatch', () => {

--- a/x-pack/plugins/fleet/server/services/epm/archive/parse.ts
+++ b/x-pack/plugins/fleet/server/services/epm/archive/parse.ts
@@ -182,7 +182,9 @@ export function parseAndVerifyArchive(
   const toplevelDir = topLevelDirOverride || paths[0].split('/')[0];
   paths.forEach((filePath) => {
     if (!filePath.startsWith(toplevelDir)) {
-      throw new PackageInvalidArchiveError('Package contains more than one top-level directory.');
+      throw new PackageInvalidArchiveError(
+        `Package contains more than one top-level directory; top-level directory found: ${toplevelDir}; filePath: ${filePath}`
+      );
     }
   });
 
@@ -190,7 +192,9 @@ export function parseAndVerifyArchive(
   const manifestFile = path.posix.join(toplevelDir, MANIFEST_NAME);
   const manifestBuffer = manifests[manifestFile];
   if (!paths.includes(manifestFile) || !manifestBuffer) {
-    throw new PackageInvalidArchiveError(`Package must contain a top-level ${MANIFEST_NAME} file.`);
+    throw new PackageInvalidArchiveError(
+      `Package at top-level directory ${toplevelDir} must contain a top-level ${MANIFEST_NAME} file.`
+    );
   }
 
   // ... which must be valid YAML
@@ -198,7 +202,9 @@ export function parseAndVerifyArchive(
   try {
     manifest = yaml.safeLoad(manifestBuffer.toString());
   } catch (error) {
-    throw new PackageInvalidArchiveError(`Could not parse top-level package manifest: ${error}.`);
+    throw new PackageInvalidArchiveError(
+      `Could not parse top-level package manifest at top-level directory ${toplevelDir}: ${error}.`
+    );
   }
 
   // must have mandatory fields
@@ -208,7 +214,7 @@ export function parseAndVerifyArchive(
   if (!requiredKeysMatch) {
     const list = requiredArchivePackageProps.join(', ');
     throw new PackageInvalidArchiveError(
-      `Invalid top-level package manifest: one or more fields missing of ${list}`
+      `Invalid top-level package manifest at top-level directory ${toplevelDir} (package name: ${manifest.name}): one or more fields missing of ${list}.`
     );
   }
 

--- a/x-pack/test/fleet_api_integration/apis/epm/install_by_upload.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/install_by_upload.ts
@@ -233,7 +233,7 @@ export default function (providerContext: FtrProviderContext) {
         .send(buf)
         .expect(400);
       expect(res.error.text).to.equal(
-        '{"statusCode":400,"error":"Bad Request","message":"Invalid top-level package manifest at top-level directory apache_0.1.4 (package name: apache): one or more fields missing of name, version, description, title, format_version, owner."}'
+        '{"statusCode":400,"error":"Bad Request","message":"Invalid top-level package manifest at top-level directory apache-0.1.4 (package name: apache): one or more fields missing of name, version, description, title, format_version, owner."}'
       );
     });
 

--- a/x-pack/test/fleet_api_integration/apis/epm/install_by_upload.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/install_by_upload.ts
@@ -194,7 +194,7 @@ export default function (providerContext: FtrProviderContext) {
         .send(buf)
         .expect(400);
       expect(res.error.text).to.equal(
-        '{"statusCode":400,"error":"Bad Request","message":"Package contains more than one top-level directory."}'
+        '{"statusCode":400,"error":"Bad Request","message":"Package contains more than one top-level directory; top-level directory found: apache-0.1.4; filePath: apache-0.1.3/manifest.yml"}'
       );
     });
 
@@ -207,7 +207,7 @@ export default function (providerContext: FtrProviderContext) {
         .send(buf)
         .expect(400);
       expect(res.error.text).to.equal(
-        '{"statusCode":400,"error":"Bad Request","message":"Package must contain a top-level manifest.yml file."}'
+        '{"statusCode":400,"error":"Bad Request","message":"Package at top-level directory apache-0.1.4 must contain a top-level manifest.yml file."}'
       );
     });
 
@@ -220,7 +220,7 @@ export default function (providerContext: FtrProviderContext) {
         .send(buf)
         .expect(400);
       expect(res.error.text).to.equal(
-        '{"statusCode":400,"error":"Bad Request","message":"Could not parse top-level package manifest: YAMLException: bad indentation of a mapping entry at line 2, column 7:\\n      name: apache\\n          ^."}'
+        '{"statusCode":400,"error":"Bad Request","message":"Could not parse top-level package manifest at top-level directory apache-0.1.4: YAMLException: bad indentation of a mapping entry at line 2, column 7:\\n      name: apache\\n          ^."}'
       );
     });
 
@@ -233,7 +233,7 @@ export default function (providerContext: FtrProviderContext) {
         .send(buf)
         .expect(400);
       expect(res.error.text).to.equal(
-        '{"statusCode":400,"error":"Bad Request","message":"Invalid top-level package manifest: one or more fields missing of name, version, description, title, format_version, owner"}'
+        '{"statusCode":400,"error":"Bad Request","message":"Invalid top-level package manifest at top-level directory apache_0.1.4 (package name: apache): one or more fields missing of name, version, description, title, format_version, owner"}'
       );
     });
 

--- a/x-pack/test/fleet_api_integration/apis/epm/install_by_upload.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/install_by_upload.ts
@@ -233,7 +233,7 @@ export default function (providerContext: FtrProviderContext) {
         .send(buf)
         .expect(400);
       expect(res.error.text).to.equal(
-        '{"statusCode":400,"error":"Bad Request","message":"Invalid top-level package manifest at top-level directory apache_0.1.4 (package name: apache): one or more fields missing of name, version, description, title, format_version, owner"}'
+        '{"statusCode":400,"error":"Bad Request","message":"Invalid top-level package manifest at top-level directory apache_0.1.4 (package name: apache): one or more fields missing of name, version, description, title, format_version, owner."}'
       );
     });
 


### PR DESCRIPTION
## Summary

Improve error messages of `PackageInvalidArchiveError` errors thrown when parsing a package archive to include the package name.

<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->