### PR TITLE
[Defend Workflows] Fix filtering of agents for automated response actions

### DIFF
--- a/x-pack/plugins/security_solution/server/endpoint/services/actions/create/index.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/services/actions/create/index.ts
@@ -13,6 +13,7 @@ import type { ResponseActionsApiCommandNames } from '../../../../../common/endpo
 import type {
   ActionDetails,
   EndpointActionDataParameterTypes,
+  HostMetadata,
 } from '../../../../../common/endpoint/types';
 import type { EndpointAppContext } from '../../../types';
 import type { FeatureKeys } from '../../feature_usage';
@@ -76,7 +77,12 @@ export const actionCreateService = (
 
   return {
     createAction,
-    createActionFromAlert: (payload, agents) =>
-      createAction(payload, agents, { minimumLicenseRequired: 'enterprise' }),
+    createActionFromAlert: async (payload) => {
+      const endpointData = await endpointContext.service
+        .getEndpointMetadataService()
+        .getMetadataForEndpoints(esClient, [...new Set(payload.endpoint_ids)]);
+      const agentIds = endpointData.map((endpoint: HostMetadata) => endpoint.elastic.agent.id);
+      return createAction(payload, agentIds, { minimumLicenseRequired: 'enterprise' });
+    },
   };
 };


### PR DESCRIPTION
This PR fixes a wrong behavior of automated actions, where we didn't check for agents containing integration. 



<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->