### PR TITLE
[Enterprise Search] Add DLS enabled CTA to scheduling tab

### DIFF
--- a/x-pack/plugins/enterprise_search/common/types/connectors.ts
+++ b/x-pack/plugins/enterprise_search/common/types/connectors.ts
@@ -60,6 +60,7 @@ export type ConnectorConfiguration = Record<
   string,
   ConnectorConfigProperties | ConnectorConfigCategoryProperties | null
 > & {
+  document_level_security?: ConnectorConfigProperties;
   extract_full_html?: { label: string; value: boolean }; // This only exists for Crawler
   use_text_extraction_service?: ConnectorConfigProperties; // This only exists for SharePoint Online
 };

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_configuration_field.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_configuration_field.tsx
@@ -142,7 +142,7 @@ export const ConnectorConfigurationField: React.FC<ConnectorConfigurationFieldPr
       );
 
     case DisplayType.TOGGLE:
-      if (key === 'document_level_security' && !hasPlatinumLicense) {
+      if (key === 'document_level_security') {
         return (
           <DocumentLevelSecurityPanel
             toggleSwitch={
@@ -157,24 +157,26 @@ export const ConnectorConfigurationField: React.FC<ConnectorConfigurationFieldPr
                     }}
                   />
                 </EuiFlexItem>
-                <EuiFlexItem grow={false}>
-                  <PlatinumLicensePopover
-                    button={
-                      <EuiButtonIcon
-                        aria-label={i18n.translate(
-                          'xpack.enterpriseSearch.content.newIndex.selectConnector.openPopoverLabel',
-                          {
-                            defaultMessage: 'Open licensing popover',
-                          }
-                        )}
-                        iconType="questionInCircle"
-                        onClick={() => setIsPopoverOpen(!isPopoverOpen)}
-                      />
-                    }
-                    closePopover={() => setIsPopoverOpen(false)}
-                    isPopoverOpen={isPopoverOpen}
-                  />
-                </EuiFlexItem>
+                {!hasPlatinumLicense && (
+                  <EuiFlexItem grow={false}>
+                    <PlatinumLicensePopover
+                      button={
+                        <EuiButtonIcon
+                          aria-label={i18n.translate(
+                            'xpack.enterpriseSearch.content.newIndex.selectConnector.openPopoverLabel',
+                            {
+                              defaultMessage: 'Open licensing popover',
+                            }
+                          )}
+                          iconType="questionInCircle"
+                          onClick={() => setIsPopoverOpen(!isPopoverOpen)}
+                        />
+                      }
+                      closePopover={() => setIsPopoverOpen(false)}
+                      isPopoverOpen={isPopoverOpen}
+                    />
+                  </EuiFlexItem>
+                )}
               </EuiFlexGroup>
             }
           />

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_scheduling.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_scheduling.tsx
@@ -28,7 +28,7 @@ import { ConnectorStatus, SyncJobType } from '../../../../../../common/types/con
 import { generateEncodedPath } from '../../../../shared/encode_path_params';
 import { KibanaLogic } from '../../../../shared/kibana';
 import { LicensingLogic } from '../../../../shared/licensing';
-import { EuiButtonTo } from '../../../../shared/react_router_helpers';
+import { EuiButtonTo, EuiLinkTo } from '../../../../shared/react_router_helpers';
 import { UnsavedChangesPrompt } from '../../../../shared/unsaved_changes_prompt';
 import { SEARCH_INDEX_TAB_PATH } from '../../../routes';
 import { IngestionStatus } from '../../../types';
@@ -236,13 +236,27 @@ export const ConnectorSchedulingComponent: React.FC = () => {
                     iconType="iInCircle"
                   >
                     <p>
-                      {i18n.translate(
-                        'xpack.enterpriseSearch.content.indices.connectorScheduling.schedulePanel.documentLevelSecurity.dlsDisabledCallout.text',
-                        {
-                          defaultMessage:
-                            'Enable document level security for this connector to activate these options.',
-                        }
-                      )}
+                      <FormattedMessage
+                        id="xpack.enterpriseSearch.content.indices.connectorScheduling.schedulePanel.documentLevelSecurity.dlsDisabledCallout.text"
+                        defaultMessage="{link} for this connector to activate these options."
+                        values={{
+                          link: (
+                            <EuiLinkTo
+                              to={generateEncodedPath(SEARCH_INDEX_TAB_PATH, {
+                                indexName: index.name,
+                                tabId: SearchIndexTabId.CONFIGURATION,
+                              })}
+                            >
+                              {i18n.translate(
+                                'xpack.enterpriseSearch.content.indices.connectorScheduling.schedulePanel.documentLevelSecurity.dlsDisabledCallout.link',
+                                {
+                                  defaultMessage: 'Enable document level security',
+                                }
+                              )}
+                            </EuiLinkTo>
+                          ),
+                        }}
+                      />
                     </p>
                   </EuiCallOut>
                 </EuiFlexItem>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_scheduling.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_scheduling.tsx
@@ -81,6 +81,9 @@ export const ConnectorSchedulingComponent: React.FC = () => {
     return <></>;
   }
 
+  const isDocumentLevelSecurityDisabled =
+    !index.connector.configuration.document_level_security?.value;
+
   if (
     index.connector.status === ConnectorStatus.CREATED ||
     index.connector.status === ConnectorStatus.NEEDS_CONFIGURATION
@@ -200,25 +203,51 @@ export const ConnectorSchedulingComponent: React.FC = () => {
         </EuiFlexItem>
         {shouldShowAccessControlSync && (
           <EuiFlexItem>
-            <SchedulePanel
-              title={i18n.translate(
-                'xpack.enterpriseSearch.content.indices.connectorScheduling.schedulePanel.documentLevelSecurity.title',
-                { defaultMessage: 'Document Level Security' }
+            <EuiFlexGroup direction="column">
+              <EuiFlexItem>
+                <SchedulePanel
+                  title={i18n.translate(
+                    'xpack.enterpriseSearch.content.indices.connectorScheduling.schedulePanel.documentLevelSecurity.title',
+                    { defaultMessage: 'Document Level Security' }
+                  )}
+                  description={i18n.translate(
+                    'xpack.enterpriseSearch.content.indices.connectorScheduling.schedulePanel.documentLevelSecurity.description',
+                    {
+                      defaultMessage:
+                        'Control the documents users can access, based on their permissions and roles. Schedule syncs to keep these access controls up to date.',
+                    }
+                  )}
+                >
+                  <ConnectorContentScheduling
+                    type={SyncJobType.ACCESS_CONTROL}
+                    index={index}
+                    hasPlatinumLicense={hasPlatinumLicense}
+                  />
+                </SchedulePanel>
+              </EuiFlexItem>
+              {isDocumentLevelSecurityDisabled && (
+                <EuiFlexItem>
+                  <EuiCallOut
+                    title={i18n.translate(
+                      'xpack.enterpriseSearch.content.indices.connectorScheduling.schedulePanel.documentLevelSecurity.dlsDisabledCallout.title',
+                      { defaultMessage: 'Permissions and identity syncs not allowed' }
+                    )}
+                    color="warning"
+                    iconType="iInCircle"
+                  >
+                    <p>
+                      {i18n.translate(
+                        'xpack.enterpriseSearch.content.indices.connectorScheduling.schedulePanel.documentLevelSecurity.dlsDisabledCallout.text',
+                        {
+                          defaultMessage:
+                            'Enable DLS connector’s configurations to activate these options.',
+                        }
+                      )}
+                    </p>
+                  </EuiCallOut>
+                </EuiFlexItem>
               )}
-              description={i18n.translate(
-                'xpack.enterpriseSearch.content.indices.connectorScheduling.schedulePanel.documentLevelSecurity.description',
-                {
-                  defaultMessage:
-                    'Control the documents users can access, based on their permissions and roles. Schedule syncs to keep these access controls up to date.',
-                }
-              )}
-            >
-              <ConnectorContentScheduling
-                type={SyncJobType.ACCESS_CONTROL}
-                index={index}
-                hasPlatinumLicense={hasPlatinumLicense}
-              />
-            </SchedulePanel>
+            </EuiFlexGroup>
           </EuiFlexItem>
         )}
       </EuiFlexGroup>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_scheduling.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_scheduling.tsx
@@ -230,7 +230,7 @@ export const ConnectorSchedulingComponent: React.FC = () => {
                   <EuiCallOut
                     title={i18n.translate(
                       'xpack.enterpriseSearch.content.indices.connectorScheduling.schedulePanel.documentLevelSecurity.dlsDisabledCallout.title',
-                      { defaultMessage: 'Permissions and identity syncs not allowed' }
+                      { defaultMessage: 'Access control syncs not allowed' }
                     )}
                     color="warning"
                     iconType="iInCircle"

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_scheduling.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_scheduling.tsx
@@ -240,7 +240,7 @@ export const ConnectorSchedulingComponent: React.FC = () => {
                         'xpack.enterpriseSearch.content.indices.connectorScheduling.schedulePanel.documentLevelSecurity.dlsDisabledCallout.text',
                         {
                           defaultMessage:
-                            'Enable DLS connector’s configurations to activate these options.',
+                            'Enable document level security for this connector to activate these options.',
                         }
                       )}
                     </p>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_scheduling/full_content.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_scheduling/full_content.tsx
@@ -115,6 +115,8 @@ export const ConnectorContentScheduling: React.FC<ConnectorContentSchedulingProp
   const [isPlatinumPopoverOpen, setIsPlatinumPopoverOpen] = useState(false);
 
   const isGated = !hasPlatinumLicense && type === SyncJobType.ACCESS_CONTROL;
+  const isDocumentLevelSecurityDisabled =
+    !index.connector.configuration.document_level_security?.value;
 
   return (
     <>
@@ -163,7 +165,7 @@ export const ConnectorContentScheduling: React.FC<ConnectorContentSchedulingProp
                 </EuiFlexItem>
                 <EuiFlexItem>
                   <EnableSwitch
-                    disabled={isGated}
+                    disabled={isGated || isDocumentLevelSecurityDisabled}
                     checked={scheduling[type].enabled}
                     onChange={(e) => {
                       if (e.target.checked) {
@@ -185,7 +187,7 @@ export const ConnectorContentScheduling: React.FC<ConnectorContentSchedulingProp
               </EuiFlexGroup>
             ) : (
               <EnableSwitch
-                disabled={isGated}
+                disabled={isGated || isDocumentLevelSecurityDisabled}
                 checked={scheduling[type].enabled}
                 onChange={(e) => {
                   if (e.target.checked) {

--- a/x-pack/plugins/enterprise_search/server/index.ts
+++ b/x-pack/plugins/enterprise_search/server/index.ts
@@ -52,4 +52,4 @@ export const CURRENT_CONNECTORS_INDEX = '.elastic-connectors-v1';
 export const CONNECTORS_JOBS_INDEX = '.elastic-connectors-sync-jobs';
 export const CONNECTORS_VERSION = 1;
 export const CRAWLERS_INDEX = '.ent-search-actastic-crawler2_configurations_v2';
-export const CONNECTORS_ACCESS_CONTROL_INDEX_PREFIX = 'search-acl-filter-';
+export const CONNECTORS_ACCESS_CONTROL_INDEX_PREFIX = '.search-acl-filter-';


### PR DESCRIPTION
## Summary

Add missing document level security disabled CTA to scheduling tab
![Screenshot 2023-06-23 at 13 13 10](https://github.com/elastic/kibana/assets/1410658/e49e7ed5-36ec-466f-aa87-ed11741ce032)


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)




<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->