### PR TITLE
[Security Solution] Fix Add Rules Page not refetching rules after package installed in background

### DIFF
--- a/x-pack/plugins/security_solution/common/detection_engine/prebuilt_rules/api/get_prebuilt_rules_status/response_schema.ts
+++ b/x-pack/plugins/security_solution/common/detection_engine/prebuilt_rules/api/get_prebuilt_rules_status/response_schema.ts
@@ -20,6 +20,9 @@ export interface PrebuiltRulesStatusStats {
   /** Number of installed prebuilt rules available for upgrade (stock + customized) */
   num_prebuilt_rules_to_upgrade: number;
 
+  /** Total number of prebuilt rules available in package (including already installed) */
+  num_prebuilt_rules_total_in_package: number;
+
   // In the future we could add more stats such as:
   // - number of installed prebuilt rules which were deprecated
   // - number of installed prebuilt rules which are not compatible with the current version of Kibana

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/api/hooks/use_bulk_install_fleet_packages_mutation.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/api/hooks/use_bulk_install_fleet_packages_mutation.ts
@@ -11,7 +11,9 @@ import { useMutation } from '@tanstack/react-query';
 import { PREBUILT_RULES_PACKAGE_NAME } from '../../../../../common/detection_engine/constants';
 import type { BulkInstallFleetPackagesProps } from '../api';
 import { bulkInstallFleetPackages } from '../api';
+import { useInvalidateFetchPrebuiltRulesInstallReviewQuery } from './prebuilt_rules/use_fetch_prebuilt_rules_install_review_query';
 import { useInvalidateFetchPrebuiltRulesStatusQuery } from './prebuilt_rules/use_fetch_prebuilt_rules_status_query';
+import { useInvalidateFetchPrebuiltRulesUpgradeReviewQuery } from './prebuilt_rules/use_fetch_prebuilt_rules_upgrade_review_query';
 
 export const BULK_INSTALL_FLEET_PACKAGES_MUTATION_KEY = [
   'POST',
@@ -22,6 +24,8 @@ export const useBulkInstallFleetPackagesMutation = (
   options?: UseMutationOptions<BulkInstallPackagesResponse, Error, BulkInstallFleetPackagesProps>
 ) => {
   const invalidatePrePackagedRulesStatus = useInvalidateFetchPrebuiltRulesStatusQuery();
+  const invalidatePrebuiltRulesInstallReview = useInvalidateFetchPrebuiltRulesInstallReviewQuery();
+  const invalidatePrebuiltRulesUpdateReview = useInvalidateFetchPrebuiltRulesUpgradeReviewQuery();
 
   return useMutation((props: BulkInstallFleetPackagesProps) => bulkInstallFleetPackages(props), {
     ...options,
@@ -34,6 +38,8 @@ export const useBulkInstallFleetPackagesMutation = (
       if (rulesPackage && 'result' in rulesPackage && rulesPackage.result.status === 'installed') {
         // The rules package was installed/updated, so invalidate the pre-packaged rules status query
         invalidatePrePackagedRulesStatus();
+        invalidatePrebuiltRulesInstallReview();
+        invalidatePrebuiltRulesUpdateReview();
       }
 
       if (options?.onSettled) {

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/api/hooks/use_install_fleet_package_mutation.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/api/hooks/use_install_fleet_package_mutation.ts
@@ -11,7 +11,9 @@ import { useMutation } from '@tanstack/react-query';
 import { PREBUILT_RULES_PACKAGE_NAME } from '../../../../../common/detection_engine/constants';
 import type { InstallFleetPackageProps } from '../api';
 import { installFleetPackage } from '../api';
+import { useInvalidateFetchPrebuiltRulesInstallReviewQuery } from './prebuilt_rules/use_fetch_prebuilt_rules_install_review_query';
 import { useInvalidateFetchPrebuiltRulesStatusQuery } from './prebuilt_rules/use_fetch_prebuilt_rules_status_query';
+import { useInvalidateFetchPrebuiltRulesUpgradeReviewQuery } from './prebuilt_rules/use_fetch_prebuilt_rules_upgrade_review_query';
 
 export const INSTALL_FLEET_PACKAGE_MUTATION_KEY = [
   'POST',
@@ -22,6 +24,8 @@ export const useInstallFleetPackageMutation = (
   options?: UseMutationOptions<InstallPackageResponse, Error, InstallFleetPackageProps>
 ) => {
   const invalidatePrePackagedRulesStatus = useInvalidateFetchPrebuiltRulesStatusQuery();
+  const invalidatePrebuiltRulesInstallReview = useInvalidateFetchPrebuiltRulesInstallReviewQuery();
+  const invalidatePrebuiltRulesUpdateReview = useInvalidateFetchPrebuiltRulesUpgradeReviewQuery();
 
   return useMutation((props: InstallFleetPackageProps) => installFleetPackage(props), {
     ...options,
@@ -31,6 +35,8 @@ export const useInstallFleetPackageMutation = (
       if (packageName === PREBUILT_RULES_PACKAGE_NAME) {
         // Invalidate the pre-packaged rules status query as there might be new rules to install
         invalidatePrePackagedRulesStatus();
+        invalidatePrebuiltRulesInstallReview();
+        invalidatePrebuiltRulesUpdateReview();
       }
 
       if (options?.onSettled) {

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/add_prebuilt_rules_table/add_prebuilt_rules_header_buttons.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/add_prebuilt_rules_table/add_prebuilt_rules_header_buttons.tsx
@@ -12,7 +12,7 @@ import * as i18n from './translations';
 
 export const AddPrebuiltRulesHeaderButtons = () => {
   const {
-    state: { rules, selectedRules, loadingRules, shouldShowLinearProgress },
+    state: { rules, selectedRules, loadingRules, isFetchingRulesPackage },
     actions: { installAllRules, installSelectedRules },
   } = useAddPrebuiltRulesTableContext();
 
@@ -21,7 +21,7 @@ export const AddPrebuiltRulesHeaderButtons = () => {
   const shouldDisplayInstallSelectedRulesButton = numberOfSelectedRules > 0;
 
   const isRuleInstalling = loadingRules.length > 0;
-  const isRequestInProgress = isRuleInstalling || shouldShowLinearProgress;
+  const isRequestInProgress = isRuleInstalling || isFetchingRulesPackage;
 
   return (
     <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false} wrap={true}>

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/add_prebuilt_rules_table/add_prebuilt_rules_header_buttons.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/add_prebuilt_rules_table/add_prebuilt_rules_header_buttons.tsx
@@ -12,7 +12,7 @@ import * as i18n from './translations';
 
 export const AddPrebuiltRulesHeaderButtons = () => {
   const {
-    state: { rules, selectedRules, loadingRules, isRefreshingTable },
+    state: { rules, selectedRules, loadingRules, isRefetching, isUpgradingSecurityPackages },
     actions: { installAllRules, installSelectedRules },
   } = useAddPrebuiltRulesTableContext();
 
@@ -21,7 +21,7 @@ export const AddPrebuiltRulesHeaderButtons = () => {
   const shouldDisplayInstallSelectedRulesButton = numberOfSelectedRules > 0;
 
   const isRuleInstalling = loadingRules.length > 0;
-  const isRequestInProgress = isRuleInstalling || isRefreshingTable;
+  const isRequestInProgress = isRuleInstalling || isRefetching || isUpgradingSecurityPackages;
 
   return (
     <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false} wrap={true}>

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/add_prebuilt_rules_table/add_prebuilt_rules_header_buttons.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/add_prebuilt_rules_table/add_prebuilt_rules_header_buttons.tsx
@@ -12,7 +12,7 @@ import * as i18n from './translations';
 
 export const AddPrebuiltRulesHeaderButtons = () => {
   const {
-    state: { rules, selectedRules, loadingRules, isFetchingRulesPackage },
+    state: { rules, selectedRules, loadingRules, isRefreshingTable },
     actions: { installAllRules, installSelectedRules },
   } = useAddPrebuiltRulesTableContext();
 
@@ -21,7 +21,7 @@ export const AddPrebuiltRulesHeaderButtons = () => {
   const shouldDisplayInstallSelectedRulesButton = numberOfSelectedRules > 0;
 
   const isRuleInstalling = loadingRules.length > 0;
-  const isRequestInProgress = isRuleInstalling || isFetchingRulesPackage;
+  const isRequestInProgress = isRuleInstalling || isRefreshingTable;
 
   return (
     <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false} wrap={true}>

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/add_prebuilt_rules_table/add_prebuilt_rules_header_buttons.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/add_prebuilt_rules_table/add_prebuilt_rules_header_buttons.tsx
@@ -12,7 +12,7 @@ import * as i18n from './translations';
 
 export const AddPrebuiltRulesHeaderButtons = () => {
   const {
-    state: { rules, selectedRules, loadingRules },
+    state: { rules, selectedRules, loadingRules, shouldShowLinearProgress },
     actions: { installAllRules, installSelectedRules },
   } = useAddPrebuiltRulesTableContext();
 
@@ -21,12 +21,13 @@ export const AddPrebuiltRulesHeaderButtons = () => {
   const shouldDisplayInstallSelectedRulesButton = numberOfSelectedRules > 0;
 
   const isRuleInstalling = loadingRules.length > 0;
+  const isRequestInProgress = isRuleInstalling || shouldShowLinearProgress;
 
   return (
     <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false} wrap={true}>
       {shouldDisplayInstallSelectedRulesButton ? (
         <EuiFlexItem grow={false}>
-          <EuiButton onClick={installSelectedRules} disabled={isRuleInstalling}>
+          <EuiButton onClick={installSelectedRules} disabled={isRequestInProgress}>
             {i18n.INSTALL_SELECTED_RULES(numberOfSelectedRules)}
             {isRuleInstalling ? <EuiLoadingSpinner size="s" /> : undefined}
           </EuiButton>
@@ -38,7 +39,7 @@ export const AddPrebuiltRulesHeaderButtons = () => {
           iconType="plusInCircle"
           data-test-subj="installAllRulesButton"
           onClick={installAllRules}
-          disabled={!isRulesAvailableForInstall || isRuleInstalling}
+          disabled={!isRulesAvailableForInstall || isRequestInProgress}
         >
           {i18n.INSTALL_ALL}
           {isRuleInstalling ? <EuiLoadingSpinner size="s" /> : undefined}

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/add_prebuilt_rules_table/add_prebuilt_rules_table.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/add_prebuilt_rules_table/add_prebuilt_rules_table.tsx
@@ -42,7 +42,6 @@ export const AddPrebuiltRulesTable = React.memo(() => {
 
   const isTableEmpty = isFetched && rules.length === 0;
 
-  const isInstallingPackageForFirstTime = isUpgradingSecurityPackages && rules.length === 0;
   const shouldShowProgress = isUpgradingSecurityPackages || isRefetching;
 
   return (
@@ -56,7 +55,7 @@ export const AddPrebuiltRulesTable = React.memo(() => {
         />
       )}
       <EuiSkeletonLoading
-        isLoading={isLoading || isInstallingPackageForFirstTime}
+        isLoading={isLoading}
         loadingContent={
           <>
             <EuiSkeletonTitle />

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/add_prebuilt_rules_table/add_prebuilt_rules_table.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/add_prebuilt_rules_table/add_prebuilt_rules_table.tsx
@@ -42,6 +42,8 @@ export const AddPrebuiltRulesTable = React.memo(() => {
 
   const isTableEmpty = isFetched && rules.length === 0;
 
+  const isInstallingPackageForFirstTime = shouldShowLinearProgress && rules.length === 0;
+
   return (
     <>
       {shouldShowLinearProgress && (
@@ -53,7 +55,7 @@ export const AddPrebuiltRulesTable = React.memo(() => {
         />
       )}
       <EuiSkeletonLoading
-        isLoading={isLoading || shouldShowLoadingOverlay}
+        isLoading={isLoading || shouldShowLoadingOverlay || isInstallingPackageForFirstTime}
         loadingContent={
           <>
             <EuiSkeletonTitle />

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/add_prebuilt_rules_table/add_prebuilt_rules_table.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/add_prebuilt_rules_table/add_prebuilt_rules_table.tsx
@@ -27,26 +27,18 @@ export const AddPrebuiltRulesTable = React.memo(() => {
   const addRulesTableContext = useAddPrebuiltRulesTableContext();
 
   const {
-    state: {
-      rules,
-      filteredRules,
-      isFetched,
-      isLoading,
-      selectedRules,
-      isFetchingRules,
-      isFetchingRulesPackage,
-    },
+    state: { rules, filteredRules, isFetched, isLoading, selectedRules, isRefreshingTable },
     actions: { selectRules },
   } = addRulesTableContext;
   const rulesColumns = useAddPrebuiltRulesTableColumns();
 
   const isTableEmpty = isFetched && rules.length === 0;
 
-  const isInstallingPackageForFirstTime = isFetchingRulesPackage && rules.length === 0;
+  const isInstallingPackageForFirstTime = isRefreshingTable && rules.length === 0;
 
   return (
     <>
-      {isFetchingRulesPackage && (
+      {isRefreshingTable && (
         <EuiProgress
           data-test-subj="loadingRulesInfoProgress"
           size="xs"
@@ -55,7 +47,7 @@ export const AddPrebuiltRulesTable = React.memo(() => {
         />
       )}
       <EuiSkeletonLoading
-        isLoading={isLoading || isFetchingRules || isInstallingPackageForFirstTime}
+        isLoading={isLoading || isInstallingPackageForFirstTime}
         loadingContent={
           <>
             <EuiSkeletonTitle />

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/add_prebuilt_rules_table/add_prebuilt_rules_table.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/add_prebuilt_rules_table/add_prebuilt_rules_table.tsx
@@ -14,7 +14,6 @@ import {
 } from '@elastic/eui';
 import React from 'react';
 
-import { useIsUpgradingSecurityPackages } from '../../../../rule_management/logic/use_upgrade_security_packages';
 import { RULES_TABLE_INITIAL_PAGE_SIZE, RULES_TABLE_PAGE_SIZE_OPTIONS } from '../constants';
 import { AddPrebuiltRulesTableNoItemsMessage } from './add_prebuilt_rules_no_items_message';
 import { useAddPrebuiltRulesTableContext } from './add_prebuilt_rules_table_context';
@@ -25,20 +24,23 @@ import { useAddPrebuiltRulesTableColumns } from './use_add_prebuilt_rules_table_
  * Table Component for displaying new rules that are available to be installed
  */
 export const AddPrebuiltRulesTable = React.memo(() => {
-  const isUpgradingSecurityPackages = useIsUpgradingSecurityPackages();
-
   const addRulesTableContext = useAddPrebuiltRulesTableContext();
 
   const {
-    state: { rules, filteredRules, isFetched, isLoading, isRefetching, selectedRules },
+    state: {
+      rules,
+      filteredRules,
+      isFetched,
+      isLoading,
+      selectedRules,
+      shouldShowLoadingOverlay,
+      shouldShowLinearProgress,
+    },
     actions: { selectRules },
   } = addRulesTableContext;
   const rulesColumns = useAddPrebuiltRulesTableColumns();
 
   const isTableEmpty = isFetched && rules.length === 0;
-
-  const shouldShowLinearProgress = (isFetched && isRefetching) || isUpgradingSecurityPackages;
-  const shouldShowLoadingOverlay = !isFetched && isRefetching;
 
   return (
     <>

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/add_prebuilt_rules_table/add_prebuilt_rules_table.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/add_prebuilt_rules_table/add_prebuilt_rules_table.tsx
@@ -33,8 +33,8 @@ export const AddPrebuiltRulesTable = React.memo(() => {
       isFetched,
       isLoading,
       selectedRules,
-      shouldShowLoadingOverlay,
-      shouldShowLinearProgress,
+      isFetchingRules,
+      isFetchingRulesPackage,
     },
     actions: { selectRules },
   } = addRulesTableContext;
@@ -42,11 +42,11 @@ export const AddPrebuiltRulesTable = React.memo(() => {
 
   const isTableEmpty = isFetched && rules.length === 0;
 
-  const isInstallingPackageForFirstTime = shouldShowLinearProgress && rules.length === 0;
+  const isInstallingPackageForFirstTime = isFetchingRulesPackage && rules.length === 0;
 
   return (
     <>
-      {shouldShowLinearProgress && (
+      {isFetchingRulesPackage && (
         <EuiProgress
           data-test-subj="loadingRulesInfoProgress"
           size="xs"
@@ -55,7 +55,7 @@ export const AddPrebuiltRulesTable = React.memo(() => {
         />
       )}
       <EuiSkeletonLoading
-        isLoading={isLoading || shouldShowLoadingOverlay || isInstallingPackageForFirstTime}
+        isLoading={isLoading || isFetchingRules || isInstallingPackageForFirstTime}
         loadingContent={
           <>
             <EuiSkeletonTitle />

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/add_prebuilt_rules_table/add_prebuilt_rules_table.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/add_prebuilt_rules_table/add_prebuilt_rules_table.tsx
@@ -27,18 +27,27 @@ export const AddPrebuiltRulesTable = React.memo(() => {
   const addRulesTableContext = useAddPrebuiltRulesTableContext();
 
   const {
-    state: { rules, filteredRules, isFetched, isLoading, selectedRules, isRefreshingTable },
+    state: {
+      rules,
+      filteredRules,
+      isFetched,
+      isLoading,
+      isRefetching,
+      selectedRules,
+      isUpgradingSecurityPackages,
+    },
     actions: { selectRules },
   } = addRulesTableContext;
   const rulesColumns = useAddPrebuiltRulesTableColumns();
 
   const isTableEmpty = isFetched && rules.length === 0;
 
-  const isInstallingPackageForFirstTime = isRefreshingTable && rules.length === 0;
+  const isInstallingPackageForFirstTime = isUpgradingSecurityPackages && rules.length === 0;
+  const shouldShowProgress = isUpgradingSecurityPackages || isRefetching;
 
   return (
     <>
-      {isRefreshingTable && (
+      {shouldShowProgress && (
         <EuiProgress
           data-test-subj="loadingRulesInfoProgress"
           size="xs"

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/add_prebuilt_rules_table/add_prebuilt_rules_table_context.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/add_prebuilt_rules_table/add_prebuilt_rules_table_context.tsx
@@ -7,6 +7,7 @@
 
 import type { Dispatch, SetStateAction } from 'react';
 import React, { createContext, useCallback, useContext, useMemo, useState } from 'react';
+import { useIsUpgradingSecurityPackages } from '../../../../rule_management/logic/use_upgrade_security_packages';
 import type { RuleInstallationInfoForReview } from '../../../../../../common/detection_engine/prebuilt_rules/api/review_rule_installation/response_schema';
 import type { RuleSignatureId } from '../../../../../../common/detection_engine/rule_schema';
 import { invariant } from '../../../../../../common/utils/invariant';
@@ -44,9 +45,14 @@ export interface AddPrebuiltRulesTableState {
    */
   isFetched: boolean;
   /**
-   * Is true whenever a background refetch is in-flight, which does not include initial loading
+   * Is true when doing an initial fetch of rules to install
    */
-  isRefetching: boolean;
+  shouldShowLoadingOverlay: boolean;
+  /**
+   * Is true when installing security_detection_rules package in background
+   * or refetching rules to install rules in the background
+   */
+  shouldShowLinearProgress: boolean;
   /**
    * List of rule IDs that are currently being upgraded
    */
@@ -92,6 +98,8 @@ export const AddPrebuiltRulesTableContextProvider = ({
     tags: [],
   });
 
+  const isUpgradingSecurityPackages = useIsUpgradingSecurityPackages();
+
   const {
     data: { rules, stats: { tags } } = {
       rules: [],
@@ -109,6 +117,9 @@ export const AddPrebuiltRulesTableContextProvider = ({
 
   const { mutateAsync: installAllRulesRequest } = usePerformInstallAllRules();
   const { mutateAsync: installSpecificRulesRequest } = usePerformInstallSpecificRules();
+
+  const shouldShowLoadingOverlay = !isFetched && isRefetching;
+  const shouldShowLinearProgress = (isFetched && isRefetching) || isUpgradingSecurityPackages;
 
   const installOneRule = useCallback(
     async (ruleId: RuleSignatureId) => {
@@ -175,6 +186,8 @@ export const AddPrebuiltRulesTableContextProvider = ({
         isLoading,
         loadingRules,
         isRefetching,
+        shouldShowLoadingOverlay,
+        shouldShowLinearProgress,
         selectedRules,
         lastUpdated: dataUpdatedAt,
       },
@@ -189,6 +202,8 @@ export const AddPrebuiltRulesTableContextProvider = ({
     isLoading,
     loadingRules,
     isRefetching,
+    shouldShowLoadingOverlay,
+    shouldShowLinearProgress,
     selectedRules,
     dataUpdatedAt,
     actions,

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/add_prebuilt_rules_table/add_prebuilt_rules_table_context.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/add_prebuilt_rules_table/add_prebuilt_rules_table_context.tsx
@@ -45,10 +45,14 @@ export interface AddPrebuiltRulesTableState {
    */
   isFetched: boolean;
   /**
-   * Is true when installing security_detection_rules package
-   *  in background or refetching rules available to install
+   * Is true whenever a background refetch is in-flight, which does not include initial loading
    */
-  isRefreshingTable: boolean;
+  isRefetching: boolean;
+  /**
+   * Is true when installing security_detection_rules
+   * package in background
+   */
+  isUpgradingSecurityPackages: boolean;
   /**
    * List of rule IDs that are currently being upgraded
    */
@@ -113,7 +117,6 @@ export const AddPrebuiltRulesTableContextProvider = ({
 
   const { mutateAsync: installAllRulesRequest } = usePerformInstallAllRules();
   const { mutateAsync: installSpecificRulesRequest } = usePerformInstallSpecificRules();
-  const isRefreshingTable = isRefetching || isUpgradingSecurityPackages;
 
   const installOneRule = useCallback(
     async (ruleId: RuleSignatureId) => {
@@ -180,7 +183,7 @@ export const AddPrebuiltRulesTableContextProvider = ({
         isLoading,
         loadingRules,
         isRefetching,
-        isRefreshingTable,
+        isUpgradingSecurityPackages,
         selectedRules,
         lastUpdated: dataUpdatedAt,
       },
@@ -195,7 +198,7 @@ export const AddPrebuiltRulesTableContextProvider = ({
     isLoading,
     loadingRules,
     isRefetching,
-    isRefreshingTable,
+    isUpgradingSecurityPackages,
     selectedRules,
     dataUpdatedAt,
     actions,

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/add_prebuilt_rules_table/add_prebuilt_rules_table_context.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/add_prebuilt_rules_table/add_prebuilt_rules_table_context.tsx
@@ -47,12 +47,12 @@ export interface AddPrebuiltRulesTableState {
   /**
    * Is true when doing an initial fetch of rules to install
    */
-  shouldShowLoadingOverlay: boolean;
+  isFetchingRules: boolean;
   /**
    * Is true when installing security_detection_rules package in background
-   * or refetching rules to install rules in the background
+   * or refetching rules to install rules
    */
-  shouldShowLinearProgress: boolean;
+  isFetchingRulesPackage: boolean;
   /**
    * List of rule IDs that are currently being upgraded
    */
@@ -118,8 +118,8 @@ export const AddPrebuiltRulesTableContextProvider = ({
   const { mutateAsync: installAllRulesRequest } = usePerformInstallAllRules();
   const { mutateAsync: installSpecificRulesRequest } = usePerformInstallSpecificRules();
 
-  const shouldShowLoadingOverlay = !isFetched && isRefetching;
-  const shouldShowLinearProgress = (isFetched && isRefetching) || isUpgradingSecurityPackages;
+  const isFetchingRules = !isFetched && isRefetching;
+  const isFetchingRulesPackage = (isFetched && isRefetching) || isUpgradingSecurityPackages;
 
   const installOneRule = useCallback(
     async (ruleId: RuleSignatureId) => {
@@ -186,8 +186,8 @@ export const AddPrebuiltRulesTableContextProvider = ({
         isLoading,
         loadingRules,
         isRefetching,
-        shouldShowLoadingOverlay,
-        shouldShowLinearProgress,
+        isFetchingRules,
+        isFetchingRulesPackage,
         selectedRules,
         lastUpdated: dataUpdatedAt,
       },
@@ -202,8 +202,8 @@ export const AddPrebuiltRulesTableContextProvider = ({
     isLoading,
     loadingRules,
     isRefetching,
-    shouldShowLoadingOverlay,
-    shouldShowLinearProgress,
+    isFetchingRules,
+    isFetchingRulesPackage,
     selectedRules,
     dataUpdatedAt,
     actions,

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/add_prebuilt_rules_table/add_prebuilt_rules_table_context.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/add_prebuilt_rules_table/add_prebuilt_rules_table_context.tsx
@@ -45,14 +45,10 @@ export interface AddPrebuiltRulesTableState {
    */
   isFetched: boolean;
   /**
-   * Is true when doing an initial fetch of rules to install
+   * Is true when installing security_detection_rules package
+   *  in background or refetching rules available to install
    */
-  isFetchingRules: boolean;
-  /**
-   * Is true when installing security_detection_rules package in background
-   * or refetching rules to install rules
-   */
-  isFetchingRulesPackage: boolean;
+  isRefreshingTable: boolean;
   /**
    * List of rule IDs that are currently being upgraded
    */
@@ -111,15 +107,13 @@ export const AddPrebuiltRulesTableContextProvider = ({
     isLoading,
     isRefetching,
   } = usePrebuiltRulesInstallReview({
-    refetchInterval: 60000, // Refetch available rules for installation every minute
+    refetchInterval: 10000, // Refetch available rules for installation every minute
     keepPreviousData: true, // Use this option so that the state doesn't jump between "success" and "loading" on page change
   });
 
   const { mutateAsync: installAllRulesRequest } = usePerformInstallAllRules();
   const { mutateAsync: installSpecificRulesRequest } = usePerformInstallSpecificRules();
-
-  const isFetchingRules = !isFetched && isRefetching;
-  const isFetchingRulesPackage = (isFetched && isRefetching) || isUpgradingSecurityPackages;
+  const isRefreshingTable = isRefetching || isUpgradingSecurityPackages;
 
   const installOneRule = useCallback(
     async (ruleId: RuleSignatureId) => {
@@ -186,8 +180,7 @@ export const AddPrebuiltRulesTableContextProvider = ({
         isLoading,
         loadingRules,
         isRefetching,
-        isFetchingRules,
-        isFetchingRulesPackage,
+        isRefreshingTable,
         selectedRules,
         lastUpdated: dataUpdatedAt,
       },
@@ -202,8 +195,7 @@ export const AddPrebuiltRulesTableContextProvider = ({
     isLoading,
     loadingRules,
     isRefetching,
-    isFetchingRules,
-    isFetchingRulesPackage,
+    isRefreshingTable,
     selectedRules,
     dataUpdatedAt,
     actions,

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/add_prebuilt_rules_table/add_prebuilt_rules_table_context.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/add_prebuilt_rules_table/add_prebuilt_rules_table_context.tsx
@@ -7,6 +7,7 @@
 
 import type { Dispatch, SetStateAction } from 'react';
 import React, { createContext, useCallback, useContext, useMemo, useState } from 'react';
+import { useFetchPrebuiltRulesStatusQuery } from '../../../../rule_management/api/hooks/prebuilt_rules/use_fetch_prebuilt_rules_status_query';
 import { useIsUpgradingSecurityPackages } from '../../../../rule_management/logic/use_upgrade_security_packages';
 import type { RuleInstallationInfoForReview } from '../../../../../../common/detection_engine/prebuilt_rules/api/review_rule_installation/response_schema';
 import type { RuleSignatureId } from '../../../../../../common/detection_engine/rule_schema';
@@ -98,6 +99,8 @@ export const AddPrebuiltRulesTableContextProvider = ({
     tags: [],
   });
 
+  const { data: prebuiltRulesStatus } = useFetchPrebuiltRulesStatusQuery();
+
   const isUpgradingSecurityPackages = useIsUpgradingSecurityPackages();
 
   const {
@@ -113,6 +116,12 @@ export const AddPrebuiltRulesTableContextProvider = ({
   } = usePrebuiltRulesInstallReview({
     refetchInterval: 60000, // Refetch available rules for installation every minute
     keepPreviousData: true, // Use this option so that the state doesn't jump between "success" and "loading" on page change
+    // Fetch rules to install only after background installation of security_detection_rules package is complete
+    enabled: Boolean(
+      !isUpgradingSecurityPackages &&
+        prebuiltRulesStatus &&
+        prebuiltRulesStatus.num_prebuilt_rules_total_in_package > 0
+    ),
   });
 
   const { mutateAsync: installAllRulesRequest } = usePerformInstallAllRules();

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/add_prebuilt_rules_table/add_prebuilt_rules_table_context.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/add_prebuilt_rules_table/add_prebuilt_rules_table_context.tsx
@@ -111,7 +111,7 @@ export const AddPrebuiltRulesTableContextProvider = ({
     isLoading,
     isRefetching,
   } = usePrebuiltRulesInstallReview({
-    refetchInterval: 10000, // Refetch available rules for installation every minute
+    refetchInterval: 60000, // Refetch available rules for installation every minute
     keepPreviousData: true, // Use this option so that the state doesn't jump between "success" and "loading" on page change
   });
 

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/add_prebuilt_rules_table/use_add_prebuilt_rules_table_columns.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/add_prebuilt_rules_table/use_add_prebuilt_rules_table_columns.tsx
@@ -86,13 +86,13 @@ const INTEGRATIONS_COLUMN: TableColumn = {
 const createInstallButtonColumn = (
   installOneRule: AddPrebuiltRulesTableActions['installOneRule'],
   loadingRules: RuleSignatureId[],
-  shouldShowLinearProgress: boolean
+  isFetchingRulesPackage: boolean
 ): TableColumn => ({
   field: 'rule_id',
   name: '',
   render: (ruleId: RuleSignatureId) => {
     const isRuleInstalling = loadingRules.includes(ruleId);
-    const isInstallButtonDisabled = isRuleInstalling || shouldShowLinearProgress;
+    const isInstallButtonDisabled = isRuleInstalling || isFetchingRulesPackage;
     return (
       <EuiButtonEmpty
         size="s"
@@ -112,7 +112,7 @@ export const useAddPrebuiltRulesTableColumns = (): TableColumn[] => {
   const hasCRUDPermissions = hasUserCRUDPermission(canUserCRUD);
   const [showRelatedIntegrations] = useUiSetting$<boolean>(SHOW_RELATED_INTEGRATIONS_SETTING);
   const {
-    state: { loadingRules, shouldShowLinearProgress },
+    state: { loadingRules, isFetchingRulesPackage },
     actions: { installOneRule },
   } = useAddPrebuiltRulesTableContext();
 
@@ -142,14 +142,14 @@ export const useAddPrebuiltRulesTableColumns = (): TableColumn[] => {
         width: '12%',
       },
       ...(hasCRUDPermissions
-        ? [createInstallButtonColumn(installOneRule, loadingRules, shouldShowLinearProgress)]
+        ? [createInstallButtonColumn(installOneRule, loadingRules, isFetchingRulesPackage)]
         : []),
     ],
     [
       hasCRUDPermissions,
       installOneRule,
       loadingRules,
-      shouldShowLinearProgress,
+      isFetchingRulesPackage,
       showRelatedIntegrations,
     ]
   );

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/add_prebuilt_rules_table/use_add_prebuilt_rules_table_columns.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/add_prebuilt_rules_table/use_add_prebuilt_rules_table_columns.tsx
@@ -112,9 +112,11 @@ export const useAddPrebuiltRulesTableColumns = (): TableColumn[] => {
   const hasCRUDPermissions = hasUserCRUDPermission(canUserCRUD);
   const [showRelatedIntegrations] = useUiSetting$<boolean>(SHOW_RELATED_INTEGRATIONS_SETTING);
   const {
-    state: { loadingRules, isRefreshingTable },
+    state: { loadingRules, isRefetching, isUpgradingSecurityPackages },
     actions: { installOneRule },
   } = useAddPrebuiltRulesTableContext();
+
+  const isDisabled = isRefetching || isUpgradingSecurityPackages;
 
   return useMemo(
     () => [
@@ -142,9 +144,9 @@ export const useAddPrebuiltRulesTableColumns = (): TableColumn[] => {
         width: '12%',
       },
       ...(hasCRUDPermissions
-        ? [createInstallButtonColumn(installOneRule, loadingRules, isRefreshingTable)]
+        ? [createInstallButtonColumn(installOneRule, loadingRules, isDisabled)]
         : []),
     ],
-    [hasCRUDPermissions, installOneRule, loadingRules, isRefreshingTable, showRelatedIntegrations]
+    [hasCRUDPermissions, installOneRule, loadingRules, isDisabled, showRelatedIntegrations]
   );
 };

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/add_prebuilt_rules_table/use_add_prebuilt_rules_table_columns.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/add_prebuilt_rules_table/use_add_prebuilt_rules_table_columns.tsx
@@ -86,13 +86,13 @@ const INTEGRATIONS_COLUMN: TableColumn = {
 const createInstallButtonColumn = (
   installOneRule: AddPrebuiltRulesTableActions['installOneRule'],
   loadingRules: RuleSignatureId[],
-  isFetchingRulesPackage: boolean
+  isDisabled: boolean
 ): TableColumn => ({
   field: 'rule_id',
   name: '',
   render: (ruleId: RuleSignatureId) => {
     const isRuleInstalling = loadingRules.includes(ruleId);
-    const isInstallButtonDisabled = isRuleInstalling || isFetchingRulesPackage;
+    const isInstallButtonDisabled = isRuleInstalling || isDisabled;
     return (
       <EuiButtonEmpty
         size="s"
@@ -112,7 +112,7 @@ export const useAddPrebuiltRulesTableColumns = (): TableColumn[] => {
   const hasCRUDPermissions = hasUserCRUDPermission(canUserCRUD);
   const [showRelatedIntegrations] = useUiSetting$<boolean>(SHOW_RELATED_INTEGRATIONS_SETTING);
   const {
-    state: { loadingRules, isFetchingRulesPackage },
+    state: { loadingRules, isRefreshingTable },
     actions: { installOneRule },
   } = useAddPrebuiltRulesTableContext();
 
@@ -142,15 +142,9 @@ export const useAddPrebuiltRulesTableColumns = (): TableColumn[] => {
         width: '12%',
       },
       ...(hasCRUDPermissions
-        ? [createInstallButtonColumn(installOneRule, loadingRules, isFetchingRulesPackage)]
+        ? [createInstallButtonColumn(installOneRule, loadingRules, isRefreshingTable)]
         : []),
     ],
-    [
-      hasCRUDPermissions,
-      installOneRule,
-      loadingRules,
-      isFetchingRulesPackage,
-      showRelatedIntegrations,
-    ]
+    [hasCRUDPermissions, installOneRule, loadingRules, isRefreshingTable, showRelatedIntegrations]
   );
 };

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/add_prebuilt_rules_table/use_add_prebuilt_rules_table_columns.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/add_prebuilt_rules_table/use_add_prebuilt_rules_table_columns.tsx
@@ -85,14 +85,20 @@ const INTEGRATIONS_COLUMN: TableColumn = {
 
 const createInstallButtonColumn = (
   installOneRule: AddPrebuiltRulesTableActions['installOneRule'],
-  loadingRules: RuleSignatureId[]
+  loadingRules: RuleSignatureId[],
+  shouldShowLinearProgress: boolean
 ): TableColumn => ({
   field: 'rule_id',
   name: '',
   render: (ruleId: RuleSignatureId) => {
     const isRuleInstalling = loadingRules.includes(ruleId);
+    const isInstallButtonDisabled = isRuleInstalling || shouldShowLinearProgress;
     return (
-      <EuiButtonEmpty size="s" disabled={isRuleInstalling} onClick={() => installOneRule(ruleId)}>
+      <EuiButtonEmpty
+        size="s"
+        disabled={isInstallButtonDisabled}
+        onClick={() => installOneRule(ruleId)}
+      >
         {isRuleInstalling ? <EuiLoadingSpinner size="s" /> : i18n.INSTALL_RULE_BUTTON}
       </EuiButtonEmpty>
     );
@@ -106,7 +112,7 @@ export const useAddPrebuiltRulesTableColumns = (): TableColumn[] => {
   const hasCRUDPermissions = hasUserCRUDPermission(canUserCRUD);
   const [showRelatedIntegrations] = useUiSetting$<boolean>(SHOW_RELATED_INTEGRATIONS_SETTING);
   const {
-    state: { loadingRules },
+    state: { loadingRules, shouldShowLinearProgress },
     actions: { installOneRule },
   } = useAddPrebuiltRulesTableContext();
 
@@ -135,8 +141,16 @@ export const useAddPrebuiltRulesTableColumns = (): TableColumn[] => {
         truncateText: true,
         width: '12%',
       },
-      ...(hasCRUDPermissions ? [createInstallButtonColumn(installOneRule, loadingRules)] : []),
+      ...(hasCRUDPermissions
+        ? [createInstallButtonColumn(installOneRule, loadingRules, shouldShowLinearProgress)]
+        : []),
     ],
-    [hasCRUDPermissions, installOneRule, loadingRules, showRelatedIntegrations]
+    [
+      hasCRUDPermissions,
+      installOneRule,
+      loadingRules,
+      shouldShowLinearProgress,
+      showRelatedIntegrations,
+    ]
   );
 };

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/upgrade_prebuilt_rules_table.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/upgrade_prebuilt_rules_table.tsx
@@ -44,8 +44,8 @@ export const UpgradePrebuiltRulesTable = React.memo(() => {
       isFetched,
       isLoading,
       selectedRules,
-      isFetchingRules,
-      isFetchingRulesPackage,
+      isRefetching,
+      isUpgradingSecurityPackages,
     },
     actions: { selectRules },
   } = upgradeRulesTableContext;
@@ -53,9 +53,11 @@ export const UpgradePrebuiltRulesTable = React.memo(() => {
 
   const isTableEmpty = isFetched && rules.length === 0;
 
+  const shouldShowProgress = isUpgradingSecurityPackages || isRefetching;
+
   return (
     <>
-      {isFetchingRulesPackage && (
+      {shouldShowProgress && (
         <EuiProgress
           data-test-subj="loadingRulesInfoProgress"
           size="xs"
@@ -64,7 +66,7 @@ export const UpgradePrebuiltRulesTable = React.memo(() => {
         />
       )}
       <EuiSkeletonLoading
-        isLoading={isLoading || isFetchingRules}
+        isLoading={isLoading}
         loadingContent={
           <>
             <EuiSkeletonTitle />

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/upgrade_prebuilt_rules_table.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/upgrade_prebuilt_rules_table.tsx
@@ -44,8 +44,8 @@ export const UpgradePrebuiltRulesTable = React.memo(() => {
       isFetched,
       isLoading,
       selectedRules,
-      shouldShowLoadingOverlay,
-      shouldShowLinearProgress,
+      isFetchingRules,
+      isFetchingRulesPackage,
     },
     actions: { selectRules },
   } = upgradeRulesTableContext;
@@ -55,7 +55,7 @@ export const UpgradePrebuiltRulesTable = React.memo(() => {
 
   return (
     <>
-      {shouldShowLinearProgress && (
+      {isFetchingRulesPackage && (
         <EuiProgress
           data-test-subj="loadingRulesInfoProgress"
           size="xs"
@@ -64,7 +64,7 @@ export const UpgradePrebuiltRulesTable = React.memo(() => {
         />
       )}
       <EuiSkeletonLoading
-        isLoading={isLoading || shouldShowLoadingOverlay}
+        isLoading={isLoading || isFetchingRules}
         loadingContent={
           <>
             <EuiSkeletonTitle />

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/upgrade_prebuilt_rules_table.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/upgrade_prebuilt_rules_table.tsx
@@ -17,7 +17,6 @@ import {
 } from '@elastic/eui';
 import React from 'react';
 import * as i18n from '../../../../../detections/pages/detection_engine/rules/translations';
-import { useIsUpgradingSecurityPackages } from '../../../../rule_management/logic/use_upgrade_security_packages';
 import { RULES_TABLE_INITIAL_PAGE_SIZE, RULES_TABLE_PAGE_SIZE_OPTIONS } from '../constants';
 import { UpgradePrebuiltRulesTableButtons } from './upgrade_prebuilt_rules_table_buttons';
 import { useUpgradePrebuiltRulesTableContext } from './upgrade_prebuilt_rules_table_context';
@@ -36,20 +35,23 @@ const NO_ITEMS_MESSAGE = (
  * Table Component for displaying rules that have available updates
  */
 export const UpgradePrebuiltRulesTable = React.memo(() => {
-  const isUpgradingSecurityPackages = useIsUpgradingSecurityPackages();
-
   const upgradeRulesTableContext = useUpgradePrebuiltRulesTableContext();
 
   const {
-    state: { rules, filteredRules, isFetched, isLoading, isRefetching, selectedRules },
+    state: {
+      rules,
+      filteredRules,
+      isFetched,
+      isLoading,
+      selectedRules,
+      shouldShowLoadingOverlay,
+      shouldShowLinearProgress,
+    },
     actions: { selectRules },
   } = upgradeRulesTableContext;
   const rulesColumns = useUpgradePrebuiltRulesTableColumns();
 
   const isTableEmpty = isFetched && rules.length === 0;
-
-  const shouldShowLinearProgress = (isFetched && isRefetching) || isUpgradingSecurityPackages;
-  const shouldShowLoadingOverlay = !isFetched && isRefetching;
 
   return (
     <>

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/upgrade_prebuilt_rules_table_buttons.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/upgrade_prebuilt_rules_table_buttons.tsx
@@ -12,7 +12,7 @@ import { useUpgradePrebuiltRulesTableContext } from './upgrade_prebuilt_rules_ta
 
 export const UpgradePrebuiltRulesTableButtons = () => {
   const {
-    state: { rules, selectedRules, loadingRules },
+    state: { rules, selectedRules, loadingRules, shouldShowLinearProgress },
     actions: { upgradeAllRules, upgradeSelectedRules },
   } = useUpgradePrebuiltRulesTableContext();
 
@@ -21,12 +21,13 @@ export const UpgradePrebuiltRulesTableButtons = () => {
   const shouldDisplayUpgradeSelectedRulesButton = numberOfSelectedRules > 0;
 
   const isRuleUpgrading = loadingRules.length > 0;
+  const isRequestInProgress = isRuleUpgrading || shouldShowLinearProgress;
 
   return (
     <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false} wrap={true}>
       {shouldDisplayUpgradeSelectedRulesButton ? (
         <EuiFlexItem grow={false}>
-          <EuiButton onClick={upgradeSelectedRules} disabled={isRuleUpgrading}>
+          <EuiButton onClick={upgradeSelectedRules} disabled={isRequestInProgress}>
             <>
               {i18n.UPDATE_SELECTED_RULES(numberOfSelectedRules)}
               {isRuleUpgrading ? <EuiLoadingSpinner size="s" /> : undefined}
@@ -39,7 +40,7 @@ export const UpgradePrebuiltRulesTableButtons = () => {
           fill
           iconType="plusInCircle"
           onClick={upgradeAllRules}
-          disabled={!isRulesAvailableForUpgrade || isRuleUpgrading}
+          disabled={!isRulesAvailableForUpgrade || isRequestInProgress}
         >
           {i18n.UPDATE_ALL}
           {isRuleUpgrading ? <EuiLoadingSpinner size="s" /> : undefined}

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/upgrade_prebuilt_rules_table_buttons.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/upgrade_prebuilt_rules_table_buttons.tsx
@@ -12,7 +12,7 @@ import { useUpgradePrebuiltRulesTableContext } from './upgrade_prebuilt_rules_ta
 
 export const UpgradePrebuiltRulesTableButtons = () => {
   const {
-    state: { rules, selectedRules, loadingRules, shouldShowLinearProgress },
+    state: { rules, selectedRules, loadingRules, isFetchingRulesPackage },
     actions: { upgradeAllRules, upgradeSelectedRules },
   } = useUpgradePrebuiltRulesTableContext();
 
@@ -21,7 +21,7 @@ export const UpgradePrebuiltRulesTableButtons = () => {
   const shouldDisplayUpgradeSelectedRulesButton = numberOfSelectedRules > 0;
 
   const isRuleUpgrading = loadingRules.length > 0;
-  const isRequestInProgress = isRuleUpgrading || shouldShowLinearProgress;
+  const isRequestInProgress = isRuleUpgrading || isFetchingRulesPackage;
 
   return (
     <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false} wrap={true}>

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/upgrade_prebuilt_rules_table_buttons.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/upgrade_prebuilt_rules_table_buttons.tsx
@@ -12,7 +12,7 @@ import { useUpgradePrebuiltRulesTableContext } from './upgrade_prebuilt_rules_ta
 
 export const UpgradePrebuiltRulesTableButtons = () => {
   const {
-    state: { rules, selectedRules, loadingRules, isFetchingRulesPackage },
+    state: { rules, selectedRules, loadingRules, isRefetching, isUpgradingSecurityPackages },
     actions: { upgradeAllRules, upgradeSelectedRules },
   } = useUpgradePrebuiltRulesTableContext();
 
@@ -21,7 +21,7 @@ export const UpgradePrebuiltRulesTableButtons = () => {
   const shouldDisplayUpgradeSelectedRulesButton = numberOfSelectedRules > 0;
 
   const isRuleUpgrading = loadingRules.length > 0;
-  const isRequestInProgress = isRuleUpgrading || isFetchingRulesPackage;
+  const isRequestInProgress = isRuleUpgrading || isRefetching || isUpgradingSecurityPackages;
 
   return (
     <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false} wrap={true}>

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/upgrade_prebuilt_rules_table_context.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/upgrade_prebuilt_rules_table_context.tsx
@@ -51,14 +51,14 @@ export interface UpgradePrebuiltRulesTableState {
    */
   isFetched: boolean;
   /**
-   * Is true when doing an initial fetch of rules to upgrade
+   * Is true whenever a background refetch is in-flight, which does not include initial loading
    */
-  isFetchingRules: boolean;
+  isRefetching: boolean;
   /**
-   * Is true when installing security_detection_rules package in background
-   * or refetching rules to upgrade
+   * Is true when installing security_detection_rules
+   * package in background
    */
-  isFetchingRulesPackage: boolean;
+  isUpgradingSecurityPackages: boolean;
   /**
    * List of rule IDs that are currently being upgraded
    */
@@ -222,13 +222,10 @@ export const UpgradePrebuiltRulesTableContextProvider = ({
         isFetched,
         isLoading: isLoading && loadingJobs,
         isRefetching,
-        isFetchingRules,
-        isFetchingRulesPackage,
+        isUpgradingSecurityPackages,
         selectedRules,
         loadingRules,
         lastUpdated: dataUpdatedAt,
-        legacyJobsInstalled,
-        isUpgradeModalVisible,
       },
       actions,
     };
@@ -241,13 +238,10 @@ export const UpgradePrebuiltRulesTableContextProvider = ({
     isLoading,
     loadingJobs,
     isRefetching,
-    isFetchingRules,
-    isFetchingRulesPackage,
+    isUpgradingSecurityPackages,
     selectedRules,
     loadingRules,
     dataUpdatedAt,
-    legacyJobsInstalled,
-    isUpgradeModalVisible,
     actions,
   ]);
 

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/upgrade_prebuilt_rules_table_context.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/upgrade_prebuilt_rules_table_context.tsx
@@ -53,12 +53,12 @@ export interface UpgradePrebuiltRulesTableState {
   /**
    * Is true when doing an initial fetch of rules to upgrade
    */
-  shouldShowLoadingOverlay: boolean;
+  isFetchingRules: boolean;
   /**
    * Is true when installing security_detection_rules package in background
-   * or refetching rules to upgrade rules in the background
+   * or refetching rules to upgrade
    */
-  shouldShowLinearProgress: boolean;
+  isFetchingRulesPackage: boolean;
   /**
    * List of rule IDs that are currently being upgraded
    */
@@ -126,8 +126,8 @@ export const UpgradePrebuiltRulesTableContextProvider = ({
   const { mutateAsync: upgradeAllRulesRequest } = usePerformUpgradeAllRules();
   const { mutateAsync: upgradeSpecificRulesRequest } = usePerformUpgradeSpecificRules();
 
-  const shouldShowLinearProgress = (isFetched && isRefetching) || isUpgradingSecurityPackages;
-  const shouldShowLoadingOverlay = !isFetched && isRefetching;
+  const isFetchingRules = !isFetched && isRefetching;
+  const isFetchingRulesPackage = (isFetched && isRefetching) || isUpgradingSecurityPackages;
 
   // Wrapper to add confirmation modal for users who may be running older ML Jobs that would
   // be overridden by updating their rules. For details, see: https://github.com/elastic/kibana/issues/128121
@@ -222,8 +222,8 @@ export const UpgradePrebuiltRulesTableContextProvider = ({
         isFetched,
         isLoading: isLoading && loadingJobs,
         isRefetching,
-        shouldShowLoadingOverlay,
-        shouldShowLinearProgress,
+        isFetchingRules,
+        isFetchingRulesPackage,
         selectedRules,
         loadingRules,
         lastUpdated: dataUpdatedAt,
@@ -241,8 +241,8 @@ export const UpgradePrebuiltRulesTableContextProvider = ({
     isLoading,
     loadingJobs,
     isRefetching,
-    shouldShowLoadingOverlay,
-    shouldShowLinearProgress,
+    isFetchingRules,
+    isFetchingRulesPackage,
     selectedRules,
     loadingRules,
     dataUpdatedAt,

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/upgrade_prebuilt_rules_table_context.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/upgrade_prebuilt_rules_table_context.tsx
@@ -126,9 +126,6 @@ export const UpgradePrebuiltRulesTableContextProvider = ({
   const { mutateAsync: upgradeAllRulesRequest } = usePerformUpgradeAllRules();
   const { mutateAsync: upgradeSpecificRulesRequest } = usePerformUpgradeSpecificRules();
 
-  const isFetchingRules = !isFetched && isRefetching;
-  const isFetchingRulesPackage = (isFetched && isRefetching) || isUpgradingSecurityPackages;
-
   // Wrapper to add confirmation modal for users who may be running older ML Jobs that would
   // be overridden by updating their rules. For details, see: https://github.com/elastic/kibana/issues/128121
   const [isUpgradeModalVisible, showUpgradeModal, hideUpgradeModal] = useBoolState(false);

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/use_upgrade_prebuilt_rules_table_columns.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/use_upgrade_prebuilt_rules_table_columns.tsx
@@ -86,13 +86,13 @@ const INTEGRATIONS_COLUMN: TableColumn = {
 const createUpgradeButtonColumn = (
   upgradeOneRule: UpgradePrebuiltRulesTableActions['upgradeOneRule'],
   loadingRules: RuleSignatureId[],
-  shouldShowLinearProgress: boolean
+  isFetchingRulesPackage: boolean
 ): TableColumn => ({
   field: 'rule_id',
   name: '',
   render: (ruleId: RuleUpgradeInfoForReview['rule_id']) => {
     const isRuleUpgrading = loadingRules.includes(ruleId);
-    const isUpgradeButtonDisabled = isRuleUpgrading || shouldShowLinearProgress;
+    const isUpgradeButtonDisabled = isRuleUpgrading || isFetchingRulesPackage;
     return (
       <EuiButtonEmpty
         size="s"
@@ -112,7 +112,7 @@ export const useUpgradePrebuiltRulesTableColumns = (): TableColumn[] => {
   const hasCRUDPermissions = hasUserCRUDPermission(canUserCRUD);
   const [showRelatedIntegrations] = useUiSetting$<boolean>(SHOW_RELATED_INTEGRATIONS_SETTING);
   const {
-    state: { loadingRules, shouldShowLinearProgress },
+    state: { loadingRules, isFetchingRulesPackage },
     actions: { upgradeOneRule },
   } = useUpgradePrebuiltRulesTableContext();
 
@@ -143,13 +143,13 @@ export const useUpgradePrebuiltRulesTableColumns = (): TableColumn[] => {
         width: '12%',
       },
       ...(hasCRUDPermissions
-        ? [createUpgradeButtonColumn(upgradeOneRule, loadingRules, shouldShowLinearProgress)]
+        ? [createUpgradeButtonColumn(upgradeOneRule, loadingRules, isFetchingRulesPackage)]
         : []),
     ],
     [
       hasCRUDPermissions,
       loadingRules,
-      shouldShowLinearProgress,
+      isFetchingRulesPackage,
       showRelatedIntegrations,
       upgradeOneRule,
     ]

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/use_upgrade_prebuilt_rules_table_columns.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/use_upgrade_prebuilt_rules_table_columns.tsx
@@ -86,13 +86,13 @@ const INTEGRATIONS_COLUMN: TableColumn = {
 const createUpgradeButtonColumn = (
   upgradeOneRule: UpgradePrebuiltRulesTableActions['upgradeOneRule'],
   loadingRules: RuleSignatureId[],
-  isFetchingRulesPackage: boolean
+  isDisabled: boolean
 ): TableColumn => ({
   field: 'rule_id',
   name: '',
   render: (ruleId: RuleUpgradeInfoForReview['rule_id']) => {
     const isRuleUpgrading = loadingRules.includes(ruleId);
-    const isUpgradeButtonDisabled = isRuleUpgrading || isFetchingRulesPackage;
+    const isUpgradeButtonDisabled = isRuleUpgrading || isDisabled;
     return (
       <EuiButtonEmpty
         size="s"
@@ -112,9 +112,11 @@ export const useUpgradePrebuiltRulesTableColumns = (): TableColumn[] => {
   const hasCRUDPermissions = hasUserCRUDPermission(canUserCRUD);
   const [showRelatedIntegrations] = useUiSetting$<boolean>(SHOW_RELATED_INTEGRATIONS_SETTING);
   const {
-    state: { loadingRules, isFetchingRulesPackage },
+    state: { loadingRules, isRefetching, isUpgradingSecurityPackages },
     actions: { upgradeOneRule },
   } = useUpgradePrebuiltRulesTableContext();
+
+  const isDisabled = isRefetching || isUpgradingSecurityPackages;
 
   return useMemo(
     () => [
@@ -143,15 +145,9 @@ export const useUpgradePrebuiltRulesTableColumns = (): TableColumn[] => {
         width: '12%',
       },
       ...(hasCRUDPermissions
-        ? [createUpgradeButtonColumn(upgradeOneRule, loadingRules, isFetchingRulesPackage)]
+        ? [createUpgradeButtonColumn(upgradeOneRule, loadingRules, isDisabled)]
         : []),
     ],
-    [
-      hasCRUDPermissions,
-      loadingRules,
-      isFetchingRulesPackage,
-      showRelatedIntegrations,
-      upgradeOneRule,
-    ]
+    [hasCRUDPermissions, loadingRules, isDisabled, showRelatedIntegrations, upgradeOneRule]
   );
 };

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/use_upgrade_prebuilt_rules_table_columns.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/use_upgrade_prebuilt_rules_table_columns.tsx
@@ -85,14 +85,20 @@ const INTEGRATIONS_COLUMN: TableColumn = {
 
 const createUpgradeButtonColumn = (
   upgradeOneRule: UpgradePrebuiltRulesTableActions['upgradeOneRule'],
-  loadingRules: RuleSignatureId[]
+  loadingRules: RuleSignatureId[],
+  shouldShowLinearProgress: boolean
 ): TableColumn => ({
   field: 'rule_id',
   name: '',
   render: (ruleId: RuleUpgradeInfoForReview['rule_id']) => {
     const isRuleUpgrading = loadingRules.includes(ruleId);
+    const isUpgradeButtonDisabled = isRuleUpgrading || shouldShowLinearProgress;
     return (
-      <EuiButtonEmpty size="s" disabled={isRuleUpgrading} onClick={() => upgradeOneRule(ruleId)}>
+      <EuiButtonEmpty
+        size="s"
+        disabled={isUpgradeButtonDisabled}
+        onClick={() => upgradeOneRule(ruleId)}
+      >
         {isRuleUpgrading ? <EuiLoadingSpinner size="s" /> : i18n.UPDATE_RULE_BUTTON}
       </EuiButtonEmpty>
     );
@@ -106,7 +112,7 @@ export const useUpgradePrebuiltRulesTableColumns = (): TableColumn[] => {
   const hasCRUDPermissions = hasUserCRUDPermission(canUserCRUD);
   const [showRelatedIntegrations] = useUiSetting$<boolean>(SHOW_RELATED_INTEGRATIONS_SETTING);
   const {
-    state: { loadingRules },
+    state: { loadingRules, shouldShowLinearProgress },
     actions: { upgradeOneRule },
   } = useUpgradePrebuiltRulesTableContext();
 
@@ -136,8 +142,16 @@ export const useUpgradePrebuiltRulesTableColumns = (): TableColumn[] => {
         truncateText: true,
         width: '12%',
       },
-      ...(hasCRUDPermissions ? [createUpgradeButtonColumn(upgradeOneRule, loadingRules)] : []),
+      ...(hasCRUDPermissions
+        ? [createUpgradeButtonColumn(upgradeOneRule, loadingRules, shouldShowLinearProgress)]
+        : []),
     ],
-    [hasCRUDPermissions, loadingRules, showRelatedIntegrations, upgradeOneRule]
+    [
+      hasCRUDPermissions,
+      loadingRules,
+      shouldShowLinearProgress,
+      showRelatedIntegrations,
+      upgradeOneRule,
+    ]
   );
 };

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/get_prebuilt_rules_status/get_prebuilt_rules_status_route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/get_prebuilt_rules_status/get_prebuilt_rules_status_route.ts
@@ -38,7 +38,7 @@ export const getPrebuiltRulesStatusRoute = (router: SecuritySolutionPluginRouter
           ruleAssetsClient,
           ruleObjectsClient,
         });
-        const { currentRules, installableRules, upgradeableRules } =
+        const { currentRules, installableRules, upgradeableRules, totalAvailableRules } =
           getVersionBuckets(ruleVersionsMap);
 
         const body: GetPrebuiltRulesStatusResponseBody = {
@@ -46,6 +46,7 @@ export const getPrebuiltRulesStatusRoute = (router: SecuritySolutionPluginRouter
             num_prebuilt_rules_installed: currentRules.length,
             num_prebuilt_rules_to_install: installableRules.length,
             num_prebuilt_rules_to_upgrade: upgradeableRules.length,
+            num_prebuilt_rules_total_in_package: totalAvailableRules.length,
           },
         };
 

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/model/rule_versions/get_version_buckets.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/model/rule_versions/get_version_buckets.ts
@@ -31,14 +31,25 @@ export interface VersionBuckets {
      */
     target: PrebuiltRuleAsset;
   }>;
+  /**
+   * All available rules
+   * (installed and not installed)
+   */
+  totalAvailableRules: PrebuiltRuleAsset[];
 }
 
 export const getVersionBuckets = (ruleVersionsMap: Map<string, RuleVersions>): VersionBuckets => {
   const currentRules: RuleResponse[] = [];
   const installableRules: PrebuiltRuleAsset[] = [];
+  const totalAvailableRules: PrebuiltRuleAsset[] = [];
   const upgradeableRules: VersionBuckets['upgradeableRules'] = [];
 
   ruleVersionsMap.forEach(({ current, target }) => {
+    if (target != null) {
+      // If this rule is available in the package
+      totalAvailableRules.push(target);
+    }
+
     if (current != null) {
       // If this rule is installed
       currentRules.push(current);
@@ -62,5 +73,6 @@ export const getVersionBuckets = (ruleVersionsMap: Map<string, RuleVersions>): V
     currentRules,
     installableRules,
     upgradeableRules,
+    totalAvailableRules,
   };
 };


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/160396

## Summary

- Invalidates cache after `security_detection_engine` package is installed in the background so rules available for installation and for upgrade are refetched, and their respective tables correctly populated with them.
- Disable Install and Upgrade buttons in both tables while the package is being installed in the background to prevent the user from attempting to install/update outdated version.
- Add a Loading Skeleton in the Add Elastic Rules when the user navigates to that page while the  `security_detection_engine` is being installed for the first time, to prevent the user from seeing a flash of the "No available rules" component, before rules are loaded.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))



<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->