### PR TITLE
[Infra UI] Fix save view infra test

### DIFF
--- a/x-pack/test/functional/apps/infra/home_page.ts
+++ b/x-pack/test/functional/apps/infra/home_page.ts
@@ -21,9 +21,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
   const kibanaServer = getService('kibanaServer');
   const testSubjects = getService('testSubjects');
 
-  // Failing: See https://github.com/elastic/kibana/issues/157713
-  // Fails on both Chrome and Firefox
-  describe.skip('Home page', function () {
+  describe('Home page', function () {
     this.tags('includeFirefox');
     before(async () => {
       await kibanaServer.savedObjects.cleanStandardList();
@@ -245,11 +243,13 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
       });
 
       it('should create a new saved view and load it', async () => {
+        await pageObjects.infraSavedViews.clickSavedViewsButton();
         await pageObjects.infraSavedViews.createView('view1');
         await pageObjects.infraSavedViews.ensureViewIsLoaded('view1');
       });
 
       it('should laod a clicked view from the manage views section', async () => {
+        await pageObjects.infraSavedViews.clickSavedViewsButton();
         await pageObjects.infraSavedViews.ensureViewIsLoaded('view1');
         const views = await pageObjects.infraSavedViews.getManageViewsEntries();
         await views[0].click();
@@ -257,18 +257,23 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
       });
 
       it('should update the current saved view and load it', async () => {
+        await pageObjects.infraSavedViews.clickSavedViewsButton();
         let views = await pageObjects.infraSavedViews.getManageViewsEntries();
         expect(views.length).to.equal(2);
         await pageObjects.infraSavedViews.pressEsc();
 
+        await pageObjects.infraSavedViews.clickSavedViewsButton();
         await pageObjects.infraSavedViews.createView('view2');
         await pageObjects.infraSavedViews.ensureViewIsLoaded('view2');
+        await pageObjects.infraSavedViews.clickSavedViewsButton();
         views = await pageObjects.infraSavedViews.getManageViewsEntries();
         expect(views.length).to.equal(3);
         await pageObjects.infraSavedViews.pressEsc();
 
+        await pageObjects.infraSavedViews.clickSavedViewsButton();
         await pageObjects.infraSavedViews.updateView('view3');
         await pageObjects.infraSavedViews.ensureViewIsLoaded('view3');
+        await pageObjects.infraSavedViews.clickSavedViewsButton();
         views = await pageObjects.infraSavedViews.getManageViewsEntries();
         expect(views.length).to.equal(3);
         await pageObjects.infraSavedViews.pressEsc();


### PR DESCRIPTION
Closes [#157713](https://github.com/elastic/kibana/issues/157713)

## Summary

This PR fixes the failing test related to the saved views on the inventory page. I checked them locally and the clicks to open the drop down were missing so I added them.