### PR TITLE
[Security Solution] Update session viewer Policy permissions to use Policy specific check

### DIFF
--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/session_tab_content/use_session_view.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/session_tab_content/use_session_view.test.tsx
@@ -158,7 +158,7 @@ describe('useSessionView with active timeline and a session id and graph event i
       height: 1000,
       sessionEntityId: 'test',
       loadAlertDetails: mockOpenDetailFn,
-      canAccessEndpointManagement: false,
+      canReadPolicyManagement: false,
     });
   });
 

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/session_tab_content/use_session_view.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/session_tab_content/use_session_view.tsx
@@ -264,7 +264,7 @@ export const useSessionView = ({
   }, [scopeId]);
   const { globalFullScreen } = useGlobalFullScreen();
   const { timelineFullScreen } = useTimelineFullScreen();
-  const { canAccessEndpointManagement } = useUserPrivileges().endpointPrivileges;
+  const { canReadPolicyManagement } = useUserPrivileges().endpointPrivileges;
 
   const defaults = isTimelineScope(scopeId) ? timelineDefaults : tableDefaults;
   const { sessionViewConfig, activeTab } = useDeepEqualSelector((state) => ({
@@ -309,7 +309,7 @@ export const useSessionView = ({
           loadAlertDetails: openEventDetailsPanel,
           isFullScreen: fullScreen,
           height: heightMinusSearchBar,
-          canAccessEndpointManagement,
+          canReadPolicyManagement,
         })
       : null;
   }, [
@@ -318,7 +318,7 @@ export const useSessionView = ({
     sessionView,
     openEventDetailsPanel,
     fullScreen,
-    canAccessEndpointManagement,
+    canReadPolicyManagement,
   ]);
 
   return {

--- a/x-pack/plugins/session_view/public/components/session_view/index.tsx
+++ b/x-pack/plugins/session_view/public/components/session_view/index.tsx
@@ -51,7 +51,7 @@ export const SessionView = ({
   jumpToCursor,
   investigatedAlertId,
   loadAlertDetails,
-  canAccessEndpointManagement,
+  canReadPolicyManagement,
 }: SessionViewDeps) => {
   // don't engage jumpTo if jumping to session leader.
   if (jumpToEntityId === sessionEntityId) {
@@ -435,7 +435,7 @@ export const SessionView = ({
         isFullscreen={isFullScreen}
         onJumpToEvent={onJumpToEvent}
         autoSeekToEntityId={currentJumpToOutputEntityId}
-        canAccessEndpointManagement={canAccessEndpointManagement}
+        canReadPolicyManagement={canReadPolicyManagement}
       />
     </div>
   );

--- a/x-pack/plugins/session_view/public/components/tty_player/index.test.tsx
+++ b/x-pack/plugins/session_view/public/components/tty_player/index.test.tsx
@@ -108,7 +108,7 @@ describe('TTYPlayer component', () => {
 
     it('renders a message warning when max_bytes exceeded with link to policies page', async () => {
       renderResult = mockedContext.render(
-        <TTYPlayer {...props} canAccessEndpointManagement={true} />
+        <TTYPlayer {...props} canReadPolicyManagement={true} />
       );
 
       await waitForApiCall();

--- a/x-pack/plugins/session_view/public/components/tty_player/index.test.tsx
+++ b/x-pack/plugins/session_view/public/components/tty_player/index.test.tsx
@@ -107,9 +107,7 @@ describe('TTYPlayer component', () => {
     });
 
     it('renders a message warning when max_bytes exceeded with link to policies page', async () => {
-      renderResult = mockedContext.render(
-        <TTYPlayer {...props} canReadPolicyManagement={true} />
-      );
+      renderResult = mockedContext.render(<TTYPlayer {...props} canReadPolicyManagement={true} />);
 
       await waitForApiCall();
       await new Promise((r) => setTimeout(r, 10));

--- a/x-pack/plugins/session_view/public/components/tty_player/index.tsx
+++ b/x-pack/plugins/session_view/public/components/tty_player/index.tsx
@@ -71,9 +71,7 @@ export const TTYPlayer = ({
   const { getUrlForApp } = useKibana<CoreStart>().services.application;
   const policiesUrl = useMemo(
     () =>
-    canReadPolicyManagement
-        ? getUrlForApp(SECURITY_APP_ID, { path: POLICIES_PAGE_PATH })
-        : '',
+      canReadPolicyManagement ? getUrlForApp(SECURITY_APP_ID, { path: POLICIES_PAGE_PATH }) : '',
     [canReadPolicyManagement, getUrlForApp]
   );
 

--- a/x-pack/plugins/session_view/public/components/tty_player/index.tsx
+++ b/x-pack/plugins/session_view/public/components/tty_player/index.tsx
@@ -41,7 +41,7 @@ export interface TTYPlayerDeps {
   isFullscreen: boolean;
   onJumpToEvent(event: ProcessEvent): void;
   autoSeekToEntityId?: string;
-  canAccessEndpointManagement?: boolean;
+  canReadPolicyManagement?: boolean;
 }
 
 export const TTYPlayer = ({
@@ -53,7 +53,7 @@ export const TTYPlayer = ({
   isFullscreen,
   onJumpToEvent,
   autoSeekToEntityId,
-  canAccessEndpointManagement,
+  canReadPolicyManagement,
 }: TTYPlayerDeps) => {
   const ref = useRef<HTMLDivElement>(null);
   const { ref: scrollRef, height: containerHeight = 1 } = useResizeObserver<HTMLDivElement>({});
@@ -71,10 +71,10 @@ export const TTYPlayer = ({
   const { getUrlForApp } = useKibana<CoreStart>().services.application;
   const policiesUrl = useMemo(
     () =>
-      canAccessEndpointManagement
+    canReadPolicyManagement
         ? getUrlForApp(SECURITY_APP_ID, { path: POLICIES_PAGE_PATH })
         : '',
-    [canAccessEndpointManagement, getUrlForApp]
+    [canReadPolicyManagement, getUrlForApp]
   );
 
   const { search, currentLine, seekToLine } = useXtermPlayer({

--- a/x-pack/plugins/session_view/public/types.ts
+++ b/x-pack/plugins/session_view/public/types.ts
@@ -34,7 +34,7 @@ export interface SessionViewDeps {
     // Callback used when alert flyout panel is closed
     handleOnAlertDetailsClosed: () => void
   ) => void;
-  canAccessEndpointManagement?: boolean;
+  canReadPolicyManagement?: boolean;
 }
 
 export interface EuiTabProps {


### PR DESCRIPTION
## Summary

This PR updates the session viewer code to use the `canReadPolicyManagement ` permission as opposed to `canAccessEndpointManagement`.  This is because `canAccessEndpointManagement` requires super user permissions while  `canReadPolicyManagement` which is a more specific permission. 


### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->