### PR TITLE
[ResponseOps][Alerting] Some legacy mustache variables are not rendering for Security Solution rules after upgrading to 8.8.x

### DIFF
--- a/x-pack/plugins/alerting/server/task_runner/transform_action_params.test.ts
+++ b/x-pack/plugins/alerting/server/task_runner/transform_action_params.test.ts
@@ -724,4 +724,108 @@ describe('transformSummaryActionParams', () => {
     expect(dateVariable).toBeGreaterThanOrEqual(dateBefore);
     expect(dateVariable).toBeLessThanOrEqual(dateAfter);
   });
+
+  test('renders alertId', () => {
+    const actionParams = {
+      message: 'Value: {{alertId}}',
+    };
+
+    const result = transformSummaryActionParams({ ...params, actionParams });
+    expect(result).toMatchInlineSnapshot(`
+        Object {
+          "message": "Value: 1",
+        }
+    `);
+  });
+
+  test('renders alertName', () => {
+    const actionParams = {
+      message: 'Value: {{alertName}}',
+    };
+
+    const result = transformSummaryActionParams({ ...params, actionParams });
+    expect(result).toMatchInlineSnapshot(`
+        Object {
+          "message": "Value: test-rule",
+        }
+    `);
+  });
+
+  test('renders spaceId', () => {
+    const actionParams = {
+      message: 'Value: {{spaceId}}',
+    };
+
+    const result = transformSummaryActionParams({ ...params, actionParams });
+    expect(result).toMatchInlineSnapshot(`
+      Object {
+        "message": "Value: space-id",
+      }
+    `);
+  });
+
+  test('renders tags', () => {
+    const actionParams = {
+      message: 'Value: {{tags}}',
+    };
+
+    const result = transformSummaryActionParams({ ...params, actionParams });
+    expect(result).toMatchInlineSnapshot(`
+      Object {
+        "message": "Value: test-tag",
+      }
+    `);
+  });
+
+  test('renders params', () => {
+    const actionParams = {
+      message: 'Value: {{params}}',
+    };
+
+    const result = transformSummaryActionParams({ ...params, actionParams });
+    expect(result).toMatchInlineSnapshot(`
+      Object {
+        "message": "Value: {\\"foo\\":\\"bar\\",\\"fooBar\\":true}",
+      }
+    `);
+  });
+
+  test('renders alertInstanceId', () => {
+    const actionParams = {
+      message: 'Value: {{alertInstanceId}}',
+    };
+
+    const result = transformSummaryActionParams({ ...params, actionParams });
+    expect(result).toMatchInlineSnapshot(`
+      Object {
+        "message": "Value: 1",
+      }
+    `);
+  });
+
+  test('renders alertActionGroup', () => {
+    const actionParams = {
+      message: 'Value: {{alertActionGroup}}',
+    };
+
+    const result = transformSummaryActionParams({ ...params, actionParams });
+    expect(result).toMatchInlineSnapshot(`
+      Object {
+        "message": "Value: default",
+      }
+    `);
+  });
+
+  test('renders alertActionGroupName', () => {
+    const actionParams = {
+      message: 'Value: {{alertActionGroupName}}',
+    };
+
+    const result = transformSummaryActionParams({ ...params, actionParams });
+    expect(result).toMatchInlineSnapshot(`
+      Object {
+        "message": "Value: Default",
+      }
+    `);
+  });
 });

--- a/x-pack/plugins/alerting/server/task_runner/transform_action_params.test.ts
+++ b/x-pack/plugins/alerting/server/task_runner/transform_action_params.test.ts
@@ -828,4 +828,18 @@ describe('transformSummaryActionParams', () => {
       }
     `);
   });
+
+  test('renders alert values', () => {
+    const actionParams = {
+      message:
+        'Value "{{alert.id}}", "{{alert.uuid}}", "{{alert.actionGroup}}", "{{alert.actionGroupName}}", and "{{alert.flapping}}" exist',
+    };
+
+    const result = transformSummaryActionParams({ ...params, actionParams });
+    expect(result).toMatchInlineSnapshot(`
+      Object {
+        "message": "Value \\"1\\", \\"1\\", \\"default\\", \\"Default\\", and \\"false\\" exist",
+      }
+    `);
+  });
 });

--- a/x-pack/plugins/alerting/server/task_runner/transform_action_params.ts
+++ b/x-pack/plugins/alerting/server/task_runner/transform_action_params.ts
@@ -150,6 +150,13 @@ export function transformSummaryActionParams({
     alertInstanceId: rule.id,
     alertActionGroup: 'default',
     alertActionGroupName: 'Default',
+    alert: {
+      id: rule.id,
+      uuid: rule.id,
+      actionGroup: 'default',
+      actionGroupName: 'Default',
+      flapping: false,
+    },
     kibanaBaseUrl,
     date: new Date().toISOString(),
     // For backwards compatibility with security solutions rules

--- a/x-pack/plugins/alerting/server/task_runner/transform_action_params.ts
+++ b/x-pack/plugins/alerting/server/task_runner/transform_action_params.ts
@@ -142,6 +142,14 @@ export function transformSummaryActionParams({
   ruleUrl?: string;
 }): RuleActionParams {
   const variables = {
+    alertId: rule.id,
+    alertName: rule.name,
+    spaceId,
+    tags: rule.tags,
+    params: rule.params,
+    alertInstanceId: rule.id,
+    alertActionGroup: 'default',
+    alertActionGroupName: 'Default',
     kibanaBaseUrl,
     date: new Date().toISOString(),
     // For backwards compatibility with security solutions rules


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/160446

## Summary

Adding the following variables to `x-pack/plugins/alerting/server/task_runner/transform_action_params.ts`:

- alertId
- alertName
- spaceId
- tags
- params
- alertInstanceId
- alertActionGroup
- alertActionGroupName
- alert.id
- alert.uuid
- alert.actionGroup
- alert.actionGroupName
- alert.flapping


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

<!--ONMERGE {"backportTargets":["8.8","8.9"]} ONMERGE-->