### PR TITLE
[Serverless Search] Indexing API - Select index

### DIFF
--- a/x-pack/plugins/serverless_search/common/types/index.ts
+++ b/x-pack/plugins/serverless_search/common/types/index.ts
@@ -11,3 +11,12 @@ export interface CreateAPIKeyArgs {
   name: string;
   role_descriptors?: Record<string, any>;
 }
+
+export interface IndexData {
+  name: string;
+  count: number;
+}
+
+export interface FetchIndicesResult {
+  indices: IndexData[];
+}

--- a/x-pack/plugins/serverless_search/common/utils/is_not_nullish.ts
+++ b/x-pack/plugins/serverless_search/common/utils/is_not_nullish.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export function isNotNullish<T>(value: T | null | undefined): value is T {
+  return value !== null && value !== undefined;
+}

--- a/x-pack/plugins/serverless_search/public/application/components/indexing_api.tsx
+++ b/x-pack/plugins/serverless_search/public/application/components/indexing_api.tsx
@@ -101,7 +101,7 @@ const IndicesContent = ({
         <EuiFlexItem grow={false}>
           <EuiStat
             // TODO: format count based on locale
-            title={selectedIndex ? selectedIndex.count : '--'}
+            title={selectedIndex ? selectedIndex.count.toLocaleString() : '--'}
             titleColor="primary"
             description={i18n.translate(
               'xpack.serverlessSearch.content.indexingApi.index.documentCount.description',

--- a/x-pack/plugins/serverless_search/public/application/components/indexing_api.tsx
+++ b/x-pack/plugins/serverless_search/public/application/components/indexing_api.tsx
@@ -81,7 +81,7 @@ const IndicesContent = ({
         <EuiFlexItem>
           <EuiFormRow
             fullWidth
-            title={i18n.translate(
+            label={i18n.translate(
               'xpack.serverlessSearch.content.indexingApi.index.comboBox.title',
               { defaultMessage: 'Index' }
             )}

--- a/x-pack/plugins/serverless_search/public/application/components/indexing_api.tsx
+++ b/x-pack/plugins/serverless_search/public/application/components/indexing_api.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 
 import {
   EuiFlexGroup,
@@ -18,10 +18,12 @@ import {
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 
+import { API_KEY_PLACEHOLDER, ELASTICSEARCH_URL_PLACEHOLDER } from '../constants';
+import { useKibanaServices } from '../hooks/use_kibana';
 import { CodeBox } from './code_box';
 import { javascriptDefinition } from './languages/javascript';
 import { languageDefinitions } from './languages/languages';
-import { LanguageDefinition } from './languages/types';
+import { LanguageDefinition, LanguageDefinitionSnippetArguments } from './languages/types';
 
 import { OverviewPanel } from './overview_panels/overview_panel';
 import { LanguageClientPanel } from './overview_panels/language_client_panel';
@@ -49,8 +51,16 @@ const NoIndicesContent = () => (
 );
 
 export const ElasticsearchIndexingApi = () => {
+  const { cloud } = useKibanaServices();
   const [selectedLanguage, setSelectedLanguage] =
     useState<LanguageDefinition>(javascriptDefinition);
+  const elasticsearchURL = useMemo(() => {
+    return cloud?.elasticsearchUrl ?? ELASTICSEARCH_URL_PLACEHOLDER;
+  }, [cloud]);
+  const codeSnippetArguments: LanguageDefinitionSnippetArguments = {
+    url: elasticsearchURL,
+    apiKey: API_KEY_PLACEHOLDER,
+  };
 
   return (
     <EuiPageTemplate offset={0} grow restrictWidth data-test-subj="svlSearchIndexingApiPage">
@@ -107,7 +117,7 @@ export const ElasticsearchIndexingApi = () => {
               <EuiSpacer />
               <CodeBox
                 code="ingestData"
-                codeArgs={{ url: '', apiKey: '' }}
+                codeArgs={codeSnippetArguments}
                 languages={languageDefinitions}
                 selectedLanguage={selectedLanguage}
                 setSelectedLanguage={setSelectedLanguage}

--- a/x-pack/plugins/serverless_search/public/application/components/indexing_api.tsx
+++ b/x-pack/plugins/serverless_search/public/application/components/indexing_api.tsx
@@ -214,6 +214,19 @@ export const ElasticsearchIndexingApi = () => {
               />
             </>
           }
+          links={
+            showNoIndices
+              ? undefined
+              : [
+                  {
+                    label: i18n.translate(
+                      'xpack.serverlessSearch.content.indexingApi.ingestDocsLink',
+                      { defaultMessage: 'Ingestion documentation' }
+                    ),
+                    href: '#', // TODO: get doc links ?
+                  },
+                ]
+          }
         >
           {showNoIndices ? (
             <NoIndicesContent />

--- a/x-pack/plugins/serverless_search/public/application/components/indexing_api.tsx
+++ b/x-pack/plugins/serverless_search/public/application/components/indexing_api.tsx
@@ -137,6 +137,7 @@ export const ElasticsearchIndexingApi = () => {
   const codeSnippetArguments: LanguageDefinitionSnippetArguments = {
     url: elasticsearchURL,
     apiKey: API_KEY_PLACEHOLDER,
+    indexName: selectedIndex?.name,
   };
   const showNoIndices = !isLoading && data?.indices?.length === 0 && indexSearchQuery === undefined;
 
@@ -205,7 +206,7 @@ export const ElasticsearchIndexingApi = () => {
               </EuiFlexGroup>
               <EuiSpacer />
               <CodeBox
-                code="ingestData"
+                code="ingestDataIndex"
                 codeArgs={codeSnippetArguments}
                 languages={languageDefinitions}
                 selectedLanguage={selectedLanguage}

--- a/x-pack/plugins/serverless_search/public/application/components/languages/console.ts
+++ b/x-pack/plugins/serverless_search/public/application/components/languages/console.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { INDEX_NAME_PLACEHOLDER } from '../../constants';
 import { LanguageDefinition } from './types';
 
 export const consoleDefinition: Partial<LanguageDefinition> = {
@@ -29,4 +30,8 @@ export const consoleDefinition: Partial<LanguageDefinition> = {
 {"name": "Brave New World", "author": "Aldous Huxley", "release_date": "1932-06-01", "page_count": 268}
 { "index" : { "_index" : "books" } }
 {"name": "The Handmaid's Tale", "author": "Margaret Atwood", "release_date": "1985-06-01", "page_count": 311}`,
+  ingestDataIndex: ({ indexName }) => `POST _bulk?pretty
+  { "index" : { "_index" : "${indexName ?? INDEX_NAME_PLACEHOLDER}" } }
+  {"name": "foo", "title": "bar"}
+`,
 };

--- a/x-pack/plugins/serverless_search/public/application/components/languages/curl.ts
+++ b/x-pack/plugins/serverless_search/public/application/components/languages/curl.ts
@@ -43,6 +43,13 @@ export API_KEY="${apiKey}"`,
 { "index" : { "_index" : "books" } }
 {"name": "The Handmaid'"'"'s Tale", "author": "Margaret Atwood", "release_date": "1985-06-01", "page_count": 311}
 '`,
+  ingestDataIndex: ({ apiKey, url, indexName }) => `curl -X POST ${url}/_bulk?pretty \\
+  -H "Authorization: ApiKey ${apiKey}" \\
+  -H "Content-Type: application/json" \\
+  -d'
+{ "index" : { "_index" : "${indexName ?? 'index_name'}" } }
+{"name": "foo", "title": "bar" }
+`,
   installClient: `# if cURL is not already installed on your system
 # then install it with the package manager of your choice
 

--- a/x-pack/plugins/serverless_search/public/application/components/languages/javascript.ts
+++ b/x-pack/plugins/serverless_search/public/application/components/languages/javascript.ts
@@ -59,6 +59,30 @@ bytes: 293,
 aborted: false
 }
 */`,
+  ingestDataIndex: ({
+    apiKey,
+    url,
+    indexName,
+  }) => `const { Client } = require('@elastic/elasticsearch');
+const client = new Client({
+  node: '${url}',
+  auth: {
+      apiKey: '${apiKey}'
+  }
+});
+const dataset = [
+  {'name': 'foo', 'title': 'bar'},
+];
+
+// Index with the bulk helper
+const result = await client.helpers.bulk({
+  datasource: dataset,
+  onDocument (doc) {
+    return { index: { _index: '${indexName ?? 'index_name'}' }};
+  }
+});
+console.log(result);
+`,
   installClient: 'npm install @elastic/elasticsearch@8',
   name: i18n.translate('xpack.serverlessSearch.languages.javascript', {
     defaultMessage: 'JavaScript / Node.js',

--- a/x-pack/plugins/serverless_search/public/application/components/languages/ruby.ts
+++ b/x-pack/plugins/serverless_search/public/application/components/languages/ruby.ts
@@ -7,6 +7,7 @@
 
 import { i18n } from '@kbn/i18n';
 import { docLinks } from '../../../../common/doc_links';
+import { INDEX_NAME_PLACEHOLDER } from '../../constants';
 import { LanguageDefinition, Languages } from './types';
 
 export const rubyDefinition: LanguageDefinition = {
@@ -31,6 +32,18 @@ export const rubyDefinition: LanguageDefinition = {
   { index: { _index: 'books', data: {name: "The Handmaid's Tale", "author": "Margaret Atwood", "release_date": "1985-06-01", "page_count": 311} } }
 ]
 client.bulk(body: documents)`,
+  ingestDataIndex: ({ apiKey, url, indexName }) => `client = ElasticsearchServerless::Client.new(
+  api_key: '${apiKey}',
+  url: '${url}'
+)
+
+documents = [
+  { index: { _index: '${
+    indexName ?? INDEX_NAME_PLACEHOLDER
+  }', data: {name: "foo", "title": "bar"} } },
+]
+client.bulk(body: documents)
+`,
   installClient: `# Requires Ruby version 3.0 or higher
 
 # From the project's root directory:$ gem build elasticsearch-serverless.gemspec

--- a/x-pack/plugins/serverless_search/public/application/components/languages/types.ts
+++ b/x-pack/plugins/serverless_search/public/application/components/languages/types.ts
@@ -21,6 +21,7 @@ export enum Languages {
 export interface LanguageDefinitionSnippetArguments {
   url: string;
   apiKey: string;
+  indexName?: string;
 }
 
 type CodeSnippet = string | ((args: LanguageDefinitionSnippetArguments) => string);
@@ -33,6 +34,7 @@ export interface LanguageDefinition {
   iconType: string;
   id: Languages;
   ingestData: CodeSnippet;
+  ingestDataIndex: CodeSnippet;
   installClient: string;
   languageStyling?: string;
   name: string;

--- a/x-pack/plugins/serverless_search/public/application/components/overview.tsx
+++ b/x-pack/plugins/serverless_search/public/application/components/overview.tsx
@@ -23,6 +23,7 @@ import React, { useMemo, useState } from 'react';
 import { docLinks } from '../../../common/doc_links';
 import { PLUGIN_ID } from '../../../common';
 import { useKibanaServices } from '../hooks/use_kibana';
+import { API_KEY_PLACEHOLDER, ELASTICSEARCH_URL_PLACEHOLDER } from '../constants';
 import { CodeBox } from './code_box';
 import { javascriptDefinition } from './languages/javascript';
 import { languageDefinitions } from './languages/languages';
@@ -34,9 +35,6 @@ import { IngestData } from './overview_panels/ingest_data';
 import { SelectClientPanel } from './overview_panels/select_client';
 import { ApiKeyPanel } from './api_key/api_key';
 import { LanguageClientPanel } from './overview_panels/language_client_panel';
-
-const ELASTICSEARCH_URL_PLACEHOLDER = 'https://your_deployment_url';
-const API_KEY_PLACEHOLDER = 'your_api_key';
 
 export const ElasticsearchOverview = () => {
   const [selectedLanguage, setSelectedLanguage] =

--- a/x-pack/plugins/serverless_search/public/application/constants.ts
+++ b/x-pack/plugins/serverless_search/public/application/constants.ts
@@ -7,3 +7,4 @@
 
 export const API_KEY_PLACEHOLDER = 'your_api_key';
 export const ELASTICSEARCH_URL_PLACEHOLDER = 'https://your_deployment_url';
+export const INDEX_NAME_PLACEHOLDER = 'index_name';

--- a/x-pack/plugins/serverless_search/public/application/constants.ts
+++ b/x-pack/plugins/serverless_search/public/application/constants.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const API_KEY_PLACEHOLDER = 'your_api_key';
+export const ELASTICSEARCH_URL_PLACEHOLDER = 'https://your_deployment_url';

--- a/x-pack/plugins/serverless_search/public/application/routes.ts
+++ b/x-pack/plugins/serverless_search/public/application/routes.ts
@@ -9,3 +9,4 @@ export const MANAGEMENT_API_KEYS = '/app/management/security/api_keys';
 
 // Server Routes
 export const CREATE_API_KEY_PATH = '/internal/security/api_key';
+export const FETCH_INDICES_PATH = '/internal/serverless_search/indices';

--- a/x-pack/plugins/serverless_search/server/lib/indices/fetch_indices.test.ts
+++ b/x-pack/plugins/serverless_search/server/lib/indices/fetch_indices.test.ts
@@ -1,0 +1,122 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ByteSizeValue } from '@kbn/config-schema';
+import { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
+import { fetchIndices } from './fetch_indices';
+
+describe('fetch indices lib functions', () => {
+  const mockClient = {
+    indices: {
+      get: jest.fn(),
+      stats: jest.fn(),
+    },
+    security: {
+      hasPrivileges: jest.fn(),
+    },
+    asInternalUser: {},
+  };
+
+  const regularIndexResponse = {
+    'search-regular-index': {
+      aliases: {},
+    },
+  };
+
+  const regularIndexStatsResponse = {
+    indices: {
+      'search-regular-index': {
+        health: 'green',
+        size: new ByteSizeValue(108000).toString(),
+        status: 'open',
+        total: {
+          docs: {
+            count: 100,
+            deleted: 0,
+          },
+          store: {
+            size_in_bytes: 108000,
+          },
+        },
+        uuid: '83a81e7e-5955-4255-b008-5d6961203f57',
+      },
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('fetchIndices', () => {
+    it('should return regular index', async () => {
+      mockClient.indices.get.mockImplementation(() => ({
+        ...regularIndexResponse,
+      }));
+      mockClient.indices.stats.mockImplementation(() => regularIndexStatsResponse);
+
+      await expect(
+        fetchIndices(mockClient as unknown as ElasticsearchClient, 0, 20, 'search')
+      ).resolves.toEqual([{ count: 100, name: 'search-regular-index' }]);
+      expect(mockClient.indices.get).toHaveBeenCalledWith({
+        expand_wildcards: ['open'],
+        features: ['aliases', 'settings'],
+        index: '*search*',
+      });
+
+      expect(mockClient.indices.stats).toHaveBeenCalledWith({
+        index: ['search-regular-index'],
+        metric: ['docs'],
+      });
+    });
+
+    it('should not return hidden indices', async () => {
+      mockClient.indices.get.mockImplementation(() => ({
+        ...regularIndexResponse,
+        ['search-regular-index']: {
+          ...regularIndexResponse['search-regular-index'],
+          ...{ settings: { index: { hidden: 'true' } } },
+        },
+      }));
+      mockClient.indices.stats.mockImplementation(() => regularIndexStatsResponse);
+
+      await expect(
+        fetchIndices(mockClient as unknown as ElasticsearchClient, 0, 20)
+      ).resolves.toEqual([]);
+      expect(mockClient.indices.get).toHaveBeenCalledWith({
+        expand_wildcards: ['open'],
+        features: ['aliases', 'settings'],
+        index: '*',
+      });
+
+      expect(mockClient.indices.stats).not.toHaveBeenCalled();
+    });
+
+    it('should handle index missing in stats call', async () => {
+      const missingStatsResponse = {
+        indices: {
+          some_other_index: { ...regularIndexStatsResponse.indices['search-regular-index'] },
+        },
+      };
+
+      mockClient.indices.get.mockImplementationOnce(() => regularIndexResponse);
+      mockClient.indices.stats.mockImplementationOnce(() => missingStatsResponse);
+      // simulates when an index has been deleted after get indices call
+      // deleted index won't be present in the indices stats call response
+      await expect(
+        fetchIndices(mockClient as unknown as ElasticsearchClient, 0, 20, 'search')
+      ).resolves.toEqual([{ count: 0, name: 'search-regular-index' }]);
+    });
+
+    it('should return empty array when no index found', async () => {
+      mockClient.indices.get.mockImplementationOnce(() => ({}));
+      await expect(
+        fetchIndices(mockClient as unknown as ElasticsearchClient, 0, 20, 'search')
+      ).resolves.toEqual([]);
+      expect(mockClient.indices.stats).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/x-pack/plugins/serverless_search/server/lib/indices/fetch_indices.ts
+++ b/x-pack/plugins/serverless_search/server/lib/indices/fetch_indices.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { IndicesStatsIndicesStats } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
+import { isNotNullish } from '../../../common/utils/is_not_nullish';
+import { isHidden, isClosed } from '../../utils/index_utils';
+
+export async function fetchIndices(
+  client: ElasticsearchClient,
+  from: number,
+  size: number,
+  searchQuery?: string
+) {
+  const indexPattern = searchQuery ? `*${searchQuery}*` : '*';
+  const indexMatches = await client.indices.get({
+    expand_wildcards: ['open'],
+    // for better performance only compute settings of indices but not mappings
+    features: ['aliases', 'settings'],
+    index: indexPattern,
+  });
+  const indexNames = Object.keys(indexMatches).filter(
+    (indexName) =>
+      indexMatches[indexName] &&
+      !isHidden(indexMatches[indexName]) &&
+      !isClosed(indexMatches[indexName])
+  );
+  const indexNameSlice = indexNames.slice(from, from + size).filter(isNotNullish);
+  if (indexNameSlice.length === 0) {
+    return [];
+  }
+  const indexCounts = await fetchIndexCounts(client, indexNameSlice);
+  return indexNameSlice.map((name) => ({
+    name,
+    count: indexCounts[name]?.total?.docs?.count ?? 0,
+  }));
+}
+
+const fetchIndexCounts = async (
+  client: ElasticsearchClient,
+  indicesNames: string[]
+): Promise<Record<string, IndicesStatsIndicesStats | undefined>> => {
+  if (indicesNames.length === 0) {
+    return {};
+  }
+  const indexCounts: Record<string, IndicesStatsIndicesStats | undefined> = {};
+  // batch calls in batches of 100 to prevent loading too much onto ES
+  for (let i = 0; i < indicesNames.length; i += 100) {
+    const stats = await client.indices.stats({
+      index: indicesNames.slice(i, i + 100),
+      metric: ['docs'],
+    });
+    Object.assign(indexCounts, stats.indices);
+  }
+  return indexCounts;
+};

--- a/x-pack/plugins/serverless_search/server/plugin.ts
+++ b/x-pack/plugins/serverless_search/server/plugin.ts
@@ -8,6 +8,7 @@
 import { IRouter, Logger, PluginInitializerContext, Plugin, CoreSetup } from '@kbn/core/server';
 import { SecurityPluginStart } from '@kbn/security-plugin/server';
 import { registerApiKeyRoutes } from './routes/api_key_routes';
+import { registerIndicesRoutes } from './routes/indices_routes';
 
 import { ServerlessSearchConfig } from './config';
 import { ServerlessSearchPluginSetup, ServerlessSearchPluginStart } from './types';
@@ -41,6 +42,7 @@ export class ServerlessSearchPlugin
       const dependencies = { logger: this.logger, router, security: this.security };
 
       registerApiKeyRoutes(dependencies);
+      registerIndicesRoutes(dependencies);
     });
     return {};
   }

--- a/x-pack/plugins/serverless_search/server/routes/indices_routes.ts
+++ b/x-pack/plugins/serverless_search/server/routes/indices_routes.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { IndicesIndexState } from '@elastic/elasticsearch/lib/api/types';
+import { schema } from '@kbn/config-schema';
+import { IScopedClusterClient } from '@kbn/core/server';
+
+import { isNotNullish } from '../../common/utils/is_not_nullish';
+import { RouteDependencies } from '../plugin';
+
+export const registerIndicesRoutes = ({ router, security }: RouteDependencies) => {
+  router.get(
+    {
+      path: '/internal/serverless_search/indices',
+      validate: {
+        query: schema.object({
+          from: schema.number({ defaultValue: 0, min: 0 }),
+          search_query: schema.maybe(schema.string()),
+          size: schema.number({ defaultValue: 20, min: 0 }),
+        }),
+      },
+    },
+    async (context, request, response) => {
+      const client = (await context.core).elasticsearch.client;
+      const user = security.authc.getCurrentUser(request);
+
+      if (!user) {
+        return response.customError({
+          statusCode: 502,
+          body: 'Could not retrieve current user, security plugin is not ready',
+        });
+      }
+      const { from, size, search_query: searchQuery } = request.query;
+      const indexPattern = searchQuery ? `*${searchQuery}*` : '*';
+      const indexMatches = await client.asCurrentUser.indices.get({
+        expand_wildcards: ['open'],
+        // for better performance only compute aliases and settings of indices but not mappings
+        features: ['aliases', 'settings'],
+        index: indexPattern,
+      });
+      const indexNames = Object.keys(indexMatches).filter(
+        (indexName) =>
+          indexMatches[indexName] &&
+          !isHidden(indexMatches[indexName]) &&
+          !isClosed(indexMatches[indexName])
+      );
+      const indexNameSlice = indexNames.slice(from, from + size).filter(isNotNullish);
+      if (indexNameSlice.length === 0) {
+        return response.ok({
+          body: {
+            indices: [],
+          },
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      const indexCounts = await fetchIndexCounts(client, indexNameSlice);
+
+      const indices = indexNameSlice.map((name) => ({
+        name,
+        count: indexCounts[name] ?? 0,
+      }));
+      return response.ok({
+        body: {
+          indices,
+        },
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+  );
+};
+
+function isHidden(index: IndicesIndexState): boolean {
+  return index.settings?.index?.hidden === true || index.settings?.index?.hidden === 'true';
+}
+function isClosed(index: IndicesIndexState): boolean {
+  return (
+    index.settings?.index?.verified_before_close === true ||
+    index.settings?.index?.verified_before_close === 'true'
+  );
+}
+
+const fetchIndexCounts = async (client: IScopedClusterClient, indicesNames: string[]) => {
+  // TODO: is there way to batch this? Passing multiple index names or a pattern still returns a singular count
+  const countPromises = indicesNames.map(async (indexName) => {
+    const { count } = await client.asCurrentUser.count({ index: indexName });
+    return { [indexName]: count };
+  });
+  const indexCountArray = await Promise.all(countPromises);
+  return indexCountArray.reduce((acc, current) => Object.assign(acc, current), {});
+};

--- a/x-pack/plugins/serverless_search/server/routes/indices_routes.ts
+++ b/x-pack/plugins/serverless_search/server/routes/indices_routes.ts
@@ -5,11 +5,9 @@
  * 2.0.
  */
 
-import { IndicesIndexState } from '@elastic/elasticsearch/lib/api/types';
 import { schema } from '@kbn/config-schema';
-import { IScopedClusterClient } from '@kbn/core/server';
 
-import { isNotNullish } from '../../common/utils/is_not_nullish';
+import { fetchIndices } from '../lib/indices/fetch_indices';
 import { RouteDependencies } from '../plugin';
 
 export const registerIndicesRoutes = ({ router, security }: RouteDependencies) => {
@@ -25,7 +23,7 @@ export const registerIndicesRoutes = ({ router, security }: RouteDependencies) =
       },
     },
     async (context, request, response) => {
-      const client = (await context.core).elasticsearch.client;
+      const client = (await context.core).elasticsearch.client.asCurrentUser;
       const user = security.authc.getCurrentUser(request);
 
       if (!user) {
@@ -34,35 +32,10 @@ export const registerIndicesRoutes = ({ router, security }: RouteDependencies) =
           body: 'Could not retrieve current user, security plugin is not ready',
         });
       }
-      const { from, size, search_query: searchQuery } = request.query;
-      const indexPattern = searchQuery ? `*${searchQuery}*` : '*';
-      const indexMatches = await client.asCurrentUser.indices.get({
-        expand_wildcards: ['open'],
-        // for better performance only compute aliases and settings of indices but not mappings
-        features: ['aliases', 'settings'],
-        index: indexPattern,
-      });
-      const indexNames = Object.keys(indexMatches).filter(
-        (indexName) =>
-          indexMatches[indexName] &&
-          !isHidden(indexMatches[indexName]) &&
-          !isClosed(indexMatches[indexName])
-      );
-      const indexNameSlice = indexNames.slice(from, from + size).filter(isNotNullish);
-      if (indexNameSlice.length === 0) {
-        return response.ok({
-          body: {
-            indices: [],
-          },
-          headers: { 'content-type': 'application/json' },
-        });
-      }
-      const indexCounts = await fetchIndexCounts(client, indexNameSlice);
 
-      const indices = indexNameSlice.map((name) => ({
-        name,
-        count: indexCounts[name] ?? 0,
-      }));
+      const { from, size, search_query: searchQuery } = request.query;
+
+      const indices = await fetchIndices(client, from, size, searchQuery);
       return response.ok({
         body: {
           indices,
@@ -71,24 +44,4 @@ export const registerIndicesRoutes = ({ router, security }: RouteDependencies) =
       });
     }
   );
-};
-
-function isHidden(index: IndicesIndexState): boolean {
-  return index.settings?.index?.hidden === true || index.settings?.index?.hidden === 'true';
-}
-function isClosed(index: IndicesIndexState): boolean {
-  return (
-    index.settings?.index?.verified_before_close === true ||
-    index.settings?.index?.verified_before_close === 'true'
-  );
-}
-
-const fetchIndexCounts = async (client: IScopedClusterClient, indicesNames: string[]) => {
-  // TODO: is there way to batch this? Passing multiple index names or a pattern still returns a singular count
-  const countPromises = indicesNames.map(async (indexName) => {
-    const { count } = await client.asCurrentUser.count({ index: indexName });
-    return { [indexName]: count };
-  });
-  const indexCountArray = await Promise.all(countPromises);
-  return indexCountArray.reduce((acc, current) => Object.assign(acc, current), {});
 };

--- a/x-pack/plugins/serverless_search/server/utils/index_utils.ts
+++ b/x-pack/plugins/serverless_search/server/utils/index_utils.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { IndicesIndexState } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+
+export function isHidden(index: IndicesIndexState): boolean {
+  return index.settings?.index?.hidden === true || index.settings?.index?.hidden === 'true';
+}
+
+export function isClosed(index: IndicesIndexState): boolean {
+  return (
+    index.settings?.index?.verified_before_close === true ||
+    index.settings?.index?.verified_before_close === 'true'
+  );
+}

--- a/x-pack/plugins/serverless_search/tsconfig.json
+++ b/x-pack/plugins/serverless_search/tsconfig.json
@@ -27,5 +27,6 @@
     "@kbn/security-plugin",
     "@kbn/cloud-plugin",
     "@kbn/share-plugin",
+    "@kbn/core-elasticsearch-server",
   ]
 }


### PR DESCRIPTION
## Summary

Adds fetching indices and showing a combox to select and search for indices to the indexing API page.

## Notes:
- Doc links are currently placeholders and will need to be set (at some point?)

### Screenshots
<img width="1840" alt="image" src="https://github.com/elastic/kibana/assets/1972968/1b60f0a3-5098-43a0-a741-3f7ed18e5107">
