### PR TITLE
move .search-acl-filter-* permissions to the right api key creation function

### DIFF
--- a/x-pack/plugins/enterprise_search/server/lib/indices/create_api_key.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/indices/create_api_key.test.ts
@@ -42,25 +42,7 @@ describe('createApiKey lib function', () => {
           cluster: [],
           index: [
             {
-              names: [indexName, `.search-acl-filter-my-index`],
-              privileges: ['all'],
-            },
-          ],
-        },
-      },
-    });
-  });
-
-  it('works with search-* prefixed indices', async () => {
-    await createApiKey(request, security, 'search-test', keyName);
-    expect(security.authc.apiKeys.create).toHaveBeenCalledWith(request, {
-      name: keyName,
-      role_descriptors: {
-        ['search-test-key-role']: {
-          cluster: [],
-          index: [
-            {
-              names: ['search-test', `.search-acl-filter-test`],
+              names: [indexName],
               privileges: ['all'],
             },
           ],

--- a/x-pack/plugins/enterprise_search/server/lib/indices/create_api_key.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/indices/create_api_key.ts
@@ -17,9 +17,6 @@ export const createApiKey = async (
   indexName: string,
   keyName: string
 ) => {
-  // removes the "search-" prefix if present, and applies the new prefix
-  const aclIndexName = indexName.replace(/^(?:search-)?(.*)$/, '.search-acl-filter-$1');
-
   return await security.authc.apiKeys.create(request, {
     name: keyName,
     role_descriptors: {
@@ -27,7 +24,7 @@ export const createApiKey = async (
         cluster: [],
         index: [
           {
-            names: [indexName, aclIndexName],
+            names: [indexName],
             privileges: ['all'],
           },
         ],

--- a/x-pack/plugins/enterprise_search/server/lib/indices/generate_api_key.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/indices/generate_api_key.test.ts
@@ -59,7 +59,7 @@ describe('generateApiKey lib function', () => {
           cluster: ['monitor'],
           index: [
             {
-              names: ['index_name', `${CONNECTORS_INDEX}*`],
+              names: ['index_name', '.search-acl-filter-index_name', `${CONNECTORS_INDEX}*`],
               privileges: ['all'],
             },
           ],
@@ -85,16 +85,16 @@ describe('generateApiKey lib function', () => {
     }));
 
     await expect(
-      generateApiKey(mockClient as unknown as IScopedClusterClient, 'index_name')
+      generateApiKey(mockClient as unknown as IScopedClusterClient, 'search-test')
     ).resolves.toEqual({ encoded: 'encoded', id: 'apiKeyId' });
     expect(mockClient.asCurrentUser.security.createApiKey).toHaveBeenCalledWith({
-      name: 'index_name-connector',
+      name: 'search-test-connector',
       role_descriptors: {
-        ['index-name-connector-role']: {
+        ['search-test-connector-role']: {
           cluster: ['monitor'],
           index: [
             {
-              names: ['index_name', `${CONNECTORS_INDEX}*`],
+              names: ['search-test', '.search-acl-filter-test', `${CONNECTORS_INDEX}*`],
               privileges: ['all'],
             },
           ],
@@ -141,7 +141,7 @@ describe('generateApiKey lib function', () => {
           cluster: ['monitor'],
           index: [
             {
-              names: ['index_name', `${CONNECTORS_INDEX}*`],
+              names: ['index_name', '.search-acl-filter-index_name', `${CONNECTORS_INDEX}*`],
               privileges: ['all'],
             },
           ],

--- a/x-pack/plugins/enterprise_search/server/lib/indices/generate_api_key.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/indices/generate_api_key.ts
@@ -12,6 +12,9 @@ import { ConnectorDocument } from '../../../common/types/connectors';
 import { toAlphanumeric } from '../../../common/utils/to_alphanumeric';
 
 export const generateApiKey = async (client: IScopedClusterClient, indexName: string) => {
+  // removes the "search-" prefix if present, and applies the new prefix
+  const aclIndexName = indexName.replace(/^(?:search-)?(.*)$/, '.search-acl-filter-$1');
+
   const apiKeyResult = await client.asCurrentUser.security.createApiKey({
     name: `${indexName}-connector`,
     role_descriptors: {
@@ -19,7 +22,7 @@ export const generateApiKey = async (client: IScopedClusterClient, indexName: st
         cluster: ['monitor'],
         index: [
           {
-            names: [indexName, `${CONNECTORS_INDEX}*`],
+            names: [indexName, aclIndexName, `${CONNECTORS_INDEX}*`],
             privileges: ['all'],
           },
         ],


### PR DESCRIPTION


## Summary
I'd added this logic in https://github.com/elastic/kibana/pull/159840 and turns out that was the wrong place to influence connector api keys.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->