### PR TITLE
[ML] Outlier detection results: ensure feature influence color persists on column position change

### DIFF
--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/components/outlier_exploration/use_outlier_data.ts
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/components/outlier_exploration/use_outlier_data.ts
@@ -11,60 +11,32 @@ import { EuiDataGridColumn } from '@elastic/eui';
 
 import type { DataView } from '@kbn/data-views-plugin/public';
 import {
-  sortExplorationResultsFields,
   ML__ID_COPY,
   ML__INCREMENTAL_ID,
-  DEFAULT_RESULTS_FIELD,
   FEATURE_INFLUENCE,
   type DataFrameAnalyticsConfig,
 } from '@kbn/ml-data-frame-analytics-utils';
 import {
   getFieldType,
-  getDataGridSchemasFromFieldTypes,
   showDataGridColumnChartErrorMessageToast,
-  useRenderCellValue,
   type UseIndexDataReturnType,
 } from '@kbn/ml-data-grid';
 
 import * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { DataLoader } from '../../../../../datavisualizer/index_based/data_loader';
-import {
-  useColorRange,
-  COLOR_RANGE,
-  COLOR_RANGE_SCALE,
-} from '../../../../../components/color_range_legend';
 import { getToastNotifications } from '../../../../../util/dependency_cache';
 
-import { getIndexData, getIndexFields } from '../../../../common';
+import { getIndexData } from '../../../../common';
 
-import { getFeatureCount, getOutlierScoreFieldName } from './common';
+import { getOutlierScoreFieldName } from './common';
 import { useExplorationDataGrid } from '../exploration_results_table/use_exploration_data_grid';
 
 export const useOutlierData = (
   indexPattern: DataView | undefined,
   jobConfig: DataFrameAnalyticsConfig | undefined,
-  searchQuery: estypes.QueryDslQueryContainer
-): UseIndexDataReturnType => {
-  const needsDestIndexFields =
-    indexPattern !== undefined && indexPattern.title === jobConfig?.source.index[0];
-
-  const columns = useMemo(() => {
-    const newColumns: EuiDataGridColumn[] = [];
-
-    if (jobConfig !== undefined && indexPattern !== undefined) {
-      const resultsField = jobConfig.dest.results_field;
-      const { fieldTypes } = getIndexFields(jobConfig, needsDestIndexFields);
-      newColumns.push(
-        ...getDataGridSchemasFromFieldTypes(fieldTypes, resultsField!).sort((a: any, b: any) =>
-          sortExplorationResultsFields(a.id, b.id, jobConfig)
-        )
-      );
-    }
-
-    return newColumns;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [jobConfig, indexPattern]);
-
+  searchQuery: estypes.QueryDslQueryContainer,
+  columns: EuiDataGridColumn[]
+): Omit<UseIndexDataReturnType, 'renderCellValue'> => {
   const dataGrid = useExplorationDataGrid(
     columns,
     // reduce default selected rows from 20 to 8 for performance reasons.
@@ -137,45 +109,5 @@ export const useOutlierData = (
     JSON.stringify([searchQuery, [...dataGrid.visibleColumns].sort()]),
   ]);
 
-  const colorRange = useColorRange(
-    COLOR_RANGE.BLUE,
-    COLOR_RANGE_SCALE.INFLUENCER,
-    jobConfig !== undefined
-      ? getFeatureCount(jobConfig.dest.results_field!, dataGrid.tableItems)
-      : 1
-  );
-
-  const renderCellValue = useRenderCellValue(
-    indexPattern,
-    dataGrid.pagination,
-    dataGrid.tableItems,
-    jobConfig?.dest.results_field ?? DEFAULT_RESULTS_FIELD,
-    (columnId, cellValue, fullItem, setCellProps) => {
-      const resultsField = jobConfig?.dest.results_field ?? '';
-      let backgroundColor;
-
-      const featureNames = fullItem[`${resultsField}.${FEATURE_INFLUENCE}`];
-
-      // column with feature values get color coded by its corresponding influencer value
-      if (Array.isArray(featureNames)) {
-        const featureForColumn = featureNames.find(
-          (feature) => columnId === feature.feature_name[0]
-        );
-        if (featureForColumn) {
-          backgroundColor = colorRange(featureForColumn.influence[0]);
-        }
-      }
-
-      if (backgroundColor !== undefined) {
-        setCellProps({
-          style: { backgroundColor: String(backgroundColor) },
-        });
-      }
-    }
-  );
-
-  return {
-    ...dataGrid,
-    renderCellValue,
-  };
+  return dataGrid;
 };


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/147768

This PR:
- simplifies the `useOutlierData` hook and replaces the use of the `useRenderCellValue` hook with a regular function so that the recommended use of `setCellProps` can be achieved to ensure all updates are propagated to the cell when there are changes to the table.


Uploading OutlierResultsFix.mp4…


### NOTE:
While testing this I discovered another bug that appears to exist on main, too - the sorting only works sporadically. Probably should be addressed in a separate PR


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

