### PR TITLE
[Discover] Prevent saving global filters with saved searches

### DIFF
--- a/src/plugins/discover/public/__mocks__/services.ts
+++ b/src/plugins/discover/public/__mocks__/services.ts
@@ -43,6 +43,7 @@ export function createDiscoverServicesMock(): DiscoverServices {
   const expressionsPlugin = expressionsPluginMock.createStartContract();
 
   dataPlugin.query.filterManager.getFilters = jest.fn(() => []);
+  dataPlugin.query.filterManager.getGlobalFilters = jest.fn(() => []);
   dataPlugin.query.filterManager.getUpdates$ = jest.fn(() => of({}) as unknown as Observable<void>);
   dataPlugin.query.timefilter.timefilter.createFilter = jest.fn();
   dataPlugin.query.timefilter.timefilter.getAbsoluteTime = jest.fn(() => ({

--- a/src/plugins/discover/public/application/main/services/discover_saved_search_container.test.ts
+++ b/src/plugins/discover/public/application/main/services/discover_saved_search_container.test.ts
@@ -12,7 +12,7 @@ import { discoverServiceMock } from '../../../__mocks__/services';
 import { savedSearchMock, savedSearchMockWithTimeField } from '../../../__mocks__/saved_search';
 import { dataViewMock } from '../../../__mocks__/data_view';
 import { dataViewComplexMock } from '../../../__mocks__/data_view_complex';
-import type { Filter, FilterStateStore } from '@kbn/es-query';
+import { Filter, FilterStateStore } from '@kbn/es-query';
 
 describe('DiscoverSavedSearchContainer', () => {
   const savedSearch = savedSearchMock;

--- a/src/plugins/discover/public/application/main/services/discover_saved_search_container.ts
+++ b/src/plugins/discover/public/application/main/services/discover_saved_search_container.ts
@@ -144,7 +144,10 @@ export function getSavedSearchContainer({
 
   const persist = async (nextSavedSearch: SavedSearch, saveOptions?: SavedObjectSaveOpts) => {
     addLog('[savedSearch] persist', { nextSavedSearch, saveOptions });
-    updateSavedSearch({ savedSearch: nextSavedSearch, services }, true);
+    updateSavedSearch(
+      { savedSearch: nextSavedSearch, services },
+      { useFilterAndQueryServices: true, excludeGlobalFilters: true }
+    );
 
     const id = await services.savedSearch.save(nextSavedSearch, saveOptions || {});
 
@@ -168,7 +171,7 @@ export function getSavedSearchContainer({
         state: nextState || {},
         services,
       },
-      useFilterAndQueryServices
+      { useFilterAndQueryServices }
     );
 
     const hasChanged = !isEqualSavedSearch(savedSearchInitial$.getValue(), nextSavedSearch);

--- a/src/plugins/discover/public/application/main/services/discover_saved_search_container.ts
+++ b/src/plugins/discover/public/application/main/services/discover_saved_search_container.ts
@@ -144,10 +144,7 @@ export function getSavedSearchContainer({
 
   const persist = async (nextSavedSearch: SavedSearch, saveOptions?: SavedObjectSaveOpts) => {
     addLog('[savedSearch] persist', { nextSavedSearch, saveOptions });
-    updateSavedSearch(
-      { savedSearch: nextSavedSearch, services },
-      { useFilterAndQueryServices: true, excludeGlobalFilters: true }
-    );
+    updateSavedSearch({ savedSearch: nextSavedSearch, services }, true);
 
     const id = await services.savedSearch.save(nextSavedSearch, saveOptions || {});
 
@@ -171,7 +168,7 @@ export function getSavedSearchContainer({
         state: nextState || {},
         services,
       },
-      { useFilterAndQueryServices }
+      useFilterAndQueryServices
     );
 
     const hasChanged = !isEqualSavedSearch(savedSearchInitial$.getValue(), nextSavedSearch);

--- a/src/plugins/discover/public/application/main/services/discover_state.test.ts
+++ b/src/plugins/discover/public/application/main/services/discover_state.test.ts
@@ -329,7 +329,7 @@ describe('Test discover state actions', () => {
     const unsubscribe = state.actions.initializeAndSync();
     await new Promise(process.nextTick);
     expect(getCurrentUrl()).toMatchInlineSnapshot(
-      `"/#?_g=(refreshInterval:(pause:!t,value:1000),time:(from:now-15d,to:now))&_a=(columns:!(default_column),index:the-data-view-id,interval:auto,sort:!())"`
+      `"/#?_g=(filters:!(),refreshInterval:(pause:!t,value:1000),time:(from:now-15d,to:now))&_a=(columns:!(default_column),index:the-data-view-id,interval:auto,sort:!())"`
     );
     expect(state.savedSearchState.getHasChanged$().getValue()).toBe(false);
     const { searchSource, ...savedSearch } = state.savedSearchState.getState();
@@ -356,7 +356,7 @@ describe('Test discover state actions', () => {
     const unsubscribe = state.actions.initializeAndSync();
     await new Promise(process.nextTick);
     expect(getCurrentUrl()).toMatchInlineSnapshot(
-      `"/#?_g=(refreshInterval:(pause:!t,value:1000),time:(from:now-15d,to:now))&_a=(columns:!(default_column),index:the-data-view-id,interval:auto,sort:!())"`
+      `"/#?_g=(filters:!(),refreshInterval:(pause:!t,value:1000),time:(from:now-15d,to:now))&_a=(columns:!(default_column),index:the-data-view-id,interval:auto,sort:!())"`
     );
     expect(state.savedSearchState.getHasChanged$().getValue()).toBe(false);
     unsubscribe();
@@ -398,7 +398,7 @@ describe('Test discover state actions', () => {
     await new Promise(process.nextTick);
     expect(newSavedSearch?.id).toBe('the-saved-search-id');
     expect(getCurrentUrl()).toMatchInlineSnapshot(
-      `"/#?_g=(refreshInterval:(pause:!t,value:1000),time:(from:now-15d,to:now))&_a=(columns:!(default_column),index:the-data-view-id,interval:auto,sort:!())"`
+      `"/#?_g=(filters:!(),refreshInterval:(pause:!t,value:1000),time:(from:now-15d,to:now))&_a=(columns:!(default_column),index:the-data-view-id,interval:auto,sort:!())"`
     );
     expect(state.savedSearchState.getHasChanged$().getValue()).toBe(false);
     unsubscribe();
@@ -658,7 +658,7 @@ describe('Test discover state actions', () => {
     const unsubscribe = state.actions.initializeAndSync();
     await new Promise(process.nextTick);
     const initialUrlState =
-      '/#?_g=(refreshInterval:(pause:!t,value:1000),time:(from:now-15d,to:now))&_a=(columns:!(default_column),index:the-data-view-id,interval:auto,sort:!())';
+      '/#?_g=(filters:!(),refreshInterval:(pause:!t,value:1000),time:(from:now-15d,to:now))&_a=(columns:!(default_column),index:the-data-view-id,interval:auto,sort:!())';
     expect(getCurrentUrl()).toBe(initialUrlState);
     expect(state.internalState.getState().dataView?.id).toBe(dataViewMock.id!);
 
@@ -666,7 +666,7 @@ describe('Test discover state actions', () => {
     await state.actions.onChangeDataView(dataViewComplexMock.id!);
     await new Promise(process.nextTick);
     expect(getCurrentUrl()).toMatchInlineSnapshot(
-      `"/#?_g=(refreshInterval:(pause:!t,value:1000),time:(from:now-15d,to:now))&_a=(columns:!(default_column),index:data-view-with-various-field-types-id,interval:auto,sort:!(!(data,desc)))"`
+      `"/#?_g=(filters:!(),refreshInterval:(pause:!t,value:1000),time:(from:now-15d,to:now))&_a=(columns:!(default_column),index:data-view-with-various-field-types-id,interval:auto,sort:!(!(data,desc)))"`
     );
     await waitFor(() => {
       expect(state.dataState.fetch).toHaveBeenCalledTimes(1);

--- a/src/plugins/discover/public/application/main/utils/update_saved_search.test.ts
+++ b/src/plugins/discover/public/application/main/utils/update_saved_search.test.ts
@@ -1,0 +1,122 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { savedSearchMock } from '../../../__mocks__/saved_search';
+import { discoverServiceMock } from '../../../__mocks__/services';
+import { Filter, FilterStateStore, Query } from '@kbn/es-query';
+import { updateSavedSearch } from './update_saved_search';
+
+describe('updateSavedSearch', () => {
+  const query: Query = {
+    query: 'extension:jpg',
+    language: 'kuery',
+  };
+  const appFilter: Filter = {
+    meta: {},
+    query: {
+      match_phrase: {
+        extension: {
+          query: 'jpg',
+          type: 'phrase',
+        },
+      },
+    },
+    $state: {
+      store: FilterStateStore.APP_STATE,
+    },
+  };
+  const globalFilter: Filter = {
+    meta: {},
+    query: {
+      match_phrase: {
+        extension: {
+          query: 'png',
+          type: 'phrase',
+        },
+      },
+    },
+    $state: {
+      store: FilterStateStore.GLOBAL_STATE,
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should set query and filters from appState', async () => {
+    const savedSearch = {
+      ...savedSearchMock,
+      searchSource: savedSearchMock.searchSource.createCopy(),
+    };
+    expect(savedSearch.searchSource.getField('query')).toBeUndefined();
+    expect(savedSearch.searchSource.getField('filter')).toBeUndefined();
+    updateSavedSearch({
+      savedSearch,
+      services: discoverServiceMock,
+      state: {
+        query,
+        filters: [appFilter],
+      },
+    });
+    expect(savedSearch.searchSource.getField('query')).toEqual(query);
+    expect(savedSearch.searchSource.getField('filter')).toEqual([appFilter]);
+  });
+
+  it('should set query and filters from services', async () => {
+    const savedSearch = {
+      ...savedSearchMock,
+      searchSource: savedSearchMock.searchSource.createCopy(),
+    };
+    expect(savedSearch.searchSource.getField('query')).toBeUndefined();
+    expect(savedSearch.searchSource.getField('filter')).toBeUndefined();
+    jest
+      .spyOn(discoverServiceMock.data.query.filterManager, 'getAppFilters')
+      .mockReturnValue([appFilter]);
+    jest.spyOn(discoverServiceMock.data.query.queryString, 'getQuery').mockReturnValue(query);
+    updateSavedSearch(
+      {
+        savedSearch,
+        services: discoverServiceMock,
+      },
+      true
+    );
+    expect(savedSearch.searchSource.getField('query')).toEqual(query);
+    expect(savedSearch.searchSource.getField('filter')).toEqual([appFilter]);
+  });
+
+  it('should exclude global filters from saved search', async () => {
+    let savedSearch = {
+      ...savedSearchMock,
+      searchSource: savedSearchMock.searchSource.createCopy(),
+    };
+    expect(savedSearch.searchSource.getField('filter')).toBeUndefined();
+    updateSavedSearch({
+      savedSearch,
+      services: discoverServiceMock,
+      state: { filters: [appFilter, globalFilter] },
+    });
+    expect(savedSearch.searchSource.getField('filter')).toEqual([appFilter]);
+    savedSearch = {
+      ...savedSearchMock,
+      searchSource: savedSearchMock.searchSource.createCopy(),
+    };
+    expect(savedSearch.searchSource.getField('filter')).toBeUndefined();
+    jest
+      .spyOn(discoverServiceMock.data.query.filterManager, 'getAppFilters')
+      .mockReturnValue([appFilter]);
+    updateSavedSearch(
+      {
+        savedSearch,
+        services: discoverServiceMock,
+      },
+      true
+    );
+    expect(savedSearch.searchSource.getField('filter')).toEqual([appFilter]);
+  });
+});

--- a/src/plugins/discover/public/application/main/utils/update_search_source.ts
+++ b/src/plugins/discover/public/application/main/utils/update_search_source.ts
@@ -35,22 +35,23 @@ export function updateVolatileSearchSource(
     uiSettings.get(SORT_DEFAULT_ORDER_SETTING)
   );
   const useNewFieldsApi = !uiSettings.get(SEARCH_FIELDS_FROM_SOURCE);
-
-  searchSource.setField('trackTotalHits', true).setField('sort', usedSort);
-
-  const filters = [...data.query.filterManager.getGlobalFilters()];
+  const { filterManager, timefilter } = data.query;
+  const filters = [...filterManager.getGlobalFilters()];
 
   if (dataView.type !== DataViewType.ROLLUP) {
     // Set the date range filter fields from timeFilter using the absolute format.
     // Search sessions requires that it be converted from a relative range.
-    const timeFilter = data.query.timefilter.timefilter.createFilter(dataView);
+    const timeFilter = timefilter.timefilter.createFilter(dataView);
 
     if (timeFilter) {
       filters.push(timeFilter);
     }
   }
 
-  searchSource.setField('filter', filters);
+  searchSource
+    .setField('trackTotalHits', true)
+    .setField('sort', usedSort)
+    .setField('filter', filters);
 
   if (useNewFieldsApi) {
     searchSource.removeField('fieldsFromSource');


### PR DESCRIPTION
## Summary

This PR prevents saving global filters with saved searches (instead only including them at request time in `updateVolatileSearchSource`), which causes issues like the one seen in #152658.

This PR also fixes a critical issue #160579 where global filters were not being included in the Discover documents request.

Fixes #152658.
Fixes #160579.

### Checklist

- [ ] ~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)~
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] ~Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))~
- [ ] ~Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))~
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))~
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)