### PR TITLE
[Infrastructure UI] Fix Unified Search container and small UI adjustments

### DIFF
--- a/x-pack/plugins/infra/public/pages/metrics/hosts/components/search_bar/controls_content.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/hosts/components/search_bar/controls_content.tsx
@@ -15,6 +15,7 @@ import { ViewMode } from '@kbn/embeddable-plugin/public';
 import type { Filter, Query, TimeRange } from '@kbn/es-query';
 import { DataView } from '@kbn/data-views-plugin/public';
 import { Subscription } from 'rxjs';
+import { euiStyled } from '@kbn/kibana-react-plugin/common';
 import { useControlPanels } from '../../hooks/use_control_panels_url_state';
 
 interface Props {
@@ -76,12 +77,20 @@ export const ControlsContent: React.FC<Props> = ({
   }, []);
 
   return (
-    <ControlGroupRenderer
-      getCreationOptions={getInitialInput}
-      ref={loadCompleteHandler}
-      timeRange={timeRange}
-      query={query}
-      filters={filters}
-    />
+    <ControlGroupContainer>
+      <ControlGroupRenderer
+        getCreationOptions={getInitialInput}
+        ref={loadCompleteHandler}
+        timeRange={timeRange}
+        query={query}
+        filters={filters}
+      />
+    </ControlGroupContainer>
   );
 };
+
+const ControlGroupContainer = euiStyled.div`
+  .controlGroup {
+    min-height: ${(props) => props.theme.eui.euiSizeXXL}
+  }
+`;

--- a/x-pack/plugins/infra/public/pages/metrics/hosts/components/search_bar/unified_search_bar.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/hosts/components/search_bar/unified_search_bar.tsx
@@ -8,13 +8,7 @@
 import React, { useCallback } from 'react';
 import type { Query, TimeRange, Filter } from '@kbn/es-query';
 import { i18n } from '@kbn/i18n';
-import {
-  EuiFlexGrid,
-  useEuiTheme,
-  EuiHorizontalRule,
-  EuiFlexGroup,
-  EuiFlexItem,
-} from '@elastic/eui';
+import { useEuiTheme, EuiHorizontalRule, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { useKibanaHeader } from '../../../../../hooks/use_kibana_header';
 import { useKibanaContextForPlugin } from '../../../../../hooks/use_kibana';
@@ -53,7 +47,7 @@ export const UnifiedSearchBar = () => {
 
   return (
     <StickyContainer>
-      <EuiFlexGroup direction="column" gutterSize="xs">
+      <EuiFlexGroup direction="column" gutterSize="s">
         <EuiFlexItem>
           <SearchBar
             appName={'Infra Hosts'}
@@ -73,7 +67,7 @@ export const UnifiedSearchBar = () => {
           />
         </EuiFlexItem>
         <EuiFlexItem>
-          <EuiFlexGroup direction="row" alignItems="center" wrap={false} gutterSize="xs">
+          <EuiFlexGroup direction="row" alignItems="center" wrap={false} gutterSize="s">
             <EuiFlexItem>
               <ControlsContent
                 timeRange={searchCriteria.dateRange}
@@ -92,18 +86,22 @@ export const UnifiedSearchBar = () => {
           </EuiFlexGroup>
         </EuiFlexItem>
       </EuiFlexGroup>
-      <EuiHorizontalRule margin="none" />
+      <EuiHorizontalRule
+        margin="xs"
+        css={css`
+          margin-bottom: 0;
+        `}
+      />
     </StickyContainer>
   );
 };
 
-const StickyContainer = (props: { children: React.ReactNode }) => {
+const StickyContainer = ({ children }: { children: React.ReactNode }) => {
   const { euiTheme } = useEuiTheme();
   const { headerHeight } = useKibanaHeader();
 
   return (
-    <EuiFlexGrid
-      gutterSize="none"
+    <div
       css={css`
         position: sticky;
         top: ${headerHeight}px;
@@ -111,8 +109,10 @@ const StickyContainer = (props: { children: React.ReactNode }) => {
         background: ${euiTheme.colors.emptyShade};
         padding: ${euiTheme.size.m} ${euiTheme.size.l} 0px;
         margin: -${euiTheme.size.l} -${euiTheme.size.l} 0px;
+        min-height: calc(${euiTheme.size.xxxl} * 2);
       `}
-      {...props}
-    />
+    >
+      {children}
+    </div>
   );
 };


### PR DESCRIPTION
closes [#160490](https://github.com/elastic/kibana/issues/160490)

## Summary

This PR fixes the Unified Search container to keep its content within its boundaries

<img width="1464" alt="image" src="https://github.com/elastic/kibana/assets/2767137/d7969529-59f3-48b2-960e-fd8ef4b94fcc">


### Bonus

I've made some changes to the ControlGroup styles, to keep the components spacing consistent with the rest of the elements in the search bar:

|  Then  | Now   |
|---|---|
|<img width="1462" alt="image" src="https://github.com/elastic/kibana/assets/2767137/eea95563-44c2-4290-aa3c-ecdd617df5cf"> | <img width="1461" alt="image" src="https://github.com/elastic/kibana/assets/2767137/94a556a9-002a-4e0a-b29b-9517fe8c9d50">|


### How to test

- Start a local Kibana instance
- Navigate to `Infrastructure > Hosts`
- Mark all checkboxes in the table and click on "Add filter"



<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->