### PR TITLE
[Profiling] removing sampling rate from label

### DIFF
--- a/x-pack/plugins/profiling/public/components/topn_functions/index.tsx
+++ b/x-pack/plugins/profiling/public/components/topn_functions/index.tsx
@@ -45,36 +45,24 @@ interface Row {
   };
 }
 
-function getTotalSamplesLabel(samplingRate?: number) {
-  if (samplingRate === undefined) {
-    return i18n.translate('xpack.profiling.functionsView.totalSampleCountLabel', {
-      defaultMessage: 'Total sample estimate:',
-    });
-  }
-  return i18n.translate('xpack.profiling.functionsView.totalSampleCountLabelWithSamplingRate', {
-    defaultMessage: 'Total sample (estimate sample rate: {samplingRate}):',
-    values: { samplingRate },
-  });
-}
-
 function TotalSamplesStat({
   totalSamples,
   newSamples,
-  samplingRateA,
-  samplingRateB,
 }: {
   totalSamples: number;
   newSamples: number | undefined;
-  samplingRateA: number;
-  samplingRateB: number | undefined;
 }) {
   const value = totalSamples.toLocaleString();
+
+  const sampleHeader = i18n.translate('xpack.profiling.functionsView.totalSampleCountLabel', {
+    defaultMessage: ' Total sample estimate: ',
+  });
 
   if (newSamples === undefined || newSamples === 0) {
     return (
       <EuiStat
         title={<EuiText style={{ fontWeight: 'bold' }}>{value}</EuiText>}
-        description={getTotalSamplesLabel(samplingRateA)}
+        description={sampleHeader}
       />
     );
   }
@@ -87,10 +75,10 @@ function TotalSamplesStat({
       title={
         <EuiText style={{ fontWeight: 'bold' }}>
           {value}
-          <GetLabel value={percentDelta} prepend=" (" append=")" />
+          <GetLabel value={percentDelta} prepend="(" append=")" />
         </EuiText>
       }
-      description={getTotalSamplesLabel(samplingRateB)}
+      description={sampleHeader}
     />
   );
 }
@@ -418,8 +406,6 @@ export function TopNFunctionsTable({
       <TotalSamplesStat
         totalSamples={totalCount}
         newSamples={comparisonTopNFunctions?.TotalCount}
-        samplingRateA={topNFunctions?.SamplingRate ?? 1.0}
-        samplingRateB={comparisonTopNFunctions?.SamplingRate ?? 1.0}
       />
       <EuiSpacer size="s" />
       <EuiHorizontalRule margin="none" style={{ height: 2 }} />


### PR DESCRIPTION
<img width="1246" alt="Screenshot 2023-06-26 at 10 10 10 AM" src="https://github.com/elastic/kibana/assets/55978943/554c5849-7b0b-49fe-830e-747b91e65c5d">


<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->