### PR TITLE
[Security Solution] Add packages storybook to CI

### DIFF
--- a/.buildkite/scripts/steps/storybooks/build_and_upload.ts
+++ b/.buildkite/scripts/steps/storybooks/build_and_upload.ts
@@ -43,6 +43,7 @@ const STORYBOOKS = [
   'observability',
   'presentation',
   'security_solution',
+  'security_solution_packages',
   'serverless',
   'shared_ux',
   'triggers_actions_ui',


### PR DESCRIPTION
## Summary

Adds the `security_solution_package` alias to the CI storybook list.
It was already added to the Storybook aliases:

https://github.com/elastic/kibana/blob/423ea73504f38e74e9d5510f92fcf83c936a1328/src/dev/storybook/aliases.ts#L50