### PR TITLE
[Security Solution] Tests: Filter by rule execution status

### DIFF
--- a/x-pack/plugins/security_solution/cypress/e2e/detection_rules/rule_fiters.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_rules/rule_fiters.cy.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { cleanKibana, resetRulesTableState, deleteAlertsAndRules } from '../../tasks/common';
+import { login, visitWithoutDateRange } from '../../tasks/login';
+import { esArchiverResetKibana } from '../../tasks/es_archiver';
+import { findRuleRowInTable } from '../../tasks/rule_snoozing';
+
+import { SECURITY_DETECTIONS_RULES_URL } from '../../urls/navigation';
+
+import { RULES_MANAGEMENT_TABLE } from '../../screens/alerts_detection_rules';
+
+import { waitForRulesTableToBeLoaded } from '../../tasks/alerts_detection_rules';
+
+import { createRule } from '../../tasks/api_calls/rules';
+import {
+  deleteIndex,
+  createIndex,
+  indexDocument,
+  waitForRulesToFinishExecution,
+} from '../../tasks/api_calls/elasticsearch';
+
+import { getNewRule } from '../../objects/rule';
+
+export const expectRulesWithExecutionStatus = (status: string, expectedCount: number) => {
+  cy.get(`[data-test-subj="ruleExecutionStatus"]:contains("${status}")`).should(
+    'have.length',
+    expectedCount
+  );
+};
+
+export const filterByExecutionStatus = (status: string) => {
+  cy.get('[data-test-subj="executionStatusFilterButton"]').click();
+  cy.get(`[data-test-subj="executionStatusFilterOption"]:contains("${status}")`).click();
+  cy.get('[data-test-subj="ruleName"]').should('have.length', 1);
+  expectRulesWithExecutionStatus(status, 1);
+};
+
+describe('Rule management filters', () => {
+  before(() => {
+    cleanKibana();
+  });
+
+  beforeEach(() => {
+    login();
+    // Make sure persisted rules table state is cleared
+    resetRulesTableState();
+    deleteAlertsAndRules();
+    esArchiverResetKibana();
+
+    deleteIndex('test_index');
+
+    createIndex('test_index', {
+      '@timestamp': {
+        type: 'date',
+      },
+    });
+
+    indexDocument('test_index');
+
+    createRule(
+      getNewRule({ name: 'Successful rule', rule_id: 'successful_rule', index: ['test_index'] })
+    );
+
+    createRule(
+      getNewRule({
+        name: 'Warning rule',
+        rule_id: 'warning_rule',
+        index: ['non_existent_index'],
+      })
+    );
+
+    createRule(
+      getNewRule({
+        name: 'Failed rule',
+        rule_id: 'failed_rule',
+        index: ['test_index'],
+        // Setting a crazy large "Additional look-back time" to force a failure
+        from: 'now-9007199254746990s',
+      })
+    );
+
+    waitForRulesToFinishExecution(['successful_rule', 'warning_rule', 'failed_rule']);
+
+    visitWithoutDateRange(SECURITY_DETECTIONS_RULES_URL);
+
+    waitForRulesTableToBeLoaded();
+  });
+
+  describe('Last response filter', () => {
+    it('Filters rules by last response', () => {
+      findRuleRowInTable(RULES_MANAGEMENT_TABLE, 'Successful rule').should('exist');
+
+      cy.get('[data-test-subj="ruleExecutionStatus"]').should('have.length', 3);
+
+      expectRulesWithExecutionStatus('Succeeded', 1);
+      expectRulesWithExecutionStatus('Warning', 1);
+      expectRulesWithExecutionStatus('Failed', 1);
+
+      filterByExecutionStatus('Succeeded');
+      filterByExecutionStatus('Warning');
+      filterByExecutionStatus('Failed');
+    });
+  });
+});

--- a/x-pack/plugins/security_solution/cypress/e2e/detection_rules/rule_fiters.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_rules/rule_fiters.cy.ts
@@ -20,13 +20,8 @@ import {
 
 import { waitForRulesTableToBeLoaded } from '../../tasks/alerts_detection_rules';
 
-import { createRule } from '../../tasks/api_calls/rules';
-import {
-  deleteIndex,
-  createIndex,
-  indexDocument,
-  waitForRulesToFinishExecution,
-} from '../../tasks/api_calls/elasticsearch';
+import { createRule, waitForRulesToFinishExecution } from '../../tasks/api_calls/rules';
+import { deleteIndex, createIndex, indexDocument } from '../../tasks/api_calls/elasticsearch';
 
 import { getNewRule } from '../../objects/rule';
 

--- a/x-pack/plugins/security_solution/cypress/e2e/detection_rules/rule_fiters.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_rules/rule_fiters.cy.ts
@@ -13,7 +13,10 @@ import { expectRulesWithExecutionStatus, filterByExecutionStatus } from '../../t
 
 import { SECURITY_DETECTIONS_RULES_URL } from '../../urls/navigation';
 
-import { RULES_MANAGEMENT_TABLE } from '../../screens/alerts_detection_rules';
+import {
+  RULES_MANAGEMENT_TABLE,
+  RULE_EXECUTION_STATUS,
+} from '../../screens/alerts_detection_rules';
 
 import { waitForRulesTableToBeLoaded } from '../../tasks/alerts_detection_rules';
 
@@ -47,10 +50,14 @@ describe('Rule management filters', () => {
       },
     });
 
-    indexDocument('test_index');
+    indexDocument('test_index', {});
 
     createRule(
-      getNewRule({ name: 'Successful rule', rule_id: 'successful_rule', index: ['test_index'] })
+      getNewRule({
+        name: 'Successful rule',
+        rule_id: 'successful_rule',
+        index: ['test_index'],
+      })
     );
 
     createRule(
@@ -82,11 +89,11 @@ describe('Rule management filters', () => {
     it('Filters rules by last response', () => {
       findRuleRowInTable(RULES_MANAGEMENT_TABLE, 'Successful rule').should('exist');
 
-      cy.get('[data-test-subj="ruleExecutionStatus"]').should('have.length', 3);
+      cy.get(RULE_EXECUTION_STATUS).should('have.length', 3);
 
-      expectRulesWithExecutionStatus('Succeeded', 1);
-      expectRulesWithExecutionStatus('Warning', 1);
-      expectRulesWithExecutionStatus('Failed', 1);
+      expectRulesWithExecutionStatus(1, 'Succeeded');
+      expectRulesWithExecutionStatus(1, 'Warning');
+      expectRulesWithExecutionStatus(1, 'Failed');
 
       filterByExecutionStatus('Succeeded');
       filterByExecutionStatus('Warning');

--- a/x-pack/plugins/security_solution/cypress/e2e/detection_rules/rule_fiters.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_rules/rule_fiters.cy.ts
@@ -9,6 +9,7 @@ import { cleanKibana, resetRulesTableState, deleteAlertsAndRules } from '../../t
 import { login, visitWithoutDateRange } from '../../tasks/login';
 import { esArchiverResetKibana } from '../../tasks/es_archiver';
 import { findRuleRowInTable } from '../../tasks/rule_snoozing';
+import { expectRulesWithExecutionStatus, filterByExecutionStatus } from '../../tasks/rule_filters';
 
 import { SECURITY_DETECTIONS_RULES_URL } from '../../urls/navigation';
 
@@ -25,20 +26,6 @@ import {
 } from '../../tasks/api_calls/elasticsearch';
 
 import { getNewRule } from '../../objects/rule';
-
-export const expectRulesWithExecutionStatus = (status: string, expectedCount: number) => {
-  cy.get(`[data-test-subj="ruleExecutionStatus"]:contains("${status}")`).should(
-    'have.length',
-    expectedCount
-  );
-};
-
-export const filterByExecutionStatus = (status: string) => {
-  cy.get('[data-test-subj="executionStatusFilterButton"]').click();
-  cy.get(`[data-test-subj="executionStatusFilterOption"]:contains("${status}")`).click();
-  cy.get('[data-test-subj="ruleName"]').should('have.length', 1);
-  expectRulesWithExecutionStatus(status, 1);
-};
 
 describe('Rule management filters', () => {
   before(() => {

--- a/x-pack/plugins/security_solution/cypress/screens/alerts_detection_rules.ts
+++ b/x-pack/plugins/security_solution/cypress/screens/alerts_detection_rules.ts
@@ -177,7 +177,7 @@ export const REFRESH_SETTINGS_SELECTION_NOTE = '[data-test-subj="refreshSettings
 
 export const REFRESH_RULES_STATUS = '[data-test-subj="refreshRulesStatus"]';
 
-export const RULE_EXECUTION_STATUS = '[data-test-subj="ruleExecutionStatus"]';
+export const RULE_EXECUTION_STATUS_BADGE = '[data-test-subj="ruleExecutionStatus"]';
 
 export const EXECUTION_STATUS_FILTER_BUTTON = '[data-test-subj="executionStatusFilterButton"]';
 

--- a/x-pack/plugins/security_solution/cypress/screens/alerts_detection_rules.ts
+++ b/x-pack/plugins/security_solution/cypress/screens/alerts_detection_rules.ts
@@ -176,3 +176,9 @@ export const REFRESH_SETTINGS_SWITCH = '[data-test-subj="refreshSettingsSwitch"]
 export const REFRESH_SETTINGS_SELECTION_NOTE = '[data-test-subj="refreshSettingsSelectionNote"]';
 
 export const REFRESH_RULES_STATUS = '[data-test-subj="refreshRulesStatus"]';
+
+export const RULE_EXECUTION_STATUS = '[data-test-subj="ruleExecutionStatus"]';
+
+export const EXECUTION_STATUS_FILTER_BUTTON = '[data-test-subj="executionStatusFilterButton"]';
+
+export const EXECUTION_STATUS_FILTER_OPTION = '[data-test-subj="executionStatusFilterOption"]';

--- a/x-pack/plugins/security_solution/cypress/tasks/api_calls/elasticsearch.ts
+++ b/x-pack/plugins/security_solution/cypress/tasks/api_calls/elasticsearch.ts
@@ -16,10 +16,9 @@ export const deleteIndex = (index: string) => {
 };
 
 export const createIndex = (indexName: string, properties: Record<string, unknown>) =>
-  cy.request({
+  rootRequest({
     method: 'PUT',
     url: `${Cypress.env('ELASTICSEARCH_URL')}/${indexName}`,
-    headers: { 'kbn-xsrf': 'cypress-creds' },
     body: {
       mappings: {
         properties,
@@ -27,11 +26,10 @@ export const createIndex = (indexName: string, properties: Record<string, unknow
     },
   });
 
-export const indexDocument = (indexName: string, document: Record<string, unknown>) =>
-  cy.request({
+export const createDocument = (indexName: string, document: Record<string, unknown>) =>
+  rootRequest({
     method: 'POST',
     url: `${Cypress.env('ELASTICSEARCH_URL')}/${indexName}/_doc`,
-    headers: { 'kbn-xsrf': 'cypress-creds' },
     body: document,
   });
 

--- a/x-pack/plugins/security_solution/cypress/tasks/api_calls/elasticsearch.ts
+++ b/x-pack/plugins/security_solution/cypress/tasks/api_calls/elasticsearch.ts
@@ -4,7 +4,6 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import type { RuleLastRun } from '@kbn/alerting-plugin/common';
 import { rootRequest } from '../common';
 
 export const deleteIndex = (index: string) => {
@@ -35,41 +34,6 @@ export const indexDocument = (indexName: string, document: Record<string, unknow
     headers: { 'kbn-xsrf': 'cypress-creds' },
     body: document,
   });
-
-export const waitForRulesToFinishExecution = (ruleIds: string[]) => {
-  return cy.waitUntil(
-    () =>
-      rootRequest<{
-        hits: {
-          hits: Array<{
-            _source: { alert: { params: { ruleId: string }; lastRun?: RuleLastRun } };
-          }>;
-        };
-      }>({
-        method: 'GET',
-        url: `${Cypress.env('ELASTICSEARCH_URL')}/.kibana_alerting_cases/_search`,
-        headers: { 'kbn-xsrf': 'cypress-creds' },
-        failOnStatusCode: false,
-        body: {
-          query: {
-            terms: {
-              'alert.params.ruleId': ruleIds,
-            },
-          },
-        },
-      }).then((response) => {
-        const areAllRulesFinished = ruleIds.every((ruleId) =>
-          response.body.hits.hits.some(
-            (ruleHit) =>
-              ruleHit._source.alert.params.ruleId === ruleId &&
-              typeof ruleHit._source.alert.lastRun !== 'undefined'
-          )
-        );
-        return areAllRulesFinished;
-      }),
-    { interval: 500, timeout: 12000 }
-  );
-};
 
 export const waitForNewDocumentToBeIndexed = (index: string, initialNumberOfDocuments: number) => {
   cy.waitUntil(

--- a/x-pack/plugins/security_solution/cypress/tasks/api_calls/rules.ts
+++ b/x-pack/plugins/security_solution/cypress/tasks/api_calls/rules.ts
@@ -7,9 +7,13 @@
 
 import moment from 'moment';
 import { rootRequest } from '../common';
-import { DETECTION_ENGINE_RULES_URL } from '../../../common/constants';
+import {
+  DETECTION_ENGINE_RULES_URL,
+  DETECTION_ENGINE_RULES_URL_FIND,
+} from '../../../common/constants';
 import type { RuleCreateProps, RuleResponse } from '../../../common/detection_engine/rule_schema';
 import { internalAlertingSnoozeRule } from '../../urls/routes';
+import type { FetchRulesResponse } from '../../../public/detection_engine/rule_management/logic/types';
 
 export const createRule = (
   rule: RuleCreateProps
@@ -72,3 +76,20 @@ export const importRule = (ndjsonPath: string) => {
         .should('be.equal', 200);
     });
 };
+
+export const waitForRulesToFinishExecution = (ruleIds: string[]) =>
+  cy.waitUntil(
+    () =>
+      rootRequest<FetchRulesResponse>({
+        method: 'GET',
+        url: DETECTION_ENGINE_RULES_URL_FIND,
+      }).then((response) => {
+        const areAllRulesFinished = ruleIds.every((ruleId) =>
+          response.body.data.some(
+            (rule) => rule.rule_id === ruleId && typeof rule.execution_summary !== 'undefined'
+          )
+        );
+        return areAllRulesFinished;
+      }),
+    { interval: 500, timeout: 12000 }
+  );

--- a/x-pack/plugins/security_solution/cypress/tasks/rule_filters.ts
+++ b/x-pack/plugins/security_solution/cypress/tasks/rule_filters.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const expectRulesWithExecutionStatus = (status: string, expectedCount: number) => {
+  cy.get(`[data-test-subj="ruleExecutionStatus"]:contains("${status}")`).should(
+    'have.length',
+    expectedCount
+  );
+};
+
+export const filterByExecutionStatus = (status: string) => {
+  cy.get('[data-test-subj="executionStatusFilterButton"]').click();
+  cy.get(`[data-test-subj="executionStatusFilterOption"]:contains("${status}")`).click();
+  cy.get('[data-test-subj="ruleName"]').should('have.length', 1);
+  expectRulesWithExecutionStatus(status, 1);
+};

--- a/x-pack/plugins/security_solution/cypress/tasks/rule_filters.ts
+++ b/x-pack/plugins/security_solution/cypress/tasks/rule_filters.ts
@@ -6,19 +6,22 @@
  */
 
 import {
-  RULE_EXECUTION_STATUS,
-  RULE_NAME,
+  RULE_EXECUTION_STATUS_BADGE,
   EXECUTION_STATUS_FILTER_BUTTON,
   EXECUTION_STATUS_FILTER_OPTION,
 } from '../screens/alerts_detection_rules';
 
 export const expectRulesWithExecutionStatus = (expectedCount: number, status: string) => {
-  cy.get(`${RULE_EXECUTION_STATUS}:contains("${status}")`).should('have.length', expectedCount);
+  cy.get(`${RULE_EXECUTION_STATUS_BADGE}:contains("${status}")`).should(
+    'have.length',
+    expectedCount
+  );
 };
+
+export const expectNumberOfRulesShownOnPage = (expectedCount: number) =>
+  cy.get(RULE_EXECUTION_STATUS_BADGE).should('have.length', expectedCount);
 
 export const filterByExecutionStatus = (status: string) => {
   cy.get(EXECUTION_STATUS_FILTER_BUTTON).click();
   cy.get(`${EXECUTION_STATUS_FILTER_OPTION}:contains("${status}")`).click();
-  cy.get(RULE_NAME).should('have.length', 1);
-  expectRulesWithExecutionStatus(1, status);
 };

--- a/x-pack/plugins/security_solution/cypress/tasks/rule_filters.ts
+++ b/x-pack/plugins/security_solution/cypress/tasks/rule_filters.ts
@@ -5,16 +5,20 @@
  * 2.0.
  */
 
-export const expectRulesWithExecutionStatus = (status: string, expectedCount: number) => {
-  cy.get(`[data-test-subj="ruleExecutionStatus"]:contains("${status}")`).should(
-    'have.length',
-    expectedCount
-  );
+import {
+  RULE_EXECUTION_STATUS,
+  RULE_NAME,
+  EXECUTION_STATUS_FILTER_BUTTON,
+  EXECUTION_STATUS_FILTER_OPTION,
+} from '../screens/alerts_detection_rules';
+
+export const expectRulesWithExecutionStatus = (expectedCount: number, status: string) => {
+  cy.get(`${RULE_EXECUTION_STATUS}:contains("${status}")`).should('have.length', expectedCount);
 };
 
 export const filterByExecutionStatus = (status: string) => {
-  cy.get('[data-test-subj="executionStatusFilterButton"]').click();
-  cy.get(`[data-test-subj="executionStatusFilterOption"]:contains("${status}")`).click();
-  cy.get('[data-test-subj="ruleName"]').should('have.length', 1);
-  expectRulesWithExecutionStatus(status, 1);
+  cy.get(EXECUTION_STATUS_FILTER_BUTTON).click();
+  cy.get(`${EXECUTION_STATUS_FILTER_OPTION}:contains("${status}")`).click();
+  cy.get(RULE_NAME).should('have.length', 1);
+  expectRulesWithExecutionStatus(1, status);
 };

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table_filters/rule_execution_status_selector.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table_filters/rule_execution_status_selector.tsx
@@ -77,6 +77,7 @@ const RuleExecutionStatusSelectorComponent = ({
       isSelected={isExecutionStatusPopoverOpen}
       hasActiveFilters={selectedStatus !== undefined}
       numActiveFilters={selectedStatus !== undefined ? 1 : 0}
+      data-test-subj="executionStatusFilterButton"
     >
       {i18n.COLUMN_LAST_RESPONSE}
     </EuiFilterButton>
@@ -108,11 +109,13 @@ const RuleExecutionStatusSelectorComponent = ({
               css={`
                 margin-top: 4px; // aligns the badge within the option
               `}
+              data-test-subj="executionStatusFilterOption"
             >
               <RuleStatusBadge status={status} showTooltip={false} />
             </div>
           );
         }}
+        data-test-subj="executionStatusFilterSelectableList"
       >
         {(list) => (
           <div

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/use_columns.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/use_columns.tsx
@@ -166,7 +166,7 @@ const useRuleExecutionStatusColumn = ({
       render: (value: RuleExecutionSummary['last_execution']['status'] | undefined, item: Rule) => {
         return (
           <EuiFlexGroup justifyContent="spaceBetween">
-            <EuiFlexItem grow={false} data-test-subj="tableRow-ruleExecutionStatus">
+            <EuiFlexItem grow={false}>
               <RuleStatusBadge
                 status={value}
                 message={item.execution_summary?.last_execution.message}

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/use_columns.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/use_columns.tsx
@@ -166,7 +166,7 @@ const useRuleExecutionStatusColumn = ({
       render: (value: RuleExecutionSummary['last_execution']['status'] | undefined, item: Rule) => {
         return (
           <EuiFlexGroup justifyContent="spaceBetween">
-            <EuiFlexItem grow={false}>
+            <EuiFlexItem grow={false} data-test-subj="tableRow-ruleExecutionStatus">
               <RuleStatusBadge
                 status={value}
                 message={item.execution_summary?.last_execution.message}


### PR DESCRIPTION
**Resolves: https://github.com/elastic/kibana/issues/138903**

## Summary

Adds an E2E Cypress test to check filtering by execution status in the rules table.
<img width="953" alt="Screenshot 2023-06-26 at 14 10 10" src="https://github.com/elastic/kibana/assets/15949146/e1eb67ed-779c-42ad-8194-04a26598cfbc">



<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->