### PR TITLE
[Lens] Create a filter with field:value when last value metric is used on a datatable

### DIFF
--- a/src/plugins/data/common/search/aggs/metrics/filtered_metric.test.ts
+++ b/src/plugins/data/common/search/aggs/metrics/filtered_metric.test.ts
@@ -7,25 +7,36 @@
  */
 
 import { AggConfigs, IAggConfigs } from '../agg_configs';
-import { mockAggTypesRegistry } from '../test_helpers';
+import { AggTypesDependencies } from '../agg_types';
+import { mockAggTypesDependencies, mockAggTypesRegistry } from '../test_helpers';
+import { getFilteredMetricAgg } from './filtered_metric';
+import { IMetricAggConfig } from './metric_agg_type';
 import { METRIC_TYPES } from './metric_agg_types';
 
 describe('filtered metric agg type', () => {
   let aggConfigs: IAggConfigs;
+  let aggTypesDependencies: AggTypesDependencies;
+  const typesRegistry = mockAggTypesRegistry();
+  const field = {
+    name: 'bytes',
+    filterable: true,
+  };
+  const indexPattern = {
+    id: '1234',
+    title: 'logstash-*',
+    fields: {
+      getByName: () => field,
+      filter: () => [field],
+      find: () => field,
+    },
+  } as any;
 
   beforeEach(() => {
-    const typesRegistry = mockAggTypesRegistry();
-    const field = {
-      name: 'bytes',
+    jest.resetAllMocks();
+    aggTypesDependencies = {
+      ...mockAggTypesDependencies,
+      getConfig: jest.fn(),
     };
-    const indexPattern = {
-      id: '1234',
-      title: 'logstash-*',
-      fields: {
-        getByName: () => field,
-        filter: () => [field],
-      },
-    } as any;
 
     aggConfigs = new AggConfigs(
       indexPattern,
@@ -75,5 +86,63 @@ describe('filtered metric agg type', () => {
     const agg = aggConfigs.getResponseAggs()[0];
 
     expect(agg.getResponseId()).toEqual('filtered_metric-bucket');
+  });
+  it('returns phrase filter for filtered metric on top metrics', () => {
+    const topMetricsAggConfigs = new AggConfigs(
+      indexPattern,
+      [
+        {
+          id: METRIC_TYPES.FILTERED_METRIC,
+          type: METRIC_TYPES.FILTERED_METRIC,
+          schema: 'metric',
+          params: {
+            customBucket: {
+              type: 'filter',
+              params: {
+                filter: { language: 'kuery', query: 'a: b' },
+              },
+            },
+            customMetric: {
+              type: 'top_metrics',
+              params: {
+                field: 'bytes',
+              },
+            },
+          },
+        },
+      ],
+      {
+        typesRegistry,
+      },
+      jest.fn()
+    );
+
+    expect(
+      getFilteredMetricAgg(aggTypesDependencies).createFilter!(
+        topMetricsAggConfigs.aggs[0] as IMetricAggConfig,
+        10
+      )
+    ).toEqual({
+      meta: { index: '1234' },
+      query: { match_phrase: { bytes: 10 } },
+    });
+  });
+  it('returns filter from the custom bucket filter parameter for metric', () => {
+    expect(
+      getFilteredMetricAgg(aggTypesDependencies).createFilter!(
+        aggConfigs.aggs[0] as IMetricAggConfig,
+        '10'
+      )
+    ).toEqual({
+      query: {
+        bool: {
+          must: [],
+          filter: [{ bool: { should: [{ match: { bytes: 'b' } }], minimum_should_match: 1 } }],
+          should: [],
+          must_not: [],
+        },
+      },
+      meta: { index: '1234', alias: 'a: b' },
+    });
   });
 });

--- a/src/plugins/data/common/search/aggs/metrics/filtered_metric.ts
+++ b/src/plugins/data/common/search/aggs/metrics/filtered_metric.ts
@@ -52,7 +52,6 @@ export const getFilteredMetricAgg = ({ getConfig }: FiltersMetricAggDependencies
     getSerializedFormat,
     createFilter: (agg, inputState) => {
       const indexPattern = agg.getIndexPattern();
-      if (!indexPattern) return;
       if (
         agg.params.customMetric.type.name === 'top_hits' ||
         agg.params.customMetric.type.name === 'top_metrics'

--- a/src/plugins/data/common/search/aggs/metrics/filtered_metric.ts
+++ b/src/plugins/data/common/search/aggs/metrics/filtered_metric.ts
@@ -51,16 +51,19 @@ export const getFilteredMetricAgg = ({ getConfig }: FiltersMetricAggDependencies
     hasNoDslParams: true,
     getSerializedFormat,
     createFilter: (agg, inputState) => {
+      const indexPattern = agg.getIndexPattern();
+      if (!indexPattern) return;
+      if (
+        agg.params.customMetric.type.name === 'top_hits' ||
+        agg.params.customMetric.type.name === 'top_metrics'
+      ) {
+        return agg.params.customMetric.createFilter(inputState);
+      }
       if (!agg.params.customBucket.params.filter) return;
       const esQueryConfigs = getEsQueryConfig({ get: getConfig });
       return buildQueryFilter(
-        buildEsQuery(
-          agg.getIndexPattern(),
-          [agg.params.customBucket.params.filter],
-          [],
-          esQueryConfigs
-        ),
-        agg.getIndexPattern().id!,
+        buildEsQuery(indexPattern, [agg.params.customBucket.params.filter], [], esQueryConfigs),
+        indexPattern.id!,
         agg.params.customBucket.params.filter.query
       );
     },

--- a/src/plugins/data/common/search/aggs/metrics/top_hit.test.ts
+++ b/src/plugins/data/common/search/aggs/metrics/top_hit.test.ts
@@ -403,9 +403,8 @@ describe('Top hit metric', () => {
       });
     });
     it('returns phrase filter', () => {
-      expect(getTopHitMetricAgg().createFilter!(aggConfig, '10')).toEqual({
-        meta: { index: '1234' },
-        query: { match_phrase: { bytes: 10 } },
+      expect(getTopHitMetricAgg().createFilter!(aggConfig, '10').query.match_phrase).toEqual({
+        bytes: 10,
       });
     });
   });

--- a/src/plugins/data/common/search/aggs/metrics/top_hit.test.ts
+++ b/src/plugins/data/common/search/aggs/metrics/top_hit.test.ts
@@ -402,5 +402,11 @@ describe('Top hit metric', () => {
         });
       });
     });
+    it('returns phrase filter', () => {
+      expect(getTopHitMetricAgg().createFilter!(aggConfig, '10')).toEqual({
+        meta: { index: '1234' },
+        query: { match_phrase: { bytes: 10 } },
+      });
+    });
   });
 });

--- a/src/plugins/data/common/search/aggs/metrics/top_hit.ts
+++ b/src/plugins/data/common/search/aggs/metrics/top_hit.ts
@@ -9,6 +9,7 @@
 import _ from 'lodash';
 import { i18n } from '@kbn/i18n';
 import { DataViewField } from '@kbn/data-views-plugin/common';
+import { buildPhraseFilter } from '@kbn/es-query';
 import { aggTopHitFnName } from './top_hit_fn';
 import { IMetricAggConfig, MetricAggType } from './metric_agg_type';
 import { METRIC_TYPES } from './metric_agg_types';
@@ -255,6 +256,12 @@ export const getTopHitMetricAgg = () => {
         }
       }
       return values;
+    },
+    createFilter: (agg, key) => {
+      const field = agg.getField();
+      if (field) {
+        return buildPhraseFilter(field, key, agg.getIndexPattern());
+      }
     },
   });
 };

--- a/src/plugins/data/common/search/aggs/metrics/top_hit.ts
+++ b/src/plugins/data/common/search/aggs/metrics/top_hit.ts
@@ -9,12 +9,12 @@
 import _ from 'lodash';
 import { i18n } from '@kbn/i18n';
 import { DataViewField } from '@kbn/data-views-plugin/common';
-import { buildPhraseFilter } from '@kbn/es-query';
 import { aggTopHitFnName } from './top_hit_fn';
 import { IMetricAggConfig, MetricAggType } from './metric_agg_type';
 import { METRIC_TYPES } from './metric_agg_types';
 import { flattenHit, KBN_FIELD_TYPES } from '../../..';
 import { BaseAggParams } from '../types';
+import { createTopHitFilter } from './lib/create_filter';
 
 export interface BaseAggParamsTopHit extends BaseAggParams {
   field: string;
@@ -257,11 +257,6 @@ export const getTopHitMetricAgg = () => {
       }
       return values;
     },
-    createFilter: (agg, key) => {
-      const field = agg.getField();
-      if (field) {
-        return buildPhraseFilter(field, key, agg.getIndexPattern());
-      }
-    },
+    createFilter: createTopHitFilter,
   });
 };

--- a/src/plugins/data/common/search/aggs/metrics/top_metrics.test.ts
+++ b/src/plugins/data/common/search/aggs/metrics/top_metrics.test.ts
@@ -197,5 +197,11 @@ describe('Top metrics metric', () => {
         query: { match_phrase: { bytes: 10 } },
       });
     });
+    it('returns combined OR filter for array values', () => {
+      expect(getTopMetricsMetricAgg().createFilter!(aggConfig, ['10', '20']).meta.params).toEqual([
+        { query: { match_phrase: { bytes: 10 } }, meta: { index: '1234' } },
+        { query: { match_phrase: { bytes: 20 } }, meta: { index: '1234' } },
+      ]);
+    });
   });
 });

--- a/src/plugins/data/common/search/aggs/metrics/top_metrics.test.ts
+++ b/src/plugins/data/common/search/aggs/metrics/top_metrics.test.ts
@@ -191,5 +191,11 @@ describe('Top metrics metric', () => {
       init({ fieldName: 'bytes' });
       expect(getTopMetricsMetricAgg().getValue(aggConfig, bucket)).toEqual([1024, 512, 256]);
     });
+    it('returns phrase filter', () => {
+      expect(getTopMetricsMetricAgg().createFilter!(aggConfig, '10')).toEqual({
+        meta: { index: '1234' },
+        query: { match_phrase: { bytes: 10 } },
+      });
+    });
   });
 });

--- a/src/plugins/data/common/search/aggs/metrics/top_metrics.ts
+++ b/src/plugins/data/common/search/aggs/metrics/top_metrics.ts
@@ -9,6 +9,7 @@
 import _ from 'lodash';
 import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { i18n } from '@kbn/i18n';
+import { buildPhraseFilter } from '@kbn/es-query';
 import { aggTopMetricsFnName } from './top_metrics_fn';
 import { IMetricAggConfig, MetricAggType } from './metric_agg_type';
 import { METRIC_TYPES } from './metric_agg_types';
@@ -161,6 +162,12 @@ export const getTopMetricsMetricAgg = () => {
       if (results.length === 0) return null;
       if (results.length === 1) return results[0];
       return results;
+    },
+    createFilter: (agg, key) => {
+      const field = agg.getField();
+      if (field) {
+        return buildPhraseFilter(field, key, agg.getIndexPattern());
+      }
     },
   });
 };

--- a/src/plugins/data/common/search/aggs/metrics/top_metrics.ts
+++ b/src/plugins/data/common/search/aggs/metrics/top_metrics.ts
@@ -9,12 +9,12 @@
 import _ from 'lodash';
 import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { i18n } from '@kbn/i18n';
-import { buildPhraseFilter } from '@kbn/es-query';
 import { aggTopMetricsFnName } from './top_metrics_fn';
 import { IMetricAggConfig, MetricAggType } from './metric_agg_type';
 import { METRIC_TYPES } from './metric_agg_types';
 import { DataViewField, KBN_FIELD_TYPES } from '../../..';
 import { BaseAggParams } from '../types';
+import { createTopHitFilter } from './lib/create_filter';
 
 export interface BaseAggParamsTopMetrics extends BaseAggParams {
   field: string;
@@ -163,11 +163,6 @@ export const getTopMetricsMetricAgg = () => {
       if (results.length === 1) return results[0];
       return results;
     },
-    createFilter: (agg, key) => {
-      const field = agg.getField();
-      if (field) {
-        return buildPhraseFilter(field, key, agg.getIndexPattern());
-      }
-    },
+    createFilter: createTopHitFilter,
   });
 };


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/152883

The task says this is the behavior that we want for datatable, but with the way data plugin interacts with Lens, it's actually impossible to modify only for datatable. In my opinion that's an improvement though, we probably want the same behavior for all supported visualization (so also metric).


### Scenarios to test:
<img width="316" alt="Screenshot 2023-06-27 at 09 10 35" src="https://github.com/elastic/kibana/assets/4283304/55b42b45-2154-4a32-b9e4-01f6fbdc4493">

1,2,3 returns the `price:${value}` filter
4. returns `price:exists` filter
5. returns `category.keyword:${value}` coming from filter by
6. `OR` filter for array values
<img width="419" alt="Screenshot 2023-06-28 at 16 31 43" src="https://github.com/elastic/kibana/assets/4283304/d7842617-7be3-4b8a-a39f-206a145f9b81">
