### PR TITLE
[8.8] [Profling][Fleet]Add a prerelease query param so who links to an integration can tell where the details must be read from  (#160244)

### DIFF
--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/index.tsx
@@ -123,6 +123,7 @@ export function Detail() {
   const { pathname, search, hash } = useLocation();
   const queryParams = useMemo(() => new URLSearchParams(search), [search]);
   const integration = useMemo(() => queryParams.get('integration'), [queryParams]);
+  const prerelease = useMemo(() => Boolean(queryParams.get('prerelease')), [queryParams]);
 
   const canInstallPackages = useAuthz().integrations.installPackages;
   const canReadPackageSettings = useAuthz().integrations.readPackageSettings;
@@ -178,9 +179,9 @@ export function Detail() {
   const { data: settings } = useGetSettingsQuery();
 
   useEffect(() => {
-    const isEnabled = Boolean(settings?.item.prerelease_integrations_enabled);
+    const isEnabled = Boolean(settings?.item.prerelease_integrations_enabled) || prerelease;
     setPrereleaseIntegrationsEnabled(isEnabled);
-  }, [settings?.item.prerelease_integrations_enabled]);
+  }, [settings?.item.prerelease_integrations_enabled, prerelease]);
 
   const { pkgName, pkgVersion } = splitPkgKey(pkgkey);
   // Fetch package info

--- a/x-pack/plugins/profiling/public/components/no_data_page.tsx
+++ b/x-pack/plugins/profiling/public/components/no_data_page.tsx
@@ -263,6 +263,61 @@ docker.elastic.co/observability/profiling-agent:${hostAgentVersion} /root/pf-hos
       ],
     },
     {
+      key: 'elasticAgentIntegration',
+      title: i18n.translate('xpack.profiling.tabs.elasticAgentIntegrarion.title', {
+        defaultMessage: 'Elastic Agent Integration',
+      }),
+      steps: [
+        {
+          title: i18n.translate('xpack.profiling.tabs.elasticAgentIntegrarion.step1', {
+            defaultMessage: 'Copy credentials',
+          }),
+          content: (
+            <>
+              <EuiText>
+                {i18n.translate('xpack.profiling.tabs.elasticAgentIntegrarion.step1.hint', {
+                  defaultMessage:
+                    "You'll need these credentials to set up Universal Profiling. Please save them in a secure location, as they will be required in the subsequent step.",
+                })}
+              </EuiText>
+              <EuiSpacer />
+              <EuiCodeBlock paddingSize="s" isCopyable>
+                {i18n.translate('xpack.profiling.tabs.elasticAgentIntegrarion.step1.secretToken', {
+                  defaultMessage: 'Secret token: {secretToken}',
+                  values: { secretToken },
+                })}
+              </EuiCodeBlock>
+              <EuiSpacer size="s" />
+              <EuiCodeBlock paddingSize="s" isCopyable>
+                {i18n.translate('xpack.profiling.tabs.elasticAgentIntegrarion.step1.apmServerUrl', {
+                  defaultMessage: 'APM server url: {apmServerUrl}',
+                  values: { apmServerUrl: collectionAgentHostPort },
+                })}
+              </EuiCodeBlock>
+            </>
+          ),
+        },
+        {
+          title: i18n.translate('xpack.profiling.tabs.elasticAgentIntegrarion.step2', {
+            defaultMessage: 'Fleet',
+          }),
+          content: (
+            <EuiButton
+              iconType="gear"
+              fill
+              href={`${core.http.basePath.prepend(
+                '/app/integrations/detail/profiler_agent-8.8.0-preview/overview?prerelease=true'
+              )}`}
+            >
+              {i18n.translate('xpack.profiling.tabs.elasticAgentIntegrarion.step2.button', {
+                defaultMessage: 'Manage Universal Profiling agent in Fleet',
+              })}
+            </EuiButton>
+          ),
+        },
+      ],
+    },
+    {
       key: 'symbols',
       title: i18n.translate('xpack.profiling.tabs.symbols.title', {
         defaultMessage: 'Upload Symbols',
@@ -345,61 +400,6 @@ docker.elastic.co/observability/profiling-agent:${hostAgentVersion} /root/pf-hos
                 />
               </EuiText>
             </div>
-          ),
-        },
-      ],
-    },
-    {
-      key: 'elasticAgentIntegration',
-      title: i18n.translate('xpack.profiling.tabs.elasticAgentIntegrarion.title', {
-        defaultMessage: 'Elastic Agent Integration',
-      }),
-      steps: [
-        {
-          title: i18n.translate('xpack.profiling.tabs.elasticAgentIntegrarion.step1', {
-            defaultMessage: 'Copy credentials',
-          }),
-          content: (
-            <>
-              <EuiText>
-                {i18n.translate('xpack.profiling.tabs.elasticAgentIntegrarion.step1.hint', {
-                  defaultMessage:
-                    "You'll need these credentials to set up Universal Profiling. Please save them in a secure location, as they will be required in the subsequent step.",
-                })}
-              </EuiText>
-              <EuiSpacer />
-              <EuiCodeBlock paddingSize="s" isCopyable>
-                {i18n.translate('xpack.profiling.tabs.elasticAgentIntegrarion.step1.secretToken', {
-                  defaultMessage: 'Secret token: {secretToken}',
-                  values: { secretToken },
-                })}
-              </EuiCodeBlock>
-              <EuiSpacer size="s" />
-              <EuiCodeBlock paddingSize="s" isCopyable>
-                {i18n.translate('xpack.profiling.tabs.elasticAgentIntegrarion.step1.apmServerUrl', {
-                  defaultMessage: 'APM server url: {apmServerUrl}',
-                  values: { apmServerUrl: collectionAgentHostPort },
-                })}
-              </EuiCodeBlock>
-            </>
-          ),
-        },
-        {
-          title: i18n.translate('xpack.profiling.tabs.elasticAgentIntegrarion.step2', {
-            defaultMessage: 'Fleet',
-          }),
-          content: (
-            <EuiButton
-              iconType="gear"
-              fill
-              href={`${core.http.basePath.prepend(
-                '/app/integrations/detail/profiler_agent-8.8.0-preview/overview'
-              )}`}
-            >
-              {i18n.translate('xpack.profiling.tabs.elasticAgentIntegrarion.step2.button', {
-                defaultMessage: 'Manage Universal Profiling agent in Fleet',
-              })}
-            </EuiButton>
           ),
         },
       ],


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.8`:
 - [[Profling][Fleet]Add a prerelease query param so who links to an integration can tell where the details must be read from  (#160244)](https://github.com/elastic/kibana/pull/160244)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Cauê Marcondes","email":"55978943+cauemarcondes@users.noreply.github.com"},"sourceCommit":{"committedDate":"2023-06-22T13:00:21Z","message":"[Profling][Fleet]Add a prerelease query param so who links to an integration can tell where the details must be read from  (#160244)\n\nProblem:\r\nIn the Profiler Add data page we show instructions on how to set up\r\nUniversal Profiling. One of the options is from the Profiler\r\nintegration. So we display a button that links to\r\n`/app/integrations/detail/profiler_agent-8.8.0-preview/overview`. The\r\nproblem is this link, is that the profiler integration is still in\r\n`Beta`, and will be until `8.10`, and when I click on that link the\r\nerror shown in the image below happens.\r\nBefore:\r\n![Screenshot 2023-06-21 at 9 58 29\r\nPM](https://github.com/elastic/kibana/assets/55978943/4800bdc3-df40-4579-9e57-d4b28e13be19)\r\n\r\nSolution:\r\nI added an optional query param `prerelase={true|false}` to the\r\nintegration link. So now I changed the link to:\r\n`/app/integrations/detail/profiler_agent-8.8.0-preview/overview?prerelease=true`,\r\nthis when true, overrides the\r\n`settings?.item.prerelease_integrations_enabled` which is false by\r\ndefault.\r\n\r\nAfter:\r\n<img width=\"1407\" alt=\"Screenshot 2023-06-22 at 11 16 52 AM\"\r\nsrc=\"https://github.com/elastic/kibana/assets/55978943/a0fd4ea5-b54b-45ea-9903-b43a24600e7e\">","sha":"7b5b61a2ad5c08716949b6a6aa5a1562bdea6a5e","branchLabelMapping":{"^v8.9.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","Team:Fleet","v8.9.0"],"number":160244,"url":"https://github.com/elastic/kibana/pull/160244","mergeCommit":{"message":"[Profling][Fleet]Add a prerelease query param so who links to an integration can tell where the details must be read from  (#160244)\n\nProblem:\r\nIn the Profiler Add data page we show instructions on how to set up\r\nUniversal Profiling. One of the options is from the Profiler\r\nintegration. So we display a button that links to\r\n`/app/integrations/detail/profiler_agent-8.8.0-preview/overview`. The\r\nproblem is this link, is that the profiler integration is still in\r\n`Beta`, and will be until `8.10`, and when I click on that link the\r\nerror shown in the image below happens.\r\nBefore:\r\n![Screenshot 2023-06-21 at 9 58 29\r\nPM](https://github.com/elastic/kibana/assets/55978943/4800bdc3-df40-4579-9e57-d4b28e13be19)\r\n\r\nSolution:\r\nI added an optional query param `prerelase={true|false}` to the\r\nintegration link. So now I changed the link to:\r\n`/app/integrations/detail/profiler_agent-8.8.0-preview/overview?prerelease=true`,\r\nthis when true, overrides the\r\n`settings?.item.prerelease_integrations_enabled` which is false by\r\ndefault.\r\n\r\nAfter:\r\n<img width=\"1407\" alt=\"Screenshot 2023-06-22 at 11 16 52 AM\"\r\nsrc=\"https://github.com/elastic/kibana/assets/55978943/a0fd4ea5-b54b-45ea-9903-b43a24600e7e\">","sha":"7b5b61a2ad5c08716949b6a6aa5a1562bdea6a5e"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.9.0","labelRegex":"^v8.9.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/160244","number":160244,"mergeCommit":{"message":"[Profling][Fleet]Add a prerelease query param so who links to an integration can tell where the details must be read from  (#160244)\n\nProblem:\r\nIn the Profiler Add data page we show instructions on how to set up\r\nUniversal Profiling. One of the options is from the Profiler\r\nintegration. So we display a button that links to\r\n`/app/integrations/detail/profiler_agent-8.8.0-preview/overview`. The\r\nproblem is this link, is that the profiler integration is still in\r\n`Beta`, and will be until `8.10`, and when I click on that link the\r\nerror shown in the image below happens.\r\nBefore:\r\n![Screenshot 2023-06-21 at 9 58 29\r\nPM](https://github.com/elastic/kibana/assets/55978943/4800bdc3-df40-4579-9e57-d4b28e13be19)\r\n\r\nSolution:\r\nI added an optional query param `prerelase={true|false}` to the\r\nintegration link. So now I changed the link to:\r\n`/app/integrations/detail/profiler_agent-8.8.0-preview/overview?prerelease=true`,\r\nthis when true, overrides the\r\n`settings?.item.prerelease_integrations_enabled` which is false by\r\ndefault.\r\n\r\nAfter:\r\n<img width=\"1407\" alt=\"Screenshot 2023-06-22 at 11 16 52 AM\"\r\nsrc=\"https://github.com/elastic/kibana/assets/55978943/a0fd4ea5-b54b-45ea-9903-b43a24600e7e\">","sha":"7b5b61a2ad5c08716949b6a6aa5a1562bdea6a5e"}},{"url":"https://github.com/elastic/kibana/pull/160388","number":160388,"branch":"8.9","state":"MERGED","mergeCommit":{"sha":"c5b17f6d69869c14dc0e9df836da413d3bb43199","message":"[8.9] [Profling][Fleet]Add a prerelease query param so who links to an integration can tell where the details must be read from  (#160244) (#160388)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.9`:\n- [[Profling][Fleet]Add a prerelease query param so who links to an\nintegration can tell where the details must be read from\n(#160244)](https://github.com/elastic/kibana/pull/160244)\n\n<!--- Backport version: 8.9.7 -->\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n<!--BACKPORT [{\"author\":{\"name\":\"Cauê\nMarcondes\",\"email\":\"55978943+cauemarcondes@users.noreply.github.com\"},\"sourceCommit\":{\"committedDate\":\"2023-06-22T13:00:21Z\",\"message\":\"[Profling][Fleet]Add\na prerelease query param so who links to an integration can tell where\nthe details must be read from (#160244)\\n\\nProblem:\\r\\nIn the Profiler\nAdd data page we show instructions on how to set up\\r\\nUniversal\nProfiling. One of the options is from the Profiler\\r\\nintegration. So we\ndisplay a button that links\nto\\r\\n`/app/integrations/detail/profiler_agent-8.8.0-preview/overview`.\nThe\\r\\nproblem is this link, is that the profiler integration is still\nin\\r\\n`Beta`, and will be until `8.10`, and when I click on that link\nthe\\r\\nerror shown in the image below\nhappens.\\r\\nBefore:\\r\\n![Screenshot 2023-06-21 at 9 58\n29\\r\\nPM](https://github.com/elastic/kibana/assets/55978943/4800bdc3-df40-4579-9e57-d4b28e13be19)\\r\\n\\r\\nSolution:\\r\\nI\nadded an optional query param `prerelase={true|false}` to\nthe\\r\\nintegration link. So now I changed the link\nto:\\r\\n`/app/integrations/detail/profiler_agent-8.8.0-preview/overview?prerelease=true`,\\r\\nthis\nwhen true, overrides\nthe\\r\\n`settings?.item.prerelease_integrations_enabled` which is false\nby\\r\\ndefault.\\r\\n\\r\\nAfter:\\r\\n<img width=\\\"1407\\\" alt=\\\"Screenshot\n2023-06-22 at 11 16 52\nAM\\\"\\r\\nsrc=\\\"https://github.com/elastic/kibana/assets/55978943/a0fd4ea5-b54b-45ea-9903-b43a24600e7e\\\">\",\"sha\":\"7b5b61a2ad5c08716949b6a6aa5a1562bdea6a5e\",\"branchLabelMapping\":{\"^v8.9.0$\":\"main\",\"^v(\\\\d+).(\\\\d+).\\\\d+$\":\"$1.$2\"}},\"sourcePullRequest\":{\"labels\":[\"bug\",\"release_note:skip\",\"Team:Fleet\",\"v8.9.0\"],\"number\":160244,\"url\":\"https://github.com/elastic/kibana/pull/160244\",\"mergeCommit\":{\"message\":\"[Profling][Fleet]Add\na prerelease query param so who links to an integration can tell where\nthe details must be read from (#160244)\\n\\nProblem:\\r\\nIn the Profiler\nAdd data page we show instructions on how to set up\\r\\nUniversal\nProfiling. One of the options is from the Profiler\\r\\nintegration. So we\ndisplay a button that links\nto\\r\\n`/app/integrations/detail/profiler_agent-8.8.0-preview/overview`.\nThe\\r\\nproblem is this link, is that the profiler integration is still\nin\\r\\n`Beta`, and will be until `8.10`, and when I click on that link\nthe\\r\\nerror shown in the image below\nhappens.\\r\\nBefore:\\r\\n![Screenshot 2023-06-21 at 9 58\n29\\r\\nPM](https://github.com/elastic/kibana/assets/55978943/4800bdc3-df40-4579-9e57-d4b28e13be19)\\r\\n\\r\\nSolution:\\r\\nI\nadded an optional query param `prerelase={true|false}` to\nthe\\r\\nintegration link. So now I changed the link\nto:\\r\\n`/app/integrations/detail/profiler_agent-8.8.0-preview/overview?prerelease=true`,\\r\\nthis\nwhen true, overrides\nthe\\r\\n`settings?.item.prerelease_integrations_enabled` which is false\nby\\r\\ndefault.\\r\\n\\r\\nAfter:\\r\\n<img width=\\\"1407\\\" alt=\\\"Screenshot\n2023-06-22 at 11 16 52\nAM\\\"\\r\\nsrc=\\\"https://github.com/elastic/kibana/assets/55978943/a0fd4ea5-b54b-45ea-9903-b43a24600e7e\\\">\",\"sha\":\"7b5b61a2ad5c08716949b6a6aa5a1562bdea6a5e\"}},\"sourceBranch\":\"main\",\"suggestedTargetBranches\":[],\"targetPullRequestStates\":[{\"branch\":\"main\",\"label\":\"v8.9.0\",\"labelRegex\":\"^v8.9.0$\",\"isSourceBranch\":true,\"state\":\"MERGED\",\"url\":\"https://github.com/elastic/kibana/pull/160244\",\"number\":160244,\"mergeCommit\":{\"message\":\"[Profling][Fleet]Add\na prerelease query param so who links to an integration can tell where\nthe details must be read from (#160244)\\n\\nProblem:\\r\\nIn the Profiler\nAdd data page we show instructions on how to set up\\r\\nUniversal\nProfiling. One of the options is from the Profiler\\r\\nintegration. So we\ndisplay a button that links\nto\\r\\n`/app/integrations/detail/profiler_agent-8.8.0-preview/overview`.\nThe\\r\\nproblem is this link, is that the profiler integration is still\nin\\r\\n`Beta`, and will be until `8.10`, and when I click on that link\nthe\\r\\nerror shown in the image below\nhappens.\\r\\nBefore:\\r\\n![Screenshot 2023-06-21 at 9 58\n29\\r\\nPM](https://github.com/elastic/kibana/assets/55978943/4800bdc3-df40-4579-9e57-d4b28e13be19)\\r\\n\\r\\nSolution:\\r\\nI\nadded an optional query param `prerelase={true|false}` to\nthe\\r\\nintegration link. So now I changed the link\nto:\\r\\n`/app/integrations/detail/profiler_agent-8.8.0-preview/overview?prerelease=true`,\\r\\nthis\nwhen true, overrides\nthe\\r\\n`settings?.item.prerelease_integrations_enabled` which is false\nby\\r\\ndefault.\\r\\n\\r\\nAfter:\\r\\n<img width=\\\"1407\\\" alt=\\\"Screenshot\n2023-06-22 at 11 16 52\nAM\\\"\\r\\nsrc=\\\"https://github.com/elastic/kibana/assets/55978943/a0fd4ea5-b54b-45ea-9903-b43a24600e7e\\\">\",\"sha\":\"7b5b61a2ad5c08716949b6a6aa5a1562bdea6a5e\"}}]}]\nBACKPORT-->"}}]}] BACKPORT-->