### PR TITLE
[Synthetics] Fixed agent count for agent policy

### DIFF
--- a/x-pack/plugins/synthetics/server/routes/settings/private_locations/get_agent_policies.ts
+++ b/x-pack/plugins/synthetics/server/routes/settings/private_locations/get_agent_policies.ts
@@ -23,6 +23,7 @@ export const getAgentPoliciesRoute: SyntheticsRestApiRouteFactory = () => ({
       sortOrder: 'asc',
       kuery: 'ingest-agent-policies.is_managed : false',
       esClient,
+      withAgentCount: true,
     });
   },
 });


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/160429

Fixed agent count for displayed agent policy name in private locations view !!

<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->