### PR TITLE
[Enterprise Search] Rename RCF config key to `use_document_level_security`

### DIFF
--- a/x-pack/plugins/enterprise_search/common/types/connectors.ts
+++ b/x-pack/plugins/enterprise_search/common/types/connectors.ts
@@ -65,8 +65,8 @@ export type ConnectorConfiguration = Record<
   string,
   ConnectorConfigProperties | ConnectorConfigCategoryProperties | null
 > & {
-  document_level_security?: ConnectorConfigProperties;
   extract_full_html?: { label: string; value: boolean }; // This only exists for Crawler
+  use_document_level_security?: ConnectorConfigProperties;
   use_text_extraction_service?: ConnectorConfigProperties; // This only exists for SharePoint Online
 };
 

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_configuration_field.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_configuration_field.tsx
@@ -142,7 +142,7 @@ export const ConnectorConfigurationField: React.FC<ConnectorConfigurationFieldPr
       );
 
     case DisplayType.TOGGLE:
-      if (key === 'document_level_security') {
+      if (key === 'use_document_level_security') {
         return (
           <DocumentLevelSecurityPanel
             toggleSwitch={

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_configuration_form_items.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_configuration_form_items.tsx
@@ -40,7 +40,7 @@ export const ConnectorConfigurationFormItems: React.FC<ConnectorConfigurationFor
           validation_errors: validationErrors,
         } = configEntry;
 
-        if (key === 'document_level_security' && !hasDocumentLevelSecurityEnabled) {
+        if (key === 'use_document_level_security' && !hasDocumentLevelSecurityEnabled) {
           return null;
         }
 

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_scheduling.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_scheduling.tsx
@@ -82,7 +82,7 @@ export const ConnectorSchedulingComponent: React.FC = () => {
   }
 
   const isDocumentLevelSecurityDisabled =
-    !index.connector.configuration.document_level_security?.value;
+    !index.connector.configuration.use_document_level_security?.value;
 
   if (
     index.connector.status === ConnectorStatus.CREATED ||

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_scheduling/full_content.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_scheduling/full_content.tsx
@@ -116,7 +116,7 @@ export const ConnectorContentScheduling: React.FC<ConnectorContentSchedulingProp
 
   const isGated = !hasPlatinumLicense && type === SyncJobType.ACCESS_CONTROL;
   const isDocumentLevelSecurityDisabled =
-    !index.connector.configuration.document_level_security?.value;
+    !index.connector.configuration.use_document_level_security?.value;
 
   return (
     <>


### PR DESCRIPTION
## Summary

Rename's rich configurable field key from `document_level_security` to `use_document_level_security`




<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->