### PR TITLE
[Cases] Fix bug in cases bulk action in the alerts table

### DIFF
--- a/x-pack/plugins/cases/public/components/all_cases/selector_modal/use_cases_add_to_existing_case_modal.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/selector_modal/use_cases_add_to_existing_case_modal.tsx
@@ -64,6 +64,7 @@ export const useCasesAddToExistingCaseModal = (props: AddToExistingCaseModalProp
       getAttachments?: ({ theCase }: { theCase?: CaseUI }) => CaseAttachmentsWithoutOwner
     ) => {
       const attachments = getAttachments?.({ theCase }) ?? [];
+
       // when the case is undefined in the modal
       // the user clicked "create new case"
       if (theCase === undefined) {

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/hooks/use_bulk_actions.test.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/hooks/use_bulk_actions.test.tsx
@@ -43,9 +43,11 @@ describe('bulk action hooks', () => {
   const refresh = jest.fn();
   const clearSelection = jest.fn();
   const openNewCase = jest.fn();
+
   const openExistingCase = jest.fn().mockImplementation(({ getAttachments }) => {
     getAttachments({ theCase: { id: caseId } });
   });
+
   mockCaseService.helpers.canUseCases = jest.fn().mockReturnValue({ create: true, read: true });
   mockCaseService.ui.getCasesContext = jest.fn().mockReturnValue(() => 'Cases context');
 
@@ -122,6 +124,55 @@ describe('bulk action hooks', () => {
 
       expect(mockCaseService.helpers.groupAlertsByRule).toHaveBeenCalled();
       expect(openExistingCase).toHaveBeenCalled();
+    });
+
+    it('should open the flyout from the case modal', async () => {
+      openExistingCase.mockImplementationOnce(({ getAttachments }) => {
+        getAttachments({ theCase: undefined });
+      });
+
+      const alerts = [
+        {
+          _id: 'alert0',
+          _index: 'idx0',
+          data: [
+            {
+              field: 'kibana.alert.case_ids',
+              value: [caseId],
+            },
+          ],
+          ecs: {
+            _id: 'alert0',
+            _index: 'idx0',
+          },
+        },
+        {
+          _id: 'alert1',
+          _index: 'idx1',
+          data: [
+            {
+              field: 'kibana.alert.case_ids',
+              value: ['test-case-2'],
+            },
+          ],
+          ecs: {
+            _id: 'alert1',
+            _index: 'idx1',
+          },
+        },
+      ];
+
+      const { result } = renderHook(
+        () => useBulkAddToCaseActions({ casesConfig, refresh, clearSelection }),
+        {
+          wrapper: appMockRender.AppWrapper,
+        }
+      );
+
+      // @ts-expect-error: cases do not need all arguments
+      result.current[1].onClick(alerts);
+
+      expect(mockCaseService.helpers.groupAlertsByRule).toHaveBeenCalledWith(alerts);
     });
 
     it('should remove alerts that are already attached to the case', async () => {

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/hooks/use_bulk_actions.ts
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/hooks/use_bulk_actions.ts
@@ -146,6 +146,10 @@ export const useBulkAddToCaseActions = ({
             onClick: (alerts?: TimelineItem[]) => {
               selectCaseModal.open({
                 getAttachments: ({ theCase }) => {
+                  if (theCase == null) {
+                    return alerts ? casesService?.helpers.groupAlertsByRule(alerts) ?? [] : [];
+                  }
+
                   return getCaseAttachments({
                     alerts,
                     caseId: theCase.id,

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/types.ts
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/types.ts
@@ -48,7 +48,7 @@ type UseCasesAddToExistingCaseModal = (props?: Record<string, unknown>) => {
   open: ({
     getAttachments,
   }: {
-    getAttachments: ({ theCase }: { theCase: { id: string } }) => any[];
+    getAttachments: ({ theCase }: { theCase?: { id: string } }) => any[];
   }) => void;
   close: () => void;
 };


### PR DESCRIPTION
## Summary

In 8.8 we move the logic of the cases action from solutions to the alerts table. A bug was introduced when you try to attach an alert to a new case through the cases modal.

Before

https://github.com/elastic/kibana/assets/7871006/771a5d28-e279-43d4-b72e-2dfb6689bae6

Error in `console`

```
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'id')
    at getAttachments (use_bulk_actions.ts:100:1)
    at use_cases_add_to_existing_case_modal.tsx:52:1
    at onRowClick (use_cases_add_to_existing_case_modal.tsx:107:1)
    at all_cases_selector_modal.tsx:36:1
    at all_cases_list.tsx:208:1
    at table_filters.tsx:128:1
    at HTMLUnknownElement.callCallback (react-dom.development.js:3945:1)
    at Object.invokeGuardedCallbackDev (react-dom.development.js:3994:1)
    at invokeGuardedCallback (react-dom.development.js:4056:1)
    at invokeGuardedCallbackAndCatchFirstError (react-dom.development.js:4070:1)
```

After 

https://github.com/elastic/kibana/assets/7871006/89e44018-49cf-41f7-8e07-01c6eb197624

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

## Release notes
Fix a bug in the alerts table where you cannot create a new case when attaching alerts to a case from the cases modal


<!--ONMERGE {"backportTargets":["8.8","8.9"]} ONMERGE-->