### PR TITLE
[8.9] [ResponseOps] only allow HTML email via notifications (#160322)

### DIFF
--- a/x-pack/plugins/actions/server/lib/action_executor.test.ts
+++ b/x-pack/plugins/actions/server/lib/action_executor.test.ts
@@ -285,6 +285,10 @@ test('successfully executes when http_request source is specified', async () => 
     },
     params: { foo: true },
     logger: loggerMock,
+    source: {
+      source: expect.anything(),
+      type: 'HTTP_REQUEST',
+    },
   });
 
   expect(loggerMock.debug).toBeCalledWith('executing action test:1: 1');
@@ -435,6 +439,13 @@ test('successfully executes when saved_object source is specified', async () => 
     },
     params: { foo: true },
     logger: loggerMock,
+    source: {
+      source: {
+        id: '573891ae-8c48-49cb-a197-0cd5ec34a88b',
+        type: 'alert',
+      },
+      type: 'SAVED_OBJECT',
+    },
   });
 
   expect(loggerMock.debug).toBeCalledWith('executing action test:1: 1');

--- a/x-pack/plugins/actions/server/lib/action_executor.ts
+++ b/x-pack/plugins/actions/server/lib/action_executor.ts
@@ -227,6 +227,7 @@ export class ActionExecutor {
             taskInfo,
             configurationUtilities,
             logger,
+            source,
           });
         } catch (err) {
           if (err.reason === ActionExecutionErrorReason.Validation) {

--- a/x-pack/plugins/actions/server/lib/index.ts
+++ b/x-pack/plugins/actions/server/lib/index.ts
@@ -33,6 +33,7 @@ export {
   isHttpRequestExecutionSource,
   asNotificationExecutionSource,
   isNotificationExecutionSource,
+  ActionExecutionSourceType,
 } from './action_execution_source';
 export { validateEmptyStrings } from './validate_empty_strings';
 export { parseDate } from './parse_date';

--- a/x-pack/plugins/actions/server/types.ts
+++ b/x-pack/plugins/actions/server/types.ts
@@ -34,6 +34,11 @@ export type ActionTypeSecrets = Record<string, unknown>;
 export type ActionTypeParams = Record<string, unknown>;
 export type ConnectorTokenClientContract = PublicMethodsOf<ConnectorTokenClient>;
 
+import type { ActionExecutionSource } from './lib';
+export type { ActionExecutionSource } from './lib';
+
+export { ActionExecutionSourceType } from './lib';
+
 export interface Services {
   savedObjectsClient: SavedObjectsClientContract;
   scopedClusterClient: ElasticsearchClient;
@@ -65,6 +70,7 @@ export interface ActionTypeExecutorOptions<Config, Secrets, Params> {
   isEphemeral?: boolean;
   taskInfo?: TaskInfo;
   configurationUtilities: ActionsConfigurationUtilities;
+  source?: ActionExecutionSource<unknown>;
 }
 
 export interface ActionResult<Config extends ActionTypeConfig = ActionTypeConfig> {

--- a/x-pack/plugins/stack_connectors/server/connector_types/email/index.test.ts
+++ b/x-pack/plugins/stack_connectors/server/connector_types/email/index.test.ts
@@ -30,6 +30,7 @@ import {
   ConnectorTypeSecretsType,
 } from '.';
 import { ValidateEmailAddressesOptions } from '@kbn/actions-plugin/common';
+import { ActionExecutionSourceType } from '@kbn/actions-plugin/server/types';
 
 const sendEmailMock = sendEmail as jest.Mock;
 
@@ -574,11 +575,12 @@ describe('execute()', () => {
     `);
   });
 
-  test('ensure parameters are as expected with HTML', async () => {
+  test('ensure parameters are as expected with HTML message with source NOTIFICATION', async () => {
     sendEmailMock.mockReset();
 
     const executorOptionsWithHTML = {
       ...executorOptions,
+      source: { type: ActionExecutionSourceType.NOTIFICATION, source: null },
       params: {
         ...executorOptions.params,
         messageHTML: '<html><body><span>My HTML message</span></body></html>',
@@ -625,6 +627,71 @@ describe('execute()', () => {
           "service": "__json",
           "user": "bob",
         },
+      }
+    `);
+  });
+
+  test('ensure error when using HTML message with no source', async () => {
+    sendEmailMock.mockReset();
+
+    const executorOptionsWithHTML = {
+      ...executorOptions,
+      params: {
+        ...executorOptions.params,
+        messageHTML: '<html><body><span>My HTML message</span></body></html>',
+      },
+    };
+
+    const result = await connectorType.executor(executorOptionsWithHTML);
+    expect(result).toMatchInlineSnapshot(`
+      Object {
+        "actionId": "some-id",
+        "message": "HTML email can only be sent via notifications",
+        "status": "error",
+      }
+    `);
+  });
+
+  test('ensure error when using HTML message with source HTTP_REQUEST', async () => {
+    sendEmailMock.mockReset();
+
+    const executorOptionsWithHTML = {
+      ...executorOptions,
+      source: { type: ActionExecutionSourceType.HTTP_REQUEST, source: null },
+      params: {
+        ...executorOptions.params,
+        messageHTML: '<html><body><span>My HTML message</span></body></html>',
+      },
+    };
+
+    const result = await connectorType.executor(executorOptionsWithHTML);
+    expect(result).toMatchInlineSnapshot(`
+      Object {
+        "actionId": "some-id",
+        "message": "HTML email can only be sent via notifications",
+        "status": "error",
+      }
+    `);
+  });
+
+  test('ensure error when using HTML message with source SAVED_OBJECT', async () => {
+    sendEmailMock.mockReset();
+
+    const executorOptionsWithHTML = {
+      ...executorOptions,
+      source: { type: ActionExecutionSourceType.HTTP_REQUEST, source: null },
+      params: {
+        ...executorOptions.params,
+        messageHTML: '<html><body><span>My HTML message</span></body></html>',
+      },
+    };
+
+    const result = await connectorType.executor(executorOptionsWithHTML);
+    expect(result).toMatchInlineSnapshot(`
+      Object {
+        "actionId": "some-id",
+        "message": "HTML email can only be sent via notifications",
+        "status": "error",
       }
     `);
   });

--- a/x-pack/plugins/stack_connectors/server/connector_types/email/index.ts
+++ b/x-pack/plugins/stack_connectors/server/connector_types/email/index.ts
@@ -26,6 +26,7 @@ import {
   renderMustacheObject,
   renderMustacheString,
 } from '@kbn/actions-plugin/server/lib/mustache_renderer';
+import { ActionExecutionSourceType } from '@kbn/actions-plugin/server/types';
 import { AdditionalEmailServices } from '../../../common';
 import { sendEmail, JSON_TRANSPORT_SERVICE, SendEmailOptions, Transport } from './send_email';
 import { portSchema } from '../lib/schemas';
@@ -283,6 +284,16 @@ async function executor(
   invalidEmailsMessage = configurationUtilities.validateEmailAddresses([config.from]);
   if (invalidEmailsMessage) {
     return { status: 'error', actionId, message: `[from]: ${invalidEmailsMessage}` };
+  }
+
+  if (params.messageHTML != null) {
+    if (execOptions.source?.type !== ActionExecutionSourceType.NOTIFICATION) {
+      return {
+        status: 'error',
+        actionId,
+        message: `HTML email can only be sent via notifications`,
+      };
+    }
   }
 
   const transport: Transport = {};

--- a/x-pack/test/alerting_api_integration/common/config.ts
+++ b/x-pack/test/alerting_api_integration/common/config.ts
@@ -215,6 +215,18 @@ export function createTestConfig(name: string, options: CreateTestConfigOptions)
                 password: 'password',
               },
             },
+            'notification-email': {
+              actionTypeId: '.email',
+              name: 'Notification Email Connector',
+              config: {
+                from: 'me@test.com',
+                service: '__json',
+              },
+              secrets: {
+                user: 'user',
+                password: 'password',
+              },
+            },
             'my-slack1': {
               actionTypeId: '.slack',
               name: 'Slack#xyz',
@@ -317,6 +329,7 @@ export function createTestConfig(name: string, options: CreateTestConfigOptions)
                 `--elasticsearch.ssl.certificateAuthorities=${CA_CERT_PATH}`,
               ]
             : []),
+          '--notifications.connectors.default.email=notification-email',
         ],
       },
     };

--- a/x-pack/test/alerting_api_integration/common/plugins/alerts/kibana.jsonc
+++ b/x-pack/test/alerting_api_integration/common/plugins/alerts/kibana.jsonc
@@ -13,7 +13,8 @@
       "alerting",
       "encryptedSavedObjects",
       "ruleRegistry",
-      "eventLog"
+      "eventLog",
+      "notifications",
     ],
     "optionalPlugins": [
       "security",

--- a/x-pack/test/alerting_api_integration/common/plugins/alerts/server/routes.ts
+++ b/x-pack/test/alerting_api_integration/common/plugins/alerts/server/routes.ts
@@ -25,12 +25,14 @@ import {
 } from '@kbn/task-manager-plugin/server';
 import { SECURITY_EXTENSION_ID, SPACES_EXTENSION_ID } from '@kbn/core-saved-objects-server';
 import { queryOptionsSchema } from '@kbn/event-log-plugin/server/event_log_client';
+import { NotificationsPluginStart } from '@kbn/notifications-plugin/server';
 import { FixtureStartDeps } from './plugin';
 import { retryIfConflicts } from './lib/retry_if_conflicts';
 
 export function defineRoutes(
   core: CoreSetup<FixtureStartDeps>,
   taskManagerStart: Promise<TaskManagerStartContract>,
+  notificationsStart: Promise<NotificationsPluginStart>,
   { logger }: { logger: Logger }
 ) {
   const router = core.http.createRouter();
@@ -481,6 +483,39 @@ export function defineRoutes(
       } catch (err) {
         return res.notFound();
       }
+    }
+  );
+
+  router.post(
+    {
+      path: '/_test/send_notification',
+      validate: {
+        body: schema.object({
+          to: schema.arrayOf(schema.string()),
+          subject: schema.string(),
+          message: schema.string(),
+          messageHTML: schema.maybe(schema.string()),
+        }),
+      },
+    },
+    async (
+      context: RequestHandlerContext,
+      req: KibanaRequest<any, any, any, any>,
+      res: KibanaResponseFactory
+    ): Promise<IKibanaResponse<any>> => {
+      const notifications = await notificationsStart;
+      const { to, subject, message, messageHTML } = req.body;
+
+      if (!notifications.isEmailServiceAvailable()) {
+        return res.ok({ body: { error: 'notifications are not available' } });
+      }
+
+      const emailService = notifications.getEmailService();
+
+      emailService.sendPlainTextEmail({ to, subject, message });
+      emailService.sendHTMLEmail({ to, subject, message, messageHTML });
+
+      return res.ok({ body: { ok: true } });
     }
   );
 }

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/email.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/email.ts
@@ -155,7 +155,7 @@ export default function emailTest({ getService }: FtrProviderContext) {
         });
     });
 
-    it('should return existing html when available', async () => {
+    it('should return an error when sending html via execute endpoint', async () => {
       await supertest
         .post(`/api/actions/connector/${createdActionId}/_execute`)
         .set('kbn-xsrf', 'foo')
@@ -170,13 +170,9 @@ export default function emailTest({ getService }: FtrProviderContext) {
         })
         .expect(200)
         .then((resp: any) => {
-          const { text, html } = resp.body.data.message;
-          expect(text).to.eql(
-            '_italic_ **bold** https://elastic.co link\n\n---\n\nThis message was sent by Elastic. [Go to Elastic](https://localhost:5601).'
-          );
-          expect(html).to.eql(
-            `<html><body><a href="https://elastic.co" style="font-weight: bold; font-style: italic">View at Elastic</a></body></html>`
-          );
+          const { status, message } = resp.body;
+          expect(status).to.eql('error');
+          expect(message).to.eql('HTML email can only be sent via notifications');
         });
     });
 

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/get_all.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/get_all.ts
@@ -80,6 +80,14 @@ export default function getAllActionTests({ getService }: FtrProviderContext) {
                   referenced_by_count: 0,
                 },
                 {
+                  connector_type_id: '.email',
+                  id: 'notification-email',
+                  is_deprecated: false,
+                  is_preconfigured: true,
+                  name: 'Notification Email Connector',
+                  referenced_by_count: 0,
+                },
+                {
                   id: 'preconfigured-es-index-action',
                   is_preconfigured: true,
                   is_deprecated: false,
@@ -223,6 +231,14 @@ export default function getAllActionTests({ getService }: FtrProviderContext) {
                   referenced_by_count: 1,
                 },
                 {
+                  connector_type_id: '.email',
+                  id: 'notification-email',
+                  is_deprecated: false,
+                  is_preconfigured: true,
+                  name: 'Notification Email Connector',
+                  referenced_by_count: 0,
+                },
+                {
                   id: 'preconfigured-es-index-action',
                   is_preconfigured: true,
                   is_deprecated: false,
@@ -329,6 +345,14 @@ export default function getAllActionTests({ getService }: FtrProviderContext) {
                 (conn: { id: string }) => !conn.id.startsWith('custom.ssl.')
               );
               expect(nonCustomSslConnectors).to.eql([
+                {
+                  connector_type_id: '.email',
+                  id: 'notification-email',
+                  is_deprecated: false,
+                  is_preconfigured: true,
+                  name: 'Notification Email Connector',
+                  referenced_by_count: 0,
+                },
                 {
                   id: 'preconfigured-es-index-action',
                   is_preconfigured: true,

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/actions/connector_types/stack/email_html.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/actions/connector_types/stack/email_html.ts
@@ -1,0 +1,187 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import expect from '@kbn/expect';
+
+import { ES_TEST_INDEX_NAME } from '@kbn/alerting-api-integration-helpers';
+import { IValidatedEvent } from '@kbn/event-log-plugin/server';
+import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import { getEventLog, ObjectRemover } from '../../../../../common/lib';
+import { EmailDomainsAllowed } from '../../config';
+
+// eslint-disable-next-line import/no-default-export
+export default function emailNotificationTest({ getService }: FtrProviderContext) {
+  const supertest = getService('supertest');
+  const retry = getService('retry');
+  const objectRemover = new ObjectRemover(supertest);
+  const from = `bob@${EmailDomainsAllowed[0]}`;
+  const to = [`jim@${EmailDomainsAllowed[0]}`];
+
+  describe('email using html', () => {
+    afterEach(async () => {
+      objectRemover.removeAll();
+    });
+
+    it('succeeds as notification', async () => {
+      const startDate = new Date().toISOString();
+
+      // The route sends two notifications, which will send two emails.
+      // see: x-pack/test/alerting_api_integration/common/plugins/alerts/server/routes.ts
+      const body = {
+        to,
+        subject: 'testing',
+        message: 'plain text message',
+        messageHTML: 'html message',
+      };
+
+      const res = await supertest
+        .post('/_test/send_notification')
+        .set('kbn-xsrf', 'foo')
+        .send(body);
+      expect(res.status).to.eql(200);
+      expect(res.body?.ok).to.eql(true);
+
+      // We don't have a way to check the emails generated, when run this
+      // way, but we can check the event log to make sure the connector
+      // ran successfully.  Filter manually with the start date, in
+      // case someone's running FT with the same ES instance - old EL
+      // docs for this test will linger.
+      const events: IValidatedEvent[] = await retry.try(async () => {
+        const events_ = await getEventLog({
+          getService,
+          spaceId: 'default',
+          type: 'action',
+          id: 'notification-email',
+          provider: 'actions',
+          actions: new Map([['execute', { gte: 2 }]]),
+        });
+
+        const filteredEvents = events_.filter((event) => event!['@timestamp']! >= startDate);
+        if (filteredEvents.length < 2) throw new Error('no recent events found yet');
+
+        return filteredEvents;
+      });
+
+      for (const event of events) {
+        expect(event?.event?.outcome).to.be('success');
+        expect(event?.kibana?.action?.execution?.source).to.be('notification');
+      }
+    });
+
+    it('fails as http execution', async () => {
+      const { body: connBody, status: connStatus } = await createConnector(
+        supertest,
+        objectRemover,
+        from
+      );
+      expect(connStatus).to.be(200);
+      const connId = connBody.id;
+
+      await supertest
+        .post(`/api/actions/connector/${connId}/_execute`)
+        .set('kbn-xsrf', 'foo')
+        .send({
+          params: {
+            to,
+            subject: 'HTML message check',
+            message: '_italic_ **bold** https://elastic.co link',
+            messageHTML: '<html><body>Hallo!</body></html>',
+          },
+        })
+        .expect(200)
+        .then((resp: any) => {
+          const { status: runStatus, message } = resp.body;
+          expect(runStatus).to.eql('error');
+          expect(message).to.eql('HTML email can only be sent via notifications');
+        });
+    });
+
+    it('fails as action execution', async () => {
+      const { body: connBody, status: connStatus } = await createConnector(
+        supertest,
+        objectRemover,
+        from
+      );
+      expect(connStatus).to.be(200);
+      const connId = connBody.id;
+
+      const ruleParams = {
+        enabled: true,
+        name: 'rule testing html email',
+        schedule: { interval: '1s' },
+        throttle: '1m',
+        rule_type_id: 'test.always-firing',
+        consumer: 'alertsFixture',
+        params: {
+          index: ES_TEST_INDEX_NAME,
+          reference: 'ignore',
+        },
+        notify_when: 'onActiveAlert',
+        actions: [
+          {
+            group: 'default',
+            id: connId,
+            params: {
+              to,
+              subject: 'HTML message check',
+              message: '_italic_ **bold** https://elastic.co link',
+              messageHTML: '<html><body>Hallo!</body></html>',
+            },
+          },
+        ],
+      };
+
+      const response = await supertest
+        .post(`/api/alerting/rule`)
+        .set('kbn-xsrf', 'foo')
+        .send(ruleParams);
+      expect(response.status).to.eql(200);
+      const ruleId = response.body.id;
+      objectRemover.add('default', ruleId, 'rule', 'alerting');
+
+      const events = await retry.try(async () => {
+        return await getEventLog({
+          getService,
+          spaceId: 'default',
+          type: 'action',
+          id: connId,
+          provider: 'actions',
+          actions: new Map([['execute', { gte: 1 }]]),
+        });
+      });
+
+      const event = events[0];
+      expect(event?.event?.outcome).to.be('failure');
+      expect(event?.error?.message).to.be('HTML email can only be sent via notifications');
+    });
+  });
+}
+
+async function createConnector(
+  supertest: ReturnType<FtrProviderContext['getService']>,
+  objectRemover: ObjectRemover,
+  from: string
+): Promise<{ status: number; body: any }> {
+  const connector: any = {
+    name: `An email connector from ${__filename}`,
+    connector_type_id: '.email',
+    config: {
+      service: '__json',
+      from,
+      hasAuth: false,
+    },
+  };
+  const { status, body } = await supertest
+    .post('/api/actions/connector')
+    .set('kbn-xsrf', 'foo')
+    .send(connector);
+
+  if (status === 200) {
+    objectRemover.add('default', body.id, 'connector', 'actions');
+  }
+
+  return { status, body };
+}

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/actions/get_all.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/actions/get_all.ts
@@ -68,6 +68,14 @@ export default function getAllActionTests({ getService }: FtrProviderContext) {
           referenced_by_count: 0,
         },
         {
+          connector_type_id: '.email',
+          id: 'notification-email',
+          is_deprecated: false,
+          is_preconfigured: true,
+          name: 'Notification Email Connector',
+          referenced_by_count: 0,
+        },
+        {
           id: 'preconfigured-es-index-action',
           is_preconfigured: true,
           is_deprecated: false,
@@ -160,6 +168,14 @@ export default function getAllActionTests({ getService }: FtrProviderContext) {
           connector_type_id: '.index',
           is_preconfigured: true,
           is_deprecated: false,
+          referenced_by_count: 0,
+        },
+        {
+          connector_type_id: '.email',
+          id: 'notification-email',
+          is_deprecated: false,
+          is_preconfigured: true,
+          name: 'Notification Email Connector',
           referenced_by_count: 0,
         },
         {
@@ -268,6 +284,14 @@ export default function getAllActionTests({ getService }: FtrProviderContext) {
             config: {
               unencrypted: `This value shouldn't get encrypted`,
             },
+            referencedByCount: 0,
+          },
+          {
+            actionTypeId: '.email',
+            id: 'notification-email',
+            isDeprecated: false,
+            isPreconfigured: true,
+            name: 'Notification Email Connector',
             referencedByCount: 0,
           },
           {

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/actions/index.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/actions/index.ts
@@ -24,6 +24,7 @@ export default function actionsTests({ loadTestFile, getService }: FtrProviderCo
     loadTestFile(require.resolve('./execute'));
     loadTestFile(require.resolve('./enqueue'));
     loadTestFile(require.resolve('./connector_types/stack/email'));
+    loadTestFile(require.resolve('./connector_types/stack/email_html'));
     loadTestFile(require.resolve('./connector_types/stack/es_index'));
     loadTestFile(require.resolve('./connector_types/stack/webhook'));
     loadTestFile(require.resolve('./connector_types/stack/preconfigured_alert_history_connector'));

--- a/x-pack/test/tsconfig.json
+++ b/x-pack/test/tsconfig.json
@@ -129,6 +129,7 @@
     "@kbn/core-http-common",
     "@kbn/slo-schema",
     "@kbn/lens-plugin",
-    "@kbn/telemetry-tools"
+    "@kbn/telemetry-tools",
+    "@kbn/notifications-plugin"
   ]
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.9`:
 - [[ResponseOps] only allow HTML email via notifications (#160322)](https://github.com/elastic/kibana/pull/160322)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Patrick Mueller","email":"patrick.mueller@elastic.co"},"sourceCommit":{"committedDate":"2023-06-26T16:38:25Z","message":"[ResponseOps] only allow HTML email via notifications (#160322)\n\nresolves https://github.com/elastic/response-ops-team/issues/122\r\n\r\nThe email connector is changed to only allow HTML email to be sent via\r\nnotifications - not via alerting rule actions or via the http execute\r\nroute.","sha":"2172a01e21e1792bc6537b9482988102ea861e0a","branchLabelMapping":{"^v8.10.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Feature:Actions","Team:ResponseOps","v8.9.0","v8.10.0"],"number":160322,"url":"https://github.com/elastic/kibana/pull/160322","mergeCommit":{"message":"[ResponseOps] only allow HTML email via notifications (#160322)\n\nresolves https://github.com/elastic/response-ops-team/issues/122\r\n\r\nThe email connector is changed to only allow HTML email to be sent via\r\nnotifications - not via alerting rule actions or via the http execute\r\nroute.","sha":"2172a01e21e1792bc6537b9482988102ea861e0a"}},"sourceBranch":"main","suggestedTargetBranches":["8.9"],"targetPullRequestStates":[{"branch":"8.9","label":"v8.9.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.10.0","labelRegex":"^v8.10.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/160322","number":160322,"mergeCommit":{"message":"[ResponseOps] only allow HTML email via notifications (#160322)\n\nresolves https://github.com/elastic/response-ops-team/issues/122\r\n\r\nThe email connector is changed to only allow HTML email to be sent via\r\nnotifications - not via alerting rule actions or via the http execute\r\nroute.","sha":"2172a01e21e1792bc6537b9482988102ea861e0a"}}]}] BACKPORT-->