### PR TITLE
[APM] Move `advancedSettings` plugin to `requiredBundles` section

### DIFF
--- a/x-pack/plugins/apm/kibana.jsonc
+++ b/x-pack/plugins/apm/kibana.jsonc
@@ -25,7 +25,6 @@
       "share",
       "unifiedSearch",
       "dataViews",
-      "advancedSettings",
       "lens",
       "maps",
       "uiActions"
@@ -48,6 +47,7 @@
       "licenseManagement"
     ],
     "requiredBundles": [
+      "advancedSettings",
       "fleet",
       "kibanaReact",
       "kibanaUtils",


### PR DESCRIPTION
Advanced Settings plugin is disabled on serverless. We need it to import some shared react components. Moving `advancedSettings` to `requiredBundles` should solve this.

<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->