### PR TITLE
[Security Solution] fix investigation guide label turning red even though form value is valid

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/markdown_editor/plugins/insight/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/markdown_editor/plugins/insight/index.tsx
@@ -449,7 +449,10 @@ const InsightEditorComponent = ({
             <EuiFormRow
               label={i18n.LABEL}
               helpText={i18n.LABEL_TEXT}
-              isInvalid={labelController.field.value != null}
+              isInvalid={
+                labelController.field.value !== undefined &&
+                labelController.field.value.trim().length === 0
+              }
               fullWidth
             >
               <EuiFieldText
@@ -520,10 +523,10 @@ const exampleInsight = `${insightPrefix}{
   "label": "Test action",
   "description": "Click to investigate",
   "providers": [
-    [     
+    [
       {"field": "event.id", "value": "{{kibana.alert.original_event.id}}", "queryType": "phrase", "excluded": "false"}
     ],
-    [  
+    [
       {"field": "event.action", "value": "", "queryType": "exists", "excluded": "false"},
       {"field": "process.pid", "value": "{{process.pid}}", "queryType": "phrase", "excluded":"false"}
     ]


### PR DESCRIPTION
## Summary

This PR fixes a small UI bug where the label input in the Investigation Guide form turns red even though the entered value is correct.

https://github.com/elastic/kibana/assets/17276605/90f223dc-e1d5-4447-8fd6-361fb0c19597

Fixes https://github.com/elastic/kibana/issues/153093

<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->