### PR TITLE
[esArchiver] Update aliases after creating the indices

### DIFF
--- a/packages/kbn-es-archiver/src/lib/indices/create_index_stream.test.ts
+++ b/packages/kbn-es-archiver/src/lib/indices/create_index_stream.test.ts
@@ -304,6 +304,7 @@ describe('esArchiver: createCreateIndexStream()', () => {
       ]);
 
       sinon.assert.notCalled(client.indices.create as sinon.SinonSpy);
+      sinon.assert.notCalled(client.indices.updateAliases as sinon.SinonSpy);
       expect(output).toEqual([createStubDocRecord('index', 1)]);
     });
   });
@@ -315,8 +316,8 @@ describe('esArchiver: createCreateIndexStream()', () => {
 
       await createPromiseFromStreams([
         createListStream([
-          createStubIndexRecord('new-index'),
-          createStubIndexRecord('existing-index'),
+          createStubIndexRecord('new-index', { 'new-index-alias': {} }),
+          createStubIndexRecord('existing-index', { 'existing-index-alias': {} }),
         ]),
         createCreateIndexStream({
           client,
@@ -336,6 +337,12 @@ describe('esArchiver: createCreateIndexStream()', () => {
         'index',
         'new-index'
       );
+
+      // only update aliases for the 'new-index'
+      sinon.assert.callCount(client.indices.updateAliases as sinon.SinonSpy, 1);
+      expect((client.indices.updateAliases as sinon.SinonSpy).args[0][0]).toHaveProperty('body', {
+        actions: [{ add: { alias: 'new-index-alias', index: 'new-index' } }],
+      });
     });
 
     it('filters documents for skipped indices', async () => {

--- a/packages/kbn-es-archiver/src/lib/indices/create_index_stream.test.ts
+++ b/packages/kbn-es-archiver/src/lib/indices/create_index_stream.test.ts
@@ -141,7 +141,12 @@ describe('esArchiver: createCreateIndexStream()', () => {
         body: {
           settings: undefined,
           mappings: undefined,
-          aliases: { foo: {} },
+        },
+      });
+
+      sinon.assert.calledWith(client.indices.updateAliases as sinon.SinonSpy, {
+        body: {
+          actions: [{ add: { alias: 'foo', index: 'index' } }],
         },
       });
     });

--- a/x-pack/test/saved_object_api_integration/spaces_only/apis/import.ts
+++ b/x-pack/test/saved_object_api_integration/spaces_only/apis/import.ts
@@ -147,10 +147,7 @@ export default function ({ getService }: FtrProviderContext) {
     return tests.flat();
   };
 
-  // FLAKY: https://github.com/elastic/kibana/issues/158586
-  // Also, https://github.com/elastic/kibana/issues/158918
-  // esArchiver fails with no_shard_available_action_exception after deleting indexes
-  describe.skip('_import', () => {
+  describe('_import', () => {
     getTestScenarios([
       [false, false],
       [false, true],

--- a/x-pack/test/saved_object_api_integration/spaces_only/apis/resolve.ts
+++ b/x-pack/test/saved_object_api_integration/spaces_only/apis/resolve.ts
@@ -41,10 +41,7 @@ export default function ({ getService }: FtrProviderContext) {
     return createTestDefinitions(testCases, false, { spaceId });
   };
 
-  // FLAKY: https://github.com/elastic/kibana/issues/156998, https://github.com/elastic/kibana/issues/156922, https://github.com/elastic/kibana/issues/156921
-  // Also, https://github.com/elastic/kibana/issues/158918
-  // esArchiver fails with no_shard_available_action_exception after deleting indexes
-  describe.skip('_resolve', () => {
+  describe('_resolve', () => {
     getTestScenarios().spaces.forEach(({ spaceId }) => {
       const tests = createTests(spaceId);
       addTests(`within the ${spaceId} space`, { spaceId, tests });

--- a/x-pack/test/saved_object_api_integration/spaces_only/apis/resolve_import_errors.ts
+++ b/x-pack/test/saved_object_api_integration/spaces_only/apis/resolve_import_errors.ts
@@ -130,10 +130,7 @@ export default function ({ getService }: FtrProviderContext) {
     return createTestDefinitions(testCases, false, { overwrite, spaceId, singleRequest });
   };
 
-  // FLAKY: https://github.com/elastic/kibana/issues/155846, https://github.com/elastic/kibana/issues/156045, https://github.com/elastic/kibana/issues/156041
-  // Also, https://github.com/elastic/kibana/issues/158918
-  // esArchiver fails with no_shard_available_action_exception after deleting indexes
-  describe.skip('_resolve_import_errors', () => {
+  describe('_resolve_import_errors', () => {
     getTestScenarios([
       [false, false],
       [false, true],

--- a/x-pack/test/saved_object_api_integration/spaces_only/apis/update.ts
+++ b/x-pack/test/saved_object_api_integration/spaces_only/apis/update.ts
@@ -52,8 +52,7 @@ export default function ({ getService }: FtrProviderContext) {
     return createTestDefinitions(testCases, false);
   };
 
-  // FLAKY: https://github.com/elastic/kibana/issues/157452
-  describe.skip('_update', () => {
+  describe('_update', () => {
     getTestScenarios().spaces.forEach(({ spaceId }) => {
       const tests = createTests(spaceId);
       addTests(`within the ${spaceId} space`, { spaceId, tests });


### PR DESCRIPTION
Tackles https://github.com/elastic/kibana/issues/158918

Updates `esArchiver` so that SO indices are created in two separate steps:

`indices.create()` and `indices.updateAliases()`

This way, any Kibana requests that target SO indices (through their aliases) will either find that the indices exist, or that they do not.

This is a less invasive approach than https://github.com/elastic/kibana/pull/159397, as it does not modify the `esArchiver.load` flow (we don't delete the `mappings.json` files here).

<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->