### PR TITLE
[ML] Hide inference stats for PyTorch models

### DIFF
--- a/x-pack/packages/ml/trained_models_utils/src/constants/trained_models.ts
+++ b/x-pack/packages/ml/trained_models_utils/src/constants/trained_models.ts
@@ -61,12 +61,8 @@ export const ELASTIC_MODEL_DEFINITIONS = {
 
 export const MODEL_STATE = {
   ...DEPLOYMENT_STATE,
-  DOWNLOADING: i18n.translate('xpack.ml.trainedModels.modelsList.downloadingStateLabel', {
-    defaultMessage: 'downloading',
-  }),
-  DOWNLOADED: i18n.translate('xpack.ml.trainedModels.modelsList.downloadedStateLabel', {
-    defaultMessage: 'downloaded',
-  }),
+  DOWNLOADING: 'downloading',
+  DOWNLOADED: 'downloaded',
 } as const;
 
 export type ModelState = typeof MODEL_STATE[keyof typeof MODEL_STATE];

--- a/x-pack/packages/ml/trained_models_utils/src/constants/trained_models.ts
+++ b/x-pack/packages/ml/trained_models_utils/src/constants/trained_models.ts
@@ -65,4 +65,4 @@ export const MODEL_STATE = {
   DOWNLOADED: 'downloaded',
 } as const;
 
-export type ModelState = typeof MODEL_STATE[keyof typeof MODEL_STATE];
+export type ModelState = typeof MODEL_STATE[keyof typeof MODEL_STATE] | null;

--- a/x-pack/plugins/ml/common/types/trained_models.ts
+++ b/x-pack/plugins/ml/common/types/trained_models.ts
@@ -202,6 +202,7 @@ export interface AllocatedModel {
     throughput_last_minute: number;
     number_of_allocations: number;
     threads_per_allocation: number;
+    error_count?: number;
   };
 }
 

--- a/x-pack/plugins/ml/public/application/memory_usage/nodes_overview/allocated_models.tsx
+++ b/x-pack/plugins/ml/public/application/memory_usage/nodes_overview/allocated_models.tsx
@@ -220,6 +220,16 @@ export const AllocatedModels: FC<AllocatedModelsProps> = ({
         return v.node.number_of_pending_requests;
       },
     },
+    {
+      name: i18n.translate('xpack.ml.trainedModels.nodesList.modelsList.errorCountHeader', {
+        defaultMessage: 'Errors',
+      }),
+      width: '60px',
+      'data-test-subj': 'mlAllocatedModelsTableErrorCount',
+      render: (v: AllocatedModel) => {
+        return v.node.error_count ?? 0;
+      },
+    },
   ].filter((v) => !hideColumns.includes(v.id!));
 
   return (

--- a/x-pack/plugins/ml/public/application/model_management/expanded_row.tsx
+++ b/x-pack/plugins/ml/public/application/model_management/expanded_row.tsx
@@ -174,6 +174,7 @@ export const ExpandedRow: FC<ExpandedRowProps> = ({ item }) => {
               'throughput_last_minute',
               'number_of_allocations',
               'threads_per_allocation',
+              'error_count',
             ]),
             name: nodeName,
           } as AllocatedModel['node'],

--- a/x-pack/plugins/ml/public/application/model_management/expanded_row.tsx
+++ b/x-pack/plugins/ml/public/application/model_management/expanded_row.tsx
@@ -27,7 +27,6 @@ import { FIELD_FORMAT_IDS } from '@kbn/field-formats-plugin/common';
 import { isPopulatedObject } from '@kbn/ml-is-populated-object';
 import { isDefined } from '@kbn/ml-is-defined';
 import { TRAINED_MODEL_TYPE } from '@kbn/ml-trained-models-utils';
-import type { PartialBy } from '../../../common/types/common';
 import type { ModelItemFull } from './models_list';
 import { ModelPipelines } from './pipelines';
 import { AllocatedModels } from '../memory_usage/nodes_overview/allocated_models';
@@ -132,17 +131,11 @@ export const ExpandedRow: FC<ExpandedRowProps> = ({ item }) => {
     description,
   } = item;
 
-  const inferenceStats = useMemo(() => {
-    if (!isPopulatedObject(stats.inference_stats)) return;
+  const inferenceStats = useMemo<TrainedModelStat['inference_stats']>(() => {
+    if (!isPopulatedObject(stats.inference_stats) || item.model_type === TRAINED_MODEL_TYPE.PYTORCH)
+      return;
 
-    const result = { ...stats.inference_stats } as PartialBy<
-      Exclude<TrainedModelStat['inference_stats'], undefined>,
-      'cache_miss_count'
-    >;
-    if (item.model_type === TRAINED_MODEL_TYPE.PYTORCH) {
-      delete result.cache_miss_count;
-    }
-    return result;
+    return stats.inference_stats;
   }, [stats.inference_stats, item.model_type]);
 
   const { analytics_config: analyticsConfig, ...restMetaData } = metadata ?? {};

--- a/x-pack/plugins/ml/public/application/model_management/models_list.tsx
+++ b/x-pack/plugins/ml/public/application/model_management/models_list.tsx
@@ -283,7 +283,7 @@ export const ModelsList: FC<Props> = ({
             (v) => v.state === DEPLOYMENT_STATE.STARTED
           )
             ? DEPLOYMENT_STATE.STARTED
-            : '';
+            : null;
         });
 
         const elasticModels = models.filter((model) =>


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/157385

Hides inference stats for the PyTorch models. 

- The salient information (`inference_count`, `timestamp`) is a repeat of what is already displayed in the Deployment Stats section.
- `missing_all_fields_count` is confusing as the PyTorch models take a single input field rather than multiple fields as DFA models do, hence omitted.
- The deployment stats have an [error_count](https://www.elastic.co/guide/en/elasticsearch/reference/current/get-trained-models-stats.html) field, hence it has been added to the Deployment Stats and `failure_count` has been removed.
- Displays the stats tab by default for expanded rows if the model has started deployments 


<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->