### PR TITLE
[Cases] Version `configure` domain object and API

### DIFF
--- a/x-pack/plugins/cases/common/types/api/configure/latest.ts
+++ b/x-pack/plugins/cases/common/types/api/configure/latest.ts
@@ -5,11 +5,4 @@
  * 2.0.
  */
 
-export * from './case';
-export * from './comment';
-export * from './status';
-export * from './user_actions';
-export * from './constants';
-export * from './alerts';
-export * from './user_profiles';
-export * from './assignee';
+export * from './v1';

--- a/x-pack/plugins/cases/common/types/api/configure/v1.test.ts
+++ b/x-pack/plugins/cases/common/types/api/configure/v1.test.ts
@@ -5,28 +5,19 @@
  * 2.0.
  */
 
-import { ConnectorTypes } from '../connectors';
+import { ConnectorTypes } from '../../../api';
 import {
-  ConfigurationAttributesRt,
   CaseConfigureRequestParamsRt,
-  ConfigurationRt,
   ConfigurationPatchRequestRt,
   ConfigurationRequestRt,
   GetConfigurationFindRequestRt,
-} from './configure';
+} from './v1';
 
 describe('configure', () => {
   const serviceNow = {
     id: 'servicenow-1',
     name: 'SN 1',
     type: ConnectorTypes.serviceNowITSM,
-    fields: null,
-  };
-
-  const resilient = {
-    id: 'resilient-2',
-    name: 'Resilient',
-    type: ConnectorTypes.resilient,
     fields: null,
   };
 
@@ -74,100 +65,6 @@ describe('configure', () => {
 
     it('removes foo:bar attributes from request', () => {
       const query = ConfigurationPatchRequestRt.decode({ ...defaultRequest, foo: 'bar' });
-
-      expect(query).toStrictEqual({
-        _tag: 'Right',
-        right: defaultRequest,
-      });
-    });
-  });
-
-  describe('ConfigurationAttributesRt', () => {
-    const defaultRequest = {
-      connector: resilient,
-      closure_type: 'close-by-user',
-      owner: 'cases',
-      created_at: '2020-02-19T23:06:33.798Z',
-      created_by: {
-        full_name: 'Leslie Knope',
-        username: 'lknope',
-        email: 'leslie.knope@elastic.co',
-      },
-      updated_at: '2020-02-19T23:06:33.798Z',
-      updated_by: {
-        full_name: 'Leslie Knope',
-        username: 'lknope',
-        email: 'leslie.knope@elastic.co',
-      },
-    };
-
-    it('has expected attributes in request', () => {
-      const query = ConfigurationAttributesRt.decode(defaultRequest);
-
-      expect(query).toStrictEqual({
-        _tag: 'Right',
-        right: defaultRequest,
-      });
-    });
-
-    it('removes foo:bar attributes from request', () => {
-      const query = ConfigurationAttributesRt.decode({ ...defaultRequest, foo: 'bar' });
-
-      expect(query).toStrictEqual({
-        _tag: 'Right',
-        right: defaultRequest,
-      });
-    });
-  });
-
-  describe('ConfigurationRt', () => {
-    const defaultRequest = {
-      connector: serviceNow,
-      closure_type: 'close-by-user',
-      created_at: '2020-02-19T23:06:33.798Z',
-      created_by: {
-        full_name: 'Leslie Knope',
-        username: 'lknope',
-        email: 'leslie.knope@elastic.co',
-      },
-      updated_at: '2020-02-19T23:06:33.798Z',
-      updated_by: null,
-      mappings: [
-        {
-          source: 'description',
-          target: 'description',
-          action_type: 'overwrite',
-        },
-      ],
-      owner: 'cases',
-      version: 'WzQ3LDFd',
-      id: 'case-id',
-      error: null,
-    };
-
-    it('has expected attributes in request', () => {
-      const query = ConfigurationRt.decode(defaultRequest);
-
-      expect(query).toStrictEqual({
-        _tag: 'Right',
-        right: defaultRequest,
-      });
-    });
-
-    it('removes foo:bar attributes from request', () => {
-      const query = ConfigurationRt.decode({ ...defaultRequest, foo: 'bar' });
-
-      expect(query).toStrictEqual({
-        _tag: 'Right',
-        right: defaultRequest,
-      });
-    });
-
-    it('removes foo:bar attributes from mappings', () => {
-      const query = ConfigurationRt.decode({
-        ...defaultRequest,
-        mappings: [{ ...defaultRequest.mappings[0], foo: 'bar' }],
-      });
 
       expect(query).toStrictEqual({
         _tag: 'Right',

--- a/x-pack/plugins/cases/common/types/api/configure/v1.ts
+++ b/x-pack/plugins/cases/common/types/api/configure/v1.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import * as rt from 'io-ts';
+import { ConfigurationBasicWithoutOwnerRt, CasesConfigureBasicRt } from '../../domain/configure/v1';
+
+export const ConfigurationRequestRt = CasesConfigureBasicRt;
+
+export const GetConfigurationFindRequestRt = rt.exact(
+  rt.partial({
+    /**
+     * The configuration plugin owner to filter the search by. If this is left empty the results will include all configurations
+     * that the user has permissions to access
+     */
+    owner: rt.union([rt.array(rt.string), rt.string]),
+  })
+);
+
+export const CaseConfigureRequestParamsRt = rt.strict({
+  configuration_id: rt.string,
+});
+
+export const ConfigurationPatchRequestRt = rt.intersection([
+  rt.exact(rt.partial(ConfigurationBasicWithoutOwnerRt.type.props)),
+  rt.strict({ version: rt.string }),
+]);
+
+export type ConfigurationRequest = rt.TypeOf<typeof ConfigurationRequestRt>;
+export type ConfigurationPatchRequest = rt.TypeOf<typeof ConfigurationPatchRequestRt>;
+export type GetConfigurationFindRequest = rt.TypeOf<typeof GetConfigurationFindRequestRt>;

--- a/x-pack/plugins/cases/common/types/api/configure/v1.ts
+++ b/x-pack/plugins/cases/common/types/api/configure/v1.ts
@@ -6,6 +6,7 @@
  */
 
 import * as rt from 'io-ts';
+import type { Configurations, Configuration } from '../../domain/configure/v1';
 import { ConfigurationBasicWithoutOwnerRt, CasesConfigureBasicRt } from '../../domain/configure/v1';
 
 export const ConfigurationRequestRt = CasesConfigureBasicRt;
@@ -32,3 +33,6 @@ export const ConfigurationPatchRequestRt = rt.intersection([
 export type ConfigurationRequest = rt.TypeOf<typeof ConfigurationRequestRt>;
 export type ConfigurationPatchRequest = rt.TypeOf<typeof ConfigurationPatchRequestRt>;
 export type GetConfigurationFindRequest = rt.TypeOf<typeof GetConfigurationFindRequestRt>;
+export type GetConfigureResponse = Configurations;
+export type CreateConfigureResponse = Configuration;
+export type UpdateConfigureResponse = Configuration;

--- a/x-pack/plugins/cases/common/types/api/index.ts
+++ b/x-pack/plugins/cases/common/types/api/index.ts
@@ -5,11 +5,8 @@
  * 2.0.
  */
 
-export * from './case';
-export * from './comment';
-export * from './status';
-export * from './user_actions';
-export * from './constants';
-export * from './alerts';
-export * from './user_profiles';
-export * from './assignee';
+// Latest
+export * from './configure/latest';
+
+// V1
+export * as configureApiV1 from './configure/v1';

--- a/x-pack/plugins/cases/common/types/domain/configure/latest.ts
+++ b/x-pack/plugins/cases/common/types/domain/configure/latest.ts
@@ -5,11 +5,4 @@
  * 2.0.
  */
 
-export * from './case';
-export * from './comment';
-export * from './status';
-export * from './user_actions';
-export * from './constants';
-export * from './alerts';
-export * from './user_profiles';
-export * from './assignee';
+export * from './v1';

--- a/x-pack/plugins/cases/common/types/domain/configure/v1.test.ts
+++ b/x-pack/plugins/cases/common/types/domain/configure/v1.test.ts
@@ -1,0 +1,119 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ConnectorTypes } from '../../../api';
+import { ConfigurationAttributesRt, ConfigurationRt } from './v1';
+
+describe('configure', () => {
+  const serviceNow = {
+    id: 'servicenow-1',
+    name: 'SN 1',
+    type: ConnectorTypes.serviceNowITSM,
+    fields: null,
+  };
+
+  const resilient = {
+    id: 'resilient-2',
+    name: 'Resilient',
+    type: ConnectorTypes.resilient,
+    fields: null,
+  };
+
+  describe('ConfigurationAttributesRt', () => {
+    const defaultRequest = {
+      connector: resilient,
+      closure_type: 'close-by-user',
+      owner: 'cases',
+      created_at: '2020-02-19T23:06:33.798Z',
+      created_by: {
+        full_name: 'Leslie Knope',
+        username: 'lknope',
+        email: 'leslie.knope@elastic.co',
+      },
+      updated_at: '2020-02-19T23:06:33.798Z',
+      updated_by: {
+        full_name: 'Leslie Knope',
+        username: 'lknope',
+        email: 'leslie.knope@elastic.co',
+      },
+    };
+
+    it('has expected attributes in request', () => {
+      const query = ConfigurationAttributesRt.decode(defaultRequest);
+
+      expect(query).toStrictEqual({
+        _tag: 'Right',
+        right: defaultRequest,
+      });
+    });
+
+    it('removes foo:bar attributes from request', () => {
+      const query = ConfigurationAttributesRt.decode({ ...defaultRequest, foo: 'bar' });
+
+      expect(query).toStrictEqual({
+        _tag: 'Right',
+        right: defaultRequest,
+      });
+    });
+  });
+
+  describe('ConfigurationRt', () => {
+    const defaultRequest = {
+      connector: serviceNow,
+      closure_type: 'close-by-user',
+      created_at: '2020-02-19T23:06:33.798Z',
+      created_by: {
+        full_name: 'Leslie Knope',
+        username: 'lknope',
+        email: 'leslie.knope@elastic.co',
+      },
+      updated_at: '2020-02-19T23:06:33.798Z',
+      updated_by: null,
+      mappings: [
+        {
+          source: 'description',
+          target: 'description',
+          action_type: 'overwrite',
+        },
+      ],
+      owner: 'cases',
+      version: 'WzQ3LDFd',
+      id: 'case-id',
+      error: null,
+    };
+
+    it('has expected attributes in request', () => {
+      const query = ConfigurationRt.decode(defaultRequest);
+
+      expect(query).toStrictEqual({
+        _tag: 'Right',
+        right: defaultRequest,
+      });
+    });
+
+    it('removes foo:bar attributes from request', () => {
+      const query = ConfigurationRt.decode({ ...defaultRequest, foo: 'bar' });
+
+      expect(query).toStrictEqual({
+        _tag: 'Right',
+        right: defaultRequest,
+      });
+    });
+
+    it('removes foo:bar attributes from mappings', () => {
+      const query = ConfigurationRt.decode({
+        ...defaultRequest,
+        mappings: [{ ...defaultRequest.mappings[0], foo: 'bar' }],
+      });
+
+      expect(query).toStrictEqual({
+        _tag: 'Right',
+        right: defaultRequest,
+      });
+    });
+  });
+});

--- a/x-pack/plugins/cases/common/types/domain/configure/v1.ts
+++ b/x-pack/plugins/cases/common/types/domain/configure/v1.ts
@@ -6,9 +6,7 @@
  */
 
 import * as rt from 'io-ts';
-import { CaseConnectorRt } from '../connectors/connector';
-import { ConnectorMappingsRt } from '../connectors/mappings';
-import { UserRt } from '../user';
+import { CaseConnectorRt, UserRt, ConnectorMappingsRt } from '../../../api';
 
 const ClosureTypeRt = rt.union([rt.literal('close-by-user'), rt.literal('close-by-pushing')]);
 
@@ -23,7 +21,7 @@ export const ConfigurationBasicWithoutOwnerRt = rt.strict({
   closure_type: ClosureTypeRt,
 });
 
-const CasesConfigureBasicRt = rt.intersection([
+export const CasesConfigureBasicRt = rt.intersection([
   ConfigurationBasicWithoutOwnerRt,
   rt.strict({
     /**
@@ -31,12 +29,6 @@ const CasesConfigureBasicRt = rt.intersection([
      */
     owner: rt.string,
   }),
-]);
-
-export const ConfigurationRequestRt = CasesConfigureBasicRt;
-export const ConfigurationPatchRequestRt = rt.intersection([
-  rt.exact(rt.partial(ConfigurationBasicWithoutOwnerRt.type.props)),
-  rt.strict({ version: rt.string }),
 ]);
 
 export const ConfigurationActivityFieldsRt = rt.strict({
@@ -62,27 +54,9 @@ export const ConfigurationRt = rt.intersection([
   }),
 ]);
 
-export const GetConfigurationFindRequestRt = rt.exact(
-  rt.partial({
-    /**
-     * The configuration plugin owner to filter the search by. If this is left empty the results will include all configurations
-     * that the user has permissions to access
-     */
-    owner: rt.union([rt.array(rt.string), rt.string]),
-  })
-);
-
-export const CaseConfigureRequestParamsRt = rt.strict({
-  configuration_id: rt.string,
-});
-
 export const ConfigurationsRt = rt.array(ConfigurationRt);
 
 export type ClosureType = rt.TypeOf<typeof ClosureTypeRt>;
-export type ConfigurationRequest = rt.TypeOf<typeof ConfigurationRequestRt>;
-export type ConfigurationPatchRequest = rt.TypeOf<typeof ConfigurationPatchRequestRt>;
 export type ConfigurationAttributes = rt.TypeOf<typeof ConfigurationAttributesRt>;
 export type Configuration = rt.TypeOf<typeof ConfigurationRt>;
 export type Configurations = rt.TypeOf<typeof ConfigurationsRt>;
-
-export type GetConfigurationFindRequest = rt.TypeOf<typeof GetConfigurationFindRequestRt>;

--- a/x-pack/plugins/cases/common/types/domain/index.ts
+++ b/x-pack/plugins/cases/common/types/domain/index.ts
@@ -5,11 +5,8 @@
  * 2.0.
  */
 
-export * from './case';
-export * from './comment';
-export * from './status';
-export * from './user_actions';
-export * from './constants';
-export * from './alerts';
-export * from './user_profiles';
-export * from './assignee';
+// Latest
+export * from './configure/latest';
+
+// V1
+export * as configureDomainV1 from './configure/v1';

--- a/x-pack/plugins/cases/public/containers/configure/__mocks__/api.ts
+++ b/x-pack/plugins/cases/public/containers/configure/__mocks__/api.ts
@@ -5,17 +5,13 @@
  * 2.0.
  */
 
-import type {
-  ConfigurationPatchRequest,
-  ConfigurationRequest,
-  ActionConnector,
-  ActionTypeConnector,
-} from '../../../../common/api';
+import type { ActionConnector, ActionTypeConnector } from '../../../../common/api';
 
 import type { ApiProps } from '../../types';
 import type { CaseConfigure } from '../types';
 import { caseConfigurationCamelCaseResponseMock } from '../mock';
 import { actionTypesMock, connectorsMock } from '../../../common/mock/connectors';
+import type { ConfigurationPatchRequest, ConfigurationRequest } from '../../../../common/types/api';
 
 export const getSupportedActionConnectors = async ({
   signal,

--- a/x-pack/plugins/cases/public/containers/configure/api.ts
+++ b/x-pack/plugins/cases/public/containers/configure/api.ts
@@ -7,15 +7,10 @@
 
 import { isEmpty } from 'lodash/fp';
 import { CasesConnectorFeatureId } from '@kbn/actions-plugin/common';
+import type { ConfigurationPatchRequest, ConfigurationRequest } from '../../../common/types/api';
+import type { Configuration, Configurations } from '../../../common/types/domain';
 import { getAllConnectorTypesUrl } from '../../../common/utils/connectors_api';
-import type {
-  ActionConnector,
-  ActionTypeConnector,
-  ConfigurationPatchRequest,
-  ConfigurationRequest,
-  Configuration,
-  Configurations,
-} from '../../../common/api';
+import type { ActionConnector, ActionTypeConnector } from '../../../common/api';
 import { getCaseConfigurationDetailsUrl } from '../../../common/api';
 import { CASE_CONFIGURE_CONNECTORS_URL, CASE_CONFIGURE_URL } from '../../../common/constants';
 import { KibanaServices } from '../../common/lib/kibana';

--- a/x-pack/plugins/cases/public/containers/configure/mock.ts
+++ b/x-pack/plugins/cases/public/containers/configure/mock.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import type { Configuration, ConfigurationRequest } from '../../../common/api';
+import type { ConfigurationRequest } from '../../../common/types/api';
+import type { Configuration } from '../../../common/types/domain';
 import { ConnectorTypes } from '../../../common/api';
 import { SECURITY_SOLUTION_OWNER } from '../../../common/constants';
 import type { CaseConfigure, CaseConnectorMapping } from './types';

--- a/x-pack/plugins/cases/public/containers/configure/types.ts
+++ b/x-pack/plugins/cases/public/containers/configure/types.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import type { ClosureType, ConfigurationAttributes } from '../../../common/types/domain';
 import type { CaseUser } from '../types';
 import type {
   ActionConnector,
@@ -12,9 +13,7 @@ import type {
   ActionType,
   CaseConnector,
   CaseField,
-  ClosureType,
   ThirdPartyField,
-  ConfigurationAttributes,
 } from '../../../common/api';
 
 export type {

--- a/x-pack/plugins/cases/public/containers/utils.ts
+++ b/x-pack/plugins/cases/public/containers/utils.ts
@@ -11,10 +11,10 @@ import { identity } from 'fp-ts/lib/function';
 import { pipe } from 'fp-ts/lib/pipeable';
 
 import type { ToastInputFields } from '@kbn/core/public';
+import type { Configuration, Configurations } from '../../common/types/domain';
+import { ConfigurationRt, ConfigurationsRt } from '../../common/types/domain';
 import { NO_ASSIGNEES_FILTERING_KEYWORD } from '../../common/constants';
 import type {
-  Configurations,
-  Configuration,
   UserActions,
   CasePatchRequest,
   CaseResolveResponse,
@@ -28,8 +28,6 @@ import {
   CaseRt,
   CasesRt,
   throwErrors,
-  ConfigurationsRt,
-  ConfigurationRt,
   UserActionsRt,
   CommentType,
   CaseResolveResponseRt,

--- a/x-pack/plugins/cases/server/client/cases/push.ts
+++ b/x-pack/plugins/cases/server/client/cases/push.ts
@@ -12,11 +12,11 @@ import type { SavedObjectsFindResponse } from '@kbn/core/server';
 import type { UserProfile } from '@kbn/security-plugin/common';
 import type { SecurityPluginStart } from '@kbn/security-plugin/server';
 import { asSavedObjectExecutionSource } from '@kbn/actions-plugin/server';
+import type { ConfigurationAttributes } from '../../../common/types/domain';
 import type {
   ActionConnector,
   Case,
   ExternalServiceResponse,
-  ConfigurationAttributes,
   CommentRequestAlertType,
   CommentAttributes,
 } from '../../../common/api';

--- a/x-pack/plugins/cases/server/client/configure/client.ts
+++ b/x-pack/plugins/cases/server/client/configure/client.ts
@@ -14,24 +14,22 @@ import type { FindActionResult } from '@kbn/actions-plugin/server/types';
 import type { ActionType } from '@kbn/actions-plugin/common';
 import { CasesConnectorFeatureId } from '@kbn/actions-plugin/common';
 import type {
-  Configurations,
+  Configuration,
   ConfigurationAttributes,
+  Configurations,
+} from '../../../common/types/domain';
+import type {
   ConfigurationPatchRequest,
   ConfigurationRequest,
-  Configuration,
-  ConnectorMappings,
   GetConfigurationFindRequest,
-  ConnectorMappingResponse,
-} from '../../../common/api';
+} from '../../../common/types/api';
 import {
-  ConfigurationsRt,
   ConfigurationPatchRequestRt,
-  GetConfigurationFindRequestRt,
-  ConfigurationRt,
-  FindActionConnectorResponseRt,
-  decodeWithExcessOrThrow,
   ConfigurationRequestRt,
-} from '../../../common/api';
+  GetConfigurationFindRequestRt,
+} from '../../../common/types/api';
+import type { ConnectorMappings, ConnectorMappingResponse } from '../../../common/api';
+import { FindActionConnectorResponseRt, decodeWithExcessOrThrow } from '../../../common/api';
 import { MAX_CONCURRENT_SEARCHES } from '../../../common/constants';
 import { createCaseError } from '../../common/error';
 import type { CasesClientInternal } from '../client_internal';
@@ -44,6 +42,7 @@ import type { MappingsArgs, CreateMappingsArgs, UpdateMappingsArgs } from './typ
 import { createMappings } from './create_mappings';
 import { updateMappings } from './update_mappings';
 import { decodeOrThrow } from '../../../common/api/runtime_types';
+import { ConfigurationRt, ConfigurationsRt } from '../../../common/types/domain';
 
 /**
  * Defines the internal helper functions.

--- a/x-pack/plugins/cases/server/client/configure/client.ts
+++ b/x-pack/plugins/cases/server/client/configure/client.ts
@@ -62,7 +62,7 @@ export interface ConfigureSubClient {
   /**
    * Retrieves the external connector configuration for a particular case owner.
    */
-  get(params: GetConfigurationFindRequest): Promise<Configuration | {}>;
+  get(params: GetConfigurationFindRequest): Promise<Configurations>;
   /**
    * Retrieves the valid external connectors supported by the cases plugin.
    */

--- a/x-pack/plugins/cases/server/common/types/configure.ts
+++ b/x-pack/plugins/cases/server/common/types/configure.ts
@@ -8,12 +8,12 @@
 import * as rt from 'io-ts';
 
 import type { SavedObject } from '@kbn/core/server';
-import type { ConfigurationAttributes } from '../../../common/api';
+import type { ConfigurationAttributes } from '../../../common/types/domain';
 import {
   ConfigurationActivityFieldsRt,
-  ConfigurationBasicWithoutOwnerRt,
   ConfigurationAttributesRt,
-} from '../../../common/api';
+  ConfigurationBasicWithoutOwnerRt,
+} from '../../../common/types/domain';
 import type { ConnectorPersisted } from './connectors';
 import type { User } from './user';
 

--- a/x-pack/plugins/cases/server/routes/api/configure/get_configure.ts
+++ b/x-pack/plugins/cases/server/routes/api/configure/get_configure.ts
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
+import type { GetConfigurationFindRequest } from '../../../../common/types/api';
 import { CASE_CONFIGURE_URL } from '../../../../common/constants';
-import type { GetConfigurationFindRequest } from '../../../../common/api';
 import { createCaseError } from '../../../common/error';
 import { createCasesRoute } from '../create_cases_route';
 

--- a/x-pack/plugins/cases/server/routes/api/configure/get_configure.ts
+++ b/x-pack/plugins/cases/server/routes/api/configure/get_configure.ts
@@ -5,10 +5,10 @@
  * 2.0.
  */
 
-import type { GetConfigurationFindRequest } from '../../../../common/types/api';
 import { CASE_CONFIGURE_URL } from '../../../../common/constants';
 import { createCaseError } from '../../../common/error';
 import { createCasesRoute } from '../create_cases_route';
+import type { configureApiV1 } from '../../../../common/types/api';
 
 export const getCaseConfigureRoute = createCasesRoute({
   method: 'get',
@@ -17,10 +17,12 @@ export const getCaseConfigureRoute = createCasesRoute({
     try {
       const caseContext = await context.cases;
       const client = await caseContext.getCasesClient();
-      const options = request.query as GetConfigurationFindRequest;
+      const options = request.query as configureApiV1.GetConfigurationFindRequest;
+
+      const res: configureApiV1.GetConfigureResponse = await client.configure.get({ ...options });
 
       return response.ok({
-        body: await client.configure.get({ ...options }),
+        body: res,
       });
     } catch (error) {
       throw createCaseError({

--- a/x-pack/plugins/cases/server/routes/api/configure/patch_configure.ts
+++ b/x-pack/plugins/cases/server/routes/api/configure/patch_configure.ts
@@ -5,12 +5,12 @@
  * 2.0.
  */
 
-import type { ConfigurationPatchRequest } from '../../../../common/types/api';
 import { CaseConfigureRequestParamsRt } from '../../../../common/types/api';
 import { decodeWithExcessOrThrow } from '../../../../common/api';
 import { CASE_CONFIGURE_DETAILS_URL } from '../../../../common/constants';
 import { createCaseError } from '../../../common/error';
 import { createCasesRoute } from '../create_cases_route';
+import type { configureApiV1 } from '../../../../common/types/api';
 
 export const patchCaseConfigureRoute = createCasesRoute({
   method: 'patch',
@@ -21,10 +21,14 @@ export const patchCaseConfigureRoute = createCasesRoute({
 
       const caseContext = await context.cases;
       const client = await caseContext.getCasesClient();
-      const configuration = request.body as ConfigurationPatchRequest;
+      const configuration = request.body as configureApiV1.ConfigurationPatchRequest;
+      const res: configureApiV1.UpdateConfigureResponse = await client.configure.update(
+        params.configuration_id,
+        configuration
+      );
 
       return response.ok({
-        body: await client.configure.update(params.configuration_id, configuration),
+        body: res,
       });
     } catch (error) {
       throw createCaseError({

--- a/x-pack/plugins/cases/server/routes/api/configure/patch_configure.ts
+++ b/x-pack/plugins/cases/server/routes/api/configure/patch_configure.ts
@@ -5,8 +5,9 @@
  * 2.0.
  */
 
-import type { ConfigurationPatchRequest } from '../../../../common/api';
-import { CaseConfigureRequestParamsRt, decodeWithExcessOrThrow } from '../../../../common/api';
+import type { ConfigurationPatchRequest } from '../../../../common/types/api';
+import { CaseConfigureRequestParamsRt } from '../../../../common/types/api';
+import { decodeWithExcessOrThrow } from '../../../../common/api';
 import { CASE_CONFIGURE_DETAILS_URL } from '../../../../common/constants';
 import { createCaseError } from '../../../common/error';
 import { createCasesRoute } from '../create_cases_route';

--- a/x-pack/plugins/cases/server/routes/api/configure/post_configure.ts
+++ b/x-pack/plugins/cases/server/routes/api/configure/post_configure.ts
@@ -10,6 +10,7 @@ import { decodeWithExcessOrThrow } from '../../../../common/api';
 import { CASE_CONFIGURE_URL } from '../../../../common/constants';
 import { createCaseError } from '../../../common/error';
 import { createCasesRoute } from '../create_cases_route';
+import type { configureApiV1 } from '../../../../common/types/api';
 
 export const postCaseConfigureRoute = createCasesRoute({
   method: 'post',
@@ -20,9 +21,10 @@ export const postCaseConfigureRoute = createCasesRoute({
 
       const caseContext = await context.cases;
       const client = await caseContext.getCasesClient();
+      const res: configureApiV1.CreateConfigureResponse = await client.configure.create(query);
 
       return response.ok({
-        body: await client.configure.create(query),
+        body: res,
       });
     } catch (error) {
       throw createCaseError({

--- a/x-pack/plugins/cases/server/routes/api/configure/post_configure.ts
+++ b/x-pack/plugins/cases/server/routes/api/configure/post_configure.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { ConfigurationRequestRt, decodeWithExcessOrThrow } from '../../../../common/api';
+import { ConfigurationRequestRt } from '../../../../common/types/api';
+import { decodeWithExcessOrThrow } from '../../../../common/api';
 import { CASE_CONFIGURE_URL } from '../../../../common/constants';
 import { createCaseError } from '../../../common/error';
 import { createCasesRoute } from '../create_cases_route';

--- a/x-pack/plugins/cases/server/saved_object_types/migrations/configuration.test.ts
+++ b/x-pack/plugins/cases/server/saved_object_types/migrations/configuration.test.ts
@@ -7,7 +7,6 @@
 
 import type { SavedObjectSanitizedDoc, SavedObjectUnsanitizedDoc } from '@kbn/core/server';
 import { ACTION_SAVED_OBJECT_TYPE } from '@kbn/actions-plugin/server';
-import type { ConfigurationAttributes } from '../../../common/api';
 import { ConnectorTypes } from '../../../common/api';
 import { CASE_CONFIGURE_SAVED_OBJECT, SECURITY_SOLUTION_OWNER } from '../../../common/constants';
 import { CONNECTOR_ID_REFERENCE_NAME } from '../../common/constants';
@@ -16,6 +15,7 @@ import type { ESCaseConnectorWithId } from '../../services/test_utils';
 import type { UnsanitizedConfigureConnector } from './configuration';
 import { createConnectorAttributeMigration, configureConnectorIdMigration } from './configuration';
 import type { ConfigurationPersistedAttributes } from '../../common/types/configure';
+import type { ConfigurationAttributes } from '../../../common/types/domain';
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 const create_7_14_0_configSchema = (connector?: ESCaseConnectorWithId) => ({

--- a/x-pack/plugins/cases/server/services/configure/index.test.ts
+++ b/x-pack/plugins/cases/server/services/configure/index.test.ts
@@ -5,11 +5,7 @@
  * 2.0.
  */
 
-import type {
-  CaseConnector,
-  ConfigurationAttributes,
-  ConfigurationPatchRequest,
-} from '../../../common/api';
+import type { CaseConnector } from '../../../common/api';
 import { ConnectorTypes } from '../../../common/api';
 import { CASE_CONFIGURE_SAVED_OBJECT, SECURITY_SOLUTION_OWNER } from '../../../common/constants';
 import { savedObjectsClientMock } from '@kbn/core/server/mocks';
@@ -30,6 +26,8 @@ import type { ESCaseConnectorWithId } from '../test_utils';
 import { createESJiraConnector, createJiraConnector } from '../test_utils';
 import type { ConfigurationPersistedAttributes } from '../../common/types/configure';
 import { unset } from 'lodash';
+import type { ConfigurationPatchRequest } from '../../../common/types/api';
+import type { ConfigurationAttributes } from '../../../common/types/domain';
 
 const basicConfigFields = {
   closure_type: 'close-by-pushing' as const,

--- a/x-pack/plugins/cases/server/services/configure/index.ts
+++ b/x-pack/plugins/cases/server/services/configure/index.ts
@@ -13,8 +13,8 @@ import type {
 } from '@kbn/core/server';
 
 import { ACTION_SAVED_OBJECT_TYPE } from '@kbn/actions-plugin/server';
+import type { ConfigurationAttributes } from '../../../common/types/domain';
 import { CONNECTOR_ID_REFERENCE_NAME } from '../../common/constants';
-import type { ConfigurationAttributes } from '../../../common/api';
 import { decodeOrThrow } from '../../../common/api';
 import { CASE_CONFIGURE_SAVED_OBJECT } from '../../../common/constants';
 import {

--- a/x-pack/plugins/cases/server/services/configure/types.ts
+++ b/x-pack/plugins/cases/server/services/configure/types.ts
@@ -6,7 +6,7 @@
  */
 
 import type { SavedObject, SavedObjectsClientContract } from '@kbn/core/server';
-import type { ConfigurationAttributes } from '../../../common/api';
+import type { ConfigurationAttributes } from '../../../common/types/domain';
 import type { IndexRefresh } from '../types';
 import type { SavedObjectFindOptionsKueryNode } from '../../common/types';
 

--- a/x-pack/test/cases_api_integration/common/lib/api/configuration.ts
+++ b/x-pack/test/cases_api_integration/common/lib/api/configuration.ts
@@ -5,13 +5,10 @@
  * 2.0.
  */
 
-import {
-  CaseConnector,
-  ConfigurationRequest,
-  Configuration,
-  ConnectorTypes,
-} from '@kbn/cases-plugin/common/api';
+import { CaseConnector, ConnectorTypes } from '@kbn/cases-plugin/common/api';
 import { CASE_CONFIGURE_URL } from '@kbn/cases-plugin/common/constants';
+import { ConfigurationRequest } from '@kbn/cases-plugin/common/types/api';
+import { Configuration } from '@kbn/cases-plugin/common/types/domain';
 import type SuperTest from 'supertest';
 import { User } from '../authentication/types';
 

--- a/x-pack/test/cases_api_integration/common/lib/api/connectors.ts
+++ b/x-pack/test/cases_api_integration/common/lib/api/connectors.ts
@@ -11,7 +11,6 @@ import http from 'http';
 import type SuperTest from 'supertest';
 import { CASE_CONFIGURE_CONNECTORS_URL } from '@kbn/cases-plugin/common/constants';
 import {
-  Configuration,
   CaseConnector,
   ConnectorTypes,
   CasePostRequest,
@@ -22,6 +21,7 @@ import {
 import { ActionResult, FindActionResult } from '@kbn/actions-plugin/server/types';
 import { getServiceNowServer } from '@kbn/actions-simulators-plugin/server/plugin';
 import { RecordingServiceNowSimulator } from '@kbn/actions-simulators-plugin/server/servicenow_simulation';
+import { Configuration } from '@kbn/cases-plugin/common/types/domain';
 import { User } from '../authentication/types';
 import { superUser } from '../authentication/users';
 import { getPostCaseRequest } from '../mock';

--- a/x-pack/test/cases_api_integration/common/lib/api/index.ts
+++ b/x-pack/test/cases_api_integration/common/lib/api/index.ts
@@ -27,15 +27,12 @@ import {
   INTERNAL_GET_CASE_CATEGORIES_URL,
 } from '@kbn/cases-plugin/common/constants';
 import {
-  Configuration,
   Case,
   CaseStatuses,
   Cases,
   CasesFindResponse,
   CasesPatchRequest,
-  ConfigurationPatchRequest,
   CasesStatusResponse,
-  Configurations,
   AlertResponse,
   ConnectorMappingsAttributes,
   CasesByAlertId,
@@ -49,6 +46,8 @@ import { ActionResult } from '@kbn/actions-plugin/server/types';
 import { CasePersistedAttributes } from '@kbn/cases-plugin/server/common/types/case';
 import type { SavedObjectsRawDocSource } from '@kbn/core/server';
 import type { ConfigurationPersistedAttributes } from '@kbn/cases-plugin/server/common/types/configure';
+import { Configurations, Configuration } from '@kbn/cases-plugin/common/types/domain';
+import { ConfigurationPatchRequest } from '@kbn/cases-plugin/common/types/api';
 import { User } from '../authentication/types';
 import { superUser } from '../authentication/users';
 import { getSpaceUrlPrefix, setupAuth } from './helpers';


### PR DESCRIPTION
## Summary

This PR versions the `configure` domain object and its corresponding APIs. Specifically:

- Initiate the folder structure for the other domain objects.

```
common
  types
    api
       configure
         latest.ts
         v1.ts
       index.ts
    domain
       configure
         latest.ts
         v1.ts
       index.ts
```

- Version the domain types of the `configure`
- Version the APIs of the `configure`

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
