### PR TITLE
[8.9] [APM] Move `advancedSettings` plugin to `requiredBundles` section (#160576)

### DIFF
--- a/x-pack/plugins/apm/kibana.jsonc
+++ b/x-pack/plugins/apm/kibana.jsonc
@@ -25,7 +25,6 @@
       "share",
       "unifiedSearch",
       "dataViews",
-      "advancedSettings",
       "unifiedFieldList",
       "lens",
       "maps",
@@ -49,6 +48,7 @@
       "licenseManagement"
     ],
     "requiredBundles": [
+      "advancedSettings",
       "fleet",
       "kibanaReact",
       "kibanaUtils",


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.9`:
 - [[APM] Move `advancedSettings` plugin to `requiredBundles` section (#160576)](https://github.com/elastic/kibana/pull/160576)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Søren Louv-Jansen","email":"soren.louv@elastic.co"},"sourceCommit":{"committedDate":"2023-06-27T07:45:45Z","message":"[APM] Move `advancedSettings` plugin to `requiredBundles` section (#160576)\n\nAdvanced Settings plugin is disabled on serverless. We need it to import\r\nsome shared react components. Moving `advancedSettings` to\r\n`requiredBundles` should solve this.","sha":"595c8f55966b73408da892176035563d4bfaf4f0","branchLabelMapping":{"^v8.10.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:APM","release_note:skip","v8.9.0","v8.10.0"],"number":160576,"url":"https://github.com/elastic/kibana/pull/160576","mergeCommit":{"message":"[APM] Move `advancedSettings` plugin to `requiredBundles` section (#160576)\n\nAdvanced Settings plugin is disabled on serverless. We need it to import\r\nsome shared react components. Moving `advancedSettings` to\r\n`requiredBundles` should solve this.","sha":"595c8f55966b73408da892176035563d4bfaf4f0"}},"sourceBranch":"main","suggestedTargetBranches":["8.9"],"targetPullRequestStates":[{"branch":"8.9","label":"v8.9.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.10.0","labelRegex":"^v8.10.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/160576","number":160576,"mergeCommit":{"message":"[APM] Move `advancedSettings` plugin to `requiredBundles` section (#160576)\n\nAdvanced Settings plugin is disabled on serverless. We need it to import\r\nsome shared react components. Moving `advancedSettings` to\r\n`requiredBundles` should solve this.","sha":"595c8f55966b73408da892176035563d4bfaf4f0"}}]}] BACKPORT-->