### PR TITLE
[Ops] Add github action for auto-approving PRs from kibanamachine

### DIFF
--- a/.github/workflows/auto-approve-backports.yml
+++ b/.github/workflows/auto-approve-backports.yml
@@ -1,0 +1,21 @@
+on:
+  pull_request_target:
+    branches-ignore:
+      - main
+    types:
+      - opened
+
+env:
+  NODE_ENV: kibana-github-action
+
+jobs:
+  approve:
+    name: Auto-approve backport
+    runs-on: ubuntu-latest
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'backport') &&
+      github.event.pull_request.user.login == 'kibanamachine'
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: hmarr/auto-approve-action@v3

--- a/.github/workflows/auto-approve-backports.yml
+++ b/.github/workflows/auto-approve-backports.yml
@@ -19,3 +19,5 @@ jobs:
       pull-requests: write
     steps:
       - uses: hmarr/auto-approve-action@v3
+        with:
+          github-token: ${{ secrets.KIBANAMACHINE_TOKEN }}


### PR DESCRIPTION
## Summary
Adds a GitHub workflow/action for auto-approving backport PRs incoming from kibanamachine.

These changes are already reviewed by an owner when it was merged to `main` - afterward the `kibanamachine` creates the PR to the non-main branches, these can be auto-approved when created, so that the backport automation is working without assistance.


<!--ONMERGE {"backportTargets":["7.17","8.9"]} ONMERGE-->