### PR TITLE
[ML] Explain Log Rate Spikes: Fix slowness of `flushFix` random payload generation.

### DIFF
--- a/x-pack/packages/ml/aiops_utils/src/stream_factory.ts
+++ b/x-pack/packages/ml/aiops_utils/src/stream_factory.ts
@@ -73,6 +73,9 @@ export function streamFactory<T = unknown>(
 ): StreamFactoryReturnType<T> {
   let streamType: StreamType;
   const isCompressed = compressOverride && acceptCompression(headers);
+  const flushPayload = flushFix
+    ? crypto.randomBytes(FLUSH_PAYLOAD_SIZE).toString('hex')
+    : undefined;
 
   const stream = isCompressed ? zlib.createGzip() : new UncompressedResponseStream();
 
@@ -149,9 +152,7 @@ export function streamFactory<T = unknown>(
           ? `${JSON.stringify({
               ...d,
               // This is a temporary fix for response streaming with proxy configurations that buffer responses up to 4KB in size.
-              ...(flushFix
-                ? { flushPayload: crypto.randomBytes(FLUSH_PAYLOAD_SIZE).toString('hex') }
-                : {}),
+              ...(flushFix ? { flushPayload } : {}),
             })}${DELIMITER}`
           : d;
 

--- a/x-pack/plugins/aiops/public/components/explain_log_rate_spikes/explain_log_rate_spikes_analysis.tsx
+++ b/x-pack/plugins/aiops/public/components/explain_log_rate_spikes/explain_log_rate_spikes_analysis.tsx
@@ -170,7 +170,7 @@ export const ExplainLogRateSpikesAnalysis: FC<ExplainLogRateSpikesAnalysisProps>
       timeFieldName: dataView.timeFieldName ?? '',
       index: dataView.getIndexPattern(),
       grouping: true,
-      flushFix: false,
+      flushFix: true,
       ...windowParameters,
       overrides,
       sampleProbability,

--- a/x-pack/plugins/aiops/public/components/explain_log_rate_spikes/explain_log_rate_spikes_analysis.tsx
+++ b/x-pack/plugins/aiops/public/components/explain_log_rate_spikes/explain_log_rate_spikes_analysis.tsx
@@ -170,7 +170,7 @@ export const ExplainLogRateSpikesAnalysis: FC<ExplainLogRateSpikesAnalysisProps>
       timeFieldName: dataView.timeFieldName ?? '',
       index: dataView.getIndexPattern(),
       grouping: true,
-      flushFix: true,
+      flushFix: false,
       ...windowParameters,
       overrides,
       sampleProbability,

--- a/x-pack/plugins/aiops/server/routes/explain_log_rate_spikes.ts
+++ b/x-pack/plugins/aiops/server/routes/explain_log_rate_spikes.ts
@@ -430,85 +430,193 @@ export const defineExplainLogRateSpikesRoute = (
                 return;
               }
 
-              if (groupingEnabled) {
-                logDebugMessage('Group results.');
+              let isGroupingDone = true;
 
-                push(
-                  updateLoadingStateAction({
-                    ccsWarning: false,
-                    loaded,
-                    loadingState: i18n.translate(
-                      'xpack.aiops.explainLogRateSpikes.loadingState.groupingResults',
-                      {
-                        defaultMessage: 'Transforming significant field/value pairs into groups.',
-                      }
-                    ),
-                    groupsMissing: true,
-                  })
-                );
-
-                try {
-                  const { fields, df } = await fetchFrequentItemSets(
-                    client,
-                    request.body.index,
-                    JSON.parse(request.body.searchQuery) as estypes.QueryDslQueryContainer,
-                    significantTerms,
-                    request.body.timeFieldName,
-                    request.body.deviationMin,
-                    request.body.deviationMax,
-                    logger,
-                    sampleProbability,
-                    pushError,
-                    abortSignal
-                  );
-
-                  if (shouldStop) {
-                    logDebugMessage('shouldStop after fetching frequent_item_sets.');
-                    end();
-                    return;
-                  }
-
-                  if (fields.length > 0 && df.length > 0) {
-                    const significantTermGroups = getSignificantTermGroups(
-                      df,
-                      significantTerms,
-                      fields
+              function asyncGrouping() {
+                return new Promise(async (resolve, reject) => {
+                  try {
+                    logDebugMessage('Group results.');
+                    isGroupingDone = false;
+                    push(
+                      updateLoadingStateAction({
+                        ccsWarning: false,
+                        loaded,
+                        loadingState: i18n.translate(
+                          'xpack.aiops.explainLogRateSpikes.loadingState.groupingResults',
+                          {
+                            defaultMessage:
+                              'Transforming significant field/value pairs into groups.',
+                          }
+                        ),
+                        groupsMissing: true,
+                      })
                     );
-
-                    // We'll find out if there's at least one group with at least two items,
-                    // only then will we return the groups to the clients and make the grouping option available.
-                    const maxItems = Math.max(...significantTermGroups.map((g) => g.group.length));
-
-                    if (maxItems > 1) {
-                      push(addSignificantTermsGroupAction(significantTermGroups));
-                    }
-
-                    loaded += PROGRESS_STEP_GROUPING;
-
-                    pushHistogramDataLoadingState();
-
-                    if (shouldStop) {
-                      logDebugMessage('shouldStop after grouping.');
-                      end();
-                      return;
-                    }
-
-                    logDebugMessage(`Fetch ${significantTermGroups.length} group histograms.`);
-
-                    const groupHistogramQueue = queue(async function (cpg: SignificantTermGroup) {
+                    try {
+                      const { fields, df } = await fetchFrequentItemSets(
+                        client,
+                        request.body.index,
+                        JSON.parse(request.body.searchQuery) as estypes.QueryDslQueryContainer,
+                        significantTerms,
+                        request.body.timeFieldName,
+                        request.body.deviationMin,
+                        request.body.deviationMax,
+                        logger,
+                        sampleProbability,
+                        pushError,
+                        abortSignal
+                      );
                       if (shouldStop) {
-                        logDebugMessage('shouldStop abort fetching group histograms.');
-                        groupHistogramQueue.kill();
-                        end();
-                        return;
+                        logDebugMessage('shouldStop after fetching frequent_item_sets.');
+                        isGroupingDone = true;
+                        resolve(shouldStop);
+                      }
+                      if (fields.length > 0 && df.length > 0) {
+                        const significantTermGroups = getSignificantTermGroups(
+                          df,
+                          significantTerms,
+                          fields
+                        );
+
+                        // We'll find out if there's at least one group with at least two items,
+                        // only then will we return the groups to the clients and make the grouping option available.
+                        const maxItems = Math.max(
+                          ...significantTermGroups.map((g) => g.group.length)
+                        );
+                        if (maxItems > 1) {
+                          push(addSignificantTermsGroupAction(significantTermGroups));
+                        }
+                        loaded += PROGRESS_STEP_GROUPING;
+                        pushHistogramDataLoadingState();
+                        if (shouldStop) {
+                          logDebugMessage('shouldStop after grouping.');
+                          isGroupingDone = true;
+                          resolve(shouldStop);
+                        }
+                        logDebugMessage(`Fetch ${significantTermGroups.length} group histograms.`);
+                        const groupHistogramQueue = queue(async function (
+                          cpg: SignificantTermGroup
+                        ) {
+                          if (shouldStop) {
+                            logDebugMessage('shouldStop abort fetching group histograms.');
+                            groupHistogramQueue.kill();
+                            isGroupingDone = true;
+                            resolve(shouldStop);
+                          }
+                          if (overallTimeSeries !== undefined) {
+                            const histogramQuery = getHistogramQuery(
+                              request.body,
+                              getGroupFilter(cpg)
+                            );
+                            let cpgTimeSeries: NumericChartData;
+                            try {
+                              cpgTimeSeries = (
+                                (await fetchHistogramsForFields(
+                                  client,
+                                  request.body.index,
+                                  histogramQuery,
+                                  // fields
+                                  [
+                                    {
+                                      fieldName: request.body.timeFieldName,
+                                      type: KBN_FIELD_TYPES.DATE,
+                                      interval: overallTimeSeries.interval,
+                                      min: overallTimeSeries.stats[0],
+                                      max: overallTimeSeries.stats[1],
+                                    },
+                                  ],
+                                  // samplerShardSize
+                                  -1,
+                                  undefined,
+                                  abortSignal,
+                                  sampleProbability,
+                                  RANDOM_SAMPLER_SEED
+                                )) as [NumericChartData]
+                              )[0];
+                            } catch (e) {
+                              if (!isRequestAbortedError(e)) {
+                                logger.error(
+                                  `Failed to fetch the histogram data for group #${
+                                    cpg.id
+                                  }, got: \n${e.toString()}`
+                                );
+                                pushError(
+                                  `Failed to fetch the histogram data for group #${cpg.id}.`
+                                );
+                              }
+                              isGroupingDone = true;
+                              reject(false);
+                            }
+                            const histogram =
+                              overallTimeSeries.data.map((o, i) => {
+                                const current = cpgTimeSeries.data.find(
+                                  (d1) => d1.key_as_string === o.key_as_string
+                                ) ?? {
+                                  doc_count: 0,
+                                };
+                                return {
+                                  key: o.key,
+                                  key_as_string: o.key_as_string ?? '',
+                                  doc_count_significant_term: current.doc_count,
+                                  doc_count_overall: Math.max(0, o.doc_count - current.doc_count),
+                                };
+                              }) ?? [];
+                            push(
+                              addSignificantTermsGroupHistogramAction([
+                                {
+                                  id: cpg.id,
+                                  histogram,
+                                },
+                              ])
+                            );
+                          }
+                        },
+                        MAX_CONCURRENT_QUERIES);
+                        groupHistogramQueue.push(significantTermGroups);
+                        await groupHistogramQueue.drain();
+                        isGroupingDone = true;
+                        resolve(false);
+                      }
+                    } catch (e) {
+                      if (!isRequestAbortedError(e)) {
+                        logger.error(
+                          `Failed to transform field/value pairs into groups, got: \n${e.toString()}`
+                        );
+                        pushError(`Failed to transform field/value pairs into groups.`);
+                      }
+                      isGroupingDone = true;
+                      reject(false);
+                    }
+                    loaded += PROGRESS_STEP_HISTOGRAMS_GROUPS;
+                  } catch (error) {
+                    isGroupingDone = true;
+                    reject(false);
+                  }
+                });
+              }
+
+              logDebugMessage(`Fetch ${significantTerms.length} field/value histograms.`);
+
+              function asyncHistograms() {
+                return new Promise(async (resolve, reject) => {
+                  try {
+                    const fieldValueHistogramQueue = queue(async function (cp: SignificantTerm) {
+                      if (shouldStop) {
+                        logDebugMessage('shouldStop abort fetching field/value histograms.');
+                        fieldValueHistogramQueue.kill();
+                        resolve(shouldStop);
                       }
 
                       if (overallTimeSeries !== undefined) {
-                        const histogramQuery = getHistogramQuery(request.body, getGroupFilter(cpg));
+                        const histogramQuery = getHistogramQuery(request.body, [
+                          {
+                            term: { [cp.fieldName]: cp.fieldValue },
+                          },
+                        ]);
 
-                        let cpgTimeSeries: NumericChartData;
+                        let cpTimeSeries: NumericChartData;
+
                         try {
-                          cpgTimeSeries = (
+                          cpTimeSeries = (
                             (await fetchHistogramsForFields(
                               client,
                               request.body.index,
@@ -532,19 +640,20 @@ export const defineExplainLogRateSpikesRoute = (
                             )) as [NumericChartData]
                           )[0];
                         } catch (e) {
-                          if (!isRequestAbortedError(e)) {
-                            logger.error(
-                              `Failed to fetch the histogram data for group #${
-                                cpg.id
-                              }, got: \n${e.toString()}`
-                            );
-                            pushError(`Failed to fetch the histogram data for group #${cpg.id}.`);
-                          }
-                          return;
+                          logger.error(
+                            `Failed to fetch the histogram data for field/value pair "${
+                              cp.fieldName
+                            }:${cp.fieldValue}", got: \n${e.toString()}`
+                          );
+                          pushError(
+                            `Failed to fetch the histogram data for field/value pair "${cp.fieldName}:${cp.fieldValue}".`
+                          );
+                          resolve(false);
                         }
+
                         const histogram =
                           overallTimeSeries.data.map((o, i) => {
-                            const current = cpgTimeSeries.data.find(
+                            const current = cpTimeSeries.data.find(
                               (d1) => d1.key_as_string === o.key_as_string
                             ) ?? {
                               doc_count: 0,
@@ -557,10 +666,17 @@ export const defineExplainLogRateSpikesRoute = (
                             };
                           }) ?? [];
 
+                        const { fieldName, fieldValue } = cp;
+
+                        loaded += (1 / significantTerms.length) * PROGRESS_STEP_HISTOGRAMS;
+                        if (isGroupingDone) {
+                          pushHistogramDataLoadingState();
+                        }
                         push(
-                          addSignificantTermsGroupHistogramAction([
+                          addSignificantTermsHistogramAction([
                             {
-                              id: cpg.id,
+                              fieldName,
+                              fieldValue,
                               histogram,
                             },
                           ])
@@ -568,118 +684,37 @@ export const defineExplainLogRateSpikesRoute = (
                       }
                     }, MAX_CONCURRENT_QUERIES);
 
-                    groupHistogramQueue.push(significantTermGroups);
-                    await groupHistogramQueue.drain();
+                    fieldValueHistogramQueue.push(significantTerms);
+                    await fieldValueHistogramQueue.drain();
+                    resolve(false);
+                  } catch (error) {
+                    reject(false);
                   }
-                } catch (e) {
-                  if (!isRequestAbortedError(e)) {
-                    logger.error(
-                      `Failed to transform field/value pairs into groups, got: \n${e.toString()}`
-                    );
-                    pushError(`Failed to transform field/value pairs into groups.`);
-                  }
-                }
+                });
               }
 
-              loaded += PROGRESS_STEP_HISTOGRAMS_GROUPS;
+              const parallelFetch = [];
 
-              logDebugMessage(`Fetch ${significantTerms.length} field/value histograms.`);
-
-              // time series filtered by fields
               if (
                 significantTerms.length > 0 &&
                 overallTimeSeries !== undefined &&
                 !request.body.overrides?.regroupOnly
               ) {
-                const fieldValueHistogramQueue = queue(async function (cp: SignificantTerm) {
-                  if (shouldStop) {
-                    logDebugMessage('shouldStop abort fetching field/value histograms.');
-                    fieldValueHistogramQueue.kill();
-                    end();
-                    return;
-                  }
-
-                  if (overallTimeSeries !== undefined) {
-                    const histogramQuery = getHistogramQuery(request.body, [
-                      {
-                        term: { [cp.fieldName]: cp.fieldValue },
-                      },
-                    ]);
-
-                    let cpTimeSeries: NumericChartData;
-
-                    try {
-                      cpTimeSeries = (
-                        (await fetchHistogramsForFields(
-                          client,
-                          request.body.index,
-                          histogramQuery,
-                          // fields
-                          [
-                            {
-                              fieldName: request.body.timeFieldName,
-                              type: KBN_FIELD_TYPES.DATE,
-                              interval: overallTimeSeries.interval,
-                              min: overallTimeSeries.stats[0],
-                              max: overallTimeSeries.stats[1],
-                            },
-                          ],
-                          // samplerShardSize
-                          -1,
-                          undefined,
-                          abortSignal,
-                          sampleProbability,
-                          RANDOM_SAMPLER_SEED
-                        )) as [NumericChartData]
-                      )[0];
-                    } catch (e) {
-                      logger.error(
-                        `Failed to fetch the histogram data for field/value pair "${cp.fieldName}:${
-                          cp.fieldValue
-                        }", got: \n${e.toString()}`
-                      );
-                      pushError(
-                        `Failed to fetch the histogram data for field/value pair "${cp.fieldName}:${cp.fieldValue}".`
-                      );
-                      return;
-                    }
-
-                    const histogram =
-                      overallTimeSeries.data.map((o, i) => {
-                        const current = cpTimeSeries.data.find(
-                          (d1) => d1.key_as_string === o.key_as_string
-                        ) ?? {
-                          doc_count: 0,
-                        };
-                        return {
-                          key: o.key,
-                          key_as_string: o.key_as_string ?? '',
-                          doc_count_significant_term: current.doc_count,
-                          doc_count_overall: Math.max(0, o.doc_count - current.doc_count),
-                        };
-                      }) ?? [];
-
-                    const { fieldName, fieldValue } = cp;
-
-                    loaded += (1 / significantTerms.length) * PROGRESS_STEP_HISTOGRAMS;
-                    pushHistogramDataLoadingState();
-                    push(
-                      addSignificantTermsHistogramAction([
-                        {
-                          fieldName,
-                          fieldValue,
-                          histogram,
-                        },
-                      ])
-                    );
-                  }
-                }, MAX_CONCURRENT_QUERIES);
-
-                fieldValueHistogramQueue.push(significantTerms);
-                await fieldValueHistogramQueue.drain();
+                parallelFetch.push(asyncHistograms());
               }
 
-              endWithUpdatedLoadingState();
+              if (groupingEnabled) {
+                parallelFetch.push(asyncGrouping());
+              } else {
+                loaded += PROGRESS_STEP_HISTOGRAMS_GROUPS;
+              }
+              const shouldStops = await Promise.all(parallelFetch);
+
+              if (shouldStops.includes(true)) {
+                end();
+              } else {
+                endWithUpdatedLoadingState();
+              }
             } catch (e) {
               if (!isRequestAbortedError(e)) {
                 logger.error(


### PR DESCRIPTION
## Summary

The random payload for the proxy flushing fix was regenerated for every push to the stream. This turned out to be quite slow. This PR updates the logic to create the payload only once and reuse it for every push.

Note: Further testing in Cloud showed the differences there are not as big as in my local testing, might be related to entropy for `crypto.randomBytes`.

### Checklist

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
