### PR TITLE
Include group-by information in query for Logs spike analysis in Logs alert detail page

### DIFF
--- a/x-pack/plugins/infra/common/alerting/logs/log_threshold/query_helpers.ts
+++ b/x-pack/plugins/infra/common/alerting/logs/log_threshold/query_helpers.ts
@@ -60,7 +60,9 @@ export const buildFiltersFromCriteria = (
     },
   };
 
-  return { rangeFilter, groupedRangeFilter, mustFilters, mustNotFilters };
+  const mustFiltersFields = positiveCriteria.map((criterion) => criterion.field);
+
+  return { rangeFilter, groupedRangeFilter, mustFilters, mustNotFilters, mustFiltersFields };
 };
 
 const buildFiltersForCriteria = (criteria: CountCriteria) => {

--- a/x-pack/plugins/infra/public/alerting/log_threshold/components/alert_details_app_section/components/explain_log_rate_spike.tsx
+++ b/x-pack/plugins/infra/public/alerting/log_threshold/components/alert_details_app_section/components/explain_log_rate_spike.tsx
@@ -28,7 +28,6 @@ import { useKibanaContextForPlugin } from '../../../../../hooks/use_kibana';
 import {
   Comparator,
   CountRuleParams,
-  hasGroupBy,
   isRatioRuleParams,
   PartialRuleParams,
   ruleParamsRT,
@@ -76,7 +75,9 @@ export const ExplainLogRateSpikes: FC<AlertDetailsExplainLogRateSpikesSectionPro
     const getQuery = (timestampField: string) => {
       const esSearchRequest = getESQueryForLogSpike(
         validatedParams as CountRuleParams,
-        timestampField
+        timestampField,
+        alert,
+        rule.params.groupBy
       ) as QueryDslQueryContainer;
 
       if (esSearchRequest) {
@@ -88,7 +89,6 @@ export const ExplainLogRateSpikes: FC<AlertDetailsExplainLogRateSpikesSectionPro
 
     if (
       !isRatioRuleParams(validatedParams) &&
-      !hasGroupBy(validatedParams) &&
       (validatedParams.count.comparator === Comparator.GT ||
         validatedParams.count.comparator === Comparator.GT_OR_EQ)
     ) {


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/160257

The group by field/value are added to the filter of the query that is passed to the Log Spikes analysis component.

Example of the query when group by on `host.name` in the below Log threshold rule.

<img width="497" alt="Screenshot 2023-06-27 at 17 15 18" src="https://github.com/elastic/kibana/assets/69037875/8e2b6622-a6d3-4273-b312-4a17a8d72824">


### Before
```
{
    "bool": {
        "filter": [
            {
                "term": {
                    "log.level": {
                        "value": "info"
                    }
                }
            }
        ],
        "must_not": [
            {
                "match": {
                    "error.log.message": "test"
                }
            }
        ]
    }
}
```

### After
```
{
    "bool": {
        "filter": [
            {
                "term": {
                    "log.level": {
                        "value": "info"
                    }
                }
            },
            {
                "term": {
                    "host.name": {
                        "value": "gke-edge-oblt-pool-2-ce49b4ca-l0nr"
                    }
                }
            }
        ],
        "must_not": [
            {
                "match": {
                    "error.log.message": "test"
                }
            }
        ]
    }
}
```

<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->