### PR TITLE
[ML][Maps] Ensure maps visualization compatibility check does not throw error when no timefield is found

### DIFF
--- a/x-pack/plugins/ml/public/application/jobs/new_job/job_from_map/quick_create_job.ts
+++ b/x-pack/plugins/ml/public/application/jobs/new_job/job_from_map/quick_create_job.ts
@@ -83,6 +83,10 @@ export class QuickGeoJobCreator extends QuickJobCreatorBase {
     const embeddableQuery = (await embeddable.getQuery()) ?? getDefaultQuery();
     const embeddableFilters = (await embeddable.getFilters()) ?? [];
 
+    if (from === undefined || to === undefined) {
+      throw new Error('Cannot create job, from and to are undefined');
+    }
+
     if (dashboardQuery === undefined || dashboardFilters === undefined) {
       throw new Error('Cannot create job, query and filters are undefined');
     }

--- a/x-pack/plugins/ml/public/application/jobs/new_job/job_from_map/utils.ts
+++ b/x-pack/plugins/ml/public/application/jobs/new_job/job_from_map/utils.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import { i18n } from '@kbn/i18n';
 import type { Query } from '@kbn/es-query';
 import type { MapEmbeddable } from '@kbn/maps-plugin/public';
 import type { SharePluginStart } from '@kbn/share-plugin/public';
@@ -57,15 +56,7 @@ export async function getJobsItemsFromEmbeddable(embeddable: MapEmbeddable) {
   // Get dashboard level query/filters
   const { filters, timeRange, ...input } = embeddable.getInput();
   const query = input.query === undefined ? { query: '', language: 'kuery' } : input.query;
-
-  if (timeRange === undefined) {
-    throw Error(
-      i18n.translate('xpack.ml.newJob.fromGeo.createJob.error.noTimeRange', {
-        defaultMessage: 'Time range not specified.',
-      })
-    );
-  }
-  const { to, from } = timeRange;
+  const { to, from } = timeRange ?? {};
   const dashboard = embeddable.parent?.type === 'dashboard' ? embeddable.parent : undefined;
 
   return {

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -24026,7 +24026,6 @@
     "xpack.ml.navMenu.trainedModelsTabBetaLabel": "技术预览",
     "xpack.ml.navMenu.trainedModelsTabBetaTooltipContent": "此功能处于技术预览状态，在未来版本中可能会更改或完全移除。Elastic 将尽最大努力来修复任何问题，但处于技术预览状态的功能不受正式 GA 功能支持 SLA 的约束。",
     "xpack.ml.navMenu.trainedModelsText": "已训练模型",
-    "xpack.ml.newJob.fromGeo.createJob.error.noTimeRange": "未指定时间范围。",
     "xpack.ml.newJob.fromLens.createJob.error.colsNoSourceField": "某些列不包含源字段。",
     "xpack.ml.newJob.fromLens.createJob.error.colsUsingFilterTimeSift": "列包含与 ML 检测工具不兼容的设置，不支持时间偏移和筛选依据。",
     "xpack.ml.newJob.fromLens.createJob.error.incompatibleLayerType": "图层不兼容。只可以使用图表图层。",


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/152343

This PR removes the thrown error when attempting to find a time field in the index.
It is common for the index which is being used for geo data, to not contain a time field.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

