### PR TITLE
chore(slo): use doclinks

### DIFF
--- a/packages/kbn-doc-links/src/get_doc_links.ts
+++ b/packages/kbn-doc-links/src/get_doc_links.ts
@@ -517,6 +517,7 @@ export const getDocLinks = ({ kibanaBranch }: GetDocLinkOptions): DocLinks => {
       syntheticsCommandReference: `${ELASTIC_WEBSITE_URL}guide/en/observability/${DOC_LINK_VERSION}/synthetics-configuration.html#synthetics-configuration-playwright-options`,
       syntheticsProjectMonitors: `${ELASTIC_WEBSITE_URL}guide/en/observability/${DOC_LINK_VERSION}/synthetic-run-tests.html#synthetic-monitor-choose-project`,
       syntheticsMigrateFromIntegration: `${ELASTIC_WEBSITE_URL}guide/en/observability/${DOC_LINK_VERSION}/synthetics-migrate-from-integration.html`,
+      sloBurnRateRule: `${ELASTIC_WEBSITE_URL}guide/en/observability/${DOC_LINK_VERSION}/slo-burn-rate-alert.html`,
     },
     alerting: {
       guide: `${KIBANA_DOCS}create-and-manage-rules.html`,

--- a/packages/kbn-doc-links/src/types.ts
+++ b/packages/kbn-doc-links/src/types.ts
@@ -397,6 +397,7 @@ export interface DocLinks {
     syntheticsCommandReference: string;
     syntheticsProjectMonitors: string;
     syntheticsMigrateFromIntegration: string;
+    sloBurnRateRule: string;
   }>;
   readonly alerting: Readonly<{
     guide: string;

--- a/x-pack/plugins/observability/public/rules/register_observability_rule_types.ts
+++ b/x-pack/plugins/observability/public/rules/register_observability_rule_types.ts
@@ -70,7 +70,7 @@ export const registerObservabilityRuleTypes = (
     },
     iconClass: 'bell',
     documentationUrl(docLinks) {
-      return 'https://www.elastic.co/guide/en/observability/current/slo-burn-rate-alert.html';
+      return `${docLinks.links.observability.sloBurnRateRule}`;
     },
     ruleParamsExpression: lazy(() => import('../components/burn_rate_rule_editor')),
     validate: validateBurnRateRule,
@@ -78,6 +78,7 @@ export const registerObservabilityRuleTypes = (
     defaultActionMessage: sloBurnRateDefaultActionMessage,
     defaultRecoveryMessage: sloBurnRateDefaultRecoveryMessage,
   });
+
   if (config.unsafe.thresholdRule.enabled) {
     observabilityRuleTypeRegistry.register({
       id: OBSERVABILITY_THRESHOLD_RULE_TYPE_ID,


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/156288

## ⭐ Summary

This PR replaces the hard coded slo burn rate rules guide link by the docLinks service.