### PR TITLE
[Search Application]Handle invalid alias name exception 

### DIFF
--- a/x-pack/plugins/enterprise_search/common/types/error_codes.ts
+++ b/x-pack/plugins/enterprise_search/common/types/error_codes.ts
@@ -21,6 +21,7 @@ export enum ErrorCode {
   PIPELINE_NOT_FOUND = 'pipeline_not_found',
   RESOURCE_NOT_FOUND = 'resource_not_found',
   SEARCH_APPLICATION_ALREADY_EXISTS = 'search_application_already_exists',
+  SEARCH_APPLICATION_NAME_INVALID = 'search_application_name_invalid',
   UNAUTHORIZED = 'unauthorized',
   UNCAUGHT_EXCEPTION = 'uncaught_exception',
 }

--- a/x-pack/plugins/enterprise_search/server/routes/enterprise_search/search_applications.test.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/enterprise_search/search_applications.test.ts
@@ -211,9 +211,9 @@ describe('engines routes', () => {
         meta: {
           body: {
             error: {
+              reason: `Invalid alias name [engine name]: must not contain the following characters ['\',' ','"','<','*','?','>','|',',','/']`,
               type: 'invalid_alias_name_exception',
             },
-            reason: `Invalid alias name [engine name]: must not contain the following characters ['\',' ','"','<','*','?','>','|',',','/']`,
           },
           statusCode: 400,
         },
@@ -221,12 +221,13 @@ describe('engines routes', () => {
       await mockRouter.callRoute({
         params: { engine_name: 'engine name' },
       });
+      const exceptionReason = `Search application name must not contain: [ '' , ' ' , '\"' , '<' , '*' , '?' , '>' , '|' , ',' , '/' ]`;
       expect(mockRouter.response.customError).toHaveBeenCalledWith({
         body: {
           attributes: {
             error_code: 'search_application_name_invalid',
           },
-          message: 'Invalid Search application name. ',
+          message: `Invalid Search application name. ${exceptionReason}`,
         },
         statusCode: 400,
       });

--- a/x-pack/plugins/enterprise_search/server/routes/enterprise_search/search_applications.test.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/enterprise_search/search_applications.test.ts
@@ -206,6 +206,31 @@ describe('engines routes', () => {
         },
       });
     });
+    it('returns 400, create search application with invalid characters', async () => {
+      (mockClient.asCurrentUser.searchApplication.put as jest.Mock).mockRejectedValueOnce({
+        meta: {
+          body: {
+            error: {
+              type: 'invalid_alias_name_exception',
+            },
+            reason: `Invalid alias name [engine name]: must not contain the following characters ['\',' ','"','<','*','?','>','|',',','/']`,
+          },
+          statusCode: 400,
+        },
+      });
+      await mockRouter.callRoute({
+        params: { engine_name: 'engine name' },
+      });
+      expect(mockRouter.response.customError).toHaveBeenCalledWith({
+        body: {
+          attributes: {
+            error_code: 'search_application_name_invalid',
+          },
+          message: 'Invalid Search application name. ',
+        },
+        statusCode: 400,
+      });
+    });
     it('PUT - Upsert API creates request - update', async () => {
       mockClient.asCurrentUser.searchApplication.put.mockImplementation(() => ({
         acknowledged: true,

--- a/x-pack/plugins/enterprise_search/server/utils/identify_exceptions.ts
+++ b/x-pack/plugins/enterprise_search/server/utils/identify_exceptions.ts
@@ -42,3 +42,6 @@ export const isIllegalArgumentException = (error: ElasticsearchResponseError) =>
 
 export const isVersionConflictEngineException = (error: ElasticsearchResponseError) =>
   error.meta?.body?.error?.type === 'version_conflict_engine_exception';
+
+export const isInvalidSearchApplicationNameException = (error: ElasticsearchResponseError) =>
+  error.meta?.body?.error?.type === 'invalid_alias_name_exception';


### PR DESCRIPTION
## Summary

* Adds a new error code `search_application_name_invalid` to denote invalid character in search application name
* Adds test cases to check invalid characters
* Adds new exception `isInvalidSearchApplicationNameException` to check if Elasticsearch returns `invalid_alias_name_exception`


### Screen Recording

https://github.com/elastic/kibana/assets/55930906/4c8e188f-817b-4926-9960-86cb22327aed




<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->