### PR TITLE
fix Failing test: X-Pack Saved Object Tagging Functional Tests.x-pack/test/saved_object_tagging/functional/tests/dashboard_integration·ts - saved objects tagging - functional tests dashboard integration creating allows to select tags for a new dashboard

### DIFF
--- a/test/functional/page_objects/dashboard_page.ts
+++ b/test/functional/page_objects/dashboard_page.ts
@@ -472,7 +472,7 @@ export class DashboardPageObject extends FtrService {
    */
   public async saveDashboard(
     dashboardName: string,
-    saveOptions: SaveDashboardOptions = { waitDialogIsClosed: true, exitFromEditMode: true },
+    saveOptions: SaveDashboardOptions = { waitDialogIsClosed: true, exitFromEditMode: true }
   ) {
     await this.retry.try(async () => {
       await this.enterDashboardTitleAndClickSave(dashboardName, saveOptions);
@@ -515,7 +515,7 @@ export class DashboardPageObject extends FtrService {
    */
   public async enterDashboardTitleAndClickSave(
     dashboardTitle: string,
-    saveOptions: SaveDashboardOptions = { waitDialogIsClosed: true },
+    saveOptions: SaveDashboardOptions = { waitDialogIsClosed: true }
   ) {
     const isSaveModalOpen = await this.testSubjects.exists('savedObjectSaveModal', {
       timeout: 2000,

--- a/test/functional/page_objects/dashboard_page.ts
+++ b/test/functional/page_objects/dashboard_page.ts
@@ -473,10 +473,9 @@ export class DashboardPageObject extends FtrService {
   public async saveDashboard(
     dashboardName: string,
     saveOptions: SaveDashboardOptions = { waitDialogIsClosed: true, exitFromEditMode: true },
-    clickMenuItem = true
   ) {
     await this.retry.try(async () => {
-      await this.enterDashboardTitleAndClickSave(dashboardName, saveOptions, clickMenuItem);
+      await this.enterDashboardTitleAndClickSave(dashboardName, saveOptions);
 
       if (saveOptions.needsConfirm) {
         await this.ensureDuplicateTitleCallout();
@@ -517,9 +516,11 @@ export class DashboardPageObject extends FtrService {
   public async enterDashboardTitleAndClickSave(
     dashboardTitle: string,
     saveOptions: SaveDashboardOptions = { waitDialogIsClosed: true },
-    clickMenuItem = true
   ) {
-    if (clickMenuItem) {
+    const isSaveModalOpen = await this.testSubjects.exists('savedObjectSaveModal', {
+      timeout: 2000,
+    });
+    if (!isSaveModalOpen) {
       await this.testSubjects.click('dashboardSaveMenuItem');
     }
     const modalDialog = await this.testSubjects.find('savedObjectSaveModal');


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/160583

flaky test runner https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2513

Harden `dashboard_page.enterDashboardTitleAndClickSave` for retry loops so does not try to open save dialog when its already open from first save attempt failure.

<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->