### PR TITLE
[Unified Search] Enable filtersBuilder depth of 1

### DIFF
--- a/src/plugins/unified_search/public/filters_builder/filter_group.tsx
+++ b/src/plugins/unified_search/public/filters_builder/filter_group.tsx
@@ -81,7 +81,7 @@ export const FilterGroup = ({
   } = useContext(FiltersBuilderContextType);
 
   const pathInArray = getPathInArray(path);
-  const isDepthReached = maxDepth <= pathInArray.length;
+  const isDepthReached = maxDepth <= pathInArray.length && renderedLevel > 0;
   const orDisabled = hideOr || (isDepthReached && booleanRelation === BooleanRelation.AND);
   const andDisabled = isDepthReached && booleanRelation === BooleanRelation.OR;
 


### PR DESCRIPTION
## Summary

Think the filters builder component does not allow a maxDepth of 1 correctly, as behavior in that state is indistinguishable from usage of the component with a maxDepth of 0, both states only allow top level ANDs only. With this change, it's possible to have 1 level of nesting of either type, but no deeper. The renderedLevel prop will never go above 0 without this change with 0 or 1 as well, it now matches maxDepth.

After:
<img width="639" alt="image" src="https://github.com/elastic/kibana/assets/56408403/405098d6-4e3a-43b3-9bf9-b783abb9eb0a">

Before maxDepth 0:
<img width="658" alt="image" src="https://github.com/elastic/kibana/assets/56408403/a3e11bc0-1b9f-4bf2-a1fa-4d8d34be5907">

(Or is never an option)

Before maxDepth 1: 
<img width="683" alt="image" src="https://github.com/elastic/kibana/assets/56408403/bde6bb59-2b41-4496-922b-6fd6d6eb29dc">

(Or is never an option)

Before maxDepth 2:
<img width="656" alt="image" src="https://github.com/elastic/kibana/assets/56408403/32f407ee-d1f5-42cb-bbef-6e8dc4ff115b">
Works as expected







<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->