### PR TITLE
[Discover] Fix documents request missing pinned filters

### DIFF
--- a/src/plugins/discover/public/__mocks__/services.ts
+++ b/src/plugins/discover/public/__mocks__/services.ts
@@ -43,7 +43,6 @@ export function createDiscoverServicesMock(): DiscoverServices {
   const expressionsPlugin = expressionsPluginMock.createStartContract();
 
   dataPlugin.query.filterManager.getFilters = jest.fn(() => []);
-  dataPlugin.query.filterManager.getGlobalFilters = jest.fn(() => []);
   dataPlugin.query.filterManager.getUpdates$ = jest.fn(() => of({}) as unknown as Observable<void>);
   dataPlugin.query.timefilter.timefilter.createFilter = jest.fn();
   dataPlugin.query.timefilter.timefilter.getAbsoluteTime = jest.fn(() => ({

--- a/src/plugins/discover/public/__mocks__/services.ts
+++ b/src/plugins/discover/public/__mocks__/services.ts
@@ -43,6 +43,7 @@ export function createDiscoverServicesMock(): DiscoverServices {
   const expressionsPlugin = expressionsPluginMock.createStartContract();
 
   dataPlugin.query.filterManager.getFilters = jest.fn(() => []);
+  dataPlugin.query.filterManager.getGlobalFilters = jest.fn(() => []);
   dataPlugin.query.filterManager.getUpdates$ = jest.fn(() => of({}) as unknown as Observable<void>);
   dataPlugin.query.timefilter.timefilter.createFilter = jest.fn();
   dataPlugin.query.timefilter.timefilter.getAbsoluteTime = jest.fn(() => ({

--- a/src/plugins/discover/public/application/main/services/discover_app_state_container.ts
+++ b/src/plugins/discover/public/application/main/services/discover_app_state_container.ts
@@ -259,8 +259,6 @@ export interface AppStateUrl extends Omit<DiscoverAppState, 'sort'> {
   sort?: string[][] | [string, string];
 }
 
-export const GLOBAL_STATE_URL_KEY = '_g';
-
 export function getInitialState(
   stateStorage: IKbnUrlStateStorage | undefined,
   savedSearch: SavedSearch,

--- a/src/plugins/discover/public/application/main/services/discover_global_state_container.ts
+++ b/src/plugins/discover/public/application/main/services/discover_global_state_container.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import type { QueryState } from '@kbn/data-plugin/common';
+import type { IKbnUrlStateStorage } from '@kbn/kibana-utils-plugin/public';
+
+export interface DiscoverGlobalStateContainer {
+  get: () => QueryState | null;
+  set: (state: QueryState) => Promise<void>;
+}
+
+const GLOBAL_STATE_URL_KEY = '_g';
+
+export const getDiscoverGlobalStateContainer = (
+  stateStorage: IKbnUrlStateStorage
+): DiscoverGlobalStateContainer => ({
+  get: () => stateStorage.get<QueryState>(GLOBAL_STATE_URL_KEY),
+  set: async (state: QueryState) => {
+    await stateStorage.set(GLOBAL_STATE_URL_KEY, state, { replace: true });
+  },
+});

--- a/src/plugins/discover/public/application/main/services/discover_saved_search_container.test.ts
+++ b/src/plugins/discover/public/application/main/services/discover_saved_search_container.test.ts
@@ -12,19 +12,22 @@ import { discoverServiceMock } from '../../../__mocks__/services';
 import { savedSearchMock, savedSearchMockWithTimeField } from '../../../__mocks__/saved_search';
 import { dataViewMock } from '../../../__mocks__/data_view';
 import { dataViewComplexMock } from '../../../__mocks__/data_view_complex';
+import { getDiscoverGlobalStateContainer } from './discover_global_state_container';
+import { createKbnUrlStateStorage } from '@kbn/kibana-utils-plugin/public';
 
 describe('DiscoverSavedSearchContainer', () => {
   const savedSearch = savedSearchMock;
   const services = discoverServiceMock;
+  const globalStateContainer = getDiscoverGlobalStateContainer(createKbnUrlStateStorage());
 
   describe('getTitle', () => {
     it('returns undefined for new saved searches', () => {
-      const container = getSavedSearchContainer({ services });
+      const container = getSavedSearchContainer({ services, globalStateContainer });
       expect(container.getTitle()).toBe(undefined);
     });
 
     it('returns the title of a persisted saved searches', () => {
-      const container = getSavedSearchContainer({ services });
+      const container = getSavedSearchContainer({ services, globalStateContainer });
       container.set(savedSearch);
       expect(container.getTitle()).toBe(savedSearch.title);
     });
@@ -32,7 +35,7 @@ describe('DiscoverSavedSearchContainer', () => {
 
   describe('set', () => {
     it('should update the current and initial state of the saved search', () => {
-      const container = getSavedSearchContainer({ services });
+      const container = getSavedSearchContainer({ services, globalStateContainer });
       const newSavedSearch: SavedSearch = { ...savedSearch, title: 'New title' };
       const result = container.set(newSavedSearch);
 
@@ -45,7 +48,7 @@ describe('DiscoverSavedSearchContainer', () => {
     });
 
     it('should reset hasChanged$ to false', () => {
-      const container = getSavedSearchContainer({ services });
+      const container = getSavedSearchContainer({ services, globalStateContainer });
       const newSavedSearch: SavedSearch = { ...savedSearch, title: 'New title' };
 
       container.set(newSavedSearch);
@@ -55,7 +58,7 @@ describe('DiscoverSavedSearchContainer', () => {
 
   describe('new', () => {
     it('should create a new saved search', async () => {
-      const container = getSavedSearchContainer({ services });
+      const container = getSavedSearchContainer({ services, globalStateContainer });
       const result = await container.new(dataViewMock);
 
       expect(result.title).toBeUndefined();
@@ -68,7 +71,7 @@ describe('DiscoverSavedSearchContainer', () => {
     });
 
     it('should create a new saved search with provided DataView', async () => {
-      const container = getSavedSearchContainer({ services });
+      const container = getSavedSearchContainer({ services, globalStateContainer });
       const result = await container.new(dataViewMock);
       expect(result.title).toBeUndefined();
       expect(result.id).toBeUndefined();
@@ -86,6 +89,7 @@ describe('DiscoverSavedSearchContainer', () => {
     it('loads a saved search', async () => {
       const savedSearchContainer = getSavedSearchContainer({
         services: discoverServiceMock,
+        globalStateContainer,
       });
       await savedSearchContainer.load('the-saved-search-id');
       expect(savedSearchContainer.getInitial$().getValue().id).toEqual('the-saved-search-id');
@@ -100,6 +104,7 @@ describe('DiscoverSavedSearchContainer', () => {
     it('calls saveSavedSearch with the given saved search and save options', async () => {
       const savedSearchContainer = getSavedSearchContainer({
         services: discoverServiceMock,
+        globalStateContainer,
       });
       const savedSearchToPersist = {
         ...savedSearchMockWithTimeField,
@@ -124,6 +129,7 @@ describe('DiscoverSavedSearchContainer', () => {
 
       const savedSearchContainer = getSavedSearchContainer({
         services: discoverServiceMock,
+        globalStateContainer,
       });
 
       const result = await savedSearchContainer.persist(persistedSavedSearch, saveOptions);
@@ -135,6 +141,7 @@ describe('DiscoverSavedSearchContainer', () => {
     it('emits false to the hasChanged$ BehaviorSubject', async () => {
       const savedSearchContainer = getSavedSearchContainer({
         services: discoverServiceMock,
+        globalStateContainer,
       });
       const savedSearchToPersist = {
         ...savedSearchMockWithTimeField,
@@ -153,6 +160,7 @@ describe('DiscoverSavedSearchContainer', () => {
       }));
       const savedSearchContainer = getSavedSearchContainer({
         services: discoverServiceMock,
+        globalStateContainer,
       });
       const savedSearchToPersist = {
         ...savedSearchMockWithTimeField,
@@ -176,6 +184,7 @@ describe('DiscoverSavedSearchContainer', () => {
 
       const savedSearchContainer = getSavedSearchContainer({
         services: discoverServiceMock,
+        globalStateContainer,
       });
       savedSearchContainer.set(savedSearch);
       savedSearchContainer.update({ nextState: { hideChart: true } });
@@ -196,28 +205,30 @@ describe('DiscoverSavedSearchContainer', () => {
     it('updates a saved search by app state providing hideChart', async () => {
       const savedSearchContainer = getSavedSearchContainer({
         services: discoverServiceMock,
+        globalStateContainer,
       });
       savedSearchContainer.set(savedSearch);
-      const updated = await savedSearchContainer.update({ nextState: { hideChart: true } });
+      const updated = savedSearchContainer.update({ nextState: { hideChart: true } });
       expect(savedSearchContainer.getHasChanged$().getValue()).toBe(true);
       savedSearchContainer.set(updated);
       expect(savedSearchContainer.getHasChanged$().getValue()).toBe(false);
-      await savedSearchContainer.update({ nextState: { hideChart: false } });
+      savedSearchContainer.update({ nextState: { hideChart: false } });
       expect(savedSearchContainer.getHasChanged$().getValue()).toBe(true);
-      await savedSearchContainer.update({ nextState: { hideChart: true } });
+      savedSearchContainer.update({ nextState: { hideChart: true } });
       expect(savedSearchContainer.getHasChanged$().getValue()).toBe(false);
     });
     it('updates a saved search by data view', async () => {
       const savedSearchContainer = getSavedSearchContainer({
         services: discoverServiceMock,
+        globalStateContainer,
       });
-      const updated = await savedSearchContainer.update({ nextDataView: dataViewMock });
+      const updated = savedSearchContainer.update({ nextDataView: dataViewMock });
       expect(savedSearchContainer.getHasChanged$().getValue()).toBe(true);
       savedSearchContainer.set(updated);
       expect(savedSearchContainer.getHasChanged$().getValue()).toBe(false);
-      await savedSearchContainer.update({ nextDataView: dataViewComplexMock });
+      savedSearchContainer.update({ nextDataView: dataViewComplexMock });
       expect(savedSearchContainer.getHasChanged$().getValue()).toBe(true);
-      await savedSearchContainer.update({ nextDataView: dataViewMock });
+      savedSearchContainer.update({ nextDataView: dataViewMock });
       expect(savedSearchContainer.getHasChanged$().getValue()).toBe(false);
     });
   });

--- a/src/plugins/discover/public/application/main/services/discover_state.test.ts
+++ b/src/plugins/discover/public/application/main/services/discover_state.test.ts
@@ -329,7 +329,7 @@ describe('Test discover state actions', () => {
     const unsubscribe = state.actions.initializeAndSync();
     await new Promise(process.nextTick);
     expect(getCurrentUrl()).toMatchInlineSnapshot(
-      `"/#?_g=(filters:!(),refreshInterval:(pause:!t,value:1000),time:(from:now-15d,to:now))&_a=(columns:!(default_column),index:the-data-view-id,interval:auto,sort:!())"`
+      `"/#?_g=(refreshInterval:(pause:!t,value:1000),time:(from:now-15d,to:now))&_a=(columns:!(default_column),index:the-data-view-id,interval:auto,sort:!())"`
     );
     expect(state.savedSearchState.getHasChanged$().getValue()).toBe(false);
     const { searchSource, ...savedSearch } = state.savedSearchState.getState();
@@ -356,7 +356,7 @@ describe('Test discover state actions', () => {
     const unsubscribe = state.actions.initializeAndSync();
     await new Promise(process.nextTick);
     expect(getCurrentUrl()).toMatchInlineSnapshot(
-      `"/#?_g=(filters:!(),refreshInterval:(pause:!t,value:1000),time:(from:now-15d,to:now))&_a=(columns:!(default_column),index:the-data-view-id,interval:auto,sort:!())"`
+      `"/#?_g=(refreshInterval:(pause:!t,value:1000),time:(from:now-15d,to:now))&_a=(columns:!(default_column),index:the-data-view-id,interval:auto,sort:!())"`
     );
     expect(state.savedSearchState.getHasChanged$().getValue()).toBe(false);
     unsubscribe();
@@ -398,7 +398,7 @@ describe('Test discover state actions', () => {
     await new Promise(process.nextTick);
     expect(newSavedSearch?.id).toBe('the-saved-search-id');
     expect(getCurrentUrl()).toMatchInlineSnapshot(
-      `"/#?_g=(filters:!(),refreshInterval:(pause:!t,value:1000),time:(from:now-15d,to:now))&_a=(columns:!(default_column),index:the-data-view-id,interval:auto,sort:!())"`
+      `"/#?_g=(refreshInterval:(pause:!t,value:1000),time:(from:now-15d,to:now))&_a=(columns:!(default_column),index:the-data-view-id,interval:auto,sort:!())"`
     );
     expect(state.savedSearchState.getHasChanged$().getValue()).toBe(false);
     unsubscribe();
@@ -658,7 +658,7 @@ describe('Test discover state actions', () => {
     const unsubscribe = state.actions.initializeAndSync();
     await new Promise(process.nextTick);
     const initialUrlState =
-      '/#?_g=(filters:!(),refreshInterval:(pause:!t,value:1000),time:(from:now-15d,to:now))&_a=(columns:!(default_column),index:the-data-view-id,interval:auto,sort:!())';
+      '/#?_g=(refreshInterval:(pause:!t,value:1000),time:(from:now-15d,to:now))&_a=(columns:!(default_column),index:the-data-view-id,interval:auto,sort:!())';
     expect(getCurrentUrl()).toBe(initialUrlState);
     expect(state.internalState.getState().dataView?.id).toBe(dataViewMock.id!);
 
@@ -666,7 +666,7 @@ describe('Test discover state actions', () => {
     await state.actions.onChangeDataView(dataViewComplexMock.id!);
     await new Promise(process.nextTick);
     expect(getCurrentUrl()).toMatchInlineSnapshot(
-      `"/#?_g=(filters:!(),refreshInterval:(pause:!t,value:1000),time:(from:now-15d,to:now))&_a=(columns:!(default_column),index:data-view-with-various-field-types-id,interval:auto,sort:!(!(data,desc)))"`
+      `"/#?_g=(refreshInterval:(pause:!t,value:1000),time:(from:now-15d,to:now))&_a=(columns:!(default_column),index:data-view-with-various-field-types-id,interval:auto,sort:!(!(data,desc)))"`
     );
     await waitFor(() => {
       expect(state.dataState.fetch).toHaveBeenCalledTimes(1);

--- a/src/plugins/discover/public/application/main/services/discover_state.test.ts
+++ b/src/plugins/discover/public/application/main/services/discover_state.test.ts
@@ -329,7 +329,7 @@ describe('Test discover state actions', () => {
     const unsubscribe = state.actions.initializeAndSync();
     await new Promise(process.nextTick);
     expect(getCurrentUrl()).toMatchInlineSnapshot(
-      `"/#?_g=(refreshInterval:(pause:!t,value:1000),time:(from:now-15d,to:now))&_a=(columns:!(default_column),index:the-data-view-id,interval:auto,sort:!())"`
+      `"/#?_g=(filters:!(),refreshInterval:(pause:!t,value:1000),time:(from:now-15d,to:now))&_a=(columns:!(default_column),index:the-data-view-id,interval:auto,sort:!())"`
     );
     expect(state.savedSearchState.getHasChanged$().getValue()).toBe(false);
     const { searchSource, ...savedSearch } = state.savedSearchState.getState();
@@ -356,7 +356,7 @@ describe('Test discover state actions', () => {
     const unsubscribe = state.actions.initializeAndSync();
     await new Promise(process.nextTick);
     expect(getCurrentUrl()).toMatchInlineSnapshot(
-      `"/#?_g=(refreshInterval:(pause:!t,value:1000),time:(from:now-15d,to:now))&_a=(columns:!(default_column),index:the-data-view-id,interval:auto,sort:!())"`
+      `"/#?_g=(filters:!(),refreshInterval:(pause:!t,value:1000),time:(from:now-15d,to:now))&_a=(columns:!(default_column),index:the-data-view-id,interval:auto,sort:!())"`
     );
     expect(state.savedSearchState.getHasChanged$().getValue()).toBe(false);
     unsubscribe();
@@ -398,7 +398,7 @@ describe('Test discover state actions', () => {
     await new Promise(process.nextTick);
     expect(newSavedSearch?.id).toBe('the-saved-search-id');
     expect(getCurrentUrl()).toMatchInlineSnapshot(
-      `"/#?_g=(refreshInterval:(pause:!t,value:1000),time:(from:now-15d,to:now))&_a=(columns:!(default_column),index:the-data-view-id,interval:auto,sort:!())"`
+      `"/#?_g=(filters:!(),refreshInterval:(pause:!t,value:1000),time:(from:now-15d,to:now))&_a=(columns:!(default_column),index:the-data-view-id,interval:auto,sort:!())"`
     );
     expect(state.savedSearchState.getHasChanged$().getValue()).toBe(false);
     unsubscribe();
@@ -658,7 +658,7 @@ describe('Test discover state actions', () => {
     const unsubscribe = state.actions.initializeAndSync();
     await new Promise(process.nextTick);
     const initialUrlState =
-      '/#?_g=(refreshInterval:(pause:!t,value:1000),time:(from:now-15d,to:now))&_a=(columns:!(default_column),index:the-data-view-id,interval:auto,sort:!())';
+      '/#?_g=(filters:!(),refreshInterval:(pause:!t,value:1000),time:(from:now-15d,to:now))&_a=(columns:!(default_column),index:the-data-view-id,interval:auto,sort:!())';
     expect(getCurrentUrl()).toBe(initialUrlState);
     expect(state.internalState.getState().dataView?.id).toBe(dataViewMock.id!);
 
@@ -666,7 +666,7 @@ describe('Test discover state actions', () => {
     await state.actions.onChangeDataView(dataViewComplexMock.id!);
     await new Promise(process.nextTick);
     expect(getCurrentUrl()).toMatchInlineSnapshot(
-      `"/#?_g=(refreshInterval:(pause:!t,value:1000),time:(from:now-15d,to:now))&_a=(columns:!(default_column),index:data-view-with-various-field-types-id,interval:auto,sort:!(!(data,desc)))"`
+      `"/#?_g=(filters:!(),refreshInterval:(pause:!t,value:1000),time:(from:now-15d,to:now))&_a=(columns:!(default_column),index:data-view-with-various-field-types-id,interval:auto,sort:!(!(data,desc)))"`
     );
     await waitFor(() => {
       expect(state.dataState.fetch).toHaveBeenCalledTimes(1);

--- a/src/plugins/discover/public/application/main/services/discover_state.ts
+++ b/src/plugins/discover/public/application/main/services/discover_state.ts
@@ -16,7 +16,6 @@ import {
 import {
   DataPublicPluginStart,
   noSearchSessionStorageCapabilityMessage,
-  QueryState,
   SearchSessionInfoProvider,
 } from '@kbn/data-plugin/public';
 import { DataView, DataViewSpec, DataViewType } from '@kbn/data-views-plugin/public';
@@ -38,7 +37,6 @@ import {
   DiscoverAppState,
   DiscoverAppStateContainer,
   getDiscoverAppStateContainer,
-  GLOBAL_STATE_URL_KEY,
 } from './discover_app_state_container';
 import {
   DiscoverInternalStateContainer,
@@ -51,6 +49,7 @@ import {
   DiscoverSavedSearchContainer,
 } from './discover_saved_search_container';
 import { updateFiltersReferences } from '../utils/update_filter_references';
+import { getDiscoverGlobalStateContainer } from './discover_global_state_container';
 interface DiscoverStateContainerParams {
   /**
    * Browser history
@@ -192,6 +191,7 @@ export function getDiscoverStateContainer({
 }: DiscoverStateContainerParams): DiscoverStateContainer {
   const storeInSessionStorage = services.uiSettings.get('state:storeInSessionStorage');
   const toasts = services.core.notifications.toasts;
+
   /**
    * state storage for state in the URL
    */
@@ -208,11 +208,18 @@ export function getDiscoverStateContainer({
     history,
     session: services.data.search.session,
   });
+
+  /**
+   * Global State Container, synced with the _g part URL
+   */
+  const globalStateContainer = getDiscoverGlobalStateContainer(stateStorage);
+
   /**
    * Saved Search State Container, the persisted saved object of Discover
    */
   const savedSearchContainer = getSavedSearchContainer({
     services,
+    globalStateContainer,
   });
 
   /**
@@ -223,6 +230,7 @@ export function getDiscoverStateContainer({
     savedSearch: savedSearchContainer.getState(),
     services,
   });
+
   /**
    * Internal State Container, state that's not persisted and not part of the URL
    */
@@ -230,13 +238,12 @@ export function getDiscoverStateContainer({
 
   const pauseAutoRefreshInterval = async (dataView: DataView) => {
     if (dataView && (!dataView.isTimeBased() || dataView.type === DataViewType.ROLLUP)) {
-      const state = stateStorage.get<QueryState>(GLOBAL_STATE_URL_KEY);
+      const state = globalStateContainer.get();
       if (state?.refreshInterval && !state.refreshInterval.pause) {
-        await stateStorage.set(
-          GLOBAL_STATE_URL_KEY,
-          { ...state, refreshInterval: { ...state?.refreshInterval, pause: true } },
-          { replace: true }
-        );
+        await globalStateContainer.set({
+          ...state,
+          refreshInterval: { ...state?.refreshInterval, pause: true },
+        });
       }
     }
   };
@@ -351,8 +358,8 @@ export function getDiscoverStateContainer({
     const unsubscribeData = dataStateContainer.subscribe();
 
     // updates saved search when query or filters change, triggers data fetching
-    const filterUnsubscribe = merge(services.filterManager.getFetches$()).subscribe(async () => {
-      await savedSearchContainer.update({
+    const filterUnsubscribe = merge(services.filterManager.getFetches$()).subscribe(() => {
+      savedSearchContainer.update({
         nextDataView: internalStateContainer.getState().dataView,
         nextState: appStateContainer.getState(),
         useFilterAndQueryServices: true,
@@ -424,7 +431,7 @@ export function getDiscoverStateContainer({
   const undoSavedSearchChanges = async () => {
     addLog('undoSavedSearchChanges');
     const nextSavedSearch = savedSearchContainer.getInitial$().getValue();
-    await savedSearchContainer.set(nextSavedSearch);
+    savedSearchContainer.set(nextSavedSearch);
     restoreStateFromSavedSearch({
       savedSearch: nextSavedSearch,
       timefilter: services.timefilter,

--- a/src/plugins/discover/public/application/main/utils/update_saved_search.test.ts
+++ b/src/plugins/discover/public/application/main/utils/update_saved_search.test.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { savedSearchMock } from '../../../__mocks__/saved_search';
+import { discoverServiceMock } from '../../../__mocks__/services';
+import { Filter, FilterStateStore, Query } from '@kbn/es-query';
+import { updateSavedSearch } from './update_saved_search';
+
+describe('updateSavedSearch', () => {
+  const query: Query = {
+    query: 'extension:jpg',
+    language: 'kuery',
+  };
+  const appFilter: Filter = {
+    meta: {},
+    query: {
+      match_phrase: {
+        extension: {
+          query: 'jpg',
+          type: 'phrase',
+        },
+      },
+    },
+    $state: {
+      store: FilterStateStore.APP_STATE,
+    },
+  };
+  const globalFilter: Filter = {
+    meta: {},
+    query: {
+      match_phrase: {
+        extension: {
+          query: 'png',
+          type: 'phrase',
+        },
+      },
+    },
+    $state: {
+      store: FilterStateStore.GLOBAL_STATE,
+    },
+  };
+  const createGlobalStateContainer = () => ({
+    get: jest.fn(() => ({ filters: [globalFilter] })),
+    set: jest.fn(),
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should set query and filters from appState and globalState', async () => {
+    const savedSearch = {
+      ...savedSearchMock,
+      searchSource: savedSearchMock.searchSource.createCopy(),
+    };
+    expect(savedSearch.searchSource.getField('query')).toBeUndefined();
+    expect(savedSearch.searchSource.getField('filter')).toBeUndefined();
+    updateSavedSearch({
+      savedSearch,
+      globalStateContainer: createGlobalStateContainer(),
+      services: discoverServiceMock,
+      state: {
+        query,
+        filters: [appFilter],
+      },
+    });
+    expect(savedSearch.searchSource.getField('query')).toEqual(query);
+    expect(savedSearch.searchSource.getField('filter')).toEqual([appFilter, globalFilter]);
+  });
+
+  it('should set query and filters from services', async () => {
+    const savedSearch = {
+      ...savedSearchMock,
+      searchSource: savedSearchMock.searchSource.createCopy(),
+    };
+    expect(savedSearch.searchSource.getField('query')).toBeUndefined();
+    expect(savedSearch.searchSource.getField('filter')).toBeUndefined();
+    jest
+      .spyOn(discoverServiceMock.data.query.filterManager, 'getFilters')
+      .mockReturnValue([appFilter, globalFilter]);
+    jest.spyOn(discoverServiceMock.data.query.queryString, 'getQuery').mockReturnValue(query);
+    updateSavedSearch({
+      savedSearch,
+      globalStateContainer: createGlobalStateContainer(),
+      services: discoverServiceMock,
+      useFilterAndQueryServices: true,
+    });
+    expect(savedSearch.searchSource.getField('query')).toEqual(query);
+    expect(savedSearch.searchSource.getField('filter')).toEqual([appFilter, globalFilter]);
+  });
+});

--- a/src/plugins/discover/public/application/main/utils/update_search_source.test.ts
+++ b/src/plugins/discover/public/application/main/utils/update_search_source.test.ts
@@ -12,7 +12,6 @@ import { dataViewMock } from '../../../__mocks__/data_view';
 import type { SortOrder } from '@kbn/saved-search-plugin/public';
 import { discoverServiceMock } from '../../../__mocks__/services';
 import { IUiSettingsClient } from '@kbn/core-ui-settings-browser';
-import { FilterStateStore, RangeFilter } from '@kbn/es-query';
 
 const getUiSettingsMock = (value: boolean) => {
   return {
@@ -68,33 +67,5 @@ describe('updateVolatileSearchSource', () => {
     });
     expect(volatileSearchSourceMock.getField('fields')).toEqual(undefined);
     expect(volatileSearchSourceMock.getField('fieldsFromSource')).toBe(undefined);
-  });
-
-  it('should add global filters and time filter to the search source', () => {
-    const searchSource = createSearchSourceMock({});
-    const filterManager = discoverServiceMock.data.query.filterManager;
-    const timefilter = discoverServiceMock.data.query.timefilter.timefilter;
-    const timeFilter = { foo: 'bar' } as unknown as RangeFilter;
-    const globalFilter = {
-      meta: {},
-      query: {
-        match_phrase: {
-          extension: {
-            query: 'png',
-            type: 'phrase',
-          },
-        },
-      },
-      $state: {
-        store: FilterStateStore.GLOBAL_STATE,
-      },
-    };
-    jest.spyOn(filterManager, 'getGlobalFilters').mockReturnValue([globalFilter]);
-    jest.spyOn(timefilter, 'createFilter').mockReturnValue(timeFilter);
-    updateVolatileSearchSource(searchSource, {
-      dataView: dataViewMock,
-      services: discoverServiceMock,
-    });
-    expect(searchSource.getField('filter')).toEqual([globalFilter, timeFilter]);
   });
 });

--- a/src/plugins/discover/public/application/main/utils/update_search_source.ts
+++ b/src/plugins/discover/public/application/main/utils/update_search_source.ts
@@ -35,27 +35,20 @@ export function updateVolatileSearchSource(
     uiSettings.get(SORT_DEFAULT_ORDER_SETTING)
   );
   const useNewFieldsApi = !uiSettings.get(SEARCH_FIELDS_FROM_SOURCE);
-  const { filterManager, timefilter } = data.query;
-  const filters = [...filterManager.getGlobalFilters()];
+  searchSource.setField('trackTotalHits', true).setField('sort', usedSort);
 
   if (dataView.type !== DataViewType.ROLLUP) {
-    // Set the date range filter fields from timeFilter using the absolute format.
-    // Search sessions requires that it be converted from a relative range.
-    const timeFilter = timefilter.timefilter.createFilter(dataView);
-
-    if (timeFilter) {
-      filters.push(timeFilter);
-    }
+    // Set the date range filter fields from timeFilter using the absolute format. Search sessions requires that it be converted from a relative range
+    searchSource.setField('filter', data.query.timefilter.timefilter.createFilter(dataView));
   }
-
-  searchSource
-    .setField('trackTotalHits', true)
-    .setField('sort', usedSort)
-    .setField('filter', filters);
 
   if (useNewFieldsApi) {
     searchSource.removeField('fieldsFromSource');
-    searchSource.setField('fields', [{ field: '*', include_unmapped: 'true' }]);
+    const fields: Record<string, string> = { field: '*' };
+
+    fields.include_unmapped = 'true';
+
+    searchSource.setField('fields', [fields]);
   } else {
     searchSource.removeField('fields');
   }

--- a/src/plugins/discover/public/application/main/utils/update_search_source.ts
+++ b/src/plugins/discover/public/application/main/utils/update_search_source.ts
@@ -35,20 +35,27 @@ export function updateVolatileSearchSource(
     uiSettings.get(SORT_DEFAULT_ORDER_SETTING)
   );
   const useNewFieldsApi = !uiSettings.get(SEARCH_FIELDS_FROM_SOURCE);
-  searchSource.setField('trackTotalHits', true).setField('sort', usedSort);
+  const { filterManager, timefilter } = data.query;
+  const filters = [...filterManager.getGlobalFilters()];
 
   if (dataView.type !== DataViewType.ROLLUP) {
-    // Set the date range filter fields from timeFilter using the absolute format. Search sessions requires that it be converted from a relative range
-    searchSource.setField('filter', data.query.timefilter.timefilter.createFilter(dataView));
+    // Set the date range filter fields from timeFilter using the absolute format.
+    // Search sessions requires that it be converted from a relative range.
+    const timeFilter = timefilter.timefilter.createFilter(dataView);
+
+    if (timeFilter) {
+      filters.push(timeFilter);
+    }
   }
+
+  searchSource
+    .setField('trackTotalHits', true)
+    .setField('sort', usedSort)
+    .setField('filter', filters);
 
   if (useNewFieldsApi) {
     searchSource.removeField('fieldsFromSource');
-    const fields: Record<string, string> = { field: '*' };
-
-    fields.include_unmapped = 'true';
-
-    searchSource.setField('fields', [fields]);
+    searchSource.setField('fields', [{ field: '*', include_unmapped: 'true' }]);
   } else {
     searchSource.removeField('fields');
   }


### PR DESCRIPTION
## Summary

This PR fixes a bug where pinned filters were not being applied to the Discover documents request.

Fixes #160579.

### Checklist

- [ ] ~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)~
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] ~Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))~
- [ ] ~Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))~
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))~
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->