### PR TITLE
Update docker.asciidoc

### DIFF
--- a/docs/setup/docker.asciidoc
+++ b/docs/setup/docker.asciidoc
@@ -99,12 +99,6 @@ endif::[]
 
 ifeval::["{release-state}"!="unreleased"]
 
-[source,sh,subs="attributes"]
-----
-docker pull {docker-image}
-docker run --name kib-01 --net elastic -p 5601:5601 {docker-image}
-----
-
 .. Pull the {kib} Docker image:
 +
 [source,sh,subs="attributes"]


### PR DESCRIPTION
This snippet is misleading as the commands are repeated and described after it. Also removing this snippet makes it consistent with the previous section, where commands are described step by step.

## Summary

Misleading repeated commands snippet

