### PR TITLE
Ftr/speedup dashboard tests

### DIFF
--- a/test/functional/page_objects/common_page.ts
+++ b/test/functional/page_objects/common_page.ts
@@ -337,7 +337,7 @@ export class CommonPageObject extends FtrService {
 
   async ensureModalOverlayHidden() {
     return this.retry.try(async () => {
-      const shown = await this.testSubjects.exists('confirmModalTitleText');
+      const shown = await this.testSubjects.exists('confirmModalTitleText', { timeout: 500 });
       if (shown) {
         throw new Error('Modal overlay is showing');
       }

--- a/test/functional/services/dashboard/add_panel.ts
+++ b/test/functional/services/dashboard/add_panel.ts
@@ -131,7 +131,7 @@ export class DashboardAddPanelService extends FtrService {
 
   async isAddPanelOpen() {
     this.log.debug('DashboardAddPanel.isAddPanelOpen');
-    return await this.testSubjects.exists('dashboardAddPanel');
+    return await this.testSubjects.exists('dashboardAddPanel', { timeout: 500 });
   }
 
   async ensureAddPanelIsShowing() {

--- a/test/functional/services/filter_bar.ts
+++ b/test/functional/services/filter_bar.ts
@@ -356,7 +356,9 @@ export class FilterBarService extends FtrService {
    * Closes field editor modal window
    */
   public async ensureFieldEditorModalIsClosed(): Promise<void> {
-    const cancelSaveFilterModalButtonExists = await this.testSubjects.exists('cancelSaveFilter');
+    const cancelSaveFilterModalButtonExists = await this.testSubjects.exists('cancelSaveFilter', {
+      timeout: 1000,
+    });
     if (cancelSaveFilterModalButtonExists) {
       await this.testSubjects.click('cancelSaveFilter');
     }

--- a/test/functional/services/flyout.ts
+++ b/test/functional/services/flyout.ts
@@ -31,20 +31,17 @@ export class FlyoutService extends FtrService {
   }
 
   public async ensureAllClosed(): Promise<void> {
-    const flyoutElements = await this.find.allByCssSelector('.euiFlyout');
-
-    if (!flyoutElements.length) {
-      return;
-    }
-
-    for (let i = 0; i < flyoutElements.length; i++) {
-      const closeBtn = await flyoutElements[i].findByCssSelector('[aria-label*="Close"]');
-      await closeBtn.click();
-    }
-
-    await this.retry.waitFor(
-      'all flyouts to be closed',
-      async () => (await this.find.allByCssSelector('.euiFlyout')).length === 0
-    );
+    await this.retry.waitFor('all flyouts to be closed', async () => {
+      let flyoutElements = await this.find.allByCssSelector('.euiFlyout', 2500);
+      if (!flyoutElements.length) {
+        return true;
+      }
+      for (let i = 0; i < flyoutElements.length; i++) {
+        const closeBtn = await flyoutElements[i].findByCssSelector('[aria-label*="Close"]');
+        await closeBtn.click();
+      }
+      flyoutElements = await this.find.allByCssSelector('.euiFlyout', 500);
+      return flyoutElements.length === 0;
+    });
   }
 }

--- a/test/functional/services/renderable.ts
+++ b/test/functional/services/renderable.ts
@@ -26,10 +26,17 @@ export class RenderableService extends FtrService {
    */
   public async waitForRender(count: number = 1): Promise<void> {
     this.log.debug(`Renderable.waitForRender for ${count} elements`);
+    // exit if there are no objects expected
+    if (count === 0) {
+      return;
+    }
     await this.retry.try(async () => {
       const completedElements = await this.find.allByCssSelector(RENDER_COMPLETE_SELECTOR);
       if (completedElements.length < count) {
-        const pendingElements = await this.find.allByCssSelector(RENDER_COMPLETE_PENDING_SELECTOR);
+        const pendingElements = await this.find.allByCssSelector(
+          RENDER_COMPLETE_PENDING_SELECTOR,
+          2500
+        );
         const pendingElementNames = [];
         for (const pendingElement of pendingElements) {
           const title = await pendingElement.getAttribute('data-title');


### PR DESCRIPTION
## Summary

While splitting `test/functional/apps/dashboard/group2/config.ts` in #160612, I noticed that some tests (`it` function level) takes 30-45 seconds  though having little actions to do in Kibana.

After closer look I found that:
- `await PageObjects.dashboard.clickNewDashboard();` call takes ~13-15 seconds when dashboard is empty
- `await dashboardAddPanel.closeAddPanel();` call takes ~12 seconds when there are no flyouts displayed

Expected improvement:
- `await PageObjects.dashboard.clickNewDashboard()` call takes **2** seconds, used **103** times in tests.
- `await dashboardAddPanel.closeAddPanel()` call takes **3** seconds, used **21** times in tests.

PR FTR configs runtime
<img width="778" alt="image" src="https://github.com/elastic/kibana/assets/10977896/673fee19-91ef-4bc3-9848-5f844b42774c">

`main` branch last 3 days avg configs runtime
<img width="1555" alt="image" src="https://github.com/elastic/kibana/assets/10977896/6e364cb9-c786-411a-9491-a749351f4c94">



flaky test runner 50x for 6 most affected configs https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2519


<!--ONMERGE {"backportTargets":["8.8","8.9"]} ONMERGE-->