### PR TITLE
[ML] Add a 16 threads option to start model deployment

### DIFF
--- a/x-pack/plugins/ml/public/application/model_management/deployment_setup.tsx
+++ b/x-pack/plugins/ml/public/application/model_management/deployment_setup.tsx
@@ -55,7 +55,7 @@ export interface ThreadingParams {
   deploymentId?: string;
 }
 
-const THREADS_MAX_EXPONENT = 4;
+const THREADS_MAX_EXPONENT = 5;
 
 /**
  * Form for setting threading params.


### PR DESCRIPTION
## Summary

The previous best was 8, now we go all the way to 16.


### Checklist

Delete any items that are not applicable to this PR.


- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials

Update the image in the tutorial : https://www.elastic.co/guide/en/machine-learning/master/ml-nlp-deploy-model.html

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->