### PR TITLE
[Search Application] Fix product card text wrapping

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_overview/components/product_card/product_card.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_overview/components/product_card/product_card.tsx
@@ -116,6 +116,7 @@ export const ProductCard: React.FC<ProductCardProps> = ({
           <EuiListGroup flush className="productCard-features">
             {features.map((item: string, index: number) => (
               <EuiListGroupItem
+                wrapText
                 key={index}
                 size="s"
                 label={item}


### PR DESCRIPTION
The Elasticsearch section on the Enterprise Search home page has the links under the Resources bleeding out of the display box when the window is shrink
Actual: 
<img width="794" alt="image" src="https://github.com/elastic/kibana/assets/17390745/a1162117-8040-4d0b-8027-9aa0253d7452">


Expected: 
<img width="803" alt="image" src="https://github.com/elastic/kibana/assets/17390745/954eac2c-b935-4a98-9733-76469d11e670">
