### PR TITLE
fix: run apm-synthtrace on systems with multiple spaces

### DIFF
--- a/packages/kbn-apm-synthtrace/src/cli/utils/get_service_urls.ts
+++ b/packages/kbn-apm-synthtrace/src/cli/utils/get_service_urls.ts
@@ -45,7 +45,10 @@ async function getKibanaUrl({ target, logger }: { target: string; logger: Logger
     });
 
     const discoveredKibanaUrl =
-      unredirectedResponse.headers.get('location')?.replace('/spaces/enter', '')?.replace('spaces/space_selector','') || target;
+      unredirectedResponse.headers
+        .get('location')
+        ?.replace('/spaces/enter', '')
+        ?.replace('spaces/space_selector', '') || target;
 
     const parsedTarget = parse(target);
 

--- a/packages/kbn-apm-synthtrace/src/cli/utils/get_service_urls.ts
+++ b/packages/kbn-apm-synthtrace/src/cli/utils/get_service_urls.ts
@@ -45,7 +45,7 @@ async function getKibanaUrl({ target, logger }: { target: string; logger: Logger
     });
 
     const discoveredKibanaUrl =
-      unredirectedResponse.headers.get('location')?.replace('/spaces/enter', '') || target;
+      unredirectedResponse.headers.get('location')?.replace('/spaces/enter', '')?.replace('spaces/space_selector','') || target;
 
     const parsedTarget = parse(target);
 


### PR DESCRIPTION
## Summary

We discover a bug in the apm-synthtrace tool when you run it against systems with multiple user spaces. The change in code allows us to run the tool without errors.

## Test locally

```bash
nvm install 16.20.1
nvm user 16.20.1
yarn kbn bootstrap
node scripts/synthtrace simple_trace.ts --target=https://${ELASTICSEARCH_USERNAME}:${ELASTICSEARCH_PASSWORD}@${ELASTICSEARCH_HOST} --live
```