### PR TITLE
[Defend workflows] Fix action status on action list

### DIFF
--- a/x-pack/plugins/security_solution/common/endpoint/data_generators/fleet_action_generator.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/data_generators/fleet_action_generator.ts
@@ -30,7 +30,7 @@ export class FleetActionGenerator extends BaseDataGenerator {
         expiration: this.randomFutureDate(timeStamp),
         type: 'INPUT_ACTION',
         input_type: 'endpoint',
-        agents: [this.seededUUIDv4()],
+        agents: overrides.agents ? overrides.agents : [this.seededUUIDv4()],
         user_id: 'elastic',
         data: {
           command: this.randomResponseActionCommand(),

--- a/x-pack/plugins/security_solution/public/common/components/endpoint/endpoint_agent_status/endpoint_agent_status.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/endpoint/endpoint_agent_status/endpoint_agent_status.tsx
@@ -90,12 +90,11 @@ export const EndpointAgentStatus = memo<EndpointAgentStatusProps>(
         return [false, {}];
       }
 
-      const endpointPending = endpointPendingActions?.data?.[0]?.pending_actions ?? {};
       const pending = pendingActions
         ? pendingActions
         : endpointPendingActions?.data[0].pending_actions ?? {};
 
-      return [Object.keys(endpointPending).length > 0, pending];
+      return [Object.keys(pending).length > 0, pending];
     }, [endpointPendingActions, pendingActions]);
 
     const status = endpointHostInfo.host_status;

--- a/x-pack/plugins/security_solution/public/common/components/endpoint/endpoint_agent_status/endpoint_agent_status.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/endpoint/endpoint_agent_status/endpoint_agent_status.tsx
@@ -90,11 +90,12 @@ export const EndpointAgentStatus = memo<EndpointAgentStatusProps>(
         return [false, {}];
       }
 
+      const endpointPending = endpointPendingActions?.data?.[0]?.pending_actions ?? {};
       const pending = pendingActions
         ? pendingActions
         : endpointPendingActions?.data[0].pending_actions ?? {};
 
-      return [Object.keys(pending).length > 0, pending];
+      return [Object.keys(endpointPending).length > 0, pending];
     }, [endpointPendingActions, pendingActions]);
 
     const status = endpointHostInfo.host_status;

--- a/x-pack/plugins/security_solution/public/management/components/endpoint_response_actions_list/components/actions_log_table.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/endpoint_response_actions_list/components/actions_log_table.tsx
@@ -212,11 +212,12 @@ const getResponseActionListTableColumns = ({
       },
     },
     {
+      field: 'status',
       name: TABLE_COLUMN_NAMES.status,
       width: !showHostNames ? '15%' : '10%',
-      render: (action: ActionListApiResponse['data'][number]) => {
-        const _status = action.errors?.length ? 'failed' : action.status;
+      render: (_status: ActionListApiResponse['data'][number]['status']) => {
         const status = getActionStatus(_status);
+
         return (
           <EuiToolTip content={status} anchorClassName="eui-textTruncate">
             <StatusBadge

--- a/x-pack/plugins/security_solution/server/endpoint/services/actions/action_details_by_id.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/services/actions/action_details_by_id.ts
@@ -118,13 +118,12 @@ export const getActionDetailsById = async (
   });
 
   const { isCompleted, completedAt, wasSuccessful, errors, outputs, agentState } =
-    getActionCompletionInfo(normalizedActionRequest.agents, actionResponses);
+    getActionCompletionInfo(normalizedActionRequest, actionResponses);
 
   const { isExpired, status } = getActionStatus({
     expirationDate: normalizedActionRequest.expiration,
     isCompleted,
     wasSuccessful,
-    error: normalizedActionRequest.error?.message,
   });
 
   const actionDetails: ActionDetails = {

--- a/x-pack/plugins/security_solution/server/endpoint/services/actions/action_details_by_id.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/services/actions/action_details_by_id.ts
@@ -124,6 +124,7 @@ export const getActionDetailsById = async (
     expirationDate: normalizedActionRequest.expiration,
     isCompleted,
     wasSuccessful,
+    error: normalizedActionRequest.error?.message,
   });
 
   const actionDetails: ActionDetails = {

--- a/x-pack/plugins/security_solution/server/endpoint/services/actions/action_list.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/services/actions/action_list.ts
@@ -276,13 +276,12 @@ const getActionDetailsList = async ({
 
     // find the specific response's details using that set of matching responses
     const { isCompleted, completedAt, wasSuccessful, errors, agentState, outputs } =
-      getActionCompletionInfo(action.agents, matchedResponses);
+      getActionCompletionInfo(action, matchedResponses);
 
     const { isExpired, status } = getActionStatus({
       expirationDate: action.expiration,
       isCompleted,
       wasSuccessful,
-      error: action.error?.message,
     });
 
     const actionRecord: ActionListApiResponse['data'][number] = {

--- a/x-pack/plugins/security_solution/server/endpoint/services/actions/action_list.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/services/actions/action_list.ts
@@ -282,6 +282,7 @@ const getActionDetailsList = async ({
       expirationDate: action.expiration,
       isCompleted,
       wasSuccessful,
+      error: action.error?.message,
     });
 
     const actionRecord: ActionListApiResponse['data'][number] = {

--- a/x-pack/plugins/security_solution/server/endpoint/services/actions/utils.test.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/services/actions/utils.test.ts
@@ -123,17 +123,45 @@ describe('When using Actions service utilities', () => {
     });
 
     it('should show complete `false` if no action ids', () => {
-      expect(getActionCompletionInfo([], [])).toEqual({ ...NOT_COMPLETED_OUTPUT, agentState: {} });
+      expect(
+        getActionCompletionInfo(
+          mapToNormalizedActionRequest(
+            fleetActionGenerator.generate({
+              agents: [],
+              '@timestamp': '2022-04-27T16:08:47.449Z',
+            })
+          ),
+          []
+        )
+      ).toEqual({
+        ...NOT_COMPLETED_OUTPUT,
+        agentState: {},
+      });
     });
 
     it('should show complete as `false` if no responses', () => {
-      expect(getActionCompletionInfo(['123'], [])).toEqual(NOT_COMPLETED_OUTPUT);
+      expect(
+        getActionCompletionInfo(
+          mapToNormalizedActionRequest(
+            fleetActionGenerator.generate({
+              agents: ['123'],
+              '@timestamp': '2022-04-27T16:08:47.449Z',
+            })
+          ),
+          []
+        )
+      ).toEqual(NOT_COMPLETED_OUTPUT);
     });
 
     it('should show complete as `false` if no Endpoint response', () => {
       expect(
         getActionCompletionInfo(
-          ['123'],
+          mapToNormalizedActionRequest(
+            fleetActionGenerator.generate({
+              agents: ['123'],
+              '@timestamp': '2022-04-27T16:08:47.449Z',
+            })
+          ),
           [
             fleetActionGenerator.generateActivityLogActionResponse({
               item: { data: { action_id: '123' } },
@@ -156,7 +184,17 @@ describe('When using Actions service utilities', () => {
           },
         },
       });
-      expect(getActionCompletionInfo(['123'], [endpointResponse])).toEqual({
+      expect(
+        getActionCompletionInfo(
+          mapToNormalizedActionRequest(
+            fleetActionGenerator.generate({
+              agents: ['123'],
+              '@timestamp': '2022-04-27T16:08:47.449Z',
+            })
+          ),
+          [endpointResponse]
+        )
+      ).toEqual({
         isCompleted: true,
         completedAt: COMPLETED_AT,
         errors: undefined,
@@ -201,7 +239,17 @@ describe('When using Actions service utilities', () => {
           },
         },
       });
-      expect(getActionCompletionInfo(['123'], [endpointResponse])).toEqual({
+      expect(
+        getActionCompletionInfo(
+          mapToNormalizedActionRequest(
+            fleetActionGenerator.generate({
+              agents: ['123'],
+              '@timestamp': '2022-04-27T16:08:47.449Z',
+            })
+          ),
+          [endpointResponse]
+        )
+      ).toEqual({
         isCompleted: true,
         completedAt: COMPLETED_AT,
         errors: undefined,
@@ -255,7 +303,17 @@ describe('When using Actions service utilities', () => {
       });
 
       it('should show `wasSuccessful` as `false` if endpoint action response has error', () => {
-        expect(getActionCompletionInfo(['123'], [endpointResponseAtError])).toEqual({
+        expect(
+          getActionCompletionInfo(
+            mapToNormalizedActionRequest(
+              fleetActionGenerator.generate({
+                agents: ['123'],
+                '@timestamp': '2022-04-27T16:08:47.449Z',
+              })
+            ),
+            [endpointResponseAtError]
+          )
+        ).toEqual({
           completedAt: endpointResponseAtError.item.data['@timestamp'],
           errors: ['Endpoint action response error: endpoint failed to apply'],
           isCompleted: true,
@@ -273,7 +331,17 @@ describe('When using Actions service utilities', () => {
       });
 
       it('should show `wasSuccessful` as `false` if fleet action response has error (no endpoint response)', () => {
-        expect(getActionCompletionInfo(['123'], [fleetResponseAtError])).toEqual({
+        expect(
+          getActionCompletionInfo(
+            mapToNormalizedActionRequest(
+              fleetActionGenerator.generate({
+                agents: ['123'],
+                '@timestamp': '2022-04-27T16:08:47.449Z',
+              })
+            ),
+            [fleetResponseAtError]
+          )
+        ).toEqual({
           completedAt: fleetResponseAtError.item.data.completed_at,
           errors: ['Fleet action response error: agent failed to deliver'],
           isCompleted: true,
@@ -292,7 +360,15 @@ describe('When using Actions service utilities', () => {
 
       it('should include both fleet and endpoint errors if both responses returned failure', () => {
         expect(
-          getActionCompletionInfo(['123'], [fleetResponseAtError, endpointResponseAtError])
+          getActionCompletionInfo(
+            mapToNormalizedActionRequest(
+              fleetActionGenerator.generate({
+                agents: ['123'],
+                '@timestamp': '2022-04-27T16:08:47.449Z',
+              })
+            ),
+            [fleetResponseAtError, endpointResponseAtError]
+          )
         ).toEqual({
           completedAt: endpointResponseAtError.item.data['@timestamp'],
           errors: [
@@ -374,7 +450,17 @@ describe('When using Actions service utilities', () => {
       });
 
       it('should show complete as `false` if no responses', () => {
-        expect(getActionCompletionInfo(agentIds, [])).toEqual({
+        expect(
+          getActionCompletionInfo(
+            mapToNormalizedActionRequest(
+              fleetActionGenerator.generate({
+                agents: agentIds,
+                '@timestamp': '2022-04-27T16:08:47.449Z',
+              })
+            ),
+            []
+          )
+        ).toEqual({
           ...NOT_COMPLETED_OUTPUT,
           agentState: {
             ...NOT_COMPLETED_OUTPUT.agentState,
@@ -396,14 +482,22 @@ describe('When using Actions service utilities', () => {
 
       it('should complete as `false` if at least one agent id has not received a response', () => {
         expect(
-          getActionCompletionInfo(agentIds, [
-            ...action123Responses,
+          getActionCompletionInfo(
+            mapToNormalizedActionRequest(
+              fleetActionGenerator.generate({
+                agents: agentIds,
+                '@timestamp': '2022-04-27T16:08:47.449Z',
+              })
+            ),
+            [
+              ...action123Responses,
 
-            // Action id: 456 === Not complete (only fleet response)
-            action456Responses[0],
+              // Action id: 456 === Not complete (only fleet response)
+              action456Responses[0],
 
-            ...action789Responses,
-          ])
+              ...action789Responses,
+            ]
+          )
         ).toEqual({
           ...NOT_COMPLETED_OUTPUT,
           outputs: expect.any(Object),
@@ -432,11 +526,15 @@ describe('When using Actions service utilities', () => {
 
       it('should show complete as `true` if all agent response were received', () => {
         expect(
-          getActionCompletionInfo(agentIds, [
-            ...action123Responses,
-            ...action456Responses,
-            ...action789Responses,
-          ])
+          getActionCompletionInfo(
+            mapToNormalizedActionRequest(
+              fleetActionGenerator.generate({
+                agents: agentIds,
+                '@timestamp': '2022-04-27T16:08:47.449Z',
+              })
+            ),
+            [...action123Responses, ...action456Responses, ...action789Responses]
+          )
         ).toEqual({
           isCompleted: true,
           completedAt: COMPLETED_AT,
@@ -471,14 +569,22 @@ describe('When using Actions service utilities', () => {
         action456Responses[0].item.data['@timestamp'] = '2022-05-06T12:50:19.747Z';
 
         expect(
-          getActionCompletionInfo(agentIds, [
-            ...action123Responses,
+          getActionCompletionInfo(
+            mapToNormalizedActionRequest(
+              fleetActionGenerator.generate({
+                agents: agentIds,
+                '@timestamp': '2022-04-27T16:08:47.449Z',
+              })
+            ),
+            [
+              ...action123Responses,
 
-            // Action id: 456 === is complete with only a fleet response that has `error`
-            action456Responses[0],
+              // Action id: 456 === is complete with only a fleet response that has `error`
+              action456Responses[0],
 
-            ...action789Responses,
-          ])
+              ...action789Responses,
+            ]
+          )
         ).toEqual({
           completedAt: '2022-05-06T12:50:19.747Z',
           errors: ['Fleet action response error: something is no good'],
@@ -528,14 +634,22 @@ describe('When using Actions service utilities', () => {
         };
 
         expect(
-          getActionCompletionInfo(agentIds, [
-            ...action123Responses,
+          getActionCompletionInfo(
+            mapToNormalizedActionRequest(
+              fleetActionGenerator.generate({
+                agents: agentIds,
+                '@timestamp': '2022-04-27T16:08:47.449Z',
+              })
+            ),
+            [
+              ...action123Responses,
 
-            // Action id: 456 === Not complete (only fleet response)
-            action456Responses[0],
+              // Action id: 456 === Not complete (only fleet response)
+              action456Responses[0],
 
-            ...action789Responses,
-          ])
+              ...action789Responses,
+            ]
+          )
         ).toEqual({
           ...NOT_COMPLETED_OUTPUT,
           agentState: {

--- a/x-pack/plugins/security_solution/server/endpoint/services/actions/utils.test.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/services/actions/utils.test.ts
@@ -128,7 +128,6 @@ describe('When using Actions service utilities', () => {
           mapToNormalizedActionRequest(
             fleetActionGenerator.generate({
               agents: [],
-              '@timestamp': '2022-04-27T16:08:47.449Z',
             })
           ),
           []
@@ -145,7 +144,6 @@ describe('When using Actions service utilities', () => {
           mapToNormalizedActionRequest(
             fleetActionGenerator.generate({
               agents: ['123'],
-              '@timestamp': '2022-04-27T16:08:47.449Z',
             })
           ),
           []
@@ -159,7 +157,6 @@ describe('When using Actions service utilities', () => {
           mapToNormalizedActionRequest(
             fleetActionGenerator.generate({
               agents: ['123'],
-              '@timestamp': '2022-04-27T16:08:47.449Z',
             })
           ),
           [
@@ -189,7 +186,6 @@ describe('When using Actions service utilities', () => {
           mapToNormalizedActionRequest(
             fleetActionGenerator.generate({
               agents: ['123'],
-              '@timestamp': '2022-04-27T16:08:47.449Z',
             })
           ),
           [endpointResponse]
@@ -244,7 +240,6 @@ describe('When using Actions service utilities', () => {
           mapToNormalizedActionRequest(
             fleetActionGenerator.generate({
               agents: ['123'],
-              '@timestamp': '2022-04-27T16:08:47.449Z',
             })
           ),
           [endpointResponse]
@@ -308,7 +303,6 @@ describe('When using Actions service utilities', () => {
             mapToNormalizedActionRequest(
               fleetActionGenerator.generate({
                 agents: ['123'],
-                '@timestamp': '2022-04-27T16:08:47.449Z',
               })
             ),
             [endpointResponseAtError]
@@ -336,7 +330,6 @@ describe('When using Actions service utilities', () => {
             mapToNormalizedActionRequest(
               fleetActionGenerator.generate({
                 agents: ['123'],
-                '@timestamp': '2022-04-27T16:08:47.449Z',
               })
             ),
             [fleetResponseAtError]
@@ -364,7 +357,6 @@ describe('When using Actions service utilities', () => {
             mapToNormalizedActionRequest(
               fleetActionGenerator.generate({
                 agents: ['123'],
-                '@timestamp': '2022-04-27T16:08:47.449Z',
               })
             ),
             [fleetResponseAtError, endpointResponseAtError]
@@ -455,7 +447,6 @@ describe('When using Actions service utilities', () => {
             mapToNormalizedActionRequest(
               fleetActionGenerator.generate({
                 agents: agentIds,
-                '@timestamp': '2022-04-27T16:08:47.449Z',
               })
             ),
             []
@@ -486,7 +477,6 @@ describe('When using Actions service utilities', () => {
             mapToNormalizedActionRequest(
               fleetActionGenerator.generate({
                 agents: agentIds,
-                '@timestamp': '2022-04-27T16:08:47.449Z',
               })
             ),
             [
@@ -530,7 +520,6 @@ describe('When using Actions service utilities', () => {
             mapToNormalizedActionRequest(
               fleetActionGenerator.generate({
                 agents: agentIds,
-                '@timestamp': '2022-04-27T16:08:47.449Z',
               })
             ),
             [...action123Responses, ...action456Responses, ...action789Responses]
@@ -573,7 +562,6 @@ describe('When using Actions service utilities', () => {
             mapToNormalizedActionRequest(
               fleetActionGenerator.generate({
                 agents: agentIds,
-                '@timestamp': '2022-04-27T16:08:47.449Z',
               })
             ),
             [
@@ -638,7 +626,6 @@ describe('When using Actions service utilities', () => {
             mapToNormalizedActionRequest(
               fleetActionGenerator.generate({
                 agents: agentIds,
-                '@timestamp': '2022-04-27T16:08:47.449Z',
               })
             ),
             [

--- a/x-pack/plugins/security_solution/server/endpoint/services/actions/utils.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/services/actions/utils.ts
@@ -115,11 +115,12 @@ type ActionCompletionInfo = Pick<
 >;
 
 export const getActionCompletionInfo = (
-  /** List of agents that the action was sent to */
-  agentIds: string[],
+  /** The normalized action request */
+  action: NormalizedActionRequest,
   /** List of action Log responses received for the action */
   actionResponses: Array<ActivityLogActionResponse | EndpointActivityLogActionResponse>
 ): ActionCompletionInfo => {
+  const agentIds = action.agents;
   const completedInfo: ActionCompletionInfo = {
     completedAt: undefined,
     errors: undefined,
@@ -191,6 +192,25 @@ export const getActionCompletionInfo = (
     }
   }
 
+  // If the action request has an Error, then we'll never get actual response from all of the agents
+  // to which this action sent. In this case, we adjust the completion information to all be "complete"
+  // and un-successful
+  if (action.error?.message) {
+    const errorMessage = action.error.message;
+
+    completedInfo.completedAt = action.createdAt;
+    completedInfo.isCompleted = true;
+    completedInfo.wasSuccessful = false;
+    completedInfo.errors = [errorMessage];
+
+    Object.values(completedInfo.agentState).forEach((agentState) => {
+      agentState.completedAt = action.createdAt;
+      agentState.isCompleted = true;
+      agentState.wasSuccessful = false;
+      agentState.errors = [errorMessage];
+    });
+  }
+
   return completedInfo;
 };
 
@@ -198,22 +218,19 @@ export const getActionStatus = ({
   expirationDate,
   isCompleted,
   wasSuccessful,
-  error,
 }: {
   expirationDate: string;
   isCompleted: boolean;
   wasSuccessful: boolean;
-  error?: string;
 }): { status: ActionDetails['status']; isExpired: boolean } => {
   const isExpired = !isCompleted && expirationDate < new Date().toISOString();
-  const status =
-    isExpired || error
-      ? 'failed'
-      : isCompleted
-      ? wasSuccessful
-        ? 'successful'
-        : 'failed'
-      : 'pending';
+  const status = isExpired
+    ? 'failed'
+    : isCompleted
+    ? wasSuccessful
+      ? 'successful'
+      : 'failed'
+    : 'pending';
 
   return { isExpired, status };
 };

--- a/x-pack/plugins/security_solution/server/endpoint/services/actions/utils.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/services/actions/utils.ts
@@ -198,19 +198,22 @@ export const getActionStatus = ({
   expirationDate,
   isCompleted,
   wasSuccessful,
+  error,
 }: {
   expirationDate: string;
   isCompleted: boolean;
   wasSuccessful: boolean;
+  error?: string;
 }): { status: ActionDetails['status']; isExpired: boolean } => {
   const isExpired = !isCompleted && expirationDate < new Date().toISOString();
-  const status = isExpired
-    ? 'failed'
-    : isCompleted
-    ? wasSuccessful
-      ? 'successful'
-      : 'failed'
-    : 'pending';
+  const status =
+    isExpired || error
+      ? 'failed'
+      : isCompleted
+      ? wasSuccessful
+        ? 'successful'
+        : 'failed'
+      : 'pending';
 
   return { isExpired, status };
 };


### PR DESCRIPTION
Fix:
- if action doc contains 'error', we set completedInfo as:
```
    completedInfo.completedAt = action.createdAt;
    completedInfo.isCompleted = true;
    completedInfo.wasSuccessful = false;
    completedInfo.errors = [errorMessage];
```


<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->