### PR TITLE
[Security Solution] Replace static scopeId with context value

### DIFF
--- a/x-pack/plugins/security_solution/public/flyout/left/components/analyze_graph.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/left/components/analyze_graph.test.tsx
@@ -34,6 +34,7 @@ describe('<AnalyzeGraph />', () => {
   it('renders analyzer graph correctly', () => {
     const contextValue = {
       eventId: 'eventId',
+      scopeId: 'flyout',
     } as unknown as LeftPanelContext;
 
     const wrapper = render(

--- a/x-pack/plugins/security_solution/public/flyout/left/components/analyze_graph.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/left/components/analyze_graph.tsx
@@ -23,8 +23,7 @@ export const ANALYZE_GRAPH_ID = 'analyze_graph';
  * Analyzer graph view displayed in the document details expandable flyout left section under the Visualize tab
  */
 export const AnalyzeGraph: FC = () => {
-  const { eventId } = useLeftPanelContext();
-  const scopeId = 'flyout'; // Different scope Id to distinguish flyout and data table analyzers
+  const { eventId, scopeId } = useLeftPanelContext();
   const { from, to, shouldUpdate, selectedPatterns } = useTimelineDataFilters(
     isActiveTimeline(scopeId)
   );


### PR DESCRIPTION
## Summary

Replaced hardcoded `scopeId` in analyze graph with context-sourced value + upated tests.

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

