### PR TITLE
[Security solution] Elastic AI Assistant Modal CSS Improvements

### DIFF
--- a/x-pack/packages/kbn-elastic-assistant/impl/assistant/assistant_overlay/index.tsx
+++ b/x-pack/packages/kbn-elastic-assistant/impl/assistant/assistant_overlay/index.tsx
@@ -19,12 +19,8 @@ const isMac = navigator.platform.toLowerCase().indexOf('mac') >= 0;
 
 const StyledEuiModal = styled(EuiModal)`
   ${({ theme }) => `margin-top: ${theme.eui.euiSizeXXL};`}
-  max-width: 95vw;
+  min-width: 95vw;
   min-height: 90vh;
-
-  > .euiModal__flex {
-    max-height: 90vh;
-  }
 `;
 /**
  * Modal container for Elastic AI Assistant conversations, receiving the page contents as context, plus whatever
@@ -82,7 +78,7 @@ export const AssistantOverlay: React.FC = React.memo(() => {
   return (
     <>
       {isModalVisible && (
-        <StyledEuiModal onClose={handleCloseModal}>
+        <StyledEuiModal onClose={handleCloseModal} data-test-subj="ai-assistant-modal">
           <Assistant conversationId={conversationId} promptContextId={promptContextId} />
         </StyledEuiModal>
       )}

--- a/x-pack/packages/kbn-elastic-assistant/impl/assistant/assistant_overlay/index.tsx
+++ b/x-pack/packages/kbn-elastic-assistant/impl/assistant/assistant_overlay/index.tsx
@@ -20,7 +20,7 @@ const isMac = navigator.platform.toLowerCase().indexOf('mac') >= 0;
 const StyledEuiModal = styled(EuiModal)`
   ${({ theme }) => `margin-top: ${theme.eui.euiSizeXXL};`}
   min-width: 95vw;
-  min-height: 90vh;
+  min-height: 25vh;
 `;
 /**
  * Modal container for Elastic AI Assistant conversations, receiving the page contents as context, plus whatever

--- a/x-pack/packages/kbn-elastic-assistant/impl/assistant/assistant_overlay/index.tsx
+++ b/x-pack/packages/kbn-elastic-assistant/impl/assistant/assistant_overlay/index.tsx
@@ -18,11 +18,14 @@ import { WELCOME_CONVERSATION_TITLE } from '../use_conversation/translations';
 const isMac = navigator.platform.toLowerCase().indexOf('mac') >= 0;
 
 const StyledEuiModal = styled(EuiModal)`
-  min-width: 1200px;
-  max-height: 100%;
-  height: 100%;
-`;
+  ${({ theme }) => `margin-top: ${theme.eui.euiSizeXXL};`}
+  max-width: 95vw;
+  min-height: 90vh;
 
+  > .euiModal__flex {
+    max-height: 90vh;
+  }
+`;
 /**
  * Modal container for Elastic AI Assistant conversations, receiving the page contents as context, plus whatever
  * component currently has focus and any specific context it may provide through the SAssInterface.

--- a/x-pack/packages/kbn-elastic-assistant/impl/assistant/index.tsx
+++ b/x-pack/packages/kbn-elastic-assistant/impl/assistant/index.tsx
@@ -492,13 +492,15 @@ const AssistantComponent: React.FC<Props> = ({
             width: 100%;
           `}
         >
+          {isWelcomeSetup && <EuiFlexItem>{connectorPrompt}</EuiFlexItem>}
+        </EuiFlexGroup>
+        <EuiFlexGroup
+          gutterSize="none"
+          css={css`
+            width: 100%;
+          `}
+        >
           <EuiFlexItem>
-            {isWelcomeSetup && (
-              <>
-                {connectorPrompt}
-                <EuiSpacer />
-              </>
-            )}
             <PromptTextArea
               onPromptSubmit={handleSendMessage}
               ref={promptTextAreaRef}

--- a/x-pack/packages/kbn-elastic-assistant/impl/assistant/index.tsx
+++ b/x-pack/packages/kbn-elastic-assistant/impl/assistant/index.tsx
@@ -14,16 +14,16 @@ import {
   EuiHorizontalRule,
   EuiCommentList,
   EuiToolTip,
-  EuiSplitPanel,
   EuiSwitchEvent,
   EuiSwitch,
   EuiCallOut,
   EuiIcon,
-  EuiTitle,
+  EuiModalFooter,
+  EuiModalHeader,
+  EuiModalBody,
+  EuiModalHeaderTitle,
 } from '@elastic/eui';
 
-// eslint-disable-next-line @kbn/eslint/module_migration
-import styled from 'styled-components';
 import { createPortal } from 'react-dom';
 import { css } from '@emotion/react';
 
@@ -48,25 +48,9 @@ import { getCombinedMessage } from './prompt/helpers';
 import * as i18n from './translations';
 import { QuickPrompts } from './quick_prompts/quick_prompts';
 import { useLoadConnectors } from '../connectorland/use_load_connectors';
-import { ConnectorSetup } from '../connectorland/connector_setup';
+import { useConnectorSetup } from '../connectorland/connector_setup';
 import { WELCOME_CONVERSATION_TITLE } from './use_conversation/translations';
 import { BASE_CONVERSATIONS } from './use_conversation/sample_conversations';
-
-const CommentsContainer = styled.div`
-  max-height: 600px;
-  max-width: 100%;
-  overflow-y: scroll;
-`;
-
-const ChatOptionsFlexItem = styled(EuiFlexItem)`
-  left: -34px;
-  position: relative;
-  top: 11px;
-`;
-
-const StyledCommentList = styled(EuiCommentList)`
-  margin-right: 20px;
-`;
 
 export interface Props {
   promptContextId?: string;
@@ -131,6 +115,13 @@ const AssistantComponent: React.FC<Props> = ({
   );
 
   const isWelcomeSetup = (connectors?.length ?? 0) === 0;
+
+  const { connectorDialog, connectorPrompt } = useConnectorSetup({
+    actionTypeRegistry,
+    http,
+    refetchConnectors,
+    isConnectorConfigured: !!connectors?.length,
+  });
   const currentTitle: { title: string | JSX.Element; titleIcon: string } =
     isWelcomeSetup && welcomeConversation.theme?.title && welcomeConversation.theme?.titleIcon
       ? { title: welcomeConversation.theme?.title, titleIcon: welcomeConversation.theme?.titleIcon }
@@ -336,29 +327,49 @@ const AssistantComponent: React.FC<Props> = ({
     setShowMissingConnectorCallout(!connectorExists);
   }, [connectors, currentConversation]);
 
+  const CodeBlockPortals = useMemo(
+    () =>
+      messageCodeBlocks.map((codeBlocks: CodeBlockDetails[]) => {
+        return codeBlocks.map((codeBlock: CodeBlockDetails) => {
+          const element: Element = codeBlock.controlContainer as Element;
+
+          return codeBlock.controlContainer != null ? (
+            createPortal(codeBlock.button, element)
+          ) : (
+            <></>
+          );
+        });
+      }),
+    [messageCodeBlocks]
+  );
   return (
-    <EuiSplitPanel.Outer
-      grow={false}
-      css={css`
-        width: 100%;
-      `}
-    >
-      <EuiSplitPanel.Inner grow={false}>
+    <>
+      <EuiModalHeader
+        css={css`
+          align-items: flex-start;
+          flex-direction: column;
+        `}
+      >
         {showTitle && (
           <>
-            <EuiFlexGroup alignItems={'center'} justifyContent={'spaceBetween'}>
+            <EuiFlexGroup
+              css={css`
+                width: 100%;
+              `}
+              alignItems={'center'}
+              justifyContent={'spaceBetween'}
+            >
               <EuiFlexItem grow={false}>
-                <EuiFlexGroup alignItems={'center'}>
-                  <EuiFlexItem grow={false}>
-                    <EuiIcon type={currentTitle.titleIcon} size="xl" />
-                  </EuiFlexItem>
-                  <EuiFlexItem grow={false}>
-                    <EuiTitle>
-                      <span>{currentTitle.title}</span>
-                    </EuiTitle>
-                  </EuiFlexItem>
-                </EuiFlexGroup>
+                <EuiModalHeaderTitle>
+                  <EuiFlexGroup alignItems={'center'}>
+                    <EuiFlexItem grow={false}>
+                      <EuiIcon type={currentTitle.titleIcon} size="xl" />
+                    </EuiFlexItem>
+                    <EuiFlexItem grow={false}>{currentTitle.title}</EuiFlexItem>
+                  </EuiFlexGroup>
+                </EuiModalHeaderTitle>
               </EuiFlexItem>
+
               <EuiFlexItem
                 grow={false}
                 css={css`
@@ -422,17 +433,7 @@ const AssistantComponent: React.FC<Props> = ({
         )}
 
         {/* Create portals for each EuiCodeBlock to add the `Investigate in Timeline` action */}
-        {messageCodeBlocks.map((codeBlocks: CodeBlockDetails[]) => {
-          return codeBlocks.map((codeBlock: CodeBlockDetails) => {
-            const element: Element = codeBlock.controlContainer as Element;
-
-            return codeBlock.controlContainer != null ? (
-              createPortal(codeBlock.button, element)
-            ) : (
-              <></>
-            );
-          });
-        })}
+        {CodeBlockPortals}
 
         {!isWelcomeSetup && (
           <>
@@ -446,44 +447,58 @@ const AssistantComponent: React.FC<Props> = ({
             {Object.keys(promptContexts).length > 0 && <EuiSpacer size={'s'} />}
           </>
         )}
+      </EuiModalHeader>
+      <EuiModalBody>
+        {isWelcomeSetup ? (
+          connectorDialog
+        ) : (
+          <>
+            <EuiCommentList
+              comments={comments}
+              css={css`
+                margin-right: 20px;
+              `}
+            />
 
-        {isWelcomeSetup && (
-          <ConnectorSetup
-            actionTypeRegistry={actionTypeRegistry}
-            http={http}
-            refetchConnectors={refetchConnectors}
-            isConnectorConfigured={!!connectors?.length}
-          />
-        )}
+            <EuiSpacer size={'m'} />
 
-        {!isWelcomeSetup && (
-          <CommentsContainer className="eui-scrollBar">
-            <>
-              <StyledCommentList comments={comments} />
+            {(currentConversation.messages.length === 0 ||
+              Object.keys(selectedPromptContexts).length > 0) && (
+              <PromptEditor
+                conversation={currentConversation}
+                isNewConversation={currentConversation.messages.length === 0}
+                promptContexts={promptContexts}
+                promptTextPreview={promptTextPreview}
+                selectedPromptContexts={selectedPromptContexts}
+                setSelectedPromptContexts={setSelectedPromptContexts}
+              />
+            )}
 
-              <EuiSpacer size={'m'} />
-
-              {(currentConversation.messages.length === 0 ||
-                Object.keys(selectedPromptContexts).length > 0) && (
-                <PromptEditor
-                  conversation={currentConversation}
-                  isNewConversation={currentConversation.messages.length === 0}
-                  promptContexts={promptContexts}
-                  promptTextPreview={promptTextPreview}
-                  selectedPromptContexts={selectedPromptContexts}
-                  setSelectedPromptContexts={setSelectedPromptContexts}
-                />
-              )}
-
-              <div ref={bottomRef} />
-            </>
-          </CommentsContainer>
+            <div ref={bottomRef} />
+          </>
         )}
 
         <EuiSpacer />
-
-        <EuiFlexGroup gutterSize="none">
+      </EuiModalBody>
+      <EuiModalFooter
+        css={css`
+          align-items: flex-start;
+          flex-direction: column;
+        `}
+      >
+        <EuiFlexGroup
+          gutterSize="none"
+          css={css`
+            width: 100%;
+          `}
+        >
           <EuiFlexItem>
+            {isWelcomeSetup && (
+              <>
+                {connectorPrompt}
+                <EuiSpacer />
+              </>
+            )}
             <PromptTextArea
               onPromptSubmit={handleSendMessage}
               ref={promptTextAreaRef}
@@ -493,7 +508,14 @@ const AssistantComponent: React.FC<Props> = ({
             />
           </EuiFlexItem>
 
-          <ChatOptionsFlexItem grow={false}>
+          <EuiFlexItem
+            grow={false}
+            css={css`
+              left: -34px;
+              position: relative;
+              top: 11px;
+            `}
+          >
             <EuiFlexGroup
               direction="column"
               gutterSize="xs"
@@ -540,21 +562,11 @@ const AssistantComponent: React.FC<Props> = ({
                 />
               </EuiFlexItem>
             </EuiFlexGroup>
-          </ChatOptionsFlexItem>
+          </EuiFlexItem>
         </EuiFlexGroup>
-      </EuiSplitPanel.Inner>
-      {!isWelcomeSetup && (
-        <EuiSplitPanel.Inner
-          grow={false}
-          color="subdued"
-          css={css`
-            padding: 8px;
-          `}
-        >
-          <QuickPrompts setInput={setSuggestedUserPrompt} />
-        </EuiSplitPanel.Inner>
-      )}
-    </EuiSplitPanel.Outer>
+        {!isWelcomeSetup && <QuickPrompts setInput={setSuggestedUserPrompt} />}
+      </EuiModalFooter>
+    </>
   );
 };
 


### PR DESCRIPTION
## Summary

Bugfix for

- [x] Can't close the Elastic Security Assistant modal

Previous to this PR, the scrolling within the AI Assistant modal was controlled by `maxHeight`/`overflowY` instead of having `EuiModalBody` handle the sizing. The max height caused issues with the modal being too big to close on small screens. Removes custom CSS in order to utilize the thoroughly tested `EuiModal` scrolling implementation

### Before (cannot close modal)
Tall, narrow screen
<img width="600" alt="Screenshot 2023-06-28 at 3 56 58 PM" src="https://github.com/elastic/kibana/assets/6935300/170c0006-cd6e-4b8e-bb98-5b337c1c30e7">
Laptop screen
<img width="1183" alt="b2" src="https://github.com/elastic/kibana/assets/6935300/23d51bf2-083d-4b94-ac9a-c874d0b351a8">

### After (close modal icon visible)
Tall, narrow screen
<img width="608" alt="a1" src="https://github.com/elastic/kibana/assets/6935300/1f1b7509-23b3-4710-8885-5141c3bbb250">
Laptop screen
<img width="1178" alt="a2" src="https://github.com/elastic/kibana/assets/6935300/f4f3afa3-e4df-433a-b5cb-f6db5f1ffaf0">

<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->