### PR TITLE
fix(NA): checking pr author through github.head_ref instead of pull_request event on auto backport approve ghaction

### DIFF
--- a/.github/workflows/auto-approve-backports.yml
+++ b/.github/workflows/auto-approve-backports.yml
@@ -5,16 +5,13 @@ on:
     types:
       - opened
 
-env:
-  NODE_ENV: kibana-github-action
-
 jobs:
   approve:
     name: Auto-approve backport
     runs-on: ubuntu-latest
     if: |
       contains(github.event.pull_request.labels.*.name, 'backport') &&
-      github.event.pull_request.user.login == 'kibanamachine'
+      contains(github.base_ref, 'kibanamachine:backport')
     permissions:
       pull-requests: write
     steps:

--- a/.github/workflows/auto-approve-backports.yml
+++ b/.github/workflows/auto-approve-backports.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       contains(github.event.pull_request.labels.*.name, 'backport') &&
-      contains(github.base_ref, 'kibanamachine:backport')
+      contains(github.head_ref, 'kibanamachine:backport')
     permissions:
       pull-requests: write
     steps:


### PR DESCRIPTION
The action is getting skipped on backports and I suspect we were not checking correctly for the pr author. I changed it a little to make sure we are getting the pr author through the head ref so we can validate is being created by kibanamachine.

<!--ONMERGE {"backportTargets":["7.17","8.9"]} ONMERGE-->