### PR TITLE
chore(NA): adds debug action to audit auto approve backports action

### DIFF
--- a/.github/workflows/auto-approve-backports.yml
+++ b/.github/workflows/auto-approve-backports.yml
@@ -2,16 +2,18 @@ on:
   pull_request_target:
     branches-ignore:
       - main
-    types:
-      - opened
 
 jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: hmarr/debug-action@v2
   approve:
     name: Auto-approve backport
     runs-on: ubuntu-latest
     if: |
-      contains(github.event.pull_request.labels.*.name, 'backport') &&
-      contains(github.head_ref, 'kibanamachine:backport')
+      contains(github.event.pull_request_target.labels.*.name, 'backport') &&
+      github.event.pull_request_target.user.login == 'kibanamachine'
     permissions:
       pull-requests: write
     steps:


### PR DESCRIPTION
This PR adds a separate debug step to the auto approve backport action so we can understand whats going on with the event payload.

<!--ONMERGE {"backportTargets":["7.17","8.9"]} ONMERGE-->