### PR TITLE
[APM] Update agent explorer text

### DIFF
--- a/x-pack/plugins/apm/public/components/app/settings/agent_explorer/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/settings/agent_explorer/index.tsx
@@ -163,7 +163,7 @@ export function AgentExplorer() {
         <EuiText color="subdued">
           {i18n.translate('xpack.apm.settings.agentExplorer.descriptionText', {
             defaultMessage:
-              'Agent Explorer Technical Preview provides an inventory and details of deployed Agents.',
+              'Agent Explorer provides an inventory and details of deployed Agents.',
           })}
         </EuiText>
       </EuiFlexItem>


### PR DESCRIPTION
### Summary

While working on https://github.com/elastic/observability-docs/issues/2886, I noticed that Agent Explorer is now in Beta. The UI is currently confusing because it shows both "Technical Preview" and "Beta" for this feature:

<img width="719" alt="Screenshot 2023-06-28 at 3 02 42 PM" src="https://github.com/elastic/kibana/assets/5618806/6e0941a4-9863-4113-ba55-99005ff690cd">

It looks like https://github.com/elastic/kibana/pull/156470 missed updating the text.

<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->