### PR TITLE
Remove unneeded `preserve_namespace` query param.

### DIFF
--- a/x-pack/plugins/synthetics/server/routes/monitor_cruds/inspect_monitor.ts
+++ b/x-pack/plugins/synthetics/server/routes/monitor_cruds/inspect_monitor.ts
@@ -26,7 +26,6 @@ export const inspectSyntheticsMonitorRoute: SyntheticsRestApiRouteFactory = () =
     body: schema.any(),
     query: schema.object({
       id: schema.maybe(schema.string()),
-      preserve_namespace: schema.maybe(schema.boolean()),
       hideParams: schema.maybe(schema.boolean()),
     }),
   },
@@ -73,8 +72,6 @@ export const inspectSyntheticsMonitorRoute: SyntheticsRestApiRouteFactory = () =
 
       const result = await syntheticsMonitorClient.inspectMonitor(
         { monitor: monitorWithNamespace as MonitorFields, id: newMonitorId },
-        request,
-        savedObjectsClient,
         privateLocations,
         spaceId,
         hideParams,

--- a/x-pack/plugins/synthetics/server/synthetics_service/synthetics_monitor/synthetics_monitor_client.ts
+++ b/x-pack/plugins/synthetics/server/synthetics_service/synthetics_monitor/synthetics_monitor_client.ts
@@ -358,8 +358,6 @@ export class SyntheticsMonitorClient {
 
   async inspectMonitor(
     monitorObj: { monitor: MonitorFields; id: string },
-    request: KibanaRequest,
-    savedObjectsClient: SavedObjectsClientContract,
     allPrivateLocations: PrivateLocation[],
     spaceId: string,
     hideParams: boolean,


### PR DESCRIPTION
Fixes #159585 

Removes `preserve_namespace` schema from inspect monitor route.

### Testing
Just create a monitor with some global or project params and ensure "Inspect configuration" button on Synthetics -> Edit Monitor page works.

<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->