### PR TITLE
[APM] Revert flaky test skip

### DIFF
--- a/x-pack/test/apm_api_integration/tests/transactions/transactions_groups_main_statistics.ts
+++ b/x-pack/test/apm_api_integration/tests/transactions/transactions_groups_main_statistics.ts
@@ -50,8 +50,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     }
   );
 
-  // FAILING FORWARD ES COMPATIBILITY: https://github.com/elastic/kibana/issues/160281
-  registry.when.skip(
+  registry.when(
     'Transaction groups main statistics when data is loaded',
     { config: 'basic', archives: [archiveName] },
     () => {


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/160281

Un-skipping the flaky test as it no more fails on 7.17
