### PR TITLE
[Ops] Fix auto-approve script

### DIFF
--- a/.github/workflows/auto-approve-backports.yml
+++ b/.github/workflows/auto-approve-backports.yml
@@ -4,10 +4,6 @@ on:
       - main
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: hmarr/debug-action@v2
   approve:
     name: Auto-approve backport
     runs-on: ubuntu-latest
@@ -18,5 +14,3 @@ jobs:
       pull-requests: write
     steps:
       - uses: hmarr/auto-approve-action@v3
-        with:
-          github-token: ${{ secrets.KIBANAMACHINE_TOKEN }}


### PR DESCRIPTION
## Summary
Our original intent of kibanamachine approving their own PRs didn't work, we switch to the default github-actions as an approver for kibanamachine's PRs.

<!--ONMERGE {"backportTargets":["7.17","8.9"]} ONMERGE-->