### PR TITLE
[APM] Add config for serverless feature flags api tests

### DIFF
--- a/.buildkite/ftr_configs.yml
+++ b/.buildkite/ftr_configs.yml
@@ -207,6 +207,7 @@ enabled:
   - x-pack/test/apm_api_integration/basic/config.ts
   - x-pack/test/apm_api_integration/cloud/config.ts
   - x-pack/test/apm_api_integration/rules/config.ts
+  - x-pack/test/apm_api_integration/serverless/config.ts
   - x-pack/test/apm_api_integration/trial/config.ts
   - x-pack/test/banners_functional/config.ts
   - x-pack/test/cases_api_integration/security_and_spaces/config_basic.ts

--- a/x-pack/plugins/apm/scripts/test/api.js
+++ b/x-pack/plugins/apm/scripts/test/api.js
@@ -22,6 +22,11 @@ const { argv } = yargs(process.argv.slice(2))
     type: 'boolean',
     description: 'Run tests with trial license',
   })
+  .option('serverlesss', {
+    default: false,
+    type: 'boolean',
+    description: 'Run tests for serverless',
+  })
   .option('server', {
     default: false,
     type: 'boolean',
@@ -76,13 +81,23 @@ const {
   grepFiles,
   inspect,
   updateSnapshots,
+  serverlesss,
 } = argv;
-
-if (trial === false && basic === false) {
-  throw new Error('Please specify either --trial or --basic');
+if (trial === false && basic === false && serverlesss === false) {
+  throw new Error('Please specify either --trial , --basic or --serverlesss');
 }
 
 const license = trial ? 'trial' : 'basic';
+
+let config;
+
+if (serverlesss) {
+  config = 'serverless';
+} else if (basic) {
+  config = 'basic';
+} else {
+  config = 'trial';
+}
 
 console.log(`License: ${license}`);
 
@@ -99,7 +114,7 @@ const cmd = [
   `../../../../../scripts/${ftrScript}`,
   ...(grep ? [`--grep "${grep}"`] : []),
   ...(updateSnapshots ? [`--updateSnapshots`] : []),
-  `--config ../../../../test/apm_api_integration/${license}/config.ts`,
+  `--config ../../../../test/apm_api_integration/${config}/config.ts`,
 ].join(' ');
 
 console.log(`Running: "${cmd}"`);

--- a/x-pack/test/apm_api_integration/configs/index.ts
+++ b/x-pack/test/apm_api_integration/configs/index.ts
@@ -46,6 +46,18 @@ const apmFtrConfigs = {
       'logging.loggers': [apmDebugLogger],
     },
   },
+  serverless: {
+    license: 'basic' as const,
+    kibanaConfig: {
+      'xpack.apm.featureFlags.agentConfigurationAvailable': 'false',
+      'xpack.apm.featureFlags.configurableIndicesAvailable': 'false',
+      'xpack.apm.featureFlags.infrastructureTabAvailable': 'false',
+      'xpack.apm.featureFlags.infraUiAvailable': 'false',
+      'xpack.apm.featureFlags.migrationToFleetAvailable': 'false',
+      'xpack.apm.featureFlags.sourcemapApiAvailable': 'false',
+      'xpack.apm.featureFlags.storageExplorerAvailable': 'false',
+    },
+  },
 };
 
 export type APMFtrConfigName = keyof typeof apmFtrConfigs;

--- a/x-pack/test/apm_api_integration/serverless/config.ts
+++ b/x-pack/test/apm_api_integration/serverless/config.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { configs } from '../configs';
+
+export default configs.serverless;

--- a/x-pack/test/apm_api_integration/tests/settings/agent_configuration/agent_configuration.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/settings/agent_configuration/agent_configuration.spec.ts
@@ -95,6 +95,16 @@ export default function agentConfigurationTests({ getService }: FtrProviderConte
   }
 
   registry.when(
+    'agent configuration for serverless',
+    { config: 'serverless', archives: [] },
+    () => {
+      it('throws error to get all configurations', async () => {
+        await expectStatusCode(() => getAllConfigurations(), 404);
+      });
+    }
+  );
+
+  registry.when(
     'agent configuration when no data is loaded',
     { config: 'basic', archives: [] },
     () => {


### PR DESCRIPTION
We want to add api test for the feature flags configuration added in https://github.com/elastic/kibana/pull/159136
