### PR TITLE
[8.9] Update dependency @elastic/charts to v59 (main) (#160700)

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "@dnd-kit/utilities": "^2.0.0",
     "@elastic/apm-rum": "^5.12.0",
     "@elastic/apm-rum-react": "^1.4.2",
-    "@elastic/charts": "58.2.0",
+    "@elastic/charts": "59.0.0",
     "@elastic/datemath": "5.0.3",
     "@elastic/elasticsearch": "npm:@elastic/elasticsearch-canary@8.8.0-canary.2",
     "@elastic/ems-client": "8.4.0",

--- a/test/functional/apps/discover/group1/_discover_histogram_breakdown.ts
+++ b/test/functional/apps/discover/group1/_discover_histogram_breakdown.ts
@@ -34,7 +34,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await PageObjects.discover.chooseBreakdownField('extension.raw');
       await PageObjects.header.waitUntilLoadingHasFinished();
       const list = await PageObjects.discover.getHistogramLegendList();
-      expect(list).to.eql(['Other', 'png', 'css', 'jpg']);
+      expect(list).to.eql(['jpg', 'css', 'png', 'Other']);
     });
 
     it('should add filter using histogram legend values', async () => {
@@ -55,7 +55,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await PageObjects.discover.loadSavedSearch('with breakdown');
       await PageObjects.header.waitUntilLoadingHasFinished();
       const list = await PageObjects.discover.getHistogramLegendList();
-      expect(list).to.eql(['Other', 'png', 'css', 'jpg']);
+      expect(list).to.eql(['jpg', 'css', 'png', 'Other']);
     });
   });
 }

--- a/test/functional/apps/visualize/replaced_vislib_chart_types/_vertical_bar_chart.ts
+++ b/test/functional/apps/visualize/replaced_vislib_chart_types/_vertical_bar_chart.ts
@@ -299,7 +299,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await PageObjects.visChart.waitForVisualizationRenderingStabilized();
         await PageObjects.visEditor.clickGo(true);
 
-        const expectedEntries = ['503', '404', '200']; // sorting aligned with rendered geometries
+        const expectedEntries = ['200', '404', '503']; // sorting order aligned with the reading direction
         const legendEntries = await PageObjects.visChart.getLegendEntriesXYCharts(xyChartSelector);
         expect(legendEntries).to.eql(expectedEntries);
       });
@@ -309,7 +309,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await PageObjects.visEditor.selectCustomSortMetric(3, 'Min', 'bytes');
         await PageObjects.visEditor.clickGo(true);
 
-        const expectedEntries = ['503', '200', '404'];
+        const expectedEntries = ['404', '200', '503'];
         const legendEntries = await PageObjects.visChart.getLegendEntriesXYCharts(xyChartSelector);
         expect(legendEntries).to.eql(expectedEntries);
       });
@@ -343,21 +343,21 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await PageObjects.visEditor.clickGo(true);
 
         const expectedEntries = [
-          '404 - win xp',
-          '404 - win 8',
-          '404 - win 7',
-          '404 - osx',
-          '503 - win xp',
-          '503 - win 8',
-          '503 - win 7',
-          '503 - osx',
-          '503 - ios',
-          '404 - ios',
-          '200 - win 7',
-          '200 - osx',
-          '200 - ios',
-          '200 - win xp',
           '200 - win 8',
+          '200 - win xp',
+          '200 - ios',
+          '200 - osx',
+          '200 - win 7',
+          '404 - ios',
+          '503 - ios',
+          '503 - osx',
+          '503 - win 7',
+          '503 - win 8',
+          '503 - win xp',
+          '404 - osx',
+          '404 - win 7',
+          '404 - win 8',
+          '404 - win xp',
         ];
         const legendEntries = await PageObjects.visChart.getLegendEntriesXYCharts(xyChartSelector);
         expect(legendEntries).to.eql(expectedEntries);
@@ -369,7 +369,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await PageObjects.visEditor.toggleDisabledAgg(3);
         await PageObjects.visEditor.clickGo(true);
 
-        const expectedEntries = ['win 7', 'osx', 'ios', 'win xp', 'win 8'];
+        const expectedEntries = ['win 8', 'win xp', 'ios', 'osx', 'win 7'];
         const legendEntries = await PageObjects.visChart.getLegendEntriesXYCharts(xyChartSelector);
         expect(legendEntries).to.eql(expectedEntries);
       });

--- a/test/functional/apps/visualize/replaced_vislib_chart_types/_vertical_bar_chart_nontimeindex.ts
+++ b/test/functional/apps/visualize/replaced_vislib_chart_types/_vertical_bar_chart_nontimeindex.ts
@@ -184,7 +184,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await PageObjects.visEditor.clickGo(true);
         await PageObjects.header.waitUntilLoadingHasFinished();
 
-        const expectedEntries = ['503', '404', '200']; // sorting aligned with rendered geometries
+        const expectedEntries = ['200', '404', '503']; // sorting order aligned with reading direction top-bottom
 
         const legendEntries = await PageObjects.visChart.getLegendEntriesXYCharts(xyChartSelector);
         expect(legendEntries).to.eql(expectedEntries);
@@ -212,21 +212,21 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await PageObjects.header.waitUntilLoadingHasFinished();
 
         const expectedEntries = [
-          '404 - win xp',
-          '404 - win 8',
-          '404 - win 7',
-          '404 - osx',
-          '503 - win xp',
-          '503 - win 8',
-          '503 - win 7',
-          '503 - osx',
-          '503 - ios',
-          '404 - ios',
-          '200 - win 7',
-          '200 - osx',
-          '200 - ios',
-          '200 - win xp',
           '200 - win 8',
+          '200 - win xp',
+          '200 - ios',
+          '200 - osx',
+          '200 - win 7',
+          '404 - ios',
+          '503 - ios',
+          '503 - osx',
+          '503 - win 7',
+          '503 - win 8',
+          '503 - win xp',
+          '404 - osx',
+          '404 - win 7',
+          '404 - win 8',
+          '404 - win xp',
         ];
         const legendEntries = await PageObjects.visChart.getLegendEntriesXYCharts(xyChartSelector);
         expect(legendEntries).to.eql(expectedEntries);
@@ -237,7 +237,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await PageObjects.visEditor.clickGo(true);
         await PageObjects.header.waitUntilLoadingHasFinished();
 
-        const expectedEntries = ['win 7', 'osx', 'ios', 'win xp', 'win 8'];
+        const expectedEntries = ['win 8', 'win xp', 'ios', 'osx', 'win 7'];
         const legendEntries = await PageObjects.visChart.getLegendEntriesXYCharts(xyChartSelector);
         expect(legendEntries).to.eql(expectedEntries);
       });

--- a/x-pack/test/functional/apps/discover/visualize_field.ts
+++ b/x-pack/test/functional/apps/discover/visualize_field.ts
@@ -114,7 +114,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
         );
 
         expect(await breakdownLabel.getVisibleText()).to.eql('Top 3 values of extension.raw');
-        expect(values).to.eql(['Other', 'png', 'css', 'jpg']);
+        expect(values).to.eql(['jpg', 'css', 'png', 'Other']);
       });
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1469,10 +1469,10 @@
   dependencies:
     object-hash "^1.3.0"
 
-"@elastic/charts@58.2.0":
-  version "58.2.0"
-  resolved "https://registry.yarnpkg.com/@elastic/charts/-/charts-58.2.0.tgz#bd2010a4081b565f539abc75938431c7590213cc"
-  integrity sha512-ZhW+3SHz6txVdrncSt3njTunmUwdL4JF5lSXy5NG8qrx0r4SKi3yLbLc83xAsv7T1hxbTgsfS4GgGMhWoBBiyg==
+"@elastic/charts@59.0.0":
+  version "59.0.0"
+  resolved "https://registry.yarnpkg.com/@elastic/charts/-/charts-59.0.0.tgz#c81a82c389011f52ac79e7c59b0551439a0e90b2"
+  integrity sha512-itEam7dpyHxMNl8eNnZbQa/7M6D741/qsZWjDnXXlirvRsMzpRwhuB0WGxGNXxCuuW/GqWXNlhsqXgKqERS4yw==
   dependencies:
     "@popperjs/core" "^2.4.0"
     bezier-easing "^2.1.0"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.9`:
 - [Update dependency @elastic/charts to v59 (main) (#160700)](https://github.com/elastic/kibana/pull/160700)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)