### PR TITLE
[Security Solution][Endpoint] Reduce fleet artifact calls

### DIFF
--- a/x-pack/plugins/security_solution/server/endpoint/lib/artifacts/lists.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/lib/artifacts/lists.ts
@@ -99,6 +99,7 @@ export async function getFilteredEndpointExceptionListRaw({
   filter: string;
   listId: ArtifactListId;
 }): Promise<ExceptionListItemSchema[]> {
+  const perPage = 1000;
   let exceptions: ExceptionListItemSchema[] = [];
   let page = 1;
   let paging = true;
@@ -108,7 +109,7 @@ export async function getFilteredEndpointExceptionListRaw({
       listId,
       namespaceType: 'agnostic',
       filter,
-      perPage: 1000,
+      perPage,
       page,
       sortField: 'created_at',
       sortOrder: 'desc',
@@ -117,7 +118,7 @@ export async function getFilteredEndpointExceptionListRaw({
     if (response?.data !== undefined) {
       exceptions = exceptions.concat(response.data);
 
-      paging = (page - 1) * 1000 + response.data.length < response.total;
+      paging = (page - 1) * perPage + response.data.length < response.total;
       page++;
     } else {
       break;

--- a/x-pack/plugins/security_solution/server/endpoint/lib/artifacts/task.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/lib/artifacts/task.ts
@@ -53,11 +53,11 @@ export class ManifestTask {
           return {
             run: async () => {
               const taskInterval = (await this.endpointAppContext.config()).packagerTaskInterval;
-              const initTime = new Date().getTime();
+              const startTime = new Date().getTime();
               await this.runTask(taskInstance.id);
               const endTime = new Date().getTime();
               this.logger.debug(
-                `${ManifestTaskConstants.TYPE} task run took ${endTime - initTime}ms`
+                `${ManifestTaskConstants.TYPE} task run took ${endTime - startTime}ms`
               );
               const nextRun = new Date();
               if (taskInterval.endsWith('s')) {

--- a/x-pack/plugins/security_solution/server/endpoint/lib/artifacts/task.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/lib/artifacts/task.ts
@@ -53,7 +53,12 @@ export class ManifestTask {
           return {
             run: async () => {
               const taskInterval = (await this.endpointAppContext.config()).packagerTaskInterval;
+              const initTime = new Date().getTime();
               await this.runTask(taskInstance.id);
+              const endTime = new Date().getTime();
+              this.logger.debug(
+                `${ManifestTaskConstants.TYPE} task run took ${endTime - initTime}ms`
+              );
               const nextRun = new Date();
               if (taskInterval.endsWith('s')) {
                 const seconds = parseInt(taskInterval.slice(0, -1), 10);

--- a/x-pack/plugins/security_solution/server/endpoint/services/artifacts/manifest_manager/manifest_manager.test.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/services/artifacts/manifest_manager/manifest_manager.test.ts
@@ -42,6 +42,7 @@ import { ManifestManager } from './manifest_manager';
 import type { EndpointArtifactClientInterface } from '../artifact_client';
 import { InvalidInternalManifestError } from '../errors';
 import { EndpointError } from '../../../../../common/endpoint/errors';
+import type { Artifact } from '@kbn/fleet-plugin/server';
 
 const getArtifactObject = (artifact: InternalArtifactSchema) =>
   JSON.parse(Buffer.from(artifact.body!, 'base64').toString());
@@ -195,8 +196,8 @@ describe('ManifestManager', () => {
 
       (
         manifestManagerContext.artifactClient as jest.Mocked<EndpointArtifactClientInterface>
-      ).getArtifact.mockImplementation(async (id) => {
-        return ARTIFACTS_BY_ID[id];
+      ).listArtifacts.mockImplementation(async () => {
+        return { items: ARTIFACTS as Artifact[], total: 100, page: 1, perPage: 100 };
       });
 
       const manifest = await manifestManager.getLastComputedManifest();
@@ -254,9 +255,19 @@ describe('ManifestManager', () => {
 
       (
         manifestManagerContext.artifactClient as jest.Mocked<EndpointArtifactClientInterface>
-      ).getArtifact.mockImplementation(async (id) => {
+      ).listArtifacts.mockImplementation(async (id) => {
         // report the MACOS Exceptions artifact as not found
-        return id === ARTIFACT_ID_EXCEPTIONS_MACOS ? undefined : ARTIFACTS_BY_ID[id];
+        return {
+          items: [
+            ARTIFACT_TRUSTED_APPS_MACOS,
+            ARTIFACT_EXCEPTIONS_WINDOWS,
+            ARTIFACT_TRUSTED_APPS_WINDOWS,
+            ARTIFACTS_BY_ID[ARTIFACT_ID_EXCEPTIONS_LINUX],
+          ] as Artifact[],
+          total: 100,
+          page: 1,
+          perPage: 100,
+        };
       });
 
       const manifest = await manifestManager.getLastComputedManifest();

--- a/x-pack/plugins/security_solution/server/endpoint/services/artifacts/manifest_manager/manifest_manager.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/services/artifacts/manifest_manager/manifest_manager.ts
@@ -421,8 +421,8 @@ export class ManifestManager {
         const fleetArtifact = fleetArtfactsByIdentifier[artifactId];
 
         if (!fleetArtifact) return;
-
         newManifest.replaceArtifact(fleetArtifact);
+        this.logger.debug(`New created artifact ${artifactId} added to the manifest`);
       });
     }
 


### PR DESCRIPTION
## Summary

- Reduces fleet artifact get calls by getting them all at one time instead of requesting it one by one using id's
- Updates unit test.
- Adds duration time log to endpoint packager task.
- Adds missing return types to functions.

Follow up of: https://github.com/elastic/kibana/pull/160387