### PR TITLE
[Synthetics] Fix certs query for empty space with no monitors

### DIFF
--- a/x-pack/plugins/synthetics/server/routes/certs/get_certificates.ts
+++ b/x-pack/plugins/synthetics/server/routes/certs/get_certificates.ts
@@ -48,6 +48,15 @@ export const getSyntheticsCertsRoute: SyntheticsRestApiRouteFactory<
       filter: `${monitorAttributes}.${AlertConfigKey.STATUS_ENABLED}: true`,
     });
 
+    if (monitors.length === 0) {
+      return {
+        data: {
+          certs: [],
+          total: 0,
+        },
+      };
+    }
+
     const { enabledMonitorQueryIds } = await processMonitors(
       monitors,
       server,


### PR DESCRIPTION
## Summary

Relates to https://github.com/elastic/kibana/pull/160113 !!

Fix certs query for empty space with no monitors !!

<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->