### PR TITLE
[Enterprise Search] Add Sync button to the last step of the native configuration

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/native_connector_configuration/native_connector_advanced_configuration.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/native_connector_configuration/native_connector_advanced_configuration.tsx
@@ -19,6 +19,7 @@ import { generateEncodedPath } from '../../../../../shared/encode_path_params';
 import { EuiButtonTo } from '../../../../../shared/react_router_helpers';
 
 import { SEARCH_INDEX_TAB_PATH } from '../../../../routes';
+import { SyncsContextMenu } from '../../components/header_actions/syncs_context_menu';
 import { IndexNameLogic } from '../../index_name_logic';
 import { SearchIndexTabId } from '../../search_index';
 
@@ -53,6 +54,9 @@ export const NativeConnectorAdvancedConfiguration: React.FC = () => {
                 }
               )}
             </EuiButtonTo>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <SyncsContextMenu />
           </EuiFlexItem>
         </EuiFlexGroup>
       </EuiFlexItem>


### PR DESCRIPTION
## Summary

Sync button in the last step of configuration was missing for native configurations
https://github.com/elastic/kibana/pull/160408


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))



<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->