### PR TITLE
[Enterprise Search] Fix scheduling wrongfully disabled for all types.

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_scheduling/full_content.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_scheduling/full_content.tsx
@@ -118,6 +118,9 @@ export const ConnectorContentScheduling: React.FC<ConnectorContentSchedulingProp
   const isDocumentLevelSecurityDisabled =
     !index.connector.configuration.use_document_level_security?.value;
 
+  const isEnableSwitchDisabled =
+    type === SyncJobType.ACCESS_CONTROL && (!hasPlatinumLicense || isDocumentLevelSecurityDisabled);
+
   return (
     <>
       <EuiPanel hasShadow={false} hasBorder>
@@ -165,7 +168,7 @@ export const ConnectorContentScheduling: React.FC<ConnectorContentSchedulingProp
                 </EuiFlexItem>
                 <EuiFlexItem>
                   <EnableSwitch
-                    disabled={isGated || isDocumentLevelSecurityDisabled}
+                    disabled={isEnableSwitchDisabled}
                     checked={scheduling[type].enabled}
                     onChange={(e) => {
                       if (e.target.checked) {
@@ -187,7 +190,7 @@ export const ConnectorContentScheduling: React.FC<ConnectorContentSchedulingProp
               </EuiFlexGroup>
             ) : (
               <EnableSwitch
-                disabled={isGated || isDocumentLevelSecurityDisabled}
+                disabled={isEnableSwitchDisabled}
                 checked={scheduling[type].enabled}
                 onChange={(e) => {
                   if (e.target.checked) {


### PR DESCRIPTION
Scheduling is gated on certain conditions and only for Access Control syncs. This fixes an issue introduced by a previous PR.


https://github.com/elastic/kibana/assets/1410658/d6d10aab-f283-42fa-bf01-54d0cdd8be26



### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->