### PR TITLE
[ML] Fixes time range selector in recognizer wizard

### DIFF
--- a/x-pack/plugins/ml/public/application/jobs/new_job/common/components/time_range_picker.tsx
+++ b/x-pack/plugins/ml/public/application/jobs/new_job/common/components/time_range_picker.tsx
@@ -44,16 +44,12 @@ export const TimeRangePicker: FC<Props> = ({ setTimeRange, timeRange }) => {
   // update the parent start and end if the timepicker changes
   useEffect(() => {
     if (startMoment !== undefined && endMoment !== undefined) {
-      const start = startMoment.valueOf();
-      const end = endMoment.valueOf();
-      if (start !== timeRange.start || end !== timeRange.end) {
-        setTimeRange({
-          start,
-          end,
-        });
-      }
+      setTimeRange({
+        start: startMoment.valueOf(),
+        end: endMoment.valueOf(),
+      });
     }
-  }, [startMoment, endMoment, setTimeRange, timeRange]);
+  }, [startMoment, endMoment, setTimeRange]);
 
   // update our local start and end moment objects if
   // the parent start and end updates.

--- a/x-pack/plugins/ml/public/application/jobs/new_job/common/components/time_range_picker.tsx
+++ b/x-pack/plugins/ml/public/application/jobs/new_job/common/components/time_range_picker.tsx
@@ -44,12 +44,16 @@ export const TimeRangePicker: FC<Props> = ({ setTimeRange, timeRange }) => {
   // update the parent start and end if the timepicker changes
   useEffect(() => {
     if (startMoment !== undefined && endMoment !== undefined) {
-      setTimeRange({
-        start: startMoment.valueOf(),
-        end: endMoment.valueOf(),
-      });
+      const start = startMoment.valueOf();
+      const end = endMoment.valueOf();
+      if (start !== timeRange.start || end !== timeRange.end) {
+        setTimeRange({
+          start,
+          end,
+        });
+      }
     }
-  }, [startMoment, endMoment, setTimeRange]);
+  }, [startMoment, endMoment, setTimeRange, timeRange]);
 
   // update our local start and end moment objects if
   // the parent start and end updates.

--- a/x-pack/plugins/ml/public/application/jobs/new_job/recognize/components/job_settings_form.tsx
+++ b/x-pack/plugins/ml/public/application/jobs/new_job/recognize/components/job_settings_form.tsx
@@ -194,12 +194,7 @@ export const JobSettingsForm: FC<JobSettingsFormProps> = ({
         {!useFullIndexData && (
           <>
             <EuiSpacer size="m" />
-            <TimeRangePicker
-              setTimeRange={(value) => {
-                setTimeRange(value);
-              }}
-              timeRange={timeRange}
-            />
+            <TimeRangePicker setTimeRange={setTimeRange} timeRange={timeRange} />
           </>
         )}
         <EuiSpacer size="l" />


### PR DESCRIPTION
Fixing issue where the time range selectors would get stuck in a infinite render loop.

![image](https://github.com/elastic/kibana/assets/22172091/eb86f958-0dec-4ce9-8550-a0d3b75b1cb2)


<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->