### PR TITLE
[Enterprise Search] Disable text extraction config for native SPO

### DIFF
--- a/x-pack/plugins/enterprise_search/common/connectors/native_connectors.ts
+++ b/x-pack/plugins/enterprise_search/common/connectors/native_connectors.ts
@@ -1622,7 +1622,7 @@ export const NATIVE_CONNECTOR_DEFINITIONS: Record<string, NativeConnector | unde
           }
         ),
         type: FieldType.BOOLEAN,
-        ui_restrictions: [],
+        ui_restrictions: ['advanced'],
         validations: [],
         value: false,
       },


### PR DESCRIPTION
## Summary

This stops text extraction from showing up for native SharePoint Online connectors.

<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->