### PR TITLE
chore(NA): update versions after v8.8.3 bump

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -14,12 +14,6 @@
       "previousMinor": true
     },
     {
-      "version": "8.8.2",
-      "branch": "8.8",
-      "currentMajor": true,
-      "previousMinor": true
-    },
-    {
       "version": "7.17.11",
       "branch": "7.17",
       "previousMajor": true


### PR DESCRIPTION
This PR is a simple update of our versions file after the recent bumps.