### PR TITLE
[Enterprise Search] Use whole config object for sync jobs

### DIFF
--- a/x-pack/plugins/enterprise_search/common/types/connectors.ts
+++ b/x-pack/plugins/enterprise_search/common/types/connectors.ts
@@ -70,13 +70,6 @@ export type ConnectorConfiguration = Record<
   use_text_extraction_service?: ConnectorConfigProperties; // This only exists for SharePoint Online
 };
 
-export interface ConnectorSyncConfigProperties {
-  label: string;
-  value: string | number | boolean | null;
-}
-
-export type ConnectorSyncConfiguration = Record<string, ConnectorSyncConfigProperties | null>;
-
 export interface ConnectorScheduling {
   enabled: boolean;
   interval: string; // interval has crontab syntax
@@ -249,7 +242,7 @@ export interface ConnectorSyncJob {
   canceled_at: string | null;
   completed_at: string | null;
   connector: {
-    configuration: ConnectorSyncConfiguration;
+    configuration: ConnectorConfiguration;
     filtering: FilteringRules | FilteringRules[] | null;
     id: string;
     index_name: string;

--- a/x-pack/plugins/enterprise_search/server/lib/connectors/start_sync.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/connectors/start_sync.ts
@@ -17,9 +17,8 @@ import { isConfigEntry } from '../../../common/connectors/is_category_entry';
 import { ENTERPRISE_SEARCH_CONNECTOR_CRAWLER_SERVICE_TYPE } from '../../../common/constants';
 
 import {
+  ConnectorConfiguration,
   ConnectorDocument,
-  ConnectorSyncConfiguration,
-  ConnectorSyncJobDocument,
   SyncJobType,
   SyncStatus,
   TriggerMethod,
@@ -38,13 +37,13 @@ export const startConnectorSync = async (
   });
   const connector = connectorResult._source;
   if (connector) {
-    const config = Object.entries(connector.configuration).reduce((prev, [key, configEntry]) => {
+    const config = Object.entries(connector.configuration).reduce((acc, [key, configEntry]) => {
       if (isConfigEntry(configEntry)) {
-        prev[key] = { label: configEntry.label, value: configEntry.value };
+        acc[key] = configEntry;
       }
-      return prev;
-    }, {} as ConnectorSyncConfiguration);
-    const configuration: ConnectorSyncConfiguration = nextSyncConfig
+      return acc;
+    }, {} as ConnectorConfiguration);
+    const configuration = nextSyncConfig
       ? {
           ...config,
           nextSyncConfig: { label: 'nextSyncConfig', value: nextSyncConfig },
@@ -73,7 +72,7 @@ export const startConnectorSync = async (
         ? `${CONNECTORS_ACCESS_CONTROL_INDEX_PREFIX}${indexNameWithoutSearchPrefix}`
         : index_name;
 
-    return await client.asCurrentUser.index<ConnectorSyncJobDocument>({
+    return await client.asCurrentUser.index({
       document: {
         cancelation_requested_at: null,
         canceled_at: null,


### PR DESCRIPTION
## Summary

This fixes a bug caused by incomplete configuration objects in connector sync jobs.

<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->