### PR TITLE
[AO] Remove default recovery messages for APM rule types

### DIFF
--- a/x-pack/plugins/apm/public/components/alerting/rule_types/register_apm_rule_types.ts
+++ b/x-pack/plugins/apm/public/components/alerting/rule_types/register_apm_rule_types.ts
@@ -16,13 +16,9 @@ import {
 import { ApmRuleType } from '../../../../common/rules/apm_rule_types';
 import {
   anomalyMessage,
-  anomalyRecoveryMessage,
   errorCountMessage,
-  errorCountRecoveryMessage,
   transactionDurationMessage,
-  transactionDurationRecoveryMessage,
   transactionErrorRateMessage,
-  transactionErrorRateRecoveryMessage,
 } from '../../../../common/rules/default_action_message';
 
 // copied from elasticsearch_fieldnames.ts to limit page load bundle size
@@ -59,7 +55,6 @@ export function registerApmRuleTypes(
     }),
     requiresAppContext: false,
     defaultActionMessage: errorCountMessage,
-    defaultRecoveryMessage: errorCountRecoveryMessage,
   });
 
   observabilityRuleTypeRegistry.register({
@@ -97,7 +92,6 @@ export function registerApmRuleTypes(
     ),
     requiresAppContext: false,
     defaultActionMessage: transactionDurationMessage,
-    defaultRecoveryMessage: transactionDurationRecoveryMessage,
   });
 
   observabilityRuleTypeRegistry.register({
@@ -130,7 +124,6 @@ export function registerApmRuleTypes(
     }),
     requiresAppContext: false,
     defaultActionMessage: transactionErrorRateMessage,
-    defaultRecoveryMessage: transactionErrorRateRecoveryMessage,
   });
 
   observabilityRuleTypeRegistry.register({
@@ -160,6 +153,5 @@ export function registerApmRuleTypes(
     }),
     requiresAppContext: false,
     defaultActionMessage: anomalyMessage,
-    defaultRecoveryMessage: anomalyRecoveryMessage,
   });
 }


### PR DESCRIPTION
Fixes #160926
Partially reverts https://github.com/elastic/kibana/pull/159571

## Summary

At the moment, we don't have any context for recovered alerts for APM rule types, and the default messages will be empty. We will bring these messages back after https://github.com/elastic/kibana/issues/158183 is done.

## 🧪 How to test
- When creating an APM rule, add an action for the recovered state. You should see the default recovery message as Recovered

<img src="https://github.com/elastic/kibana/assets/12370520/eb6ef0cc-0dbc-4758-a73e-4647b068f9a1" width="500"/>


<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->