### PR TITLE
[Fleet] sign unenroll action

### DIFF
--- a/x-pack/plugins/fleet/common/types/models/agent.ts
+++ b/x-pack/plugins/fleet/common/types/models/agent.ts
@@ -407,5 +407,11 @@ export interface FleetServerAgentAction {
   /** Trace id */
   traceparent?: string | null;
 
+  // signed data + signature
+  signed?: {
+    data: string;
+    signature: string;
+  };
+
   [k: string]: unknown;
 }

--- a/x-pack/plugins/fleet/server/mocks/index.ts
+++ b/x-pack/plugins/fleet/server/mocks/index.ts
@@ -178,8 +178,13 @@ export function createMessageSigningServiceMock(): MessageSigningServiceInterfac
   return {
     isEncryptionAvailable: true,
     generateKeyPair: jest.fn(),
-    sign: jest.fn(),
-    getPublicKey: jest.fn(),
+    sign: jest.fn().mockImplementation((message: Record<string, unknown>) =>
+      Promise.resolve({
+        data: Buffer.from(JSON.stringify(message), 'utf8'),
+        signature: 'thisisasignature',
+      })
+    ),
+    getPublicKey: jest.fn().mockResolvedValue('thisisapublickey'),
     rotateKeyPair: jest.fn(),
   };
 }

--- a/x-pack/plugins/fleet/server/services/agent_policies/full_agent_policy.test.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policies/full_agent_policy.test.ts
@@ -461,7 +461,7 @@ describe('getFullAgentPolicy', () => {
       signing_key: 'thisisapublickey',
     });
     expect(agentPolicy!.signed).toMatchObject({
-      data: 'eyJpZCI6ImFnZW50LXBvbGljeSIsImFnZW50Ijp7InByb3RlY3Rpb24iOnsiZW5hYmxlZCI6ZmFsc2UsInVuaW5zdGFsbF90b2tlbl9oYXNoIjoiIiwic2lnbmluZ19rZXkiOiJ0aGlzaXNhcHVibGlja2V5In19fQ==',
+      data: 'eyJpZCI6ImFnZW50LXBvbGljeSIsImFnZW50Ijp7ImZlYXR1cmVzIjp7fSwicHJvdGVjdGlvbiI6eyJlbmFibGVkIjpmYWxzZSwidW5pbnN0YWxsX3Rva2VuX2hhc2giOiIiLCJzaWduaW5nX2tleSI6InRoaXNpc2FwdWJsaWNrZXkifX0sImlucHV0cyI6W119',
       signature: 'thisisasignature',
     });
   });

--- a/x-pack/plugins/fleet/server/services/agent_policies/full_agent_policy.test.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policies/full_agent_policy.test.ts
@@ -438,19 +438,7 @@ describe('getFullAgentPolicy', () => {
   });
 
   it('should populate agent.protection and signed properties if encryption is available', async () => {
-    const mockContext = createAppContextStartContractMock();
-    mockContext.messageSigningService.sign = jest
-      .fn()
-      .mockImplementation((message: Record<string, unknown>) =>
-        Promise.resolve({
-          data: Buffer.from(JSON.stringify(message), 'utf8'),
-          signature: 'thisisasignature',
-        })
-      );
-    mockContext.messageSigningService.getPublicKey = jest
-      .fn()
-      .mockResolvedValue('thisisapublickey');
-    appContextService.start(mockContext);
+    appContextService.start(createAppContextStartContractMock());
 
     mockAgentPolicy({});
     const agentPolicy = await getFullAgentPolicy(savedObjectsClientMock.create(), 'agent-policy');

--- a/x-pack/plugins/fleet/server/services/agent_policies/full_agent_policy.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policies/full_agent_policy.ts
@@ -94,6 +94,10 @@ export async function getFullAgentPolicy(
     packageInfoCache,
     getOutputIdForAgentPolicy(dataOutput)
   );
+  const features = (agentPolicy.agent_features || []).reduce((acc, { name, ...featureConfig }) => {
+    acc[name] = featureConfig;
+    return acc;
+  }, {} as NonNullable<FullAgentPolicy['agent']>['features']);
   const fullAgentPolicy: FullAgentPolicy = {
     id: agentPolicy.id,
     outputs: {
@@ -126,10 +130,7 @@ export async function getFullAgentPolicy(
               metrics: agentPolicy.monitoring_enabled.includes(dataTypes.Metrics),
             }
           : { enabled: false, logs: false, metrics: false },
-      features: (agentPolicy.agent_features || []).reduce((acc, { name, ...featureConfig }) => {
-        acc[name] = featureConfig;
-        return acc;
-      }, {} as NonNullable<FullAgentPolicy['agent']>['features']),
+      features,
       protection: {
         enabled: agentPolicy.is_protected,
         uninstall_token_hash: '',
@@ -207,6 +208,7 @@ export async function getFullAgentPolicy(
     const dataToSign = {
       id: fullAgentPolicy.id,
       agent: {
+        features,
         protection: fullAgentPolicy.agent.protection,
       },
       inputs: inputs.map(({ id, name, revision, type }) => ({

--- a/x-pack/plugins/fleet/server/services/agent_policies/full_agent_policy.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policies/full_agent_policy.ts
@@ -211,8 +211,8 @@ export async function getFullAgentPolicy(
         features,
         protection: fullAgentPolicy.agent.protection,
       },
-      inputs: inputs.map(({ id, name, revision, type }) => ({
-        id,
+      inputs: inputs.map(({ id: inputId, name, revision, type }) => ({
+        id: inputId,
         name,
         revision,
         type,

--- a/x-pack/plugins/fleet/server/services/agent_policies/full_agent_policy.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policies/full_agent_policy.ts
@@ -89,6 +89,11 @@ export async function getFullAgentPolicy(
     })
   );
 
+  const inputs = await storedPackagePoliciesToAgentInputs(
+    agentPolicy.package_policies as PackagePolicy[],
+    packageInfoCache,
+    getOutputIdForAgentPolicy(dataOutput)
+  );
   const fullAgentPolicy: FullAgentPolicy = {
     id: agentPolicy.id,
     outputs: {
@@ -102,11 +107,7 @@ export async function getFullAgentPolicy(
         return acc;
       }, {}),
     },
-    inputs: await storedPackagePoliciesToAgentInputs(
-      agentPolicy.package_policies as PackagePolicy[],
-      packageInfoCache,
-      getOutputIdForAgentPolicy(dataOutput)
-    ),
+    inputs,
     secret_references: (agentPolicy?.package_policies || []).flatMap(
       (policy) => policy.secret_references || []
     ),
@@ -208,6 +209,12 @@ export async function getFullAgentPolicy(
       agent: {
         protection: fullAgentPolicy.agent.protection,
       },
+      inputs: inputs.map(({ id, name, revision, type }) => ({
+        id,
+        name,
+        revision,
+        type,
+      })),
     };
 
     const { data: signedData, signature } = await messageSigningService.sign(dataToSign);

--- a/x-pack/plugins/fleet/server/services/agents/actions.test.ts
+++ b/x-pack/plugins/fleet/server/services/agents/actions.test.ts
@@ -7,9 +7,9 @@
 
 import { elasticsearchServiceMock } from '@kbn/core/server/mocks';
 
-import type { NewAgentAction } from '../../../common/types';
+import type { NewAgentAction, AgentActionType } from '../../../common/types';
 
-import { createAppContextStartContractMock } from '../../mocks';
+import { createAppContextStartContractMock, type MockedFleetAppContext } from '../../mocks';
 import { appContextService } from '../app_context';
 import { auditLoggingService } from '../audit_logging';
 
@@ -29,8 +29,11 @@ const mockedBulkUpdateAgents = bulkUpdateAgents as jest.MockedFunction<typeof bu
 const mockedAuditLoggingService = auditLoggingService as jest.Mocked<typeof auditLoggingService>;
 
 describe('Agent actions', () => {
+  let mockContext: MockedFleetAppContext;
+
   beforeEach(async () => {
-    appContextService.start(createAppContextStartContractMock());
+    mockContext = createAppContextStartContractMock();
+    appContextService.start(mockContext);
   });
 
   afterEach(() => {
@@ -66,6 +69,17 @@ describe('Agent actions', () => {
   });
 
   describe('createAgentAction', () => {
+    beforeEach(() => {
+      mockContext.messageSigningService.sign = jest
+        .fn()
+        .mockImplementation((message: Record<string, unknown>) =>
+          Promise.resolve({
+            data: Buffer.from(JSON.stringify(message), 'utf8'),
+            signature: 'thisisasignature',
+          })
+        );
+    });
+
     it('should call audit logger', async () => {
       const esClient = elasticsearchServiceMock.createInternalClient();
       esClient.search.mockResolvedValue({
@@ -92,6 +106,85 @@ describe('Agent actions', () => {
       expect(mockedAuditLoggingService.writeCustomAuditLog).toHaveBeenCalledWith({
         message: expect.stringMatching(/User created Fleet action/),
       });
+    });
+
+    it.each(['UNENROLL', 'UPGRADE'] as AgentActionType[])(
+      'should sign %s action',
+      async (actionType: AgentActionType) => {
+        const esClient = elasticsearchServiceMock.createInternalClient();
+        esClient.search.mockResolvedValue({
+          hits: {
+            hits: [
+              {
+                _source: {
+                  type: actionType,
+                  action_id: 'action1',
+                  agents: ['agent1', 'agent2'],
+                  expiration: new Date().toISOString(),
+                },
+              },
+            ],
+          },
+        } as any);
+
+        await createAgentAction(esClient, {
+          id: 'action1',
+          type: actionType,
+          agents: ['agent1'],
+        });
+
+        expect(esClient.create).toBeCalledWith(
+          expect.objectContaining({
+            body: expect.objectContaining({
+              signed: {
+                data: expect.any(String),
+                signature: expect.any(String),
+              },
+            }),
+          })
+        );
+      }
+    );
+
+    it.each([
+      'SETTINGS',
+      'POLICY_REASSIGN',
+      'CANCEL',
+      'FORCE_UNENROLL',
+      'UPDATE_TAGS',
+      'REQUEST_DIAGNOSTICS',
+      'POLICY_CHANGE',
+      'INPUT_ACTION',
+    ] as AgentActionType[])('should not sign %s action', async (actionType: AgentActionType) => {
+      const esClient = elasticsearchServiceMock.createInternalClient();
+      esClient.search.mockResolvedValue({
+        hits: {
+          hits: [
+            {
+              _source: {
+                type: actionType,
+                action_id: 'action1',
+                agents: ['agent1', 'agent2'],
+                expiration: new Date().toISOString(),
+              },
+            },
+          ],
+        },
+      } as any);
+
+      await createAgentAction(esClient, {
+        id: 'action1',
+        type: actionType,
+        agents: ['agent1'],
+      });
+
+      expect(esClient.create).toBeCalledWith(
+        expect.objectContaining({
+          body: expect.not.objectContaining({
+            signed: expect.any(Object),
+          }),
+        })
+      );
     });
   });
 

--- a/x-pack/plugins/fleet/server/services/agents/update_agent_tags.test.ts
+++ b/x-pack/plugins/fleet/server/services/agents/update_agent_tags.test.ts
@@ -21,6 +21,7 @@ jest.mock('../app_context', () => {
     appContextService: {
       getLogger: () => loggerMock.create(),
       getConfig: () => {},
+      getMessageSigningService: jest.fn(),
     },
   };
 });

--- a/x-pack/plugins/fleet/server/services/setup.ts
+++ b/x-pack/plugins/fleet/server/services/setup.ts
@@ -179,6 +179,11 @@ async function createSetupSideEffects(
     await appContextService.getUninstallTokenService()?.encryptTokens();
   }
 
+  console.log(
+    '~~~~~~~~~~~~ tokens:',
+    JSON.stringify(await appContextService.getUninstallTokenService()?.getAllTokens())
+  );
+
   logger.debug('Upgrade Agent policy schema version');
   await upgradeAgentPolicySchemaVersion(soClient);
 

--- a/x-pack/plugins/fleet/server/services/setup.ts
+++ b/x-pack/plugins/fleet/server/services/setup.ts
@@ -179,11 +179,6 @@ async function createSetupSideEffects(
     await appContextService.getUninstallTokenService()?.encryptTokens();
   }
 
-  console.log(
-    '~~~~~~~~~~~~ tokens:',
-    JSON.stringify(await appContextService.getUninstallTokenService()?.getAllTokens())
-  );
-
   logger.debug('Upgrade Agent policy schema version');
   await upgradeAgentPolicySchemaVersion(soClient);
 


### PR DESCRIPTION
## Summary

Signs unenroll and upgrade actions. The signature is used by agent/endpoint to validate that it is safe to unenroll when tamper protection is enabled.

Related: https://github.com/elastic/ingest-dev/issues/1882


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
