### PR TITLE
[Security Solution] Coverage Overview Dashboard API integration

### DIFF
--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/api/api.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/api/api.ts
@@ -16,6 +16,7 @@ import type { ActionResult } from '@kbn/actions-plugin/server';
 import type { BulkInstallPackagesResponse } from '@kbn/fleet-plugin/common';
 import { epmRouteService } from '@kbn/fleet-plugin/common';
 import type { InstallPackageResponse } from '@kbn/fleet-plugin/common/types';
+import type { CoverageOverviewResponse } from '../../../../common/detection_engine/rule_management/api/rules/coverage_overview/response_schema';
 import { convertRulesFilterToKQL } from '../../../../common/utils/kql';
 import type { UpgradeSpecificRulesRequest } from '../../../../common/detection_engine/prebuilt_rules/api/perform_rule_upgrade/perform_rule_upgrade_request_schema';
 import type { PerformRuleUpgradeResponseBody } from '../../../../common/detection_engine/prebuilt_rules/api/perform_rule_upgrade/perform_rule_upgrade_response_schema';
@@ -23,7 +24,10 @@ import type { InstallSpecificRulesRequest } from '../../../../common/detection_e
 import type { PerformRuleInstallationResponseBody } from '../../../../common/detection_engine/prebuilt_rules/api/perform_rule_installation/perform_rule_installation_response_schema';
 import type { GetPrebuiltRulesStatusResponseBody } from '../../../../common/detection_engine/prebuilt_rules/api/get_prebuilt_rules_status/response_schema';
 import type { RuleManagementFiltersResponse } from '../../../../common/detection_engine/rule_management/api/rules/filters/response_schema';
-import { RULE_MANAGEMENT_FILTERS_URL } from '../../../../common/detection_engine/rule_management/api/urls';
+import {
+  RULE_MANAGEMENT_COVERAGE_OVERVIEW_URL,
+  RULE_MANAGEMENT_FILTERS_URL,
+} from '../../../../common/detection_engine/rule_management/api/urls';
 import type { BulkActionsDryRunErrCode } from '../../../../common/constants';
 import {
   DETECTION_ENGINE_RULES_BULK_ACTION,
@@ -59,6 +63,7 @@ import * as i18n from '../../../detections/pages/detection_engine/rules/translat
 import type {
   CreateRulesProps,
   ExportDocumentsProps,
+  FetchCoverageOverviewProps,
   FetchRuleProps,
   FetchRuleSnoozingProps,
   FetchRulesProps,
@@ -239,6 +244,18 @@ export const fetchRulesSnoozeSettings = async ({
     return result;
   }, {} as RulesSnoozeSettingsMap);
 };
+
+export const fetchCoverageOverview = async ({
+  filter,
+  signal,
+}: FetchCoverageOverviewProps): Promise<CoverageOverviewResponse> =>
+  KibanaServices.get().http.fetch<CoverageOverviewResponse>(RULE_MANAGEMENT_COVERAGE_OVERVIEW_URL, {
+    method: 'POST',
+    body: JSON.stringify({
+      filter,
+    }),
+    signal,
+  });
 
 export const fetchConnectors = (
   signal?: AbortSignal

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/api/hooks/use_fetch_coverage_overview.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/api/hooks/use_fetch_coverage_overview.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { UseQueryOptions } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useCallback } from 'react';
+import { RULE_MANAGEMENT_COVERAGE_OVERVIEW_URL } from '../../../../../common/detection_engine/rule_management/api/urls';
+import type { CoverageOverviewFilter } from '../../../../../common/detection_engine/rule_management/api/rules/coverage_overview/request_schema';
+import { fetchCoverageOverview } from '../api';
+import { buildCoverageOverviewDashboardModel } from '../../logic/coverage_overview/build_coverage_overview_dashboard_model';
+import type { CoverageOverviewDashboard } from '../../model/coverage_overview/dashboard';
+import { DEFAULT_QUERY_OPTIONS } from './constants';
+
+const COVERAGE_OVERVIEW_QUERY_KEY = ['POST', RULE_MANAGEMENT_COVERAGE_OVERVIEW_URL];
+
+/**
+ * A wrapper around useQuery provides default values to the underlying query,
+ * like query key, abortion signal, and error handler.
+ *
+ * @param filter - coverage overview filter, see CoverageOverviewFilter type
+ * @param options - react-query options
+ * @returns useQuery result
+ */
+export const useFetchCoverageOverviewQuery = (
+  filter: CoverageOverviewFilter = {},
+  options?: UseQueryOptions<CoverageOverviewDashboard>
+) => {
+  return useQuery<CoverageOverviewDashboard>(
+    [...COVERAGE_OVERVIEW_QUERY_KEY, filter],
+    async ({ signal }) => {
+      const response = await fetchCoverageOverview({ signal, filter });
+
+      return buildCoverageOverviewDashboardModel(response);
+    },
+    {
+      ...DEFAULT_QUERY_OPTIONS,
+      ...options,
+    }
+  );
+};
+
+/**
+ * We should use this hook to invalidate the coverage overview cache. For example, rule
+ * mutations that affect rule set size, like creation or deletion, should lead
+ * to cache invalidation.
+ *
+ * @returns A coverage overview cache invalidation callback
+ */
+export const useInvalidateFetchCoverageOverviewQuery = () => {
+  const queryClient = useQueryClient();
+
+  return useCallback(() => {
+    queryClient.invalidateQueries(COVERAGE_OVERVIEW_QUERY_KEY, {
+      refetchType: 'active',
+    });
+  }, [queryClient]);
+};

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/logic/coverage_overview/build_coverage_overview_dashboard_model.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/logic/coverage_overview/build_coverage_overview_dashboard_model.ts
@@ -1,0 +1,110 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { CoverageOverviewRuleActivity } from '../../../../../common/detection_engine/rule_management/api/rules/coverage_overview/request_schema';
+import type {
+  CoverageOverviewResponse,
+  CoverageOverviewRuleAttributes,
+} from '../../../../../common/detection_engine/rule_management/api/rules/coverage_overview/response_schema';
+import {
+  subtechniques,
+  tactics,
+  technique as techniques,
+} from '../../../../detections/mitre/mitre_tactics_techniques';
+import type { CoverageOverviewDashboard } from '../../model/coverage_overview/dashboard';
+import type { CoverageOverviewRule } from '../../model/coverage_overview/rule';
+import { buildCoverageOverviewMitreGraph } from './build_coverage_overview_mitre_graph';
+
+export function buildCoverageOverviewDashboardModel(
+  apiResponse: CoverageOverviewResponse
+): CoverageOverviewDashboard {
+  const mitreTactics = buildCoverageOverviewMitreGraph(tactics, techniques, subtechniques);
+
+  for (const tactic of mitreTactics) {
+    for (const ruleId of apiResponse.coverage[tactic.id] ?? []) {
+      addRule(tactic, ruleId, apiResponse.rules_data[ruleId]);
+    }
+
+    for (const technique of tactic.techniques) {
+      for (const ruleId of apiResponse.coverage[technique.id] ?? []) {
+        addRule(technique, ruleId, apiResponse.rules_data[ruleId]);
+      }
+
+      for (const subtechnique of technique.subtechniques) {
+        for (const ruleId of apiResponse.coverage[subtechnique.id] ?? []) {
+          addRule(subtechnique, ruleId, apiResponse.rules_data[ruleId]);
+        }
+      }
+    }
+  }
+
+  return {
+    mitreTactics,
+    unmappedRules: buildUnmapedRules(apiResponse),
+    metrics: calcMetrics(apiResponse.rules_data),
+  };
+}
+
+function calcMetrics(
+  rulesData: Record<string, CoverageOverviewRuleAttributes>
+): CoverageOverviewDashboard['metrics'] {
+  const ruleIds = Object.keys(rulesData);
+  const metrics: CoverageOverviewDashboard['metrics'] = {
+    totalRulesCount: ruleIds.length,
+    totalEnabledRulesCount: 0,
+  };
+
+  for (const ruleId of Object.keys(rulesData)) {
+    if (rulesData[ruleId].activity === CoverageOverviewRuleActivity.Enabled) {
+      metrics.totalEnabledRulesCount++;
+    }
+  }
+
+  return metrics;
+}
+
+function buildUnmapedRules(
+  apiResponse: CoverageOverviewResponse
+): CoverageOverviewDashboard['unmappedRules'] {
+  const unmappedRules: CoverageOverviewDashboard['unmappedRules'] = {
+    enabledRules: [],
+    disabledRules: [],
+    availableRules: [],
+  };
+
+  for (const ruleId of apiResponse.unmapped_rule_ids) {
+    addRule(unmappedRules, ruleId, apiResponse.rules_data[ruleId]);
+  }
+
+  return unmappedRules;
+}
+
+function addRule(
+  container: {
+    enabledRules: CoverageOverviewRule[];
+    disabledRules: CoverageOverviewRule[];
+    availableRules: CoverageOverviewRule[];
+  },
+  ruleId: string,
+  ruleData: CoverageOverviewRuleAttributes
+): void {
+  if (!ruleData) {
+    return;
+  }
+
+  if (ruleData.activity === CoverageOverviewRuleActivity.Enabled) {
+    container.enabledRules.push({
+      id: ruleId,
+      name: ruleData.name,
+    });
+  } else if (ruleData.activity === CoverageOverviewRuleActivity.Disabled) {
+    container.disabledRules.push({
+      id: ruleId,
+      name: ruleData.name,
+    });
+  }
+}

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/logic/coverage_overview/build_coverage_overview_mitre_graph.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/logic/coverage_overview/build_coverage_overview_mitre_graph.ts
@@ -15,7 +15,7 @@ import type { CoverageOverviewMitreSubTechnique } from '../../model/coverage_ove
 import type { CoverageOverviewMitreTactic } from '../../model/coverage_overview/mitre_tactic';
 import type { CoverageOverviewMitreTechnique } from '../../model/coverage_overview/mitre_technique';
 
-export function buildCoverageOverviewModel(
+export function buildCoverageOverviewMitreGraph(
   tactics: MitreTactic[],
   techniques: MitreTechnique[],
   subtechniques: MitreSubTechnique[]

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/logic/coverage_overview/build_coverage_overview_model.test.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/logic/coverage_overview/build_coverage_overview_model.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { buildCoverageOverviewModel } from './build_coverage_overview_model';
+import { buildCoverageOverviewMitreGraph } from './build_coverage_overview_mitre_graph';
 
 describe('buildCoverageOverviewModel', () => {
   it('builds domain model', () => {
@@ -52,7 +52,7 @@ describe('buildCoverageOverviewModel', () => {
       },
     ];
 
-    const model = buildCoverageOverviewModel(tactics, techniques, subtechniques);
+    const model = buildCoverageOverviewMitreGraph(tactics, techniques, subtechniques);
 
     expect(model).toEqual([
       {

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/logic/coverage_overview/build_coverage_overview_model.test.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/logic/coverage_overview/build_coverage_overview_model.test.ts
@@ -1,0 +1,124 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { buildCoverageOverviewModel } from './build_coverage_overview_model';
+
+describe('buildCoverageOverviewModel', () => {
+  it('builds domain model', () => {
+    const tactics = [
+      {
+        name: 'Tactic 1',
+        id: 'TA001',
+        reference: 'https://some-link/TA001',
+      },
+      {
+        name: 'Tactic 2',
+        id: 'TA002',
+        reference: 'https://some-link/TA002',
+      },
+    ];
+    const techniques = [
+      {
+        name: 'Technique 1',
+        id: 'T001',
+        reference: 'https://some-link/T001',
+        tactics: ['tactic-1'],
+      },
+      {
+        name: 'Technique 2',
+        id: 'T002',
+        reference: 'https://some-link/T002',
+        tactics: ['tactic-1', 'tactic-2'],
+      },
+    ];
+    const subtechniques = [
+      {
+        name: 'Subtechnique 1',
+        id: 'T001.001',
+        reference: 'https://some-link/T001/001',
+        tactics: ['tactic-1'],
+        techniqueId: 'T001',
+      },
+      {
+        name: 'Subtechnique 2',
+        id: 'T001.002',
+        reference: 'https://some-link/T001/002',
+        tactics: ['tactic-1'],
+        techniqueId: 'T001',
+      },
+    ];
+
+    const model = buildCoverageOverviewModel(tactics, techniques, subtechniques);
+
+    expect(model).toEqual([
+      {
+        id: 'TA001',
+        name: 'Tactic 1',
+        reference: 'https://some-link/TA001',
+        techniques: [
+          {
+            id: 'T001',
+            name: 'Technique 1',
+            reference: 'https://some-link/T001',
+            subtechniques: [
+              {
+                id: 'T001.001',
+                name: 'Subtechnique 1',
+                reference: 'https://some-link/T001/001',
+                enabledRules: [],
+                disabledRules: [],
+                availableRules: [],
+              },
+              {
+                id: 'T001.002',
+                name: 'Subtechnique 2',
+                reference: 'https://some-link/T001/002',
+                enabledRules: [],
+                disabledRules: [],
+                availableRules: [],
+              },
+            ],
+            enabledRules: [],
+            disabledRules: [],
+            availableRules: [],
+          },
+          {
+            id: 'T002',
+            name: 'Technique 2',
+            reference: 'https://some-link/T002',
+            subtechniques: [],
+            enabledRules: [],
+            disabledRules: [],
+            availableRules: [],
+          },
+        ],
+        enabledRules: [],
+        disabledRules: [],
+        availableRules: [],
+      },
+      {
+        id: 'TA002',
+        name: 'Tactic 2',
+        reference: 'https://some-link/TA002',
+        techniques: [
+          {
+            id: 'T002',
+            name: 'Technique 2',
+            reference: 'https://some-link/T002',
+            subtechniques: [],
+            enabledRules: [],
+            disabledRules: [],
+            availableRules: [],
+          },
+        ],
+        enabledRules: [],
+        disabledRules: [],
+        availableRules: [],
+      },
+    ]);
+  });
+});

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/logic/coverage_overview/build_coverage_overview_model.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/logic/coverage_overview/build_coverage_overview_model.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { kebabCase } from 'lodash';
+import type {
+  MitreTactic,
+  MitreTechnique,
+  MitreSubTechnique,
+} from '../../../../detections/mitre/types';
+import type { CoverageOverviewMitreSubTechnique } from '../../model/coverage_overview/mitre_subtechnique';
+import type { CoverageOverviewMitreTactic } from '../../model/coverage_overview/mitre_tactic';
+import type { CoverageOverviewMitreTechnique } from '../../model/coverage_overview/mitre_technique';
+
+export function buildCoverageOverviewModel(
+  tactics: MitreTactic[],
+  techniques: MitreTechnique[],
+  subtechniques: MitreSubTechnique[]
+): CoverageOverviewMitreTactic[] {
+  const techniqueToSubtechniquesMap = new Map<string, CoverageOverviewMitreSubTechnique[]>(); // Map(TechniqueId -> SubTechniqueId[])
+
+  for (const subtechnique of subtechniques) {
+    const coverageOverviewMitreSubTechnique = {
+      id: subtechnique.id,
+      name: subtechnique.name,
+      reference: subtechnique.reference,
+      enabledRules: [],
+      disabledRules: [],
+      availableRules: [],
+    };
+
+    const techniqueSubtechniques = techniqueToSubtechniquesMap.get(subtechnique.techniqueId);
+
+    if (!techniqueSubtechniques) {
+      techniqueToSubtechniquesMap.set(subtechnique.techniqueId, [
+        coverageOverviewMitreSubTechnique,
+      ]);
+    } else {
+      techniqueSubtechniques.push(coverageOverviewMitreSubTechnique);
+    }
+  }
+
+  const tacticToTechniquesMap = new Map<string, CoverageOverviewMitreTechnique[]>(); // Map(kebabCase(tactic name) -> CoverageOverviewMitreTechnique)
+
+  for (const technique of techniques) {
+    const coverageOverviewMitreTechnique: CoverageOverviewMitreTechnique = {
+      id: technique.id,
+      name: technique.name,
+      reference: technique.reference,
+      subtechniques: techniqueToSubtechniquesMap.get(technique.id) ?? [],
+      enabledRules: [],
+      disabledRules: [],
+      availableRules: [],
+    };
+
+    for (const kebabCaseTacticName of technique.tactics) {
+      const tacticTechniques = tacticToTechniquesMap.get(kebabCaseTacticName);
+
+      if (!tacticTechniques) {
+        tacticToTechniquesMap.set(kebabCaseTacticName, [coverageOverviewMitreTechnique]);
+      } else {
+        tacticTechniques.push(coverageOverviewMitreTechnique);
+      }
+    }
+  }
+
+  const result: CoverageOverviewMitreTactic[] = [];
+
+  for (const tactic of tactics) {
+    result.push({
+      id: tactic.id,
+      name: tactic.name,
+      reference: tactic.reference,
+      techniques: tacticToTechniquesMap.get(kebabCase(tactic.name)) ?? [],
+      enabledRules: [],
+      disabledRules: [],
+      availableRules: [],
+    });
+  }
+
+  return result;
+}

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/logic/types.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/logic/types.ts
@@ -31,6 +31,7 @@ import type { NamespaceType } from '@kbn/securitysolution-io-ts-list-types';
 import type { RuleSnoozeSettings } from '@kbn/triggers-actions-ui-plugin/public/types';
 
 import { PositiveInteger } from '@kbn/securitysolution-io-ts-types';
+import type { CoverageOverviewFilter } from '../../../../common/detection_engine/rule_management/api/rules/coverage_overview/request_schema';
 import type { WarningSchema } from '../../../../common/detection_engine/schemas/response';
 import { RuleExecutionSummary } from '../../../../common/detection_engine/rule_monitoring';
 import type { RuleExecutionStatus } from '../../../../common/detection_engine/rule_monitoring';
@@ -268,6 +269,11 @@ export interface FetchRuleProps {
 
 export interface FetchRuleSnoozingProps {
   ids: string[];
+  signal?: AbortSignal;
+}
+
+export interface FetchCoverageOverviewProps {
+  filter: CoverageOverviewFilter;
   signal?: AbortSignal;
 }
 

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/model/coverage_overview/mitre_subtechnique.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/model/coverage_overview/mitre_subtechnique.ts
@@ -5,17 +5,15 @@
  * 2.0.
  */
 
-import type { CoverageOverviewMitreSubTechnique } from './mitre_subtechnique';
 import type { CoverageOverviewRule } from './rule';
 
-export interface CoverageOverviewMitreTechnique {
+export interface CoverageOverviewMitreSubTechnique {
   id: string;
   name: string;
   /**
-   * An url leading to the technique's page
+   * An url leading to the subtechnique's page
    */
   reference: string;
-  subtechniques: CoverageOverviewMitreSubTechnique[];
   enabledRules: CoverageOverviewRule[];
   disabledRules: CoverageOverviewRule[];
   availableRules: CoverageOverviewRule[];

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/model/coverage_overview/mitre_tactic.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/model/coverage_overview/mitre_tactic.ts
@@ -9,6 +9,7 @@ import type { CoverageOverviewRule } from './rule';
 import type { CoverageOverviewMitreTechnique } from './mitre_technique';
 
 export interface CoverageOverviewMitreTactic {
+  id: string;
   name: string;
   /**
    * An url leading to the tactic's page

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/pages/coverage_overview/index.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/pages/coverage_overview/index.tsx
@@ -5,19 +5,55 @@
  * 2.0.
  */
 import React from 'react';
+import { EuiFlexGroup, EuiFlexItem, EuiPanel } from '@elastic/eui';
 import { SecuritySolutionPageWrapper } from '../../../../common/components/page_wrapper';
 import { SpyRoute } from '../../../../common/utils/route/spy_routes';
 import { SecurityPageName } from '../../../../app/types';
 import { HeaderPage } from '../../../../common/components/header_page';
 
 import * as i18n from './translations';
+import { useFetchCoverageOverviewQuery } from '../../../rule_management/api/hooks/use_fetch_coverage_overview';
 
 const CoverageOverviewPageComponent = () => {
+  const { data } = useFetchCoverageOverviewQuery();
+
   return (
     <>
       <SecuritySolutionPageWrapper data-test-subj="coverageOverviewPage">
         <HeaderPage title={i18n.COVERAGE_OVERVIEW_DASHBOARD_TITLE} />
       </SecuritySolutionPageWrapper>
+
+      <EuiFlexGroup>
+        {data?.mitreTactics.map((tactic) => (
+          <EuiFlexGroup direction="column">
+            <EuiFlexItem grow={false}>
+              <EuiPanel style={{ width: 100, height: 100, background: 'grey' }}>
+                {tactic.name}
+                <br />
+                <small>{'Enabled: '}</small>
+                <small>{tactic.enabledRules.length}</small>
+                <br />
+                <small>{'Disabled: '}</small>
+                <small>{tactic.disabledRules.length}</small>
+              </EuiPanel>
+            </EuiFlexItem>
+
+            {tactic.techniques.map((technique) => (
+              <EuiFlexItem grow={false}>
+                <EuiPanel style={{ width: 100, height: 100 }}>
+                  {technique.name}
+                  <br />
+                  <small>{'Enabled: '}</small>
+                  <small>{technique.enabledRules.length}</small>
+                  <br />
+                  <small>{'Disabled: '}</small>
+                  <small>{technique.disabledRules.length}</small>
+                </EuiPanel>
+              </EuiFlexItem>
+            ))}
+          </EuiFlexGroup>
+        ))}
+      </EuiFlexGroup>
 
       <SpyRoute pageName={SecurityPageName.coverageOverview} />
     </>

--- a/x-pack/plugins/security_solution/public/detections/mitre/types.ts
+++ b/x-pack/plugins/security_solution/public/detections/mitre/types.ts
@@ -24,3 +24,24 @@ export interface MitreTechniquesOptions extends MitreOptions {
 export interface MitreSubtechniquesOptions extends MitreTechniquesOptions {
   techniqueId: string;
 }
+
+export interface MitreTactic {
+  id: string;
+  name: string;
+  reference: string; // A link to the tactic's page
+}
+
+export interface MitreTechnique {
+  id: string;
+  name: string;
+  reference: string; // A link to the technique's page
+  tactics: string[]; // Tactics this technique assigned to (lowercase dash separated)
+}
+
+export interface MitreSubTechnique {
+  id: string;
+  name: string;
+  reference: string; // A link to the subtechnique's page
+  tactics: string[]; // Tactics this technique assigned to (lowercase dash separated)
+  techniqueId: string; // A technique id this subtechnique assigned to
+}


### PR DESCRIPTION
**Addresses:** https://github.com/elastic/kibana/issues/158249

## Summary

This PR adds logic to integrate Coverage Overview Dashboard UI with the API. On top of that it adds utility functions to build the domain model and primitive dashboard render to verify it works.

## Details

The PR isn't finalized yet and can be closed in favour of better implementations. The main goal is to share the code and ideas behind. It includes

- API integration layer `useFetchCoverageOverviewQuery` and `fetchCoverageOverview`
- Coverage Overview domain model utility functions `buildCoverageOverviewDashboardModel` and `buildCoverageOverviewMitreGraph `
- Primitive dashboard rendering for referencing and verification (doesn't go to prod and has to be removed)
