### PR TITLE
[8.9] [Logs onboarding] Make existing APIs internal only (#160749)

### DIFF
--- a/x-pack/plugins/observability_onboarding/public/assets/standalone_agent_setup.sh
+++ b/x-pack/plugins/observability_onboarding/public/assets/standalone_agent_setup.sh
@@ -9,11 +9,12 @@ AUTO_DOWNLOAD_CONFIG=$5
 updateStepProgress() {
   local STEPNAME="$1"
   local STATUS="$2" # "incomplete" | "complete" | "disabled" | "loading" | "warning" | "danger" | "current"
-  curl --request GET \
-    --url "${API_ENDPOINT}/custom_logs/${ONBOARDING_ID}/step/${STEPNAME}?status=${STATUS}" \
+  curl --request POST \
+    --url "${API_ENDPOINT}/custom_logs/${ONBOARDING_ID}/step/${STEPNAME}" \
     --header "Authorization: ApiKey ${API_KEY_ENCODED}" \
     --header "Content-Type: application/json" \
     --header "kbn-xsrf: true" \
+    --data "{\"status\":\"${STATUS}\"}" \
     --output /dev/null \
     --no-progress-meter
 }

--- a/x-pack/plugins/observability_onboarding/public/components/app/custom_logs/wizard/install_elastic_agent.tsx
+++ b/x-pack/plugins/observability_onboarding/public/components/app/custom_logs/wizard/install_elastic_agent.tsx
@@ -164,7 +164,7 @@ export function InstallElasticAgent() {
         onboardingId
       ) {
         return callApi(
-          'GET /api/observability_onboarding/elastic_agent/config 2023-05-24',
+          'GET /internal/observability_onboarding/elastic_agent/config',
           {
             headers: { authorization: `ApiKey ${apiKeyEncoded}` },
             params: { query: { onboardingId } },

--- a/x-pack/plugins/observability_onboarding/server/routes/custom_logs/route.ts
+++ b/x-pack/plugins/observability_onboarding/server/routes/custom_logs/route.ts
@@ -53,7 +53,7 @@ const installShipperSetupRoute = createObservabilityOnboardingServerRoute({
       plugins.cloud?.setup?.kibanaUrl ?? // then cloud id
       getFallbackUrls(coreStart).kibanaUrl; // falls back to local network binding
     const scriptDownloadUrl = `${kibanaUrl}/plugins/observabilityOnboarding/assets/standalone_agent_setup.sh`;
-    const apiEndpoint = `${kibanaUrl}/api/observability_onboarding`;
+    const apiEndpoint = `${kibanaUrl}/internal/observability_onboarding`;
 
     return {
       apiEndpoint,
@@ -137,14 +137,14 @@ const updateOnboardingStateRoute = createObservabilityOnboardingServerRoute({
 
 const stepProgressUpdateRoute = createObservabilityOnboardingServerRoute({
   endpoint:
-    'GET /api/observability_onboarding/custom_logs/{id}/step/{name} 2023-05-24',
+    'POST /internal/observability_onboarding/custom_logs/{id}/step/{name}',
   options: { tags: [] },
   params: t.type({
     path: t.type({
       id: t.string,
       name: t.string,
     }),
-    query: t.type({
+    body: t.type({
       status: t.string,
     }),
   }),
@@ -152,7 +152,7 @@ const stepProgressUpdateRoute = createObservabilityOnboardingServerRoute({
     const {
       params: {
         path: { id, name },
-        query: { status },
+        body: { status },
       },
       core,
     } = resources;

--- a/x-pack/plugins/observability_onboarding/server/routes/elastic_agent/route.ts
+++ b/x-pack/plugins/observability_onboarding/server/routes/elastic_agent/route.ts
@@ -13,7 +13,7 @@ import { generateYml } from './generate_yml';
 import { getFallbackUrls } from '../custom_logs/get_fallback_urls';
 
 const generateConfig = createObservabilityOnboardingServerRoute({
-  endpoint: 'GET /api/observability_onboarding/elastic_agent/config 2023-05-24',
+  endpoint: 'GET /internal/observability_onboarding/elastic_agent/config',
   params: t.type({
     query: t.type({ onboardingId: t.string }),
   }),


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.9`:
 - [[Logs onboarding] Make existing APIs internal only](https://github.com/elastic/kibana/pull/160749)

This backport PR was created manually.