### PR TITLE
[APM] Diagnostics: show both doc count and event count

### DIFF
--- a/x-pack/plugins/apm/common/utils/formatters/formatters.test.ts
+++ b/x-pack/plugins/apm/common/utils/formatters/formatters.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { asPercent, asDecimalOrInteger } from './formatters';
+import { asPercent, asDecimalOrInteger, asBigNumber } from './formatters';
 
 describe('formatters', () => {
   describe('asPercent', () => {
@@ -70,6 +70,55 @@ describe('formatters', () => {
       it('formats as decimal when number is below 1 ', () => {
         expect(asDecimalOrInteger(0.25435632645, 1)).toEqual('0.3');
       });
+    });
+  });
+});
+
+describe('asBigNumber', () => {
+  [
+    {
+      input: 0,
+      output: '0',
+    },
+    {
+      input: 999,
+      output: '999',
+    },
+    {
+      input: 999.999,
+      output: '1,000',
+    },
+    {
+      input: 449900,
+      output: '450k',
+    },
+    {
+      input: 450000,
+      output: '450k',
+    },
+    {
+      input: 450010,
+      output: '450k',
+    },
+    {
+      input: 2.4991e7,
+      output: '25m',
+    },
+    {
+      input: 9e9,
+      output: '9b',
+    },
+    {
+      input: 1e12,
+      output: '1t',
+    },
+    {
+      input: 1e15,
+      output: '1,000t',
+    },
+  ].forEach(({ input, output }) => {
+    it(`${input} becomes ${output}`, () => {
+      expect(asBigNumber(input)).toBe(output);
     });
   });
 });

--- a/x-pack/plugins/apm/common/utils/formatters/formatters.ts
+++ b/x-pack/plugins/apm/common/utils/formatters/formatters.ts
@@ -62,3 +62,23 @@ export function asDecimalOrInteger(value: number, threshold = 10) {
   }
   return asDecimal(value);
 }
+
+export function asBigNumber(value: number): string {
+  if (value < 1e3) {
+    return asInteger(value);
+  }
+
+  if (value < 1e6) {
+    return `${asInteger(value / 1e3)}k`;
+  }
+
+  if (value < 1e9) {
+    return `${asInteger(value / 1e6)}m`;
+  }
+
+  if (value < 1e12) {
+    return `${asInteger(value / 1e9)}b`;
+  }
+
+  return `${asInteger(value / 1e12)}t`;
+}

--- a/x-pack/plugins/apm/public/components/app/diagnostics/apm_documents_tab.tsx
+++ b/x-pack/plugins/apm/public/components/app/diagnostics/apm_documents_tab.tsx
@@ -10,6 +10,8 @@ import {
   EuiBasicTable,
   EuiBasicTableColumn,
   EuiSpacer,
+  EuiText,
+  EuiToolTip,
 } from '@elastic/eui';
 import React, { useState, useMemo } from 'react';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
@@ -21,14 +23,6 @@ import type { ApmEvent } from '../../../../server/routes/diagnostics/bundle/get_
 import { useDiagnosticsContext } from './context/use_diagnostics';
 import { ApmPluginStartDeps } from '../../../plugin';
 import { SearchBar } from '../../shared/search_bar/search_bar';
-
-function formatDocCount(count?: number) {
-  if (count === undefined) {
-    return '-';
-  }
-
-  return asInteger(count);
-}
 
 export function DiagnosticsApmDocuments() {
   const { diagnosticsBundle, isImported } = useDiagnosticsContext();
@@ -46,7 +40,9 @@ export function DiagnosticsApmDocuments() {
           legacy === true &&
           docCount === 0 &&
           intervals &&
-          Object.values(intervals).every((interval) => interval === 0);
+          Object.values(intervals).every(
+            (interval) => interval.eventDocCount === 0
+          );
 
         return !isLegacyAndUnused;
       }) ?? []
@@ -62,31 +58,35 @@ export function DiagnosticsApmDocuments() {
     {
       name: 'Doc count',
       field: 'docCount',
-      render: (_, { docCount }) => asInteger(docCount),
+      render: (_, { docCount }) => (
+        <EuiToolTip content={`${asInteger(docCount)} docs`}>
+          <div style={{ cursor: 'pointer' }}>{asBigNumber(docCount)}</div>
+        </EuiToolTip>
+      ),
       sortable: true,
     },
     {
       name: '1m',
       field: 'intervals.1m',
       render: (_, { intervals }) => {
-        const docCount = intervals?.['1m'];
-        return formatDocCount(docCount);
+        const interval = intervals?.['1m'];
+        return <IntervalDocCount interval={interval} />;
       },
     },
     {
       name: '10m',
       field: 'intervals.10m',
       render: (_, { intervals }) => {
-        const docCount = intervals?.['10m'];
-        return formatDocCount(docCount);
+        const interval = intervals?.['10m'];
+        return <IntervalDocCount interval={interval} />;
       },
     },
     {
       name: '60m',
       field: 'intervals.60m',
       render: (_, { intervals }) => {
-        const docCount = intervals?.['60m'];
-        return formatDocCount(docCount);
+        const interval = intervals?.['60m'];
+        return <IntervalDocCount interval={interval} />;
       },
     },
     {
@@ -158,4 +158,50 @@ export function DiagnosticsApmDocuments() {
       />
     </>
   );
+}
+
+function IntervalDocCount({
+  interval,
+}: {
+  interval?: {
+    metricDocCount: number;
+    eventDocCount: number;
+  };
+}) {
+  if (interval === undefined) {
+    return <>-</>;
+  }
+
+  return (
+    <EuiToolTip
+      content={`${asInteger(interval.metricDocCount)} docs / ${asInteger(
+        interval.eventDocCount
+      )} events`}
+    >
+      <div style={{ cursor: 'pointer' }}>
+        {asBigNumber(interval.metricDocCount)}&nbsp;
+        <EuiText
+          css={{ fontStyle: 'italic', fontSize: '80%', display: 'inline' }}
+        >
+          ({asBigNumber(interval.eventDocCount)})
+        </EuiText>
+      </div>
+    </EuiToolTip>
+  );
+}
+
+function asBigNumber(value: number): string {
+  if (value < 1e3) {
+    return value.toString();
+  }
+
+  if (value < 1e6) {
+    return `${asInteger(value / 1e3)}k`;
+  }
+
+  if (value < 1e9) {
+    return `${asInteger(value / 1e6)}m`;
+  }
+
+  return `${asInteger(value / 1e9)}b`;
 }

--- a/x-pack/plugins/apm/public/components/app/diagnostics/apm_documents_tab.tsx
+++ b/x-pack/plugins/apm/public/components/app/diagnostics/apm_documents_tab.tsx
@@ -53,7 +53,7 @@ export function DiagnosticsApmDocuments() {
     {
       name: 'Name',
       field: 'name',
-      width: '40%',
+      width: '30%',
     },
     {
       name: 'Doc count',
@@ -183,7 +183,7 @@ function IntervalDocCount({
         <EuiText
           css={{ fontStyle: 'italic', fontSize: '80%', display: 'inline' }}
         >
-          ({asBigNumber(interval.eventDocCount)})
+          ({asBigNumber(interval.eventDocCount)} events)
         </EuiText>
       </div>
     </EuiToolTip>

--- a/x-pack/plugins/apm/public/components/app/diagnostics/apm_documents_tab.tsx
+++ b/x-pack/plugins/apm/public/components/app/diagnostics/apm_documents_tab.tsx
@@ -17,7 +17,7 @@ import React, { useState, useMemo } from 'react';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { orderBy } from 'lodash';
 import { useApmParams } from '../../../hooks/use_apm_params';
-import { asInteger } from '../../../../common/utils/formatters';
+import { asBigNumber, asInteger } from '../../../../common/utils/formatters';
 import { APM_STATIC_DATA_VIEW_ID } from '../../../../common/data_view_constants';
 import type { ApmEvent } from '../../../../server/routes/diagnostics/bundle/get_apm_events';
 import { useDiagnosticsContext } from './context/use_diagnostics';
@@ -188,20 +188,4 @@ function IntervalDocCount({
       </div>
     </EuiToolTip>
   );
-}
-
-function asBigNumber(value: number): string {
-  if (value < 1e3) {
-    return value.toString();
-  }
-
-  if (value < 1e6) {
-    return `${asInteger(value / 1e3)}k`;
-  }
-
-  if (value < 1e9) {
-    return `${asInteger(value / 1e6)}m`;
-  }
-
-  return `${asInteger(value / 1e9)}b`;
 }

--- a/x-pack/plugins/apm/server/routes/diagnostics/bundle/get_apm_events.ts
+++ b/x-pack/plugins/apm/server/routes/diagnostics/bundle/get_apm_events.ts
@@ -13,6 +13,7 @@ import {
   METRICSET_NAME,
   METRICSET_INTERVAL,
   TRANSACTION_DURATION_SUMMARY,
+  INDEX,
 } from '../../../../common/es_fields/apm';
 import { ApmIndicesConfig } from '../../settings/apm_indices/get_apm_indices';
 import { getTypedSearch, TypedSearch } from '../create_typed_es_client';
@@ -93,19 +94,19 @@ export async function getApmEvents({
     }),
     getEventWithMetricsetInterval({
       ...commonProps,
-      name: 'Metric: Span breakdown',
-      index: getApmIndexPatterns([apmIndices.metric]),
-      kuery: mergeKueries(
-        `${PROCESSOR_EVENT}: "metric" AND ${METRICSET_NAME}: "span_breakdown"`,
-        kuery
-      ),
-    }),
-    getEventWithMetricsetInterval({
-      ...commonProps,
       name: 'Metric: Service summary',
       index: getApmIndexPatterns([apmIndices.metric]),
       kuery: mergeKueries(
         `${PROCESSOR_EVENT}: "metric" AND ${METRICSET_NAME}: "service_summary"`,
+        kuery
+      ),
+    }),
+    getEvent({
+      ...commonProps,
+      name: 'Metric: Span breakdown',
+      index: getApmIndexPatterns([apmIndices.metric]),
+      kuery: mergeKueries(
+        `${PROCESSOR_EVENT}: "metric" AND ${METRICSET_NAME}: "span_breakdown"`,
         kuery
       ),
     }),
@@ -168,7 +169,7 @@ async function getEventWithMetricsetInterval({
         aggs: {
           metric_doc_count: {
             value_count: {
-              field: '_index',
+              field: INDEX,
             },
           },
         },

--- a/x-pack/test/apm_api_integration/tests/diagnostics/apm_events.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/diagnostics/apm_events.spec.ts
@@ -7,6 +7,7 @@
 
 import expect from '@kbn/expect';
 import { apm, timerange } from '@kbn/apm-synthtrace-client';
+import { APIReturnType } from '@kbn/apm-plugin/public/services/rest/create_call_apm_api';
 import { FtrProviderContext } from '../../common/ftr_provider_context';
 
 export default function ApiTest({ getService }: FtrProviderContext) {
@@ -95,6 +96,60 @@ export default function ApiTest({ getService }: FtrProviderContext) {
           },
           { kuery: 'processor.event: "transaction"', docCount: 450 },
         ]);
+      });
+
+      describe.only('transactions', async () => {
+        let body: APIReturnType<'GET /internal/apm/diagnostics'>;
+
+        const expectedDocCount = 450;
+
+        beforeEach(async () => {
+          const res = await apmApiClient.adminUser({
+            endpoint: 'GET /internal/apm/diagnostics',
+            params: {
+              query: { start: new Date(start).toISOString(), end: new Date(end).toISOString() },
+            },
+          });
+
+          body = res.body;
+        });
+
+        it('raw transaction events', () => {
+          const rawTransactions = body.apmEvents.find(({ kuery }) =>
+            kuery.includes('processor.event: "transaction"')
+          );
+
+          expect(rawTransactions?.docCount).to.be(expectedDocCount);
+        });
+
+        it('transaction metrics', () => {
+          const transactionMetrics = body.apmEvents.find(({ kuery }) =>
+            kuery.includes('metricset.name: "transaction"')
+          );
+
+          expect(transactionMetrics?.docCount).to.be(21);
+          expect(transactionMetrics?.intervals).to.eql({
+            '1m': { metricDocCount: 15, eventDocCount: expectedDocCount },
+            '10m': { metricDocCount: 4, eventDocCount: expectedDocCount },
+            '60m': { metricDocCount: 2, eventDocCount: expectedDocCount },
+          });
+        });
+
+        it('service transactions', () => {
+          const serviceTransactionMetrics = body.apmEvents.find(({ kuery }) =>
+            kuery.includes('metricset.name: "service_transaction"')
+          );
+          expect(serviceTransactionMetrics?.docCount).to.be(21);
+          expect(serviceTransactionMetrics?.kuery).to.be(
+            'processor.event: "metric" AND metricset.name: "service_transaction" AND transaction.duration.summary :* '
+          );
+
+          expect(serviceTransactionMetrics?.intervals).to.eql({
+            '1m': { metricDocCount: 15, eventDocCount: expectedDocCount },
+            '10m': { metricDocCount: 4, eventDocCount: expectedDocCount },
+            '60m': { metricDocCount: 2, eventDocCount: expectedDocCount },
+          });
+        });
       });
 
       it('returns zero doc_counts when filtering by a non-existing service', async () => {

--- a/x-pack/test/apm_api_integration/tests/diagnostics/apm_events.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/diagnostics/apm_events.spec.ts
@@ -98,7 +98,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         ]);
       });
 
-      describe.only('transactions', async () => {
+      describe('transactions', async () => {
         let body: APIReturnType<'GET /internal/apm/diagnostics'>;
 
         const expectedDocCount = 450;

--- a/x-pack/test/apm_api_integration/tests/diagnostics/apm_events.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/diagnostics/apm_events.spec.ts
@@ -90,11 +90,11 @@ export default function ApiTest({ getService }: FtrProviderContext) {
               'processor.event: "metric" AND metricset.name: "transaction" AND transaction.duration.summary :* ',
             docCount: 21,
           },
-          { kuery: 'processor.event: "metric" AND metricset.name: "span_breakdown"', docCount: 15 },
           {
             kuery: 'processor.event: "metric" AND metricset.name: "service_summary"',
             docCount: 21,
           },
+          { kuery: 'processor.event: "metric" AND metricset.name: "span_breakdown"', docCount: 15 },
           { kuery: 'processor.event: "transaction"', docCount: 450 },
         ]);
       });

--- a/x-pack/test/apm_api_integration/tests/diagnostics/apm_events.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/diagnostics/apm_events.spec.ts
@@ -8,6 +8,7 @@
 import expect from '@kbn/expect';
 import { apm, timerange } from '@kbn/apm-synthtrace-client';
 import { APIReturnType } from '@kbn/apm-plugin/public/services/rest/create_call_apm_api';
+import { sumBy } from 'lodash';
 import { FtrProviderContext } from '../../common/ftr_provider_context';
 
 export default function ApiTest({ getService }: FtrProviderContext) {
@@ -127,7 +128,13 @@ export default function ApiTest({ getService }: FtrProviderContext) {
             kuery.includes('metricset.name: "transaction"')
           );
 
+          const intervalDocCount = sumBy(
+            Object.values(transactionMetrics?.intervals ?? {}),
+            ({ metricDocCount }) => metricDocCount
+          );
+          expect(transactionMetrics?.docCount).to.be(intervalDocCount);
           expect(transactionMetrics?.docCount).to.be(21);
+
           expect(transactionMetrics?.intervals).to.eql({
             '1m': { metricDocCount: 15, eventDocCount: expectedDocCount },
             '10m': { metricDocCount: 4, eventDocCount: expectedDocCount },
@@ -139,7 +146,15 @@ export default function ApiTest({ getService }: FtrProviderContext) {
           const serviceTransactionMetrics = body.apmEvents.find(({ kuery }) =>
             kuery.includes('metricset.name: "service_transaction"')
           );
+
+          const intervalDocCount = sumBy(
+            Object.values(serviceTransactionMetrics?.intervals ?? {}),
+            ({ metricDocCount }) => metricDocCount
+          );
+
+          expect(serviceTransactionMetrics?.docCount).to.be(intervalDocCount);
           expect(serviceTransactionMetrics?.docCount).to.be(21);
+
           expect(serviceTransactionMetrics?.kuery).to.be(
             'processor.event: "metric" AND metricset.name: "service_transaction" AND transaction.duration.summary :* '
           );


### PR DESCRIPTION
Adds support for showing both doc count and event count for metrics, and improve number formatting for large numbers

<img width="1482" alt="image" src="https://github.com/elastic/kibana/assets/209966/18cec5ac-e65a-49c9-96c1-536843a68502">


<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->