### PR TITLE
Navigation vertical scroll fixes

### DIFF
--- a/packages/core/chrome/core-chrome-browser-internal/src/ui/header/collapsible_nav.tsx
+++ b/packages/core/chrome/core-chrome-browser-internal/src/ui/header/collapsible_nav.tsx
@@ -20,7 +20,7 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { groupBy, sortBy } from 'lodash';
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import useObservable from 'react-use/lib/useObservable';
 import * as Rx from 'rxjs';
 import type { HttpStart } from '@kbn/core-http-browser';
@@ -138,6 +138,7 @@ export function CollapsibleNav({
   const { undefined: unknowns = [], ...allCategorizedLinks } = groupedNavLinks;
   const categoryDictionary = getAllCategories(allCategorizedLinks);
   const orderedCategories = getOrderedCategories(allCategorizedLinks, categoryDictionary);
+  const [selectedCategory, setSelectedCategory] = useState({ category: '', isCategoryOpen: false });
   const readyForEUI = (link: ChromeNavLink, needsIcon: boolean = false) => {
     return createEuiListItem({
       link,
@@ -311,8 +312,20 @@ export function CollapsibleNav({
                 )
               }
               isCollapsible={true}
+              forceState={
+                selectedCategory.category === ''
+                  ? undefined
+                  : selectedCategory.category === category.id
+                  ? selectedCategory.isCategoryOpen
+                    ? 'open'
+                    : 'closed'
+                  : 'closed'
+              }
               initialIsOpen={getIsCategoryOpen(category.id, storage)}
-              onToggle={(isCategoryOpen) => setIsCategoryOpen(category.id, isCategoryOpen, storage)}
+              onToggle={(isCategoryOpen) => {
+                setSelectedCategory({ category: category.id, isCategoryOpen });
+                setIsCategoryOpen(category.id, isCategoryOpen, storage);
+              }}
               data-test-subj={`collapsibleNavGroup-${category.id}`}
             >
               <EuiListGroup

--- a/packages/shared-ux/chrome/navigation/src/ui/components/navigation_ui.tsx
+++ b/packages/shared-ux/chrome/navigation/src/ui/components/navigation_ui.tsx
@@ -24,11 +24,13 @@ export const NavigationUI: FC<Props> = ({ children, unstyled, footerChildren, da
         <EuiFlexGroup
           direction="column"
           gutterSize="none"
-          style={{ overflowY: 'auto' }}
+          style={{ height: `calc(100% - 48px)` }}
           justifyContent="spaceBetween"
           data-test-subj={dataTestSubj}
         >
-          <EuiFlexItem grow={false}>{children}</EuiFlexItem>
+          <EuiFlexItem style={{ overflowY: 'auto' }} grow={false}>
+            {children}
+          </EuiFlexItem>
 
           {footerChildren && <EuiFlexItem grow={false}>{footerChildren}</EuiFlexItem>}
         </EuiFlexGroup>


### PR DESCRIPTION
## What does this PR do?
* User must only be able to expand a single root-level accordion bucket at a time.
* Navigation scrolling must not hide the bottom root-level accordion buckets (Developer tools & Management)

## Issue References
* https://github.com/elastic/kibana/issues/158123

## Video/Screenshot Demo 

###### FIX:
* https://www.loom.com/share/e485a02de0ff4d22afb9d6aeeeb3371c?sid=e0e61f16-5037-4e37-85e4-df4b031cc512

---
This code was written and reviewed by GitStart Community. Growing future engineers, one PR at a time.
