### PR TITLE
Remove 8.8.2 coming tag

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -47,8 +47,6 @@ Review important information about the {kib} 8.x releases.
 [[release-notes-8.8.2]]
 == {kib} 8.8.2
 
-coming::[8.8.2]
-
 Review the following information about the {kib} 8.8.2 release.
 
 [float]


### PR DESCRIPTION
Removes the `coming` tag from the 8.8.2 release notes.

<!--ONMERGE {"backportTargets":["8.8","8.9"]} ONMERGE-->