### PR TITLE
Remove 7.17.11 coming tag

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -86,8 +86,6 @@ Review important information about the {kib} 7.17.x releases.
 
 Review the following information about the {kib} 7.17.11 release.
 
-coming::[7.17.11]
-
 [float]
 [[fixes-v7.17.11]]
 === Bug Fixes


### PR DESCRIPTION
Removes the `coming` tag from the 7.17.11 release notes.