### PR TITLE
[Enterprise Search] Add minute cron editor

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_scheduling/connector_cron_editor.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_scheduling/connector_cron_editor.tsx
@@ -22,6 +22,7 @@ import { ConnectorSchedulingLogic } from '../connector_scheduling_logic';
 
 interface ConnectorCronEditorProps {
   disabled?: boolean;
+  frequencyBlockList?: string[];
   onReset?(): void;
   onSave?(interval: ConnectorScheduling['interval']): void;
   scheduling: ConnectorScheduling;
@@ -30,6 +31,7 @@ interface ConnectorCronEditorProps {
 
 export const ConnectorCronEditor: React.FC<ConnectorCronEditorProps> = ({
   disabled = false,
+  frequencyBlockList = ['MINUTE'],
   scheduling,
   onSave,
   onReset,
@@ -77,7 +79,7 @@ export const ConnectorCronEditor: React.FC<ConnectorCronEditorProps> = ({
             setNewInterval(expression);
             setHasChanges(type);
           }}
-          frequencyBlockList={['MINUTE']}
+          frequencyBlockList={frequencyBlockList}
         />
       </EuiFlexItem>
       <EuiFlexItem>
@@ -133,7 +135,7 @@ function cronToFrequency(cron: string): Frequency {
   if (fields.length < 4) {
     return 'YEAR';
   }
-  if (fields[1] === '*') {
+  if (fields[1] === '*' || fields[1].startsWith('*/')) {
     return 'MINUTE';
   }
   if (fields[2] === '*') {
@@ -142,7 +144,7 @@ function cronToFrequency(cron: string): Frequency {
   if (fields[3] === '*') {
     return 'DAY';
   }
-  if (fields[4] === '?') {
+  if (fields[3] === '?') {
     return 'WEEK';
   }
   if (fields[4] === '*') {

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_scheduling/full_content.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_scheduling/full_content.tsx
@@ -215,6 +215,7 @@ export const ConnectorContentScheduling: React.FC<ConnectorContentSchedulingProp
             <EuiFlexItem>
               <ConnectorCronEditor
                 disabled={isGated}
+                frequencyBlockList={type === SyncJobType.ACCESS_CONTROL ? [] : undefined}
                 scheduling={scheduling[type]}
                 type={type}
                 onReset={() => {

--- a/x-pack/plugins/enterprise_search/public/applications/shared/cron_editor/__snapshots__/cron_editor.test.tsx.snap
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/cron_editor/__snapshots__/cron_editor.test.tsx.snap
@@ -3387,6 +3387,995 @@ exports[`CronEditor is rendered with a MINUTE frequency 1`] = `
       </div>
     </div>
   </EuiFormRow>
+  <CronMinutely
+    minute="10"
+    minuteOptions={
+      Array [
+        Object {
+          "text": "1",
+          "value": "*/1",
+        },
+        Object {
+          "text": "2",
+          "value": "*/2",
+        },
+        Object {
+          "text": "3",
+          "value": "*/3",
+        },
+        Object {
+          "text": "4",
+          "value": "*/4",
+        },
+        Object {
+          "text": "5",
+          "value": "*/5",
+        },
+        Object {
+          "text": "6",
+          "value": "*/6",
+        },
+        Object {
+          "text": "7",
+          "value": "*/7",
+        },
+        Object {
+          "text": "8",
+          "value": "*/8",
+        },
+        Object {
+          "text": "9",
+          "value": "*/9",
+        },
+        Object {
+          "text": "10",
+          "value": "*/10",
+        },
+        Object {
+          "text": "11",
+          "value": "*/11",
+        },
+        Object {
+          "text": "12",
+          "value": "*/12",
+        },
+        Object {
+          "text": "13",
+          "value": "*/13",
+        },
+        Object {
+          "text": "14",
+          "value": "*/14",
+        },
+        Object {
+          "text": "15",
+          "value": "*/15",
+        },
+        Object {
+          "text": "16",
+          "value": "*/16",
+        },
+        Object {
+          "text": "17",
+          "value": "*/17",
+        },
+        Object {
+          "text": "18",
+          "value": "*/18",
+        },
+        Object {
+          "text": "19",
+          "value": "*/19",
+        },
+        Object {
+          "text": "20",
+          "value": "*/20",
+        },
+        Object {
+          "text": "21",
+          "value": "*/21",
+        },
+        Object {
+          "text": "22",
+          "value": "*/22",
+        },
+        Object {
+          "text": "23",
+          "value": "*/23",
+        },
+        Object {
+          "text": "24",
+          "value": "*/24",
+        },
+        Object {
+          "text": "25",
+          "value": "*/25",
+        },
+        Object {
+          "text": "26",
+          "value": "*/26",
+        },
+        Object {
+          "text": "27",
+          "value": "*/27",
+        },
+        Object {
+          "text": "28",
+          "value": "*/28",
+        },
+        Object {
+          "text": "29",
+          "value": "*/29",
+        },
+        Object {
+          "text": "30",
+          "value": "*/30",
+        },
+        Object {
+          "text": "31",
+          "value": "*/31",
+        },
+        Object {
+          "text": "32",
+          "value": "*/32",
+        },
+        Object {
+          "text": "33",
+          "value": "*/33",
+        },
+        Object {
+          "text": "34",
+          "value": "*/34",
+        },
+        Object {
+          "text": "35",
+          "value": "*/35",
+        },
+        Object {
+          "text": "36",
+          "value": "*/36",
+        },
+        Object {
+          "text": "37",
+          "value": "*/37",
+        },
+        Object {
+          "text": "38",
+          "value": "*/38",
+        },
+        Object {
+          "text": "39",
+          "value": "*/39",
+        },
+        Object {
+          "text": "40",
+          "value": "*/40",
+        },
+        Object {
+          "text": "41",
+          "value": "*/41",
+        },
+        Object {
+          "text": "42",
+          "value": "*/42",
+        },
+        Object {
+          "text": "43",
+          "value": "*/43",
+        },
+        Object {
+          "text": "44",
+          "value": "*/44",
+        },
+        Object {
+          "text": "45",
+          "value": "*/45",
+        },
+        Object {
+          "text": "46",
+          "value": "*/46",
+        },
+        Object {
+          "text": "47",
+          "value": "*/47",
+        },
+        Object {
+          "text": "48",
+          "value": "*/48",
+        },
+        Object {
+          "text": "49",
+          "value": "*/49",
+        },
+        Object {
+          "text": "50",
+          "value": "*/50",
+        },
+        Object {
+          "text": "51",
+          "value": "*/51",
+        },
+        Object {
+          "text": "52",
+          "value": "*/52",
+        },
+        Object {
+          "text": "53",
+          "value": "*/53",
+        },
+        Object {
+          "text": "54",
+          "value": "*/54",
+        },
+        Object {
+          "text": "55",
+          "value": "*/55",
+        },
+        Object {
+          "text": "56",
+          "value": "*/56",
+        },
+        Object {
+          "text": "57",
+          "value": "*/57",
+        },
+        Object {
+          "text": "58",
+          "value": "*/58",
+        },
+        Object {
+          "text": "59",
+          "value": "*/59",
+        },
+      ]
+    }
+    onChange={[Function]}
+  >
+    <EuiFormRow
+      data-test-subj="cronFrequencyConfiguration"
+      describedByIds={Array []}
+      display="row"
+      fullWidth={true}
+      hasChildLabel={true}
+      hasEmptyLabelSpace={false}
+      label={
+        <FormattedMessage
+          defaultMessage="Minute"
+          id="xpack.enterpriseSearch.cronEditor.cronMinutely.fieldTimeLabel"
+          values={Object {}}
+        />
+      }
+      labelType="label"
+    >
+      <div
+        className="euiFormRow euiFormRow--fullWidth euiFormRow--hasLabel"
+        data-test-subj="cronFrequencyConfiguration"
+        id="generated-id-row"
+      >
+        <div
+          className="euiFormRow__labelWrapper"
+        >
+          <EuiFormLabel
+            className="euiFormRow__label"
+            htmlFor="generated-id"
+            id="generated-id-label"
+            isFocused={false}
+            type="label"
+          >
+            <label
+              className="euiFormLabel euiFormRow__label"
+              htmlFor="generated-id"
+              id="generated-id-label"
+            >
+              <FormattedMessage
+                defaultMessage="Minute"
+                id="xpack.enterpriseSearch.cronEditor.cronMinutely.fieldTimeLabel"
+                values={Object {}}
+              >
+                Minute
+              </FormattedMessage>
+            </label>
+          </EuiFormLabel>
+        </div>
+        <div
+          className="euiFormRow__fieldWrapper"
+        >
+          <EuiSelect
+            append="minutes"
+            data-test-subj="cronFrequencyMinutelyMinuteSelect"
+            fullWidth={true}
+            id="generated-id"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            options={
+              Array [
+                Object {
+                  "text": "1",
+                  "value": "*/1",
+                },
+                Object {
+                  "text": "2",
+                  "value": "*/2",
+                },
+                Object {
+                  "text": "3",
+                  "value": "*/3",
+                },
+                Object {
+                  "text": "4",
+                  "value": "*/4",
+                },
+                Object {
+                  "text": "5",
+                  "value": "*/5",
+                },
+                Object {
+                  "text": "6",
+                  "value": "*/6",
+                },
+                Object {
+                  "text": "7",
+                  "value": "*/7",
+                },
+                Object {
+                  "text": "8",
+                  "value": "*/8",
+                },
+                Object {
+                  "text": "9",
+                  "value": "*/9",
+                },
+                Object {
+                  "text": "10",
+                  "value": "*/10",
+                },
+                Object {
+                  "text": "11",
+                  "value": "*/11",
+                },
+                Object {
+                  "text": "12",
+                  "value": "*/12",
+                },
+                Object {
+                  "text": "13",
+                  "value": "*/13",
+                },
+                Object {
+                  "text": "14",
+                  "value": "*/14",
+                },
+                Object {
+                  "text": "15",
+                  "value": "*/15",
+                },
+                Object {
+                  "text": "16",
+                  "value": "*/16",
+                },
+                Object {
+                  "text": "17",
+                  "value": "*/17",
+                },
+                Object {
+                  "text": "18",
+                  "value": "*/18",
+                },
+                Object {
+                  "text": "19",
+                  "value": "*/19",
+                },
+                Object {
+                  "text": "20",
+                  "value": "*/20",
+                },
+                Object {
+                  "text": "21",
+                  "value": "*/21",
+                },
+                Object {
+                  "text": "22",
+                  "value": "*/22",
+                },
+                Object {
+                  "text": "23",
+                  "value": "*/23",
+                },
+                Object {
+                  "text": "24",
+                  "value": "*/24",
+                },
+                Object {
+                  "text": "25",
+                  "value": "*/25",
+                },
+                Object {
+                  "text": "26",
+                  "value": "*/26",
+                },
+                Object {
+                  "text": "27",
+                  "value": "*/27",
+                },
+                Object {
+                  "text": "28",
+                  "value": "*/28",
+                },
+                Object {
+                  "text": "29",
+                  "value": "*/29",
+                },
+                Object {
+                  "text": "30",
+                  "value": "*/30",
+                },
+                Object {
+                  "text": "31",
+                  "value": "*/31",
+                },
+                Object {
+                  "text": "32",
+                  "value": "*/32",
+                },
+                Object {
+                  "text": "33",
+                  "value": "*/33",
+                },
+                Object {
+                  "text": "34",
+                  "value": "*/34",
+                },
+                Object {
+                  "text": "35",
+                  "value": "*/35",
+                },
+                Object {
+                  "text": "36",
+                  "value": "*/36",
+                },
+                Object {
+                  "text": "37",
+                  "value": "*/37",
+                },
+                Object {
+                  "text": "38",
+                  "value": "*/38",
+                },
+                Object {
+                  "text": "39",
+                  "value": "*/39",
+                },
+                Object {
+                  "text": "40",
+                  "value": "*/40",
+                },
+                Object {
+                  "text": "41",
+                  "value": "*/41",
+                },
+                Object {
+                  "text": "42",
+                  "value": "*/42",
+                },
+                Object {
+                  "text": "43",
+                  "value": "*/43",
+                },
+                Object {
+                  "text": "44",
+                  "value": "*/44",
+                },
+                Object {
+                  "text": "45",
+                  "value": "*/45",
+                },
+                Object {
+                  "text": "46",
+                  "value": "*/46",
+                },
+                Object {
+                  "text": "47",
+                  "value": "*/47",
+                },
+                Object {
+                  "text": "48",
+                  "value": "*/48",
+                },
+                Object {
+                  "text": "49",
+                  "value": "*/49",
+                },
+                Object {
+                  "text": "50",
+                  "value": "*/50",
+                },
+                Object {
+                  "text": "51",
+                  "value": "*/51",
+                },
+                Object {
+                  "text": "52",
+                  "value": "*/52",
+                },
+                Object {
+                  "text": "53",
+                  "value": "*/53",
+                },
+                Object {
+                  "text": "54",
+                  "value": "*/54",
+                },
+                Object {
+                  "text": "55",
+                  "value": "*/55",
+                },
+                Object {
+                  "text": "56",
+                  "value": "*/56",
+                },
+                Object {
+                  "text": "57",
+                  "value": "*/57",
+                },
+                Object {
+                  "text": "58",
+                  "value": "*/58",
+                },
+                Object {
+                  "text": "59",
+                  "value": "*/59",
+                },
+              ]
+            }
+            prepend="Every"
+            value="10"
+          >
+            <EuiFormControlLayout
+              append="minutes"
+              compressed={false}
+              fullWidth={true}
+              inputId="generated-id"
+              isDropdown={true}
+              isLoading={false}
+              prepend="Every"
+            >
+              <div
+                className="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--group"
+              >
+                <EuiFormLabel
+                  className="euiFormControlLayout__prepend"
+                  htmlFor="generated-id"
+                >
+                  <label
+                    className="euiFormLabel euiFormControlLayout__prepend"
+                    htmlFor="generated-id"
+                  >
+                    Every
+                  </label>
+                </EuiFormLabel>
+                <div
+                  className="euiFormControlLayout__childrenWrapper"
+                >
+                  <EuiValidatableControl>
+                    <select
+                      className="euiSelect euiFormControlLayout--1icons euiSelect--fullWidth euiSelect--inGroup"
+                      data-test-subj="cronFrequencyMinutelyMinuteSelect"
+                      id="generated-id"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onMouseUp={[Function]}
+                      value="10"
+                    >
+                      <option
+                        key="0"
+                        value="*/1"
+                      >
+                        1
+                      </option>
+                      <option
+                        key="1"
+                        value="*/2"
+                      >
+                        2
+                      </option>
+                      <option
+                        key="2"
+                        value="*/3"
+                      >
+                        3
+                      </option>
+                      <option
+                        key="3"
+                        value="*/4"
+                      >
+                        4
+                      </option>
+                      <option
+                        key="4"
+                        value="*/5"
+                      >
+                        5
+                      </option>
+                      <option
+                        key="5"
+                        value="*/6"
+                      >
+                        6
+                      </option>
+                      <option
+                        key="6"
+                        value="*/7"
+                      >
+                        7
+                      </option>
+                      <option
+                        key="7"
+                        value="*/8"
+                      >
+                        8
+                      </option>
+                      <option
+                        key="8"
+                        value="*/9"
+                      >
+                        9
+                      </option>
+                      <option
+                        key="9"
+                        value="*/10"
+                      >
+                        10
+                      </option>
+                      <option
+                        key="10"
+                        value="*/11"
+                      >
+                        11
+                      </option>
+                      <option
+                        key="11"
+                        value="*/12"
+                      >
+                        12
+                      </option>
+                      <option
+                        key="12"
+                        value="*/13"
+                      >
+                        13
+                      </option>
+                      <option
+                        key="13"
+                        value="*/14"
+                      >
+                        14
+                      </option>
+                      <option
+                        key="14"
+                        value="*/15"
+                      >
+                        15
+                      </option>
+                      <option
+                        key="15"
+                        value="*/16"
+                      >
+                        16
+                      </option>
+                      <option
+                        key="16"
+                        value="*/17"
+                      >
+                        17
+                      </option>
+                      <option
+                        key="17"
+                        value="*/18"
+                      >
+                        18
+                      </option>
+                      <option
+                        key="18"
+                        value="*/19"
+                      >
+                        19
+                      </option>
+                      <option
+                        key="19"
+                        value="*/20"
+                      >
+                        20
+                      </option>
+                      <option
+                        key="20"
+                        value="*/21"
+                      >
+                        21
+                      </option>
+                      <option
+                        key="21"
+                        value="*/22"
+                      >
+                        22
+                      </option>
+                      <option
+                        key="22"
+                        value="*/23"
+                      >
+                        23
+                      </option>
+                      <option
+                        key="23"
+                        value="*/24"
+                      >
+                        24
+                      </option>
+                      <option
+                        key="24"
+                        value="*/25"
+                      >
+                        25
+                      </option>
+                      <option
+                        key="25"
+                        value="*/26"
+                      >
+                        26
+                      </option>
+                      <option
+                        key="26"
+                        value="*/27"
+                      >
+                        27
+                      </option>
+                      <option
+                        key="27"
+                        value="*/28"
+                      >
+                        28
+                      </option>
+                      <option
+                        key="28"
+                        value="*/29"
+                      >
+                        29
+                      </option>
+                      <option
+                        key="29"
+                        value="*/30"
+                      >
+                        30
+                      </option>
+                      <option
+                        key="30"
+                        value="*/31"
+                      >
+                        31
+                      </option>
+                      <option
+                        key="31"
+                        value="*/32"
+                      >
+                        32
+                      </option>
+                      <option
+                        key="32"
+                        value="*/33"
+                      >
+                        33
+                      </option>
+                      <option
+                        key="33"
+                        value="*/34"
+                      >
+                        34
+                      </option>
+                      <option
+                        key="34"
+                        value="*/35"
+                      >
+                        35
+                      </option>
+                      <option
+                        key="35"
+                        value="*/36"
+                      >
+                        36
+                      </option>
+                      <option
+                        key="36"
+                        value="*/37"
+                      >
+                        37
+                      </option>
+                      <option
+                        key="37"
+                        value="*/38"
+                      >
+                        38
+                      </option>
+                      <option
+                        key="38"
+                        value="*/39"
+                      >
+                        39
+                      </option>
+                      <option
+                        key="39"
+                        value="*/40"
+                      >
+                        40
+                      </option>
+                      <option
+                        key="40"
+                        value="*/41"
+                      >
+                        41
+                      </option>
+                      <option
+                        key="41"
+                        value="*/42"
+                      >
+                        42
+                      </option>
+                      <option
+                        key="42"
+                        value="*/43"
+                      >
+                        43
+                      </option>
+                      <option
+                        key="43"
+                        value="*/44"
+                      >
+                        44
+                      </option>
+                      <option
+                        key="44"
+                        value="*/45"
+                      >
+                        45
+                      </option>
+                      <option
+                        key="45"
+                        value="*/46"
+                      >
+                        46
+                      </option>
+                      <option
+                        key="46"
+                        value="*/47"
+                      >
+                        47
+                      </option>
+                      <option
+                        key="47"
+                        value="*/48"
+                      >
+                        48
+                      </option>
+                      <option
+                        key="48"
+                        value="*/49"
+                      >
+                        49
+                      </option>
+                      <option
+                        key="49"
+                        value="*/50"
+                      >
+                        50
+                      </option>
+                      <option
+                        key="50"
+                        value="*/51"
+                      >
+                        51
+                      </option>
+                      <option
+                        key="51"
+                        value="*/52"
+                      >
+                        52
+                      </option>
+                      <option
+                        key="52"
+                        value="*/53"
+                      >
+                        53
+                      </option>
+                      <option
+                        key="53"
+                        value="*/54"
+                      >
+                        54
+                      </option>
+                      <option
+                        key="54"
+                        value="*/55"
+                      >
+                        55
+                      </option>
+                      <option
+                        key="55"
+                        value="*/56"
+                      >
+                        56
+                      </option>
+                      <option
+                        key="56"
+                        value="*/57"
+                      >
+                        57
+                      </option>
+                      <option
+                        key="57"
+                        value="*/58"
+                      >
+                        58
+                      </option>
+                      <option
+                        key="58"
+                        value="*/59"
+                      >
+                        59
+                      </option>
+                    </select>
+                  </EuiValidatableControl>
+                  <EuiFormControlLayoutIcons
+                    compressed={false}
+                    isDropdown={true}
+                    isLoading={false}
+                    side="right"
+                  >
+                    <div
+                      className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right euiFormControlLayoutIcons--absolute"
+                    >
+                      <EuiFormControlLayoutCustomIcon
+                        size="m"
+                        type="arrowDown"
+                      >
+                        <span
+                          className="euiFormControlLayoutCustomIcon"
+                        >
+                          <EuiIcon
+                            aria-hidden="true"
+                            className="euiFormControlLayoutCustomIcon__icon"
+                            size="m"
+                            type="arrowDown"
+                          >
+                            <span
+                              aria-hidden="true"
+                              className="euiFormControlLayoutCustomIcon__icon"
+                              data-euiicon-type="arrowDown"
+                              size="m"
+                            />
+                          </EuiIcon>
+                        </span>
+                      </EuiFormControlLayoutCustomIcon>
+                    </div>
+                  </EuiFormControlLayoutIcons>
+                </div>
+                <EuiFormLabel
+                  className="euiFormControlLayout__append"
+                  htmlFor="generated-id"
+                >
+                  <label
+                    className="euiFormLabel euiFormControlLayout__append"
+                    htmlFor="generated-id"
+                  >
+                    minutes
+                  </label>
+                </EuiFormLabel>
+              </div>
+            </EuiFormControlLayout>
+          </EuiSelect>
+        </div>
+      </div>
+    </EuiFormRow>
+  </CronMinutely>
 </CronEditor>
 `;
 

--- a/x-pack/plugins/enterprise_search/public/applications/shared/cron_editor/constants.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/cron_editor/constants.ts
@@ -24,6 +24,11 @@ function makeSequence(min: number, max: number): number[] {
   return values;
 }
 
+export const EVERY_MINUTE_OPTIONS = makeSequence(1, 59).map((value) => ({
+  value: '*/' + value.toString(),
+  text: value.toString(),
+}));
+
 export const MINUTE_OPTIONS = makeSequence(0, 59).map((value) => ({
   value: value.toString(),
   text: padStart(value.toString(), 2, '0'),
@@ -77,7 +82,7 @@ export const UNITS: EuiSelectOption[] = [
 ];
 
 export const frequencyToFieldsMap: Record<Frequency, FieldFlags> = {
-  MINUTE: {},
+  MINUTE: { minute: true },
   HOUR: {
     minute: true,
   },
@@ -106,7 +111,7 @@ export const frequencyToFieldsMap: Record<Frequency, FieldFlags> = {
 export const frequencyToBaselineFieldsMap: Record<Frequency, FieldToValueMap> = {
   MINUTE: {
     second: '0',
-    minute: '*',
+    minute: '*/1',
     hour: '*',
     date: '*',
     month: '*',

--- a/x-pack/plugins/enterprise_search/public/applications/shared/cron_editor/cron_editor.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/cron_editor/cron_editor.test.tsx
@@ -72,6 +72,20 @@ describe('CronEditor', () => {
         const minuteSelect = findTestSubject(component, 'cronFrequencyYearlyMinuteSelect');
         expect(minuteSelect.props().value).toBe('20');
       });
+
+      it('sets the values of the fields for minute', () => {
+        const component = mountWithI18nProvider(
+          <CronEditor
+            fieldToPreferredValueMap={{}}
+            frequency={'MINUTE'}
+            cronExpression="0 */18 * * * ?"
+            onChange={() => {}}
+          />
+        );
+
+        const monthSelect = findTestSubject(component, 'cronFrequencyMinutelyMinuteSelect');
+        expect(monthSelect.prop('value')).toBe('*/18');
+      });
     });
 
     describe('onChange', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/shared/cron_editor/cron_minutely.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/cron_editor/cron_minutely.tsx
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { Fragment } from 'react';
+
+import { EuiFormRow, EuiSelect, EuiSelectOption } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
+
+interface Props {
+  disabled?: boolean;
+  minute?: string;
+  minuteOptions: EuiSelectOption[];
+  onChange: ({ minute }: { minute?: string }) => void;
+}
+
+export const CronMinutely: React.FunctionComponent<Props> = ({
+  disabled,
+  minute,
+  minuteOptions,
+  onChange,
+}) => (
+  <Fragment>
+    <EuiFormRow
+      label={
+        <FormattedMessage
+          id="xpack.enterpriseSearch.cronEditor.cronMinutely.fieldTimeLabel"
+          defaultMessage="Minute"
+        />
+      }
+      fullWidth
+      data-test-subj="cronFrequencyConfiguration"
+    >
+      <EuiSelect
+        disabled={disabled}
+        options={minuteOptions}
+        value={minute}
+        onChange={(e) => onChange({ minute: e.target.value })}
+        fullWidth
+        prepend={i18n.translate(
+          'xpack.enterpriseSearch.cronEditor.cronMinutely.fieldMinute.textAtLabel',
+          {
+            defaultMessage: 'Every',
+          }
+        )}
+        append={i18n.translate(
+          'xpack.enterpriseSearch.cronEditor.cronMinutely.fieldMinute.textAppendLabel',
+          {
+            defaultMessage: 'minutes',
+          }
+        )}
+        data-test-subj="cronFrequencyMinutelyMinuteSelect"
+      />
+    </EuiFormRow>
+  </Fragment>
+);

--- a/x-pack/plugins/enterprise_search/public/applications/shared/cron_editor/services/cron.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/cron_editor/services/cron.ts
@@ -56,3 +56,18 @@ export function cronPartsToExpression({
 }: FieldToValueMap): string {
   return `${second} ${minute} ${hour} ${date} ${month} ${day}`;
 }
+
+export function convertToEveryXMinute(
+  minute: FieldToValueMap['minute']
+): FieldToValueMap['minute'] {
+  if (!minute) return minute;
+  if (minute.startsWith('*/')) return minute;
+  return '*/' + minute;
+}
+
+export function convertFromEveryXMinute(
+  minute: FieldToValueMap['minute']
+): FieldToValueMap['minute'] {
+  if (!minute) return minute;
+  return minute.startsWith('*/') ? minute.slice(2) : minute;
+}


### PR DESCRIPTION
## Summary

https://github.com/elastic/kibana/assets/1410658/b66d0278-e80b-4f2f-a1b3-d1d0f96c226d

Add minute cron editor.
Enable Minute for Access Control.
Fix Week not being remembered on page load.
Add helpers to convert cron expression in between `Every X Minutes` and back.

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))


<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->