### PR TITLE
[Security Solution] Added changelog links to the rules install and update pages

### DIFF
--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/add_prebuilt_rules_table/add_prebuilt_rules_table.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/add_prebuilt_rules_table/add_prebuilt_rules_table.tsx
@@ -11,10 +11,13 @@ import {
   EuiProgress,
   EuiSkeletonTitle,
   EuiSkeletonText,
+  EuiFlexGroup,
+  EuiFlexItem,
 } from '@elastic/eui';
 import React from 'react';
 
 import { RULES_TABLE_INITIAL_PAGE_SIZE, RULES_TABLE_PAGE_SIZE_OPTIONS } from '../constants';
+import { RulesChangelogLink } from '../rules_changelog_link';
 import { AddPrebuiltRulesTableNoItemsMessage } from './add_prebuilt_rules_no_items_message';
 import { useAddPrebuiltRulesTableContext } from './add_prebuilt_rules_table_context';
 import { AddPrebuiltRulesTableFilters } from './add_prebuilt_rules_table_filters';
@@ -67,7 +70,14 @@ export const AddPrebuiltRulesTable = React.memo(() => {
             <AddPrebuiltRulesTableNoItemsMessage />
           ) : (
             <>
-              <AddPrebuiltRulesTableFilters />
+              <EuiFlexGroup direction="column">
+                <EuiFlexItem grow={false}>
+                  <RulesChangelogLink />
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                  <AddPrebuiltRulesTableFilters />
+                </EuiFlexItem>
+              </EuiFlexGroup>
               <EuiInMemoryTable
                 items={filteredRules}
                 sorting

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_changelog_link.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_changelog_link.tsx
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { EuiLink } from '@elastic/eui';
+import React from 'react';
+import { useKibana } from '../../../../common/lib/kibana';
+import * as i18n from '../../../../detections/pages/detection_engine/rules/translations';
+
+export const RulesChangelogLink = React.memo(() => {
+  const { docLinks } = useKibana().services;
+
+  return (
+    <EuiLink
+      href={docLinks.links.siem.ruleChangeLog}
+      target="_blank"
+      external
+      data-test-subj="rules-changelog-link"
+    >
+      {i18n.RULE_UPDATES_DOCUMENTATION_LINK}
+    </EuiLink>
+  );
+});
+
+RulesChangelogLink.displayName = 'RulesChangelogLink';

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/upgrade_prebuilt_rules_table.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/upgrade_prebuilt_rules_table.tsx
@@ -18,6 +18,7 @@ import {
 import React from 'react';
 import * as i18n from '../../../../../detections/pages/detection_engine/rules/translations';
 import { RULES_TABLE_INITIAL_PAGE_SIZE, RULES_TABLE_PAGE_SIZE_OPTIONS } from '../constants';
+import { RulesChangelogLink } from '../rules_changelog_link';
 import { UpgradePrebuiltRulesTableButtons } from './upgrade_prebuilt_rules_table_buttons';
 import { useUpgradePrebuiltRulesTableContext } from './upgrade_prebuilt_rules_table_context';
 import { UpgradePrebuiltRulesTableFilters } from './upgrade_prebuilt_rules_table_filters';
@@ -78,12 +79,24 @@ export const UpgradePrebuiltRulesTable = React.memo(() => {
             NO_ITEMS_MESSAGE
           ) : (
             <>
-              <EuiFlexGroup alignItems="flexStart" gutterSize="s" responsive={false} wrap={true}>
-                <EuiFlexItem grow={true}>
-                  <UpgradePrebuiltRulesTableFilters />
+              <EuiFlexGroup direction="column">
+                <EuiFlexItem grow={false}>
+                  <RulesChangelogLink />
                 </EuiFlexItem>
                 <EuiFlexItem grow={false}>
-                  <UpgradePrebuiltRulesTableButtons />
+                  <EuiFlexGroup
+                    alignItems="flexStart"
+                    gutterSize="s"
+                    responsive={false}
+                    wrap={true}
+                  >
+                    <EuiFlexItem grow={true}>
+                      <UpgradePrebuiltRulesTableFilters />
+                    </EuiFlexItem>
+                    <EuiFlexItem grow={false}>
+                      <UpgradePrebuiltRulesTableButtons />
+                    </EuiFlexItem>
+                  </EuiFlexGroup>
                 </EuiFlexItem>
               </EuiFlexGroup>
 

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/translations.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/translations.ts
@@ -1218,3 +1218,10 @@ export const GO_BACK_TO_RULES_TABLE_BUTTON = i18n.translate(
     defaultMessage: 'Go back to installed Elastic rules',
   }
 );
+
+export const RULE_UPDATES_DOCUMENTATION_LINK = i18n.translate(
+  'xpack.securitySolution.ruleUpdates.documentationLink',
+  {
+    defaultMessage: "See what's new in Prebuilt Security Detection Rules",
+  }
+);


### PR DESCRIPTION
## Summary

Added links to documentation with the prebuilt rules package changelog from the Add and Update rules pages.

**Add rules page:**
![image](https://github.com/elastic/kibana/assets/1938181/bbe89be9-277a-4047-8981-2261cd4ee9a1)


**Update rules page:**
![image](https://github.com/elastic/kibana/assets/1938181/3d369efa-98d9-476d-9964-349c47482385)

**The link leads to the following documentation page:**
![image](https://github.com/elastic/kibana/assets/1938181/0db7f188-2947-494e-96f0-07cf4d5e60b9)



<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->