### PR TITLE
[Ops] Fix es snapshot startup for params with dots in their path

### DIFF
--- a/packages/kbn-es/src/utils/extract_config_files.test.js
+++ b/packages/kbn-es/src/utils/extract_config_files.test.js
@@ -10,6 +10,11 @@ jest.mock('fs', () => ({
   readFileSync: jest.fn(),
   existsSync: jest.fn().mockImplementation(() => true),
   writeFileSync: jest.fn(),
+  statSync: jest.fn((fileName) => {
+    return {
+      isFile: () => fileName.endsWith('.yml'),
+    };
+  }),
 }));
 
 const { extractConfigFiles } = require('./extract_config_files');
@@ -62,4 +67,11 @@ test('ignores directories', () => {
   const config = extractConfigFiles(['path=/data/foo.yml', 'foo.bar=/data/bar'], '/es');
 
   expect(config).toEqual(['path=foo.yml', 'foo.bar=/data/bar']);
+});
+
+test('ignores directories with dots in their names', () => {
+  fs.existsSync = () => true;
+  const config = extractConfigFiles(['path=/data/foo.yml', 'foo.bar=/data/ba/r.baz'], '/es');
+
+  expect(config).toEqual(['path=foo.yml', 'foo.bar=/data/ba/r.baz']);
 });

--- a/packages/kbn-es/src/utils/extract_config_files.ts
+++ b/packages/kbn-es/src/utils/extract_config_files.ts
@@ -29,6 +29,7 @@ export function extractConfigFiles(
     if (isFile(value)) {
       const filename = path.basename(value);
       const destPath = path.resolve(dest, 'config', filename);
+
       copyFileSync(value, destPath);
 
       options?.log.info('moved %s in config to %s', value, destPath);
@@ -43,7 +44,7 @@ export function extractConfigFiles(
 }
 
 function isFile(dest = '') {
-  return path.isAbsolute(dest) && path.extname(dest).length > 0 && fs.existsSync(dest);
+  return fs.existsSync(dest) && fs.statSync(dest).isFile();
 }
 
 function copyFileSync(src: string, dest: string) {


### PR DESCRIPTION
## Summary
In a module where we'd copy configuration files, an `isFile` function would give false positives on folders with `.` in their names (mistaking them for extensions). It's now fixed to use `statSync(...).isFile()`.

Closes #161013

### Checklist
[x] Unit test added, and works 

<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->