### PR TITLE
[Cloud Security] Remove CloudFormation from manual options

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/components/fleet_extensions/aws_credentials_form/get_aws_credentials_form_options.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/fleet_extensions/aws_credentials_form/get_aws_credentials_form_options.tsx
@@ -103,10 +103,12 @@ export const getAwsCredentialsFormManualOptions = (): Array<{
   value: AwsCredentialsType;
   text: string;
 }> => {
-  return Object.entries(getAwsCredentialsFormOptions()).map(([key, value]) => ({
-    value: key as AwsCredentialsType,
-    text: value.label,
-  }));
+  return Object.entries(getAwsCredentialsFormOptions())
+    .map(([key, value]) => ({
+      value: key as AwsCredentialsType,
+      text: value.label,
+    }))
+    .filter(({ value }) => value !== 'cloud_formation');
 };
 
 export const DEFAULT_MANUAL_AWS_CREDENTIALS_TYPE = 'assume_role';


### PR DESCRIPTION
## Summary

it #160879

This PR removes `cloud_formation` from manual options, as it must be selected using the Radio Button

### Screenshot

Before

![image](https://github.com/elastic/kibana/assets/19270322/eab12e8f-ce69-4875-b606-3418d1b7a952)


After

![image](https://github.com/elastic/kibana/assets/19270322/935589c3-d6fe-41ae-950b-3e064f8db1c8)


<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->