### PR TITLE
[http] capture errors thrown from handlers

### DIFF
--- a/src/core/server/integration_tests/http/router.test.mocks.ts
+++ b/src/core/server/integration_tests/http/router.test.mocks.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+export const captureErrorMock = jest.fn();
+
+jest.doMock('elastic-apm-node', () => {
+  const real = jest.requireActual('elastic-apm-node');
+  return {
+    ...real,
+    captureError: captureErrorMock,
+  };
+});

--- a/src/core/server/integration_tests/http/router.test.ts
+++ b/src/core/server/integration_tests/http/router.test.ts
@@ -6,6 +6,8 @@
  * Side Public License, v 1.
  */
 
+import { captureErrorMock } from './router.test.mocks';
+
 import { Stream } from 'stream';
 import Boom from '@hapi/boom';
 import supertest from 'supertest';
@@ -35,6 +37,7 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  captureErrorMock.mockReset();
   await server.stop();
 });
 
@@ -581,6 +584,22 @@ describe('Handler', () => {
     `);
   });
 
+  it('captures the error if handler throws', async () => {
+    const { server: innerServer, createRouter } = await server.setup(setupDeps);
+    const router = createRouter('/');
+
+    const error = new Error(`some error`);
+    router.get({ path: '/', validate: false }, (context, req, res) => {
+      throw error;
+    });
+    await server.start();
+
+    await supertest(innerServer.listener).get('/').expect(500);
+
+    expect(captureErrorMock).toHaveBeenCalledTimes(1);
+    expect(captureErrorMock).toHaveBeenCalledWith(error);
+  });
+
   it('returns 500 Server error if handler throws Boom error', async () => {
     const { server: innerServer, createRouter } = await server.setup(setupDeps);
     const router = createRouter('/');
@@ -602,6 +621,7 @@ describe('Handler', () => {
         ],
       ]
     `);
+    expect(captureErrorMock).toHaveBeenCalledTimes(1);
   });
 
   it('returns 500 Server error if handler returns unexpected result', async () => {

--- a/src/core/server/integration_tests/http/versioned_router.test.mocks.ts
+++ b/src/core/server/integration_tests/http/versioned_router.test.mocks.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+export const captureErrorMock = jest.fn();
+
+jest.doMock('elastic-apm-node', () => {
+  const real = jest.requireActual('elastic-apm-node');
+  return {
+    ...real,
+    captureError: captureErrorMock,
+  };
+});

--- a/src/core/server/integration_tests/http/versioned_router.test.ts
+++ b/src/core/server/integration_tests/http/versioned_router.test.ts
@@ -61,6 +61,7 @@ describe('Routing versioned requests', () => {
   });
 
   afterEach(async () => {
+    captureErrorMock.mockReset();
     await server.stop();
   });
 
@@ -169,6 +170,7 @@ describe('Routing versioned requests', () => {
         message: expect.stringMatching(/expected value of type/),
       })
     );
+    expect(captureErrorMock).not.toHaveBeenCalled();
   });
 
   it('returns the version in response headers', async () => {
@@ -212,6 +214,7 @@ describe('Routing versioned requests', () => {
         message: expect.stringMatching(/Failed output validation/),
       })
     );
+    expect(captureErrorMock).not.toHaveBeenCalled();
   });
 
   it('does not run response validation in prod', async () => {
@@ -297,6 +300,7 @@ describe('Routing versioned requests', () => {
     ).resolves.toEqual(
       expect.objectContaining({ message: expect.stringMatching(/No handlers registered/) })
     );
+    expect(captureErrorMock).not.toHaveBeenCalled();
   });
 
   it('resolves the newest handler on serverless', async () => {

--- a/src/core/server/integration_tests/http/versioned_router.test.ts
+++ b/src/core/server/integration_tests/http/versioned_router.test.ts
@@ -6,6 +6,8 @@
  * Side Public License, v 1.
  */
 
+import { captureErrorMock } from './versioned_router.test.mocks';
+
 import Supertest from 'supertest';
 import { createTestEnv, getEnvOptions } from '@kbn/config-mocks';
 import { schema } from '@kbn/config-schema';
@@ -339,5 +341,22 @@ describe('Routing versioned requests', () => {
         .expect(200)
         .then(({ body }) => body.v)
     ).resolves.toEqual('oldest');
+  });
+
+  it('captures the error if handler throws', async () => {
+    const error = new Error(`some error`);
+
+    router.versioned
+      .get({ path: '/my-path', access: 'internal' })
+      .addVersion({ validate: false, version: '1' }, async (ctx, req, res) => {
+        throw error;
+      });
+
+    await server.start();
+
+    await supertest.get('/my-path').set('Elastic-Api-Version', '1').expect(500);
+
+    expect(captureErrorMock).toHaveBeenCalledTimes(1);
+    expect(captureErrorMock).toHaveBeenCalledWith(error);
   });
 });


### PR DESCRIPTION
## Summary

Fix https://github.com/elastic/kibana/issues/156803

Use `apm.captureError` to properly capture errors thrown by the route handler (as those errors are then converted to generic 500 errors before being returned by the server to avoid leaking internal info)