### PR TITLE
[ftr/test_serverless] Remove common tests from serverless pipeline

### DIFF
--- a/.buildkite/pipelines/serverless.yml
+++ b/.buildkite/pipelines/serverless.yml
@@ -21,19 +21,6 @@ steps:
         - exit_status: '-1'
           limit: 3
 
-  - command: SERVERLESS_ENVIRONMENT=common .buildkite/scripts/steps/functional/serverless_ftr.sh
-    label: 'Serverless Common Tests'
-    agents:
-      queue: n2-4-spot
-    depends_on: build
-    timeout_in_minutes: 40
-    retry:
-      automatic:
-        - exit_status: '-1'
-          limit: 3
-        - exit_status: '*'
-          limit: 1
-
   - command: SERVERLESS_ENVIRONMENT=observability .buildkite/scripts/steps/functional/serverless_ftr.sh
     label: 'Serverless Observability Tests'
     agents:


### PR DESCRIPTION
## Summary

This PR removes the common tests from the serverless buildkite pipeline.

This is a follow-up on #160783 where I forgot to modify this script as the issue only occurred on main runs after PR merge.


<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->