### PR TITLE
[Infrastructure UI] Fix disk space usage chart Y axis

### DIFF
--- a/x-pack/plugins/infra/public/common/visualizations/lens/formulas/host/disk_space_usage.ts
+++ b/x-pack/plugins/infra/public/common/visualizations/lens/formulas/host/disk_space_usage.ts
@@ -5,8 +5,18 @@
  * 2.0.
  */
 
-import type { LensChartConfig } from '../../../types';
+import type { LensChartConfig, LensLineChartConfig } from '../../../types';
 import { getFilters } from './utils';
+
+export const diskSpaceUsageLineChart: LensLineChartConfig = {
+  extraVisualizationState: {
+    yLeftExtent: {
+      mode: 'custom',
+      lowerBound: 0,
+      upperBound: 1,
+    },
+  },
+};
 
 export const diskSpaceUsage: LensChartConfig = {
   title: 'Disk Space Usage',
@@ -20,4 +30,5 @@ export const diskSpaceUsage: LensChartConfig = {
     },
   },
   getFilters,
+  lineChartConfig: diskSpaceUsageLineChart,
 };


### PR DESCRIPTION
closes: [#161083](https://github.com/elastic/kibana/issues/161083)

## Summary

This PR fixes the Disk Space Usage Y axis to display the percentage range from 0% to 100%

<img width="725" alt="image" src="https://github.com/elastic/kibana/assets/2767137/60051a22-f693-4828-bd7b-b5f0e260cfa4">



### How to test

- Start a local Kibana instance
- Navigate to `Infrastructure` > `Hosts`
- Check the Disk Space Usage chart in the metrics tab


<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->