### PR TITLE
[8.9] [Synthetics] Fix test now monitor in non default space (#160976)

### DIFF
--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/manual_test_runs/actions.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/manual_test_runs/actions.ts
@@ -13,8 +13,12 @@ import { createAsyncAction } from '../utils/actions';
 export const toggleTestNowFlyoutAction = createAction<string>('TOGGLE TEST NOW FLYOUT ACTION');
 export const hideTestNowFlyoutAction = createAction('HIDE ALL TEST NOW FLYOUT ACTION');
 
+export interface TestNowPayload {
+  configId: string;
+  name: string;
+}
 export const manualTestMonitorAction = createAsyncAction<
-  { configId: string; name: string },
+  TestNowPayload,
   TestNowResponse | undefined
 >('TEST_NOW_MONITOR_ACTION');
 

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/manual_test_runs/index.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/manual_test_runs/index.ts
@@ -10,12 +10,14 @@ import { createReducer, PayloadAction } from '@reduxjs/toolkit';
 import { WritableDraft } from 'immer/dist/types/types-external';
 import { IHttpFetchError } from '@kbn/core-http-browser';
 
+import { ActionPayload } from '../utils/actions';
 import { TestNowResponse } from '../../../../../common/types';
 import {
   clearTestNowMonitorAction,
   hideTestNowFlyoutAction,
   manualTestMonitorAction,
   manualTestRunUpdateAction,
+  TestNowPayload,
   toggleTestNowFlyoutAction,
 } from './actions';
 import {
@@ -57,10 +59,7 @@ export const manualTestRunsReducer = createReducer(initialState, (builder) => {
   builder
     .addCase(
       String(manualTestMonitorAction.get),
-      (
-        state: WritableDraft<ManualTestRunsState>,
-        action: PayloadAction<{ configId: string; name: string }>
-      ) => {
+      (state: WritableDraft<ManualTestRunsState>, action: PayloadAction<TestNowPayload>) => {
         state = Object.values(state).reduce((acc, curr) => {
           acc[curr.configId] = {
             ...curr,
@@ -98,9 +97,12 @@ export const manualTestRunsReducer = createReducer(initialState, (builder) => {
     )
     .addCase(
       String(manualTestMonitorAction.fail),
-      (state: WritableDraft<ManualTestRunsState>, action: PayloadAction<TestNowResponse>) => {
+      (
+        state: WritableDraft<ManualTestRunsState>,
+        action: ActionPayload<TestNowResponse, TestNowPayload>
+      ) => {
         const fetchError = action.payload as unknown as IHttpFetchError;
-        if (fetchError?.request.url) {
+        if (fetchError?.request?.url) {
           const { name, message } = fetchError;
 
           const [, errorMonitor] =
@@ -117,10 +119,10 @@ export const manualTestRunsReducer = createReducer(initialState, (builder) => {
             };
           }
         }
-
-        if (action.payload.configId) {
-          state[action.payload.configId] = {
-            ...state[action.payload.configId],
+        const configId = action.payload.configId ?? action.payload.getPayload?.configId;
+        if (configId) {
+          state[configId] = {
+            ...state[configId],
             status: TestRunStatus.COMPLETED,
             errors: action.payload.errors,
             fetchError: undefined,

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/utils/actions.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/utils/actions.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { createAction } from '@reduxjs/toolkit';
+import { createAction, PayloadAction } from '@reduxjs/toolkit';
 import type { IHttpSerializedFetchError } from './http_error';
 
 export function createAsyncAction<
@@ -30,4 +30,8 @@ function prepareForTimestamp<Payload>(payload: Payload) {
       dispatchedAt: Date.now(),
     },
   };
+}
+
+export interface ActionPayload<P, G> extends PayloadAction<P> {
+  payload: P & { getPayload?: G };
 }

--- a/x-pack/plugins/synthetics/server/routes/monitor_cruds/add_monitor.ts
+++ b/x-pack/plugins/synthetics/server/routes/monitor_cruds/add_monitor.ts
@@ -316,9 +316,13 @@ const setupGettingStarted = (configId: string, routeContext: RouteContext) => {
 
     if (gettingStarted) {
       // ignore await, since we don't want to block the response
-      triggerTestNow(configId, routeContext).then(() => {
-        server.logger.debug(`Successfully triggered test for monitor: ${configId}`);
-      });
+      triggerTestNow(configId, routeContext)
+        .then(() => {
+          server.logger.debug(`Successfully triggered test for monitor: ${configId}`);
+        })
+        .catch((e) => {
+          server.logger.error(`Error triggering test for monitor: ${configId}: ${e}`);
+        });
     }
   } catch (e) {
     server.logger.info(`Error triggering test for getting started monitor: ${configId}`);

--- a/x-pack/plugins/synthetics/server/routes/synthetics_service/test_now_monitor.ts
+++ b/x-pack/plugins/synthetics/server/routes/synthetics_service/test_now_monitor.ts
@@ -40,7 +40,10 @@ export const triggerTestNow = async (
   const monitorWithSecrets =
     await encryptedClient.getDecryptedAsInternalUser<SyntheticsMonitorWithSecrets>(
       syntheticsMonitorType,
-      monitorId
+      monitorId,
+      {
+        namespace: spaceId,
+      }
     );
   const normalizedMonitor = normalizeSecrets(monitorWithSecrets);
 

--- a/x-pack/test/api_integration/apis/synthetics/index.ts
+++ b/x-pack/test/api_integration/apis/synthetics/index.ts
@@ -32,5 +32,6 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
     loadTestFile(require.resolve('./add_edit_params'));
     loadTestFile(require.resolve('./add_monitor_project_private_location'));
     loadTestFile(require.resolve('./inspect_monitor'));
+    loadTestFile(require.resolve('./test_now_monitor'));
   });
 }

--- a/x-pack/test/api_integration/apis/synthetics/services/synthetics_monitor_test_service.ts
+++ b/x-pack/test/api_integration/apis/synthetics/services/synthetics_monitor_test_service.ts
@@ -10,14 +10,17 @@ import { syntheticsMonitorType } from '@kbn/synthetics-plugin/common/types/saved
 import { SavedObject } from '@kbn/core-saved-objects-common/src/server_types';
 import { MonitorFields } from '@kbn/synthetics-plugin/common/runtime_types';
 import { MonitorInspectResponse } from '@kbn/synthetics-plugin/public/apps/synthetics/state/monitor_management/api';
+import { v4 as uuidv4 } from 'uuid';
 import { FtrProviderContext } from '../../../ftr_provider_context';
 import { KibanaSupertestProvider } from '../../../../../../test/api_integration/services/supertest';
 
 export class SyntheticsMonitorTestService {
   private supertest: ReturnType<typeof KibanaSupertestProvider>;
+  private getService: FtrProviderContext['getService'];
 
   constructor(getService: FtrProviderContext['getService']) {
     this.supertest = getService('supertest');
+    this.getService = getService;
   }
 
   async getMonitor(monitorId: string, decrypted: boolean = true, space?: string) {
@@ -94,5 +97,35 @@ export class SyntheticsMonitorTestService {
       // eslint-disable-next-line no-console
       console.error(e);
     }
+  }
+
+  async addsNewSpace() {
+    const username = 'admin';
+    const password = `${username}-password`;
+    const roleName = 'uptime-role';
+    const SPACE_ID = `test-space-${uuidv4()}`;
+    const SPACE_NAME = `test-space-name ${uuidv4()}`;
+
+    const security = this.getService('security');
+    const kibanaServer = this.getService('kibanaServer');
+
+    await kibanaServer.spaces.create({ id: SPACE_ID, name: SPACE_NAME });
+    await security.role.create(roleName, {
+      kibana: [
+        {
+          feature: {
+            uptime: ['all'],
+          },
+          spaces: ['*'],
+        },
+      ],
+    });
+    await security.user.create(username, {
+      password,
+      roles: [roleName],
+      full_name: 'a kibana user',
+    });
+
+    return { username, password, SPACE_ID };
   }
 }

--- a/x-pack/test/api_integration/apis/synthetics/test_now_monitor.ts
+++ b/x-pack/test/api_integration/apis/synthetics/test_now_monitor.ts
@@ -1,0 +1,112 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { MonitorFields } from '@kbn/synthetics-plugin/common/runtime_types';
+import { SYNTHETICS_API_URLS } from '@kbn/synthetics-plugin/common/constants';
+import expect from '@kbn/expect';
+import { omit } from 'lodash';
+import { FtrProviderContext } from '../../ftr_provider_context';
+import { getFixtureJson } from './helper/get_fixture_json';
+import { SyntheticsMonitorTestService } from './services/synthetics_monitor_test_service';
+
+export default function ({ getService }: FtrProviderContext) {
+  describe('RunTestManually', function () {
+    this.tags('skipCloud');
+
+    const supertest = getService('supertest');
+    const supertestWithoutAuth = getService('supertestWithoutAuth');
+
+    const monitorTestService = new SyntheticsMonitorTestService(getService);
+    const kibanaServer = getService('kibanaServer');
+
+    let newMonitor: MonitorFields;
+
+    before(async () => {
+      await kibanaServer.savedObjects.cleanStandardList();
+      await supertest
+        .put(SYNTHETICS_API_URLS.SYNTHETICS_ENABLEMENT)
+        .set('kbn-xsrf', 'true')
+        .expect(200);
+      newMonitor = getFixtureJson('http_monitor');
+    });
+
+    it('runs test manually', async () => {
+      const resp = await monitorTestService.addMonitor(newMonitor);
+
+      const res = await supertest
+        .get(SYNTHETICS_API_URLS.TRIGGER_MONITOR + `/${resp.id}`)
+        .set('kbn-xsrf', 'true')
+        .expect(200);
+
+      const result = res.body;
+      expect(typeof result.testRunId).to.eql('string');
+      expect(typeof result.configId).to.eql('string');
+      expect(result.schedule).to.eql({ number: '5', unit: 'm' });
+      expect(result.locations).to.eql([
+        {
+          id: 'eu-west-01',
+          label: 'Europe East',
+          geo: { lat: 33.2343132435, lon: 73.2342343434 },
+          url: 'https://example-url.com',
+          isServiceManaged: true,
+        },
+        {
+          id: 'eu-west-02',
+          label: 'Europe West',
+          geo: { lat: 33.2343132435, lon: 73.2342343434 },
+          url: 'https://example-url.com',
+          isServiceManaged: true,
+        },
+      ]);
+
+      expect(omit(result.monitor, ['id', 'config_id'])).to.eql(
+        omit(newMonitor, ['id', 'config_id'])
+      );
+    });
+
+    it('works in non default space', async () => {
+      const { username, SPACE_ID, password } = await monitorTestService.addsNewSpace();
+
+      const resp = await supertestWithoutAuth
+        .post(`/s/${SPACE_ID}${SYNTHETICS_API_URLS.SYNTHETICS_MONITORS}`)
+        .auth(username, password)
+        .set('kbn-xsrf', 'true')
+        .send(newMonitor)
+        .expect(200);
+
+      const res = await supertest
+        .get(`/s/${SPACE_ID}${SYNTHETICS_API_URLS.TRIGGER_MONITOR}/${resp.body.id}`)
+        .set('kbn-xsrf', 'true')
+        .expect(200);
+
+      const result = res.body;
+      expect(typeof result.testRunId).to.eql('string');
+      expect(typeof result.configId).to.eql('string');
+      expect(result.schedule).to.eql({ number: '5', unit: 'm' });
+      expect(result.locations).to.eql([
+        {
+          id: 'eu-west-01',
+          label: 'Europe East',
+          geo: { lat: 33.2343132435, lon: 73.2342343434 },
+          url: 'https://example-url.com',
+          isServiceManaged: true,
+        },
+        {
+          id: 'eu-west-02',
+          label: 'Europe West',
+          geo: { lat: 33.2343132435, lon: 73.2342343434 },
+          url: 'https://example-url.com',
+          isServiceManaged: true,
+        },
+      ]);
+
+      expect(omit(result.monitor, ['id', 'config_id'])).to.eql(
+        omit(newMonitor, ['id', 'config_id'])
+      );
+    });
+  });
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.9`:
 - [[Synthetics] Fix test now monitor in non default space (#160976)](https://github.com/elastic/kibana/pull/160976)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Shahzad","email":"shahzad31comp@gmail.com"},"sourceCommit":{"committedDate":"2023-07-03T11:45:31Z","message":"[Synthetics] Fix test now monitor in non default space (#160976)","sha":"933a3666d056e16dbd0aca4044ac904b7723a24f","branchLabelMapping":{"^v8.10.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:uptime","release_note:skip","v8.9.0","v8.10.0"],"number":160976,"url":"https://github.com/elastic/kibana/pull/160976","mergeCommit":{"message":"[Synthetics] Fix test now monitor in non default space (#160976)","sha":"933a3666d056e16dbd0aca4044ac904b7723a24f"}},"sourceBranch":"main","suggestedTargetBranches":["8.9"],"targetPullRequestStates":[{"branch":"8.9","label":"v8.9.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.10.0","labelRegex":"^v8.10.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/160976","number":160976,"mergeCommit":{"message":"[Synthetics] Fix test now monitor in non default space (#160976)","sha":"933a3666d056e16dbd0aca4044ac904b7723a24f"}}]}] BACKPORT-->