### PR TITLE
[ML] Removing unused reset and records endpoints

### DIFF
--- a/x-pack/plugins/ml/public/application/services/ml_api_service/index.ts
+++ b/x-pack/plugins/ml/public/application/services/ml_api_service/index.ts
@@ -20,10 +20,7 @@ import type {
 } from '../../../../common/types/ml_server_info';
 import type { MlCapabilitiesResponse } from '../../../../common/types/capabilities';
 import type { Calendar, CalendarId, UpdateCalendar } from '../../../../common/types/calendars';
-import type {
-  BucketSpanEstimatorData,
-  ResetJobsResponse,
-} from '../../../../common/types/job_service';
+import type { BucketSpanEstimatorData } from '../../../../common/types/job_service';
 import type {
   Job,
   JobStats,
@@ -202,14 +199,6 @@ export function mlApiServicesProvider(httpService: HttpService) {
         path: `${ML_INTERNAL_BASE_PATH}/anomaly_detectors/${jobId}/_update`,
         method: 'POST',
         body,
-        version: '1',
-      });
-    },
-
-    resetJob({ jobId }: { jobId: string }) {
-      return httpService.http<ResetJobsResponse>({
-        path: `${ML_INTERNAL_BASE_PATH}/anomaly_detectors/${jobId}/_reset`,
-        method: 'POST',
         version: '1',
       });
     },

--- a/x-pack/plugins/ml/server/routes/anomaly_detectors.ts
+++ b/x-pack/plugins/ml/server/routes/anomaly_detectors.ts
@@ -14,7 +14,6 @@ import {
   anomalyDetectionJobSchema,
   anomalyDetectionUpdateJobSchema,
   jobIdSchema,
-  getRecordsSchema,
   getBucketsSchema,
   getOverallBucketsSchema,
   getCategoriesSchema,
@@ -24,7 +23,6 @@ import {
   updateModelSnapshotsSchema,
   updateModelSnapshotBodySchema,
   forceQuerySchema,
-  jobResetQuerySchema,
 } from './schemas/anomaly_detectors_schema';
 import { getAuthorizationHeader } from '../lib/request_authorization';
 
@@ -365,53 +363,6 @@ export function jobRoutes({ router, routeGuard }: RouteInitialization) {
   /**
    * @apiGroup AnomalyDetectors
    *
-   * @api {post} /internal/ml/anomaly_detectors/:jobId/_reset Reset specified job
-   * @apiName ResetAnomalyDetectorsJob
-   * @apiDescription Resets an anomaly detection job.
-   *
-   * @apiSchema (params) jobIdSchema
-   * @apiSchema (query) jobResetQuerySchema
-   */
-  router.versioned
-    .post({
-      path: `${ML_INTERNAL_BASE_PATH}/anomaly_detectors/{jobId}/_reset`,
-      access: 'internal',
-      options: {
-        tags: ['access:ml:canCloseJob'],
-      },
-    })
-    .addVersion(
-      {
-        version: '1',
-        validate: {
-          request: {
-            params: jobIdSchema,
-            query: jobResetQuerySchema,
-          },
-        },
-      },
-      routeGuard.fullLicenseAPIGuard(async ({ mlClient, request, response }) => {
-        try {
-          const options: { job_id: string; wait_for_completion?: boolean } = {
-            // TODO change this to correct resetJob request type
-            job_id: request.params.jobId,
-            ...(request.query.wait_for_completion !== undefined
-              ? { wait_for_completion: request.query.wait_for_completion }
-              : {}),
-          };
-          const body = await mlClient.resetJob(options);
-          return response.ok({
-            body,
-          });
-        } catch (e) {
-          return response.customError(wrapError(e));
-        }
-      })
-    );
-
-  /**
-   * @apiGroup AnomalyDetectors
-   *
    * @api {delete} /internal/ml/anomaly_detectors/:jobId Delete specified job
    * @apiName DeleteAnomalyDetectorsJob
    * @apiDescription Deletes specified anomaly detection job.
@@ -530,52 +481,6 @@ export function jobRoutes({ router, routeGuard }: RouteInitialization) {
             body: {
               duration,
             },
-          });
-          return response.ok({
-            body,
-          });
-        } catch (e) {
-          return response.customError(wrapError(e));
-        }
-      })
-    );
-
-  /**
-   * @apiGroup AnomalyDetectors
-   *
-   * @api {post} /internal/ml/anomaly_detectors/:jobId/results/records  Retrieves anomaly records for a job.
-   * @apiName GetRecords
-   * @apiDescription Retrieves anomaly records for a job.
-   *
-   * @apiSchema (params) jobIdSchema
-   * @apiSchema (body) getRecordsSchema
-   *
-   * @apiSuccess {Number} count
-   * @apiSuccess {Object[]} records
-   */
-  router.versioned
-    .post({
-      path: `${ML_INTERNAL_BASE_PATH}/anomaly_detectors/{jobId}/results/records`,
-      access: 'internal',
-      options: {
-        tags: ['access:ml:canGetJobs'],
-      },
-    })
-    .addVersion(
-      {
-        version: '1',
-        validate: {
-          request: {
-            params: jobIdSchema,
-            body: getRecordsSchema,
-          },
-        },
-      },
-      routeGuard.fullLicenseAPIGuard(async ({ mlClient, request, response }) => {
-        try {
-          const body = await mlClient.getRecords({
-            job_id: request.params.jobId,
-            body: request.body,
           });
           return response.ok({
             body,

--- a/x-pack/plugins/ml/server/routes/schemas/anomaly_detectors_schema.ts
+++ b/x-pack/plugins/ml/server/routes/schemas/anomaly_detectors_schema.ts
@@ -145,21 +145,6 @@ export const jobIdSchema = schema.object({
   jobId: schema.string(),
 });
 
-export const getRecordsSchema = schema.object({
-  desc: schema.maybe(schema.boolean()),
-  end: schema.maybe(schema.string()),
-  exclude_interim: schema.maybe(schema.boolean()),
-  page: schema.maybe(
-    schema.object({
-      from: schema.number(),
-      size: schema.number(),
-    })
-  ),
-  record_score: schema.maybe(schema.number()),
-  sort: schema.maybe(schema.string()),
-  start: schema.maybe(schema.string()),
-});
-
 export const getBucketsSchema = schema.object({
   anomaly_score: schema.maybe(schema.number()),
   desc: schema.maybe(schema.boolean()),
@@ -221,11 +206,6 @@ export const updateModelSnapshotBodySchema = schema.object({
 });
 
 export const forecastAnomalyDetector = schema.object({ duration: schema.any() });
-
-export const jobResetQuerySchema = schema.object({
-  /** wait for completion */
-  wait_for_completion: schema.maybe(schema.boolean()),
-});
 
 export const forceQuerySchema = schema.object({
   /** force close */


### PR DESCRIPTION
Removing two endpoints in the kibana server which are no longer used by ML on the client side.

`/anomaly_detectors/${jobId}/_reset`
This has been superseded by `/jobs/reset_jobs` which takes multiple job IDs

`/anomaly_detectors/{jobId}/results/records`
I believe this has never been used, as it didn't have a client side function.

Relates to https://github.com/elastic/kibana/issues/157980