### PR TITLE
[Enterprise Search] Remove access control as well if exists

### DIFF
--- a/x-pack/plugins/enterprise_search/server/lib/indices/delete_access_control_index.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/indices/delete_access_control_index.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { IScopedClusterClient } from '@kbn/core/server';
+
+import { CONNECTORS_ACCESS_CONTROL_INDEX_PREFIX } from '../..';
+
+export const deleteAccessControlIndex = async (client: IScopedClusterClient, index: string) => {
+  const accessControlExists = await client.asCurrentUser.indices.exists({
+    index: index.replace('search-', CONNECTORS_ACCESS_CONTROL_INDEX_PREFIX),
+  });
+  if (accessControlExists) {
+    await client.asCurrentUser.indices.delete({
+      index: index.replace('search-', CONNECTORS_ACCESS_CONTROL_INDEX_PREFIX),
+    });
+  }
+};

--- a/x-pack/plugins/enterprise_search/server/routes/enterprise_search/indices.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/enterprise_search/indices.ts
@@ -202,9 +202,9 @@ export function registerIndexRoutes({
         }
 
         await deleteIndexPipelines(client, indexName);
+        await deleteAccessControlIndex(client, indexName);
 
         await client.asCurrentUser.indices.delete({ index: indexName });
-        await deleteAccessControlIndex(client, indexName);
 
         return response.ok({
           body: {},

--- a/x-pack/plugins/enterprise_search/server/routes/enterprise_search/indices.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/enterprise_search/indices.ts
@@ -26,6 +26,7 @@ import { fetchConnectorByIndexName, fetchConnectors } from '../../lib/connectors
 import { fetchCrawlerByIndexName, fetchCrawlers } from '../../lib/crawler/fetch_crawlers';
 
 import { createIndex } from '../../lib/indices/create_index';
+import { deleteAccessControlIndex } from '../../lib/indices/delete_access_control_index';
 import { indexOrAliasExists } from '../../lib/indices/exists_index';
 import { fetchIndex } from '../../lib/indices/fetch_index';
 import { fetchIndices, fetchSearchIndices } from '../../lib/indices/fetch_indices';
@@ -203,6 +204,7 @@ export function registerIndexRoutes({
         await deleteIndexPipelines(client, indexName);
 
         await client.asCurrentUser.indices.delete({ index: indexName });
+        await deleteAccessControlIndex(client, indexName);
 
         return response.ok({
           body: {},

--- a/x-pack/plugins/enterprise_search/tsconfig.json
+++ b/x-pack/plugins/enterprise_search/tsconfig.json
@@ -61,5 +61,6 @@
     "@kbn/shared-ux-link-redirect-app",
     "@kbn/global-search-plugin",
     "@kbn/share-plugin",
+    "@kbn/core-saved-objects-migration-server-internal",
   ]
 }


### PR DESCRIPTION
## Summary

- Add access control remove
- Deletes access control index too after content index is deleted.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->