### PR TITLE
[APM] Add type for route options

### DIFF
--- a/x-pack/plugins/apm/server/routes/typings.ts
+++ b/x-pack/plugins/apm/server/routes/typings.ts
@@ -11,6 +11,7 @@ import {
   Logger,
   KibanaRequest,
   CoreStart,
+  RouteConfigOptions,
 } from '@kbn/core/server';
 import { IRuleDataClient } from '@kbn/rule-registry-plugin/server';
 import { AlertingApiRequestHandlerContext } from '@kbn/alerting-plugin/server';
@@ -41,7 +42,7 @@ export interface APMRouteCreateOptions {
     >;
     body?: { accepts: Array<'application/json' | 'multipart/form-data'> };
     disableTelemetry?: boolean;
-  };
+  } & RouteConfigOptions<any>;
 }
 
 export type TelemetryUsageCounter = ReturnType<


### PR DESCRIPTION
Add missing type for route options. This is necessary for specifying `maxBytes`.

cc @LikeTheSalad 