### PR TITLE
[Fleet] using common package cache

### DIFF
--- a/x-pack/plugins/fleet/server/services/agent_policies/full_agent_policy.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policies/full_agent_policy.ts
@@ -48,15 +48,13 @@ async function fetchAgentPolicy(soClient: SavedObjectsClientContract, id: string
 
 export async function getFullAgentPolicies(
   soClient: SavedObjectsClientContract,
-  ids: string[]
+  ids: string[],
+  packageCache: Map<string, PackageInfo>
 ): Promise<Array<FullAgentPolicy | null>> {
   const fullAgentPolicies = [];
 
-  // Using a common cache for bulk update of agent policies
-  const packageInfoCache = new Map<string, PackageInfo>();
-
   for (const id of ids) {
-    const fullAgentPolicy = await getFullAgentPolicy(soClient, id, undefined, packageInfoCache);
+    const fullAgentPolicy = await getFullAgentPolicy(soClient, id, undefined, packageCache);
     fullAgentPolicies.push(fullAgentPolicy);
   }
   return fullAgentPolicies;

--- a/x-pack/plugins/fleet/server/services/agent_policies/index.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policies/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-export { getFullAgentPolicy } from './full_agent_policy';
+export { getFullAgentPolicy, getFullAgentPolicies } from './full_agent_policy';
 export {
   storedPackagePolicyToAgentInputs,
   storedPackagePoliciesToAgentInputs,

--- a/x-pack/plugins/fleet/server/services/agent_policy.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policy.ts
@@ -806,7 +806,11 @@ class AgentPolicyService {
     await this.deployPolicies(soClient, [agentPolicyId]);
   }
 
-  public async deployPolicies(soClient: SavedObjectsClientContract, agentPolicyIds: string[]) {
+  public async deployPolicies(
+    soClient: SavedObjectsClientContract,
+    agentPolicyIds: string[],
+    packageCache: Map<string, PackageInfo>
+  ) {
     // Use internal ES client so we have permissions to write to .fleet* indices
     const esClient = appContextService.getInternalUserESClient();
     const defaultOutputId = await outputService.getDefaultDataOutputId(soClient);
@@ -823,7 +827,11 @@ class AgentPolicyService {
 
     const policies = await agentPolicyService.getByIDs(soClient, agentPolicyIds);
     const policiesMap = keyBy(policies, 'id');
-    const fullPolicies = await agentPolicyService.getFullAgentPolicies(soClient, agentPolicyIds);
+    const fullPolicies = await agentPolicyService.getFullAgentPolicies(
+      soClient,
+      agentPolicyIds,
+      packageCache
+    );
 
     const fleetServerPolicies = fullPolicies.reduce((acc, fullPolicy) => {
       if (!fullPolicy || !fullPolicy.revision) {
@@ -1018,9 +1026,10 @@ class AgentPolicyService {
 
   public async getFullAgentPolicies(
     soClient: SavedObjectsClientContract,
-    ids: string[]
-  ): Promise<FullAgentPolicy | null> {
-    return getFullAgentPolicies(soClient, ids);
+    ids: string[],
+    packageCache: Map<string, PackageInfo>
+  ): Promise<Array<FullAgentPolicy | null>> {
+    return getFullAgentPolicies(soClient, ids, packageCache);
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/158361

Created `getFullAgentPolicies` that builds a common `packageInfoCache`. This helps speed up the bulk agent policy update on schema update, that used too much RSS in 8.8 upgrade.

Further improvement: use a common cache across all batches in [upgradeAgentPolicySchemaVersion]( https://github.com/elastic/kibana/blob/main/x-pack/plugins/fleet/server/services/setup/upgrade_agent_policy_schema_version.ts#L42)

### Checklist

- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
