### PR TITLE
[DOCS] Update the 8.8.2 release notes

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -54,7 +54,6 @@ Review the following information about the {kib} 8.8.2 release.
 === Bug Fixes
 
 APM::
-* Circuit breaker and performance improvements for service map {kibana-pull}159883[#159883]
 * Fixes the latency graph displaying all service transactions, rather than the selected one, on the transaction detail page {kibana-pull}159085[#159085]
 
 Dashboard::


### PR DESCRIPTION
Removes the following entry `Circuit breaker and performance improvements for service map [#159883](https://github.com/elastic/kibana/pull/159883)` as it was reverted by https://github.com/elastic/kibana/pull/160132 and was not released in 8.8.2.

<img width="1706" alt="image" src="https://github.com/elastic/kibana/assets/5831975/691e7688-0be4-49ef-b6a0-ac1e6468af02">


<!--ONMERGE {"backportTargets":["8.8","8.9"]} ONMERGE-->