### PR TITLE
[Synthetics] Remove TLS alert option for ICMP monitor

### DIFF
--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/form/field_config.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/form/field_config.tsx
@@ -507,9 +507,13 @@ export const FIELD = (readOnly?: boolean): FieldMap => ({
     controlled: true,
     props: ({ setValue, field }): EuiSwitchProps => ({
       id: 'syntheticsMonitorConfigIsAlertEnabled',
-      label: i18n.translate('xpack.synthetics.monitorConfig.enabledAlerting.label', {
-        defaultMessage: 'Enable status alerts',
-      }),
+      label: field?.value
+        ? i18n.translate('xpack.synthetics.monitorConfig.enabledAlerting.label', {
+            defaultMessage: 'Disable status alerts on this monitor',
+          })
+        : i18n.translate('xpack.synthetics.monitorConfig.disabledAlerting.label', {
+            defaultMessage: 'Enable status alerts on this monitor',
+          }),
       checked: field?.value || false,
       onChange: (event) => {
         setValue(AlertConfigKey.STATUS_ENABLED, !!event.target.checked);
@@ -522,18 +526,15 @@ export const FIELD = (readOnly?: boolean): FieldMap => ({
   [AlertConfigKey.TLS_ENABLED]: {
     fieldKey: AlertConfigKey.TLS_ENABLED,
     component: Switch,
-    label: i18n.translate('xpack.synthetics.monitorConfig.enabledAlerting.tls.label', {
-      defaultMessage: 'Enable TLS alerts',
-    }),
     controlled: true,
-    props: ({ isEdit, setValue, field }): EuiSwitchProps => ({
+    props: ({ setValue, field }): EuiSwitchProps => ({
       id: 'syntheticsMonitorConfigIsTlsAlertEnabled',
-      label: isEdit
+      label: field?.value
         ? i18n.translate('xpack.synthetics.monitorConfig.edit.alertTlsEnabled.label', {
-            defaultMessage: 'Disabling will stop tls alerting on this monitor.',
+            defaultMessage: 'Disable TLS alerts on this monitor.',
           })
         : i18n.translate('xpack.synthetics.monitorConfig.create.alertTlsEnabled.label', {
-            defaultMessage: 'Enable tls alerts on this monitor.',
+            defaultMessage: 'Enable TLS alerts on this monitor.',
           }),
       checked: field?.value || false,
       onChange: (event) => {

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/form/form_config.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/form/form_config.tsx
@@ -287,7 +287,6 @@ export const FORM_CONFIG = (readOnly: boolean): FieldConfig => ({
       FIELD(readOnly)[ConfigKey.TIMEOUT],
       FIELD(readOnly)[ConfigKey.ENABLED],
       FIELD(readOnly)[AlertConfigKey.STATUS_ENABLED],
-      FIELD(readOnly)[AlertConfigKey.TLS_ENABLED],
     ],
     advanced: [DEFAULT_DATA_OPTIONS(readOnly), ICMP_ADVANCED(readOnly).requestConfig],
   },

--- a/x-pack/plugins/synthetics/server/alert_rules/tls_rule/tls_rule_executor.test.ts
+++ b/x-pack/plugins/synthetics/server/alert_rules/tls_rule/tls_rule_executor.test.ts
@@ -75,7 +75,8 @@ describe('tlsRuleExecutor', () => {
     expect(certs).toEqual([]);
 
     expect(spy).toHaveBeenCalledWith({
-      filter: 'synthetics-monitor.attributes.alert.tls.enabled: true',
+      filter:
+        'synthetics-monitor.attributes.alert.tls.enabled: true and (synthetics-monitor.attributes.type: http or synthetics-monitor.attributes.type: tcp)',
       soClient,
     });
   });

--- a/x-pack/plugins/synthetics/server/alert_rules/tls_rule/tls_rule_executor.ts
+++ b/x-pack/plugins/synthetics/server/alert_rules/tls_rule/tls_rule_executor.ts
@@ -21,7 +21,7 @@ import {
   getAllMonitors,
   processMonitors,
 } from '../../saved_objects/synthetics_monitor/get_all_monitors';
-import { CertResult, EncryptedSyntheticsMonitor } from '../../../common/runtime_types';
+import { CertResult, ConfigKey, EncryptedSyntheticsMonitor } from '../../../common/runtime_types';
 import { SyntheticsMonitorClient } from '../../synthetics_service/synthetics_monitor/synthetics_monitor_client';
 import { monitorAttributes } from '../../../common/types/saved_objects';
 import { AlertConfigKey } from '../../../common/constants/monitor_management';
@@ -55,9 +55,10 @@ export class TLSRuleExecutor {
   }
 
   async getMonitors() {
+    const HTTP_OR_TCP = `${monitorAttributes}.${ConfigKey.MONITOR_TYPE}: http or ${monitorAttributes}.${ConfigKey.MONITOR_TYPE}: tcp`;
     this.monitors = await getAllMonitors({
       soClient: this.soClient,
-      filter: `${monitorAttributes}.${AlertConfigKey.TLS_ENABLED}: true`,
+      filter: `${monitorAttributes}.${AlertConfigKey.TLS_ENABLED}: true and (${HTTP_OR_TCP})`,
     });
 
     const {


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/161100

Removed TLS alert option for ICMP monitor

Also 

- Updated TLS key migration to only apply to tcp and http monitor
- Update tls alert query as same

<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->