### PR TITLE
[DOC+] License not available is KB-ES connection error

### DIFF
--- a/docs/setup/access.asciidoc
+++ b/docs/setup/access.asciidoc
@@ -61,5 +61,5 @@ curl -XGET elasticsearch_ip_or_hostname:9200/_cat/indices/.kibana,.kibana_task_m
 +
 For example:
 
-* When {kib} is unable to connect to a healthy {es} cluster, the `master_not_discovered_exception` or `Unable to revive connection` errors appear.
+* When {kib} is unable to connect to a healthy {es} cluster, errors like `master_not_discovered_exception` or `unable to revive connection` or `license is not available` errors appear.
 * When one or more {kib}-backing indices are unhealthy, the `index_not_green_timeout` error appears.


### PR DESCRIPTION
👋🏼 howdy, team! 

## Summary

When Kibana can't connect to Elasticsearch (past finding master / network issue, just unhealthy cluster ballpark), its code logic cascades into first tripping warn/error log `license is not available`. 

This is a red-herring in that the license can not be determined and user should investigate the network connection / Elasticsearch health rather than investigating for lapsed licenses. 

Adding this into the "Kibana not ready" docs since it raises at this point in the flow to hopefully allow users to search-find it in our official docs rather than e.g. top-goggle-results: [Elastic Discuss](https://discuss.elastic.co/t/license-not-available/265931), [external Github](https://github.com/spujadas/elk-docker/issues/349).

### Checklist

### Risk Matrix

### For maintainers


<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->