### PR TITLE
[ML] Adding update_groups api tests

### DIFF
--- a/x-pack/plugins/ml/common/types/job_service.ts
+++ b/x-pack/plugins/ml/common/types/job_service.ts
@@ -56,3 +56,7 @@ export interface ResetJobsResponse {
     error?: ErrorType;
   };
 }
+
+export interface UpdateGroupsRequest {
+  jobs: Array<{ jobId: string; groups: string[] }>;
+}

--- a/x-pack/plugins/ml/server/models/job_service/groups.ts
+++ b/x-pack/plugins/ml/server/models/job_service/groups.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { UpdateGroupsRequest } from '../../../common/types/job_service';
 import { CalendarManager } from '../calendar';
 import { GLOBAL_CALENDAR } from '../../../common/constants/calendars';
 import type { Group } from '../../../common/types/groups';
@@ -68,7 +69,7 @@ export function groupsProvider(mlClient: MlClient) {
       .map((g) => groups[g]);
   }
 
-  async function updateGroups(jobs: Array<{ jobId: string; groups: string[] }>) {
+  async function updateGroups(jobs: UpdateGroupsRequest['jobs']) {
     const results: Results = {};
     for (const job of jobs) {
       const { jobId, groups } = job;

--- a/x-pack/plugins/ml/server/models/job_service/groups.ts
+++ b/x-pack/plugins/ml/server/models/job_service/groups.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { UpdateGroupsRequest } from '../../../common/types/job_service';
+import type { UpdateGroupsRequest } from '../../../common/types/job_service';
 import { CalendarManager } from '../calendar';
 import { GLOBAL_CALENDAR } from '../../../common/constants/calendars';
 import type { Group } from '../../../common/types/groups';

--- a/x-pack/test/api_integration/apis/ml/jobs/index.ts
+++ b/x-pack/test/api_integration/apis/ml/jobs/index.ts
@@ -25,5 +25,6 @@ export default function ({ loadTestFile }: FtrProviderContext) {
     loadTestFile(require.resolve('./get_groups'));
     loadTestFile(require.resolve('./jobs'));
     loadTestFile(require.resolve('./reset'));
+    loadTestFile(require.resolve('./update_groups'));
   });
 }

--- a/x-pack/test/api_integration/apis/ml/jobs/update_groups.ts
+++ b/x-pack/test/api_integration/apis/ml/jobs/update_groups.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import type { Group } from '@kbn/ml-plugin/common/types/groups';
+import type { UpdateGroupsRequest } from '@kbn/ml-plugin/common/types/job_service';
+import { FtrProviderContext } from '../../../ftr_provider_context';
+import { getCommonRequestHeader } from '../../../../functional/services/ml/common_api';
+import { USER } from '../../../../functional/services/ml/security_common';
+import { SINGLE_METRIC_JOB_CONFIG, MULTI_METRIC_JOB_CONFIG } from './common_jobs';
+
+export default ({ getService }: FtrProviderContext) => {
+  const esArchiver = getService('esArchiver');
+  const supertest = getService('supertestWithoutAuth');
+  const ml = getService('ml');
+
+  const testSetupJobConfigs = [SINGLE_METRIC_JOB_CONFIG, MULTI_METRIC_JOB_CONFIG];
+
+  async function runUpdateGroupsRequest(
+    user: USER,
+    payload: UpdateGroupsRequest,
+    expectedResponsecode: number
+  ): Promise<Group[]> {
+    const { body, status } = await supertest
+      .post('/internal/ml/jobs/update_groups')
+      .auth(user, ml.securityCommon.getPasswordForUser(user))
+      .send(payload)
+      .set(getCommonRequestHeader('1'));
+    ml.api.assertResponseStatusCode(expectedResponsecode, status, body);
+
+    return body;
+  }
+
+  const expectedBeforeGroups = [
+    {
+      id: 'automated',
+      jobIds: [MULTI_METRIC_JOB_CONFIG.job_id, SINGLE_METRIC_JOB_CONFIG.job_id],
+      calendarIds: [],
+    },
+    {
+      id: 'farequote',
+      jobIds: [MULTI_METRIC_JOB_CONFIG.job_id, SINGLE_METRIC_JOB_CONFIG.job_id],
+      calendarIds: [],
+    },
+    { id: 'multi-metric', jobIds: [MULTI_METRIC_JOB_CONFIG.job_id], calendarIds: [] },
+    { id: 'single-metric', jobIds: [SINGLE_METRIC_JOB_CONFIG.job_id], calendarIds: [] },
+  ];
+
+  const expectedAfterGroups = [
+    { id: 'automated', jobIds: [MULTI_METRIC_JOB_CONFIG.job_id], calendarIds: [] },
+    { id: 'farequote', jobIds: [MULTI_METRIC_JOB_CONFIG.job_id], calendarIds: [] },
+    { id: 'multi-metric', jobIds: [MULTI_METRIC_JOB_CONFIG.job_id], calendarIds: [] },
+    { id: 'new_group', jobIds: [SINGLE_METRIC_JOB_CONFIG.job_id], calendarIds: [] },
+  ];
+
+  describe('update groups', function () {
+    before(async () => {
+      await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/farequote');
+      await ml.testResources.setKibanaTimeZoneToUTC();
+
+      for (const job of testSetupJobConfigs) {
+        await ml.api.createAnomalyDetectionJob(job);
+      }
+    });
+
+    after(async () => {
+      await ml.api.cleanMlIndices();
+    });
+
+    it('returns expected list of groups after update', async () => {
+      const beforeGroups = await ml.api.getGroups();
+      expect(beforeGroups).to.eql(
+        expectedBeforeGroups,
+        `response groups list before update should equal the expected groups ${JSON.stringify(
+          expectedBeforeGroups
+        )}), got ${JSON.stringify(beforeGroups)}`
+      );
+
+      const newGroups = {
+        jobs: [
+          {
+            jobId: SINGLE_METRIC_JOB_CONFIG.job_id,
+            groups: ['new_group'],
+          },
+        ],
+      };
+
+      await runUpdateGroupsRequest(USER.ML_POWERUSER, newGroups, 200);
+
+      const afterGroups = await ml.api.getGroups();
+      expect(afterGroups).to.eql(
+        expectedAfterGroups,
+        `response groups list after update should equal the expected groups ${JSON.stringify(
+          expectedAfterGroups
+        )}), got ${JSON.stringify(afterGroups)}`
+      );
+    });
+  });
+};

--- a/x-pack/test/functional/services/ml/api.ts
+++ b/x-pack/test/functional/services/ml/api.ts
@@ -1065,6 +1065,15 @@ export function MachineLearningAPIProvider({ getService }: FtrProviderContext) {
       });
     },
 
+    async getGroups(space?: string) {
+      const { body, status } = await kbnSupertest
+        .get(`${space ? `/s/${space}` : ''}/internal/ml/jobs/groups`)
+        .set(getCommonRequestHeader('1'));
+      this.assertResponseStatusCode(200, status, module);
+
+      return body;
+    },
+
     async getAnnotations(jobId: string) {
       log.debug(`Fetching annotations for job '${jobId}'...`);
 


### PR DESCRIPTION
Adds a test to ensure the `update_groups` api works as expected.

Related to https://github.com/elastic/kibana/issues/160712