### PR TITLE
[Enterprise Search]Add 404 error handling for mappings and documents endpoints

### DIFF
--- a/x-pack/plugins/enterprise_search/common/constants.ts
+++ b/x-pack/plugins/enterprise_search/common/constants.ts
@@ -210,3 +210,5 @@ export const DEFAULT_PRODUCT_FEATURES: ProductFeatures = {
   hasNativeConnectors: true,
   hasWebCrawler: true,
 };
+
+export const CONNECTORS_ACCESS_CONTROL_INDEX_PREFIX = '.search-acl-filter-';

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/documents.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/documents.tsx
@@ -20,6 +20,8 @@ import {
 
 import { i18n } from '@kbn/i18n';
 
+import { CONNECTORS_ACCESS_CONTROL_INDEX_PREFIX } from '../../../../../common/constants';
+
 import { KibanaLogic } from '../../../shared/kibana';
 
 import {
@@ -44,7 +46,7 @@ export const SearchIndexDocuments: React.FC = () => {
   const indexToShow =
     selectedIndexType === 'content-index'
       ? indexName
-      : indexName.replace('search-', '.search-acl-filter-');
+      : indexName.replace('search-', CONNECTORS_ACCESS_CONTROL_INDEX_PREFIX);
 
   const shouldShowAccessControlSwitcher =
     hasDocumentLevelSecurityFeature && productFeatures.hasDocumentLevelSecurityEnabled;

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/index_mappings.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/index_mappings.tsx
@@ -25,6 +25,8 @@ import {
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 
+import { CONNECTORS_ACCESS_CONTROL_INDEX_PREFIX } from '../../../../../common/constants';
+
 import { docLinks } from '../../../shared/doc_links';
 
 import { KibanaLogic } from '../../../shared/kibana';
@@ -51,7 +53,7 @@ export const SearchIndexIndexMappings: React.FC = () => {
   const indexToShow =
     selectedIndexType === 'content-index'
       ? indexName
-      : indexName.replace('search-', '.search-acl-filter-');
+      : indexName.replace('search-', CONNECTORS_ACCESS_CONTROL_INDEX_PREFIX);
 
   const shouldShowAccessControlSwitch =
     hasDocumentLevelSecurityFeature && productFeatures.hasDocumentLevelSecurityEnabled;

--- a/x-pack/plugins/enterprise_search/server/index.ts
+++ b/x-pack/plugins/enterprise_search/server/index.ts
@@ -53,4 +53,3 @@ export const CURRENT_CONNECTORS_INDEX = '.elastic-connectors-v1';
 export const CONNECTORS_JOBS_INDEX = '.elastic-connectors-sync-jobs';
 export const CONNECTORS_VERSION = 1;
 export const CRAWLERS_INDEX = '.ent-search-actastic-crawler2_configurations_v2';
-export const CONNECTORS_ACCESS_CONTROL_INDEX_PREFIX = '.search-acl-filter-';

--- a/x-pack/plugins/enterprise_search/server/lib/connectors/start_sync.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/connectors/start_sync.test.ts
@@ -7,11 +7,9 @@
 
 import { IScopedClusterClient } from '@kbn/core/server';
 
-import {
-  CONNECTORS_ACCESS_CONTROL_INDEX_PREFIX,
-  CONNECTORS_INDEX,
-  CONNECTORS_JOBS_INDEX,
-} from '../..';
+import { CONNECTORS_INDEX, CONNECTORS_JOBS_INDEX } from '../..';
+import { CONNECTORS_ACCESS_CONTROL_INDEX_PREFIX } from '../../../common/constants';
+
 import { SyncJobType, SyncStatus, TriggerMethod } from '../../../common/types/connectors';
 
 import { ErrorCode } from '../../../common/types/error_codes';

--- a/x-pack/plugins/enterprise_search/server/lib/connectors/start_sync.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/connectors/start_sync.ts
@@ -7,14 +7,13 @@
 
 import { IScopedClusterClient } from '@kbn/core/server';
 
-import {
-  CONNECTORS_ACCESS_CONTROL_INDEX_PREFIX,
-  CONNECTORS_INDEX,
-  CONNECTORS_JOBS_INDEX,
-} from '../..';
+import { CONNECTORS_INDEX, CONNECTORS_JOBS_INDEX } from '../..';
 import { isConfigEntry } from '../../../common/connectors/is_category_entry';
 
-import { ENTERPRISE_SEARCH_CONNECTOR_CRAWLER_SERVICE_TYPE } from '../../../common/constants';
+import {
+  CONNECTORS_ACCESS_CONTROL_INDEX_PREFIX,
+  ENTERPRISE_SEARCH_CONNECTOR_CRAWLER_SERVICE_TYPE,
+} from '../../../common/constants';
 
 import {
   ConnectorConfiguration,

--- a/x-pack/plugins/enterprise_search/server/lib/indices/delete_access_control_index.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/indices/delete_access_control_index.ts
@@ -8,7 +8,7 @@
 import { isIndexNotFoundException } from '@kbn/core-saved-objects-migration-server-internal';
 import { IScopedClusterClient } from '@kbn/core/server';
 
-import { CONNECTORS_ACCESS_CONTROL_INDEX_PREFIX } from '../..';
+import { CONNECTORS_ACCESS_CONTROL_INDEX_PREFIX } from '../../../common/constants';
 
 export const deleteAccessControlIndex = async (client: IScopedClusterClient, index: string) => {
   try {


### PR DESCRIPTION
## Summary

Add 404 handler for the Document and mappings endpoints. They were default handlers before and returning 502. Error message is much more meaningful at the moment.
![Screenshot 2023-07-04 at 18 16 53](https://github.com/elastic/kibana/assets/1410658/f595391b-2889-4370-907f-7e5c0d331f2c)
![Screenshot 2023-07-04 at 18 17 01](https://github.com/elastic/kibana/assets/1410658/018d34d1-273a-4d85-9f5a-78bbf15cf526)


### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios




<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->