### PR TITLE
Update publicBaseUrl warning id

### DIFF
--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -37728,7 +37728,6 @@
     "xpack.triggersActionsUI.sections.actionTypeForm.addNewConnectorEmptyButton": "添加连接器",
     "xpack.triggersActionsUI.sections.actionTypeForm.notifyWhenThrottleWarning": "定制操作时间间隔不能短于规则的检查时间间隔",
     "xpack.triggersActionsUI.sections.actionTypeForm.summaryGroupTitle": "告警的摘要",
-    "xpack.triggersActionsUI.sections.actionTypeForm.warning.publicUrl": "未设置 server.publicBaseUrl。操作将使用相对 URL。",
     "xpack.triggersActionsUI.sections.addConnectorForm.flyoutHeaderCompatibility": "兼容性：",
     "xpack.triggersActionsUI.sections.addConnectorForm.selectConnectorFlyoutTitle": "选择连接器",
     "xpack.triggersActionsUI.sections.addConnectorForm.updateSuccessNotificationText": "已创建“{connectorName}”",

--- a/x-pack/plugins/triggers_actions_ui/public/application/lib/validate_params_for_warnings.ts
+++ b/x-pack/plugins/triggers_actions_ui/public/application/lib/validate_params_for_warnings.ts
@@ -11,7 +11,7 @@ import { ActionVariable, RuleActionParam } from '@kbn/alerting-plugin/common';
 import Mustache from 'mustache';
 
 const publicUrlWarning = i18n.translate(
-  'xpack.triggersActionsUI.sections.actionTypeForm.warning.publicUrl',
+  'xpack.triggersActionsUI.sections.actionTypeForm.warning.publicBaseUrl',
   {
     defaultMessage:
       'server.publicBaseUrl is not set. Generated URLs will be either relative or empty.',


### PR DESCRIPTION
Related to #161091

## Summary

I learned that when we update a default message, we should manually remove outdated translations. 

In this PR, I updated the ID and removed outdated translations. I will not backport this PR since the translation for the previous version is already started so I will keep the previous translation for v8.9. Please let me know if there is an issue with this approach.
