### PR TITLE
[DOCS] Remove deprecated action variables from rule APIs

### DIFF
--- a/docs/api/alerting/create_rule.asciidoc
+++ b/docs/api/alerting/create_rule.asciidoc
@@ -173,7 +173,7 @@ POST api/alerting/rule
          "group":"threshold met",
          "params":{
             "level":"info",
-            "message":"alert '{{alertName}}' is active for group '{{context.group}}':\n\n- Value: {{context.value}}\n- Conditions Met: {{context.conditions}} over {{params.timeWindowSize}}{{params.timeWindowUnit}}\n- Timestamp: {{context.date}}"
+            "message":"Rule '{{rule.name}}' is active for group '{{context.group}}':\n\n- Value: {{context.value}}\n- Conditions Met: {{context.conditions}} over {{rule.params.timeWindowSize}}{{rule.params.timeWindowUnit}}\n- Timestamp: {{context.date}}"
          }
       }
    ],
@@ -231,7 +231,7 @@ The API returns the following:
       "id": "dceeb5d0-6b41-11eb-802b-85b0c1bc8ba2",
       "params": {
         "level": "info",
-        "message": "alert {{alertName}} is active for group {{context.group}}:\n\n- Value: {{context.value}}\n- Conditions Met: {{context.conditions}} over {{params.timeWindowSize}}{{params.timeWindowUnit}}\n- Timestamp: {{context.date}}"
+        "message": "Rule {{rule.name}} is active for group {{context.group}}:\n\n- Value: {{context.value}}\n- Conditions Met: {{context.conditions}} over {{rule.params.timeWindowSize}}{{rule.params.timeWindowUnit}}\n- Timestamp: {{context.date}}"
       },
       "connector_type_id": ".server-log"
     }

--- a/docs/api/alerting/get_rules.asciidoc
+++ b/docs/api/alerting/get_rules.asciidoc
@@ -103,7 +103,7 @@ The API returns the following:
     "id":"1007a0c0-7a6e-11ed-89d5-abec321c0def",
     "params":{
       "level":"info",
-      "message":"alert {{alertName}} is active for group {{context.group}}:\n\n- Value: {{context.value}}\n- Conditions Met: {{context.conditions}} over {{params.timeWindowSize}}{{params.timeWindowUnit}}\n- Timestamp: {{context.date}}"
+      "message":"Rule {{rule.name}} is active for group {{context.group}}:\n\n- Value: {{context.value}}\n- Conditions Met: {{context.conditions}} over {{rule.params.timeWindowSize}}{{rule.params.timeWindowUnit}}\n- Timestamp: {{context.date}}"
     },
     "connector_type_id":".server-log"
   }],

--- a/docs/api/alerting/legacy/create.asciidoc
+++ b/docs/api/alerting/legacy/create.asciidoc
@@ -127,7 +127,7 @@ $ curl -X POST api/alerts/alert  -H 'kbn-xsrf: true' -H 'Content-Type: applicati
          "group":"threshold met",
          "params":{
             "level":"info",
-            "message":"alert '{{alertName}}' is active for group '{{context.group}}':\n\n- Value: {{context.value}}\n- Conditions Met: {{context.conditions}} over {{params.timeWindowSize}}{{params.timeWindowUnit}}\n- Timestamp: {{context.date}}"
+            "message":"Rule '{{rule.name}}' is active for group '{{context.group}}':\n\n- Value: {{context.value}}\n- Conditions Met: {{context.conditions}} over {{rule.params.timeWindowSize}}{{rule.params.timeWindowUnit}}\n- Timestamp: {{context.date}}"
          }
       }
    ],
@@ -175,7 +175,7 @@ The API returns the following:
       "group": "threshold met",
       "params": {
         "level": "info",
-        "message": "alert {{alertName}} is active for group {{context.group}}:\n\n- Value: {{context.value}}\n- Conditions Met: {{context.conditions}} over {{params.timeWindowSize}}{{params.timeWindowUnit}}\n- Timestamp: {{context.date}}"
+        "message": "Rule {{rule.name}} is active for group {{context.group}}:\n\n- Value: {{context.value}}\n- Conditions Met: {{context.conditions}} over {{rule.params.timeWindowSize}}{{rule.params.timeWindowUnit}}\n- Timestamp: {{context.date}}"
       },
       "id": "dceeb5d0-6b41-11eb-802b-85b0c1bc8ba2"
     }

--- a/x-pack/plugins/alerting/docs/openapi/bundled.json
+++ b/x-pack/plugins/alerting/docs/openapi/bundled.json
@@ -6397,7 +6397,7 @@
               "group": "threshold met",
               "params": {
                 "level": "info",
-                "message": "alert '{{alertName}}' is active for group '{{context.group}}':\n\n- Value: {{context.value}}\n- Conditions Met: {{context.conditions}} over {{params.timeWindowSize}}{{params.timeWindowUnit}}\n- Timestamp: {{context.date}}"
+                "message": "Rule '{{rule.name}}' is active for group '{{context.group}}':\n\n- Value: {{context.value}}\n- Conditions Met: {{context.conditions}} over {{rule.params.timeWindowSize}}{{rule.params.timeWindowUnit}}\n- Timestamp: {{context.date}}"
               }
             }
           ],
@@ -6445,7 +6445,7 @@
               },
               "params": {
                 "level": "info",
-                "message": "alert {{alertName}} is active for group {{context.group} :\n\n- Value: {{context.value}}\n- Conditions Met: {{context.conditions}} over {{params.timeWindowSize}}{{params.timeWindowUnit}}\n- Timestamp: {{context.date}}"
+                "message": "Rule {{rule.name}} is active for group {{context.group} :\n\n- Value: {{context.value}}\n- Conditions Met: {{context.conditions}} over {{rule.params.timeWindowSize}}{{rule.params.timeWindowUnit}}\n- Timestamp: {{context.date}}"
               }
             }
           ],
@@ -6550,7 +6550,7 @@
               "uuid": "1c7a1280-f28c-4e06-96b2-e4e5f05d1d61",
               "params": {
                 "level": "info",
-                "message": "alert {{alertName}} is active for group {{context.group}}:\n\n- Value: {{context.value}}\n- Conditions Met: {{context.conditions}} over {{params.timeWindowSize}}{{params.timeWindowUnit}}\n- Timestamp: {{context.date}",
+                "message": "Rule {{rule.name}} is active for group {{context.group}}:\n\n- Value: {{context.value}}\n- Conditions Met: {{context.conditions}} over {{rule.params.timeWindowSize}}{{rule.params.timeWindowUnit}}\n- Timestamp: {{context.date}",
                 "connector_type_id": ".server-log"
               },
               "connector_type_id": ".server-log",
@@ -6589,7 +6589,7 @@
               "id": "96b668d0-a1b6-11ed-afdf-d39a49596974",
               "params": {
                 "level": "info",
-                "message": "alert {{alertName}} is active for group {{context.group}}:\n\n- Value: {{context.value}}\n- Conditions Met: {{context.conditions}} over {{params.timeWindowSize}}{{params.timeWindowUnit}}\n- Timestamp: {{context.date}}"
+                "message": "Rule {{rule.name}} is active for group {{context.group}}:\n\n- Value: {{context.value}}\n- Conditions Met: {{context.conditions}} over {{rule.params.timeWindowSize}}{{rule.params.timeWindowUnit}}\n- Timestamp: {{context.date}}"
               }
             }
           ],
@@ -6668,7 +6668,7 @@
               "group": "threshold met",
               "params": {
                 "level": "info",
-                "message": "alert {{alertName}} is active for group {{context.group}}:\n\n- Value: {{context.value}}\n- Conditions Met: {{context.conditions}} over {{params.timeWindowSize}}{{params.timeWindowUnit}}\n- Timestamp: {{context.date}"
+                "message": "Rule {{rule.name}} is active for group {{context.group}}:\n\n- Value: {{context.value}}\n- Conditions Met: {{context.conditions}} over {{rule.params.timeWindowSize}}{{rule.params.timeWindowUnit}}\n- Timestamp: {{context.date}"
               },
               "id": "96b668d0-a1b6-11ed-afdf-d39a49596974",
               "uuid": "07aef2a0-9eed-4ef9-94ec-39ba58eb609d",
@@ -6753,7 +6753,7 @@
                   "uuid": "1c7a1280-f28c-4e06-96b2-e4e5f05d1d61",
                   "params": {
                     "level": "info",
-                    "message": "alert {{alertName}} is active for group {{context.group}}:\n\n- Value: {{context.value}}\n- Conditions Met: {{context.conditions}} over {{params.timeWindowSize}}{{params.timeWindowUnit}}\n- Timestamp: {{context.date}}",
+                    "message": "Rule {{rule.name}} is active for group {{context.group}}:\n\n- Value: {{context.value}}\n- Conditions Met: {{context.conditions}} over {{rule.params.timeWindowSize}}{{rule.params.timeWindowUnit}}\n- Timestamp: {{context.date}}",
                     "connector_type_id": ".server-log"
                   },
                   "frequency": {

--- a/x-pack/plugins/alerting/docs/openapi/bundled.yaml
+++ b/x-pack/plugins/alerting/docs/openapi/bundled.yaml
@@ -4360,10 +4360,10 @@ components:
             params:
               level: info
               message: |-
-                alert '{{alertName}}' is active for group '{{context.group}}':
+                Rule '{{rule.name}}' is active for group '{{context.group}}':
 
                 - Value: {{context.value}}
-                - Conditions Met: {{context.conditions}} over {{params.timeWindowSize}}{{params.timeWindowUnit}}
+                - Conditions Met: {{context.conditions}} over {{rule.params.timeWindowSize}}{{rule.params.timeWindowUnit}}
                 - Timestamp: {{context.date}}
         consumer: alerts
         name: my rule
@@ -4401,10 +4401,10 @@ components:
             params:
               level: info
               message: |-
-                alert {{alertName}} is active for group {{context.group} :
+                Rule {{rule.name}} is active for group {{context.group} :
 
                 - Value: {{context.value}}
-                - Conditions Met: {{context.conditions}} over {{params.timeWindowSize}}{{params.timeWindowUnit}}
+                - Conditions Met: {{context.conditions}} over {{rule.params.timeWindowSize}}{{rule.params.timeWindowUnit}}
                 - Timestamp: {{context.date}}
         api_key_created_by_user: false
         api_key_owner: elastic
@@ -4493,10 +4493,10 @@ components:
             params:
               level: info
               message: |-
-                alert {{alertName}} is active for group {{context.group}}:
+                Rule {{rule.name}} is active for group {{context.group}}:
 
                 - Value: {{context.value}}
-                - Conditions Met: {{context.conditions}} over {{params.timeWindowSize}}{{params.timeWindowUnit}}
+                - Conditions Met: {{context.conditions}} over {{rule.params.timeWindowSize}}{{rule.params.timeWindowUnit}}
                 - Timestamp: {{context.date}
               connector_type_id: .server-log
             connector_type_id: .server-log
@@ -4527,10 +4527,10 @@ components:
             params:
               level: info
               message: |-
-                alert {{alertName}} is active for group {{context.group}}:
+                Rule {{rule.name}} is active for group {{context.group}}:
 
                 - Value: {{context.value}}
-                - Conditions Met: {{context.conditions}} over {{params.timeWindowSize}}{{params.timeWindowUnit}}
+                - Conditions Met: {{context.conditions}} over {{rule.params.timeWindowSize}}{{rule.params.timeWindowUnit}}
                 - Timestamp: {{context.date}}
         params:
           aggField: sheet.version
@@ -4596,10 +4596,10 @@ components:
             params:
               level: info
               message: |-
-                alert {{alertName}} is active for group {{context.group}}:
+                Rule {{rule.name}} is active for group {{context.group}}:
 
                 - Value: {{context.value}}
-                - Conditions Met: {{context.conditions}} over {{params.timeWindowSize}}{{params.timeWindowUnit}}
+                - Conditions Met: {{context.conditions}} over {{rule.params.timeWindowSize}}{{rule.params.timeWindowUnit}}
                 - Timestamp: {{context.date}
             id: 96b668d0-a1b6-11ed-afdf-d39a49596974
             uuid: 07aef2a0-9eed-4ef9-94ec-39ba58eb609d
@@ -4670,10 +4670,10 @@ components:
                 params:
                   level: info
                   message: |-
-                    alert {{alertName}} is active for group {{context.group}}:
+                    Rule {{rule.name}} is active for group {{context.group}}:
 
                     - Value: {{context.value}}
-                    - Conditions Met: {{context.conditions}} over {{params.timeWindowSize}}{{params.timeWindowUnit}}
+                    - Conditions Met: {{context.conditions}} over {{rule.params.timeWindowSize}}{{rule.params.timeWindowUnit}}
                     - Timestamp: {{context.date}}
                   connector_type_id: .server-log
                 frequency:

--- a/x-pack/plugins/alerting/docs/openapi/components/examples/create_rule_request.yaml
+++ b/x-pack/plugins/alerting/docs/openapi/components/examples/create_rule_request.yaml
@@ -8,7 +8,7 @@ value:
       group: threshold met
       params:
         level: info
-        message: "alert '{{alertName}}' is active for group '{{context.group}}':\n\n- Value: {{context.value}}\n- Conditions Met: {{context.conditions}} over {{params.timeWindowSize}}{{params.timeWindowUnit}}\n- Timestamp: {{context.date}}"
+        message: "Rule '{{rule.name}}' is active for group '{{context.group}}':\n\n- Value: {{context.value}}\n- Conditions Met: {{context.conditions}} over {{rule.params.timeWindowSize}}{{rule.params.timeWindowUnit}}\n- Timestamp: {{context.date}}"
   consumer: alerts
   name: my rule
   params:

--- a/x-pack/plugins/alerting/docs/openapi/components/examples/create_rule_response.yaml
+++ b/x-pack/plugins/alerting/docs/openapi/components/examples/create_rule_response.yaml
@@ -11,7 +11,7 @@ value:
         throttle: null
       params:
         level: info
-        message: "alert {{alertName}} is active for group {{context.group} :\n\n- Value: {{context.value}}\n- Conditions Met: {{context.conditions}} over {{params.timeWindowSize}}{{params.timeWindowUnit}}\n- Timestamp: {{context.date}}"
+        message: "Rule {{rule.name}} is active for group {{context.group} :\n\n- Value: {{context.value}}\n- Conditions Met: {{context.conditions}} over {{rule.params.timeWindowSize}}{{rule.params.timeWindowUnit}}\n- Timestamp: {{context.date}}"
   api_key_created_by_user: false
   api_key_owner: elastic
   consumer: alerts

--- a/x-pack/plugins/alerting/docs/openapi/components/examples/find_rules_response.yaml
+++ b/x-pack/plugins/alerting/docs/openapi/components/examples/find_rules_response.yaml
@@ -47,7 +47,7 @@ value:
           uuid: 1c7a1280-f28c-4e06-96b2-e4e5f05d1d61
           params:
             level: info
-            message: "alert {{alertName}} is active for group {{context.group}}:\n\n- Value: {{context.value}}\n- Conditions Met: {{context.conditions}} over {{params.timeWindowSize}}{{params.timeWindowUnit}}\n- Timestamp: {{context.date}}"
+            message: "Rule {{rule.name}} is active for group {{context.group}}:\n\n- Value: {{context.value}}\n- Conditions Met: {{context.conditions}} over {{rule.params.timeWindowSize}}{{rule.params.timeWindowUnit}}\n- Timestamp: {{context.date}}"
             connector_type_id: .server-log
           frequency:
             summary: false

--- a/x-pack/plugins/alerting/docs/openapi/components/examples/get_rule_response.yaml
+++ b/x-pack/plugins/alerting/docs/openapi/components/examples/get_rule_response.yaml
@@ -44,7 +44,7 @@ value:
       uuid: 1c7a1280-f28c-4e06-96b2-e4e5f05d1d61
       params:
         level: info
-        message: "alert {{alertName}} is active for group {{context.group}}:\n\n- Value: {{context.value}}\n- Conditions Met: {{context.conditions}} over {{params.timeWindowSize}}{{params.timeWindowUnit}}\n- Timestamp: {{context.date}"
+        message: "Rule {{rule.name}} is active for group {{context.group}}:\n\n- Value: {{context.value}}\n- Conditions Met: {{context.conditions}} over {{rule.params.timeWindowSize}}{{rule.params.timeWindowUnit}}\n- Timestamp: {{context.date}"
         connector_type_id: .server-log
       connector_type_id: .server-log
       frequency:

--- a/x-pack/plugins/alerting/docs/openapi/components/examples/update_rule_request.yaml
+++ b/x-pack/plugins/alerting/docs/openapi/components/examples/update_rule_request.yaml
@@ -8,7 +8,7 @@ value:
       id: 96b668d0-a1b6-11ed-afdf-d39a49596974
       params:
         level: info
-        message: "alert {{alertName}} is active for group {{context.group}}:\n\n- Value: {{context.value}}\n- Conditions Met: {{context.conditions}} over {{params.timeWindowSize}}{{params.timeWindowUnit}}\n- Timestamp: {{context.date}}"
+        message: "Rule {{rule.name}} is active for group {{context.group}}:\n\n- Value: {{context.value}}\n- Conditions Met: {{context.conditions}} over {{rule.params.timeWindowSize}}{{rule.params.timeWindowUnit}}\n- Timestamp: {{context.date}}"
   params:
     aggField: sheet.version
     aggType: avg

--- a/x-pack/plugins/alerting/docs/openapi/components/examples/update_rule_response.yaml
+++ b/x-pack/plugins/alerting/docs/openapi/components/examples/update_rule_response.yaml
@@ -39,7 +39,7 @@ value:
     - group: threshold met
       params:
         level: info
-        message: "alert {{alertName}} is active for group {{context.group}}:\n\n- Value: {{context.value}}\n- Conditions Met: {{context.conditions}} over {{params.timeWindowSize}}{{params.timeWindowUnit}}\n- Timestamp: {{context.date}"
+        message: "Rule {{rule.name}} is active for group {{context.group}}:\n\n- Value: {{context.value}}\n- Conditions Met: {{context.conditions}} over {{rule.params.timeWindowSize}}{{rule.params.timeWindowUnit}}\n- Timestamp: {{context.date}"
       id: 96b668d0-a1b6-11ed-afdf-d39a49596974
       uuid: 07aef2a0-9eed-4ef9-94ec-39ba58eb609d
       connector_type_id: .server-log


### PR DESCRIPTION
## Summary

Relates to https://github.com/elastic/kibana/issues/161126, https://github.com/elastic/kibana/issues/160760

This PR replaces `alertName` with `rule.name` and `params` with `rule.params` in the API examples.



<!--ONMERGE {"backportTargets":["7.17","8.9"]} ONMERGE-->