### PR TITLE
[Search Application] Connect page : update search application search doc link and minor wording

### DIFF
--- a/packages/kbn-doc-links/src/get_doc_links.ts
+++ b/packages/kbn-doc-links/src/get_doc_links.ts
@@ -177,7 +177,7 @@ export const getDocLinks = ({ kibanaBranch }: GetDocLinkOptions): DocLinks => {
       searchApplicationsTemplates: `${ENTERPRISE_SEARCH_DOCS}search-applications-templates.html`,
       searchApplicationsSearchApi: `${ENTERPRISE_SEARCH_DOCS}search-applications-safe-search.html`,
       searchApplications: `${ENTERPRISE_SEARCH_DOCS}search-applications.html`,
-      searchApplicationsGettingStarted: `${ENTERPRISE_SEARCH_DOCS}search-applications.html#search-applications-get-started`,
+      searchApplicationsSearch: `${ENTERPRISE_SEARCH_DOCS}search-applications-search.html`,
       searchTemplates: `${ELASTICSEARCH_DOCS}search-template.html`,
       start: `${ENTERPRISE_SEARCH_DOCS}start.html`,
       supportedNlpModels: `${MACHINE_LEARNING_DOCS}ml-nlp-model-ref.html`,

--- a/packages/kbn-doc-links/src/types.ts
+++ b/packages/kbn-doc-links/src/types.ts
@@ -161,7 +161,7 @@ export interface DocLinks {
     readonly searchApplicationsTemplates: string;
     readonly searchApplicationsSearchApi: string;
     readonly searchApplications: string;
-    readonly searchApplicationsGettingStarted: string;
+    readonly searchApplicationsSearch: string;
     readonly searchTemplates: string;
     readonly start: string;
     readonly supportedNlpModels: string;

--- a/x-pack/plugins/enterprise_search/public/applications/applications/components/search_application/connect/search_application_api_integration.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/applications/components/search_application/connect/search_application_api_integration.tsx
@@ -232,7 +232,7 @@ export const SearchApplicationApiIntegrationStage: React.FC = () => {
             <EuiText>
               <FormattedMessage
                 id="xpack.enterpriseSearch.searchApplications.searchApplication.searchApi.step4.clientUsageDescription"
-                defaultMessage="To get the most out of the client, use the javascript client's example template and follow our {searchapplicationSearchDocLink} on building a search experience."
+                defaultMessage="To get the most out of the JavaScript client, use the client's example template and follow our {searchapplicationSearchDocLink} on building a search experience."
                 values={{
                   searchapplicationSearchDocLink: (
                     <EuiLink href={docLinks.searchApplicationsSearch}>

--- a/x-pack/plugins/enterprise_search/public/applications/applications/components/search_application/connect/search_application_api_integration.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/applications/components/search_application/connect/search_application_api_integration.tsx
@@ -60,7 +60,7 @@ curl --location --request POST '${esUrl}/_application/search_application/${searc
 --header 'Content-Type: application/json' \\
 --data-raw '${JSON.stringify({ params }, null, 2)}'`;
 
-const apiRequestSnippet = (searchApplicationName: string, params: unknown) => {
+const consoleSnippet = (searchApplicationName: string, params: unknown) => {
   const body = JSON.stringify({ params }, null, 2);
   return `
 POST /_application/search_application/${searchApplicationName}/_search
@@ -94,13 +94,13 @@ export const SearchApplicationApiIntegrationStage: React.FC = () => {
   const params = { query: 'pizza', myCustomParameter: 'example value' };
   const Tabs: Record<TabId, Tab> = {
     apirequest: {
-      code: apiRequestSnippet(searchApplicationName, params),
+      code: consoleSnippet(searchApplicationName, params),
       copy: false,
       language: 'http',
       title: i18n.translate(
-        'xpack.enterpriseSearch.searchApplications.searchApplication.searchApi.tab.apirequestTitle',
+        'xpack.enterpriseSearch.searchApplications.searchApplication.searchApi.tab.consoleTitle',
         {
-          defaultMessage: 'API Request',
+          defaultMessage: 'Console',
         }
       ),
     },
@@ -147,19 +147,7 @@ export const SearchApplicationApiIntegrationStage: React.FC = () => {
         <p>
           <FormattedMessage
             id="xpack.enterpriseSearch.searchApplications.searchApplication.searchApi.step4.description"
-            defaultMessage="Simplify your API calls by using one of our {clientsDocumentationLink}."
-            values={{
-              clientsDocumentationLink: (
-                <EuiLink href={docLinks.clientsGuide}>
-                  {i18n.translate(
-                    'xpack.enterpriseSearch.searchApplications.searchApplication.searchApi.step4.clientsDocumenation',
-                    {
-                      defaultMessage: 'programming language clients',
-                    }
-                  )}
-                </EuiLink>
-              ),
-            }}
+            defaultMessage="Simplify your API calls. We recommend using the JavaScript client."
           />
         </p>
       </EuiText>
@@ -244,10 +232,10 @@ export const SearchApplicationApiIntegrationStage: React.FC = () => {
             <EuiText>
               <FormattedMessage
                 id="xpack.enterpriseSearch.searchApplications.searchApplication.searchApi.step4.clientUsageDescription"
-                defaultMessage="To get the most out of the client, use the javascript client's example template and follow our {searchapplicationGettingStartedDocLink} on building a search experience."
+                defaultMessage="To get the most out of the client, use the javascript client's example template and follow our {searchapplicationSearchDocLink} on building a search experience."
                 values={{
-                  searchapplicationGettingStartedDocLink: (
-                    <EuiLink href={docLinks.searchApplicationsGettingStarted}>
+                  searchapplicationSearchDocLink: (
+                    <EuiLink href={docLinks.searchApplicationsSearch}>
                       {i18n.translate(
                         'xpack.enterpriseSearch.searchApplications.searchApplication.searchApi.step3.clientDocumenation',
                         {
@@ -272,7 +260,7 @@ export const SearchApplicationApiIntegrationStage: React.FC = () => {
           <EuiFlexGroup direction="column" alignItems="flexEnd">
             <EuiLink href={consolePreviewLink} target="_blank">
               <FormattedMessage
-                id="xpack.enterpriseSearch.searchApplications.searchApplication.searchApi.step4.apiRequestConsoleButton"
+                id="xpack.enterpriseSearch.searchApplications.searchApplication.searchApi.step4.consoleButton"
                 defaultMessage="Try in console"
               />
             </EuiLink>

--- a/x-pack/plugins/enterprise_search/public/applications/shared/doc_links/doc_links.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/doc_links/doc_links.ts
@@ -115,7 +115,7 @@ class DocLinks {
   public queryDsl: string;
   public rrf: string;
   public searchApplications: string;
-  public searchApplicationsGettingStarted: string;
+  public searchApplicationsSearch: string;
   public searchApplicationsTemplates: string;
   public searchApplicationsSearchApi: string;
   public searchTemplates: string;
@@ -273,7 +273,7 @@ class DocLinks {
     this.searchUIElasticsearch = '';
     this.searchApplicationsTemplates = '';
     this.searchApplications = '';
-    this.searchApplicationsGettingStarted = '';
+    this.searchApplicationsSearch = '';
     this.searchApplicationsSearchApi = '';
     this.searchTemplates = '';
     this.start = '';
@@ -431,8 +431,7 @@ class DocLinks {
     this.searchApplicationsTemplates = docLinks.links.enterpriseSearch.searchApplicationsTemplates;
     this.searchApplicationsSearchApi = docLinks.links.enterpriseSearch.searchApplicationsSearchApi;
     this.searchApplications = docLinks.links.enterpriseSearch.searchApplications;
-    this.searchApplicationsGettingStarted =
-      docLinks.links.enterpriseSearch.searchApplicationsGettingStarted;
+    this.searchApplicationsSearch = docLinks.links.enterpriseSearch.searchApplicationsSearch;
     this.searchTemplates = docLinks.links.enterpriseSearch.searchTemplates;
     this.start = docLinks.links.enterpriseSearch.start;
     this.supportedNlpModels = docLinks.links.enterpriseSearch.supportedNlpModels;


### PR DESCRIPTION
## Summary

* Change UI wording from API Request to **Console** and minor wording change
* Make `how to guide` url in javascript client tab to point to [Search application search doc](https://www.elastic.co/guide/en/enterprise-search/master/search-applications-search.html )

Related [discussion](https://elastic.slack.com/archives/C02U50QNEAG/p1688394299778629)

## Screen Recording

https://github.com/elastic/kibana/assets/55930906/8c6482c0-68b2-4374-87b4-fcf6305e5bc2





<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->