### PR TITLE
[Security Solution] Allow Rule type changes in upgrade _review endpoint

### DIFF
--- a/x-pack/plugins/security_solution/common/detection_engine/prebuilt_rules/model/diff/three_way_diff/three_way_diff.ts
+++ b/x-pack/plugins/security_solution/common/detection_engine/prebuilt_rules/model/diff/three_way_diff/three_way_diff.ts
@@ -22,24 +22,48 @@ export type MissingVersion = typeof MissingVersion;
 /**
  * Three versions of a value to pass to a diff algorithm.
  */
-export interface ThreeVersionsOf<TValue> {
+export interface ThreeVersionsOf<TValueBaseAndCurrent, TValueTarget> {
   /**
    * Corresponds to the stock version of the currently installed prebuilt rule.
    * This field is optional because the base version is not always available in the package.
    */
-  base_version: TValue | MissingVersion;
+  base_version: TValueBaseAndCurrent | MissingVersion;
 
   /**
    * Corresponds exactly to the currently installed prebuilt rule:
    *   - to the customized version (if it's customized)
    *   - to the stock version (if it's not customized)
    */
-  current_version: TValue;
+  current_version: TValueBaseAndCurrent;
 
   /**
    * Corresponds to the "new" stock version that the user is trying to upgrade to.
    */
-  target_version: TValue;
+  target_version: TValueTarget;
+}
+
+/**
+ * Three versions of a value to pass to a diff algorithm.
+ */
+export interface RuleTypeChangeThreeVersions<BaseAndCurrentValue, TargetValue> {
+  /**
+   * Corresponds to the stock version of the currently installed prebuilt rule.
+   * This field is optional because the base version is not always available in the package.
+   */
+  base_version: BaseAndCurrentValue | MissingVersion;
+
+  /**
+   * Corresponds exactly to the currently installed prebuilt rule:
+   *   - to the customized version (if it's customized)
+   *   - to the stock version (if it's not customized)
+   */
+  current_version: BaseAndCurrentValue;
+
+  /**
+   * Corresponds to the "new" stock version that the user is trying to upgrade to.
+   * when the rule type is changed, the target version is the new rule type
+   */
+  target_version: TargetValue;
 }
 
 /**
@@ -66,7 +90,7 @@ export interface ThreeVersionsOf<TValue> {
  * 6. base=A, current=B, target=C => merged=C, conflict=true
  *    Customized rule, the value has changed, conflict between B and C couldn't be resolved automatically.
  */
-export interface ThreeWayDiff<TValue> extends ThreeVersionsOf<TValue> {
+export interface ThreeWayDiff<TValue> extends ThreeVersionsOf<TValue, TValue> {
   /**
    * The result of an automatic three-way merge of three values:
    *   - base version
@@ -122,5 +146,5 @@ export interface ThreeWayDiff<TValue> extends ThreeVersionsOf<TValue> {
  * Given the three versions of a value, calculates a three-way diff for it.
  */
 export type ThreeWayDiffAlgorithm<TValue> = (
-  versions: ThreeVersionsOf<TValue>
+  versions: ThreeVersionsOf<TValue, TValue>
 ) => ThreeWayDiff<TValue>;

--- a/x-pack/plugins/security_solution/common/detection_engine/prebuilt_rules/model/diff/three_way_diff/three_way_diff.ts
+++ b/x-pack/plugins/security_solution/common/detection_engine/prebuilt_rules/model/diff/three_way_diff/three_way_diff.ts
@@ -43,30 +43,6 @@ export interface ThreeVersionsOf<TValueBaseAndCurrent, TValueTarget> {
 }
 
 /**
- * Three versions of a value to pass to a diff algorithm.
- */
-export interface RuleTypeChangeThreeVersions<BaseAndCurrentValue, TargetValue> {
-  /**
-   * Corresponds to the stock version of the currently installed prebuilt rule.
-   * This field is optional because the base version is not always available in the package.
-   */
-  base_version: BaseAndCurrentValue | MissingVersion;
-
-  /**
-   * Corresponds exactly to the currently installed prebuilt rule:
-   *   - to the customized version (if it's customized)
-   *   - to the stock version (if it's not customized)
-   */
-  current_version: BaseAndCurrentValue;
-
-  /**
-   * Corresponds to the "new" stock version that the user is trying to upgrade to.
-   * when the rule type is changed, the target version is the new rule type
-   */
-  target_version: TargetValue;
-}
-
-/**
  * Represents a result of an abstract three-way diff/merge operation on a value
  * (could be a whole rule JSON or a given rule field).
  *

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/logic/diff/calculation/algorithms/simple_diff_algorithm.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/logic/diff/calculation/algorithms/simple_diff_algorithm.ts
@@ -18,7 +18,7 @@ import {
 import { ThreeWayMergeOutcome } from '../../../../../../../../common/detection_engine/prebuilt_rules/model/diff/three_way_diff/three_way_merge_outcome';
 
 export const simpleDiffAlgorithm = <TValue>(
-  versions: ThreeVersionsOf<TValue>
+  versions: ThreeVersionsOf<TValue, TValue>
 ): ThreeWayDiff<TValue> => {
   const {
     base_version: baseVersion,

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/logic/diff/calculation/calculate_rule_fields_diff.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/logic/diff/calculation/calculate_rule_fields_diff.ts
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import { assertUnreachable } from '../../../../../../../common/utility_types';
 import { invariant } from '../../../../../../../common/utils/invariant';
+import { assertUnreachable } from '../../../../../../../common/utility_types';
 
 import type {
   DiffableCommonFields,
@@ -52,25 +52,46 @@ export const calculateRuleFieldsDiff = (
   const { base_version, current_version, target_version } = ruleVersions;
   const hasBaseVersion = base_version !== MissingVersion;
 
-  switch (current_version.type) {
+  switch (target_version.type) {
     case 'query': {
-      if (hasBaseVersion) {
-        invariant(base_version.type === 'query', BASE_TYPE_ERROR);
+      // if (ruleVersions.target_version.rule_id === 'd76b02ef-fc95-4001-9297-01cb7412232f') { // Python
+      if (ruleVersions.target_version.rule_id === 'a00681e3-9ed6-447c-ab2c-be648821c622') {
+        // First seen AWS
+        debugger;
       }
 
-      return {
-        ...commonFieldsDiff,
-        ...calculateCustomQueryFieldsDiff<typeof base_version, typeof target_version>({
-          base_version,
-          current_version,
-          target_version,
-        }),
-      };
+      switch (current_version.type) {
+        case 'query': {
+          if (hasBaseVersion) {
+            invariant(base_version.type === 'query', BASE_TYPE_ERROR);
+          }
+          return {
+            ...commonFieldsDiff,
+            ...calculateCustomQueryFieldsDiff<DiffableCustomQueryFields, DiffableCustomQueryFields>(
+              {
+                base_version,
+                current_version,
+                target_version,
+              }
+            ),
+          };
+        }
+        case 'saved_query': {
+          if (hasBaseVersion) {
+            invariant(base_version.type === 'saved_query', BASE_TYPE_ERROR);
+          }
+          return {
+            ...commonFieldsDiff,
+            ...calculateSavedQueryFieldsDiff<DiffableSavedQueryFields, DiffableCustomQueryFields>({
+              base_version,
+              current_version,
+              target_version,
+            }),
+          };
+        }
+      }
     }
     case 'saved_query': {
-      if (hasBaseVersion) {
-        invariant(base_version.type === 'saved_query', BASE_TYPE_ERROR);
-      }
       return {
         ...commonFieldsDiff,
         ...calculateSavedQueryFieldsDiff<typeof base_version, typeof target_version>({
@@ -81,9 +102,6 @@ export const calculateRuleFieldsDiff = (
       };
     }
     case 'eql': {
-      if (hasBaseVersion) {
-        invariant(base_version.type === 'eql', BASE_TYPE_ERROR);
-      }
       return {
         ...commonFieldsDiff,
         ...calculateEqlFieldsDiff<typeof base_version, typeof target_version>({
@@ -94,9 +112,6 @@ export const calculateRuleFieldsDiff = (
       };
     }
     case 'threat_match': {
-      if (hasBaseVersion) {
-        invariant(base_version.type === 'threat_match', BASE_TYPE_ERROR);
-      }
       return {
         ...commonFieldsDiff,
         ...calculateThreatMatchFieldsDiff<typeof base_version, typeof target_version>({
@@ -107,9 +122,6 @@ export const calculateRuleFieldsDiff = (
       };
     }
     case 'threshold': {
-      if (hasBaseVersion) {
-        invariant(base_version.type === 'threshold', BASE_TYPE_ERROR);
-      }
       return {
         ...commonFieldsDiff,
         ...calculateThresholdFieldsDiff<typeof base_version, typeof target_version>({
@@ -120,9 +132,6 @@ export const calculateRuleFieldsDiff = (
       };
     }
     case 'machine_learning': {
-      if (hasBaseVersion) {
-        invariant(base_version.type === 'machine_learning', BASE_TYPE_ERROR);
-      }
       return {
         ...commonFieldsDiff,
         ...calculateMachineLearningFieldsDiff<typeof base_version, typeof target_version>({
@@ -133,8 +142,9 @@ export const calculateRuleFieldsDiff = (
       };
     }
     case 'new_terms': {
-      if (hasBaseVersion) {
-        invariant(base_version.type === 'new_terms', BASE_TYPE_ERROR);
+      if (ruleVersions.target_version.rule_id === 'a00681e3-9ed6-447c-ab2c-be648821c622') {
+        // First seen AWS
+        debugger;
       }
       return {
         ...commonFieldsDiff,
@@ -146,7 +156,7 @@ export const calculateRuleFieldsDiff = (
       };
     }
     default: {
-      return assertUnreachable(current_version, 'Unhandled rule type');
+      return assertUnreachable(target_version, 'Unhandled rule type');
     }
   }
 };
@@ -191,6 +201,11 @@ const commonFieldsDiffAlgorithms: FieldsDiffAlgorithmsFor<DiffableCommonFields> 
 const calculateCustomQueryFieldsDiff = <TValueBaseAndCurrent, TValueTarget>(
   ruleVersions: ThreeVersionsOf<TValueBaseAndCurrent, TValueTarget>
 ): CustomQueryFieldsDiff => {
+  // if (ruleVersions.target_version.rule_id === 'd76b02ef-fc95-4001-9297-01cb7412232f') { // Python
+  if (ruleVersions.target_version.rule_id === 'a00681e3-9ed6-447c-ab2c-be648821c622') {
+    // First seen AWS
+    debugger;
+  }
   return calculateFieldsDiffFor(ruleVersions, customQueryFieldsDiffAlgorithms);
 };
 

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/logic/diff/calculation/calculate_rule_fields_diff.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/logic/diff/calculation/calculate_rule_fields_diff.ts
@@ -38,7 +38,6 @@ import { calculateFieldsDiffFor } from './diff_calculation_helpers';
 import { simpleDiffAlgorithm } from './algorithms/simple_diff_algorithm';
 
 const BASE_TYPE_ERROR = `Base version can't be of different rule type`;
-const TARGET_TYPE_ERROR = `Target version can't be of different rule type`;
 
 /**
  * Calculates a three-way diff per each top-level rule field.
@@ -46,7 +45,7 @@ const TARGET_TYPE_ERROR = `Target version can't be of different rule type`;
  * three-way diffs calculated for those fields.
  */
 export const calculateRuleFieldsDiff = (
-  ruleVersions: ThreeVersionsOf<DiffableRule>
+  ruleVersions: ThreeVersionsOf<DiffableRule, DiffableRule>
 ): RuleFieldsDiff => {
   const commonFieldsDiff = calculateCommonFieldsDiff(ruleVersions);
   // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -58,70 +57,92 @@ export const calculateRuleFieldsDiff = (
       if (hasBaseVersion) {
         invariant(base_version.type === 'query', BASE_TYPE_ERROR);
       }
-      invariant(target_version.type === 'query', TARGET_TYPE_ERROR);
+
       return {
         ...commonFieldsDiff,
-        ...calculateCustomQueryFieldsDiff({ base_version, current_version, target_version }),
+        ...calculateCustomQueryFieldsDiff<typeof base_version, typeof target_version>({
+          base_version,
+          current_version,
+          target_version,
+        }),
       };
     }
     case 'saved_query': {
       if (hasBaseVersion) {
         invariant(base_version.type === 'saved_query', BASE_TYPE_ERROR);
       }
-      invariant(target_version.type === 'saved_query', TARGET_TYPE_ERROR);
       return {
         ...commonFieldsDiff,
-        ...calculateSavedQueryFieldsDiff({ base_version, current_version, target_version }),
+        ...calculateSavedQueryFieldsDiff<typeof base_version, typeof target_version>({
+          base_version,
+          current_version,
+          target_version,
+        }),
       };
     }
     case 'eql': {
       if (hasBaseVersion) {
         invariant(base_version.type === 'eql', BASE_TYPE_ERROR);
       }
-      invariant(target_version.type === 'eql', TARGET_TYPE_ERROR);
       return {
         ...commonFieldsDiff,
-        ...calculateEqlFieldsDiff({ base_version, current_version, target_version }),
+        ...calculateEqlFieldsDiff<typeof base_version, typeof target_version>({
+          base_version,
+          current_version,
+          target_version,
+        }),
       };
     }
     case 'threat_match': {
       if (hasBaseVersion) {
         invariant(base_version.type === 'threat_match', BASE_TYPE_ERROR);
       }
-      invariant(target_version.type === 'threat_match', TARGET_TYPE_ERROR);
       return {
         ...commonFieldsDiff,
-        ...calculateThreatMatchFieldsDiff({ base_version, current_version, target_version }),
+        ...calculateThreatMatchFieldsDiff<typeof base_version, typeof target_version>({
+          base_version,
+          current_version,
+          target_version,
+        }),
       };
     }
     case 'threshold': {
       if (hasBaseVersion) {
         invariant(base_version.type === 'threshold', BASE_TYPE_ERROR);
       }
-      invariant(target_version.type === 'threshold', TARGET_TYPE_ERROR);
       return {
         ...commonFieldsDiff,
-        ...calculateThresholdFieldsDiff({ base_version, current_version, target_version }),
+        ...calculateThresholdFieldsDiff<typeof base_version, typeof target_version>({
+          base_version,
+          current_version,
+          target_version,
+        }),
       };
     }
     case 'machine_learning': {
       if (hasBaseVersion) {
         invariant(base_version.type === 'machine_learning', BASE_TYPE_ERROR);
       }
-      invariant(target_version.type === 'machine_learning', TARGET_TYPE_ERROR);
       return {
         ...commonFieldsDiff,
-        ...calculateMachineLearningFieldsDiff({ base_version, current_version, target_version }),
+        ...calculateMachineLearningFieldsDiff<typeof base_version, typeof target_version>({
+          base_version,
+          current_version,
+          target_version,
+        }),
       };
     }
     case 'new_terms': {
       if (hasBaseVersion) {
         invariant(base_version.type === 'new_terms', BASE_TYPE_ERROR);
       }
-      invariant(target_version.type === 'new_terms', TARGET_TYPE_ERROR);
       return {
         ...commonFieldsDiff,
-        ...calculateNewTermsFieldsDiff({ base_version, current_version, target_version }),
+        ...calculateNewTermsFieldsDiff<typeof base_version, typeof target_version>({
+          base_version,
+          current_version,
+          target_version,
+        }),
       };
     }
     default: {
@@ -131,7 +152,7 @@ export const calculateRuleFieldsDiff = (
 };
 
 const calculateCommonFieldsDiff = (
-  ruleVersions: ThreeVersionsOf<DiffableCommonFields>
+  ruleVersions: ThreeVersionsOf<DiffableCommonFields, DiffableCommonFields>
 ): CommonFieldsDiff => {
   return calculateFieldsDiffFor(ruleVersions, commonFieldsDiffAlgorithms);
 };
@@ -167,8 +188,8 @@ const commonFieldsDiffAlgorithms: FieldsDiffAlgorithmsFor<DiffableCommonFields> 
   building_block: simpleDiffAlgorithm,
 };
 
-const calculateCustomQueryFieldsDiff = (
-  ruleVersions: ThreeVersionsOf<DiffableCustomQueryFields>
+const calculateCustomQueryFieldsDiff = <TValueBaseAndCurrent, TValueTarget>(
+  ruleVersions: ThreeVersionsOf<TValueBaseAndCurrent, TValueTarget>
 ): CustomQueryFieldsDiff => {
   return calculateFieldsDiffFor(ruleVersions, customQueryFieldsDiffAlgorithms);
 };
@@ -180,8 +201,8 @@ const customQueryFieldsDiffAlgorithms: FieldsDiffAlgorithmsFor<DiffableCustomQue
   alert_suppression: simpleDiffAlgorithm,
 };
 
-const calculateSavedQueryFieldsDiff = (
-  ruleVersions: ThreeVersionsOf<DiffableSavedQueryFields>
+const calculateSavedQueryFieldsDiff = <TValueBaseAndCurrent, TValueTarget>(
+  ruleVersions: ThreeVersionsOf<TValueBaseAndCurrent, TValueTarget>
 ): SavedQueryFieldsDiff => {
   return calculateFieldsDiffFor(ruleVersions, savedQueryFieldsDiffAlgorithms);
 };
@@ -193,8 +214,8 @@ const savedQueryFieldsDiffAlgorithms: FieldsDiffAlgorithmsFor<DiffableSavedQuery
   alert_suppression: simpleDiffAlgorithm,
 };
 
-const calculateEqlFieldsDiff = (
-  ruleVersions: ThreeVersionsOf<DiffableEqlFields>
+const calculateEqlFieldsDiff = <TValueBaseAndCurrent, TValueTarget>(
+  ruleVersions: ThreeVersionsOf<TValueBaseAndCurrent, TValueTarget>
 ): EqlFieldsDiff => {
   return calculateFieldsDiffFor(ruleVersions, eqlFieldsDiffAlgorithms);
 };
@@ -208,8 +229,8 @@ const eqlFieldsDiffAlgorithms: FieldsDiffAlgorithmsFor<DiffableEqlFields> = {
   tiebreaker_field: simpleDiffAlgorithm,
 };
 
-const calculateThreatMatchFieldsDiff = (
-  ruleVersions: ThreeVersionsOf<DiffableThreatMatchFields>
+const calculateThreatMatchFieldsDiff = <TValueBaseAndCurrent, TValueTarget>(
+  ruleVersions: ThreeVersionsOf<TValueBaseAndCurrent, TValueTarget>
 ): ThreatMatchFieldsDiff => {
   return calculateFieldsDiffFor(ruleVersions, threatMatchFieldsDiffAlgorithms);
 };
@@ -226,8 +247,8 @@ const threatMatchFieldsDiffAlgorithms: FieldsDiffAlgorithmsFor<DiffableThreatMat
   items_per_search: simpleDiffAlgorithm,
 };
 
-const calculateThresholdFieldsDiff = (
-  ruleVersions: ThreeVersionsOf<DiffableThresholdFields>
+const calculateThresholdFieldsDiff = <TValueBaseAndCurrent, TValueTarget>(
+  ruleVersions: ThreeVersionsOf<TValueBaseAndCurrent, TValueTarget>
 ): ThresholdFieldsDiff => {
   return calculateFieldsDiffFor(ruleVersions, thresholdFieldsDiffAlgorithms);
 };
@@ -239,8 +260,8 @@ const thresholdFieldsDiffAlgorithms: FieldsDiffAlgorithmsFor<DiffableThresholdFi
   threshold: simpleDiffAlgorithm,
 };
 
-const calculateMachineLearningFieldsDiff = (
-  ruleVersions: ThreeVersionsOf<DiffableMachineLearningFields>
+const calculateMachineLearningFieldsDiff = <TValueBaseAndCurrent, TValueTarget>(
+  ruleVersions: ThreeVersionsOf<TValueBaseAndCurrent, TValueTarget>
 ): MachineLearningFieldsDiff => {
   return calculateFieldsDiffFor(ruleVersions, machineLearningFieldsDiffAlgorithms);
 };
@@ -252,8 +273,8 @@ const machineLearningFieldsDiffAlgorithms: FieldsDiffAlgorithmsFor<DiffableMachi
     anomaly_threshold: simpleDiffAlgorithm,
   };
 
-const calculateNewTermsFieldsDiff = (
-  ruleVersions: ThreeVersionsOf<DiffableNewTermsFields>
+const calculateNewTermsFieldsDiff = <TValueBaseAndCurrent, TValueTarget>(
+  ruleVersions: ThreeVersionsOf<TValueBaseAndCurrent, TValueTarget>
 ): NewTermsFieldsDiff => {
   return calculateFieldsDiffFor(ruleVersions, newTermsFieldsDiffAlgorithms);
 };

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/logic/diff/calculation/diff_calculation_helpers.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/logic/diff/calculation/diff_calculation_helpers.ts
@@ -22,7 +22,10 @@ export const calculateFieldsDiffFor = <TObject extends object>(
     const fieldDiff = calculateFieldDiff(fieldVersions);
     return fieldDiff;
   });
-
+  // if (ruleVersions.target_version.rule_id === 'd76b02ef-fc95-4001-9297-01cb7412232f') { // Python
+  if (ruleVersions.target_version.rule_id === 'a00681e3-9ed6-447c-ab2c-be648821c622') { // First seen AWS
+    debugger;
+  }
   // TODO: try to improve strict typing and get rid of this "as" operator.
   return result as FieldsDiff<TObject>;
 };

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/logic/diff/calculation/diff_calculation_helpers.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/logic/diff/calculation/diff_calculation_helpers.ts
@@ -23,7 +23,8 @@ export const calculateFieldsDiffFor = <TObject extends object>(
     return fieldDiff;
   });
   // if (ruleVersions.target_version.rule_id === 'd76b02ef-fc95-4001-9297-01cb7412232f') { // Python
-  if (ruleVersions.target_version.rule_id === 'a00681e3-9ed6-447c-ab2c-be648821c622') { // First seen AWS
+  if (ruleVersions.target_version.rule_id === 'a00681e3-9ed6-447c-ab2c-be648821c622') {
+    // First seen AWS
     debugger;
   }
   // TODO: try to improve strict typing and get rid of this "as" operator.

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/logic/diff/calculation/diff_calculation_helpers.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/logic/diff/calculation/diff_calculation_helpers.ts
@@ -14,7 +14,7 @@ import type { ThreeVersionsOf } from '../../../../../../../common/detection_engi
 import { MissingVersion } from '../../../../../../../common/detection_engine/prebuilt_rules/model/diff/three_way_diff/three_way_diff';
 
 export const calculateFieldsDiffFor = <TObject extends object>(
-  ruleVersions: ThreeVersionsOf<TObject>,
+  ruleVersions: ThreeVersionsOf<TObject, TObject>,
   fieldsDiffAlgorithms: FieldsDiffAlgorithmsFor<TObject>
 ): FieldsDiff<TObject> => {
   const result = mapValues(fieldsDiffAlgorithms, (calculateFieldDiff, fieldName) => {
@@ -29,8 +29,8 @@ export const calculateFieldsDiffFor = <TObject extends object>(
 
 const pickField = <TObject extends object>(
   fieldName: keyof TObject,
-  versions: ThreeVersionsOf<TObject>
-): ThreeVersionsOf<TObject[typeof fieldName]> => {
+  versions: ThreeVersionsOf<TObject, TObject>
+): ThreeVersionsOf<TObject[typeof fieldName], TObject[typeof fieldName]> => {
   return {
     base_version:
       versions.base_version !== MissingVersion ? versions.base_version[fieldName] : MissingVersion,


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
