### PR TITLE
[Fleet] Fix permissions in integrations Assets page

### DIFF
--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/assets/assets.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/assets/assets.tsx
@@ -46,7 +46,7 @@ export const AssetsPage = ({ packageInfo }: AssetsPanelProps) => {
   const { spaces } = useStartServices();
   const customAssetsExtension = useUIExtension(packageInfo.name, 'package-detail-assets');
 
-  const canReadPackageSettings = useAuthz().integrations.readPackageSettings;
+  const canReadPackageSettings = useAuthz().integrations.readPackageInfo;
 
   const { getPath } = useLink();
   const getPackageInstallStatus = useGetPackageInstallStatus();


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/161058

## Summary
Fix permissions for Integrations assets tab. A user with role "Fleet All - Integration Read" wasn't able to visualize the assets tab.

### Test

-  Create a user with "Fleet All - Integration Read" as shown in this video:

https://github.com/elastic/kibana/assets/16084106/a13c6ddd-a3d1-4e15-9c9d-9d56e1dbb0f0

- Log in with this new user
- Navigate to any installed integration, then to the Assets tab
- Verify that the assets are shown as usual (no warnings are shown)

<img width="2556" alt="Screenshot 2023-07-05 at 10 22 36" src="https://github.com/elastic/kibana/assets/16084106/b050d7ee-3794-41c4-b429-50eb6291697a">




<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->