### PR TITLE
[Index management] Fix flaky functional tests

### DIFF
--- a/x-pack/test/functional/apps/index_management/index_template_wizard.ts
+++ b/x-pack/test/functional/apps/index_management/index_template_wizard.ts
@@ -102,8 +102,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
       });
     });
 
-    // FLAKY: https://github.com/elastic/kibana/issues/159403
-    describe.skip('Mappings step', async () => {
+    describe('Mappings step', async () => {
       beforeEach(async () => {
         await pageObjects.common.navigateToApp('indexManagement');
         // Navigate to the index templates tab


### PR DESCRIPTION
Fix https://github.com/elastic/kibana/issues/159403
Fix https://github.com/elastic/kibana/issues/159524

This PR unskips the flaky tests that were fixed in https://github.com/elastic/kibana/pull/160128 but the `skip()` call was mistakenly left out.

The flaky test runner passed all 100 runs: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2557
