### PR TITLE
[8.9] [Synthetics] Remove TLS alert option for ICMP monitor (#161173)

### DIFF
--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/form/field_config.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/form/field_config.tsx
@@ -507,9 +507,13 @@ export const FIELD = (readOnly?: boolean): FieldMap => ({
     controlled: true,
     props: ({ setValue, field }): EuiSwitchProps => ({
       id: 'syntheticsMonitorConfigIsAlertEnabled',
-      label: i18n.translate('xpack.synthetics.monitorConfig.enabledAlerting.label', {
-        defaultMessage: 'Enable status alerts',
-      }),
+      label: field?.value
+        ? i18n.translate('xpack.synthetics.monitorConfig.enabledAlerting.label', {
+            defaultMessage: 'Disable status alerts on this monitor',
+          })
+        : i18n.translate('xpack.synthetics.monitorConfig.disabledAlerting.label', {
+            defaultMessage: 'Enable status alerts on this monitor',
+          }),
       checked: field?.value || false,
       onChange: (event) => {
         setValue(AlertConfigKey.STATUS_ENABLED, !!event.target.checked);
@@ -522,18 +526,15 @@ export const FIELD = (readOnly?: boolean): FieldMap => ({
   [AlertConfigKey.TLS_ENABLED]: {
     fieldKey: AlertConfigKey.TLS_ENABLED,
     component: Switch,
-    label: i18n.translate('xpack.synthetics.monitorConfig.enabledAlerting.tls.label', {
-      defaultMessage: 'Enable TLS alerts',
-    }),
     controlled: true,
-    props: ({ isEdit, setValue, field }): EuiSwitchProps => ({
+    props: ({ setValue, field }): EuiSwitchProps => ({
       id: 'syntheticsMonitorConfigIsTlsAlertEnabled',
-      label: isEdit
+      label: field?.value
         ? i18n.translate('xpack.synthetics.monitorConfig.edit.alertTlsEnabled.label', {
-            defaultMessage: 'Disabling will stop tls alerting on this monitor.',
+            defaultMessage: 'Disable TLS alerts on this monitor.',
           })
         : i18n.translate('xpack.synthetics.monitorConfig.create.alertTlsEnabled.label', {
-            defaultMessage: 'Enable tls alerts on this monitor.',
+            defaultMessage: 'Enable TLS alerts on this monitor.',
           }),
       checked: field?.value || false,
       onChange: (event) => {

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/form/form_config.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/form/form_config.tsx
@@ -287,7 +287,6 @@ export const FORM_CONFIG = (readOnly: boolean): FieldConfig => ({
       FIELD(readOnly)[ConfigKey.TIMEOUT],
       FIELD(readOnly)[ConfigKey.ENABLED],
       FIELD(readOnly)[AlertConfigKey.STATUS_ENABLED],
-      FIELD(readOnly)[AlertConfigKey.TLS_ENABLED],
     ],
     advanced: [DEFAULT_DATA_OPTIONS(readOnly), ICMP_ADVANCED(readOnly).requestConfig],
   },

--- a/x-pack/plugins/synthetics/server/alert_rules/tls_rule/tls_rule_executor.test.ts
+++ b/x-pack/plugins/synthetics/server/alert_rules/tls_rule/tls_rule_executor.test.ts
@@ -75,7 +75,8 @@ describe('tlsRuleExecutor', () => {
     expect(certs).toEqual([]);
 
     expect(spy).toHaveBeenCalledWith({
-      filter: 'synthetics-monitor.attributes.alert.tls.enabled: true',
+      filter:
+        'synthetics-monitor.attributes.alert.tls.enabled: true and (synthetics-monitor.attributes.type: http or synthetics-monitor.attributes.type: tcp)',
       soClient,
     });
   });

--- a/x-pack/plugins/synthetics/server/alert_rules/tls_rule/tls_rule_executor.ts
+++ b/x-pack/plugins/synthetics/server/alert_rules/tls_rule/tls_rule_executor.ts
@@ -20,7 +20,7 @@ import {
   processMonitors,
 } from '../../saved_objects/synthetics_monitor/get_all_monitors';
 import { UptimeEsClient } from '../../legacy_uptime/lib/lib';
-import { CertResult, EncryptedSyntheticsMonitor } from '../../../common/runtime_types';
+import { CertResult, ConfigKey, EncryptedSyntheticsMonitor } from '../../../common/runtime_types';
 import { SyntheticsMonitorClient } from '../../synthetics_service/synthetics_monitor/synthetics_monitor_client';
 import { UptimeServerSetup } from '../../legacy_uptime/lib/adapters';
 import { monitorAttributes } from '../../../common/types/saved_objects';
@@ -55,9 +55,10 @@ export class TLSRuleExecutor {
   }
 
   async getMonitors() {
+    const HTTP_OR_TCP = `${monitorAttributes}.${ConfigKey.MONITOR_TYPE}: http or ${monitorAttributes}.${ConfigKey.MONITOR_TYPE}: tcp`;
     this.monitors = await getAllMonitors({
       soClient: this.soClient,
-      filter: `${monitorAttributes}.${AlertConfigKey.TLS_ENABLED}: true`,
+      filter: `${monitorAttributes}.${AlertConfigKey.TLS_ENABLED}: true and (${HTTP_OR_TCP})`,
     });
 
     const {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.9`:
 - [[Synthetics] Remove TLS alert option for ICMP monitor (#161173)](https://github.com/elastic/kibana/pull/161173)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Shahzad","email":"shahzad31comp@gmail.com"},"sourceCommit":{"committedDate":"2023-07-05T09:55:38Z","message":"[Synthetics] Remove TLS alert option for ICMP monitor (#161173)","sha":"6a84ea186b664b55c19a9465b2ea80ddd29c6ffd","branchLabelMapping":{"^v8.10.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:uptime","release_note:skip","v8.9.0","v8.10.0"],"number":161173,"url":"https://github.com/elastic/kibana/pull/161173","mergeCommit":{"message":"[Synthetics] Remove TLS alert option for ICMP monitor (#161173)","sha":"6a84ea186b664b55c19a9465b2ea80ddd29c6ffd"}},"sourceBranch":"main","suggestedTargetBranches":["8.9"],"targetPullRequestStates":[{"branch":"8.9","label":"v8.9.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.10.0","labelRegex":"^v8.10.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/161173","number":161173,"mergeCommit":{"message":"[Synthetics] Remove TLS alert option for ICMP monitor (#161173)","sha":"6a84ea186b664b55c19a9465b2ea80ddd29c6ffd"}}]}] BACKPORT-->