### PR TITLE
[Fleet] Change default batch size

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/index.tsx
@@ -410,6 +410,7 @@ export const AgentListPage: React.FunctionComponent<{}> = () => {
   };
 
   const isCurrentRequestIncremented = currentRequestRef?.current === 1;
+
   return (
     <>
       {isAgentActivityFlyoutOpen ? (
@@ -509,6 +510,17 @@ export const AgentListPage: React.FunctionComponent<{}> = () => {
           }}
         />
       )}
+      {showUnhealthyCallout && (
+        <>
+          {cloud?.deploymentUrl ? (
+            <FleetServerCloudUnhealthyCallout deploymentUrl={cloud.deploymentUrl} />
+          ) : (
+            <FleetServerOnPremUnhealthyCallout onClickAddFleetServer={onClickAddFleetServer} />
+          )}
+          <EuiSpacer size="l" />
+        </>
+      )}
+      {/* TODO serverless agent soft limit */}
       {showUnhealthyCallout && (
         <>
           {cloud?.deploymentUrl ? (

--- a/x-pack/plugins/fleet/server/services/setup/upgrade_agent_policy_schema_version.ts
+++ b/x-pack/plugins/fleet/server/services/setup/upgrade_agent_policy_schema_version.ts
@@ -14,7 +14,7 @@ import {
 import { agentPolicyService } from '../agent_policy';
 import { appContextService } from '../app_context';
 
-const DEFAULT_BATCH_SIZE = 100;
+const DEFAULT_BATCH_SIZE = 2;
 function getOutdatedAgentPoliciesBatch(soClient: SavedObjectsClientContract, batchSize: number) {
   return agentPolicyService.list(soClient, {
     perPage: batchSize,


### PR DESCRIPTION
## Summary

Resolve https://github.com/elastic/kibana/issues/158361 

Change default batch size for schema version upgrade from 100 concurrent policies to 2 to reduce memory usage.

When we have to do a schema change on the policy we need to update all the policies, the current code was doing 100 policies concurently that could cause some memory issue on small Kibana instance. (as we recommend to have at max 500 agent policies, and that upgrade is triggered asynchronously during Kibana start it should still happen in a reasonable amount of time)

## Alternative solution

Instead of configuring this as a default we could configure this in the stackpack only for small Kibana instances


<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->