### PR TITLE
[ZDT] support registering new types

### DIFF
--- a/packages/core/saved-objects/core-saved-objects-base-server-internal/src/model_version/get_version_delta.test.ts
+++ b/packages/core/saved-objects/core-saved-objects-base-server-internal/src/model_version/get_version_delta.test.ts
@@ -37,6 +37,33 @@ describe('getModelVersionDelta', () => {
     ]);
   });
 
+  it('accepts adding types for upward delta', () => {
+    const result = getModelVersionDelta({
+      currentVersions: {
+        a: '10.1.0',
+      },
+      targetVersions: {
+        a: '10.2.0',
+        b: '10.1.0',
+      },
+      deletedTypes: [],
+    });
+
+    expect(result.status).toEqual('upward');
+    expect(result.diff).toEqual([
+      {
+        name: 'a',
+        current: '10.1.0',
+        target: '10.2.0',
+      },
+      {
+        name: 'b',
+        current: undefined,
+        target: '10.1.0',
+      },
+    ]);
+  });
+
   it('generates a downward delta', () => {
     const result = getModelVersionDelta({
       currentVersions: {
@@ -61,6 +88,33 @@ describe('getModelVersionDelta', () => {
         name: 'b',
         current: '10.2.0',
         target: '7.17.2',
+      },
+    ]);
+  });
+
+  it('accepts removing types for downward delta', () => {
+    const result = getModelVersionDelta({
+      currentVersions: {
+        a: '10.4.0',
+        b: '10.2.0',
+      },
+      targetVersions: {
+        a: '10.1.0',
+      },
+      deletedTypes: [],
+    });
+
+    expect(result.status).toEqual('downward');
+    expect(result.diff).toEqual([
+      {
+        name: 'a',
+        current: '10.4.0',
+        target: '10.1.0',
+      },
+      {
+        name: 'b',
+        current: '10.2.0',
+        target: undefined,
       },
     ]);
   });

--- a/packages/core/saved-objects/core-saved-objects-base-server-internal/src/model_version/get_version_delta.ts
+++ b/packages/core/saved-objects/core-saved-objects-base-server-internal/src/model_version/get_version_delta.ts
@@ -25,10 +25,16 @@ interface ModelVersionDeltaResult {
 interface ModelVersionDeltaTypeResult {
   /** the name of the type */
   name: string;
-  /** the current version the type is at */
-  current: VirtualVersion;
-  /** the target version the type should go to */
-  target: VirtualVersion;
+  /**
+   * the current version the type is at,
+   * or undefined if the type is not present in the current versions
+   */
+  current: VirtualVersion | undefined;
+  /**
+   * the target version the type should go to,
+   * or undefined if the type is not present in the target versions
+   * */
+  target: VirtualVersion | undefined;
 }
 
 /**
@@ -81,18 +87,9 @@ const getTypeDelta = ({
   currentVersions: VirtualVersionMap;
   targetVersions: VirtualVersionMap;
 }): ModelVersionDeltaTypeResult => {
-  const currentVersion = currentVersions[type];
-  const targetVersion = targetVersions[type];
-  if (currentVersion === undefined || targetVersion === undefined) {
-    // should never occur given we've been checking consistency numerous times before getting there
-    // but better safe than sorry.
-    throw new Error(
-      `Consistency error: trying to generate delta with missing entry for type ${type}`
-    );
-  }
   return {
     name: type,
-    current: currentVersion,
-    target: targetVersion,
+    current: currentVersions[type],
+    target: targetVersions[type],
   };
 };

--- a/src/core/server/integration_tests/saved_objects/migrations/zdt_2/type_addition.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/zdt_2/type_addition.test.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import Path from 'path';
+import fs from 'fs/promises';
+import { type TestElasticsearchUtils } from '@kbn/core-test-helpers-kbn-server';
+import '../jest_matchers';
+import { getKibanaMigratorTestKit, startElasticsearch } from '../kibana_migrator_test_kit';
+import { delay, parseLogFile } from '../test_utils';
+import { getBaseMigratorParams, getFooType, getBarType } from '../fixtures/zdt_base.fixtures';
+
+export const logFilePath = Path.join(__dirname, 'type_addition.test.log');
+
+describe('ZDT upgrades - introducing a new SO type', () => {
+  let esServer: TestElasticsearchUtils['es'];
+
+  beforeAll(async () => {
+    await fs.unlink(logFilePath).catch(() => {});
+    esServer = await startElasticsearch();
+  });
+
+  afterAll(async () => {
+    await esServer?.stop();
+    await delay(10);
+  });
+
+  const createBaseline = async () => {
+    const fooType = getFooType();
+    const { runMigrations } = await getKibanaMigratorTestKit({
+      ...getBaseMigratorParams(),
+      types: [fooType],
+    });
+    await runMigrations();
+  };
+
+  it('should support adding the bar type', async () => {
+    await createBaseline();
+
+    const fooType = getFooType();
+    const barType = getBarType();
+
+    const { runMigrations } = await getKibanaMigratorTestKit({
+      ...getBaseMigratorParams(),
+      logFilePath,
+      types: [fooType, barType],
+    });
+
+    await runMigrations();
+
+    const records = await parseLogFile(logFilePath);
+
+    expect(records).toContainLogEntries(
+      [
+        'mapping version check result: greater',
+        'INIT -> UPDATE_INDEX_MAPPINGS',
+        'INDEX_STATE_UPDATE_DONE -> DOCUMENTS_UPDATE_INIT',
+        '-> DONE',
+        'Migration completed',
+      ],
+      { ordered: true }
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Related to https://github.com/elastic/kibana/issues/150296

Fix a bug causing the ZDT migration algorithm to fail when a new type gets introduced between two versions. 
