### PR TITLE
[DOCS] Link to rule and connector Elasticstack provider resources

### DIFF
--- a/docs/management/action-types.asciidoc
+++ b/docs/management/action-types.asciidoc
@@ -159,6 +159,9 @@ action in the current space.
 For out-of-the-box and standardized connectors, refer to
 <<pre-configured-connectors,preconfigured connectors>>.
 
+TIP: You can also manage connectors as resources with the https://registry.terraform.io/providers/elastic/elasticstack/latest[Elasticstack provider] for Terraform.
+For more details, refer to the https://registry.terraform.io/providers/elastic/elasticstack/latest/docs/resources/kibana_action_connector[elasticstack_kibana_action_connector] resource.
+
 [float]
 [[importing-and-exporting-connectors]]
 === Importing and exporting connectors

--- a/docs/user/alerting/create-and-manage-rules.asciidoc
+++ b/docs/user/alerting/create-and-manage-rules.asciidoc
@@ -43,7 +43,7 @@ a rule type and configuring its conditions and actions.
 After a rule is created, you can open the action menu (…) and select *Edit rule*
 to re-open the flyout and change the rule properties.
 
-TIP: You can also manage connectors as resources with the https://registry.terraform.io/providers/elastic/elasticstack/latest[Elasticstack provider] for Terraform.
+TIP: You can also manage rules as resources with the https://registry.terraform.io/providers/elastic/elasticstack/latest[Elasticstack provider] for Terraform.
 For more details, refer to the https://registry.terraform.io/providers/elastic/elasticstack/latest/docs/resources/kibana_alerting_rule[elasticstack_kibana_alerting_rule] resource.
 
 [float]

--- a/docs/user/alerting/create-and-manage-rules.asciidoc
+++ b/docs/user/alerting/create-and-manage-rules.asciidoc
@@ -43,6 +43,9 @@ a rule type and configuring its conditions and actions.
 After a rule is created, you can open the action menu (…) and select *Edit rule*
 to re-open the flyout and change the rule properties.
 
+TIP: You can also manage connectors as resources with the https://registry.terraform.io/providers/elastic/elasticstack/latest[Elasticstack provider] for Terraform.
+For more details, refer to the https://registry.terraform.io/providers/elastic/elasticstack/latest/docs/resources/kibana_alerting_rule[elasticstack_kibana_alerting_rule] resource.
+
 [float]
 [[defining-rules-type-conditions]]
 ==== Rule type and conditions


### PR DESCRIPTION
## Summary

Relates to https://github.com/elastic/kibana/issues/158647

This PR adds links to the [Elasticstack provider docs](https://registry.terraform.io/providers/elastic/elasticstack/latest/docs) from the [Rules](https://www.elastic.co/guide/en/kibana/current/create-and-manage-rules.html) and [Connectors](https://www.elastic.co/guide/en/kibana/current/action-types.html) documentation.



<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->