### PR TITLE
[Synthetics] Removing passing of error object to logger.error as meta parameter 

### DIFF
--- a/x-pack/plugins/synthetics/server/synthetics_service/synthetics_service.ts
+++ b/x-pack/plugins/synthetics/server/synthetics_service/synthetics_service.ts
@@ -238,9 +238,10 @@ export class SyntheticsService {
         stackVersion: this.server.stackVersion,
       });
 
+      this.logger?.error(e);
+
       this.logger?.error(
-        `Error running task: ${SYNTHETICS_SERVICE_SYNC_MONITORS_TASK_ID}, `,
-        e?.message ?? e
+        `Error running synthetics syncs task: ${SYNTHETICS_SERVICE_SYNC_MONITORS_TASK_ID}, ${e?.message}`
       );
 
       return null;


### PR DESCRIPTION
## Summary

Removing passing of error object to logger.error as meta parameter !!

<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->