### PR TITLE
Add config deprecation for securitySolutionServerless config rename

### DIFF
--- a/x-pack/plugins/security_solution_serverless/server/config.ts
+++ b/x-pack/plugins/security_solution_serverless/server/config.ts
@@ -20,4 +20,11 @@ export const config: PluginConfigDescriptor<ServerlessSecurityConfig> = {
     productTypes: true,
   },
   schema: configSchema,
+  deprecations: ({ renameFromRoot }) => [
+    renameFromRoot(
+      'xpack.serverless.security.productTypes',
+      'xpack.securitySolutionServerless.productTypes',
+      { silent: true, level: 'warning' }
+    ),
+  ],
 };


### PR DESCRIPTION
## Summary

Related to https://github.com/elastic/kibana/pull/161153
Add a config deprecation renaming the old `productTypes` config key to the new one 