### PR TITLE
[Cases] Update notify user HTML email template to use current year dynamically

### DIFF
--- a/x-pack/plugins/cases/server/services/notifications/templates/assignees/renderer.ts
+++ b/x-pack/plugins/cases/server/services/notifications/templates/assignees/renderer.ts
@@ -7,7 +7,6 @@
 
 import fs from 'fs';
 import mustache from 'mustache';
-import moment from 'moment-timezone';
 import { join } from 'path';
 import { assertNever } from '@elastic/eui';
 import type { CaseSavedObjectTransformed } from '../../../../common/types/case';
@@ -80,7 +79,7 @@ export const assigneesTemplateRenderer = async (
         ? `${caseData.attributes.description.slice(0, DESCRIPTION_LIMIT)}...`
         : caseData.attributes.description,
     url: caseUrl,
-    currentYear: moment().year(),
+    currentYear: new Date().getUTCFullYear(),
   });
 
   return template;

--- a/x-pack/plugins/cases/server/services/notifications/templates/assignees/renderer.ts
+++ b/x-pack/plugins/cases/server/services/notifications/templates/assignees/renderer.ts
@@ -7,6 +7,7 @@
 
 import fs from 'fs';
 import mustache from 'mustache';
+import moment from 'moment-timezone';
 import { join } from 'path';
 import { assertNever } from '@elastic/eui';
 import type { CaseSavedObjectTransformed } from '../../../../common/types/case';
@@ -79,6 +80,7 @@ export const assigneesTemplateRenderer = async (
         ? `${caseData.attributes.description.slice(0, DESCRIPTION_LIMIT)}...`
         : caseData.attributes.description,
     url: caseUrl,
+    currentYear: moment().year(),
   });
 
   return template;

--- a/x-pack/plugins/cases/server/services/notifications/templates/assignees/template.html
+++ b/x-pack/plugins/cases/server/services/notifications/templates/assignees/template.html
@@ -186,7 +186,7 @@
                                 <tr>
                                     <td
                                         style="border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; line-height: 24px;">
-                                        © 2022 Elasticsearch B.V. All Rights Reserved.<br />
+                                        © {{currentYear}} Elasticsearch B.V. All Rights Reserved.<br />
                                         Elasticsearch is a trademark of Elasticsearch BV, registered in the
                                         U.S. and in other countries / <a href="https://www.elastic.co/legal/trademarks"
                                             style="text-decoration: none; color: #0071C2; border-width: 0;">Trademarks</a>

--- a/x-pack/plugins/cases/server/services/notifications/templates/assignees/template.test.ts
+++ b/x-pack/plugins/cases/server/services/notifications/templates/assignees/template.test.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import moment from 'moment-timezone';
 import { mockCases } from '../../../../mocks';
 import { getByText } from '@testing-library/dom';
 import { assigneesTemplateRenderer } from './renderer';
@@ -24,6 +25,11 @@ describe('Assignees template', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    moment.tz.setDefault('UTC');
+  });
+
+  afterEach(() => {
+    moment.tz.setDefault('Browser');
   });
 
   it('renders case data correctly', async () => {
@@ -72,5 +78,14 @@ describe('Assignees template', () => {
     const container = await getHTMLNode(caseSO, null);
 
     expect(container.querySelector('.btn')).not.toBeTruthy();
+  });
+
+  it('renders current year correctly', async () => {
+    const currentYear = moment().year();
+    const footerText = `© ${currentYear} Elasticsearch B.V. All Rights Reserved.`;
+
+    const container = await getHTMLNode(caseSO, mockCaseUrl);
+
+    expect(getByText(container, footerText, { exact: false })).toBeTruthy();
   });
 });

--- a/x-pack/plugins/cases/server/services/notifications/templates/assignees/template.test.ts
+++ b/x-pack/plugins/cases/server/services/notifications/templates/assignees/template.test.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import moment from 'moment-timezone';
 import { mockCases } from '../../../../mocks';
 import { getByText } from '@testing-library/dom';
 import { assigneesTemplateRenderer } from './renderer';
@@ -25,11 +24,6 @@ describe('Assignees template', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    moment.tz.setDefault('UTC');
-  });
-
-  afterEach(() => {
-    moment.tz.setDefault('Browser');
   });
 
   it('renders case data correctly', async () => {
@@ -81,7 +75,7 @@ describe('Assignees template', () => {
   });
 
   it('renders current year correctly', async () => {
-    const currentYear = moment().year();
+    const currentYear = new Date().getUTCFullYear();
     const footerText = `© ${currentYear} Elasticsearch B.V. All Rights Reserved.`;
 
     const container = await getHTMLNode(caseSO, mockCaseUrl);


### PR DESCRIPTION
## Summary

This PR adds current year dynamcially to notify user HTML email template footer.

![image](https://github.com/elastic/kibana/assets/117571355/0169d58b-d567-4061-bb7d-36326348aa99)

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->