### PR TITLE
[APM] Improve trace waterfall error message

### DIFF
--- a/x-pack/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/index.tsx
@@ -118,9 +118,8 @@ export function Waterfall({
           iconType="warning"
           title={i18n.translate('xpack.apm.waterfall.exceedsMax', {
             defaultMessage:
-              'The number of items in this trace is {traceItemCount} which is higher than the current limit of {maxTraceItems}. Please increase the limit to see the full trace',
+              'The number of items in this trace is higher than the current limit of {maxTraceItems}. Please increase `xpack.apm.ui.maxTraceItem` to see the full trace',
             values: {
-              traceItemCount: waterfall.traceItemCount,
               maxTraceItems: waterfall.maxTraceItems,
             },
           })}


### PR DESCRIPTION
Related to this sdh: https://github.com/elastic/sdh-apm/issues/1005

This improves the error message by specifying which setting the user have to increase to see the full trace.


**Before:**
> The number of items in this trace is 10001 which is higher than the current limit of 10000. Please increase the limit to see the full trace

**After:**
> The number of items in this trace is higher than the current limit of 10000. Please increase `xpack.apm.ui.maxTraceItem` to see the full trace