### PR TITLE
[Serverless Search] Use Enterprise Search logo for connectors

### DIFF
--- a/x-pack/plugins/serverless_search/public/application/components/overview_panels/integrations_panel.tsx
+++ b/x-pack/plugins/serverless_search/public/application/components/overview_panels/integrations_panel.tsx
@@ -111,7 +111,7 @@ export const IntegrationsPanel: React.FC = () => {
         <EuiSpacer size="l" />
         <EuiFlexGroup alignItems="center" justifyContent="flexStart">
           <EuiFlexItem grow={false}>
-            <EuiIcon type="logoBeats" size="xxl" />
+            <EuiIcon type="logoEnterpriseSearch" size="xxl" />
           </EuiFlexItem>
           <EuiFlexItem>
             <EuiTitle size="l">


### PR DESCRIPTION
## Summary

Use the Enterprise Search logo to link to connectors, instead of the Beats logo.