### PR TITLE
[Enterprise Search] Add Google Drive connector tile to content UI

### DIFF
--- a/packages/kbn-doc-links/src/get_doc_links.ts
+++ b/packages/kbn-doc-links/src/get_doc_links.ts
@@ -139,6 +139,7 @@ export const getDocLinks = ({ kibanaBranch }: GetDocLinkOptions): DocLinks => {
       connectorsDropbox: `${ENTERPRISE_SEARCH_DOCS}connectors-dropbox.html`,
       connectorsContentExtraction: `${ENTERPRISE_SEARCH_DOCS}connectors-content-extraction.html`,
       connectorsGoogleCloudStorage: `${ENTERPRISE_SEARCH_DOCS}connectors-google-cloud.html`,
+      connectorsGoogleDrive: `${ENTERPRISE_SEARCH_DOCS}connectors-google-drive.html`,
       connectorsJira: `${ENTERPRISE_SEARCH_DOCS}connectors-jira.html`,
       connectorsMicrosoftSQL: `${ENTERPRISE_SEARCH_DOCS}connectors-ms-sql.html`,
       connectorsMongoDB: `${ENTERPRISE_SEARCH_DOCS}connectors-mongodb.html`,

--- a/packages/kbn-doc-links/src/types.ts
+++ b/packages/kbn-doc-links/src/types.ts
@@ -123,6 +123,7 @@ export interface DocLinks {
     readonly connectorsContentExtraction: string;
     readonly connectorsDropbox: string;
     readonly connectorsGoogleCloudStorage: string;
+    readonly connectorsGoogleDrive: string;
     readonly connectorsJira: string;
     readonly connectorsMicrosoftSQL: string;
     readonly connectorsMongoDB: string;

--- a/x-pack/plugins/enterprise_search/common/connectors/connectors.ts
+++ b/x-pack/plugins/enterprise_search/common/connectors/connectors.ts
@@ -59,6 +59,16 @@ export const CONNECTOR_DEFINITIONS: ConnectorServerSideDefinition[] = [
     serviceType: 'google_cloud_storage',
   },
   {
+    iconPath: 'google_drive.svg',
+    isBeta: true,
+    isNative: false,
+    keywords: ['google', 'drive', 'connector'],
+    name: i18n.translate('xpack.enterpriseSearch.content.nativeConnectors.googleDrive.name', {
+      defaultMessage: 'Google Drive',
+    }),
+    serviceType: 'google_drive',
+  },
+  {
     iconPath: 'mongodb.svg',
     isBeta: false,
     isNative: true,

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/constants.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/constants.ts
@@ -43,6 +43,12 @@ export const CONNECTORS_DICT: Record<string, ConnectorClientSideDefinition> = {
     externalDocsUrl: 'https://cloud.google.com/storage/docs',
     icon: CONNECTOR_ICONS.google_cloud_storage,
   },
+  google_drive: {
+    docsUrl: docLinks.connectorsGoogleDrive,
+    externalAuthDocsUrl: 'https://cloud.google.com/iam/docs/service-account-overview',
+    externalDocsUrl: 'https://developers.google.com/drive',
+    icon: CONNECTOR_ICONS.google_drive,
+  },
   jira: {
     docsUrl: docLinks.connectorsJira,
     externalAuthDocsUrl: '',

--- a/x-pack/plugins/enterprise_search/public/applications/shared/doc_links/doc_links.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/doc_links/doc_links.ts
@@ -68,6 +68,7 @@ class DocLinks {
   public connectorsContentExtraction: string;
   public connectorsDropbox: string;
   public connectorsGoogleCloudStorage: string;
+  public connectorsGoogleDrive: string;
   public connectorsJira: string;
   public connectorsMicrosoftSQL: string;
   public connectorsMongoDB: string;
@@ -223,6 +224,7 @@ class DocLinks {
     this.connectorsClients = '';
     this.connectorsDropbox = '';
     this.connectorsGoogleCloudStorage = '';
+    this.connectorsGoogleDrive = '';
     this.connectorsJira = '';
     this.connectorsMicrosoftSQL = '';
     this.connectorsMongoDB = '';
@@ -380,6 +382,8 @@ class DocLinks {
     this.connectorsDropbox = docLinks.links.enterpriseSearch.connectorsDropbox;
     this.connectorsGoogleCloudStorage =
       docLinks.links.enterpriseSearch.connectorsGoogleCloudStorage;
+    this.connectorsGoogleDrive =
+      docLinks.links.enterpriseSearch.connectorsGoogleDrive;
     this.connectorsJira = docLinks.links.enterpriseSearch.connectorsJira;
     this.connectorsMicrosoftSQL = docLinks.links.enterpriseSearch.connectorsMicrosoftSQL;
     this.connectorsMongoDB = docLinks.links.enterpriseSearch.connectorsMongoDB;

--- a/x-pack/plugins/enterprise_search/public/applications/shared/doc_links/doc_links.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/doc_links/doc_links.ts
@@ -382,8 +382,7 @@ class DocLinks {
     this.connectorsDropbox = docLinks.links.enterpriseSearch.connectorsDropbox;
     this.connectorsGoogleCloudStorage =
       docLinks.links.enterpriseSearch.connectorsGoogleCloudStorage;
-    this.connectorsGoogleDrive =
-      docLinks.links.enterpriseSearch.connectorsGoogleDrive;
+    this.connectorsGoogleDrive = docLinks.links.enterpriseSearch.connectorsGoogleDrive;
     this.connectorsJira = docLinks.links.enterpriseSearch.connectorsJira;
     this.connectorsMicrosoftSQL = docLinks.links.enterpriseSearch.connectorsMicrosoftSQL;
     this.connectorsMongoDB = docLinks.links.enterpriseSearch.connectorsMongoDB;

--- a/x-pack/plugins/enterprise_search/public/applications/shared/icons/connector_icons.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/icons/connector_icons.ts
@@ -11,6 +11,7 @@ import custom from '../../../assets/source_icons/custom.svg';
 import dropbox from '../../../assets/source_icons/dropbox.svg';
 import github from '../../../assets/source_icons/github.svg';
 import google_cloud_storage from '../../../assets/source_icons/google_cloud_storage.svg';
+import google_drive from '../../../assets/source_icons/google_drive.svg';
 import jira_cloud from '../../../assets/source_icons/jira_cloud.svg';
 import mongodb from '../../../assets/source_icons/mongodb.svg';
 import microsoft_sql from '../../../assets/source_icons/mssql.svg';
@@ -31,6 +32,7 @@ export const CONNECTOR_ICONS = {
   dropbox,
   github,
   google_cloud_storage,
+  google_drive,
   jira_cloud,
   microsoft_sql,
   mongodb,


### PR DESCRIPTION
## Summary

This adds Google Drive connector tile to Enterprise Search.

### Preview

Google drive connector documentation link: https://www.elastic.co/guide/en/enterprise-search/master/connectors-google-drive.html

Tile view:

<img width="1681" alt="Screenshot 2023-07-06 at 16 18 33" src="https://github.com/elastic/kibana/assets/14121688/805dea1c-70ca-46f8-b4df-78802a614b37">


Google Drive configuration - we only require service account JSON:

<img width="869" alt="Screenshot 2023-07-06 at 16 20 03" src="https://github.com/elastic/kibana/assets/14121688/ea50966f-64a6-49ed-a2e0-f697cb870e9c">


