### PR TITLE
[DOCS] Add TOC to landing page

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -7,6 +7,8 @@ include::{docs-root}/shared/versions/stack/{source_branch}.asciidoc[]
 
 include::{docs-root}/shared/attributes.asciidoc[]
 
+include::landing-page.asciidoc[]
+
 include::user/index.asciidoc[]
 
 include::accessibility.asciidoc[]

--- a/docs/landing-page.asciidoc
+++ b/docs/landing-page.asciidoc
@@ -286,7 +286,7 @@
 window.addEventListener("DOMContentLoaded", (event) => {
   const left_col = document.getElementById("left_col")
   left_col.classList.remove('col-0')
-  left_col.classList.add("col-12", "order-2", "col-md-4", "col-lg-3", "h-almost-full-md", "sticky-top-md")
+  left_col.classList.add("col-12", "col-md-4", "col-lg-3", "h-almost-full-md", "sticky-top-md")
   const right_col = document.getElementById("right_col")
   right_col.classList.add('d-none')
   const middle_col = document.getElementById("middle_col")

--- a/docs/landing-page.asciidoc
+++ b/docs/landing-page.asciidoc
@@ -286,7 +286,7 @@
 window.addEventListener("DOMContentLoaded", (event) => {
   const left_col = document.getElementById("left_col")
   left_col.classList.remove('col-0')
-  left_col.classList.add("col-12", "col-md-4", "col-lg-3", "h-almost-full-md", "sticky-top-md")
+  left_col.classList.add("col-12", "order-2", "col-md-4", "col-lg-3", "h-almost-full-md", "sticky-top-md")
   const right_col = document.getElementById("right_col")
   right_col.classList.add('d-none')
   const middle_col = document.getElementById("middle_col")

--- a/docs/landing-page.asciidoc
+++ b/docs/landing-page.asciidoc
@@ -1,3 +1,4 @@
+++++
 <style>
   * {
     box-sizing: border-box;
@@ -281,4 +282,19 @@
   </div>
 </div>
 
-<p class="my-4"><a href="https://www.elastic.co/guide/index.html">View all Elastic docs</a></p>
+<script>
+window.addEventListener("DOMContentLoaded", (event) => {
+  const left_col = document.getElementById("left_col")
+  left_col.classList.remove('col-0')
+  left_col.classList.add("col-12", "col-md-4", "col-lg-3", "h-almost-full-md", "sticky-top-md")
+  const right_col = document.getElementById("right_col")
+  right_col.classList.add('d-none')
+  const middle_col = document.getElementById("middle_col")
+  middle_col.classList.remove("col-lg-7")
+  middle_col.classList.add("col-lg-9", "col-md-8")
+  const toc = middle_col.getElementsByClassName("toc")[0]
+  toc.remove()
+  left_col.appendChild(toc);
+});
+</script>
+++++


### PR DESCRIPTION
### Summary
- Adds the TOC to the Kibana docs landing page. Removes the right sidebar from the landing page.
- Removes the "View all Elastic docs" link from the bottom of the landing page

### Screenshots

<details><summary><b>Before</b></summary>

![kibana-before](https://github.com/elastic/kibana/assets/40268737/f58ada3c-012a-4865-b8a5-5b34909b79df)

</details> 

<details><summary><b>After</b></summary>

![kibana-after](https://github.com/elastic/kibana/assets/40268737/8ca96298-df92-4930-a42d-03b85a35fc7e)

</details> 

<!--ONMERGE {"backportTargets":["8.8","8.9"]} ONMERGE-->