### PR TITLE
[Synthetics] Fixed a label for lens viz in synthetics apps

### DIFF
--- a/x-pack/plugins/exploratory_view/public/components/shared/exploratory_view/configurations/lens_attributes/single_metric_attributes.test.ts
+++ b/x-pack/plugins/exploratory_view/public/components/shared/exploratory_view/configurations/lens_attributes/single_metric_attributes.test.ts
@@ -81,6 +81,7 @@ describe('SingleMetricAttributes', () => {
                 columnOrder: ['layer-0-column-1'],
                 columns: {
                   'layer-0-column-1': {
+                    customLabel: true,
                     dataType: 'number',
                     isBucketed: false,
                     label: 'Page load time',

--- a/x-pack/plugins/exploratory_view/public/components/shared/exploratory_view/configurations/lens_attributes/single_metric_attributes.ts
+++ b/x-pack/plugins/exploratory_view/public/components/shared/exploratory_view/configurations/lens_attributes/single_metric_attributes.ts
@@ -42,6 +42,8 @@ export class SingleMetricLensAttributes extends LensAttributes {
     this.globalFilter = this.getGlobalFilter(this.isMultiSeries);
     const layer0 = this.getSingleMetricLayer()!;
 
+    console.log('layer0', layer0);
+
     this.layers = {
       layer0,
     };
@@ -106,6 +108,7 @@ export class SingleMetricLensAttributes extends LensAttributes {
         columns: {
           [this.columnId]: {
             ...buildNumberColumn(sourceField),
+            customLabel: true,
             label: name ?? columnLabel,
             operationType: sourceField === RECORDS_FIELD ? 'count' : operationType || 'median',
             filter: columnFilter,
@@ -175,6 +178,7 @@ export class SingleMetricLensAttributes extends LensAttributes {
           ...this.getPercentileNumberColumn(sourceField, operationType!, seriesConfig),
           label: columnLabel ?? '',
           filter: columnFilter,
+          customLabel: true,
         },
       },
       columnOrder: [this.columnId],

--- a/x-pack/plugins/exploratory_view/public/components/shared/exploratory_view/configurations/lens_attributes/single_metric_attributes.ts
+++ b/x-pack/plugins/exploratory_view/public/components/shared/exploratory_view/configurations/lens_attributes/single_metric_attributes.ts
@@ -42,8 +42,6 @@ export class SingleMetricLensAttributes extends LensAttributes {
     this.globalFilter = this.getGlobalFilter(this.isMultiSeries);
     const layer0 = this.getSingleMetricLayer()!;
 
-    console.log('layer0', layer0);
-
     this.layers = {
       layer0,
     };

--- a/x-pack/plugins/synthetics/e2e/synthetics/journeys/monitor_details_page/monitor_summary.journey.ts
+++ b/x-pack/plugins/synthetics/e2e/synthetics/journeys/monitor_details_page/monitor_summary.journey.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { journey, step, before, after } from '@elastic/synthetics';
+import { journey, step, before, after, expect } from '@elastic/synthetics';
 import { byTestId } from '@kbn/ux-plugin/e2e/journeys/utils';
 import { RetryService } from '@kbn/ftr-common-functional-services';
 import moment from 'moment';
@@ -83,5 +83,19 @@ journey(`MonitorSummaryTab`, async ({ page, params }) => {
         `${byTestId('monitorActiveAlertsCount')}  .legacyMtrVis__value:has-text("1")`
       );
     });
+    const existingLabels = [
+      'Availability',
+      'Median duration',
+      'Errors',
+      'All',
+      'Active',
+      'Recovered',
+    ];
+
+    const labels = await page.$$(byTestId('metric_label'));
+    for (const label of labels) {
+      const text = await label.textContent();
+      expect(existingLabels).toContain(text);
+    }
   });
 });


### PR DESCRIPTION
## Summary

Some refactor broke our labels, added a test case to make sure it's part of e2e tests.

### After

<img width="1456" alt="image" src="https://github.com/elastic/kibana/assets/3505601/23f8cd56-ad4b-4c9d-97e7-2681c963406d">

### Before

<img width="1495" alt="image" src="https://github.com/elastic/kibana/assets/3505601/f835742b-d506-4beb-b68f-1d51d164ad96">



<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->