### PR TITLE
[8.9] [Unified search] Make the dataview optional in the search input ui (#161166)

### DIFF
--- a/src/plugins/unified_search/public/query_string_input/query_bar_top_row.tsx
+++ b/src/plugins/unified_search/public/query_string_input/query_bar_top_row.tsx
@@ -398,7 +398,7 @@ export const QueryBarTopRow = React.memo(
     );
 
     function shouldRenderQueryInput(): boolean {
-      return Boolean(showQueryInput && props.indexPatterns && props.query && storage);
+      return Boolean(showQueryInput && props.query && storage);
     }
 
     function shouldRenderDatePicker(): boolean {

--- a/x-pack/plugins/apm/public/components/shared/unified_search_bar/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/unified_search_bar/index.tsx
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { i18n } from '@kbn/i18n';
 import {
   Filter,
@@ -16,7 +16,6 @@ import {
 import { useHistory, useLocation } from 'react-router-dom';
 import deepEqual from 'fast-deep-equal';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
-import { EuiSkeletonRectangle } from '@elastic/eui';
 import qs from 'query-string';
 import { DataView, UI_SETTINGS } from '@kbn/data-plugin/common';
 import { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
@@ -158,7 +157,6 @@ export function UnifiedSearchBar({
     UI_SETTINGS.TIMEPICKER_TIME_DEFAULTS
   );
   const urlTimeRange = useUrlTimeRange(timePickerTimeDefaults);
-  const [displaySearchBar, setDisplaySearchBar] = useState(false);
 
   const syncSearchBarWithUrl = useCallback(() => {
     // Sync Kuery params with Search Bar
@@ -201,10 +199,6 @@ export function UnifiedSearchBar({
     placeholder,
     processorEvent
   );
-
-  useEffect(() => {
-    if (dataView) setDisplaySearchBar(true);
-  }, [dataView]);
 
   const customFilters =
     boolFilter ??
@@ -288,32 +282,26 @@ export function UnifiedSearchBar({
   };
 
   return (
-    <EuiSkeletonRectangle
-      isLoading={!displaySearchBar}
-      width="100%"
-      height="40px"
-    >
-      <SearchBar
-        appName={i18n.translate('xpack.apm.appName', {
-          defaultMessage: 'APM',
-        })}
-        iconType="search"
-        placeholder={searchbarPlaceholder}
-        useDefaultBehaviors={true}
-        indexPatterns={dataView ? [dataView] : undefined}
-        showQueryInput={true}
-        showQueryMenu={false}
-        showFilterBar={false}
-        showDatePicker={showDatePicker}
-        showSubmitButton={showSubmitButton}
-        displayStyle="inPage"
-        onQuerySubmit={handleSubmit}
-        onRefresh={onRefresh}
-        onRefreshChange={onRefreshChange}
-        isClearable={isClearable}
-        dataTestSubj="apmUnifiedSearchBar"
-        filtersForSuggestions={filtersForSearchBarSuggestions}
-      />
-    </EuiSkeletonRectangle>
+    <SearchBar
+      appName={i18n.translate('xpack.apm.appName', {
+        defaultMessage: 'APM',
+      })}
+      iconType="search"
+      placeholder={searchbarPlaceholder}
+      useDefaultBehaviors={true}
+      indexPatterns={dataView ? [dataView] : undefined}
+      showQueryInput={true}
+      showQueryMenu={false}
+      showFilterBar={false}
+      showDatePicker={showDatePicker}
+      showSubmitButton={showSubmitButton}
+      displayStyle="inPage"
+      onQuerySubmit={handleSubmit}
+      onRefresh={onRefresh}
+      onRefreshChange={onRefreshChange}
+      isClearable={isClearable}
+      dataTestSubj="apmUnifiedSearchBar"
+      filtersForSuggestions={filtersForSearchBarSuggestions}
+    />
   );
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.9`:
 - [[Unified search] Make the dataview optional in the search input ui (#161166)](https://github.com/elastic/kibana/pull/161166)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Stratoula Kalafateli","email":"efstratia.kalafateli@elastic.co"},"sourceCommit":{"committedDate":"2023-07-06T09:45:30Z","message":"[Unified search] Make the dataview optional in the search input ui (#161166)\n\n## Summary\r\n\r\nCloses https://github.com/elastic/kibana/issues/158986\r\n\r\nThis PR is applying a very simple fix on the unified search bar. It\r\nmakes the dataview to not be required to load the text area.\r\n\r\nThe dataview(s) is required for the suggestions but not for running a\r\nquery.\r\n\r\n\r\n![apm](https://github.com/elastic/kibana/assets/17003240/be5fc64e-4c90-4d69-90b8-4f30ccf7913e)\r\n\r\nThere is currently a bug\r\nhttps://github.com/elastic/kibana/issues/158986#issuecomment-1620099640\r\non the apm side. It is happening because the url update is not allowed\r\nwhen the dataview is not set. This needs to be fixed on the apm side so\r\nI synced with the apm team and they are going to take it.","sha":"75140a89775a4341cdbd8d0788971b3fde1fb010","branchLabelMapping":{"^v8.10.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:APM","Team:Visualizations","release_note:skip","backport:skip","Feature:Unified search","v8.10.0"],"number":161166,"url":"https://github.com/elastic/kibana/pull/161166","mergeCommit":{"message":"[Unified search] Make the dataview optional in the search input ui (#161166)\n\n## Summary\r\n\r\nCloses https://github.com/elastic/kibana/issues/158986\r\n\r\nThis PR is applying a very simple fix on the unified search bar. It\r\nmakes the dataview to not be required to load the text area.\r\n\r\nThe dataview(s) is required for the suggestions but not for running a\r\nquery.\r\n\r\n\r\n![apm](https://github.com/elastic/kibana/assets/17003240/be5fc64e-4c90-4d69-90b8-4f30ccf7913e)\r\n\r\nThere is currently a bug\r\nhttps://github.com/elastic/kibana/issues/158986#issuecomment-1620099640\r\non the apm side. It is happening because the url update is not allowed\r\nwhen the dataview is not set. This needs to be fixed on the apm side so\r\nI synced with the apm team and they are going to take it.","sha":"75140a89775a4341cdbd8d0788971b3fde1fb010"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.10.0","labelRegex":"^v8.10.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/161166","number":161166,"mergeCommit":{"message":"[Unified search] Make the dataview optional in the search input ui (#161166)\n\n## Summary\r\n\r\nCloses https://github.com/elastic/kibana/issues/158986\r\n\r\nThis PR is applying a very simple fix on the unified search bar. It\r\nmakes the dataview to not be required to load the text area.\r\n\r\nThe dataview(s) is required for the suggestions but not for running a\r\nquery.\r\n\r\n\r\n![apm](https://github.com/elastic/kibana/assets/17003240/be5fc64e-4c90-4d69-90b8-4f30ccf7913e)\r\n\r\nThere is currently a bug\r\nhttps://github.com/elastic/kibana/issues/158986#issuecomment-1620099640\r\non the apm side. It is happening because the url update is not allowed\r\nwhen the dataview is not set. This needs to be fixed on the apm side so\r\nI synced with the apm team and they are going to take it.","sha":"75140a89775a4341cdbd8d0788971b3fde1fb010"}}]}] BACKPORT-->