### PR TITLE
[Guided onboarding] Migrate all usages of EuiPage*_Deprecated

### DIFF
--- a/examples/guided_onboarding_example/public/components/main.tsx
+++ b/examples/guided_onboarding_example/public/components/main.tsx
@@ -18,8 +18,8 @@ import {
   EuiFlexItem,
   EuiFormRow,
   EuiHorizontalRule,
-  EuiPageContentBody_Deprecated as EuiPageContentBody,
-  EuiPageContentHeader_Deprecated as EuiPageContentHeader,
+  EuiPageSection,
+  EuiPageHeader,
   EuiSelect,
   EuiSpacer,
   EuiText,
@@ -149,7 +149,7 @@ export const Main = (props: MainProps) => {
 
   return (
     <>
-      <EuiPageContentHeader>
+      <EuiPageHeader>
         <EuiTitle>
           <h2>
             <FormattedMessage
@@ -158,8 +158,8 @@ export const Main = (props: MainProps) => {
             />
           </h2>
         </EuiTitle>
-      </EuiPageContentHeader>
-      <EuiPageContentBody>
+      </EuiPageHeader>
+      <EuiPageSection>
         <EuiText>
           <h3>
             <FormattedMessage
@@ -354,7 +354,7 @@ export const Main = (props: MainProps) => {
             </EuiButton>
           </EuiFlexItem>
         </EuiFlexGroup>
-      </EuiPageContentBody>
+      </EuiPageSection>
     </>
   );
 };

--- a/examples/guided_onboarding_example/public/components/step_four.tsx
+++ b/examples/guided_onboarding_example/public/components/step_four.tsx
@@ -13,8 +13,8 @@ import { EuiButton, EuiSpacer, EuiText, EuiTitle } from '@elastic/eui';
 import { GuidedOnboardingPluginStart } from '@kbn/guided-onboarding-plugin/public/types';
 import { FormattedMessage } from '@kbn/i18n-react';
 import {
-  EuiPageContentHeader_Deprecated as EuiPageContentHeader,
-  EuiPageContentBody_Deprecated as EuiPageContentBody,
+  EuiPageHeader,
+  EuiPageSection,
   EuiCode,
 } from '@elastic/eui';
 import { useParams } from 'react-router-dom';
@@ -41,7 +41,7 @@ export const StepFour: React.FC<StepFourProps> = ({
 
   return (
     <>
-      <EuiPageContentHeader>
+      <EuiPageHeader>
         <EuiTitle>
           <h2>
             <FormattedMessage
@@ -50,8 +50,8 @@ export const StepFour: React.FC<StepFourProps> = ({
             />
           </h2>
         </EuiTitle>
-      </EuiPageContentHeader>
-      <EuiPageContentBody>
+      </EuiPageHeader>
+      <EuiPageSection>
         <EuiText>
           <p>
             <FormattedMessage
@@ -74,7 +74,7 @@ export const StepFour: React.FC<StepFourProps> = ({
         >
           Complete step 4
         </EuiButton>
-      </EuiPageContentBody>
+      </EuiPageSection>
     </>
   );
 };

--- a/examples/guided_onboarding_example/public/components/step_four.tsx
+++ b/examples/guided_onboarding_example/public/components/step_four.tsx
@@ -12,11 +12,7 @@ import { EuiButton, EuiSpacer, EuiText, EuiTitle } from '@elastic/eui';
 
 import { GuidedOnboardingPluginStart } from '@kbn/guided-onboarding-plugin/public/types';
 import { FormattedMessage } from '@kbn/i18n-react';
-import {
-  EuiPageHeader,
-  EuiPageSection,
-  EuiCode,
-} from '@elastic/eui';
+import { EuiPageHeader, EuiPageSection, EuiCode } from '@elastic/eui';
 import { useParams } from 'react-router-dom';
 
 interface StepFourProps {

--- a/examples/guided_onboarding_example/public/components/step_one.tsx
+++ b/examples/guided_onboarding_example/public/components/step_one.tsx
@@ -13,8 +13,8 @@ import {
   EuiText,
   EuiTourStep,
   EuiTitle,
-  EuiPageContentHeader_Deprecated as EuiPageContentHeader,
-  EuiPageContentBody_Deprecated as EuiPageContentBody,
+  EuiPageHeader,
+  EuiPageSection,
   EuiSpacer,
   EuiCode,
   EuiFieldText,
@@ -46,7 +46,7 @@ export const StepOne = ({ guidedOnboarding }: GuidedOnboardingExampleAppDeps) =>
   }, [isTourActive]);
   return (
     <>
-      <EuiPageContentHeader>
+      <EuiPageHeader>
         <EuiTitle>
           <h2>
             <FormattedMessage
@@ -55,8 +55,8 @@ export const StepOne = ({ guidedOnboarding }: GuidedOnboardingExampleAppDeps) =>
             />
           </h2>
         </EuiTitle>
-      </EuiPageContentHeader>
-      <EuiPageContentBody>
+      </EuiPageHeader>
+      <EuiPageSection>
         <EuiText>
           <p>
             <FormattedMessage
@@ -118,7 +118,7 @@ export const StepOne = ({ guidedOnboarding }: GuidedOnboardingExampleAppDeps) =>
             </EuiFormRow>
           </EuiFlexItem>
         </EuiFlexGroup>
-      </EuiPageContentBody>
+      </EuiPageSection>
     </>
   );
 };

--- a/examples/guided_onboarding_example/public/components/step_three.tsx
+++ b/examples/guided_onboarding_example/public/components/step_three.tsx
@@ -12,10 +12,7 @@ import { EuiButton, EuiSpacer, EuiText, EuiTitle, EuiTourStep } from '@elastic/e
 
 import { GuidedOnboardingPluginStart } from '@kbn/guided-onboarding-plugin/public/types';
 import { FormattedMessage } from '@kbn/i18n-react';
-import {
-  EuiPageHeader,
-  EuiPageSection,
-} from '@elastic/eui';
+import { EuiPageHeader, EuiPageSection } from '@elastic/eui';
 
 interface StepThreeProps {
   guidedOnboarding: GuidedOnboardingPluginStart;

--- a/examples/guided_onboarding_example/public/components/step_three.tsx
+++ b/examples/guided_onboarding_example/public/components/step_three.tsx
@@ -13,8 +13,8 @@ import { EuiButton, EuiSpacer, EuiText, EuiTitle, EuiTourStep } from '@elastic/e
 import { GuidedOnboardingPluginStart } from '@kbn/guided-onboarding-plugin/public/types';
 import { FormattedMessage } from '@kbn/i18n-react';
 import {
-  EuiPageContentHeader_Deprecated as EuiPageContentHeader,
-  EuiPageContentBody_Deprecated as EuiPageContentBody,
+  EuiPageHeader,
+  EuiPageSection,
 } from '@elastic/eui';
 
 interface StepThreeProps {
@@ -39,7 +39,7 @@ export const StepThree = (props: StepThreeProps) => {
 
   return (
     <>
-      <EuiPageContentHeader>
+      <EuiPageHeader>
         <EuiTitle>
           <h2>
             <FormattedMessage
@@ -48,8 +48,8 @@ export const StepThree = (props: StepThreeProps) => {
             />
           </h2>
         </EuiTitle>
-      </EuiPageContentHeader>
-      <EuiPageContentBody>
+      </EuiPageHeader>
+      <EuiPageSection>
         <EuiText>
           <p>
             <FormattedMessage
@@ -92,7 +92,7 @@ export const StepThree = (props: StepThreeProps) => {
             Complete step 3
           </EuiButton>
         </EuiTourStep>
-      </EuiPageContentBody>
+      </EuiPageSection>
     </>
   );
 };

--- a/examples/guided_onboarding_example/public/components/step_two.tsx
+++ b/examples/guided_onboarding_example/public/components/step_two.tsx
@@ -11,10 +11,7 @@ import React from 'react';
 import { EuiText, EuiTitle } from '@elastic/eui';
 
 import { FormattedMessage } from '@kbn/i18n-react';
-import {
-  EuiPageHeader,
-  EuiPageSection,
-} from '@elastic/eui';
+import { EuiPageHeader, EuiPageSection } from '@elastic/eui';
 
 export const StepTwo = () => {
   return (

--- a/examples/guided_onboarding_example/public/components/step_two.tsx
+++ b/examples/guided_onboarding_example/public/components/step_two.tsx
@@ -12,14 +12,14 @@ import { EuiText, EuiTitle } from '@elastic/eui';
 
 import { FormattedMessage } from '@kbn/i18n-react';
 import {
-  EuiPageContentHeader_Deprecated as EuiPageContentHeader,
-  EuiPageContentBody_Deprecated as EuiPageContentBody,
+  EuiPageHeader,
+  EuiPageSection,
 } from '@elastic/eui';
 
 export const StepTwo = () => {
   return (
     <>
-      <EuiPageContentHeader>
+      <EuiPageHeader>
         <EuiTitle>
           <h2>
             <FormattedMessage
@@ -28,8 +28,8 @@ export const StepTwo = () => {
             />
           </h2>
         </EuiTitle>
-      </EuiPageContentHeader>
-      <EuiPageContentBody>
+      </EuiPageHeader>
+      <EuiPageSection>
         <EuiText>
           <p>
             <FormattedMessage
@@ -39,7 +39,7 @@ export const StepTwo = () => {
             />
           </p>
         </EuiText>
-      </EuiPageContentBody>
+      </EuiPageSection>
     </>
   );
 };


### PR DESCRIPTION
## Summary

This PR removes all usages of EuiPage*_Deprecated for:

- EuiPageContentBody_Deprecated -> Use EuiPageSection instead
- EuiPageContentHeader_Deprecated -> Use EuiPageHeader instead


Fixes: #161427