### PR TITLE
[Docs] Try to make it clear drilldows only available in dashboard

### DIFF
--- a/docs/maps/search.asciidoc
+++ b/docs/maps/search.asciidoc
@@ -99,16 +99,18 @@ To filter your dashboard by your map bounds as you pan and zoom your map:
 
 A spatial filter narrows search results to documents that either intersect with, are within, or do not intersect with the specified geometry.
 
-You can create spatial filters in two ways:
-
-* Click the tool icon image:maps/images/tools_icon.png[], and then draw a shape, bounding box, or distance on the map to define the spatial filter.
-* Click *Filter by geometry* in a <<maps-vector-tooltip-locking, locked tooltip>>, and then use the feature's geometry for the spatial filter.
-
 Spatial filters have the following properties:
 
 * *Geometry label* enables you to provide a meaningful name for your spatial filter.
 * *Spatial relation* determines the {ref}/query-dsl-geo-shape-query.html#geo-shape-spatial-relations[spatial relation operator] to use at search time.
-* *Action* specifies whether to apply the filter to the current view or to a drilldown action. Only available when the map is a panel in a {kibana-ref}/dashboard.html[dashboard] with {kibana-ref}/drilldowns.html[drilldowns].
+* *Action* specifies whether to apply the filter to the current view or to a drilldown action. 
+
+NOTE: {kibana-ref}/drilldowns.html[Drilldowns] are only available if the map is a panel in a {kibana-ref}/dashboard.html[dashboard], and not within the Maps application.
+
+You can create spatial filters in two ways:
+
+* Click the tool icon image:maps/images/tools_icon.png[], and then draw a shape, bounding box, or distance on the map to define the spatial filter.
+* Click *Filter by geometry* in a <<maps-vector-tooltip-locking, locked tooltip>>, and then use the feature's geometry for the spatial filter.
 
 [role="screenshot"]
 image::maps/images/create_spatial_filter.png[]

--- a/docs/maps/search.asciidoc
+++ b/docs/maps/search.asciidoc
@@ -105,7 +105,7 @@ Spatial filters have the following properties:
 * *Spatial relation* determines the {ref}/query-dsl-geo-shape-query.html#geo-shape-spatial-relations[spatial relation operator] to use at search time.
 * *Action* specifies whether to apply the filter to the current view or to a drilldown action. 
 
-NOTE: {kibana-ref}/drilldowns.html[Drilldowns] are only available if the map is a panel in a {kibana-ref}/dashboard.html[dashboard], and not within the Maps application.
+NOTE: {kibana-ref}/drilldowns.html[Drilldowns] are available only if the map is a panel in a {kibana-ref}/dashboard.html[dashboard], and not within the Maps application.
 
 You can create spatial filters in two ways:
 

--- a/docs/maps/search.asciidoc
+++ b/docs/maps/search.asciidoc
@@ -109,7 +109,7 @@ NOTE: {kibana-ref}/drilldowns.html[Drilldowns] are only available if the map is 
 
 You can create spatial filters in two ways:
 
-* Click the tool icon image:maps/images/tools_icon.png[], and then draw a shape, bounding box, or distance on the map to define the spatial filter.
+* Click the tool icon image:maps/images/tools_icon.png[tool icon], and then draw a shape, bounding box, or distance on the map to define the spatial filter.
 * Click *Filter by geometry* in a <<maps-vector-tooltip-locking, locked tooltip>>, and then use the feature's geometry for the spatial filter.
 
 [role="screenshot"]


### PR DESCRIPTION
## Summary

Issue [raised on Slack](https://elastic.slack.com/archives/C0D8P2XK5/p1688661541837369) that it was a bit unclear on our [docs page](https://www.elastic.co/guide/en/kibana/8.8/maps-create-filter-from-map.html#maps-spatial-filters) that to use drilldowns you had to embed your map in Dashboard, and can't be used from the Maps application. 

Original:
<img width="808" alt="Screenshot 2023-07-07 at 15 32 27" src="https://github.com/elastic/kibana/assets/61687663/176e7f22-1bb3-4dd0-95d5-4a601487aa6b">

Updated:
<img width="843" alt="Screenshot 2023-07-07 at 11 47 45" src="https://github.com/elastic/kibana/assets/61687663/4d33a39f-2cee-4097-b730-3b24d613c498">



<!--ONMERGE {"backportTargets":["7.14","7.15","7.16","7.17","8.0","8.1","8.2","8.3","8.4","8.5","8.6","8.7","8.8","8.9"]} ONMERGE-->