### PR TITLE
[Controls] Fix style of options list button

### DIFF
--- a/src/plugins/controls/public/options_list/components/options_list.scss
+++ b/src/plugins/controls/public/options_list/components/options_list.scss
@@ -68,6 +68,8 @@
 }
 
 .optionsList--filterBtn {
+  border-radius: 0 $euiFormControlBorderRadius $euiFormControlBorderRadius 0 !important;
+
   .euiFilterButton__text-hasNotification {
     flex-grow: 1;
     justify-content: space-between;


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/161464

## Summary

This PR fixes the styling of the options list control:

| Before | After |
|--------|--------|
| ![image](https://github.com/elastic/kibana/assets/8698078/7e71ade8-1b17-4e56-919f-179b370d7de0) | ![image](https://github.com/elastic/kibana/assets/8698078/0c01bd91-0bc6-4e59-b6a9-ed8cfd8f290a) |


### Checklist

- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
