### PR TITLE
[DOCS] Add more automated screenshots for security cases

### DIFF
--- a/x-pack/test/screenshot_creation/apps/response_ops_docs/security_cases/list_view.ts
+++ b/x-pack/test/screenshot_creation/apps/response_ops_docs/security_cases/list_view.ts
@@ -7,12 +7,17 @@
 
 import { CaseSeverity } from '@kbn/cases-plugin/common/api';
 import { FtrProviderContext } from '../../../ftr_provider_context';
+import { createAndUploadFile } from '../../../../cases_api_integration/common/lib/api';
+import { SECURITY_SOLUTION_FILE_KIND } from '../../../../cases_api_integration/common/lib/constants';
 
 export default function ({ getPageObject, getService, getPageObjects }: FtrProviderContext) {
   const cases = getService('cases');
   const commonScreenshots = getService('commonScreenshots');
-  const screenshotDirectories = ['response_ops_docs', 'security_cases'];
   const pageObjects = getPageObjects(['common', 'header']);
+  const screenshotDirectories = ['response_ops_docs', 'security_cases'];
+  const supertest = getService('supertest');
+  let caseIdSuspiciousEmail: string;
+  let caseOwnerSuspiciousEmail: string;
 
   describe('list view', function () {
     before(async () => {
@@ -24,12 +29,14 @@ export default function ({ getPageObject, getService, getPageObjects }: FtrProvi
         severity: CaseSeverity.HIGH,
       });
 
-      await cases.api.createCase({
+      const caseSuspiciousEmail = await cases.api.createCase({
         title: 'Suspicious emails reported',
         tags: ['email', 'phishing'],
-        description: 'Test.',
+        description: 'Several employees have received suspicious emails from an unknown address.',
         owner: 'securitySolution',
       });
+      caseIdSuspiciousEmail = caseSuspiciousEmail.id;
+      caseOwnerSuspiciousEmail = caseSuspiciousEmail.owner;
 
       await cases.api.createCase({
         title: 'Malware investigation',
@@ -37,6 +44,20 @@ export default function ({ getPageObject, getService, getPageObjects }: FtrProvi
         description: 'Test.',
         owner: 'securitySolution',
         severity: CaseSeverity.MEDIUM,
+      });
+
+      await createAndUploadFile({
+        supertest,
+        createFileParams: {
+          name: 'testfile',
+          kind: SECURITY_SOLUTION_FILE_KIND,
+          mimeType: 'image/png',
+          meta: {
+            caseIds: [caseIdSuspiciousEmail],
+            owner: [caseOwnerSuspiciousEmail],
+          },
+        },
+        data: 'abc',
       });
     });
 
@@ -48,6 +69,13 @@ export default function ({ getPageObject, getService, getPageObjects }: FtrProvi
       await pageObjects.common.navigateToApp('security', { path: 'cases' });
       await pageObjects.header.waitUntilLoadingHasFinished();
       await commonScreenshots.takeScreenshot('cases-home-page', screenshotDirectories, 1700, 1024);
+    });
+
+    it('case details screenshot', async () => {
+      await pageObjects.common.navigateToApp('security', {
+        path: `cases/${caseIdSuspiciousEmail}`,
+      });
+      await commonScreenshots.takeScreenshot('cases-ui-open', screenshotDirectories, 1400, 1024);
     });
   });
 }

--- a/x-pack/test/screenshot_creation/apps/response_ops_docs/security_cases/list_view.ts
+++ b/x-pack/test/screenshot_creation/apps/response_ops_docs/security_cases/list_view.ts
@@ -16,6 +16,7 @@ export default function ({ getPageObject, getService, getPageObjects }: FtrProvi
   const pageObjects = getPageObjects(['common', 'header']);
   const screenshotDirectories = ['response_ops_docs', 'security_cases'];
   const supertest = getService('supertest');
+  const testSubjects = getService('testSubjects');
   let caseIdSuspiciousEmail: string;
   let caseOwnerSuspiciousEmail: string;
 
@@ -76,6 +77,10 @@ export default function ({ getPageObject, getService, getPageObjects }: FtrProvi
         path: `cases/${caseIdSuspiciousEmail}`,
       });
       await commonScreenshots.takeScreenshot('cases-ui-open', screenshotDirectories, 1400, 1024);
+
+      const filesTab = await testSubjects.find('case-view-tab-title-files');
+      await filesTab.click();
+      await commonScreenshots.takeScreenshot('cases-files', screenshotDirectories, 1400, 1024);
     });
   });
 }


### PR DESCRIPTION
## Summary

This PR automates the creation of two screenshots that are used in https://www.elastic.co/guide/en/security/current/cases-open-manage.html

<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->