### PR TITLE
[Proposal] Change default Discover grid styles

### DIFF
--- a/src/plugins/discover/public/components/discover_grid/constants.ts
+++ b/src/plugins/discover/public/components/discover_grid/constants.ts
@@ -11,10 +11,11 @@ import { EuiDataGridStyle } from '@elastic/eui';
 // data types
 export const kibanaJSON = 'kibana-json';
 export const GRID_STYLE = {
-  border: 'all',
+  border: 'horizontal',
   fontSize: 's',
-  cellPadding: 's',
-  rowHover: 'none',
+  cellPadding: 'm',
+  rowHover: 'highlight',
+  header: 'underline',
 } as EuiDataGridStyle;
 
 export const defaultTimeColumnWidth = 210;


### PR DESCRIPTION
## Summary

We've received feedback - and felt - that the table (i.e. data grid) in Discover is visually 'busy' and, perhaps, too dense.
Fortunately, `EuiDataGrid` provides several style props that - as exemplified by this PR - could make for some quick albeit subtle enhancements to the default styles. I'm curious to hear how others find this but, for me, it does allow for more room to breathe.

Note: Additional considerations are being made such as typography, necessity of current page container, exposing additional display options, etc., but this feels like an improvement straight away. 

**This PR vs main**

Changes include:
- Less borders
- More padding
- Remove shading from headers
- Highlight on hover
- (Zebra striping is another prop, but that feels like a thing to expose as an 'option')


**Single line**

<img width="1753" alt="Screenshot 2023-07-07 at 11 37 58 AM" src="https://github.com/elastic/kibana/assets/446285/b55098b2-d67c-48de-89f1-cc6da5cee86c">

**Multi-line**

<img width="1751" alt="Screenshot 2023-07-07 at 11 37 39 AM" src="https://github.com/elastic/kibana/assets/446285/dda6fabc-112c-4192-bedd-976df3fed45c">

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
