### PR TITLE
Correct ordering of log levels

### DIFF
--- a/docs/setup/configuring-logging.asciidoc
+++ b/docs/setup/configuring-logging.asciidoc
@@ -21,11 +21,11 @@ __<<logging-layouts,Layouts>>__ define how log messages are formatted and what t
 [[log-level]]
 === Log level
 
-Currently we support the following log levels: _all_, _fatal_, _error_, _warn_, _info_, _debug_, _trace_, _off_.
+Currently we support the following log levels: _off_, _fatal_, _error_, _warn_, _info_, _debug_, _trace_, _all_.
 
-Levels are ordered, so _all_ > _fatal_ > _error_ > _warn_ > _info_ > _debug_ > _trace_ > _off_.
+Levels are ordered, so _off_ > _fatal_ > _error_ > _warn_ > _info_ > _debug_ > _trace_ > _all_.
 
-A log record will be logged by the logger if its level is higher than or equal to the level of its logger. Otherwise, the log record is ignored.
+A log record will be logged if its level is greater than or equal to the level of its logger. Otherwise, the log record is ignored.
 
 The _all_ and _off_ levels can only be used in configuration and are handy shortcuts that allow you to log every log record or disable logging entirely for a specific logger. These levels can also be specified using <<logging-cli-migration,cli arguments>>.
 


### PR DESCRIPTION
I was reading through these docs and the order of the levels seemed incorrect, but perhaps it's just nonstandard?

Additionally, I didn't quite comprehend the use of comparators in the ordering; I changed the wording to use the more-often-accompanying "greater" to make that linkage more clear. However, I think those might also need to be reversed? E.g. `off < fatal < error`. If I'm misunderstanding, then perhaps we could add an example to make it more clear.