### PR TITLE
[Defend workflows] Add tooltip on automated endpoint action form

### DIFF
--- a/x-pack/plugins/security_solution/public/detection_engine/rule_response_actions/endpoint/action_type_field.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_response_actions/endpoint/action_type_field.tsx
@@ -55,7 +55,7 @@ const ActionTypeFieldComponent = ({
         return {
           value: name,
           inputDisplay: name,
-          dropdownDisplay: <EndpointActionText name={name} />,
+          dropdownDisplay: <EndpointActionText name={name} isDisabled={isDisabled} />,
           disabled: isDisabled,
           'data-test-subj': `command-type-${name}`,
         };

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_response_actions/endpoint/action_type_field.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_response_actions/endpoint/action_type_field.tsx
@@ -45,17 +45,17 @@ const ActionTypeFieldComponent = ({
   const fieldOptions = useMemo(
     () =>
       ENABLED_AUTOMATED_RESPONSE_ACTION_COMMANDS.map((name) => {
-        const isDisabled =
-          map(data.responseActions, 'params.command').includes(name) ||
-          !getRbacControl({
-            commandName: getUiCommand(name),
-            privileges: endpointPrivileges,
-          });
+        const missingRbac = !getRbacControl({
+          commandName: getUiCommand(name),
+          privileges: endpointPrivileges,
+        });
+        const commandAlreadyExists = map(data.responseActions, 'params.command').includes(name);
+        const isDisabled = commandAlreadyExists || missingRbac;
 
         return {
           value: name,
           inputDisplay: name,
-          dropdownDisplay: <EndpointActionText name={name} isDisabled={isDisabled} />,
+          dropdownDisplay: <EndpointActionText name={name} isDisabled={missingRbac} />,
           disabled: isDisabled,
           'data-test-subj': `command-type-${name}`,
         };

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_response_actions/endpoint/callout.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_response_actions/endpoint/callout.tsx
@@ -13,11 +13,38 @@ import { get } from 'lodash';
 
 interface EndpointCallOutProps {
   basePath: string;
+  editDisabled: boolean;
 }
 
-const EndpointActionCalloutComponent = ({ basePath }: EndpointCallOutProps) => {
+const EndpointActionCalloutComponent = ({ basePath, editDisabled }: EndpointCallOutProps) => {
   const [data] = useFormData();
   const currentCommand = get(data, `${basePath}.command`);
+
+  if (editDisabled) {
+    return (
+      <>
+        <EuiSpacer size="s" />
+        <EuiCallOut
+          color="warning"
+          iconType="warning"
+          title={
+            <FormattedMessage
+              id="xpack.securitySolution.responseActionsList.endpoint.privileges"
+              defaultMessage="Insufficient privileges"
+            />
+          }
+        >
+          <EuiText size={'xs'}>
+            <FormattedMessage
+              id="xpack.securitySolution.responseActions.endpoint.isolateTooltip"
+              defaultMessage="Insufficient privileges to isolate hosts. Contact your Kibana administrator if you think you should have this permission."
+            />
+          </EuiText>
+        </EuiCallOut>
+        <EuiSpacer size="s" />
+      </>
+    );
+  }
 
   if (currentCommand === 'isolate') {
     return (

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_response_actions/endpoint/endpoint_response_action.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_response_actions/endpoint/endpoint_response_action.tsx
@@ -27,7 +27,7 @@ export const EndpointResponseAction = React.memo((props: EndpointResponseActionP
         readDefaultValueOnForm={!props.item.isNew}
       />
 
-      <EndpointActionCallout basePath={paramsPath} />
+      <EndpointActionCallout basePath={paramsPath} editDisabled={props.editDisabled} />
 
       <CommentField
         basePath={paramsPath}

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_response_actions/endpoint/utils.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_response_actions/endpoint/utils.tsx
@@ -6,17 +6,19 @@
  */
 import type { ReactNode } from 'react';
 import React from 'react';
-import { EuiText, EuiTitle, EuiSpacer } from '@elastic/eui';
+import { EuiText, EuiTitle, EuiSpacer, EuiToolTip } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import type { EnabledAutomatedResponseActionsCommands } from '../../../../common/endpoint/service/response_actions/constants';
 
 interface EndpointActionTextProps {
   name: EnabledAutomatedResponseActionsCommands;
+  isDisabled: boolean;
 }
 
-const EndpointActionTextComponent = ({ name }: EndpointActionTextProps) => {
-  const { title, description } = useGetCommandText(name);
-  return (
+const EndpointActionTextComponent = ({ name, isDisabled }: EndpointActionTextProps) => {
+  const { title, description, tooltip } = useGetCommandText(name);
+
+  const content = (
     <>
       <EuiTitle size="xs">
         <EuiText>{title}</EuiText>
@@ -25,11 +27,19 @@ const EndpointActionTextComponent = ({ name }: EndpointActionTextProps) => {
       <EuiText>{description}</EuiText>
     </>
   );
+  if (isDisabled) {
+    return (
+      <EuiToolTip position="top" content={tooltip}>
+        {content}
+      </EuiToolTip>
+    );
+  }
+  return content;
 };
 
 const useGetCommandText = (
   name: EndpointActionTextProps['name']
-): { title: ReactNode; description: ReactNode } => {
+): { title: ReactNode; description: ReactNode; tooltip: ReactNode } => {
   switch (name) {
     case 'isolate':
       return {
@@ -45,11 +55,18 @@ const useGetCommandText = (
             defaultMessage="Quarantine a host from the network to prevent further spread of threats and limit potential damage"
           />
         ),
+        tooltip: (
+          <FormattedMessage
+            id="xpack.securitySolution.responseActions.endpoint.isolateTooltip"
+            defaultMessage="Insufficient privileges to isolate hosts. Contact your Kibana administrator if you think you should have this permission."
+          />
+        ),
       };
     default:
       return {
         title: '',
         description: '',
+        tooltip: '',
       };
   }
 };


### PR DESCRIPTION
Solves: https://github.com/elastic/kibana/issues/160868 
Adding a tooltip in order to explain to the user why using Isolate is no available. 
If user has an action configured, but end up having no RBAC, we display the missing privileges callout too.

![Zrzut ekranu 2023-07-10 o 16 58 46](https://github.com/elastic/kibana/assets/16632552/7c2ec978-31b1-480a-869e-6dd0cfd353f3)


<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->