### PR TITLE
Validate array types for strictKeysRt

### DIFF
--- a/packages/kbn-io-ts-utils/src/strict_keys_rt/index.test.ts
+++ b/packages/kbn-io-ts-utils/src/strict_keys_rt/index.test.ts
@@ -202,6 +202,11 @@ describe('strictKeysRt', () => {
           { body: { duration: false } },
         ],
       },
+      {
+        type: t.array(t.type({ foo: t.string })),
+        passes: [[{ foo: 'bar' }], [{ foo: 'baz' }, { foo: 'bar' }]],
+        fails: [],
+      },
     ];
 
     checks.forEach((check) => {

--- a/packages/kbn-io-ts-utils/src/strict_keys_rt/index.ts
+++ b/packages/kbn-io-ts-utils/src/strict_keys_rt/index.ts
@@ -23,7 +23,8 @@ type ParsableType =
   | t.ExactType<ParsableType>
   | t.InterfaceType<any>
   | MergeType<any, any>
-  | t.DictionaryType<any, any>;
+  | t.DictionaryType<any, any>
+  | t.ArrayType<any, any>;
 
 const tags = [
   'DictionaryType',
@@ -33,6 +34,7 @@ const tags = [
   'PartialType',
   'ExactType',
   'UnionType',
+  'ArrayType',
 ];
 
 function isParsableType(type: t.Mixed): type is ParsableType {
@@ -45,6 +47,9 @@ function getHandlingTypes(type: t.Mixed, key: string, value: object): t.Mixed[] 
   }
 
   switch (type._tag) {
+    case 'ArrayType':
+      return [type.type];
+
     case 'DictionaryType':
       return [type.codomain];
 


### PR DESCRIPTION
Closes #158499

Previously, array types were not "unpacked" when validating, resulting in an error for seemingly correct values.