### PR TITLE
[Infra UI] Fix Normalized Load tooltip

### DIFF
--- a/x-pack/plugins/infra/public/pages/metrics/hosts/components/kpis/kpi_grid.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/hosts/components/kpis/kpi_grid.tsx
@@ -37,7 +37,7 @@ const KPI_CHARTS: Array<Omit<KPIChartProps, 'loading' | 'subtitle' | 'style'>> =
     title: i18n.translate('xpack.infra.hostsViewPage.metricTrend.normalizedLoad1m.title', {
       defaultMessage: 'Normalized Load',
     }),
-    toolTip: TOOLTIP.rx,
+    toolTip: TOOLTIP.normalizedLoad1m,
   },
   {
     type: 'memoryUsage',
@@ -46,9 +46,7 @@ const KPI_CHARTS: Array<Omit<KPIChartProps, 'loading' | 'subtitle' | 'style'>> =
     title: i18n.translate('xpack.infra.hostsViewPage.metricTrend.memoryUsage.title', {
       defaultMessage: 'Memory Usage',
     }),
-    toolTip: i18n.translate('xpack.infra.hostsViewPage.metricTrend.memoryUsage.tooltip', {
-      defaultMessage: 'Main memory usage excluding page cache.',
-    }),
+    toolTip: TOOLTIP.memoryUsage,
   },
   {
     type: 'diskSpaceUsage',


### PR DESCRIPTION
closes [#161527](https://github.com/elastic/kibana/issues/161527)

## Summary

This PR fixes the tooltip for the Normalized Load metric

<img width="1445" alt="image" src="https://github.com/elastic/kibana/assets/2767137/cac013c0-fc30-43a6-9754-9fb77ecefe25">



###  How to test
- Start a local Kibana instance
- Navigate to `Infrastructure` > `Hosts`
- Hover the mouse over the Normalized Load KPI
