### PR TITLE
Add cloud links in serverless.yml

### DIFF
--- a/config/serverless.yml
+++ b/config/serverless.yml
@@ -8,6 +8,12 @@ xpack.fleet.internal.disableILMPolicies: true
 xpack.fleet.internal.disableProxies: true
 xpack.fleet.internal.activeAgentsSoftLimit: 25000
 
+# Cloud links
+xpack.cloud.base_url: "https://cloud.elastic.co"
+xpack.cloud.profile_url: "/user/settings"
+xpack.cloud.billing_url: "/billing"
+xpack.cloud.organization_url: "/account"
+
 # Enable ZDT migration algorithm
 migrations.algorithm: zdt
 


### PR DESCRIPTION
This is a follow up of https://github.com/elastic/kibana/issues/159419

To be able to see the links in cloud we need to add the urls in the `kibana.yml`.
This PR adds the link for the user profile menu

<img width="298" alt="Screenshot 2023-06-26 at 15 39 43" src="https://github.com/elastic/kibana/assets/2854616/dc6ccae9-28be-4b96-a029-3bd015aba9b1">
