### PR TITLE
[Security Solution] expandable flyout - move visualizations section up

### DIFF
--- a/x-pack/plugins/security_solution/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_right_panel_overview_tab.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_right_panel_overview_tab.cy.ts
@@ -139,6 +139,23 @@ describe(
       });
     });
 
+    describe('visualizations section', () => {
+      it('should display analyzer and session previews', () => {
+        toggleOverviewTabAboutSection();
+        toggleOverviewTabVisualizationsSection();
+
+        cy.log('analyzer graph preview');
+
+        cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_ANALYZER_TREE).scrollIntoView();
+        cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_ANALYZER_TREE).should('be.visible');
+
+        cy.log('session view preview');
+
+        cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_SESSION_PREVIEW).scrollIntoView();
+        cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_SESSION_PREVIEW).should('be.visible');
+      });
+    });
+
     describe('investigation section', () => {
       it('should display investigation section', () => {
         toggleOverviewTabAboutSection();
@@ -319,23 +336,6 @@ describe(
 
         clickPrevalenceViewAllButton();
         cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_ENTITIES_CONTENT).should('be.visible'); // TODO update when we can navigate to Prevalence sub tab directly
-      });
-    });
-
-    describe('visualizations section', () => {
-      it('should display analyzer and session previews', () => {
-        toggleOverviewTabAboutSection();
-        toggleOverviewTabVisualizationsSection();
-
-        cy.log('analyzer graph preview');
-
-        cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_ANALYZER_TREE).scrollIntoView();
-        cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_ANALYZER_TREE).should('be.visible');
-
-        cy.log('session view preview');
-
-        cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_SESSION_PREVIEW).scrollIntoView();
-        cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_SESSION_PREVIEW).should('be.visible');
       });
     });
   }

--- a/x-pack/plugins/security_solution/public/flyout/right/tabs/overview_tab.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/right/tabs/overview_tab.tsx
@@ -21,11 +21,11 @@ export const OverviewTab: FC = memo(() => {
     <>
       <AboutSection />
       <EuiHorizontalRule margin="l" />
+      <VisualizationsSection />
+      <EuiHorizontalRule margin="l" />
       <InvestigationSection />
       <EuiHorizontalRule margin="l" />
       <InsightsSection />
-      <EuiHorizontalRule margin="l" />
-      <VisualizationsSection />
     </>
   );
 });


### PR DESCRIPTION
## Summary

After discussing with PM, we decided to move up the `Visualizations` section up in second position, in between `Description` (soon to be renamed `About`) and `Investigations`.

![Screenshot 2023-07-10 at 4 04 47 PM](https://github.com/elastic/kibana/assets/17276605/31fea325-bb16-4a98-909b-ecb36285e232)

https://github.com/elastic/security-team/issues/7005