### PR TITLE
[Infra UI]  Stop click propagation on tooltip

### DIFF
--- a/x-pack/plugins/infra/public/common/visualizations/metric_explanation/tooltip_content.tsx
+++ b/x-pack/plugins/infra/public/common/visualizations/metric_explanation/tooltip_content.tsx
@@ -19,8 +19,12 @@ interface Props extends Pick<HTMLAttributes<HTMLDivElement>, 'style'> {
 
 export const TooltipContent = React.memo(
   ({ description, formula, showDocumentationLink = false, style }: Props) => {
+    const onClick = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+      e.stopPropagation();
+    };
+
     return (
-      <EuiText size="xs" style={style}>
+      <EuiText size="xs" style={style} onClick={onClick}>
         <p>{description}</p>
         {formula && (
           <p>


### PR DESCRIPTION
fixes [#161553](https://github.com/elastic/kibana/issues/161553)

## Summary

Fixes click event on the tooltip content


https://github.com/elastic/kibana/assets/2767137/13c8fde1-7dfe-4fb0-92f2-b3e45bd36972


### How to test

- Start a local Kibana instance
- Navigate to `Infrastructure` > `Hosts`
- Click on the `?` icon in the table column headers and then click on the content. It must not sort the table


<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->