### PR TITLE
[Detection Engine] - Unskip flakey test after running through test runner

### DIFF
--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/group7/exception_operators_data_types/double.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/group7/exception_operators_data_types/double.ts
@@ -491,7 +491,7 @@ export default ({ getService }: FtrProviderContext) => {
       });
 
       // FLAKY: https://github.com/elastic/kibana/issues/155122
-      describe.skip('working against string values in the data set', () => {
+      describe('working against string values in the data set', () => {
         it('will return 3 results if we have a list that includes 1 double', async () => {
           await importFile(supertest, log, 'double', ['1.0'], 'list_items.txt');
           const rule = getRuleForSignalTesting(['double_as_string']);

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/group7/exception_operators_data_types/double.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/group7/exception_operators_data_types/double.ts
@@ -490,7 +490,6 @@ export default ({ getService }: FtrProviderContext) => {
         });
       });
 
-      // FLAKY: https://github.com/elastic/kibana/issues/155122
       describe('working against string values in the data set', () => {
         it('will return 3 results if we have a list that includes 1 double', async () => {
           await importFile(supertest, log, 'double', ['1.0'], 'list_items.txt');


### PR DESCRIPTION
## Summary

Resolving https://github.com/elastic/kibana/issues/155122 . Unskipping after running through flakey test runner 100 times.

https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2597


<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->