### PR TITLE
[Enterprise Search] rebrand ent-search breadcrumbs to Search

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/shared/kibana_chrome/generate_breadcrumbs.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/kibana_chrome/generate_breadcrumbs.test.ts
@@ -20,6 +20,7 @@ import {
   useEuiBreadcrumbs,
   useEnterpriseSearchBreadcrumbs,
   useAppSearchBreadcrumbs,
+  useSearchBreadcrumbs,
   useWorkplaceSearchBreadcrumbs,
 } from './generate_breadcrumbs';
 
@@ -139,6 +140,49 @@ describe('useEuiBreadcrumbs', () => {
       expect(breadcrumb.href).toBeUndefined();
       expect(breadcrumb.onClick).toBeUndefined();
     });
+  });
+});
+
+describe('useSearchBreadcrumbs', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('builds a chain of breadcrumbs with Search at the root', () => {
+    const breadcrumbs = [
+      {
+        text: 'Page 1',
+        path: '/page1',
+      },
+      {
+        text: 'Page 2',
+        path: '/page2',
+      },
+    ];
+
+    expect(useSearchBreadcrumbs(breadcrumbs)).toEqual([
+      {
+        text: 'Search',
+        href: '/app/enterprise_search/overview',
+        onClick: expect.any(Function),
+      },
+      {
+        text: 'Page 1',
+        href: '/app/enterprise_search/page1',
+        onClick: expect.any(Function),
+      },
+      {
+        text: 'Page 2',
+      },
+    ]);
+  });
+
+  it('shows just the root if breadcrumbs is empty', () => {
+    expect(useSearchBreadcrumbs()).toEqual([
+      {
+        text: 'Search',
+      },
+    ]);
   });
 });
 

--- a/x-pack/plugins/enterprise_search/public/applications/shared/kibana_chrome/generate_breadcrumbs.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/kibana_chrome/generate_breadcrumbs.ts
@@ -8,6 +8,7 @@
 import { useValues } from 'kea';
 
 import { EuiBreadcrumb } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 
 import {
   ANALYTICS_PLUGIN,
@@ -125,7 +126,15 @@ export const useAnalyticsBreadcrumbs = (breadcrumbs: Breadcrumbs = []) =>
   useSearchBreadcrumbs([{ text: ANALYTICS_PLUGIN.NAME, path: '/' }, ...breadcrumbs]);
 
 export const useElasticsearchBreadcrumbs = (breadcrumbs: Breadcrumbs = []) =>
-  useSearchBreadcrumbs([{ text: 'Getting started with Elasticsearch', path: '/' }, ...breadcrumbs]);
+  useSearchBreadcrumbs([
+    {
+      text: i18n.translate('xpack.enterpriseSearch.elasticsearch.breadcrumbs.title', {
+        defaultMessage: 'Getting started with Elasticsearch',
+      }),
+      path: '/',
+    },
+    ...breadcrumbs,
+  ]);
 
 export const useAppSearchBreadcrumbs = (breadcrumbs: Breadcrumbs = []) =>
   useEnterpriseSearchBreadcrumbs([{ text: APP_SEARCH_PLUGIN.NAME, path: '/' }, ...breadcrumbs]);

--- a/x-pack/plugins/enterprise_search/public/applications/shared/kibana_chrome/generate_breadcrumbs.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/kibana_chrome/generate_breadcrumbs.ts
@@ -17,6 +17,7 @@ import {
   ENTERPRISE_SEARCH_PRODUCT_NAME,
   ESRE_PLUGIN,
   SEARCH_EXPERIENCES_PLUGIN,
+  SEARCH_PRODUCT_NAME,
   VECTOR_SEARCH_PLUGIN,
   WORKPLACE_SEARCH_PLUGIN,
 } from '../../../../common/constants';
@@ -100,6 +101,16 @@ export const useEuiBreadcrumbs = (breadcrumbs: Breadcrumbs): EuiBreadcrumb[] => 
  * Product-specific breadcrumb helpers
  */
 
+export const useSearchBreadcrumbs = (breadcrumbs: Breadcrumbs = []) =>
+  useEuiBreadcrumbs([
+    {
+      text: SEARCH_PRODUCT_NAME,
+      path: ENTERPRISE_SEARCH_OVERVIEW_PLUGIN.URL,
+      shouldNotCreateHref: true,
+    },
+    ...breadcrumbs,
+  ]);
+
 export const useEnterpriseSearchBreadcrumbs = (breadcrumbs: Breadcrumbs = []) =>
   useEuiBreadcrumbs([
     {
@@ -111,13 +122,10 @@ export const useEnterpriseSearchBreadcrumbs = (breadcrumbs: Breadcrumbs = []) =>
   ]);
 
 export const useAnalyticsBreadcrumbs = (breadcrumbs: Breadcrumbs = []) =>
-  useEnterpriseSearchBreadcrumbs([{ text: ANALYTICS_PLUGIN.NAME, path: '/' }, ...breadcrumbs]);
+  useSearchBreadcrumbs([{ text: ANALYTICS_PLUGIN.NAME, path: '/' }, ...breadcrumbs]);
 
 export const useElasticsearchBreadcrumbs = (breadcrumbs: Breadcrumbs = []) =>
-  useEnterpriseSearchBreadcrumbs([
-    { text: 'Getting started with Elasticsearch', path: '/' },
-    ...breadcrumbs,
-  ]);
+  useSearchBreadcrumbs([{ text: 'Getting started with Elasticsearch', path: '/' }, ...breadcrumbs]);
 
 export const useAppSearchBreadcrumbs = (breadcrumbs: Breadcrumbs = []) =>
   useEnterpriseSearchBreadcrumbs([{ text: APP_SEARCH_PLUGIN.NAME, path: '/' }, ...breadcrumbs]);
@@ -129,22 +137,19 @@ export const useWorkplaceSearchBreadcrumbs = (breadcrumbs: Breadcrumbs = []) =>
   ]);
 
 export const useEnterpriseSearchContentBreadcrumbs = (breadcrumbs: Breadcrumbs = []) =>
-  useEnterpriseSearchBreadcrumbs([
+  useSearchBreadcrumbs([
     { text: ENTERPRISE_SEARCH_CONTENT_PLUGIN.NAV_TITLE, path: '/' },
     ...breadcrumbs,
   ]);
 
 export const useSearchExperiencesBreadcrumbs = (breadcrumbs: Breadcrumbs = []) =>
-  useEnterpriseSearchBreadcrumbs([
-    { text: SEARCH_EXPERIENCES_PLUGIN.NAV_TITLE, path: '/' },
-    ...breadcrumbs,
-  ]);
+  useSearchBreadcrumbs([{ text: SEARCH_EXPERIENCES_PLUGIN.NAV_TITLE, path: '/' }, ...breadcrumbs]);
 
 export const useEnterpriseSearchApplicationsBreadcrumbs = (breadcrumbs: Breadcrumbs = []) =>
-  useEnterpriseSearchBreadcrumbs(breadcrumbs);
+  useSearchBreadcrumbs(breadcrumbs);
 
 export const useEsreBreadcrumbs = (breadcrumbs: Breadcrumbs = []) =>
-  useEnterpriseSearchBreadcrumbs([{ text: ESRE_PLUGIN.NAME, path: '/' }, ...breadcrumbs]);
+  useSearchBreadcrumbs([{ text: ESRE_PLUGIN.NAME, path: '/' }, ...breadcrumbs]);
 
 export const useVectorSearchBreadcrumbs = (breadcrumbs: Breadcrumbs = []) =>
-  useEnterpriseSearchBreadcrumbs([{ text: VECTOR_SEARCH_PLUGIN.NAME, path: '/' }, ...breadcrumbs]);
+  useSearchBreadcrumbs([{ text: VECTOR_SEARCH_PLUGIN.NAV_TITLE, path: '/' }, ...breadcrumbs]);

--- a/x-pack/plugins/enterprise_search/public/applications/shared/kibana_chrome/set_chrome.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/kibana_chrome/set_chrome.test.tsx
@@ -15,12 +15,12 @@ import { shallow } from 'enzyme';
 
 jest.mock('./generate_breadcrumbs', () => ({
   useGenerateBreadcrumbs: jest.requireActual('./generate_breadcrumbs').useGenerateBreadcrumbs,
-  useEnterpriseSearchBreadcrumbs: jest.fn(() => (crumbs: any) => crumbs),
+  useSearchBreadcrumbs: jest.fn(() => (crumbs: any) => crumbs),
   useAppSearchBreadcrumbs: jest.fn(() => (crumbs: any) => crumbs),
   useWorkplaceSearchBreadcrumbs: jest.fn(() => (crumbs: any) => crumbs),
 }));
 import {
-  useEnterpriseSearchBreadcrumbs,
+  useSearchBreadcrumbs,
   useAppSearchBreadcrumbs,
   useWorkplaceSearchBreadcrumbs,
 } from './generate_breadcrumbs';
@@ -53,7 +53,7 @@ describe('Set Kibana Chrome helpers', () => {
       shallow(<SetSearchChrome trail={['Hello World']} />);
 
       expect(searchTitle).toHaveBeenCalledWith(['Hello World']);
-      expect(useEnterpriseSearchBreadcrumbs).toHaveBeenCalledWith([
+      expect(useSearchBreadcrumbs).toHaveBeenCalledWith([
         {
           text: 'Hello World',
           path: '/current-path',
@@ -65,7 +65,7 @@ describe('Set Kibana Chrome helpers', () => {
       shallow(<SetSearchChrome />);
 
       expect(searchTitle).toHaveBeenCalledWith([]);
-      expect(useEnterpriseSearchBreadcrumbs).toHaveBeenCalledWith([]);
+      expect(useSearchBreadcrumbs).toHaveBeenCalledWith([]);
     });
   });
 

--- a/x-pack/plugins/enterprise_search/public/applications/shared/kibana_chrome/set_chrome.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/kibana_chrome/set_chrome.tsx
@@ -9,13 +9,13 @@ import React, { useEffect } from 'react';
 
 import { useValues } from 'kea';
 
-import { APPLICATIONS_PLUGIN, VECTOR_SEARCH_PLUGIN } from '../../../../common/constants';
+import { APPLICATIONS_PLUGIN } from '../../../../common/constants';
 
 import { KibanaLogic } from '../kibana';
 
 import {
   useGenerateBreadcrumbs,
-  useEnterpriseSearchBreadcrumbs,
+  useSearchBreadcrumbs,
   useEnterpriseSearchApplicationsBreadcrumbs,
   useAnalyticsBreadcrumbs,
   useEnterpriseSearchContentBreadcrumbs,
@@ -64,7 +64,7 @@ export const SetSearchChrome: React.FC<SetChromeProps> = ({ trail = [] }) => {
   const docTitle = searchTitle(title);
 
   const crumbs = useGenerateBreadcrumbs(trail);
-  const breadcrumbs = useEnterpriseSearchBreadcrumbs(crumbs);
+  const breadcrumbs = useSearchBreadcrumbs(crumbs);
 
   useEffect(() => {
     setBreadcrumbs(breadcrumbs);
@@ -217,9 +217,7 @@ export const SetVectorSearchChrome: React.FC<SetChromeProps> = ({ trail = [] }) 
   const title = reverseArray(trail);
   const docTitle = vectorSearchTitle(title);
 
-  const breadcrumbs = useVectorSearchBreadcrumbs(
-    useGenerateBreadcrumbs([VECTOR_SEARCH_PLUGIN.NAV_TITLE, ...trail])
-  );
+  const breadcrumbs = useVectorSearchBreadcrumbs(useGenerateBreadcrumbs(trail));
 
   useEffect(() => {
     setBreadcrumbs(breadcrumbs);


### PR DESCRIPTION
## Summary

Updated the enterprise-search base breadcrumbs to `Search` except for App Search & Workplace Search remain with Enterprise Search.
Additionally fixed a small bug where the Vector Search breadcrumbs was Search > Vector Search > Vector Search

### Screenshots
<img width="1700" alt="image" src="https://github.com/elastic/kibana/assets/1972968/b8e2e39f-25fc-4907-892b-2e460ebcb173">
<img width="1700" alt="image" src="https://github.com/elastic/kibana/assets/1972968/e17a0932-5506-4be0-ab22-e0537cf7a7e1">
<img width="1700" alt="image" src="https://github.com/elastic/kibana/assets/1972968/04e63218-8a2d-41d6-af8d-b9875fe7e295">
