### PR TITLE
[8.10] [ESRE] Filter already attached pipelines

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/ml_inference_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/ml_inference_logic.test.ts
@@ -297,7 +297,7 @@ describe('MlInferenceLogic', () => {
           },
         ]);
       });
-      it('returns disabled pipeline option if pipeline already attached', () => {
+      it('filters pipeline if pipeline already attached', () => {
         FetchMlInferencePipelineProcessorsApiLogic.actions.apiSuccess([
           {
             modelId: 'test-model',
@@ -324,17 +324,7 @@ describe('MlInferenceLogic', () => {
           },
         });
 
-        expect(MLInferenceLogic.values.existingInferencePipelines).toEqual([
-          {
-            disabled: true,
-            disabledReason: expect.any(String),
-            pipelineName: 'unit-test',
-            modelType: '',
-            modelId: 'test-model',
-            sourceFields: ['body'],
-            indexFields: ['body'],
-          },
-        ]);
+        expect(MLInferenceLogic.values.existingInferencePipelines).toEqual([]);
       });
     });
     describe('mlInferencePipeline', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/ml_inference_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/ml_inference_logic.ts
@@ -82,7 +82,7 @@ import {
 } from './types';
 
 import {
-  EXISTING_PIPELINE_DISABLED_MISSING_SOURCE_FIELD,
+  EXISTING_PIPELINE_DISABLED_MISSING_SOURCE_FIELDS,
   validateInferencePipelineConfiguration,
   validateInferencePipelineFields,
   validatePipelineNameIsAvailable,
@@ -597,7 +597,7 @@ export const MLInferenceLogic = kea<
             const modelType = mlModel ? getMLType(getMlModelTypesForModelConfig(mlModel)) : '';
             const disabledReason =
               missingSourceFields.length > 0
-                ? EXISTING_PIPELINE_DISABLED_MISSING_SOURCE_FIELD(missingSourceFields.join(', '))
+                ? EXISTING_PIPELINE_DISABLED_MISSING_SOURCE_FIELDS(missingSourceFields.join(', '))
                 : undefined;
 
             return {

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/ml_inference_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/ml_inference_logic.ts
@@ -82,7 +82,7 @@ import {
 } from './types';
 
 import {
-  getDisabledReason,
+  EXISTING_PIPELINE_DISABLED_MISSING_SOURCE_FIELD,
   validateInferencePipelineConfiguration,
   validateInferencePipelineFields,
   validatePipelineNameIsAvailable,
@@ -595,11 +595,10 @@ export const MLInferenceLogic = kea<
             const missingSourceFields = sourceFields.filter((f) => !indexFields?.includes(f)) ?? [];
             const mlModel = supportedMLModels.find((model) => model.model_id === modelId);
             const modelType = mlModel ? getMLType(getMlModelTypesForModelConfig(mlModel)) : '';
-            const disabledReason = getDisabledReason(
-              missingSourceFields,
-              indexProcessorNames,
-              pipelineName
-            );
+            const disabledReason =
+              missingSourceFields.length > 0
+                ? EXISTING_PIPELINE_DISABLED_MISSING_SOURCE_FIELD(missingSourceFields.join(', '))
+                : undefined;
 
             return {
               disabled: disabledReason !== undefined,

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/ml_inference_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/ml_inference_logic.ts
@@ -584,7 +584,9 @@ export const MLInferenceLogic = kea<
           mlInferencePipelinesData
         )
           .map(([pipelineName, pipeline]): MLInferencePipelineOption | undefined => {
-            if (!pipeline) return undefined;
+            if (!pipeline || indexProcessorNames.includes(pipelineName)) return undefined;
+
+            // Parse configuration from pipeline definition
             const pipelineParams = parseMlInferenceParametersFromPipeline(pipelineName, pipeline);
             if (!pipelineParams) return undefined;
             const { model_id: modelId, field_mappings: fieldMappings } = pipelineParams;

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/utils.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/utils.ts
@@ -95,27 +95,6 @@ export const EXISTING_PIPELINE_DISABLED_MISSING_SOURCE_FIELDS = (
     }
   );
 
-export const EXISTING_PIPELINE_DISABLED_PIPELINE_EXISTS = i18n.translate(
-  'xpack.enterpriseSearch.content.indices.pipelines.addInferencePipelineModal.steps.configure.existingPipeline.disabledPipelineExistsDescription',
-  {
-    defaultMessage: 'This pipeline cannot be selected because it is already attached.',
-  }
-);
-
-export const getDisabledReason = (
-  missingSourceFields: string[],
-  indexProcessorNames: string[],
-  pipelineName: string
-): string | undefined => {
-  if (missingSourceFields.length > 0) {
-    return EXISTING_PIPELINE_DISABLED_MISSING_SOURCE_FIELDS(missingSourceFields.join(', '));
-  } else if (indexProcessorNames.includes(pipelineName)) {
-    return EXISTING_PIPELINE_DISABLED_PIPELINE_EXISTS;
-  }
-
-  return undefined;
-};
-
 export const MODEL_SELECT_PLACEHOLDER = i18n.translate(
   'xpack.enterpriseSearch.content.indices.pipelines.addInferencePipelineModal.steps.configure.model.placeholder',
   { defaultMessage: 'Select a model' }

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -13142,7 +13142,6 @@
     "xpack.enterpriseSearch.content.indices.pipelines.addInferencePipelineModal.steps.configure.docsLink": "详细了解如何在 Enterprise Search 中导入并使用 ML 模型",
     "xpack.enterpriseSearch.content.indices.pipelines.addInferencePipelineModal.steps.configure.emptyValueError": "“字段”必填。",
     "xpack.enterpriseSearch.content.indices.pipelines.addInferencePipelineModal.steps.configure.existingPipeline.chooseLabel": "选择",
-    "xpack.enterpriseSearch.content.indices.pipelines.addInferencePipelineModal.steps.configure.existingPipeline.disabledPipelineExistsDescription": "无法选择此管道，因为已附加该管道。",
     "xpack.enterpriseSearch.content.indices.pipelines.addInferencePipelineModal.steps.configure.existingPipeline.existingLabel": "现有管道",
     "xpack.enterpriseSearch.content.indices.pipelines.addInferencePipelineModal.steps.configure.existingPipeline.newLabel": "新建管道",
     "xpack.enterpriseSearch.content.indices.pipelines.addInferencePipelineModal.steps.configure.existingPipeline.placeholder": "选择一个",


### PR DESCRIPTION
## Summary

Filter out pipelines from the existing pipeline selection dropdown that are already attached to the current index. This also updates the evaluation of the "Existing pipeline" option in the configuration panel.

Example: 2 pipelines that are already attached are filtered from the dropdown; when attaching the 3rd one, the existing pipelines option is disabled.
![filter_attached_pipelines](https://github.com/elastic/kibana/assets/14224983/b401fcc4-e72a-4f62-ac37-a20dfab106f6)

### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
