### PR TITLE
[Enterprise Search] rebrand ent-search Kibana nav category to Search

### DIFF
--- a/packages/core/application/core-application-common/src/default_app_categories.ts
+++ b/packages/core/application/core-application-common/src/default_app_categories.ts
@@ -21,8 +21,8 @@ export const DEFAULT_APP_CATEGORIES: Record<string, AppCategory> = Object.freeze
   },
   enterpriseSearch: {
     id: 'enterpriseSearch',
-    label: i18n.translate('core.ui.enterpriseSearchNavList.label', {
-      defaultMessage: 'Enterprise Search',
+    label: i18n.translate('core.ui.searchNavList.label', {
+      defaultMessage: 'Search',
     }),
     order: 2000,
     euiIconType: 'logoEnterpriseSearch',

--- a/x-pack/plugins/enterprise_search/public/plugin.ts
+++ b/x-pack/plugins/enterprise_search/public/plugin.ts
@@ -145,6 +145,29 @@ export class EnterpriseSearchPlugin implements Plugin {
     });
 
     core.application.register({
+      appRoute: ENTERPRISE_SEARCH_CONTENT_PLUGIN.URL,
+      category: DEFAULT_APP_CATEGORIES.enterpriseSearch,
+      euiIconType: ENTERPRISE_SEARCH_CONTENT_PLUGIN.LOGO,
+      id: ENTERPRISE_SEARCH_CONTENT_PLUGIN.ID,
+      mount: async (params: AppMountParameters) => {
+        const kibanaDeps = await this.getKibanaDeps(core, params, cloud);
+        const { chrome, http } = kibanaDeps.core;
+        chrome.docTitle.change(ENTERPRISE_SEARCH_CONTENT_PLUGIN.NAME);
+
+        await this.getInitialData(http);
+        const pluginData = this.getPluginData();
+
+        const { renderApp } = await import('./applications');
+        const { EnterpriseSearchContent } = await import(
+          './applications/enterprise_search_content'
+        );
+
+        return renderApp(EnterpriseSearchContent, kibanaDeps, pluginData);
+      },
+      title: ENTERPRISE_SEARCH_CONTENT_PLUGIN.NAV_TITLE,
+    });
+
+    core.application.register({
       appRoute: ESRE_PLUGIN.URL,
       category: DEFAULT_APP_CATEGORIES.enterpriseSearch,
       euiIconType: ESRE_PLUGIN.LOGO,
@@ -184,29 +207,6 @@ export class EnterpriseSearchPlugin implements Plugin {
         return renderApp(EnterpriseSearchVectorSearch, kibanaDeps, pluginData);
       },
       title: VECTOR_SEARCH_PLUGIN.NAV_TITLE,
-    });
-
-    core.application.register({
-      appRoute: ENTERPRISE_SEARCH_CONTENT_PLUGIN.URL,
-      category: DEFAULT_APP_CATEGORIES.enterpriseSearch,
-      euiIconType: ENTERPRISE_SEARCH_CONTENT_PLUGIN.LOGO,
-      id: ENTERPRISE_SEARCH_CONTENT_PLUGIN.ID,
-      mount: async (params: AppMountParameters) => {
-        const kibanaDeps = await this.getKibanaDeps(core, params, cloud);
-        const { chrome, http } = kibanaDeps.core;
-        chrome.docTitle.change(ENTERPRISE_SEARCH_CONTENT_PLUGIN.NAME);
-
-        await this.getInitialData(http);
-        const pluginData = this.getPluginData();
-
-        const { renderApp } = await import('./applications');
-        const { EnterpriseSearchContent } = await import(
-          './applications/enterprise_search_content'
-        );
-
-        return renderApp(EnterpriseSearchContent, kibanaDeps, pluginData);
-      },
-      title: ENTERPRISE_SEARCH_CONTENT_PLUGIN.NAV_TITLE,
     });
 
     core.application.register({
@@ -295,6 +295,7 @@ export class EnterpriseSearchPlugin implements Plugin {
 
           return renderApp(AppSearch, kibanaDeps, pluginData);
         },
+        navLinkStatus: AppNavLinkStatus.hidden,
         title: APP_SEARCH_PLUGIN.NAME,
       });
 
@@ -319,6 +320,7 @@ export class EnterpriseSearchPlugin implements Plugin {
 
           return renderApp(WorkplaceSearch, kibanaDeps, pluginData);
         },
+        navLinkStatus: AppNavLinkStatus.hidden,
         title: WORKPLACE_SEARCH_PLUGIN.NAME,
       });
     }

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -998,7 +998,6 @@
     "core.ui.chrome.headerGlobalNav.helpMenuOpenGitHubIssueTitle": "在 GitHub 中提出问题",
     "core.ui.chrome.headerGlobalNav.helpMenuTitle": "帮助",
     "core.ui.chrome.headerGlobalNav.logoAriaLabel": "Elastic 徽标",
-    "core.ui.enterpriseSearchNavList.label": "Enterprise Search",
     "core.ui.errorUrlOverflow.bigUrlWarningNotificationMessage.advancedSettingsLinkText": "高级设置",
     "core.ui.errorUrlOverflow.bigUrlWarningNotificationTitle": "URL 过长，Kibana 可能无法工作",
     "core.ui.errorUrlOverflow.errorTitle": "此对象的 URL 过长，我们无法显示它",


### PR DESCRIPTION
## Summary

Updated the Kibana collapsible nav Enterprise Search category to Search.
Updated the App Search & Workplace Search app navLinkStatuses to `hidden` to remove them from the Kibana nav.

### Screenshots
<img width="270" alt="image" src="https://github.com/elastic/kibana/assets/1972968/1397e701-ca87-46f2-8c15-565bc3a9202c">
