### PR TITLE
[embeddable] add should_fetch unit test

### DIFF
--- a/src/plugins/embeddable/public/lib/filterable_embeddable/should_fetch.test.tsx
+++ b/src/plugins/embeddable/public/lib/filterable_embeddable/should_fetch.test.tsx
@@ -11,7 +11,6 @@ import type { FilterableEmbeddableInput } from './types';
 import { shouldFetch$ } from './should_fetch';
 
 describe('shouldFetch$', () => {
-  
   let shouldFetchCount = 0;
   let subscription: Subscription;
   let updateInput: (inputFragment: Partial<FilterableEmbeddableInput>) => void;
@@ -30,7 +29,7 @@ describe('shouldFetch$', () => {
         ...inputFragment,
       };
       subject.next(input);
-    }
+    };
 
     subscription = shouldFetch$<FilterableEmbeddableInput>(subject, () => {
       return input;
@@ -59,7 +58,7 @@ describe('shouldFetch$', () => {
       timeRange: {
         to: 'now',
         from: 'now-25m',
-      }
+      },
     });
     expect(shouldFetchCount).toBe(initialCount + 1);
   });

--- a/src/plugins/embeddable/public/lib/filterable_embeddable/should_fetch.test.tsx
+++ b/src/plugins/embeddable/public/lib/filterable_embeddable/should_fetch.test.tsx
@@ -11,7 +11,7 @@ import type { FilterableEmbeddableInput } from './types';
 import { shouldFetch$ } from  './should_fetch';
 
 describe('shouldFetch$', () => {
-  let input = {
+  let input: FilterableEmbeddableInput = {
     timeRange: {
       to: 'now',
       from: 'now-15m',

--- a/src/plugins/embeddable/public/lib/filterable_embeddable/should_fetch.test.tsx
+++ b/src/plugins/embeddable/public/lib/filterable_embeddable/should_fetch.test.tsx
@@ -11,17 +11,27 @@ import type { FilterableEmbeddableInput } from './types';
 import { shouldFetch$ } from './should_fetch';
 
 describe('shouldFetch$', () => {
-  let input: FilterableEmbeddableInput = {
-    id: '1',
-    timeRange: {
-      to: 'now',
-      from: 'now-15m',
-    },
-  };
-  const subject = new BehaviorSubject(input);
+  
   let shouldFetchCount = 0;
-  let subscription: Subscription | undefined;
+  let subscription: Subscription;
+  let updateInput: (inputFragment: Partial<FilterableEmbeddableInput>) => void;
   beforeAll(() => {
+    let input: FilterableEmbeddableInput = {
+      id: '1',
+      timeRange: {
+        to: 'now',
+        from: 'now-15m',
+      },
+    };
+    const subject = new BehaviorSubject(input);
+    updateInput = (inputFragment: Partial<FilterableEmbeddableInput>) => {
+      input = {
+        ...input,
+        ...inputFragment,
+      };
+      subject.next(input);
+    }
+
     subscription = shouldFetch$<FilterableEmbeddableInput>(subject, () => {
       return input;
     }).subscribe(() => {
@@ -30,18 +40,8 @@ describe('shouldFetch$', () => {
   });
 
   afterAll(() => {
-    if (subscription) {
-      subscription.unsubscribe();
-    }
+    subscription.unsubscribe();
   });
-
-  function updateInput(inputFragment: Partial<FilterableEmbeddableInput>) {
-    input = {
-      ...input,
-      ...inputFragment,
-    };
-    subject.next(input);
-  }
 
   test('should not fire on initial subscription', () => {
     expect(shouldFetchCount).toBe(0);

--- a/src/plugins/embeddable/public/lib/filterable_embeddable/should_fetch.test.tsx
+++ b/src/plugins/embeddable/public/lib/filterable_embeddable/should_fetch.test.tsx
@@ -8,7 +8,7 @@
 
 import { BehaviorSubject } from 'rxjs';
 import type { FilterableEmbeddableInput } from './types';
-import { shouldFetch$ } from  './should_fetch';
+import { shouldFetch$ } from './should_fetch';
 
 describe('shouldFetch$', () => {
   let input: FilterableEmbeddableInput = {
@@ -58,4 +58,3 @@ describe('shouldFetch$', () => {
     expect(shouldFetchCount).toBe(initialCount + 1);
   });
 });
-

--- a/src/plugins/embeddable/public/lib/filterable_embeddable/should_fetch.test.tsx
+++ b/src/plugins/embeddable/public/lib/filterable_embeddable/should_fetch.test.tsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { BehaviorSubject } from 'rxjs';
+import type { FilterableEmbeddableInput } from './types';
+import { shouldFetch$ } from  './should_fetch';
+
+describe('shouldFetch$', () => {
+  let input = {
+    timeRange: {
+      to: 'now',
+      from: 'now-15m',
+    },
+  };
+  const subject = new BehaviorSubject(input);
+  let shouldFetchCount = 0;
+  let subscription;
+  beforeAll(() => {
+    subscription = shouldFetch$<FilterableEmbeddableInput>(subject, () => {
+      return input;
+    }).subscribe((newInput) => {
+      shouldFetchCount++;
+      input = newInput;
+    });
+  });
+
+  afterAll(() => {
+    if (subscription) {
+      subscription.unsubscribe();
+    }
+  });
+
+  test('should not fire on initial subscription', () => {
+    expect(shouldFetchCount).toBe(0);
+  });
+
+  test('should not fire when there are no changes', () => {
+    const initialCount = shouldFetchCount;
+    subject.next();
+    expect(shouldFetchCount).toBe(initialCount);
+  });
+
+  test('should fire when timeRange changes', () => {
+    const initialCount = shouldFetchCount;
+    input = {
+      ...input,
+      timeRange: {
+        to: 'now',
+        from: 'now-25m',
+      },
+    };
+    subject.next();
+    expect(shouldFetchCount).toBe(initialCount + 1);
+  });
+});
+

--- a/src/plugins/embeddable/public/lib/filterable_embeddable/should_fetch.test.tsx
+++ b/src/plugins/embeddable/public/lib/filterable_embeddable/should_fetch.test.tsx
@@ -6,12 +6,13 @@
  * Side Public License, v 1.
  */
 
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, Subscription } from 'rxjs';
 import type { FilterableEmbeddableInput } from './types';
 import { shouldFetch$ } from './should_fetch';
 
 describe('shouldFetch$', () => {
   let input: FilterableEmbeddableInput = {
+    id: '1',
     timeRange: {
       to: 'now',
       from: 'now-15m',
@@ -19,7 +20,7 @@ describe('shouldFetch$', () => {
   };
   const subject = new BehaviorSubject(input);
   let shouldFetchCount = 0;
-  let subscription;
+  let subscription: Subscription | undefined;
   beforeAll(() => {
     subscription = shouldFetch$<FilterableEmbeddableInput>(subject, () => {
       return input;
@@ -35,26 +36,32 @@ describe('shouldFetch$', () => {
     }
   });
 
+  function updateInput(inputFragment: Partial<FilterableEmbeddableInput>) {
+    input = {
+      ...input,
+      ...inputFragment,
+    };
+    subject.next(input);
+  }
+
   test('should not fire on initial subscription', () => {
     expect(shouldFetchCount).toBe(0);
   });
 
   test('should not fire when there are no changes', () => {
     const initialCount = shouldFetchCount;
-    subject.next();
+    updateInput({});
     expect(shouldFetchCount).toBe(initialCount);
   });
 
   test('should fire when timeRange changes', () => {
     const initialCount = shouldFetchCount;
-    input = {
-      ...input,
+    updateInput({
       timeRange: {
         to: 'now',
         from: 'now-25m',
-      },
-    };
-    subject.next();
+      }
+    });
     expect(shouldFetchCount).toBe(initialCount + 1);
   });
 });

--- a/src/plugins/embeddable/public/lib/filterable_embeddable/should_fetch.test.tsx
+++ b/src/plugins/embeddable/public/lib/filterable_embeddable/should_fetch.test.tsx
@@ -24,9 +24,8 @@ describe('shouldFetch$', () => {
   beforeAll(() => {
     subscription = shouldFetch$<FilterableEmbeddableInput>(subject, () => {
       return input;
-    }).subscribe((newInput) => {
+    }).subscribe(() => {
       shouldFetchCount++;
-      input = newInput;
     });
   });
 


### PR DESCRIPTION
While messing around with time slider control and custom time ranges, I noticed shouldFetch$ is triggered (turns out search session id is changing - maybe a separate issue).

During investigation, I found it difficult to explore without unit test for shouldFetch$. 