### PR TITLE
[Security Solution] expandable flyout - replace feature flag with advanced settings toggle

### DIFF
--- a/src/plugins/kibana_usage_collection/server/collectors/management/schema.ts
+++ b/src/plugins/kibana_usage_collection/server/collectors/management/schema.ts
@@ -110,6 +110,10 @@ export const stackManagementSchema: MakeSchemaFrom<UsageStats> = {
     type: 'boolean',
     _meta: { description: 'Non-default value of setting.' },
   },
+  'securitySolution:enableExpandableFlyout': {
+    type: 'boolean',
+    _meta: { description: 'Non-default value of setting.' },
+  },
   'securitySolution:enableCcsWarning': {
     type: 'boolean',
     _meta: { description: 'Non-default value of setting.' },

--- a/src/plugins/kibana_usage_collection/server/collectors/management/types.ts
+++ b/src/plugins/kibana_usage_collection/server/collectors/management/types.ts
@@ -63,6 +63,7 @@ export interface UsageStats {
   'securitySolution:defaultAnomalyScore': number;
   'securitySolution:refreshIntervalDefaults': string;
   'securitySolution:enableNewsFeed': boolean;
+  'securitySolution:enableExpandableFlyout': boolean;
   'securitySolution:enableCcsWarning': boolean;
   'search:includeFrozen': boolean;
   'courier:maxConcurrentShardRequests': number;

--- a/src/plugins/telemetry/schema/oss_plugins.json
+++ b/src/plugins/telemetry/schema/oss_plugins.json
@@ -9207,6 +9207,12 @@
             "description": "Non-default value of setting."
           }
         },
+        "securitySolution:enableExpandableFlyout": {
+          "type": "boolean",
+          "_meta": {
+            "description": "Non-default value of setting."
+          }
+        },
         "securitySolution:enableCcsWarning": {
           "type": "boolean",
           "_meta": {

--- a/x-pack/plugins/security_solution/common/constants.ts
+++ b/x-pack/plugins/security_solution/common/constants.ts
@@ -163,6 +163,9 @@ export const DEFAULT_INDEX_PATTERN = [...INCLUDE_INDEX_PATTERN, ...EXCLUDE_ELAST
 /** This Kibana Advanced Setting enables the `Security news` feed widget */
 export const ENABLE_NEWS_FEED_SETTING = 'securitySolution:enableNewsFeed' as const;
 
+/** This Kibana Advanced Setting allows users to enable/disable the Expandable Flyout */
+export const ENABLE_EXPANDABLE_FLYOUT_SETTING = 'securitySolution:enableExpandableFlyout' as const;
+
 /** This Kibana Advanced Setting enables the warnings for CCS read permissions */
 export const ENABLE_CCS_READ_WARNING_SETTING = 'securitySolution:enableCcsWarning' as const;
 
@@ -210,7 +213,6 @@ export const UPDATE_OR_CREATE_LEGACY_ACTIONS = '/internal/api/detection/legacy/n
 /**
  * Exceptions management routes
  */
-
 export const SHARED_EXCEPTION_LIST_URL = `/api${EXCEPTIONS_PATH}/shared` as const;
 
 /**
@@ -322,12 +324,12 @@ export const ALERTS_AS_DATA_FIND_URL = `${ALERTS_AS_DATA_URL}/find` as const;
  */
 export const UNAUTHENTICATED_USER = 'Unauthenticated' as const;
 
-/*
+/**
   Licensing requirements
  */
 export const MINIMUM_ML_LICENSE = 'platinum' as const;
 
-/*
+/**
   Machine Learning constants
  */
 export const ML_GROUP_ID = 'security' as const;

--- a/x-pack/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/plugins/security_solution/common/experimental_features.ts
@@ -76,10 +76,6 @@ export const allowedExperimentalValues = Object.freeze({
    */
   alertsPageChartsEnabled: true,
   alertTypeEnabled: false,
-  /**
-   * Enables the new security flyout over the current alert details flyout
-   */
-  securityFlyoutEnabled: false,
 
   /*
    * Enables new Set of filters on the Alerts page.

--- a/x-pack/plugins/security_solution/cypress/e2e/detection_alerts/cti_enrichments.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_alerts/cti_enrichments.cy.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { disableExpandableFlyout } from '../../tasks/api_calls/kibana_advanced_settings';
 import { getNewThreatIndicatorRule, indicatorRuleMatchingDoc } from '../../objects/rule';
 import { cleanKibana } from '../../tasks/common';
 import { login, visitWithoutDateRange } from '../../tasks/login';
@@ -34,6 +35,7 @@ describe('CTI Enrichment', () => {
     cy.task('esArchiverLoad', 'suspicious_source_event');
     login();
     createRule({ ...getNewThreatIndicatorRule(), rule_id: 'rule_testing', enabled: true });
+    disableExpandableFlyout();
   });
 
   after(() => {

--- a/x-pack/plugins/security_solution/cypress/e2e/detection_alerts/enrichments.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_alerts/enrichments.cy.ts
@@ -24,6 +24,7 @@ import {
   scrollAlertTableColumnIntoView,
   closeAlertFlyout,
 } from '../../tasks/alerts';
+import { disableExpandableFlyout } from '../../tasks/api_calls/kibana_advanced_settings';
 
 import { login, visit } from '../../tasks/login';
 
@@ -41,6 +42,7 @@ describe('Enrichment', () => {
 
   describe('Custom query rule', () => {
     beforeEach(() => {
+      disableExpandableFlyout();
       cy.task('esArchiverLoad', 'risk_hosts');
       deleteAlertsAndRules();
       createRule(getNewRule({ rule_id: 'rule1' }));

--- a/x-pack/plugins/security_solution/cypress/e2e/explore/guided_onboarding/tour.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/explore/guided_onboarding/tour.cy.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { disableExpandableFlyout } from '../../../tasks/api_calls/kibana_advanced_settings';
 import { navigateFromHeaderTo } from '../../../tasks/security_header';
 import { ALERTS, TIMELINES } from '../../../screens/security_header';
 import { closeAlertFlyout, expandFirstAlert } from '../../../tasks/alerts';
@@ -36,6 +37,7 @@ describe('Guided onboarding tour', () => {
   });
   beforeEach(() => {
     login();
+    disableExpandableFlyout();
     startAlertsCasesTour();
     visit(ALERTS_URL);
     waitForAlertsToPopulate();

--- a/x-pack/plugins/security_solution/cypress/e2e/investigations/alerts/alerts_details.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/investigations/alerts/alerts_details.cy.ts
@@ -6,6 +6,7 @@
  */
 
 import type { DataTableModel } from '@kbn/securitysolution-data-table';
+import { disableExpandableFlyout } from '../../../tasks/api_calls/kibana_advanced_settings';
 import {
   ALERT_FLYOUT,
   CELL_TEXT,
@@ -39,6 +40,7 @@ describe('Alert details flyout', () => {
     before(() => {
       cleanKibana();
       login();
+      disableExpandableFlyout();
       createRule(getNewRule());
       visitWithoutDateRange(ALERTS_URL);
       waitForAlertsToPopulate();
@@ -64,6 +66,7 @@ describe('Alert details flyout', () => {
 
     beforeEach(() => {
       login();
+      disableExpandableFlyout();
       visitWithoutDateRange(ALERTS_URL);
       waitForAlertsToPopulate();
       expandFirstAlert();
@@ -128,6 +131,7 @@ describe('Alert details flyout', () => {
 
     beforeEach(() => {
       login();
+      disableExpandableFlyout();
       visit(ALERTS_URL);
       waitForAlertsToPopulate();
       expandFirstAlert();
@@ -173,6 +177,7 @@ describe('Alert details flyout', () => {
 
     beforeEach(() => {
       login();
+      disableExpandableFlyout();
       visit(ALERTS_URL);
       waitForAlertsToPopulate();
       expandFirstAlert();

--- a/x-pack/plugins/security_solution/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_analyzer_graph_tab.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_analyzer_graph_tab.cy.ts
@@ -24,34 +24,30 @@ import { getNewRule } from '../../../../objects/rule';
 import { ALERTS_URL } from '../../../../urls/navigation';
 import { waitForAlertsToPopulate } from '../../../../tasks/create_new_rule';
 
-describe(
-  'Alert details expandable flyout left panel analyzer graph',
-  { env: { ftrConfig: { enableExperimental: ['securityFlyoutEnabled'] } } },
-  () => {
-    beforeEach(() => {
-      cleanKibana();
-      login();
-      createRule(getNewRule());
-      visit(ALERTS_URL);
-      waitForAlertsToPopulate();
-      expandFirstAlertExpandableFlyout();
-      expandDocumentDetailsExpandableFlyoutLeftSection();
-      openGraphAnalyzerTab();
-    });
+describe('Alert details expandable flyout left panel analyzer graph', () => {
+  beforeEach(() => {
+    cleanKibana();
+    login();
+    createRule(getNewRule());
+    visit(ALERTS_URL);
+    waitForAlertsToPopulate();
+    expandFirstAlertExpandableFlyout();
+    expandDocumentDetailsExpandableFlyoutLeftSection();
+    openGraphAnalyzerTab();
+  });
 
-    it('should display analyzer graph and node list under visualize', () => {
-      cy.get(DOCUMENT_DETAILS_FLYOUT_VISUALIZE_TAB)
-        .should('be.visible')
-        .and('have.text', 'Visualize');
+  it('should display analyzer graph and node list under visualize', () => {
+    cy.get(DOCUMENT_DETAILS_FLYOUT_VISUALIZE_TAB)
+      .should('be.visible')
+      .and('have.text', 'Visualize');
 
-      cy.get(DOCUMENT_DETAILS_FLYOUT_VISUALIZE_TAB_BUTTON_GROUP).should('be.visible');
+    cy.get(DOCUMENT_DETAILS_FLYOUT_VISUALIZE_TAB_BUTTON_GROUP).should('be.visible');
 
-      cy.get(DOCUMENT_DETAILS_FLYOUT_VISUALIZE_TAB_GRAPH_ANALYZER_BUTTON)
-        .should('be.visible')
-        .and('have.text', 'Analyzer Graph');
+    cy.get(DOCUMENT_DETAILS_FLYOUT_VISUALIZE_TAB_GRAPH_ANALYZER_BUTTON)
+      .should('be.visible')
+      .and('have.text', 'Analyzer Graph');
 
-      cy.get(DOCUMENT_DETAILS_FLYOUT_VISUALIZE_TAB_GRAPH_ANALYZER_CONTENT).should('be.visible');
-      cy.get(ANALYZER_NODE).first().should('be.visible');
-    });
-  }
-);
+    cy.get(DOCUMENT_DETAILS_FLYOUT_VISUALIZE_TAB_GRAPH_ANALYZER_CONTENT).should('be.visible');
+    cy.get(ANALYZER_NODE).first().should('be.visible');
+  });
+});

--- a/x-pack/plugins/security_solution/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_correlations_tab.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_correlations_tab.cy.ts
@@ -34,60 +34,54 @@ import { waitForAlertsToPopulate } from '../../../../tasks/create_new_rule';
 import { login, visit } from '../../../../tasks/login';
 import { ALERTS_URL } from '../../../../urls/navigation';
 
-describe(
-  'Expandable flyout left panel correlations',
-  { env: { ftrConfig: { enableExperimental: ['securityFlyoutEnabled'] } } },
-  () => {
-    beforeEach(() => {
-      cleanKibana();
-      login();
-      createRule(getNewRule());
-      visit(ALERTS_URL);
-      waitForAlertsToPopulate();
-      expandFirstAlertExpandableFlyout();
-      expandDocumentDetailsExpandableFlyoutLeftSection();
-      createNewCaseFromExpandableFlyout();
-      openInsightsTab();
-      openCorrelationsTab();
-    });
+describe('Expandable flyout left panel correlations', () => {
+  beforeEach(() => {
+    cleanKibana();
+    login();
+    createRule(getNewRule());
+    visit(ALERTS_URL);
+    waitForAlertsToPopulate();
+    expandFirstAlertExpandableFlyout();
+    expandDocumentDetailsExpandableFlyoutLeftSection();
+    createNewCaseFromExpandableFlyout();
+    openInsightsTab();
+    openCorrelationsTab();
+  });
 
-    it('should render correlations details correctly', () => {
-      cy.log('link the alert to a new case');
+  it('should render correlations details correctly', () => {
+    cy.log('link the alert to a new case');
 
-      cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB).scrollIntoView();
+    cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB).scrollIntoView();
 
-      cy.log('should render the Insights header');
-      cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB)
-        .should('be.visible')
-        .and('have.text', 'Insights');
+    cy.log('should render the Insights header');
+    cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB).should('be.visible').and('have.text', 'Insights');
 
-      cy.log('should render the inner tab switch');
-      cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_BUTTON_GROUP).should('be.visible');
+    cy.log('should render the inner tab switch');
+    cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_BUTTON_GROUP).should('be.visible');
 
-      cy.log('should render correlations tab activator / button');
-      cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_CORRELATIONS_BUTTON)
-        .should('be.visible')
-        .and('have.text', 'Correlations');
+    cy.log('should render correlations tab activator / button');
+    cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_CORRELATIONS_BUTTON)
+      .should('be.visible')
+      .and('have.text', 'Correlations');
 
-      cy.log('should render all the correlations sections');
+    cy.log('should render all the correlations sections');
 
-      cy.get(CORRELATIONS_ANCESTRY_SECTION)
-        .should('be.visible')
-        .and('have.text', '1 alert related by ancestry');
+    cy.get(CORRELATIONS_ANCESTRY_SECTION)
+      .should('be.visible')
+      .and('have.text', '1 alert related by ancestry');
 
-      cy.get(CORRELATIONS_SOURCE_SECTION)
-        .should('be.visible')
-        .and('have.text', '0 alerts related by source event');
+    cy.get(CORRELATIONS_SOURCE_SECTION)
+      .should('be.visible')
+      .and('have.text', '0 alerts related by source event');
 
-      cy.get(CORRELATIONS_SESSION_SECTION)
-        .should('be.visible')
-        .and('have.text', '1 alert related by session');
+    cy.get(CORRELATIONS_SESSION_SECTION)
+      .should('be.visible')
+      .and('have.text', '1 alert related by session');
 
-      cy.get(CORRELATIONS_CASES_SECTION).should('be.visible').and('have.text', '1 related case');
+    cy.get(CORRELATIONS_CASES_SECTION).should('be.visible').and('have.text', '1 related case');
 
-      expandCorrelationsSection(CORRELATIONS_ANCESTRY_SECTION);
+    expandCorrelationsSection(CORRELATIONS_ANCESTRY_SECTION);
 
-      cy.get(CORRELATIONS_ANCESTRY_TABLE).should('be.visible');
-    });
-  }
-);
+    cy.get(CORRELATIONS_ANCESTRY_TABLE).should('be.visible');
+  });
+});

--- a/x-pack/plugins/security_solution/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_entities_tab.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_entities_tab.cy.ts
@@ -25,38 +25,32 @@ import { getNewRule } from '../../../../objects/rule';
 import { ALERTS_URL } from '../../../../urls/navigation';
 import { waitForAlertsToPopulate } from '../../../../tasks/create_new_rule';
 
-describe(
-  'Alert details expandable flyout left panel entities',
-  { env: { ftrConfig: { enableExperimental: ['securityFlyoutEnabled'] } } },
-  () => {
-    beforeEach(() => {
-      cleanKibana();
-      login();
-      createRule(getNewRule());
-      visit(ALERTS_URL);
-      waitForAlertsToPopulate();
-      expandFirstAlertExpandableFlyout();
-      expandDocumentDetailsExpandableFlyoutLeftSection();
-      openInsightsTab();
-      openEntitiesTab();
-    });
+describe('Alert details expandable flyout left panel entities', () => {
+  beforeEach(() => {
+    cleanKibana();
+    login();
+    createRule(getNewRule());
+    visit(ALERTS_URL);
+    waitForAlertsToPopulate();
+    expandFirstAlertExpandableFlyout();
+    expandDocumentDetailsExpandableFlyoutLeftSection();
+    openInsightsTab();
+    openEntitiesTab();
+  });
 
-    it('should display analyzer graph and node list under Insights Entities', () => {
-      cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB)
-        .should('be.visible')
-        .and('have.text', 'Insights');
+  it('should display analyzer graph and node list under Insights Entities', () => {
+    cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB).should('be.visible').and('have.text', 'Insights');
 
-      cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_BUTTON_GROUP).should('be.visible');
+    cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_BUTTON_GROUP).should('be.visible');
 
-      cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_ENTITIES_BUTTON)
-        .should('be.visible')
-        .and('have.text', 'Entities');
+    cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_ENTITIES_BUTTON)
+      .should('be.visible')
+      .and('have.text', 'Entities');
 
-      cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_HOST_DETAILS).scrollIntoView();
-      cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_HOST_DETAILS).should('be.visible');
+    cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_HOST_DETAILS).scrollIntoView();
+    cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_HOST_DETAILS).should('be.visible');
 
-      cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_USER_DETAILS).scrollIntoView();
-      cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_USER_DETAILS).should('be.visible');
-    });
-  }
-);
+    cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_USER_DETAILS).scrollIntoView();
+    cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_USER_DETAILS).should('be.visible');
+  });
+});

--- a/x-pack/plugins/security_solution/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_investigation_tab.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_investigation_tab.cy.ts
@@ -19,27 +19,23 @@ import { getNewRule } from '../../../../objects/rule';
 import { ALERTS_URL } from '../../../../urls/navigation';
 import { waitForAlertsToPopulate } from '../../../../tasks/create_new_rule';
 
-describe(
-  'Alert details expandable flyout left panel investigation',
-  { env: { ftrConfig: { enableExperimental: ['securityFlyoutEnabled'] } } },
-  () => {
-    beforeEach(() => {
-      cleanKibana();
-      login();
-      createRule(getNewRule());
-      visit(ALERTS_URL);
-      waitForAlertsToPopulate();
-      expandFirstAlertExpandableFlyout();
-      expandDocumentDetailsExpandableFlyoutLeftSection();
-      openInvestigationTab();
-    });
+describe('Alert details expandable flyout left panel investigation', () => {
+  beforeEach(() => {
+    cleanKibana();
+    login();
+    createRule(getNewRule());
+    visit(ALERTS_URL);
+    waitForAlertsToPopulate();
+    expandFirstAlertExpandableFlyout();
+    expandDocumentDetailsExpandableFlyoutLeftSection();
+    openInvestigationTab();
+  });
 
-    it('should display investigation guide', () => {
-      cy.get(DOCUMENT_DETAILS_FLYOUT_INVESTIGATION_TAB)
-        .should('be.visible')
-        .and('have.text', 'Investigation');
+  it('should display investigation guide', () => {
+    cy.get(DOCUMENT_DETAILS_FLYOUT_INVESTIGATION_TAB)
+      .should('be.visible')
+      .and('have.text', 'Investigation');
 
-      cy.get(DOCUMENT_DETAILS_FLYOUT_INVESTIGATION_TAB_CONTENT).should('be.visible');
-    });
-  }
-);
+    cy.get(DOCUMENT_DETAILS_FLYOUT_INVESTIGATION_TAB_CONTENT).should('be.visible');
+  });
+});

--- a/x-pack/plugins/security_solution/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_prevalence_tab.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_prevalence_tab.cy.ts
@@ -52,29 +52,28 @@ describe('Alert details expandable flyout left panel prevalence', () => {
       .should('be.visible')
       .and('have.text', 'Prevalence');
 
-      cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_PREVALENCE_TABLE).should('be.visible');
-      cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_PREVALENCE_TABLE_TYPE_CELL)
-        .should('contain.text', 'host.name')
-        .and('contain.text', 'user.name');
-      cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_PREVALENCE_TABLE_NAME_CELL)
-        .should('contain.text', 'siem-kibana')
-        .and('contain.text', 'test');
-      cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_PREVALENCE_TABLE_ALERT_COUNT_CELL).should(
-        'contain.text',
-        2
-      );
-      cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_PREVALENCE_TABLE_DOC_COUNT_CELL).should(
-        'contain.text',
-        0
-      );
-      cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_PREVALENCE_TABLE_HOST_PREVALENCE_CELL).should(
-        'contain.text',
-        100
-      );
-      cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_PREVALENCE_TABLE_USER_PREVALENCE_CELL).should(
-        'contain.text',
-        100
-      );
-    });
-  }
-);
+    cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_PREVALENCE_TABLE).should('be.visible');
+    cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_PREVALENCE_TABLE_TYPE_CELL)
+      .should('contain.text', 'host.name')
+      .and('contain.text', 'user.name');
+    cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_PREVALENCE_TABLE_NAME_CELL)
+      .should('contain.text', 'siem-kibana')
+      .and('contain.text', 'test');
+    cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_PREVALENCE_TABLE_ALERT_COUNT_CELL).should(
+      'contain.text',
+      2
+    );
+    cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_PREVALENCE_TABLE_DOC_COUNT_CELL).should(
+      'contain.text',
+      0
+    );
+    cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_PREVALENCE_TABLE_HOST_PREVALENCE_CELL).should(
+      'contain.text',
+      100
+    );
+    cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_PREVALENCE_TABLE_USER_PREVALENCE_CELL).should(
+      'contain.text',
+      100
+    );
+  });
+});

--- a/x-pack/plugins/security_solution/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_prevalence_tab.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_prevalence_tab.cy.ts
@@ -30,32 +30,27 @@ import { getNewRule } from '../../../../objects/rule';
 import { ALERTS_URL } from '../../../../urls/navigation';
 import { waitForAlertsToPopulate } from '../../../../tasks/create_new_rule';
 
-describe(
-  'Alert details expandable flyout left panel prevalence',
-  { env: { ftrConfig: { enableExperimental: ['securityFlyoutEnabled'] } } },
-  () => {
-    beforeEach(() => {
-      cleanKibana();
-      login();
-      createRule(getNewRule());
-      visit(ALERTS_URL);
-      waitForAlertsToPopulate();
-      expandFirstAlertExpandableFlyout();
-      expandDocumentDetailsExpandableFlyoutLeftSection();
-      openInsightsTab();
-      openPrevalenceTab();
-    });
+describe('Alert details expandable flyout left panel prevalence', () => {
+  beforeEach(() => {
+    cleanKibana();
+    login();
+    createRule(getNewRule());
+    visit(ALERTS_URL);
+    waitForAlertsToPopulate();
+    expandFirstAlertExpandableFlyout();
+    expandDocumentDetailsExpandableFlyoutLeftSection();
+    openInsightsTab();
+    openPrevalenceTab();
+  });
 
-    it('should display prevalence tab', () => {
-      cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB)
-        .should('be.visible')
-        .and('have.text', 'Insights');
+  it('should display prevalence tab', () => {
+    cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB).should('be.visible').and('have.text', 'Insights');
 
-      cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_BUTTON_GROUP).should('be.visible');
+    cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_BUTTON_GROUP).should('be.visible');
 
-      cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_PREVALENCE_BUTTON)
-        .should('be.visible')
-        .and('have.text', 'Prevalence');
+    cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_PREVALENCE_BUTTON)
+      .should('be.visible')
+      .and('have.text', 'Prevalence');
 
       cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_PREVALENCE_TABLE).should('be.visible');
       cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_PREVALENCE_TABLE_TYPE_CELL)

--- a/x-pack/plugins/security_solution/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_response_tab.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_response_tab.cy.ts
@@ -16,23 +16,19 @@ import { getNewRule } from '../../../../objects/rule';
 import { ALERTS_URL } from '../../../../urls/navigation';
 import { waitForAlertsToPopulate } from '../../../../tasks/create_new_rule';
 
-describe(
-  'Alert details expandable flyout left panel investigation',
-  { env: { ftrConfig: { enableExperimental: ['securityFlyoutEnabled'] } } },
-  () => {
-    beforeEach(() => {
-      cleanKibana();
-      login();
-      createRule(getNewRule());
-      visit(ALERTS_URL);
-      waitForAlertsToPopulate();
-      expandFirstAlertExpandableFlyout();
-      expandDocumentDetailsExpandableFlyoutLeftSection();
-      openResponseTab();
-    });
+describe('Alert details expandable flyout left panel investigation', () => {
+  beforeEach(() => {
+    cleanKibana();
+    login();
+    createRule(getNewRule());
+    visit(ALERTS_URL);
+    waitForAlertsToPopulate();
+    expandFirstAlertExpandableFlyout();
+    expandDocumentDetailsExpandableFlyoutLeftSection();
+    openResponseTab();
+  });
 
-    it('should display empty response message', () => {
-      cy.get(DOCUMENT_DETAILS_FLYOUT_RESPONSE_EMPTY).should('be.visible');
-    });
-  }
-);
+  it('should display empty response message', () => {
+    cy.get(DOCUMENT_DETAILS_FLYOUT_RESPONSE_EMPTY).should('be.visible');
+  });
+});

--- a/x-pack/plugins/security_solution/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_session_view_tab.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_session_view_tab.cy.ts
@@ -22,36 +22,32 @@ import { getNewRule } from '../../../../objects/rule';
 import { ALERTS_URL } from '../../../../urls/navigation';
 import { waitForAlertsToPopulate } from '../../../../tasks/create_new_rule';
 
-describe(
-  'Alert details expandable flyout left panel session view',
-  { env: { ftrConfig: { enableExperimental: ['securityFlyoutEnabled'] } } },
-  () => {
-    beforeEach(() => {
-      cleanKibana();
-      login();
-      createRule(getNewRule());
-      visit(ALERTS_URL);
-      waitForAlertsToPopulate();
-      expandFirstAlertExpandableFlyout();
-      expandDocumentDetailsExpandableFlyoutLeftSection();
-    });
+describe('Alert details expandable flyout left panel session view', () => {
+  beforeEach(() => {
+    cleanKibana();
+    login();
+    createRule(getNewRule());
+    visit(ALERTS_URL);
+    waitForAlertsToPopulate();
+    expandFirstAlertExpandableFlyout();
+    expandDocumentDetailsExpandableFlyoutLeftSection();
+  });
 
-    it('should display session view under visualize', () => {
-      cy.get(DOCUMENT_DETAILS_FLYOUT_VISUALIZE_TAB)
-        .should('be.visible')
-        .and('have.text', 'Visualize');
+  it('should display session view under visualize', () => {
+    cy.get(DOCUMENT_DETAILS_FLYOUT_VISUALIZE_TAB)
+      .should('be.visible')
+      .and('have.text', 'Visualize');
 
-      cy.get(DOCUMENT_DETAILS_FLYOUT_VISUALIZE_TAB_BUTTON_GROUP).should('be.visible');
+    cy.get(DOCUMENT_DETAILS_FLYOUT_VISUALIZE_TAB_BUTTON_GROUP).should('be.visible');
 
-      cy.get(DOCUMENT_DETAILS_FLYOUT_VISUALIZE_TAB_SESSION_VIEW_BUTTON)
-        .should('be.visible')
-        .and('have.text', 'Session View');
+    cy.get(DOCUMENT_DETAILS_FLYOUT_VISUALIZE_TAB_SESSION_VIEW_BUTTON)
+      .should('be.visible')
+      .and('have.text', 'Session View');
 
-      // TODO ideally we would have a test for the session view component instead
-      cy.get(DOCUMENT_DETAILS_FLYOUT_VISUALIZE_TAB_SESSION_VIEW_ERROR)
-        .should('be.visible')
-        .and('contain.text', 'Unable to display session view')
-        .and('contain.text', 'There was an error displaying session view');
-    });
-  }
-);
+    // TODO ideally we would have a test for the session view component instead
+    cy.get(DOCUMENT_DETAILS_FLYOUT_VISUALIZE_TAB_SESSION_VIEW_ERROR)
+      .should('be.visible')
+      .and('contain.text', 'Unable to display session view')
+      .and('contain.text', 'There was an error displaying session view');
+  });
+});

--- a/x-pack/plugins/security_solution/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_threat_intelligence_tab.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_threat_intelligence_tab.cy.ts
@@ -22,34 +22,28 @@ import {
 } from '../../../../screens/expandable_flyout/alert_details_left_panel';
 import { DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_THREAT_INTELLIGENCE_BUTTON } from '../../../../screens/expandable_flyout/alert_details_left_panel_threat_intelligence_tab';
 
-describe(
-  'Expandable flyout left panel threat intelligence',
-  { env: { ftrConfig: { enableExperimental: ['securityFlyoutEnabled'] } } },
-  () => {
-    beforeEach(() => {
-      cleanKibana();
-      login();
-      createRule(getNewRule());
-      visit(ALERTS_URL);
-      waitForAlertsToPopulate();
-      expandFirstAlertExpandableFlyout();
-      expandDocumentDetailsExpandableFlyoutLeftSection();
-      openInsightsTab();
-      openThreatIntelligenceTab();
-    });
+describe('Expandable flyout left panel threat intelligence', () => {
+  beforeEach(() => {
+    cleanKibana();
+    login();
+    createRule(getNewRule());
+    visit(ALERTS_URL);
+    waitForAlertsToPopulate();
+    expandFirstAlertExpandableFlyout();
+    expandDocumentDetailsExpandableFlyoutLeftSection();
+    openInsightsTab();
+    openThreatIntelligenceTab();
+  });
 
-    it('should serialize its state to url', () => {
-      cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB)
-        .should('be.visible')
-        .and('have.text', 'Insights');
+  it('should serialize its state to url', () => {
+    cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB).should('be.visible').and('have.text', 'Insights');
 
-      cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_BUTTON_GROUP).should('be.visible');
+    cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_BUTTON_GROUP).should('be.visible');
 
-      cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_THREAT_INTELLIGENCE_BUTTON)
-        .should('be.visible')
-        .and('have.text', 'Threat Intelligence');
+    cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_THREAT_INTELLIGENCE_BUTTON)
+      .should('be.visible')
+      .and('have.text', 'Threat Intelligence');
 
-      cy.get(INDICATOR_MATCH_ENRICHMENT_SECTION).should('be.visible');
-    });
-  }
-);
+    cy.get(INDICATOR_MATCH_ENRICHMENT_SECTION).should('be.visible');
+  });
+});

--- a/x-pack/plugins/security_solution/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_preview_panel_rule_preview.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_preview_panel_rule_preview.cy.ts
@@ -34,68 +34,63 @@ import { getNewRule } from '../../../../objects/rule';
 import { ALERTS_URL } from '../../../../urls/navigation';
 import { waitForAlertsToPopulate } from '../../../../tasks/create_new_rule';
 
-describe(
-  'Alert details expandable flyout rule preview panel',
-  { env: { ftrConfig: { enableExperimental: ['securityFlyoutEnabled'] } } },
-  () => {
-    const rule = getNewRule();
+describe('Alert details expandable flyout rule preview panel', () => {
+  const rule = getNewRule();
 
-    beforeEach(() => {
-      cleanKibana();
-      login();
-      createRule(rule);
-      visit(ALERTS_URL);
-      waitForAlertsToPopulate();
-      expandFirstAlertExpandableFlyout();
-      clickRuleSummaryButton();
+  beforeEach(() => {
+    cleanKibana();
+    login();
+    createRule(rule);
+    visit(ALERTS_URL);
+    waitForAlertsToPopulate();
+    expandFirstAlertExpandableFlyout();
+    clickRuleSummaryButton();
+  });
+
+  describe('rule preview', () => {
+    it('should display rule preview and its sub sections', () => {
+      cy.log('rule preview panel');
+
+      cy.get(DOCUMENT_DETAILS_FLYOUT_RULE_PREVIEW_SECTION).scrollIntoView();
+      cy.get(DOCUMENT_DETAILS_FLYOUT_RULE_PREVIEW_HEADER).should('be.visible');
+      cy.get(DOCUMENT_DETAILS_FLYOUT_RULE_PREVIEW_BODY).should('be.visible');
+
+      cy.log('title');
+
+      cy.get(DOCUMENT_DETAILS_FLYOUT_RULE_PREVIEW_TITLE).scrollIntoView();
+      cy.get(DOCUMENT_DETAILS_FLYOUT_RULE_PREVIEW_TITLE).should('be.visible');
+      cy.get(DOCUMENT_DETAILS_FLYOUT_CREATED_BY).should('be.visible');
+      cy.get(DOCUMENT_DETAILS_FLYOUT_UPDATED_BY).should('be.visible');
+
+      cy.log('about');
+
+      cy.get(DOCUMENT_DETAILS_FLYOUT_RULE_PREVIEW_ABOUT_SECTION_HEADER)
+        .should('be.visible')
+        .and('contain.text', 'About');
+      cy.get(DOCUMENT_DETAILS_FLYOUT_RULE_PREVIEW_ABOUT_SECTION_CONTENT).should('be.visible');
+      toggleRulePreviewAboutSection();
+
+      cy.log('definition');
+
+      toggleRulePreviewDefinitionSection();
+      cy.get(DOCUMENT_DETAILS_FLYOUT_RULE_PREVIEW_DEFINITION_SECTION_HEADER)
+        .should('be.visible')
+        .and('contain.text', 'Definition');
+      cy.get(DOCUMENT_DETAILS_FLYOUT_RULE_PREVIEW_DEFINITION_SECTION_CONTENT).should('be.visible');
+      toggleRulePreviewDefinitionSection();
+
+      cy.log('schedule');
+
+      toggleRulePreviewScheduleSection();
+      cy.get(DOCUMENT_DETAILS_FLYOUT_RULE_PREVIEW_SCHEDULE_SECTION_HEADER)
+        .should('be.visible')
+        .and('contain.text', 'Schedule');
+      cy.get(DOCUMENT_DETAILS_FLYOUT_RULE_PREVIEW_SCHEDULE_SECTION_CONTENT).should('be.visible');
+      toggleRulePreviewScheduleSection();
+
+      cy.log('footer');
+      cy.get(DOCUMENT_DETAILS_FLYOUT_RULE_PREVIEW_FOOTER).scrollIntoView();
+      cy.get(DOCUMENT_DETAILS_FLYOUT_RULE_PREVIEW_FOOTER).should('be.visible');
     });
-
-    describe('rule preview', () => {
-      it('should display rule preview and its sub sections', () => {
-        cy.log('rule preview panel');
-
-        cy.get(DOCUMENT_DETAILS_FLYOUT_RULE_PREVIEW_SECTION).scrollIntoView();
-        cy.get(DOCUMENT_DETAILS_FLYOUT_RULE_PREVIEW_HEADER).should('be.visible');
-        cy.get(DOCUMENT_DETAILS_FLYOUT_RULE_PREVIEW_BODY).should('be.visible');
-
-        cy.log('title');
-        cy.get(DOCUMENT_DETAILS_FLYOUT_RULE_PREVIEW_TITLE).scrollIntoView();
-        cy.get(DOCUMENT_DETAILS_FLYOUT_RULE_PREVIEW_TITLE).should('be.visible');
-        cy.get(DOCUMENT_DETAILS_FLYOUT_CREATED_BY).should('be.visible');
-        cy.get(DOCUMENT_DETAILS_FLYOUT_UPDATED_BY).should('be.visible');
-
-        cy.log('about');
-
-        cy.get(DOCUMENT_DETAILS_FLYOUT_RULE_PREVIEW_ABOUT_SECTION_HEADER)
-          .should('be.visible')
-          .and('contain.text', 'About');
-        cy.get(DOCUMENT_DETAILS_FLYOUT_RULE_PREVIEW_ABOUT_SECTION_CONTENT).should('be.visible');
-        toggleRulePreviewAboutSection();
-
-        cy.log('definition');
-
-        toggleRulePreviewDefinitionSection();
-        cy.get(DOCUMENT_DETAILS_FLYOUT_RULE_PREVIEW_DEFINITION_SECTION_HEADER)
-          .should('be.visible')
-          .and('contain.text', 'Definition');
-        cy.get(DOCUMENT_DETAILS_FLYOUT_RULE_PREVIEW_DEFINITION_SECTION_CONTENT).should(
-          'be.visible'
-        );
-        toggleRulePreviewDefinitionSection();
-
-        cy.log('schedule');
-
-        toggleRulePreviewScheduleSection();
-        cy.get(DOCUMENT_DETAILS_FLYOUT_RULE_PREVIEW_SCHEDULE_SECTION_HEADER)
-          .should('be.visible')
-          .and('contain.text', 'Schedule');
-        cy.get(DOCUMENT_DETAILS_FLYOUT_RULE_PREVIEW_SCHEDULE_SECTION_CONTENT).should('be.visible');
-        toggleRulePreviewScheduleSection();
-
-        cy.log('footer');
-        cy.get(DOCUMENT_DETAILS_FLYOUT_RULE_PREVIEW_FOOTER).scrollIntoView();
-        cy.get(DOCUMENT_DETAILS_FLYOUT_RULE_PREVIEW_FOOTER).should('be.visible');
-      });
-    });
-  }
-);
+  });
+});

--- a/x-pack/plugins/security_solution/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_right_panel.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_right_panel.cy.ts
@@ -65,173 +65,167 @@ import { getNewRule } from '../../../../objects/rule';
 import { ALERTS_URL } from '../../../../urls/navigation';
 import { waitForAlertsToPopulate } from '../../../../tasks/create_new_rule';
 
-describe(
-  'Alert details expandable flyout right panel',
-  { env: { ftrConfig: { enableExperimental: ['securityFlyoutEnabled'] } } },
-  () => {
-    const rule = getNewRule();
+describe('Alert details expandable flyout right panel', () => {
+  const rule = getNewRule();
 
-    beforeEach(() => {
-      cleanKibana();
-      login();
-      createRule(rule);
-      visit(ALERTS_URL);
-      waitForAlertsToPopulate();
-    });
+  beforeEach(() => {
+    cleanKibana();
+    login();
+    createRule(rule);
+    visit(ALERTS_URL);
+    waitForAlertsToPopulate();
+  });
 
-    it('should display header and footer basics', () => {
-      expandFirstAlertExpandableFlyout();
+  it('should display header and footer basics', () => {
+    expandFirstAlertExpandableFlyout();
 
-      cy.get(DOCUMENT_DETAILS_FLYOUT_HEADER_TITLE).should('be.visible').and('have.text', rule.name);
+    cy.get(DOCUMENT_DETAILS_FLYOUT_HEADER_TITLE).should('be.visible').and('have.text', rule.name);
 
-      cy.get(DOCUMENT_DETAILS_FLYOUT_HEADER_CHAT_BUTTON).should('be.visible');
+    cy.get(DOCUMENT_DETAILS_FLYOUT_HEADER_CHAT_BUTTON).should('be.visible');
 
-      cy.get(DOCUMENT_DETAILS_FLYOUT_HEADER_STATUS).should('be.visible');
+    cy.get(DOCUMENT_DETAILS_FLYOUT_HEADER_STATUS).should('be.visible');
 
-      cy.get(DOCUMENT_DETAILS_FLYOUT_HEADER_RISK_SCORE).should('be.visible');
-      cy.get(DOCUMENT_DETAILS_FLYOUT_HEADER_RISK_SCORE_VALUE)
-        .should('be.visible')
-        .and('have.text', rule.risk_score);
+    cy.get(DOCUMENT_DETAILS_FLYOUT_HEADER_RISK_SCORE).should('be.visible');
+    cy.get(DOCUMENT_DETAILS_FLYOUT_HEADER_RISK_SCORE_VALUE)
+      .should('be.visible')
+      .and('have.text', rule.risk_score);
 
-      cy.get(DOCUMENT_DETAILS_FLYOUT_HEADER_SEVERITY).should('be.visible');
-      cy.get(DOCUMENT_DETAILS_FLYOUT_HEADER_SEVERITY_VALUE)
-        .should('be.visible')
-        .and('have.text', upperFirst(rule.severity));
+    cy.get(DOCUMENT_DETAILS_FLYOUT_HEADER_SEVERITY).should('be.visible');
+    cy.get(DOCUMENT_DETAILS_FLYOUT_HEADER_SEVERITY_VALUE)
+      .should('be.visible')
+      .and('have.text', upperFirst(rule.severity));
 
-      cy.log('Verify all 3 tabs are visible');
+    cy.log('Verify all 3 tabs are visible');
 
-      cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB)
-        .should('be.visible')
-        .and('have.text', 'Overview');
-      cy.get(DOCUMENT_DETAILS_FLYOUT_TABLE_TAB).should('be.visible').and('have.text', 'Table');
-      cy.get(DOCUMENT_DETAILS_FLYOUT_JSON_TAB).should('be.visible').and('have.text', 'JSON');
+    cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB).should('be.visible').and('have.text', 'Overview');
+    cy.get(DOCUMENT_DETAILS_FLYOUT_TABLE_TAB).should('be.visible').and('have.text', 'Table');
+    cy.get(DOCUMENT_DETAILS_FLYOUT_JSON_TAB).should('be.visible').and('have.text', 'JSON');
 
-      cy.log('Verify the expand/collapse button is visible and functionality works');
+    cy.log('Verify the expand/collapse button is visible and functionality works');
 
-      expandDocumentDetailsExpandableFlyoutLeftSection();
-      cy.get(DOCUMENT_DETAILS_FLYOUT_COLLAPSE_DETAILS_BUTTON)
-        .should('be.visible')
-        .and('have.text', 'Collapse details');
+    expandDocumentDetailsExpandableFlyoutLeftSection();
+    cy.get(DOCUMENT_DETAILS_FLYOUT_COLLAPSE_DETAILS_BUTTON)
+      .should('be.visible')
+      .and('have.text', 'Collapse details');
 
-      collapseDocumentDetailsExpandableFlyoutLeftSection();
-      cy.get(DOCUMENT_DETAILS_FLYOUT_EXPAND_DETAILS_BUTTON)
-        .should('be.visible')
-        .and('have.text', 'Expand details');
+    collapseDocumentDetailsExpandableFlyoutLeftSection();
+    cy.get(DOCUMENT_DETAILS_FLYOUT_EXPAND_DETAILS_BUTTON)
+      .should('be.visible')
+      .and('have.text', 'Expand details');
 
-      cy.log('Verify the take action button is visible on all tabs');
+    cy.log('Verify the take action button is visible on all tabs');
 
-      cy.get(DOCUMENT_DETAILS_FLYOUT_FOOTER).scrollIntoView();
-      cy.get(DOCUMENT_DETAILS_FLYOUT_FOOTER).should('be.visible');
-      cy.get(DOCUMENT_DETAILS_FLYOUT_FOOTER_TAKE_ACTION_BUTTON).should('be.visible');
+    cy.get(DOCUMENT_DETAILS_FLYOUT_FOOTER).scrollIntoView();
+    cy.get(DOCUMENT_DETAILS_FLYOUT_FOOTER).should('be.visible');
+    cy.get(DOCUMENT_DETAILS_FLYOUT_FOOTER_TAKE_ACTION_BUTTON).should('be.visible');
 
-      openTableTab();
-      cy.get(DOCUMENT_DETAILS_FLYOUT_FOOTER).scrollIntoView();
-      cy.get(DOCUMENT_DETAILS_FLYOUT_FOOTER).should('be.visible');
-      cy.get(DOCUMENT_DETAILS_FLYOUT_FOOTER_TAKE_ACTION_BUTTON).should('be.visible');
+    openTableTab();
+    cy.get(DOCUMENT_DETAILS_FLYOUT_FOOTER).scrollIntoView();
+    cy.get(DOCUMENT_DETAILS_FLYOUT_FOOTER).should('be.visible');
+    cy.get(DOCUMENT_DETAILS_FLYOUT_FOOTER_TAKE_ACTION_BUTTON).should('be.visible');
 
-      openJsonTab();
-      cy.get(DOCUMENT_DETAILS_FLYOUT_FOOTER).scrollIntoView();
-      cy.get(DOCUMENT_DETAILS_FLYOUT_FOOTER).should('be.visible');
-      cy.get(DOCUMENT_DETAILS_FLYOUT_FOOTER_TAKE_ACTION_BUTTON).should('be.visible');
-    });
+    openJsonTab();
+    cy.get(DOCUMENT_DETAILS_FLYOUT_FOOTER).scrollIntoView();
+    cy.get(DOCUMENT_DETAILS_FLYOUT_FOOTER).should('be.visible');
+    cy.get(DOCUMENT_DETAILS_FLYOUT_FOOTER_TAKE_ACTION_BUTTON).should('be.visible');
+  });
 
-    // TODO this will change when add to existing case is improved
-    //  https://github.com/elastic/security-team/issues/6298
-    it('should add to existing case', () => {
-      navigateToCasesPage();
-      createNewCaseFromCases();
+  // TODO this will change when add to existing case is improved
+  //  https://github.com/elastic/security-team/issues/6298
+  it('should add to existing case', () => {
+    navigateToCasesPage();
+    createNewCaseFromCases();
 
-      cy.get(CASE_DETAILS_PAGE_TITLE).should('be.visible').and('have.text', 'case');
-      navigateToAlertsPage();
-      expandFirstAlertExpandableFlyout();
-      openTakeActionButtonAndSelectItem(DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_TO_EXISTING_CASE);
+    cy.get(CASE_DETAILS_PAGE_TITLE).should('be.visible').and('have.text', 'case');
+    navigateToAlertsPage();
+    expandFirstAlertExpandableFlyout();
+    openTakeActionButtonAndSelectItem(DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_TO_EXISTING_CASE);
 
-      cy.get(EXISTING_CASE_SELECT_BUTTON).should('be.visible').contains('Select').click();
-      cy.get(VIEW_CASE_TOASTER_LINK).should('be.visible').and('contain.text', 'View case');
-    });
+    cy.get(EXISTING_CASE_SELECT_BUTTON).should('be.visible').contains('Select').click();
+    cy.get(VIEW_CASE_TOASTER_LINK).should('be.visible').and('contain.text', 'View case');
+  });
 
-    // TODO this will change when add to new case is improved
-    //  https://github.com/elastic/security-team/issues/6298
-    it('should add to new case', () => {
-      expandFirstAlertExpandableFlyout();
-      openTakeActionButtonAndSelectItem(DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_TO_NEW_CASE);
+  // TODO this will change when add to new case is improved
+  //  https://github.com/elastic/security-team/issues/6298
+  it('should add to new case', () => {
+    expandFirstAlertExpandableFlyout();
+    openTakeActionButtonAndSelectItem(DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_TO_NEW_CASE);
 
-      cy.get(DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_TO_NEW_CASE_NAME_INPUT).type('case');
-      cy.get(DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_TO_NEW_CASE_DESCRIPTION_INPUT).type(
-        'case description'
+    cy.get(DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_TO_NEW_CASE_NAME_INPUT).type('case');
+    cy.get(DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_TO_NEW_CASE_DESCRIPTION_INPUT).type(
+      'case description'
+    );
+    cy.get(DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_TO_NEW_CASE_CREATE_BUTTON).click();
+
+    cy.get(VIEW_CASE_TOASTER_LINK).should('be.visible').and('contain.text', 'View case');
+  });
+
+  it('should mark as acknowledged', () => {
+    cy.get(ALERT_CHECKBOX).should('have.length', 2);
+
+    expandFirstAlertExpandableFlyout();
+    openTakeActionButtonAndSelectItem(DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_MARK_AS_ACKNOWLEDGED);
+
+    // TODO figure out how to verify the toasts pops up
+    // cy.get(KIBANA_TOAST)
+    //   .should('be.visible')
+    //   .and('have.text', 'Successfully marked 1 alert as acknowledged.');
+    cy.get(ALERT_CHECKBOX).should('have.length', 1);
+  });
+
+  it('should mark as closed', () => {
+    cy.get(ALERT_CHECKBOX).should('have.length', 2);
+
+    expandFirstAlertExpandableFlyout();
+    openTakeActionButtonAndSelectItem(DOCUMENT_DETAILS_FLYOUT_FOOTER_MARK_AS_CLOSED);
+
+    // TODO figure out how to verify the toasts pops up
+    // cy.get(KIBANA_TOAST).should('be.visible').and('have.text', 'Successfully closed 1 alert.');
+    cy.get(ALERT_CHECKBOX).should('have.length', 1);
+  });
+
+  // these actions are now grouped together as we're not really testing their functionality but just the existence of the option in the dropdown
+  it('should test other action within take action dropdown', () => {
+    expandFirstAlertExpandableFlyout();
+
+    cy.log('should add endpoint exception');
+
+    // TODO figure out why this option is disabled in Cypress but not running the app locally
+    //  https://github.com/elastic/security-team/issues/6300
+    openTakeActionButton();
+    cy.get(DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_ENDPOINT_EXCEPTION).should('be.disabled');
+
+    cy.log('should add rule exception');
+
+    // TODO this isn't fully testing the add rule exception yet
+    //  https://github.com/elastic/security-team/issues/6301
+    selectTakeActionItem(DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_RULE_EXCEPTION);
+    cy.get(DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_RULE_EXCEPTION_FLYOUT_HEADER).should('be.visible');
+    cy.get(DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_RULE_EXCEPTION_FLYOUT_CANCEL_BUTTON)
+      .should('be.visible')
+      .click();
+
+    // cy.log('should isolate host');
+
+    // TODO figure out why isolate host isn't showing up in the dropdown
+    //  https://github.com/elastic/security-team/issues/6302
+    // openTakeActionButton();
+    // cy.get(DOCUMENT_DETAILS_FLYOUT_FOOTER_ISOLATE_HOST).should('be.visible');
+
+    cy.log('should respond');
+
+    // TODO this will change when respond is improved
+    //  https://github.com/elastic/security-team/issues/6303
+    openTakeActionButton();
+    cy.get(DOCUMENT_DETAILS_FLYOUT_FOOTER_RESPOND).should('be.disabled');
+
+    cy.log('should investigate in timeline');
+
+    selectTakeActionItem(DOCUMENT_DETAILS_FLYOUT_FOOTER_INVESTIGATE_IN_TIMELINE);
+    cy.get(DOCUMENT_DETAILS_FLYOUT_FOOTER_INVESTIGATE_IN_TIMELINE_SECTION)
+      .first()
+      .within(() =>
+        cy.get(DOCUMENT_DETAILS_FLYOUT_FOOTER_INVESTIGATE_IN_TIMELINE_ENTRY).should('be.visible')
       );
-      cy.get(DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_TO_NEW_CASE_CREATE_BUTTON).click();
-
-      cy.get(VIEW_CASE_TOASTER_LINK).should('be.visible').and('contain.text', 'View case');
-    });
-
-    it('should mark as acknowledged', () => {
-      cy.get(ALERT_CHECKBOX).should('have.length', 2);
-
-      expandFirstAlertExpandableFlyout();
-      openTakeActionButtonAndSelectItem(DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_MARK_AS_ACKNOWLEDGED);
-
-      // TODO figure out how to verify the toasts pops up
-      // cy.get(KIBANA_TOAST)
-      //   .should('be.visible')
-      //   .and('have.text', 'Successfully marked 1 alert as acknowledged.');
-      cy.get(ALERT_CHECKBOX).should('have.length', 1);
-    });
-
-    it('should mark as closed', () => {
-      cy.get(ALERT_CHECKBOX).should('have.length', 2);
-
-      expandFirstAlertExpandableFlyout();
-      openTakeActionButtonAndSelectItem(DOCUMENT_DETAILS_FLYOUT_FOOTER_MARK_AS_CLOSED);
-
-      // TODO figure out how to verify the toasts pops up
-      // cy.get(KIBANA_TOAST).should('be.visible').and('have.text', 'Successfully closed 1 alert.');
-      cy.get(ALERT_CHECKBOX).should('have.length', 1);
-    });
-
-    // these actions are now grouped together as we're not really testing their functionality but just the existence of the option in the dropdown
-    it('should test other action within take action dropdown', () => {
-      expandFirstAlertExpandableFlyout();
-
-      cy.log('should add endpoint exception');
-
-      // TODO figure out why this option is disabled in Cypress but not running the app locally
-      //  https://github.com/elastic/security-team/issues/6300
-      openTakeActionButton();
-      cy.get(DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_ENDPOINT_EXCEPTION).should('be.disabled');
-
-      cy.log('should add rule exception');
-
-      // TODO this isn't fully testing the add rule exception yet
-      //  https://github.com/elastic/security-team/issues/6301
-      selectTakeActionItem(DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_RULE_EXCEPTION);
-      cy.get(DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_RULE_EXCEPTION_FLYOUT_HEADER).should('be.visible');
-      cy.get(DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_RULE_EXCEPTION_FLYOUT_CANCEL_BUTTON)
-        .should('be.visible')
-        .click();
-
-      // cy.log('should isolate host');
-
-      // TODO figure out why isolate host isn't showing up in the dropdown
-      //  https://github.com/elastic/security-team/issues/6302
-      // openTakeActionButton();
-      // cy.get(DOCUMENT_DETAILS_FLYOUT_FOOTER_ISOLATE_HOST).should('be.visible');
-
-      cy.log('should respond');
-
-      // TODO this will change when respond is improved
-      //  https://github.com/elastic/security-team/issues/6303
-      openTakeActionButton();
-      cy.get(DOCUMENT_DETAILS_FLYOUT_FOOTER_RESPOND).should('be.disabled');
-
-      cy.log('should investigate in timeline');
-
-      selectTakeActionItem(DOCUMENT_DETAILS_FLYOUT_FOOTER_INVESTIGATE_IN_TIMELINE);
-      cy.get(DOCUMENT_DETAILS_FLYOUT_FOOTER_INVESTIGATE_IN_TIMELINE_SECTION)
-        .first()
-        .within(() =>
-          cy.get(DOCUMENT_DETAILS_FLYOUT_FOOTER_INVESTIGATE_IN_TIMELINE_ENTRY).should('be.visible')
-        );
-    });
-  }
-);
+  });
+});

--- a/x-pack/plugins/security_solution/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_right_panel_json_tab.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_right_panel_json_tab.cy.ts
@@ -16,25 +16,21 @@ import { getNewRule } from '../../../../objects/rule';
 import { ALERTS_URL } from '../../../../urls/navigation';
 import { waitForAlertsToPopulate } from '../../../../tasks/create_new_rule';
 
-describe(
-  'Alert details expandable flyout right panel json tab',
-  { env: { ftrConfig: { enableExperimental: ['securityFlyoutEnabled'] } } },
-  () => {
-    beforeEach(() => {
-      cleanKibana();
-      login();
-      createRule(getNewRule());
-      visit(ALERTS_URL);
-      waitForAlertsToPopulate();
-      expandFirstAlertExpandableFlyout();
-      openJsonTab();
-    });
+describe('Alert details expandable flyout right panel json tab', () => {
+  beforeEach(() => {
+    cleanKibana();
+    login();
+    createRule(getNewRule());
+    visit(ALERTS_URL);
+    waitForAlertsToPopulate();
+    expandFirstAlertExpandableFlyout();
+    openJsonTab();
+  });
 
-    it('should display the json component', () => {
-      // the json component is rendered within a dom element with overflow, so Cypress isn't finding it
-      // this next line is a hack that vertically scrolls down to ensure Cypress finds it
-      scrollWithinDocumentDetailsExpandableFlyoutRightSection(0, 7000);
-      cy.get(DOCUMENT_DETAILS_FLYOUT_JSON_TAB_CONTENT).should('be.visible');
-    });
-  }
-);
+  it('should display the json component', () => {
+    // the json component is rendered within a dom element with overflow, so Cypress isn't finding it
+    // this next line is a hack that vertically scrolls down to ensure Cypress finds it
+    scrollWithinDocumentDetailsExpandableFlyoutRightSection(0, 7000);
+    cy.get(DOCUMENT_DETAILS_FLYOUT_JSON_TAB_CONTENT).should('be.visible');
+  });
+});

--- a/x-pack/plugins/security_solution/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_right_panel_overview_tab.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_right_panel_overview_tab.cy.ts
@@ -232,7 +232,8 @@ describe('Alert details expandable flyout right panel overview tab', () => {
       cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_ENTITIES_CONTENT).should('be.visible');
     });
 
-    it('should display threat intelligence section', () => {
+    // TODO: skipping this due to flakiness
+    it.skip('should display threat intelligence section', () => {
       toggleOverviewTabAboutSection();
       toggleOverviewTabInsightsSection();
 

--- a/x-pack/plugins/security_solution/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_right_panel_overview_tab.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_right_panel_overview_tab.cy.ts
@@ -69,292 +69,286 @@ import {
   DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_USER_DETAILS,
 } from '../../../../screens/expandable_flyout/alert_details_left_panel_entities_tab';
 
-describe(
-  'Alert details expandable flyout right panel overview tab',
-  { env: { ftrConfig: { enableExperimental: ['securityFlyoutEnabled'] } } },
-  () => {
-    const rule = getNewRule();
+describe('Alert details expandable flyout right panel overview tab', () => {
+  const rule = getNewRule();
 
-    beforeEach(() => {
-      cleanKibana();
-      login();
-      createRule(rule);
-      visit(ALERTS_URL);
-      waitForAlertsToPopulate();
-      expandFirstAlertExpandableFlyout();
+  beforeEach(() => {
+    cleanKibana();
+    login();
+    createRule(rule);
+    visit(ALERTS_URL);
+    waitForAlertsToPopulate();
+    expandFirstAlertExpandableFlyout();
+  });
+
+  describe('about section', () => {
+    it('should display about section', () => {
+      cy.log('header and content');
+
+      cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_ABOUT_SECTION_HEADER)
+        .should('be.visible')
+        .and('have.text', 'About');
+      cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_ABOUT_SECTION_CONTENT).should('be.visible');
+
+      cy.log('description');
+
+      cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_DESCRIPTION_TITLE)
+        .should('be.visible')
+        .and('contain.text', 'Rule description');
+      cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_DESCRIPTION_TITLE)
+        .should('be.visible')
+        .within(() => {
+          cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_OPEN_RULE_PREVIEW_BUTTON)
+            .should('be.visible')
+            .and('have.text', 'Rule summary');
+        });
+      cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_DESCRIPTION_DETAILS)
+        .should('be.visible')
+        .and('have.text', rule.description);
+
+      cy.log('reason');
+
+      cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_REASON_TITLE)
+        .should('be.visible')
+        .and('have.text', 'Alert reason');
+      cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_REASON_DETAILS)
+        .should('be.visible')
+        .and('contain.text', rule.name);
+
+      cy.log('mitre attack');
+
+      cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_MITRE_ATTACK_TITLE)
+        .should('be.visible')
+        // @ts-ignore
+        .and('contain.text', rule.threat[0].framework);
+
+      cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_MITRE_ATTACK_DETAILS)
+        .should('be.visible')
+        // @ts-ignore
+        .and('contain.text', rule.threat[0].technique[0].name)
+        // @ts-ignore
+        .and('contain.text', rule.threat[0].tactic.name);
+    });
+  });
+
+  describe('visualizations section', () => {
+    it('should display analyzer and session previews', () => {
+      toggleOverviewTabAboutSection();
+      toggleOverviewTabVisualizationsSection();
+
+      cy.log('analyzer graph preview');
+
+      cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_ANALYZER_TREE).scrollIntoView();
+      cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_ANALYZER_TREE).should('be.visible');
+
+      cy.log('session view preview');
+
+      cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_SESSION_PREVIEW).scrollIntoView();
+      cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_SESSION_PREVIEW).should('be.visible');
+    });
+  });
+
+  describe('investigation section', () => {
+    it('should display investigation section', () => {
+      toggleOverviewTabAboutSection();
+      toggleOverviewTabInvestigationSection();
+
+      cy.log('header and content');
+
+      cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INVESTIGATION_SECTION_HEADER)
+        .should('be.visible')
+        .and('have.text', 'Investigation');
+      cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INVESTIGATION_SECTION_CONTENT).should(
+        'be.visible'
+      );
+
+      cy.log('investigation guide button');
+
+      cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INVESTIGATION_GUIDE_BUTTON)
+        .should('be.visible')
+        .and('have.text', 'Investigation guide');
+
+      cy.log('should navigate to left Investigation tab');
+
+      clickInvestigationGuideButton();
+      cy.get(DOCUMENT_DETAILS_FLYOUT_INVESTIGATION_TAB_CONTENT).scrollIntoView();
+      cy.get(DOCUMENT_DETAILS_FLYOUT_INVESTIGATION_TAB_CONTENT).should('be.visible');
+
+      cy.log('highlighted fields');
+
+      cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_HIGHLIGHTED_FIELDS_HEADER_TITLE)
+        .should('be.visible')
+        .and('have.text', 'Highlighted fields');
+      cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_HIGHLIGHTED_FIELDS_DETAILS).should('be.visible');
+
+      cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_HIGHLIGHTED_FIELDS_TABLE_FIELD_CELL)
+        .should('be.visible')
+        .and('contain.text', 'host.name');
+      const hostNameCell =
+        DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_HIGHLIGHTED_FIELDS_TABLE_VALUE_CELL('siem-kibana');
+      cy.get(hostNameCell).should('be.visible').and('have.text', 'siem-kibana');
+
+      cy.get(hostNameCell).click();
+      cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_HOST_DETAILS).scrollIntoView();
+      cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_HOST_DETAILS).should('be.visible');
+
+      collapseDocumentDetailsExpandableFlyoutLeftSection();
+
+      cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_HIGHLIGHTED_FIELDS_TABLE_FIELD_CELL)
+        .should('be.visible')
+        .and('contain.text', 'user.name');
+      const userNameCell =
+        DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_HIGHLIGHTED_FIELDS_TABLE_VALUE_CELL('test');
+      cy.get(userNameCell).should('be.visible').and('have.text', 'test');
+
+      cy.get(userNameCell).click();
+      cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_USER_DETAILS).scrollIntoView();
+      cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_USER_DETAILS).should('be.visible');
+    });
+  });
+
+  describe('insights section', () => {
+    it('should display entities section', () => {
+      toggleOverviewTabAboutSection();
+      toggleOverviewTabInsightsSection();
+
+      cy.log('header and content');
+
+      cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INSIGHTS_ENTITIES_HEADER).scrollIntoView();
+      cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INSIGHTS_ENTITIES_HEADER)
+        .should('be.visible')
+        .and('have.text', 'Entities');
+      cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INSIGHTS_ENTITIES_CONTENT).should('be.visible');
+      cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INSIGHTS_ENTITY_PANEL_HEADER).should(
+        'be.visible'
+      );
+      cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INSIGHTS_ENTITY_PANEL_CONTENT).should(
+        'be.visible'
+      );
+
+      cy.log('should navigate to left panel Entities tab');
+
+      clickEntitiesViewAllButton();
+      cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_ENTITIES_CONTENT).should('be.visible');
     });
 
-    describe('about section', () => {
-      it('should display about section', () => {
-        cy.log('header and content');
+    it('should display threat intelligence section', () => {
+      toggleOverviewTabAboutSection();
+      toggleOverviewTabInsightsSection();
 
-        cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_ABOUT_SECTION_HEADER)
-          .should('be.visible')
-          .and('have.text', 'About');
-        cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_ABOUT_SECTION_CONTENT).should('be.visible');
+      cy.log('header and content');
 
-        cy.log('description');
+      cy.get(
+        DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INSIGHTS_THREAT_INTELLIGENCE_HEADER
+      ).scrollIntoView();
+      cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INSIGHTS_THREAT_INTELLIGENCE_HEADER)
+        .should('be.visible')
+        .and('have.text', 'Threat Intelligence');
+      cy.get(
+        DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INSIGHTS_THREAT_INTELLIGENCE_CONTENT
+      ).scrollIntoView();
+      cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INSIGHTS_THREAT_INTELLIGENCE_CONTENT)
+        .should('be.visible')
+        .within(() => {
+          // threat match detected
+          cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INSIGHTS_THREAT_INTELLIGENCE_VALUES)
+            .eq(0)
+            .should('be.visible')
+            .and('have.text', '0 threat match detected'); // TODO work on getting proper IoC data to get proper data here
 
-        cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_DESCRIPTION_TITLE)
-          .should('be.visible')
-          .and('contain.text', 'Rule description');
-        cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_DESCRIPTION_TITLE)
-          .should('be.visible')
-          .within(() => {
-            cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_OPEN_RULE_PREVIEW_BUTTON)
-              .should('be.visible')
-              .and('have.text', 'Rule summary');
-          });
-        cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_DESCRIPTION_DETAILS)
-          .should('be.visible')
-          .and('have.text', rule.description);
+          // field with threat enrichement
+          cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INSIGHTS_THREAT_INTELLIGENCE_VALUES)
+            .eq(1)
+            .should('be.visible')
+            .and('have.text', '0 field enriched with threat intelligence'); // TODO work on getting proper IoC data to get proper data here
+        });
 
-        cy.log('reason');
+      cy.log('should navigate to left panel Threat Intelligence tab');
 
-        cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_REASON_TITLE)
-          .should('be.visible')
-          .and('have.text', 'Alert reason');
-        cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_REASON_DETAILS)
-          .should('be.visible')
-          .and('contain.text', rule.name);
-
-        cy.log('mitre attack');
-
-        cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_MITRE_ATTACK_TITLE)
-          .should('be.visible')
-          // @ts-ignore
-          .and('contain.text', rule.threat[0].framework);
-
-        cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_MITRE_ATTACK_DETAILS)
-          .should('be.visible')
-          // @ts-ignore
-          .and('contain.text', rule.threat[0].technique[0].name)
-          // @ts-ignore
-          .and('contain.text', rule.threat[0].tactic.name);
-      });
+      clickThreatIntelligenceViewAllButton();
+      cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_ENTITIES_CONTENT).should('be.visible'); // TODO update when we can navigate to Threat Intelligence sub tab directly
     });
 
-    describe('visualizations section', () => {
-      it('should display analyzer and session previews', () => {
-        toggleOverviewTabAboutSection();
-        toggleOverviewTabVisualizationsSection();
+    // TODO: skipping this due to flakiness
+    it.skip('should display correlations section', () => {
+      cy.log('link the alert to a new case');
 
-        cy.log('analyzer graph preview');
+      createNewCaseFromExpandableFlyout();
 
-        cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_ANALYZER_TREE).scrollIntoView();
-        cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_ANALYZER_TREE).should('be.visible');
+      toggleOverviewTabAboutSection();
+      toggleOverviewTabInsightsSection();
 
-        cy.log('session view preview');
+      cy.log('header and content');
 
-        cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_SESSION_PREVIEW).scrollIntoView();
-        cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_SESSION_PREVIEW).should('be.visible');
-      });
+      cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INSIGHTS_CORRELATIONS_HEADER).scrollIntoView();
+      cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INSIGHTS_CORRELATIONS_HEADER)
+        .should('be.visible')
+        .and('have.text', 'Correlations');
+      cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INSIGHTS_CORRELATIONS_CONTENT).scrollIntoView();
+      cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INSIGHTS_CORRELATIONS_CONTENT)
+        .should('be.visible')
+        .within(() => {
+          // TODO the order in which these appear is not deterministic currently, hence this can cause flakiness
+          cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INSIGHTS_CORRELATIONS_VALUES)
+            .eq(0)
+            .should('be.visible')
+            .and('have.text', '1 alert related by ancestry');
+          cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INSIGHTS_CORRELATIONS_VALUES)
+            .eq(1)
+            .should('be.visible')
+            .and('have.text', '1 related case');
+          // cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INSIGHTS_CORRELATIONS_VALUES)
+          //   .eq(2)
+          //   .should('be.visible')
+          //   .and('have.text', '1 alert related by the same source event'); // TODO work on getting proper data to display some same source data here
+          cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INSIGHTS_CORRELATIONS_VALUES)
+            .eq(2)
+            .should('be.visible')
+            .and('have.text', '1 alert related by session');
+        });
+
+      cy.log('should navigate to left panel Correlations tab');
+
+      clickCorrelationsViewAllButton();
+      cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_ENTITIES_CONTENT).should('be.visible'); // TODO update when we can navigate to Correlations sub tab directly
     });
 
-    describe('investigation section', () => {
-      it('should display investigation section', () => {
-        toggleOverviewTabAboutSection();
-        toggleOverviewTabInvestigationSection();
+    // TODO work on getting proper data to make the prevalence section work here
+    //  we need to generate enough data to have at least one field with prevalence
+    it.skip('should display prevalence section', () => {
+      toggleOverviewTabAboutSection();
+      toggleOverviewTabInsightsSection();
 
-        cy.log('header and content');
+      cy.log('header and content');
 
-        cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INVESTIGATION_SECTION_HEADER)
-          .should('be.visible')
-          .and('have.text', 'Investigation');
-        cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INVESTIGATION_SECTION_CONTENT).should(
-          'be.visible'
-        );
+      cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INSIGHTS_PREVALENCE_HEADER).scrollIntoView();
+      cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INSIGHTS_PREVALENCE_HEADER)
+        .should('be.visible')
+        .and('have.text', 'Prevalence');
+      cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INSIGHTS_PREVALENCE_CONTENT).scrollIntoView();
+      cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INSIGHTS_PREVALENCE_CONTENT)
+        .should('be.visible')
+        .within(() => {
+          cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INSIGHTS_PREVALENCE_VALUES)
+            .should('be.visible')
+            .and('have.text', 'is uncommon');
+        });
 
-        cy.log('investigation guide button');
+      cy.log('should navigate to left panel Prevalence tab');
 
-        cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INVESTIGATION_GUIDE_BUTTON)
-          .should('be.visible')
-          .and('have.text', 'Investigation guide');
-
-        cy.log('should navigate to left Investigation tab');
-
-        clickInvestigationGuideButton();
-        cy.get(DOCUMENT_DETAILS_FLYOUT_INVESTIGATION_TAB_CONTENT).scrollIntoView();
-        cy.get(DOCUMENT_DETAILS_FLYOUT_INVESTIGATION_TAB_CONTENT).should('be.visible');
-
-        cy.log('highlighted fields');
-
-        cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_HIGHLIGHTED_FIELDS_HEADER_TITLE)
-          .should('be.visible')
-          .and('have.text', 'Highlighted fields');
-        cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_HIGHLIGHTED_FIELDS_DETAILS).should(
-          'be.visible'
-        );
-
-        cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_HIGHLIGHTED_FIELDS_TABLE_FIELD_CELL)
-          .should('be.visible')
-          .and('contain.text', 'host.name');
-        const hostNameCell =
-          DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_HIGHLIGHTED_FIELDS_TABLE_VALUE_CELL('siem-kibana');
-        cy.get(hostNameCell).should('be.visible').and('have.text', 'siem-kibana');
-
-        cy.get(hostNameCell).click();
-        cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_HOST_DETAILS).scrollIntoView();
-        cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_HOST_DETAILS).should('be.visible');
-
-        collapseDocumentDetailsExpandableFlyoutLeftSection();
-
-        cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_HIGHLIGHTED_FIELDS_TABLE_FIELD_CELL)
-          .should('be.visible')
-          .and('contain.text', 'user.name');
-        const userNameCell =
-          DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_HIGHLIGHTED_FIELDS_TABLE_VALUE_CELL('test');
-        cy.get(userNameCell).should('be.visible').and('have.text', 'test');
-
-        cy.get(userNameCell).click();
-        cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_USER_DETAILS).scrollIntoView();
-        cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_USER_DETAILS).should('be.visible');
-      });
+      clickPrevalenceViewAllButton();
+      cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_ENTITIES_CONTENT).should('be.visible'); // TODO update when we can navigate to Prevalence sub tab directly
     });
+  });
 
-    describe('insights section', () => {
-      it('should display entities section', () => {
-        toggleOverviewTabAboutSection();
-        toggleOverviewTabInsightsSection();
+  describe('response section', () => {
+    it('should display empty message', () => {
+      toggleOverviewTabAboutSection();
+      toggleOverviewTabResponseSection();
 
-        cy.log('header and content');
-
-        cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INSIGHTS_ENTITIES_HEADER).scrollIntoView();
-        cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INSIGHTS_ENTITIES_HEADER)
-          .should('be.visible')
-          .and('have.text', 'Entities');
-        cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INSIGHTS_ENTITIES_CONTENT).should('be.visible');
-        cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INSIGHTS_ENTITY_PANEL_HEADER).should(
-          'be.visible'
-        );
-        cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INSIGHTS_ENTITY_PANEL_CONTENT).should(
-          'be.visible'
-        );
-
-        cy.log('should navigate to left panel Entities tab');
-
-        clickEntitiesViewAllButton();
-        cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_ENTITIES_CONTENT).should('be.visible');
-      });
-
-      it('should display threat intelligence section', () => {
-        toggleOverviewTabAboutSection();
-        toggleOverviewTabInsightsSection();
-
-        cy.log('header and content');
-
-        cy.get(
-          DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INSIGHTS_THREAT_INTELLIGENCE_HEADER
-        ).scrollIntoView();
-        cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INSIGHTS_THREAT_INTELLIGENCE_HEADER)
-          .should('be.visible')
-          .and('have.text', 'Threat Intelligence');
-        cy.get(
-          DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INSIGHTS_THREAT_INTELLIGENCE_CONTENT
-        ).scrollIntoView();
-        cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INSIGHTS_THREAT_INTELLIGENCE_CONTENT)
-          .should('be.visible')
-          .within(() => {
-            // threat match detected
-            cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INSIGHTS_THREAT_INTELLIGENCE_VALUES)
-              .eq(0)
-              .should('be.visible')
-              .and('have.text', '0 threat match detected'); // TODO work on getting proper IoC data to get proper data here
-
-            // field with threat enrichement
-            cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INSIGHTS_THREAT_INTELLIGENCE_VALUES)
-              .eq(1)
-              .should('be.visible')
-              .and('have.text', '0 field enriched with threat intelligence'); // TODO work on getting proper IoC data to get proper data here
-          });
-
-        cy.log('should navigate to left panel Threat Intelligence tab');
-
-        clickThreatIntelligenceViewAllButton();
-        cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_ENTITIES_CONTENT).should('be.visible'); // TODO update when we can navigate to Threat Intelligence sub tab directly
-      });
-
-      // TODO: skipping this due to flakiness
-      it.skip('should display correlations section', () => {
-        cy.log('link the alert to a new case');
-
-        createNewCaseFromExpandableFlyout();
-
-        toggleOverviewTabAboutSection();
-        toggleOverviewTabInsightsSection();
-
-        cy.log('header and content');
-
-        cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INSIGHTS_CORRELATIONS_HEADER).scrollIntoView();
-        cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INSIGHTS_CORRELATIONS_HEADER)
-          .should('be.visible')
-          .and('have.text', 'Correlations');
-        cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INSIGHTS_CORRELATIONS_CONTENT).scrollIntoView();
-        cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INSIGHTS_CORRELATIONS_CONTENT)
-          .should('be.visible')
-          .within(() => {
-            // TODO the order in which these appear is not deterministic currently, hence this can cause flakiness
-            cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INSIGHTS_CORRELATIONS_VALUES)
-              .eq(0)
-              .should('be.visible')
-              .and('have.text', '1 alert related by ancestry');
-            cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INSIGHTS_CORRELATIONS_VALUES)
-              .eq(1)
-              .should('be.visible')
-              .and('have.text', '1 related case');
-            // cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INSIGHTS_CORRELATIONS_VALUES)
-            //   .eq(2)
-            //   .should('be.visible')
-            //   .and('have.text', '1 alert related by the same source event'); // TODO work on getting proper data to display some same source data here
-            cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INSIGHTS_CORRELATIONS_VALUES)
-              .eq(2)
-              .should('be.visible')
-              .and('have.text', '1 alert related by session');
-          });
-
-        cy.log('should navigate to left panel Correlations tab');
-
-        clickCorrelationsViewAllButton();
-        cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_ENTITIES_CONTENT).should('be.visible'); // TODO update when we can navigate to Correlations sub tab directly
-      });
-
-      // TODO work on getting proper data to make the prevalence section work here
-      //  we need to generate enough data to have at least one field with prevalence
-      it.skip('should display prevalence section', () => {
-        toggleOverviewTabAboutSection();
-        toggleOverviewTabInsightsSection();
-
-        cy.log('header and content');
-
-        cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INSIGHTS_PREVALENCE_HEADER).scrollIntoView();
-        cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INSIGHTS_PREVALENCE_HEADER)
-          .should('be.visible')
-          .and('have.text', 'Prevalence');
-        cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INSIGHTS_PREVALENCE_CONTENT).scrollIntoView();
-        cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INSIGHTS_PREVALENCE_CONTENT)
-          .should('be.visible')
-          .within(() => {
-            cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INSIGHTS_PREVALENCE_VALUES)
-              .should('be.visible')
-              .and('have.text', 'is uncommon');
-          });
-
-        cy.log('should navigate to left panel Prevalence tab');
-
-        clickPrevalenceViewAllButton();
-        cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_ENTITIES_CONTENT).should('be.visible'); // TODO update when we can navigate to Prevalence sub tab directly
-      });
+      cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_RESPONSE_SECTION_EMPTY_RESPONSE).should(
+        'be.visible'
+      );
     });
-
-    describe('response section', () => {
-      it('should display empty message', () => {
-        toggleOverviewTabAboutSection();
-        toggleOverviewTabResponseSection();
-
-        cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_RESPONSE_SECTION_EMPTY_RESPONSE).should(
-          'be.visible'
-        );
-      });
-    });
-  }
-);
+  });
+});

--- a/x-pack/plugins/security_solution/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_right_panel_table_tab.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_right_panel_table_tab.cy.ts
@@ -31,52 +31,48 @@ import { getNewRule } from '../../../../objects/rule';
 import { ALERTS_URL } from '../../../../urls/navigation';
 import { waitForAlertsToPopulate } from '../../../../tasks/create_new_rule';
 
-describe(
-  'Alert details expandable flyout right panel table tab',
-  { env: { ftrConfig: { enableExperimental: ['securityFlyoutEnabled'] } } },
-  () => {
-    beforeEach(() => {
-      cleanKibana();
-      login();
-      createRule(getNewRule());
-      visit(ALERTS_URL);
-      waitForAlertsToPopulate();
-      expandFirstAlertExpandableFlyout();
-      openTableTab();
-    });
+describe('Alert details expandable flyout right panel table tab', () => {
+  beforeEach(() => {
+    cleanKibana();
+    login();
+    createRule(getNewRule());
+    visit(ALERTS_URL);
+    waitForAlertsToPopulate();
+    expandFirstAlertExpandableFlyout();
+    openTableTab();
+  });
 
-    it('should display and filter the table', () => {
-      cy.get(DOCUMENT_DETAILS_FLYOUT_TABLE_TAB_TIMESTAMP_ROW).should('be.visible');
-      cy.get(DOCUMENT_DETAILS_FLYOUT_TABLE_TAB_ID_ROW).should('be.visible');
-      filterTableTabTable('timestamp');
-      cy.get(DOCUMENT_DETAILS_FLYOUT_TABLE_TAB_TIMESTAMP_ROW).should('be.visible');
-      clearFilterTableTabTable();
-    });
+  it('should display and filter the table', () => {
+    cy.get(DOCUMENT_DETAILS_FLYOUT_TABLE_TAB_TIMESTAMP_ROW).should('be.visible');
+    cy.get(DOCUMENT_DETAILS_FLYOUT_TABLE_TAB_ID_ROW).should('be.visible');
+    filterTableTabTable('timestamp');
+    cy.get(DOCUMENT_DETAILS_FLYOUT_TABLE_TAB_TIMESTAMP_ROW).should('be.visible');
+    clearFilterTableTabTable();
+  });
 
-    it('should test cell actions', () => {
-      cy.log('cell actions filter in');
+  it('should test cell actions', () => {
+    cy.log('cell actions filter in');
 
-      filterInTableTabTable();
-      cy.get(FILTER_BADGE).first().should('contain.text', '@timestamp:');
-      removeKqlFilter();
+    filterInTableTabTable();
+    cy.get(FILTER_BADGE).first().should('contain.text', '@timestamp:');
+    removeKqlFilter();
 
-      cy.log('cell actions filter out');
+    cy.log('cell actions filter out');
 
-      filterOutTableTabTable();
-      cy.get(FILTER_BADGE).first().should('contain.text', 'NOT @timestamp:');
-      removeKqlFilter();
+    filterOutTableTabTable();
+    cy.get(FILTER_BADGE).first().should('contain.text', 'NOT @timestamp:');
+    removeKqlFilter();
 
-      cy.log('cell actions add to timeline');
+    cy.log('cell actions add to timeline');
 
-      addToTimelineTableTabTable();
-      openActiveTimeline();
-      cy.get(PROVIDER_BADGE).first().should('contain.text', '@timestamp');
-      closeTimeline();
+    addToTimelineTableTabTable();
+    openActiveTimeline();
+    cy.get(PROVIDER_BADGE).first().should('contain.text', '@timestamp');
+    closeTimeline();
 
-      cy.log('cell actions copy to clipboard');
+    cy.log('cell actions copy to clipboard');
 
-      copyToClipboardTableTabTable();
-      cy.get(DOCUMENT_DETAILS_FLYOUT_TABLE_TAB_ROW_CELL_COPY_TO_CLIPBOARD).should('be.visible');
-    });
-  }
-);
+    copyToClipboardTableTabTable();
+    cy.get(DOCUMENT_DETAILS_FLYOUT_TABLE_TAB_ROW_CELL_COPY_TO_CLIPBOARD).should('be.visible');
+  });
+});

--- a/x-pack/plugins/security_solution/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_url_sync.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_url_sync.cy.ts
@@ -15,43 +15,39 @@ import { closeFlyout } from '../../../../tasks/expandable_flyout/alert_details_r
 import { expandFirstAlertExpandableFlyout } from '../../../../tasks/expandable_flyout/common';
 import { DOCUMENT_DETAILS_FLYOUT_HEADER_TITLE } from '../../../../screens/expandable_flyout/alert_details_right_panel';
 
-describe(
-  'Expandable flyout state sync',
-  { env: { ftrConfig: { enableExperimental: ['securityFlyoutEnabled'] } } },
-  () => {
-    const rule = getNewRule();
+describe('Expandable flyout state sync', () => {
+  const rule = getNewRule();
 
-    beforeEach(() => {
-      cleanKibana();
-      login();
-      createRule(rule);
-      visit(ALERTS_URL);
-      waitForAlertsToPopulate();
-    });
+  beforeEach(() => {
+    cleanKibana();
+    login();
+    createRule(rule);
+    visit(ALERTS_URL);
+    waitForAlertsToPopulate();
+  });
 
-    it('should test flyout url sync', () => {
-      cy.url().should('not.include', 'eventFlyout');
+  it('should test flyout url sync', () => {
+    cy.url().should('not.include', 'eventFlyout');
 
-      expandFirstAlertExpandableFlyout();
+    expandFirstAlertExpandableFlyout();
 
-      cy.log('should serialize its state to url');
+    cy.log('should serialize its state to url');
 
-      cy.url().should('include', 'eventFlyout');
-      cy.get(DOCUMENT_DETAILS_FLYOUT_HEADER_TITLE).should('be.visible').and('have.text', rule.name);
+    cy.url().should('include', 'eventFlyout');
+    cy.get(DOCUMENT_DETAILS_FLYOUT_HEADER_TITLE).should('be.visible').and('have.text', rule.name);
 
-      cy.log('should reopen the flyout after browser refresh');
+    cy.log('should reopen the flyout after browser refresh');
 
-      cy.reload();
-      waitForAlertsToPopulate();
+    cy.reload();
+    waitForAlertsToPopulate();
 
-      cy.url().should('include', 'eventFlyout');
-      cy.get(DOCUMENT_DETAILS_FLYOUT_HEADER_TITLE).should('be.visible').and('have.text', rule.name);
+    cy.url().should('include', 'eventFlyout');
+    cy.get(DOCUMENT_DETAILS_FLYOUT_HEADER_TITLE).should('be.visible').and('have.text', rule.name);
 
-      cy.log('should clear the url state when flyout is closed');
+    cy.log('should clear the url state when flyout is closed');
 
-      closeFlyout();
+    closeFlyout();
 
-      cy.url().should('not.include', 'eventFlyout');
-    });
-  }
-);
+    cy.url().should('not.include', 'eventFlyout');
+  });
+});

--- a/x-pack/plugins/security_solution/cypress/e2e/investigations/alerts/investigate_in_timeline.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/investigations/alerts/investigate_in_timeline.cy.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { disableExpandableFlyout } from '../../../tasks/api_calls/kibana_advanced_settings';
 import { getNewRule } from '../../../objects/rule';
 import { PROVIDER_BADGE, QUERY_TAB_BUTTON, TIMELINE_TITLE } from '../../../screens/timeline';
 import { FILTER_BADGE } from '../../../screens/alerts';
@@ -53,6 +54,7 @@ describe('Investigate in timeline', () => {
   describe('From alerts details flyout', () => {
     beforeEach(() => {
       login();
+      disableExpandableFlyout();
       visit(ALERTS_URL);
       waitForAlertsToPopulate();
       expandFirstAlert();

--- a/x-pack/plugins/security_solution/cypress/tasks/api_calls/kibana_advanced_settings.ts
+++ b/x-pack/plugins/security_solution/cypress/tasks/api_calls/kibana_advanced_settings.ts
@@ -27,3 +27,8 @@ export const enableRelatedIntegrations = () => {
 export const disableRelatedIntegrations = () => {
   kibanaSettings(relatedIntegrationsBody(false));
 };
+
+export const disableExpandableFlyout = () => {
+  const body = { changes: { 'securitySolution:enableExpandableFlyout': false } };
+  kibanaSettings(body);
+};

--- a/x-pack/plugins/security_solution/public/common/components/control_columns/row_action/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/control_columns/row_action/index.tsx
@@ -10,6 +10,8 @@ import React, { useCallback, useMemo } from 'react';
 import { useDispatch } from 'react-redux';
 import { useExpandableFlyoutContext } from '@kbn/expandable-flyout';
 import { dataTableActions } from '@kbn/securitysolution-data-table';
+import { useUiSetting$ } from '@kbn/kibana-react-plugin/public';
+import { ENABLE_EXPANDABLE_FLYOUT_SETTING } from '../../../../../common/constants';
 import { RightPanelKey } from '../../../../flyout/right';
 import type {
   SetEventsDeleted,
@@ -21,7 +23,6 @@ import { getMappedNonEcsValue } from '../../../../timelines/components/timeline/
 
 import type { TimelineItem, TimelineNonEcsData } from '../../../../../common/search_strategy';
 import type { ColumnHeaderOptions, OnRowSelected } from '../../../../../common/types/timeline';
-import { useIsExperimentalFeatureEnabled } from '../../../hooks/use_experimental_features';
 
 type Props = EuiDataGridCellValueElementProps & {
   columnHeaders: ColumnHeaderOptions[];
@@ -70,7 +71,7 @@ const RowActionComponent = ({
   const { openFlyout } = useExpandableFlyoutContext();
 
   const dispatch = useDispatch();
-  const isSecurityFlyoutEnabled = useIsExperimentalFeatureEnabled('securityFlyoutEnabled');
+  const [isSecurityFlyoutEnabled] = useUiSetting$<boolean>(ENABLE_EXPANDABLE_FLYOUT_SETTING);
 
   const columnValues = useMemo(
     () =>

--- a/x-pack/plugins/security_solution/public/detections/pages/alerts/alert_details_redirect.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/alerts/alert_details_redirect.test.tsx
@@ -156,7 +156,7 @@ describe('AlertDetailsRedirect', () => {
 
         const [{ search, pathname }] = historyMock.replace.mock.lastCall;
 
-        expect(search as string).toMatch(/eventFlyout.*right/);
+        expect(search as string).toMatch(/eventFlyout.*/);
         expect(pathname).toEqual(ALERTS_PATH);
       });
     });

--- a/x-pack/plugins/security_solution/public/detections/pages/alerts/alert_details_redirect.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/alerts/alert_details_redirect.tsx
@@ -12,12 +12,16 @@ import { Redirect, useLocation, useParams } from 'react-router-dom';
 import moment from 'moment';
 import { encode } from '@kbn/rison';
 import { ALERT_WORKFLOW_STATUS } from '@kbn/rule-data-utils';
+import { useUiSetting$ } from '@kbn/kibana-react-plugin/public';
 import type { FilterItemObj } from '../../../common/components/filter_group/types';
-import { ALERTS_PATH, DEFAULT_ALERTS_INDEX } from '../../../../common/constants';
+import {
+  ALERTS_PATH,
+  DEFAULT_ALERTS_INDEX,
+  ENABLE_EXPANDABLE_FLYOUT_SETTING,
+} from '../../../../common/constants';
 import { URL_PARAM_KEY } from '../../../common/hooks/use_url_state';
 import { inputsSelectors } from '../../../common/store';
 import { formatPageFilterSearchParam } from '../../../../common/utils/format_page_filter_search_param';
-import { useIsExperimentalFeatureEnabled } from '../../../common/hooks/use_experimental_features';
 import { resolveFlyoutParams } from './utils';
 import { FLYOUT_URL_PARAM } from '../../../flyout/shared/hooks/url/use_sync_flyout_state_with_url';
 
@@ -70,7 +74,7 @@ export const AlertDetailsRedirect = () => {
 
   const currentFlyoutParams = searchParams.get(FLYOUT_URL_PARAM);
 
-  const isSecurityFlyoutEnabled = useIsExperimentalFeatureEnabled('securityFlyoutEnabled');
+  const [isSecurityFlyoutEnabled] = useUiSetting$<boolean>(ENABLE_EXPANDABLE_FLYOUT_SETTING);
 
   const urlParams = new URLSearchParams({
     [URL_PARAM_KEY.appQuery]: kqlAppQuery,

--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/endpoint/automated_response_actions.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/endpoint/automated_response_actions.cy.ts
@@ -11,7 +11,7 @@ import { closeAllToasts } from '../../tasks/toasts';
 import { toggleRuleOffAndOn, visitRuleAlerts } from '../../tasks/isolate';
 import { cleanupRule, loadRule } from '../../tasks/api_fixtures';
 import { login } from '../../tasks/login';
-import { loadPage } from '../../tasks/common';
+import { disableExpandableFlyoutAdvancedSettings, loadPage } from '../../tasks/common';
 import type { IndexedFleetEndpointPolicyResponse } from '../../../../../common/endpoint/data_loaders/index_fleet_endpoint_policy';
 import { createAgentPolicyTask, getEndpointIntegrationVersion } from '../../tasks/fleet';
 import { changeAlertsFilter } from '../../tasks/alerts';
@@ -60,6 +60,7 @@ describe('Automated Response Actions', () => {
 
   beforeEach(() => {
     login();
+    disableExpandableFlyoutAdvancedSettings();
   });
 
   describe('From alerts', () => {

--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/endpoint/isolate.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/endpoint/isolate.cy.ts
@@ -23,7 +23,7 @@ import {
 } from '../../tasks/isolate';
 import { cleanupCase, cleanupRule, loadCase, loadRule } from '../../tasks/api_fixtures';
 import { login } from '../../tasks/login';
-import { loadPage } from '../../tasks/common';
+import { disableExpandableFlyoutAdvancedSettings, loadPage } from '../../tasks/common';
 import type { IndexedFleetEndpointPolicyResponse } from '../../../../../common/endpoint/data_loaders/index_fleet_endpoint_policy';
 import { createAgentPolicyTask, getEndpointIntegrationVersion } from '../../tasks/fleet';
 import type { CreateAndEnrollEndpointHostResponse } from '../../../../../scripts/endpoint/common/endpoint_host_services';
@@ -72,6 +72,7 @@ describe('Isolate command', () => {
 
   beforeEach(() => {
     login();
+    disableExpandableFlyoutAdvancedSettings();
   });
 
   describe('From manage', () => {

--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/mocked_data/automated_response_actions/no_license.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/mocked_data/automated_response_actions/no_license.cy.ts
@@ -6,6 +6,7 @@
  */
 
 import { generateRandomStringName } from '@kbn/osquery-plugin/cypress/tasks/integrations';
+import { disableExpandableFlyoutAdvancedSettings } from '../../../tasks/common';
 import { APP_ALERTS_PATH } from '../../../../../../common/constants';
 import { closeAllToasts } from '../../../tasks/toasts';
 import { fillUpNewRule } from '../../../tasks/response_actions';
@@ -39,6 +40,7 @@ describe('No License', { env: { ftrConfig: { license: 'basic' } } }, () => {
     const [endpointAgentId, endpointHostname] = generateRandomStringName(2);
     before(() => {
       login();
+      disableExpandableFlyoutAdvancedSettings();
       indexEndpointRuleAlerts({
         endpointAgentId,
         endpointHostname,

--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/mocked_data/automated_response_actions/results.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/mocked_data/automated_response_actions/results.cy.ts
@@ -6,6 +6,7 @@
  */
 
 import { generateRandomStringName } from '@kbn/osquery-plugin/cypress/tasks/integrations';
+import { disableExpandableFlyoutAdvancedSettings } from '../../../tasks/common';
 import { APP_ALERTS_PATH } from '../../../../../../common/constants';
 import { closeAllToasts } from '../../../tasks/toasts';
 import { indexEndpointHosts } from '../../../tasks/index_endpoint_hosts';
@@ -52,6 +53,7 @@ describe('Results', () => {
   describe('see results when has RBAC', () => {
     before(() => {
       login(ROLE.endpoint_response_actions_access);
+      disableExpandableFlyoutAdvancedSettings();
     });
 
     it('see endpoint action', () => {
@@ -67,6 +69,7 @@ describe('Results', () => {
   describe('do not see results results when does not have RBAC', () => {
     before(() => {
       login(ROLE.endpoint_response_actions_no_access);
+      disableExpandableFlyoutAdvancedSettings();
     });
 
     it('show the permission denied callout', () => {

--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/mocked_data/isolate.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/mocked_data/isolate.cy.ts
@@ -24,7 +24,7 @@ import type { ReturnTypeFromChainable } from '../../types';
 import { addAlertsToCase } from '../../tasks/add_alerts_to_case';
 import { APP_ALERTS_PATH, APP_CASES_PATH, APP_PATH } from '../../../../../common/constants';
 import { login } from '../../tasks/login';
-import { loadPage } from '../../tasks/common';
+import { disableExpandableFlyoutAdvancedSettings, loadPage } from '../../tasks/common';
 import { indexNewCase } from '../../tasks/index_new_case';
 import { indexEndpointHosts } from '../../tasks/index_endpoint_hosts';
 import { indexEndpointRuleAlerts } from '../../tasks/index_endpoint_rule_alerts';
@@ -95,6 +95,7 @@ describe('Isolate command', () => {
     let hostname: string;
 
     before(() => {
+      disableExpandableFlyoutAdvancedSettings();
       indexEndpointHosts({ withResponseActions: false, isolation: false }).then(
         (indexEndpoints) => {
           endpointData = indexEndpoints;

--- a/x-pack/plugins/security_solution/public/management/cypress/tasks/common.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/tasks/common.ts
@@ -34,3 +34,23 @@ export const request = <T = unknown>({
     headers: { ...COMMON_API_HEADERS, ...headers },
     ...options,
   });
+
+const API_HEADERS = Object.freeze({ 'kbn-xsrf': 'cypress' });
+export const rootRequest = <T = unknown>(
+  options: Partial<Cypress.RequestOptions>
+): Cypress.Chainable<Cypress.Response<T>> =>
+  cy.request<T>({
+    auth: API_AUTH,
+    headers: API_HEADERS,
+    ...options,
+  });
+
+export const disableExpandableFlyoutAdvancedSettings = () => {
+  const body = { changes: { 'securitySolution:enableExpandableFlyout': false } };
+  rootRequest({
+    method: 'POST',
+    url: 'internal/kibana/settings',
+    body,
+    headers: { 'kbn-xsrf': 'cypress-creds' },
+  });
+};

--- a/x-pack/plugins/security_solution/server/ui_settings.ts
+++ b/x-pack/plugins/security_solution/server/ui_settings.ts
@@ -36,6 +36,7 @@ import {
   EXTENDED_RULE_EXECUTION_LOGGING_MIN_LEVEL_SETTING,
   DEFAULT_ALERT_TAGS_KEY,
   DEFAULT_ALERT_TAGS_VALUE,
+  ENABLE_EXPANDABLE_FLYOUT_SETTING,
 } from '../common/constants';
 import type { ExperimentalFeatures } from '../common/experimental_features';
 import { LogLevelSetting } from '../common/api/detection_engine/rule_monitoring';
@@ -158,6 +159,22 @@ export const initUiSettings = (
       description: i18n.translate('xpack.securitySolution.uiSettings.enableNewsFeedDescription', {
         defaultMessage: '<p>Enables the News feed</p>',
       }),
+      type: 'boolean',
+      category: [APP_ID],
+      requiresPageReload: true,
+      schema: schema.boolean(),
+    },
+    [ENABLE_EXPANDABLE_FLYOUT_SETTING]: {
+      name: i18n.translate('xpack.securitySolution.uiSettings.enableExpandableFlyoutLabel', {
+        defaultMessage: 'Expandable flyout',
+      }),
+      value: true,
+      description: i18n.translate(
+        'xpack.securitySolution.uiSettings.enableExpandableFlyoutDescription',
+        {
+          defaultMessage: '<p>Enables the expandable flyout</p>',
+        }
+      ),
       type: 'boolean',
       category: [APP_ID],
       requiresPageReload: true,

--- a/x-pack/test/security_solution_endpoint/apps/endpoint/responder.ts
+++ b/x-pack/test/security_solution_endpoint/apps/endpoint/responder.ts
@@ -197,6 +197,12 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
       let indexedAlerts: IndexedEndpointRuleAlerts;
 
       before(async () => {
+        await getService('kibanaServer').request({
+          path: `internal/kibana/settings`,
+          method: 'POST',
+          body: { changes: { 'securitySolution:enableExpandableFlyout': false } },
+        });
+
         indexedAlerts = await detectionsTestService.loadEndpointRuleAlerts(endpointAgentId);
 
         await detectionsTestService.waitForAlerts(


### PR DESCRIPTION
## Summary

We are going GA with the new Expandable Flyout in Security Solution in 8.10. We still want to allow users to use the old flyout.
Until now we were allowing users to switch to the new flyout by modifying the `kibana.yml` like so
```xpack.securitySolution.enableExperimental: ['securityFlyoutEnabled']```
Using a toggle within the `Stack Management` => `Advanced Settings` page under the `Security Solution` section is a lot more user friendly.

This PR replaces the feature flag experimental feature by an advanced settings toggle.
The new advanced settings toggle is set to `true` by default.

![Screenshot 2023-07-11 at 8 35 17 AM](https://github.com/elastic/kibana/assets/17276605/64190773-5b11-4c19-b646-43d9597f25c5)

https://github.com/elastic/kibana/assets/17276605/7e14e84f-746a-4d92-ae0e-a9dfc099b61d

### Primary changes:

- add new `securitySolution:enableExpandableFlyout` advanced settings and remove `securityFlyoutEnabled` feature flag
- remove all enableExperimental tags in investigations/alerts flyout Cypress tests
- programmatically turn the new advanced settings off for all the other teams's Cypress tests (these will be updated to the new final once we remove the advanced settings entirely - most likely for `8.11` or `8.12`)

https://github.com/elastic/security-team/issues/6641