### PR TITLE
[Enterprise Search] Remove GitHub connector and GCS native

### DIFF
--- a/x-pack/plugins/enterprise_search/common/connectors/connectors.ts
+++ b/x-pack/plugins/enterprise_search/common/connectors/connectors.ts
@@ -51,7 +51,7 @@ export const CONNECTOR_DEFINITIONS: ConnectorServerSideDefinition[] = [
   {
     iconPath: 'google_cloud_storage.svg',
     isBeta: true,
-    isNative: true,
+    isNative: false,
     keywords: ['google', 'cloud', 'blob', 's3', 'connector'],
     name: i18n.translate('xpack.enterpriseSearch.content.nativeConnectors.googleCloud.name', {
       defaultMessage: 'Google Cloud Storage',
@@ -139,17 +139,6 @@ export const CONNECTOR_DEFINITIONS: ConnectorServerSideDefinition[] = [
       defaultMessage: 'Dropbox',
     }),
     serviceType: 'dropbox',
-  },
-  {
-    iconPath: 'github.svg',
-    isBeta: true,
-    isNative: false,
-    isTechPreview: false,
-    keywords: ['github', 'cloud', 'server', 'connector'],
-    name: i18n.translate('xpack.enterpriseSearch.content.nativeConnectors.github.name', {
-      defaultMessage: 'GitHub',
-    }),
-    serviceType: 'github',
   },
   {
     iconPath: 'oracle.svg',


### PR DESCRIPTION
## Summary

This removes the GitHub connector (which is not ready yet) and moves the Google Cloud Storage connector to non-native.


<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->