### PR TITLE
[Migrations - v2] Allow for 1 byte size variation in es_response_too_large

### DIFF
--- a/src/core/server/integration_tests/saved_objects/migrations/group3/actions/actions.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/group3/actions/actions.test.ts
@@ -1296,8 +1296,10 @@ describe('migration actions', () => {
       const leftResponse = (await readWithPitTask()) as Either.Left<EsResponseTooLargeError>;
 
       expect(leftResponse.left.type).toBe('es_response_too_large');
-      // ES response has a 1 byte size variation, there must be a glitch somewhere on ES side :shrug:
+      // ES response contains a field that indicates how long it took ES to get the response, e.g.: "took": 7
+      // if ES takes more than 9ms, the payload will be 1 byte bigger.
       // see https://github.com/elastic/kibana/issues/160994
+      // Thus, the statements below account for response times up to 99ms
       expect(leftResponse.left.contentLength).toBeGreaterThanOrEqual(3184);
       expect(leftResponse.left.contentLength).toBeLessThanOrEqual(3185);
     });

--- a/src/core/server/integration_tests/saved_objects/migrations/group3/actions/actions.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/group3/actions/actions.test.ts
@@ -1117,8 +1117,7 @@ describe('migration actions', () => {
     });
   });
 
-  // FLAKY: https://github.com/elastic/kibana/issues/160994
-  describe.skip('readWithPit', () => {
+  describe('readWithPit', () => {
     it('requests documents from an index using given PIT', async () => {
       const openPitTask = openPit({ client, index: 'existing_index_with_docs' });
       const pitResponse = (await openPitTask()) as Either.Right<OpenPitResponse>;
@@ -1270,7 +1269,8 @@ describe('migration actions', () => {
       );
     });
 
-    it('returns a left es_response_too_large error when a read batch exceeds the maxResponseSize', async () => {
+    // eslint-disable-next-line jest/no-focused-tests
+    fit('returns a left es_response_too_large error when a read batch exceeds the maxResponseSize', async () => {
       const openPitTask = openPit({ client, index: 'existing_index_with_docs' });
       const pitResponse = (await openPitTask()) as Either.Right<OpenPitResponse>;
 
@@ -1297,7 +1297,10 @@ describe('migration actions', () => {
       const leftResponse = (await readWithPitTask()) as Either.Left<EsResponseTooLargeError>;
 
       expect(leftResponse.left.type).toBe('es_response_too_large');
-      expect(leftResponse.left.contentLength).toBe(3184);
+      // ES response has a 1 byte size variation, there must be a glitch somewhere on ES side :shrug:
+      // see https://github.com/elastic/kibana/issues/160994
+      expect(leftResponse.left.contentLength).toBeGreaterThanOrEqual(3184);
+      expect(leftResponse.left.contentLength).toBeLessThanOrEqual(3185);
     });
 
     it('rejects if PIT does not exist', async () => {

--- a/src/core/server/integration_tests/saved_objects/migrations/group3/actions/actions.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/group3/actions/actions.test.ts
@@ -1269,8 +1269,7 @@ describe('migration actions', () => {
       );
     });
 
-    // eslint-disable-next-line jest/no-focused-tests
-    fit('returns a left es_response_too_large error when a read batch exceeds the maxResponseSize', async () => {
+    it('returns a left es_response_too_large error when a read batch exceeds the maxResponseSize', async () => {
       const openPitTask = openPit({ client, index: 'existing_index_with_docs' });
       const pitResponse = (await openPitTask()) as Either.Right<OpenPitResponse>;
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/160994

There must be some randomness factor that causes the response payload size to have a 1 byte size variation, as observed in the `es_response_too_large` error.

This PR relaxes the constraint and accepts a `es_response_too_large` error with either 3184 or 3185 bytes.

<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->