### PR TITLE
[Synthetics] De-dupe overview status request on load

### DIFF
--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/hooks/use_overview_status.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/hooks/use_overview_status.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { useEffect, useCallback } from 'react';
+import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useSyntheticsRefreshContext } from '../../../contexts/synthetics_refresh_context';
 import { selectOverviewPageState } from '../../../state';
@@ -23,21 +23,19 @@ export function useOverviewStatus({ scopeStatusByLocation }: { scopeStatusByLoca
   const { lastRefresh } = useSyntheticsRefreshContext();
 
   const dispatch = useDispatch();
-  const reload = useCallback(() => {
-    dispatch(fetchOverviewStatusAction.get({ pageState, scopeStatusByLocation }));
-  }, [dispatch, pageState, scopeStatusByLocation]);
 
   useEffect(() => {
     if (loaded) {
       dispatch(quietFetchOverviewStatusAction.get({ pageState, scopeStatusByLocation }));
     } else {
-      reload();
+      dispatch(fetchOverviewStatusAction.get({ pageState, scopeStatusByLocation }));
     }
-  }, [dispatch, reload, lastRefresh, pageState, loaded, scopeStatusByLocation]);
+    // loaded is omitted from the dependency array because it is not used in the callback
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dispatch, lastRefresh, pageState, scopeStatusByLocation]);
 
   return {
     status,
     error,
-    reload,
   };
 }


### PR DESCRIPTION
## Summary

De-dupe overview status request on load !!

### Before

<img width="1724" alt="image" src="https://github.com/elastic/kibana/assets/3505601/84985df1-c818-4f91-bb19-54f3c4b55691">

### After
<img width="1725" alt="image" src="https://github.com/elastic/kibana/assets/3505601/f20b8c4a-94d4-4ef5-a945-133a7ab41855">


<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->