### PR TITLE
[APM] Fix broken unit tests

### DIFF
--- a/x-pack/plugins/apm/public/components/alerting/rule_types/error_count_rule_type/index.stories.tsx
+++ b/x-pack/plugins/apm/public/components/alerting/rule_types/error_count_rule_type/index.stories.tsx
@@ -10,6 +10,7 @@ import React, { useState } from 'react';
 import { CoreStart } from '@kbn/core/public';
 import { createKibanaReactContext } from '@kbn/kibana-react-plugin/public';
 import { TIME_UNITS } from '@kbn/triggers-actions-ui-plugin/public';
+import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
 import { RuleParams, ErrorCountRuleType } from '.';
 import { ENVIRONMENT_ALL } from '../../../../../common/environment_filter_values';
 import { createCallApmApi } from '../../../../services/rest/create_call_apm_api';
@@ -36,11 +37,13 @@ const stories: Meta<{}> = {
       createCallApmApi(coreMock);
 
       return (
-        <KibanaReactContext.Provider>
-          <div style={{ width: 400 }}>
-            <StoryComponent />
-          </div>
-        </KibanaReactContext.Provider>
+        <IntlProvider locale="en">
+          <KibanaReactContext.Provider>
+            <div style={{ width: 400 }}>
+              <StoryComponent />
+            </div>
+          </KibanaReactContext.Provider>
+        </IntlProvider>
       );
     },
   ],

--- a/x-pack/plugins/apm/public/components/app/service_map/index.test.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_map/index.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import { render } from '@testing-library/react';
-import { createMemoryHistory } from 'history';
+import { createMemoryHistory, MemoryHistory } from 'history';
 import { CoreStart } from '@kbn/core/public';
 import React, { ReactNode } from 'react';
 import { createKibanaReactContext } from '@kbn/kibana-react-plugin/public';
@@ -18,7 +18,7 @@ import * as useFetcherModule from '../../../hooks/use_fetcher';
 import { ServiceMap } from '.';
 import { ENVIRONMENT_ALL } from '../../../../common/environment_filter_values';
 
-const history = createMemoryHistory();
+let history: MemoryHistory<unknown>;
 
 const KibanaReactContext = createKibanaReactContext({
   usageCollection: { reportUiCounter: () => {} },
@@ -47,6 +47,7 @@ const expiredLicense = new License({
 });
 
 function createWrapper(license: License | null) {
+  history = createMemoryHistory();
   history.replace('/service-map?rangeFrom=now-15m&rangeTo=now');
 
   return ({ children }: { children?: ReactNode }) => {

--- a/x-pack/plugins/apm/public/components/app/transaction_overview/transaction_overview.test.tsx
+++ b/x-pack/plugins/apm/public/components/app/transaction_overview/transaction_overview.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import { queryByLabelText } from '@testing-library/react';
-import { createMemoryHistory } from 'history';
+import { createMemoryHistory, MemoryHistory } from 'history';
 import { CoreStart } from '@kbn/core/public';
 import React from 'react';
 import { createKibanaReactContext } from '@kbn/kibana-react-plugin/public';
@@ -32,9 +32,7 @@ const KibanaReactContext = createKibanaReactContext({
   usageCollection: { reportUiCounter: () => {} },
 } as unknown as Partial<CoreStart>);
 
-const history = createMemoryHistory();
-jest.spyOn(history, 'push');
-jest.spyOn(history, 'replace');
+let history: MemoryHistory<unknown>;
 
 function setup({
   urlParams,
@@ -43,6 +41,10 @@ function setup({
   urlParams: ApmUrlParams;
   serviceTransactionTypes: string[];
 }) {
+  history = createMemoryHistory();
+  jest.spyOn(history, 'push');
+  jest.spyOn(history, 'replace');
+
   history.replace({
     pathname: '/services/foo/transactions',
     search: fromQuery(urlParams),


### PR DESCRIPTION
A bunch of APM unit tests were passing on CI but failing locally. This PR fixes the unit tests

**Why fail locally and pass on CI??**
The reason they pass on CI is because `console.*` is disabled on CI:
https://github.com/elastic/kibana/blob/a78c7b02b3b825826f39289e91e545ee6f4a67d9/packages/kbn-test/src/jest/setup/disable_console_logs.js#L9-L12

Whereas in the APM jest config `console.error` is treated as a test failure:

https://github.com/elastic/kibana/blob/7ea0dd6b116a93024d68ea2d93fa4ce90e9bf189/x-pack/plugins/apm/jest_setup.js#L12-L15

<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->