### PR TITLE
[Synthetics] Refactor e2e tests for silent failures

### DIFF
--- a/x-pack/plugins/synthetics/e2e/synthetics/journeys/services/synthetics_services.ts
+++ b/x-pack/plugins/synthetics/e2e/synthetics/journeys/services/synthetics_services.ts
@@ -200,70 +200,29 @@ export class SyntheticsServices {
     });
   }
 
-  async cleaUp(things: Array<'monitors' | 'alerts' | 'rules'> = ['monitors', 'alerts', 'rules']) {
-    const promises = [];
-    if (things.includes('monitors')) {
-      promises.push(this.cleanTestMonitors());
-    }
-    if (things.includes('alerts')) {
-      promises.push(this.cleaUpAlerts());
-    }
-
-    if (things.includes('rules')) {
-      promises.push(this.cleaUpRules());
-    }
-
-    await Promise.all(promises);
-  }
-
-  async cleaUpAlerts() {
-    const getService = this.params.getService;
-    const es: Client = getService('es');
-    const listOfIndices = await es.cat.indices({ format: 'json' });
-    for (const index of listOfIndices) {
-      if (index.index?.startsWith('.internal.alerts-observability.uptime.alerts')) {
-        await es.deleteByQuery({ index: index.index, query: { match_all: {} } });
-      }
-    }
-  }
-
-  async cleaUpRules() {
+  async cleaUp() {
     try {
-      const { data: response } = await this.requester.request({
-        description: 'get monitors by name',
-        path: `/internal/alerting/rules/_find`,
-        query: {
-          per_page: 10,
-          page: 1,
-        },
-        method: 'GET',
-      });
-      const { data = [] } = response as any;
+      const getService = this.params.getService;
+      const server = getService('kibanaServer');
 
-      if (data.length > 0) {
-        // eslint-disable-next-line no-console
-        console.log(`Deleting ${data.length} rules`);
-
-        await axios.patch(
-          this.kibanaUrl + '/internal/alerting/rules/_bulk_delete',
-          {
-            ids: data.map((rule: any) => rule.id),
-          },
-          { auth: { username: 'elastic', password: 'changeme' }, headers: { 'kbn-xsrf': 'true' } }
-        );
-      }
+      await server.savedObjects.clean({ types: ['synthetics-monitor', 'alert'] });
+      await this.cleaUpAlerts();
     } catch (e) {
       // eslint-disable-next-line no-console
       console.log(e);
     }
   }
 
-  async cleanTestMonitors() {
-    const getService = this.params.getService;
-    const server = getService('kibanaServer');
-
+  async cleaUpAlerts() {
     try {
-      await server.savedObjects.clean({ types: ['synthetics-monitor'] });
+      const getService = this.params.getService;
+      const es: Client = getService('es');
+      const listOfIndices = await es.cat.indices({ format: 'json' });
+      for (const index of listOfIndices) {
+        if (index.index?.startsWith('.internal.alerts-observability.uptime.alerts')) {
+          await es.deleteByQuery({ index: index.index, query: { match_all: {} } });
+        }
+      }
     } catch (e) {
       // eslint-disable-next-line no-console
       console.log(e);


### PR DESCRIPTION
## Summary

Refactor e2e tests for silent failures. Since some after hooks were causing failures. 

<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->