### PR TITLE
[Security Solution] Fix endpoint permissions for rule installation and update

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/perform_rule_installation/perform_rule_installation_route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/perform_rule_installation/perform_rule_installation_route.ts
@@ -35,7 +35,7 @@ export const performRuleInstallationRoute = (router: SecuritySolutionPluginRoute
         body: buildRouteValidation(PerformRuleInstallationRequestBody),
       },
       options: {
-        tags: ['access:securitySolution-all'],
+        tags: ['access:securitySolution'],
       },
     },
     async (context, request, response) => {

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/perform_rule_upgrade/perform_rule_upgrade_route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/perform_rule_upgrade/perform_rule_upgrade_route.ts
@@ -39,7 +39,7 @@ export const performRuleUpgradeRoute = (router: SecuritySolutionPluginRouter) =>
         body: buildRouteValidation(PerformRuleUpgradeRequestBody),
       },
       options: {
-        tags: ['access:securitySolution-all'],
+        tags: ['access:securitySolution'],
       },
     },
     async (context, request, response) => {


### PR DESCRIPTION
**Related to: https://github.com/elastic/kibana/issues/161443, https://github.com/elastic/kibana/pull/161454**

## Summary

The `access:securitySolution-all` access level prevents a properly configured role from installing or updating detection rules. This PR aligns the access level for the `installation/_perform` and `upgrade/_perform` endpoints with the rest of the detection engine APIs. 

### Test instructions

Configure a role with the following permissions:

```json
{
  "test": {
    "cluster": [],
    "indices": [
      {
        "names": [
          ".alerts-security.alerts-default",
          ".lists-default",
          ".items-default"
        ],
        "privileges": [
          "read",
          "write",
          "view_index_metadata",
          "maintenance"
        ],
        "field_security": {
          "grant": [
            "*"
          ]
        },
        "allow_restricted_indices": false
      }
    ],
    "applications": [
      {
        "application": "kibana-.kibana",
        "privileges": [
          "feature_siem.all"
        ],
        "resources": [
          "*"
        ]
      }
    ],
    "run_as": [],
    "metadata": {},
    "transient_metadata": {
      "enabled": true
    }
  }
}
```

Call the upgrade/install APIs on behalf of that role to see that no 403 is returned:

```sh
curl --location 'http://localhost:5601/kbn/internal/detection_engine/prebuilt_rules/installation/_perform' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--data '{
    "mode": "ALL_RULES"
}'

curl --location 'http://localhost:5601/kbn/internal/detection_engine/prebuilt_rules/upgrade/_perform' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--data '{
    "mode": "ALL_RULES"
}'
```

<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->