### PR TITLE
[Cloud Security] Adding vuln filter to the scores index

### DIFF
--- a/x-pack/plugins/cloud_security_posture/server/tasks/findings_stats_task.ts
+++ b/x-pack/plugins/cloud_security_posture/server/tasks/findings_stats_task.ts
@@ -14,6 +14,7 @@ import {
 import { SearchRequest } from '@kbn/data-plugin/common';
 import { ElasticsearchClient } from '@kbn/core/server';
 import type { Logger } from '@kbn/core/server';
+import { getSafeVulnerabilitiesQueryFilter } from '../../common/utils/get_safe_vulnerabilities_query_filter';
 import { getSafePostureTypeRuntimeMapping } from '../../common/runtime_mappings/get_safe_posture_type_runtime_mapping';
 import { getIdentifierRuntimeMapping } from '../../common/runtime_mappings/get_identifier_runtime_mapping';
 import {
@@ -181,9 +182,7 @@ const getScoreQuery = (): SearchRequest => ({
 const getVulnStatsTrendQuery = (): SearchRequest => ({
   index: LATEST_VULNERABILITIES_INDEX_DEFAULT_NS,
   size: 0,
-  query: {
-    match_all: {},
-  },
+  query: getSafeVulnerabilitiesQueryFilter(),
   aggs: {
     critical: {
       filter: { term: { 'vulnerability.severity': VULNERABILITIES_SEVERITY.CRITICAL } },


### PR DESCRIPTION
Solves #161089

## Summary

Adding missing data filter to the scores index

![image](https://github.com/elastic/kibana/assets/51442161/0afe949f-9344-49d4-bc76-fa50e5f453e3)


<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->