### PR TITLE
[Docs] Removing 'display' property as it's unused

### DIFF
--- a/docs/management/advanced-options.asciidoc
+++ b/docs/management/advanced-options.asciidoc
@@ -198,7 +198,7 @@ to be displayed).
 
 [[timepicker-refreshintervaldefaults]]`timepicker:refreshIntervalDefaults`::
 The default refresh interval for the time filter. Example:
-`{ "display": "15 seconds", "pause": true, "value": 15000 }`.
+`{ "pause": true, "value": 15000 }`.
 
 [[timepicker-timedefaults]]`timepicker:timeDefaults`::
 The default selection in the time filter.


### PR DESCRIPTION
## Summary

Removing 'display' property as it's unused in `timepicker:refreshIntervalDefaults`. Small docs change.

Previous:
<img width="819" alt="Screenshot 2023-07-11 at 15 59 03" src="https://github.com/elastic/kibana/assets/61687663/4c89cbd9-3320-41cc-b28e-94060fab5a0b">


Updated:
<img width="794" alt="Screenshot 2023-07-11 at 15 59 17" src="https://github.com/elastic/kibana/assets/61687663/e566d456-6eed-4193-bc11-8d6068a6b768">

Closes: #140249




<!--ONMERGE {"backportTargets":["7.17","8.8","8.9"]} ONMERGE-->