### PR TITLE
[http] Default route access to `internal`

### DIFF
--- a/packages/core/http/core-http-router-server-internal/src/request.ts
+++ b/packages/core/http/core-http-router-server-internal/src/request.ts
@@ -223,11 +223,10 @@ export class CoreKibanaRequest<
       options,
     };
   }
-  /** infer route access from path if not declared */
+  /** set route access to internal if not declared */
   private getAccess(request: RawRequest): 'internal' | 'public' {
     return (
-      ((request.route?.settings as RouteOptions)?.app as KibanaRouteOptions)?.access ??
-      (request.path.startsWith('/internal') ? 'internal' : 'public')
+      ((request.route?.settings as RouteOptions)?.app as KibanaRouteOptions)?.access ?? 'internal'
     );
   }
 

--- a/packages/core/http/core-http-router-server-mocks/src/router.mock.ts
+++ b/packages/core/http/core-http-router-server-mocks/src/router.mock.ts
@@ -73,7 +73,7 @@ function createKibanaRequestMock<P = any, Q = any, B = any>({
   routeTags,
   routeAuthRequired,
   validation = {},
-  kibanaRouteOptions = { xsrfRequired: true, access: 'public' },
+  kibanaRouteOptions = { xsrfRequired: true, access: 'internal' },
   kibanaRequestState = {
     requestId: '123',
     requestUuid: '123e4567-e89b-12d3-a456-426614174000',

--- a/packages/core/http/core-http-server-internal/src/http_server.test.ts
+++ b/packages/core/http/core-http-server-internal/src/http_server.test.ts
@@ -836,9 +836,9 @@ test('allows declaring route access to flag a route as public or internal', asyn
   registerRouter(router);
 
   await server.start();
-  await supertest(innerServer.listener).get('/with-access').expect(200, { access });
+  await supertest(innerServer.listener).get('/with-access').expect(200, { access: 'internal' });
 
-  await supertest(innerServer.listener).get('/without-access').expect(200, { access: 'public' });
+  await supertest(innerServer.listener).get('/without-access').expect(200, { access: 'internal' });
 });
 
 test(`sets access flag to 'internal' if not defined`, async () => {

--- a/packages/core/http/core-http-server-internal/src/http_server.test.ts
+++ b/packages/core/http/core-http-server-internal/src/http_server.test.ts
@@ -841,7 +841,7 @@ test('allows declaring route access to flag a route as public or internal', asyn
   await supertest(innerServer.listener).get('/without-access').expect(200, { access: 'public' });
 });
 
-test('infers access flag from path if not defined', async () => {
+test(`sets access flag to 'internal' if not defined`, async () => {
   const { registerRouter, server: innerServer } = await server.setup(config);
 
   const router = new Router('', logger, enhanceWithContext, routerOptions);
@@ -863,13 +863,13 @@ test('infers access flag from path if not defined', async () => {
   await server.start();
   await supertest(innerServer.listener).get('/internal/foo').expect(200, { access: 'internal' });
 
-  await supertest(innerServer.listener).get('/random/foo').expect(200, { access: 'public' });
+  await supertest(innerServer.listener).get('/random/foo').expect(200, { access: 'internal' });
   await supertest(innerServer.listener)
     .get('/random/internal/foo')
-    .expect(200, { access: 'public' });
+    .expect(200, { access: 'internal' });
   await supertest(innerServer.listener)
     .get('/api/foo/internal/my-foo')
-    .expect(200, { access: 'public' });
+    .expect(200, { access: 'internal' });
 });
 
 test('exposes route details of incoming request to a route handler', async () => {
@@ -888,7 +888,7 @@ test('exposes route details of incoming request to a route handler', async () =>
       options: {
         authRequired: true,
         xsrfRequired: false,
-        access: 'public',
+        access: 'internal',
         tags: [],
         timeout: {},
       },
@@ -1066,7 +1066,7 @@ test('exposes route details of incoming request to a route handler (POST + paylo
       options: {
         authRequired: true,
         xsrfRequired: true,
-        access: 'public',
+        access: 'internal',
         tags: [],
         timeout: {
           payload: 10000,

--- a/packages/core/http/core-http-server-internal/src/http_server.ts
+++ b/packages/core/http/core-http-server-internal/src/http_server.ts
@@ -606,7 +606,7 @@ export class HttpServer {
 
     const kibanaRouteOptions: KibanaRouteOptions = {
       xsrfRequired: route.options.xsrfRequired ?? !isSafeMethod(route.method),
-      access: route.options.access ?? (route.path.startsWith('/internal') ? 'internal' : 'public'),
+      access: route.options.access ?? 'internal',
     };
     // Log HTTP API target consumer.
     optionsLogger.debug(

--- a/packages/core/http/core-http-server-internal/src/lifecycle_handlers.test.ts
+++ b/packages/core/http/core-http-server-internal/src/lifecycle_handlers.test.ts
@@ -174,7 +174,7 @@ describe('xsrf post-auth handler', () => {
         path: '/some-path',
         kibanaRouteOptions: {
           xsrfRequired: false,
-          access: 'public',
+          access: 'internal',
         },
       });
 

--- a/packages/core/http/core-http-server/src/router/route.ts
+++ b/packages/core/http/core-http-server/src/router/route.ts
@@ -126,9 +126,7 @@ export interface RouteConfigOptions<Method extends RouteMethod> {
    *           In the future, may require an incomming request to contain a specified header.
    * - internal. The route is internal and intended for internal access only.
    *
-   * If not declared, infers access from route path:
-   * - access =`internal` for '/internal' route path prefix
-   * - access = `public` for everything else
+   * Defaults to 'internal' If not declared,
    */
   access?: 'public' | 'internal';
 


### PR DESCRIPTION
fix https://github.com/elastic/kibana/issues/161371
Kibana enforces [restricting access](https://github.com/elastic/kibana/issues/151940) to public APIs if a request can't be verified using a header.

By default, Kibana interprets if an API is internal or public based on the route path string if not explicitly set otherwise. 

That means that all routes that _don't_ have an `internal` prefix in the path string become `public`, and need the header to pass [validation](https://github.com/elastic/kibana/blob/main/packages/core/http/core-http-server-internal/src/lifecycle_handlers.ts#L52-L57) in core's server route handler.

We need to change that to rather set the default as `internal` and allow teams who specifically want their APIs to be `public`, to declare their route `access` property as `public` themselves.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list]


### Risk Matrix

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Teams who specifically want their APIs as `public` don't override the default | High | High (serverless) | Integration tests will verify that requests to `public` APIs without the required header will fail. |

