### PR TITLE
[DOCS] Edits FormatNumber examples for rule action variables

### DIFF
--- a/docs/user/alerting/action-variables.asciidoc
+++ b/docs/user/alerting/action-variables.asciidoc
@@ -273,17 +273,18 @@ Numbers can be formatted with the following `Intl.NumberFormat` options:
 To use the lambda, surround the number and formatting options with `{{#FormatNumber}}...{{/FormatNumber}}`.
 
 The format of the text passed to the lambda is: `<number>; <locales>; <options>`, where semicolons (`;`) separate each parameter.
-The `<number>` parameter is required.  It is the value to be formatted.  The `<locales>` and `<options>` parameters are optional, but the semicolons must be provided - the values may be empty strings.
-The `<locales>` parameter is a list of locales, separated by commas (`,`).
-The `<options>` parameter is a list of key value pairs, separated by commas (`,`).  The key value pairs are strings separated by colons (`:`) where the key is the name of the option and the value is the value of the option.
+The `<number>` parameter is required; it is the value to be formatted.
+The `<locales>` and `<options>` parameters are optional, but the semicolons must be provided; the values may be empty strings.
+The `<locales>` parameter is a list of locales separated by commas (`,`).
+The `<options>` parameter is a list of key value pairs separated by commas (`,`).
+The key value pairs are strings separated by colons (`:`) where the key is the name of the option and the value is the value of the option.
 The default locale is `en-US` and no options are set by default.
 
-For more information on locale strings, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#locales_argument[the `locales` argument documentation from the `Intl` reference].
+For more information on locale strings, refer to https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#locales_argument[the `locales` argument documentation from the `Intl` reference].
 
 The options and values that can be used with them are listed under `options` in the https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat[Intl.NumberFormat() constructor documentation].
 
-For example, the following template, given the value of context variable
-`context.value.condition0` is 628.4, will render as shown below.
+For example:
 
 [source,sh]
 ----
@@ -293,7 +294,7 @@ For example, the following template, given the value of context variable
     {{/FormatNumber}}
 ----
 
-Rendered text:
+If the context variable `context.value.condition0` has a value of `628.4`, it results in the following text:
 
 [source,sh]
 ----
@@ -301,10 +302,7 @@ Rendered text:
     formatted value: 628,40 €
 ----
 
-The `{{FormatNumber}}` and `{{EvalMath}}` lambdas can be used together to perform calculations on numbers and then format them.
-
-For example, the following template, given the value of context variable
-`context.value.condition0` is 628.4 will render as shown below.
+The `{{FormatNumber}}` and `{{EvalMath}}` lambdas can be used together to perform calculations on numbers and then format them. For example:
 
 [source,sh]
 ----
@@ -315,7 +313,7 @@ For example, the following template, given the value of context variable
     {{/FormatNumber}}
 ----
 
-Rendered text:
+If the context variable `context.value.condition0` has a value of `628.4`, it results in the following text:
 
 [source,sh]
 ----

--- a/docs/user/alerting/action-variables.asciidoc
+++ b/docs/user/alerting/action-variables.asciidoc
@@ -116,14 +116,14 @@ For diagnostic or exploratory purposes, action variables whose values are object
 
 For situations where your rule response returns arrays of data, you can loop through the `context`:
 
-[source]
+[source,sh]
 --------------------------------------------------
 {{#context}}{{.}}{{/context}}
 --------------------------------------------------
 
 For example, looping through search result hits:
 
-[source]
+[source,sh]
 --------------------------------------------------
 triggering data was:
 {{#context.hits}} - {{_source.message}}
@@ -154,7 +154,7 @@ The following capabilities are available:
 Mustache lambdas provide additional rendering capabilities for Mustache templates.
 A Mustache lambda is formatted like a Mustache section. For example:
 
-[source]
+[source,sh]
 ----
 {{#EvalMath}} round(context.value, 1) {{/EvalMath}}
 ----
@@ -169,7 +169,7 @@ The EvalMath lambda will evaluate the text passed to it as <<canvas-tinymath-fun
 
 For example, when the Mustache variable `context.value` is `3.1234`, the following template will render as `3.1`:
 
-[source]
+[source,sh]
 ----
 {{#EvalMath}} round(context.value, 1) {{/EvalMath}}
 ----
@@ -178,7 +178,7 @@ This lambda can access Mustache variables without having to wrap them in `{{}}`.
 However, if the value is in a string form (for example, an Elasticsearch numeric field whose source was indexed as a string), or could be escaped, escaping the value with triple quotes should allow this to work.
 For example, if the Mustache variable `context.value` is `"3.1234"`, the following template will render as `3.1`:
 
-[source]
+[source,sh]
 ----
 {{#EvalMath}} round( {{{context.value}}} , 1) {{/EvalMath}}
 ----
@@ -200,7 +200,7 @@ https://hjson.github.io/[Hjson] is a syntax extension to JSON. It has the follow
 To use it, surround your Hjson content with `{{#ParseHjson}}...{{/ParseHjson}}`.
 For example:
  
-[source]
+[source,sh]
 ----
 {{#ParseHjson}}
 {
@@ -234,7 +234,7 @@ The `<date>` parameter is required; the `<time zone>` and `<date format>` parame
 The default time zone is `"UTC"` and the default date format is `"YYYY-MM-DD hh:mma"`.
 For example, the following templates all render the same value:
  
-[source]
+[source,sh]
 ----
     {{#FormatDate}} {{{timestamp}}} {{/FormatDate}}
     {{#FormatDate}} {{{timestamp}}} ; UTC {{/FormatDate}}
@@ -285,7 +285,7 @@ The options and values that can be used with them are listed under `options` in 
 For example, the following template, given the value of context variable
 `context.value.condition0` is 628.4, will render as shown below.
 
-[source]
+[source,sh]
 ----
     original value: {{{context.value.condition0}}}
     formatted value: {{#FormatNumber}}
@@ -295,7 +295,7 @@ For example, the following template, given the value of context variable
 
 Rendered text:
 
-[source]
+[source,sh]
 ----
     original value: 628.4
     formatted value: 628,40 €
@@ -306,7 +306,7 @@ The `{{FormatNumber}}` and `{{EvalMath}}` lambdas can be used together to perfor
 For example, the following template, given the value of context variable
 `context.value.condition0` is 628.4 will render as shown below.
 
-[source]
+[source,sh]
 ----
     original value: {{{context.value.condition0}}}
     formatted value: {{#FormatNumber}}
@@ -317,7 +317,7 @@ For example, the following template, given the value of context variable
 
 Rendered text:
 
-[source]
+[source,sh]
 ----
     original value: 628.4
     formatted value: 62,84 €


### PR DESCRIPTION
## Summary

Relates to https://github.com/elastic/kibana/issues/155869

This PR edits minor issues in the https://www.elastic.co/guide/en/kibana/master/rule-action-variables.html#_formatnumber documentation. For example, it adds a language to the code blocks so they're formatted uniformly. It also updates some of the example introductory text and punctuation.



<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->