### PR TITLE
[Security solution] Elastic Assistant adds beta label

### DIFF
--- a/x-pack/packages/kbn-elastic-assistant/impl/assistant/assistant_title/index.tsx
+++ b/x-pack/packages/kbn-elastic-assistant/impl/assistant/assistant_title/index.tsx
@@ -1,0 +1,90 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { FunctionComponent, useMemo, useState } from 'react';
+import {
+  EuiButtonIcon,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiIcon,
+  EuiLink,
+  EuiModalHeaderTitle,
+  EuiPopover,
+  EuiText,
+} from '@elastic/eui';
+import { DocLinksStart } from '@kbn/core-doc-links-browser';
+import { FormattedMessage } from '@kbn/i18n-react';
+import * as i18n from '../translations';
+
+export const AssistantTitle: FunctionComponent<{
+  currentTitle: { title: string | JSX.Element; titleIcon: string };
+  docLinks: Omit<DocLinksStart, 'links'>;
+}> = ({ currentTitle, docLinks }) => {
+  const { ELASTIC_WEBSITE_URL, DOC_LINK_VERSION } = docLinks;
+  const url = `${ELASTIC_WEBSITE_URL}guide/en/security/${DOC_LINK_VERSION}/security-assistant.html`;
+
+  const documentationLink = useMemo(
+    () => (
+      <EuiLink
+        aria-label={i18n.DOCUMENTATION_ARIA_LABEL}
+        href={url}
+        target="_blank"
+        rel="noopener"
+        data-test-subj="externalDocumentationLink"
+      >
+        {i18n.DOCUMENTATION}
+      </EuiLink>
+    ),
+    [url]
+  );
+
+  const content = useMemo(
+    () => (
+      <FormattedMessage
+        id="xpack.elasticAssistant.assistant.technicalPreview.tooltipContent"
+        defaultMessage="The Elastic AI Assistant is currently in beta. For more information on the assistant feature and its usage, please reference the {documentationLink}."
+        values={{
+          documentationLink,
+        }}
+      />
+    ),
+    [documentationLink]
+  );
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const onButtonClick = () => setIsPopoverOpen((isOpen: boolean) => !isOpen);
+  const closePopover = () => setIsPopoverOpen(false);
+  return (
+    <EuiModalHeaderTitle>
+      <EuiFlexGroup gutterSize="xs" alignItems="center">
+        <EuiFlexItem grow={false}>
+          <EuiIcon type={currentTitle.titleIcon} size="xl" />
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>{currentTitle.title}</EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiPopover
+            button={
+              <EuiButtonIcon
+                aria-label={i18n.TOOLTIP_ARIA_LABEL}
+                iconType="iInCircle"
+                onClick={onButtonClick}
+                iconSize="l"
+              />
+            }
+            isOpen={isPopoverOpen}
+            closePopover={closePopover}
+            anchorPosition="upCenter"
+          >
+            <EuiText grow={false} css={{ maxWidth: '400px' }}>
+              <h4>{i18n.TOOLTIP_TITLE}</h4>
+              <p>{content}</p>
+            </EuiText>
+          </EuiPopover>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiModalHeaderTitle>
+  );
+};

--- a/x-pack/packages/kbn-elastic-assistant/impl/assistant/assistant_title/index.tsx
+++ b/x-pack/packages/kbn-elastic-assistant/impl/assistant/assistant_title/index.tsx
@@ -30,11 +30,11 @@ export const AssistantTitle: FunctionComponent<{
   const documentationLink = useMemo(
     () => (
       <EuiLink
-        aria-label={i18n.DOCUMENTATION_ARIA_LABEL}
-        href={url}
-        target="_blank"
-        rel="noopener"
+        aria-label={i18n.TOOLTIP_ARIA_LABEL}
         data-test-subj="externalDocumentationLink"
+        href={url}
+        rel="noopener"
+        target="_blank"
       >
         {i18n.DOCUMENTATION}
       </EuiLink>
@@ -45,8 +45,8 @@ export const AssistantTitle: FunctionComponent<{
   const content = useMemo(
     () => (
       <FormattedMessage
-        id="xpack.elasticAssistant.assistant.technicalPreview.tooltipContent"
         defaultMessage="The Elastic AI Assistant is currently in beta. For more information on the assistant feature and its usage, please reference the {documentationLink}."
+        id="xpack.elasticAssistant.assistant.technicalPreview.tooltipContent"
         values={{
           documentationLink,
         }}
@@ -69,9 +69,9 @@ export const AssistantTitle: FunctionComponent<{
             button={
               <EuiButtonIcon
                 aria-label={i18n.TOOLTIP_ARIA_LABEL}
+                iconSize="l"
                 iconType="iInCircle"
                 onClick={onButtonClick}
-                iconSize="l"
               />
             }
             isOpen={isPopoverOpen}

--- a/x-pack/packages/kbn-elastic-assistant/impl/assistant/assistant_title/index.tsx
+++ b/x-pack/packages/kbn-elastic-assistant/impl/assistant/assistant_title/index.tsx
@@ -16,7 +16,7 @@ import {
   EuiPopover,
   EuiText,
 } from '@elastic/eui';
-import { DocLinksStart } from '@kbn/core-doc-links-browser';
+import type { DocLinksStart } from '@kbn/core-doc-links-browser';
 import { FormattedMessage } from '@kbn/i18n-react';
 import * as i18n from '../translations';
 
@@ -32,8 +32,8 @@ export const AssistantTitle: FunctionComponent<{
       <EuiLink
         aria-label={i18n.TOOLTIP_ARIA_LABEL}
         data-test-subj="externalDocumentationLink"
+        external
         href={url}
-        rel="noopener"
         target="_blank"
       >
         {i18n.DOCUMENTATION}

--- a/x-pack/packages/kbn-elastic-assistant/impl/assistant/index.tsx
+++ b/x-pack/packages/kbn-elastic-assistant/impl/assistant/index.tsx
@@ -17,11 +17,9 @@ import {
   EuiSwitchEvent,
   EuiSwitch,
   EuiCallOut,
-  EuiIcon,
   EuiModalFooter,
   EuiModalHeader,
   EuiModalBody,
-  EuiModalHeaderTitle,
 } from '@elastic/eui';
 
 import { createPortal } from 'react-dom';
@@ -29,6 +27,7 @@ import { css } from '@emotion/react';
 
 import { OpenAiProviderType } from '@kbn/stack-connectors-plugin/common/gen_ai/constants';
 import { ActionConnectorProps } from '@kbn/triggers-actions-ui-plugin/public/types';
+import { AssistantTitle } from './assistant_title';
 import { UpgradeButtons } from '../upgrade/upgrade_buttons';
 import { getMessageFromRawResponse } from './helpers';
 
@@ -78,6 +77,7 @@ const AssistantComponent: React.FC<Props> = ({
     conversations,
     defaultAllow,
     defaultAllowReplacement,
+    docLinks,
     getComments,
     http,
     promptContexts,
@@ -458,14 +458,7 @@ const AssistantComponent: React.FC<Props> = ({
               justifyContent={'spaceBetween'}
             >
               <EuiFlexItem grow={false}>
-                <EuiModalHeaderTitle>
-                  <EuiFlexGroup alignItems={'center'}>
-                    <EuiFlexItem grow={false}>
-                      <EuiIcon type={currentTitle.titleIcon} size="xl" />
-                    </EuiFlexItem>
-                    <EuiFlexItem grow={false}>{currentTitle.title}</EuiFlexItem>
-                  </EuiFlexGroup>
-                </EuiModalHeaderTitle>
+                <AssistantTitle currentTitle={currentTitle} docLinks={docLinks} />
               </EuiFlexItem>
 
               <EuiFlexItem

--- a/x-pack/packages/kbn-elastic-assistant/impl/assistant/translations.ts
+++ b/x-pack/packages/kbn-elastic-assistant/impl/assistant/translations.ts
@@ -98,6 +98,6 @@ export const TOOLTIP_ARIA_LABEL = i18n.translate(
 export const DOCUMENTATION = i18n.translate(
   'xpack.elasticAssistant.documentationLinks.documentation',
   {
-    defaultMessage: 'Documentation',
+    defaultMessage: 'documentation',
   }
 );

--- a/x-pack/packages/kbn-elastic-assistant/impl/assistant/translations.ts
+++ b/x-pack/packages/kbn-elastic-assistant/impl/assistant/translations.ts
@@ -80,3 +80,24 @@ export const API_ERROR = i18n.translate('xpack.elasticAssistant.assistant.apiErr
   defaultMessage:
     'An error occurred sending your message. If the problem persists, please test the connector configuration.',
 });
+
+export const TOOLTIP_TITLE = i18n.translate(
+  'xpack.elasticAssistant.assistant.technicalPreview.tooltipTitle',
+  {
+    defaultMessage: 'Beta',
+  }
+);
+
+export const TOOLTIP_ARIA_LABEL = i18n.translate(
+  'xpack.elasticAssistant.documentationLinks.ariaLabel',
+  {
+    defaultMessage: 'Click to open Elastic Assistant documentation in a new tab',
+  }
+);
+
+export const DOCUMENTATION = i18n.translate(
+  'xpack.elasticAssistant.documentationLinks.documentation',
+  {
+    defaultMessage: 'Documentation',
+  }
+);

--- a/x-pack/packages/kbn-elastic-assistant/impl/assistant_context/index.test.tsx
+++ b/x-pack/packages/kbn-elastic-assistant/impl/assistant_context/index.test.tsx
@@ -25,6 +25,10 @@ const ContextWrapper: React.FC = ({ children }) => (
     baseAllowReplacement={[]}
     defaultAllow={[]}
     defaultAllowReplacement={[]}
+    docLinks={{
+      ELASTIC_WEBSITE_URL: 'https://www.elastic.co/',
+      DOC_LINK_VERSION: 'current',
+    }}
     getInitialConversations={mockGetInitialConversations}
     getComments={mockGetComments}
     http={mockHttp}

--- a/x-pack/packages/kbn-elastic-assistant/impl/assistant_context/index.tsx
+++ b/x-pack/packages/kbn-elastic-assistant/impl/assistant_context/index.tsx
@@ -12,6 +12,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { ActionTypeRegistryContract } from '@kbn/triggers-actions-ui-plugin/public';
 import { useLocalStorage } from 'react-use';
+import { DocLinksStart } from '@kbn/core-doc-links-browser';
 import { updatePromptContexts } from './helpers';
 import type {
   PromptContext,
@@ -52,6 +53,7 @@ interface AssistantProviderProps {
   basePromptContexts?: PromptContextTemplate[];
   baseQuickPrompts?: QuickPrompt[];
   baseSystemPrompts?: Prompt[];
+  docLinks: Omit<DocLinksStart, 'links'>;
   children: React.ReactNode;
   getComments: ({
     currentConversation,
@@ -119,6 +121,7 @@ export const AssistantProvider: React.FC<AssistantProviderProps> = ({
   baseAllowReplacement,
   defaultAllow,
   defaultAllowReplacement,
+  docLinks,
   basePromptContexts = [],
   baseQuickPrompts = [],
   baseSystemPrompts = BASE_SYSTEM_PROMPTS,
@@ -234,6 +237,7 @@ export const AssistantProvider: React.FC<AssistantProviderProps> = ({
       conversations,
       defaultAllow: uniq(defaultAllow),
       defaultAllowReplacement: uniq(defaultAllowReplacement),
+      docLinks,
       getComments,
       http,
       promptContexts,
@@ -261,6 +265,7 @@ export const AssistantProvider: React.FC<AssistantProviderProps> = ({
       conversations,
       defaultAllow,
       defaultAllowReplacement,
+      docLinks,
       getComments,
       http,
       localStorageQuickPrompts,

--- a/x-pack/packages/kbn-elastic-assistant/impl/assistant_context/index.tsx
+++ b/x-pack/packages/kbn-elastic-assistant/impl/assistant_context/index.tsx
@@ -12,7 +12,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { ActionTypeRegistryContract } from '@kbn/triggers-actions-ui-plugin/public';
 import { useLocalStorage } from 'react-use';
-import { DocLinksStart } from '@kbn/core-doc-links-browser';
+import type { DocLinksStart } from '@kbn/core-doc-links-browser';
 import { updatePromptContexts } from './helpers';
 import type {
   PromptContext,

--- a/x-pack/packages/kbn-elastic-assistant/impl/assistant_context/index.tsx
+++ b/x-pack/packages/kbn-elastic-assistant/impl/assistant_context/index.tsx
@@ -80,6 +80,7 @@ interface UseAssistantContext {
   allSystemPrompts: Prompt[];
   baseAllow: string[];
   baseAllowReplacement: string[];
+  docLinks: Omit<DocLinksStart, 'links'>;
   defaultAllow: string[];
   defaultAllowReplacement: string[];
   basePromptContexts: PromptContextTemplate[];

--- a/x-pack/packages/kbn-elastic-assistant/impl/mock/test_providers/test_providers.tsx
+++ b/x-pack/packages/kbn-elastic-assistant/impl/mock/test_providers/test_providers.tsx
@@ -38,6 +38,10 @@ export const TestProvidersComponent: React.FC<Props> = ({ children }) => {
           baseAllowReplacement={[]}
           defaultAllow={[]}
           defaultAllowReplacement={[]}
+          docLinks={{
+            ELASTIC_WEBSITE_URL: 'https://www.elastic.co/',
+            DOC_LINK_VERSION: 'current',
+          }}
           getComments={mockGetComments}
           getInitialConversations={mockGetInitialConversations}
           setConversations={jest.fn()}

--- a/x-pack/packages/kbn-elastic-assistant/tsconfig.json
+++ b/x-pack/packages/kbn-elastic-assistant/tsconfig.json
@@ -27,5 +27,6 @@
     "@kbn/core-notifications-browser",
     "@kbn/i18n-react",
     "@kbn/ui-theme",
+    "@kbn/core-doc-links-browser",
   ]
 }

--- a/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality/mock/test_providers/test_providers.tsx
+++ b/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality/mock/test_providers/test_providers.tsx
@@ -39,6 +39,10 @@ export const TestProvidersComponent: React.FC<Props> = ({ children }) => {
           baseAllowReplacement={[]}
           defaultAllow={[]}
           defaultAllowReplacement={[]}
+          docLinks={{
+            ELASTIC_WEBSITE_URL: 'https://www.elastic.co/',
+            DOC_LINK_VERSION: 'current',
+          }}
           getComments={mockGetComments}
           getInitialConversations={mockGetInitialConversations}
           setConversations={jest.fn()}

--- a/x-pack/plugins/security_solution/public/app/app.tsx
+++ b/x-pack/plugins/security_solution/public/app/app.tsx
@@ -76,6 +76,8 @@ const StartAppComponent: FC<StartAppComponent> = ({
   const nameSpace = `${APP_ID}.${LOCAL_STORAGE_KEY}`;
 
   const [darkMode] = useUiSetting$<boolean>(DEFAULT_DARK_MODE);
+
+  const { ELASTIC_WEBSITE_URL, DOC_LINK_VERSION } = useKibana().services.docLinks;
   return (
     <EuiErrorBoundary>
       <i18n.Context>
@@ -88,6 +90,7 @@ const StartAppComponent: FC<StartAppComponent> = ({
                   augmentMessageCodeBlocks={augmentMessageCodeBlocks}
                   defaultAllow={defaultAllow}
                   defaultAllowReplacement={defaultAllowReplacement}
+                  docLinks={{ ELASTIC_WEBSITE_URL, DOC_LINK_VERSION }}
                   baseAllow={DEFAULT_ALLOW}
                   baseAllowReplacement={DEFAULT_ALLOW_REPLACEMENT}
                   basePromptContexts={Object.values(PROMPT_CONTEXTS)}

--- a/x-pack/plugins/security_solution/public/common/mock/mock_assistant_provider.tsx
+++ b/x-pack/plugins/security_solution/public/common/mock/mock_assistant_provider.tsx
@@ -30,6 +30,10 @@ export const MockAssistantProviderComponent: React.FC<Props> = ({ children }) =>
       baseAllow={[]}
       baseAllowReplacement={[]}
       defaultAllow={[]}
+      docLinks={{
+        ELASTIC_WEBSITE_URL: 'https://www.elastic.co/',
+        DOC_LINK_VERSION: 'current',
+      }}
       defaultAllowReplacement={[]}
       getComments={jest.fn(() => [])}
       getInitialConversations={jest.fn(() => ({}))}


### PR DESCRIPTION
## Summary

This PR adds a Beta label to the Elastic Assistant modal header, to indicate is not a GA feature.

PM requested a tooltip with a link in it, which is [against EUI guidelines](https://elastic.github.io/eui/#/display/tooltip). I instead opted for a popover as they advise


https://github.com/elastic/kibana/assets/6935300/5b15ccea-24be-48f3-ab02-8669c3093266




<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->