### PR TITLE
[Security Solution] Close the assistant dialog on add to case #6973

### DIFF
--- a/x-pack/plugins/security_solution/public/assistant/comment_actions/index.tsx
+++ b/x-pack/plugins/security_solution/public/assistant/comment_actions/index.tsx
@@ -11,6 +11,7 @@ import type { Message } from '@kbn/elastic-assistant';
 import React, { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
 
+import { useAssistantContext } from '@kbn/elastic-assistant/impl/assistant_context';
 import { useKibana, useToasts } from '../../common/lib/kibana';
 import type { Note } from '../../common/lib/note';
 import { appActions } from '../../common/store/actions';
@@ -27,6 +28,8 @@ const CommentActionsComponent: React.FC<Props> = ({ message }) => {
   const toasts = useToasts();
   const { cases } = useKibana().services;
   const dispatch = useDispatch();
+
+  const { showAssistantOverlay } = useAssistantContext();
 
   const associateNote = useCallback(
     (noteId: string) => dispatch(timelineActions.addNote({ id: TimelineId.active, noteId })),
@@ -57,6 +60,8 @@ const CommentActionsComponent: React.FC<Props> = ({ message }) => {
   });
 
   const onAddToExistingCase = useCallback(() => {
+    showAssistantOverlay({ showOverlay: false });
+
     selectCaseModal.open({
       getAttachments: () => [
         {
@@ -66,7 +71,7 @@ const CommentActionsComponent: React.FC<Props> = ({ message }) => {
         },
       ],
     });
-  }, [message.content, selectCaseModal]);
+  }, [message.content, selectCaseModal, showAssistantOverlay]);
 
   return (
     <EuiFlexGroup alignItems="center" gutterSize="none">


### PR DESCRIPTION
This PR closes #6973 where the assistant should not obscure new case modal (diplayed in the flyout)



<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->