### PR TITLE
[Fleet] Test disabled API in serverless

### DIFF
--- a/x-pack/plugins/fleet/server/errors/index.ts
+++ b/x-pack/plugins/fleet/server/errors/index.ts
@@ -77,8 +77,8 @@ export class OutputInvalidError extends FleetError {}
 export class OutputLicenceError extends FleetError {}
 export class DownloadSourceError extends FleetError {}
 
-export class FleetServerHostUnauthorizedError extends FleetError {}
-export class FleetProxyUnauthorizedError extends FleetError {}
+export class FleetServerHostUnauthorizedError extends FleetUnauthorizedError {}
+export class FleetProxyUnauthorizedError extends FleetUnauthorizedError {}
 
 export class ArtifactsClientError extends FleetError {}
 export class ArtifactsClientAccessDeniedError extends FleetError {

--- a/x-pack/plugins/fleet/server/routes/fleet_proxies/handler.ts
+++ b/x-pack/plugins/fleet/server/routes/fleet_proxies/handler.ts
@@ -22,7 +22,7 @@ import {
   updateFleetProxy,
   getFleetProxyRelatedSavedObjects,
 } from '../../services/fleet_proxies';
-import { defaultFleetErrorHandler } from '../../errors';
+import { defaultFleetErrorHandler, FleetProxyUnauthorizedError } from '../../errors';
 import type {
   GetOneFleetProxyRequestSchema,
   PostFleetProxyRequestSchema,
@@ -68,7 +68,7 @@ async function bumpRelatedPolicies(
 
 function checkProxiesAvailable() {
   if (appContextService.getConfig()?.internal?.disableProxies) {
-    throw new Error('Proxies are not available');
+    throw new FleetProxyUnauthorizedError('Proxies write APIs are disabled');
   }
 }
 

--- a/x-pack/test_serverless/api_integration/test_suites/observability/fleet.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/observability/fleet.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from 'expect';
+import { FtrProviderContext } from '../../ftr_provider_context';
+
+export default function ({ getService }: FtrProviderContext) {
+  const svlCommonApi = getService('svlCommonApi');
+  const supertest = getService('supertest');
+
+  describe('fleet', function () {
+    it('rejects request to create a new fleet server hosts', async () => {
+      const { body, status } = await supertest
+        .post('/api/fleet/fleet_server_hosts')
+        .set(svlCommonApi.getCommonRequestHeader())
+        .send({
+          name: 'test',
+          host_urls: ['https://localhost:8220'],
+        });
+
+      // in a non-serverless environment this would succeed with a 200
+      expect(body).toEqual({
+        statusCode: 403,
+        error: 'Forbidden',
+        message: 'Fleet server host write APIs are disabled',
+      });
+      expect(status).toBe(403);
+    });
+
+    it('rejects request to create a new proxy', async () => {
+      const { body, status } = await supertest
+        .post('/api/fleet/proxies')
+        .set(svlCommonApi.getCommonRequestHeader())
+        .send({
+          name: 'test',
+          url: 'https://localhost:8220',
+        });
+
+      // in a non-serverless environment this would succeed with a 200
+      expect(body).toEqual({
+        statusCode: 403,
+        error: 'Forbidden',
+        message: 'Proxies write APIs are disabled',
+      });
+      expect(status).toBe(403);
+    });
+  });
+}

--- a/x-pack/test_serverless/api_integration/test_suites/observability/index.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/observability/index.ts
@@ -9,6 +9,7 @@ import { FtrProviderContext } from '../../ftr_provider_context';
 
 export default function ({ loadTestFile }: FtrProviderContext) {
   describe('serverless observability API', function () {
+    loadTestFile(require.resolve('./fleet'));
     loadTestFile(require.resolve('./snapshot_telemetry'));
   });
 }

--- a/x-pack/test_serverless/api_integration/test_suites/security/fleet.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/security/fleet.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from 'expect';
+import { FtrProviderContext } from '../../ftr_provider_context';
+
+export default function ({ getService }: FtrProviderContext) {
+  const svlCommonApi = getService('svlCommonApi');
+  const supertest = getService('supertest');
+
+  describe('fleet', function () {
+    it('rejects request to create a new fleet server hosts', async () => {
+      const { body, status } = await supertest
+        .post('/api/fleet/fleet_server_hosts')
+        .set(svlCommonApi.getCommonRequestHeader())
+        .send({
+          name: 'test',
+          host_urls: ['https://localhost:8220'],
+        });
+
+      // in a non-serverless environment this would succeed with a 200
+      expect(body).toEqual({
+        statusCode: 403,
+        error: 'Forbidden',
+        message: 'Fleet server host write APIs are disabled',
+      });
+      expect(status).toBe(403);
+    });
+
+    it('rejects request to create a new proxy', async () => {
+      const { body, status } = await supertest
+        .post('/api/fleet/proxies')
+        .set(svlCommonApi.getCommonRequestHeader())
+        .send({
+          name: 'test',
+          url: 'https://localhost:8220',
+        });
+
+      // in a non-serverless environment this would succeed with a 200
+      expect(body).toEqual({
+        statusCode: 403,
+        error: 'Forbidden',
+        message: 'Proxies write APIs are disabled',
+      });
+      expect(status).toBe(403);
+    });
+  });
+}

--- a/x-pack/test_serverless/api_integration/test_suites/security/index.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/security/index.ts
@@ -9,6 +9,7 @@ import { FtrProviderContext } from '../../ftr_provider_context';
 
 export default function ({ loadTestFile }: FtrProviderContext) {
   describe('serverless security API', function () {
+    loadTestFile(require.resolve('./fleet'));
     loadTestFile(require.resolve('./snapshot_telemetry'));
   });
 }


### PR DESCRIPTION
## Summary

That PR test that write APIs for fleet server hosts and proxies are disabled in serverless.

I had to fix fleet errors and adjusted error message here. => Trying to create a fleet server hosts or a proxy will return a 403



