### PR TITLE
Update _fields_for_wildcard endpoint schema to support 'position' time series metric fields

### DIFF
--- a/src/plugins/data_views/server/rest_api_routes/internal/fields_for.ts
+++ b/src/plugins/data_views/server/rest_api_routes/internal/fields_for.ts
@@ -86,6 +86,7 @@ const FieldDescriptorSchema = schema.object({
       schema.literal('summary'),
       schema.literal('counter'),
       schema.literal('gauge'),
+      schema.literal('position'),
     ])
   ),
   timeSeriesDimension: schema.maybe(schema.boolean()),


### PR DESCRIPTION
`position` is valid response for field_caps `time_series_metric` field. It has been added to elasticsearch-specification, https://github.com/elastic/elasticsearch-specification/pull/2143, (but is not yet in Kibana). This PR updates _fields_for_wildcard schema to include 'position' as valid value

### Test instructions
* clone https://github.com/thomasneirynck/faketracks
* cd into `faketracks`
* run `npm install`
* run `node ./generate_tracks.js --isTimeSeries`
* In Kibana, create `tracks` data view
* Verify _fields_for_wildcard endpoint does not return 500 error