### PR TITLE
Changes the theme override tip from EuiIconTip to EuiToolTip

### DIFF
--- a/x-pack/plugins/security/public/account_management/user_profile/user_profile.test.tsx
+++ b/x-pack/plugins/security/public/account_management/user_profile/user_profile.test.tsx
@@ -257,8 +257,9 @@ describe('useUserProfileForm', () => {
         </Providers>
       );
 
-      const overrideMsg = testWrapper.find('EuiText[data-test-subj="themeOverrideMessage"]');
-      expect(overrideMsg).toHaveLength(0);
+      const overrideMsg = testWrapper.find('EuiToolTip[data-test-subj="themeOverrideTooltip"]');
+      expect(overrideMsg).toHaveLength(1);
+      expect(overrideMsg.getElement().props.content).toEqual('');
 
       const themeMenu = testWrapper.find('EuiKeyPadMenu[data-test-subj="themeMenu"]');
       expect(themeMenu).toHaveLength(1);
@@ -343,8 +344,9 @@ describe('useUserProfileForm', () => {
         </Providers>
       );
 
-      const overrideMsg = testWrapper.find('EuiIconTip[data-test-subj="themeOverrideTooltip"]');
+      const overrideMsg = testWrapper.find('EuiToolTip[data-test-subj="themeOverrideTooltip"]');
       expect(overrideMsg).toHaveLength(1);
+      expect(overrideMsg.getElement().props.content).not.toEqual('');
 
       const themeMenu = testWrapper.find('EuiKeyPadMenu[data-test-subj="themeMenu"]');
       expect(themeMenu).toHaveLength(1);
@@ -380,8 +382,9 @@ describe('useUserProfileForm', () => {
         </Providers>
       );
 
-      const overrideMsg = testWrapper.find('EuiIconTip[data-test-subj="themeOverrideTooltip"]');
+      const overrideMsg = testWrapper.find('EuiToolTip[data-test-subj="themeOverrideTooltip"]');
       expect(overrideMsg).toHaveLength(1);
+      expect(overrideMsg.getElement().props.content).not.toEqual('');
 
       const themeMenu = testWrapper.find('EuiKeyPadMenu[data-test-subj="themeMenu"]');
       expect(themeMenu).toHaveLength(1);

--- a/x-pack/plugins/security/public/account_management/user_profile/user_profile.test.tsx
+++ b/x-pack/plugins/security/public/account_management/user_profile/user_profile.test.tsx
@@ -258,8 +258,7 @@ describe('useUserProfileForm', () => {
       );
 
       const overrideMsg = testWrapper.find('EuiToolTip[data-test-subj="themeOverrideTooltip"]');
-      expect(overrideMsg).toHaveLength(1);
-      expect(overrideMsg.getElement().props.content).toEqual('');
+      expect(overrideMsg).toHaveLength(0);
 
       const themeMenu = testWrapper.find('EuiKeyPadMenu[data-test-subj="themeMenu"]');
       expect(themeMenu).toHaveLength(1);

--- a/x-pack/plugins/security/public/account_management/user_profile/user_profile.tsx
+++ b/x-pack/plugins/security/public/account_management/user_profile/user_profile.tsx
@@ -174,7 +174,7 @@ function UserSettingsEditor({
     icon: string;
   }
 
-  const themeKeyPadMenuItem = ({ id, label, icon }: ThemeKeyPadItem) => {
+  const themeItem = ({ id, label, icon }: ThemeKeyPadItem) => {
     return (
       <EuiKeyPadMenuItem
         name={id}
@@ -186,6 +186,67 @@ function UserSettingsEditor({
       >
         <EuiIcon type={icon} size="l" />
       </EuiKeyPadMenuItem>
+    );
+  };
+
+  const themeMenu = (themeOverridden: boolean) => {
+    const themeKeyPadMenu = (
+      <EuiKeyPadMenu
+        aria-label={i18n.translate(
+          'xpack.security.accountManagement.userProfile.userSettings.themeGroupDescription',
+          {
+            defaultMessage: 'Elastic theme',
+          }
+        )}
+        data-test-subj="themeMenu"
+        checkable={{
+          legend: (
+            <FormLabel for="data.userSettings.darkMode">
+              <FormattedMessage
+                id="xpack.security.accountManagement.userProfile.userSettings.theme"
+                defaultMessage="Mode"
+              />
+            </FormLabel>
+          ),
+        }}
+      >
+        {themeItem({
+          id: '',
+          label: i18n.translate('xpack.security.accountManagement.userProfile.defaultModeButton', {
+            defaultMessage: 'Space default',
+          }),
+          icon: 'spaces',
+        })}
+        {themeItem({
+          id: 'light',
+          label: i18n.translate('xpack.security.accountManagement.userProfile.lightModeButton', {
+            defaultMessage: 'Light',
+          }),
+          icon: 'sun',
+        })}
+        {themeItem({
+          id: 'dark',
+          label: i18n.translate('xpack.security.accountManagement.userProfile.darkModeButton', {
+            defaultMessage: 'Dark',
+          }),
+          icon: 'moon',
+        })}
+      </EuiKeyPadMenu>
+    );
+    return themeOverridden ? (
+      <EuiToolTip
+        data-test-subj="themeOverrideTooltip"
+        content={
+          <FormattedMessage
+            id="xpack.security.accountManagement.userProfile.overriddenMessage"
+            defaultMessage="This setting is overridden by the Kibana server and can not be changed."
+          />
+        }
+      >
+        {themeKeyPadMenu}
+      </EuiToolTip>
+    ) : (
+      themeKeyPadMenu
     );
   };
 
@@ -208,70 +269,8 @@ function UserSettingsEditor({
         />
       }
     >
-      <FormRow
-        name="data.userSettings.darkMode"
-        label={
-          <FormLabel for="data.userSettings.darkMode">
-            <FormattedMessage
-              id="xpack.security.accountManagement.userProfile.userSettings.theme"
-              defaultMessage="Mode"
-            />
-          </FormLabel>
-        }
-        fullWidth
-      >
-        <EuiToolTip
-          data-test-subj="themeOverrideTooltip"
-          content={
-            isThemeOverridden ? (
-              <FormattedMessage
-                id="xpack.security.accountManagement.userProfile.overriddenMessage"
-                defaultMessage="This setting is overridden by the Kibana server and can not be changed."
-              />
-            ) : (
-              ''
-            )
-          }
-        >
-          <EuiKeyPadMenu
-            aria-label={i18n.translate(
-              'xpack.security.accountManagement.userProfile.userSettings.themeGroupDescription',
-              {
-                defaultMessage: 'Elastic theme',
-              }
-            )}
-            data-test-subj="themeMenu"
-            checkable={true}
-          >
-            {themeKeyPadMenuItem({
-              id: '',
-              label: i18n.translate(
-                'xpack.security.accountManagement.userProfile.defaultModeButton',
-                {
-                  defaultMessage: 'Space default',
-                }
-              ),
-              icon: 'spaces',
-            })}
-            {themeKeyPadMenuItem({
-              id: 'light',
-              label: i18n.translate(
-                'xpack.security.accountManagement.userProfile.lightModeButton',
-                {
-                  defaultMessage: 'Light',
-                }
-              ),
-              icon: 'sun',
-            })}
-            {themeKeyPadMenuItem({
-              id: 'dark',
-              label: i18n.translate('xpack.security.accountManagement.userProfile.darkModeButton', {
-                defaultMessage: 'Dark',
-              }),
-              icon: 'moon',
-            })}
-          </EuiKeyPadMenu>
-        </EuiToolTip>
+      <FormRow name="data.userSettings.darkMode" fullWidth>
+        {themeMenu(isThemeOverridden)}
       </FormRow>
     </EuiDescribedFormGroup>
   );

--- a/x-pack/plugins/security/public/account_management/user_profile/user_profile.tsx
+++ b/x-pack/plugins/security/public/account_management/user_profile/user_profile.tsx
@@ -23,6 +23,7 @@ import {
   EuiPageTemplate_Deprecated as EuiPageTemplate,
   EuiSpacer,
   EuiText,
+  EuiToolTip,
   useEuiTheme,
   useGeneratedHtmlId,
 } from '@elastic/eui';
@@ -210,55 +211,67 @@ function UserSettingsEditor({
       <FormRow
         name="data.userSettings.darkMode"
         label={
-          <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
-            <EuiFlexItem grow={false}>
-              <FormLabel for="data.userSettings.darkMode">
-                <FormattedMessage
-                  id="xpack.security.accountManagement.userProfile.userSettings.theme"
-                  defaultMessage="Mode"
-                />
-              </FormLabel>
-            </EuiFlexItem>
-            <EuiFlexItem grow={false}>{renderHelpText(isThemeOverridden)}</EuiFlexItem>
-          </EuiFlexGroup>
+          <FormLabel for="data.userSettings.darkMode">
+            <FormattedMessage
+              id="xpack.security.accountManagement.userProfile.userSettings.theme"
+              defaultMessage="Mode"
+            />
+          </FormLabel>
         }
         fullWidth
       >
-        <EuiKeyPadMenu
-          aria-label={i18n.translate(
-            'xpack.security.accountManagement.userProfile.userSettings.themeGroupDescription',
-            {
-              defaultMessage: 'Elastic theme',
-            }
-          )}
-          data-test-subj="themeMenu"
-          checkable={true}
+        <EuiToolTip
+          data-test-subj="themeOverrideTooltip"
+          content={
+            isThemeOverridden ? (
+              <FormattedMessage
+                id="xpack.security.accountManagement.userProfile.overriddenMessage"
+                defaultMessage="This setting is overridden by the Kibana server and can not be changed."
+              />
+            ) : (
+              ''
+            )
+          }
         >
-          {themeKeyPadMenuItem({
-            id: '',
-            label: i18n.translate(
-              'xpack.security.accountManagement.userProfile.defaultModeButton',
+          <EuiKeyPadMenu
+            aria-label={i18n.translate(
+              'xpack.security.accountManagement.userProfile.userSettings.themeGroupDescription',
               {
-                defaultMessage: 'Space default',
+                defaultMessage: 'Elastic theme',
               }
-            ),
-            icon: 'spaces',
-          })}
-          {themeKeyPadMenuItem({
-            id: 'light',
-            label: i18n.translate('xpack.security.accountManagement.userProfile.lightModeButton', {
-              defaultMessage: 'Light',
-            }),
-            icon: 'sun',
-          })}
-          {themeKeyPadMenuItem({
-            id: 'dark',
-            label: i18n.translate('xpack.security.accountManagement.userProfile.darkModeButton', {
-              defaultMessage: 'Dark',
-            }),
-            icon: 'moon',
-          })}
-        </EuiKeyPadMenu>
+            )}
+            data-test-subj="themeMenu"
+            checkable={true}
+          >
+            {themeKeyPadMenuItem({
+              id: '',
+              label: i18n.translate(
+                'xpack.security.accountManagement.userProfile.defaultModeButton',
+                {
+                  defaultMessage: 'Space default',
+                }
+              ),
+              icon: 'spaces',
+            })}
+            {themeKeyPadMenuItem({
+              id: 'light',
+              label: i18n.translate(
+                'xpack.security.accountManagement.userProfile.lightModeButton',
+                {
+                  defaultMessage: 'Light',
+                }
+              ),
+              icon: 'sun',
+            })}
+            {themeKeyPadMenuItem({
+              id: 'dark',
+              label: i18n.translate('xpack.security.accountManagement.userProfile.darkModeButton', {
+                defaultMessage: 'Dark',
+              }),
+              icon: 'moon',
+            })}
+          </EuiKeyPadMenu>
+        </EuiToolTip>
       </FormRow>
     </EuiDescribedFormGroup>
   );
@@ -925,30 +938,6 @@ export const SaveChangesBottomBar: FunctionComponent = () => {
     </EuiFlexGroup>
   );
 };
-
-function renderHelpText(isOverridden: boolean) {
-  if (isOverridden) {
-    return (
-      <EuiIconTip
-        data-test-subj="themeOverrideTooltip"
-        aria-label={i18n.translate(
-          'xpack.security.accountManagement.userProfile.themeModeLockedLabel',
-          {
-            defaultMessage: 'Theme mode locked',
-          }
-        )}
-        size="s"
-        type="lock"
-        content={
-          <FormattedMessage
-            id="xpack.security.accountManagement.userProfile.overriddenMessage"
-            defaultMessage="This setting is overridden by the Kibana server and can not be changed."
-          />
-        }
-      />
-    );
-  }
-}
 
 function determineIfThemeOverridden(settingsClient: IUiSettingsClient): {
   isThemeOverridden: boolean;


### PR DESCRIPTION
## Summary

Removes the lock tip icon in favor of a standard tool tip for the theme mode keypad menu.

Previous render:
<img width="1051" alt="Screenshot 2023-06-30 at 12 24 12 PM" src="https://github.com/elastic/kibana/assets/103939324/5968e1e4-88ae-43a6-8fea-0df7cf2db25b">

New Render:
<img width="1051" alt="Screenshot 2023-07-11 at 2 41 28 PM" src="https://github.com/elastic/kibana/assets/103939324/b45d5df6-4f04-446f-8d5c-f2c4dda2fa06">

### Tests
- `x-pack/plugins/security/public/account_management/user_profile/user_profile.test.tsx`

### Manual Testing
- Start Elasricsearch, and start Kibana with an empty  kibana.yml/kibana.dev.yml
- Navigate to the _Edit profile_ screen via the profile/avatar button in the top right portion of the uI

<img width="269" alt="Screenshot 2023-06-29 at 11 47 42 AM" src="https://github.com/elastic/kibana/assets/103939324/52f5288f-0623-4658-a7a2-2ef85164cadc">

- Verify the theme settings appear as a KeyPadMenu and function as expected

<img width="1079" alt="Screenshot 2023-06-28 at 2 38 44 PM" src="https://github.com/elastic/kibana/assets/103939324/a3745b8b-f908-4cd0-bcf6-2bf878578499">

- Modify the kibana.yml (or kibana.dev.yml) with the line `uiSettings.overrides.theme:darkMode: true`
- Refresh Kibana and verify that the dark theme is rendered and the theme settings are disabled and includes a tooltip explaining why the mode setting is locked
<img width="1051" alt="Screenshot 2023-07-11 at 2 41 28 PM" src="https://github.com/elastic/kibana/assets/103939324/b45d5df6-4f04-446f-8d5c-f2c4dda2fa06">
