### PR TITLE
[Enterprise Search] include app search & workplace search in search results

### DIFF
--- a/x-pack/plugins/enterprise_search/server/utils/search_result_provider.test.ts
+++ b/x-pack/plugins/enterprise_search/server/utils/search_result_provider.test.ts
@@ -28,7 +28,7 @@ describe('Enterprise Search search provider', () => {
     id: 'elastic-crawler',
     score: 75,
     title: 'Elastic Web Crawler',
-    type: 'Enterprise Search',
+    type: 'Search',
     url: {
       path: `${ENTERPRISE_SEARCH_CONTENT_PLUGIN.URL}/search_indices/new_index/crawler`,
       prependBasePath: true,
@@ -40,7 +40,7 @@ describe('Enterprise Search search provider', () => {
     id: 'mongodb',
     score: 75,
     title: 'MongoDB',
-    type: 'Enterprise Search',
+    type: 'Search',
     url: {
       path: `${ENTERPRISE_SEARCH_CONTENT_PLUGIN.URL}/search_indices/new_index/connector?service_type=mongodb`,
       prependBasePath: true,

--- a/x-pack/plugins/enterprise_search/server/utils/search_result_provider.ts
+++ b/x-pack/plugins/enterprise_search/server/utils/search_result_provider.ts
@@ -9,13 +9,29 @@ import { from, takeUntil } from 'rxjs';
 
 import { IBasePath } from '@kbn/core-http-server';
 import { GlobalSearchResultProvider } from '@kbn/global-search-plugin/server';
+import { i18n } from '@kbn/i18n';
 
 import { ConfigType } from '..';
-import { CONNECTOR_DEFINITIONS } from '../../common/connectors/connectors';
+import {
+  CONNECTOR_DEFINITIONS,
+  ConnectorServerSideDefinition,
+} from '../../common/connectors/connectors';
 import {
   ENTERPRISE_SEARCH_CONNECTOR_CRAWLER_SERVICE_TYPE,
   ENTERPRISE_SEARCH_CONTENT_PLUGIN,
+  APP_SEARCH_PLUGIN,
+  WORKPLACE_SEARCH_PLUGIN,
 } from '../../common/constants';
+
+type ServiceDefinition =
+  | ConnectorServerSideDefinition
+  | {
+      iconPath?: string;
+      keywords: string[];
+      name: string;
+      serviceType: string;
+      url?: string;
+    };
 
 export function toSearchResult({
   basePath,
@@ -23,12 +39,14 @@ export function toSearchResult({
   name,
   score,
   serviceType,
+  url,
 }: {
   basePath: IBasePath;
-  iconPath: string;
+  iconPath?: string;
   name: string;
   score: number;
   serviceType: string;
+  url?: string;
 }) {
   return {
     icon: iconPath
@@ -37,13 +55,17 @@ export function toSearchResult({
     id: serviceType,
     score,
     title: name,
-    type: 'Enterprise Search',
+    type: i18n.translate('xpack.enterpriseSearch.searchProvider.type.name', {
+      defaultMessage: 'Search',
+    }),
     url: {
-      path: `${ENTERPRISE_SEARCH_CONTENT_PLUGIN.URL}/search_indices/new_index/${
-        serviceType === ENTERPRISE_SEARCH_CONNECTOR_CRAWLER_SERVICE_TYPE
-          ? 'crawler'
-          : `connector?service_type=${serviceType}`
-      }`,
+      path:
+        url ??
+        `${ENTERPRISE_SEARCH_CONTENT_PLUGIN.URL}/search_indices/new_index/${
+          serviceType === ENTERPRISE_SEARCH_CONNECTOR_CRAWLER_SERVICE_TYPE
+            ? 'crawler'
+            : `connector?service_type=${serviceType}`
+        }`,
       prependBasePath: true,
     },
   };
@@ -61,20 +83,43 @@ export function getSearchResultProvider(
       ) {
         return from([[]]);
       }
-      const result = [
+      const services: ServiceDefinition[] = [
         ...(config.hasWebCrawler
           ? [
               {
                 iconPath: 'crawler.svg',
                 keywords: ['crawler', 'web', 'website', 'internet', 'google'],
-                name: 'Elastic Web Crawler',
+                name: i18n.translate('xpack.enterpriseSearch.searchProvider.webCrawler.name', {
+                  defaultMessage: 'Elastic Web Crawler',
+                }),
                 serviceType: ENTERPRISE_SEARCH_CONNECTOR_CRAWLER_SERVICE_TYPE,
               },
             ]
           : []),
         ...(config.hasConnectors ? CONNECTOR_DEFINITIONS : []),
-      ]
-        .map(({ iconPath, keywords, name, serviceType }) => {
+        ...[
+          {
+            keywords: ['app', 'search', 'engines'],
+            name: i18n.translate('xpack.enterpriseSearch.searchProvider.appSearch.name', {
+              defaultMessage: 'App Search',
+            }),
+            serviceType: 'app_search',
+            url: APP_SEARCH_PLUGIN.URL,
+          },
+          {
+            keywords: ['workplace', 'search'],
+            name: i18n.translate('xpack.enterpriseSearch.searchProvider.workplaceSearch.name', {
+              defaultMessage: 'Workplace Search',
+            }),
+            serviceType: 'workplace_search',
+            url: WORKPLACE_SEARCH_PLUGIN.URL,
+          },
+        ],
+      ];
+      const result = services
+        .map((service) => {
+          const { iconPath, keywords, name, serviceType } = service;
+          const url = 'url' in service ? service.url : undefined;
           let score = 0;
           const searchTerm = (term || '').toLowerCase();
           const searchName = name.toLowerCase();
@@ -91,7 +136,7 @@ export function getSearchResultProvider(
           } else if (keywords.some((keyword) => keyword.includes(searchTerm))) {
             score = 50;
           }
-          return toSearchResult({ basePath, iconPath, name, score, serviceType });
+          return toSearchResult({ basePath, iconPath, name, score, serviceType, url });
         })
         .filter(({ score }) => score > 0)
         .slice(0, maxResults);

--- a/x-pack/plugins/global_search_bar/public/lib/result_to_option.tsx
+++ b/x-pack/plugins/global_search_bar/public/lib/result_to_option.tsx
@@ -22,7 +22,10 @@ export const resultToOption = (
   const { tagIds = [], categoryLabel = '' } = meta as { tagIds: string[]; categoryLabel: string };
   // only displaying icons for applications and integrations
   const useIcon =
-    type === 'application' || type === 'integration' || type.toLowerCase() === 'enterprise search';
+    type === 'application' ||
+    type === 'integration' ||
+    type.toLowerCase() === 'enterprise search' ||
+    type.toLowerCase() === 'search';
   const option: EuiSelectableTemplateSitewideOption = {
     key: id,
     label: title,


### PR DESCRIPTION
## Summary

Updated enterprise search search provider to use "Search" as type instead of Enterprise Search. Manaully added App Search & Workplace Search for search results now that we removed the apps from the global nav.

### Screenshots
<img width="1689" alt="image" src="https://github.com/elastic/kibana/assets/1972968/888d527a-b755-4baf-b58b-1c5f4cbb7a73">
<img width="1689" alt="image" src="https://github.com/elastic/kibana/assets/1972968/17e8c4e9-5bdc-4114-a08a-a1c321fc64ee">
