### PR TITLE
[Security Solution] expandable flyout - open rule in new tab

### DIFF
--- a/x-pack/plugins/security_solution/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_right_panel_overview_tab.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_right_panel_overview_tab.cy.ts
@@ -100,7 +100,7 @@ describe(
           .within(() => {
             cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_NAVIGATE_TO_RULE_DETAILS_BUTTON)
               .should('be.visible')
-              .and('have.text', 'View rule');
+              .and('contain.text', 'View rule');
           });
         cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_DESCRIPTION_DETAILS)
           .should('be.visible')

--- a/x-pack/plugins/security_solution/public/flyout/right/components/description.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/right/components/description.tsx
@@ -5,12 +5,11 @@
  * 2.0.
  */
 
-import { EuiButtonEmpty, EuiFlexGroup, EuiFlexItem, EuiTitle, EuiIcon } from '@elastic/eui';
+import { EuiButtonEmpty, EuiFlexGroup, EuiFlexItem, EuiTitle } from '@elastic/eui';
 import type { VFC } from 'react';
 import React, { useState, useMemo } from 'react';
 import { css } from '@emotion/react';
 import { isEmpty } from 'lodash';
-import styled from 'styled-components';
 import { useRightPanelContext } from '../context';
 import { useBasicDataFromDetailsData } from '../../../timelines/components/side_panel/event_details/helpers';
 import {
@@ -27,10 +26,6 @@ import {
 } from './translations';
 import { RenderRuleName } from '../../../timelines/components/timeline/body/renderers/formatted_field_helpers';
 import { SIGNAL_RULE_NAME_FIELD_NAME } from '../../../timelines/components/timeline/body/renderers/constants';
-
-const StyledEuiIcon = styled(EuiIcon)`
-  margin-left: ${({ theme }) => theme.eui.euiSizeXS};
-`;
 
 export interface DescriptionProps {
   /**
@@ -66,10 +61,8 @@ export const Description: VFC<DescriptionProps> = ({ expanded = false }) => {
             isDraggable={false}
             linkValue={ruleId}
             value={VIEW_RULE_TEXT}
-          >
-            {VIEW_RULE_TEXT}
-            <StyledEuiIcon type="popout" size="m" />
-          </RenderRuleName>
+            openInNewTab
+          />
         </EuiFlexItem>
       ),
     [ruleName, ruleId, scopeId, eventId]

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/formatted_field_helpers.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/formatted_field_helpers.tsx
@@ -44,6 +44,7 @@ interface RenderRuleNameProps {
   isButton?: boolean;
   onClick?: () => void;
   linkValue: string | null | undefined;
+  openInNewTab?: boolean;
   truncate?: boolean;
   title?: string;
   value: string | number | null | undefined;
@@ -61,6 +62,7 @@ export const RenderRuleName: React.FC<RenderRuleNameProps> = ({
   isButton,
   onClick,
   linkValue,
+  openInNewTab = false,
   truncate,
   title,
   value,
@@ -76,9 +78,10 @@ export const RenderRuleName: React.FC<RenderRuleNameProps> = ({
       navigateToApp(APP_UI_ID, {
         deepLinkId: SecurityPageName.rules,
         path: getRuleDetailsUrl(ruleId ?? '', search),
+        openInNewTab,
       });
     },
-    [navigateToApp, ruleId, search]
+    [navigateToApp, ruleId, search, openInNewTab]
   );
 
   const href = useMemo(
@@ -121,16 +124,21 @@ export const RenderRuleName: React.FC<RenderRuleNameProps> = ({
           {title ?? value}
         </Component>
       );
-    } else if (children) {
+    } else if (openInNewTab) {
       return (
-        <LinkAnchor onClick={goToRuleDetails} href={href} data-test-subj="goToRuleDetails">
-          {children}
+        <LinkAnchor
+          onClick={goToRuleDetails}
+          href={href}
+          data-test-subj="goToRuleDetails"
+          target="_blank"
+        >
+          {children ?? content}
         </LinkAnchor>
       );
     } else {
       return (
         <LinkAnchor onClick={goToRuleDetails} href={href} data-test-subj="ruleName">
-          {content}
+          {children ?? content}
         </LinkAnchor>
       );
     }
@@ -146,6 +154,7 @@ export const RenderRuleName: React.FC<RenderRuleNameProps> = ({
     title,
     truncate,
     value,
+    openInNewTab,
   ]);
 
   if (isString(value) && ruleName.length > 0 && ruleId != null) {


### PR DESCRIPTION
## Summary

This PR updates the `View rule` button to open rule detail page in a new tab. This is option 1 of improving the UX experience on rules in expandable flyout

![image](https://github.com/elastic/kibana/assets/18648970/f7e94101-1524-475d-8aa7-7a7fec432457)


