### PR TITLE
fix: return decoded urls on CloudStart as well as CloudSetup

### DIFF
--- a/x-pack/plugins/cloud/public/plugin.tsx
+++ b/x-pack/plugins/cloud/public/plugin.tsx
@@ -103,6 +103,11 @@ export class CloudPlugin implements Plugin<CloudSetup> {
 
     const { deploymentUrl, profileUrl, billingUrl, organizationUrl } = this.getCloudUrls();
 
+    let decodedId: DecodedCloudId | undefined;
+    if (this.config.id) {
+      decodedId = decodeCloudId(this.config.id, this.logger);
+    }
+
     return {
       CloudContextProvider,
       isCloudEnabled: this.isCloudEnabled,
@@ -111,6 +116,8 @@ export class CloudPlugin implements Plugin<CloudSetup> {
       deploymentUrl,
       profileUrl,
       organizationUrl,
+      elasticsearchUrl: decodedId?.elasticsearchUrl,
+      kibanaUrl: decodedId?.kibanaUrl,
     };
   }
 


### PR DESCRIPTION
## Summary

#159442 updated the decoding of the cloud id and added `elasticsearchUrl` & `kibanaUrl` to the `CloudStart` type, but it only set them on the `CloudSetup` result.

This change will also add them to the `CloudStart` so they are available to code that is trying to read the values from `CloudStart` , mainly [serverless_search](https://github.com/elastic/kibana/blob/main/x-pack/plugins/serverless_search/public/application/components/overview.tsx#L49-L51) is what I'm concerned with. 