### PR TITLE
Enable restriction of internal APIs for serverless

### DIFF
--- a/config/serverless.yml
+++ b/config/serverless.yml
@@ -48,7 +48,7 @@ data.search.sessions.enabled: false
 advanced_settings.enabled: false
 
 # Enforce restring access to internal APIs see https://github.com/elastic/kibana/issues/151940
-# server.restrictInternalApis: true
+server.restrictInternalApis: true
 # Telemetry enabled by default and not disableable via UI
 telemetry.optIn: true
 telemetry.allowChangingOptInStatus: false

--- a/x-pack/test_serverless/api_integration/services/svl_common_api.ts
+++ b/x-pack/test_serverless/api_integration/services/svl_common_api.ts
@@ -11,6 +11,7 @@ import { FtrProviderContext } from '../ftr_provider_context';
 
 const COMMON_REQUEST_HEADERS = {
   'kbn-xsrf': 'some-xsrf-token',
+  'x-elastic-internal-origin': 'some-value',
 };
 
 export function SvlCommonApiServiceProvider({}: FtrProviderContext) {


### PR DESCRIPTION
## Summary

This PR enables the serverless configuration entry to restrict internal API access and adds the required header to serverless API integration tests so they can still request these APIs.

Follow up on #156935
