### PR TITLE
[Synthetics] Fixes dom warnings for p > div

### DIFF
--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/metric_item.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/metric_item.tsx
@@ -139,13 +139,14 @@ export const MetricItem = ({
                       justifyContent="flexEnd"
                       // empty title to prevent default title from showing
                       title=""
+                      component="span"
                     >
-                      <EuiFlexItem grow={false}>
+                      <EuiFlexItem grow={false} component="span">
                         {i18n.translate('xpack.synthetics.overview.duration.label', {
                           defaultMessage: 'Duration',
                         })}
                       </EuiFlexItem>
-                      <EuiFlexItem grow={false}>
+                      <EuiFlexItem grow={false} component="span">
                         <EuiIconTip
                           title={i18n.translate('xpack.synthetics.overview.duration.description', {
                             defaultMessage: 'Median duration of last 24 checks',


### PR DESCRIPTION
## Summary

Fixes following dom warnings 

<img width="984" alt="image" src="https://github.com/elastic/kibana/assets/3505601/544b58c7-3a47-4cc7-860d-953caa2582e1">


<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->