### PR TITLE
[Fleet] Fix dupplicate unhealthy callout

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/index.tsx
@@ -529,17 +529,6 @@ export const AgentListPage: React.FunctionComponent<{}> = () => {
           <EuiSpacer size="l" />
         </>
       )}
-      {/* TODO serverless agent soft limit */}
-      {showUnhealthyCallout && (
-        <>
-          {cloud?.deploymentUrl ? (
-            <FleetServerCloudUnhealthyCallout deploymentUrl={cloud.deploymentUrl} />
-          ) : (
-            <FleetServerOnPremUnhealthyCallout onClickAddFleetServer={onClickAddFleetServer} />
-          )}
-          <EuiSpacer size="l" />
-        </>
-      )}
       {/* Search and filter bar */}
       <SearchAndFilterBar
         agentPolicies={agentPolicies}


### PR DESCRIPTION
## Summary

Fix a typo that was showing a duplicate Fleet Server unhealthy callout.

Introduced in [#161289 ](https://github.com/elastic/kibana/pull/161249)


<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->