### PR TITLE
[Chrome left nav] Fix infinite loop

### DIFF
--- a/packages/core/chrome/core-chrome-browser-internal/src/chrome_service.tsx
+++ b/packages/core/chrome/core-chrome-browser-internal/src/chrome_service.tsx
@@ -267,9 +267,6 @@ export class ChromeService {
     const getHeaderComponent = () => {
       if (chromeStyle$.getValue() === 'project') {
         const projectNavigationComponent$ = projectNavigation.getProjectSideNavComponent$();
-        const projectNavigation$ = projectNavigation
-          .getProjectNavigation$()
-          .pipe(takeUntil(this.stop$));
         const projectBreadcrumbs$ = projectNavigation
           .getProjectBreadcrumbs$()
           .pipe(takeUntil(this.stop$));
@@ -279,11 +276,7 @@ export class ChromeService {
           const CustomSideNavComponent = useObservable(projectNavigationComponent$, undefined);
           const activeNodes = useObservable(activeNodes$, []);
 
-          const currentProjectNavigation = useObservable(projectNavigation$, undefined);
-          // TODO: remove this switch once security sets project navigation tree
-          const currentProjectBreadcrumbs$ = currentProjectNavigation
-            ? projectBreadcrumbs$
-            : breadcrumbs$;
+          const currentProjectBreadcrumbs$ = projectBreadcrumbs$;
 
           let SideNavComponent: ISideNavComponent = () => null;
 

--- a/packages/shared-ux/chrome/navigation/src/services.tsx
+++ b/packages/shared-ux/chrome/navigation/src/services.tsx
@@ -40,11 +40,7 @@ export const NavigationKibanaProvider: FC<NavigationKibanaDependencies> = ({
     activeNodes$: serverless.getActiveNavigationNodes$(),
   };
 
-  return (
-    <Context.Provider {...{ value }} {...dependencies}>
-      {children}
-    </Context.Provider>
-  );
+  return <Context.Provider value={value}>{children}</Context.Provider>;
 };
 
 /**

--- a/packages/shared-ux/chrome/navigation/src/ui/components/navigation_group.tsx
+++ b/packages/shared-ux/chrome/navigation/src/ui/components/navigation_group.tsx
@@ -46,11 +46,19 @@ function NavigationGroupInternalComp<
   ChildrenId extends string = Id
 >(props: Props<LinkId, Id, ChildrenId>) {
   const navigationContext = useNavigation();
-  const { children, defaultIsCollapsed, ...node } = props;
-  const { navNode, registerChildNode, path, childrenNodes } = useInitNavNode({
-    ...node,
-    isActive: defaultIsCollapsed !== undefined ? defaultIsCollapsed === false : undefined,
-  });
+
+  const { children, node } = useMemo(() => {
+    const { children: _children, defaultIsCollapsed, ...rest } = props;
+    return {
+      children: _children,
+      node: {
+        ...rest,
+        isActive: defaultIsCollapsed !== undefined ? defaultIsCollapsed === false : undefined,
+      },
+    };
+  }, [props]);
+
+  const { navNode, registerChildNode, path, childrenNodes } = useInitNavNode(node);
 
   const unstyled = props.unstyled ?? navigationContext.unstyled;
 

--- a/packages/shared-ux/chrome/navigation/src/ui/components/navigation_item.tsx
+++ b/packages/shared-ux/chrome/navigation/src/ui/components/navigation_item.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React, { Fragment, ReactElement, ReactNode, useEffect } from 'react';
+import React, { Fragment, ReactElement, ReactNode, useEffect, useMemo } from 'react';
 
 import type { AppDeepLinkId } from '@kbn/core-chrome-browser';
 import type { ChromeProjectNavigationNodeEnhanced, NodeProps } from '../types';
@@ -34,7 +34,14 @@ function NavigationItemComp<
   const navigationContext = useNavigation();
   const navNodeRef = React.useRef<ChromeProjectNavigationNodeEnhanced | null>(null);
 
-  const { element, children, ...node } = props;
+  const { element, children, node } = useMemo(() => {
+    const { element: _element, children: _children, ...rest } = props;
+    return {
+      element: _element,
+      children: _children,
+      node: rest,
+    };
+  }, [props]);
   const unstyled = props.unstyled ?? navigationContext.unstyled;
 
   let renderItem: (() => ReactElement) | undefined;

--- a/packages/shared-ux/chrome/navigation/src/ui/components/recently_accessed.tsx
+++ b/packages/shared-ux/chrome/navigation/src/ui/components/recently_accessed.tsx
@@ -31,7 +31,7 @@ export const RecentlyAccessed: FC<Props> = ({
   defaultIsCollapsed = false,
 }) => {
   const strings = getI18nStrings();
-  const { recentlyAccessed$ } = useServices();
+  const { recentlyAccessed$, basePath, navigateToUrl } = useServices();
   const recentlyAccessed = useObservable(recentlyAccessedProp$ ?? recentlyAccessed$, []);
 
   if (recentlyAccessed.length === 0) {
@@ -42,11 +42,20 @@ export const RecentlyAccessed: FC<Props> = ({
     {
       name: '', // no list header title
       id: 'recents_root',
-      items: recentlyAccessed.map(({ id, label, link }) => ({
-        id,
-        name: label,
-        href: link,
-      })),
+      items: recentlyAccessed.map((recent) => {
+        const { id, label, link } = recent;
+        const href = basePath.prepend(link);
+
+        return {
+          id,
+          name: label,
+          href,
+          onClick: (e: React.MouseEvent) => {
+            e.preventDefault();
+            navigateToUrl(href);
+          },
+        };
+      }),
     },
   ];
 


### PR DESCRIPTION
We introduced a regression in the side navigation in https://github.com/elastic/kibana/pull/160252

By trying to support both breadcrumbs (old and new project breadcrumb) we created an infinite loop re-render.

This is because we were reading the `projectNavigation$` Observable in the component that renders the tree which in turn updates the `projectNavigation` object which updates the Observable which.... 

## Other fixes

I detected other UI problem and decided to fix them all in this PR

* Removed hack to control the group collapsed state (https://github.com/elastic/kibana/commit/4dcc1e4466783a0013d56a523511b790350e67f2). - The `500ms` wait was not enough anymore. I realised that the implementation was brittle and decided to refactor it.
* [Memoize node passed to hook](https://github.com/elastic/kibana/commit/9fda34c9a7deaf06e0464e76b1630783fea6334d) - Provide a stable object to the `useInitNavNode` object
* [Refactor context provider value](https://github.com/elastic/kibana/commit/1b1166f25b9313c39033fc7b1ba9c412d76085f0) - Tiny refactor, big impact 😊 
* [Fix recently accessed link navigation](https://github.com/elastic/kibana/commit/09d7531bae4fcb148c156eb4647b1078d552ff7e) - We didn't add the path prefix to the route so the recently accessed link where going to `404` page.

Fixes https://github.com/elastic/kibana/issues/161730