### PR TITLE
[Fleet] Fix GET /package_policies schema

### DIFF
--- a/x-pack/plugins/fleet/server/types/rest_spec/package_policy.ts
+++ b/x-pack/plugins/fleet/server/types/rest_spec/package_policy.ts
@@ -15,13 +15,10 @@ import {
 
 import { inputsFormat } from '../../../common/constants';
 
-import { BulkRequestBodySchema } from './common';
+import { ListWithKuerySchema, BulkRequestBodySchema } from './common';
 
 export const GetPackagePoliciesRequestSchema = {
-  query: schema.object({
-    page: schema.number({ defaultValue: 1 }),
-    perPage: schema.number({ defaultValue: 20 }),
-    kuery: schema.maybe(schema.string()),
+  query: ListWithKuerySchema.extends({
     format: schema.maybe(
       schema.oneOf([schema.literal(inputsFormat.Simplified), schema.literal(inputsFormat.Legacy)])
     ),


### PR DESCRIPTION
## Summary

Followup fix to https://github.com/elastic/kibana/pull/160921/files.

In the above PR, I had flagged the following issue:
![Screenshot 2023-07-12 at 16 46 01](https://github.com/elastic/kibana/assets/23701614/a9065c86-eae4-43ce-bf4a-f1c9786076b5)

As it turns out, this was due to inadvertently removing the `ListWithKuerySchema` from the schema definition for `GET /package_policies`, which escaped code review. This PR fixes that.

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
