### PR TITLE
remove native config for selecting fetch strategy

### DIFF
--- a/x-pack/plugins/enterprise_search/common/connectors/native_connectors.ts
+++ b/x-pack/plugins/enterprise_search/common/connectors/native_connectors.ts
@@ -1652,32 +1652,6 @@ export const NATIVE_CONNECTOR_DEFINITIONS: Record<string, NativeConnector | unde
         validations: [],
         value: false,
       },
-      fetch_users_by_site: {
-        default_value: false,
-        depends_on: [{ field: 'use_document_level_security', value: true }],
-        display: DisplayType.TOGGLE,
-        label: i18n.translate(
-          'xpack.enterpriseSearch.nativeConnectors.sharepoint_online.configuration.fetchUsersBySiteLabel',
-          {
-            defaultMessage: 'Discover users by site membership',
-          }
-        ),
-        options: [],
-        order: 8,
-        required: true,
-        sensitive: false,
-        tooltip: i18n.translate(
-          'xpack.enterpriseSearch.nativeConnectors.sharepoint_online.configuration.fetchUsersBySiteTooltip',
-          {
-            defaultMessage:
-              'When syncing only a small subset of sites, it can be more efficient to only fetch users who have access to those sites. This becomes increasingly inefficient the more sites (and the more users) concerned.',
-          }
-        ),
-        type: FieldType.BOOLEAN,
-        ui_restrictions: [],
-        validations: [],
-        value: false,
-      },
     },
     features: {
       [FeatureName.SYNC_RULES]: {


### PR DESCRIPTION
## Summary

Part of https://github.com/elastic/enterprise-search-team/issues/5162

Effectively reverting https://github.com/elastic/kibana/pull/161546, as the new strategy has completely replaced the old.

See also: https://github.com/elastic/connectors-python/pull/1255

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->