### PR TITLE
fix(slo): APM transaction error rate calculation

### DIFF
--- a/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/apm_transaction_error_rate.test.ts.snap
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/apm_transaction_error_rate.test.ts.snap
@@ -5,25 +5,16 @@ Object {
   "bool": Object {
     "filter": Array [
       Object {
-        "terms": Object {
-          "processor.event": Array [
-            "metric",
-          ],
-        },
-      },
-      Object {
         "term": Object {
           "metricset.name": "transaction",
         },
       },
       Object {
-        "exists": Object {
-          "field": "transaction.duration.histogram",
-        },
-      },
-      Object {
-        "exists": Object {
-          "field": "transaction.result",
+        "terms": Object {
+          "event.outcome": Array [
+            "success",
+            "failure",
+          ],
         },
       },
       Object {
@@ -116,25 +107,16 @@ Object {
   "bool": Object {
     "filter": Array [
       Object {
-        "terms": Object {
-          "processor.event": Array [
-            "metric",
-          ],
-        },
-      },
-      Object {
         "term": Object {
           "metricset.name": "transaction",
         },
       },
       Object {
-        "exists": Object {
-          "field": "transaction.duration.histogram",
-        },
-      },
-      Object {
-        "exists": Object {
-          "field": "transaction.result",
+        "terms": Object {
+          "event.outcome": Array [
+            "success",
+            "failure",
+          ],
         },
       },
       Object {
@@ -165,15 +147,15 @@ Object {
   "pivot": Object {
     "aggregations": Object {
       "slo.denominator": Object {
-        "value_count": Object {
-          "field": "transaction.duration.histogram",
+        "filter": Object {
+          "match_all": Object {},
         },
       },
       "slo.isGoodSlice": Object {
         "bucket_script": Object {
           "buckets_path": Object {
             "goodEvents": "slo.numerator>_count",
-            "totalEvents": "slo.denominator.value",
+            "totalEvents": "slo.denominator>_count",
           },
           "script": "params.goodEvents / params.totalEvents >= 0.95 ? 1 : 0",
         },
@@ -218,25 +200,16 @@ Object {
       "bool": Object {
         "filter": Array [
           Object {
-            "terms": Object {
-              "processor.event": Array [
-                "metric",
-              ],
-            },
-          },
-          Object {
             "term": Object {
               "metricset.name": "transaction",
             },
           },
           Object {
-            "exists": Object {
-              "field": "transaction.duration.histogram",
-            },
-          },
-          Object {
-            "exists": Object {
-              "field": "transaction.result",
+            "terms": Object {
+              "event.outcome": Array [
+                "success",
+                "failure",
+              ],
             },
           },
           Object {
@@ -310,8 +283,8 @@ Object {
   "pivot": Object {
     "aggregations": Object {
       "slo.denominator": Object {
-        "value_count": Object {
-          "field": "transaction.duration.histogram",
+        "filter": Object {
+          "match_all": Object {},
         },
       },
       "slo.numerator": Object {
@@ -354,25 +327,16 @@ Object {
       "bool": Object {
         "filter": Array [
           Object {
-            "terms": Object {
-              "processor.event": Array [
-                "metric",
-              ],
-            },
-          },
-          Object {
             "term": Object {
               "metricset.name": "transaction",
             },
           },
           Object {
-            "exists": Object {
-              "field": "transaction.duration.histogram",
-            },
-          },
-          Object {
-            "exists": Object {
-              "field": "transaction.result",
+            "terms": Object {
+              "event.outcome": Array [
+                "success",
+                "failure",
+              ],
             },
           },
           Object {


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/161801

## Summary

This PR filters the APM data with `event.outcome` on "success" or "failure". We then simply count the "success" transaction over the "success" or "failure" ones.

