### PR TITLE
[Core][Chrome] Fix misaligned header logo

### DIFF
--- a/packages/core/chrome/core-chrome-browser-internal/src/ui/header/__snapshots__/header.test.tsx.snap
+++ b/packages/core/chrome/core-chrome-browser-internal/src/ui/header/__snapshots__/header.test.tsx.snap
@@ -55,7 +55,7 @@ Array [
           >
             <a
               aria-label="Elastic home"
-              class="euiHeaderLogo"
+              class="chrHeaderLogo"
               data-test-subj="logo"
               href="/"
             >

--- a/packages/core/chrome/core-chrome-browser-internal/src/ui/header/header_logo.scss
+++ b/packages/core/chrome/core-chrome-browser-internal/src/ui/header/header_logo.scss
@@ -1,6 +1,7 @@
 .chrHeaderLogo {
   display: flex;
   align-items: center;
+  height: $euiHeaderChildSize;
   padding-inline: $euiSizeS;
 }
 

--- a/packages/core/chrome/core-chrome-browser-internal/src/ui/header/header_logo.scss
+++ b/packages/core/chrome/core-chrome-browser-internal/src/ui/header/header_logo.scss
@@ -1,3 +1,9 @@
+.chrHeaderLogo {
+  display: flex;
+  align-items: center;
+  padding-inline: $euiSizeS;
+}
+
 .chrHeaderLogo__mark {
   margin-left: $euiSizeS;
   fill: $euiColorGhost;

--- a/packages/core/chrome/core-chrome-browser-internal/src/ui/header/header_logo.tsx
+++ b/packages/core/chrome/core-chrome-browser-internal/src/ui/header/header_logo.tsx
@@ -95,7 +95,7 @@ export function HeaderLogo({ href, navigateToApp, loadingCount$, ...observables 
   return (
     <a
       onClick={(e) => onClick(e, forceNavigation, navLinks, navigateToApp)}
-      className="euiHeaderLogo"
+      className="chrHeaderLogo"
       href={href}
       data-test-subj="logo"
       aria-label={i18n.translate('core.ui.chrome.headerGlobalNav.goHomePageIconAriaLabel', {

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/helpers.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/helpers.tsx
@@ -207,7 +207,7 @@ export const focusUtilityBarAction = (containerElement: HTMLElement | null) => {
  * Resets keyboard focus on the page
  */
 export const resetKeyboardFocus = () => {
-  document.querySelector<HTMLAnchorElement>('header.headerGlobalNav a.euiHeaderLogo')?.focus();
+  document.querySelector<HTMLAnchorElement>('header.headerGlobalNav a.chrHeaderLogo')?.focus();
 };
 
 interface OperatorHandler {


### PR DESCRIPTION
## Summary

### Problem

The `HeaderLogo` being used by Kibana's nav isn't actually using the `<EuiHeaderLogo>` component, it's instead a completely custom logo that happens to bogart `EuiHeaderLogo`'s CSS styles. When `EuiHeaderLogo` was recently converted from Sass to Emotion, any styles attached to that CSS completely disappeared, hence the misaligned appearance below:

### Before
<img width="432" alt="" src="https://github.com/elastic/kibana/assets/549407/f28e870c-e407-4c8b-b144-dd65fb27708d">

### After
<img width="443" alt="" src="https://github.com/elastic/kibana/assets/549407/8c3ab23d-f942-4473-b7d5-c8c558933eb9">

### Solution

I opted to resolve the bug with the following interim steps:

1. Remove the `euiHeaderLogo` className - it isn't doing anything, and this isn't an EuiHeaderLogo, so it might as well go
2. Add a `chrHeaderLogo` className (based on the className of a nearby child element) and reinstate the most relevant CSS (flex alignment and layout) needed to restore the logo visual behavior

Long-term, fixing `HeaderLogo` to use `EuiHeaderLogo` (this will require updating `EuiHeaderLogo` to facilitate loading behavior and non-text children) is probably the better solution, instead of making Kibana use its own custom logo component.

### Checklist

- [x] Snapshots ~[Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)~ were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->