### PR TITLE
[FTR][Cloud Security Posture] Unskip skipped FTR test

### DIFF
--- a/x-pack/test/api_integration/apis/cloud_security_posture/benchmark.ts
+++ b/x-pack/test/api_integration/apis/cloud_security_posture/benchmark.ts
@@ -15,8 +15,7 @@ export default function ({ getService }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');
   const kibanaServer = getService('kibanaServer');
 
-  // FLAKY: https://github.com/elastic/kibana/issues/159732
-  describe.skip('GET /internal/cloud_security_posture/benchmark', () => {
+  describe('GET /internal/cloud_security_posture/benchmark', () => {
     let agentPolicyId: string;
     let agentPolicyId2: string;
     let agentPolicyId3: string;


### PR DESCRIPTION
## Summary

around 4 weeks ago, some of FTR test are skipped due to it being 'unstable' (this was caused by Error: socket hang up issue, however this issue has stopped occurring 2 weeks ago as such the skipped test should be included back into our test cycle)
https://github.com/elastic/kibana/issues/159554

