### PR TITLE
[Enterprise Search] Fix connectors jobs index name

### DIFF
--- a/x-pack/plugins/enterprise_search/server/index.ts
+++ b/x-pack/plugins/enterprise_search/server/index.ts
@@ -51,6 +51,6 @@ export const config: PluginConfigDescriptor<ConfigType> = {
 export const CONNECTORS_INDEX = '.elastic-connectors';
 export const CURRENT_CONNECTORS_INDEX = '.elastic-connectors-v1';
 export const CONNECTORS_JOBS_INDEX = '.elastic-connectors-sync-jobs';
-export const CURRENT_CONNECTORS_JOB_INDEX = '.elastic-connectors-v1';
+export const CURRENT_CONNECTORS_JOB_INDEX = '.elastic-connectors-sync-jobs-v1';
 export const CONNECTORS_VERSION = 1;
 export const CRAWLERS_INDEX = '.ent-search-actastic-crawler2_configurations_v2';


### PR DESCRIPTION
## Summary

This fixes the wrong index name for the connectors job index.