### PR TITLE
[Synthetics] Handle a case where settings were never saved

### DIFF
--- a/x-pack/plugins/uptime/server/legacy_uptime/lib/lib.ts
+++ b/x-pack/plugins/uptime/server/legacy_uptime/lib/lib.ts
@@ -10,6 +10,7 @@ import {
   SavedObjectsClientContract,
   KibanaRequest,
   CoreRequestHandlerContext,
+  SavedObjectsErrorHelpers,
 } from '@kbn/core/server';
 import chalk from 'chalk';
 import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
@@ -18,9 +19,11 @@ import { RequestStatus } from '@kbn/inspector-plugin/common';
 import { InspectResponse } from '@kbn/observability-plugin/typings/common';
 import { enableInspectEsQueries } from '@kbn/observability-plugin/common';
 import { getInspectResponse } from '@kbn/observability-shared-plugin/common';
+import { DYNAMIC_SETTINGS_DEFAULT_ATTRIBUTES } from '../../constants/settings';
+import { DynamicSettingsAttributes } from '../../runtime_types/settings';
+import { settingsObjectId, umDynamicSettings } from './saved_objects/uptime_settings';
 import { API_URLS } from '../../../common/constants';
 import { UptimeServerSetup } from './adapters';
-import { savedObjectsAdapter } from './saved_objects/saved_objects';
 
 export type { UMServerLibs } from '../uptime_server';
 
@@ -202,14 +205,31 @@ export class UptimeEsClient {
     // if isLegacyAlert appends synthetics-* if it's not already there
     let indices = '';
     let syntheticsIndexRemoved = false;
+    let settingsChangedByUser = true;
+    let settings: DynamicSettingsAttributes = DYNAMIC_SETTINGS_DEFAULT_ATTRIBUTES;
     if (this.heartbeatIndices) {
       indices = this.heartbeatIndices;
     } else {
-      const settings = await savedObjectsAdapter.getUptimeDynamicSettings(this.savedObjectsClient);
+      try {
+        const obj = await this.savedObjectsClient.get<DynamicSettingsAttributes>(
+          umDynamicSettings.name,
+          settingsObjectId
+        );
+        settings = obj.attributes;
+      } catch (getErr) {
+        if (SavedObjectsErrorHelpers.isNotFoundError(getErr)) {
+          settingsChangedByUser = false;
+        }
+      }
+
       indices = settings?.heartbeatIndices || '';
       syntheticsIndexRemoved = settings.syntheticsIndexRemoved ?? false;
     }
-    if (this.isLegacyAlert && !indices.includes('synthetics-') && syntheticsIndexRemoved) {
+    if (
+      this.isLegacyAlert &&
+      !indices.includes('synthetics-') &&
+      (syntheticsIndexRemoved || !settingsChangedByUser)
+    ) {
       indices = indices + ',synthetics-*';
     }
     return indices;

--- a/x-pack/plugins/uptime/tsconfig.json
+++ b/x-pack/plugins/uptime/tsconfig.json
@@ -72,6 +72,7 @@
     "@kbn/core-http-server",
     "@kbn/core-http-router-server-internal",
     "@kbn/actions-plugin",
+    "@kbn/core-saved-objects-server",
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
## Summary

this is a follow up to https://github.com/elastic/kibana/pull/160063

 Handle a case where settings were never saved !!

So let's say user never said settings, in that case the default values always included `synthetics-*` pattern, so for this we still need to add that for existing alerts. 

<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->