### PR TITLE
[APM] Update column widths in OTel config settings table

### DIFF
--- a/x-pack/plugins/apm/public/components/app/onboarding/instructions/otel_agent.tsx
+++ b/x-pack/plugins/apm/public/components/app/onboarding/instructions/otel_agent.tsx
@@ -196,6 +196,7 @@ export function OpenTelemetryInstructions({
   const columns: Array<EuiBasicTableColumn<ValuesType<typeof items>>> = [
     {
       field: 'setting',
+      width: '23%',
       name: i18n.translate(
         'xpack.apm.onboarding.config_otel.column.configSettings',
         {
@@ -205,6 +206,7 @@ export function OpenTelemetryInstructions({
     },
     {
       field: 'value',
+      width: '55%',
       name: i18n.translate(
         'xpack.apm.onboarding.config_otel.column.configValue',
         {

--- a/x-pack/plugins/apm/public/tutorial/config_agent/opentelemetry_instructions.tsx
+++ b/x-pack/plugins/apm/public/tutorial/config_agent/opentelemetry_instructions.tsx
@@ -57,6 +57,7 @@ export function OpenTelemetryInstructions({
   const columns: Array<EuiBasicTableColumn<ValuesType<typeof items>>> = [
     {
       field: 'setting',
+      width: '23%',
       name: i18n.translate(
         'xpack.apm.tutorial.config_otel.column.configSettings',
         {
@@ -66,6 +67,7 @@ export function OpenTelemetryInstructions({
     },
     {
       field: 'value',
+      width: '55%',
       name: i18n.translate(
         'xpack.apm.tutorial.config_otel.column.configValue',
         {


### PR DESCRIPTION
### Before
<img width="1137" alt="Screenshot 2023-07-13 at 10 26 18" src="https://github.com/elastic/kibana/assets/5831975/105c8897-d8d9-4e10-9869-4c091ce6e815">


### After
<img width="1131" alt="Screenshot 2023-07-13 at 10 23 15" src="https://github.com/elastic/kibana/assets/5831975/43a1b10b-71d3-49a8-ac88-a93fb208adfb">


Closes https://github.com/elastic/kibana/issues/136600