### PR TITLE
[Security Solution][Detection Engine] Validate failing ES Promotion test

### DIFF
--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/rule_execution_logic/non_ecs_fields.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/rule_execution_logic/non_ecs_fields.ts
@@ -56,8 +56,7 @@ export default ({ getService }: FtrProviderContext) => {
     };
   };
 
-  // FAILING ES PROMOTION: https://github.com/elastic/kibana/issues/154277
-  describe.skip('Non ECS fields in alert document source', () => {
+  describe('Non ECS fields in alert document source', () => {
     before(async () => {
       await esArchiver.load(
         'x-pack/test/functional/es_archives/security_solution/ecs_non_compliant'

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/rule_execution_logic/threat_match.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/rule_execution_logic/threat_match.ts
@@ -149,7 +149,6 @@ export default ({ getService }: FtrProviderContext) => {
   /**
    * Specific api integration tests for threat matching rule type
    */
-  // FLAKY: https://github.com/elastic/kibana/issues/155304
   describe('Threat match type rules', () => {
     before(async () => {
       // await deleteSignalsIndex(supertest, log);


### PR DESCRIPTION
## Summary
- Unskip `non_ecs_fields` test
- Addresses  https://github.com/elastic/kibana/issues/154277 