### PR TITLE
[Security Solution] [Detection Engine] examine `manage_lists` flakines

### DIFF
--- a/x-pack/plugins/security_solution/cypress/e2e/exceptions/shared_exception_lists_management/shared_exception_list_page/manage_lists.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/exceptions/shared_exception_lists_management/shared_exception_list_page/manage_lists.cy.ts
@@ -44,7 +44,8 @@ const getExceptionList2 = () => ({
   list_id: 'exception_list_2',
 });
 
-describe('Manage lists from "Shared Exception Lists" page', () => {
+// eslint-disable-next-line ban/ban
+describe.only('Manage lists from "Shared Exception Lists" page', () => {
   describe('Create/Export/Delete List', () => {
     before(() => {
       esArchiverResetKibana();

--- a/x-pack/plugins/security_solution/package.json
+++ b/x-pack/plugins/security_solution/package.json
@@ -11,7 +11,7 @@
     "cypress:open": "TZ=UTC node ./scripts/start_cypress_parallel open --spec './cypress/e2e/**/*.cy.ts' --config-file ./cypress/cypress.config.ts --ftr-config-file ../../../../../../x-pack/test/security_solution_cypress/cli_config",
     "cypress:open:ccs": "yarn cypress:open --config specPattern=./cypress/ccs_e2e/**/*.cy.ts",
     "cypress:open:upgrade": "yarn cypress:open --config specPattern=./cypress/upgrade_e2e/**/*.cy.ts",
-    "cypress:run": "yarn cypress:run:reporter --browser chrome --spec './cypress/e2e/{,!(investigations,explore)/**/}*.cy.ts'; status=$?; yarn junit:merge && exit $status",
+    "cypress:run": "yarn cypress:run:reporter --browser chrome --spec './cypress/e2e/**/manage_lists.cy.ts'; status=$?; yarn junit:merge && exit $status",
     "cypress:run:cases": "yarn cypress:run:reporter --browser chrome --spec './cypress/e2e/explore/cases/*.cy.ts' --ftr-config-file ../../../../../../x-pack/test/security_solution_cypress/cli_config; status=$?; yarn junit:merge && exit $status",
     "cypress:run:firefox": "yarn cypress:run:reporter --browser firefox --spec './cypress/e2e/**/*.cy.ts'; status=$?; yarn junit:merge && exit $status",
     "cypress:run:reporter": "TZ=UTC node ./scripts/start_cypress_parallel run --config-file ./cypress/cypress_ci.config.ts --ftr-config-file ../../../../../../x-pack/test/security_solution_cypress/cli_config --reporter ../../../node_modules/cypress-multi-reporters --reporter-options configFile=./cypress/reporter_config.json",


### PR DESCRIPTION
## Summary
- Run only `./cypress/e2e/exceptions/**/manage_lists.cy.ts`
- Addresses https://github.com/elastic/kibana/issues/153781 