### PR TITLE
[Security Solution] Intercept individual package installation via Fleet

### DIFF
--- a/x-pack/plugins/security_solution/cypress/e2e/detection_rules/prebuilt_rules_install_update_workflows.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_rules/prebuilt_rules_install_update_workflows.cy.ts
@@ -111,19 +111,15 @@ describe('Detection rules, Prebuilt Rules Installation and Update workflow', () 
         });
       };
       /* Retrieve how many rules were installed from the Fleet package */
-      cy.wait('@installPackage', {
+      /* See comments in test above for more details */
+      cy.wait('@installPackageBulk', {
         timeout: 60000,
       }).then(({ response: bulkResponse }) => {
         cy.wrap(bulkResponse?.statusCode).should('eql', 200);
 
-        const packages = bulkResponse?.body.items.map(
-          ({ name, result }: BulkInstallPackageInfo) => ({
-            name,
-            installSource: result.installSource,
-          })
+        const packagesBulkInstalled = bulkResponse?.body.items.map(
+          ({ name }: { name: string }) => name
         );
-
-        const packagesBulkInstalled = packages.map(({ name }: { name: string }) => name);
 
         if (!packagesBulkInstalled.includes('security_detection_engine')) {
           cy.wait('@installPackage').then(() => {

--- a/x-pack/plugins/security_solution/cypress/tasks/api_calls/prebuilt_rules.ts
+++ b/x-pack/plugins/security_solution/cypress/tasks/api_calls/prebuilt_rules.ts
@@ -170,6 +170,7 @@ export const getRuleAssets = (index: string | undefined = '.kibana_security_solu
 /* during e2e tests, and allow for manual installation of mock rules instead. */
 export const preventPrebuiltRulesPackageInstallation = () => {
   cy.intercept('POST', '/api/fleet/epm/packages/_bulk*', {});
+  cy.intercept('POST', '/api/fleet/epm/packages/security_detection_engine/*', {});
 };
 
 /**


### PR DESCRIPTION
## Summary

During Cypress tests, intercept `POST /api/fleet/epm/packages/security_detection_engine/*`.

This is the endpoint used when a specific `security_detection_engine` package is set to be used via the `--xpack.securitySolution.prebuiltRulesPackageVersion` config flag, which is used to test by the TRADE team.

This PR updates the test to account for that flow.

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->