### PR TITLE
[root] only shutdown once

### DIFF
--- a/packages/core/elasticsearch/core-elasticsearch-server-internal/src/is_valid_connection.ts
+++ b/packages/core/elasticsearch/core-elasticsearch-server-internal/src/is_valid_connection.ts
@@ -6,9 +6,9 @@
  * Side Public License, v 1.
  */
 
-import { filter, first } from 'rxjs/operators';
+import { filter } from 'rxjs/operators';
 import { errors } from '@elastic/elasticsearch';
-import { Observable } from 'rxjs';
+import { Observable, firstValueFrom } from 'rxjs';
 import { NodesVersionCompatibility } from './version_check/ensure_es_version';
 
 /**
@@ -23,8 +23,8 @@ import { NodesVersionCompatibility } from './version_check/ensure_es_version';
 export async function isValidConnection(
   esNodesCompatibility$: Observable<NodesVersionCompatibility>
 ) {
-  return await esNodesCompatibility$
-    .pipe(
+  return await firstValueFrom(
+    esNodesCompatibility$.pipe(
       filter(({ nodesInfoRequestError, isCompatible }) => {
         if (
           nodesInfoRequestError &&
@@ -35,8 +35,7 @@ export async function isValidConnection(
           throw nodesInfoRequestError;
         }
         return isCompatible;
-      }),
-      first()
+      })
     )
-    .toPromise();
+  );
 }

--- a/packages/core/root/core-root-server-internal/src/root/index.test.ts
+++ b/packages/core/root/core-root-server-internal/src/root/index.test.ts
@@ -139,6 +139,21 @@ test('stops services on "shutdown" an calls `onShutdown` with error passed to `s
   expect(mockServer.stop).toHaveBeenCalledTimes(1);
 });
 
+test('only shutdowns once', async () => {
+  const mockOnShutdown = jest.fn();
+  const root = new Root(rawConfigService, env, mockOnShutdown);
+
+  await root.preboot();
+  await root.setup();
+  await root.start();
+
+  await root.shutdown();
+  await root.shutdown();
+
+  expect(mockOnShutdown).toHaveBeenCalledTimes(1);
+  expect(mockServer.stop).toHaveBeenCalledTimes(1);
+});
+
 test('fails and stops services if server preboot fails', async () => {
   const mockOnShutdown = jest.fn();
   const root = new Root(rawConfigService, env, mockOnShutdown);

--- a/packages/core/root/core-root-server-internal/src/root/index.ts
+++ b/packages/core/root/core-root-server-internal/src/root/index.ts
@@ -34,6 +34,7 @@ export class Root {
   private readonly server: Server;
   private loggingConfigSubscription?: Subscription;
   private apmConfigSubscription?: Subscription;
+  private shuttingDown: boolean = false;
 
   constructor(
     rawConfigProvider: RawConfigurationProvider,
@@ -81,6 +82,11 @@ export class Root {
   }
 
   public async shutdown(reason?: any) {
+    if (this.shuttingDown) {
+      return;
+    }
+    this.shuttingDown = true;
+
     this.log.info('Kibana is shutting down');
 
     if (reason) {


### PR DESCRIPTION
## Summary

Analyzing the MKI QA logs, I discovered that errors encountered during shutdown were effectively triggering a second shutdown process, making the logs unclear:

<img width="1564" alt="Screenshot 2023-07-13 at 16 07 22" src="https://github.com/elastic/kibana/assets/1532934/8d718a99-2187-4fa3-b6f6-9c3f0e7a3925">

it has the side effect to also make "normals" shutdown (e.g via SIGINT like in the screenshot) to appear as error shutdowns because of the error thrown during the shutdown.

This PR addresses it, by making sure that `Root` only shutdown once. Errors occurring during the shutdown will be appearing in the logs, but they will not surface as the cause of the shutdown (no `FATAL` log entry).

