### PR TITLE
[Console] Remove an unused function for "extension" files

### DIFF
--- a/src/plugins/console/server/plugin.ts
+++ b/src/plugins/console/server/plugin.ts
@@ -76,10 +76,6 @@ export class ConsoleServerPlugin implements Plugin<ConsoleSetup, ConsoleStart> {
       },
       kibanaVersion,
     });
-
-    return {
-      ...this.specDefinitionsService.setup(),
-    };
   }
 
   start() {

--- a/src/plugins/console/server/services/spec_definitions_service.ts
+++ b/src/plugins/console/server/services/spec_definitions_service.ts
@@ -29,7 +29,6 @@ export class SpecDefinitionsService {
 
   private readonly globalRules: Record<string, any> = {};
   private readonly endpoints: Record<string, any> = {};
-  private readonly extensionSpecFilePaths: string[] = [];
 
   private hasLoadedSpec = false;
 
@@ -82,16 +81,6 @@ export class SpecDefinitionsService {
     };
   }
 
-  public addExtensionSpecFilePath(path: string) {
-    this.extensionSpecFilePaths.push(path);
-  }
-
-  public setup() {
-    return {
-      addExtensionSpecFilePath: this.addExtensionSpecFilePath.bind(this),
-    };
-  }
-
   public start() {
     if (!this.hasLoadedSpec) {
       this.loadJsonSpec();
@@ -129,9 +118,6 @@ export class SpecDefinitionsService {
 
   private loadJsonSpec() {
     const result = this.loadJSONSpecInDir(AUTOCOMPLETE_DEFINITIONS_FOLDER);
-    this.extensionSpecFilePaths.forEach((extensionSpecFilePath) => {
-      merge(result, this.loadJSONSpecInDir(extensionSpecFilePath));
-    });
 
     Object.keys(result).forEach((endpoint) => {
       this.addEndpointDescription(endpoint, result[endpoint]);


### PR DESCRIPTION
## Summary
Related to https://github.com/elastic/kibana/pull/159041 

While working on https://github.com/elastic/kibana/pull/161684, I noticed another unused function. There is no usage in the code base of the "extensions" function and I think it would be better to delete it from Console. That makes the remaining code that we need to work with easier to understand. 

### Release note
The function `addExtensionSpecFilePath` is removed from the Console plugin setup contract (server side).