### PR TITLE
[Infrastructure UI] Fix filters passed to Lens

### DIFF
--- a/x-pack/plugins/infra/public/pages/metrics/hosts/components/kpis/tile.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/hosts/components/kpis/tile.tsx
@@ -20,10 +20,7 @@ import {
 import styled from 'styled-components';
 import { Action } from '@kbn/ui-actions-plugin/public';
 import { KPIChartProps } from '../../../../../common/visualizations/lens/dashboards/host/kpi_grid_config';
-import {
-  buildCombinedHostsFilter,
-  buildExistsHostsFilter,
-} from '../../../../../utils/filters/build';
+import { buildCombinedHostsFilter } from '../../../../../utils/filters/build';
 import { useLensAttributes } from '../../../../../hooks/use_lens_attributes';
 import { useMetricsDataViewContext } from '../../hooks/use_data_view';
 import { useUnifiedSearchContext } from '../../hooks/use_unified_search';
@@ -39,6 +36,8 @@ export const Tile = ({ id, title, layers, style, toolTip, ...props }: KPIChartPr
   const { dataView } = useMetricsDataViewContext();
   const { requestTs, hostNodes, loading: hostsLoading } = useHostsViewContext();
   const { data: hostCountData, isRequestRunning: hostCountLoading } = useHostCountContext();
+
+  const shouldUseSearchCriteria = hostNodes.length === 0;
 
   const getSubtitle = () => {
     return searchCriteria.limit < (hostCountData?.count.value ?? 0)
@@ -61,16 +60,43 @@ export const Tile = ({ id, title, layers, style, toolTip, ...props }: KPIChartPr
   });
 
   const filters = useMemo(() => {
-    return [
-      ...searchCriteria.filters,
-      buildCombinedHostsFilter({
-        field: 'host.name',
-        values: hostNodes.map((p) => p.name),
-        dataView,
+    return shouldUseSearchCriteria
+      ? searchCriteria.filters
+      : [
+          buildCombinedHostsFilter({
+            field: 'host.name',
+            values: hostNodes.map((p) => p.name),
+            dataView,
+          }),
+        ];
+  }, [shouldUseSearchCriteria, searchCriteria.filters, hostNodes, dataView]);
+
+  const loading = hostsLoading || !attributes || hostCountLoading;
+
+  // prevents requestTs and serchCriteria states from reloading the chart
+  // we want it to reload only once the host count and table have finished loading
+  const { afterLoadedState } = useAfterLoadedState(loading, {
+    attributes,
+    lastReloadRequestTime: requestTs,
+    ...searchCriteria,
+    filters,
+  });
+
+  const extraActions: Action[] = useMemo(
+    () =>
+      getExtraActions({
+        timeRange: afterLoadedState.dateRange,
+        query: shouldUseSearchCriteria ? afterLoadedState.query : undefined,
+        filters,
       }),
-      buildExistsHostsFilter({ field: 'host.name', dataView }),
-    ];
-  }, [searchCriteria.filters, hostNodes, dataView]);
+    [
+      afterLoadedState.dateRange,
+      afterLoadedState.query,
+      filters,
+      getExtraActions,
+      shouldUseSearchCriteria,
+    ]
+  );
 
   const handleBrushEnd = useCallback(
     ({ range }: BrushTriggerEvent['data']) => {
@@ -84,27 +110,6 @@ export const Tile = ({ id, title, layers, style, toolTip, ...props }: KPIChartPr
       });
     },
     [onSubmit]
-  );
-
-  const loading = hostsLoading || !attributes || hostCountLoading;
-
-  // prevents requestTs and serchCriteria states from reloading the chart
-  // we want it to reload only once the table has finished loading
-  const { afterLoadedState } = useAfterLoadedState(loading, {
-    attributes,
-    lastReloadRequestTime: requestTs,
-    ...searchCriteria,
-    filters,
-  });
-
-  const extraActions: Action[] = useMemo(
-    () =>
-      getExtraActions({
-        timeRange: afterLoadedState.dateRange,
-        query: searchCriteria.query,
-        filters,
-      }),
-    [afterLoadedState.dateRange, filters, getExtraActions, searchCriteria.query]
   );
 
   return (
@@ -148,7 +153,7 @@ export const Tile = ({ id, title, layers, style, toolTip, ...props }: KPIChartPr
               lastReloadRequestTime={afterLoadedState.lastReloadRequestTime}
               dateRange={afterLoadedState.dateRange}
               filters={afterLoadedState.filters}
-              query={afterLoadedState.query}
+              query={shouldUseSearchCriteria ? afterLoadedState.query : undefined}
               onBrushEnd={handleBrushEnd}
               loading={loading}
             />


### PR DESCRIPTION
## Summary

This PR fixes the filters passed to Lens charts that was the query to not return the data

Filter by  inexistent `service.name`
<img width="907" alt="image" src="https://github.com/elastic/kibana/assets/2767137/49d68710-7958-4ed5-a20f-c73aa3c30581">

Query by  inexistent `service.name`

<img width="904" alt="image" src="https://github.com/elastic/kibana/assets/2767137/a67cc1df-10ef-4d2d-8072-5ba698d16313">

Filter by  existent `service.name`

<img width="904" alt="image" src="https://github.com/elastic/kibana/assets/2767137/55a86ca9-f0a1-486a-974f-ab0c9e09dbc0">

Query by  existent `service.name`

<img width="910" alt="image" src="https://github.com/elastic/kibana/assets/2767137/1c31ca45-e47b-42cd-bee8-26bc0e93f3de">



### How to test
-  Start a local Kibana instance
- Navigate to `Infrastructure` > `Hosts`
- Change the filters and see how the charts react. 
  - Open a chart in Lens and confirm whether the data there is the same as in the Hosts View


<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->