### PR TITLE
[kbn-es-archiver] increase highWaterMark to 5000

### DIFF
--- a/packages/kbn-es-archiver/src/lib/docs/index_doc_records_stream.ts
+++ b/packages/kbn-es-archiver/src/lib/docs/index_doc_records_stream.ts
@@ -68,7 +68,7 @@ export function createIndexDocRecordsStream(
   }
 
   return new Writable({
-    highWaterMark: 300,
+    highWaterMark: 5000,
     objectMode: true,
 
     async write(record, enc, callback) {


### PR DESCRIPTION
⚠️ **DO NOT MERGE - Requires further consideration** ⚠️ 

## Summary

@dolaru tested it with loading `logstash_functional` archive in serverless project and load time went down to 10s from 33s.
