### PR TITLE
Always bump revision on update

### DIFF
--- a/x-pack/plugins/observability/server/services/slo/delete_slo.test.ts
+++ b/x-pack/plugins/observability/server/services/slo/delete_slo.test.ts
@@ -5,11 +5,11 @@
  * 2.0.
  */
 
-import { RulesClientApi } from '@kbn/alerting-plugin/server/types';
 import { rulesClientMock } from '@kbn/alerting-plugin/server/rules_client.mock';
+import { RulesClientApi } from '@kbn/alerting-plugin/server/types';
 import { ElasticsearchClient } from '@kbn/core/server';
 import { elasticsearchServiceMock } from '@kbn/core/server/mocks';
-import { getSLOTransformId, SLO_INDEX_TEMPLATE_NAME } from '../../assets/constants';
+import { getSLOTransformId, SLO_DESTINATION_INDEX_PATTERN } from '../../assets/constants';
 import { DeleteSLO } from './delete_slo';
 import { createAPMTransactionErrorRateIndicator, createSLO } from './fixtures/slo';
 import { createSLORepositoryMock, createTransformManagerMock } from './mocks';
@@ -47,7 +47,7 @@ describe('DeleteSLO', () => {
       );
       expect(mockEsClient.deleteByQuery).toHaveBeenCalledWith(
         expect.objectContaining({
-          index: `${SLO_INDEX_TEMPLATE_NAME}*`,
+          index: SLO_DESTINATION_INDEX_PATTERN,
           query: {
             match: {
               'slo.id': slo.id,

--- a/x-pack/plugins/observability/server/services/slo/delete_slo.ts
+++ b/x-pack/plugins/observability/server/services/slo/delete_slo.ts
@@ -7,8 +7,7 @@
 
 import { RulesClientApi } from '@kbn/alerting-plugin/server/types';
 import { ElasticsearchClient } from '@kbn/core/server';
-import { getSLOTransformId, SLO_INDEX_TEMPLATE_NAME } from '../../assets/constants';
-
+import { getSLOTransformId, SLO_DESTINATION_INDEX_PATTERN } from '../../assets/constants';
 import { SLORepository } from './slo_repository';
 import { TransformManager } from './transform_manager';
 
@@ -34,7 +33,7 @@ export class DeleteSLO {
 
   private async deleteRollupData(sloId: string): Promise<void> {
     await this.esClient.deleteByQuery({
-      index: `${SLO_INDEX_TEMPLATE_NAME}*`,
+      index: SLO_DESTINATION_INDEX_PATTERN,
       wait_for_completion: false,
       query: {
         match: {

--- a/x-pack/plugins/observability/server/services/slo/update_slo.test.ts
+++ b/x-pack/plugins/observability/server/services/slo/update_slo.test.ts
@@ -34,131 +34,94 @@ describe('UpdateSLO', () => {
     updateSLO = new UpdateSLO(mockRepository, mockTransformManager, mockEsClient);
   });
 
-  describe('without breaking changes', () => {
-    it('updates the SLO saved object without revision bump', async () => {
-      const slo = createSLO({ indicator: createAPMTransactionErrorRateIndicator() });
-      mockRepository.findById.mockResolvedValueOnce(slo);
+  it('updates the settings correctly', async () => {
+    const slo = createSLO();
+    mockRepository.findById.mockResolvedValueOnce(slo);
 
-      const newName = 'new slo name';
-      const newTags = ['other', 'tags'];
-      const response = await updateSLO.execute(slo.id, { name: newName, tags: newTags });
+    const newSettings = { ...slo.settings, timestamp_field: 'newField' };
+    await updateSLO.execute(slo.id, { settings: newSettings });
 
-      expectTransformManagerNeverCalled();
-      expect(mockEsClient.deleteByQuery).not.toBeCalled();
-      expect(mockRepository.save).toBeCalledWith(
-        expect.objectContaining({
-          ...slo,
-          name: newName,
-          tags: newTags,
-          updatedAt: expect.anything(),
-        })
-      );
-      expect(slo.name).not.toEqual(newName);
-      expect(response.name).toEqual(newName);
-      expect(response.updatedAt).not.toEqual(slo.updatedAt);
-      expect(response.revision).toEqual(slo.revision);
-      expect(response.tags).toEqual(newTags);
-      expect(slo.tags).not.toEqual(newTags);
-    });
+    expectDeletionOfObsoleteSLOData(slo);
+    expect(mockRepository.save).toBeCalledWith(
+      expect.objectContaining({
+        ...slo,
+        settings: newSettings,
+        revision: 2,
+        updatedAt: expect.anything(),
+      })
+    );
+    expectInstallationOfNewSLOTransform();
   });
 
-  describe('with breaking changes', () => {
-    it('consideres settings as a breaking change', async () => {
-      const slo = createSLO();
-      mockRepository.findById.mockResolvedValueOnce(slo);
+  it('updates the budgeting method correctly', async () => {
+    const slo = createSLO({ budgetingMethod: 'occurrences' });
+    mockRepository.findById.mockResolvedValueOnce(slo);
 
-      const newSettings = { ...slo.settings, timestamp_field: 'newField' };
-      await updateSLO.execute(slo.id, { settings: newSettings });
-
-      expectDeletionOfObsoleteSLOData(slo);
-      expect(mockRepository.save).toBeCalledWith(
-        expect.objectContaining({
-          ...slo,
-          settings: newSettings,
-          revision: 2,
-          updatedAt: expect.anything(),
-        })
-      );
-      expectInstallationOfNewSLOTransform();
+    await updateSLO.execute(slo.id, {
+      budgetingMethod: 'timeslices',
+      objective: {
+        target: slo.objective.target,
+        timesliceTarget: 0.9,
+        timesliceWindow: oneMinute(),
+      },
     });
 
-    it('consideres a budgeting method change as a breaking change', async () => {
-      const slo = createSLO({ budgetingMethod: 'occurrences' });
-      mockRepository.findById.mockResolvedValueOnce(slo);
-
-      await updateSLO.execute(slo.id, {
-        budgetingMethod: 'timeslices',
-        objective: {
-          target: slo.objective.target,
-          timesliceTarget: 0.9,
-          timesliceWindow: oneMinute(),
-        },
-      });
-
-      expectDeletionOfObsoleteSLOData(slo);
-      expectInstallationOfNewSLOTransform();
-    });
-
-    it('consideres a timeslice target change as a breaking change', async () => {
-      const slo = createSLOWithTimeslicesBudgetingMethod();
-      mockRepository.findById.mockResolvedValueOnce(slo);
-
-      await updateSLO.execute(slo.id, {
-        objective: {
-          target: slo.objective.target,
-          timesliceTarget: 0.1,
-          timesliceWindow: slo.objective.timesliceWindow,
-        },
-      });
-
-      expectDeletionOfObsoleteSLOData(slo);
-      expectInstallationOfNewSLOTransform();
-    });
-
-    it('consideres a timeslice window change as a breaking change', async () => {
-      const slo = createSLOWithTimeslicesBudgetingMethod();
-      mockRepository.findById.mockResolvedValueOnce(slo);
-
-      await updateSLO.execute(slo.id, {
-        objective: {
-          target: slo.objective.target,
-          timesliceTarget: slo.objective.timesliceTarget,
-          timesliceWindow: fiveMinute(),
-        },
-      });
-
-      expectDeletionOfObsoleteSLOData(slo);
-      expectInstallationOfNewSLOTransform();
-    });
-
-    it('removes the obsolete data from the SLO previous revision', async () => {
-      const slo = createSLO({
-        indicator: createAPMTransactionErrorRateIndicator({ environment: 'development' }),
-      });
-      mockRepository.findById.mockResolvedValueOnce(slo);
-
-      const newIndicator = createAPMTransactionErrorRateIndicator({ environment: 'production' });
-      await updateSLO.execute(slo.id, { indicator: newIndicator });
-
-      expectDeletionOfObsoleteSLOData(slo);
-      expect(mockRepository.save).toBeCalledWith(
-        expect.objectContaining({
-          ...slo,
-          indicator: newIndicator,
-          revision: 2,
-          updatedAt: expect.anything(),
-        })
-      );
-      expectInstallationOfNewSLOTransform();
-    });
+    expectDeletionOfObsoleteSLOData(slo);
+    expectInstallationOfNewSLOTransform();
   });
 
-  function expectTransformManagerNeverCalled() {
-    expect(mockTransformManager.stop).not.toBeCalled();
-    expect(mockTransformManager.uninstall).not.toBeCalled();
-    expect(mockTransformManager.start).not.toBeCalled();
-    expect(mockTransformManager.install).not.toBeCalled();
-  }
+  it('updates the timeslice target correctly', async () => {
+    const slo = createSLOWithTimeslicesBudgetingMethod();
+    mockRepository.findById.mockResolvedValueOnce(slo);
+
+    await updateSLO.execute(slo.id, {
+      objective: {
+        target: slo.objective.target,
+        timesliceTarget: 0.1,
+        timesliceWindow: slo.objective.timesliceWindow,
+      },
+    });
+
+    expectDeletionOfObsoleteSLOData(slo);
+    expectInstallationOfNewSLOTransform();
+  });
+
+  it('consideres a timeslice window change as a breaking change', async () => {
+    const slo = createSLOWithTimeslicesBudgetingMethod();
+    mockRepository.findById.mockResolvedValueOnce(slo);
+
+    await updateSLO.execute(slo.id, {
+      objective: {
+        target: slo.objective.target,
+        timesliceTarget: slo.objective.timesliceTarget,
+        timesliceWindow: fiveMinute(),
+      },
+    });
+
+    expectDeletionOfObsoleteSLOData(slo);
+    expectInstallationOfNewSLOTransform();
+  });
+
+  it('removes the obsolete data from the SLO previous revision', async () => {
+    const slo = createSLO({
+      indicator: createAPMTransactionErrorRateIndicator({ environment: 'development' }),
+    });
+    mockRepository.findById.mockResolvedValueOnce(slo);
+
+    const newIndicator = createAPMTransactionErrorRateIndicator({ environment: 'production' });
+    await updateSLO.execute(slo.id, { indicator: newIndicator });
+
+    expectDeletionOfObsoleteSLOData(slo);
+    expect(mockRepository.save).toBeCalledWith(
+      expect.objectContaining({
+        ...slo,
+        indicator: newIndicator,
+        revision: 2,
+        updatedAt: expect.anything(),
+      })
+    );
+    expectInstallationOfNewSLOTransform();
+  });
 
   function expectInstallationOfNewSLOTransform() {
     expect(mockTransformManager.start).toBeCalled();


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/161896

## ✨ Summary

This PR simplify the update logic, and always bump the revision on any update.

## 🧪 Testing

1. Create an SLO
2. Update the name, ensure the revision changed
3. Update a parameter from the indicator, ensure the revision changed
