### PR TITLE
[Enterprise Search] feat: rebrand ent-search content Enterprise Search to Search

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/empty_state.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/empty_state.tsx
@@ -32,7 +32,7 @@ export const SearchIndexEmptyState: React.FC = () => {
           <p>
             {i18n.translate('xpack.enterpriseSearch.content.newIndex.emptyState.description', {
               defaultMessage:
-                'Data you add in Enterprise Search is called a search index and it’s searchable in both App Search and Workplace Search. Now you can use your connectors in App Search and your web crawlers in Workplace Search.',
+                'Data you add in Search is called a search index and it’s searchable in both App Search and Workplace Search. Now you can use your connectors in App Search and your web crawlers in Workplace Search.',
             })}
           </p>
         }

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_configuration.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_configuration.tsx
@@ -132,7 +132,7 @@ export const ConnectorConfiguration: React.FC = () => {
                       <EuiText size="s">
                         <FormattedMessage
                           id="xpack.enterpriseSearch.content.indices.configurationConnector.connectorPackage.description.thirdParagraph"
-                          defaultMessage="In this step, you will need to clone or fork the repository, and copy the generated API key and connector ID to the associated {link}. The connector ID will identify this connector to Enterprise Search. The service type will determine which type of data source the connector is configured for."
+                          defaultMessage="In this step, you will need to clone or fork the repository, and copy the generated API key and connector ID to the associated {link}. The connector ID will identify this connector to Search. The service type will determine which type of data source the connector is configured for."
                           values={{
                             link: (
                               <EuiLink
@@ -203,7 +203,7 @@ service_type: "${index.connector.service_type || 'changeme'}"
                             'xpack.enterpriseSearch.content.indices.configurationConnector.connectorPackage.waitingForConnectorText',
                             {
                               defaultMessage:
-                                'Your connector has not connected to Enterprise Search. Troubleshoot your configuration and refresh the page.',
+                                'Your connector has not connected to Search. Troubleshoot your configuration and refresh the page.',
                             }
                           )}
                           <EuiSpacer size="s" />
@@ -229,7 +229,7 @@ service_type: "${index.connector.service_type || 'changeme'}"
                             'xpack.enterpriseSearch.content.indices.configurationConnector.connectorPackage.connectorConnected',
                             {
                               defaultMessage:
-                                'Your connector {name} has connected to Enterprise Search successfully.',
+                                'Your connector {name} has connected to Search successfully.',
                               values: { name: index.connector.name },
                             }
                           )}

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/native_connector_configuration/native_connector_configuration_config.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/native_connector_configuration/native_connector_configuration_config.tsx
@@ -75,8 +75,7 @@ export const NativeConnectorConfigurationConfig: React.FC<
             title={i18n.translate(
               'xpack.enterpriseSearch.content.indices.configurationConnector.nativeConnector.connectorConnected',
               {
-                defaultMessage:
-                  'Your connector {name} has connected to Enterprise Search successfully.',
+                defaultMessage: 'Your connector {name} has connected to Search successfully.',
                 values: { name: nativeConnector.name },
               }
             )}

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/generate_api_key_panel.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/generate_api_key_panel.tsx
@@ -135,7 +135,7 @@ export const GenerateApiKeyPanel: React.FC = () => {
                     onChange={(event) => setOptimizedRequest(event.target.checked)}
                     label={i18n.translate(
                       'xpack.enterpriseSearch.content.overview.optimizedRequest.label',
-                      { defaultMessage: 'View Enterprise Search optimized request' }
+                      { defaultMessage: 'View Search optimized request' }
                     )}
                     checked={optimizedRequest}
                   />

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ingest_pipelines/ingest_pipeline_flyout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ingest_pipelines/ingest_pipeline_flyout.tsx
@@ -160,7 +160,7 @@ export const IngestPipelineFlyout: React.FC<IngestPipelineFlyoutProps> = ({
                       'xpack.enterpriseSearch.content.index.pipelines.ingestFlyout.modalBodyConnectorText',
                       {
                         defaultMessage:
-                          'This pipeline runs automatically on all Crawler and Connector indices created through Enterprise Search.',
+                          'This pipeline runs automatically on all Crawler and Connector indices created through Search.',
                       }
                     )
                   )}
@@ -172,7 +172,7 @@ export const IngestPipelineFlyout: React.FC<IngestPipelineFlyoutProps> = ({
                   {i18n.translate(
                     'xpack.enterpriseSearch.content.index.pipelines.ingestFlyout.modalIngestLinkLabel',
                     {
-                      defaultMessage: 'Learn more about Enterprise Search ingest pipelines',
+                      defaultMessage: 'Learn more about Search ingest pipelines',
                     }
                   )}
                 </EuiLink>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/configure_pipeline.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/configure_pipeline.tsx
@@ -278,8 +278,7 @@ export const ConfigurePipeline: React.FC = () => {
               {i18n.translate(
                 'xpack.enterpriseSearch.content.indices.pipelines.addInferencePipelineModal.steps.configure.docsLink',
                 {
-                  defaultMessage:
-                    'Learn more about importing and using ML models in Enterprise Search',
+                  defaultMessage: 'Learn more about importing and using ML models in Search',
                 }
               )}
             </EuiLink>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/pipeline_json_badges.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/pipeline_json_badges.tsx
@@ -71,7 +71,7 @@ const SharedPipelineBadge: React.FC = () => (
     position="top"
     content={i18n.translate(
       'xpack.enterpriseSearch.content.indices.pipelines.tabs.jsonConfigurations.shared.description',
-      { defaultMessage: 'This pipeline is shared across all Enterprise Search ingestion methods' }
+      { defaultMessage: 'This pipeline is shared across all Search ingestion methods' }
     )}
   >
     <EuiBadge iconType="logstashIf" color="hollow">

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/pipelines.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/pipelines.tsx
@@ -129,7 +129,7 @@ export const SearchIndexPipelines: React.FC = () => {
                 {i18n.translate(
                   'xpack.enterpriseSearch.content.indices.pipelines.ingestionPipeline.docLink',
                   {
-                    defaultMessage: 'Learn more about using pipelines in Enterprise Search',
+                    defaultMessage: 'Learn more about using pipelines in Search',
                   }
                 )}
               </EuiLink>
@@ -218,7 +218,7 @@ export const SearchIndexPipelines: React.FC = () => {
                     'xpack.enterpriseSearch.content.indices.pipelines.mlInferencePipelines.subtitleAPIindex',
                     {
                       defaultMessage:
-                        "Inference pipelines will be run as processors from the Enterprise Search Ingest Pipeline. In order to use these pipelines on API-based indices you'll need to reference the {pipelineName} pipeline in your API requests.",
+                        "Inference pipelines will be run as processors from the Search Ingest Pipeline. In order to use these pipelines on API-based indices you'll need to reference the {pipelineName} pipeline in your API requests.",
                       values: {
                         pipelineName,
                       },
@@ -228,7 +228,7 @@ export const SearchIndexPipelines: React.FC = () => {
                     'xpack.enterpriseSearch.content.indices.pipelines.mlInferencePipelines.subtitle',
                     {
                       defaultMessage:
-                        'Inference pipelines will be run as processors from the Enterprise Search Ingest Pipeline',
+                        'Inference pipelines will be run as processors from the Search Ingest Pipeline',
                     }
                   )
             }

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/pipelines_json_configurations.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/pipelines_json_configurations.tsx
@@ -62,7 +62,7 @@ export const PipelinesJSONConfigurations: React.FC = () => {
             {i18n.translate(
               'xpack.enterpriseSearch.content.indices.pipelines.tabs.jsonConfigurations.ingestionPipelines.docLink',
               {
-                defaultMessage: 'Learn more about how Enterprise Search uses ingest pipelines',
+                defaultMessage: 'Learn more about how Search uses ingest pipelines',
               }
             )}
           </EuiLink>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_indices/search_indices.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_indices/search_indices.tsx
@@ -87,7 +87,7 @@ export const SearchIndices: React.FC = () => {
     ? ''
     : hasNoIndices
     ? i18n.translate('xpack.enterpriseSearch.content.searchIndices.searchIndices.emptyPageTitle', {
-        defaultMessage: 'Welcome to Enterprise Search',
+        defaultMessage: 'Welcome to Search',
       })
     : i18n.translate('xpack.enterpriseSearch.content.searchIndices.searchIndices.pageTitle', {
         defaultMessage: 'Elasticsearch indices',
@@ -131,14 +131,14 @@ export const SearchIndices: React.FC = () => {
                 <EuiCallOut
                   size="m"
                   title={i18n.translate('xpack.enterpriseSearch.content.callout.title', {
-                    defaultMessage: 'Introducing Elasticsearch indices in Enterprise Search',
+                    defaultMessage: 'Introducing Elasticsearch indices in Search',
                   })}
                   iconType="iInCircle"
                 >
                   <p>
                     <FormattedMessage
                       id="xpack.enterpriseSearch.content.indices.callout.text"
-                      defaultMessage="Your Elasticsearch indices are now front and center in Enterprise Search. You can create new indices and build search experiences with them directly. To learn more about how to use Elasticsearch indices in Enterprise Search {docLink}"
+                      defaultMessage="Your Elasticsearch indices are now front and center in Search. You can create new indices and build search experiences with them directly. To learn more about how to use Elasticsearch indices in Search {docLink}"
                       values={{
                         docLink: (
                           <EuiLink
@@ -264,7 +264,7 @@ export const SearchIndices: React.FC = () => {
                   {i18n.translate(
                     'xpack.enterpriseSearch.content.searchIndices.searchIndices.stepsTitle',
                     {
-                      defaultMessage: 'Build beautiful search experiences with Enterprise Search',
+                      defaultMessage: 'Build beautiful search experiences with Search',
                     }
                   )}
                 </h2>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/settings/settings.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/settings/settings.tsx
@@ -41,7 +41,7 @@ export const Settings: React.FC = () => {
         description: (
           <FormattedMessage
             id="xpack.enterpriseSearch.content.settings.description"
-            defaultMessage="These settings apply to all new Elasticsearch indices created by Enterprise Search ingestion mechanisms. For API ingest-based indices, remember to include the pipeline when you ingest documents. These features are powered by {link}."
+            defaultMessage="These settings apply to all new Elasticsearch indices created by Search ingestion mechanisms. For API ingest-based indices, remember to include the pipeline when you ingest documents. These features are powered by {link}."
             values={{
               link: (
                 <EuiLink href={docLinks.ingestPipelines} target="_blank">

--- a/x-pack/plugins/enterprise_search/public/applications/shared/add_content_empty_prompt/add_content_empty_prompt.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/add_content_empty_prompt/add_content_empty_prompt.test.tsx
@@ -21,7 +21,7 @@ describe('AddContentEmptyPrompt', () => {
   });
 
   it('renders', () => {
-    expect(wrapper.find('h2').text()).toEqual('Add content to Enterprise Search');
+    expect(wrapper.find('h2').text()).toEqual('Add content to Search');
     expect(wrapper.find(EuiLinkTo).prop('to')).toEqual(
       '/app/enterprise_search/content/search_indices/new_index'
     );

--- a/x-pack/plugins/enterprise_search/public/applications/shared/add_content_empty_prompt/add_content_empty_prompt.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/add_content_empty_prompt/add_content_empty_prompt.tsx
@@ -51,7 +51,7 @@ export const AddContentEmptyPrompt: React.FC<EmptyPromptProps> = ({ title, butto
                 <h2>
                   {title ||
                     i18n.translate('xpack.enterpriseSearch.overview.emptyState.heading', {
-                      defaultMessage: 'Add content to Enterprise Search',
+                      defaultMessage: 'Add content to Search',
                     })}
                 </h2>
               </EuiTitle>
@@ -81,7 +81,7 @@ export const AddContentEmptyPrompt: React.FC<EmptyPromptProps> = ({ title, butto
                     <EuiButton color="primary" fill>
                       {buttonLabel ||
                         i18n.translate('xpack.enterpriseSearch.overview.emptyState.buttonTitle', {
-                          defaultMessage: 'Add content to Enterprise Search',
+                          defaultMessage: 'Add content to Search',
                         })}
                     </EuiButton>
                   </EuiLinkTo>

--- a/x-pack/plugins/enterprise_search/public/applications/shared/getting_started_steps/getting_started_steps.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/getting_started_steps/getting_started_steps.test.tsx
@@ -44,7 +44,7 @@ describe('GettingStartedSteps', () => {
         ...rest,
       }));
 
-    expect(steps[0].title).toEqual('Add your documents to Enterprise Search');
+    expect(steps[0].title).toEqual('Add your documents to Search');
     expect(steps[0].status).toEqual('current');
     expect(steps[0].children.find(IconRow).length).toEqual(1);
 

--- a/x-pack/plugins/enterprise_search/public/applications/shared/getting_started_steps/getting_started_steps.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/getting_started_steps/getting_started_steps.tsx
@@ -29,7 +29,7 @@ export const GettingStartedSteps: React.FC<GettingStartedStepsProps> = ({ step =
             {
               title: i18n.translate(
                 'xpack.enterpriseSearch.overview.gettingStartedSteps.addData.title',
-                { defaultMessage: 'Add your documents to Enterprise Search' }
+                { defaultMessage: 'Add your documents to Search' }
               ),
               children: (
                 <>
@@ -39,7 +39,7 @@ export const GettingStartedSteps: React.FC<GettingStartedStepsProps> = ({ step =
                         'xpack.enterpriseSearch.overview.gettingStartedSteps.addData.message',
                         {
                           defaultMessage:
-                            'Add your data to Enterprise Search. You can crawl website content with the Elastic web crawler, connect your existing application with Elasticsearch API endpoints, or use connectors to directly add third party content from providers like Google Drive, Microsoft Sharepoint and more.',
+                            'Add your data to Search. You can crawl website content with the Elastic web crawler, connect your existing application with Elasticsearch API endpoints, or use connectors to directly add third party content from providers like Google Drive, Microsoft Sharepoint and more.',
                         }
                       )}
                     </p>


### PR DESCRIPTION
## Summary

Updated usages of "Enterprise Search" to "Search" in the content application