### PR TITLE
[Enterprise Search] rebrand ent-search uncaught exception error message

### DIFF
--- a/x-pack/plugins/enterprise_search/server/routes/enterprise_search/indices.test.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/enterprise_search/indices.test.ts
@@ -983,7 +983,7 @@ describe('Enterprise Search Managed Indices', () => {
           attributes: {
             error_code: 'uncaught_exception',
           },
-          message: 'Enterprise Search encountered an error. Check Kibana Server logs for details.',
+          message: 'Search encountered an error. Check Kibana Server logs for details.',
         },
         statusCode: 502,
       });

--- a/x-pack/plugins/enterprise_search/server/routes/enterprise_search/search_applications.test.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/enterprise_search/search_applications.test.ts
@@ -574,7 +574,7 @@ describe('engines routes', () => {
           attributes: {
             error_code: 'uncaught_exception',
           },
-          message: 'Enterprise Search encountered an error. Check Kibana Server logs for details.',
+          message: 'Search encountered an error. Check Kibana Server logs for details.',
         },
         statusCode: 502,
       });

--- a/x-pack/plugins/enterprise_search/server/utils/elasticsearch_error_handler.ts
+++ b/x-pack/plugins/enterprise_search/server/utils/elasticsearch_error_handler.ts
@@ -37,7 +37,7 @@ export function elasticsearchErrorHandler<ContextType, RequestType, ResponseType
         enterpriseSearchError = {
           errorCode: ErrorCode.UNCAUGHT_EXCEPTION,
           message: i18n.translate('xpack.enterpriseSearch.server.routes.uncaughtExceptionError', {
-            defaultMessage: 'Enterprise Search encountered an error.',
+            defaultMessage: 'Search encountered an error.',
           }),
           statusCode: 502,
         };


### PR DESCRIPTION
## Summary

Update "Enterprise Search" to "Search" for the uncaught exception error message