### PR TITLE
[SLO] Unregistering from/to fields for histogram indicator

### DIFF
--- a/x-pack/plugins/observability/public/pages/slo_edit/components/histogram/histogram_indicator.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/histogram/histogram_indicator.tsx
@@ -216,6 +216,7 @@ export function HistogramIndicator({ type, indexFields, isLoadingIndex }: Histog
                     defaultValue={NaN}
                     control={control}
                     rules={{ required: true }}
+                    shouldUnregister
                     render={({ field: { ref, ...field }, fieldState }) => (
                       <EuiFieldNumber
                         {...field}
@@ -244,6 +245,7 @@ export function HistogramIndicator({ type, indexFields, isLoadingIndex }: Histog
                     name={`indicator.params.${type}.to`}
                     defaultValue={NaN}
                     rules={{ required: true }}
+                    shouldUnregister
                     control={control}
                     render={({ field: { ref, ...field }, fieldState }) => (
                       <EuiFieldNumber


### PR DESCRIPTION
## Summary

This PR fixes #161861 by adding `shouldUnregister` to the `Controller` components for `indicator.params.from` and `indicator.params.to` to ensure the fields are unregistered when they are unmounted.

### Testing

1. Create a new SLO using the histogram indicator.
2. Set both the  "good" and "total" events to use value count
3. Ensure the preview chart displays data
4. Set the "good" events to a range, the previous chart should update.