### PR TITLE
Fixing theme tag issue and adding more testing

### DIFF
--- a/packages/core/rendering/core-rendering-server-internal/src/bootstrap/bootstrap_renderer.test.ts
+++ b/packages/core/rendering/core-rendering-server-internal/src/bootstrap/bootstrap_renderer.test.ts
@@ -92,7 +92,7 @@ describe('bootstrapRenderer', () => {
       expect(uiSettingsClient.get).toHaveBeenCalledWith('theme:darkMode');
     });
 
-    it('calls getThemeTag with the values from the UiSettingsClient when the UserSettingsService is not provided', async () => {
+    it('calls getThemeTag with the values from the UiSettingsClient (true/dark) when the UserSettingsService is not provided', async () => {
       uiSettingsClient.get.mockResolvedValue(true);
 
       const request = httpServerMock.createKibanaRequest();
@@ -109,7 +109,24 @@ describe('bootstrapRenderer', () => {
       });
     });
 
-    it('calls getThemeTag with values from the UserSettingsService when provided', async () => {
+    it('calls getThemeTag with the values from the UiSettingsClient (false/light) when the UserSettingsService is not provided', async () => {
+      uiSettingsClient.get.mockResolvedValue(false);
+
+      const request = httpServerMock.createKibanaRequest();
+
+      await renderer({
+        request,
+        uiSettingsClient,
+      });
+
+      expect(getThemeTagMock).toHaveBeenCalledTimes(1);
+      expect(getThemeTagMock).toHaveBeenCalledWith({
+        themeVersion: 'v8',
+        darkMode: false,
+      });
+    });
+
+    it('calls getThemeTag with values (true/dark) from the UserSettingsService when provided', async () => {
       userSettingsService.getUserSettingDarkMode.mockReturnValueOnce(true);
 
       renderer = bootstrapRendererFactory({
@@ -135,7 +152,33 @@ describe('bootstrapRenderer', () => {
       });
     });
 
-    it('calls getThemeTag with values from the UiSettingsClient when values from UserSettingsService are `undefined`', async () => {
+    it('calls getThemeTag with values (false/light) from the UserSettingsService when provided', async () => {
+      userSettingsService.getUserSettingDarkMode.mockReturnValueOnce(false);
+
+      renderer = bootstrapRendererFactory({
+        auth,
+        packageInfo,
+        uiPlugins,
+        serverBasePath: '/base-path',
+        userSettingsService,
+      });
+
+      uiSettingsClient.get.mockResolvedValue(true);
+      const request = httpServerMock.createKibanaRequest();
+
+      await renderer({
+        request,
+        uiSettingsClient,
+      });
+
+      expect(getThemeTagMock).toHaveBeenCalledTimes(1);
+      expect(getThemeTagMock).toHaveBeenCalledWith({
+        themeVersion: 'v8',
+        darkMode: false,
+      });
+    });
+
+    it('calls getThemeTag with values from the UiSettingsClient when values (false/light) from UserSettingsService are `undefined`', async () => {
       userSettingsService.getUserSettingDarkMode.mockReturnValueOnce(undefined);
 
       renderer = bootstrapRendererFactory({
@@ -158,6 +201,32 @@ describe('bootstrapRenderer', () => {
       expect(getThemeTagMock).toHaveBeenCalledWith({
         themeVersion: 'v8',
         darkMode: false,
+      });
+    });
+
+    it('calls getThemeTag with values from the UiSettingsClient when values (true/dark) from UserSettingsService are `undefined`', async () => {
+      userSettingsService.getUserSettingDarkMode.mockReturnValueOnce(undefined);
+
+      renderer = bootstrapRendererFactory({
+        auth,
+        packageInfo,
+        uiPlugins,
+        serverBasePath: '/base-path',
+        userSettingsService,
+      });
+
+      uiSettingsClient.get.mockResolvedValue(true);
+      const request = httpServerMock.createKibanaRequest();
+
+      await renderer({
+        request,
+        uiSettingsClient,
+      });
+
+      expect(getThemeTagMock).toHaveBeenCalledTimes(1);
+      expect(getThemeTagMock).toHaveBeenCalledWith({
+        themeVersion: 'v8',
+        darkMode: true,
       });
     });
   });

--- a/packages/core/rendering/core-rendering-server-internal/src/bootstrap/bootstrap_renderer.ts
+++ b/packages/core/rendering/core-rendering-server-internal/src/bootstrap/bootstrap_renderer.ts
@@ -63,7 +63,7 @@ export const bootstrapRendererFactory: BootstrapRendererFactory = ({
       if (authenticated) {
         const userSettingDarkMode = await userSettingsService?.getUserSettingDarkMode(request);
 
-        if (userSettingDarkMode) {
+        if (userSettingDarkMode !== undefined) {
           darkMode = userSettingDarkMode;
         } else {
           darkMode = await uiSettingsClient.get('theme:darkMode');


### PR DESCRIPTION
## Summary

Fixing calculated theme tags. An issue found was in the bootstrap renderer when User Profile's Theme was set to 'Light' and Adv. Setting's Theme was set to 'Dark'. 

In my original PR, I had originally had the UserSettings > darkMode be a string ('', 'light', 'dark'), but changed it to a boolean | undefined and the conditional no longer worked.

This should fix a number of sporadic darkmode issues

<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->