### PR TITLE
[Textbased] Moves the error message in the beginning of the footer

### DIFF
--- a/packages/kbn-text-based-editor/src/editor_footer.tsx
+++ b/packages/kbn-text-based-editor/src/editor_footer.tsx
@@ -56,42 +56,6 @@ export const EditorFooter = memo(function EditorFooter({
     >
       <EuiFlexItem grow={false}>
         <EuiFlexGroup gutterSize="s" responsive={false} alignItems="center">
-          <EuiFlexItem grow={false} style={{ marginRight: '8px' }}>
-            <EuiText size="xs" color="subdued" data-test-subj="TextBasedLangEditor-footer-lines">
-              <p>
-                {i18n.translate('textBasedEditor.query.textBasedLanguagesEditor.lineCount', {
-                  defaultMessage: '{count} {count, plural, one {line} other {lines}}',
-                  values: { count: lines },
-                })}
-              </p>
-            </EuiText>
-          </EuiFlexItem>
-          <EuiFlexItem grow={false} style={{ marginRight: '16px' }}>
-            <EuiFlexGroup gutterSize="xs" responsive={false} alignItems="center">
-              <EuiFlexItem grow={false}>
-                <EuiIcon type="calendar" color="subdued" size="s" />
-              </EuiFlexItem>
-              <EuiFlexItem grow={false}>
-                <EuiText size="xs" color="subdued" data-test-subj="TextBasedLangEditor-date-info">
-                  <p>
-                    {detectTimestamp
-                      ? i18n.translate(
-                          'textBasedEditor.query.textBasedLanguagesEditor.timestampDetected',
-                          {
-                            defaultMessage: '@timestamp detected',
-                          }
-                        )
-                      : i18n.translate(
-                          'textBasedEditor.query.textBasedLanguagesEditor.timestampNotDetected',
-                          {
-                            defaultMessage: '@timestamp not detected',
-                          }
-                        )}
-                  </p>
-                </EuiText>
-              </EuiFlexItem>
-            </EuiFlexGroup>
-          </EuiFlexItem>
           {errors && errors.length > 0 && (
             <EuiFlexItem grow={false}>
               <EuiFlexGroup gutterSize="xs" responsive={false} alignItems="center">
@@ -185,6 +149,42 @@ export const EditorFooter = memo(function EditorFooter({
               </EuiFlexGroup>
             </EuiFlexItem>
           )}
+          <EuiFlexItem grow={false} style={{ marginRight: '8px' }}>
+            <EuiText size="xs" color="subdued" data-test-subj="TextBasedLangEditor-footer-lines">
+              <p>
+                {i18n.translate('textBasedEditor.query.textBasedLanguagesEditor.lineCount', {
+                  defaultMessage: '{count} {count, plural, one {line} other {lines}}',
+                  values: { count: lines },
+                })}
+              </p>
+            </EuiText>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false} style={{ marginRight: '16px' }}>
+            <EuiFlexGroup gutterSize="xs" responsive={false} alignItems="center">
+              <EuiFlexItem grow={false}>
+                <EuiIcon type="calendar" color="subdued" size="s" />
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiText size="xs" color="subdued" data-test-subj="TextBasedLangEditor-date-info">
+                  <p>
+                    {detectTimestamp
+                      ? i18n.translate(
+                          'textBasedEditor.query.textBasedLanguagesEditor.timestampDetected',
+                          {
+                            defaultMessage: '@timestamp detected',
+                          }
+                        )
+                      : i18n.translate(
+                          'textBasedEditor.query.textBasedLanguagesEditor.timestampNotDetected',
+                          {
+                            defaultMessage: '@timestamp not detected',
+                          }
+                        )}
+                  </p>
+                </EuiText>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiFlexItem>
         </EuiFlexGroup>
       </EuiFlexItem>
       <EuiFlexItem grow={false}>


### PR DESCRIPTION
## Summary

This PR just moves the error message to the beginning of the footer.

<img width="504" alt="image" src="https://github.com/elastic/kibana/assets/17003240/f215c416-0eba-4afb-bf28-44bca471e8b1">
