### PR TITLE
[Enterprise Search] Import correct exception identifier

### DIFF
--- a/x-pack/plugins/enterprise_search/server/lib/indices/delete_access_control_index.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/indices/delete_access_control_index.test.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { IScopedClusterClient } from '@kbn/core/server';
+
+import { ElasticsearchResponseError } from '../../utils/identify_exceptions';
+
+import { deleteAccessControlIndex } from './delete_access_control_index';
+
+describe('deleteAccessControlIndex lib function', () => {
+  const mockClient = {
+    asCurrentUser: {
+      indices: {
+        delete: jest.fn(),
+      },
+    },
+    asInternalUser: {},
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('when ACL index exists', () => {
+    it('should delete index', async () => {
+      mockClient.asCurrentUser.indices.delete.mockImplementation(() => true);
+      await expect(
+        deleteAccessControlIndex(mockClient as unknown as IScopedClusterClient, 'indexName')
+      ).resolves.toEqual(true);
+      expect(mockClient.asCurrentUser.indices.delete).toHaveBeenCalledWith({
+        index: 'indexName',
+      });
+    });
+  });
+
+  describe('when ACL index is missing', () => {
+    const mockErrorRejection: ElasticsearchResponseError = {
+      meta: {
+        body: {
+          error: {
+            type: 'index_not_found_exception',
+          },
+        },
+        statusCode: 404,
+      },
+      name: 'ResponseError',
+    };
+
+    it('exits gracefully', async () => {
+      mockClient.asCurrentUser.indices.delete.mockImplementation(() => {
+        return Promise.reject(mockErrorRejection);
+      });
+      await expect(
+        deleteAccessControlIndex(mockClient as unknown as IScopedClusterClient, 'indexName')
+      ).resolves.not.toThrowError();
+      expect(mockClient.asCurrentUser.indices.delete).toHaveBeenCalledWith({
+        index: 'indexName',
+      });
+    });
+  });
+
+  describe('when index exists but another error is thrown', () => {
+    const mockErrorRejection: ElasticsearchResponseError = {
+      meta: {
+        body: {
+          error: {
+            type: 'uncaught_exception',
+          },
+        },
+        statusCode: 500,
+      },
+      name: 'ResponseError',
+    };
+
+    it('throws the error', async () => {
+      mockClient.asCurrentUser.indices.delete.mockImplementation(() => {
+        return Promise.reject(mockErrorRejection);
+      });
+
+      try {
+        await deleteAccessControlIndex(mockClient as unknown as IScopedClusterClient, 'indexName');
+      } catch (e) {
+        const asResponseError = e as unknown as ElasticsearchResponseError;
+        expect(asResponseError.meta?.body?.error?.type).toEqual('uncaught_exception');
+      }
+
+      expect(mockClient.asCurrentUser.indices.delete).toHaveBeenCalledWith({
+        index: 'indexName',
+      });
+    });
+  });
+});

--- a/x-pack/plugins/enterprise_search/server/lib/indices/delete_access_control_index.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/indices/delete_access_control_index.test.ts
@@ -80,14 +80,9 @@ describe('deleteAccessControlIndex lib function', () => {
       mockClient.asCurrentUser.indices.delete.mockImplementation(() => {
         return Promise.reject(mockErrorRejection);
       });
-
-      try {
-        await deleteAccessControlIndex(mockClient as unknown as IScopedClusterClient, 'indexName');
-      } catch (e) {
-        const asResponseError = e as unknown as ElasticsearchResponseError;
-        expect(asResponseError.meta?.body?.error?.type).toEqual('uncaught_exception');
-      }
-
+      await expect(
+        deleteAccessControlIndex(mockClient as unknown as IScopedClusterClient, 'indexName')
+      ).rejects.toEqual(mockErrorRejection);
       expect(mockClient.asCurrentUser.indices.delete).toHaveBeenCalledWith({
         index: 'indexName',
       });

--- a/x-pack/plugins/enterprise_search/server/lib/indices/delete_access_control_index.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/indices/delete_access_control_index.ts
@@ -12,7 +12,7 @@ import { isIndexNotFoundException } from '../../utils/identify_exceptions';
 
 export const deleteAccessControlIndex = async (client: IScopedClusterClient, index: string) => {
   try {
-    await client.asCurrentUser.indices.delete({
+    return await client.asCurrentUser.indices.delete({
       index: index.replace('search-', CONNECTORS_ACCESS_CONTROL_INDEX_PREFIX),
     });
   } catch (e) {

--- a/x-pack/plugins/enterprise_search/server/lib/indices/delete_access_control_index.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/indices/delete_access_control_index.ts
@@ -5,10 +5,10 @@
  * 2.0.
  */
 
-import { isIndexNotFoundException } from '@kbn/core-saved-objects-migration-server-internal';
 import { IScopedClusterClient } from '@kbn/core/server';
 
 import { CONNECTORS_ACCESS_CONTROL_INDEX_PREFIX } from '../../../common/constants';
+import { isIndexNotFoundException } from '../../utils/identify_exceptions';
 
 export const deleteAccessControlIndex = async (client: IScopedClusterClient, index: string) => {
   try {


### PR DESCRIPTION
## Summary

The access control deletion function was importing the wrong `isIndexNotFoundException` to identify when an index doesn't exist. This would cause index deletion to fail if a search index is missing an access control index.
