### PR TITLE
[Unified search] Fixes editing of multi values filters whend adding a custom item

### DIFF
--- a/src/plugins/unified_search/public/filters_builder/filter_item/filter_item.tsx
+++ b/src/plugins/unified_search/public/filters_builder/filter_item/filter_item.tsx
@@ -114,7 +114,7 @@ export function FilterItem({
   }
   const [multiValueFilterParams, setMultiValueFilterParams] = useState<
     Array<Filter | boolean | string | number>
-  >([]);
+  >(Array.isArray(params) ? params : []);
 
   const onHandleField = useCallback(
     (selectedField: DataViewField) => {


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/160729

Fixes the bug described in the issue.
When you try to edit a multi values filter (is one of, is not one of) and add a custom label, the selected values are all vanishing. The problem was on the initialization of the state

![uni](https://github.com/elastic/kibana/assets/17003240/2cb322fb-3978-4147-bd5d-d440b598804e)