### PR TITLE
[ftr] define default FTR services for serverless

### DIFF
--- a/x-pack/test_serverless/functional/test_suites/security/cypress/runner.ts
+++ b/x-pack/test_serverless/functional/test_suites/security/cypress/runner.ts
@@ -17,6 +17,7 @@ export async function SecuritySolutionCypressTestRunner(
   command: string
 ) {
   const log = getService('log');
+  const esArchiver = getService('esArchiver');
 
   await withProcRunner(log, async (procs) => {
     await procs.run('cypress', {

--- a/x-pack/test_serverless/functional/test_suites/security/cypress/runner.ts
+++ b/x-pack/test_serverless/functional/test_suites/security/cypress/runner.ts
@@ -17,7 +17,6 @@ export async function SecuritySolutionCypressTestRunner(
   command: string
 ) {
   const log = getService('log');
-  const esArchiver = getService('esArchiver');
 
   await withProcRunner(log, async (procs) => {
     await procs.run('cypress', {

--- a/x-pack/test_serverless/functional/test_suites/security/cypress/security_config.base.ts
+++ b/x-pack/test_serverless/functional/test_suites/security/cypress/security_config.base.ts
@@ -20,7 +20,6 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
         ...svlSharedConfig.get('esTestCluster.serverArgs'),
         // define custom es server here
         // API Keys is enabled at the top level
-        'xpack.security.enabled=true',
       ],
     },
     kbnTestServer: {

--- a/x-pack/test_serverless/shared/config.base.ts
+++ b/x-pack/test_serverless/shared/config.base.ts
@@ -10,6 +10,7 @@ import { format as formatUrl } from 'url';
 
 import { REPO_ROOT } from '@kbn/repo-info';
 import { esTestConfig, kbnTestConfig, kibanaServerTestUser } from '@kbn/test';
+import { commonFunctionalServices } from '@kbn/ftr-common-functional-services';
 
 export default async () => {
   const servers = {
@@ -65,6 +66,10 @@ export default async () => {
 
     // Used by FTR to recognize serverless project and change its behavior accordingly
     serverless: true,
+
+    services: {
+      ...commonFunctionalServices,
+    },
 
     // overriding default timeouts from packages/kbn-test/src/functional_test_runner/lib/config/schema.ts
     // so we can easily adjust them for serverless where needed

--- a/x-pack/test_serverless/tsconfig.json
+++ b/x-pack/test_serverless/tsconfig.json
@@ -26,5 +26,6 @@
     "@kbn/telemetry-plugin",
     "@kbn/telemetry-collection-xpack-plugin",
     "@kbn/telemetry-tools",
+    "@kbn/ftr-common-functional-services",
   ]
 }


### PR DESCRIPTION
Cypress tests were failing with esArchiver service unavailability.

This PR fixes it by adding  basic services  (es, kibanaServier, esArchive & retry) from `@kbn/ftr-common-functional-services` in shared FTR configuration file. This way all the child config files will have these services pre-loaded.