### PR TITLE
feat: enable /oblt-deploy-serverless

### DIFF
--- a/.github/workflows/deploy-my-kibana.yml
+++ b/.github/workflows/deploy-my-kibana.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   deploy-my-kibana:
-    if: ${{ github.event.issue.pull_request && github.event.comment.body == '/oblt-deploy'}}
+    if: ${{ github.event.issue.pull_request && (github.event.comment.body == '/oblt-deploy' || github.event.comment.body == '/oblt-deploy-serverless') }}
     runs-on: ubuntu-latest
     steps:
       - uses: elastic/apm-pipeline-library/.github/actions/deploy-my-kibana@current
@@ -28,3 +28,4 @@ jobs:
           vaultUrl: ${{ secrets.OBLT_VAULT_ADDR }}
           vaultRoleId: ${{ secrets.OBLT_VAULT_ROLE_ID }}
           vaultSecretId: ${{ secrets.OBLT_VAULT_SECRET_ID }}
+          serverless: ${{ github.event.comment.body == '/oblt-deploy-serverless' }}

--- a/.github/workflows/oblt-github-commands.yml
+++ b/.github/workflows/oblt-github-commands.yml
@@ -50,6 +50,7 @@ jobs:
 
               Just comment with:
               - \`/oblt-deploy\` : Deploy a Kibana instance using the Observability test environments.
+              - \`/oblt-deploy-serverless\` : Deploy a serverless Kibana instance using the Observability test environments.
               - \`run\` \`elasticsearch-ci/docs\` : Re-trigger the docs validation. (use unformatted text in the comment!)
 
               </p>


### PR DESCRIPTION
## Summary

This PR enables the GitHub command  /oblt-deploy-serverless. This command allows Elasticians to deploy their PRs in a serverless environment with Observability data.

### For maintainers

- [x] Requiere to merge https://github.com/elastic/apm-pipeline-library/pull/2288
