### PR TITLE
[APM] Prevent console.error causing unit tests to fail locally

### DIFF
--- a/x-pack/plugins/apm/jest.config.js
+++ b/x-pack/plugins/apm/jest.config.js
@@ -11,10 +11,7 @@ module.exports = {
   preset: '@kbn/test',
   rootDir: path.resolve(__dirname, '../../..'),
   roots: ['<rootDir>/x-pack/plugins/apm'],
-  setupFiles: [
-    '<rootDir>/x-pack/plugins/apm/jest_setup.js',
-    '<rootDir>/x-pack/plugins/apm/.storybook/jest_setup.js',
-  ],
+  setupFiles: ['<rootDir>/x-pack/plugins/apm/.storybook/jest_setup.js'],
   coverageDirectory: '<rootDir>/target/kibana-coverage/jest/x-pack/plugins/apm',
   coverageReporters: ['text', 'html'],
   collectCoverageFrom: [

--- a/x-pack/plugins/apm/jest_setup.js
+++ b/x-pack/plugins/apm/jest_setup.js
@@ -1,6 +1,0 @@
-/*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0; you may not use this file except in compliance with the Elastic License
- * 2.0.
- */

--- a/x-pack/plugins/apm/jest_setup.js
+++ b/x-pack/plugins/apm/jest_setup.js
@@ -4,12 +4,3 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-
-/* global jest */
-
-// When a `console.error` is encountered, throw the error to make the test fail.
-// This effectively treats logged errors during the test run as failures.
-jest.spyOn(console, 'error').mockImplementation((message, ...args) => {
-  console.log(message, ...args);
-  throw new Error(message);
-});


### PR DESCRIPTION
https://github.com/elastic/kibana/pull/161636 fixed a couple of unit tests that were failing locally but passing on CI. This PR should prevent this from happening again.

**Why they failed locally and not on CI??**
Locally `console.error` is treated as a test failure:
https://github.com/elastic/kibana/blob/7ea0dd6b116a93024d68ea2d93fa4ce90e9bf189/x-pack/plugins/apm/jest_setup.js#L12-L15

Whereas on CI `console.*` is disabled:
https://github.com/elastic/kibana/blob/a78c7b02b3b825826f39289e91e545ee6f4a67d9/packages/kbn-test/src/jest/setup/disable_console_logs.js#L9-L12

This means that if a test logs `console.error` it would fail locally but not on CI. This PR changes that so console.error will not cause unit tests to fail anywhere.

<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->