### PR TITLE
[8.9] [Infrastructure UI] Fix filters passed to Lens (#161890)

### DIFF
--- a/x-pack/plugins/infra/public/pages/metrics/hosts/components/tabs/metrics/metric_chart.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/hosts/components/tabs/metrics/metric_chart.tsx
@@ -46,6 +46,8 @@ export const MetricChart = ({ title, type, breakdownSize }: MetricChartProps) =>
   const { requestTs, loading } = useHostsViewContext();
   const { currentPage } = useHostsTableContext();
 
+  const shouldUseSearchCriteria = currentPage.length === 0;
+
   // prevents requestTs and serchCriteria states from reloading the chart
   // we want it to reload only once the table has finished loading
   const { afterLoadedState } = useAfterLoadedState(loading, {
@@ -64,24 +66,31 @@ export const MetricChart = ({ title, type, breakdownSize }: MetricChartProps) =>
   });
 
   const filters = useMemo(() => {
-    return [
-      ...searchCriteria.filters,
-      buildCombinedHostsFilter({
-        field: 'host.name',
-        values: currentPage.map((p) => p.name),
-        dataView,
-      }),
-    ];
-  }, [currentPage, dataView, searchCriteria.filters]);
+    return shouldUseSearchCriteria
+      ? afterLoadedState.filters
+      : [
+          buildCombinedHostsFilter({
+            field: 'host.name',
+            values: currentPage.map((p) => p.name),
+            dataView,
+          }),
+        ];
+  }, [afterLoadedState.filters, currentPage, dataView, shouldUseSearchCriteria]);
 
   const extraActions: Action[] = useMemo(
     () =>
       getExtraActions({
         timeRange: afterLoadedState.dateRange,
-        query: afterLoadedState.query,
+        query: shouldUseSearchCriteria ? afterLoadedState.query : undefined,
         filters,
       }),
-    [afterLoadedState.dateRange, afterLoadedState.query, filters, getExtraActions]
+    [
+      afterLoadedState.dateRange,
+      afterLoadedState.query,
+      filters,
+      getExtraActions,
+      shouldUseSearchCriteria,
+    ]
   );
 
   const handleBrushEnd = useCallback(
@@ -139,7 +148,7 @@ export const MetricChart = ({ title, type, breakdownSize }: MetricChartProps) =>
           lastReloadRequestTime={afterLoadedState.lastReloadRequestTime}
           dateRange={afterLoadedState.dateRange}
           filters={filters}
-          query={afterLoadedState.query}
+          query={shouldUseSearchCriteria ? afterLoadedState.query : undefined}
           onBrushEnd={handleBrushEnd}
           loading={loading}
           hasTitle


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.9`:
 - [[Infrastructure UI] Fix filters passed to Lens (#161890)](https://github.com/elastic/kibana/pull/161890)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Carlos Crespo","email":"crespocarlos@users.noreply.github.com"},"sourceCommit":{"committedDate":"2023-07-14T11:57:43Z","message":"[Infrastructure UI] Fix filters passed to Lens (#161890)\n\n## Summary\r\n\r\nThis PR fixes the filters passed to Lens charts that was the query to\r\nnot return the data\r\n\r\nFilter by  inexistent `service.name`\r\n<img width=\"907\" alt=\"image\"\r\nsrc=\"https://github.com/elastic/kibana/assets/2767137/49d68710-7958-4ed5-a20f-c73aa3c30581\">\r\n\r\nQuery by  inexistent `service.name`\r\n\r\n<img width=\"904\" alt=\"image\"\r\nsrc=\"https://github.com/elastic/kibana/assets/2767137/a67cc1df-10ef-4d2d-8072-5ba698d16313\">\r\n\r\nFilter by  existent `service.name`\r\n\r\n<img width=\"904\" alt=\"image\"\r\nsrc=\"https://github.com/elastic/kibana/assets/2767137/55a86ca9-f0a1-486a-974f-ab0c9e09dbc0\">\r\n\r\nQuery by  existent `service.name`\r\n\r\n<img width=\"910\" alt=\"image\"\r\nsrc=\"https://github.com/elastic/kibana/assets/2767137/1c31ca45-e47b-42cd-bee8-26bc0e93f3de\">\r\n\r\n\r\n\r\n### How to test\r\n-  Start a local Kibana instance\r\n- Navigate to `Infrastructure` > `Hosts`\r\n- Change the filters and see how the charts react. \r\n- Open a chart in Lens and confirm whether the data there is the same as\r\nin the Hosts View","sha":"3a48f8876611eb8bec2c587e8efb4d47bacf3132","branchLabelMapping":{"^v8.10.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Metrics UI","Team:Infra Monitoring UI","release_note:skip","backport:prev-minor","Feature:ObsHosts","v8.9.0","v8.10.0"],"number":161890,"url":"https://github.com/elastic/kibana/pull/161890","mergeCommit":{"message":"[Infrastructure UI] Fix filters passed to Lens (#161890)\n\n## Summary\r\n\r\nThis PR fixes the filters passed to Lens charts that was the query to\r\nnot return the data\r\n\r\nFilter by  inexistent `service.name`\r\n<img width=\"907\" alt=\"image\"\r\nsrc=\"https://github.com/elastic/kibana/assets/2767137/49d68710-7958-4ed5-a20f-c73aa3c30581\">\r\n\r\nQuery by  inexistent `service.name`\r\n\r\n<img width=\"904\" alt=\"image\"\r\nsrc=\"https://github.com/elastic/kibana/assets/2767137/a67cc1df-10ef-4d2d-8072-5ba698d16313\">\r\n\r\nFilter by  existent `service.name`\r\n\r\n<img width=\"904\" alt=\"image\"\r\nsrc=\"https://github.com/elastic/kibana/assets/2767137/55a86ca9-f0a1-486a-974f-ab0c9e09dbc0\">\r\n\r\nQuery by  existent `service.name`\r\n\r\n<img width=\"910\" alt=\"image\"\r\nsrc=\"https://github.com/elastic/kibana/assets/2767137/1c31ca45-e47b-42cd-bee8-26bc0e93f3de\">\r\n\r\n\r\n\r\n### How to test\r\n-  Start a local Kibana instance\r\n- Navigate to `Infrastructure` > `Hosts`\r\n- Change the filters and see how the charts react. \r\n- Open a chart in Lens and confirm whether the data there is the same as\r\nin the Hosts View","sha":"3a48f8876611eb8bec2c587e8efb4d47bacf3132"}},"sourceBranch":"main","suggestedTargetBranches":["8.9"],"targetPullRequestStates":[{"branch":"8.9","label":"v8.9.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.10.0","labelRegex":"^v8.10.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/161890","number":161890,"mergeCommit":{"message":"[Infrastructure UI] Fix filters passed to Lens (#161890)\n\n## Summary\r\n\r\nThis PR fixes the filters passed to Lens charts that was the query to\r\nnot return the data\r\n\r\nFilter by  inexistent `service.name`\r\n<img width=\"907\" alt=\"image\"\r\nsrc=\"https://github.com/elastic/kibana/assets/2767137/49d68710-7958-4ed5-a20f-c73aa3c30581\">\r\n\r\nQuery by  inexistent `service.name`\r\n\r\n<img width=\"904\" alt=\"image\"\r\nsrc=\"https://github.com/elastic/kibana/assets/2767137/a67cc1df-10ef-4d2d-8072-5ba698d16313\">\r\n\r\nFilter by  existent `service.name`\r\n\r\n<img width=\"904\" alt=\"image\"\r\nsrc=\"https://github.com/elastic/kibana/assets/2767137/55a86ca9-f0a1-486a-974f-ab0c9e09dbc0\">\r\n\r\nQuery by  existent `service.name`\r\n\r\n<img width=\"910\" alt=\"image\"\r\nsrc=\"https://github.com/elastic/kibana/assets/2767137/1c31ca45-e47b-42cd-bee8-26bc0e93f3de\">\r\n\r\n\r\n\r\n### How to test\r\n-  Start a local Kibana instance\r\n- Navigate to `Infrastructure` > `Hosts`\r\n- Change the filters and see how the charts react. \r\n- Open a chart in Lens and confirm whether the data there is the same as\r\nin the Hosts View","sha":"3a48f8876611eb8bec2c587e8efb4d47bacf3132"}}]}] BACKPORT-->