### PR TITLE
[Fleet] Do not ignore coreMigrationVersion and typeMigrationVersion when importing saved object

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/kibana/assets/install.ts
+++ b/x-pack/plugins/fleet/server/services/epm/kibana/assets/install.ts
@@ -45,7 +45,12 @@ type SavedObjectToBe = Required<Pick<SavedObjectsBulkCreateObject, keyof Archive
 };
 export type ArchiveAsset = Pick<
   SavedObject,
-  'id' | 'attributes' | 'migrationVersion' | 'references'
+  | 'id'
+  | 'attributes'
+  | 'migrationVersion'
+  | 'references'
+  | 'coreMigrationVersion'
+  | 'typeMigrationVersion'
 > & {
   type: KibanaSavedObjectType;
 };
@@ -86,7 +91,9 @@ export function createSavedObjectKibanaAsset(asset: ArchiveAsset): SavedObjectTo
     id: asset.id,
     attributes: asset.attributes,
     references: asset.references || [],
-    migrationVersion: asset.migrationVersion || {},
+    migrationVersion: asset.migrationVersion,
+    coreMigrationVersion: asset.coreMigrationVersion,
+    typeMigrationVersion: asset.typeMigrationVersion,
   };
 }
 

--- a/x-pack/plugins/fleet/server/services/epm/kibana/assets/install.ts
+++ b/x-pack/plugins/fleet/server/services/epm/kibana/assets/install.ts
@@ -86,15 +86,24 @@ export async function getKibanaAsset(key: string): Promise<ArchiveAsset> {
 
 export function createSavedObjectKibanaAsset(asset: ArchiveAsset): SavedObjectToBe {
   // convert that to an object
-  return {
+  const so: Partial<SavedObjectToBe> = {
     type: asset.type,
     id: asset.id,
     attributes: asset.attributes,
     references: asset.references || [],
-    migrationVersion: asset.migrationVersion,
-    coreMigrationVersion: asset.coreMigrationVersion,
-    typeMigrationVersion: asset.typeMigrationVersion,
   };
+
+  if (asset.migrationVersion) {
+    so.migrationVersion = asset.migrationVersion;
+  } else {
+    if (asset.coreMigrationVersion) {
+      so.coreMigrationVersion = asset.coreMigrationVersion;
+    }
+    if (asset.typeMigrationVersion) {
+      so.typeMigrationVersion = asset.typeMigrationVersion;
+    }
+  }
+  return so as SavedObjectToBe;
 }
 
 export async function installKibanaAssets(options: {


### PR DESCRIPTION
## Description 

To avoid running all migrations again we should import `coreMigrationVersion` and `typeMigrationVersion`

## Tests

I tested this by installing the system integration from that PR that was failing https://github.com/elastic/integrations/pull/6743 

And I also run locally the `node scripts/install_all_packages` to install all package.


