### PR TITLE
Update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,8 @@ x-pack/plugins/fleet/cypress.config.d.ts
 x-pack/plugins/fleet/cypress.config.js
 x-pack/plugins/osquery/cypress.config.d.ts
 x-pack/plugins/osquery/cypress.config.js
+x-pack/plugins/enterprise_search/cypress.config.d.ts
+x-pack/plugins/enterprise_search/cypress.config.js
 x-pack/plugins/security_solution/public/management/cypress.config.d.ts
 x-pack/plugins/security_solution/public/management/cypress.config.js
 x-pack/plugins/security_solution/public/management/cypress_endpoint.config.d.ts

--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,10 @@ x-pack/plugins/fleet/cypress.config.d.ts
 x-pack/plugins/fleet/cypress.config.js
 x-pack/plugins/osquery/cypress.config.d.ts
 x-pack/plugins/osquery/cypress.config.js
+x-pack/plugins/security_solution/public/management/cypress.config.d.ts
+x-pack/plugins/security_solution/public/management/cypress.config.js
+x-pack/plugins/security_solution/public/management/cypress_endpoint.config.d.ts
+x-pack/plugins/security_solution/public/management/cypress_endpoint.config.js
 
 # release notes script output
 report.csv


### PR DESCRIPTION
Includes a few compiled cypress typescript files generated during `node scripts/type_check`.  We're not using a global glob due to some plugins using a javascript base.