### PR TITLE
fix: flaky execution-dependent test

### DIFF
--- a/test/functional/apps/visualize/_area_chart.ts
+++ b/test/functional/apps/visualize/_area_chart.ts
@@ -433,8 +433,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         expect(isFieldErrorMessageExists).to.be(false);
       });
 
-      // FLAKY: https://github.com/elastic/kibana/issues/160913
-      describe.skip('interval errors', () => {
+      describe('interval errors', () => {
         before(async () => {
           // to trigger displaying of error messages
           await testSubjects.clickWhenNotDisabled('visualizeEditorRenderButton');

--- a/test/functional/page_objects/visualize_editor_page.ts
+++ b/test/functional/page_objects/visualize_editor_page.ts
@@ -441,6 +441,8 @@ export class VisualizeEditorPageObject extends FtrService {
     const newValueString = `${newValue}`;
     const { type = 'default', aggNth = 2, append = false } = options;
     this.log.debug(`visEditor.setInterval(${newValueString}, {${type}, ${aggNth}, ${append}})`);
+    const comboBoxElement = await this.testSubjects.find('visEditorInterval');
+    await this.comboBox.openOptionsList(comboBoxElement);
     if (type === 'default') {
       await this.comboBox.set('visEditorInterval', newValueString);
     } else if (type === 'custom') {


### PR DESCRIPTION
## Summary

Fixes flaky test in `_area_series`. In isolation, the test passes just fine, but when running entire test file, the test hangs on an unopened `comboBox`.

fixes #160913

FTR: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2644