### PR TITLE
[DOCS] Remove outdated Maps video

### DIFF
--- a/docs/maps/index.asciidoc
+++ b/docs/maps/index.asciidoc
@@ -13,22 +13,6 @@ Create beautiful maps from your geographical data. With **Maps**, you can:
 * Symbolize features using data values.
 * Focus on only the data that’s important to you.
 
-*Ready to get started?* Watch the https://videos.elastic.co/watch/BYzRDtH4u7RSD8wKhuEW1b[video], and then start your tour of **Maps** with the <<maps-getting-started, getting started tutorial>>.
-
-++++
-<script type="text/javascript" async src="https://play.vidyard.com/embed/v4.js">
-</script>
-<img
-style="width: 100%; margin: auto; display: block;"
-class="vidyard-player-embed"
-src="https://play.vidyard.com/mBuWenQ2uSLY9YjEkPtzJC.jpg"
-data-uuid="mBuWenQ2uSLY9YjEkPtzJC"
-data-v="4"
-data-type="inline"
-/>
-</br>
-++++
-
 [float]
 === Build maps with multiple layers and indices
 Use multiple layers and indices to show all your data in a single map. Show how data sits relative to physical features like weather patterns, human-made features like international borders, and business-specific features like sales regions. Plot individual documents or use aggregations to plot any data set, no matter how large.

--- a/docs/user/dashboard/make-dashboards-interactive.asciidoc
+++ b/docs/user/dashboard/make-dashboards-interactive.asciidoc
@@ -9,6 +9,9 @@
 
 Add interactive capabilities to your dashboard, such as interactive filter controls, and drilldowns that allow you to navigate to *Discover*, other dashboards, and external websites. 
 
+// Video is slightly outdated. Left in at request of dev team.
+// See https://github.com/elastic/kibana/pull/161090#issuecomment-1620410065
+
 ++++
 <script type="text/javascript" async 
 src="https://play.vidyard.com/embed/v4.js"></script>


### PR DESCRIPTION
## Summary

- Removes a video from the [Maps](https://www.elastic.co/guide/en/kibana/current/maps.html) docs. The video's UI is outdated. There are no current plans to update the video.
- Adds a comment to the [Make dashboards interactive](https://www.elastic.co/guide/en/kibana/current/drilldowns.html). This video is slightly outdated, but we're leaving it in at the request of the dev team.

Closes https://github.com/elastic/platform-docs-team/issues/131

<!--ONMERGE {"backportTargets":["8.8","8.9"]} ONMERGE-->