### PR TITLE
[RAM] Allow producers on rule type

### DIFF
--- a/x-pack/plugins/alerting/server/types.ts
+++ b/x-pack/plugins/alerting/server/types.ts
@@ -289,7 +289,8 @@ export interface RuleType<
     WithoutReservedActionGroups<ActionGroupIds, RecoveryActionGroupId>,
     AlertData
   >;
-  producer: string;
+  // TODO Accept string[] && string
+  producer: string[] | string;
   actionVariables?: {
     context?: ActionVariable[];
     state?: ActionVariable[];

--- a/x-pack/plugins/infra/server/features.ts
+++ b/x-pack/plugins/infra/server/features.ts
@@ -8,6 +8,7 @@
 import { i18n } from '@kbn/i18n';
 import { DEFAULT_APP_CATEGORIES } from '@kbn/core/server';
 import { logViewSavedObjectName } from '@kbn/logs-shared-plugin/server';
+import { OBSERVABILITY_THRESHOLD_RULE_TYPE_ID } from '@kbn/observability-plugin/common/constants';
 import { LOG_DOCUMENT_COUNT_RULE_TYPE_ID } from '../common/alerting/logs/log_threshold/types';
 import {
   METRIC_INVENTORY_THRESHOLD_ALERT_TYPE_ID,
@@ -28,7 +29,11 @@ export const METRICS_FEATURE = {
   management: {
     insightsAndAlerting: ['triggersActions'],
   },
-  alerting: [METRIC_THRESHOLD_ALERT_TYPE_ID, METRIC_INVENTORY_THRESHOLD_ALERT_TYPE_ID],
+  alerting: [
+    METRIC_THRESHOLD_ALERT_TYPE_ID,
+    METRIC_INVENTORY_THRESHOLD_ALERT_TYPE_ID,
+    OBSERVABILITY_THRESHOLD_RULE_TYPE_ID,
+  ],
   privileges: {
     all: {
       app: ['infra', 'metrics', 'kibana'],
@@ -40,10 +45,18 @@ export const METRICS_FEATURE = {
       },
       alerting: {
         rule: {
-          all: [METRIC_THRESHOLD_ALERT_TYPE_ID, METRIC_INVENTORY_THRESHOLD_ALERT_TYPE_ID],
+          all: [
+            METRIC_THRESHOLD_ALERT_TYPE_ID,
+            METRIC_INVENTORY_THRESHOLD_ALERT_TYPE_ID,
+            OBSERVABILITY_THRESHOLD_RULE_TYPE_ID,
+          ],
         },
         alert: {
-          all: [METRIC_THRESHOLD_ALERT_TYPE_ID, METRIC_INVENTORY_THRESHOLD_ALERT_TYPE_ID],
+          all: [
+            METRIC_THRESHOLD_ALERT_TYPE_ID,
+            METRIC_INVENTORY_THRESHOLD_ALERT_TYPE_ID,
+            OBSERVABILITY_THRESHOLD_RULE_TYPE_ID,
+          ],
         },
       },
       management: {
@@ -61,10 +74,18 @@ export const METRICS_FEATURE = {
       },
       alerting: {
         rule: {
-          read: [METRIC_THRESHOLD_ALERT_TYPE_ID, METRIC_INVENTORY_THRESHOLD_ALERT_TYPE_ID],
+          read: [
+            METRIC_THRESHOLD_ALERT_TYPE_ID,
+            METRIC_INVENTORY_THRESHOLD_ALERT_TYPE_ID,
+            OBSERVABILITY_THRESHOLD_RULE_TYPE_ID,
+          ],
         },
         alert: {
-          read: [METRIC_THRESHOLD_ALERT_TYPE_ID, METRIC_INVENTORY_THRESHOLD_ALERT_TYPE_ID],
+          read: [
+            METRIC_THRESHOLD_ALERT_TYPE_ID,
+            METRIC_INVENTORY_THRESHOLD_ALERT_TYPE_ID,
+            OBSERVABILITY_THRESHOLD_RULE_TYPE_ID,
+          ],
         },
       },
       management: {
@@ -87,7 +108,7 @@ export const LOGS_FEATURE = {
   management: {
     insightsAndAlerting: ['triggersActions'],
   },
-  alerting: [LOG_DOCUMENT_COUNT_RULE_TYPE_ID],
+  alerting: [LOG_DOCUMENT_COUNT_RULE_TYPE_ID, OBSERVABILITY_THRESHOLD_RULE_TYPE_ID],
   privileges: {
     all: {
       app: ['infra', 'logs', 'kibana'],
@@ -99,10 +120,10 @@ export const LOGS_FEATURE = {
       },
       alerting: {
         rule: {
-          all: [LOG_DOCUMENT_COUNT_RULE_TYPE_ID],
+          all: [LOG_DOCUMENT_COUNT_RULE_TYPE_ID, OBSERVABILITY_THRESHOLD_RULE_TYPE_ID],
         },
         alert: {
-          all: [LOG_DOCUMENT_COUNT_RULE_TYPE_ID],
+          all: [LOG_DOCUMENT_COUNT_RULE_TYPE_ID, OBSERVABILITY_THRESHOLD_RULE_TYPE_ID],
         },
       },
       management: {

--- a/x-pack/plugins/observability/server/lib/rules/threshold/register_threshold_rule_type.ts
+++ b/x-pack/plugins/observability/server/lib/rules/threshold/register_threshold_rule_type.ts
@@ -18,7 +18,7 @@ import {
 } from '@kbn/rule-registry-plugin/server';
 import { LicenseType } from '@kbn/licensing-plugin/server';
 import { EsQueryRuleParamsExtractedParams } from '@kbn/stack-alerts-plugin/server/rule_types/es_query/rule_type_params';
-import { observabilityFeatureId } from '../../../../common';
+import { AlertConsumers } from '@kbn/rule-registry-plugin/common/technical_rule_data_field_names';
 import { Comparator } from '../../../../common/threshold_rule/types';
 import { OBSERVABILITY_THRESHOLD_RULE_TYPE_ID } from '../../../../common/constants';
 import { THRESHOLD_RULE_REGISTRATION_CONTEXT } from '../../../common/constants';
@@ -219,8 +219,10 @@ export function thresholdRuleType(
         };
       },
     },
-    producer: observabilityFeatureId,
+    producer: [AlertConsumers.LOGS, AlertConsumers.INFRASTRUCTURE],
     getSummarizedAlerts: getSummarizedAlerts(),
     alerts: MetricsRulesTypeAlertDefinition,
+    // TO ALLOW grouping on the creation flyout page
+    // groupRuleBy: 'observability',
   };
 }

--- a/x-pack/plugins/rule_registry/server/alert_data_client/alerts_client.ts
+++ b/x-pack/plugins/rule_registry/server/alert_data_client/alerts_client.ts
@@ -1017,8 +1017,12 @@ export class AlertsClient {
       // the user should be provided that features' alerts index.
       // Limiting which alerts that user can read on that index will be done via the findAuthorizationFilter
       const authorizedFeatures = new Set<string>();
+
       for (const ruleType of augmentedRuleTypes.authorizedRuleTypes) {
-        authorizedFeatures.add(ruleType.producer);
+        const producers = Array.isArray(ruleType.producer)
+          ? ruleType.producer
+          : [ruleType.producer];
+        producers.forEach((p) => authorizedFeatures.add(p));
       }
       const validAuthorizedFeatures = Array.from(authorizedFeatures).filter(
         (feature): feature is ValidFeatureId =>
@@ -1061,7 +1065,10 @@ export class AlertsClient {
         // Limiting which alerts that user can read on that index will be done via the findAuthorizationFilter
         const authorizedFeatures = new Set<string>();
         for (const ruleType of augmentedRuleTypes.authorizedRuleTypes) {
-          authorizedFeatures.add(ruleType.producer);
+          const producers = Array.isArray(ruleType.producer)
+            ? ruleType.producer
+            : [ruleType.producer];
+          producers.forEach((p) => authorizedFeatures.add(p));
         }
         const validAuthorizedFeatures = Array.from(authorizedFeatures).filter(
           (feature): feature is ValidFeatureId =>
@@ -1101,7 +1108,8 @@ export class AlertsClient {
 
   public async getAADFields({ ruleTypeId }: { ruleTypeId: string }) {
     const { producer, fieldsForAAD = [] } = this.getRuleType(ruleTypeId);
-    const indices = await this.getAuthorizedAlertsIndices([producer]);
+    const producers = Array.isArray(producer) ? producer : [producer];
+    const indices = await this.getAuthorizedAlertsIndices(producers);
     const o11yIndices = indices?.filter((index) => index.startsWith('.alerts-observability')) ?? [];
     const indexPatternsFetcherAsInternalUser = new IndexPatternsFetcher(this.esClient);
     const { fields } = await indexPatternsFetcherAsInternalUser.getFieldsForWildcard({

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/rule_form/rule_form.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/rule_form/rule_form.tsx
@@ -351,18 +351,22 @@ export const RuleForm = ({
       >,
       ruleTypeValue
     ) => {
-      const producer = ruleTypeValue.ruleType.producer;
-      if (producer) {
+      const producers = Array.isArray(ruleTypeValue.ruleType.producer)
+        ? ruleTypeValue.ruleType.producer
+        : [ruleTypeValue.ruleType.producer];
+      if (producers.length > 0) {
         const checkEnabledResult = checkRuleTypeEnabled(ruleTypeValue.ruleType);
-        if (!checkEnabledResult.isEnabled) {
-          hasDisabledByLicenseRuleTypes = true;
+        for (const producer of producers) {
+          if (!checkEnabledResult.isEnabled) {
+            hasDisabledByLicenseRuleTypes = true;
+          }
+          (result[producer] = result[producer] || []).push({
+            name: ruleTypeValue.ruleType.name,
+            id: ruleTypeValue.ruleTypeModel.id,
+            checkEnabledResult,
+            ruleTypeItem: ruleTypeValue.ruleTypeModel,
+          });
         }
-        (result[producer] = result[producer] || []).push({
-          name: ruleTypeValue.ruleType.name,
-          id: ruleTypeValue.ruleTypeModel.id,
-          checkEnabledResult,
-          ruleTypeItem: ruleTypeValue.ruleTypeModel,
-        });
       }
       return result;
     },


### PR DESCRIPTION
## Summary

This PR is just a POC to show how to allow the `generic threshold rule` from o11y without `superuser` privilege but with only `LOGS` privileges in kibana and to only see the alerts and rules. To make it work, we still need to fix the bug that when you create a rule from the o11y rule management page you need to set the consumer to `logs` and note `alerts` @JiaweiWu.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
