### PR TITLE
[APM] Pass `transaction.name` and error `groupId` in alert flyout

### DIFF
--- a/x-pack/plugins/apm/public/components/alerting/ui_components/alerting_flyout/index.tsx
+++ b/x-pack/plugins/apm/public/components/alerting/ui_components/alerting_flyout/index.tsx
@@ -29,7 +29,7 @@ export function AlertingFlyout(props: Props) {
   const { addFlyoutVisible, setAddFlyoutVisibility, ruleType } = props;
 
   const serviceName = useServiceName();
-  const { query } = useApmParams('/*');
+  const { query, path } = useApmParams('/*');
 
   const rangeFrom = 'rangeFrom' in query ? query.rangeFrom : undefined;
   const rangeTo = 'rangeTo' in query ? query.rangeTo : undefined;
@@ -40,6 +40,9 @@ export function AlertingFlyout(props: Props) {
     'environment' in query ? query.environment : ENVIRONMENT_ALL.value;
   const transactionType =
     'transactionType' in query ? query.transactionType : undefined;
+  const transactionName =
+    'transactionName' in query ? query.transactionName : undefined;
+  const errorGroupingKey = 'groupId' in path ? path.groupId : undefined;
 
   const { services } = useKibana<ApmPluginStartDeps>();
   const initialValues = getInitialAlertValues(ruleType, serviceName);
@@ -62,6 +65,8 @@ export function AlertingFlyout(props: Props) {
           environment,
           serviceName,
           ...(ruleType === ApmRuleType.ErrorCount ? {} : { transactionType }),
+          transactionName,
+          errorGroupingKey,
           start,
           end,
         } as AlertMetadata,
@@ -73,6 +78,8 @@ export function AlertingFlyout(props: Props) {
       onCloseAddFlyout,
       services.triggersActionsUi,
       serviceName,
+      transactionName,
+      errorGroupingKey,
       transactionType,
       environment,
       start,


### PR DESCRIPTION
closes https://github.com/elastic/kibana/issues/156805 https://github.com/elastic/kibana/issues/156804

- Auto-complete when params are present. 

- The params are not present when creating a rule from the Alerts page or Management rules page. 

https://github.com/elastic/kibana/assets/3369346/e4563072-6c9d-4245-9075-b6939c1542e7

