### PR TITLE
[8.8] [DOC+] License not available is KB-ES connection error (#161176)

### DIFF
--- a/docs/setup/access.asciidoc
+++ b/docs/setup/access.asciidoc
@@ -61,5 +61,5 @@ curl -XGET elasticsearch_ip_or_hostname:9200/_cat/indices/.kibana,.kibana_task_m
 +
 For example:
 
-* When {kib} is unable to connect to a healthy {es} cluster, the `master_not_discovered_exception` or `Unable to revive connection` errors appear.
+* When {kib} is unable to connect to a healthy {es} cluster, errors like `master_not_discovered_exception` or `unable to revive connection` or `license is not available` errors appear.
 * When one or more {kib}-backing indices are unhealthy, the `index_not_green_timeout` error appears.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.8`:
 - [[DOC+] License not available is KB-ES connection error (#161176)](https://github.com/elastic/kibana/pull/161176)


