### PR TITLE
Updates header filters for request logs.

### DIFF
--- a/packages/core/elasticsearch/core-elasticsearch-client-server-internal/src/get_ecs_response_log.test.ts
+++ b/packages/core/elasticsearch/core-elasticsearch-client-server-internal/src/get_ecs_response_log.test.ts
@@ -91,6 +91,23 @@ describe('getEcsResponseLog', () => {
       `);
     });
 
+    test('redacts es-client-authentication headers by default', () => {
+      const event = createResponseEvent({
+        requestParams: {
+          headers: { 'es-client-authentication': 'ae3fda37-xxx', 'user-agent': 'world' },
+        },
+        response: { headers: { 'content-length': '123' } },
+      });
+      const log = getEcsResponseLog(event);
+      // @ts-expect-error ECS custom field
+      expect(log.http.request.headers).toMatchInlineSnapshot(`
+        Object {
+          "es-client-authentication": "[REDACTED]",
+          "user-agent": "world",
+        }
+      `);
+    });
+
     test('does not mutate original headers', () => {
       const reqHeaders = { a: 'foo', b: ['hello', 'world'] };
       const resHeaders = { c: 'bar' };

--- a/packages/core/elasticsearch/core-elasticsearch-client-server-internal/src/get_ecs_response_log.ts
+++ b/packages/core/elasticsearch/core-elasticsearch-client-server-internal/src/get_ecs_response_log.ts
@@ -12,7 +12,13 @@ import { type LogMeta } from '@kbn/logging';
 
 // If you are updating these, consider whether they should also be updated in the
 // http service `getResponseLog`
-const FORBIDDEN_HEADERS = ['authorization', 'cookie', 'set-cookie', 'x-elastic-app-auth'];
+const FORBIDDEN_HEADERS = [
+  'authorization',
+  'cookie',
+  'set-cookie',
+  'x-elastic-app-auth',
+  'es-client-authentication',
+];
 const REDACTED_HEADER_TEXT = '[REDACTED]';
 
 // We are excluding sensitive headers by default, until we have a log filtering mechanism.

--- a/packages/core/http/core-http-server-internal/src/logging/get_response_log.test.ts
+++ b/packages/core/http/core-http-server-internal/src/logging/get_response_log.test.ts
@@ -211,6 +211,21 @@ describe('getEcsResponseLog', () => {
       `);
     });
 
+    test('redacts es-client-authentication headers by default', () => {
+      const req = createMockHapiRequest({
+        headers: { 'es-client-authentication': 'ae3fda37-xxx', 'user-agent': 'world' },
+        response: { headers: { 'content-length': '123' } },
+      });
+      const result = getEcsResponseLog(req, logger);
+      // @ts-expect-error ECS custom field
+      expect(result.meta.http.request.headers).toMatchInlineSnapshot(`
+        Object {
+          "es-client-authentication": "[REDACTED]",
+          "user-agent": "world",
+        }
+      `);
+    });
+
     test('does not mutate original headers', () => {
       const reqHeaders = { a: 'foo', b: ['hello', 'world'] };
       const resHeaders = { headers: { c: 'bar' } };

--- a/packages/core/http/core-http-server-internal/src/logging/get_response_log.ts
+++ b/packages/core/http/core-http-server-internal/src/logging/get_response_log.ts
@@ -16,7 +16,13 @@ import { getResponsePayloadBytes } from './get_payload_size';
 
 // If you are updating these, consider whether they should also be updated in the
 // elasticsearch service `getEcsResponseLog`
-const FORBIDDEN_HEADERS = ['authorization', 'cookie', 'set-cookie', 'x-elastic-app-auth'];
+const FORBIDDEN_HEADERS = [
+  'authorization',
+  'cookie',
+  'set-cookie',
+  'x-elastic-app-auth',
+  'es-client-authentication',
+];
 const REDACTED_HEADER_TEXT = '[REDACTED]';
 
 type HapiHeaders = Record<string, string | string[]>;


### PR DESCRIPTION
## Summary

Updates [header](https://www.elastic.co/guide/en/elasticsearch/reference/master/jwt-auth-realm.html#hmac-oidc-example-request-headers) filters for request logs.

/cc @elastic/kibana-security 

<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->