### PR TITLE
feat(slo): Add more fields into the rollup and summary data

### DIFF
--- a/x-pack/plugins/observability/server/assets/component_templates/slo_mappings_template.ts
+++ b/x-pack/plugins/observability/server/assets/component_templates/slo_mappings_template.ts
@@ -29,6 +29,26 @@ export const getSLOMappingsTemplate = (name: string) => ({
               type: 'keyword',
               ignore_above: 256,
             },
+            name: {
+              type: 'keyword',
+              ignore_above: 256,
+            },
+            description: {
+              type: 'keyword',
+              ignore_above: 256,
+            },
+            tags: {
+              type: 'keyword',
+              ignore_above: 256,
+            },
+            indicator: {
+              properties: {
+                type: {
+                  type: 'keyword',
+                  ignore_above: 256,
+                },
+              },
+            },
             objective: {
               properties: {
                 target: {

--- a/x-pack/plugins/observability/server/assets/component_templates/slo_mappings_template.ts
+++ b/x-pack/plugins/observability/server/assets/component_templates/slo_mappings_template.ts
@@ -16,6 +16,31 @@ export const getSLOMappingsTemplate = (name: string) => ({
           type: 'date',
           format: 'date_optional_time||epoch_millis',
         },
+        // APM service and transaction specific fields
+        service: {
+          properties: {
+            name: {
+              type: 'keyword',
+              ignore_above: 256,
+            },
+            environment: {
+              type: 'keyword',
+              ignore_above: 256,
+            },
+          },
+        },
+        transaction: {
+          properties: {
+            name: {
+              type: 'keyword',
+              ignore_above: 256,
+            },
+            type: {
+              type: 'keyword',
+              ignore_above: 256,
+            },
+          },
+        },
         slo: {
           properties: {
             id: {

--- a/x-pack/plugins/observability/server/assets/component_templates/slo_summary_mappings_template.ts
+++ b/x-pack/plugins/observability/server/assets/component_templates/slo_summary_mappings_template.ts
@@ -25,6 +25,26 @@ export const getSLOSummaryMappingsTemplate = (name: string) => ({
               type: 'keyword',
               ignore_above: 256,
             },
+            name: {
+              type: 'keyword',
+              ignore_above: 256,
+            },
+            description: {
+              type: 'keyword',
+              ignore_above: 256,
+            },
+            tags: {
+              type: 'keyword',
+              ignore_above: 256,
+            },
+            indicator: {
+              properties: {
+                type: {
+                  type: 'keyword',
+                  ignore_above: 256,
+                },
+              },
+            },
             budgetingMethod: {
               type: 'keyword',
             },

--- a/x-pack/plugins/observability/server/assets/component_templates/slo_summary_mappings_template.ts
+++ b/x-pack/plugins/observability/server/assets/component_templates/slo_summary_mappings_template.ts
@@ -12,6 +12,31 @@ export const getSLOSummaryMappingsTemplate = (name: string) => ({
   template: {
     mappings: {
       properties: {
+        // APM service and transaction specific fields
+        service: {
+          properties: {
+            name: {
+              type: 'keyword',
+              ignore_above: 256,
+            },
+            environment: {
+              type: 'keyword',
+              ignore_above: 256,
+            },
+          },
+        },
+        transaction: {
+          properties: {
+            name: {
+              type: 'keyword',
+              ignore_above: 256,
+            },
+            type: {
+              type: 'keyword',
+              ignore_above: 256,
+            },
+          },
+        },
         slo: {
           properties: {
             id: {

--- a/x-pack/plugins/observability/server/routes/slo/route.ts
+++ b/x-pack/plugins/observability/server/routes/slo/route.ts
@@ -315,8 +315,9 @@ const getSloDiagnosisRoute = createObservabilityServerRoute({
   handler: async ({ context, params }) => {
     const esClient = (await context.core).elasticsearch.client.asCurrentUser;
     const soClient = (await context.core).savedObjects.client;
+    const repository = new KibanaSavedObjectsSLORepository(soClient);
 
-    return getSloDiagnosis(params.path.id, { esClient, soClient });
+    return getSloDiagnosis(params.path.id, { esClient, repository });
   },
 });
 

--- a/x-pack/plugins/observability/server/services/slo/delete_slo.test.ts
+++ b/x-pack/plugins/observability/server/services/slo/delete_slo.test.ts
@@ -9,7 +9,11 @@ import { rulesClientMock } from '@kbn/alerting-plugin/server/rules_client.mock';
 import { RulesClientApi } from '@kbn/alerting-plugin/server/types';
 import { ElasticsearchClient } from '@kbn/core/server';
 import { elasticsearchServiceMock } from '@kbn/core/server/mocks';
-import { getSLOTransformId, SLO_DESTINATION_INDEX_PATTERN } from '../../assets/constants';
+import {
+  getSLOTransformId,
+  SLO_DESTINATION_INDEX_PATTERN,
+  SLO_SUMMARY_DESTINATION_INDEX_PATTERN,
+} from '../../assets/constants';
 import { DeleteSLO } from './delete_slo';
 import { createAPMTransactionErrorRateIndicator, createSLO } from './fixtures/slo';
 import { createSLORepositoryMock, createTransformManagerMock } from './mocks';
@@ -45,9 +49,22 @@ describe('DeleteSLO', () => {
       expect(mockTransformManager.uninstall).toHaveBeenCalledWith(
         getSLOTransformId(slo.id, slo.revision)
       );
-      expect(mockEsClient.deleteByQuery).toHaveBeenCalledWith(
+      expect(mockEsClient.deleteByQuery).toHaveBeenCalledTimes(2);
+      expect(mockEsClient.deleteByQuery).toHaveBeenNthCalledWith(
+        1,
         expect.objectContaining({
           index: SLO_DESTINATION_INDEX_PATTERN,
+          query: {
+            match: {
+              'slo.id': slo.id,
+            },
+          },
+        })
+      );
+      expect(mockEsClient.deleteByQuery).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          index: SLO_SUMMARY_DESTINATION_INDEX_PATTERN,
           query: {
             match: {
               'slo.id': slo.id,

--- a/x-pack/plugins/observability/server/services/slo/delete_slo.ts
+++ b/x-pack/plugins/observability/server/services/slo/delete_slo.ts
@@ -53,8 +53,8 @@ export class DeleteSLO {
       index: SLO_SUMMARY_DESTINATION_INDEX_PATTERN,
       wait_for_completion: false,
       query: {
-        bool: {
-          filter: [{ term: { 'slo.id': sloId } }],
+        match: {
+          'slo.id': sloId,
         },
       },
     });

--- a/x-pack/plugins/observability/server/services/slo/delete_slo.ts
+++ b/x-pack/plugins/observability/server/services/slo/delete_slo.ts
@@ -7,7 +7,11 @@
 
 import { RulesClientApi } from '@kbn/alerting-plugin/server/types';
 import { ElasticsearchClient } from '@kbn/core/server';
-import { getSLOTransformId, SLO_DESTINATION_INDEX_PATTERN } from '../../assets/constants';
+import {
+  getSLOTransformId,
+  SLO_DESTINATION_INDEX_PATTERN,
+  SLO_SUMMARY_DESTINATION_INDEX_PATTERN,
+} from '../../assets/constants';
 import { SLORepository } from './slo_repository';
 import { TransformManager } from './transform_manager';
 
@@ -27,6 +31,7 @@ export class DeleteSLO {
     await this.transformManager.uninstall(sloTransformId);
 
     await this.deleteRollupData(slo.id);
+    await this.deleteSummaryData(slo.id);
     await this.deleteAssociatedRules(slo.id);
     await this.repository.deleteById(slo.id);
   }
@@ -43,6 +48,17 @@ export class DeleteSLO {
     });
   }
 
+  private async deleteSummaryData(sloId: string): Promise<void> {
+    await this.esClient.deleteByQuery({
+      index: SLO_SUMMARY_DESTINATION_INDEX_PATTERN,
+      wait_for_completion: false,
+      query: {
+        bool: {
+          filter: [{ term: { 'slo.id': sloId } }],
+        },
+      },
+    });
+  }
   private async deleteAssociatedRules(sloId: string): Promise<void> {
     try {
       await this.rulesClient.bulkDeleteRules({

--- a/x-pack/plugins/observability/server/services/slo/summary_transform/__snapshots__/summary_transform_installer.test.ts.snap
+++ b/x-pack/plugins/observability/server/services/slo/summary_transform/__snapshots__/summary_transform_installer.test.ts.snap
@@ -1,0 +1,1057 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Summary Transform Installer installs only the missing summary transforms 1`] = `
+Array [
+  Array [
+    Object {
+      "_meta": Object {
+        "managed": true,
+        "managed_by": "observability",
+        "version": 2,
+      },
+      "description": "Summarize every SLO with timeslices budgeting method and a 7 days rolling time window",
+      "dest": Object {
+        "index": ".slo-observability.summary-v2",
+      },
+      "frequency": "1m",
+      "pivot": Object {
+        "aggregations": Object {
+          "_objectiveTarget": Object {
+            "max": Object {
+              "field": "slo.objective.target",
+            },
+          },
+          "errorBudgetConsumed": Object {
+            "bucket_script": Object {
+              "buckets_path": Object {
+                "errorBudgetInitial": "errorBudgetInitial",
+                "sliValue": "sliValue",
+              },
+              "script": "if (params.sliValue == -1) { return 0 } else { return (1 - params.sliValue) / params.errorBudgetInitial }",
+            },
+          },
+          "errorBudgetInitial": Object {
+            "bucket_script": Object {
+              "buckets_path": Object {
+                "objectiveTarget": "_objectiveTarget",
+              },
+              "script": "1 - params.objectiveTarget",
+            },
+          },
+          "errorBudgetRemaining": Object {
+            "bucket_script": Object {
+              "buckets_path": Object {
+                "errorBudgetConsummed": "errorBudgetConsumed",
+              },
+              "script": "1 - params.errorBudgetConsummed",
+            },
+          },
+          "goodEvents": Object {
+            "sum": Object {
+              "field": "slo.isGoodSlice",
+            },
+          },
+          "sliValue": Object {
+            "bucket_script": Object {
+              "buckets_path": Object {
+                "goodEvents": "goodEvents",
+                "totalEvents": "totalEvents",
+              },
+              "script": "if (params.totalEvents == 0) { return -1 } else { return params.goodEvents / params.totalEvents }",
+            },
+          },
+          "status": Object {
+            "bucket_script": Object {
+              "buckets_path": Object {
+                "errorBudgetRemaining": "errorBudgetRemaining",
+                "objectiveTarget": "_objectiveTarget",
+                "sliValue": "sliValue",
+              },
+              "script": Object {
+                "source": "if (params.sliValue == -1) { return 0 } else if (params.sliValue >= params.objectiveTarget) { return 4 } else if (params.errorBudgetRemaining > 0) { return 2 } else { return 1 }",
+              },
+            },
+          },
+          "totalEvents": Object {
+            "value_count": Object {
+              "field": "slo.isGoodSlice",
+            },
+          },
+        },
+        "group_by": Object {
+          "service.environment": Object {
+            "terms": Object {
+              "field": "service.environment",
+              "missing_bucket": true,
+            },
+          },
+          "service.name": Object {
+            "terms": Object {
+              "field": "service.name",
+              "missing_bucket": true,
+            },
+          },
+          "slo.budgetingMethod": Object {
+            "terms": Object {
+              "field": "slo.budgetingMethod",
+            },
+          },
+          "slo.description": Object {
+            "terms": Object {
+              "field": "slo.description",
+            },
+          },
+          "slo.id": Object {
+            "terms": Object {
+              "field": "slo.id",
+            },
+          },
+          "slo.indicator.type": Object {
+            "terms": Object {
+              "field": "slo.indicator.type",
+            },
+          },
+          "slo.instanceId": Object {
+            "terms": Object {
+              "field": "slo.instanceId",
+            },
+          },
+          "slo.name": Object {
+            "terms": Object {
+              "field": "slo.name",
+            },
+          },
+          "slo.revision": Object {
+            "terms": Object {
+              "field": "slo.revision",
+            },
+          },
+          "slo.tags": Object {
+            "terms": Object {
+              "field": "slo.tags",
+            },
+          },
+          "slo.timeWindow.duration": Object {
+            "terms": Object {
+              "field": "slo.timeWindow.duration",
+            },
+          },
+          "slo.timeWindow.type": Object {
+            "terms": Object {
+              "field": "slo.timeWindow.type",
+            },
+          },
+          "transaction.name": Object {
+            "terms": Object {
+              "field": "transaction.name",
+              "missing_bucket": true,
+            },
+          },
+          "transaction.type": Object {
+            "terms": Object {
+              "field": "transaction.type",
+              "missing_bucket": true,
+            },
+          },
+        },
+      },
+      "settings": Object {
+        "deduce_mappings": false,
+      },
+      "source": Object {
+        "index": ".slo-observability.sli-v2*",
+        "query": Object {
+          "bool": Object {
+            "filter": Array [
+              Object {
+                "range": Object {
+                  "@timestamp": Object {
+                    "gte": "now-7d/m",
+                    "lte": "now/m",
+                  },
+                },
+              },
+              Object {
+                "term": Object {
+                  "slo.budgetingMethod": "timeslices",
+                },
+              },
+              Object {
+                "term": Object {
+                  "slo.timeWindow.type": "rolling",
+                },
+              },
+              Object {
+                "term": Object {
+                  "slo.timeWindow.duration": "7d",
+                },
+              },
+            ],
+          },
+        },
+      },
+      "sync": Object {
+        "time": Object {
+          "delay": "60s",
+          "field": "@timestamp",
+        },
+      },
+      "transform_id": "slo-summary-timeslices-7d-rolling",
+    },
+    Object {
+      "ignore": Array [
+        409,
+      ],
+    },
+  ],
+  Array [
+    Object {
+      "_meta": Object {
+        "managed": true,
+        "managed_by": "observability",
+        "version": 2,
+      },
+      "description": "Summarize every SLO with timeslices budgeting method and a 30 days rolling time window",
+      "dest": Object {
+        "index": ".slo-observability.summary-v2",
+      },
+      "frequency": "1m",
+      "pivot": Object {
+        "aggregations": Object {
+          "_objectiveTarget": Object {
+            "max": Object {
+              "field": "slo.objective.target",
+            },
+          },
+          "errorBudgetConsumed": Object {
+            "bucket_script": Object {
+              "buckets_path": Object {
+                "errorBudgetInitial": "errorBudgetInitial",
+                "sliValue": "sliValue",
+              },
+              "script": "if (params.sliValue == -1) { return 0 } else { return (1 - params.sliValue) / params.errorBudgetInitial }",
+            },
+          },
+          "errorBudgetInitial": Object {
+            "bucket_script": Object {
+              "buckets_path": Object {
+                "objectiveTarget": "_objectiveTarget",
+              },
+              "script": "1 - params.objectiveTarget",
+            },
+          },
+          "errorBudgetRemaining": Object {
+            "bucket_script": Object {
+              "buckets_path": Object {
+                "errorBudgetConsummed": "errorBudgetConsumed",
+              },
+              "script": "1 - params.errorBudgetConsummed",
+            },
+          },
+          "goodEvents": Object {
+            "sum": Object {
+              "field": "slo.isGoodSlice",
+            },
+          },
+          "sliValue": Object {
+            "bucket_script": Object {
+              "buckets_path": Object {
+                "goodEvents": "goodEvents",
+                "totalEvents": "totalEvents",
+              },
+              "script": "if (params.totalEvents == 0) { return -1 } else { return params.goodEvents / params.totalEvents }",
+            },
+          },
+          "status": Object {
+            "bucket_script": Object {
+              "buckets_path": Object {
+                "errorBudgetRemaining": "errorBudgetRemaining",
+                "objectiveTarget": "_objectiveTarget",
+                "sliValue": "sliValue",
+              },
+              "script": Object {
+                "source": "if (params.sliValue == -1) { return 0 } else if (params.sliValue >= params.objectiveTarget) { return 4 } else if (params.errorBudgetRemaining > 0) { return 2 } else { return 1 }",
+              },
+            },
+          },
+          "totalEvents": Object {
+            "value_count": Object {
+              "field": "slo.isGoodSlice",
+            },
+          },
+        },
+        "group_by": Object {
+          "service.environment": Object {
+            "terms": Object {
+              "field": "service.environment",
+              "missing_bucket": true,
+            },
+          },
+          "service.name": Object {
+            "terms": Object {
+              "field": "service.name",
+              "missing_bucket": true,
+            },
+          },
+          "slo.budgetingMethod": Object {
+            "terms": Object {
+              "field": "slo.budgetingMethod",
+            },
+          },
+          "slo.description": Object {
+            "terms": Object {
+              "field": "slo.description",
+            },
+          },
+          "slo.id": Object {
+            "terms": Object {
+              "field": "slo.id",
+            },
+          },
+          "slo.indicator.type": Object {
+            "terms": Object {
+              "field": "slo.indicator.type",
+            },
+          },
+          "slo.instanceId": Object {
+            "terms": Object {
+              "field": "slo.instanceId",
+            },
+          },
+          "slo.name": Object {
+            "terms": Object {
+              "field": "slo.name",
+            },
+          },
+          "slo.revision": Object {
+            "terms": Object {
+              "field": "slo.revision",
+            },
+          },
+          "slo.tags": Object {
+            "terms": Object {
+              "field": "slo.tags",
+            },
+          },
+          "slo.timeWindow.duration": Object {
+            "terms": Object {
+              "field": "slo.timeWindow.duration",
+            },
+          },
+          "slo.timeWindow.type": Object {
+            "terms": Object {
+              "field": "slo.timeWindow.type",
+            },
+          },
+          "transaction.name": Object {
+            "terms": Object {
+              "field": "transaction.name",
+              "missing_bucket": true,
+            },
+          },
+          "transaction.type": Object {
+            "terms": Object {
+              "field": "transaction.type",
+              "missing_bucket": true,
+            },
+          },
+        },
+      },
+      "settings": Object {
+        "deduce_mappings": false,
+      },
+      "source": Object {
+        "index": ".slo-observability.sli-v2*",
+        "query": Object {
+          "bool": Object {
+            "filter": Array [
+              Object {
+                "range": Object {
+                  "@timestamp": Object {
+                    "gte": "now-30d/m",
+                    "lte": "now/m",
+                  },
+                },
+              },
+              Object {
+                "term": Object {
+                  "slo.budgetingMethod": "timeslices",
+                },
+              },
+              Object {
+                "term": Object {
+                  "slo.timeWindow.type": "rolling",
+                },
+              },
+              Object {
+                "term": Object {
+                  "slo.timeWindow.duration": "30d",
+                },
+              },
+            ],
+          },
+        },
+      },
+      "sync": Object {
+        "time": Object {
+          "delay": "60s",
+          "field": "@timestamp",
+        },
+      },
+      "transform_id": "slo-summary-timeslices-30d-rolling",
+    },
+    Object {
+      "ignore": Array [
+        409,
+      ],
+    },
+  ],
+  Array [
+    Object {
+      "_meta": Object {
+        "managed": true,
+        "managed_by": "observability",
+        "version": 2,
+      },
+      "description": "Summarize every SLO with timeslices budgeting method and a 90 days rolling time window",
+      "dest": Object {
+        "index": ".slo-observability.summary-v2",
+      },
+      "frequency": "1m",
+      "pivot": Object {
+        "aggregations": Object {
+          "_objectiveTarget": Object {
+            "max": Object {
+              "field": "slo.objective.target",
+            },
+          },
+          "errorBudgetConsumed": Object {
+            "bucket_script": Object {
+              "buckets_path": Object {
+                "errorBudgetInitial": "errorBudgetInitial",
+                "sliValue": "sliValue",
+              },
+              "script": "if (params.sliValue == -1) { return 0 } else { return (1 - params.sliValue) / params.errorBudgetInitial }",
+            },
+          },
+          "errorBudgetInitial": Object {
+            "bucket_script": Object {
+              "buckets_path": Object {
+                "objectiveTarget": "_objectiveTarget",
+              },
+              "script": "1 - params.objectiveTarget",
+            },
+          },
+          "errorBudgetRemaining": Object {
+            "bucket_script": Object {
+              "buckets_path": Object {
+                "errorBudgetConsummed": "errorBudgetConsumed",
+              },
+              "script": "1 - params.errorBudgetConsummed",
+            },
+          },
+          "goodEvents": Object {
+            "sum": Object {
+              "field": "slo.isGoodSlice",
+            },
+          },
+          "sliValue": Object {
+            "bucket_script": Object {
+              "buckets_path": Object {
+                "goodEvents": "goodEvents",
+                "totalEvents": "totalEvents",
+              },
+              "script": "if (params.totalEvents == 0) { return -1 } else { return params.goodEvents / params.totalEvents }",
+            },
+          },
+          "status": Object {
+            "bucket_script": Object {
+              "buckets_path": Object {
+                "errorBudgetRemaining": "errorBudgetRemaining",
+                "objectiveTarget": "_objectiveTarget",
+                "sliValue": "sliValue",
+              },
+              "script": Object {
+                "source": "if (params.sliValue == -1) { return 0 } else if (params.sliValue >= params.objectiveTarget) { return 4 } else if (params.errorBudgetRemaining > 0) { return 2 } else { return 1 }",
+              },
+            },
+          },
+          "totalEvents": Object {
+            "value_count": Object {
+              "field": "slo.isGoodSlice",
+            },
+          },
+        },
+        "group_by": Object {
+          "service.environment": Object {
+            "terms": Object {
+              "field": "service.environment",
+              "missing_bucket": true,
+            },
+          },
+          "service.name": Object {
+            "terms": Object {
+              "field": "service.name",
+              "missing_bucket": true,
+            },
+          },
+          "slo.budgetingMethod": Object {
+            "terms": Object {
+              "field": "slo.budgetingMethod",
+            },
+          },
+          "slo.description": Object {
+            "terms": Object {
+              "field": "slo.description",
+            },
+          },
+          "slo.id": Object {
+            "terms": Object {
+              "field": "slo.id",
+            },
+          },
+          "slo.indicator.type": Object {
+            "terms": Object {
+              "field": "slo.indicator.type",
+            },
+          },
+          "slo.instanceId": Object {
+            "terms": Object {
+              "field": "slo.instanceId",
+            },
+          },
+          "slo.name": Object {
+            "terms": Object {
+              "field": "slo.name",
+            },
+          },
+          "slo.revision": Object {
+            "terms": Object {
+              "field": "slo.revision",
+            },
+          },
+          "slo.tags": Object {
+            "terms": Object {
+              "field": "slo.tags",
+            },
+          },
+          "slo.timeWindow.duration": Object {
+            "terms": Object {
+              "field": "slo.timeWindow.duration",
+            },
+          },
+          "slo.timeWindow.type": Object {
+            "terms": Object {
+              "field": "slo.timeWindow.type",
+            },
+          },
+          "transaction.name": Object {
+            "terms": Object {
+              "field": "transaction.name",
+              "missing_bucket": true,
+            },
+          },
+          "transaction.type": Object {
+            "terms": Object {
+              "field": "transaction.type",
+              "missing_bucket": true,
+            },
+          },
+        },
+      },
+      "settings": Object {
+        "deduce_mappings": false,
+      },
+      "source": Object {
+        "index": ".slo-observability.sli-v2*",
+        "query": Object {
+          "bool": Object {
+            "filter": Array [
+              Object {
+                "range": Object {
+                  "@timestamp": Object {
+                    "gte": "now-90d/m",
+                    "lte": "now/m",
+                  },
+                },
+              },
+              Object {
+                "term": Object {
+                  "slo.budgetingMethod": "timeslices",
+                },
+              },
+              Object {
+                "term": Object {
+                  "slo.timeWindow.type": "rolling",
+                },
+              },
+              Object {
+                "term": Object {
+                  "slo.timeWindow.duration": "90d",
+                },
+              },
+            ],
+          },
+        },
+      },
+      "sync": Object {
+        "time": Object {
+          "delay": "60s",
+          "field": "@timestamp",
+        },
+      },
+      "transform_id": "slo-summary-timeslices-90d-rolling",
+    },
+    Object {
+      "ignore": Array [
+        409,
+      ],
+    },
+  ],
+  Array [
+    Object {
+      "_meta": Object {
+        "managed": true,
+        "managed_by": "observability",
+        "version": 2,
+      },
+      "description": "Summarize every SLO with timeslices budgeting method and a weekly calendar aligned time window",
+      "dest": Object {
+        "index": ".slo-observability.summary-v2",
+      },
+      "frequency": "1m",
+      "pivot": Object {
+        "aggregations": Object {
+          "_objectiveTarget": Object {
+            "max": Object {
+              "field": "slo.objective.target",
+            },
+          },
+          "_sliceDurationInSeconds": Object {
+            "max": Object {
+              "field": "slo.objective.sliceDurationInSeconds",
+            },
+          },
+          "_totalSlicesInPeriod": Object {
+            "bucket_script": Object {
+              "buckets_path": Object {
+                "sliceDurationInSeconds": "_sliceDurationInSeconds",
+              },
+              "script": "Math.ceil(7 * 24 * 60 * 60 / params.sliceDurationInSeconds)",
+            },
+          },
+          "errorBudgetConsumed": Object {
+            "bucket_script": Object {
+              "buckets_path": Object {
+                "errorBudgetInitial": "errorBudgetInitial",
+                "goodEvents": "goodEvents",
+                "totalEvents": "totalEvents",
+                "totalSlicesInPeriod": "_totalSlicesInPeriod",
+              },
+              "script": "if (params.totalEvents == 0) { return 0 } else { return (params.totalEvents - params.goodEvents) / (params.totalSlicesInPeriod * params.errorBudgetInitial) }",
+            },
+          },
+          "errorBudgetInitial": Object {
+            "bucket_script": Object {
+              "buckets_path": Object {
+                "objective": "_objectiveTarget",
+              },
+              "script": "1 - params.objective",
+            },
+          },
+          "errorBudgetRemaining": Object {
+            "bucket_script": Object {
+              "buckets_path": Object {
+                "errorBudgetConsumed": "errorBudgetConsumed",
+              },
+              "script": "1 - params.errorBudgetConsumed",
+            },
+          },
+          "goodEvents": Object {
+            "sum": Object {
+              "field": "slo.isGoodSlice",
+            },
+          },
+          "sliValue": Object {
+            "bucket_script": Object {
+              "buckets_path": Object {
+                "goodEvents": "goodEvents",
+                "totalEvents": "totalEvents",
+              },
+              "script": "if (params.totalEvents == 0) { return -1 } else { return params.goodEvents / params.totalEvents }",
+            },
+          },
+          "status": Object {
+            "bucket_script": Object {
+              "buckets_path": Object {
+                "errorBudgetRemaining": "errorBudgetRemaining",
+                "objective": "_objectiveTarget",
+                "sliValue": "sliValue",
+              },
+              "script": "if (params.sliValue == -1) { return 0 } else if (params.sliValue >= params.objective) { return 4 } else if (params.errorBudgetRemaining > 0) { return 2 } else { return 1 }",
+            },
+          },
+          "totalEvents": Object {
+            "value_count": Object {
+              "field": "slo.isGoodSlice",
+            },
+          },
+        },
+        "group_by": Object {
+          "service.environment": Object {
+            "terms": Object {
+              "field": "service.environment",
+              "missing_bucket": true,
+            },
+          },
+          "service.name": Object {
+            "terms": Object {
+              "field": "service.name",
+              "missing_bucket": true,
+            },
+          },
+          "slo.budgetingMethod": Object {
+            "terms": Object {
+              "field": "slo.budgetingMethod",
+            },
+          },
+          "slo.description": Object {
+            "terms": Object {
+              "field": "slo.description",
+            },
+          },
+          "slo.id": Object {
+            "terms": Object {
+              "field": "slo.id",
+            },
+          },
+          "slo.indicator.type": Object {
+            "terms": Object {
+              "field": "slo.indicator.type",
+            },
+          },
+          "slo.instanceId": Object {
+            "terms": Object {
+              "field": "slo.instanceId",
+            },
+          },
+          "slo.name": Object {
+            "terms": Object {
+              "field": "slo.name",
+            },
+          },
+          "slo.revision": Object {
+            "terms": Object {
+              "field": "slo.revision",
+            },
+          },
+          "slo.tags": Object {
+            "terms": Object {
+              "field": "slo.tags",
+            },
+          },
+          "slo.timeWindow.duration": Object {
+            "terms": Object {
+              "field": "slo.timeWindow.duration",
+            },
+          },
+          "slo.timeWindow.type": Object {
+            "terms": Object {
+              "field": "slo.timeWindow.type",
+            },
+          },
+          "transaction.name": Object {
+            "terms": Object {
+              "field": "transaction.name",
+              "missing_bucket": true,
+            },
+          },
+          "transaction.type": Object {
+            "terms": Object {
+              "field": "transaction.type",
+              "missing_bucket": true,
+            },
+          },
+        },
+      },
+      "settings": Object {
+        "deduce_mappings": false,
+      },
+      "source": Object {
+        "index": ".slo-observability.sli-v2*",
+        "query": Object {
+          "bool": Object {
+            "filter": Array [
+              Object {
+                "range": Object {
+                  "@timestamp": Object {
+                    "gte": "now/w",
+                    "lte": "now/m",
+                  },
+                },
+              },
+              Object {
+                "term": Object {
+                  "slo.budgetingMethod": "timeslices",
+                },
+              },
+              Object {
+                "term": Object {
+                  "slo.timeWindow.type": "calendarAligned",
+                },
+              },
+              Object {
+                "term": Object {
+                  "slo.timeWindow.duration": "1w",
+                },
+              },
+            ],
+          },
+        },
+      },
+      "sync": Object {
+        "time": Object {
+          "delay": "60s",
+          "field": "@timestamp",
+        },
+      },
+      "transform_id": "slo-summary-timeslices-weekly-aligned",
+    },
+    Object {
+      "ignore": Array [
+        409,
+      ],
+    },
+  ],
+  Array [
+    Object {
+      "_meta": Object {
+        "managed": true,
+        "managed_by": "observability",
+        "version": 2,
+      },
+      "description": "Summarize every SLO with timeslices budgeting method and a monthly calendar aligned time window",
+      "dest": Object {
+        "index": ".slo-observability.summary-v2",
+      },
+      "frequency": "1m",
+      "pivot": Object {
+        "aggregations": Object {
+          "_objectiveTarget": Object {
+            "max": Object {
+              "field": "slo.objective.target",
+            },
+          },
+          "_sliceDurationInSeconds": Object {
+            "max": Object {
+              "field": "slo.objective.sliceDurationInSeconds",
+            },
+          },
+          "_totalSlicesInPeriod": Object {
+            "bucket_script": Object {
+              "buckets_path": Object {
+                "sliceDurationInSeconds": "_sliceDurationInSeconds",
+              },
+              "script": Object {
+                "source": "
+              Date d = new Date(); 
+              Instant instant = Instant.ofEpochMilli(d.getTime());
+              LocalDateTime now = LocalDateTime.ofInstant(instant, ZoneOffset.UTC);
+              LocalDateTime startOfMonth = now
+                .withDayOfMonth(1)
+                .withHour(0)
+                .withMinute(0)
+                .withSecond(0);
+              LocalDateTime startOfNextMonth = startOfMonth.plusMonths(1);
+              double sliceDurationInMinutes = params.sliceDurationInSeconds / 60;
+              
+              return Math.ceil(Duration.between(startOfMonth, startOfNextMonth).toMinutes() / sliceDurationInMinutes);
+            ",
+              },
+            },
+          },
+          "errorBudgetConsumed": Object {
+            "bucket_script": Object {
+              "buckets_path": Object {
+                "errorBudgetInitial": "errorBudgetInitial",
+                "goodEvents": "goodEvents",
+                "totalEvents": "totalEvents",
+                "totalSlicesInPeriod": "_totalSlicesInPeriod",
+              },
+              "script": "if (params.totalEvents == 0) { return 0 } else { return (params.totalEvents - params.goodEvents) / (params.totalSlicesInPeriod * params.errorBudgetInitial) }",
+            },
+          },
+          "errorBudgetInitial": Object {
+            "bucket_script": Object {
+              "buckets_path": Object {
+                "objective": "_objectiveTarget",
+              },
+              "script": "1 - params.objective",
+            },
+          },
+          "errorBudgetRemaining": Object {
+            "bucket_script": Object {
+              "buckets_path": Object {
+                "errorBudgetConsumed": "errorBudgetConsumed",
+              },
+              "script": "1 - params.errorBudgetConsumed",
+            },
+          },
+          "goodEvents": Object {
+            "sum": Object {
+              "field": "slo.isGoodSlice",
+            },
+          },
+          "sliValue": Object {
+            "bucket_script": Object {
+              "buckets_path": Object {
+                "goodEvents": "goodEvents",
+                "totalEvents": "totalEvents",
+              },
+              "script": "if (params.totalEvents == 0) { return -1 } else { return params.goodEvents / params.totalEvents }",
+            },
+          },
+          "status": Object {
+            "bucket_script": Object {
+              "buckets_path": Object {
+                "errorBudgetRemaining": "errorBudgetRemaining",
+                "objective": "_objectiveTarget",
+                "sliValue": "sliValue",
+              },
+              "script": "if (params.sliValue == -1) { return 0 } else if (params.sliValue >= params.objective) { return 4 } else if (params.errorBudgetRemaining > 0) { return 2 } else { return 1 }",
+            },
+          },
+          "totalEvents": Object {
+            "value_count": Object {
+              "field": "slo.isGoodSlice",
+            },
+          },
+        },
+        "group_by": Object {
+          "service.environment": Object {
+            "terms": Object {
+              "field": "service.environment",
+              "missing_bucket": true,
+            },
+          },
+          "service.name": Object {
+            "terms": Object {
+              "field": "service.name",
+              "missing_bucket": true,
+            },
+          },
+          "slo.budgetingMethod": Object {
+            "terms": Object {
+              "field": "slo.budgetingMethod",
+            },
+          },
+          "slo.description": Object {
+            "terms": Object {
+              "field": "slo.description",
+            },
+          },
+          "slo.id": Object {
+            "terms": Object {
+              "field": "slo.id",
+            },
+          },
+          "slo.indicator.type": Object {
+            "terms": Object {
+              "field": "slo.indicator.type",
+            },
+          },
+          "slo.instanceId": Object {
+            "terms": Object {
+              "field": "slo.instanceId",
+            },
+          },
+          "slo.name": Object {
+            "terms": Object {
+              "field": "slo.name",
+            },
+          },
+          "slo.revision": Object {
+            "terms": Object {
+              "field": "slo.revision",
+            },
+          },
+          "slo.tags": Object {
+            "terms": Object {
+              "field": "slo.tags",
+            },
+          },
+          "slo.timeWindow.duration": Object {
+            "terms": Object {
+              "field": "slo.timeWindow.duration",
+            },
+          },
+          "slo.timeWindow.type": Object {
+            "terms": Object {
+              "field": "slo.timeWindow.type",
+            },
+          },
+          "transaction.name": Object {
+            "terms": Object {
+              "field": "transaction.name",
+              "missing_bucket": true,
+            },
+          },
+          "transaction.type": Object {
+            "terms": Object {
+              "field": "transaction.type",
+              "missing_bucket": true,
+            },
+          },
+        },
+      },
+      "settings": Object {
+        "deduce_mappings": false,
+      },
+      "source": Object {
+        "index": ".slo-observability.sli-v2*",
+        "query": Object {
+          "bool": Object {
+            "filter": Array [
+              Object {
+                "range": Object {
+                  "@timestamp": Object {
+                    "gte": "now/M",
+                    "lte": "now/m",
+                  },
+                },
+              },
+              Object {
+                "term": Object {
+                  "slo.budgetingMethod": "timeslices",
+                },
+              },
+              Object {
+                "term": Object {
+                  "slo.timeWindow.type": "calendarAligned",
+                },
+              },
+              Object {
+                "term": Object {
+                  "slo.timeWindow.duration": "1M",
+                },
+              },
+            ],
+          },
+        },
+      },
+      "sync": Object {
+        "time": Object {
+          "delay": "60s",
+          "field": "@timestamp",
+        },
+      },
+      "transform_id": "slo-summary-timeslices-monthly-aligned",
+    },
+    Object {
+      "ignore": Array [
+        409,
+      ],
+    },
+  ],
+]
+`;

--- a/x-pack/plugins/observability/server/services/slo/summary_transform/summary_transform_installer.test.ts
+++ b/x-pack/plugins/observability/server/services/slo/summary_transform/summary_transform_installer.test.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import {
+  ElasticsearchClientMock,
+  elasticsearchServiceMock,
+  loggingSystemMock,
+} from '@kbn/core/server/mocks';
+import { MockedLogger } from '@kbn/logging-mocks';
+import { DefaultSummaryTransformInstaller } from './summary_transform_installer';
+import { ALL_TRANSFORM_TEMPLATES } from './templates';
+
+describe('Summary Transform Installer', () => {
+  let esClientMock: ElasticsearchClientMock;
+  let loggerMock: jest.Mocked<MockedLogger>;
+
+  beforeEach(() => {
+    esClientMock = elasticsearchServiceMock.createElasticsearchClient();
+    loggerMock = loggingSystemMock.createLogger();
+  });
+
+  it('skips the installation when latest version already installed', async () => {
+    esClientMock.transform.getTransform.mockResolvedValue({
+      count: ALL_TRANSFORM_TEMPLATES.length,
+      // @ts-ignore
+      transforms: ALL_TRANSFORM_TEMPLATES.map((transform) => ({
+        id: transform.transform_id,
+        _meta: transform._meta,
+      })),
+    });
+    const installer = new DefaultSummaryTransformInstaller(esClientMock, loggerMock);
+
+    await installer.installAndStart();
+
+    expect(esClientMock.transform.stopTransform).not.toHaveBeenCalled();
+    expect(esClientMock.transform.deleteTransform).not.toHaveBeenCalled();
+    expect(esClientMock.transform.putTransform).not.toHaveBeenCalled();
+    expect(esClientMock.transform.startTransform).not.toHaveBeenCalled();
+  });
+
+  it('installs every summary transforms when none are already installed', async () => {
+    esClientMock.transform.getTransform.mockResolvedValue({ count: 0, transforms: [] });
+    const installer = new DefaultSummaryTransformInstaller(esClientMock, loggerMock);
+
+    await installer.installAndStart();
+
+    const nbOfTransforms = ALL_TRANSFORM_TEMPLATES.length;
+
+    expect(esClientMock.transform.stopTransform).not.toHaveBeenCalled();
+    expect(esClientMock.transform.deleteTransform).not.toHaveBeenCalled();
+    expect(esClientMock.transform.putTransform).toHaveBeenCalledTimes(nbOfTransforms);
+    expect(esClientMock.transform.startTransform).toHaveBeenCalledTimes(nbOfTransforms);
+  });
+
+  it('desinstalls previous summary transforms prior to installing the new ones', async () => {
+    esClientMock.transform.getTransform.mockResolvedValue({
+      count: ALL_TRANSFORM_TEMPLATES.length,
+      // @ts-ignore
+      transforms: ALL_TRANSFORM_TEMPLATES.map((transform) => ({
+        id: transform.transform_id,
+        _meta: { ...transform._meta, version: -1 },
+      })),
+    });
+    const installer = new DefaultSummaryTransformInstaller(esClientMock, loggerMock);
+
+    await installer.installAndStart();
+
+    const nbOfTransforms = ALL_TRANSFORM_TEMPLATES.length;
+
+    expect(esClientMock.transform.stopTransform).toHaveBeenCalledTimes(nbOfTransforms);
+    expect(esClientMock.transform.deleteTransform).toHaveBeenCalledTimes(nbOfTransforms);
+    expect(esClientMock.transform.putTransform).toHaveBeenCalledTimes(nbOfTransforms);
+    expect(esClientMock.transform.startTransform).toHaveBeenCalledTimes(nbOfTransforms);
+  });
+
+  it('installs only the missing summary transforms', async () => {
+    const occurrencesSummaryTransforms = ALL_TRANSFORM_TEMPLATES.filter((transform) =>
+      transform.transform_id.includes('-occurrences-')
+    );
+    esClientMock.transform.getTransform.mockResolvedValue({
+      count: occurrencesSummaryTransforms.length,
+      // @ts-ignore
+      transforms: occurrencesSummaryTransforms.map((transform) => ({
+        id: transform.transform_id,
+        _meta: transform._meta,
+      })),
+    });
+    const installer = new DefaultSummaryTransformInstaller(esClientMock, loggerMock);
+
+    await installer.installAndStart();
+
+    const nbOfTransforms = ALL_TRANSFORM_TEMPLATES.length - occurrencesSummaryTransforms.length;
+
+    expect(esClientMock.transform.stopTransform).not.toHaveBeenCalled();
+    expect(esClientMock.transform.deleteTransform).not.toHaveBeenCalled();
+    expect(esClientMock.transform.putTransform).toHaveBeenCalledTimes(nbOfTransforms);
+    expect(esClientMock.transform.startTransform).toHaveBeenCalledTimes(nbOfTransforms);
+    expect(esClientMock.transform.putTransform.mock.calls).toMatchSnapshot();
+  });
+});

--- a/x-pack/plugins/observability/server/services/slo/summary_transform/templates/common.ts
+++ b/x-pack/plugins/observability/server/services/slo/summary_transform/templates/common.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const groupBy = {
+  'slo.id': {
+    terms: {
+      field: 'slo.id',
+    },
+  },
+  'slo.revision': {
+    terms: {
+      field: 'slo.revision',
+    },
+  },
+  'slo.instanceId': {
+    terms: {
+      field: 'slo.instanceId',
+    },
+  },
+  'slo.name': {
+    terms: {
+      field: 'slo.name',
+    },
+  },
+  'slo.description': {
+    terms: {
+      field: 'slo.description',
+    },
+  },
+  'slo.tags': {
+    terms: {
+      field: 'slo.tags',
+    },
+  },
+  'slo.indicator.type': {
+    terms: {
+      field: 'slo.indicator.type',
+    },
+  },
+  'slo.budgetingMethod': {
+    terms: {
+      field: 'slo.budgetingMethod',
+    },
+  },
+  'slo.timeWindow.duration': {
+    terms: {
+      field: 'slo.timeWindow.duration',
+    },
+  },
+  'slo.timeWindow.type': {
+    terms: {
+      field: 'slo.timeWindow.type',
+    },
+  },
+  // optional fields: only specified for APM indicators. Must include missing_bucket:true
+  'service.name': {
+    terms: {
+      field: 'service.name',
+      missing_bucket: true,
+    },
+  },
+  'service.environment': {
+    terms: {
+      field: 'service.environment',
+      missing_bucket: true,
+    },
+  },
+  'transaction.name': {
+    terms: {
+      field: 'transaction.name',
+      missing_bucket: true,
+    },
+  },
+  'transaction.type': {
+    terms: {
+      field: 'transaction.type',
+      missing_bucket: true,
+    },
+  },
+};

--- a/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_occurrences_30d_rolling.ts
+++ b/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_occurrences_30d_rolling.ts
@@ -67,6 +67,26 @@ export const SUMMARY_OCCURRENCES_30D_ROLLING: TransformPutTransformRequest = {
           field: 'slo.instanceId',
         },
       },
+      'slo.name': {
+        terms: {
+          field: 'slo.name',
+        },
+      },
+      'slo.description': {
+        terms: {
+          field: 'slo.description',
+        },
+      },
+      'slo.tags': {
+        terms: {
+          field: 'slo.tags',
+        },
+      },
+      'slo.indicator.type': {
+        terms: {
+          field: 'slo.indicator.type',
+        },
+      },
       'slo.budgetingMethod': {
         terms: {
           field: 'slo.budgetingMethod',

--- a/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_occurrences_30d_rolling.ts
+++ b/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_occurrences_30d_rolling.ts
@@ -12,6 +12,7 @@ import {
   SLO_SUMMARY_DESTINATION_INDEX_NAME,
   SLO_SUMMARY_TRANSFORM_NAME_PREFIX,
 } from '../../../../assets/constants';
+import { groupBy } from './common';
 
 export const SUMMARY_OCCURRENCES_30D_ROLLING: TransformPutTransformRequest = {
   transform_id: `${SLO_SUMMARY_TRANSFORM_NAME_PREFIX}occurrences-30d-rolling`,
@@ -51,58 +52,7 @@ export const SUMMARY_OCCURRENCES_30D_ROLLING: TransformPutTransformRequest = {
     },
   },
   pivot: {
-    group_by: {
-      'slo.id': {
-        terms: {
-          field: 'slo.id',
-        },
-      },
-      'slo.revision': {
-        terms: {
-          field: 'slo.revision',
-        },
-      },
-      'slo.instanceId': {
-        terms: {
-          field: 'slo.instanceId',
-        },
-      },
-      'slo.name': {
-        terms: {
-          field: 'slo.name',
-        },
-      },
-      'slo.description': {
-        terms: {
-          field: 'slo.description',
-        },
-      },
-      'slo.tags': {
-        terms: {
-          field: 'slo.tags',
-        },
-      },
-      'slo.indicator.type': {
-        terms: {
-          field: 'slo.indicator.type',
-        },
-      },
-      'slo.budgetingMethod': {
-        terms: {
-          field: 'slo.budgetingMethod',
-        },
-      },
-      'slo.timeWindow.duration': {
-        terms: {
-          field: 'slo.timeWindow.duration',
-        },
-      },
-      'slo.timeWindow.type': {
-        terms: {
-          field: 'slo.timeWindow.type',
-        },
-      },
-    },
+    group_by: groupBy,
     aggregations: {
       goodEvents: {
         sum: {

--- a/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_occurrences_7d_rolling.ts
+++ b/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_occurrences_7d_rolling.ts
@@ -67,6 +67,26 @@ export const SUMMARY_OCCURRENCES_7D_ROLLING: TransformPutTransformRequest = {
           field: 'slo.instanceId',
         },
       },
+      'slo.name': {
+        terms: {
+          field: 'slo.name',
+        },
+      },
+      'slo.description': {
+        terms: {
+          field: 'slo.description',
+        },
+      },
+      'slo.tags': {
+        terms: {
+          field: 'slo.tags',
+        },
+      },
+      'slo.indicator.type': {
+        terms: {
+          field: 'slo.indicator.type',
+        },
+      },
       'slo.budgetingMethod': {
         terms: {
           field: 'slo.budgetingMethod',

--- a/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_occurrences_7d_rolling.ts
+++ b/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_occurrences_7d_rolling.ts
@@ -12,6 +12,7 @@ import {
   SLO_SUMMARY_DESTINATION_INDEX_NAME,
   SLO_SUMMARY_TRANSFORM_NAME_PREFIX,
 } from '../../../../assets/constants';
+import { groupBy } from './common';
 
 export const SUMMARY_OCCURRENCES_7D_ROLLING: TransformPutTransformRequest = {
   transform_id: `${SLO_SUMMARY_TRANSFORM_NAME_PREFIX}occurrences-7d-rolling`,
@@ -51,58 +52,7 @@ export const SUMMARY_OCCURRENCES_7D_ROLLING: TransformPutTransformRequest = {
     },
   },
   pivot: {
-    group_by: {
-      'slo.id': {
-        terms: {
-          field: 'slo.id',
-        },
-      },
-      'slo.revision': {
-        terms: {
-          field: 'slo.revision',
-        },
-      },
-      'slo.instanceId': {
-        terms: {
-          field: 'slo.instanceId',
-        },
-      },
-      'slo.name': {
-        terms: {
-          field: 'slo.name',
-        },
-      },
-      'slo.description': {
-        terms: {
-          field: 'slo.description',
-        },
-      },
-      'slo.tags': {
-        terms: {
-          field: 'slo.tags',
-        },
-      },
-      'slo.indicator.type': {
-        terms: {
-          field: 'slo.indicator.type',
-        },
-      },
-      'slo.budgetingMethod': {
-        terms: {
-          field: 'slo.budgetingMethod',
-        },
-      },
-      'slo.timeWindow.duration': {
-        terms: {
-          field: 'slo.timeWindow.duration',
-        },
-      },
-      'slo.timeWindow.type': {
-        terms: {
-          field: 'slo.timeWindow.type',
-        },
-      },
-    },
+    group_by: groupBy,
     aggregations: {
       goodEvents: {
         sum: {

--- a/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_occurrences_90d_rolling.ts
+++ b/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_occurrences_90d_rolling.ts
@@ -12,6 +12,7 @@ import {
   SLO_SUMMARY_DESTINATION_INDEX_NAME,
   SLO_SUMMARY_TRANSFORM_NAME_PREFIX,
 } from '../../../../assets/constants';
+import { groupBy } from './common';
 
 export const SUMMARY_OCCURRENCES_90D_ROLLING: TransformPutTransformRequest = {
   transform_id: `${SLO_SUMMARY_TRANSFORM_NAME_PREFIX}occurrences-90d-rolling`,
@@ -51,58 +52,7 @@ export const SUMMARY_OCCURRENCES_90D_ROLLING: TransformPutTransformRequest = {
     },
   },
   pivot: {
-    group_by: {
-      'slo.id': {
-        terms: {
-          field: 'slo.id',
-        },
-      },
-      'slo.revision': {
-        terms: {
-          field: 'slo.revision',
-        },
-      },
-      'slo.instanceId': {
-        terms: {
-          field: 'slo.instanceId',
-        },
-      },
-      'slo.name': {
-        terms: {
-          field: 'slo.name',
-        },
-      },
-      'slo.description': {
-        terms: {
-          field: 'slo.description',
-        },
-      },
-      'slo.tags': {
-        terms: {
-          field: 'slo.tags',
-        },
-      },
-      'slo.indicator.type': {
-        terms: {
-          field: 'slo.indicator.type',
-        },
-      },
-      'slo.budgetingMethod': {
-        terms: {
-          field: 'slo.budgetingMethod',
-        },
-      },
-      'slo.timeWindow.duration': {
-        terms: {
-          field: 'slo.timeWindow.duration',
-        },
-      },
-      'slo.timeWindow.type': {
-        terms: {
-          field: 'slo.timeWindow.type',
-        },
-      },
-    },
+    group_by: groupBy,
     aggregations: {
       goodEvents: {
         sum: {

--- a/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_occurrences_90d_rolling.ts
+++ b/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_occurrences_90d_rolling.ts
@@ -67,6 +67,26 @@ export const SUMMARY_OCCURRENCES_90D_ROLLING: TransformPutTransformRequest = {
           field: 'slo.instanceId',
         },
       },
+      'slo.name': {
+        terms: {
+          field: 'slo.name',
+        },
+      },
+      'slo.description': {
+        terms: {
+          field: 'slo.description',
+        },
+      },
+      'slo.tags': {
+        terms: {
+          field: 'slo.tags',
+        },
+      },
+      'slo.indicator.type': {
+        terms: {
+          field: 'slo.indicator.type',
+        },
+      },
       'slo.budgetingMethod': {
         terms: {
           field: 'slo.budgetingMethod',

--- a/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_occurrences_monthly_aligned.ts
+++ b/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_occurrences_monthly_aligned.ts
@@ -12,6 +12,7 @@ import {
   SLO_SUMMARY_DESTINATION_INDEX_NAME,
   SLO_SUMMARY_TRANSFORM_NAME_PREFIX,
 } from '../../../../assets/constants';
+import { groupBy } from './common';
 
 export const SUMMARY_OCCURRENCES_MONTHLY_ALIGNED: TransformPutTransformRequest = {
   transform_id: `${SLO_SUMMARY_TRANSFORM_NAME_PREFIX}occurrences-monthly-aligned`,
@@ -51,58 +52,7 @@ export const SUMMARY_OCCURRENCES_MONTHLY_ALIGNED: TransformPutTransformRequest =
     },
   },
   pivot: {
-    group_by: {
-      'slo.id': {
-        terms: {
-          field: 'slo.id',
-        },
-      },
-      'slo.revision': {
-        terms: {
-          field: 'slo.revision',
-        },
-      },
-      'slo.instanceId': {
-        terms: {
-          field: 'slo.instanceId',
-        },
-      },
-      'slo.name': {
-        terms: {
-          field: 'slo.name',
-        },
-      },
-      'slo.description': {
-        terms: {
-          field: 'slo.description',
-        },
-      },
-      'slo.tags': {
-        terms: {
-          field: 'slo.tags',
-        },
-      },
-      'slo.indicator.type': {
-        terms: {
-          field: 'slo.indicator.type',
-        },
-      },
-      'slo.budgetingMethod': {
-        terms: {
-          field: 'slo.budgetingMethod',
-        },
-      },
-      'slo.timeWindow.duration': {
-        terms: {
-          field: 'slo.timeWindow.duration',
-        },
-      },
-      'slo.timeWindow.type': {
-        terms: {
-          field: 'slo.timeWindow.type',
-        },
-      },
-    },
+    group_by: groupBy,
     aggregations: {
       _objectiveTarget: {
         max: {

--- a/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_occurrences_monthly_aligned.ts
+++ b/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_occurrences_monthly_aligned.ts
@@ -67,6 +67,26 @@ export const SUMMARY_OCCURRENCES_MONTHLY_ALIGNED: TransformPutTransformRequest =
           field: 'slo.instanceId',
         },
       },
+      'slo.name': {
+        terms: {
+          field: 'slo.name',
+        },
+      },
+      'slo.description': {
+        terms: {
+          field: 'slo.description',
+        },
+      },
+      'slo.tags': {
+        terms: {
+          field: 'slo.tags',
+        },
+      },
+      'slo.indicator.type': {
+        terms: {
+          field: 'slo.indicator.type',
+        },
+      },
       'slo.budgetingMethod': {
         terms: {
           field: 'slo.budgetingMethod',

--- a/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_occurrences_weekly_aligned.ts
+++ b/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_occurrences_weekly_aligned.ts
@@ -67,6 +67,26 @@ export const SUMMARY_OCCURRENCES_WEEKLY_ALIGNED: TransformPutTransformRequest = 
           field: 'slo.instanceId',
         },
       },
+      'slo.name': {
+        terms: {
+          field: 'slo.name',
+        },
+      },
+      'slo.description': {
+        terms: {
+          field: 'slo.description',
+        },
+      },
+      'slo.tags': {
+        terms: {
+          field: 'slo.tags',
+        },
+      },
+      'slo.indicator.type': {
+        terms: {
+          field: 'slo.indicator.type',
+        },
+      },
       'slo.budgetingMethod': {
         terms: {
           field: 'slo.budgetingMethod',

--- a/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_occurrences_weekly_aligned.ts
+++ b/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_occurrences_weekly_aligned.ts
@@ -12,6 +12,7 @@ import {
   SLO_SUMMARY_DESTINATION_INDEX_NAME,
   SLO_SUMMARY_TRANSFORM_NAME_PREFIX,
 } from '../../../../assets/constants';
+import { groupBy } from './common';
 
 export const SUMMARY_OCCURRENCES_WEEKLY_ALIGNED: TransformPutTransformRequest = {
   transform_id: `${SLO_SUMMARY_TRANSFORM_NAME_PREFIX}occurrences-weekly-aligned`,
@@ -51,58 +52,7 @@ export const SUMMARY_OCCURRENCES_WEEKLY_ALIGNED: TransformPutTransformRequest = 
     },
   },
   pivot: {
-    group_by: {
-      'slo.id': {
-        terms: {
-          field: 'slo.id',
-        },
-      },
-      'slo.revision': {
-        terms: {
-          field: 'slo.revision',
-        },
-      },
-      'slo.instanceId': {
-        terms: {
-          field: 'slo.instanceId',
-        },
-      },
-      'slo.name': {
-        terms: {
-          field: 'slo.name',
-        },
-      },
-      'slo.description': {
-        terms: {
-          field: 'slo.description',
-        },
-      },
-      'slo.tags': {
-        terms: {
-          field: 'slo.tags',
-        },
-      },
-      'slo.indicator.type': {
-        terms: {
-          field: 'slo.indicator.type',
-        },
-      },
-      'slo.budgetingMethod': {
-        terms: {
-          field: 'slo.budgetingMethod',
-        },
-      },
-      'slo.timeWindow.duration': {
-        terms: {
-          field: 'slo.timeWindow.duration',
-        },
-      },
-      'slo.timeWindow.type': {
-        terms: {
-          field: 'slo.timeWindow.type',
-        },
-      },
-    },
+    group_by: groupBy,
     aggregations: {
       _objectiveTarget: {
         max: {

--- a/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_timeslices_30d_rolling.ts
+++ b/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_timeslices_30d_rolling.ts
@@ -67,6 +67,26 @@ export const SUMMARY_TIMESLICES_30D_ROLLING: TransformPutTransformRequest = {
           field: 'slo.instanceId',
         },
       },
+      'slo.name': {
+        terms: {
+          field: 'slo.name',
+        },
+      },
+      'slo.description': {
+        terms: {
+          field: 'slo.description',
+        },
+      },
+      'slo.tags': {
+        terms: {
+          field: 'slo.tags',
+        },
+      },
+      'slo.indicator.type': {
+        terms: {
+          field: 'slo.indicator.type',
+        },
+      },
       'slo.budgetingMethod': {
         terms: {
           field: 'slo.budgetingMethod',

--- a/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_timeslices_30d_rolling.ts
+++ b/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_timeslices_30d_rolling.ts
@@ -12,6 +12,7 @@ import {
   SLO_SUMMARY_DESTINATION_INDEX_NAME,
   SLO_SUMMARY_TRANSFORM_NAME_PREFIX,
 } from '../../../../assets/constants';
+import { groupBy } from './common';
 
 export const SUMMARY_TIMESLICES_30D_ROLLING: TransformPutTransformRequest = {
   transform_id: `${SLO_SUMMARY_TRANSFORM_NAME_PREFIX}timeslices-30d-rolling`,
@@ -51,58 +52,7 @@ export const SUMMARY_TIMESLICES_30D_ROLLING: TransformPutTransformRequest = {
     },
   },
   pivot: {
-    group_by: {
-      'slo.id': {
-        terms: {
-          field: 'slo.id',
-        },
-      },
-      'slo.revision': {
-        terms: {
-          field: 'slo.revision',
-        },
-      },
-      'slo.instanceId': {
-        terms: {
-          field: 'slo.instanceId',
-        },
-      },
-      'slo.name': {
-        terms: {
-          field: 'slo.name',
-        },
-      },
-      'slo.description': {
-        terms: {
-          field: 'slo.description',
-        },
-      },
-      'slo.tags': {
-        terms: {
-          field: 'slo.tags',
-        },
-      },
-      'slo.indicator.type': {
-        terms: {
-          field: 'slo.indicator.type',
-        },
-      },
-      'slo.budgetingMethod': {
-        terms: {
-          field: 'slo.budgetingMethod',
-        },
-      },
-      'slo.timeWindow.duration': {
-        terms: {
-          field: 'slo.timeWindow.duration',
-        },
-      },
-      'slo.timeWindow.type': {
-        terms: {
-          field: 'slo.timeWindow.type',
-        },
-      },
-    },
+    group_by: groupBy,
     aggregations: {
       goodEvents: {
         sum: {

--- a/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_timeslices_7d_rolling.ts
+++ b/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_timeslices_7d_rolling.ts
@@ -67,6 +67,26 @@ export const SUMMARY_TIMESLICES_7D_ROLLING: TransformPutTransformRequest = {
           field: 'slo.instanceId',
         },
       },
+      'slo.name': {
+        terms: {
+          field: 'slo.name',
+        },
+      },
+      'slo.description': {
+        terms: {
+          field: 'slo.description',
+        },
+      },
+      'slo.tags': {
+        terms: {
+          field: 'slo.tags',
+        },
+      },
+      'slo.indicator.type': {
+        terms: {
+          field: 'slo.indicator.type',
+        },
+      },
       'slo.budgetingMethod': {
         terms: {
           field: 'slo.budgetingMethod',

--- a/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_timeslices_7d_rolling.ts
+++ b/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_timeslices_7d_rolling.ts
@@ -12,6 +12,7 @@ import {
   SLO_SUMMARY_DESTINATION_INDEX_NAME,
   SLO_SUMMARY_TRANSFORM_NAME_PREFIX,
 } from '../../../../assets/constants';
+import { groupBy } from './common';
 
 export const SUMMARY_TIMESLICES_7D_ROLLING: TransformPutTransformRequest = {
   transform_id: `${SLO_SUMMARY_TRANSFORM_NAME_PREFIX}timeslices-7d-rolling`,
@@ -51,58 +52,7 @@ export const SUMMARY_TIMESLICES_7D_ROLLING: TransformPutTransformRequest = {
     },
   },
   pivot: {
-    group_by: {
-      'slo.id': {
-        terms: {
-          field: 'slo.id',
-        },
-      },
-      'slo.revision': {
-        terms: {
-          field: 'slo.revision',
-        },
-      },
-      'slo.instanceId': {
-        terms: {
-          field: 'slo.instanceId',
-        },
-      },
-      'slo.name': {
-        terms: {
-          field: 'slo.name',
-        },
-      },
-      'slo.description': {
-        terms: {
-          field: 'slo.description',
-        },
-      },
-      'slo.tags': {
-        terms: {
-          field: 'slo.tags',
-        },
-      },
-      'slo.indicator.type': {
-        terms: {
-          field: 'slo.indicator.type',
-        },
-      },
-      'slo.budgetingMethod': {
-        terms: {
-          field: 'slo.budgetingMethod',
-        },
-      },
-      'slo.timeWindow.duration': {
-        terms: {
-          field: 'slo.timeWindow.duration',
-        },
-      },
-      'slo.timeWindow.type': {
-        terms: {
-          field: 'slo.timeWindow.type',
-        },
-      },
-    },
+    group_by: groupBy,
     aggregations: {
       goodEvents: {
         sum: {

--- a/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_timeslices_90d_rolling.ts
+++ b/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_timeslices_90d_rolling.ts
@@ -67,6 +67,26 @@ export const SUMMARY_TIMESLICES_90D_ROLLING: TransformPutTransformRequest = {
           field: 'slo.instanceId',
         },
       },
+      'slo.name': {
+        terms: {
+          field: 'slo.name',
+        },
+      },
+      'slo.description': {
+        terms: {
+          field: 'slo.description',
+        },
+      },
+      'slo.tags': {
+        terms: {
+          field: 'slo.tags',
+        },
+      },
+      'slo.indicator.type': {
+        terms: {
+          field: 'slo.indicator.type',
+        },
+      },
       'slo.budgetingMethod': {
         terms: {
           field: 'slo.budgetingMethod',

--- a/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_timeslices_90d_rolling.ts
+++ b/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_timeslices_90d_rolling.ts
@@ -12,6 +12,7 @@ import {
   SLO_SUMMARY_DESTINATION_INDEX_NAME,
   SLO_SUMMARY_TRANSFORM_NAME_PREFIX,
 } from '../../../../assets/constants';
+import { groupBy } from './common';
 
 export const SUMMARY_TIMESLICES_90D_ROLLING: TransformPutTransformRequest = {
   transform_id: `${SLO_SUMMARY_TRANSFORM_NAME_PREFIX}timeslices-90d-rolling`,
@@ -51,58 +52,7 @@ export const SUMMARY_TIMESLICES_90D_ROLLING: TransformPutTransformRequest = {
     },
   },
   pivot: {
-    group_by: {
-      'slo.id': {
-        terms: {
-          field: 'slo.id',
-        },
-      },
-      'slo.revision': {
-        terms: {
-          field: 'slo.revision',
-        },
-      },
-      'slo.instanceId': {
-        terms: {
-          field: 'slo.instanceId',
-        },
-      },
-      'slo.name': {
-        terms: {
-          field: 'slo.name',
-        },
-      },
-      'slo.description': {
-        terms: {
-          field: 'slo.description',
-        },
-      },
-      'slo.tags': {
-        terms: {
-          field: 'slo.tags',
-        },
-      },
-      'slo.indicator.type': {
-        terms: {
-          field: 'slo.indicator.type',
-        },
-      },
-      'slo.budgetingMethod': {
-        terms: {
-          field: 'slo.budgetingMethod',
-        },
-      },
-      'slo.timeWindow.duration': {
-        terms: {
-          field: 'slo.timeWindow.duration',
-        },
-      },
-      'slo.timeWindow.type': {
-        terms: {
-          field: 'slo.timeWindow.type',
-        },
-      },
-    },
+    group_by: groupBy,
     aggregations: {
       goodEvents: {
         sum: {

--- a/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_timeslices_monthly_aligned.ts
+++ b/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_timeslices_monthly_aligned.ts
@@ -12,6 +12,7 @@ import {
   SLO_SUMMARY_DESTINATION_INDEX_NAME,
   SLO_SUMMARY_TRANSFORM_NAME_PREFIX,
 } from '../../../../assets/constants';
+import { groupBy } from './common';
 
 export const SUMMARY_TIMESLICES_MONTHLY_ALIGNED: TransformPutTransformRequest = {
   transform_id: `${SLO_SUMMARY_TRANSFORM_NAME_PREFIX}timeslices-monthly-aligned`,
@@ -51,58 +52,7 @@ export const SUMMARY_TIMESLICES_MONTHLY_ALIGNED: TransformPutTransformRequest = 
     },
   },
   pivot: {
-    group_by: {
-      'slo.id': {
-        terms: {
-          field: 'slo.id',
-        },
-      },
-      'slo.revision': {
-        terms: {
-          field: 'slo.revision',
-        },
-      },
-      'slo.instanceId': {
-        terms: {
-          field: 'slo.instanceId',
-        },
-      },
-      'slo.name': {
-        terms: {
-          field: 'slo.name',
-        },
-      },
-      'slo.description': {
-        terms: {
-          field: 'slo.description',
-        },
-      },
-      'slo.tags': {
-        terms: {
-          field: 'slo.tags',
-        },
-      },
-      'slo.indicator.type': {
-        terms: {
-          field: 'slo.indicator.type',
-        },
-      },
-      'slo.budgetingMethod': {
-        terms: {
-          field: 'slo.budgetingMethod',
-        },
-      },
-      'slo.timeWindow.duration': {
-        terms: {
-          field: 'slo.timeWindow.duration',
-        },
-      },
-      'slo.timeWindow.type': {
-        terms: {
-          field: 'slo.timeWindow.type',
-        },
-      },
-    },
+    group_by: groupBy,
     aggregations: {
       _sliceDurationInSeconds: {
         max: {

--- a/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_timeslices_monthly_aligned.ts
+++ b/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_timeslices_monthly_aligned.ts
@@ -67,6 +67,26 @@ export const SUMMARY_TIMESLICES_MONTHLY_ALIGNED: TransformPutTransformRequest = 
           field: 'slo.instanceId',
         },
       },
+      'slo.name': {
+        terms: {
+          field: 'slo.name',
+        },
+      },
+      'slo.description': {
+        terms: {
+          field: 'slo.description',
+        },
+      },
+      'slo.tags': {
+        terms: {
+          field: 'slo.tags',
+        },
+      },
+      'slo.indicator.type': {
+        terms: {
+          field: 'slo.indicator.type',
+        },
+      },
       'slo.budgetingMethod': {
         terms: {
           field: 'slo.budgetingMethod',

--- a/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_timeslices_weekly_aligned.ts
+++ b/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_timeslices_weekly_aligned.ts
@@ -12,6 +12,7 @@ import {
   SLO_SUMMARY_DESTINATION_INDEX_NAME,
   SLO_SUMMARY_TRANSFORM_NAME_PREFIX,
 } from '../../../../assets/constants';
+import { groupBy } from './common';
 
 export const SUMMARY_TIMESLICES_WEEKLY_ALIGNED: TransformPutTransformRequest = {
   transform_id: `${SLO_SUMMARY_TRANSFORM_NAME_PREFIX}timeslices-weekly-aligned`,
@@ -51,58 +52,7 @@ export const SUMMARY_TIMESLICES_WEEKLY_ALIGNED: TransformPutTransformRequest = {
     },
   },
   pivot: {
-    group_by: {
-      'slo.id': {
-        terms: {
-          field: 'slo.id',
-        },
-      },
-      'slo.revision': {
-        terms: {
-          field: 'slo.revision',
-        },
-      },
-      'slo.instanceId': {
-        terms: {
-          field: 'slo.instanceId',
-        },
-      },
-      'slo.name': {
-        terms: {
-          field: 'slo.name',
-        },
-      },
-      'slo.description': {
-        terms: {
-          field: 'slo.description',
-        },
-      },
-      'slo.tags': {
-        terms: {
-          field: 'slo.tags',
-        },
-      },
-      'slo.indicator.type': {
-        terms: {
-          field: 'slo.indicator.type',
-        },
-      },
-      'slo.budgetingMethod': {
-        terms: {
-          field: 'slo.budgetingMethod',
-        },
-      },
-      'slo.timeWindow.duration': {
-        terms: {
-          field: 'slo.timeWindow.duration',
-        },
-      },
-      'slo.timeWindow.type': {
-        terms: {
-          field: 'slo.timeWindow.type',
-        },
-      },
-    },
+    group_by: groupBy,
     aggregations: {
       _sliceDurationInSeconds: {
         max: {

--- a/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_timeslices_weekly_aligned.ts
+++ b/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_timeslices_weekly_aligned.ts
@@ -67,6 +67,26 @@ export const SUMMARY_TIMESLICES_WEEKLY_ALIGNED: TransformPutTransformRequest = {
           field: 'slo.instanceId',
         },
       },
+      'slo.name': {
+        terms: {
+          field: 'slo.name',
+        },
+      },
+      'slo.description': {
+        terms: {
+          field: 'slo.description',
+        },
+      },
+      'slo.tags': {
+        terms: {
+          field: 'slo.tags',
+        },
+      },
+      'slo.indicator.type': {
+        terms: {
+          field: 'slo.indicator.type',
+        },
+      },
       'slo.budgetingMethod': {
         terms: {
           field: 'slo.budgetingMethod',

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/apm_transaction_duration.test.ts.snap
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/apm_transaction_duration.test.ts.snap
@@ -199,14 +199,29 @@ Object {
           "field": "slo.budgetingMethod",
         },
       },
+      "slo.description": Object {
+        "terms": Object {
+          "field": "slo.description",
+        },
+      },
       "slo.id": Object {
         "terms": Object {
           "field": "slo.id",
         },
       },
+      "slo.indicator.type": Object {
+        "terms": Object {
+          "field": "slo.indicator.type",
+        },
+      },
       "slo.instanceId": Object {
         "terms": Object {
           "field": "slo.instanceId",
+        },
+      },
+      "slo.name": Object {
+        "terms": Object {
+          "field": "slo.name",
         },
       },
       "slo.objective.sliceDurationInSeconds": Object {
@@ -222,6 +237,11 @@ Object {
       "slo.revision": Object {
         "terms": Object {
           "field": "slo.revision",
+        },
+      },
+      "slo.tags": Object {
+        "terms": Object {
+          "field": "slo.tags",
         },
       },
       "slo.timeWindow.duration": Object {
@@ -298,15 +318,33 @@ Object {
         },
         "type": "keyword",
       },
+      "slo.description": Object {
+        "script": Object {
+          "source": "emit('irrelevant')",
+        },
+        "type": "keyword",
+      },
       "slo.id": Object {
         "script": Object {
           "source": Any<String>,
         },
         "type": "keyword",
       },
+      "slo.indicator.type": Object {
+        "script": Object {
+          "source": "emit('sli.apm.transactionDuration')",
+        },
+        "type": "keyword",
+      },
       "slo.instanceId": Object {
         "script": Object {
           "source": "emit('*')",
+        },
+        "type": "keyword",
+      },
+      "slo.name": Object {
+        "script": Object {
+          "source": "emit('irrelevant')",
         },
         "type": "keyword",
       },
@@ -327,6 +365,12 @@ Object {
           "source": "emit(1)",
         },
         "type": "long",
+      },
+      "slo.tags": Object {
+        "script": Object {
+          "source": "emit('critical,k8s')",
+        },
+        "type": "keyword",
       },
       "slo.timeWindow.duration": Object {
         "script": Object {
@@ -403,14 +447,29 @@ Object {
           "field": "slo.budgetingMethod",
         },
       },
+      "slo.description": Object {
+        "terms": Object {
+          "field": "slo.description",
+        },
+      },
       "slo.id": Object {
         "terms": Object {
           "field": "slo.id",
         },
       },
+      "slo.indicator.type": Object {
+        "terms": Object {
+          "field": "slo.indicator.type",
+        },
+      },
       "slo.instanceId": Object {
         "terms": Object {
           "field": "slo.instanceId",
+        },
+      },
+      "slo.name": Object {
+        "terms": Object {
+          "field": "slo.name",
         },
       },
       "slo.objective.target": Object {
@@ -421,6 +480,11 @@ Object {
       "slo.revision": Object {
         "terms": Object {
           "field": "slo.revision",
+        },
+      },
+      "slo.tags": Object {
+        "terms": Object {
+          "field": "slo.tags",
         },
       },
       "slo.timeWindow.duration": Object {
@@ -497,15 +561,33 @@ Object {
         },
         "type": "keyword",
       },
+      "slo.description": Object {
+        "script": Object {
+          "source": "emit('irrelevant')",
+        },
+        "type": "keyword",
+      },
       "slo.id": Object {
         "script": Object {
           "source": Any<String>,
         },
         "type": "keyword",
       },
+      "slo.indicator.type": Object {
+        "script": Object {
+          "source": "emit('sli.apm.transactionDuration')",
+        },
+        "type": "keyword",
+      },
       "slo.instanceId": Object {
         "script": Object {
           "source": "emit('*')",
+        },
+        "type": "keyword",
+      },
+      "slo.name": Object {
+        "script": Object {
+          "source": "emit('irrelevant')",
         },
         "type": "keyword",
       },
@@ -520,6 +602,12 @@ Object {
           "source": "emit(1)",
         },
         "type": "long",
+      },
+      "slo.tags": Object {
+        "script": Object {
+          "source": "emit('critical,k8s')",
+        },
+        "type": "keyword",
       },
       "slo.timeWindow.duration": Object {
         "script": Object {

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/apm_transaction_duration.test.ts.snap
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/apm_transaction_duration.test.ts.snap
@@ -139,6 +139,442 @@ Object {
 }
 `;
 
+exports[`APM Transaction Duration Transform Generator groups by the 'service.environment' 1`] = `
+Object {
+  "bool": Object {
+    "filter": Array [
+      Object {
+        "terms": Object {
+          "processor.event": Array [
+            "metric",
+          ],
+        },
+      },
+      Object {
+        "term": Object {
+          "metricset.name": "transaction",
+        },
+      },
+      Object {
+        "exists": Object {
+          "field": "transaction.duration.histogram",
+        },
+      },
+      Object {
+        "range": Object {
+          "@timestamp": Object {
+            "gte": "now-7d",
+          },
+        },
+      },
+      Object {
+        "match": Object {
+          "service.environment": "production",
+        },
+      },
+    ],
+  },
+}
+`;
+
+exports[`APM Transaction Duration Transform Generator groups by the 'service.environment' 2`] = `
+Object {
+  "@timestamp": Object {
+    "date_histogram": Object {
+      "field": "@timestamp",
+      "fixed_interval": "1m",
+    },
+  },
+  "service.environment": Object {
+    "terms": Object {
+      "field": "service.environment",
+    },
+  },
+  "slo.budgetingMethod": Object {
+    "terms": Object {
+      "field": "slo.budgetingMethod",
+    },
+  },
+  "slo.description": Object {
+    "terms": Object {
+      "field": "slo.description",
+    },
+  },
+  "slo.id": Object {
+    "terms": Object {
+      "field": "slo.id",
+    },
+  },
+  "slo.indicator.type": Object {
+    "terms": Object {
+      "field": "slo.indicator.type",
+    },
+  },
+  "slo.instanceId": Object {
+    "terms": Object {
+      "field": "slo.instanceId",
+    },
+  },
+  "slo.name": Object {
+    "terms": Object {
+      "field": "slo.name",
+    },
+  },
+  "slo.objective.target": Object {
+    "terms": Object {
+      "field": "slo.objective.target",
+    },
+  },
+  "slo.revision": Object {
+    "terms": Object {
+      "field": "slo.revision",
+    },
+  },
+  "slo.tags": Object {
+    "terms": Object {
+      "field": "slo.tags",
+    },
+  },
+  "slo.timeWindow.duration": Object {
+    "terms": Object {
+      "field": "slo.timeWindow.duration",
+    },
+  },
+  "slo.timeWindow.type": Object {
+    "terms": Object {
+      "field": "slo.timeWindow.type",
+    },
+  },
+}
+`;
+
+exports[`APM Transaction Duration Transform Generator groups by the 'service.name' 1`] = `
+Object {
+  "bool": Object {
+    "filter": Array [
+      Object {
+        "terms": Object {
+          "processor.event": Array [
+            "metric",
+          ],
+        },
+      },
+      Object {
+        "term": Object {
+          "metricset.name": "transaction",
+        },
+      },
+      Object {
+        "exists": Object {
+          "field": "transaction.duration.histogram",
+        },
+      },
+      Object {
+        "range": Object {
+          "@timestamp": Object {
+            "gte": "now-7d",
+          },
+        },
+      },
+      Object {
+        "match": Object {
+          "service.name": "my-service",
+        },
+      },
+    ],
+  },
+}
+`;
+
+exports[`APM Transaction Duration Transform Generator groups by the 'service.name' 2`] = `
+Object {
+  "@timestamp": Object {
+    "date_histogram": Object {
+      "field": "@timestamp",
+      "fixed_interval": "1m",
+    },
+  },
+  "service.name": Object {
+    "terms": Object {
+      "field": "service.name",
+    },
+  },
+  "slo.budgetingMethod": Object {
+    "terms": Object {
+      "field": "slo.budgetingMethod",
+    },
+  },
+  "slo.description": Object {
+    "terms": Object {
+      "field": "slo.description",
+    },
+  },
+  "slo.id": Object {
+    "terms": Object {
+      "field": "slo.id",
+    },
+  },
+  "slo.indicator.type": Object {
+    "terms": Object {
+      "field": "slo.indicator.type",
+    },
+  },
+  "slo.instanceId": Object {
+    "terms": Object {
+      "field": "slo.instanceId",
+    },
+  },
+  "slo.name": Object {
+    "terms": Object {
+      "field": "slo.name",
+    },
+  },
+  "slo.objective.target": Object {
+    "terms": Object {
+      "field": "slo.objective.target",
+    },
+  },
+  "slo.revision": Object {
+    "terms": Object {
+      "field": "slo.revision",
+    },
+  },
+  "slo.tags": Object {
+    "terms": Object {
+      "field": "slo.tags",
+    },
+  },
+  "slo.timeWindow.duration": Object {
+    "terms": Object {
+      "field": "slo.timeWindow.duration",
+    },
+  },
+  "slo.timeWindow.type": Object {
+    "terms": Object {
+      "field": "slo.timeWindow.type",
+    },
+  },
+}
+`;
+
+exports[`APM Transaction Duration Transform Generator groups by the 'transaction.name' 1`] = `
+Object {
+  "bool": Object {
+    "filter": Array [
+      Object {
+        "terms": Object {
+          "processor.event": Array [
+            "metric",
+          ],
+        },
+      },
+      Object {
+        "term": Object {
+          "metricset.name": "transaction",
+        },
+      },
+      Object {
+        "exists": Object {
+          "field": "transaction.duration.histogram",
+        },
+      },
+      Object {
+        "range": Object {
+          "@timestamp": Object {
+            "gte": "now-7d",
+          },
+        },
+      },
+      Object {
+        "match": Object {
+          "transaction.name": "GET /foo",
+        },
+      },
+    ],
+  },
+}
+`;
+
+exports[`APM Transaction Duration Transform Generator groups by the 'transaction.name' 2`] = `
+Object {
+  "@timestamp": Object {
+    "date_histogram": Object {
+      "field": "@timestamp",
+      "fixed_interval": "1m",
+    },
+  },
+  "slo.budgetingMethod": Object {
+    "terms": Object {
+      "field": "slo.budgetingMethod",
+    },
+  },
+  "slo.description": Object {
+    "terms": Object {
+      "field": "slo.description",
+    },
+  },
+  "slo.id": Object {
+    "terms": Object {
+      "field": "slo.id",
+    },
+  },
+  "slo.indicator.type": Object {
+    "terms": Object {
+      "field": "slo.indicator.type",
+    },
+  },
+  "slo.instanceId": Object {
+    "terms": Object {
+      "field": "slo.instanceId",
+    },
+  },
+  "slo.name": Object {
+    "terms": Object {
+      "field": "slo.name",
+    },
+  },
+  "slo.objective.target": Object {
+    "terms": Object {
+      "field": "slo.objective.target",
+    },
+  },
+  "slo.revision": Object {
+    "terms": Object {
+      "field": "slo.revision",
+    },
+  },
+  "slo.tags": Object {
+    "terms": Object {
+      "field": "slo.tags",
+    },
+  },
+  "slo.timeWindow.duration": Object {
+    "terms": Object {
+      "field": "slo.timeWindow.duration",
+    },
+  },
+  "slo.timeWindow.type": Object {
+    "terms": Object {
+      "field": "slo.timeWindow.type",
+    },
+  },
+  "transaction.name": Object {
+    "terms": Object {
+      "field": "transaction.name",
+    },
+  },
+}
+`;
+
+exports[`APM Transaction Duration Transform Generator groups by the 'transaction.type' 1`] = `
+Object {
+  "bool": Object {
+    "filter": Array [
+      Object {
+        "terms": Object {
+          "processor.event": Array [
+            "metric",
+          ],
+        },
+      },
+      Object {
+        "term": Object {
+          "metricset.name": "transaction",
+        },
+      },
+      Object {
+        "exists": Object {
+          "field": "transaction.duration.histogram",
+        },
+      },
+      Object {
+        "range": Object {
+          "@timestamp": Object {
+            "gte": "now-7d",
+          },
+        },
+      },
+      Object {
+        "match": Object {
+          "transaction.type": "request",
+        },
+      },
+    ],
+  },
+}
+`;
+
+exports[`APM Transaction Duration Transform Generator groups by the 'transaction.type' 2`] = `
+Object {
+  "@timestamp": Object {
+    "date_histogram": Object {
+      "field": "@timestamp",
+      "fixed_interval": "1m",
+    },
+  },
+  "slo.budgetingMethod": Object {
+    "terms": Object {
+      "field": "slo.budgetingMethod",
+    },
+  },
+  "slo.description": Object {
+    "terms": Object {
+      "field": "slo.description",
+    },
+  },
+  "slo.id": Object {
+    "terms": Object {
+      "field": "slo.id",
+    },
+  },
+  "slo.indicator.type": Object {
+    "terms": Object {
+      "field": "slo.indicator.type",
+    },
+  },
+  "slo.instanceId": Object {
+    "terms": Object {
+      "field": "slo.instanceId",
+    },
+  },
+  "slo.name": Object {
+    "terms": Object {
+      "field": "slo.name",
+    },
+  },
+  "slo.objective.target": Object {
+    "terms": Object {
+      "field": "slo.objective.target",
+    },
+  },
+  "slo.revision": Object {
+    "terms": Object {
+      "field": "slo.revision",
+    },
+  },
+  "slo.tags": Object {
+    "terms": Object {
+      "field": "slo.tags",
+    },
+  },
+  "slo.timeWindow.duration": Object {
+    "terms": Object {
+      "field": "slo.timeWindow.duration",
+    },
+  },
+  "slo.timeWindow.type": Object {
+    "terms": Object {
+      "field": "slo.timeWindow.type",
+    },
+  },
+  "transaction.type": Object {
+    "terms": Object {
+      "field": "transaction.type",
+    },
+  },
+}
+`;
+
 exports[`APM Transaction Duration Transform Generator returns the expected transform params for timeslices slo 1`] = `
 Object {
   "_meta": Object {

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/apm_transaction_duration.test.ts.snap
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/apm_transaction_duration.test.ts.snap
@@ -194,6 +194,16 @@ Object {
           "fixed_interval": "2m",
         },
       },
+      "service.environment": Object {
+        "terms": Object {
+          "field": "service.environment",
+        },
+      },
+      "service.name": Object {
+        "terms": Object {
+          "field": "service.name",
+        },
+      },
       "slo.budgetingMethod": Object {
         "terms": Object {
           "field": "slo.budgetingMethod",
@@ -254,6 +264,16 @@ Object {
           "field": "slo.timeWindow.type",
         },
       },
+      "transaction.name": Object {
+        "terms": Object {
+          "field": "transaction.name",
+        },
+      },
+      "transaction.type": Object {
+        "terms": Object {
+          "field": "transaction.type",
+        },
+      },
     },
   },
   "settings": Object {
@@ -312,6 +332,18 @@ Object {
       },
     },
     "runtime_mappings": Object {
+      "service.environment": Object {
+        "script": Object {
+          "source": "emit('irrelevant')",
+        },
+        "type": "keyword",
+      },
+      "service.name": Object {
+        "script": Object {
+          "source": "emit('irrelevant')",
+        },
+        "type": "keyword",
+      },
       "slo.budgetingMethod": Object {
         "script": Object {
           "source": "emit('timeslices')",
@@ -384,6 +416,18 @@ Object {
         },
         "type": "keyword",
       },
+      "transaction.name": Object {
+        "script": Object {
+          "source": "emit('irrelevant')",
+        },
+        "type": "keyword",
+      },
+      "transaction.type": Object {
+        "script": Object {
+          "source": "emit('irrelevant')",
+        },
+        "type": "keyword",
+      },
     },
   },
   "sync": Object {
@@ -442,6 +486,16 @@ Object {
           "fixed_interval": "1m",
         },
       },
+      "service.environment": Object {
+        "terms": Object {
+          "field": "service.environment",
+        },
+      },
+      "service.name": Object {
+        "terms": Object {
+          "field": "service.name",
+        },
+      },
       "slo.budgetingMethod": Object {
         "terms": Object {
           "field": "slo.budgetingMethod",
@@ -495,6 +549,16 @@ Object {
       "slo.timeWindow.type": Object {
         "terms": Object {
           "field": "slo.timeWindow.type",
+        },
+      },
+      "transaction.name": Object {
+        "terms": Object {
+          "field": "transaction.name",
+        },
+      },
+      "transaction.type": Object {
+        "terms": Object {
+          "field": "transaction.type",
         },
       },
     },
@@ -555,6 +619,18 @@ Object {
       },
     },
     "runtime_mappings": Object {
+      "service.environment": Object {
+        "script": Object {
+          "source": "emit('irrelevant')",
+        },
+        "type": "keyword",
+      },
+      "service.name": Object {
+        "script": Object {
+          "source": "emit('irrelevant')",
+        },
+        "type": "keyword",
+      },
       "slo.budgetingMethod": Object {
         "script": Object {
           "source": "emit('occurrences')",
@@ -618,6 +694,18 @@ Object {
       "slo.timeWindow.type": Object {
         "script": Object {
           "source": "emit('rolling')",
+        },
+        "type": "keyword",
+      },
+      "transaction.name": Object {
+        "script": Object {
+          "source": "emit('irrelevant')",
+        },
+        "type": "keyword",
+      },
+      "transaction.type": Object {
+        "script": Object {
+          "source": "emit('irrelevant')",
         },
         "type": "keyword",
       },

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/apm_transaction_duration.test.ts.snap
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/apm_transaction_duration.test.ts.snap
@@ -332,18 +332,6 @@ Object {
       },
     },
     "runtime_mappings": Object {
-      "service.environment": Object {
-        "script": Object {
-          "source": "emit('irrelevant')",
-        },
-        "type": "keyword",
-      },
-      "service.name": Object {
-        "script": Object {
-          "source": "emit('irrelevant')",
-        },
-        "type": "keyword",
-      },
       "slo.budgetingMethod": Object {
         "script": Object {
           "source": "emit('timeslices')",
@@ -413,18 +401,6 @@ Object {
       "slo.timeWindow.type": Object {
         "script": Object {
           "source": "emit('rolling')",
-        },
-        "type": "keyword",
-      },
-      "transaction.name": Object {
-        "script": Object {
-          "source": "emit('irrelevant')",
-        },
-        "type": "keyword",
-      },
-      "transaction.type": Object {
-        "script": Object {
-          "source": "emit('irrelevant')",
         },
         "type": "keyword",
       },
@@ -619,18 +595,6 @@ Object {
       },
     },
     "runtime_mappings": Object {
-      "service.environment": Object {
-        "script": Object {
-          "source": "emit('irrelevant')",
-        },
-        "type": "keyword",
-      },
-      "service.name": Object {
-        "script": Object {
-          "source": "emit('irrelevant')",
-        },
-        "type": "keyword",
-      },
       "slo.budgetingMethod": Object {
         "script": Object {
           "source": "emit('occurrences')",
@@ -694,18 +658,6 @@ Object {
       "slo.timeWindow.type": Object {
         "script": Object {
           "source": "emit('rolling')",
-        },
-        "type": "keyword",
-      },
-      "transaction.name": Object {
-        "script": Object {
-          "source": "emit('irrelevant')",
-        },
-        "type": "keyword",
-      },
-      "transaction.type": Object {
-        "script": Object {
-          "source": "emit('irrelevant')",
         },
         "type": "keyword",
       },

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/apm_transaction_error_rate.test.ts.snap
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/apm_transaction_error_rate.test.ts.snap
@@ -313,18 +313,6 @@ Object {
       },
     },
     "runtime_mappings": Object {
-      "service.environment": Object {
-        "script": Object {
-          "source": "emit('irrelevant')",
-        },
-        "type": "keyword",
-      },
-      "service.name": Object {
-        "script": Object {
-          "source": "emit('irrelevant')",
-        },
-        "type": "keyword",
-      },
       "slo.budgetingMethod": Object {
         "script": Object {
           "source": "emit('timeslices')",
@@ -394,18 +382,6 @@ Object {
       "slo.timeWindow.type": Object {
         "script": Object {
           "source": "emit('rolling')",
-        },
-        "type": "keyword",
-      },
-      "transaction.name": Object {
-        "script": Object {
-          "source": "emit('irrelevant')",
-        },
-        "type": "keyword",
-      },
-      "transaction.type": Object {
-        "script": Object {
-          "source": "emit('irrelevant')",
         },
         "type": "keyword",
       },
@@ -589,18 +565,6 @@ Object {
       },
     },
     "runtime_mappings": Object {
-      "service.environment": Object {
-        "script": Object {
-          "source": "emit('irrelevant')",
-        },
-        "type": "keyword",
-      },
-      "service.name": Object {
-        "script": Object {
-          "source": "emit('irrelevant')",
-        },
-        "type": "keyword",
-      },
       "slo.budgetingMethod": Object {
         "script": Object {
           "source": "emit('occurrences')",
@@ -664,18 +628,6 @@ Object {
       "slo.timeWindow.type": Object {
         "script": Object {
           "source": "emit('rolling')",
-        },
-        "type": "keyword",
-      },
-      "transaction.name": Object {
-        "script": Object {
-          "source": "emit('irrelevant')",
-        },
-        "type": "keyword",
-      },
-      "transaction.type": Object {
-        "script": Object {
-          "source": "emit('irrelevant')",
         },
         "type": "keyword",
       },

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/apm_transaction_error_rate.test.ts.snap
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/apm_transaction_error_rate.test.ts.snap
@@ -184,14 +184,29 @@ Object {
           "field": "slo.budgetingMethod",
         },
       },
+      "slo.description": Object {
+        "terms": Object {
+          "field": "slo.description",
+        },
+      },
       "slo.id": Object {
         "terms": Object {
           "field": "slo.id",
         },
       },
+      "slo.indicator.type": Object {
+        "terms": Object {
+          "field": "slo.indicator.type",
+        },
+      },
       "slo.instanceId": Object {
         "terms": Object {
           "field": "slo.instanceId",
+        },
+      },
+      "slo.name": Object {
+        "terms": Object {
+          "field": "slo.name",
         },
       },
       "slo.objective.sliceDurationInSeconds": Object {
@@ -207,6 +222,11 @@ Object {
       "slo.revision": Object {
         "terms": Object {
           "field": "slo.revision",
+        },
+      },
+      "slo.tags": Object {
+        "terms": Object {
+          "field": "slo.tags",
         },
       },
       "slo.timeWindow.duration": Object {
@@ -279,15 +299,33 @@ Object {
         },
         "type": "keyword",
       },
+      "slo.description": Object {
+        "script": Object {
+          "source": "emit('irrelevant')",
+        },
+        "type": "keyword",
+      },
       "slo.id": Object {
         "script": Object {
           "source": Any<String>,
         },
         "type": "keyword",
       },
+      "slo.indicator.type": Object {
+        "script": Object {
+          "source": "emit('sli.apm.transactionErrorRate')",
+        },
+        "type": "keyword",
+      },
       "slo.instanceId": Object {
         "script": Object {
           "source": "emit('*')",
+        },
+        "type": "keyword",
+      },
+      "slo.name": Object {
+        "script": Object {
+          "source": "emit('irrelevant')",
         },
         "type": "keyword",
       },
@@ -308,6 +346,12 @@ Object {
           "source": "emit(1)",
         },
         "type": "long",
+      },
+      "slo.tags": Object {
+        "script": Object {
+          "source": "emit('critical,k8s')",
+        },
+        "type": "keyword",
       },
       "slo.timeWindow.duration": Object {
         "script": Object {
@@ -377,14 +421,29 @@ Object {
           "field": "slo.budgetingMethod",
         },
       },
+      "slo.description": Object {
+        "terms": Object {
+          "field": "slo.description",
+        },
+      },
       "slo.id": Object {
         "terms": Object {
           "field": "slo.id",
         },
       },
+      "slo.indicator.type": Object {
+        "terms": Object {
+          "field": "slo.indicator.type",
+        },
+      },
       "slo.instanceId": Object {
         "terms": Object {
           "field": "slo.instanceId",
+        },
+      },
+      "slo.name": Object {
+        "terms": Object {
+          "field": "slo.name",
         },
       },
       "slo.objective.target": Object {
@@ -395,6 +454,11 @@ Object {
       "slo.revision": Object {
         "terms": Object {
           "field": "slo.revision",
+        },
+      },
+      "slo.tags": Object {
+        "terms": Object {
+          "field": "slo.tags",
         },
       },
       "slo.timeWindow.duration": Object {
@@ -467,15 +531,33 @@ Object {
         },
         "type": "keyword",
       },
+      "slo.description": Object {
+        "script": Object {
+          "source": "emit('irrelevant')",
+        },
+        "type": "keyword",
+      },
       "slo.id": Object {
         "script": Object {
           "source": Any<String>,
         },
         "type": "keyword",
       },
+      "slo.indicator.type": Object {
+        "script": Object {
+          "source": "emit('sli.apm.transactionErrorRate')",
+        },
+        "type": "keyword",
+      },
       "slo.instanceId": Object {
         "script": Object {
           "source": "emit('*')",
+        },
+        "type": "keyword",
+      },
+      "slo.name": Object {
+        "script": Object {
+          "source": "emit('irrelevant')",
         },
         "type": "keyword",
       },
@@ -490,6 +572,12 @@ Object {
           "source": "emit(1)",
         },
         "type": "long",
+      },
+      "slo.tags": Object {
+        "script": Object {
+          "source": "emit('critical,k8s')",
+        },
+        "type": "keyword",
       },
       "slo.timeWindow.duration": Object {
         "script": Object {

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/apm_transaction_error_rate.test.ts.snap
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/apm_transaction_error_rate.test.ts.snap
@@ -131,6 +131,426 @@ Object {
 }
 `;
 
+exports[`APM Transaction Error Rate Transform Generator groups by the 'service.environment' 1`] = `
+Object {
+  "bool": Object {
+    "filter": Array [
+      Object {
+        "term": Object {
+          "metricset.name": "transaction",
+        },
+      },
+      Object {
+        "terms": Object {
+          "event.outcome": Array [
+            "success",
+            "failure",
+          ],
+        },
+      },
+      Object {
+        "range": Object {
+          "@timestamp": Object {
+            "gte": "now-7d",
+          },
+        },
+      },
+      Object {
+        "match": Object {
+          "service.environment": "production",
+        },
+      },
+    ],
+  },
+}
+`;
+
+exports[`APM Transaction Error Rate Transform Generator groups by the 'service.environment' 2`] = `
+Object {
+  "@timestamp": Object {
+    "date_histogram": Object {
+      "field": "@timestamp",
+      "fixed_interval": "1m",
+    },
+  },
+  "service.environment": Object {
+    "terms": Object {
+      "field": "service.environment",
+    },
+  },
+  "slo.budgetingMethod": Object {
+    "terms": Object {
+      "field": "slo.budgetingMethod",
+    },
+  },
+  "slo.description": Object {
+    "terms": Object {
+      "field": "slo.description",
+    },
+  },
+  "slo.id": Object {
+    "terms": Object {
+      "field": "slo.id",
+    },
+  },
+  "slo.indicator.type": Object {
+    "terms": Object {
+      "field": "slo.indicator.type",
+    },
+  },
+  "slo.instanceId": Object {
+    "terms": Object {
+      "field": "slo.instanceId",
+    },
+  },
+  "slo.name": Object {
+    "terms": Object {
+      "field": "slo.name",
+    },
+  },
+  "slo.objective.target": Object {
+    "terms": Object {
+      "field": "slo.objective.target",
+    },
+  },
+  "slo.revision": Object {
+    "terms": Object {
+      "field": "slo.revision",
+    },
+  },
+  "slo.tags": Object {
+    "terms": Object {
+      "field": "slo.tags",
+    },
+  },
+  "slo.timeWindow.duration": Object {
+    "terms": Object {
+      "field": "slo.timeWindow.duration",
+    },
+  },
+  "slo.timeWindow.type": Object {
+    "terms": Object {
+      "field": "slo.timeWindow.type",
+    },
+  },
+}
+`;
+
+exports[`APM Transaction Error Rate Transform Generator groups by the 'service.name' 1`] = `
+Object {
+  "bool": Object {
+    "filter": Array [
+      Object {
+        "term": Object {
+          "metricset.name": "transaction",
+        },
+      },
+      Object {
+        "terms": Object {
+          "event.outcome": Array [
+            "success",
+            "failure",
+          ],
+        },
+      },
+      Object {
+        "range": Object {
+          "@timestamp": Object {
+            "gte": "now-7d",
+          },
+        },
+      },
+      Object {
+        "match": Object {
+          "service.name": "my-service",
+        },
+      },
+    ],
+  },
+}
+`;
+
+exports[`APM Transaction Error Rate Transform Generator groups by the 'service.name' 2`] = `
+Object {
+  "@timestamp": Object {
+    "date_histogram": Object {
+      "field": "@timestamp",
+      "fixed_interval": "1m",
+    },
+  },
+  "service.name": Object {
+    "terms": Object {
+      "field": "service.name",
+    },
+  },
+  "slo.budgetingMethod": Object {
+    "terms": Object {
+      "field": "slo.budgetingMethod",
+    },
+  },
+  "slo.description": Object {
+    "terms": Object {
+      "field": "slo.description",
+    },
+  },
+  "slo.id": Object {
+    "terms": Object {
+      "field": "slo.id",
+    },
+  },
+  "slo.indicator.type": Object {
+    "terms": Object {
+      "field": "slo.indicator.type",
+    },
+  },
+  "slo.instanceId": Object {
+    "terms": Object {
+      "field": "slo.instanceId",
+    },
+  },
+  "slo.name": Object {
+    "terms": Object {
+      "field": "slo.name",
+    },
+  },
+  "slo.objective.target": Object {
+    "terms": Object {
+      "field": "slo.objective.target",
+    },
+  },
+  "slo.revision": Object {
+    "terms": Object {
+      "field": "slo.revision",
+    },
+  },
+  "slo.tags": Object {
+    "terms": Object {
+      "field": "slo.tags",
+    },
+  },
+  "slo.timeWindow.duration": Object {
+    "terms": Object {
+      "field": "slo.timeWindow.duration",
+    },
+  },
+  "slo.timeWindow.type": Object {
+    "terms": Object {
+      "field": "slo.timeWindow.type",
+    },
+  },
+}
+`;
+
+exports[`APM Transaction Error Rate Transform Generator groups by the 'transaction.name' 1`] = `
+Object {
+  "bool": Object {
+    "filter": Array [
+      Object {
+        "term": Object {
+          "metricset.name": "transaction",
+        },
+      },
+      Object {
+        "terms": Object {
+          "event.outcome": Array [
+            "success",
+            "failure",
+          ],
+        },
+      },
+      Object {
+        "range": Object {
+          "@timestamp": Object {
+            "gte": "now-7d",
+          },
+        },
+      },
+      Object {
+        "match": Object {
+          "transaction.name": "GET /foo",
+        },
+      },
+    ],
+  },
+}
+`;
+
+exports[`APM Transaction Error Rate Transform Generator groups by the 'transaction.name' 2`] = `
+Object {
+  "@timestamp": Object {
+    "date_histogram": Object {
+      "field": "@timestamp",
+      "fixed_interval": "1m",
+    },
+  },
+  "slo.budgetingMethod": Object {
+    "terms": Object {
+      "field": "slo.budgetingMethod",
+    },
+  },
+  "slo.description": Object {
+    "terms": Object {
+      "field": "slo.description",
+    },
+  },
+  "slo.id": Object {
+    "terms": Object {
+      "field": "slo.id",
+    },
+  },
+  "slo.indicator.type": Object {
+    "terms": Object {
+      "field": "slo.indicator.type",
+    },
+  },
+  "slo.instanceId": Object {
+    "terms": Object {
+      "field": "slo.instanceId",
+    },
+  },
+  "slo.name": Object {
+    "terms": Object {
+      "field": "slo.name",
+    },
+  },
+  "slo.objective.target": Object {
+    "terms": Object {
+      "field": "slo.objective.target",
+    },
+  },
+  "slo.revision": Object {
+    "terms": Object {
+      "field": "slo.revision",
+    },
+  },
+  "slo.tags": Object {
+    "terms": Object {
+      "field": "slo.tags",
+    },
+  },
+  "slo.timeWindow.duration": Object {
+    "terms": Object {
+      "field": "slo.timeWindow.duration",
+    },
+  },
+  "slo.timeWindow.type": Object {
+    "terms": Object {
+      "field": "slo.timeWindow.type",
+    },
+  },
+  "transaction.name": Object {
+    "terms": Object {
+      "field": "transaction.name",
+    },
+  },
+}
+`;
+
+exports[`APM Transaction Error Rate Transform Generator groups by the 'transaction.type' 1`] = `
+Object {
+  "bool": Object {
+    "filter": Array [
+      Object {
+        "term": Object {
+          "metricset.name": "transaction",
+        },
+      },
+      Object {
+        "terms": Object {
+          "event.outcome": Array [
+            "success",
+            "failure",
+          ],
+        },
+      },
+      Object {
+        "range": Object {
+          "@timestamp": Object {
+            "gte": "now-7d",
+          },
+        },
+      },
+      Object {
+        "match": Object {
+          "transaction.type": "request",
+        },
+      },
+    ],
+  },
+}
+`;
+
+exports[`APM Transaction Error Rate Transform Generator groups by the 'transaction.type' 2`] = `
+Object {
+  "@timestamp": Object {
+    "date_histogram": Object {
+      "field": "@timestamp",
+      "fixed_interval": "1m",
+    },
+  },
+  "slo.budgetingMethod": Object {
+    "terms": Object {
+      "field": "slo.budgetingMethod",
+    },
+  },
+  "slo.description": Object {
+    "terms": Object {
+      "field": "slo.description",
+    },
+  },
+  "slo.id": Object {
+    "terms": Object {
+      "field": "slo.id",
+    },
+  },
+  "slo.indicator.type": Object {
+    "terms": Object {
+      "field": "slo.indicator.type",
+    },
+  },
+  "slo.instanceId": Object {
+    "terms": Object {
+      "field": "slo.instanceId",
+    },
+  },
+  "slo.name": Object {
+    "terms": Object {
+      "field": "slo.name",
+    },
+  },
+  "slo.objective.target": Object {
+    "terms": Object {
+      "field": "slo.objective.target",
+    },
+  },
+  "slo.revision": Object {
+    "terms": Object {
+      "field": "slo.revision",
+    },
+  },
+  "slo.tags": Object {
+    "terms": Object {
+      "field": "slo.tags",
+    },
+  },
+  "slo.timeWindow.duration": Object {
+    "terms": Object {
+      "field": "slo.timeWindow.duration",
+    },
+  },
+  "slo.timeWindow.type": Object {
+    "terms": Object {
+      "field": "slo.timeWindow.type",
+    },
+  },
+  "transaction.type": Object {
+    "terms": Object {
+      "field": "transaction.type",
+    },
+  },
+}
+`;
+
 exports[`APM Transaction Error Rate Transform Generator returns the expected transform params for timeslices slo 1`] = `
 Object {
   "_meta": Object {

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/apm_transaction_error_rate.test.ts.snap
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/apm_transaction_error_rate.test.ts.snap
@@ -179,6 +179,16 @@ Object {
           "fixed_interval": "2m",
         },
       },
+      "service.environment": Object {
+        "terms": Object {
+          "field": "service.environment",
+        },
+      },
+      "service.name": Object {
+        "terms": Object {
+          "field": "service.name",
+        },
+      },
       "slo.budgetingMethod": Object {
         "terms": Object {
           "field": "slo.budgetingMethod",
@@ -239,6 +249,16 @@ Object {
           "field": "slo.timeWindow.type",
         },
       },
+      "transaction.name": Object {
+        "terms": Object {
+          "field": "transaction.name",
+        },
+      },
+      "transaction.type": Object {
+        "terms": Object {
+          "field": "transaction.type",
+        },
+      },
     },
   },
   "settings": Object {
@@ -293,6 +313,18 @@ Object {
       },
     },
     "runtime_mappings": Object {
+      "service.environment": Object {
+        "script": Object {
+          "source": "emit('irrelevant')",
+        },
+        "type": "keyword",
+      },
+      "service.name": Object {
+        "script": Object {
+          "source": "emit('irrelevant')",
+        },
+        "type": "keyword",
+      },
       "slo.budgetingMethod": Object {
         "script": Object {
           "source": "emit('timeslices')",
@@ -365,6 +397,18 @@ Object {
         },
         "type": "keyword",
       },
+      "transaction.name": Object {
+        "script": Object {
+          "source": "emit('irrelevant')",
+        },
+        "type": "keyword",
+      },
+      "transaction.type": Object {
+        "script": Object {
+          "source": "emit('irrelevant')",
+        },
+        "type": "keyword",
+      },
     },
   },
   "sync": Object {
@@ -414,6 +458,16 @@ Object {
         "date_histogram": Object {
           "field": "@timestamp",
           "fixed_interval": "1m",
+        },
+      },
+      "service.environment": Object {
+        "terms": Object {
+          "field": "service.environment",
+        },
+      },
+      "service.name": Object {
+        "terms": Object {
+          "field": "service.name",
         },
       },
       "slo.budgetingMethod": Object {
@@ -471,6 +525,16 @@ Object {
           "field": "slo.timeWindow.type",
         },
       },
+      "transaction.name": Object {
+        "terms": Object {
+          "field": "transaction.name",
+        },
+      },
+      "transaction.type": Object {
+        "terms": Object {
+          "field": "transaction.type",
+        },
+      },
     },
   },
   "settings": Object {
@@ -525,6 +589,18 @@ Object {
       },
     },
     "runtime_mappings": Object {
+      "service.environment": Object {
+        "script": Object {
+          "source": "emit('irrelevant')",
+        },
+        "type": "keyword",
+      },
+      "service.name": Object {
+        "script": Object {
+          "source": "emit('irrelevant')",
+        },
+        "type": "keyword",
+      },
       "slo.budgetingMethod": Object {
         "script": Object {
           "source": "emit('occurrences')",
@@ -588,6 +664,18 @@ Object {
       "slo.timeWindow.type": Object {
         "script": Object {
           "source": "emit('rolling')",
+        },
+        "type": "keyword",
+      },
+      "transaction.name": Object {
+        "script": Object {
+          "source": "emit('irrelevant')",
+        },
+        "type": "keyword",
+      },
+      "transaction.type": Object {
+        "script": Object {
+          "source": "emit('irrelevant')",
         },
         "type": "keyword",
       },

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/histogram.test.ts.snap
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/histogram.test.ts.snap
@@ -143,14 +143,29 @@ Object {
           "field": "slo.budgetingMethod",
         },
       },
+      "slo.description": Object {
+        "terms": Object {
+          "field": "slo.description",
+        },
+      },
       "slo.id": Object {
         "terms": Object {
           "field": "slo.id",
         },
       },
+      "slo.indicator.type": Object {
+        "terms": Object {
+          "field": "slo.indicator.type",
+        },
+      },
       "slo.instanceId": Object {
         "terms": Object {
           "field": "slo.instanceId",
+        },
+      },
+      "slo.name": Object {
+        "terms": Object {
+          "field": "slo.name",
         },
       },
       "slo.objective.sliceDurationInSeconds": Object {
@@ -166,6 +181,11 @@ Object {
       "slo.revision": Object {
         "terms": Object {
           "field": "slo.revision",
+        },
+      },
+      "slo.tags": Object {
+        "terms": Object {
+          "field": "slo.tags",
         },
       },
       "slo.timeWindow.duration": Object {
@@ -204,15 +224,33 @@ Object {
         },
         "type": "keyword",
       },
+      "slo.description": Object {
+        "script": Object {
+          "source": "emit('irrelevant')",
+        },
+        "type": "keyword",
+      },
       "slo.id": Object {
         "script": Object {
           "source": Any<String>,
         },
         "type": "keyword",
       },
+      "slo.indicator.type": Object {
+        "script": Object {
+          "source": "emit('sli.histogram.custom')",
+        },
+        "type": "keyword",
+      },
       "slo.instanceId": Object {
         "script": Object {
           "source": "emit('*')",
+        },
+        "type": "keyword",
+      },
+      "slo.name": Object {
+        "script": Object {
+          "source": "emit('irrelevant')",
         },
         "type": "keyword",
       },
@@ -233,6 +271,12 @@ Object {
           "source": "emit(1)",
         },
         "type": "long",
+      },
+      "slo.tags": Object {
+        "script": Object {
+          "source": "emit('critical,k8s')",
+        },
+        "type": "keyword",
       },
       "slo.timeWindow.duration": Object {
         "script": Object {
@@ -333,14 +377,29 @@ Object {
           "field": "slo.budgetingMethod",
         },
       },
+      "slo.description": Object {
+        "terms": Object {
+          "field": "slo.description",
+        },
+      },
       "slo.id": Object {
         "terms": Object {
           "field": "slo.id",
         },
       },
+      "slo.indicator.type": Object {
+        "terms": Object {
+          "field": "slo.indicator.type",
+        },
+      },
       "slo.instanceId": Object {
         "terms": Object {
           "field": "slo.instanceId",
+        },
+      },
+      "slo.name": Object {
+        "terms": Object {
+          "field": "slo.name",
         },
       },
       "slo.objective.target": Object {
@@ -351,6 +410,11 @@ Object {
       "slo.revision": Object {
         "terms": Object {
           "field": "slo.revision",
+        },
+      },
+      "slo.tags": Object {
+        "terms": Object {
+          "field": "slo.tags",
         },
       },
       "slo.timeWindow.duration": Object {
@@ -389,15 +453,33 @@ Object {
         },
         "type": "keyword",
       },
+      "slo.description": Object {
+        "script": Object {
+          "source": "emit('irrelevant')",
+        },
+        "type": "keyword",
+      },
       "slo.id": Object {
         "script": Object {
           "source": Any<String>,
         },
         "type": "keyword",
       },
+      "slo.indicator.type": Object {
+        "script": Object {
+          "source": "emit('sli.histogram.custom')",
+        },
+        "type": "keyword",
+      },
       "slo.instanceId": Object {
         "script": Object {
           "source": "emit('*')",
+        },
+        "type": "keyword",
+      },
+      "slo.name": Object {
+        "script": Object {
+          "source": "emit('irrelevant')",
         },
         "type": "keyword",
       },
@@ -412,6 +494,12 @@ Object {
           "source": "emit(1)",
         },
         "type": "long",
+      },
+      "slo.tags": Object {
+        "script": Object {
+          "source": "emit('critical,k8s')",
+        },
+        "type": "keyword",
       },
       "slo.timeWindow.duration": Object {
         "script": Object {

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/kql_custom.test.ts.snap
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/kql_custom.test.ts.snap
@@ -158,14 +158,29 @@ Object {
           "field": "slo.budgetingMethod",
         },
       },
+      "slo.description": Object {
+        "terms": Object {
+          "field": "slo.description",
+        },
+      },
       "slo.id": Object {
         "terms": Object {
           "field": "slo.id",
         },
       },
+      "slo.indicator.type": Object {
+        "terms": Object {
+          "field": "slo.indicator.type",
+        },
+      },
       "slo.instanceId": Object {
         "terms": Object {
           "field": "slo.instanceId",
+        },
+      },
+      "slo.name": Object {
+        "terms": Object {
+          "field": "slo.name",
         },
       },
       "slo.objective.sliceDurationInSeconds": Object {
@@ -181,6 +196,11 @@ Object {
       "slo.revision": Object {
         "terms": Object {
           "field": "slo.revision",
+        },
+      },
+      "slo.tags": Object {
+        "terms": Object {
+          "field": "slo.tags",
         },
       },
       "slo.timeWindow.duration": Object {
@@ -219,15 +239,33 @@ Object {
         },
         "type": "keyword",
       },
+      "slo.description": Object {
+        "script": Object {
+          "source": "emit('irrelevant')",
+        },
+        "type": "keyword",
+      },
       "slo.id": Object {
         "script": Object {
           "source": Any<String>,
         },
         "type": "keyword",
       },
+      "slo.indicator.type": Object {
+        "script": Object {
+          "source": "emit('sli.kql.custom')",
+        },
+        "type": "keyword",
+      },
       "slo.instanceId": Object {
         "script": Object {
           "source": "emit('*')",
+        },
+        "type": "keyword",
+      },
+      "slo.name": Object {
+        "script": Object {
+          "source": "emit('irrelevant')",
         },
         "type": "keyword",
       },
@@ -248,6 +286,12 @@ Object {
           "source": "emit(1)",
         },
         "type": "long",
+      },
+      "slo.tags": Object {
+        "script": Object {
+          "source": "emit('critical,k8s')",
+        },
+        "type": "keyword",
       },
       "slo.timeWindow.duration": Object {
         "script": Object {
@@ -322,14 +366,29 @@ Object {
           "field": "slo.budgetingMethod",
         },
       },
+      "slo.description": Object {
+        "terms": Object {
+          "field": "slo.description",
+        },
+      },
       "slo.id": Object {
         "terms": Object {
           "field": "slo.id",
         },
       },
+      "slo.indicator.type": Object {
+        "terms": Object {
+          "field": "slo.indicator.type",
+        },
+      },
       "slo.instanceId": Object {
         "terms": Object {
           "field": "slo.instanceId",
+        },
+      },
+      "slo.name": Object {
+        "terms": Object {
+          "field": "slo.name",
         },
       },
       "slo.objective.target": Object {
@@ -340,6 +399,11 @@ Object {
       "slo.revision": Object {
         "terms": Object {
           "field": "slo.revision",
+        },
+      },
+      "slo.tags": Object {
+        "terms": Object {
+          "field": "slo.tags",
         },
       },
       "slo.timeWindow.duration": Object {
@@ -378,15 +442,33 @@ Object {
         },
         "type": "keyword",
       },
+      "slo.description": Object {
+        "script": Object {
+          "source": "emit('irrelevant')",
+        },
+        "type": "keyword",
+      },
       "slo.id": Object {
         "script": Object {
           "source": Any<String>,
         },
         "type": "keyword",
       },
+      "slo.indicator.type": Object {
+        "script": Object {
+          "source": "emit('sli.kql.custom')",
+        },
+        "type": "keyword",
+      },
       "slo.instanceId": Object {
         "script": Object {
           "source": "emit('*')",
+        },
+        "type": "keyword",
+      },
+      "slo.name": Object {
+        "script": Object {
+          "source": "emit('irrelevant')",
         },
         "type": "keyword",
       },
@@ -401,6 +483,12 @@ Object {
           "source": "emit(1)",
         },
         "type": "long",
+      },
+      "slo.tags": Object {
+        "script": Object {
+          "source": "emit('critical,k8s')",
+        },
+        "type": "keyword",
       },
       "slo.timeWindow.duration": Object {
         "script": Object {

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/metric_custom.test.ts.snap
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/metric_custom.test.ts.snap
@@ -167,14 +167,29 @@ Object {
           "field": "slo.budgetingMethod",
         },
       },
+      "slo.description": Object {
+        "terms": Object {
+          "field": "slo.description",
+        },
+      },
       "slo.id": Object {
         "terms": Object {
           "field": "slo.id",
         },
       },
+      "slo.indicator.type": Object {
+        "terms": Object {
+          "field": "slo.indicator.type",
+        },
+      },
       "slo.instanceId": Object {
         "terms": Object {
           "field": "slo.instanceId",
+        },
+      },
+      "slo.name": Object {
+        "terms": Object {
+          "field": "slo.name",
         },
       },
       "slo.objective.sliceDurationInSeconds": Object {
@@ -190,6 +205,11 @@ Object {
       "slo.revision": Object {
         "terms": Object {
           "field": "slo.revision",
+        },
+      },
+      "slo.tags": Object {
+        "terms": Object {
+          "field": "slo.tags",
         },
       },
       "slo.timeWindow.duration": Object {
@@ -228,15 +248,33 @@ Object {
         },
         "type": "keyword",
       },
+      "slo.description": Object {
+        "script": Object {
+          "source": "emit('irrelevant')",
+        },
+        "type": "keyword",
+      },
       "slo.id": Object {
         "script": Object {
           "source": Any<String>,
         },
         "type": "keyword",
       },
+      "slo.indicator.type": Object {
+        "script": Object {
+          "source": "emit('sli.metric.custom')",
+        },
+        "type": "keyword",
+      },
       "slo.instanceId": Object {
         "script": Object {
           "source": "emit('*')",
+        },
+        "type": "keyword",
+      },
+      "slo.name": Object {
+        "script": Object {
+          "source": "emit('irrelevant')",
         },
         "type": "keyword",
       },
@@ -257,6 +295,12 @@ Object {
           "source": "emit(1)",
         },
         "type": "long",
+      },
+      "slo.tags": Object {
+        "script": Object {
+          "source": "emit('critical,k8s')",
+        },
+        "type": "keyword",
       },
       "slo.timeWindow.duration": Object {
         "script": Object {
@@ -369,14 +413,29 @@ Object {
           "field": "slo.budgetingMethod",
         },
       },
+      "slo.description": Object {
+        "terms": Object {
+          "field": "slo.description",
+        },
+      },
       "slo.id": Object {
         "terms": Object {
           "field": "slo.id",
         },
       },
+      "slo.indicator.type": Object {
+        "terms": Object {
+          "field": "slo.indicator.type",
+        },
+      },
       "slo.instanceId": Object {
         "terms": Object {
           "field": "slo.instanceId",
+        },
+      },
+      "slo.name": Object {
+        "terms": Object {
+          "field": "slo.name",
         },
       },
       "slo.objective.target": Object {
@@ -387,6 +446,11 @@ Object {
       "slo.revision": Object {
         "terms": Object {
           "field": "slo.revision",
+        },
+      },
+      "slo.tags": Object {
+        "terms": Object {
+          "field": "slo.tags",
         },
       },
       "slo.timeWindow.duration": Object {
@@ -425,15 +489,33 @@ Object {
         },
         "type": "keyword",
       },
+      "slo.description": Object {
+        "script": Object {
+          "source": "emit('irrelevant')",
+        },
+        "type": "keyword",
+      },
       "slo.id": Object {
         "script": Object {
           "source": Any<String>,
         },
         "type": "keyword",
       },
+      "slo.indicator.type": Object {
+        "script": Object {
+          "source": "emit('sli.metric.custom')",
+        },
+        "type": "keyword",
+      },
       "slo.instanceId": Object {
         "script": Object {
           "source": "emit('*')",
+        },
+        "type": "keyword",
+      },
+      "slo.name": Object {
+        "script": Object {
+          "source": "emit('irrelevant')",
         },
         "type": "keyword",
       },
@@ -448,6 +530,12 @@ Object {
           "source": "emit(1)",
         },
         "type": "long",
+      },
+      "slo.tags": Object {
+        "script": Object {
+          "source": "emit('critical,k8s')",
+        },
+        "type": "keyword",
       },
       "slo.timeWindow.duration": Object {
         "script": Object {

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/apm_transaction_duration.test.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/apm_transaction_duration.test.ts
@@ -15,28 +15,28 @@ import { ApmTransactionDurationTransformGenerator } from './apm_transaction_dura
 const generator = new ApmTransactionDurationTransformGenerator();
 
 describe('APM Transaction Duration Transform Generator', () => {
-  it('returns the expected transform params with every specified indicator params', async () => {
-    const anSLO = createSLO({ indicator: createAPMTransactionDurationIndicator() });
-    const transform = generator.getTransformParams(anSLO);
+  it('returns the expected transform params with every specified indicator params', () => {
+    const slo = createSLO({ indicator: createAPMTransactionDurationIndicator() });
+    const transform = generator.getTransformParams(slo);
 
     expect(transform).toMatchSnapshot({
       transform_id: expect.any(String),
       source: { runtime_mappings: { 'slo.id': { script: { source: expect.any(String) } } } },
     });
-    expect(transform.transform_id).toEqual(`slo-${anSLO.id}-${anSLO.revision}`);
+    expect(transform.transform_id).toEqual(`slo-${slo.id}-${slo.revision}`);
     expect(transform.source.runtime_mappings!['slo.id']).toMatchObject({
-      script: { source: `emit('${anSLO.id}')` },
+      script: { source: `emit('${slo.id}')` },
     });
     expect(transform.source.runtime_mappings!['slo.revision']).toMatchObject({
-      script: { source: `emit(${anSLO.revision})` },
+      script: { source: `emit(${slo.revision})` },
     });
   });
 
-  it('returns the expected transform params for timeslices slo', async () => {
-    const anSLO = createSLOWithTimeslicesBudgetingMethod({
+  it('returns the expected transform params for timeslices slo', () => {
+    const slo = createSLOWithTimeslicesBudgetingMethod({
       indicator: createAPMTransactionDurationIndicator(),
     });
-    const transform = generator.getTransformParams(anSLO);
+    const transform = generator.getTransformParams(slo);
 
     expect(transform).toMatchSnapshot({
       transform_id: expect.any(String),
@@ -44,8 +44,8 @@ describe('APM Transaction Duration Transform Generator', () => {
     });
   });
 
-  it("does not include the query filter when params are '*'", async () => {
-    const anSLO = createSLO({
+  it("does not include the query filter when params are '*'", () => {
+    const slo = createSLO({
       indicator: createAPMTransactionDurationIndicator({
         environment: '*',
         service: '*',
@@ -53,32 +53,96 @@ describe('APM Transaction Duration Transform Generator', () => {
         transactionType: '*',
       }),
     });
-    const transform = generator.getTransformParams(anSLO);
+    const transform = generator.getTransformParams(slo);
 
     expect(transform.source.query).toMatchSnapshot();
   });
 
-  it('uses the provided index params as source index', async () => {
+  it('uses the provided index params as source index', () => {
     const index = 'my-custom-apm-index*';
-    const anSLO = createSLO({
+    const slo = createSLO({
       indicator: createAPMTransactionDurationIndicator({
         index,
       }),
     });
-    const transform = generator.getTransformParams(anSLO);
+    const transform = generator.getTransformParams(slo);
 
     expect(transform.source.index).toEqual(index);
   });
 
-  it('adds the custom kql filter to the query', async () => {
+  it('adds the custom kql filter to the query', () => {
     const filter = `"my.field" : "value" and ("foo" >= 12 or "bar" <= 100)`;
-    const anSLO = createSLO({
+    const slo = createSLO({
       indicator: createAPMTransactionDurationIndicator({
         filter,
       }),
     });
-    const transform = generator.getTransformParams(anSLO);
+    const transform = generator.getTransformParams(slo);
 
     expect(transform.source.query).toMatchSnapshot();
+  });
+
+  it("groups by the 'service.name'", () => {
+    const slo = createSLO({
+      indicator: createAPMTransactionDurationIndicator({
+        service: 'my-service',
+        environment: '*',
+        transactionName: '*',
+        transactionType: '*',
+      }),
+    });
+
+    const transform = generator.getTransformParams(slo);
+
+    expect(transform.source.query).toMatchSnapshot();
+    expect(transform.pivot?.group_by).toMatchSnapshot();
+  });
+
+  it("groups by the 'service.environment'", () => {
+    const slo = createSLO({
+      indicator: createAPMTransactionDurationIndicator({
+        service: '*',
+        environment: 'production',
+        transactionName: '*',
+        transactionType: '*',
+      }),
+    });
+
+    const transform = generator.getTransformParams(slo);
+
+    expect(transform.source.query).toMatchSnapshot();
+    expect(transform.pivot?.group_by).toMatchSnapshot();
+  });
+
+  it("groups by the 'transaction.name'", () => {
+    const slo = createSLO({
+      indicator: createAPMTransactionDurationIndicator({
+        service: '*',
+        environment: '*',
+        transactionName: 'GET /foo',
+        transactionType: '*',
+      }),
+    });
+
+    const transform = generator.getTransformParams(slo);
+
+    expect(transform.source.query).toMatchSnapshot();
+    expect(transform.pivot?.group_by).toMatchSnapshot();
+  });
+
+  it("groups by the 'transaction.type'", () => {
+    const slo = createSLO({
+      indicator: createAPMTransactionDurationIndicator({
+        service: '*',
+        environment: '*',
+        transactionName: '*',
+        transactionType: 'request',
+      }),
+    });
+
+    const transform = generator.getTransformParams(slo);
+
+    expect(transform.source.query).toMatchSnapshot();
+    expect(transform.pivot?.group_by).toMatchSnapshot();
   });
 });

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/apm_transaction_error_rate.test.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/apm_transaction_error_rate.test.ts
@@ -16,27 +16,27 @@ const generator = new ApmTransactionErrorRateTransformGenerator();
 
 describe('APM Transaction Error Rate Transform Generator', () => {
   it('returns the expected transform params with every specified indicator params', async () => {
-    const anSLO = createSLO({ indicator: createAPMTransactionErrorRateIndicator() });
-    const transform = generator.getTransformParams(anSLO);
+    const slo = createSLO({ indicator: createAPMTransactionErrorRateIndicator() });
+    const transform = generator.getTransformParams(slo);
 
     expect(transform).toMatchSnapshot({
       transform_id: expect.any(String),
       source: { runtime_mappings: { 'slo.id': { script: { source: expect.any(String) } } } },
     });
-    expect(transform.transform_id).toEqual(`slo-${anSLO.id}-${anSLO.revision}`);
+    expect(transform.transform_id).toEqual(`slo-${slo.id}-${slo.revision}`);
     expect(transform.source.runtime_mappings!['slo.id']).toMatchObject({
-      script: { source: `emit('${anSLO.id}')` },
+      script: { source: `emit('${slo.id}')` },
     });
     expect(transform.source.runtime_mappings!['slo.revision']).toMatchObject({
-      script: { source: `emit(${anSLO.revision})` },
+      script: { source: `emit(${slo.revision})` },
     });
   });
 
   it('returns the expected transform params for timeslices slo', async () => {
-    const anSLO = createSLOWithTimeslicesBudgetingMethod({
+    const slo = createSLOWithTimeslicesBudgetingMethod({
       indicator: createAPMTransactionErrorRateIndicator(),
     });
-    const transform = generator.getTransformParams(anSLO);
+    const transform = generator.getTransformParams(slo);
 
     expect(transform).toMatchSnapshot({
       transform_id: expect.any(String),
@@ -45,7 +45,7 @@ describe('APM Transaction Error Rate Transform Generator', () => {
   });
 
   it("does not include the query filter when params are '*'", async () => {
-    const anSLO = createSLO({
+    const slo = createSLO({
       indicator: createAPMTransactionErrorRateIndicator({
         environment: '*',
         service: '*',
@@ -53,32 +53,96 @@ describe('APM Transaction Error Rate Transform Generator', () => {
         transactionType: '*',
       }),
     });
-    const transform = generator.getTransformParams(anSLO);
+    const transform = generator.getTransformParams(slo);
 
     expect(transform.source.query).toMatchSnapshot();
   });
 
   it('uses the provided index params as source index', async () => {
     const index = 'my-custom-apm-index*';
-    const anSLO = createSLO({
+    const slo = createSLO({
       indicator: createAPMTransactionErrorRateIndicator({
         index,
       }),
     });
-    const transform = generator.getTransformParams(anSLO);
+    const transform = generator.getTransformParams(slo);
 
     expect(transform.source.index).toEqual(index);
   });
 
   it('adds the custom kql filter to the query', async () => {
     const filter = `"my.field" : "value" and ("foo" >= 12 or "bar" <= 100)`;
-    const anSLO = createSLO({
+    const slo = createSLO({
       indicator: createAPMTransactionErrorRateIndicator({
         filter,
       }),
     });
-    const transform = generator.getTransformParams(anSLO);
+    const transform = generator.getTransformParams(slo);
 
     expect(transform.source.query).toMatchSnapshot();
+  });
+
+  it("groups by the 'service.name'", () => {
+    const slo = createSLO({
+      indicator: createAPMTransactionErrorRateIndicator({
+        service: 'my-service',
+        environment: '*',
+        transactionName: '*',
+        transactionType: '*',
+      }),
+    });
+
+    const transform = generator.getTransformParams(slo);
+
+    expect(transform.source.query).toMatchSnapshot();
+    expect(transform.pivot?.group_by).toMatchSnapshot();
+  });
+
+  it("groups by the 'service.environment'", () => {
+    const slo = createSLO({
+      indicator: createAPMTransactionErrorRateIndicator({
+        service: '*',
+        environment: 'production',
+        transactionName: '*',
+        transactionType: '*',
+      }),
+    });
+
+    const transform = generator.getTransformParams(slo);
+
+    expect(transform.source.query).toMatchSnapshot();
+    expect(transform.pivot?.group_by).toMatchSnapshot();
+  });
+
+  it("groups by the 'transaction.name'", () => {
+    const slo = createSLO({
+      indicator: createAPMTransactionErrorRateIndicator({
+        service: '*',
+        environment: '*',
+        transactionName: 'GET /foo',
+        transactionType: '*',
+      }),
+    });
+
+    const transform = generator.getTransformParams(slo);
+
+    expect(transform.source.query).toMatchSnapshot();
+    expect(transform.pivot?.group_by).toMatchSnapshot();
+  });
+
+  it("groups by the 'transaction.type'", () => {
+    const slo = createSLO({
+      indicator: createAPMTransactionErrorRateIndicator({
+        service: '*',
+        environment: '*',
+        transactionName: '*',
+        transactionType: 'request',
+      }),
+    });
+
+    const transform = generator.getTransformParams(slo);
+
+    expect(transform.source.query).toMatchSnapshot();
+    expect(transform.pivot?.group_by).toMatchSnapshot();
   });
 });

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/apm_transaction_error_rate.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/apm_transaction_error_rate.ts
@@ -29,29 +29,12 @@ export class ApmTransactionErrorRateTransformGenerator extends TransformGenerato
       throw new InvalidTransformError(`Cannot handle SLO of indicator type: ${slo.indicator.type}`);
     }
 
-    // These groupBy fields must be the one specified in the source query, otherwise
-    // the transform will create many permutation for each field values
-    const extraGroupByFields = {
-      ...(slo.indicator.params.service !== ALL_VALUE && {
-        'service.name': { terms: { field: 'service.name' } },
-      }),
-      ...(slo.indicator.params.environment !== ALL_VALUE && {
-        'service.environment': { terms: { field: 'service.environment' } },
-      }),
-      ...(slo.indicator.params.transactionName !== ALL_VALUE && {
-        'transaction.name': { terms: { field: 'transaction.name' } },
-      }),
-      ...(slo.indicator.params.transactionType !== ALL_VALUE && {
-        'transaction.type': { terms: { field: 'transaction.type' } },
-      }),
-    };
-
     return getSLOTransformTemplate(
       this.buildTransformId(slo),
       this.buildDescription(slo),
       this.buildSource(slo, slo.indicator),
       this.buildDestination(),
-      this.buildGroupBy(slo, '@timestamp', extraGroupByFields),
+      this.buildGroupBy(slo, slo.indicator),
       this.buildAggregations(slo),
       this.buildSettings(slo)
     );
@@ -59,6 +42,29 @@ export class ApmTransactionErrorRateTransformGenerator extends TransformGenerato
 
   private buildTransformId(slo: SLO): string {
     return getSLOTransformId(slo.id, slo.revision);
+  }
+
+  private buildGroupBy(slo: SLO, indicator: APMTransactionErrorRateIndicator) {
+    // These groupBy fields must match the fields from the source query, otherwise
+    // the transform will create permutations for each value present in the source.
+    // E.g. if environment is not specified in the source query, but we include it in the groupBy,
+    // we'll output documents for each environment value
+    const extraGroupByFields = {
+      ...(indicator.params.service !== ALL_VALUE && {
+        'service.name': { terms: { field: 'service.name' } },
+      }),
+      ...(indicator.params.environment !== ALL_VALUE && {
+        'service.environment': { terms: { field: 'service.environment' } },
+      }),
+      ...(indicator.params.transactionName !== ALL_VALUE && {
+        'transaction.name': { terms: { field: 'transaction.name' } },
+      }),
+      ...(indicator.params.transactionType !== ALL_VALUE && {
+        'transaction.type': { terms: { field: 'transaction.type' } },
+      }),
+    };
+
+    return this.buildCommonGroupBy(slo, '@timestamp', extraGroupByFields);
   }
 
   private buildSource(slo: SLO, indicator: APMTransactionErrorRateIndicator) {

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/histogram.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/histogram.ts
@@ -34,7 +34,7 @@ export class HistogramTransformGenerator extends TransformGenerator {
       this.buildDescription(slo),
       this.buildSource(slo, slo.indicator),
       this.buildDestination(),
-      this.buildGroupBy(slo, slo.indicator.params.timestampField),
+      this.buildCommonGroupBy(slo, slo.indicator.params.timestampField),
       this.buildAggregations(slo, slo.indicator),
       this.buildSettings(slo, slo.indicator.params.timestampField)
     );

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/kql_custom.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/kql_custom.ts
@@ -29,7 +29,7 @@ export class KQLCustomTransformGenerator extends TransformGenerator {
       this.buildDescription(slo),
       this.buildSource(slo, slo.indicator),
       this.buildDestination(),
-      this.buildGroupBy(slo, slo.indicator.params.timestampField),
+      this.buildCommonGroupBy(slo, slo.indicator.params.timestampField),
       this.buildAggregations(slo, slo.indicator),
       this.buildSettings(slo, slo.indicator.params.timestampField)
     );

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/metric_custom.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/metric_custom.ts
@@ -32,7 +32,7 @@ export class MetricCustomTransformGenerator extends TransformGenerator {
       this.buildDescription(slo),
       this.buildSource(slo, slo.indicator),
       this.buildDestination(),
-      this.buildGroupBy(slo, slo.indicator.params.timestampField),
+      this.buildCommonGroupBy(slo, slo.indicator.params.timestampField),
       this.buildAggregations(slo, slo.indicator),
       this.buildSettings(slo, slo.indicator.params.timestampField)
     );

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/transform_generator.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/transform_generator.ts
@@ -99,7 +99,7 @@ export abstract class TransformGenerator {
     return `Rolled-up SLI data for SLO: ${slo.name}`;
   }
 
-  public buildGroupBy(
+  public buildCommonGroupBy(
     slo: SLO,
     sourceIndexTimestampField: string | undefined = '@timestamp',
     extraGroupByFields = {}

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/transform_generator.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/transform_generator.ts
@@ -34,6 +34,30 @@ export abstract class TransformGenerator {
           source: `emit('${ALL_VALUE}')`,
         },
       },
+      'slo.name': {
+        type: 'keyword' as MappingRuntimeFieldType,
+        script: {
+          source: `emit('${slo.name}')`,
+        },
+      },
+      'slo.description': {
+        type: 'keyword' as MappingRuntimeFieldType,
+        script: {
+          source: `emit('${slo.description}')`,
+        },
+      },
+      'slo.tags': {
+        type: 'keyword' as MappingRuntimeFieldType,
+        script: {
+          source: `emit('${slo.tags}')`,
+        },
+      },
+      'slo.indicator.type': {
+        type: 'keyword' as MappingRuntimeFieldType,
+        script: {
+          source: `emit('${slo.indicator.type}')`,
+        },
+      },
       'slo.objective.target': {
         type: 'double' as MappingRuntimeFieldType,
         script: {
@@ -83,6 +107,10 @@ export abstract class TransformGenerator {
       'slo.id': { terms: { field: 'slo.id' } },
       'slo.revision': { terms: { field: 'slo.revision' } },
       'slo.instanceId': { terms: { field: 'slo.instanceId' } },
+      'slo.name': { terms: { field: 'slo.name' } },
+      'slo.description': { terms: { field: 'slo.description' } },
+      'slo.tags': { terms: { field: 'slo.tags' } },
+      'slo.indicator.type': { terms: { field: 'slo.indicator.type' } },
       'slo.objective.target': { terms: { field: 'slo.objective.target' } },
       ...(slo.objective.timesliceWindow && {
         'slo.objective.sliceDurationInSeconds': {

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/transform_generator.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/transform_generator.ts
@@ -16,10 +16,7 @@ import { SLO } from '../../../domain/models';
 export abstract class TransformGenerator {
   public abstract getTransformParams(slo: SLO): TransformPutTransformRequest;
 
-  public buildCommonRuntimeMappings(
-    slo: SLO,
-    extraRuntimeMappings: MappingRuntimeFields = {}
-  ): MappingRuntimeFields {
+  public buildCommonRuntimeMappings(slo: SLO): MappingRuntimeFields {
     return {
       'slo.id': {
         type: 'keyword',
@@ -95,7 +92,6 @@ export abstract class TransformGenerator {
           source: `emit('${slo.timeWindow.type}')`,
         },
       },
-      ...extraRuntimeMappings,
     };
   }
 


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/162152

## ✨ Summary

This PR adds more fields in the SLO rollup and summary data indices. Namely, we always add the `name`, `description`, `tags` and `indicator type` into the rollup and the summary indices. 
For both APM indicator, we also include the `service.name`, `service.environment`, `transaction.name` and `transaction.type` in the group by pivot when the source data is filtered with them.


