### PR TITLE
[D4C] process blocking now enabled for process responses

### DIFF
--- a/x-pack/plugins/cloud_defend/public/components/control_general_view_response/index.tsx
+++ b/x-pack/plugins/cloud_defend/public/components/control_general_view_response/index.tsx
@@ -405,20 +405,18 @@ export const ControlGeneralViewResponse = ({
                 onChange={onToggleAction}
               />
             </EuiFlexItem>
-            {response.type === 'file' && (
-              <EuiFlexItem grow={false}>
-                <EuiToolTip content={i18n.actionBlockHelp}>
-                  <EuiCheckbox
-                    id={`response_${index}_block`}
-                    data-test-subj="cloud-defend-chkblockaction"
-                    label={i18n.actionBlock}
-                    checked={blockSelected}
-                    onChange={onToggleAction}
-                    disabled={!alertSelected}
-                  />
-                </EuiToolTip>
-              </EuiFlexItem>
-            )}
+            <EuiFlexItem grow={false}>
+              <EuiToolTip content={i18n.actionBlockHelp}>
+                <EuiCheckbox
+                  id={`response_${index}_block`}
+                  data-test-subj="cloud-defend-chkblockaction"
+                  label={i18n.actionBlock}
+                  checked={blockSelected}
+                  onChange={onToggleAction}
+                  disabled={!alertSelected}
+                />
+              </EuiToolTip>
+            </EuiFlexItem>
           </EuiFlexGroup>
         </EuiFormRow>
       </EuiForm>


### PR DESCRIPTION
## Summary

Removes restriction on using 'block' action for process responses. The cloud-defend binary now supports blocking 'fork' and 'exec' events using bpf LSMs.

For more info on "Defend for containers (D4C)" policies, see here: https://github.com/elastic/integrations/tree/main/packages/cloud_defend#responses

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials. see: https://github.com/elastic/integrations/pull/6987