### PR TITLE
[Discover] Re-enable `_request_counts` saved search test for SQL mode

### DIFF
--- a/test/functional/apps/discover/group3/_request_counts.ts
+++ b/test/functional/apps/discover/group3/_request_counts.ts
@@ -87,14 +87,12 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       query1,
       query2,
       setQuery,
-      skipSavedSearchTests,
     }: {
       type: 'ese' | 'sql';
       savedSearch: string;
       query1: string;
       query2: string;
       setQuery: (query: string) => Promise<void>;
-      skipSavedSearchTests?: boolean;
     }) => {
       it('should send 2 search requests (documents + chart) on page load', async () => {
         await browser.refresh();
@@ -137,37 +135,35 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         });
       });
 
-      if (!skipSavedSearchTests) {
-        it('should send 2 requests for saved search changes', async () => {
-          await setQuery(query1);
-          await queryBar.clickQuerySubmitButton();
-          await PageObjects.timePicker.setAbsoluteRange(
-            'Sep 21, 2015 @ 06:31:44.000',
-            'Sep 23, 2015 @ 00:00:00.000'
-          );
-          await waitForLoadingToFinish();
-          // creating the saved search
-          await expectSearches(type, 2, async () => {
-            await PageObjects.discover.saveSearch(savedSearch);
-          });
-          // resetting the saved search
-          await setQuery(query2);
-          await queryBar.clickQuerySubmitButton();
-          await waitForLoadingToFinish();
-          await expectSearches(type, 2, async () => {
-            await PageObjects.discover.clickResetSavedSearchButton();
-          });
-          // clearing the saved search
-          await expectSearches(type, 2, async () => {
-            await testSubjects.click('discoverNewButton');
-            await waitForLoadingToFinish();
-          });
-          // loading the saved search
-          await expectSearches(type, 2, async () => {
-            await PageObjects.discover.loadSavedSearch(savedSearch);
-          });
+      it('should send 2 requests for saved search changes', async () => {
+        await setQuery(query1);
+        await queryBar.clickQuerySubmitButton();
+        await PageObjects.timePicker.setAbsoluteRange(
+          'Sep 21, 2015 @ 06:31:44.000',
+          'Sep 23, 2015 @ 00:00:00.000'
+        );
+        await waitForLoadingToFinish();
+        // creating the saved search
+        await expectSearches(type, 2, async () => {
+          await PageObjects.discover.saveSearch(savedSearch);
         });
-      }
+        // resetting the saved search
+        await setQuery(query2);
+        await queryBar.clickQuerySubmitButton();
+        await waitForLoadingToFinish();
+        await expectSearches(type, 2, async () => {
+          await PageObjects.discover.clickResetSavedSearchButton();
+        });
+        // clearing the saved search
+        await expectSearches('ese', 2, async () => {
+          await testSubjects.click('discoverNewButton');
+          await waitForLoadingToFinish();
+        });
+        // loading the saved search
+        await expectSearches(type, 2, async () => {
+          await PageObjects.discover.loadSavedSearch(savedSearch);
+        });
+      });
     };
 
     describe('data view mode', () => {
@@ -238,9 +234,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         query1: 'SELECT type, count(*) FROM "logstash-*" WHERE bytes > 1000 GROUP BY type',
         query2: 'SELECT type, count(*) FROM "logstash-*" WHERE bytes < 2000 GROUP BY type',
         setQuery: (query) => monacoEditor.setCodeEditorValue(query),
-        // TODO: We get 4 requests instead of 2 for the saved search test in SQL mode,
-        // so we're skipping them for now until we fix the issue.
-        skipSavedSearchTests: true,
       });
     });
   });


### PR DESCRIPTION
## Summary

This PR re-enables the disabled saved search functional test for SQL mode in `test/functional/apps/discover/group3/_request_counts.ts`. Recent improvements we've made to data fetching in SQL mode fixed the underlying issue and the test now runs as expected.

Flaky test runs:
- x100: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2654 🟢

### Checklist

- [ ] ~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)~
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] ~Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))~
- [ ] ~Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))~
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))~
- [ ] ~This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)~

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)