### PR TITLE
[D4C] beta labels removed from k8s dashboard and tty output feature.

### DIFF
--- a/x-pack/plugins/cloud_defend/common/v1.ts
+++ b/x-pack/plugins/cloud_defend/common/v1.ts
@@ -110,7 +110,7 @@ export interface Selector {
 export interface Response {
   match: string[];
   exclude?: string[];
-  actions: ResponseAction[];
+  actions?: ResponseAction[];
 
   // non yaml fields
   type: SelectorType;

--- a/x-pack/plugins/cloud_defend/public/common/utils.ts
+++ b/x-pack/plugins/cloud_defend/public/common/utils.ts
@@ -124,7 +124,7 @@ export function validateBlockRestrictions(selectors: Selector[], responses: Resp
   const errors: string[] = [];
 
   responses.forEach((response) => {
-    if (response.actions.includes('block')) {
+    if (response.actions?.includes('block')) {
       // check if any selectors are using FIM operations
       // and verify that targetFilePath is specfied in all 'match' selectors
       // or at least one 'exclude' selector

--- a/x-pack/plugins/cloud_defend/public/components/control_general_view_response/index.tsx
+++ b/x-pack/plugins/cloud_defend/public/components/control_general_view_response/index.tsx
@@ -66,9 +66,9 @@ export const ControlGeneralViewResponse = ({
     responses.length - 1 === index ? 'open' : 'closed'
   );
 
-  const logSelected = response.actions.includes('log');
-  const alertSelected = response.actions.includes('alert');
-  const blockSelected = response.actions.includes('block');
+  const logSelected = response.actions?.includes('log');
+  const alertSelected = response.actions?.includes('alert');
+  const blockSelected = response.actions?.includes('block');
 
   const warnFIMUsingSlashStarStar = useMemo(
     () =>
@@ -84,7 +84,7 @@ export const ControlGeneralViewResponse = ({
       errs.match = [i18n.errorValueRequired];
     }
 
-    if (response.actions.length === 0) {
+    if (response.actions?.length === 0) {
       errs.actions = [i18n.errorActionRequired];
     }
 
@@ -284,12 +284,12 @@ export const ControlGeneralViewResponse = ({
                 </>
               )}
               <b>{i18n.actions}: </b>
-              {response.actions.map((action, i) => (
+              {response.actions?.map((action, i) => (
                 <span key={action}>
                   <b style={{ color: action === 'block' ? colors.danger : colors.ink }}>
                     {action[0].toUpperCase() + action.slice(1)}
                   </b>
-                  {i !== response.actions.length - 1 && ', '}
+                  {i !== (response.actions?.length || 0) - 1 && ', '}
                 </span>
               ))}
               <div css={selectorStyles.verticalDivider} />

--- a/x-pack/plugins/kubernetes_security/common/translations.ts
+++ b/x-pack/plugins/kubernetes_security/common/translations.ts
@@ -7,10 +7,6 @@
 
 import { i18n } from '@kbn/i18n';
 
-export const BETA = i18n.translate('xpack.kubernetesSecurity.beta', {
-  defaultMessage: 'Beta',
-});
-
 export const SEARCH_GROUP_CLUSTER = i18n.translate('xpack.kubernetesSecurity.searchGroup.cluster', {
   defaultMessage: 'Cluster',
 });

--- a/x-pack/plugins/kubernetes_security/public/components/kubernetes_security_routes/index.tsx
+++ b/x-pack/plugins/kubernetes_security/public/components/kubernetes_security_routes/index.tsx
@@ -8,14 +8,7 @@
 import React, { useCallback } from 'react';
 import { Routes, Route } from '@kbn/shared-ux-router';
 import useLocalStorage from 'react-use/lib/useLocalStorage';
-import {
-  EuiBetaBadge,
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiIconTip,
-  EuiText,
-  EuiTitle,
-} from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiIconTip, EuiText, EuiTitle } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { euiThemeVars } from '@kbn/ui-theme';
@@ -45,7 +38,6 @@ import { useStyles } from './styles';
 import { TreeViewContainer } from '../tree_view_container';
 import { ChartsToggle } from '../charts_toggle';
 import {
-  BETA,
   COUNT_WIDGET_CLUSTERS,
   COUNT_WIDGET_NAMESPACE,
   COUNT_WIDGET_NODES,
@@ -101,10 +93,7 @@ const KubernetesSecurityRoutesComponent = ({
         <EuiFlexGroup gutterSize="none" css={styles.titleSection}>
           <EuiFlexItem>
             <EuiTitle size="l">
-              <h1 css={styles.titleText}>
-                {KUBERNETES_TITLE}
-                <EuiBetaBadge label={BETA} size="s" css={styles.betaBadge} />
-              </h1>
+              <h1 css={styles.titleText}>{KUBERNETES_TITLE}</h1>
             </EuiTitle>
           </EuiFlexItem>
           <EuiFlexItem grow={false} css={styles.titleActions}>

--- a/x-pack/plugins/kubernetes_security/public/components/kubernetes_security_routes/styles.ts
+++ b/x-pack/plugins/kubernetes_security/public/components/kubernetes_security_routes/styles.ts
@@ -91,10 +91,6 @@ export const useStyles = () => {
       },
     };
 
-    const betaBadge: CSSObject = {
-      marginLeft: size.m,
-    };
-
     return {
       titleSection,
       titleText,
@@ -108,7 +104,6 @@ export const useStyles = () => {
       widgetsBottomSpacing,
       percentageChartTitle,
       widgetsGroup,
-      betaBadge,
     };
   }, [euiTheme]);
 

--- a/x-pack/plugins/security_solution/public/cloud_defend/links.ts
+++ b/x-pack/plugins/security_solution/public/cloud_defend/links.ts
@@ -12,7 +12,6 @@ import type { LinkItem } from '../common/links/types';
 import { IconCloudDefend } from '../common/icons/cloud_defend';
 
 const commonLinkProperties: Partial<LinkItem> = {
-  isBeta: true,
   hideTimeline: true,
   capabilities: [`${SERVER_APP_ID}.show`],
 };

--- a/x-pack/plugins/security_solution/public/kubernetes/links.ts
+++ b/x-pack/plugins/security_solution/public/kubernetes/links.ts
@@ -20,7 +20,6 @@ export const links: LinkItem = {
       'Provides interactive visualizations of your Kubernetes workload and session data.',
   }),
   path: KUBERNETES_PATH,
-  isBeta: true,
   experimentalKey: 'kubernetesEnabled',
   globalSearchKeywords: ['Kubernetes'],
 };

--- a/x-pack/plugins/session_view/public/components/session_view/translations.ts
+++ b/x-pack/plugins/session_view/public/components/session_view/translations.ts
@@ -6,10 +6,6 @@
  */
 import { i18n } from '@kbn/i18n';
 
-export const BETA = i18n.translate('xpack.sessionView.beta', {
-  defaultMessage: 'Beta',
-});
-
 export const REFRESH_SESSION = i18n.translate('xpack.sessionView.refreshSession', {
   defaultMessage: 'Refresh session',
 });

--- a/x-pack/plugins/session_view/public/components/tty_player/index.tsx
+++ b/x-pack/plugins/session_view/public/components/tty_player/index.tsx
@@ -5,14 +5,7 @@
  * 2.0.
  */
 import React, { useRef, useState, useCallback, useMemo, useEffect } from 'react';
-import {
-  EuiPanel,
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiButtonIcon,
-  EuiButton,
-  EuiBetaBadge,
-} from '@elastic/eui';
+import { EuiPanel, EuiFlexGroup, EuiFlexItem, EuiButtonIcon, EuiButton } from '@elastic/eui';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { CoreStart } from '@kbn/core/public';
 import useResizeObserver from 'use-resize-observer';
@@ -31,7 +24,7 @@ import {
 import { SessionViewTelemetryKey } from '../../types';
 import { useFetchIOEvents, useIOLines, useXtermPlayer } from './hooks';
 import { TTYPlayerControls } from '../tty_player_controls';
-import { BETA, TOGGLE_TTY_PLAYER, DETAIL_PANEL } from '../session_view/translations';
+import { TOGGLE_TTY_PLAYER, DETAIL_PANEL } from '../session_view/translations';
 
 export interface TTYPlayerDeps {
   index: string;
@@ -174,9 +167,6 @@ export const TTYPlayer = ({
     <div css={styles.container}>
       <EuiPanel hasShadow={false} borderRadius="none" hasBorder={false} css={styles.header}>
         <EuiFlexGroup alignItems="center" gutterSize="s">
-          <EuiFlexItem grow={false}>
-            <EuiBetaBadge label={BETA} size="s" css={styles.betaBadge} />
-          </EuiFlexItem>
           <EuiFlexItem data-test-subj="sessionView:TTYSearch">
             <TTYSearchBar
               lines={lines}

--- a/x-pack/plugins/session_view/public/components/tty_player/styles.ts
+++ b/x-pack/plugins/session_view/public/components/tty_player/styles.ts
@@ -75,16 +75,11 @@ export const useStyles = (tty?: Teletype, show?: boolean) => {
       backgroundColor: colors.ink,
     };
 
-    const betaBadge: CSSObject = {
-      backgroundColor: `${colors.emptyShade}`,
-    };
-
     return {
       container,
       header,
       terminal,
       scrollPane,
-      betaBadge,
     };
   }, [euiTheme, show, euiVars.euiFormBackgroundDisabledColor, tty?.rows, tty?.columns]);
 

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -34909,7 +34909,6 @@
     "xpack.sessionView.alerts": "告警",
     "xpack.sessionView.alertsLoadMoreButton": "加载更多告警",
     "xpack.sessionView.backToInvestigatedAlert": "返回到已调查告警",
-    "xpack.sessionView.beta": "公测版",
     "xpack.sessionView.blockedBadge": "已阻止",
     "xpack.sessionView.childProcesses": "子进程",
     "xpack.sessionView.collapseAll": "折叠全部",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -20570,7 +20570,6 @@
     "xpack.ingestPipelines.testPipelineFlyout.successNotificationText": "管道已执行",
     "xpack.ingestPipelines.testPipelineFlyout.title": "测试管道",
     "xpack.kubernetesSecurity.treeNavigation.loadMore": "显示更多 {name}",
-    "xpack.kubernetesSecurity.beta": "公测版",
     "xpack.kubernetesSecurity.chartsToggle.hide": "隐藏图表",
     "xpack.kubernetesSecurity.chartsToggle.show": "显示图表",
     "xpack.kubernetesSecurity.containerNameWidget.containerImage": "容器映像",


### PR DESCRIPTION
## Summary

- Removes the Beta badges from the k8s dashboard and TTY output feature.
- Fixes a null pointer exception when using yaml editor and removing all actions.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios