### PR TITLE
Fix bug on null description

### DIFF
--- a/src/plugins/visualizations/common/content_management/v1/cm_services.ts
+++ b/src/plugins/visualizations/common/content_management/v1/cm_services.ts
@@ -29,7 +29,7 @@ const referencesSchema = schema.arrayOf(referenceSchema);
 const visualizeAttributesSchema = schema.object(
   {
     title: schema.string(),
-    description: schema.maybe(schema.string()),
+    description: schema.maybe(schema.nullable(schema.string())),
     version: schema.maybe(schema.number()),
     kibanaSavedObjectMeta: schema.maybe(schema.object({ searchSourceJSON: schema.string() })),
     uiStateJSON: schema.maybe(schema.string()),

--- a/x-pack/plugins/lens/common/content_management/v1/cm_services.ts
+++ b/x-pack/plugins/lens/common/content_management/v1/cm_services.ts
@@ -28,7 +28,7 @@ const referencesSchema = schema.arrayOf(referenceSchema);
 const lensAttributesSchema = schema.object(
   {
     title: schema.string(),
-    description: schema.maybe(schema.string()),
+    description: schema.maybe(schema.nullable(schema.string())),
     visualizationType: schema.maybe(schema.string()),
     state: schema.maybe(schema.any()),
     uiStateJSON: schema.maybe(schema.string()),


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/162069

Fixes the validation error on the content management service if the description is set to null.

I am not sure how the description can be set to null. If I create a Lens so in 7.17 and I don't set the description then it is automatically set to '' (empty string)

I can think of 2 ways:
- It was possible in older kibana versions
- Someone changed the SO manually and set this to null

This change fixes it with allowing the schema to also set nullable values.

Note: Maybe covers the undefined case.

To test it just import the SO given by Bhavya here https://github.com/elastic/kibana/issues/162069

<img width="2496" alt="image" src="https://github.com/elastic/kibana/assets/17003240/481ef105-2efb-47c0-9d06-94f7fddbf703">



<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->