### PR TITLE
[Security Solution][Serverless] Adding screenshots folder to Cypress

### DIFF
--- a/x-pack/test_serverless/functional/test_suites/security/cypress/cypress.config.ts
+++ b/x-pack/test_serverless/functional/test_suites/security/cypress/cypress.config.ts
@@ -12,6 +12,7 @@ export default defineCypressConfig({
   execTimeout: 60000,
   pageLoadTimeout: 60000,
   responseTimeout: 60000,
+  screenshotsFolder: '../../../../../../target/kibana-security-solution/cypress/screenshots',
   trashAssetsBeforeRuns: false,
   video: false,
   viewportHeight: 946,


### PR DESCRIPTION
## Summary

The initial structure we added for Cypress is pretty basic, so we need to complete it. In this PR we are adding the screenshots folder to the cypress configuration. In this way, each time a test fails a screenshot is going to be uploaded to buildkite with the aim of helping with the debug process.