### PR TITLE
[Fleet] fix multi space test

### DIFF
--- a/x-pack/test/fleet_api_integration/apis/epm/install_integration_in_multiple_spaces.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/install_integration_in_multiple_spaces.ts
@@ -16,6 +16,7 @@ export default function (providerContext: FtrProviderContext) {
   const kibanaServer = getService('kibanaServer');
   const supertest = getService('supertest');
   const dockerServers = getService('dockerServers');
+  const esArchiver = getService('esArchiver');
   const server = dockerServers.get('registry');
   const pkgName = 'system';
   const pkgVersion = '1.27.0';
@@ -72,6 +73,7 @@ export default function (providerContext: FtrProviderContext) {
 
     before(async () => {
       if (!server.enabled) return;
+      await esArchiver.load('x-pack/test/functional/es_archives/fleet/empty_fleet_server');
       await installPackage(pkgName, pkgVersion);
 
       await createSpace(testSpaceId);
@@ -81,6 +83,7 @@ export default function (providerContext: FtrProviderContext) {
 
     after(async () => {
       await deleteSpace(testSpaceId);
+      await esArchiver.unload('x-pack/test/functional/es_archives/fleet/empty_fleet_server');
     });
 
     it('should install kibana assets', async function () {


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/161624

Test failed due to an unrelated endpoint installation error, loading empty ES to make sure endpoint doesn't cause trouble, as the test installs system integration.