### PR TITLE
[Defend workflows] Stop spreading whole request to ES dsl

### DIFF
--- a/x-pack/plugins/osquery/server/search_strategy/osquery/index.ts
+++ b/x-pack/plugins/osquery/server/search_strategy/osquery/index.ts
@@ -39,7 +39,17 @@ export const osquerySearchStrategyProvider = <T extends FactoryQueryTypes>(
         })
       ).pipe(
         mergeMap((exists) => {
-          const dsl = queryFactory.buildDsl({ ...request, componentTemplateExists: exists });
+          const strictRequest = {
+            factoryQueryType: request.factoryQueryType,
+            filterQuery: request.filterQuery,
+            ...('aggregations' in request ? { aggregations: request.aggregations } : {}),
+            ...('pagination' in request ? { pagination: request.pagination } : {}),
+            ...('sort' in request ? { sort: request.sort } : {}),
+            ...('actionId' in request ? { actionId: request.actionId } : {}),
+            ...('agentId' in request ? { agentId: request.agentId } : {}),
+            componentTemplateExists: exists,
+          } as StrategyRequestType<T>;
+          const dsl = queryFactory.buildDsl(strictRequest);
           // use internal user for searching .fleet* indices
           es =
             dsl.index?.includes('fleet') || dsl.index?.includes('logs-osquery_manager.action')
@@ -48,7 +58,7 @@ export const osquerySearchStrategyProvider = <T extends FactoryQueryTypes>(
 
           return es.search(
             {
-              ...request,
+              ...strictRequest,
               params: dsl,
             },
             options,

--- a/x-pack/plugins/osquery/server/search_strategy/osquery/index.ts
+++ b/x-pack/plugins/osquery/server/search_strategy/osquery/index.ts
@@ -47,9 +47,12 @@ export const osquerySearchStrategyProvider = <T extends FactoryQueryTypes>(
             ...('sort' in request ? { sort: request.sort } : {}),
             ...('actionId' in request ? { actionId: request.actionId } : {}),
             ...('agentId' in request ? { agentId: request.agentId } : {}),
+          };
+
+          const dsl = queryFactory.buildDsl({
+            ...strictRequest,
             componentTemplateExists: exists,
-          } as StrategyRequestType<T>;
-          const dsl = queryFactory.buildDsl(strictRequest);
+          } as StrategyRequestType<T>);
           // use internal user for searching .fleet* indices
           es =
             dsl.index?.includes('fleet') || dsl.index?.includes('logs-osquery_manager.action')


### PR DESCRIPTION
This PR solved a part of  https://github.com/elastic/security-team/issues/6988 which was firstly implemented in: https://github.com/elastic/kibana/pull/161806
After giving it some thoughts we decided not to introduce breaking changes to our API yet. 
- [x] remove spreading request in to ES when internal user (osquerySearchStrategyProvider)
- [ ] replace filterQuery with a string (this needs more discussion and spcification of what is needed)
