### PR TITLE
[8.9] [Security Solution][Fix] Empty Alert Table when upgrading from 8.8.x -> 8.9 (#162063)

### DIFF
--- a/x-pack/plugins/security_solution/public/timelines/containers/local_storage/index.test.ts
+++ b/x-pack/plugins/security_solution/public/timelines/containers/local_storage/index.test.ts
@@ -15,6 +15,7 @@ import {
   getAllDataTablesInStorage,
   addTableInStorage,
   migrateAlertTableStateToTriggerActionsState,
+  migrateTriggerActionsVisibleColumnsAlertTable88xTo89,
 } from '.';
 
 import { mockDataTableModel, createSecuritySolutionStorageMock } from '../../../common/mock';
@@ -22,6 +23,7 @@ import { useKibana } from '../../../common/lib/kibana';
 import { VIEW_SELECTION } from '../../../../common/constants';
 import type { DataTableModel, DataTableState } from '@kbn/securitysolution-data-table';
 import { TableId } from '@kbn/securitysolution-data-table';
+import { v88xAlertOrignalData, v89xAlertsOriginalData } from './test.data';
 
 jest.mock('../../../common/lib/kibana');
 
@@ -788,7 +790,7 @@ describe('SiemLocalStorage', () => {
     });
   });
 
-  describe('Trigger Actions Alert Table Migration', () => {
+  describe('Trigger Actions Alert Table Migration -> Migration from 8.7', () => {
     const legacyDataTableState: DataTableState['dataTable']['tableById'] = {
       'alerts-page': {
         queryFields: [],
@@ -1261,17 +1263,66 @@ describe('SiemLocalStorage', () => {
           ],
           sort: [{ '@timestamp': { order: 'desc' } }],
           visibleColumns: [
-            '@timestamp',
-            'kibana.alert.rule.name',
-            'kibana.alert.severity',
-            'kibana.alert.risk_score',
-            'kibana.alert.reason',
-            'host.name',
-            'user.name',
-            'process.name',
-            'file.name',
-            'source.ip',
-            'destination.ip',
+            {
+              columnHeaderType: 'not-filtered',
+              id: '@timestamp',
+              initialWidth: 180,
+            },
+            {
+              columnHeaderType: 'not-filtered',
+              displayAsText: 'Rule',
+              id: 'kibana.alert.rule.name',
+              initialWidth: 180,
+              linkField: 'kibana.alert.rule.uuid',
+            },
+            {
+              columnHeaderType: 'not-filtered',
+              displayAsText: 'Severity',
+              id: 'kibana.alert.severity',
+              initialWidth: 180,
+            },
+            {
+              columnHeaderType: 'not-filtered',
+              displayAsText: 'Risk Score',
+              id: 'kibana.alert.risk_score',
+              initialWidth: 180,
+            },
+            {
+              columnHeaderType: 'not-filtered',
+              displayAsText: 'Reason',
+              id: 'kibana.alert.reason',
+              initialWidth: 180,
+            },
+            {
+              columnHeaderType: 'not-filtered',
+              id: 'host.name',
+              initialWidth: 180,
+            },
+            {
+              columnHeaderType: 'not-filtered',
+              id: 'user.name',
+              initialWidth: 180,
+            },
+            {
+              columnHeaderType: 'not-filtered',
+              id: 'process.name',
+              initialWidth: 180,
+            },
+            {
+              columnHeaderType: 'not-filtered',
+              id: 'file.name',
+              initialWidth: 180,
+            },
+            {
+              columnHeaderType: 'not-filtered',
+              id: 'source.ip',
+              initialWidth: 180,
+            },
+            {
+              columnHeaderType: 'not-filtered',
+              id: 'destination.ip',
+              initialWidth: 180,
+            },
           ],
         },
       },
@@ -1344,17 +1395,66 @@ describe('SiemLocalStorage', () => {
             { 'kibana.alert.rule.name': { order: 'desc' } },
           ],
           visibleColumns: [
-            '@timestamp',
-            'kibana.alert.rule.name',
-            'kibana.alert.severity',
-            'kibana.alert.risk_score',
-            'kibana.alert.reason',
-            'host.name',
-            'user.name',
-            'process.name',
-            'file.name',
-            'source.ip',
-            'destination.ip',
+            {
+              columnHeaderType: 'not-filtered',
+              id: '@timestamp',
+              initialWidth: 180,
+            },
+            {
+              columnHeaderType: 'not-filtered',
+              displayAsText: 'Rule',
+              id: 'kibana.alert.rule.name',
+              initialWidth: 180,
+              linkField: 'kibana.alert.rule.uuid',
+            },
+            {
+              columnHeaderType: 'not-filtered',
+              displayAsText: 'Severity',
+              id: 'kibana.alert.severity',
+              initialWidth: 180,
+            },
+            {
+              columnHeaderType: 'not-filtered',
+              displayAsText: 'Risk Score',
+              id: 'kibana.alert.risk_score',
+              initialWidth: 180,
+            },
+            {
+              columnHeaderType: 'not-filtered',
+              displayAsText: 'Reason',
+              id: 'kibana.alert.reason',
+              initialWidth: 180,
+            },
+            {
+              columnHeaderType: 'not-filtered',
+              id: 'host.name',
+              initialWidth: 180,
+            },
+            {
+              columnHeaderType: 'not-filtered',
+              id: 'user.name',
+              initialWidth: 180,
+            },
+            {
+              columnHeaderType: 'not-filtered',
+              id: 'process.name',
+              initialWidth: 180,
+            },
+            {
+              columnHeaderType: 'not-filtered',
+              id: 'file.name',
+              initialWidth: 180,
+            },
+            {
+              columnHeaderType: 'not-filtered',
+              id: 'source.ip',
+              initialWidth: 180,
+            },
+            {
+              columnHeaderType: 'not-filtered',
+              id: 'destination.ip',
+              initialWidth: 180,
+            },
           ],
         },
       },
@@ -1385,6 +1485,46 @@ describe('SiemLocalStorage', () => {
           }
         }
       }
+    });
+  });
+
+  describe('should migrate Alert Table visible columns from v8.8.x', () => {
+    // PR: https://github.com/elastic/kibana/pull/161054
+    beforeEach(() => storage.clear());
+    it('should migrate correctly when upgrading from 8.8.x -> 8.9', () => {
+      Object.keys(v88xAlertOrignalData).forEach((k) => {
+        storage.set(k, v88xAlertOrignalData[k as keyof typeof v88xAlertOrignalData]);
+      });
+
+      migrateTriggerActionsVisibleColumnsAlertTable88xTo89(storage);
+
+      Object.keys(v89xAlertsOriginalData).forEach((k) => {
+        const expectedResult = v89xAlertsOriginalData[k as keyof typeof v89xAlertsOriginalData];
+        expect(storage.get(k)).toMatchObject(expectedResult);
+      });
+    });
+    it('should be a no-op when reinstalling from 8.9 when data is already present.', () => {
+      Object.keys(v89xAlertsOriginalData).forEach((k) => {
+        storage.set(k, v89xAlertsOriginalData[k as keyof typeof v89xAlertsOriginalData]);
+      });
+
+      migrateTriggerActionsVisibleColumnsAlertTable88xTo89(storage);
+
+      Object.keys(v89xAlertsOriginalData).forEach((k) => {
+        const expectedResult = v89xAlertsOriginalData[k as keyof typeof v89xAlertsOriginalData];
+        expect(storage.get(k)).toMatchObject(expectedResult);
+      });
+    });
+
+    it('should be a no-op when installing 8.9 for the first time', () => {
+      migrateTriggerActionsVisibleColumnsAlertTable88xTo89(storage);
+
+      expect(
+        storage.get('detection-engine-alert-table-securitySolution-alerts-page-gridView')
+      ).toBeNull();
+      expect(
+        storage.get('detection-engine-alert-table-securitySolution-rule-details-gridView')
+      ).toBeNull();
     });
   });
 });

--- a/x-pack/plugins/security_solution/public/timelines/containers/local_storage/test.data.ts
+++ b/x-pack/plugins/security_solution/public/timelines/containers/local_storage/test.data.ts
@@ -1,0 +1,579 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const v88xAlertOrignalData = {
+  'detection-engine-alert-table-securitySolution-rule-details-gridView': {
+    columns: [
+      {
+        initialWidth: 200,
+        columnHeaderType: 'not-filtered',
+        id: '@timestamp',
+        schema: 'datetime',
+      },
+      {
+        id: '_id',
+        schema: 'string',
+      },
+      {
+        initialWidth: 180,
+        columnHeaderType: 'not-filtered',
+        displayAsText: 'Rule',
+        id: 'kibana.alert.rule.name',
+        linkField: 'kibana.alert.rule.uuid',
+        schema: 'string',
+      },
+      {
+        initialWidth: 105,
+        columnHeaderType: 'not-filtered',
+        displayAsText: 'Severity',
+        id: 'kibana.alert.severity',
+        schema: 'string',
+      },
+      {
+        initialWidth: 100,
+        columnHeaderType: 'not-filtered',
+        displayAsText: 'Risk Score',
+        id: 'kibana.alert.risk_score',
+        schema: 'numeric',
+      },
+      {
+        initialWidth: 450,
+        columnHeaderType: 'not-filtered',
+        displayAsText: 'Reason',
+        id: 'kibana.alert.reason',
+        schema: 'string',
+      },
+      {
+        initialWidth: 180,
+        columnHeaderType: 'not-filtered',
+        id: 'host.name',
+        schema: 'string',
+      },
+      {
+        initialWidth: 180,
+        columnHeaderType: 'not-filtered',
+        id: 'host.risk.calculated_level',
+        schema: 'string',
+      },
+      {
+        initialWidth: 180,
+        columnHeaderType: 'not-filtered',
+        id: 'user.name',
+        schema: 'string',
+      },
+      {
+        initialWidth: 180,
+        columnHeaderType: 'not-filtered',
+        id: 'user.risk.calculated_level',
+        schema: 'string',
+      },
+      {
+        initialWidth: 180,
+        columnHeaderType: 'not-filtered',
+        id: 'process.name',
+        schema: 'string',
+      },
+      {
+        initialWidth: 180,
+        columnHeaderType: 'not-filtered',
+        id: 'file.name',
+        schema: 'string',
+      },
+      {
+        initialWidth: 180,
+        columnHeaderType: 'not-filtered',
+        id: 'source.ip',
+        schema: 'ip',
+      },
+      {
+        initialWidth: 180,
+        columnHeaderType: 'not-filtered',
+        id: 'destination.ip',
+        schema: 'ip',
+      },
+    ],
+    sort: [
+      {
+        '@timestamp': {
+          order: 'desc',
+        },
+      },
+    ],
+    visibleColumns: [
+      {
+        initialWidth: 200,
+        columnHeaderType: 'not-filtered',
+        id: '@timestamp',
+      },
+      {
+        initialWidth: 180,
+        columnHeaderType: 'not-filtered',
+        displayAsText: 'Rule',
+        id: 'kibana.alert.rule.name',
+        linkField: 'kibana.alert.rule.uuid',
+      },
+      {
+        initialWidth: 105,
+        columnHeaderType: 'not-filtered',
+        displayAsText: 'Severity',
+        id: 'kibana.alert.severity',
+      },
+      {
+        initialWidth: 100,
+        columnHeaderType: 'not-filtered',
+        displayAsText: 'Risk Score',
+        id: 'kibana.alert.risk_score',
+      },
+      {
+        initialWidth: 450,
+        columnHeaderType: 'not-filtered',
+        displayAsText: 'Reason',
+        id: 'kibana.alert.reason',
+      },
+      {
+        initialWidth: 180,
+        columnHeaderType: 'not-filtered',
+        id: 'host.name',
+      },
+      {
+        initialWidth: 180,
+        columnHeaderType: 'not-filtered',
+        id: 'host.risk.calculated_level',
+      },
+      {
+        initialWidth: 180,
+        columnHeaderType: 'not-filtered',
+        id: 'user.name',
+      },
+      {
+        initialWidth: 180,
+        columnHeaderType: 'not-filtered',
+        id: 'user.risk.calculated_level',
+      },
+      {
+        initialWidth: 180,
+        columnHeaderType: 'not-filtered',
+        id: 'process.name',
+      },
+      {
+        initialWidth: 180,
+        columnHeaderType: 'not-filtered',
+        id: 'file.name',
+      },
+      {
+        initialWidth: 180,
+        columnHeaderType: 'not-filtered',
+        id: 'source.ip',
+      },
+      {
+        initialWidth: 180,
+        columnHeaderType: 'not-filtered',
+        id: 'destination.ip',
+      },
+    ],
+  },
+  'detection-engine-alert-table-securitySolution-alerts-page-gridView': {
+    columns: [
+      {
+        initialWidth: 200,
+        columnHeaderType: 'not-filtered',
+        id: '@timestamp',
+        schema: 'datetime',
+      },
+      {
+        id: '_id',
+        schema: 'string',
+      },
+      {
+        initialWidth: 180,
+        columnHeaderType: 'not-filtered',
+        displayAsText: 'Rule',
+        id: 'kibana.alert.rule.name',
+        linkField: 'kibana.alert.rule.uuid',
+        schema: 'string',
+      },
+      {
+        initialWidth: 105,
+        columnHeaderType: 'not-filtered',
+        displayAsText: 'Severity',
+        id: 'kibana.alert.severity',
+        schema: 'string',
+      },
+      {
+        initialWidth: 100,
+        columnHeaderType: 'not-filtered',
+        displayAsText: 'Risk Score',
+        id: 'kibana.alert.risk_score',
+        schema: 'numeric',
+      },
+      {
+        initialWidth: 450,
+        columnHeaderType: 'not-filtered',
+        displayAsText: 'Reason',
+        id: 'kibana.alert.reason',
+        schema: 'string',
+      },
+      {
+        initialWidth: 180,
+        columnHeaderType: 'not-filtered',
+        id: 'host.name',
+        schema: 'string',
+      },
+      {
+        initialWidth: 180,
+        columnHeaderType: 'not-filtered',
+        id: 'host.risk.calculated_level',
+        schema: 'string',
+      },
+      {
+        initialWidth: 180,
+        columnHeaderType: 'not-filtered',
+        id: 'user.name',
+        schema: 'string',
+      },
+      {
+        initialWidth: 180,
+        columnHeaderType: 'not-filtered',
+        id: 'user.risk.calculated_level',
+        schema: 'string',
+      },
+      {
+        initialWidth: 180,
+        columnHeaderType: 'not-filtered',
+        id: 'process.name',
+        schema: 'string',
+      },
+      {
+        initialWidth: 180,
+        columnHeaderType: 'not-filtered',
+        id: 'file.name',
+        schema: 'string',
+      },
+      {
+        initialWidth: 180,
+        columnHeaderType: 'not-filtered',
+        id: 'source.ip',
+        schema: 'ip',
+      },
+      {
+        initialWidth: 180,
+        columnHeaderType: 'not-filtered',
+        id: 'destination.ip',
+        schema: 'ip',
+      },
+    ],
+    sort: [
+      {
+        '@timestamp': {
+          order: 'desc',
+        },
+      },
+    ],
+    visibleColumns: [
+      {
+        initialWidth: 200,
+        columnHeaderType: 'not-filtered',
+        id: '@timestamp',
+      },
+      {
+        initialWidth: 180,
+        columnHeaderType: 'not-filtered',
+        displayAsText: 'Rule',
+        id: 'kibana.alert.rule.name',
+        linkField: 'kibana.alert.rule.uuid',
+      },
+      {
+        initialWidth: 105,
+        columnHeaderType: 'not-filtered',
+        displayAsText: 'Severity',
+        id: 'kibana.alert.severity',
+      },
+      {
+        initialWidth: 100,
+        columnHeaderType: 'not-filtered',
+        displayAsText: 'Risk Score',
+        id: 'kibana.alert.risk_score',
+      },
+      {
+        initialWidth: 450,
+        columnHeaderType: 'not-filtered',
+        displayAsText: 'Reason',
+        id: 'kibana.alert.reason',
+      },
+      {
+        initialWidth: 180,
+        columnHeaderType: 'not-filtered',
+        id: 'host.name',
+      },
+      {
+        initialWidth: 180,
+        columnHeaderType: 'not-filtered',
+        id: 'host.risk.calculated_level',
+      },
+      {
+        initialWidth: 180,
+        columnHeaderType: 'not-filtered',
+        id: 'user.name',
+      },
+      {
+        initialWidth: 180,
+        columnHeaderType: 'not-filtered',
+        id: 'user.risk.calculated_level',
+      },
+      {
+        initialWidth: 180,
+        columnHeaderType: 'not-filtered',
+        id: 'process.name',
+      },
+      {
+        initialWidth: 180,
+        columnHeaderType: 'not-filtered',
+        id: 'file.name',
+      },
+      {
+        initialWidth: 180,
+        columnHeaderType: 'not-filtered',
+        id: 'source.ip',
+      },
+      {
+        initialWidth: 180,
+        columnHeaderType: 'not-filtered',
+        id: 'destination.ip',
+      },
+    ],
+  },
+};
+
+// when upgrading from 8.9.x => 8.9.y
+export const v89xAlertsOriginalData = {
+  'detection-engine-alert-table-securitySolution-rule-details-gridView': {
+    columns: [
+      {
+        initialWidth: 200,
+        columnHeaderType: 'not-filtered',
+        id: '@timestamp',
+        schema: 'datetime',
+      },
+      {
+        id: '_id',
+        schema: 'string',
+      },
+      {
+        initialWidth: 180,
+        columnHeaderType: 'not-filtered',
+        displayAsText: 'Rule',
+        id: 'kibana.alert.rule.name',
+        linkField: 'kibana.alert.rule.uuid',
+        schema: 'string',
+      },
+      {
+        initialWidth: 105,
+        columnHeaderType: 'not-filtered',
+        displayAsText: 'Severity',
+        id: 'kibana.alert.severity',
+        schema: 'string',
+      },
+      {
+        initialWidth: 100,
+        columnHeaderType: 'not-filtered',
+        displayAsText: 'Risk Score',
+        id: 'kibana.alert.risk_score',
+        schema: 'numeric',
+      },
+      {
+        initialWidth: 450,
+        columnHeaderType: 'not-filtered',
+        displayAsText: 'Reason',
+        id: 'kibana.alert.reason',
+        schema: 'string',
+      },
+      {
+        initialWidth: 180,
+        columnHeaderType: 'not-filtered',
+        id: 'host.name',
+        schema: 'string',
+      },
+      {
+        initialWidth: 180,
+        columnHeaderType: 'not-filtered',
+        id: 'host.risk.calculated_level',
+        schema: 'string',
+      },
+      {
+        initialWidth: 180,
+        columnHeaderType: 'not-filtered',
+        id: 'user.name',
+        schema: 'string',
+      },
+      {
+        initialWidth: 180,
+        columnHeaderType: 'not-filtered',
+        id: 'user.risk.calculated_level',
+        schema: 'string',
+      },
+      {
+        initialWidth: 180,
+        columnHeaderType: 'not-filtered',
+        id: 'process.name',
+        schema: 'string',
+      },
+      {
+        initialWidth: 180,
+        columnHeaderType: 'not-filtered',
+        id: 'file.name',
+        schema: 'string',
+      },
+      {
+        initialWidth: 180,
+        columnHeaderType: 'not-filtered',
+        id: 'source.ip',
+        schema: 'ip',
+      },
+      {
+        initialWidth: 180,
+        columnHeaderType: 'not-filtered',
+        id: 'destination.ip',
+        schema: 'ip',
+      },
+    ],
+    sort: [
+      {
+        '@timestamp': {
+          order: 'desc',
+        },
+      },
+    ],
+    visibleColumns: [
+      '@timestamp',
+      'kibana.alert.rule.name',
+      'kibana.alert.severity',
+      'kibana.alert.risk_score',
+      'kibana.alert.reason',
+      'host.name',
+      'host.risk.calculated_level',
+      'user.name',
+      'user.risk.calculated_level',
+      'process.name',
+      'file.name',
+      'source.ip',
+      'destination.ip',
+    ],
+  },
+  'detection-engine-alert-table-securitySolution-alerts-page-gridView': {
+    columns: [
+      {
+        initialWidth: 200,
+        columnHeaderType: 'not-filtered',
+        id: '@timestamp',
+        schema: 'datetime',
+      },
+      {
+        id: '_id',
+        schema: 'string',
+      },
+      {
+        initialWidth: 180,
+        columnHeaderType: 'not-filtered',
+        displayAsText: 'Rule',
+        id: 'kibana.alert.rule.name',
+        linkField: 'kibana.alert.rule.uuid',
+        schema: 'string',
+      },
+      {
+        initialWidth: 105,
+        columnHeaderType: 'not-filtered',
+        displayAsText: 'Severity',
+        id: 'kibana.alert.severity',
+        schema: 'string',
+      },
+      {
+        initialWidth: 100,
+        columnHeaderType: 'not-filtered',
+        displayAsText: 'Risk Score',
+        id: 'kibana.alert.risk_score',
+        schema: 'numeric',
+      },
+      {
+        initialWidth: 450,
+        columnHeaderType: 'not-filtered',
+        displayAsText: 'Reason',
+        id: 'kibana.alert.reason',
+        schema: 'string',
+      },
+      {
+        initialWidth: 180,
+        columnHeaderType: 'not-filtered',
+        id: 'host.name',
+        schema: 'string',
+      },
+      {
+        initialWidth: 180,
+        columnHeaderType: 'not-filtered',
+        id: 'host.risk.calculated_level',
+        schema: 'string',
+      },
+      {
+        initialWidth: 180,
+        columnHeaderType: 'not-filtered',
+        id: 'user.name',
+        schema: 'string',
+      },
+      {
+        initialWidth: 180,
+        columnHeaderType: 'not-filtered',
+        id: 'user.risk.calculated_level',
+        schema: 'string',
+      },
+      {
+        initialWidth: 180,
+        columnHeaderType: 'not-filtered',
+        id: 'process.name',
+        schema: 'string',
+      },
+      {
+        initialWidth: 180,
+        columnHeaderType: 'not-filtered',
+        id: 'file.name',
+        schema: 'string',
+      },
+      {
+        initialWidth: 180,
+        columnHeaderType: 'not-filtered',
+        id: 'source.ip',
+        schema: 'ip',
+      },
+      {
+        initialWidth: 180,
+        columnHeaderType: 'not-filtered',
+        id: 'destination.ip',
+        schema: 'ip',
+      },
+    ],
+    sort: [
+      {
+        '@timestamp': {
+          order: 'desc',
+        },
+      },
+    ],
+    visibleColumns: [
+      '@timestamp',
+      'kibana.alert.rule.name',
+      'kibana.alert.severity',
+      'kibana.alert.risk_score',
+      'kibana.alert.reason',
+      'host.name',
+      'host.risk.calculated_level',
+      'user.name',
+      'user.risk.calculated_level',
+      'process.name',
+      'file.name',
+      'source.ip',
+      'destination.ip',
+    ],
+  },
+};


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.9`:
 - [[Security Solution][Fix] Empty Alert Table when upgrading from 8.8.x -> 8.9 (#162063)](https://github.com/elastic/kibana/pull/162063)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Jatin Kathuria","email":"jatin.kathuria@elastic.co"},"sourceCommit":{"committedDate":"2023-07-18T08:57:12Z","message":"[Security Solution][Fix] Empty Alert Table when upgrading from 8.8.x -> 8.9 (#162063)\n\n## Summary\r\n\r\nWhen users upgrade from `8.8.x` -> `8.9` version, users observe empty\r\ntable as shown below.\r\n\r\n\r\n![image](https://github.com/elastic/kibana/assets/7485038/20549edb-07b9-4124-a0ac-7515cf0e2796)\r\n\r\n\r\nBelow are steps to reproduce this issue and test it:\r\n\r\n1. Boot Kibana@v8.8.1\r\n2. Clear Local storage.\r\n3. Go to Security -> Alerts\r\n4. Add Columns `_id` or any other column \r\n5. Upgrade to `8.9`\r\n6. The table will empty as shown in above screenshot.\r\n\r\n\r\n## Fix\r\n\r\nThis fix saperates out the migraton from 8.7 -> 8.8 and add a new\r\nmigration for upgrading from 8.8 -> 8.9\r\n\r\n`migrateAlertTableStateToTriggerActionsState` migrates table from `v8.7\r\n-> v8.8`,\r\n\r\n`migrateTriggerActionsVisibleColumnsAlertTable88xTo89` migrates from\r\n`v8.8.x` -> `v8.9`\r\n\r\nCombining both of them may lead to issues when users are migrating from\r\n`v8.7` -> `v8.9` or `v8.8` -> `v8.9`","sha":"0516caed1de3b72efa3f5c1282975c34962f7999","branchLabelMapping":{"^v8.10.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:ResponseOps","Team:Threat Hunting:Investigations","v8.9.0","v8.10.0"],"number":162063,"url":"https://github.com/elastic/kibana/pull/162063","mergeCommit":{"message":"[Security Solution][Fix] Empty Alert Table when upgrading from 8.8.x -> 8.9 (#162063)\n\n## Summary\r\n\r\nWhen users upgrade from `8.8.x` -> `8.9` version, users observe empty\r\ntable as shown below.\r\n\r\n\r\n![image](https://github.com/elastic/kibana/assets/7485038/20549edb-07b9-4124-a0ac-7515cf0e2796)\r\n\r\n\r\nBelow are steps to reproduce this issue and test it:\r\n\r\n1. Boot Kibana@v8.8.1\r\n2. Clear Local storage.\r\n3. Go to Security -> Alerts\r\n4. Add Columns `_id` or any other column \r\n5. Upgrade to `8.9`\r\n6. The table will empty as shown in above screenshot.\r\n\r\n\r\n## Fix\r\n\r\nThis fix saperates out the migraton from 8.7 -> 8.8 and add a new\r\nmigration for upgrading from 8.8 -> 8.9\r\n\r\n`migrateAlertTableStateToTriggerActionsState` migrates table from `v8.7\r\n-> v8.8`,\r\n\r\n`migrateTriggerActionsVisibleColumnsAlertTable88xTo89` migrates from\r\n`v8.8.x` -> `v8.9`\r\n\r\nCombining both of them may lead to issues when users are migrating from\r\n`v8.7` -> `v8.9` or `v8.8` -> `v8.9`","sha":"0516caed1de3b72efa3f5c1282975c34962f7999"}},"sourceBranch":"main","suggestedTargetBranches":["8.9"],"targetPullRequestStates":[{"branch":"8.9","label":"v8.9.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.10.0","labelRegex":"^v8.10.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/162063","number":162063,"mergeCommit":{"message":"[Security Solution][Fix] Empty Alert Table when upgrading from 8.8.x -> 8.9 (#162063)\n\n## Summary\r\n\r\nWhen users upgrade from `8.8.x` -> `8.9` version, users observe empty\r\ntable as shown below.\r\n\r\n\r\n![image](https://github.com/elastic/kibana/assets/7485038/20549edb-07b9-4124-a0ac-7515cf0e2796)\r\n\r\n\r\nBelow are steps to reproduce this issue and test it:\r\n\r\n1. Boot Kibana@v8.8.1\r\n2. Clear Local storage.\r\n3. Go to Security -> Alerts\r\n4. Add Columns `_id` or any other column \r\n5. Upgrade to `8.9`\r\n6. The table will empty as shown in above screenshot.\r\n\r\n\r\n## Fix\r\n\r\nThis fix saperates out the migraton from 8.7 -> 8.8 and add a new\r\nmigration for upgrading from 8.8 -> 8.9\r\n\r\n`migrateAlertTableStateToTriggerActionsState` migrates table from `v8.7\r\n-> v8.8`,\r\n\r\n`migrateTriggerActionsVisibleColumnsAlertTable88xTo89` migrates from\r\n`v8.8.x` -> `v8.9`\r\n\r\nCombining both of them may lead to issues when users are migrating from\r\n`v8.7` -> `v8.9` or `v8.8` -> `v8.9`","sha":"0516caed1de3b72efa3f5c1282975c34962f7999"}}]}] BACKPORT-->