### PR TITLE
[Observability AI Assistant] Remove default feedback URL

### DIFF
--- a/x-pack/plugins/observability/server/routes/copilot/route.ts
+++ b/x-pack/plugins/observability/server/routes/copilot/route.ts
@@ -92,7 +92,11 @@ const trackRoute = createObservabilityServerRoute({
   handler: async (resources): Promise<void> => {
     const { params, config } = resources;
 
-    if (!config.aiAssistant?.enabled) {
+    if (
+      !config.aiAssistant?.enabled ||
+      !config.aiAssistant.feedback.enabled ||
+      !config.aiAssistant.feedback.url
+    ) {
       throw Boom.notImplemented();
     }
 

--- a/x-pack/plugins/observability/server/services/openai/config.ts
+++ b/x-pack/plugins/observability/server/services/openai/config.ts
@@ -26,9 +26,7 @@ export const observabilityCoPilotConfig = schema.object({
   enabled: schema.boolean({ defaultValue: false }),
   feedback: schema.object({
     enabled: schema.boolean({ defaultValue: false }),
-    url: schema.string({
-      defaultValue: `https://0d0uj24psl.execute-api.us-east-1.amazonaws.com/gaifeedback`,
-    }),
+    url: schema.maybe(schema.string()),
   }),
   provider: schema.oneOf([openAIConfig, azureOpenAIConfig]),
 });


### PR DESCRIPTION
Removing the default feedback URL, as we've not been able to vet the external endpoint in time.

<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->