### PR TITLE
Update docker.asciidoc

### DIFF
--- a/docs/setup/docker.asciidoc
+++ b/docs/setup/docker.asciidoc
@@ -53,7 +53,7 @@ docker pull {es-docker-image}
 [source,sh,subs="attributes"]
 ----
 wget https://artifacts.elastic.co/cosign.pub
-cosign verify --key cosign.pub {docker-repo}:{version}
+cosign verify --key cosign.pub {es-docker-image}
 ----
 +
 For details about this step, refer to {ref}/docker.html#docker-verify-signature[Verify the {es} Docker image signature] in the {es} documentation.


### PR DESCRIPTION
Verifying Elasticsearch cosign.pub instead of Kibana fixed in documentation.

## Summary

I changed reference from Kibana into Elasticsaerch because of mismatch in documentation