### PR TITLE
[SecuritySolution] Styling for embeddable

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_embeddable.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_embeddable.tsx
@@ -39,9 +39,13 @@ const LensComponentWrapper = styled.div<{
   width: ${({ width }) => width ?? 'auto'};
 
   ${({ $addHoverActionsPadding }) =>
-    $addHoverActionsPadding
-      ? `.embPanel__header--floater { top: ${HOVER_ACTIONS_PADDING * -1}px; }`
-      : ''}
+    $addHoverActionsPadding ? `.embPanel__header { top: ${HOVER_ACTIONS_PADDING * -1}px; }` : ''}
+
+  .embPanel__header {
+    z-index: 2;
+    position: absolute;
+    right: 0;
+  }
 
   .expExpressionRenderer__expression {
     padding: 2px 0 0 0 !important;


### PR DESCRIPTION
## Summary


Metrics and histograms on Hosts, network, users, rules and alerts page are cropped.


Before:

<img width="784" alt="Screenshot 2023-07-18 at 12 40 52" src="https://github.com/elastic/kibana/assets/6295984/56ade48c-03dd-4095-a3e6-c87b2de895ad">



After:

<img width="766" alt="Screenshot 2023-07-18 at 12 38 48" src="https://github.com/elastic/kibana/assets/6295984/e0c37138-e043-4075-8842-b7ace669d163">


