### PR TITLE
[Cases] Fix flaky tests of severity in `list_view`

### DIFF
--- a/x-pack/test/functional/services/cases/list.ts
+++ b/x-pack/test/functional/services/cases/list.ts
@@ -192,7 +192,10 @@ export function CasesTableServiceProvider(
 
       const row = rows[index];
       await row.click();
-      await find.existsByCssSelector('[data-test-subj*="case-action-popover-"');
+      await retry.waitFor(
+        'popover-action-exists',
+        async () => await find.existsByCssSelector('[data-test-subj*="case-action-popover-"')
+      );
     },
 
     async openAssigneesPopover() {
@@ -223,6 +226,7 @@ export function CasesTableServiceProvider(
 
       await testSubjects.existOrFail(`cases-bulk-action-status-${status}`);
       await testSubjects.click(`cases-bulk-action-status-${status}`);
+      await header.waitUntilLoadingHasFinished();
     },
 
     async changeSeverity(severity: CaseSeverity, index: number) {
@@ -240,6 +244,7 @@ export function CasesTableServiceProvider(
 
       await testSubjects.existOrFail(`cases-bulk-action-severity-${severity}`);
       await testSubjects.click(`cases-bulk-action-severity-${severity}`);
+      await header.waitUntilLoadingHasFinished();
     },
 
     async bulkChangeStatusCases(status: CaseStatuses) {

--- a/x-pack/test/functional_with_es_ssl/apps/cases/group2/list_view.ts
+++ b/x-pack/test/functional_with_es_ssl/apps/cases/group2/list_view.ts
@@ -602,8 +602,7 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
         });
       });
 
-      // FLAKY: https://github.com/elastic/kibana/issues/160622
-      describe.skip('Severity', () => {
+      describe('Severity', () => {
         before(async () => {
           await cases.api.createNthRandomCases(1);
           await header.waitUntilLoadingHasFinished();


### PR DESCRIPTION
## Summary

Fixes #160622


### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Flaky test runner
https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2660


<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->