### PR TITLE
[Logs+] Aggregate unmanaged datasets

### DIFF
--- a/x-pack/plugins/discover_log_explorer/public/state_machines/datasets/src/state_machine.ts
+++ b/x-pack/plugins/discover_log_explorer/public/state_machines/datasets/src/state_machine.ts
@@ -40,7 +40,7 @@ export const createPureDatasetsStateMachine = (
             src: 'loadDatasets',
             onDone: {
               target: 'loaded',
-              actions: ['storeInCache', 'storeDatasets', 'storeSearch'],
+              actions: ['storeInCache', 'aggregateAndStoreDatasets', 'storeSearch'],
             },
             onError: 'loadingFailed',
           },
@@ -78,7 +78,7 @@ export const createPureDatasetsStateMachine = (
           // Store search from search event
           ...('search' in event && { search: event.search }),
         })),
-        storeDatasets: assign((_context, event) =>
+        aggregateAndStoreDatasets: assign((_context, event) =>
           'data' in event && !isError(event.data)
             ? { datasets: Dataset.createWildcardDatasetsFrom(event.data.items) }
             : {}

--- a/x-pack/plugins/discover_log_explorer/public/state_machines/datasets/src/state_machine.ts
+++ b/x-pack/plugins/discover_log_explorer/public/state_machines/datasets/src/state_machine.ts
@@ -7,6 +7,7 @@
 
 import { isEmpty, isError, omitBy } from 'lodash';
 import { assign, createMachine } from 'xstate';
+import { Dataset } from '../../../../common/datasets';
 import { IDatasetsClient } from '../../../services/datasets';
 import { DEFAULT_CONTEXT } from './defaults';
 import type {
@@ -78,7 +79,9 @@ export const createPureDatasetsStateMachine = (
           ...('search' in event && { search: event.search }),
         })),
         storeDatasets: assign((_context, event) =>
-          'data' in event && !isError(event.data) ? { datasets: event.data.items } : {}
+          'data' in event && !isError(event.data)
+            ? { datasets: Dataset.createWildcardDatasetsFrom(event.data.items) }
+            : {}
         ),
         storeInCache: (context, event) => {
           if ('data' in event && !isError(event.data)) {


### PR DESCRIPTION
## 📓 Summary

Closes #162061 

This implementation updates and aggregates the unmanaged datasets once they are retrieved by the state machine on initialization.

I implemented this step in the state machine against doing it on the dataset service to keep the service pure and able to serve the whole response in case we need to use it on other plugins/use cases.

https://github.com/elastic/kibana/assets/34506779/a5883521-6dd7-4291-9b90-0cd7665bed65