### PR TITLE
[Files management] Fix flaky functional test

### DIFF
--- a/test/functional/apps/management/_files.ts
+++ b/test/functional/apps/management/_files.ts
@@ -6,12 +6,12 @@
  * Side Public License, v 1.
  */
 
-import expect from '@kbn/expect';
 import { FtrProviderContext } from '../../ftr_provider_context';
 
 export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const PageObjects = getPageObjects(['common', 'filesManagement']);
   const testSubjects = getService('testSubjects');
+  const retry = getService('retry');
 
   describe('Files management', () => {
     before(async () => {
@@ -21,9 +21,10 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     it(`should render an empty prompt`, async () => {
       await testSubjects.existOrFail('filesManagementApp');
 
-      const pageText = await (await testSubjects.find('filesManagementApp')).getVisibleText();
-
-      expect(pageText).to.contain('No files found');
+      await retry.waitFor('Render empty files prompt', async () => {
+        const pageText = await (await testSubjects.find('filesManagementApp')).getVisibleText();
+        return pageText.includes('No files found');
+      });
     });
   });
 }


### PR DESCRIPTION
There is still some flakiness in the File management test. Probably due to the 300ms delay to render the Empty prompt.

I updated the test to be more resilient.

Fixes https://github.com/elastic/kibana/issues/160178

<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->