### PR TITLE
[Console] Update autocomplete variables

### DIFF
--- a/src/plugins/console/public/application/models/sense_editor/integration.test.js
+++ b/src/plugins/console/public/application/models/sense_editor/integration.test.js
@@ -196,7 +196,7 @@ describe('Integration', () => {
     endpoints: {
       _search: {
         methods: ['GET', 'POST'],
-        patterns: ['{indices}/_search', '_search'],
+        patterns: ['{index}/_search', '_search'],
         data_autocomplete_rules: {
           query: {
             match_all: {},
@@ -996,7 +996,7 @@ describe('Integration', () => {
   const CLUSTER_KB = {
     endpoints: {
       _search: {
-        patterns: ['_search', '{indices}/_search'],
+        patterns: ['_search', '{index}/_search'],
         url_params: {
           search_type: ['count', 'query_then_fetch'],
           scroll: '10m',

--- a/src/plugins/console/public/lib/kb/kb.js
+++ b/src/plugins/console/public/lib/kb/kb.js
@@ -57,9 +57,6 @@ const parametrizedComponentFactories = {
   user: function (name, parent) {
     return new UsernameAutocompleteComponent(name, parent);
   },
-  template: function (name, parent) {
-    return new LegacyTemplateAutocompleteComponent(name, parent);
-  },
   task_id: function (name, parent) {
     return idAutocompleteComponentFactory(name, parent);
   },
@@ -82,14 +79,19 @@ const parametrizedComponentFactories = {
   node: function (name, parent) {
     return new ListComponent(name, [], parent, false);
   },
-  index_template: function (name, parent) {
-    return new IndexTemplateAutocompleteComponent(name, parent);
-  },
-  component_template: function (name, parent) {
-    return new ComponentTemplateAutocompleteComponent(name, parent);
-  },
-  data_stream: function (name, parent) {
-    return new DataStreamAutocompleteComponent(name, parent);
+  name: function (name, parent) {
+    switch (parent?.name) {
+      case '_template':
+        return new LegacyTemplateAutocompleteComponent(name, parent);
+      case '_index_template':
+        return new IndexTemplateAutocompleteComponent(name, parent);
+      case '_component_template':
+        return new ComponentTemplateAutocompleteComponent(name, parent);
+      case '_data_stream':
+        return new DataStreamAutocompleteComponent(name, parent);
+      default:
+        return new ListComponent(name, [], parent, false);
+    }
   },
 };
 

--- a/src/plugins/console/public/lib/kb/kb.js
+++ b/src/plugins/console/public/lib/kb/kb.js
@@ -76,9 +76,6 @@ const parametrizedComponentFactories = {
       parent
     );
   },
-  node: function (name, parent) {
-    return new ListComponent(name, [], parent, false);
-  },
   name: function (name, parent) {
     switch (parent?.name) {
       case '_template':

--- a/src/plugins/console/public/lib/kb/kb.js
+++ b/src/plugins/console/public/lib/kb/kb.js
@@ -45,9 +45,6 @@ const parametrizedComponentFactories = {
   type: function (name, parent) {
     return new TypeAutocompleteComponent(name, parent, false);
   },
-  types: function (name, parent) {
-    return new TypeAutocompleteComponent(name, parent, true);
-  },
   id: function (name, parent) {
     return idAutocompleteComponentFactory(name, parent);
   },

--- a/src/plugins/console/public/lib/kb/kb.js
+++ b/src/plugins/console/public/lib/kb/kb.js
@@ -40,10 +40,6 @@ const parametrizedComponentFactories = {
   },
   index: function (name, parent) {
     if (isNotAnIndexName(name)) return;
-    return new IndexAutocompleteComponent(name, parent, false);
-  },
-  indices: function (name, parent) {
-    if (isNotAnIndexName(name)) return;
     return new IndexAutocompleteComponent(name, parent, true);
   },
   type: function (name, parent) {
@@ -79,7 +75,7 @@ const parametrizedComponentFactories = {
   field: function (name, parent) {
     return new FieldAutocompleteComponent(name, parent, false);
   },
-  nodes: function (name, parent) {
+  node_id: function (name, parent) {
     return new ListComponent(
       name,
       ['_local', '_master', 'data:true', 'data:false', 'master:true', 'master:false'],

--- a/src/plugins/console/public/lib/kb/kb.test.js
+++ b/src/plugins/console/public/lib/kb/kb.test.js
@@ -95,10 +95,6 @@ describe('Knowledge base', () => {
     expect(context).toEqual(expectedContext);
   }
 
-  function t(term) {
-    return { name: term, meta: 'type' };
-  }
-
   function i(term) {
     return { name: term, meta: 'index' };
   }

--- a/src/plugins/console/public/lib/kb/kb.test.js
+++ b/src/plugins/console/public/lib/kb/kb.test.js
@@ -111,7 +111,7 @@ describe('Knowledge base', () => {
           indexTest: {
             endpoints: {
               _multi_indices: {
-                patterns: ['{indices}/_multi_indices'],
+                patterns: ['{index}/_multi_indices'],
               },
               _single_index: { patterns: ['{index}/_single_index'] },
               _no_index: {
@@ -150,7 +150,7 @@ describe('Knowledge base', () => {
 
   indexTest('Index integration 2', [['index1', 'index2']], [], {
     indices: ['index1', 'index2'],
-    autoCompleteSet: ['_multi_indices'],
+    autoCompleteSet: ['_multi_indices', '_single_index'],
   });
 
   function typeTest(name, tokenPath, otherTokenValues, expectedContext) {
@@ -159,9 +159,8 @@ describe('Knowledge base', () => {
         {
           typeTest: {
             endpoints: {
-              _multi_types: { patterns: ['{indices}/{types}/_multi_types'] },
-              _single_type: { patterns: ['{indices}/{type}/_single_type'] },
-              _no_types: { patterns: ['{indices}/_no_types'] },
+              _single_type: { patterns: ['{index}/{type}/_single_type'] },
+              _no_types: { patterns: ['{index}/_no_types'] },
             },
           },
         },
@@ -177,38 +176,30 @@ describe('Knowledge base', () => {
 
   typeTest('Type integration 1', ['index1'], [], {
     indices: ['index1'],
-    autoCompleteSet: ['_no_types', t('type1.1'), t('type1.2')],
+    autoCompleteSet: ['_no_types'],
   });
   typeTest(
     'Type integration 2',
     ['index1'],
     ['type1.2'],
     // we are not yet comitted to type1.2, so _no_types is returned
-    { indices: ['index1'], autoCompleteSet: ['_no_types', t('type1.1')] }
+    { indices: ['index1'], autoCompleteSet: ['_no_types'] }
   );
 
   typeTest('Type integration 3', ['index2'], [], {
     indices: ['index2'],
-    autoCompleteSet: ['_no_types', t('type2.1')],
+    autoCompleteSet: ['_no_types'],
   });
 
   typeTest('Type integration 4', ['index1', 'type1.2'], [], {
     indices: ['index1'],
     types: ['type1.2'],
-    autoCompleteSet: ['_multi_types', '_single_type'],
+    autoCompleteSet: ['_single_type'],
   });
 
-  typeTest(
-    'Type integration 5',
-    [
-      ['index1', 'index2'],
-      ['type1.2', 'type1.1'],
-    ],
-    [],
-    {
-      indices: ['index1', 'index2'],
-      types: ['type1.2', 'type1.1'],
-      autoCompleteSet: ['_multi_types'],
-    }
-  );
+  typeTest('Type integration 5', [['index1', 'index2'], ['type1.1']], [], {
+    indices: ['index1', 'index2'],
+    types: ['type1.1'],
+    autoCompleteSet: ['_single_type'],
+  });
 });


### PR DESCRIPTION
This PR is WIP

Closes https://github.com/elastic/kibana/issues/160539

## Summary

This PR updates the autocomplete variables defined in the Console code so that they correspond to the variables in the [Es specification repo](https://github.com/elastic/elasticsearch-specification). 

The following differences have been identified:

Variable name in Console | Variable name in Es specification (example) | Action required
------------------- | ------------------------------------- | ----------------
`nodes` | `node_id` (e.g. [GET _nodes/{node_id}](https://github.com/elastic/elasticsearch-specification/blob/33e8a1c9cad22a5946ac735c4fba31af2da2cec2/specification/nodes/info/NodesInfoRequest.ts#L33)) | Rename `nodes` variable to `node_id`
`indices` | `index` (e.g. [GET _cat/indices/{index}](https://github.com/elastic/elasticsearch-specification/blob/33e8a1c9cad22a5946ac735c4fba31af2da2cec2/specification/cat/indices/CatIndicesRequest.ts#L44)) | Delete `indices` variable (since an `index` variable already exists)
`types` | Not used | Delete `types` variable
`node` | Not used | Delete `node` variable
`type` | Used in [PUT _monitoring/{type}/bulk](https://github.com/elastic/elasticsearch-specification/blob/33e8a1c9cad22a5946ac735c4fba31af2da2cec2/specification/monitoring/bulk/BulkMonitoringRequest.ts#L33) but might have a different context | ?
`template` | `name` (e.g. [GET _template/{name}](https://github.com/elastic/elasticsearch-specification/blob/33e8a1c9cad22a5946ac735c4fba31af2da2cec2/specification/indices/get_template/IndicesGetTemplateRequest.ts#L31C7-L31C7)) | Match a `name` variable with `_template` parent to a template autocomplete component
`index_template` | `name` (e.g. [GET _index_template/{name}](https://github.com/elastic/elasticsearch-specification/blob/33e8a1c9cad22a5946ac735c4fba31af2da2cec2/specification/indices/get_index_template/IndicesGetIndexTemplateRequest.ts#L34)) | Match a `name` variable with `_index_template` parent to a index template autocomplete component
`component_template` | `name` (e.g. [GET _component_template/{name}](https://github.com/elastic/elasticsearch-specification/blob/33e8a1c9cad22a5946ac735c4fba31af2da2cec2/specification/cluster/get_component_template/ClusterGetComponentTemplateRequest.ts#L38)) | Match a `name` variable with `_component_template` parent to a component template autocomplete component
`data_stream` | `name` (e.g. [GET _data_stream/{name}](https://github.com/elastic/elasticsearch-specification/blob/33e8a1c9cad22a5946ac735c4fba31af2da2cec2/specification/indices/get_data_stream/IndicesGetDataStreamRequest.ts#L36)) | Match a `name` variable with `_data_stream` parent to a data stream autocomplete component

**How to test:**
1. Checkout the [ES specification repo](https://github.com/elastic/elasticsearch-specification)
2. Run the command with `node scripts/generate_console_definitions.js --source <ES_SPECIFICATION_REPO> --dest src/plugins/console/server/lib/spec_definitions/json/new_script/generated` where `<ES_SPECIFICATION_REPO>` is the absolute path to the root of the ES specification repo
3. Modify [this line](https://github.com/elastic/kibana/blob/9a87af0cc334c58362191f6e3c7a47d0ecf19c92/src/plugins/console/common/constants/autocomplete_definitions.ts#L13) to `'../../server/lib/spec_definitions/json/new_script'`
4. Start Es with `yarn es snapshot` and run Kibana with `yarn start`.
5. Go to Console.
6. For each modified variable from the table above, type in an example url pattern that includes this variable. For example,  typing `GET _cat/indices/` should suggest a list of index names.


