### PR TITLE
[ML] Uses model supplied mask token for testing trained models

### DIFF
--- a/x-pack/plugins/ml/public/application/model_management/test_models/models/text_classification/fill_mask_inference.ts
+++ b/x-pack/plugins/ml/public/application/model_management/test_models/models/text_classification/fill_mask_inference.ts
@@ -85,7 +85,8 @@ export class FillMaskInference extends InferenceBase<TextClassificationResponse>
       const placeholder = i18n.translate(
         'xpack.ml.trainedModels.testModelsFlyout.fillMask.inputText',
         {
-          defaultMessage: `Enter a phrase to test. Use ${this.maskToken} as a placeholder for the missing words.`,
+          defaultMessage: `Enter a phrase to test. Use {maskToken} as a placeholder for the missing words.`,
+          values: { maskToken: this.maskToken },
         }
       );
 

--- a/x-pack/plugins/ml/public/application/model_management/test_models/models/text_classification/fill_mask_inference.ts
+++ b/x-pack/plugins/ml/public/application/model_management/test_models/models/text_classification/fill_mask_inference.ts
@@ -16,7 +16,7 @@ import { getGeneralInputComponent } from '../text_input';
 import { getFillMaskOutputComponent } from './fill_mask_output';
 import { trainedModelsApiProvider } from '../../../../services/ml_api_service/trained_models';
 
-const MASK = '[MASK]';
+const DEFAULT_MASK_TOKEN = '[MASK]';
 
 export class FillMaskInference extends InferenceBase<TextClassificationResponse> {
   protected inferenceType = SUPPORTED_PYTORCH_TASKS.FILL_MASK;
@@ -30,6 +30,7 @@ export class FillMaskInference extends InferenceBase<TextClassificationResponse>
       defaultMessage: 'Test how well the model predicts a missing word in a phrase.',
     }),
   ];
+  private maskToken = DEFAULT_MASK_TOKEN;
 
   constructor(
     trainedModelsApi: ReturnType<typeof trainedModelsApiProvider>,
@@ -38,9 +39,14 @@ export class FillMaskInference extends InferenceBase<TextClassificationResponse>
     deploymentId: string
   ) {
     super(trainedModelsApi, model, inputType, deploymentId);
+    // @ts-expect-error mask_token is missing in type
+    const maskToken = model.inference_config?.[this.inferenceType]?.mask_token;
+    if (maskToken) {
+      this.maskToken = maskToken;
+    }
 
     this.initialize([
-      this.inputText$.pipe(map((inputText) => inputText.every((t) => t.includes(MASK)))),
+      this.inputText$.pipe(map((inputText) => inputText.every((t) => t.includes(this.maskToken)))),
     ]);
   }
 
@@ -71,7 +77,7 @@ export class FillMaskInference extends InferenceBase<TextClassificationResponse>
 
   public predictedValue(resp: TextClassificationResponse) {
     const { response, inputText } = resp;
-    return response[0]?.value ? inputText.replace(MASK, response[0].value) : inputText;
+    return response[0]?.value ? inputText.replace(this.maskToken, response[0].value) : inputText;
   }
 
   public getInputComponent(): JSX.Element | null {
@@ -79,8 +85,7 @@ export class FillMaskInference extends InferenceBase<TextClassificationResponse>
       const placeholder = i18n.translate(
         'xpack.ml.trainedModels.testModelsFlyout.fillMask.inputText',
         {
-          defaultMessage:
-            'Enter a phrase to test. Use [MASK] as a placeholder for the missing words.',
+          defaultMessage: `Enter a phrase to test. Use ${this.maskToken} as a placeholder for the missing words.`,
         }
       );
 

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -24795,7 +24795,6 @@
     "xpack.ml.trainedModels.nodesList.totalAmountLabel": "Machine Learning 节点总数",
     "xpack.ml.trainedModels.testModelsFlyout.deploymentIdLabel": "部署 ID",
     "xpack.ml.trainedModels.testModelsFlyout.fillMask.info1": "测试模型预测短语中缺失的词的表现。",
-    "xpack.ml.trainedModels.testModelsFlyout.fillMask.inputText": "输入短语以进行测试。将 [MASK] 用作缺失词的占位符。",
     "xpack.ml.trainedModels.testModelsFlyout.fillMask.label": "填充掩码",
     "xpack.ml.trainedModels.testModelsFlyout.generalTextInput.inputText": "输入文本",
     "xpack.ml.trainedModels.testModelsFlyout.generalTextInput.inputTitle": "输入文本",


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/159577

Using the `mask_token` property from the model config for testing the model.
This is shown in the input placeholder text, in the input validation and for displaying the results.

<img width="433" alt="image" src="https://github.com/elastic/kibana/assets/7405507/bc63f9e6-a3d5-402c-a451-8d80b758acbc">


