### PR TITLE
[Security solution] Bump GenAI connector license to Enterprise

### DIFF
--- a/x-pack/plugins/stack_connectors/server/connector_types/gen_ai/index.ts
+++ b/x-pack/plugins/stack_connectors/server/connector_types/gen_ai/index.ts
@@ -34,7 +34,7 @@ export const getConnectorType = (): SubActionConnectorType<GenAiConfig, GenAiSec
   },
   validators: [{ type: ValidatorType.CONFIG, validator: configValidator }],
   supportedFeatureIds: [GeneralConnectorFeatureId],
-  minimumLicenseRequired: 'platinum' as const,
+  minimumLicenseRequired: 'enterprise' as const,
   renderParameterTemplates,
 });
 


### PR DESCRIPTION
## Summary

Bump the GenAI license to enterprise to be consistent with the rest of the OpenAI licensing. See https://github.com/elastic/security-team/issues/6982

<img width="1107" alt="Screenshot 2023-07-18 at 2 53 57 PM" src="https://github.com/elastic/kibana/assets/6935300/9ea88a1c-fbfd-4ed8-a2a4-ca3c75b221ef">


<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->