### PR TITLE
[Serverless] Change default value of enabling config of security apps

### DIFF
--- a/config/serverless.yml
+++ b/config/serverless.yml
@@ -47,6 +47,11 @@ xpack.cloud_integrations.data_migration.enabled: false
 data.search.sessions.enabled: false
 advanced_settings.enabled: false
 
+# Disable UI of security management plugins
+xpack.security.ui.userManagementEnabled: false
+xpack.security.ui.roleManagementEnabled: false
+xpack.security.ui.roleMappingManagementEnabled: false
+
 # Enforce restring access to internal APIs see https://github.com/elastic/kibana/issues/151940
 # server.restrictInternalApis: true
 # Telemetry enabled by default and not disableable via UI

--- a/x-pack/plugins/security/server/config.ts
+++ b/x-pack/plugins/security/server/config.ts
@@ -303,9 +303,9 @@ export const ConfigSchema = schema.object({
     schema.contextRef('serverless'),
     true,
     schema.object({
-      userManagementEnabled: schema.boolean({ defaultValue: false }),
-      roleManagementEnabled: schema.boolean({ defaultValue: false }),
-      roleMappingManagementEnabled: schema.boolean({ defaultValue: false }),
+      userManagementEnabled: schema.boolean({ defaultValue: true }),
+      roleManagementEnabled: schema.boolean({ defaultValue: true }),
+      roleMappingManagementEnabled: schema.boolean({ defaultValue: true }),
     }),
     schema.never()
   ),


### PR DESCRIPTION
This is a follow-up to https://github.com/elastic/kibana/pull/160671, where the Management plugins were disabled using `contextRef`. 

The configs for disabling the UI of the security management plugins were added in https://github.com/elastic/kibana/pull/158186. In this PR, they are changed so that they follow the same convention for disabling the Management plugins - setting the default values of the configs to `true` and explicitly setting them to `false` in the `serverless.yml` file. This way, we have a clear view in `serverless.yml` of all plugins/functionalities that have been disabled.
