### PR TITLE
[Embeddables] Fix Notifications show header

### DIFF
--- a/src/plugins/embeddable/public/embeddable_panel/panel_header/embeddable_panel_header.tsx
+++ b/src/plugins/embeddable/public/embeddable_panel/panel_header/embeddable_panel_header.tsx
@@ -37,6 +37,8 @@ export const EmbeddablePanelHeader = ({
   );
 
   const { notificationComponents, badgeComponents } = useEmbeddablePanelBadges(
+    showNotifications,
+    showBadges,
     embeddable,
     getActions
   );

--- a/src/plugins/embeddable/public/embeddable_panel/panel_header/use_embeddable_panel_badges.tsx
+++ b/src/plugins/embeddable/public/embeddable_panel/panel_header/use_embeddable_panel_badges.tsx
@@ -26,6 +26,8 @@ import {
 } from '../types';
 
 export const useEmbeddablePanelBadges = (
+  showNotifications: boolean,
+  showBadges: boolean,
   embeddable: IEmbeddable,
   getActions: EmbeddablePanelProps['getActions']
 ) => {
@@ -35,6 +37,7 @@ export const useEmbeddablePanelBadges = (
   const [notifications, setNotifications] = useState<EmbeddableNotificationAction[]>();
 
   const getAllBadgesFromEmbeddable = useCallback(async () => {
+    if (!showBadges) return;
     let currentBadges: EmbeddableBadgeAction[] =
       ((await getActionsForTrigger(PANEL_BADGE_TRIGGER, {
         embeddable,
@@ -45,9 +48,10 @@ export const useEmbeddablePanelBadges = (
       currentBadges = currentBadges.filter((badge) => disabledActions.indexOf(badge.id) === -1);
     }
     return currentBadges;
-  }, [embeddable, getActionsForTrigger]);
+  }, [embeddable, getActionsForTrigger, showBadges]);
 
   const getAllNotificationsFromEmbeddable = useCallback(async () => {
+    if (!showNotifications) return;
     let currentNotifications: EmbeddableNotificationAction[] =
       ((await getActionsForTrigger(PANEL_NOTIFICATION_TRIGGER, {
         embeddable,
@@ -60,7 +64,7 @@ export const useEmbeddablePanelBadges = (
       );
     }
     return currentNotifications;
-  }, [embeddable, getActionsForTrigger]);
+  }, [embeddable, getActionsForTrigger, showNotifications]);
 
   /**
    * On embeddable creation get initial badges & notifications then subscribe to all


### PR DESCRIPTION
## Summary
Fixes a regression introduced in https://github.com/elastic/kibana/pull/159837 where the Embeddable panel would show its header when given a custom `getActions` function and `showBadges` or `showNotifications` turned to false.

This caused a problem in the `infrastructure -> hosts` page where the title bars were being shown erroneously. 

![image](https://github.com/elastic/kibana/assets/14276393/980f53f9-c557-49a3-bea8-cb0e916dfb09)

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios