### PR TITLE
[Dashboard][Event annotations][Lens] append postfix when duplicate title instead of interrupting save flow

### DIFF
--- a/src/plugins/saved_objects/public/save_modal/saved_object_save_modal.tsx
+++ b/src/plugins/saved_objects/public/save_modal/saved_object_save_modal.tsx
@@ -237,6 +237,31 @@ export class SavedObjectSaveModal extends React.Component<Props, SaveModalState>
     }
   };
 
+  private saveSavedObjectAsNewGroup = async () => {
+    let duplicateIndex = 1;
+
+    while (true) {
+      this.setState({ hasTitleDuplicate: false });
+
+      const duplicateIndexPattern = duplicateIndex > 0 ? `[${duplicateIndex}]` : '';
+      const duplicatedTitle = `${this.state.title} ${duplicateIndexPattern}`;
+
+      const saveProps = {
+        newTitle: duplicatedTitle,
+        newCopyOnSave: this.state.copyOnSave,
+        isTitleDuplicateConfirmed: false,
+        onTitleDuplicate: this.onTitleDuplicate,
+        newDescription: this.state.visualizationDescription,
+      };
+
+      await this.props.onSave(saveProps);
+
+      if (!this.state.hasTitleDuplicate) break;
+
+      duplicateIndex++;
+    }
+  };
+
   private saveSavedObject = async () => {
     if (this.state.isLoading) {
       // ignore extra clicks
@@ -247,13 +272,17 @@ export class SavedObjectSaveModal extends React.Component<Props, SaveModalState>
       isLoading: true,
     });
 
-    await this.props.onSave({
-      newTitle: this.state.title,
-      newCopyOnSave: this.state.copyOnSave,
-      isTitleDuplicateConfirmed: this.state.isTitleDuplicateConfirmed,
-      onTitleDuplicate: this.onTitleDuplicate,
-      newDescription: this.state.visualizationDescription,
-    });
+    if (!this.state.copyOnSave) {
+      await this.props.onSave({
+        newTitle: this.state.title,
+        newCopyOnSave: this.state.copyOnSave,
+        isTitleDuplicateConfirmed: this.state.isTitleDuplicateConfirmed,
+        onTitleDuplicate: this.onTitleDuplicate,
+        newDescription: this.state.visualizationDescription,
+      });
+    } else {
+      this.saveSavedObjectAsNewGroup();
+    }
   };
 
   private onTitleChange = (event: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
 ## What does this PR do?
 * This feature addresses the problem of **duplicated titles** in **annotations** when saving. It adds a **postfix** `[n]` to the duplicated title, with **'n'** representing the current **copy count**. This **ensures** each duplicate title is uniquely identified and differentiated **during the saving** process when `Save as new group` toggle is set as `true`.
 
 ## Issue References
 * https://github.com/elastic/kibana/issues/161119
 
 ## Video/Screenshot Demo
 ##### Before:
https://www.loom.com/share/dce2338f8bd844c4aa4e09f40b7da0ac?sid=9c87043b-10b7-4110-b4f2-b07d810241d9

 ##### Fix:
https://www.loom.com/share/b6879c0ccebb48d1b36d808105c82940?sid=c7ca85d1-ae17-454f-ba2f-e49954ceb388

___
 
 This code was written and reviewed by GitStart Community. Growing future engineers, one PR at a time.