### PR TITLE
[8.9] [Infra UI] Hosts view test: fix apm services link (#162147)

### DIFF
--- a/x-pack/test/functional/apps/infra/hosts_view.ts
+++ b/x-pack/test/functional/apps/infra/hosts_view.ts
@@ -150,6 +150,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
   const returnTo = async (path: string, timeout = 2000) =>
     retry.waitForWithTimeout('returned to hosts view', timeout, async () => {
       await browser.goBack();
+      await pageObjects.header.waitUntilLoadingHasFinished();
       const currentUrl = await browser.getCurrentUrl();
       return !!currentUrl.match(path);
     });
@@ -313,35 +314,31 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
         });
       });
 
-      it('should navigate to Uptime after click', async () => {
-        await pageObjects.infraHostsView.clickFlyoutUptimeLink();
-        const url = parse(await browser.getCurrentUrl());
+      describe('Flyout links', () => {
+        it('should navigate to Uptime after click', async () => {
+          await pageObjects.infraHostsView.clickFlyoutUptimeLink();
+          const url = parse(await browser.getCurrentUrl());
 
-        const search = 'search=host.name: "Jennys-MBP.fritz.box" OR host.ip: "192.168.1.79"';
-        const query = decodeURIComponent(url.query ?? '');
+          const search = 'search=host.name: "Jennys-MBP.fritz.box" OR host.ip: "192.168.1.79"';
+          const query = decodeURIComponent(url.query ?? '');
 
-        expect(url.pathname).to.eql('/app/uptime/');
-        expect(query).to.contain(search);
+          expect(url.pathname).to.eql('/app/uptime/');
+          expect(query).to.contain(search);
 
-        await returnTo(HOSTS_VIEW_PATH);
-      });
+          await returnTo(HOSTS_VIEW_PATH);
+        });
+      
+        it('should navigate to APM services after click', async () => {
+          await pageObjects.infraHostsView.clickFlyoutApmServicesLink();
+          const url = parse(await browser.getCurrentUrl());
+          const query = decodeURIComponent(url.query ?? '');
+          const kuery = 'kuery=host.hostname:"Jennys-MBP.fritz.box"';
 
-      it('should navigate to APM services after click', async () => {
-        await pageObjects.infraHostsView.clickFlyoutApmServicesLink();
-        const url = parse(await browser.getCurrentUrl());
+          expect(url.pathname).to.eql('/app/apm/services');
+          expect(query).to.contain(kuery);
 
-        const query = decodeURIComponent(url.query ?? '');
-
-        const kuery = 'kuery=host.hostname:"Jennys-MBP.fritz.box"';
-        const rangeFrom = 'rangeFrom=2023-03-28T18:20:00.000Z';
-        const rangeTo = 'rangeTo=2023-03-28T18:21:00.000Z';
-
-        expect(url.pathname).to.eql('/app/apm/services');
-        expect(query).to.contain(kuery);
-        expect(query).to.contain(rangeFrom);
-        expect(query).to.contain(rangeTo);
-
-        await returnTo(HOSTS_VIEW_PATH);
+          await returnTo(HOSTS_VIEW_PATH);
+        });
       });
 
       describe('Processes Tab', () => {

--- a/x-pack/test/functional/apps/infra/hosts_view.ts
+++ b/x-pack/test/functional/apps/infra/hosts_view.ts
@@ -327,7 +327,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
 
           await returnTo(HOSTS_VIEW_PATH);
         });
-      
+
         it('should navigate to APM services after click', async () => {
           await pageObjects.infraHostsView.clickFlyoutApmServicesLink();
           const url = parse(await browser.getCurrentUrl());


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.9`:
 - [[Infra UI] Hosts view test: fix apm services link (#162147)](https://github.com/elastic/kibana/pull/162147)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"jennypavlova","email":"dzheni.pavlova@elastic.co"},"sourceCommit":{"committedDate":"2023-07-19T08:30:43Z","message":"[Infra UI] Hosts view test: fix apm services link (#162147)\n\nCloses https://github.com/elastic/kibana/issues/162051\r\nCloses #159368\r\n## Summary\r\n\r\nThis PR aims to make the APM services link test more stable. For some\r\nreason, some of the query parameters are not present in the URL the\r\nmoment we navigate but we can see in the screenshot that the correct\r\ndates are applied (it could be that the moment we load APM the URL is\r\nnot updated - when checking locally those parameters exist in the URL)\r\n<img width=\"1612\" alt=\"image\"\r\nsrc=\"https://github.com/elastic/kibana/assets/14139027/2363108a-329e-4f28-a0d8-9f177d01d4ef\">\r\n\r\n---------\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"e98abd0fb5896b573de7ab811534d134d15d7cb9","branchLabelMapping":{"^v8.10.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Infra Monitoring UI","release_note:skip","backport:prev-minor","v8.10.0"],"number":162147,"url":"https://github.com/elastic/kibana/pull/162147","mergeCommit":{"message":"[Infra UI] Hosts view test: fix apm services link (#162147)\n\nCloses https://github.com/elastic/kibana/issues/162051\r\nCloses #159368\r\n## Summary\r\n\r\nThis PR aims to make the APM services link test more stable. For some\r\nreason, some of the query parameters are not present in the URL the\r\nmoment we navigate but we can see in the screenshot that the correct\r\ndates are applied (it could be that the moment we load APM the URL is\r\nnot updated - when checking locally those parameters exist in the URL)\r\n<img width=\"1612\" alt=\"image\"\r\nsrc=\"https://github.com/elastic/kibana/assets/14139027/2363108a-329e-4f28-a0d8-9f177d01d4ef\">\r\n\r\n---------\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"e98abd0fb5896b573de7ab811534d134d15d7cb9"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.10.0","labelRegex":"^v8.10.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/162147","number":162147,"mergeCommit":{"message":"[Infra UI] Hosts view test: fix apm services link (#162147)\n\nCloses https://github.com/elastic/kibana/issues/162051\r\nCloses #159368\r\n## Summary\r\n\r\nThis PR aims to make the APM services link test more stable. For some\r\nreason, some of the query parameters are not present in the URL the\r\nmoment we navigate but we can see in the screenshot that the correct\r\ndates are applied (it could be that the moment we load APM the URL is\r\nnot updated - when checking locally those parameters exist in the URL)\r\n<img width=\"1612\" alt=\"image\"\r\nsrc=\"https://github.com/elastic/kibana/assets/14139027/2363108a-329e-4f28-a0d8-9f177d01d4ef\">\r\n\r\n---------\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"e98abd0fb5896b573de7ab811534d134d15d7cb9"}}]}] BACKPORT-->