### PR TITLE
[Security Solution] Test rule_details_ui/pages/rule_details/index.test.tsx logs a warning about wrong props passed to EuiSwitch

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/components/rules/rule_switch/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/rule_switch/index.tsx
@@ -88,7 +88,8 @@ export const RuleSwitchComponent = ({
         ) : (
           <StaticSwitch
             data-test-subj="ruleSwitch"
-            label={undefined}
+            showLabel={false}
+            label=""
             disabled={isDisabled}
             checked={enabled}
             onChange={onRuleStateChange}


### PR DESCRIPTION
## Summary

Related ticket: https://github.com/elastic/kibana/issues/147065

This PR fixes the warning within the `rule_details_ui/pages/rule_details/index.test.tsx` test which happens because instead of using required `EuiSwitch`'s `label` field we pass `undefined`.

Since, we do not intend to show the label we make it explicitly with `showLabel={false}` and set `label` to an empty string.

For more details see [the overview of the EuiSwitch](https://elastic.github.io/eui/#/forms/selection-controls) component.

