### PR TITLE
Failing ES Promotion: FTR Configs #22 / detection engine api security and spaces enabled - rule execution logic Non ECS fields in alert document source should fail creating alert when ECS field mapping is geo_point

### DIFF
--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/rule_execution_logic/non_ecs_fields.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/rule_execution_logic/non_ecs_fields.ts
@@ -57,7 +57,7 @@ export default ({ getService }: FtrProviderContext) => {
   };
 
   // FAILING ES PROMOTION: https://github.com/elastic/kibana/issues/154277
-  describe.skip('Non ECS fields in alert document source', () => {
+  describe('Non ECS fields in alert document source', () => {
     before(async () => {
       await esArchiver.load(
         'x-pack/test/functional/es_archives/security_solution/ecs_non_compliant'
@@ -232,7 +232,7 @@ export default ({ getService }: FtrProviderContext) => {
       // invalid ECS field is getting removed
       expect(alertSource).toHaveProperty('threat.enrichments', []);
 
-      expect(alertSource).toHaveProperty('threat.indicator.port', 443);
+      expect(alertSource).toHaveProperty(['threat', 'indicator.port'], 443);
     });
 
     // source client.bytes is text, ECS mapping for client.bytes is long
@@ -271,8 +271,8 @@ export default ({ getService }: FtrProviderContext) => {
 
       const { errors } = await indexAndCreatePreviewAlert(document);
 
-      expect(errors).toContain(
-        'Bulk Indexing of signals failed: failed to parse field [client.geo.location] of type [geo_point]'
+      expect(errors[0]).toContain(
+        'Bulk Indexing of signals failed: [1:1193] failed to parse field [client.geo.location] of type [geo_point]'
       );
     });
 

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/rule_execution_logic/non_ecs_fields.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/rule_execution_logic/non_ecs_fields.ts
@@ -271,8 +271,9 @@ export default ({ getService }: FtrProviderContext) => {
 
       const { errors } = await indexAndCreatePreviewAlert(document);
 
+      expect(errors[0]).toContain('Bulk Indexing of signals failed');
       expect(errors[0]).toContain(
-        'Bulk Indexing of signals failed: [1:1193] failed to parse field [client.geo.location] of type [geo_point]'
+        'failed to parse field [client.geo.location] of type [geo_point]'
       );
     });
 


### PR DESCRIPTION
## Summary

Failing tests ticket: https://github.com/elastic/kibana/issues/154277

This PR fixes the non ECS fields in alert document source failing tests.

There are two failing tests:
1. `should remove source array of keywords field from alert if ECS field mapping is nested` was filing due to wrong key path format passed to jest's `toHaveProperty`. When the field name has dot notation we should be using array format as a key path. See discussion [here](https://github.com/jestjs/jest/issues/5653) and usage examples [here](https://github.com/jestjs/jest/blob/main/docs/ExpectAPI.md#tohavepropertykeypath-value).
2. `should fail creating alert when ECS field mapping is geo_point` was failing due to changed error message format.

