### PR TITLE
[Cloud Security] rename 'Cloud Security Posture rule template' to 'Benchmark rules'

### DIFF
--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/constants.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/constants.tsx
@@ -86,7 +86,7 @@ export const AssetTitleMap: Record<DisplayedAssetType, string> = {
   csp_rule_template: i18n.translate(
     'xpack.fleet.epm.assetTitles.cloudSecurityPostureRuleTemplate',
     {
-      defaultMessage: 'Cloud Security Posture rule template',
+      defaultMessage: 'Benchmark rules',
     }
   ),
 };


### PR DESCRIPTION
## Summary

Renaming "Cloud Security Posture rule template" into "Benchmark rules"

A part of Quick Wins 8.10.0 https://github.com/elastic/security-team/issues/7167 

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)

### Screenshot
<img width="1725" alt="Screenshot 2023-07-19 at 15 38 51" src="https://github.com/elastic/kibana/assets/478762/8b663b7a-14e8-48cf-8dda-5f886ba70403">

