### PR TITLE
[Cloud Security] Render vuln flyout's description using markdown

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/pages/configurations/findings_flyout/findings_flyout.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/configurations/findings_flyout/findings_flyout.tsx
@@ -82,7 +82,7 @@ export const CodeBlock: React.FC<PropsOf<typeof EuiCodeBlock>> = (props) => (
   <EuiCodeBlock isCopyable paddingSize="s" overflowHeight={300} {...props} />
 );
 
-export const Markdown: React.FC<PropsOf<typeof EuiMarkdownFormat>> = (props) => (
+export const CspFlyoutMarkdown: React.FC<PropsOf<typeof EuiMarkdownFormat>> = (props) => (
   <EuiMarkdownFormat textSize="s" {...props} />
 );
 

--- a/x-pack/plugins/cloud_security_posture/public/pages/configurations/findings_flyout/overview_tab.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/configurations/findings_flyout/overview_tab.tsx
@@ -28,7 +28,7 @@ import {
 import { useLatestFindingsDataView } from '../../../common/api/use_latest_findings_data_view';
 import { useKibana } from '../../../common/hooks/use_kibana';
 import { CspFinding } from '../../../../common/schemas/csp_finding';
-import { CisKubernetesIcons, Markdown, CodeBlock } from './findings_flyout';
+import { CisKubernetesIcons, CspFlyoutMarkdown, CodeBlock } from './findings_flyout';
 
 type Accordion = Pick<EuiAccordionProps, 'title' | 'id' | 'initialIsOpen'> &
   Pick<EuiDescriptionListProps, 'listItems'>;
@@ -102,7 +102,7 @@ const getDetailsList = (data: CspFinding, discoverIndexLink: string | undefined)
 export const getRemediationList = (rule: CspFinding['rule']) => [
   {
     title: '',
-    description: <Markdown>{rule.remediation}</Markdown>,
+    description: <CspFlyoutMarkdown>{rule.remediation}</CspFlyoutMarkdown>,
   },
   ...(rule.impact
     ? [
@@ -110,7 +110,7 @@ export const getRemediationList = (rule: CspFinding['rule']) => [
           title: i18n.translate('xpack.csp.findings.findingsFlyout.overviewTab.impactTitle', {
             defaultMessage: 'Impact',
           }),
-          description: <Markdown>{rule.impact}</Markdown>,
+          description: <CspFlyoutMarkdown>{rule.impact}</CspFlyoutMarkdown>,
         },
       ]
     : []),
@@ -120,7 +120,7 @@ export const getRemediationList = (rule: CspFinding['rule']) => [
           title: i18n.translate('xpack.csp.findings.findingsFlyout.overviewTab.defaultValueTitle', {
             defaultMessage: 'Default Value',
           }),
-          description: <Markdown>{rule.default_value}</Markdown>,
+          description: <CspFlyoutMarkdown>{rule.default_value}</CspFlyoutMarkdown>,
         },
       ]
     : []),
@@ -128,7 +128,7 @@ export const getRemediationList = (rule: CspFinding['rule']) => [
     title: i18n.translate('xpack.csp.findings.findingsFlyout.overviewTab.rationaleTitle', {
       defaultMessage: 'Rationale',
     }),
-    description: <Markdown>{rule.rationale}</Markdown>,
+    description: <CspFlyoutMarkdown>{rule.rationale}</CspFlyoutMarkdown>,
   },
 ];
 

--- a/x-pack/plugins/cloud_security_posture/public/pages/configurations/findings_flyout/rule_tab.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/configurations/findings_flyout/rule_tab.tsx
@@ -9,7 +9,7 @@ import { EuiBadge, EuiDescriptionList } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
 import { CspFinding } from '../../../../common/schemas/csp_finding';
-import { CisKubernetesIcons, Markdown } from './findings_flyout';
+import { CisKubernetesIcons, CspFlyoutMarkdown } from './findings_flyout';
 
 export const getRuleList = (rule: CspFinding['rule']) => [
   {
@@ -22,7 +22,7 @@ export const getRuleList = (rule: CspFinding['rule']) => [
     title: i18n.translate('xpack.csp.findings.findingsFlyout.ruleTab.descriptionTitle', {
       defaultMessage: 'Description',
     }),
-    description: <Markdown>{rule.description}</Markdown>,
+    description: <CspFlyoutMarkdown>{rule.description}</CspFlyoutMarkdown>,
   },
   {
     title: i18n.translate('xpack.csp.findings.findingsFlyout.ruleTab.tagsTitle', {
@@ -54,7 +54,7 @@ export const getRuleList = (rule: CspFinding['rule']) => [
     title: i18n.translate('xpack.csp.findings.findingsFlyout.ruleTab.profileApplicabilityTitle', {
       defaultMessage: 'Profile Applicability',
     }),
-    description: <Markdown>{rule.profile_applicability}</Markdown>,
+    description: <CspFlyoutMarkdown>{rule.profile_applicability}</CspFlyoutMarkdown>,
   },
   {
     title: i18n.translate('xpack.csp.findings.findingsFlyout.ruleTab.benchmarkTitle', {
@@ -66,7 +66,7 @@ export const getRuleList = (rule: CspFinding['rule']) => [
     title: i18n.translate('xpack.csp.findings.findingsFlyout.ruleTab.auditTitle', {
       defaultMessage: 'Audit',
     }),
-    description: <Markdown>{rule.audit}</Markdown>,
+    description: <CspFlyoutMarkdown>{rule.audit}</CspFlyoutMarkdown>,
   },
   ...(rule.references
     ? [
@@ -74,7 +74,7 @@ export const getRuleList = (rule: CspFinding['rule']) => [
           title: i18n.translate('xpack.csp.findings.findingsFlyout.ruleTab.referencesTitle', {
             defaultMessage: 'References',
           }),
-          description: <Markdown>{rule.references}</Markdown>,
+          description: <CspFlyoutMarkdown>{rule.references}</CspFlyoutMarkdown>,
         },
       ]
     : []),

--- a/x-pack/plugins/cloud_security_posture/public/pages/vulnerabilities/vulnerabilities_finding_flyout/vulnerability_overview_tab.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/vulnerabilities/vulnerabilities_finding_flyout/vulnerability_overview_tab.tsx
@@ -19,6 +19,7 @@ import moment from 'moment';
 import React from 'react';
 import { euiThemeVars } from '@kbn/ui-theme';
 import { i18n } from '@kbn/i18n';
+import { Markdown } from '../../configurations/findings_flyout/findings_flyout';
 import { NvdLogo } from '../../../assets/icons/nvd_logo_svg';
 import { CVSScoreBadge } from '../../../components/vulnerability_badges';
 import { CVSScoreProps, VectorScoreBase, Vendor, Vulnerability } from '../types';
@@ -245,13 +246,7 @@ export const VulnerabilityOverviewTab = ({ vulnerability }: VulnerabilityTabProp
             defaultMessage="Description"
           />
         </h4>
-        <EuiText>
-          <FormattedMessage
-            id="xpack.csp.vulnerabilities.vulnerabilityOverviewTab.descriptionText"
-            defaultMessage="{description}"
-            values={{ description: vulnerability?.description }}
-          />
-        </EuiText>
+        <Markdown>{vulnerability?.description || ''}</Markdown>
       </EuiFlexItem>
 
       <EuiHorizontalRule css={horizontalStyle} />

--- a/x-pack/plugins/cloud_security_posture/public/pages/vulnerabilities/vulnerabilities_finding_flyout/vulnerability_overview_tab.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/vulnerabilities/vulnerabilities_finding_flyout/vulnerability_overview_tab.tsx
@@ -19,7 +19,7 @@ import moment from 'moment';
 import React from 'react';
 import { euiThemeVars } from '@kbn/ui-theme';
 import { i18n } from '@kbn/i18n';
-import { Markdown } from '../../configurations/findings_flyout/findings_flyout';
+import { CspFlyoutMarkdown } from '../../configurations/findings_flyout/findings_flyout';
 import { NvdLogo } from '../../../assets/icons/nvd_logo_svg';
 import { CVSScoreBadge } from '../../../components/vulnerability_badges';
 import { CVSScoreProps, VectorScoreBase, Vendor, Vulnerability } from '../types';
@@ -246,7 +246,7 @@ export const VulnerabilityOverviewTab = ({ vulnerability }: VulnerabilityTabProp
             defaultMessage="Description"
           />
         </h4>
-        <Markdown>{vulnerability?.description || ''}</Markdown>
+        <CspFlyoutMarkdown>{vulnerability?.description || ''}</CspFlyoutMarkdown>
       </EuiFlexItem>
 
       <EuiHorizontalRule css={horizontalStyle} />

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -11366,7 +11366,6 @@
     "xpack.csp.vulnerabilities.vulnerabilitiesTableCell.addFilterButtonTooltip": "添加 {columnId} 筛选",
     "xpack.csp.vulnerabilities.vulnerabilitiesTableCell.addNegatedFilterButtonTooltip": "添加 {columnId} 作废筛选",
     "xpack.csp.vulnerabilities.vulnerabilitiesTableCell.addNegateFilterButton": "添加 {columnId} 作废筛选",
-    "xpack.csp.vulnerabilities.vulnerabilityOverviewTab.descriptionText": "{description}",
     "xpack.csp.vulnerabilities.vulnerabilityOverviewTile.publishedDateText": "{date}",
     "xpack.csp.vulnerabilitiesByResource.totalResources": "{total, plural, other {# 项资源}}",
     "xpack.csp.vulnerabilitiesByResource.totalVulnerabilities": "{total, plural, other {# 个漏洞}}",


### PR DESCRIPTION
## Summary

Part of [Quick wins task](https://github.com/elastic/security-team/issues/7167)

I've used an exported markdown component from the misconfigs flyout in order to keep them both aligned in terms of styles. there is a case to be made to move this markdown component to an higher directory but i think its still very minor and we can start doing that if this scenario will repeat

![image](https://github.com/elastic/kibana/assets/51442161/53ab686c-4400-405c-bd72-1b54ea29f752)