### PR TITLE
[Serverless nav] Remove link to "performance"

### DIFF
--- a/packages/shared-ux/chrome/navigation/src/ui/__snapshots__/default_navigation.test.tsx.snap
+++ b/packages/shared-ux/chrome/navigation/src/ui/__snapshots__/default_navigation.test.tsx.snap
@@ -626,20 +626,6 @@ Array [
           Object {
             "children": undefined,
             "deepLink": undefined,
-            "href": "https://cloud.elastic.co/deployments/123456789/performance",
-            "id": "cloudLinkPerformance",
-            "isActive": false,
-            "path": Array [
-              "project_settings_project_nav",
-              "settings",
-              "cloudLinkPerformance",
-            ],
-            "renderItem": undefined,
-            "title": "Mock Performance",
-          },
-          Object {
-            "children": undefined,
-            "deepLink": undefined,
             "href": "https://cloud.elastic.co/account/billing",
             "id": "cloudLinkBilling",
             "isActive": false,

--- a/packages/shared-ux/chrome/navigation/src/ui/default_navigation.test.tsx
+++ b/packages/shared-ux/chrome/navigation/src/ui/default_navigation.test.tsx
@@ -712,14 +712,6 @@ describe('<DefaultNavigation />', () => {
 
         expect(
           await (
-            await findByTestId(
-              /nav-item-project_settings_project_nav.settings.cloudLinkPerformance/
-            )
-          ).textContent
-        ).toBe('Mock PerformanceExternal link');
-
-        expect(
-          await (
             await findByTestId(/nav-item-project_settings_project_nav.settings.cloudLinkBilling/)
           ).textContent
         ).toBe('Mock Billing & SubscriptionsExternal link');

--- a/packages/shared-ux/chrome/navigation/src/ui/default_navigation.tsx
+++ b/packages/shared-ux/chrome/navigation/src/ui/default_navigation.tsx
@@ -85,10 +85,6 @@ const getDefaultNavigationTree = (
                 cloudLink: 'userAndRoles',
               },
               {
-                id: 'cloudLinkPerformance',
-                cloudLink: 'performance',
-              },
-              {
                 id: 'cloudLinkBilling',
                 cloudLink: 'billingAndSub',
               },

--- a/x-pack/plugins/serverless_observability/public/components/side_navigation/index.tsx
+++ b/x-pack/plugins/serverless_observability/public/components/side_navigation/index.tsx
@@ -175,10 +175,6 @@ const navigationTree: NavigationTreeDefinition = {
               cloudLink: 'userAndRoles',
             },
             {
-              id: 'cloudLinkPerformance',
-              cloudLink: 'performance',
-            },
-            {
               id: 'cloudLinkBilling',
               cloudLink: 'billingAndSub',
             },

--- a/x-pack/plugins/serverless_search/public/layout/nav.tsx
+++ b/x-pack/plugins/serverless_search/public/layout/nav.tsx
@@ -146,10 +146,6 @@ const navigationTree: NavigationTreeDefinition = {
               cloudLink: 'userAndRoles',
             },
             {
-              id: 'cloudLinkPerformance',
-              cloudLink: 'performance',
-            },
-            {
               id: 'cloudLinkBilling',
               cloudLink: 'billingAndSub',
             },


### PR DESCRIPTION
Control Plane team will not be including the "performance" as part of Gated Preview so I removed it from the search and observability navigations.