### PR TITLE
[8.9] chore(NA): use a n2-8-spot instance to build storybooks (#162200)

### DIFF
--- a/.buildkite/pipelines/on_merge.yml
+++ b/.buildkite/pipelines/on_merge.yml
@@ -139,7 +139,7 @@ steps:
   - command: .buildkite/scripts/steps/storybooks/build_and_upload.sh
     label: 'Build Storybooks'
     agents:
-      queue: n2-4-spot
+      queue: n2-8-spot
     key: storybooks
     timeout_in_minutes: 60
     retry:

--- a/.buildkite/scripts/steps/storybooks/build_and_upload.ts
+++ b/.buildkite/scripts/steps/storybooks/build_and_upload.ts
@@ -42,7 +42,7 @@ const STORYBOOKS = [
   'lists',
   'observability',
   'presentation',
-  'security_solution',
+  // 'security_solution', => This build is error out and failing CI. SEE: https://github.com/elastic/kibana/issues/162290
   'serverless',
   'shared_ux',
   'triggers_actions_ui',


### PR DESCRIPTION
This is a backport from https://github.com/elastic/kibana/pull/162200