### PR TITLE
Fix @kbn/import-resolver detection of nested node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 !/src/dev/npm/integration_tests/__fixtures__/fixture1/node_modules
 !/src/dev/notice/__fixtures__/node_modules
 !/packages/kbn-import-resolver/src/__fixtures__/node_modules
+!/packages/kbn-import-resolver/src/__fixtures__/packages/box/node_modules
 trash
 /optimize
 /built_assets

--- a/packages/kbn-import-resolver/src/import_resolver.ts
+++ b/packages/kbn-import-resolver/src/import_resolver.ts
@@ -86,7 +86,7 @@ export class ImportResolver {
 
   getPackageIdForPath(path: string) {
     const relative = Path.relative(this.cwd, path);
-    if (relative.startsWith('..')) {
+    if (relative.startsWith('..') || path.includes(NODE_MODULE_SEG)) {
       return null;
     }
 

--- a/packages/kbn-import-resolver/src/integration_tests/import_resolver.test.ts
+++ b/packages/kbn-import-resolver/src/integration_tests/import_resolver.test.ts
@@ -42,6 +42,17 @@ describe('#resolve()', () => {
     `);
   });
 
+  it('resolves nested node_module imports', () => {
+    expect(resolver.resolve('bar', Path.join(FIXTURES_DIR, 'packages', 'box')))
+      .toMatchInlineSnapshot(`
+      Object {
+        "absolute": <absolute path>/packages/kbn-import-resolver/src/__fixtures__/packages/box/node_modules/bar/index.js,
+        "nodeModule": "bar",
+        "type": "file",
+      }
+    `);
+  });
+
   it('resolves requests to src/', () => {
     expect(resolver.resolve('src/core/public', FIXTURES_DIR)).toMatchInlineSnapshot(`
       Object {


### PR DESCRIPTION
Ensure that a plugin containing a nested `node_modules` folder, correctly identifies imports from that folder as regular node modules instead of relative imports.

~🚨 This issue was introduced in #146212 but somehow hasn't failed on CI 🤷~

## How to reproduce

~For example, when running the following command without the fix introduced by this PR:~

```sh
node scripts/eslint x-pack/plugins/infra/server/routes/metadata/lib/get_node_info.ts --no-cache
```

~The following ESLint error would be produced:~

```
/Users/watson/code/elastic/kibana/x-pack/plugins/infra/server/routes/metadata/lib/get_node_info.ts
  9:35  error  Use import request [../../../../node_modules/lodash/lodash]  @kbn/imports/uniform_imports
```

~Obviously, this is not correct as `import {...} from 'lodash'` should not be rewritten as `import {...} from '../../../../node_modules/lodash/lodash'`.~

~In this instance, it's because `x-pack/plugins/infra` contains `node_modules` folder containing its own version of `lodash`, which is then wrongly interpreted as being part of the `infra` plugin and hence is re-written with a relative path.~

*Update:* Turns out that I, for some reason, had a stray `node_modules` folder inside `x-pack/plugins/infra` which wasn't supposed to be there (ignored by git). So this isn't really a big issue. However, I still believe that there's a logic error in the import resolver that is fixed by this PR.

## Alternative fix

Instead of adding the check for `path.includes(NODE_MODULE_SEG)` to the `getPackageIdForPath` function, this could also have been achieved by simply swapping these two if-blocks inside the `tryNodeResolve` function:

https://github.com/elastic/kibana/blob/e160ea511dddc0918395c8b9a481eb09ea5c51ca/packages/kbn-import-resolver/src/import_resolver.ts#L177-L196

<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->