### PR TITLE
Add feature flag for new Threshold Alert details page

### DIFF
--- a/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker
+++ b/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker
@@ -307,6 +307,7 @@ kibana_vars=(
     xpack.observability.unsafe.alertDetails.metrics.enabled
     xpack.observability.unsafe.alertDetails.logs.enabled
     xpack.observability.unsafe.alertDetails.uptime.enabled
+    xpack.observability.unsafe.alertDetails.observability.enabled
     xpack.observability.unsafe.thresholdRule.enabled
     xpack.observability.compositeSlo.enabled
     xpack.reporting.capture.browser.autoDownload

--- a/test/plugin_functional/test_suites/core_plugins/rendering.ts
+++ b/test/plugin_functional/test_suites/core_plugins/rendering.ts
@@ -284,6 +284,7 @@ export default function ({ getService }: PluginFunctionalProviderContext) {
         'xpack.observability.unsafe.alertDetails.metrics.enabled (boolean)',
         'xpack.observability.unsafe.alertDetails.logs.enabled (boolean)',
         'xpack.observability.unsafe.alertDetails.uptime.enabled (boolean)',
+        'xpack.observability.unsafe.alertDetails.observability.enabled (boolean)',
         'xpack.observability.unsafe.thresholdRule.enabled (boolean)',
         'xpack.observability_onboarding.ui.enabled (boolean)',
       ];

--- a/x-pack/README.md
+++ b/x-pack/README.md
@@ -26,6 +26,12 @@ xpack.observability.unsafe.alertDetails.uptime.enabled: true
 
 **[For Uptime rule type]** In Kibana configuration, will allow the user to navigate to the new Alert Details page, instead of the Alert Flyout when clicking on `View alert details` in the Alert table
 
+```yaml
+xpack.observability.unsafe.alertDetails.observability.enabled: true
+```
+
+**[For Observability Threshold rule type]** In Kibana configuration, will allow the user to navigate to the new Alert Details page, instead of the Alert Flyout when clicking on `View alert details` in the Alert table
+
 # Development
 
 By default, Kibana will run with X-Pack installed as mentioned in the [contributing guide](../CONTRIBUTING.md).

--- a/x-pack/plugins/observability/public/pages/overview/overview.stories.tsx
+++ b/x-pack/plugins/observability/public/pages/overview/overview.stories.tsx
@@ -84,6 +84,7 @@ const withCore = makeDecorator({
           logs: { enabled: false },
           metrics: { enabled: false },
           uptime: { enabled: false },
+          observability: { enabled: false },
         },
         thresholdRule: { enabled: false },
       },

--- a/x-pack/plugins/observability/public/pages/rules/rules.test.tsx
+++ b/x-pack/plugins/observability/public/pages/rules/rules.test.tsx
@@ -40,6 +40,7 @@ jest.spyOn(pluginContext, 'usePluginContext').mockImplementation(() => ({
         logs: { enabled: false },
         metrics: { enabled: false },
         uptime: { enabled: false },
+        observability: { enabled: false },
       },
       thresholdRule: { enabled: false },
     },

--- a/x-pack/plugins/observability/public/plugin.ts
+++ b/x-pack/plugins/observability/public/plugin.ts
@@ -86,6 +86,9 @@ export interface ConfigSchema {
       uptime: {
         enabled: boolean;
       };
+      observability: {
+        enabled: boolean;
+      };
     };
     thresholdRule: {
       enabled: boolean;

--- a/x-pack/plugins/observability/public/utils/is_alert_details_enabled.ts
+++ b/x-pack/plugins/observability/public/utils/is_alert_details_enabled.ts
@@ -14,7 +14,7 @@ const ALLOWED_RULE_TYPES = ['apm.transaction_duration'];
 const isUnsafeAlertDetailsFlag = (
   subject: string
 ): subject is keyof ConfigSchema['unsafe']['alertDetails'] =>
-  ['uptime', 'logs', 'metrics'].includes(subject);
+  ['uptime', 'logs', 'metrics', 'observability'].includes(subject);
 
 // We are mapping the ruleTypeId from the feature flag with the ruleTypeId from the alert
 // to know whether the feature flag is enabled or not.

--- a/x-pack/plugins/observability/public/utils/kibana_react.storybook_decorator.tsx
+++ b/x-pack/plugins/observability/public/utils/kibana_react.storybook_decorator.tsx
@@ -31,6 +31,7 @@ export function KibanaReactStorybookDecorator(Story: ComponentType) {
         logs: { enabled: false },
         metrics: { enabled: false },
         uptime: { enabled: false },
+        observability: { enabled: false },
       },
       thresholdRule: { enabled: false },
     },

--- a/x-pack/plugins/observability/public/utils/test_helper.tsx
+++ b/x-pack/plugins/observability/public/utils/test_helper.tsx
@@ -35,6 +35,7 @@ const defaultConfig: ConfigSchema = {
       logs: { enabled: false },
       metrics: { enabled: false },
       uptime: { enabled: false },
+      observability: { enabled: false },
     },
     thresholdRule: { enabled: false },
   },

--- a/x-pack/plugins/observability/server/index.ts
+++ b/x-pack/plugins/observability/server/index.ts
@@ -42,6 +42,9 @@ const configSchema = schema.object({
       uptime: schema.object({
         enabled: schema.boolean({ defaultValue: false }),
       }),
+      observability: schema.object({
+        enabled: schema.boolean({ defaultValue: false }),
+      }),
     }),
     thresholdRule: schema.object({
       enabled: schema.boolean({ defaultValue: false }),


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/162393

Adds a new feature flag `xpack.observability.unsafe.alertDetails.observability.enabled` to show/hide threshold alert details page until it is ready for GA.