### PR TITLE
Fix task manager error message on Kibana startup

### DIFF
--- a/x-pack/plugins/security_solution/server/endpoint/lib/metadata/check_metadata_transforms_task.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/lib/metadata/check_metadata_transforms_task.ts
@@ -96,7 +96,7 @@ export class CheckMetadataTransformsTask {
     // if task was not `.start()`'d yet, then exit
     if (!this.wasStarted) {
       this.logger.debug('[runTask()] Aborted. MetadataTask not started yet');
-      return;
+      return { state: taskInstance.state };
     }
 
     // Check that this task is current
@@ -121,14 +121,14 @@ export class CheckMetadataTransformsTask {
       const errMessage = `failed to get transform stats with error: ${err}`;
       this.logger.error(errMessage);
 
-      return;
+      return { state: taskInstance.state };
     }
 
     const packageClient = this.endpointAppContext.service.getInternalFleetServices().packages;
     const installation = await packageClient.getInstallation(FLEET_ENDPOINT_PACKAGE);
     if (!installation) {
       this.logger.info('no endpoint installation found');
-      return;
+      return { state: taskInstance.state };
     }
     const expectedTransforms = installation.installed_es.filter(
       (asset) => asset.type === ElasticsearchAssetType.transform


### PR DESCRIPTION
This PR fixes an error logged on Kibana startup by making the `endpoint:metadata-check-transforms-task` task always return the state object.

### Error logged
```
[2023-07-24T11:00:25.201-04:00][ERROR][plugins.taskManager] Task endpoint:metadata-check-transforms-task "endpoint:metadata-check-transforms-task:0.0.1" failed: Error: [restartAttempts]: expected value of type [object] but got [undefined]
```
### Steps to reproduce
1. Startup a fresh Kibana from main
2. Notice the error logged

### Steps to verify PR:
1. Startup a fresh Kibana from main
2. Notice the error is no longer logged