### PR TITLE
Explicitly fail tests owned by Elastic Security to test failed test triaging workflows

### DIFF
--- a/x-pack/plugins/security_solution/cypress/e2e/value_lists/value_lists.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/value_lists/value_lists.cy.ts
@@ -53,6 +53,8 @@ describe('value lists', () => {
       });
 
       it('creates a "keyword" list from an uploaded file', () => {
+        // explicitly fail this test
+        expect(false).toBe(true);
         const listName = 'value_list.txt';
         selectValueListType('keyword');
         selectValueListsFile(listName);


### PR DESCRIPTION
See https://github.com/elastic/kibana-operations/pull/4
Note: this will never be merged. I made it because I thought it just might help with this error: https://buildkite.com/elastic/kibana-on-merge-unsupported-ftrs/builds/4772#018988e2-8b6c-4209-adaa-c1eee3732af1/254-261