### PR TITLE
Clean up imports of ESLint types

### DIFF
--- a/packages/kbn-eslint-plugin-disable/src/helpers/regex.ts
+++ b/packages/kbn-eslint-plugin-disable/src/helpers/regex.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import type Eslint from 'eslint';
+import type { AST } from 'eslint';
 
 const ESLINT_DISABLE_RE = /^eslint-disable(?:-next-line|-line)?(?<rulesBlock>.*)/;
 
@@ -17,16 +17,16 @@ export enum ESLINT_DISABLE_VALUE {
 }
 
 export interface ParsedEslintDisableComment {
-  type: Eslint.AST.Program['comments'][0]['type'];
-  range: Eslint.AST.Program['comments'][0]['range'];
-  loc: Eslint.AST.Program['comments'][0]['loc'];
-  value: Eslint.AST.Program['comments'][0]['value'];
+  type: AST.Program['comments'][0]['type'];
+  range: AST.Program['comments'][0]['range'];
+  loc: AST.Program['comments'][0]['loc'];
+  value: AST.Program['comments'][0]['value'];
   disableValueType: ESLINT_DISABLE_VALUE;
   rules: string[];
 }
 
 export function parseEslintDisableComment(
-  comment: Eslint.AST.Program['comments'][0]
+  comment: AST.Program['comments'][0]
 ): ParsedEslintDisableComment | undefined {
   const commentVal = comment.value.trim();
   const nakedESLintRegexResult = commentVal.match(ESLINT_DISABLE_RE);

--- a/packages/kbn-eslint-plugin-disable/src/helpers/report.ts
+++ b/packages/kbn-eslint-plugin-disable/src/helpers/report.ts
@@ -6,12 +6,12 @@
  * Side Public License, v 1.
  */
 
-import type Eslint from 'eslint';
+import type { AST } from 'eslint';
 import { ESLINT_DISABLE_VALUE, ParsedEslintDisableComment } from './regex';
 
 export function getReportLocFromComment(
   comment: ParsedEslintDisableComment
-): Eslint.AST.SourceLocation | undefined {
+): AST.SourceLocation | undefined {
   const cStart = comment?.loc?.start;
   const cEnd = comment?.loc?.end;
   const cStartLine = comment?.loc?.start?.line;

--- a/packages/kbn-eslint-plugin-disable/src/rules/no_naked_eslint_disable.ts
+++ b/packages/kbn-eslint-plugin-disable/src/rules/no_naked_eslint_disable.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import Eslint from 'eslint';
+import type { Rule, AST } from 'eslint';
 import { getReportLocFromComment, parseEslintDisableComment } from '../helpers';
 
 export const NAKED_DISABLE_MSG_ID = 'no-naked-eslint-disable';
@@ -15,7 +15,7 @@ const messages = {
     'Using a naked eslint disable is not allowed. Please specify the specific rules to disable.',
 };
 
-const meta: Eslint.Rule.RuleMetaData = {
+const meta: Rule.RuleMetaData = {
   type: 'problem',
   fixable: 'code',
   docs: {
@@ -25,7 +25,7 @@ const meta: Eslint.Rule.RuleMetaData = {
   messages,
 };
 
-const create = (context: Eslint.Rule.RuleContext): Eslint.Rule.RuleListener => {
+const create = (context: Rule.RuleContext): Rule.RuleListener => {
   return {
     Program(node) {
       const nodeComments = node.comments || [];
@@ -56,7 +56,7 @@ const create = (context: Eslint.Rule.RuleContext): Eslint.Rule.RuleListener => {
           loc: reportLoc,
           messageId: NAKED_DISABLE_MSG_ID,
           fix(fixer) {
-            return fixer.removeRange(parsedEslintDisable.range as Eslint.AST.Range);
+            return fixer.removeRange(parsedEslintDisable.range as AST.Range);
           },
         });
       });
@@ -64,7 +64,7 @@ const create = (context: Eslint.Rule.RuleContext): Eslint.Rule.RuleListener => {
   };
 };
 
-export const NoNakedESLintDisableRule: Eslint.Rule.RuleModule = {
+export const NoNakedESLintDisableRule: Rule.RuleModule = {
   meta,
   create,
 };

--- a/packages/kbn-eslint-plugin-disable/src/rules/no_protected_eslint_disable.ts
+++ b/packages/kbn-eslint-plugin-disable/src/rules/no_protected_eslint_disable.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import Eslint from 'eslint';
+import type { Rule, AST } from 'eslint';
 import { PROTECTED_RULES, getReportLocFromComment, parseEslintDisableComment } from '../helpers';
 
 export const PROTECTED_DISABLE_MSG_ID = 'no-protected-eslint-disable';
@@ -15,7 +15,7 @@ const messages = {
     "The rule '{{ disabledRuleName }}' is protected and disabling it is not allowed. Please remove it from the statement.",
 };
 
-const meta: Eslint.Rule.RuleMetaData = {
+const meta: Rule.RuleMetaData = {
   type: 'problem',
   fixable: 'code',
   docs: {
@@ -24,7 +24,7 @@ const meta: Eslint.Rule.RuleMetaData = {
   messages,
 };
 
-const create = (context: Eslint.Rule.RuleContext): Eslint.Rule.RuleListener => {
+const create = (context: Rule.RuleContext): Rule.RuleListener => {
   return {
     Program(node) {
       const nodeComments = node.comments || [];
@@ -68,7 +68,7 @@ const create = (context: Eslint.Rule.RuleContext): Eslint.Rule.RuleListener => {
           fix(fixer) {
             // if we only have a single disabled rule and that is protected, we can remove the entire comment
             if (disabledRules.length === 1) {
-              return fixer.removeRange(parsedEslintDisable.range as Eslint.AST.Range);
+              return fixer.removeRange(parsedEslintDisable.range as AST.Range);
             }
 
             // it's impossible to fix as we don't have a range
@@ -80,7 +80,7 @@ const create = (context: Eslint.Rule.RuleContext): Eslint.Rule.RuleListener => {
             const fixedComment = ` ${parsedEslintDisable.disableValueType} ${remainingRules.join(
               ', '
             )}${parsedEslintDisable.type === 'Block' ? ' ' : ''}`;
-            const rangeToFix: Eslint.AST.Range =
+            const rangeToFix: AST.Range =
               parsedEslintDisable.type === 'Line'
                 ? [parsedEslintDisable.range[0] + 2, parsedEslintDisable.range[1]]
                 : [parsedEslintDisable.range[0] + 2, parsedEslintDisable.range[1] - 2];
@@ -93,7 +93,7 @@ const create = (context: Eslint.Rule.RuleContext): Eslint.Rule.RuleListener => {
   };
 };
 
-export const NoProtectedESLintDisableRule: Eslint.Rule.RuleModule = {
+export const NoProtectedESLintDisableRule: Rule.RuleModule = {
   meta,
   create,
 };

--- a/packages/kbn-eslint-plugin-imports/src/get_import_resolver.ts
+++ b/packages/kbn-eslint-plugin-imports/src/get_import_resolver.ts
@@ -8,7 +8,7 @@
 
 import { ImportResolver } from '@kbn/import-resolver';
 import { REPO_ROOT } from '@kbn/repo-info';
-import { Rule } from 'eslint';
+import type { Rule } from 'eslint';
 import { RUNNING_IN_EDITOR } from './helpers/running_in_editor';
 
 let importResolverCache: ImportResolver | undefined;

--- a/packages/kbn-eslint-plugin-imports/src/helpers/report.ts
+++ b/packages/kbn-eslint-plugin-imports/src/helpers/report.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import Eslint from 'eslint';
+import type { Rule } from 'eslint';
 import { SomeNode } from './visit_all_import_statements';
 
 interface ReportOptions {
@@ -18,7 +18,7 @@ interface ReportOptions {
 /**
  * Simple wrapper around context.report so that the types work better with typescript-estree
  */
-export function report(context: Eslint.Rule.RuleContext, options: ReportOptions) {
+export function report(context: Rule.RuleContext, options: ReportOptions) {
   context.report({
     node: options.node as any,
     message: options.message,

--- a/packages/kbn-eslint-plugin-imports/src/helpers/source.ts
+++ b/packages/kbn-eslint-plugin-imports/src/helpers/source.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { Rule } from 'eslint';
+import type { Rule } from 'eslint';
 
 /**
  * Get the path of the sourcefile being linted

--- a/packages/kbn-eslint-plugin-imports/src/helpers/visit_all_import_statements.ts
+++ b/packages/kbn-eslint-plugin-imports/src/helpers/visit_all_import_statements.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { Rule } from 'eslint';
+import type { Rule } from 'eslint';
 import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/typescript-estree';
 import * as T from '@babel/types';
 import { ImportType } from '@kbn/import-resolver';

--- a/packages/kbn-eslint-plugin-imports/src/rules/exports_moved_packages.ts
+++ b/packages/kbn-eslint-plugin-imports/src/rules/exports_moved_packages.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { Rule, AST } from 'eslint';
+import type { Rule, AST } from 'eslint';
 import * as T from '@babel/types';
 import { TSESTree } from '@typescript-eslint/typescript-estree';
 

--- a/packages/kbn-eslint-plugin-imports/src/rules/no_boundary_crossing.ts
+++ b/packages/kbn-eslint-plugin-imports/src/rules/no_boundary_crossing.ts
@@ -10,7 +10,7 @@ import Path from 'path';
 
 import { TSESTree } from '@typescript-eslint/typescript-estree';
 import * as Bt from '@babel/types';
-import { Rule } from 'eslint';
+import type { Rule } from 'eslint';
 import ESTree from 'estree';
 import { ModuleType } from '@kbn/repo-source-classifier';
 

--- a/packages/kbn-eslint-plugin-imports/src/rules/no_unresolvable_imports.ts
+++ b/packages/kbn-eslint-plugin-imports/src/rules/no_unresolvable_imports.ts
@@ -7,7 +7,7 @@
  */
 
 import Path from 'path';
-import { Rule } from 'eslint';
+import type { Rule } from 'eslint';
 
 import { report } from '../helpers/report';
 import { getSourcePath } from '../helpers/source';

--- a/packages/kbn-eslint-plugin-imports/src/rules/no_unused_imports.ts
+++ b/packages/kbn-eslint-plugin-imports/src/rules/no_unused_imports.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { Rule, Scope, AST } from 'eslint';
+import type { Rule, Scope, AST } from 'eslint';
 import type { Comment } from 'estree';
 import * as T from '@babel/types';
 import { TSESTree } from '@typescript-eslint/typescript-estree';

--- a/packages/kbn-eslint-plugin-imports/src/rules/uniform_imports.ts
+++ b/packages/kbn-eslint-plugin-imports/src/rules/uniform_imports.ts
@@ -8,7 +8,7 @@
 
 import Path from 'path';
 
-import Eslint from 'eslint';
+import type { Rule } from 'eslint';
 import { getRelativeImportReq, getPackageRelativeImportReq } from '@kbn/import-resolver';
 
 import { report } from '../helpers/report';
@@ -16,7 +16,7 @@ import { visitAllImportStatements } from '../helpers/visit_all_import_statements
 import { getSourcePath } from '../helpers/source';
 import { getImportResolver } from '../get_import_resolver';
 
-export const UniformImportsRule: Eslint.Rule.RuleModule = {
+export const UniformImportsRule: Rule.RuleModule = {
   meta: {
     fixable: 'code',
     docs: {


### PR DESCRIPTION
Align on _one_ way to import eslint types, so it's the same across the entire code-base.

This is in preparation for upgrading ESLint from v7 to v8 in #162309.

The rules followed are:

- All ESLint type imports must use the `type` keyword.
- Don't just import everything into a big `Eslint` object, but import only the types needed.

These two rules seems to be the common approach used in the rest of the code-base.

<!--ONMERGE {"backportTargets":["7.17","8.9"]} ONMERGE-->