### PR TITLE
Remove eslint-plugin-prefer-object-spread dependency

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -639,7 +639,7 @@ module.exports = {
       files: ['scripts/**/*.js', 'src/setup_node_env/**/*.js'],
       rules: {
         'import/no-commonjs': 'off',
-        'prefer-object-spread/prefer-object-spread': 'off',
+        'prefer-object-spread': 'off',
         'no-var': 'off',
         'prefer-const': 'off',
         'prefer-destructuring': 'off',
@@ -672,7 +672,7 @@ module.exports = {
         '**/browser_exec_scripts/**/*.js',
       ],
       rules: {
-        'prefer-object-spread/prefer-object-spread': 'off',
+        'prefer-object-spread': 'off',
         'no-var': 'off',
         'prefer-const': 'off',
         'prefer-destructuring': 'off',
@@ -708,7 +708,7 @@ module.exports = {
       excludedFiles: ['**/integration_tests/**/*'],
       rules: {
         'import/no-commonjs': 'off',
-        'prefer-object-spread/prefer-object-spread': 'off',
+        'prefer-object-spread': 'off',
         'no-restricted-syntax': [
           'error',
           'ImportDeclaration',

--- a/package.json
+++ b/package.json
@@ -1423,7 +1423,6 @@
     "eslint-plugin-mocha": "^10.0.5",
     "eslint-plugin-no-unsanitized": "^3.1.5",
     "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-prefer-object-spread": "^1.2.1",
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-react": "^7.26.1",
     "eslint-plugin-react-hooks": "^4.2.0",

--- a/packages/kbn-eslint-config/javascript.js
+++ b/packages/kbn-eslint-config/javascript.js
@@ -15,7 +15,6 @@ module.exports = {
         '@babel',
         'import',
         'no-unsanitized',
-        'prefer-object-spread',
       ],
 
       env: {
@@ -94,7 +93,7 @@ module.exports = {
         'import/no-duplicates': 'error',
         'import/no-dynamic-require': 'error',
 
-        'prefer-object-spread/prefer-object-spread': 'error',
+        'prefer-object-spread': 'error',
       }
     },
   ]

--- a/packages/kbn-eslint-config/typescript.js
+++ b/packages/kbn-eslint-config/typescript.js
@@ -20,7 +20,6 @@ module.exports = {
         '@typescript-eslint',
         'ban',
         'import',
-        'prefer-object-spread',
         'eslint-comments'
       ],
 

--- a/packages/kbn-tinymath/src/index.js
+++ b/packages/kbn-tinymath/src/index.js
@@ -35,7 +35,7 @@ function evaluate(expression, scope = {}, injectedFunctions = {}) {
 }
 
 function interpret(node, scope, injectedFunctions) {
-  const functions = Object.assign({}, includedFunctions, injectedFunctions); // eslint-disable-line prefer-object-spread/prefer-object-spread
+  const functions = Object.assign({}, includedFunctions, injectedFunctions); // eslint-disable-line prefer-object-spread
   return exec(node);
 
   function exec(node) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -15380,11 +15380,6 @@ eslint-plugin-node@^11.1.0:
     resolve "^1.10.1"
     semver "^6.1.0"
 
-eslint-plugin-prefer-object-spread@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-prefer-object-spread/-/eslint-plugin-prefer-object-spread-1.2.1.tgz#27fb91853690cceb3ae6101d9c8aecc6a67a402c"
-  integrity sha1-J/uRhTaQzOs65hAdnIrsxqZ6QCw=
-
 eslint-plugin-prettier@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-4.0.0.tgz#8b99d1e4b8b24a762472b4567992023619cb98e0"


### PR DESCRIPTION
Remove the `eslint-plugin-prefer-object-spread` dependency as the `prefer-object-spread` rule has been part of ESLint since v5 (we currently run ESLint v7).

<!--ONMERGE {"backportTargets":["7.17","8.9"]} ONMERGE-->