### PR TITLE
chore(NA): update versions after v8.9.1 bump

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -8,7 +8,7 @@
       "currentMinor": true
     },
     {
-      "version": "8.9.0",
+      "version": "8.9.1",
       "branch": "8.9",
       "currentMajor": true,
       "previousMinor": true


### PR DESCRIPTION
This PR is a simple update of our versions file after the recent bumps.